### PR TITLE
fix(hover): surface inline POD inside sub bodies + stop POD leak between decls (#3407)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/semantic/node_analysis.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/node_analysis.rs
@@ -138,7 +138,9 @@ impl SemanticAnalyzer {
 
                     let hover = HoverInfo {
                         signature: signature_str,
-                        documentation: self.extract_documentation(node.location.start),
+                        documentation: self
+                            .extract_documentation(node.location.start)
+                            .or_else(|| self.extract_pod_in_range(body.location)),
                         details: if attributes.is_empty() {
                             vec![]
                         } else {
@@ -173,7 +175,9 @@ impl SemanticAnalyzer {
 
                     let hover = HoverInfo {
                         signature: signature_str,
-                        documentation: self.extract_documentation(node.location.start),
+                        documentation: self
+                            .extract_documentation(node.location.start)
+                            .or_else(|| self.extract_pod_in_range(body.location)),
                         details,
                     };
 
@@ -205,7 +209,9 @@ impl SemanticAnalyzer {
                 // Add hover info
                 let hover = HoverInfo {
                     signature: format!("method {}", name),
-                    documentation: self.extract_documentation(node.location.start),
+                    documentation: self
+                        .extract_documentation(node.location.start)
+                        .or_else(|| self.extract_pod_in_range(body.location)),
                     details: if attributes.is_empty() {
                         vec![]
                     } else {
@@ -918,9 +924,17 @@ impl SemanticAnalyzer {
         }
         let before = &self.source[..start];
 
-        // Check for POD blocks ending with =cut
+        // Check for POD blocks ending with =cut immediately before `start`.
+        //
+        // The anchor must be true end-of-string (`\z`), not end-of-line: with
+        // multi-line mode `$` matches at every `\n`, which would allow a POD
+        // block buried earlier in the file to "leak" forward and attach to a
+        // later declaration that has no documentation of its own. `\z` makes
+        // the match specifically "POD block followed only by whitespace up to
+        // `start`". Dotall (`(?s)`) is still required so `.*?` can span lines
+        // within the POD block.
         let pod_re = POD_RE
-            .get_or_init(|| Regex::new(r"(?ms)(=[a-zA-Z0-9].*?\n=cut\n?)\s*$"))
+            .get_or_init(|| Regex::new(r"(?s)(=[a-zA-Z0-9].*?\n=cut\n?)\s*\z"))
             .as_ref()
             .ok()?;
         if let Some(caps) = pod_re.captures(before) {
@@ -944,6 +958,70 @@ impl SemanticAnalyzer {
                     .join(" ");
                 return Some(doc);
             }
+        }
+
+        None
+    }
+
+    /// Extract the first POD block inside a source range.
+    ///
+    /// This is the companion to [`extract_documentation`], which only looks
+    /// *before* a position. For subroutine and method bodies we also want to
+    /// pick up POD embedded *inside* the body (issue #3407) — a valid and
+    /// occasional Perl idiom where a sub's documentation lives next to its
+    /// implementation rather than preceding its declaration.
+    ///
+    /// POD blocks in Perl are recognised only when the `=<directive>` line
+    /// starts at column 0 (enforced by `perl-lexer`). The scan therefore
+    /// requires each `=` to follow a newline (or sit at position 0), which
+    /// avoids matching a literal `=pod` that appears inside a string or an
+    /// expression.
+    ///
+    /// Returns the POD text (from the opening directive through `=cut`,
+    /// trimmed) or `None` when the range contains no POD block.
+    pub(super) fn extract_pod_in_range(&self, range: SourceLocation) -> Option<String> {
+        let start = range.start;
+        let end = range.end;
+        if self.source.is_empty() || start >= end || end > self.source.len() {
+            return None;
+        }
+        let bytes = self.source.as_bytes();
+
+        // Scan for a line-starting `=<directive>` within [start, end).
+        let mut i = start;
+        while i < end {
+            let at_line_start = i == 0 || bytes[i - 1] == b'\n';
+            if at_line_start
+                && bytes[i] == b'='
+                && i + 1 < end
+                && bytes[i + 1].is_ascii_alphabetic()
+            {
+                // Confirm this is a POD directive (word-like after `=`). The
+                // lexer also recognises `=for`, `=encoding`, etc., but any
+                // alphabetic directive is treated as POD start.
+                let pod_start = i;
+
+                // Scan forward for a line starting with `=cut` within the range.
+                let mut j = pod_start;
+                while j < end {
+                    let line_start = j == 0 || bytes[j - 1] == b'\n';
+                    if line_start && bytes[j..end.min(bytes.len())].starts_with(b"=cut") {
+                        // Advance j to end of `=cut` line so the returned
+                        // text includes the closing directive.
+                        let mut k = j + 4;
+                        while k < end && bytes[k] != b'\n' {
+                            k += 1;
+                        }
+                        let text = self.source.get(pod_start..k)?.trim().to_string();
+                        return Some(text);
+                    }
+                    j += 1;
+                }
+                // Opening directive found but no `=cut` in range — treat as
+                // no well-formed POD block and stop scanning.
+                return None;
+            }
+            i += 1;
         }
 
         None

--- a/crates/perl-semantic-analyzer/tests/pod_in_sub_body_hover_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/pod_in_sub_body_hover_tests.rs
@@ -1,0 +1,185 @@
+//! Hover documentation tests for POD embedded *inside* subroutine bodies.
+//!
+//! Perl permits POD blocks anywhere a statement is valid, including inside a
+//! `sub { ... }` body. Historically the semantic analyzer only looked backwards
+//! from the subroutine's start position to collect docs — so inline POD was
+//! dropped on the floor. Issue #3407 tracks this gap.
+//!
+//! POD in Perl must start at column 0 (the `=<directive>` line has no leading
+//! whitespace); the lexer in `perl-lexer` enforces that rule. These tests use
+//! column-0 POD directives accordingly and verify that the analyzer falls back
+//! to scanning the subroutine body for inline POD when no preceding doc block
+//! is present.
+
+use perl_semantic_analyzer::Parser;
+use perl_semantic_analyzer::analysis::semantic::SemanticAnalyzer;
+use perl_tdd_support::{must, must_some};
+
+fn sub_hover_doc(code: &str, sub_name: &str) -> Option<String> {
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+    let symbols = analyzer.symbol_table().find_symbol(
+        sub_name,
+        0,
+        perl_semantic_analyzer::analysis::symbol::SymbolKind::Subroutine,
+    );
+    let symbol = symbols.first()?;
+    let hover = analyzer.hover_at(symbol.location)?;
+    hover.documentation.clone()
+}
+
+#[test]
+fn pod_inline_in_sub_body_surfaces_in_hover() {
+    let code = "sub process_data {
+=pod
+
+Internal documentation for this sub
+
+=cut
+    my $data = shift;
+    return $data;
+}
+";
+    let doc = must_some(sub_hover_doc(code, "process_data"));
+    assert!(
+        doc.contains("Internal documentation for this sub"),
+        "hover doc should include inline POD content; got: {doc:?}"
+    );
+}
+
+#[test]
+fn pod_head1_inside_sub_body_surfaces_in_hover() {
+    let code = "sub compute {
+=head1 DESCRIPTION
+
+Computes a value from the arguments.
+
+=cut
+    return 42;
+}
+";
+    let doc = must_some(sub_hover_doc(code, "compute"));
+    assert!(
+        doc.contains("Computes a value from the arguments"),
+        "hover doc should include inline =head1 POD content; got: {doc:?}"
+    );
+}
+
+#[test]
+fn preceding_comment_wins_over_inline_pod() {
+    // Preceding documentation remains the canonical source when both are
+    // present — the inline POD is only a fallback.
+    let code = "# Adds two numbers together
+sub add {
+=pod
+
+Internal details nobody should read.
+
+=cut
+    my ($x, $y) = @_;
+    return $x + $y;
+}
+";
+    let doc = must_some(sub_hover_doc(code, "add"));
+    assert!(
+        doc.contains("Adds two numbers together"),
+        "preceding comment should win; got: {doc:?}"
+    );
+    assert!(
+        !doc.contains("Internal details nobody should read"),
+        "preceding comment should suppress inline POD fallback; got: {doc:?}"
+    );
+}
+
+#[test]
+fn preceding_pod_wins_over_inline_pod() {
+    let code = "=head1 NAME
+
+pick - returns the first element
+
+=cut
+sub pick {
+=pod
+
+fallback text
+
+=cut
+    return shift;
+}
+";
+    let doc = must_some(sub_hover_doc(code, "pick"));
+    assert!(
+        doc.contains("pick - returns the first element"),
+        "preceding POD should win over inline POD; got: {doc:?}"
+    );
+}
+
+#[test]
+fn sub_without_any_pod_has_no_doc() {
+    // Regression guard: subs with no documentation in or before the body
+    // should continue to report `None`, not an empty string or a stray match.
+    let code = "sub plain {
+    my $x = shift;
+    return $x;
+}
+";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+    let symbols = analyzer.symbol_table().find_symbol(
+        "plain",
+        0,
+        perl_semantic_analyzer::analysis::symbol::SymbolKind::Subroutine,
+    );
+    let symbol = must_some(symbols.first());
+    let hover = must_some(analyzer.hover_at(symbol.location));
+    assert!(
+        hover.documentation.is_none(),
+        "sub with no documentation should report no hover doc; got: {:?}",
+        hover.documentation
+    );
+}
+
+#[test]
+fn pod_in_body_does_not_bleed_to_later_sub() {
+    // When sub A has inline POD, sub B should not accidentally inherit it.
+    let code = "sub first {
+=pod
+
+Documents first only.
+
+=cut
+    return 1;
+}
+
+sub second {
+    return 2;
+}
+";
+    let first_doc = must_some(sub_hover_doc(code, "first"));
+    assert!(
+        first_doc.contains("Documents first only"),
+        "first's hover should include its inline POD; got: {first_doc:?}"
+    );
+
+    // second has no POD of its own. Its hover entry exists, but its
+    // documentation should not contain first's inline POD.
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+    let symbols = analyzer.symbol_table().find_symbol(
+        "second",
+        0,
+        perl_semantic_analyzer::analysis::symbol::SymbolKind::Subroutine,
+    );
+    let symbol = must_some(symbols.first());
+    let hover = must_some(analyzer.hover_at(symbol.location));
+    assert!(
+        hover.documentation.as_deref().is_none_or(|d| !d.contains("Documents first only")),
+        "second should not inherit first's inline POD; got: {:?}",
+        hover.documentation
+    );
+}


### PR DESCRIPTION
Closes #3407.

## Summary

Two related hover-documentation fixes in `perl-semantic-analyzer`:

1. **Inline POD inside subroutine bodies is now surfaced as hover docs.** Perl permits `=pod...=cut` blocks anywhere a statement is valid, including inside a `sub { ... }` body. The analyzer previously only searched *backwards* from a subroutine's start position, so inline POD was silently dropped.
2. **The backward POD search no longer leaks a POD block from earlier in the file.** The existing `extract_documentation` regex used a multi-line `$` anchor, which matched at every newline — allowing a POD block buried inside an earlier sub body to satisfy the anchor when the analyzer searched backwards from a later sub. Now anchored to true end-of-string (`\z`).

Both changes show up on the **editor-intelligence scorecard** (#4066): hover correctness for subroutine/method symbols, with no false-positive doc attribution.

## Why this matters

Hover docs are one of the highest-frequency LSP interactions. Before this PR:

- A `sub foo { =pod … =cut ... }` returned no documentation on hover even though the module author clearly documented the sub.
- A module with a single documented top-level `sub first { =pod ... =cut }` would cause every *following* undocumented sub in the same file to display `first`'s POD as its own hover — a silent but user-visible correctness bug in the pre-existing `extract_documentation` implementation. This was latent for any file with inline POD plus additional subs below it.

Fixing both together is necessary: without the regex fix, the new inline-POD fallback has nothing to fall back *to* for clean cases because the buggy backward search matches earlier POD first.

## Root cause

`crates/perl-semantic-analyzer/src/analysis/semantic/node_analysis.rs`

### 1. `extract_documentation` never searched inside bodies

```rust
pub(super) fn extract_documentation(&self, start: usize) -> Option<String> {
    // ...
    let before = &self.source[..start];   // only ever looks *backwards*
    // ...
}
```

For `Subroutine { body, .. }` and `Method { body, .. }` nodes we had the byte range of the body available but never consulted it.

### 2. The POD regex used `(?ms)...\s*$`

```rust
Regex::new(r"(?ms)(=[a-zA-Z0-9].*?\n=cut\n?)\s*$")
```

Under multi-line mode, `$` matches at *every* `\n`. So for a file like:

```perl
sub first {
=pod
Docs for first.
=cut
    return 1;
}
sub second { return 2; }
```

when looking backwards from `sub second`, the engine happily matched `=pod\n...\n=cut` followed by `\s*` (zero-width) followed by `$` at the newline immediately after `=cut\n` — three lines earlier — and returned `first`'s POD as `second`'s documentation.

## Fix

### New helper: `extract_pod_in_range(SourceLocation) -> Option<String>`

Scans `source[range.start..range.end]` for the first column-0 POD directive (`=pod`, `=head1`, `=over`, etc.) and the matching `=cut`. Implemented as a small byte-level walker (not a regex) because:

- It needs explicit column-0 anchoring: POD is recognised by `perl-lexer` only when the `=` follows a newline or sits at position 0. A regex with `(?m)^` would get the column-0 check, but we'd still need manual range bounds handling, and the byte walker is straightforward and readable.
- It keeps the `OnceLock<Regex>` count stable (no new cached regex at startup).
- The hot path is bounded by body length, so a single linear byte scan is appropriate.

Wired in at three hover emission sites, using the `extract_documentation` preceding-doc result as the primary source and `extract_pod_in_range(body.location)` as the fallback:

- Named subroutines
- Anonymous subroutines (closures)
- Methods (`method foo { ... }`)

### Regex fix: `(?s)...\s*\z`

Swapped `(?ms)...\s*$` for `(?s)...\s*\z`. `\z` matches only true end-of-string regardless of flags, so the anchor now means what the original author intended: "POD block immediately before `start` with only whitespace in between." Dotall (`(?s)`) is preserved so `.*?` can span lines within a POD block.

## Behaviour matrix

| File shape | Before | After |
|---|---|---|
| `# comment \n sub foo { ... }` | `# comment` | `# comment` ✅ |
| `=pod ... =cut \n sub foo { ... }` | POD block | POD block ✅ |
| `sub foo { =pod Internal =cut; my $x = ...; }` | *no doc* | Inline POD surfaced ✅ |
| `# comment \n sub add { =pod Internal =cut; ... }` | `# comment` | `# comment` (preceding wins) ✅ |
| `sub first { =pod … =cut ... } sub second { ... }` | `second` inherits `first`'s POD 🐛 | `second` has no doc ✅ |
| `sub plain { my $x = ... }` | `None` | `None` ✅ (regression guard) |

## Test plan

New test file `crates/perl-semantic-analyzer/tests/pod_in_sub_body_hover_tests.rs` with six targeted cases:

- [x] `pod_inline_in_sub_body_surfaces_in_hover` — inline `=pod`/`=cut` attaches to its sub
- [x] `pod_head1_inside_sub_body_surfaces_in_hover` — same, with `=head1` directive
- [x] `preceding_comment_wins_over_inline_pod` — fallback precedence
- [x] `preceding_pod_wins_over_inline_pod` — fallback precedence (POD variant)
- [x] `sub_without_any_pod_has_no_doc` — no phantom docs on bare subs
- [x] `pod_in_body_does_not_bleed_to_later_sub` — regression guard for the regex bug

All pass; full `perl-semantic-analyzer` suite (≈775 tests across 25 binaries) is green, and `cargo build -p perl-lsp-rs` succeeds.

```bash
cargo test -p perl-semantic-analyzer --test pod_in_sub_body_hover_tests   # 6/6 pass
cargo test -p perl-semantic-analyzer                                      # all green
cargo clippy -p perl-semantic-analyzer --lib --test pod_in_sub_body_hover_tests   # clean
cargo fmt --check -p perl-semantic-analyzer                               # clean
cargo build -p perl-lsp-rs                                                # green
```

Pre-existing clippy `expect_used` errors in `tests/frameworks_web.rs` and a `map_or`→`is_none_or` warning in `tests/frameworks_catalyst.rs` are unrelated to this PR (verified via `git diff` — those files are unchanged here).

## Scope

Touches two files only:

- `crates/perl-semantic-analyzer/src/analysis/semantic/node_analysis.rs` — `extract_pod_in_range` helper, POD regex anchor fix, three hover sites get the fallback
- `crates/perl-semantic-analyzer/tests/pod_in_sub_body_hover_tests.rs` — new test file

No public API changes; the new helper is `pub(super)`. No dependency changes. No docs regeneration needed (metrics are computed post-merge).

## Related

- Closes #3407 ("POD inside subroutine bodies not associated with subroutine hover")
- Improves signal for the editor-intelligence scorecard (#4066) — hover correctness row
