### PR TITLE
fix(ci): replace cargo fmt --all with cargo xtask fmt (#4339)

### DIFF
--- a/.claude/commands/coding-standards.md
+++ b/.claude/commands/coding-standards.md
@@ -37,7 +37,7 @@ context.
 
 ## Verification (per-crate default)
 ```bash
-cargo fmt --all
+cargo xtask fmt
 cargo clippy -p <crate> --tests -- -D warnings
 cargo test -p <crate>
 ```

--- a/.claude/commands/parser-fix.md
+++ b/.claude/commands/parser-fix.md
@@ -36,7 +36,7 @@ fn test_description() -> Result<()> {
 
 ### 4. Verify
 ```bash
-cargo fmt --all
+cargo xtask fmt
 cargo clippy -p perl-parser-core --lib
 cargo test -p perl-parser-core
 cargo test -p perl-parser

--- a/.claude/commands/pr-respond.md
+++ b/.claude/commands/pr-respond.md
@@ -44,7 +44,7 @@ gh pr comment $ARGUMENTS --body "Addressed review feedback:
 
 ### 5. Re-verify
 ```bash
-cargo fmt --all
+cargo xtask fmt
 cargo clippy -p <crate> --tests -- -D warnings
 cargo test -p <crate>
 ```

--- a/.claude/commands/scout-test-spec.md
+++ b/.claude/commands/scout-test-spec.md
@@ -34,7 +34,7 @@ fn test_<feature_name>() {
 
 ```bash
 cargo test -p <crate> -- <test_name> --exact
-cargo fmt --all && cargo clippy -p <crate> --tests
+cargo xtask fmt && cargo clippy -p <crate> --tests
 ```
 
 ## Output

--- a/.claude/commands/worktree-pr.md
+++ b/.claude/commands/worktree-pr.md
@@ -22,7 +22,7 @@ git diff HEAD
 
 3. **Validate** — run checks in the worktree:
 ```bash
-cargo fmt --all -- --check
+cargo xtask fmt --check
 cargo clippy --workspace --lib 2>&1 | tail -5
 cargo test --workspace --lib 2>&1 | tail -10
 ```

--- a/.claude/hooks/task-completed.sh
+++ b/.claude/hooks/task-completed.sh
@@ -41,8 +41,8 @@ elif ! git rev-parse HEAD~1 &>/dev/null 2>&1 && git ls-files -- '*.rs' 2>/dev/nu
 fi
 
 if [[ "${HAS_RS_DIFF}" -eq 1 ]]; then
-  if ! cargo fmt --all -- --check 2>/dev/null; then
-    echo "Task completion blocked: cargo fmt check failed. Run 'cargo fmt --all' before marking complete."
+  if ! cargo xtask fmt --check 2>/dev/null; then
+    echo "Task completion blocked: cargo fmt check failed. Run 'cargo xtask fmt' before marking complete."
     exit 2
   fi
 fi

--- a/.claude/skills/scout-issue/SKILL.md
+++ b/.claude/skills/scout-issue/SKILL.md
@@ -60,7 +60,7 @@ fn test_<name>() {
 **Verify:**
 \`\`\`bash
 cargo test -p <crate> -- <test_name> --exact
-cargo fmt --all && cargo clippy -p <crate> --tests
+cargo xtask fmt && cargo clippy -p <crate> --tests
 \`\`\`
 
 ## Acceptance Criteria

--- a/.github/ISSUE_TEMPLATE/scout_report.yml
+++ b/.github/ISSUE_TEMPLATE/scout_report.yml
@@ -147,7 +147,7 @@ body:
         ```bash
         cargo test -p perl-parser-core -- test_check_as_label --exact
         cargo test -p perl-parser-core -- test_end_as_label --exact
-        cargo fmt --all && cargo clippy -p perl-parser-core --tests
+        cargo xtask fmt && cargo clippy -p perl-parser-core --tests
         ```
       render: markdown
     validations:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 <!-- What test was added? Does it fail before the fix and pass after? -->
 
 ## Verification
-- [ ] `cargo fmt --all` — clean
+- [ ] `cargo xtask fmt` — clean
 - [ ] I used a narrow orthogonal pass first (freshness check, truth-check, or targeted repro) before the broader gate.
 - [ ] `cargo clippy -p <crate> --tests` — clean
 - [ ] `cargo test -p <crate>` — pass

--- a/.github/actions/rust-checks/action.yml
+++ b/.github/actions/rust-checks/action.yml
@@ -72,11 +72,11 @@ runs:
   steps:
     - name: Check formatting
       id: fmt
-      if: inputs.check-fmt == 'true' && runner.os != 'Windows'
+      if: inputs.check-fmt == 'true'
       shell: bash
       run: |
         echo "::group::Format Check"
-        cargo fmt --all --check
+        cargo xtask fmt --check
         echo "status=$?" >> $GITHUB_OUTPUT
         echo "::endgroup::"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Auto-fix formatting
         run: |
-          cargo fmt --all
+          cargo xtask fmt
           if ! git diff --quiet; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ Prefer cheap, orthogonal passes over one broad gate:
 
 ## Coding Expectations
 
-- Run `cargo fmt --all` for formatting.
+- Run `cargo xtask fmt` for formatting (per-crate invocation, Windows-safe).
 - Run the narrowest relevant tests first, then the broader gate when the change is ready.
 - `unwrap()`, `expect()`, `panic!()`, `todo!()`, and `unimplemented!()` are banned in production code.
 - In tests, prefer `Result<()>` and helpers such as `perl_tdd_support::must` and `must_some`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ just ci-lsp-def                       # Semantic definition tests
 ### Lint, Format, Quality
 
 ```bash
-cargo fmt --all                       # Format code
+cargo xtask fmt                       # Format code (per-crate, Windows-safe)
 cargo clippy --workspace              # Lint all crates
 cargo clippy --workspace --lib        # Lint libraries only (faster)
 just dead-code                        # Dead code report

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,7 +237,7 @@ For full detail and rationale, see [CLAUDE.md](CLAUDE.md#coding-standards).
 
 ### Formatting and Linting
 
-- Run `cargo fmt --all` before every commit — `just ci-gate` will catch this, but the sooner the better
+- Run `cargo xtask fmt` before every commit — `just ci-gate` will catch this, but the sooner the better
 - Fix all `cargo clippy --workspace` warnings — clippy is treated as errors in CI
 - Use [conventional commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, etc.
 - Scope-qualify commit subjects: `feat(lsp): ...`, `fix(dap): ...`, `chore(release): ...`

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ See [docs/README.md](docs/README.md) for the full crate map and design notes.
 
 ```bash
 cargo test --workspace --lib
-cargo fmt --all
+cargo xtask fmt
 cargo clippy --workspace
 nix develop -c just ci-gate   # required before merge
 ```

--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -2065,7 +2065,7 @@ if [ "$GATE_STATUS" -ne 0 ]; then
     fi
     if grep -qE 'cargo (xtask )?fmt.*--check' "$GATE_LOG" 2>/dev/null && \
        grep -qE 'Diff in|rustfmt' "$GATE_LOG" 2>/dev/null; then
-        echo "   • Formatting drift — run \`cargo xtask fmt\` (or \`cargo fmt --all\`) to auto-fix"
+        echo "   • Formatting drift — run \`cargo xtask fmt\` to auto-fix"
         HINTED=true
     fi
     if grep -qE 'clippy::|warning: .*-> .*\.rs' "$GATE_LOG" 2>/dev/null; then
@@ -2073,10 +2073,11 @@ if [ "$GATE_STATUS" -ne 0 ]; then
         HINTED=true
     fi
     if grep -qE 'os error 206|filename.*too long|ERROR_FILENAME_EXCED' "$GATE_LOG" 2>/dev/null; then
-        echo "   • Windows MAX_PATH (os error 206) — paths exceed 260 chars"
-        echo "     Fix A: Enable long paths (requires admin terminal):"
-        echo "       reg add HKLM\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f"
-        echo "     Fix B: bash scripts/install-githooks.sh  (stale hook may be the cause)"
+        echo "   • Windows CreateProcess command-line length limit (os error 206)"
+        echo "     'cargo fmt --all' passes all 1200+ source files in one command,"
+        echo "     exceeding the ~32K-char CreateProcess limit on Windows."
+        echo "     Fix: bash scripts/install-githooks.sh"
+        echo "     This installs the current hook which uses 'cargo xtask fmt' (per-crate)."
         echo "     See: docs/contributing/FIRST_PR.md"
         HINTED=true
     fi
@@ -2513,8 +2514,8 @@ fn cmd_check_local(repo_root: &Path) -> Result<i32> {
     println!();
 
     println!("{}1. Format check...{}", YELLOW, NC);
-    if command_status_strict(repo_root, "cargo", &["fmt", "--all", "--", "--check"], &[]).is_err() {
-        println!("{}✗ Format check failed - run 'cargo fmt --all' to fix{}", RED, NC);
+    if command_status_strict(repo_root, "cargo", &["xtask", "fmt", "--check"], &[]).is_err() {
+        println!("{}✗ Format check failed - run 'cargo xtask fmt' to fix{}", RED, NC);
         return Ok(1);
     }
     println!();
@@ -4454,11 +4455,11 @@ mod tests {
     #[test]
     fn pre_push_hook_has_os_error_206_hint() {
         let hook = pre_push_hook_script();
-        // Issue #4220 — Windows MAX_PATH (os error 206) hint must appear in the
-        // gate-failure handler so contributors know how to fix it.
+        // Issue #4220 — Windows CreateProcess command-line limit (os error 206)
+        // hint must appear in the gate-failure handler so contributors know how to fix it.
         assert!(
-            hook.contains("os error 206") || hook.contains("LongPathsEnabled"),
-            "hook must hint at Windows MAX_PATH fix (issue #4220)"
+            hook.contains("os error 206") || hook.contains("CreateProcess"),
+            "hook must hint at Windows CreateProcess limit fix (issue #4220)"
         );
     }
 

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -229,7 +229,7 @@ if [ "$GATE_STATUS" -ne 0 ]; then
     fi
     if grep -qE 'cargo (xtask )?fmt.*--check' "$GATE_LOG" 2>/dev/null && \
        grep -qE 'Diff in|rustfmt' "$GATE_LOG" 2>/dev/null; then
-        echo "   • Formatting drift — run \`cargo xtask fmt\` (or \`cargo fmt --all\`) to auto-fix"
+        echo "   • Formatting drift — run \`cargo xtask fmt\` to auto-fix"
         HINTED=true
     fi
     if grep -qE 'clippy::|warning: .*-> .*\.rs' "$GATE_LOG" 2>/dev/null; then
@@ -237,10 +237,11 @@ if [ "$GATE_STATUS" -ne 0 ]; then
         HINTED=true
     fi
     if grep -qE 'os error 206|filename.*too long|ERROR_FILENAME_EXCED' "$GATE_LOG" 2>/dev/null; then
-        echo "   • Windows MAX_PATH (os error 206) — paths exceed 260 chars"
-        echo "     Fix A: Enable long paths (requires admin terminal):"
-        echo "       reg add HKLM\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f"
-        echo "     Fix B: bash scripts/install-githooks.sh  (stale hook may be the cause)"
+        echo "   • Windows CreateProcess command-line length limit (os error 206)"
+        echo "     'cargo fmt --all' passes all 1200+ source files in one command,"
+        echo "     exceeding the ~32K-char CreateProcess limit on Windows."
+        echo "     Fix: bash scripts/install-githooks.sh"
+        echo "     This installs the current hook which uses 'cargo xtask fmt' (per-crate)."
         echo "     See: docs/contributing/FIRST_PR.md"
         HINTED=true
     fi

--- a/scripts/gate-local.sh
+++ b/scripts/gate-local.sh
@@ -90,7 +90,7 @@ fi
 
 echo ""
 echo ">>> fmt check"
-cargo fmt --all -- --check
+cargo xtask fmt --check
 
 echo ""
 # cspell:ignore clippy

--- a/scripts/production-gates-validation.sh
+++ b/scripts/production-gates-validation.sh
@@ -76,7 +76,7 @@ echo "1. Code Quality Gates"
 echo "--------------------"
 
 # Formatting check
-check_gate "Code Formatting" "cargo fmt --all -- --check" "success"
+check_gate "Code Formatting" "cargo xtask fmt --check" "success"
 
 # Clippy checks
 check_gate "Clippy Linting" "cargo clippy --workspace --locked -- -D warnings" "success"


### PR DESCRIPTION
## Summary

- Replaces all `cargo fmt --all` invocations with `cargo xtask fmt` across 19 files
- Fixes the Windows CreateProcess() command-line length limit (os error 206) that breaks formatting on this 134-crate workspace
- Corrects the misleading "MAX_PATH" error hint to explain the actual root cause

## Root cause

`cargo fmt --all` collects all 1,200+ source files and passes them to a single `rustfmt` invocation. On Windows, `CreateProcess()` has a ~32,767-character command-line limit. This workspace generates a 109K-char command line — 3.3x over the limit.

This is **not** a `MAX_PATH` issue. `LongPathsEnabled` is already on and does not help. The longest individual path is only 108 chars.

## Fix

`cargo xtask fmt` (`xtask/src/tasks/fmt.rs`) already exists and runs `cargo fmt --manifest-path <path>` per crate, staying well within limits. This PR simply routes all callers to it:

| Surface | File | Before | After |
|---------|------|--------|-------|
| Pre-push hook | `hooks/pre-push` | error hint says MAX_PATH | says CreateProcess, recommends install-githooks |
| CI gate | `ci-hygiene cmd_check_local` | `cargo fmt --all --check` | `cargo xtask fmt --check` |
| CI workflow | `.github/workflows/ci.yml` | `cargo fmt --all` | `cargo xtask fmt` |
| CI action | `.github/actions/rust-checks/action.yml` | `cargo fmt --all --check` (skip Windows) | `cargo xtask fmt --check` (all platforms) |
| Task hook | `.claude/hooks/task-completed.sh` | `cargo fmt --all -- --check` | `cargo xtask fmt --check` |
| Scripts | `gate-local.sh`, `production-gates-validation.sh` | `cargo fmt --all -- --check` | `cargo xtask fmt --check` |
| Docs/templates | CLAUDE.md, README, CONTRIBUTING, PR template, etc. | `cargo fmt --all` | `cargo xtask fmt` |

## Test plan

- [x] `cargo test -p perl-ci-hygiene -- pre_push_hook` — 11/11 pass
- [x] `cargo check -p perl-ci-hygiene` — clean
- [ ] CI passes on this PR (validates the workflow/action changes)
- [ ] Push from Windows without `--no-verify` succeeds after merging