### PR TITLE
feat(diagnostics): add PL410 for undefined next/last/redo labels (#3372)

### DIFF
--- a/crates/perl-diagnostics-codes/src/lib.rs
+++ b/crates/perl-diagnostics-codes/src/lib.rs
@@ -165,6 +165,8 @@ pub enum DiagnosticCode {
     DuplicateHashKey,
     /// `goto LABEL` references a label that does not exist in this file
     GotoUndefinedLabel,
+    /// `next LABEL` / `last LABEL` / `redo LABEL` references a label that does not exist in this file
+    LoopControlUndefinedLabel,
 
     // Pragma pitfalls / deprecated syntax (PL500-PL599)
     /// Use of deprecated defined(@array) / defined(%hash)
@@ -267,6 +269,7 @@ impl DiagnosticCode {
             DiagnosticCode::EvalErrorFlow => "PL407",
             DiagnosticCode::DuplicateHashKey => "PL408",
             DiagnosticCode::GotoUndefinedLabel => "PL409",
+            DiagnosticCode::LoopControlUndefinedLabel => "PL410",
             DiagnosticCode::DeprecatedDefined => "PL500",
             DiagnosticCode::DeprecatedArrayBase => "PL501",
             DiagnosticCode::PhaseScopedStrictPragma => "PL502",
@@ -337,6 +340,7 @@ impl DiagnosticCode {
             "PL407" => "https://docs.perl-lsp.org/errors/PL407",
             "PL408" => "https://docs.perl-lsp.org/errors/PL408",
             "PL409" => "https://docs.perl-lsp.org/errors/PL409",
+            "PL410" => "https://docs.perl-lsp.org/errors/PL410",
             "PL500" => "https://docs.perl-lsp.org/errors/PL500",
             "PL501" => "https://docs.perl-lsp.org/errors/PL501",
             "PL502" => "https://docs.perl-lsp.org/errors/PL502",
@@ -397,6 +401,7 @@ impl DiagnosticCode {
             | DiagnosticCode::PrintfFormatMismatch
             | DiagnosticCode::DuplicateHashKey
             | DiagnosticCode::GotoUndefinedLabel
+            | DiagnosticCode::LoopControlUndefinedLabel
             | DiagnosticCode::DeprecatedDefined
             | DiagnosticCode::DeprecatedArrayBase
             | DiagnosticCode::PhaseScopedStrictPragma
@@ -543,6 +548,10 @@ impl DiagnosticCode {
             DiagnosticCode::GotoUndefinedLabel => Some(
                 "This goto target label is not defined in the current file. \
                 Define the label or use a dynamic goto form only when the target is known at runtime.",
+            ),
+            DiagnosticCode::LoopControlUndefinedLabel => Some(
+                "This loop control label (next/last/redo) is not defined in the current file. \
+                Define the label on an enclosing loop, e.g. `OUTER: while (...) { ... }`.",
             ),
             DiagnosticCode::PrintfFormatMismatch => Some(
                 "The number of format specifiers does not match the number of arguments. \
@@ -746,6 +755,7 @@ impl DiagnosticCode {
             "PL407" => Some(DiagnosticCode::EvalErrorFlow),
             "PL408" => Some(DiagnosticCode::DuplicateHashKey),
             "PL409" => Some(DiagnosticCode::GotoUndefinedLabel),
+            "PL410" => Some(DiagnosticCode::LoopControlUndefinedLabel),
             "PL500" => Some(DiagnosticCode::DeprecatedDefined),
             "PL501" => Some(DiagnosticCode::DeprecatedArrayBase),
             "PL502" => Some(DiagnosticCode::PhaseScopedStrictPragma),
@@ -849,7 +859,8 @@ impl DiagnosticCode {
             | DiagnosticCode::UnreachableCode
             | DiagnosticCode::EvalErrorFlow
             | DiagnosticCode::DuplicateHashKey
-            | DiagnosticCode::GotoUndefinedLabel => DiagnosticCategory::BestPractices,
+            | DiagnosticCode::GotoUndefinedLabel
+            | DiagnosticCode::LoopControlUndefinedLabel => DiagnosticCategory::BestPractices,
 
             DiagnosticCode::DeprecatedDefined | DiagnosticCode::DeprecatedArrayBase => {
                 DiagnosticCategory::Deprecated
@@ -902,6 +913,7 @@ mod tests {
         assert_eq!(DiagnosticCode::CriticSeverity1.as_str(), "PC001");
         assert_eq!(DiagnosticCode::SecuritySignalHandler.as_str(), "PL602");
         assert_eq!(DiagnosticCode::GotoUndefinedLabel.as_str(), "PL409");
+        assert_eq!(DiagnosticCode::LoopControlUndefinedLabel.as_str(), "PL410");
         assert_eq!(DiagnosticCode::PhaseScopedStrictPragma.as_str(), "PL502");
         assert_eq!(DiagnosticCode::PhaseScopedWarningsPragma.as_str(), "PL503");
     }

--- a/crates/perl-lsp-diagnostics/src/diagnostics.rs
+++ b/crates/perl-lsp-diagnostics/src/diagnostics.rs
@@ -17,6 +17,7 @@ use crate::lints::duplicate_hash_keys::check_duplicate_hash_keys;
 use crate::lints::eval_error_flow::check_eval_error_flow;
 use crate::lints::ffi_checklib::check_ffi_checklib;
 use crate::lints::goto_label::check_goto_labels;
+use crate::lints::loop_control_label::check_loop_control_labels;
 use crate::lints::package_subroutine::{
     check_duplicate_package, check_duplicate_subroutine, check_missing_package_declaration,
 };
@@ -154,6 +155,7 @@ impl DiagnosticsProvider {
         // Moo/Moose role conflict diagnostics (same-file only)
         check_role_conflicts(ast, &symbol_table, &mut diagnostics);
         check_goto_labels(ast, &symbol_table, &mut diagnostics);
+        check_loop_control_labels(ast, &symbol_table, &mut diagnostics);
 
         // Security anti-pattern detection (string eval, two-arg open, backtick exec)
         check_security(ast, &mut diagnostics);

--- a/crates/perl-lsp-diagnostics/src/lints/loop_control_label.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/loop_control_label.rs
@@ -1,0 +1,68 @@
+//! Conservative `next LABEL` / `last LABEL` / `redo LABEL` validation.
+//!
+//! This lint warns when a loop control statement (`next`, `last`, `redo`)
+//! references a label that is not defined anywhere in the current file.
+//! Loop control statements without labels are not validated — they implicitly
+//! target the innermost enclosing loop, which is always present at runtime if
+//! the code parses successfully.
+//!
+//! The check is intentionally file-scoped (not block-scoped) for parity with
+//! the `goto LABEL` lint (`PL409`). A reference is accepted as long as some
+//! `LABEL:` appears in the file; tighter scope-aware validation can layer on
+//! top later without changing the diagnostic code.
+//!
+//! # Diagnostic codes
+//!
+//! | Code | Severity | Description |
+//! |------|----------|-------------|
+//! | `PL410` | Warning | `next`/`last`/`redo LABEL` references a label not defined in the file |
+
+use perl_diagnostics_codes::DiagnosticCode;
+use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity, RelatedInformation};
+use perl_parser_core::ast::{Node, NodeKind};
+use perl_semantic_analyzer::symbol::{SymbolKind, SymbolTable};
+
+use super::super::walker::walk_node;
+
+fn has_label(symbol_table: &SymbolTable, label: &str) -> bool {
+    symbol_table
+        .symbols
+        .get(label)
+        .is_some_and(|symbols| symbols.iter().any(|symbol| symbol.kind == SymbolKind::Label))
+}
+
+/// Warn when a `next`/`last`/`redo LABEL` target does not have a matching label
+/// definition somewhere in the same file.
+pub fn check_loop_control_labels(
+    root: &Node,
+    symbol_table: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    walk_node(root, &mut |node| {
+        let NodeKind::LoopControl { op, label: Some(label) } = &node.kind else {
+            return;
+        };
+
+        if has_label(symbol_table, label) {
+            return;
+        }
+
+        diagnostics.push(Diagnostic {
+            range: (node.location.start, node.location.end),
+            severity: DiagnosticSeverity::Warning,
+            code: Some(DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()),
+            message: format!("Loop control label '{label}' is not defined in this file"),
+            related_information: vec![RelatedInformation {
+                location: (node.location.start, node.location.end),
+                message: format!(
+                    "`{op} {label}` requires a `{label}:` label on an enclosing loop. \
+                    Perl raises a fatal error at runtime when the label is not in scope."
+                ),
+            }],
+            tags: Vec::new(),
+            suggestion: Some(format!(
+                "Add a `{label}:` prefix to the enclosing loop or remove the label from `{op}`"
+            )),
+        });
+    });
+}

--- a/crates/perl-lsp-diagnostics/src/lints/mod.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/mod.rs
@@ -14,6 +14,7 @@
 //! - **security**: Security anti-patterns (two-arg open, string eval, backtick execution, global signal handlers)
 //! - **eval_error_flow**: Conservative `$@` / `$EVAL_ERROR` flow checks after `eval` / `try`
 //! - **goto_label**: Conservative `goto LABEL` validation when no matching label exists in-file
+//! - **loop_control_label**: Conservative `next/last/redo LABEL` validation when no matching label exists in-file
 //!
 //! # Diagnostic Code Reference
 //!
@@ -115,6 +116,12 @@
 //! |------|----------|-------------|
 //! | `PL409` | Warning | `goto LABEL` references a label that is not defined in the file |
 //!
+//! ## Loop control labels (`loop_control_label.rs`)
+//!
+//! | Code | Severity | Description |
+//! |------|----------|-------------|
+//! | `PL410` | Warning | `next`/`last`/`redo LABEL` references a label that is not defined in the file |
+//!
 //! # Severity Levels
 //!
 //! Each lint produces diagnostics with appropriate severity:
@@ -142,6 +149,8 @@ pub mod eval_error_flow;
 pub mod ffi_checklib;
 /// Conservative `goto LABEL` validation
 pub mod goto_label;
+/// Conservative `next`/`last`/`redo LABEL` validation (PL410)
+pub mod loop_control_label;
 /// Missing module detection (PL701)
 pub mod missing_module;
 /// Package and subroutine diagnostics (PL200, PL201, PL300, PL303)

--- a/crates/perl-lsp-diagnostics/tests/loop_control_label_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/loop_control_label_tests.rs
@@ -1,0 +1,129 @@
+use std::sync::Arc;
+
+use perl_lsp_diagnostics::{Diagnostic, DiagnosticsProvider};
+use perl_parser::Parser;
+
+fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
+    let output = Parser::new(source).parse_with_recovery();
+    let ast = Arc::new(output.ast);
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    provider.get_diagnostics(&ast, &output.diagnostics, source, None)
+}
+
+fn pl410_messages(source: &str) -> Vec<String> {
+    diagnostics_for(source)
+        .into_iter()
+        .filter(|d| d.code.as_deref() == Some("PL410"))
+        .map(|d| d.message)
+        .collect()
+}
+
+#[test]
+fn next_to_missing_label_warns() {
+    let source = "use v5.40;\nwhile (1) { next MISSING; }\n";
+    let messages = pl410_messages(source);
+    assert!(
+        messages.iter().any(|m| m.contains("not defined in this file")),
+        "expected PL410 for missing next label, got: {messages:?}"
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("MISSING")),
+        "expected the label name in the message, got: {messages:?}"
+    );
+}
+
+#[test]
+fn last_to_missing_label_warns() {
+    let source = "use v5.40;\nwhile (1) { last MISSING; }\n";
+    let messages = pl410_messages(source);
+    assert_eq!(messages.len(), 1, "expected exactly one PL410, got: {messages:?}");
+}
+
+#[test]
+fn redo_to_missing_label_warns() {
+    let source = "use v5.40;\nwhile (1) { redo MISSING; }\n";
+    let messages = pl410_messages(source);
+    assert_eq!(messages.len(), 1, "expected exactly one PL410, got: {messages:?}");
+}
+
+#[test]
+fn loop_control_to_existing_label_is_allowed() {
+    let source = "use v5.40;\nOUTER: while (1) { next OUTER; }\n";
+    let messages = pl410_messages(source);
+    assert!(messages.is_empty(), "next to an existing label should not warn, got: {messages:?}");
+}
+
+#[test]
+fn last_to_existing_outer_label_is_allowed() {
+    let source = "use v5.40;\nOUTER: for my $i (1..10) {\n    INNER: for my $j (1..10) {\n        last OUTER if $i * $j > 50;\n    }\n}\n";
+    let messages = pl410_messages(source);
+    assert!(
+        messages.is_empty(),
+        "last to a defined outer label should not warn, got: {messages:?}"
+    );
+}
+
+#[test]
+fn unlabeled_loop_control_is_ignored() {
+    // Bare `next` / `last` / `redo` with no label always target the innermost
+    // enclosing loop and require no validation.
+    let source = "use v5.40;\nwhile (1) { next; last; redo; }\n";
+    let messages = pl410_messages(source);
+    assert!(
+        messages.is_empty(),
+        "bare loop control without a label should not warn, got: {messages:?}"
+    );
+}
+
+#[test]
+fn label_visible_from_nested_block_is_allowed() {
+    let source = "use v5.40;\nOUTER: while (1) {\n    if (1) {\n        last OUTER;\n    }\n}\n";
+    let messages = pl410_messages(source);
+    assert!(
+        messages.is_empty(),
+        "label visible from nested block should not warn, got: {messages:?}"
+    );
+}
+
+#[test]
+fn label_is_case_sensitive() {
+    // Perl labels are case-sensitive; `outer` does not match `OUTER`.
+    let source = "use v5.40;\nOUTER: while (1) { next outer; }\n";
+    let messages = pl410_messages(source);
+    assert!(
+        messages.iter().any(|m| m.contains("'outer'")),
+        "expected PL410 for case-mismatched label, got: {messages:?}"
+    );
+}
+
+#[test]
+fn diagnostic_carries_pl410_code_and_warning_severity() {
+    use perl_lsp_diagnostics::DiagnosticSeverity;
+
+    let source = "use v5.40;\nwhile (1) { next NOPE; }\n";
+    let pl410: Vec<_> = diagnostics_for(source)
+        .into_iter()
+        .filter(|d| d.code.as_deref() == Some("PL410"))
+        .collect();
+    assert_eq!(pl410.len(), 1);
+    assert_eq!(pl410[0].severity, DiagnosticSeverity::Warning);
+    assert!(
+        !pl410[0].related_information.is_empty(),
+        "PL410 should include related information explaining the fix"
+    );
+    assert!(pl410[0].suggestion.is_some(), "PL410 should include a suggestion");
+}
+
+#[test]
+fn forward_reference_to_label_in_same_file_is_allowed() {
+    // The lint is intentionally file-scoped (matches PL409). Forward references
+    // to a label declared later in the file should not warn — this avoids
+    // false positives for codepaths where the loop is hoisted or organized
+    // differently. Tighter scope-aware validation can layer on later.
+    let source = "use v5.40;\nsub run { last DONE }\nDONE: while (0) {}\n";
+    let messages = pl410_messages(source);
+    assert!(
+        messages.is_empty(),
+        "forward-declared label in the same file should not warn, got: {messages:?}"
+    );
+}


### PR DESCRIPTION
Closes #3372.

## Summary

Adds a conservative file-scoped lint that warns when `next LABEL`, `last LABEL`, or `redo LABEL` references a label that does not exist anywhere in the current file. Mirrors the existing `PL409` (`goto LABEL`) implementation: walk the AST, look up the label in the symbol table (`SymbolKind::Label`, populated by `SymbolExtractor` for `LabeledStatement` nodes), emit a `Warning` when the lookup fails.

```perl
# Before: parses cleanly, fails at runtime with "Label not found for 'OUTER'"
while (1) {
    last OUTER;   # ← now flagged with PL410
}

# OK: label exists in the same file
OUTER: while (1) {
    last OUTER;   # ← no diagnostic
}
```

Bare `next` / `last` / `redo` without a label are not validated — they implicitly target the innermost enclosing loop and are always valid when the code parses.

## Why file-scoped (not block-scoped)

The research comment on #3372 outlines a fully scope-aware approach. This PR deliberately mirrors `PL409` (`goto LABEL`) instead, which is also file-scoped:

- Conservative — no false positives on hoisted/forward-declared loops
- Same surface area as the existing label lint, so users get one consistent rule
- Tighter scope-aware validation can layer on top later under the same diagnostic code without changing the public contract

## Changes

| File | Change |
|------|--------|
| `crates/perl-diagnostics-codes/src/lib.rs` | Add `LoopControlUndefinedLabel` (PL410) — code string, doc URL, severity (Warning), category (BestPractices), context hint, parse_code round-trip, test |
| `crates/perl-lsp-diagnostics/src/lints/loop_control_label.rs` | New lint module |
| `crates/perl-lsp-diagnostics/src/lints/mod.rs` | Register module + docs |
| `crates/perl-lsp-diagnostics/src/diagnostics.rs` | Wire into `DiagnosticsProvider::get_diagnostics_with_path` |
| `crates/perl-lsp-diagnostics/tests/loop_control_label_tests.rs` | 10 integration tests |

## Test coverage

- `next` / `last` / `redo` with missing label → warns
- `next OUTER` with `OUTER:` defined → silent
- `last OUTER` from a nested labeled loop → silent
- Bare `next` / `last` / `redo` → silent (not validated)
- Label visible from a nested `if` block → silent
- Case sensitivity (`OUTER` ≠ `outer`) → warns
- Forward reference within same file → silent (file-scoped, matches PL409)
- Diagnostic shape: `PL410`, `Warning` severity, related info, suggestion

## Test plan

- [x] `cargo build -p perl-diagnostics-codes` — clean
- [x] `cargo build -p perl-lsp-diagnostics` — clean
- [x] `cargo test -p perl-diagnostics-codes` — 29 passed
- [x] `cargo test -p perl-lsp-diagnostics --lib` — 76 passed
- [x] `cargo test -p perl-lsp-diagnostics --test loop_control_label_tests` — 10/10 passed
- [x] `cargo test -p perl-lsp-diagnostics --test goto_label_tests` — 3/3 passed (PL409 unaffected)
- [x] `cargo clippy -p perl-diagnostics-codes -p perl-lsp-diagnostics --tests` — clean
- [x] `cargo fmt --all` — clean

Pre-existing failure on `master` for `tests/diagnostics_gold_suite.rs` (gold-fixture loader expects 25 fixtures, only loads 20) is unrelated to this change — same failure on a fresh clone of `master`.
