### PR TITLE
feat(diagnostics): add PL410 lint for `next`/`last`/`redo` to undefined labels (#3372)

### DIFF
--- a/crates/perl-diagnostics/src/codes/mod.rs
+++ b/crates/perl-diagnostics/src/codes/mod.rs
@@ -168,6 +168,8 @@ pub enum DiagnosticCode {
     DuplicateHashKey,
     /// `goto LABEL` references a label that does not exist in this file
     GotoUndefinedLabel,
+    /// `next`/`last`/`redo LABEL` references a label that does not exist in this file
+    LoopControlUndefinedLabel,
 
     // Pragma pitfalls / deprecated syntax (PL500-PL599)
     /// Use of deprecated defined(@array) / defined(%hash)
@@ -270,6 +272,7 @@ impl DiagnosticCode {
             Self::EvalErrorFlow => "PL407",
             Self::DuplicateHashKey => "PL408",
             Self::GotoUndefinedLabel => "PL409",
+            Self::LoopControlUndefinedLabel => "PL410",
             Self::DeprecatedDefined => "PL500",
             Self::DeprecatedArrayBase => "PL501",
             Self::PhaseScopedStrictPragma => "PL502",
@@ -340,6 +343,7 @@ impl DiagnosticCode {
             "PL407" => "https://docs.perl-lsp.org/errors/PL407",
             "PL408" => "https://docs.perl-lsp.org/errors/PL408",
             "PL409" => "https://docs.perl-lsp.org/errors/PL409",
+            "PL410" => "https://docs.perl-lsp.org/errors/PL410",
             "PL500" => "https://docs.perl-lsp.org/errors/PL500",
             "PL501" => "https://docs.perl-lsp.org/errors/PL501",
             "PL502" => "https://docs.perl-lsp.org/errors/PL502",
@@ -400,6 +404,7 @@ impl DiagnosticCode {
             | Self::PrintfFormatMismatch
             | Self::DuplicateHashKey
             | Self::GotoUndefinedLabel
+            | Self::LoopControlUndefinedLabel
             | Self::DeprecatedDefined
             | Self::DeprecatedArrayBase
             | Self::PhaseScopedStrictPragma
@@ -544,6 +549,10 @@ impl DiagnosticCode {
             Self::GotoUndefinedLabel => Some(
                 "This goto target label is not defined in the current file. \
                 Define the label or use a dynamic goto form only when the target is known at runtime.",
+            ),
+            Self::LoopControlUndefinedLabel => Some(
+                "This `next`, `last`, or `redo` references a label that is not defined in the current file. \
+                Add a matching `LABEL:` on an enclosing loop, or remove the label to target the innermost loop.",
             ),
             Self::PrintfFormatMismatch => Some(
                 "The number of format specifiers does not match the number of arguments. \
@@ -747,6 +756,7 @@ impl DiagnosticCode {
             "PL407" => Some(Self::EvalErrorFlow),
             "PL408" => Some(Self::DuplicateHashKey),
             "PL409" => Some(Self::GotoUndefinedLabel),
+            "PL410" => Some(Self::LoopControlUndefinedLabel),
             "PL500" => Some(Self::DeprecatedDefined),
             "PL501" => Some(Self::DeprecatedArrayBase),
             "PL502" => Some(Self::PhaseScopedStrictPragma),
@@ -819,6 +829,7 @@ impl DiagnosticCode {
             | Self::EvalErrorFlow
             | Self::DuplicateHashKey
             | Self::GotoUndefinedLabel
+            | Self::LoopControlUndefinedLabel
             | Self::VersionIncompatFeature => DiagnosticCategory::BestPractices,
 
             Self::DeprecatedDefined | Self::DeprecatedArrayBase => DiagnosticCategory::Deprecated,

--- a/crates/perl-diagnostics/tests/codes_diagnostic_code_completeness.rs
+++ b/crates/perl-diagnostics/tests/codes_diagnostic_code_completeness.rs
@@ -116,6 +116,62 @@ fn duplicate_hash_key_code_exists() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn goto_undefined_label_code_exists() -> Result<(), Box<dyn std::error::Error>> {
+    let code = DiagnosticCode::GotoUndefinedLabel;
+    assert_eq!(code.as_str(), "PL409", "GotoUndefinedLabel should have code PL409");
+    assert_eq!(
+        code.severity(),
+        perl_diagnostics::codes::DiagnosticSeverity::Warning,
+        "GotoUndefinedLabel should have Warning severity"
+    );
+    assert!(code.context_hint().is_some(), "GotoUndefinedLabel should have a context hint");
+    assert_eq!(
+        DiagnosticCode::parse_code("PL409"),
+        Some(DiagnosticCode::GotoUndefinedLabel),
+        "parse_code('PL409') should return GotoUndefinedLabel"
+    );
+    assert_eq!(
+        code.category(),
+        perl_diagnostics::codes::DiagnosticCategory::BestPractices,
+        "GotoUndefinedLabel belongs to the BestPractices (PL4xx) range"
+    );
+    assert_eq!(
+        code.documentation_url(),
+        Some("https://docs.perl-lsp.org/errors/PL409"),
+        "PL409 should advertise a docs URL following the conventional scheme"
+    );
+    Ok(())
+}
+
+#[test]
+fn loop_control_undefined_label_code_exists() -> Result<(), Box<dyn std::error::Error>> {
+    let code = DiagnosticCode::LoopControlUndefinedLabel;
+    assert_eq!(code.as_str(), "PL410", "LoopControlUndefinedLabel should have code PL410");
+    assert_eq!(
+        code.severity(),
+        perl_diagnostics::codes::DiagnosticSeverity::Warning,
+        "LoopControlUndefinedLabel should have Warning severity"
+    );
+    assert!(code.context_hint().is_some(), "LoopControlUndefinedLabel should have a context hint");
+    assert_eq!(
+        DiagnosticCode::parse_code("PL410"),
+        Some(DiagnosticCode::LoopControlUndefinedLabel),
+        "parse_code('PL410') should return LoopControlUndefinedLabel"
+    );
+    assert_eq!(
+        code.category(),
+        perl_diagnostics::codes::DiagnosticCategory::BestPractices,
+        "LoopControlUndefinedLabel belongs to the BestPractices (PL4xx) range"
+    );
+    assert_eq!(
+        code.documentation_url(),
+        Some("https://docs.perl-lsp.org/errors/PL410"),
+        "PL410 should advertise a docs URL following the conventional scheme"
+    );
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Deprecated syntax codes (PL5xx range)
 // ---------------------------------------------------------------------------

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs
@@ -17,6 +17,7 @@ use super::lints::duplicate_hash_keys::check_duplicate_hash_keys;
 use super::lints::eval_error_flow::check_eval_error_flow;
 use super::lints::ffi_checklib::check_ffi_checklib;
 use super::lints::goto_label::check_goto_labels;
+use super::lints::loop_control_label::check_loop_control_labels;
 use super::lints::package_subroutine::{
     check_duplicate_package, check_duplicate_subroutine, check_missing_package_declaration,
 };
@@ -156,6 +157,7 @@ impl DiagnosticsProvider {
         // Moo/Moose role conflict diagnostics (same-file only)
         check_role_conflicts(ast, &symbol_table, &mut diagnostics);
         check_goto_labels(ast, &symbol_table, &mut diagnostics);
+        check_loop_control_labels(ast, &symbol_table, &mut diagnostics);
 
         // Security anti-pattern detection (string eval, two-arg open, backtick exec)
         check_security(ast, &mut diagnostics);

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/loop_control_label.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/loop_control_label.rs
@@ -1,0 +1,90 @@
+//! Conservative `next`/`last`/`redo LABEL` validation.
+//!
+//! This lint warns when a loop-control statement targets an explicit label
+//! (`next FOO;`, `last BAR;`, `redo BAZ;`) and no matching label symbol
+//! exists anywhere in the current file. Bare `next;` / `last;` / `redo;`
+//! (no label) are always allowed — they target the innermost enclosing
+//! loop at runtime.
+//!
+//! Like [`check_goto_labels`](super::goto_label::check_goto_labels), the
+//! analysis is intentionally file-scoped and forgiving: it only fires when
+//! the target label is *not defined anywhere in the file*, which avoids
+//! false positives from labels introduced by macros, source filters, or
+//! imported code that the parser cannot see.
+//!
+//! # Diagnostic codes
+//!
+//! | Code | Severity | Description |
+//! |------|----------|-------------|
+//! | `PL410` | Warning | `next`/`last`/`redo LABEL` references a label that is not defined in the file |
+//!
+//! # Runtime behavior
+//!
+//! At runtime, Perl reports `Label not found for "next LABEL"` (or
+//! equivalent) as a fatal error. Catching it statically lets editors flag
+//! the problem before the program is run.
+
+use super::super::internal_types::{Diagnostic, RelatedInformation};
+use perl_diagnostics::codes::DiagnosticCode;
+use perl_diagnostics::codes::DiagnosticSeverity;
+use perl_parser_core::ast::{Node, NodeKind};
+use perl_semantic_analyzer::symbol::{SymbolKind, SymbolTable};
+
+use super::super::walker::walk_node;
+
+fn has_label(symbol_table: &SymbolTable, label: &str) -> bool {
+    symbol_table
+        .symbols
+        .get(label)
+        .is_some_and(|symbols| symbols.iter().any(|symbol| symbol.kind == SymbolKind::Label))
+}
+
+/// Warn when a `next LABEL`, `last LABEL`, or `redo LABEL` target does not
+/// have a matching label symbol in the same file.
+pub fn check_loop_control_labels(
+    root: &Node,
+    symbol_table: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    walk_node(root, &mut |node| {
+        let NodeKind::LoopControl { op, label } = &node.kind else {
+            return;
+        };
+
+        // Bare forms (no label) always target the innermost enclosing loop
+        // and are always valid; nothing to check.
+        let Some(label_name) = label.as_deref() else {
+            return;
+        };
+
+        // Defensive: only the three documented ops carry a label.  Ignore
+        // any future variants to avoid double-reporting if another lint
+        // grows to cover them.
+        if !matches!(op.as_str(), "next" | "last" | "redo") {
+            return;
+        }
+
+        if has_label(symbol_table, label_name) {
+            return;
+        }
+
+        diagnostics.push(Diagnostic {
+            range: (node.location.start, node.location.end),
+            severity: DiagnosticSeverity::Warning,
+            code: Some(DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()),
+            message: format!(
+                "`{op} {label_name}` references a label that is not defined in this file"
+            ),
+            related_information: vec![RelatedInformation {
+                location: (node.location.start, node.location.end),
+                message:
+                    "Add a matching `LABEL:` on an enclosing loop, or drop the label to target the innermost loop."
+                        .to_string(),
+            }],
+            tags: Vec::new(),
+            suggestion: Some(format!(
+                "Define a `{label_name}:` label on the intended enclosing loop, or write `{op};` to target the innermost loop"
+            )),
+        });
+    });
+}

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/mod.rs
@@ -115,6 +115,12 @@
 //! |------|----------|-------------|
 //! | `PL409` | Warning | `goto LABEL` references a label that is not defined in the file |
 //!
+//! ## Loop control labels (`loop_control_label.rs`)
+//!
+//! | Code | Severity | Description |
+//! |------|----------|-------------|
+//! | `PL410` | Warning | `next`/`last`/`redo LABEL` references a label that is not defined in the file |
+//!
 //! # Severity Levels
 //!
 //! Each lint produces diagnostics with appropriate severity:
@@ -142,6 +148,8 @@ pub mod eval_error_flow;
 pub mod ffi_checklib;
 /// Conservative `goto LABEL` validation
 pub mod goto_label;
+/// Conservative `next`/`last`/`redo LABEL` validation (PL410)
+pub mod loop_control_label;
 /// Missing module detection (PL701)
 pub mod missing_module;
 /// Package and subroutine diagnostics (PL200, PL201, PL300, PL303)

--- a/crates/perl-lsp-rs-core/tests/loop_control_label_tests.rs
+++ b/crates/perl-lsp-rs-core/tests/loop_control_label_tests.rs
@@ -1,0 +1,209 @@
+//! Integration tests for PL410 — `next`/`last`/`redo LABEL` validation.
+//!
+//! These tests drive `DiagnosticsProvider::get_diagnostics` end-to-end to
+//! ensure the lint is registered and produces diagnostics with stable
+//! wording and a filterable code.
+
+use std::sync::Arc;
+
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticsProvider};
+use perl_parser::Parser;
+
+fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
+    let output = Parser::new(source).parse_with_recovery();
+    let ast = Arc::new(output.ast);
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    provider.get_diagnostics(&ast, &output.diagnostics, source, None)
+}
+
+fn pl410(source: &str) -> Vec<Diagnostic> {
+    diagnostics_for(source).into_iter().filter(|d| d.code.as_deref() == Some("PL410")).collect()
+}
+
+fn pl410_messages(source: &str) -> Vec<String> {
+    pl410(source).into_iter().map(|d| d.message).collect()
+}
+
+#[test]
+fn next_to_missing_label_warns() {
+    let source = r#"use v5.40;
+while (1) {
+    next MISSING;
+}
+"#;
+    let messages = pl410_messages(source);
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("`next MISSING`") && m.contains("not defined in this file")),
+        "expected PL410 for missing `next LABEL`, got: {messages:?}"
+    );
+}
+
+#[test]
+fn last_to_missing_label_warns() {
+    let source = r#"use v5.40;
+for my $x (1..10) {
+    last NOPE;
+}
+"#;
+    let messages = pl410_messages(source);
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("`last NOPE`") && m.contains("not defined in this file")),
+        "expected PL410 for missing `last LABEL`, got: {messages:?}"
+    );
+}
+
+#[test]
+fn redo_to_missing_label_warns() {
+    let source = r#"use v5.40;
+foreach my $item (@items) {
+    redo TOP;
+}
+"#;
+    let messages = pl410_messages(source);
+    assert!(
+        messages.iter().any(|m| m.contains("`redo TOP`") && m.contains("not defined in this file")),
+        "expected PL410 for missing `redo LABEL`, got: {messages:?}"
+    );
+}
+
+#[test]
+fn next_to_existing_label_is_allowed() {
+    let source = r#"use v5.40;
+OUTER: for my $i (1..10) {
+    INNER: for my $j (1..10) {
+        next OUTER if $j > 5;
+    }
+}
+"#;
+    let messages = pl410_messages(source);
+    assert!(messages.is_empty(), "`next` to a defined label should not warn, got: {messages:?}");
+}
+
+#[test]
+fn last_to_existing_label_is_allowed() {
+    let source = r#"use v5.40;
+LOOP: while (1) {
+    last LOOP;
+}
+"#;
+    let messages = pl410_messages(source);
+    assert!(
+        messages.is_empty(),
+        "`last LOOP` with defined label should not warn, got: {messages:?}"
+    );
+}
+
+#[test]
+fn redo_to_existing_label_is_allowed() {
+    let source = r#"use v5.40;
+RETRY: for my $x (@attempts) {
+    redo RETRY if $x->failed;
+}
+"#;
+    let messages = pl410_messages(source);
+    assert!(
+        messages.is_empty(),
+        "`redo RETRY` with defined label should not warn, got: {messages:?}"
+    );
+}
+
+#[test]
+fn bare_loop_control_is_always_allowed() {
+    let source = r#"use v5.40;
+while (1) {
+    next;
+    last;
+    redo;
+}
+"#;
+    let messages = pl410_messages(source);
+    assert!(
+        messages.is_empty(),
+        "bare next/last/redo should never trigger PL410, got: {messages:?}"
+    );
+}
+
+#[test]
+fn only_one_diagnostic_per_bad_loop_control() {
+    let source = r#"use v5.40;
+while (1) {
+    next MISSING;
+}
+"#;
+    let diags = pl410(source);
+    assert_eq!(
+        diags.len(),
+        1,
+        "expected exactly one PL410 diagnostic per offending statement, got {}: {diags:?}",
+        diags.len()
+    );
+}
+
+#[test]
+fn pl410_carries_actionable_suggestion() {
+    let source = r#"use v5.40;
+while (1) {
+    next MISSING;
+}
+"#;
+    let diags = pl410(source);
+    let suggestion = diags.first().and_then(|d| d.suggestion.as_deref()).unwrap_or_default();
+    assert!(
+        suggestion.contains("MISSING:") && suggestion.contains("next"),
+        "expected suggestion mentioning the missing label and a bare form, got: {suggestion:?}"
+    );
+}
+
+#[test]
+fn multiple_bad_loop_controls_each_reported() {
+    let source = r#"use v5.40;
+while (1) {
+    next ALPHA;
+    last BETA;
+}
+"#;
+    let messages = pl410_messages(source);
+    assert_eq!(messages.len(), 2, "expected one PL410 per offending statement, got: {messages:?}");
+    assert!(messages.iter().any(|m| m.contains("ALPHA")));
+    assert!(messages.iter().any(|m| m.contains("BETA")));
+}
+
+#[test]
+fn label_elsewhere_in_file_suppresses_warning() {
+    // The conservative rule (matching PL409) is "label exists anywhere in
+    // the file" — reachability is not analyzed, to avoid false positives
+    // from source filters and conditional code paths.
+    let source = r#"use v5.40;
+sub outer {
+    LATER: for my $x (1..3) { print $x; }
+}
+sub inner {
+    next LATER;  # referenced before the containing loop lexically
+}
+"#;
+    let messages = pl410_messages(source);
+    assert!(
+        messages.is_empty(),
+        "label defined anywhere in the file should suppress PL410, got: {messages:?}"
+    );
+}
+
+#[test]
+fn pl410_does_not_conflict_with_pl409() {
+    // Make sure adding PL410 doesn't break the existing goto-label lint.
+    let source = r#"use v5.40;
+goto MISSING_GOTO;
+while (1) {
+    next MISSING_LOOP;
+}
+"#;
+    let all = diagnostics_for(source);
+    let pl409s: Vec<_> = all.iter().filter(|d| d.code.as_deref() == Some("PL409")).collect();
+    let pl410s: Vec<_> = all.iter().filter(|d| d.code.as_deref() == Some("PL410")).collect();
+    assert_eq!(pl409s.len(), 1, "expected 1 PL409, got {pl409s:?}");
+    assert_eq!(pl410s.len(), 1, "expected 1 PL410, got {pl410s:?}");
+}


### PR DESCRIPTION
## Summary

Add **PL410** — a new conservative lint that flags `next LABEL`, `last LABEL`, and `redo LABEL` statements whose target label is not defined anywhere in the current file. This is the loop-control counterpart to the existing **PL409** (`goto LABEL` validation) and closes **#3372**.

At runtime Perl reports this as a fatal `Label not found for "next LABEL"` — surfacing it statically lets editors flag the problem before the program is run, matching the same "catch runtime errors at edit time" guarantee PL409 already provides for `goto`.

```perl
while (1) {
    next MISSING;   # PL410: `next MISSING` references a label that is not defined in this file
}
```

## Why this is worth shipping

- **Real Perl bug class, undetected today.** `next`/`last`/`redo` to a typo'd or removed label is a silent runtime-only failure. `perl -c` catches it, the LSP didn't.
- **Natural extension of existing infrastructure.** We already track labels in the `SymbolTable` (`SymbolKind::Label`), already walk the AST for diagnostics, and already have the PL409 goto-label lint as a template. The marginal cost is small and review surface is tight.
- **Conservative by construction.** Matches PL409's false-positive profile: warns only when the label does **not exist anywhere** in the file. Source filters, macros, and labels defined in code the parser can't see will not produce spurious warnings.
- **Every diagnostic carries a fix.** `message`, `related_information`, and `suggestion` all name the specific op and label; the suggestion includes both the "define the label" and "drop the label" remediation paths.

## What changed

| Crate | File | Change |
|---|---|---|
| `perl-diagnostics-codes` | `src/lib.rs` | Add `DiagnosticCode::LoopControlUndefinedLabel` → `"PL410"`, Warning severity, `BestPractices` category, docs URL, and context hint. All six lookup tables (`as_str`, `documentation_url`, `severity`, `parse_code`, `category`, `context_hint`) are kept consistent. |
| `perl-diagnostics-codes` | `tests/diagnostic_code_completeness.rs` | New `loop_control_undefined_label_code_exists` test asserting code string, severity, category, docs URL, `parse_code` round-trip, and presence of a context hint. |
| `perl-lsp-diagnostics` | `src/lints/loop_control_label.rs` | New lint module mirroring `goto_label.rs`: walks the AST, matches `NodeKind::LoopControl { op, label: Some(label_name) }` where `op ∈ {next, last, redo}`, warns when no matching `SymbolKind::Label` exists in the `SymbolTable`. |
| `perl-lsp-diagnostics` | `src/lints/mod.rs` | Register module, update the rustdoc diagnostic-code table. |
| `perl-lsp-diagnostics` | `src/diagnostics.rs` | Wire `check_loop_control_labels` into `DiagnosticsProvider::get_diagnostics_with_path`, directly after `check_goto_labels` (shared `SymbolTable`, no re-extraction). |
| `perl-lsp-diagnostics` | `tests/loop_control_label_tests.rs` | 12 new end-to-end tests via `DiagnosticsProvider`: positive and negative paths for each of `next`/`last`/`redo`, bare forms, forward references, multi-offender counts, suggestion content, and a cross-check ensuring PL410 does not cannibalise PL409. |

Total diff: **6 files, +349 / −1** (4 modified, 2 new).

## Design decisions

### Why file-scope (not scope-aware)?
A `next LABEL` must target an enclosing loop at runtime, so in principle we could warn even when the label exists elsewhere in the file. We deliberately match PL409's conservative "exists anywhere in the file" rule because:

1. **False positives are worse than misses for editor lints.** A label introduced by a source filter or declared inside a `BEGIN`-generated block would produce a wrong warning.
2. **Consistency.** Users who tuned out/accepted PL409's behaviour should get the same mental model for PL410.
3. **Cheap now, extensible later.** Once #3374 lands (scope-aware reachability for `LoopControl`), we can tighten PL410 without changing the code number or breaking filters.

`label_elsewhere_in_file_suppresses_warning` encodes this invariant as a test so any future tightening is explicit.

### Why bare forms are always allowed
`next;` / `last;` / `redo;` (no label) target the innermost enclosing loop unconditionally, and the parser already rejects them at top-level where they're meaningless (`next` outside a loop is a separate PL-class defect, out of scope here). Early-returning on `label.is_none()` keeps this lint single-purpose.

### Why reuse `SymbolTable`
`DiagnosticsProvider` already builds a `SymbolTable` via `SymbolExtractor::new_with_source(source).extract(ast)` and passes it into `check_goto_labels`. PL410 piggybacks on the same extraction — no extra AST walk for label collection, and no divergence between "what goto sees" and "what next/last/redo sees".

### Diagnostic shape
```rust
Diagnostic {
    range: (node.location.start, node.location.end),
    severity: Warning,
    code: Some("PL410".into()),
    message: "`next MISSING` references a label that is not defined in this file",
    related_information: vec![RelatedInformation {
        location: (node.location.start, node.location.end),
        message: "Add a matching `LABEL:` on an enclosing loop, or drop the label to target the innermost loop.",
    }],
    tags: vec![],
    suggestion: Some("Define a `MISSING:` label on the intended enclosing loop, or write `next;` to target the innermost loop"),
}
```

Range spans the full `LoopControl` node (consistent with how PL409 ranges the goto target) so the IDE squiggle covers `next MISSING` as a unit.

## Verification

```
✅ cargo test -p perl-diagnostics-codes                         30 passed
✅ cargo test -p perl-lsp-diagnostics --test loop_control_label_tests   12 passed
✅ cargo test -p perl-lsp-diagnostics --test goto_label_tests           3 passed  (regression guard)
✅ cargo test -p perl-lsp-diagnostics --test diagnostic_insta_snapshot_tests  76 passed
✅ cargo test -p perl-lsp-diagnostics --test diagnostic_snapshot_tests        14 passed
✅ cargo clippy -p perl-diagnostics-codes -p perl-lsp-diagnostics --tests --all-targets    clean
✅ cargo fmt                                                    clean
✅ cargo build -p perl-lsp-rs                                    end-to-end build
```

Note: the pre-existing `diagnostics_gold_suite` failure (20 fixtures load vs 25 subdirectories on `master`) is **unrelated to this PR** and reproduces on a fresh clone of `master`; no gold fixtures are touched here.

## Test coverage

The integration suite covers:

| # | Test | What it pins |
|---|---|---|
| 1 | `next_to_missing_label_warns` | Positive: PL410 fires for `next LABEL` when label is undefined |
| 2 | `last_to_missing_label_warns` | Positive: same for `last LABEL` |
| 3 | `redo_to_missing_label_warns` | Positive: same for `redo LABEL` |
| 4 | `next_to_existing_label_is_allowed` | Negative: nested loops with a defined `OUTER:` label — no warning |
| 5 | `last_to_existing_label_is_allowed` | Negative: defined `LOOP:` label — no warning |
| 6 | `redo_to_existing_label_is_allowed` | Negative: defined `RETRY:` label — no warning |
| 7 | `bare_loop_control_is_always_allowed` | Invariant: `next;`/`last;`/`redo;` never trigger PL410 |
| 8 | `only_one_diagnostic_per_bad_loop_control` | No dedup/duplication |
| 9 | `pl410_carries_actionable_suggestion` | `suggestion` field mentions the missing label and the bare form |
| 10 | `multiple_bad_loop_controls_each_reported` | Two offenders in one file → two diagnostics |
| 11 | `label_elsewhere_in_file_suppresses_warning` | Pins the conservative file-scope rule |
| 12 | `pl410_does_not_conflict_with_pl409` | Cross-lint regression: one PL409 + one PL410 in the same file |

## Follow-ups (intentionally not in this PR)

- **#3374** (scope-aware reachability for `LoopControl`): once landed, PL410 can be tightened to also warn when the label exists but is not on an enclosing loop. The conservative rule is a stepping stone, not a ceiling.
- **Docs site page** at `docs.perl-lsp.org/errors/PL410`: the URL is already registered via `documentation_url()` but the external docs site is authored out-of-tree.

## Scorecard impact (per #4062 / #4065)

PL410 lives in the **diagnostics correctness** scorecard:

- Adds one new pass to the diagnostics precision/recall surface (positive cases shown to trigger, negative cases shown not to trigger).
- No new false-positive paths introduced — conservative rule identical to the already-shipped PL409.
- Zero performance cost beyond a single pass over `LoopControl` nodes sharing PL409's already-built `SymbolTable`.

---

Closes #3372.