### PR TITLE
release: source GitHub Release body from docs/releases/vX.Y.Z.md

### DIFF
--- a/.github/workflows/ci-gate-self-tests.yml
+++ b/.github/workflows/ci-gate-self-tests.yml
@@ -16,8 +16,12 @@ on:
     paths:
       - 'scripts/cargo-package-workspace-dry-run.sh'
       - 'scripts/publish-topo.py'
+      - 'scripts/extract-release-notes.sh'
       - 'scripts/tests/test-publish-dry-run-gate.sh'
+      - 'scripts/tests/test-extract-release-notes.sh'
       - '.github/workflows/publish-dry-run.yml'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/release-orchestration.yml'
       - '.github/workflows/ci-gate-self-tests.yml'
   workflow_dispatch: {}
 
@@ -51,6 +55,9 @@ jobs:
       - name: Run publish dry-run gate self-test
         run: bash scripts/tests/test-publish-dry-run-gate.sh
 
+      - name: Run release-notes extractor self-test
+        run: bash scripts/tests/test-extract-release-notes.sh
+
       - name: Summary
         if: always()
         run: |
@@ -61,6 +68,12 @@ jobs:
             echo "- Invalid TOML (duplicate keys) — cargo metadata rejects it" >> "$GITHUB_STEP_SUMMARY"
             echo "- Nonexistent dependencies — cargo package fails to resolve" >> "$GITHUB_STEP_SUMMARY"
             echo "- Clean manifests — passes without false-failing" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The release-notes extractor correctly:" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Strips YAML front-matter from docs/releases/vX.Y.Z.md" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Fails hard (exit 2) when the notes file is missing" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Fails hard (exit 3) when the notes file has no body" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Accepts both bare (0.12.4) and tag-prefixed (v0.12.4) versions" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "## CI gate self-tests FAILED" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -126,6 +126,19 @@ jobs:
 
           echo "✅ Changelog checked"
 
+      - name: Check curated release notes exist
+        run: |
+          # The release workflow sources its GitHub Release body from
+          # docs/releases/vX.Y.Z.md. Fail here — before we create the tag —
+          # if the curated notes file is missing, so a release can't be
+          # dispatched with a half-finished ledger.
+          VERSION="${{ steps.resolve.outputs.version }}"
+          bash scripts/extract-release-notes.sh "${VERSION}" /tmp/release-notes-preview.md
+          echo "::group::Release body preview (docs/releases/v${VERSION}.md)"
+          cat /tmp/release-notes-preview.md
+          echo "::endgroup::"
+          echo "✅ Release notes present and non-empty"
+
       - name: Summary
         run: |
           echo "## Release Validation Complete :white_check_mark:" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,37 +244,15 @@ jobs:
         id: release_notes
         run: |
           VERSION="${{ needs.release-metadata.outputs.version }}"
-          cat > release_notes.md << EOF
-          ## Perl LSP ${VERSION}
-
-          This release ships the binaries and the docs needed to install, configure, and troubleshoot the current release line.
-
-          ### Install or upgrade
-
-          ```bash
-          cargo install perllsp
-          cargo install perl-dap
-          ```
-
-          ### Read this first
-
-          - [Docs home](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/README.md)
-          - [Docs index](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/INDEX.md)
-          - [Getting Started](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/tutorials/GETTING_STARTED.md)
-          - [Installation Guide](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/how-to/INSTALLATION.md)
-          - [Editor Setup](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/how-to/EDITOR_SETUP.md)
-          - [Troubleshooting](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/how-to/TROUBLESHOOTING.md)
-
-          ### Release assets
-
-          - Platform binaries are attached to this release.
-          - Verify downloads with the consolidated \`SHA256SUMS\` file.
-
-          ### Change log
-
-          See the [CHANGELOG](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/CHANGELOG.md) for the full release history.
-          EOF
+          # Source the GitHub Release body from docs/releases/vX.Y.Z.md so
+          # the published release matches the curated in-repo notes. The
+          # extractor strips the YAML front-matter and fails hard if the
+          # notes file is missing, which is the behaviour we want — a
+          # release without curated notes should not ship.
+          bash scripts/extract-release-notes.sh "${VERSION}" release_notes.md
+          echo "::group::Release body"
           cat release_notes.md
+          echo "::endgroup::"
 
       - name: Create GitHub Release
         if: github.event_name == 'workflow_dispatch'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -430,12 +430,25 @@ Every public release **must** update three surfaces. See [RELEASE_HISTORY.md](RE
 
 ### Before publishing
 
-- [ ] Create `docs/releases/vX.Y.Z.md` (use an existing file as template)
+- [ ] Create `docs/releases/vX.Y.Z.md` (use an existing file as template) — **required**; the release workflow sources the GitHub Release body from this file and fails hard if it is missing
 - [ ] Add a new row to `RELEASE_HISTORY.md` for vX.Y.Z (fill what you know; mark unknowns with `—`)
 - [ ] Ensure `CHANGELOG.md` has a `[X.Y.Z]` section with links to:
   - `docs/releases/vX.Y.Z.md`
   - GitHub Release URL
   - Compare range `vPrev...vX.Y.Z`
+
+> **GitHub Release body source.** `release-orchestration.yml` runs
+> `scripts/extract-release-notes.sh <version>` during its `validate` job and
+> aborts before creating the tag if `docs/releases/vX.Y.Z.md` is missing.
+> `release.yml` runs the same extractor to produce the release body, so the
+> published notes match the in-repo notes exactly. The auto-generated
+> "What's Changed" PR list is appended below the curated body by
+> `softprops/action-gh-release`.
+>
+> Preview the body locally before dispatching:
+> ```bash
+> bash scripts/extract-release-notes.sh 0.12.5
+> ```
 
 ### After publishing
 

--- a/scripts/extract-release-notes.sh
+++ b/scripts/extract-release-notes.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Extract the curated release notes body for a given version from
+# docs/releases/vX.Y.Z.md, stripping the YAML front-matter so the output is
+# ready to use as a GitHub Release body.
+#
+# Why this exists:
+#   The release workflow historically generated a generic "Docs home / Install"
+#   body for every GitHub Release. The repo now publishes curated per-release
+#   notes at docs/releases/vX.Y.Z.md with structured summaries, highlights, and
+#   upgrade guidance. This script is the single source of truth for how that
+#   file is turned into release-body markdown — both the release workflow and
+#   the self-test consume it.
+#
+# Usage:
+#   scripts/extract-release-notes.sh <version>           # writes body to stdout
+#   scripts/extract-release-notes.sh <version> <outfile> # writes body to outfile
+#
+# <version> may be bare ("0.12.4") or tag-prefixed ("v0.12.4").
+#
+# Exit codes:
+#   0  success
+#   1  missing arguments / malformed version
+#   2  docs/releases/vX.Y.Z.md does not exist
+#   3  notes file is empty or contained only front-matter
+#
+# The repo root is resolved relative to the script so callers can invoke it
+# from any working directory (workflow steps, local shells, etc).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: extract-release-notes.sh <version> [outfile]
+
+  <version>  Release version, e.g. 0.12.4 or v0.12.4
+  [outfile]  Optional path to write the extracted body to (default: stdout)
+USAGE
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 1
+fi
+
+RAW_VERSION="$1"
+OUTFILE="${2:-}"
+
+# Accept either "0.12.4" or "v0.12.4" and normalise to a bare version.
+VERSION="${RAW_VERSION#v}"
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+  echo "::error::Invalid version format: ${RAW_VERSION}" >&2
+  exit 1
+fi
+
+NOTES_FILE="${REPO_ROOT}/docs/releases/v${VERSION}.md"
+
+if [[ ! -f "$NOTES_FILE" ]]; then
+  echo "::error::Release notes file not found: docs/releases/v${VERSION}.md" >&2
+  echo "::error::Every release must ship a curated notes file. See RELEASE.md #release-history-updates." >&2
+  exit 2
+fi
+
+# Strip an optional YAML front-matter block delimited by lines that contain
+# only `---`. The front-matter is the block opening on line 1 (if present);
+# anything after the closing `---` is the body we want to publish.
+#
+# awk state machine:
+#   state=0  haven't seen any `---` yet and first non-blank line is `---`
+#            -> switch to state=1 (inside front-matter)
+#   state=0  first non-blank line is NOT `---`
+#            -> switch to state=2 (no front-matter, print everything from here)
+#   state=1  inside front-matter, waiting for closing `---`
+#            -> on match, switch to state=2; otherwise skip
+#   state=2  print every line
+BODY="$(awk '
+  BEGIN { state = 0 }
+  state == 0 {
+    if ($0 ~ /^---[[:space:]]*$/) { state = 1; next }
+    if ($0 ~ /^[[:space:]]*$/)    { next }        # skip leading blanks
+    state = 2
+  }
+  state == 1 {
+    if ($0 ~ /^---[[:space:]]*$/) { state = 2; next }
+    next
+  }
+  state == 2 { print }
+' "$NOTES_FILE")"
+
+# Trim leading blank lines so the body starts at its first real line.
+BODY="$(printf '%s\n' "$BODY" | awk 'NF { found = 1 } found')"
+
+if [[ -z "$BODY" ]]; then
+  echo "::error::Release notes file has no body content: docs/releases/v${VERSION}.md" >&2
+  exit 3
+fi
+
+if [[ -n "$OUTFILE" ]]; then
+  printf '%s\n' "$BODY" > "$OUTFILE"
+else
+  printf '%s\n' "$BODY"
+fi

--- a/scripts/tests/test-extract-release-notes.sh
+++ b/scripts/tests/test-extract-release-notes.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Self-test for scripts/extract-release-notes.sh.
+#
+# Problem it prevents: the release workflow sources its GitHub Release body
+# from docs/releases/vX.Y.Z.md. If the front-matter stripper silently
+# malfunctions (e.g. eats the first paragraph, fails to detect a missing
+# file, or passes through the YAML block into the release body) the public
+# release notes are wrong on a channel that is painful to correct.
+#
+# This test verifies five properties of the extractor:
+#
+#   CASE 1 - Valid file with front-matter: body is emitted, front-matter is
+#             stripped, and the first output line is the markdown heading.
+#
+#   CASE 2 - Missing file: script exits with code 2 and a clear error.
+#
+#   CASE 3 - Body-only file (no front-matter): body is emitted verbatim.
+#
+#   CASE 4 - Front-matter only (empty body): script exits with code 3.
+#
+#   CASE 5 - "v" prefix is tolerated: "v0.12.4" resolves the same file as
+#             "0.12.4".
+#
+# The extractor path is resolved relative to this test's location so the
+# test runs in CI, under Nix, and locally without environment setup.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+EXTRACTOR="${REPO_ROOT}/scripts/extract-release-notes.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_BASE=""
+
+cleanup() {
+  if [[ -n "${TMPDIR_BASE:-}" && -d "${TMPDIR_BASE}" ]]; then
+    rm -rf "${TMPDIR_BASE}"
+  fi
+}
+trap cleanup EXIT
+
+TMPDIR_BASE="$(mktemp -d)"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "PASS  ${label}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  ${label}"
+    echo "      expected: ${expected}"
+    echo "      actual:   ${actual}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_exit() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" -eq "$actual" ]]; then
+    echo "PASS  ${label} (exit ${actual})"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  ${label} (expected exit ${expected}, got ${actual})"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1"
+  local needle="$2"
+  local haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "PASS  ${label}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  ${label}"
+    echo "      expected to contain: ${needle}"
+    echo "      got:"
+    printf '      %s\n' "$haystack" | head -5
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local label="$1"
+  local needle="$2"
+  local haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "PASS  ${label}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  ${label}"
+    echo "      expected NOT to contain: ${needle}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Build a fake repo root with controlled fixtures so tests don't depend on
+# the real docs/releases/ content (which changes over time).
+FAKE_REPO="${TMPDIR_BASE}/repo"
+mkdir -p "${FAKE_REPO}/docs/releases"
+
+# CASE 1 fixture: valid front-matter + body
+cat > "${FAKE_REPO}/docs/releases/v1.2.3.md" <<'FIXTURE_EOF'
+---
+version: "1.2.3"
+tag: "v1.2.3"
+release_date_utc: "2026-01-01"
+---
+
+# v1.2.3
+
+## Summary
+
+First release of the fixture.
+
+## Highlights
+
+- Thing one
+- Thing two
+FIXTURE_EOF
+
+# CASE 3 fixture: body only, no front-matter
+cat > "${FAKE_REPO}/docs/releases/v4.5.6.md" <<'FIXTURE_EOF'
+# v4.5.6
+
+Body with no front-matter at all.
+FIXTURE_EOF
+
+# CASE 4 fixture: front-matter only, no body
+cat > "${FAKE_REPO}/docs/releases/v7.8.9.md" <<'FIXTURE_EOF'
+---
+version: "7.8.9"
+---
+FIXTURE_EOF
+
+# ---------------------------------------------------------------------------
+# CASE 1: valid file with front-matter
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 1: valid file with front-matter ==="
+
+CASE1_OUT="$(REPO_ROOT="${FAKE_REPO}" bash "${EXTRACTOR}" 1.2.3 2>&1)"
+CASE1_EXIT=$?
+
+assert_exit "exits 0 on valid file" 0 "${CASE1_EXIT}"
+assert_contains "body contains markdown heading" "# v1.2.3" "${CASE1_OUT}"
+assert_contains "body contains Summary section" "## Summary" "${CASE1_OUT}"
+assert_contains "body contains Highlights bullet" "- Thing one" "${CASE1_OUT}"
+assert_not_contains "front-matter version key is stripped" 'version: "1.2.3"' "${CASE1_OUT}"
+assert_not_contains "front-matter tag key is stripped" 'tag: "v1.2.3"' "${CASE1_OUT}"
+assert_not_contains "front-matter delimiter is stripped" $'---\n' "${CASE1_OUT}"
+
+FIRST_LINE="$(printf '%s\n' "${CASE1_OUT}" | head -1)"
+assert_eq "first line is the markdown heading" "# v1.2.3" "${FIRST_LINE}"
+
+# ---------------------------------------------------------------------------
+# CASE 2: missing file
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 2: missing release notes file ==="
+
+CASE2_OUT="$(REPO_ROOT="${FAKE_REPO}" bash "${EXTRACTOR}" 0.0.0 2>&1)"
+CASE2_EXIT=$?
+
+assert_exit "exits 2 on missing file" 2 "${CASE2_EXIT}"
+assert_contains "error mentions the missing path" "docs/releases/v0.0.0.md" "${CASE2_OUT}"
+assert_contains "error points to RELEASE.md" "RELEASE.md" "${CASE2_OUT}"
+
+# ---------------------------------------------------------------------------
+# CASE 3: body-only file (no front-matter)
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 3: body-only file (no front-matter) ==="
+
+CASE3_OUT="$(REPO_ROOT="${FAKE_REPO}" bash "${EXTRACTOR}" 4.5.6 2>&1)"
+CASE3_EXIT=$?
+
+assert_exit "exits 0 on body-only file" 0 "${CASE3_EXIT}"
+assert_contains "body passes through verbatim" "# v4.5.6" "${CASE3_OUT}"
+assert_contains "body text is preserved" "Body with no front-matter at all." "${CASE3_OUT}"
+
+# ---------------------------------------------------------------------------
+# CASE 4: front-matter only (empty body)
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 4: front-matter only (empty body) ==="
+
+CASE4_OUT="$(REPO_ROOT="${FAKE_REPO}" bash "${EXTRACTOR}" 7.8.9 2>&1)"
+CASE4_EXIT=$?
+
+assert_exit "exits 3 on empty body" 3 "${CASE4_EXIT}"
+assert_contains "error mentions no body content" "no body content" "${CASE4_OUT}"
+
+# ---------------------------------------------------------------------------
+# CASE 5: tag-prefixed version is accepted
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 5: tag-prefixed version (v1.2.3) ==="
+
+CASE5_OUT="$(REPO_ROOT="${FAKE_REPO}" bash "${EXTRACTOR}" v1.2.3 2>&1)"
+CASE5_EXIT=$?
+
+assert_exit "exits 0 for v-prefixed version" 0 "${CASE5_EXIT}"
+assert_eq "v-prefixed and bare version produce identical output" "${CASE1_OUT}" "${CASE5_OUT}"
+
+# ---------------------------------------------------------------------------
+# CASE 6: outfile argument is honoured
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 6: outfile argument ==="
+
+OUTFILE="${TMPDIR_BASE}/case6.md"
+REPO_ROOT="${FAKE_REPO}" bash "${EXTRACTOR}" 1.2.3 "${OUTFILE}" > /dev/null 2>&1
+CASE6_EXIT=$?
+
+assert_exit "exits 0 when writing to outfile" 0 "${CASE6_EXIT}"
+if [[ -s "${OUTFILE}" ]]; then
+  echo "PASS  outfile is non-empty"
+  PASS=$((PASS + 1))
+  FILE_CONTENT="$(cat "${OUTFILE}")"
+  assert_contains "outfile contains body heading" "# v1.2.3" "${FILE_CONTENT}"
+else
+  echo "FAIL  outfile is empty or missing: ${OUTFILE}"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# CASE 7: malformed version rejected with usage-class exit
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 7: malformed version argument ==="
+
+CASE7_OUT="$(REPO_ROOT="${FAKE_REPO}" bash "${EXTRACTOR}" "not-a-version" 2>&1)"
+CASE7_EXIT=$?
+
+assert_exit "exits 1 on malformed version" 1 "${CASE7_EXIT}"
+assert_contains "error mentions invalid format" "Invalid version format" "${CASE7_OUT}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+TOTAL=$((PASS + FAIL))
+echo ""
+echo "=== Results: ${PASS}/${TOTAL} passed ==="
+
+if [[ "${FAIL}" -gt 0 ]]; then
+  echo "FAIL: ${FAIL} assertion(s) failed."
+  exit 1
+fi
+
+echo "All assertions passed — the release notes extractor does what it claims."
+exit 0


### PR DESCRIPTION
Closes #4340.

## Problem

GitHub Release bodies were auto-generated from a `release.yml` heredoc that emitted a generic "Docs home / Install" blurb for every release. Meanwhile, the repo has been shipping curated per-release notes at `docs/releases/vX.Y.Z.md` (structured summary, highlights, install/upgrade, links) — and these were never used by the release workflow.

The two surfaces diverged: in-repo notes told the real story, while GitHub Releases carried the boilerplate plus the auto-generated "What's Changed" PR dump.

## What this PR does

Wires the curated notes file into the release workflow as the single source of truth for the GitHub Release body, with a fail-fast gate that prevents dispatching a release without curated notes.

### New: `scripts/extract-release-notes.sh`

A small, self-contained bash script that:

- Takes a version argument (bare `0.12.4` or tag-prefixed `v0.12.4`).
- Resolves `docs/releases/v<version>.md` relative to the repo root (overridable via `REPO_ROOT` env, which makes the test harness possible).
- Strips the YAML front-matter block (the `---`-delimited header at the top) using an awk state machine — no `yq`/`python` dependency needed in the release runner.
- Writes the body to stdout, or to an optional `[outfile]` argument.

Exit codes are explicit and documented in the script header:

| Exit | Meaning |
|-----:|---------|
| `0`  | success |
| `1`  | missing/malformed version argument |
| `2`  | `docs/releases/vX.Y.Z.md` does not exist |
| `3`  | notes file is empty or contains only front-matter |

The error messages use GitHub Actions' `::error::` annotation prefix so they surface as inline annotations on workflow runs.

### New: `scripts/tests/test-extract-release-notes.sh`

23-assertion self-test covering:

- **CASE 1** — valid file with front-matter: body is emitted, front-matter is stripped, first line is the markdown heading.
- **CASE 2** — missing file: exits 2 with an error that names the missing path and points operators at RELEASE.md.
- **CASE 3** — body-only file (no front-matter): body passes through verbatim.
- **CASE 4** — front-matter only, no body: exits 3 (prevents a release with empty notes).
- **CASE 5** — tag-prefixed version (`v1.2.3`) resolves the same file as the bare form and produces byte-identical output.
- **CASE 6** — `[outfile]` argument is honoured and the file is non-empty.
- **CASE 7** — malformed version is rejected with exit 1.

Tests build fixtures in a temp dir and point the extractor at a synthetic repo root via `REPO_ROOT=...`, so they do not depend on `docs/releases/` content drifting over time.

### Workflow changes

**`.github/workflows/release.yml`** — the `Generate release notes` step now calls the extractor instead of building a heredoc:

```yaml
- name: Generate release notes
  id: release_notes
  run: |
    VERSION="${{ needs.release-metadata.outputs.version }}"
    bash scripts/extract-release-notes.sh "${VERSION}" release_notes.md
    echo "::group::Release body"
    cat release_notes.md
    echo "::endgroup::"
```

The downstream `softprops/action-gh-release` step is unchanged — it still passes `body_path: release_notes.md` with `generate_release_notes: true`, which prepends the curated body and appends the auto-generated "What's Changed" PR list below it (acceptance criterion #3).

**`.github/workflows/release-orchestration.yml`** — the `validate` job now runs the extractor *before* the tag is created. If `docs/releases/vX.Y.Z.md` is missing, the release fails in the first ~15 seconds instead of after ~25 minutes of binary builds:

```yaml
- name: Check curated release notes exist
  run: |
    VERSION="${{ steps.resolve.outputs.version }}"
    bash scripts/extract-release-notes.sh "${VERSION}" /tmp/release-notes-preview.md
    ...
```

**`.github/workflows/ci-gate-self-tests.yml`** — runs the new self-test on any PR that touches the extractor, its test, or the release workflows. Path filters updated; summary step lists what the extractor now guarantees.

**`RELEASE.md`** — the "Release History Updates" section now calls out that `docs/releases/vX.Y.Z.md` is required (not just recommended) and documents the local preview command:

```bash
bash scripts/extract-release-notes.sh 0.12.5
```

## Verification

### Self-test (runs in `ci-gate-self-tests.yml`)

```
$ bash scripts/tests/test-extract-release-notes.sh
...
=== Results: 23/23 passed ===
All assertions passed — the release notes extractor does what it claims.
```

### Dry run against the real v0.12.4 notes

```
$ bash scripts/extract-release-notes.sh 0.12.4 | head -3
# v0.12.4

## Summary
```

Front-matter is stripped; the first body line is the markdown heading, ready to ship as the release body.

### Negative path

```
$ bash scripts/extract-release-notes.sh 99.99.99; echo exit=$?
::error::Release notes file not found: docs/releases/v99.99.99.md
::error::Every release must ship a curated notes file. See RELEASE.md #release-history-updates.
exit=2
```

### YAML validity

All three workflow files parse cleanly under `yaml.safe_load`.

## Acceptance criteria (from #4340)

- [x] `gh release view vX.Y.Z` body matches `docs/releases/vX.Y.Z.md` content — `body_path: release_notes.md` now points at the extracted body.
- [x] Release workflow fails if `docs/releases/vX.Y.Z.md` doesn't exist at tag time — enforced in both `release-orchestration.yml`'s `validate` job (before tag) and `release.yml`'s `release` job (second line of defence).
- [x] Auto-generated "What's Changed" section can optionally be appended below the curated notes — preserved by keeping `generate_release_notes: true` in the `softprops/action-gh-release` step; `body_path` goes first, auto-generated notes go after.

## Why this is low-risk to merge

- The release workflow only fires on `workflow_dispatch` or `release: published` — no behaviour change until the next release is cut, and the failure mode (missing notes file) is louder and earlier than today's "silently published the wrong body" outcome.
- `docs/releases/v0.12.4.md` (the current release) already exists and extracts cleanly, so re-dispatching the most recent release would work end-to-end.
- The extractor has a 23-case self-test that runs in CI on any change to it.
- All other release-workflow behaviour (binary builds, SBOM upload, tag creation, package-manager bumps) is untouched.

## Test plan

- [x] `bash scripts/tests/test-extract-release-notes.sh` — 23/23 pass locally
- [x] `bash scripts/extract-release-notes.sh 0.12.4` — extracts the current release notes correctly
- [x] `python3 -c "import yaml; yaml.safe_load(open('...'))"` on all three edited workflow files
- [ ] CI: `ci-gate-self-tests.yml` runs the new self-test on this PR
- [ ] Next release: operator dispatches `release-orchestration.yml` and confirms the published body matches `docs/releases/vX.Y.Z.md`