### PR TITLE
feat(release): source GitHub Release body from docs/releases/vX.Y.Z.md (#4340)

### DIFF
--- a/.github/workflows/ci-gate-self-tests.yml
+++ b/.github/workflows/ci-gate-self-tests.yml
@@ -16,8 +16,12 @@ on:
     paths:
       - 'scripts/cargo-package-workspace-dry-run.sh'
       - 'scripts/publish-topo.py'
+      - 'scripts/extract-release-notes.sh'
       - 'scripts/tests/test-publish-dry-run-gate.sh'
+      - 'scripts/tests/test-extract-release-notes.sh'
       - '.github/workflows/publish-dry-run.yml'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/release-orchestration.yml'
       - '.github/workflows/ci-gate-self-tests.yml'
   workflow_dispatch: {}
 
@@ -66,4 +70,35 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "A gate self-test assertion failed — the gate may not be catching errors it claims to catch." >> "$GITHUB_STEP_SUMMARY"
             echo "Check the step output above for which case failed." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  extract-release-notes-self-test:
+    name: Extract release notes self-test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run extract-release-notes self-test
+        run: bash scripts/tests/test-extract-release-notes.sh
+
+      - name: Summary
+        if: always()
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "## extract-release-notes self-tests passed" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The release-notes extractor correctly:" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Strips YAML front-matter and preserves the body" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Returns exit 2 when docs/releases/vX.Y.Z.md is missing" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Returns exit 3 on malformed (unterminated) front-matter" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Writes to stdout or a given outfile interchangeably" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Extracts the latest shipped notes file cleanly" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## extract-release-notes self-tests FAILED" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The GitHub Release body would be wrong or the release workflow would false-fail." >> "$GITHUB_STEP_SUMMARY"
+            echo "Check the step output for the failing case." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -126,6 +126,21 @@ jobs:
 
           echo "✅ Changelog checked"
 
+      - name: Require curated release notes
+        # The release workflow sources the GitHub Release body from
+        # docs/releases/vX.Y.Z.md. Fail here — before a tag is created — if
+        # the notes file is missing or malformed, so we never publish a tag
+        # that produces a blank release body. See RELEASE.md and issue #4340.
+        run: |
+          VERSION="${{ steps.resolve.outputs.version }}"
+          NOTES_FILE="docs/releases/v${VERSION}.md"
+          if [ ! -f "${NOTES_FILE}" ]; then
+            echo "::error file=${NOTES_FILE}::Missing release notes file ${NOTES_FILE}. Create it before dispatching the release (see RELEASE.md, 'Release History Updates')."
+            exit 1
+          fi
+          bash scripts/extract-release-notes.sh "${VERSION}" > /dev/null
+          echo "✅ Release notes file present and parseable: ${NOTES_FILE}"
+
       - name: Summary
         run: |
           echo "## Release Validation Complete :white_check_mark:" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
       prerelease: ${{ steps.meta.outputs.prerelease }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Resolve and validate tag
         id: meta
         run: |
@@ -77,6 +80,24 @@ jobs:
           echo "Resolved release tag: $TAG"
           echo "Resolved version: $VERSION"
           echo "Resolved prerelease: $PRERELEASE"
+
+      - name: Require curated release notes
+        # Fail fast if docs/releases/vX.Y.Z.md is missing. The notes file is the
+        # single source of truth for the GitHub Release body — releasing without
+        # it would fall back to auto-generated PR lists, which diverges from the
+        # curated narrative we keep in the repo. See RELEASE.md, "Release
+        # History Updates", and issue #4340.
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          NOTES_FILE="docs/releases/v${VERSION}.md"
+          if [ ! -f "${NOTES_FILE}" ]; then
+            echo "::error file=${NOTES_FILE}::Missing release notes file ${NOTES_FILE}. Create it (see RELEASE.md, 'Release History Updates') and re-run the release workflow."
+            exit 1
+          fi
+          # Confirm the extractor can parse the file — this catches malformed
+          # front-matter before we finish building binaries.
+          bash scripts/extract-release-notes.sh "${VERSION}" > /dev/null
+          echo "✅ Release notes file present and parseable: ${NOTES_FILE}"
 
   build:
     name: Build ${{ matrix.target }}
@@ -242,39 +263,17 @@ jobs:
 
       - name: Generate release notes
         id: release_notes
+        # Source the GitHub Release body from docs/releases/vX.Y.Z.md so the
+        # release surface matches the curated narrative in the repo. The
+        # auto-generated "What's Changed" PR list is still appended below by
+        # softprops/action-gh-release via `generate_release_notes: true`.
+        # See issue #4340 and RELEASE.md ("Release History Updates").
         run: |
           VERSION="${{ needs.release-metadata.outputs.version }}"
-          cat > release_notes.md << EOF
-          ## Perl LSP ${VERSION}
-
-          This release ships the binaries and the docs needed to install, configure, and troubleshoot the current release line.
-
-          ### Install or upgrade
-
-          ```bash
-          cargo install perllsp
-          cargo install perl-dap
-          ```
-
-          ### Read this first
-
-          - [Docs home](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/README.md)
-          - [Docs index](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/INDEX.md)
-          - [Getting Started](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/tutorials/GETTING_STARTED.md)
-          - [Installation Guide](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/how-to/INSTALLATION.md)
-          - [Editor Setup](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/how-to/EDITOR_SETUP.md)
-          - [Troubleshooting](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/how-to/TROUBLESHOOTING.md)
-
-          ### Release assets
-
-          - Platform binaries are attached to this release.
-          - Verify downloads with the consolidated \`SHA256SUMS\` file.
-
-          ### Change log
-
-          See the [CHANGELOG](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/CHANGELOG.md) for the full release history.
-          EOF
+          bash scripts/extract-release-notes.sh "${VERSION}" release_notes.md
+          echo "--- release_notes.md ---"
           cat release_notes.md
+          echo "--- end release_notes.md ---"
 
       - name: Create GitHub Release
         if: github.event_name == 'workflow_dispatch'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -428,6 +428,14 @@ This creates a `release/vNEW_VERSION` branch with updated `Cargo.toml` and `CHAN
 
 Every public release **must** update three surfaces. See [RELEASE_HISTORY.md](RELEASE_HISTORY.md) for the canonical ledger.
 
+> **The GitHub Release body is sourced from `docs/releases/vX.Y.Z.md`.**
+> The release-orchestration workflow and the build/release workflow both
+> validate the file exists and is parseable (via
+> [`scripts/extract-release-notes.sh`](scripts/extract-release-notes.sh)) before
+> creating a tag or uploading assets. **If this file is missing or malformed,
+> the release will fail fast.** GitHub's auto-generated "What's Changed" PR
+> list is appended below the curated body by `softprops/action-gh-release`.
+
 ### Before publishing
 
 - [ ] Create `docs/releases/vX.Y.Z.md` (use an existing file as template)
@@ -436,6 +444,10 @@ Every public release **must** update three surfaces. See [RELEASE_HISTORY.md](RE
   - `docs/releases/vX.Y.Z.md`
   - GitHub Release URL
   - Compare range `vPrev...vX.Y.Z`
+- [ ] (Optional) Preview what the GitHub Release body will look like:
+  ```bash
+  bash scripts/extract-release-notes.sh X.Y.Z
+  ```
 
 ### After publishing
 
@@ -464,6 +476,16 @@ grep 'X.Y.Z' RELEASE_HISTORY.md
 # 3. CHANGELOG section exists
 grep '\[X.Y.Z\]' CHANGELOG.md
 
-# 4. GitHub Release matches
+# 4. Notes file is extractable (mirrors what the release workflow runs)
+bash scripts/extract-release-notes.sh X.Y.Z > /dev/null
+
+# 5. GitHub Release matches
 gh release view vX.Y.Z --json tagName,assets --jq '{tag: .tagName, assets: [.assets[].name]}'
+
+# 6. GitHub Release body matches the curated notes (strip auto-appended
+#    "## What's Changed" section before comparing)
+EXPECTED=$(bash scripts/extract-release-notes.sh X.Y.Z)
+ACTUAL=$(gh release view vX.Y.Z --json body --jq .body \
+  | awk '/^## What'"'"'s Changed$/{exit} {print}')
+diff <(printf '%s\n' "$EXPECTED") <(printf '%s\n' "$ACTUAL")
 ```

--- a/scripts/extract-release-notes.sh
+++ b/scripts/extract-release-notes.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Extract curated release notes for a given version from docs/releases/vX.Y.Z.md.
+#
+# The notes file contains a YAML front-matter block followed by the prose body
+# that should ship as the GitHub Release description. This script strips the
+# front-matter and emits the body to stdout so the release workflow can feed it
+# to softprops/action-gh-release as `body_path`.
+#
+# Usage:
+#   scripts/extract-release-notes.sh <version>            # writes body to stdout
+#   scripts/extract-release-notes.sh <version> <outfile>  # writes body to <outfile>
+#
+# Arguments:
+#   <version>  Semantic version without leading 'v' (e.g. 0.12.4, 1.0.0-beta.1)
+#   <outfile>  Optional output path. When omitted the body is printed to stdout.
+#
+# Environment:
+#   RELEASE_NOTES_DIR  Override the notes directory (default: docs/releases).
+#   REPO_ROOT          Override the repo root (default: git rev-parse result).
+#
+# Exit codes:
+#   0  success
+#   1  unknown flag or usage error
+#   2  notes file does not exist
+#   3  front-matter block is malformed (opened with `---` but never closed)
+#
+# The script is deliberately dependency-free (pure bash + sed/awk) so it works
+# in the minimal Ubuntu image used by release.yml without installing anything.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: extract-release-notes.sh <version> [outfile]
+
+Reads docs/releases/v<version>.md, strips the YAML front-matter block, and
+writes the remaining body to stdout (or <outfile> when provided).
+
+Exit codes:
+  0 success
+  1 usage error
+  2 notes file missing
+  3 malformed front-matter (unterminated --- block)
+USAGE
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 1
+fi
+
+case "$1" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+
+VERSION="$1"
+OUTFILE="${2:-}"
+
+if [[ -z "${VERSION}" ]]; then
+  echo "error: <version> must be non-empty" >&2
+  usage
+  exit 1
+fi
+
+# Strip a leading 'v' if the caller passed 'v0.12.4' by accident, so the script
+# is forgiving in both directions.
+VERSION="${VERSION#v}"
+
+# Resolve repo root so the script works when invoked from any cwd.
+if [[ -n "${REPO_ROOT:-}" ]]; then
+  ROOT="${REPO_ROOT}"
+elif ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  :
+else
+  # Fallback: assume the script lives in <root>/scripts/
+  ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+
+NOTES_DIR="${RELEASE_NOTES_DIR:-${ROOT}/docs/releases}"
+NOTES_FILE="${NOTES_DIR}/v${VERSION}.md"
+
+if [[ ! -f "${NOTES_FILE}" ]]; then
+  cat >&2 <<EOF
+error: release notes file not found: ${NOTES_FILE}
+
+Every tagged release must ship with a curated notes file at
+docs/releases/v<version>.md. See RELEASE.md ("Release History Updates") for the
+template. Create the file, commit it, and re-run the release workflow.
+EOF
+  exit 2
+fi
+
+# Strip YAML front-matter with a small awk program. The rule:
+#   - if line 1 is exactly '---', skip lines until the next '---', then emit
+#     everything after it;
+#   - otherwise emit the file verbatim (no front-matter present).
+#
+# We also leading-trim blank lines after the closing '---' so the body starts
+# at the first real content line (usually `# vX.Y.Z`).
+BODY="$(
+  awk '
+    BEGIN { state = "start" }
+    state == "start" {
+      if (NR == 1 && $0 == "---") { state = "in_fm"; next }
+      else { state = "body" }
+    }
+    state == "in_fm" {
+      if ($0 == "---") { state = "post_fm"; next }
+      next
+    }
+    state == "post_fm" {
+      if ($0 ~ /^[[:space:]]*$/) next
+      state = "body"
+    }
+    state == "body" { print }
+    END {
+      if (state == "in_fm") exit 3
+    }
+  ' "${NOTES_FILE}"
+)" || {
+  status=$?
+  if [[ "${status}" -eq 3 ]]; then
+    echo "error: front-matter in ${NOTES_FILE} opens with '---' but is never closed" >&2
+    exit 3
+  fi
+  exit "${status}"
+}
+
+if [[ -n "${OUTFILE}" ]]; then
+  printf '%s\n' "${BODY}" > "${OUTFILE}"
+else
+  printf '%s\n' "${BODY}"
+fi

--- a/scripts/tests/test-extract-release-notes.sh
+++ b/scripts/tests/test-extract-release-notes.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# Self-test for scripts/extract-release-notes.sh.
+#
+# Problem it prevents: the release workflow now fails the whole release if the
+# notes file is missing or the front-matter is malformed. A silent bug in the
+# extractor (stripping too much, not enough, or misreporting an exit code)
+# would either ship a blank release body or block every release on false
+# positives. This self-test feeds known-good and known-bad inputs to the
+# extractor and asserts both the exit code and the emitted body.
+#
+# Usage:
+#   bash scripts/tests/test-extract-release-notes.sh
+#
+# Returns:
+#   Exit 0 if all assertions pass.
+#   Exit 1 if any assertion fails.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT_DEFAULT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+EXTRACTOR="${REPO_ROOT_DEFAULT}/scripts/extract-release-notes.sh"
+
+PASS=0
+FAIL=0
+FIXTURE_ROOT=""
+
+cleanup() {
+  if [[ -n "${FIXTURE_ROOT:-}" && -d "${FIXTURE_ROOT}" ]]; then
+    rm -rf "${FIXTURE_ROOT}"
+  fi
+}
+trap cleanup EXIT
+
+FIXTURE_ROOT="$(mktemp -d)"
+mkdir -p "${FIXTURE_ROOT}/docs/releases"
+
+run_extract() {
+  # Usage: run_extract <version> [extra env]... -- args...
+  # Always isolates to the fixture tree via REPO_ROOT.
+  REPO_ROOT="${FIXTURE_ROOT}" "${EXTRACTOR}" "$@"
+}
+
+assert_eq() {
+  local label="$1"; local want="$2"; local got="$3"
+  if [[ "${want}" == "${got}" ]]; then
+    echo "PASS  ${label}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  ${label}"
+    echo "      want: ${want}"
+    echo "      got:  ${got}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1"; local needle="$2"; local haystack="$3"
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    echo "PASS  ${label}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  ${label}"
+    echo "      expected to contain: ${needle}"
+    echo "      actual: ${haystack}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local label="$1"; local needle="$2"; local haystack="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "PASS  ${label}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  ${label}"
+    echo "      did not want: ${needle}"
+    echo "      actual: ${haystack}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# CASE 1: canonical file with YAML front-matter
+#
+# The extractor must strip the block between the leading and trailing `---`
+# markers and emit the body starting at the first non-blank line below.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 1: front-matter stripped, body preserved ==="
+
+cat > "${FIXTURE_ROOT}/docs/releases/v1.2.3.md" <<'EOF'
+---
+version: "1.2.3"
+tag: "v1.2.3"
+notes_status: canonical
+---
+
+# v1.2.3
+
+## Summary
+
+Hello from the curated notes.
+
+- bullet one
+- bullet two
+EOF
+
+OUT="$(run_extract 1.2.3)"
+RC=$?
+assert_eq "case1 exit code" 0 "${RC}"
+assert_contains "case1 starts with heading" "# v1.2.3" "${OUT}"
+assert_contains "case1 contains summary" "Hello from the curated notes." "${OUT}"
+assert_not_contains "case1 front-matter key stripped" 'notes_status:' "${OUT}"
+assert_not_contains "case1 opening --- stripped" "$(printf '%s\n---' "")" "${OUT:0:4}"
+
+# ---------------------------------------------------------------------------
+# CASE 2: file without front-matter is emitted verbatim
+#
+# Older notes may not have a YAML block. The extractor must not drop content.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 2: no front-matter → verbatim body ==="
+
+cat > "${FIXTURE_ROOT}/docs/releases/v0.9.0.md" <<'EOF'
+# v0.9.0
+
+Legacy release notes body.
+EOF
+
+OUT="$(run_extract 0.9.0)"
+RC=$?
+assert_eq "case2 exit code" 0 "${RC}"
+assert_contains "case2 body preserved" "Legacy release notes body." "${OUT}"
+assert_contains "case2 heading preserved" "# v0.9.0" "${OUT}"
+
+# ---------------------------------------------------------------------------
+# CASE 3: missing file → exit 2 and actionable error
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 3: missing notes file → exit 2 ==="
+
+ERR="$(run_extract 9.9.9 2>&1 >/dev/null || true)"
+RC=0
+run_extract 9.9.9 >/dev/null 2>&1 || RC=$?
+assert_eq "case3 exit code" 2 "${RC}"
+assert_contains "case3 error message points at path" "v9.9.9.md" "${ERR}"
+assert_contains "case3 error message mentions RELEASE.md" "RELEASE.md" "${ERR}"
+
+# ---------------------------------------------------------------------------
+# CASE 4: malformed front-matter (opens with --- but never closes) → exit 3
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 4: unterminated front-matter → exit 3 ==="
+
+cat > "${FIXTURE_ROOT}/docs/releases/v2.0.0.md" <<'EOF'
+---
+version: "2.0.0"
+oops: forgot to close
+
+# body below, but the YAML block never ended
+EOF
+
+ERR="$(run_extract 2.0.0 2>&1 >/dev/null || true)"
+RC=0
+run_extract 2.0.0 >/dev/null 2>&1 || RC=$?
+assert_eq "case4 exit code" 3 "${RC}"
+assert_contains "case4 error message" "never closed" "${ERR}"
+
+# ---------------------------------------------------------------------------
+# CASE 5: script tolerates a leading 'v' prefix on the version argument
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 5: 'v'-prefixed version is accepted ==="
+
+OUT="$(run_extract v1.2.3)"
+RC=$?
+assert_eq "case5 exit code" 0 "${RC}"
+assert_contains "case5 body preserved" "Hello from the curated notes." "${OUT}"
+
+# ---------------------------------------------------------------------------
+# CASE 6: usage error when called with no args → exit 1
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 6: usage error → exit 1 ==="
+
+RC=0
+run_extract >/dev/null 2>&1 || RC=$?
+assert_eq "case6 exit code" 1 "${RC}"
+
+# ---------------------------------------------------------------------------
+# CASE 7: <outfile> argument writes the body to the given path
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 7: outfile argument ==="
+
+OUTFILE="${FIXTURE_ROOT}/out.md"
+run_extract 1.2.3 "${OUTFILE}" >/dev/null
+RC=$?
+assert_eq "case7 exit code" 0 "${RC}"
+BODY="$(cat "${OUTFILE}")"
+assert_contains "case7 outfile contains heading" "# v1.2.3" "${BODY}"
+assert_not_contains "case7 outfile front-matter stripped" 'notes_status:' "${BODY}"
+
+# ---------------------------------------------------------------------------
+# CASE 8: the workflow contract — a real shipped notes file extracts cleanly.
+#
+# This asserts the extractor works against the actual docs/releases tree, not
+# just synthetic fixtures. It guards against subtle regressions (e.g. the
+# front-matter delimiter format drifting).
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== CASE 8: real shipped notes file extracts cleanly ==="
+
+LATEST_NOTES="$(ls -1 "${REPO_ROOT_DEFAULT}/docs/releases/"v*.md 2>/dev/null | sort -V | tail -1 || true)"
+if [[ -n "${LATEST_NOTES}" ]]; then
+  LATEST_VERSION="$(basename "${LATEST_NOTES}" .md)"
+  LATEST_VERSION="${LATEST_VERSION#v}"
+  OUT="$(REPO_ROOT="${REPO_ROOT_DEFAULT}" "${EXTRACTOR}" "${LATEST_VERSION}")"
+  RC=$?
+  assert_eq "case8 exit code" 0 "${RC}"
+  assert_not_contains "case8 no front-matter leakage" 'notes_status:' "${OUT}"
+  # Body must be non-trivial (>= 10 lines) to rule out over-aggressive stripping.
+  LINE_COUNT="$(printf '%s\n' "${OUT}" | wc -l | tr -d ' ')"
+  if [[ "${LINE_COUNT}" -ge 10 ]]; then
+    echo "PASS  case8 body has ${LINE_COUNT} lines"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  case8 body unexpectedly short (${LINE_COUNT} lines)"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo "SKIP  case8 no release notes files found under docs/releases/"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+TOTAL=$((PASS + FAIL))
+echo ""
+echo "=== Results: ${PASS}/${TOTAL} passed ==="
+
+if [[ "${FAIL}" -gt 0 ]]; then
+  echo "FAIL: ${FAIL} assertion(s) failed."
+  exit 1
+fi
+
+echo "All assertions passed — extract-release-notes.sh does what it claims."
+exit 0


### PR DESCRIPTION
## Summary

Closes #4340.

GitHub Release bodies were being assembled from a boilerplate heredoc in `release.yml` and GitHub's auto-generated "What's Changed" PR list. The repo has curated per-release narrative files at `docs/releases/vX.Y.Z.md` — front-matter with metadata, summary, highlights, install instructions, links — but those files were never consumed by the release workflow. The two surfaces drifted apart: the repo held the story, the Release page held a PR dump.

This PR wires the release workflow to source the Release body from the curated notes file and to **fail fast** if the notes file is missing or malformed, so every tagged release ships with the narrative the team actually wrote.

## What this PR does

### New: `scripts/extract-release-notes.sh`

Dependency-free bash + awk script (the release runner is minimal Ubuntu — no jq, no Python assumed). Reads `docs/releases/v<version>.md`, strips the YAML front-matter block between the leading and trailing `---` markers, and writes the body to stdout (or to an outfile when given).

Exit-code contract used by the workflow:
- `0` success
- `1` usage error
- `2` notes file missing — clear message pointing at the expected path and RELEASE.md
- `3` front-matter opens with `---` but is never closed

Forgiving on input: accepts `0.12.4` or `v0.12.4`, falls back to `docs/releases/` resolution via `git rev-parse --show-toplevel`, and honours `REPO_ROOT` / `RELEASE_NOTES_DIR` overrides so tests can isolate fixtures.

### New: `scripts/tests/test-extract-release-notes.sh` (22 assertions)

Follows the existing CI-gate self-test pattern (`scripts/tests/test-publish-dry-run-gate.sh`, from issue #3322). Covers:

- Canonical file with front-matter → body extracted, heading preserved, front-matter keys stripped
- File without front-matter → emitted verbatim
- Missing file → exit 2, error message references the path and `RELEASE.md`
- Unterminated front-matter → exit 3 with an actionable error
- `v`-prefix tolerance on the version argument
- No-args usage error → exit 1
- `<outfile>` argument round-trips the body to disk
- A live check against the latest real `docs/releases/v*.md` so the gate doesn't drift from the actual file format

```
=== Results: 22/22 passed ===
All assertions passed — extract-release-notes.sh does what it claims.
```

### `.github/workflows/release.yml`

- Added a `Checkout` step to the `release-metadata` job (it had none before — the existing `Resolve and validate tag` step only read workflow inputs).
- Added `Require curated release notes`: fails the job with a GitHub-annotated error when `docs/releases/v${VERSION}.md` is missing, and also runs the extractor to catch malformed front-matter **before** we spend 30 minutes building binaries across 7 targets.
- Replaced the 30-line `Generate release notes` heredoc with a single call to `scripts/extract-release-notes.sh "${VERSION}" release_notes.md`.
- `generate_release_notes: true` stays, so GitHub's auto "What's Changed" section is still appended **below** the curated body (acceptance criterion #3).

### `.github/workflows/release-orchestration.yml`

Added the same "require curated release notes" validation to the `validate` job — this is the fail-fast entry point for dispatched releases. Catching a missing notes file here blocks a tag from being created, so we never publish a tag that produces a blank release body.

### `.github/workflows/ci-gate-self-tests.yml`

- Added `scripts/extract-release-notes.sh`, `scripts/tests/test-extract-release-notes.sh`, and the two release workflows to the PR path filters so the self-test runs whenever any of them change.
- Added an `extract-release-notes-self-test` job that runs the new 22-assertion test and emits a step summary mirroring the existing publish-dry-run self-test.

### `RELEASE.md`

- New callout in "Release History Updates" explaining that the GitHub Release body is now sourced from the notes file and that the workflow fails fast if it's missing.
- Added a local preview command (`bash scripts/extract-release-notes.sh X.Y.Z`) so release managers can see exactly what will ship before dispatching.
- Extended the verification block with an extractor round-trip and a `diff` of the curated body against the published Release body (stripping GitHub's auto-appended `## What's Changed` section before comparing).

## Acceptance criteria (from #4340)

- [x] `gh release view vX.Y.Z` body matches `docs/releases/vX.Y.Z.md` content — release body is now written by `extract-release-notes.sh` from that file, verified by the new self-test and the `diff` snippet in RELEASE.md.
- [x] Release workflow fails if `docs/releases/vX.Y.Z.md` doesn't exist at tag time — enforced in both `release-orchestration.yml` (before the tag is created) and `release.yml` (after dispatch) with a GitHub-annotated error pointing at the expected path.
- [x] Auto-generated "What's Changed" section can optionally be appended below the curated notes — preserved via `generate_release_notes: true` on `softprops/action-gh-release`, which appends below the `body_path` content.

## Why this is shaped this way

- **Two-tier validation.** The orchestration workflow validates on `master` before creating a tag; the release workflow validates again after checking out the tag. One guards against forgetting the notes file when dispatching; the other guards against someone creating a tag manually. Both are cheap.
- **Script in `scripts/`, not inline in YAML.** Inline bash in workflow YAML is invisible to `bash -n`, unreviewable in a diff, and untestable. Extracting the logic lets us run it in CI against known-good and known-bad fixtures and lets release managers preview locally with one command.
- **Dependency-free.** No `yq`, `jq`, or Python — just `bash` + `awk`. Keeps the release runner small and removes a class of "transient PyPI failure broke our release" incidents.
- **Self-test follows the `#3322` pattern.** The repo already has `docs/reference/PROCESS_LESSONS.md — "CI Gate Self-Tests"` and a working example in `scripts/tests/test-publish-dry-run-gate.sh`. The new test uses the same helpers, the same labelling style, and plugs into the same workflow so it gets run on every relevant PR.
- **Fail-fast on malformed front-matter.** Previous scripts that silently dropped the body or emitted the front-matter verbatim would produce a non-obvious bad release. Exit 3 with a clear error makes the failure visible at the moment of the typo.

## Test plan

- [x] `bash scripts/tests/test-extract-release-notes.sh` — 22/22 locally
- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` over all three modified workflows — parse clean
- [x] `bash -n` over both new scripts — syntax clean
- [x] Manual extraction against the latest real shipped notes (`v0.12.4`) — front-matter stripped, 47-line body preserved including headings, highlights, install block, links
- [x] Edge cases: missing file (exit 2), unterminated front-matter (exit 3), no-args (exit 1), `v`-prefix tolerated, outfile argument round-trips
- [x] CI self-test job will run on this PR because the workflow path filter matches `scripts/extract-release-notes.sh` and `.github/workflows/release.yml`

## Files changed

| File | Change |
|---|---|
| `scripts/extract-release-notes.sh` | **new** — dependency-free extractor with documented exit codes |
| `scripts/tests/test-extract-release-notes.sh` | **new** — 22-assertion self-test over 8 cases |
| `.github/workflows/release.yml` | checkout + notes validation in metadata job; replace heredoc with extractor call |
| `.github/workflows/release-orchestration.yml` | notes validation in validate job (fail before tag creation) |
| `.github/workflows/ci-gate-self-tests.yml` | new self-test job; extend path filters |
| `RELEASE.md` | document new behavior, preview command, extended verification block |

https://claude.ai/code/session_01Evg7vrkGpfAALzAcxZNPPo