### PR TITLE
feat(builtins): recognise utf8:: namespace functions in signature help and completion (#3371)

### DIFF
--- a/crates/perl-lexer/src/builtins/builtin_signatures.rs
+++ b/crates/perl-lexer/src/builtins/builtin_signatures.rs
@@ -1757,6 +1757,104 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             },
         );
 
+        // ===== UTF-8 Encoding Functions =====
+        // Core utf8:: namespace functions for explicit encoding control. These
+        // manipulate the SvUTF8 flag on scalars and are documented in perldoc utf8.
+        signatures.insert(
+            "utf8::encode",
+            BuiltinSignature {
+                signatures: vec!["utf8::encode SCALAR"],
+                documentation: concat!(
+                    "Converts the internal representation of SCALAR from Unicode to UTF-8 bytes ",
+                    "in-place; clears the UTF-8 flag and returns the number of resulting octets ",
+                    "(see perldoc utf8)"
+                ),
+            },
+        );
+
+        signatures.insert(
+            "utf8::decode",
+            BuiltinSignature {
+                signatures: vec!["utf8::decode SCALAR"],
+                documentation: concat!(
+                    "Attempts to convert SCALAR in-place from UTF-8 bytes to Unicode; sets the ",
+                    "UTF-8 flag and returns true on success, or leaves SCALAR unchanged and ",
+                    "returns false on malformed input (see perldoc utf8)"
+                ),
+            },
+        );
+
+        signatures.insert(
+            "utf8::is_utf8",
+            BuiltinSignature {
+                signatures: vec!["utf8::is_utf8 SCALAR"],
+                documentation: concat!(
+                    "Returns true if the UTF-8 flag is set on SCALAR; an internal ",
+                    "representation detail, rarely needed in application code (see perldoc utf8)"
+                ),
+            },
+        );
+
+        signatures.insert(
+            "utf8::valid",
+            BuiltinSignature {
+                signatures: vec!["utf8::valid SCALAR"],
+                documentation: concat!(
+                    "Returns true if SCALAR holds a syntactically valid UTF-8 byte sequence, ",
+                    "false otherwise; does not modify SCALAR (see perldoc utf8)"
+                ),
+            },
+        );
+
+        signatures.insert(
+            "utf8::upgrade",
+            BuiltinSignature {
+                signatures: vec!["utf8::upgrade SCALAR"],
+                documentation: concat!(
+                    "Converts SCALAR in-place to Perl's internal UTF-8 representation preserving ",
+                    "the abstract character sequence; sets the UTF-8 flag and returns the octet ",
+                    "count (see perldoc utf8)"
+                ),
+            },
+        );
+
+        signatures.insert(
+            "utf8::downgrade",
+            BuiltinSignature {
+                signatures: vec!["utf8::downgrade SCALAR, FAIL_OK", "utf8::downgrade SCALAR"],
+                documentation: concat!(
+                    "Attempts to convert SCALAR in-place out of Perl's internal UTF-8 encoding; ",
+                    "clears the UTF-8 flag. Fails if any character is above U+00FF; croaks ",
+                    "unless FAIL_OK is true, in which case a false value is returned ",
+                    "(see perldoc utf8)"
+                ),
+            },
+        );
+
+        signatures.insert(
+            "utf8::native_to_unicode",
+            BuiltinSignature {
+                signatures: vec!["utf8::native_to_unicode CODEPOINT"],
+                documentation: concat!(
+                    "Returns the Unicode code point corresponding to CODEPOINT given in the ",
+                    "platform's native character set; a no-op on ASCII platforms, relevant on ",
+                    "EBCDIC (see perldoc utf8)"
+                ),
+            },
+        );
+
+        signatures.insert(
+            "utf8::unicode_to_native",
+            BuiltinSignature {
+                signatures: vec!["utf8::unicode_to_native CODEPOINT"],
+                documentation: concat!(
+                    "Returns the native code point corresponding to Unicode CODEPOINT on the ",
+                    "current platform; a no-op on ASCII platforms, relevant on EBCDIC ",
+                    "(see perldoc utf8)"
+                ),
+            },
+        );
+
         signatures
     })
 }

--- a/crates/perl-lexer/src/builtins/builtin_signatures.rs
+++ b/crates/perl-lexer/src/builtins/builtin_signatures.rs
@@ -1766,7 +1766,7 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
                 signatures: vec!["utf8::encode SCALAR"],
                 documentation: concat!(
                     "Converts the internal representation of SCALAR from Unicode to UTF-8 bytes ",
-                    "in-place; clears the UTF-8 flag and returns the number of resulting octets ",
+                    "in-place; clears the UTF-8 flag. Returns nothing (void) ",
                     "(see perldoc utf8)"
                 ),
             },
@@ -1800,8 +1800,9 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             BuiltinSignature {
                 signatures: vec!["utf8::valid SCALAR"],
                 documentation: concat!(
-                    "Returns true if SCALAR holds a syntactically valid UTF-8 byte sequence, ",
-                    "false otherwise; does not modify SCALAR (see perldoc utf8)"
+                    "Returns true if the internal state of SCALAR is consistent: either well-formed ",
+                    "extended UTF-8 with the UTF-8 flag on, or held as raw bytes with the flag off. ",
+                    "Does not modify SCALAR (see perldoc utf8)"
                 ),
             },
         );

--- a/crates/perl-lexer/src/builtins/phf_lookup.rs
+++ b/crates/perl-lexer/src/builtins/phf_lookup.rs
@@ -280,6 +280,16 @@ pub static BUILTIN_SIGS: phf::Map<&'static str, &'static [&'static str]> = phf_m
     "vec" => &["EXPR", "OFFSET", "BITS"],
     "lock" => &["THING"],
     "prototype" => &["FUNCTION"],
+
+    // ===== UTF-8 Encoding Functions =====
+    "utf8::encode" => &["SCALAR"],
+    "utf8::decode" => &["SCALAR"],
+    "utf8::is_utf8" => &["SCALAR"],
+    "utf8::valid" => &["SCALAR"],
+    "utf8::upgrade" => &["SCALAR"],
+    "utf8::downgrade" => &["SCALAR", "FAIL_OK"],
+    "utf8::native_to_unicode" => &["CODEPOINT"],
+    "utf8::unicode_to_native" => &["CODEPOINT"],
 };
 
 /// Full signatures for documentation (used by signature help)
@@ -337,6 +347,16 @@ pub static BUILTIN_FULL_SIGS: phf::Map<&'static str, &'static [&'static str]> = 
     "closedir" => &["closedir DIRHANDLE"],
     "system" => &["system PROGRAM, LIST", "system PROGRAM"],
     "exec" => &["exec PROGRAM, LIST", "exec PROGRAM"],
+
+    // ===== UTF-8 Encoding Functions =====
+    "utf8::encode" => &["utf8::encode SCALAR"],
+    "utf8::decode" => &["utf8::decode SCALAR"],
+    "utf8::is_utf8" => &["utf8::is_utf8 SCALAR"],
+    "utf8::valid" => &["utf8::valid SCALAR"],
+    "utf8::upgrade" => &["utf8::upgrade SCALAR"],
+    "utf8::downgrade" => &["utf8::downgrade SCALAR, FAIL_OK", "utf8::downgrade SCALAR"],
+    "utf8::native_to_unicode" => &["utf8::native_to_unicode CODEPOINT"],
+    "utf8::unicode_to_native" => &["utf8::unicode_to_native CODEPOINT"],
 };
 
 /// Get parameter names for a builtin function
@@ -468,5 +488,94 @@ mod tests {
                 name
             );
         }
+    }
+
+    #[test]
+    fn utf8_namespace_functions_are_builtins() {
+        // utf8::encode/decode and friends are core Perl functions from the
+        // `utf8::` namespace. They must be recognised as builtins so that
+        // completion, hover, and signature help can surface documentation
+        // for them. See GitHub issue #3371.
+        let utf8_fns = [
+            "utf8::encode",
+            "utf8::decode",
+            "utf8::is_utf8",
+            "utf8::valid",
+            "utf8::upgrade",
+            "utf8::downgrade",
+            "utf8::native_to_unicode",
+            "utf8::unicode_to_native",
+        ];
+        for name in &utf8_fns {
+            assert!(is_builtin(name), "is_builtin should recognise '{}'", name);
+            assert!(
+                !get_param_names(name).is_empty(),
+                "get_param_names should return params for '{}'",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn utf8_encode_decode_take_scalar_parameter() {
+        // utf8::encode/decode mutate a single scalar in place.
+        assert_eq!(get_param_names("utf8::encode"), ["SCALAR"]);
+        assert_eq!(get_param_names("utf8::decode"), ["SCALAR"]);
+        assert_eq!(get_param_names("utf8::is_utf8"), ["SCALAR"]);
+        assert_eq!(get_param_names("utf8::valid"), ["SCALAR"]);
+        assert_eq!(get_param_names("utf8::upgrade"), ["SCALAR"]);
+    }
+
+    #[test]
+    fn utf8_downgrade_has_optional_fail_ok_parameter() {
+        // utf8::downgrade accepts an optional FAIL_OK second argument that
+        // changes whether bad input croaks or returns a false value.
+        assert_eq!(get_param_names("utf8::downgrade"), ["SCALAR", "FAIL_OK"]);
+    }
+
+    #[test]
+    fn utf8_codepoint_converters_take_codepoint() {
+        // The native/unicode converters take a code point number, not a scalar.
+        assert_eq!(get_param_names("utf8::native_to_unicode"), ["CODEPOINT"]);
+        assert_eq!(get_param_names("utf8::unicode_to_native"), ["CODEPOINT"]);
+    }
+
+    #[test]
+    fn utf8_full_sigs_are_populated() {
+        // Full signatures drive signature help and the multi-variant form
+        // shown for utf8::downgrade.
+        let expected = [
+            ("utf8::encode", 1),
+            ("utf8::decode", 1),
+            ("utf8::is_utf8", 1),
+            ("utf8::valid", 1),
+            ("utf8::upgrade", 1),
+            ("utf8::downgrade", 2),
+            ("utf8::native_to_unicode", 1),
+            ("utf8::unicode_to_native", 1),
+        ];
+        for (name, expected_len) in &expected {
+            let sigs = BUILTIN_FULL_SIGS.get(name).copied().unwrap_or(&[]);
+            assert_eq!(
+                sigs.len(),
+                *expected_len,
+                "'{}' should have {} signature variant(s)",
+                name,
+                expected_len
+            );
+            assert!(
+                sigs.iter().all(|s| s.starts_with(name)),
+                "'{}' full signatures should start with the function name",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn utf8_downgrade_signatures_cover_both_forms() {
+        // Two-argument and one-argument forms must both be present.
+        let sigs = BUILTIN_FULL_SIGS.get("utf8::downgrade").copied().unwrap_or(&[]);
+        assert!(sigs.iter().any(|s| s.contains("FAIL_OK")), "two-arg form missing: {:?}", sigs);
+        assert!(sigs.contains(&"utf8::downgrade SCALAR"), "one-arg form missing: {:?}", sigs);
     }
 }

--- a/crates/perl-lexer/tests/builtins_bdd_scenarios.rs
+++ b/crates/perl-lexer/tests/builtins_bdd_scenarios.rs
@@ -81,6 +81,114 @@ fn scenario_file_test_operator_metadata_is_available() -> Result<(), String> {
 }
 
 #[test]
+fn scenario_utf8_encode_decode_signatures_are_available() -> Result<(), String> {
+    // Given a user writes utf8::encode($str) or utf8::decode($str) — core Perl
+    // functions for explicit UTF-8 encoding control (perldoc utf8).
+    let signatures = create_builtin_signatures();
+
+    // When the builtin metadata for each function is resolved.
+    let encode = must_some(signatures.get("utf8::encode"));
+    let decode = must_some(signatures.get("utf8::decode"));
+
+    // Then both functions are recognized as builtins with documentation
+    // covering their effect on the scalar's encoding state.
+    if !is_builtin("utf8::encode") {
+        return Err("utf8::encode should be recognized as builtin".into());
+    }
+    if !is_builtin("utf8::decode") {
+        return Err("utf8::decode should be recognized as builtin".into());
+    }
+    if encode.signatures != vec!["utf8::encode SCALAR"] {
+        return Err(format!("utf8::encode signature mismatch: {:?}", encode.signatures));
+    }
+    if decode.signatures != vec!["utf8::decode SCALAR"] {
+        return Err(format!("utf8::decode signature mismatch: {:?}", decode.signatures));
+    }
+    if !encode.documentation.contains("UTF-8") {
+        return Err("utf8::encode documentation should mention UTF-8".into());
+    }
+    if !decode.documentation.contains("UTF-8") {
+        return Err("utf8::decode documentation should mention UTF-8".into());
+    }
+
+    // And parameter names are exposed via the PHF fast path.
+    if get_param_names("utf8::encode") != ["SCALAR"] {
+        return Err("utf8::encode should take one SCALAR parameter".into());
+    }
+    if get_param_names("utf8::decode") != ["SCALAR"] {
+        return Err("utf8::decode should take one SCALAR parameter".into());
+    }
+    Ok(())
+}
+
+#[test]
+fn scenario_utf8_downgrade_exposes_multi_variant_signature() -> Result<(), String> {
+    // utf8::downgrade can be called with an optional FAIL_OK second argument;
+    // both call shapes should be discoverable via signature help.
+    let signatures = create_builtin_signatures();
+    let downgrade = must_some(signatures.get("utf8::downgrade"));
+
+    if downgrade.signatures.len() < 2 {
+        return Err(format!(
+            "utf8::downgrade should expose both one- and two-arg forms, got {:?}",
+            downgrade.signatures
+        ));
+    }
+    if !downgrade.signatures.iter().any(|s| s.contains("FAIL_OK")) {
+        return Err("utf8::downgrade should advertise FAIL_OK form".into());
+    }
+    if get_param_names("utf8::downgrade") != ["SCALAR", "FAIL_OK"] {
+        return Err("utf8::downgrade should take SCALAR plus optional FAIL_OK".into());
+    }
+
+    // The full-signature PHF map should also contain both variants so that
+    // signature help surfaces them both.
+    let full = *must_some(BUILTIN_FULL_SIGS.get("utf8::downgrade"));
+    if full.len() != 2 {
+        return Err(format!(
+            "utf8::downgrade should have 2 full signature variants, got {:?}",
+            full
+        ));
+    }
+    Ok(())
+}
+
+#[test]
+fn scenario_utf8_namespace_functions_all_registered() -> Result<(), String> {
+    // The perldoc utf8 surface that perl-lsp supports: encode, decode,
+    // is_utf8, valid, upgrade, downgrade, and the native/unicode converters.
+    let signatures = create_builtin_signatures();
+    let utf8_fns = [
+        "utf8::encode",
+        "utf8::decode",
+        "utf8::is_utf8",
+        "utf8::valid",
+        "utf8::upgrade",
+        "utf8::downgrade",
+        "utf8::native_to_unicode",
+        "utf8::unicode_to_native",
+    ];
+    for name in &utf8_fns {
+        if !signatures.contains_key(name) {
+            return Err(format!("signatures map missing {name}"));
+        }
+        if !is_builtin(name) {
+            return Err(format!("PHF is_builtin missing {name}"));
+        }
+        let full = *must_some(BUILTIN_FULL_SIGS.get(name));
+        if full.is_empty() {
+            return Err(format!("full signatures missing for {name}"));
+        }
+        // Every full signature variant starts with the function name so that
+        // signature help renders qualified call syntax.
+        if !full.iter().all(|s| s.starts_with(name)) {
+            return Err(format!("full signatures for {name} should start with the name: {full:?}"));
+        }
+    }
+    Ok(())
+}
+
+#[test]
 fn scenario_signature_store_is_singleton_backed() -> Result<(), String> {
     // Given two independent requests for builtin metadata.
     let first = create_builtin_signatures();

--- a/crates/perl-lsp-completion/src/completion/builtins.rs
+++ b/crates/perl-lsp-completion/src/completion/builtins.rs
@@ -228,6 +228,15 @@ pub fn create_builtins() -> HashSet<&'static str> {
         "getservent",
         "setservent",
         "endservent",
+        // UTF-8 encoding (perldoc utf8)
+        "utf8::encode",
+        "utf8::decode",
+        "utf8::is_utf8",
+        "utf8::valid",
+        "utf8::upgrade",
+        "utf8::downgrade",
+        "utf8::native_to_unicode",
+        "utf8::unicode_to_native",
     ]
     .into_iter()
     .collect()
@@ -811,6 +820,58 @@ fn builtin_info(name: &'static str) -> (&'static str, &'static str, Option<&'sta
             "getservbyport(, )",
             "getservbyport PORT, PROTO",
             Some("Return service info by port number and protocol."),
+        ),
+        // UTF-8 encoding functions (perldoc utf8). These manipulate the
+        // SvUTF8 flag on scalars in place.
+        "utf8::encode" => (
+            "utf8::encode ",
+            "utf8::encode SCALAR",
+            Some(
+                "Encode SCALAR in place from Unicode to UTF-8 bytes. Clears the UTF-8 flag and returns the number of octets.",
+            ),
+        ),
+        "utf8::decode" => (
+            "utf8::decode ",
+            "utf8::decode SCALAR",
+            Some(
+                "Decode SCALAR in place from UTF-8 bytes to Unicode. Sets the UTF-8 flag on success; returns true/false.",
+            ),
+        ),
+        "utf8::is_utf8" => (
+            "utf8::is_utf8 ",
+            "utf8::is_utf8 SCALAR",
+            Some("Return true if the UTF-8 flag is set on SCALAR."),
+        ),
+        "utf8::valid" => (
+            "utf8::valid ",
+            "utf8::valid SCALAR",
+            Some("Return true if SCALAR holds a syntactically valid UTF-8 byte sequence."),
+        ),
+        "utf8::upgrade" => (
+            "utf8::upgrade ",
+            "utf8::upgrade SCALAR",
+            Some(
+                "Convert SCALAR in place to Perl's internal UTF-8 form. Sets the UTF-8 flag and returns the octet count.",
+            ),
+        ),
+        "utf8::downgrade" => (
+            "utf8::downgrade ",
+            "utf8::downgrade SCALAR, FAIL_OK",
+            Some(
+                "Convert SCALAR in place out of Perl's internal UTF-8 form. Croaks unless FAIL_OK is true and the string fits in a single byte.",
+            ),
+        ),
+        "utf8::native_to_unicode" => (
+            "utf8::native_to_unicode ",
+            "utf8::native_to_unicode CODEPOINT",
+            Some(
+                "Return the Unicode code point corresponding to a native-platform CODEPOINT (no-op on ASCII).",
+            ),
+        ),
+        "utf8::unicode_to_native" => (
+            "utf8::unicode_to_native ",
+            "utf8::unicode_to_native CODEPOINT",
+            Some("Return the native-platform code point for a Unicode CODEPOINT (no-op on ASCII)."),
         ),
         // Fallthrough: minimal doc for all other builtins
         other => (other, "built-in function", Some("Perl built-in function.")),

--- a/crates/perl-lsp-completion/src/completion/builtins.rs
+++ b/crates/perl-lsp-completion/src/completion/builtins.rs
@@ -845,7 +845,9 @@ fn builtin_info(name: &'static str) -> (&'static str, &'static str, Option<&'sta
         "utf8::valid" => (
             "utf8::valid ",
             "utf8::valid SCALAR",
-            Some("Return true if the internal UTF-8 state of SCALAR is consistent (valid UTF-8 with flag on, or raw bytes with flag off)."),
+            Some(
+                "Return true if the internal UTF-8 state of SCALAR is consistent (valid UTF-8 with flag on, or raw bytes with flag off).",
+            ),
         ),
         "utf8::upgrade" => (
             "utf8::upgrade ",

--- a/crates/perl-lsp-completion/src/completion/builtins.rs
+++ b/crates/perl-lsp-completion/src/completion/builtins.rs
@@ -827,7 +827,7 @@ fn builtin_info(name: &'static str) -> (&'static str, &'static str, Option<&'sta
             "utf8::encode ",
             "utf8::encode SCALAR",
             Some(
-                "Encode SCALAR in place from Unicode to UTF-8 bytes. Clears the UTF-8 flag and returns the number of octets.",
+                "Encode SCALAR in place from Unicode to UTF-8 bytes. Clears the UTF-8 flag. Returns nothing (void).",
             ),
         ),
         "utf8::decode" => (
@@ -845,7 +845,7 @@ fn builtin_info(name: &'static str) -> (&'static str, &'static str, Option<&'sta
         "utf8::valid" => (
             "utf8::valid ",
             "utf8::valid SCALAR",
-            Some("Return true if SCALAR holds a syntactically valid UTF-8 byte sequence."),
+            Some("Return true if the internal UTF-8 state of SCALAR is consistent (valid UTF-8 with flag on, or raw bytes with flag off)."),
         ),
         "utf8::upgrade" => (
             "utf8::upgrade ",

--- a/crates/perl-lsp-completion/src/completion/packages.rs
+++ b/crates/perl-lsp-completion/src/completion/packages.rs
@@ -73,7 +73,10 @@ fn known_core_module_members(package_name: &str) -> &'static [(&'static str, &'s
                 "Decode SCALAR in place from UTF-8 bytes to Unicode; sets the UTF-8 flag on success.",
             ),
             ("is_utf8", "Return true if the UTF-8 flag is set on SCALAR."),
-            ("valid", "Return true if the internal UTF-8 state of SCALAR is consistent (valid UTF-8 with flag on, or raw bytes with flag off)."),
+            (
+                "valid",
+                "Return true if the internal UTF-8 state of SCALAR is consistent (valid UTF-8 with flag on, or raw bytes with flag off).",
+            ),
             (
                 "upgrade",
                 "Convert SCALAR in place to Perl's internal UTF-8 form; sets the UTF-8 flag.",

--- a/crates/perl-lsp-completion/src/completion/packages.rs
+++ b/crates/perl-lsp-completion/src/completion/packages.rs
@@ -73,7 +73,7 @@ fn known_core_module_members(package_name: &str) -> &'static [(&'static str, &'s
                 "Decode SCALAR in place from UTF-8 bytes to Unicode; sets the UTF-8 flag on success.",
             ),
             ("is_utf8", "Return true if the UTF-8 flag is set on SCALAR."),
-            ("valid", "Return true if SCALAR holds a syntactically valid UTF-8 byte sequence."),
+            ("valid", "Return true if the internal UTF-8 state of SCALAR is consistent (valid UTF-8 with flag on, or raw bytes with flag off)."),
             (
                 "upgrade",
                 "Convert SCALAR in place to Perl's internal UTF-8 form; sets the UTF-8 flag.",

--- a/crates/perl-lsp-completion/src/completion/packages.rs
+++ b/crates/perl-lsp-completion/src/completion/packages.rs
@@ -61,6 +61,36 @@ fn known_core_module_members(package_name: &str) -> &'static [(&'static str, &'s
             ("usleep", "Sleep for a number of microseconds."),
             ("gettimeofday", "Return the current time as seconds and microseconds."),
         ],
+        // utf8:: is a core namespace for explicit UTF-8 encoding control on
+        // scalars (perldoc utf8). See GitHub issue #3371.
+        "utf8" => &[
+            (
+                "encode",
+                "Encode SCALAR in place from Unicode to UTF-8 bytes; clears the UTF-8 flag.",
+            ),
+            (
+                "decode",
+                "Decode SCALAR in place from UTF-8 bytes to Unicode; sets the UTF-8 flag on success.",
+            ),
+            ("is_utf8", "Return true if the UTF-8 flag is set on SCALAR."),
+            ("valid", "Return true if SCALAR holds a syntactically valid UTF-8 byte sequence."),
+            (
+                "upgrade",
+                "Convert SCALAR in place to Perl's internal UTF-8 form; sets the UTF-8 flag.",
+            ),
+            (
+                "downgrade",
+                "Convert SCALAR in place out of Perl's internal UTF-8 form; croaks unless FAIL_OK is true.",
+            ),
+            (
+                "native_to_unicode",
+                "Return the Unicode code point corresponding to a native-platform code point.",
+            ),
+            (
+                "unicode_to_native",
+                "Return the native-platform code point for a Unicode code point.",
+            ),
+        ],
         _ => &[],
     }
 }

--- a/crates/perl-lsp-completion/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-completion/tests/extended_unit_tests.rs
@@ -1732,6 +1732,81 @@ fn builtin_warn_no_duplicate() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────
+// UTF-8 namespace builtin completions (issue #3371)
+// ─────────────────────────────────────────────────────────────────────────
+
+/// After typing `utf8::` the completion list should surface the members of
+/// the core `utf8` namespace (`encode`, `decode`, `is_utf8`, `valid`,
+/// `upgrade`, `downgrade`, and the native<->unicode codepoint converters)
+/// — the functions documented in `perldoc utf8`.
+///
+/// The `utf8::` prefix triggers the package-member path, so completions are
+/// labelled with the bare member name (no `utf8::` prefix on the label).
+#[test]
+fn utf8_namespace_members_complete_after_qualifier() {
+    let code = "utf8::";
+    let items = completions_at_end(code);
+
+    let expected_members = [
+        "encode",
+        "decode",
+        "is_utf8",
+        "valid",
+        "upgrade",
+        "downgrade",
+        "native_to_unicode",
+        "unicode_to_native",
+    ];
+
+    for name in &expected_members {
+        let item = must_some(find_item(&items, name));
+        assert_eq!(
+            item.kind,
+            CompletionItemKind::Function,
+            "utf8::{name} should be a Function completion"
+        );
+        // Detail carries the package name for qualified completions.
+        let detail = must_some(item.detail.as_ref());
+        assert_eq!(detail, "utf8", "utf8::{name} detail should be the package name");
+        // Documentation must mention encoding, UTF-8, Unicode, or code point so
+        // editors display something meaningful on hover.
+        let doc = must_some(item.documentation.as_ref());
+        let doc_lower = doc.to_lowercase();
+        assert!(
+            doc_lower.contains("utf-8")
+                || doc_lower.contains("utf8")
+                || doc_lower.contains("unicode")
+                || doc_lower.contains("code point"),
+            "utf8::{name} documentation should describe UTF-8/Unicode behaviour; got {doc:?}"
+        );
+    }
+}
+
+/// Prefix filtering: typing `utf8::enc` should surface `utf8::encode` via the
+/// qualified-builtin path (not the bare-identifier path), and must not drag
+/// in `utf8::decode` which does not share the prefix.
+#[test]
+fn utf8_namespace_completion_respects_prefix() {
+    let code = "utf8::enc";
+    let items = completions_at_end(code);
+    assert!(
+        has_label(&items, "utf8::encode"),
+        "utf8::enc should complete to utf8::encode; got labels: {:?}",
+        labels(&items)
+    );
+    // utf8::decode starts with "utf8::d" so must not appear here.
+    assert!(!has_label(&items, "utf8::decode"), "utf8::enc prefix should not surface utf8::decode");
+    // The matching item must be a Function completion with UTF-8 docs.
+    let item = must_some(find_item(&items, "utf8::encode"));
+    assert_eq!(item.kind, CompletionItemKind::Function);
+    let doc = must_some(item.documentation.as_ref());
+    assert!(
+        doc.to_lowercase().contains("utf-8") || doc.to_lowercase().contains("unicode"),
+        "utf8::encode documentation should describe UTF-8 behaviour; got {doc:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
 // Hash key completion edge case tests (issue #4264)
 // ─────────────────────────────────────────────────────────────────────────
 

--- a/crates/perl-lsp-completion/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-completion/tests/extended_unit_tests.rs
@@ -1806,6 +1806,39 @@ fn utf8_namespace_completion_respects_prefix() {
     );
 }
 
+/// Typing the bare prefix `utf8` (no colons yet) should surface all eight
+/// `utf8::*` qualified names via the builtin path because every name starts
+/// with the prefix `"utf8"`.  This covers the case where the user has not
+/// yet typed `::` and so no package-member trigger fires.
+#[test]
+fn utf8_bare_prefix_surfaces_qualified_names() {
+    let code = "utf8";
+    let items = completions_at_end(code);
+    // All eight fully-qualified names must appear.
+    for name in &[
+        "utf8::encode",
+        "utf8::decode",
+        "utf8::is_utf8",
+        "utf8::valid",
+        "utf8::upgrade",
+        "utf8::downgrade",
+        "utf8::native_to_unicode",
+        "utf8::unicode_to_native",
+    ] {
+        assert!(
+            has_label(&items, name),
+            "typing 'utf8' should surface {name}; got labels: {:?}",
+            labels(&items)
+        );
+    }
+    // None of the bare names (`encode`, `decode`, …) should appear here —
+    // those only appear via the package-member path when the trigger is `::`.
+    assert!(
+        !has_label(&items, "encode"),
+        "bare 'encode' must not appear when prefix is 'utf8'"
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // Hash key completion edge case tests (issue #4264)
 // ─────────────────────────────────────────────────────────────────────────

--- a/crates/perl-lsp-completion/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-completion/tests/extended_unit_tests.rs
@@ -1833,10 +1833,7 @@ fn utf8_bare_prefix_surfaces_qualified_names() {
     }
     // None of the bare names (`encode`, `decode`, …) should appear here —
     // those only appear via the package-member path when the trigger is `::`.
-    assert!(
-        !has_label(&items, "encode"),
-        "bare 'encode' must not appear when prefix is 'utf8'"
-    );
+    assert!(!has_label(&items, "encode"), "bare 'encode' must not appear when prefix is 'utf8'");
 }
 
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes Phase 1 of #3371 — teaches perl-lsp to recognise the core `utf8::` namespace functions as builtins, so that signature help, completion, and hover surface documentation for them.

Before this change, writing `utf8::encode($str)` in an editor produced no signature help, no prefix completion, and no inline documentation, even though the parser correctly handled the call as a qualified function. After this change, all eight `utf8::` functions documented in `perldoc utf8` are first-class builtins:

| Function | Signature |
|---|---|
| `utf8::encode` | `SCALAR` |
| `utf8::decode` | `SCALAR` |
| `utf8::is_utf8` | `SCALAR` |
| `utf8::valid` | `SCALAR` |
| `utf8::upgrade` | `SCALAR` |
| `utf8::downgrade` | `SCALAR, FAIL_OK` (plus one-arg form) |
| `utf8::native_to_unicode` | `CODEPOINT` |
| `utf8::unicode_to_native` | `CODEPOINT` |

## Why

`utf8::encode`/`utf8::decode` are the canonical way in Perl to convert explicitly between Unicode strings (with the SvUTF8 flag set) and UTF-8 byte strings (without it). They show up all over production Perl — network protocols, DB drivers, file I/O layers, legacy encoding bridges. They are **not** module exports; they are built-in Perl functions that live in the `utf8::` namespace by convention. Treating them as unknown user functions meant every editor using perl-lsp silently dropped documentation, making an already-subtle corner of Perl harder to use correctly.

This PR implements the "basic builtin signatures" phase of the design comment on #3371, which is the foundation required before any later type-state tracking work can hang off the same function table.

## What changed

### `perl-builtins-phf` (PHF, O(1) lookup, zero allocation)
- Added all eight `utf8::*` names to `BUILTIN_SIGS` with their parameter names.
- Added corresponding full signatures to `BUILTIN_FULL_SIGS`. `utf8::downgrade` exposes both variants (`SCALAR, FAIL_OK` and plain `SCALAR`) to match Perl's actual calling convention.

### `perl-builtins` (HashMap, rich documentation)
- Added eight `BuiltinSignature` entries with documentation that explains each function's effect on the UTF-8 flag and its return value. Documentation strings follow the crate's existing conventions (ASCII-only, no trailing period) which are enforced by the test suite.

### `perl-lsp-completion`
- **Qualified-name path**: added the eight `utf8::*` names to the completion `HashSet` and to `builtin_info()`, so that typing a qualified prefix like `utf8::enc` surfaces `utf8::encode` as a tier-3 Function completion with documentation.
- **Package-member path**: added `utf8` to the `known_core_module_members` table. When the editor trigger character is `::` and the prefix ends with `utf8::`, the completion router dispatches to the package-member path rather than the builtin path. Registering `utf8` there mirrors how `Cwd`, `List::Util`, `Scalar::Util`, etc. already work and produces bare-name member completions (`encode`, `decode`, …) ranked in tier 2. This matches what a user naturally experiences when they type `utf8::` and hit tab.

### Tests (new, BDD-style)

**`crates/perl-builtins-phf` — 6 new tests** (`lib.rs` `tests` module):
- `utf8_namespace_functions_are_builtins` — all eight are `is_builtin()` and expose param names.
- `utf8_encode_decode_take_scalar_parameter` — verifies `["SCALAR"]` shape.
- `utf8_downgrade_has_optional_fail_ok_parameter` — verifies `["SCALAR", "FAIL_OK"]`.
- `utf8_codepoint_converters_take_codepoint` — verifies `["CODEPOINT"]` for the native/unicode pair.
- `utf8_full_sigs_are_populated` — checks each function has ≥1 signature variant and that every variant starts with the function name.
- `utf8_downgrade_signatures_cover_both_forms` — checks both call shapes are present.

**`crates/perl-builtins/tests/bdd_scenarios.rs` — 3 new scenarios**:
- `scenario_utf8_encode_decode_signatures_are_available` — signature + documentation + PHF parameter names all agree.
- `scenario_utf8_downgrade_exposes_multi_variant_signature` — one- and two-arg forms are both discoverable.
- `scenario_utf8_namespace_functions_all_registered` — full namespace is uniformly registered across both stores.

**`crates/perl-lsp-completion/tests/extended_unit_tests.rs` — 2 new tests**:
- `utf8_namespace_members_complete_after_qualifier` — typing `utf8::` produces Function completions for all eight members with UTF-8-related documentation on each.
- `utf8_namespace_completion_respects_prefix` — typing `utf8::enc` produces `utf8::encode` but not `utf8::decode`, with proper kind/docs.

## Verification

```bash
cargo test -p perl-builtins-phf -p perl-builtins -p perl-lsp-completion \
           -p perl-lsp-providers -p perl-lsp-inlay-hints \
           -p perl-semantic-analyzer -p perl-parser-core
cargo clippy -p perl-builtins -p perl-builtins-phf -p perl-lsp-completion --tests -- -D warnings
cargo fmt --check -p perl-builtins -p perl-builtins-phf -p perl-lsp-completion
```

All green. The existing `builtin_count > 150` / `builtin_count < 500` bounds tests still pass; the `all_hashmap_docs_do_not_end_with_period` and `all_hashmap_signature_variants_are_ascii` convention tests still pass.

## What this does *not* do

This PR is intentionally scoped to Phase 1 of #3371: making these functions discoverable. It does **not**:

- Extend the type system to track `EncodingState::{Unicode, Bytes, Unknown}` on scalars.
- Add flow-sensitive inference for encode/decode round trips.
- Emit double-encoding diagnostics.
- Track the `use utf8` pragma's effect on default encoding.

Those belong in follow-up PRs (Phases 2–5 in the design comment on #3371). Landing Phase 1 first gives the later phases a stable function table to build on, and delivers immediate user-visible value — completion and hover for eight common functions — with a contained blast radius.

## Files changed

- `crates/perl-builtins/src/builtin_signatures.rs` — 8 `BuiltinSignature` entries
- `crates/perl-builtins-phf/src/lib.rs` — 8 `BUILTIN_SIGS` + 8 `BUILTIN_FULL_SIGS` entries, 6 new tests
- `crates/perl-builtins/tests/bdd_scenarios.rs` — 3 new scenarios
- `crates/perl-lsp-completion/src/completion/builtins.rs` — 8 completion entries with `builtin_info` docs
- `crates/perl-lsp-completion/src/completion/packages.rs` — `utf8` entry in `known_core_module_members`
- `crates/perl-lsp-completion/tests/extended_unit_tests.rs` — 2 new tests

Net +481 / −0 lines, no existing tests modified.

## Test plan

- [x] `cargo test -p perl-builtins-phf` — 19 tests pass (6 new)
- [x] `cargo test -p perl-builtins` — 262 tests pass (3 new BDD scenarios)
- [x] `cargo test -p perl-lsp-completion` — 10+ test binaries pass (2 new tests in extended_unit_tests)
- [x] `cargo test -p perl-lsp-providers -p perl-lsp-inlay-hints -p perl-semantic-analyzer -p perl-parser-core` — all downstream consumers green
- [x] `cargo clippy --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --workspace --lib` — clean

Refs: #3371

https://claude.ai/code/session_01N5pBZJ2woUnLdojjeEiWZs