### PR TITLE
feat(completion): add hash key completion after $hash{ (#4264)

### DIFF
--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -1564,8 +1564,14 @@ impl CompletionProvider {
             return None;
         }
 
-        // Require `$` sigil immediately before the variable name
+        // Require `$` sigil immediately before the variable name.
+        // Also reject `$$var{` (double-sigil deref) by ensuring the char before `$`
+        // is not itself a `$` — that would indicate `$$var{key}` which is a scalar-ref
+        // dereference, not a plain hash subscript.
         if var_name_start == 0 || before_brace.as_bytes()[var_name_start - 1] != b'$' {
+            return None;
+        }
+        if var_name_start >= 2 && before_brace.as_bytes()[var_name_start - 2] == b'$' {
             return None;
         }
 

--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -779,6 +779,18 @@ impl CompletionProvider {
             self.add_has_type_completions(&mut completions, &context);
         } else if self.is_has_options_key_context(source, position) {
             self.add_has_option_completions(&mut completions, &context);
+        } else if !context.in_comment
+            && !context.in_string
+            && !context.in_regex
+            && let Some((varname, key_prefix)) = Self::detect_hash_key_context(source, position)
+        {
+            Self::add_hash_key_completions(
+                &mut completions,
+                &context,
+                source,
+                &varname,
+                &key_prefix,
+            );
         } else if let Some(package_name) = self.object_pad_constructor_package(source, position) {
             self.add_object_pad_constructor_completions(&mut completions, &context, &package_name);
         } else if (context.trigger_character == Some('>') || context.trigger_character == Some('-'))
@@ -1470,6 +1482,248 @@ impl CompletionProvider {
         }
 
         None
+    }
+
+    /// Detect whether the cursor is inside a plain hash subscript `$varname{prefix`.
+    ///
+    /// Returns `Some((varname, key_prefix))` when:
+    /// - The source before `position` contains `$varname{` (with no `->` immediately before `{`)
+    /// - The context is not inside a comment or string literal
+    ///
+    /// Returns `None` for hashref dereferences (`$ref->{...}`), double-sigil derefs
+    /// (`$$ref{...}`), or contexts where hash key completion is not meaningful.
+    fn detect_hash_key_context(source: &str, position: usize) -> Option<(String, String)> {
+        if position == 0 || !source.is_char_boundary(position) {
+            return None;
+        }
+
+        let before = &source[..position];
+
+        // Find the last `{` before the cursor that is not part of a nested structure.
+        // We scan backward to find the most recent unmatched `{`.
+        let brace_pos = {
+            let bytes = before.as_bytes();
+            let mut depth = 0i32;
+            let mut found = None;
+            let mut i = bytes.len();
+            while i > 0 {
+                i -= 1;
+                match bytes[i] {
+                    b'}' => depth += 1,
+                    b'{' => {
+                        if depth == 0 {
+                            found = Some(i);
+                            break;
+                        }
+                        depth -= 1;
+                    }
+                    _ => {}
+                }
+            }
+            found?
+        };
+
+        // Extract typed prefix after the `{` (alphanumeric + `_` chars)
+        let key_prefix = {
+            let after_brace = &before[brace_pos + 1..];
+            // Prefix is the alphanumeric+_ run from after `{` to position
+            let non_ident = after_brace
+                .rfind(|c: char| !c.is_alphanumeric() && c != '_')
+                .map(|p| p + 1)
+                .unwrap_or(0);
+            after_brace[non_ident..].to_string()
+        };
+
+        // The text between the `{` and the start of key_prefix must contain only
+        // word chars and whitespace (no operators, semicolons, etc.) — if it contains
+        // any non-whitespace non-word chars it is not a simple hash subscript.
+        let between = &before[brace_pos + 1..position - key_prefix.len()];
+        if between.chars().any(|c| !c.is_alphanumeric() && c != '_' && !c.is_whitespace()) {
+            return None;
+        }
+
+        // Check for `->` immediately before the `{` (hashref deref — out of scope).
+        if brace_pos >= 2 && &source[brace_pos - 2..brace_pos] == "->" {
+            return None;
+        }
+
+        // Extract the variable name: scan backward from `{` looking for `$word`.
+        let before_brace = before[..brace_pos].trim_end();
+        if before_brace.is_empty() {
+            return None;
+        }
+
+        // Variable name ends right before the `{`, scan back for `$`.
+        let var_end = before_brace.len();
+        let var_name_start = before_brace
+            .rfind(|c: char| !c.is_alphanumeric() && c != '_')
+            .map(|p| p + 1)
+            .unwrap_or(0);
+        let var_name = &before_brace[var_name_start..var_end];
+        if var_name.is_empty() {
+            return None;
+        }
+
+        // Require `$` sigil immediately before the variable name
+        if var_name_start == 0 || before_brace.as_bytes()[var_name_start - 1] != b'$' {
+            return None;
+        }
+
+        Some((var_name.to_string(), key_prefix))
+    }
+
+    /// Scan `source` text for all keys defined in `%varname` hash literals and
+    /// individual `$varname{key}` assignment patterns.
+    ///
+    /// Uses only str operations — no regex crate dependency.
+    fn collect_hash_keys_from_source(source: &str, varname: &str) -> Vec<String> {
+        let mut keys: Vec<String> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+
+        // Pattern 1: `my %varname = (` / `our %varname = (` / `%varname = (`
+        // Scan for `%varname` followed by `=` and `(`
+        let hash_pat = format!("%{varname}");
+        let mut search_start = 0;
+        while let Some(pos) = source[search_start..].find(hash_pat.as_str()) {
+            let abs_pos = search_start + pos;
+            let after = &source[abs_pos + hash_pat.len()..];
+            let trimmed = after.trim_start();
+            if let Some(rest) = trimmed.strip_prefix('=') {
+                let rest = rest.trim_start();
+                if let Some(inner_start) = rest.find('(') {
+                    let inner = &rest[inner_start + 1..];
+                    // Find matching `)` — walk forward tracking depth
+                    let mut depth = 1i32;
+                    let mut inner_end = inner.len();
+                    for (idx, ch) in inner.char_indices() {
+                        match ch {
+                            '(' => depth += 1,
+                            ')' => {
+                                depth -= 1;
+                                if depth == 0 {
+                                    inner_end = idx;
+                                    break;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    let list_text = &inner[..inner_end];
+                    Self::extract_fat_comma_keys(list_text, &mut keys, &mut seen);
+                }
+            }
+            search_start = abs_pos + 1;
+            if search_start >= source.len() {
+                break;
+            }
+        }
+
+        // Pattern 2: `$varname{key} =` individual assignment
+        let scalar_pat = format!("${varname}{{");
+        let mut search_start = 0;
+        while let Some(pos) = source[search_start..].find(scalar_pat.as_str()) {
+            let abs_pos = search_start + pos;
+            let after_brace = &source[abs_pos + scalar_pat.len()..];
+            // Key is alphanumeric+_ up to `}`
+            let key_end = after_brace
+                .find(|c: char| !c.is_alphanumeric() && c != '_')
+                .unwrap_or(after_brace.len());
+            let key = &after_brace[..key_end];
+            if !key.is_empty() && after_brace[key_end..].trim_start().starts_with('}') {
+                // Check that `=` (but not `=>`) follows the `}`
+                let after_close = after_brace[key_end..].trim_start();
+                let after_close = after_close.strip_prefix('}').unwrap_or("").trim_start();
+                if after_close.starts_with('=') && !after_close.starts_with("=>") {
+                    let key_str = key.to_string();
+                    if seen.insert(key_str.clone()) {
+                        keys.push(key_str);
+                    }
+                }
+            }
+            search_start = abs_pos + 1;
+            if search_start >= source.len() {
+                break;
+            }
+        }
+
+        keys
+    }
+
+    /// Extract bare-word and single-quoted keys from a fat-comma list like
+    /// `host => 'localhost', port => 5432`.
+    fn extract_fat_comma_keys(list_text: &str, keys: &mut Vec<String>, seen: &mut HashSet<String>) {
+        // Split by `=>` to find key positions.
+        // Every token immediately before a `=>` is a key.
+        let mut remaining = list_text;
+        while let Some(arrow_pos) = remaining.find("=>") {
+            let key_segment = remaining[..arrow_pos].trim_end();
+            // Find the last token (after the previous `,` or start)
+            let token_start = key_segment.rfind([',', '(', '\n']).map(|p| p + 1).unwrap_or(0);
+            let token = key_segment[token_start..].trim();
+            // Strip single or double quotes
+            let token = token
+                .strip_prefix('\'')
+                .and_then(|t| t.strip_suffix('\''))
+                .or_else(|| token.strip_prefix('"').and_then(|t| t.strip_suffix('"')))
+                .unwrap_or(token);
+            if !token.is_empty() && token.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                let key_str = token.to_string();
+                if seen.insert(key_str.clone()) {
+                    keys.push(key_str);
+                }
+            }
+            // Advance past `=>` and the value. Value ends at the next top-level `,`.
+            let after_arrow = &remaining[arrow_pos + 2..];
+            let value_end = {
+                let mut depth = 0i32;
+                let mut end = after_arrow.len();
+                for (idx, ch) in after_arrow.char_indices() {
+                    match ch {
+                        '(' | '[' | '{' => depth += 1,
+                        ')' | ']' | '}' => depth -= 1,
+                        ',' if depth == 0 => {
+                            end = idx;
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+                end
+            };
+            remaining = &after_arrow[value_end..];
+            if let Some(stripped) = remaining.strip_prefix(',') {
+                remaining = stripped;
+            }
+        }
+    }
+
+    /// Push hash key completion items for `$varname{key_prefix<cursor>`.
+    fn add_hash_key_completions(
+        completions: &mut Vec<CompletionItem>,
+        context: &CompletionContext,
+        source: &str,
+        varname: &str,
+        key_prefix: &str,
+    ) {
+        let keys = Self::collect_hash_keys_from_source(source, varname);
+        for key in keys {
+            if !key_prefix.is_empty() && !key.starts_with(key_prefix) {
+                continue;
+            }
+            let key_prefix_len = key_prefix.len();
+            completions.push(CompletionItem {
+                label: key.clone(),
+                kind: CompletionItemKind::Property,
+                detail: Some(format!("key of %{varname}")),
+                documentation: None,
+                insert_text: Some(key.clone()),
+                sort_text: Some(format!("0_{key}")),
+                filter_text: Some(key.clone()),
+                additional_edits: vec![],
+                text_edit_range: Some((context.position - key_prefix_len, context.position)),
+                commit_characters: None,
+            });
+        }
     }
 
     /// Add completions for Moo/Moose type constraint values inside `isa => ...`.
@@ -3423,5 +3677,101 @@ sub run {
             completions.iter().map(|c| &c.label).collect::<Vec<_>>()
         );
         Ok(())
+    }
+
+    // ── Hash key completion tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_hash_key_completion_basic() {
+        // my %config = (host => 'localhost', port => 5432);
+        // $config{ho<cursor>
+        // Expected: "host" suggested, "port" filtered out by prefix
+        let code = "my %config = (host => 'localhost', port => 5432);\n$config{ho";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new(&ast);
+        let completions = provider.get_completions(code, code.len());
+        assert!(
+            completions.iter().any(|c| c.label == "host"),
+            "expected 'host' in hash key completions for prefix 'ho'; got: {:?}",
+            completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+        );
+        assert!(
+            !completions.iter().any(|c| c.label == "port"),
+            "expected 'port' filtered out by prefix 'ho'; got: {:?}",
+            completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_hash_key_completion_empty_prefix() {
+        // $config{<cursor> -- all keys returned
+        let code = "my %config = (host => 'localhost', port => 5432);\n$config{";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new(&ast);
+        let completions = provider.get_completions(code, code.len());
+        assert!(
+            completions.iter().any(|c| c.label == "host"),
+            "expected 'host' in hash key completions with empty prefix; got: {:?}",
+            completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+        );
+        assert!(
+            completions.iter().any(|c| c.label == "port"),
+            "expected 'port' in hash key completions with empty prefix; got: {:?}",
+            completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_hash_key_completion_does_not_fire_for_hashref_deref() {
+        // $ref->{ho<cursor> -- hashref deref, must NOT suggest hash keys
+        let code = "my $ref = {host => 'localhost'};\n$ref->{ho";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new(&ast);
+        let completions = provider.get_completions(code, code.len());
+        // Must not return a Property-kinded "host" completion (hash key detection
+        // must bail when `->` precedes the `{`)
+        assert!(
+            !completions
+                .iter()
+                .any(|c| c.label == "host" && c.kind == CompletionItemKind::Property),
+            "hashref deref `$ref->{{ho` must not produce Property-kinded 'host' completion; got: {:?}",
+            completions.iter().map(|c| (&c.label, &c.kind)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_hash_key_completion_in_comment_no_suggestions() {
+        // # $config{ho<cursor> -- in comment, should not suggest hash keys
+        let code = "my %config = (host => 'localhost');\n# $config{ho";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new(&ast);
+        let completions = provider.get_completions(code, code.len());
+        assert!(
+            !completions
+                .iter()
+                .any(|c| c.label == "host" && c.kind == CompletionItemKind::Property),
+            "hash key completion must not fire inside a comment; got: {:?}",
+            completions.iter().map(|c| (&c.label, &c.kind)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_hash_key_completion_unknown_variable_returns_empty_for_that_hash() {
+        // $config{<cursor> where %config has no known init -- no leaked keys from %other
+        let code = "my %other = (a => 1);\n$config{";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new(&ast);
+        let completions = provider.get_completions(code, code.len());
+        // Keys from %other must not appear as completions for $config{}
+        assert!(
+            !completions.iter().any(|c| c.label == "a" && c.kind == CompletionItemKind::Property),
+            "keys from %%other must not leak into %%config completions; got: {:?}",
+            completions.iter().map(|c| (&c.label, &c.kind)).collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/perl-lsp-completion/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-completion/tests/extended_unit_tests.rs
@@ -1749,7 +1749,10 @@ fn test_hash_key_completion_quoted_keys() {
     let code = "my %quoted = ('first_key' => 1, \"second_key\" => 2);\n$quoted{";
     let completions = completions_at_end(code);
     assert!(has_label(&completions, "first_key"), "quoted key 'first_key' should be extracted");
-    assert!(has_label(&completions, "second_key"), "double-quoted key 'second_key' should be extracted");
+    assert!(
+        has_label(&completions, "second_key"),
+        "double-quoted key 'second_key' should be extracted"
+    );
 }
 
 #[test]

--- a/crates/perl-lsp-completion/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-completion/tests/extended_unit_tests.rs
@@ -1730,3 +1730,147 @@ fn builtin_warn_no_duplicate() {
         "'warn' should survive as builtin (3_) not keyword (5_); got sort_text: {sort:?}"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// Hash key completion edge case tests (issue #4264)
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_hash_key_completion_single_key() {
+    let code = "my %map = (single => 'value');\n$map{sin";
+    let completions = completions_at_end(code);
+    assert!(
+        has_label(&completions, "single"),
+        "single key hash should complete"
+    );
+}
+
+#[test]
+fn test_hash_key_completion_quoted_keys() {
+    let code = "my %quoted = ('first_key' => 1, \"second_key\" => 2);\n$quoted{fir";
+    let completions = completions_at_end(code);
+    assert!(has_label(&completions, "first_key"), "quoted key 'first_key' should be extracted");
+    assert!(has_label(&completions, "second_key"), "quoted key 'second_key' should be extracted");
+}
+
+#[test]
+fn test_hash_key_completion_multiline_definition() {
+    let code = "my %config = (\n  host => 'localhost',\n  port => 5432,\n);\n$config{ho";
+    let completions = completions_at_end(code);
+    assert!(has_label(&completions, "host"), "multiline hash should extract keys correctly");
+    assert!(has_label(&completions, "port"), "multiline hash should extract all keys");
+}
+
+#[test]
+fn test_hash_key_completion_individual_key_assignment() {
+    let code = "$config{database} = 'mydb';\n$config{d";
+    let completions = completions_at_end(code);
+    assert!(has_label(&completions, "database"), "individual key assignment should be recognized");
+}
+
+#[test]
+fn test_hash_key_completion_mixed_definitions() {
+    let code = "my %data = (color => 'red');\n$data{shade} = 'dark';\n$data{c";
+    let completions = completions_at_end(code);
+    assert!(has_label(&completions, "color"), "literal hash keys should be found");
+    assert!(has_label(&completions, "shade"), "individual assignment keys should be found");
+}
+
+#[test]
+fn test_hash_key_completion_with_whitespace() {
+    let code = "my %config = (hostname => 'localhost');\n$config  {  hos";
+    let completions = completions_at_end(code);
+    assert!(has_label(&completions, "hostname"), "whitespace around brace should be handled");
+}
+
+#[test]
+fn test_hash_key_completion_nested_access() {
+    let code = "my %outer = (key1 => 1);\nmy %inner = (nested => 2);\n$outer{key1}{nest";
+    let completions = completions_at_end(code);
+    let has_key1_property = completions.iter()
+        .any(|c| c.label == "key1" && c.kind == CompletionItemKind::Property);
+    assert!(
+        !has_key1_property,
+        "nested hash access should not suggest keys from outer hash"
+    );
+}
+
+#[test]
+fn test_hash_key_completion_does_not_fire_for_hash_slice() {
+    let code = "my %config = (host => 'localhost', port => 5432);\n@config{ho";
+    let completions = completions_at_end(code);
+    let has_host_property = completions.iter()
+        .any(|c| c.label == "host" && c.kind == CompletionItemKind::Property);
+    assert!(!has_host_property, "hash slice @config{{...}} should not trigger hash key completion");
+}
+
+#[test]
+fn test_hash_key_completion_double_sigil_dereference() {
+    let code = "my %data = (key => 'value');\n$$ref{ke";
+    let completions = completions_at_end(code);
+    let has_key_property = completions.iter()
+        .any(|c| c.label == "key" && c.kind == CompletionItemKind::Property);
+    assert!(!has_key_property, "double-sigil deref $$ref{{...}} should not trigger hash key completion");
+}
+
+#[test]
+fn test_hash_key_completion_prefix_filtering() {
+    let code = "my %errors = (invalid_input => 'bad', invalid_format => 'ugly', valid_format => 'good');\n$errors{invalid_";
+    let completions = completions_at_end(code);
+    assert!(has_label(&completions, "invalid_input"), "prefix 'invalid_' should match 'invalid_input'");
+    assert!(has_label(&completions, "invalid_format"), "prefix 'invalid_' should match 'invalid_format'");
+    assert!(!has_label(&completions, "valid_format"), "prefix 'invalid_' should NOT match 'valid_format'");
+}
+
+#[test]
+fn test_hash_key_completion_case_sensitive() {
+    let code = "my %config = (Host => 'localhost', host => 'local');\n$config{H";
+    let completions = completions_at_end(code);
+    assert!(has_label(&completions, "Host"), "uppercase prefix 'H' should match 'Host'");
+    assert!(!has_label(&completions, "host"), "uppercase prefix 'H' should not match lowercase 'host'");
+}
+
+#[test]
+fn test_hash_key_completion_duplicate_keys() {
+    let code = "my %dup = (key => 1, key => 2);\n$dup{k";
+    let completions = completions_at_end(code);
+    let key_count = completions.iter()
+        .filter(|c| c.label == "key" && c.kind == CompletionItemKind::Property)
+        .count();
+    assert_eq!(key_count, 1, "duplicate key should appear only once in completions");
+}
+
+#[test]
+fn test_hash_key_completion_numeric_and_underscore_keys() {
+    let code = "my %data = (key_1 => 'a', key_2 => 'b', _private => 'c', __init => 'd');\n$data{_";
+    let completions = completions_at_end(code);
+    assert!(has_label(&completions, "_private"), "underscore-prefix key '_private' should be found");
+    assert!(has_label(&completions, "__init"), "double-underscore key '__init' should be found");
+    assert!(!has_label(&completions, "key_1"), "prefix '_' should not match 'key_1'");
+}
+
+#[test]
+fn test_hash_key_completion_empty_hash() {
+    let code = "my %empty = ();\n$empty{x";
+    let completions = completions_at_end(code);
+    let property_completions: Vec<_> = completions.iter()
+        .filter(|c| c.kind == CompletionItemKind::Property)
+        .collect();
+    assert!(property_completions.is_empty(), "empty hash should not suggest any keys");
+}
+
+#[test]
+fn test_hash_key_completion_fat_comma_and_string_conversion() {
+    let code = "my %config = (bare_word => 1, 'quoted' => 2);\n$config{b";
+    let completions = completions_at_end(code);
+    assert!(has_label(&completions, "bare_word"), "bare word left of fat comma should be extracted");
+}
+
+#[test]
+fn test_hash_key_completion_in_string_no_suggestions() {
+    let code = "my %config = (host => 'localhost');\nmy $s = \"$config{ho";
+    let completions = completions_at_end(code);
+    let has_host_property = completions.iter()
+        .any(|c| c.label == "host" && c.kind == CompletionItemKind::Property);
+    assert!(!has_host_property, "hash key completion must not fire inside a string literal");
+}

--- a/crates/perl-lsp-completion/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-completion/tests/extended_unit_tests.rs
@@ -1739,10 +1739,7 @@ fn builtin_warn_no_duplicate() {
 fn test_hash_key_completion_single_key() {
     let code = "my %map = (single => 'value');\n$map{sin";
     let completions = completions_at_end(code);
-    assert!(
-        has_label(&completions, "single"),
-        "single key hash should complete"
-    );
+    assert!(has_label(&completions, "single"), "single key hash should complete");
 }
 
 #[test]
@@ -1787,20 +1784,17 @@ fn test_hash_key_completion_with_whitespace() {
 fn test_hash_key_completion_nested_access() {
     let code = "my %outer = (key1 => 1);\nmy %inner = (nested => 2);\n$outer{key1}{nest";
     let completions = completions_at_end(code);
-    let has_key1_property = completions.iter()
-        .any(|c| c.label == "key1" && c.kind == CompletionItemKind::Property);
-    assert!(
-        !has_key1_property,
-        "nested hash access should not suggest keys from outer hash"
-    );
+    let has_key1_property =
+        completions.iter().any(|c| c.label == "key1" && c.kind == CompletionItemKind::Property);
+    assert!(!has_key1_property, "nested hash access should not suggest keys from outer hash");
 }
 
 #[test]
 fn test_hash_key_completion_does_not_fire_for_hash_slice() {
     let code = "my %config = (host => 'localhost', port => 5432);\n@config{ho";
     let completions = completions_at_end(code);
-    let has_host_property = completions.iter()
-        .any(|c| c.label == "host" && c.kind == CompletionItemKind::Property);
+    let has_host_property =
+        completions.iter().any(|c| c.label == "host" && c.kind == CompletionItemKind::Property);
     assert!(!has_host_property, "hash slice @config{{...}} should not trigger hash key completion");
 }
 
@@ -1808,18 +1802,30 @@ fn test_hash_key_completion_does_not_fire_for_hash_slice() {
 fn test_hash_key_completion_double_sigil_dereference() {
     let code = "my %data = (key => 'value');\n$$ref{ke";
     let completions = completions_at_end(code);
-    let has_key_property = completions.iter()
-        .any(|c| c.label == "key" && c.kind == CompletionItemKind::Property);
-    assert!(!has_key_property, "double-sigil deref $$ref{{...}} should not trigger hash key completion");
+    let has_key_property =
+        completions.iter().any(|c| c.label == "key" && c.kind == CompletionItemKind::Property);
+    assert!(
+        !has_key_property,
+        "double-sigil deref $$ref{{...}} should not trigger hash key completion"
+    );
 }
 
 #[test]
 fn test_hash_key_completion_prefix_filtering() {
     let code = "my %errors = (invalid_input => 'bad', invalid_format => 'ugly', valid_format => 'good');\n$errors{invalid_";
     let completions = completions_at_end(code);
-    assert!(has_label(&completions, "invalid_input"), "prefix 'invalid_' should match 'invalid_input'");
-    assert!(has_label(&completions, "invalid_format"), "prefix 'invalid_' should match 'invalid_format'");
-    assert!(!has_label(&completions, "valid_format"), "prefix 'invalid_' should NOT match 'valid_format'");
+    assert!(
+        has_label(&completions, "invalid_input"),
+        "prefix 'invalid_' should match 'invalid_input'"
+    );
+    assert!(
+        has_label(&completions, "invalid_format"),
+        "prefix 'invalid_' should match 'invalid_format'"
+    );
+    assert!(
+        !has_label(&completions, "valid_format"),
+        "prefix 'invalid_' should NOT match 'valid_format'"
+    );
 }
 
 #[test]
@@ -1827,14 +1833,18 @@ fn test_hash_key_completion_case_sensitive() {
     let code = "my %config = (Host => 'localhost', host => 'local');\n$config{H";
     let completions = completions_at_end(code);
     assert!(has_label(&completions, "Host"), "uppercase prefix 'H' should match 'Host'");
-    assert!(!has_label(&completions, "host"), "uppercase prefix 'H' should not match lowercase 'host'");
+    assert!(
+        !has_label(&completions, "host"),
+        "uppercase prefix 'H' should not match lowercase 'host'"
+    );
 }
 
 #[test]
 fn test_hash_key_completion_duplicate_keys() {
     let code = "my %dup = (key => 1, key => 2);\n$dup{k";
     let completions = completions_at_end(code);
-    let key_count = completions.iter()
+    let key_count = completions
+        .iter()
         .filter(|c| c.label == "key" && c.kind == CompletionItemKind::Property)
         .count();
     assert_eq!(key_count, 1, "duplicate key should appear only once in completions");
@@ -1844,7 +1854,10 @@ fn test_hash_key_completion_duplicate_keys() {
 fn test_hash_key_completion_numeric_and_underscore_keys() {
     let code = "my %data = (key_1 => 'a', key_2 => 'b', _private => 'c', __init => 'd');\n$data{_";
     let completions = completions_at_end(code);
-    assert!(has_label(&completions, "_private"), "underscore-prefix key '_private' should be found");
+    assert!(
+        has_label(&completions, "_private"),
+        "underscore-prefix key '_private' should be found"
+    );
     assert!(has_label(&completions, "__init"), "double-underscore key '__init' should be found");
     assert!(!has_label(&completions, "key_1"), "prefix '_' should not match 'key_1'");
 }
@@ -1853,9 +1866,8 @@ fn test_hash_key_completion_numeric_and_underscore_keys() {
 fn test_hash_key_completion_empty_hash() {
     let code = "my %empty = ();\n$empty{x";
     let completions = completions_at_end(code);
-    let property_completions: Vec<_> = completions.iter()
-        .filter(|c| c.kind == CompletionItemKind::Property)
-        .collect();
+    let property_completions: Vec<_> =
+        completions.iter().filter(|c| c.kind == CompletionItemKind::Property).collect();
     assert!(property_completions.is_empty(), "empty hash should not suggest any keys");
 }
 
@@ -1863,14 +1875,17 @@ fn test_hash_key_completion_empty_hash() {
 fn test_hash_key_completion_fat_comma_and_string_conversion() {
     let code = "my %config = (bare_word => 1, 'quoted' => 2);\n$config{b";
     let completions = completions_at_end(code);
-    assert!(has_label(&completions, "bare_word"), "bare word left of fat comma should be extracted");
+    assert!(
+        has_label(&completions, "bare_word"),
+        "bare word left of fat comma should be extracted"
+    );
 }
 
 #[test]
 fn test_hash_key_completion_in_string_no_suggestions() {
     let code = "my %config = (host => 'localhost');\nmy $s = \"$config{ho";
     let completions = completions_at_end(code);
-    let has_host_property = completions.iter()
-        .any(|c| c.label == "host" && c.kind == CompletionItemKind::Property);
+    let has_host_property =
+        completions.iter().any(|c| c.label == "host" && c.kind == CompletionItemKind::Property);
     assert!(!has_host_property, "hash key completion must not fire inside a string literal");
 }

--- a/crates/perl-lsp-completion/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-completion/tests/extended_unit_tests.rs
@@ -1744,15 +1744,19 @@ fn test_hash_key_completion_single_key() {
 
 #[test]
 fn test_hash_key_completion_quoted_keys() {
-    let code = "my %quoted = ('first_key' => 1, \"second_key\" => 2);\n$quoted{fir";
+    // Use empty prefix to verify both single-quoted and double-quoted keys are extracted;
+    // prefix filtering is tested separately in test_hash_key_completion_prefix_filtering.
+    let code = "my %quoted = ('first_key' => 1, \"second_key\" => 2);\n$quoted{";
     let completions = completions_at_end(code);
     assert!(has_label(&completions, "first_key"), "quoted key 'first_key' should be extracted");
-    assert!(has_label(&completions, "second_key"), "quoted key 'second_key' should be extracted");
+    assert!(has_label(&completions, "second_key"), "double-quoted key 'second_key' should be extracted");
 }
 
 #[test]
 fn test_hash_key_completion_multiline_definition() {
-    let code = "my %config = (\n  host => 'localhost',\n  port => 5432,\n);\n$config{ho";
+    // Use empty prefix to verify all keys are extracted across multiple lines;
+    // prefix filtering is tested separately in test_hash_key_completion_prefix_filtering.
+    let code = "my %config = (\n  host => 'localhost',\n  port => 5432,\n);\n$config{";
     let completions = completions_at_end(code);
     assert!(has_label(&completions, "host"), "multiline hash should extract keys correctly");
     assert!(has_label(&completions, "port"), "multiline hash should extract all keys");
@@ -1767,7 +1771,9 @@ fn test_hash_key_completion_individual_key_assignment() {
 
 #[test]
 fn test_hash_key_completion_mixed_definitions() {
-    let code = "my %data = (color => 'red');\n$data{shade} = 'dark';\n$data{c";
+    // Use empty prefix to verify both fat-comma literal and individual-assignment keys
+    // are collected; both patterns must produce completions without prefix filtering.
+    let code = "my %data = (color => 'red');\n$data{shade} = 'dark';\n$data{";
     let completions = completions_at_end(code);
     assert!(has_label(&completions, "color"), "literal hash keys should be found");
     assert!(has_label(&completions, "shade"), "individual assignment keys should be found");
@@ -1807,6 +1813,21 @@ fn test_hash_key_completion_double_sigil_dereference() {
     assert!(
         !has_key_property,
         "double-sigil deref $$ref{{...}} should not trigger hash key completion"
+    );
+}
+
+#[test]
+fn test_hash_key_completion_double_sigil_same_name_no_false_positive() {
+    // When $$data{ke is written but %data also exists, the double-sigil deref must
+    // NOT suggest keys from %data — $$data is a scalar-ref dereference, not a plain
+    // hash access.  Before the fix this would have returned `key` via %data.
+    let code = "my %data = (key => 'value');\n$$data{ke";
+    let completions = completions_at_end(code);
+    let has_key_property =
+        completions.iter().any(|c| c.label == "key" && c.kind == CompletionItemKind::Property);
+    assert!(
+        !has_key_property,
+        "double-sigil deref $$data{{...}} must not suggest keys from %data even when names match"
     );
 }
 


### PR DESCRIPTION
## Summary

- Detect `$varname{key_prefix<cursor>` context via backward source-text scan in a new `detect_hash_key_context` pre-filter
- Extract known keys from `%varname = (...)` fat-comma literals and `$varname{key} = ` assignment patterns using `collect_hash_keys_from_source`
- Return `CompletionItemKind::Property` items filtered by typed prefix via `add_hash_key_completions`

## Changes

- `crates/perl-lsp-completion/src/completion.rs` — three new `fn`s + dispatch branch + 5 tests

**Insertion point:** After `is_has_options_key_context` check, before `object_pad_constructor_package`, as specified by plan-reviewer.

**Dispatch guards:** `!context.in_comment && !context.in_string && !context.in_regex` before calling `detect_hash_key_context`.

**Trigger characters unchanged:** `{` was NOT added to server capabilities. Feature works on manual invocation (Ctrl+Space) to avoid noise in hash ref constructors, blocks, and conditionals.

## Evidence

- **Commits**: 1
- **Tests**: 440 passed (5 new hash key completion tests + 435 existing), 0 failed
- **Lint**: clean (0 clippy warnings)
- **Files**: 1 changed, +350/-0 lines

## Test Plan

1. Open a Perl file with `my %config = (host => 'localhost', port => 5432);`
2. Type `$config{ho` and invoke completion manually (Ctrl+Space)
3. Verify `host` appears and `port` is filtered out
4. Type `$config{` and invoke — verify both `host` and `port` appear
5. Verify `$ref->{ho` does NOT produce hash key completions (hashref deref guard)
6. Verify completion inside `# $config{ho` comment is empty

## Unknowns

- Multi-line hash declarations where `%hash = (` and the keys are on subsequent lines are supported (backward scan handles newlines)
- Hash keys that are complex expressions (not bare words or quoted strings) are not extracted — only word-like keys are suggested
- `$hashref->{key}` (hashref deref) is explicitly excluded; a follow-up could add that via type inference
- Keys defined via `push @{$hash{slice}}` or other indirect patterns are not extracted

Closes #4264