### PR TITLE
fix(hover): associate inline POD inside sub bodies with subroutine hover (#3407)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
@@ -1557,6 +1557,191 @@ sub process {
     }
 
     #[test]
+    fn test_subroutine_with_inline_pod_in_body_hover() -> Result<(), Box<dyn std::error::Error>> {
+        // Inline POD inside a subroutine body (rare but valid Perl) should be
+        // associated with the subroutine for hover documentation. See issue #3407.
+        //
+        // Per perlpod, POD directives must start at column 0 — the block below
+        // temporarily drops out of the sub body for documentation and resumes
+        // with `=cut`, which is a legitimate Perl idiom.
+        let code = r#"sub process_data {
+=pod
+
+Internal documentation for this sub.
+
+=cut
+
+    my $data = shift;
+    return $data * 2;
+}
+"#;
+        let mut parser = Parser::new(code);
+        let ast = parser.parse()?;
+        let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+        let sub_symbols =
+            analyzer.symbol_table().find_symbol("process_data", 0, SymbolKind::Subroutine);
+        assert!(!sub_symbols.is_empty(), "Should find sub process_data");
+
+        let hover = analyzer.hover_at(sub_symbols[0].location);
+        assert!(hover.is_some(), "Should have hover for sub process_data");
+
+        let hover = hover.unwrap();
+        assert!(
+            hover.signature.contains("sub process_data"),
+            "Hover should show sub signature, got: {}",
+            hover.signature
+        );
+        let doc = hover
+            .documentation
+            .as_ref()
+            .ok_or("Sub hover should include documentation from inline POD in body")?;
+        assert!(
+            doc.contains("Internal documentation"),
+            "Sub hover should contain inline POD body text, got: {}",
+            doc
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_subroutine_prefers_preceding_pod_over_inline_pod()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // When POD precedes the sub AND inline POD exists in the body,
+        // the preceding POD takes precedence (it is the idiomatic doc location).
+        let code = r#"=head2 outer
+
+Preceding doc for process_data.
+
+=cut
+
+sub process_data {
+=pod
+
+Inline doc inside body.
+
+=cut
+
+    my $data = shift;
+    return $data;
+}
+"#;
+        let mut parser = Parser::new(code);
+        let ast = parser.parse()?;
+        let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+        let sub_symbols =
+            analyzer.symbol_table().find_symbol("process_data", 0, SymbolKind::Subroutine);
+        assert!(!sub_symbols.is_empty(), "Should find sub process_data");
+
+        let hover = analyzer.hover_at(sub_symbols[0].location).ok_or("hover missing")?;
+        let doc = hover.documentation.as_ref().ok_or("documentation missing")?;
+        assert!(doc.contains("Preceding doc"), "Preceding POD should take precedence, got: {doc}");
+        assert!(
+            !doc.contains("Inline doc"),
+            "Inline body POD should not be used when preceding POD exists, got: {doc}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_method_with_inline_pod_in_body_hover() -> Result<(), Box<dyn std::error::Error>> {
+        // `method` declarations inside a `class` block share the sub-body POD path.
+        let code = r#"class Foo {
+    method bar {
+=pod
+
+Inline doc for method bar.
+
+=cut
+
+        return 1;
+    }
+}
+"#;
+        let mut parser = Parser::new(code);
+        let ast = parser.parse()?;
+        let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+        // Locate the "method bar" hover via the method name position.
+        let bar_pos = code.find("method bar").ok_or("method bar not found")?;
+        let hover = analyzer
+            .hover_info
+            .iter()
+            .find(|(loc, _)| loc.start <= bar_pos && loc.end > bar_pos)
+            .map(|(_, h)| h)
+            .ok_or("hover missing for method bar")?;
+
+        assert!(
+            hover.signature.contains("method bar"),
+            "hover signature should be 'method bar', got: {}",
+            hover.signature
+        );
+        let doc = hover.documentation.as_ref().ok_or("documentation missing")?;
+        assert!(
+            doc.contains("Inline doc for method bar"),
+            "Method hover should contain inline POD body text, got: {doc}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_subroutine_without_any_pod_has_no_documentation()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // No preceding or inline POD — documentation must remain None so that
+        // downstream consumers can distinguish "no doc" from "empty doc".
+        let code = r#"sub plain {
+    return 1;
+}
+"#;
+        let mut parser = Parser::new(code);
+        let ast = parser.parse()?;
+        let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+        let sub_symbols = analyzer.symbol_table().find_symbol("plain", 0, SymbolKind::Subroutine);
+        assert!(!sub_symbols.is_empty(), "Should find sub plain");
+
+        let hover = analyzer.hover_at(sub_symbols[0].location).ok_or("hover missing")?;
+        assert!(
+            hover.documentation.is_none(),
+            "Hover documentation should be None for a sub with no POD, got: {:?}",
+            hover.documentation
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_subroutine_with_head_inline_pod_in_body() -> Result<(), Box<dyn std::error::Error>> {
+        // An =head-style POD block (not =pod) inside a sub body should also be
+        // recognised, matching how the preceding-POD path works.
+        let code = r#"sub calculate {
+=head2 calculate
+
+Performs a calculation.
+
+=cut
+
+    return 42;
+}
+"#;
+        let mut parser = Parser::new(code);
+        let ast = parser.parse()?;
+        let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+        let sub_symbols =
+            analyzer.symbol_table().find_symbol("calculate", 0, SymbolKind::Subroutine);
+        assert!(!sub_symbols.is_empty(), "Should find sub calculate");
+
+        let hover = analyzer.hover_at(sub_symbols[0].location).ok_or("hover missing")?;
+        let doc = hover.documentation.as_ref().ok_or("documentation missing")?;
+        assert!(
+            doc.contains("Performs a calculation"),
+            "Inline =head2 POD body text should be captured, got: {doc}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_variable_hover_shows_declaration_type() -> Result<(), Box<dyn std::error::Error>> {
         let code = r#"my $count = 42;
 my @items = (1, 2, 3);

--- a/crates/perl-semantic-analyzer/src/analysis/semantic/node_analysis.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/node_analysis.rs
@@ -138,7 +138,11 @@ impl SemanticAnalyzer {
 
                     let hover = HoverInfo {
                         signature: signature_str,
-                        documentation: self.extract_documentation(node.location.start),
+                        documentation: self.extract_sub_documentation(
+                            node.location.start,
+                            body.location.start,
+                            body.location.end,
+                        ),
                         details: if attributes.is_empty() {
                             vec![]
                         } else {
@@ -173,7 +177,11 @@ impl SemanticAnalyzer {
 
                     let hover = HoverInfo {
                         signature: signature_str,
-                        documentation: self.extract_documentation(node.location.start),
+                        documentation: self.extract_sub_documentation(
+                            node.location.start,
+                            body.location.start,
+                            body.location.end,
+                        ),
                         details,
                     };
 
@@ -205,7 +213,11 @@ impl SemanticAnalyzer {
                 // Add hover info
                 let hover = HoverInfo {
                     signature: format!("method {}", name),
-                    documentation: self.extract_documentation(node.location.start),
+                    documentation: self.extract_sub_documentation(
+                        node.location.start,
+                        body.location.start,
+                        body.location.end,
+                    ),
                     details: if attributes.is_empty() {
                         vec![]
                     } else {
@@ -947,6 +959,46 @@ impl SemanticAnalyzer {
         }
 
         None
+    }
+
+    /// Extract documentation for a subroutine-like node (sub, method).
+    ///
+    /// First falls back to [`extract_documentation`](Self::extract_documentation)
+    /// which searches for POD or comments immediately preceding the node. If no
+    /// doc is found there, this method also searches *inside* the body for an
+    /// inline POD block — a rare but valid Perl idiom used when code and
+    /// narrative documentation live together.
+    ///
+    /// See issue #3407.
+    pub(super) fn extract_sub_documentation(
+        &self,
+        start: usize,
+        body_start: usize,
+        body_end: usize,
+    ) -> Option<String> {
+        self.extract_documentation(start).or_else(|| self.find_pod_in_range(body_start, body_end))
+    }
+
+    /// Find the first POD block inside `[start, end)` and return its text.
+    ///
+    /// Per perlpod, POD directives must begin at column 0 (line start) with
+    /// `=` followed by an ASCII alphanumeric, and the block ends with a line
+    /// beginning with `=cut`. We require both anchors so indented text that
+    /// merely resembles POD does not produce false positives.
+    pub(super) fn find_pod_in_range(&self, start: usize, end: usize) -> Option<String> {
+        static POD_INLINE_RE: OnceLock<Result<Regex, regex::Error>> = OnceLock::new();
+
+        if self.source.is_empty() || end <= start || end > self.source.len() {
+            return None;
+        }
+
+        let slice = &self.source[start..end];
+        let pod_re = POD_INLINE_RE
+            .get_or_init(|| Regex::new(r"(?ms)^(=[a-zA-Z0-9].*?\n=cut\b)"))
+            .as_ref()
+            .ok()?;
+
+        pod_re.captures(slice).and_then(|caps| caps.get(1)).map(|m| m.as_str().trim().to_string())
     }
 
     /// Extract the POD `=head1 NAME` section for a package.


### PR DESCRIPTION
## Summary

Closes #3407.

POD blocks that live **inside** a subroutine body (a rare but legitimate Perl idiom — the "literate programming" style where narrative documentation sits alongside the code it describes) were silently dropped from hover. The existing `extract_documentation` helper only searches the source text *before* a node's start offset, so it could never see `=pod … =cut` appearing after the opening brace.

This PR teaches the semantic analyzer to fall back to an **in-body** POD scan for subroutine-like nodes when no preceding POD or comment block is found. Preceding POD continues to win — it's the idiomatic documentation location — so no existing hover output changes.

## Example

Before this change, hovering `process_data` returned no documentation. After it, the hover now includes "Internal documentation for this sub":

```perl
sub process_data {
=pod

Internal documentation for this sub.

=cut

    my $data = shift;
    return $data * 2;
}
```

## What changed

`crates/perl-semantic-analyzer/src/analysis/semantic/node_analysis.rs`

- **New** `extract_sub_documentation(node_start, body_start, body_end)` — thin wrapper that first calls the existing `extract_documentation(node_start)` and, only if that returns `None`, falls back to an in-body POD scan via the new helper. Preceding POD → inline POD is the precedence rule.
- **New** `find_pod_in_range(start, end)` — scans a byte range for the first `(?ms)^(=[a-zA-Z0-9].*?\n=cut\b)` POD block. The regex requires both the opening directive and `=cut` to be anchored at column 0 (per `perlpod`), so indented text that happens to contain an `=` cannot produce a false positive. The compiled regex is cached in a `OnceLock` to match the pattern used by `extract_documentation`.
- Wired the new helper into three hover sites that previously called `extract_documentation(node.location.start)` directly:
  - `NodeKind::Subroutine` named sub (line 141)
  - `NodeKind::Subroutine` anonymous sub / closure (line 176)
  - `NodeKind::Method` (line 208)

No other call sites changed — variable, package, and list-variable hovers still use the preceding-text search, which is correct for them.

## Why this design

The issue template suggested a separate `extract_sub_documentation` that composes preceding + in-body lookups. I followed that structure because:

1. **Precedence is explicit and testable** — preceding POD wins, in-body POD is strictly a fallback. This matches the test for `test_subroutine_prefers_preceding_pod_over_inline_pod`.
2. **No regression surface for non-sub nodes** — only callers that pass a body range opt into the in-body scan. Variable/package hovers are untouched.
3. **Body range is already available** — `NodeKind::Subroutine` and `NodeKind::Method` both carry a `body: Box<Node>`, so we reuse its `location.start..location.end` rather than re-walking the AST.
4. **Column-0 anchoring** — real Perl POD *must* start at column 0. Anchoring the regex at line boundaries (`(?m)^=…`) avoids matching things like `my $x = "=pod"` or indented fake-POD inside string literals.

## Tests

Added 5 new tests under `crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs`:

| Test | What it proves |
|------|---------------|
| `test_subroutine_with_inline_pod_in_body_hover` | `=pod … =cut` inside the body surfaces in hover documentation. |
| `test_subroutine_with_head_inline_pod_in_body` | `=head2 … =cut` (not just `=pod`) is recognised — any POD directive works. |
| `test_subroutine_prefers_preceding_pod_over_inline_pod` | Precedence rule: preceding POD takes priority, inline POD is never shown when a preceding block exists. |
| `test_method_with_inline_pod_in_body_hover` | Regression guard for the `NodeKind::Method` path used by `class … { method … }` blocks. |
| `test_subroutine_without_any_pod_has_no_documentation` | Negative test: a plain sub still yields `documentation: None` so downstream consumers can distinguish "no doc" from "empty doc". |

All new tests were verified red-before-green (confirmed failing prior to the implementation change), then green after. The full `perl-semantic-analyzer` suite (~700 tests across lib + integration targets) passes.

## Verification

```
$ cargo test -p perl-semantic-analyzer --lib
test result: ok. 121 passed; 0 failed; 0 ignored

$ cargo test -p perl-semantic-analyzer      # lib + all integration targets
test result: ok. (all green)

$ cargo test -p perl-lsp-providers --lib
test result: ok. 4 passed; 0 failed

$ cargo test -p perl-parser --lib
test result: ok. 12 passed; 0 failed

$ cargo clippy -p perl-semantic-analyzer --lib
Finished (clean)

$ cargo fmt -p perl-semantic-analyzer -- --check
(clean)
```

*Note:* `cargo clippy -p perl-semantic-analyzer --lib --tests` surfaces two `expect_used` errors in `tests/frameworks_web.rs:343,345` — these are pre-existing on `master` and unrelated to this change (the file is untouched by this PR).

## Risk assessment

- **Scope:** strictly additive to the hover documentation path; no change to semantic tokens, symbol extraction, scope analysis, or any other consumer.
- **Non-sub hovers:** untouched. Variable/package/import hovers still use `extract_documentation` directly.
- **Perf:** one extra regex run *per sub hover*, and only when no preceding POD exists. The regex is cached in a `OnceLock` like the existing one. Body scans are bounded by the sub body's byte range.
- **False positives:** prevented by requiring both `=<alpha>` and `=cut` to start at column 0.
- **Backward compat:** every sub that previously returned a documentation string still returns the same string (preceding POD still wins). This can only *add* documentation where there was none; it cannot change existing hover output.

## Follow-ups (out of scope, not required for merge)

- Consider applying the same fallback to comment-style docs inside sub bodies (unusual, but mechanically similar).
- Consider a `#[ignore]`-removal follow-up for the pre-existing `frameworks_web.rs` clippy violations.

Fixes #3407.