### PR TITLE
fix(security): resolve RUSTSEC-2026-0097 by bumping rand 0.9.2 → 0.9.4 (#4149)

### DIFF
--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -258,8 +258,7 @@ gates:
     description: "Check dependencies for known security vulnerabilities"
     required: true
     # cargo-audit must be installed; CI installs it if missing
-    # Temporary ignore for rand unsoundness advisory tracked in #4149.
-    command: cargo audit --deny warnings --ignore RUSTSEC-2023-0089 --ignore RUSTSEC-2026-0097 2>/dev/null || cargo install cargo-audit --locked && cargo audit --deny warnings --ignore RUSTSEC-2023-0089 --ignore RUSTSEC-2026-0097
+    command: cargo audit --deny warnings --ignore RUSTSEC-2023-0089 2>/dev/null || cargo install cargo-audit --locked && cargo audit --deny warnings --ignore RUSTSEC-2023-0089
     timeout_seconds: 300
     retry_count: 1
     budgets:

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -69,8 +69,7 @@ jobs:
         id: audit
         run: |
           set +e
-          # Temporary ignore tracked in #4149 until upstream rand fixes land.
-          cargo audit --ignore RUSTSEC-2026-0097 --json > audit-results.json 2>&1
+          cargo audit --json > audit-results.json 2>&1
           AUDIT_EXIT=$?
           echo "exit_code=$AUDIT_EXIT" >> $GITHUB_OUTPUT
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3121,7 +3121,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -3169,9 +3169,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",

--- a/justfile
+++ b/justfile
@@ -192,7 +192,7 @@ lsp-smoke:
 security-audit:
     @echo "Running security audit..."
     @if command -v cargo-audit >/dev/null 2>&1; then \
-        cargo audit --ignore RUSTSEC-2026-0097 2>&1 || echo "Audit warnings (non-blocking)"; \
+        cargo audit 2>&1 || echo "Audit warnings (non-blocking)"; \
     else \
         echo "SKIP: cargo-audit not installed (run: cargo install cargo-audit)"; \
     fi


### PR DESCRIPTION
## Summary
- Bump rand from 0.9.2 to 0.9.4 in Cargo.lock — the soundness fix (rust-random/rand#1763) was backported to the 0.9.x line
- Remove all temporary `--ignore RUSTSEC-2026-0097` flags from `.ci/gate-policy.yaml`, `justfile`, and `.github/workflows/ci-security.yml`
- `cargo audit` now passes clean with zero advisories

Closes #4149

## Test plan
- [x] `cargo audit` returns clean (verified locally)
- [ ] CI security audit workflow passes without the ignore flag