### PR TITLE
fix(windows): replace hardcoded /tmp writes in tests with tempfile::tempdir() (#4229)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -4536,13 +4536,20 @@ mod tests {
                     let mut tmp_vars: Vec<&str> = Vec::new();
                     for line in contents.lines() {
                         let trimmed = line.trim();
-                        // Detect: let var_name = "/tmp/...";
+                        // Detect: let [mut] var_name[: type] = "/tmp/...";
                         if trimmed.starts_with("let ") && trimmed.contains("= \"/tmp/") {
-                            // Extract variable name between "let " and " ="
+                            // Extract variable name between "let [mut]" and "[: type] ="
                             if let Some(rest) = trimmed.strip_prefix("let ")
-                                && let Some(var) = rest.split('=').next()
+                                && let Some(raw) = rest.split('=').next()
                             {
-                                tmp_vars.push(var.trim());
+                                // Strip optional `mut ` keyword
+                                let raw = raw.trim();
+                                let raw = raw.strip_prefix("mut ").map_or(raw, str::trim);
+                                // Strip optional type annotation (`: &str`, `: String`, …)
+                                let var = raw.split(':').next().map_or(raw, str::trim);
+                                if !var.is_empty() {
+                                    tmp_vars.push(var);
+                                }
                             }
                         }
                         // Detect: fs::write(var_name, ...) where var_name is a known /tmp var.

--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -4485,4 +4485,104 @@ mod tests {
         // On Windows this will be C:\Users\...\AppData\Local\Temp\e2e-suite.lock
         assert!(!lock_str.is_empty(), "lock file path must be non-empty");
     }
+
+    /// Regression guard for issue #4229: test files must not write to hardcoded /tmp paths.
+    ///
+    /// Tests that assign a hardcoded `/tmp/...` string to a variable and then call
+    /// `fs::write(variable, ...)` will fail on minimal Windows environments that lack Git
+    /// for Windows (where `/tmp` is mapped). All file-writing tests must use
+    /// `tempfile::tempdir()` or `std::env::temp_dir()` instead.
+    ///
+    /// Detection heuristic: any line matching `let <name> = "/tmp/` where the same
+    /// variable name appears on a later `fs::write(` line in the same file.
+    #[test]
+    fn no_hardcoded_tmp_writes_in_tests() {
+        // Crates whose test files are checked. Extend this list as new crates are added.
+        const CHECKED_CRATES: &[&str] = &[
+            "perl-lsp",
+            "perl-dap",
+            "perl-uri",
+            "perl-workspace-index",
+            "perl-workspace-discovery",
+            "perl-dap-platform",
+        ];
+
+        let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let mut violations: Vec<String> = Vec::new();
+
+        for crate_name in CHECKED_CRATES {
+            let crate_dir = workspace_root.join("crates").join(crate_name);
+
+            // Scan both src (inline #[test] modules) and tests directories
+            for subdir in &["src", "tests"] {
+                let dir = crate_dir.join(subdir);
+                if !dir.exists() {
+                    continue;
+                }
+
+                for entry in walkdir::WalkDir::new(&dir)
+                    .into_iter()
+                    .flatten()
+                    .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rs"))
+                {
+                    let path = entry.path();
+                    let Ok(contents) = std::fs::read_to_string(path) else {
+                        continue;
+                    };
+
+                    // Look for pattern: let <var_name> = "/tmp/..."; followed by fs::write(<var_name>
+                    // This is the problematic pattern: variable holds a hardcoded /tmp path,
+                    // then that variable is used in a filesystem write.
+                    let mut tmp_vars: Vec<&str> = Vec::new();
+                    for line in contents.lines() {
+                        let trimmed = line.trim();
+                        // Detect: let var_name = "/tmp/...";
+                        if trimmed.starts_with("let ") && trimmed.contains("= \"/tmp/") {
+                            // Extract variable name between "let " and " ="
+                            if let Some(rest) = trimmed.strip_prefix("let ")
+                                && let Some(var) = rest.split('=').next()
+                            {
+                                tmp_vars.push(var.trim());
+                            }
+                        }
+                        // Detect: fs::write(var_name, ...) where var_name is a known /tmp var.
+                        // Require that `var_name` appears as an argument (preceded by `(` or `, `)
+                        // to avoid false positives like `var` matching `file_var`.
+                        if trimmed.contains("fs::write(") || trimmed.contains("fs::write(&") {
+                            for var in &tmp_vars {
+                                // Match `(var` or `(&var` or `, var` but NOT `file_var`
+                                let as_arg1 = format!("({var},");
+                                let as_arg2 = format!("(&{var},");
+                                let as_arg3 = format!("({var})");
+                                if trimmed.contains(&as_arg1)
+                                    || trimmed.contains(&as_arg2)
+                                    || trimmed.contains(&as_arg3)
+                                {
+                                    let rel = path
+                                        .strip_prefix(&workspace_root)
+                                        .unwrap_or(path)
+                                        .to_string_lossy()
+                                        .replace('\\', "/");
+                                    let violation =
+                                        format!("{rel}: `fs::write({var}, ...)` with /tmp path");
+                                    if !violations.contains(&violation) {
+                                        violations.push(violation);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        assert!(
+            violations.is_empty(),
+            "Test files write to hardcoded /tmp paths (issue #4229).\n\
+             Replace `let path = \"/tmp/...\"; fs::write(path, ...)` with\n\
+             `let tmp = tempfile::tempdir()?; let path = tmp.path().join(\"...\");`\n\
+             Violations found in:\n  {}",
+            violations.join("\n  ")
+        );
+    }
 }

--- a/crates/perl-lsp/src/execute_command/tests.rs
+++ b/crates/perl-lsp/src/execute_command/tests.rs
@@ -3,7 +3,6 @@ use super::provider::{ExecuteCommandProvider, TestRunner, select_test_runner};
 use super::test_support::mock_status;
 use serde_json::Value;
 use std::fs;
-use std::path::Path;
 use tempfile::tempdir;
 
 // ============= GO-TO-TEST / GO-TO-IMPLEMENTATION TESTS =============
@@ -747,16 +746,13 @@ fn test_run_critic_file_exists_check() -> Result<(), Box<dyn std::error::Error>>
 fn test_run_builtin_critic_with_valid_file() -> Result<(), Box<dyn std::error::Error>> {
     let provider = ExecuteCommandProvider::new();
 
-    // Create a temporary file with content
+    // Create a temporary file with content using a portable temp directory
+    let tmp = tempdir()?;
     let test_content = "#!/usr/bin/perl\nmy $var = 42;\nprint $var;\n";
-    let temp_file = "/tmp/test_builtin_critic.pl";
-    fs::write(temp_file, test_content)?;
+    let temp_file = tmp.path().join("test_builtin_critic.pl");
+    fs::write(&temp_file, test_content)?;
 
-    let path = Path::new(temp_file);
-    let result = provider.run_builtin_critic(path);
-
-    // Clean up
-    fs::remove_file(temp_file).ok();
+    let result = provider.run_builtin_critic(&temp_file);
 
     assert!(result.is_ok(), "Built-in critic should execute successfully");
     let result_value = result?;
@@ -953,14 +949,12 @@ fn test_run_builtin_critic_arithmetic_mutations() -> Result<(), Box<dyn std::err
     let provider = ExecuteCommandProvider::new();
 
     // Create a test file with content at known line/column positions
+    let tmp = tempdir()?;
     let test_content = "#!/usr/bin/perl\n# Line 2\nmy $var = 42;\nprint $var;\n";
-    let temp_file = "/tmp/test_arithmetic_mutations.pl";
-    fs::write(temp_file, test_content)?;
+    let temp_file = tmp.path().join("test_arithmetic_mutations.pl");
+    fs::write(&temp_file, test_content)?;
 
-    let path = Path::new(temp_file);
-    let result = provider.run_builtin_critic(path);
-
-    fs::remove_file(temp_file).ok();
+    let result = provider.run_builtin_critic(&temp_file);
 
     assert!(result.is_ok(), "Should analyze file successfully");
     let result_value = result?;
@@ -1112,36 +1106,35 @@ fn test_run_critic_file_existence_logic() -> Result<(), Box<dyn std::error::Erro
 fn test_method_return_values_not_defaults() -> Result<(), Box<dyn std::error::Error>> {
     let provider = ExecuteCommandProvider::new();
 
-    // Create a real test file
+    // Create real test files using a portable temp directory
+    let tmp = tempdir()?;
+
     let test_content = "#!/usr/bin/perl\nuse strict;\nprint 'hello';\n";
-    let temp_file = "/tmp/test_return_values.pl";
-    fs::write(temp_file, test_content)?;
+    let temp_file = tmp.path().join("test_return_values.pl");
+    fs::write(&temp_file, test_content)?;
 
     // Test run_file doesn't return Ok(Default::default())
-    let result = provider.run_file(Path::new(temp_file));
+    let result = provider.run_file(&temp_file);
     assert!(result.is_ok(), "run_file should succeed");
     let result_value = result?;
     assert_ne!(result_value, Value::Object(serde_json::Map::new()), "Should not be empty object");
 
     // Test run_tests doesn't return Ok(Default::default())
-    let result = provider.run_tests(Path::new(temp_file));
+    let result = provider.run_tests(&temp_file);
     assert!(result.is_ok(), "run_tests should succeed");
     let result_value = result?;
     assert_ne!(result_value, Value::Object(serde_json::Map::new()), "Should not be empty object");
 
     // Test run_test_sub doesn't return Ok(Default::default())
     let sub_content = "#!/usr/bin/perl\nuse strict;\nsub test_func { print 'test'; }\n";
-    let sub_file = "/tmp/test_sub_return.pl";
-    fs::write(sub_file, sub_content)?;
+    let sub_file = tmp.path().join("test_sub_return.pl");
+    fs::write(&sub_file, sub_content)?;
 
-    let result = provider.run_test_sub(Path::new(sub_file), "test_func");
+    let result = provider.run_test_sub(&sub_file, "test_func");
     assert!(result.is_ok(), "run_test_sub should succeed");
     let result_value = result?;
     assert_ne!(result_value, Value::Object(serde_json::Map::new()), "Should not be empty object");
 
-    // Clean up
-    fs::remove_file(temp_file).ok();
-    fs::remove_file(sub_file).ok();
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Converts 3 tests in `execute_command/tests.rs` from hardcoded `/tmp/...` string paths to `tempfile::tempdir()` — these tests used `let temp_file = "/tmp/..."; fs::write(temp_file, ...)` which fails on minimal Windows environments without Git for Windows mapping `/tmp`
- Adds a regression-guard lint test in `perl-ci-hygiene` (`no_hardcoded_tmp_writes_in_tests`) that statically scans 6 key crates for the `let <var> = "/tmp/..."; fs::write(var, ...)` pattern to prevent recurrence
- Removes manual `fs::remove_file()` cleanup calls (replaced by RAII cleanup via `tempdir()` drop)

## Context

Issue #4229 (Windows compatibility: Unix-only paths and shell assumptions). The production-code fixes (`cmd_preflight()` `/proc` guard, `cmd_e2e_gate()` lock file using `temp_dir()`, `command_exists()` PATH-based detection, `home_dir()` fallback, `is_allowlisted_prod_panic_hit()` path separator) were already merged to master in prior commits. This PR addresses the remaining test-code gap.

## Changes

- `crates/perl-ci-hygiene/src/main.rs` — Add `no_hardcoded_tmp_writes_in_tests` regression guard test (+100 lines)
- `crates/perl-lsp/src/execute_command/tests.rs` — Convert `test_run_builtin_critic_with_valid_file`, `test_run_builtin_critic_arithmetic_mutations`, and `test_method_return_values_not_defaults` to use `tempfile::tempdir()` (-26 lines, +19 lines); remove unused `use std::path::Path` import

## Evidence

- **Commits**: 1
- **Tests**: perl-ci-hygiene: 32 passed, 0 failed | perl-lsp-rs --lib: 370 passed, 0 failed
- **Lint**: `cargo clippy -p perl-ci-hygiene --tests` PASS | `cargo clippy -p perl-lsp-rs --lib` PASS
- **Files**: 2 changed, +119/-26 lines (our changes only)
- **Pre-push gate**: pr-fast passed (fmt-check, clippy-core, test-core all green)

## Test Plan

- `cargo test -p perl-ci-hygiene -- tests::no_hardcoded_tmp_writes_in_tests` — verifies the regression guard catches violations
- `RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --lib -- --test-threads=2` — verifies the converted tests work with portable temp paths
- To verify Windows portability: tests now use `tempfile::tempdir()` which resolves to `C:\Users\...\AppData\Local\Temp` on Windows (not `/tmp`)

## Unknowns

- The lint test (`no_hardcoded_tmp_writes_in_tests`) uses a heuristic scan (per-file, not per-function scope), so there is a theoretical risk of cross-function false positives if two functions in the same file both happen to use a variable named `temp_file` — one assigning `/tmp/...` and another calling `fs::write(temp_file, ...)`. In practice this has not been observed. The test passed correctly on all 6 checked crates.
- The `perl-dap` tests with `/tmp` in mock protocol data (e.g., `capability_honesty.pl` paths in JSON fixtures) were intentionally left as-is — these are string literals in test data, not filesystem paths, so they pose no cross-platform risk.
- Follow-up issue recommended: consider adding platform-specific test guards (`#[cfg(unix)]`) to any tests that test Unix-specific path semantics, as noted in the issue's scope for future work.

Closes #4229