### PR TITLE
fix(completion): rank own-class methods above inherited in $obj-> completion (#4266)

### DIFF
--- a/crates/perl-lsp-completion/src/completion/workspace.rs
+++ b/crates/perl-lsp-completion/src/completion/workspace.rs
@@ -516,6 +516,11 @@ pub fn add_workspace_method_completions(
             format!("{package_name} method (from {defining_pkg})")
         };
 
+        // Own-class methods rank above inherited: tier 2 for own, tier 3 for inherited.
+        // This ensures $obj->zoom (own) sorts before $obj->abstract_method (inherited)
+        // even when the own method name is alphabetically after the inherited name.
+        let method_tier = if defining_pkg == package_name { "2" } else { "3" };
+
         completions.push(CompletionItem {
             label: symbol.name.clone(),
             kind: CompletionItemKind::Function,
@@ -524,7 +529,7 @@ pub fn add_workspace_method_completions(
                 Some(format!("Method `{}::{}` from workspace index.", defining_pkg, symbol.name))
             }),
             insert_text: Some(format!("{}()", symbol.name)),
-            sort_text: Some(format!("2_{}", symbol.name)), // After local, before generic
+            sort_text: Some(format!("{method_tier}_{}", symbol.name)), // tier 2=own, 3=inherited, after local (tier 1)
             filter_text: Some(symbol.name.clone()),
             additional_edits,
             text_edit_range: Some((context.prefix_start, context.position)),

--- a/crates/perl-lsp-completion/tests/completion_behavior_tests.rs
+++ b/crates/perl-lsp-completion/tests/completion_behavior_tests.rs
@@ -597,3 +597,57 @@ fn open_builtin_snippet_includes_or_die() {
         "open snippet must contain 'or die' for idiomatic error handling; got: {insert_text:?}"
     );
 }
+
+// ===========================================================================
+// Method ranking: own-class vs inherited (#4266)
+// ===========================================================================
+
+/// #4266 — Own-class methods must sort before inherited methods after `$obj->`.
+///
+/// When a workspace-indexed class `Dog` inherits from `Animal`, completing
+/// `$dog->` must show `Dog`'s own methods in a higher tier than `Animal`'s
+/// inherited methods — even when the own method name is alphabetically AFTER
+/// the inherited method name, so the tier prefix is the decisive factor.
+///
+/// Test uses `Dog::zoom` (own, z...) vs `Animal::abstract_method` (inherited, a...)
+/// to verify that tier assignment drives sort order, not alphabetical coincidence.
+#[test]
+fn own_class_methods_rank_before_inherited_methods() {
+    // Base class with a method that alphabetically precedes the own-class method
+    let index = Arc::new(WorkspaceIndex::new());
+    let base_uri = must(Url::parse("file:///workspace/Animal.pm"));
+    let base_code = "package Animal;\nsub abstract_method { }\n1;";
+    must(index.index_file(base_uri, base_code.to_string()));
+
+    // Derived class with its own method whose name is alphabetically AFTER
+    // the inherited method — so alphabetical sort alone would put zoom last
+    let derived_uri = must(Url::parse("file:///workspace/Dog.pm"));
+    let derived_code = "package Dog;\nuse parent 'Animal';\nsub zoom { }\n1;";
+    must(index.index_file(derived_uri, derived_code.to_string()));
+
+    let code = "my $dog = Dog->new();\n$dog->";
+    let pos = code.len();
+    let items = completions_with_index(code, pos, index);
+
+    // Both own and inherited methods must appear
+    assert!(has_label(&items, "zoom"), "should include own method zoom; got: {:?}", labels(&items));
+    assert!(
+        has_label(&items, "abstract_method"),
+        "should include inherited method abstract_method; got: {:?}",
+        labels(&items)
+    );
+
+    // Own methods must sort before inherited methods via sort_text tier prefix.
+    // zoom (own, tier-2) must beat abstract_method (inherited, tier-3) even though
+    // 'z' > 'a' alphabetically — the tier prefix must be the decisive factor.
+    let zoom_sort =
+        must_some(items.iter().find(|c| c.label == "zoom").and_then(|c| c.sort_text.as_deref()));
+    let inherited_sort = must_some(
+        items.iter().find(|c| c.label == "abstract_method").and_then(|c| c.sort_text.as_deref()),
+    );
+
+    assert!(
+        zoom_sort < inherited_sort,
+        "own method 'zoom' (sort_text: {zoom_sort:?}) should rank before inherited 'abstract_method' (sort_text: {inherited_sort:?}); tier prefix must be decisive, not alphabetical order"
+    );
+}


### PR DESCRIPTION
## Summary

- Own-class methods now sort before inherited methods after `$obj->` — the receiver's own methods float to the top of the completion list regardless of alphabetical order
- Uses the already-computed `defining_pkg == package_name` comparison (same one used for the `detail` string) to assign sort_text tier `"2_"` (own) vs `"3_"` (inherited)
- Zero new dependencies, zero new infrastructure — 3-line change in `add_workspace_method_completions`

## Changes

- `crates/perl-lsp-completion/src/completion/workspace.rs`: Add `method_tier` binding before `CompletionItem` push; use `"{method_tier}_{name}"` instead of hardcoded `"2_{name}"` for `sort_text`
- `crates/perl-lsp-completion/tests/completion_behavior_tests.rs`: Add `own_class_methods_rank_before_inherited_methods` test — uses `Dog::zoom` (own, alphabetically last) vs `Animal::abstract_method` (inherited, alphabetically first) to verify tier prefix is the decisive factor, not alphabetical coincidence

## Evidence

- **Commits**: 1
- **Tests**: 436 passed, 0 failed (perl-lsp-completion)
- **Lint**: clean (clippy -D warnings)
- **Fmt**: clean (cargo fmt --check)
- **Files**: 2 changed, +60/-1 lines

## Test Plan

1. Run `cargo test -p perl-lsp-completion -- own_class_methods_rank_before_inherited_methods` — should pass
2. Run `cargo test -p perl-lsp-completion` — all 436 tests should pass
3. In editor: open a Perl file with a class that inherits from another, type `$obj->`, observe own-class methods appear before inherited ones

## Unknowns

- DBI-inferred completions (via `methods.rs::add_method_completions`) are unaffected — they use their own path with existing tier-2 sort_text and do not go through `add_workspace_method_completions`
- Chained calls like `$obj->foo->bar->` gracefully degrade (type inference bails, no workspace completions emitted) — no change to that path
- Diamond inheritance: `collect_all_package_members` BFS dedup ensures child methods shadow parent methods; the tier split applies on top of this correctly

Closes #4266