### PR TITLE
feat(release): source GitHub Release body from docs/releases/vX.Y.Z.md (#4355)

### DIFF
--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -126,6 +126,22 @@ jobs:
 
           echo "✅ Changelog checked"
 
+      - name: Verify curated release notes exist
+        run: |
+          TAG="${{ steps.resolve.outputs.tag }}"
+          NOTE_FILE="docs/releases/${TAG}.md"
+          if [ ! -f "$NOTE_FILE" ]; then
+            echo "::error file=$NOTE_FILE::Release notes file missing: $NOTE_FILE"
+            echo "::error::Every release must ship a curated note at docs/releases/${TAG}.md before tagging."
+            echo "::error::See RELEASE.md \"Release History Updates\" for the template."
+            exit 1
+          fi
+          if ! head -1 "$NOTE_FILE" | grep -q '^---$'; then
+            echo "::error file=$NOTE_FILE::Release notes must open with a YAML frontmatter block (---)."
+            exit 1
+          fi
+          echo "✅ Found curated release notes: $NOTE_FILE"
+
       - name: Summary
         run: |
           echo "## Release Validation Complete :white_check_mark:" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,41 +240,29 @@ jobs:
           cd ..
           cat SHA256SUMS
 
-      - name: Generate release notes
+      - name: Verify curated release notes exist
+        id: release_notes_preflight
+        run: |
+          TAG="${{ needs.release-metadata.outputs.tag }}"
+          NOTE_FILE="docs/releases/${TAG}.md"
+          if [ ! -f "$NOTE_FILE" ]; then
+            echo "::error file=$NOTE_FILE::Curated release notes missing for ${TAG}. See RELEASE.md \"Release History Updates\" — every release must ship docs/releases/${TAG}.md before tagging."
+            exit 1
+          fi
+          echo "note_file=$NOTE_FILE" >> "$GITHUB_OUTPUT"
+          echo "✅ Found curated release notes: $NOTE_FILE"
+
+      - name: Generate release notes from docs/releases/<tag>.md
         id: release_notes
         run: |
-          VERSION="${{ needs.release-metadata.outputs.version }}"
-          cat > release_notes.md << EOF
-          ## Perl LSP ${VERSION}
-
-          This release ships the binaries and the docs needed to install, configure, and troubleshoot the current release line.
-
-          ### Install or upgrade
-
-          ```bash
-          cargo install perllsp
-          cargo install perl-dap
-          ```
-
-          ### Read this first
-
-          - [Docs home](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/README.md)
-          - [Docs index](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/INDEX.md)
-          - [Getting Started](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/tutorials/GETTING_STARTED.md)
-          - [Installation Guide](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/how-to/INSTALLATION.md)
-          - [Editor Setup](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/how-to/EDITOR_SETUP.md)
-          - [Troubleshooting](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/how-to/TROUBLESHOOTING.md)
-
-          ### Release assets
-
-          - Platform binaries are attached to this release.
-          - Verify downloads with the consolidated \`SHA256SUMS\` file.
-
-          ### Change log
-
-          See the [CHANGELOG](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/CHANGELOG.md) for the full release history.
-          EOF
+          TAG="${{ needs.release-metadata.outputs.tag }}"
+          # xtask strips YAML frontmatter and emits the curated body. The
+          # command fails hard if the note file is missing — the earlier
+          # preflight step makes that a clearer error message in the UI.
+          cargo xtask release-notes --tag "$TAG" --output release_notes.md
+          echo "--- release_notes.md ---"
           cat release_notes.md
+          echo "--- /release_notes.md ---"
 
       - name: Create GitHub Release
         if: github.event_name == 'workflow_dispatch'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -430,12 +430,22 @@ Every public release **must** update three surfaces. See [RELEASE_HISTORY.md](RE
 
 ### Before publishing
 
-- [ ] Create `docs/releases/vX.Y.Z.md` (use an existing file as template)
+- [ ] Create `docs/releases/vX.Y.Z.md` (use an existing file as template).
+  **Required** — `release-orchestration.yml` refuses to tag without this file,
+  and `release.yml` uses its body (minus YAML frontmatter) as the GitHub
+  Release body.
 - [ ] Add a new row to `RELEASE_HISTORY.md` for vX.Y.Z (fill what you know; mark unknowns with `—`)
 - [ ] Ensure `CHANGELOG.md` has a `[X.Y.Z]` section with links to:
   - `docs/releases/vX.Y.Z.md`
   - GitHub Release URL
   - Compare range `vPrev...vX.Y.Z`
+- [ ] Preview the extracted release body locally before dispatching the workflow:
+  ```bash
+  cargo xtask release-notes --tag vX.Y.Z
+  ```
+  What the command prints is exactly what will become the GitHub Release
+  body. GitHub then appends its auto-generated "What's Changed" PR list
+  below that body (via `generate_release_notes: true` in `release.yml`).
 
 ### After publishing
 
@@ -464,6 +474,12 @@ grep 'X.Y.Z' RELEASE_HISTORY.md
 # 3. CHANGELOG section exists
 grep '\[X.Y.Z\]' CHANGELOG.md
 
-# 4. GitHub Release matches
+# 4. Curated body parses cleanly (frontmatter strips, body non-empty)
+cargo xtask release-notes --tag vX.Y.Z > /tmp/body.md && test -s /tmp/body.md
+
+# 5. GitHub Release matches
 gh release view vX.Y.Z --json tagName,assets --jq '{tag: .tagName, assets: [.assets[].name]}'
+
+# 6. GitHub Release body starts with the curated content (not a PR dump)
+gh release view vX.Y.Z --json body --jq '.body' | head -1   # should be "# vX.Y.Z"
 ```

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -500,6 +500,28 @@ enum Commands {
         yes: bool,
     },
 
+    /// Extract the curated release body from `docs/releases/<tag>.md`.
+    ///
+    /// Reads the file, strips its YAML frontmatter, and emits the body to
+    /// stdout (or to `--output` if provided). Used by the `release.yml`
+    /// workflow to drive GitHub Release bodies from the curated per-release
+    /// notes that ship in the repo.
+    ReleaseNotes {
+        /// Release tag (e.g. `v0.12.4`). A bare version like `0.12.4` is
+        /// accepted and normalized to `v0.12.4`.
+        #[arg(long)]
+        tag: String,
+
+        /// Optional output file. When omitted, the body is written to stdout.
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Override the repository root used to resolve `docs/releases/`.
+        /// Intended as a testing seam; the release workflow never passes this.
+        #[arg(long, hide = true)]
+        root: Option<PathBuf>,
+    },
+
     /// Trigger PR-driven release orchestration workflow
     ReleaseTurnkey {
         /// Release version (preferred: use `--version`; positional is also accepted).
@@ -1274,6 +1296,7 @@ fn main() -> Result<()> {
             parse_rust::run(source, sexp, ast, bench)
         }
         Commands::Release { version, yes } => release::run(version, yes),
+        Commands::ReleaseNotes { tag, output, root } => release_notes::run(tag, output, root),
         Commands::ReleaseTurnkey {
             version,
             positional_version,

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -56,6 +56,7 @@ pub mod publish;
 pub mod publish_receipts;
 pub mod receipts;
 pub mod release;
+pub mod release_notes;
 pub mod release_turnkey;
 pub mod srp_microcrates;
 pub mod swarm_summary;

--- a/xtask/src/tasks/release_notes.rs
+++ b/xtask/src/tasks/release_notes.rs
@@ -1,0 +1,320 @@
+//! Extract curated release-note bodies from `docs/releases/<tag>.md`.
+//!
+//! Release note files follow a fixed convention:
+//!
+//! ```text
+//! ---
+//! version: "X.Y.Z"
+//! tag: "vX.Y.Z"
+//! ...
+//! ---
+//!
+//! # vX.Y.Z
+//!
+//! ## Summary
+//! ...
+//! ```
+//!
+//! This task reads such a file and emits the body (everything after the closing
+//! `---` of the YAML frontmatter) so the release workflow can use it as the
+//! `body_path` for the GitHub Release.
+//!
+//! The command is intentionally strict: if the file is missing, or the
+//! frontmatter opens without closing, we fail loudly. A release without a
+//! curated note file is a pipeline bug, not a silent fall-through to
+//! auto-generated PR lists (see issue #4340).
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Result, WrapErr, bail};
+
+use crate::utils::project_root;
+
+/// Strip a leading YAML frontmatter block (delimited by `---` lines) from
+/// `content` and return the trailing body.
+///
+/// Behavior:
+/// - If the first non-empty line is `---`, a frontmatter block is expected and
+///   must terminate with another `---` line. Everything between is discarded.
+/// - One blank line immediately after the closing `---` is also consumed so
+///   the returned body starts at the first real content line.
+/// - If no frontmatter is present, the whole content is returned unchanged.
+/// - A frontmatter block that opens but never closes is a hard error.
+pub fn extract_body(content: &str) -> Result<&str> {
+    // Locate the first non-empty line — it must be `---` to open a frontmatter
+    // block. If it's anything else, treat the whole file as body.
+    let mut cursor = 0usize;
+    let bytes = content.as_bytes();
+
+    // Skip a single leading UTF-8 BOM if present.
+    if content.starts_with('\u{feff}') {
+        cursor += '\u{feff}'.len_utf8();
+    }
+
+    // Skip leading blank lines before the frontmatter delimiter.
+    let scan_start = cursor;
+    let mut pos = scan_start;
+    while pos < bytes.len() {
+        let line_end = find_line_end(content, pos);
+        let line = &content[pos..line_end];
+        if line.trim().is_empty() {
+            pos = advance_past_newline(content, line_end);
+            continue;
+        }
+        break;
+    }
+
+    if pos >= bytes.len() || !line_is_fence(content, pos) {
+        // No frontmatter — return original content.
+        return Ok(content);
+    }
+
+    // We're at the opening `---`. Advance past that line, then look for the
+    // closing fence.
+    let opening_end = find_line_end(content, pos);
+    let mut scan = advance_past_newline(content, opening_end);
+
+    while scan < bytes.len() {
+        let line_end = find_line_end(content, scan);
+        if line_is_fence(content, scan) {
+            // Consume the closing fence line.
+            let after_close = advance_past_newline(content, line_end);
+            // Also consume one immediately-following blank line so the body
+            // starts on the first real content line.
+            let body_start = if after_close < bytes.len() {
+                let next_end = find_line_end(content, after_close);
+                if content[after_close..next_end].trim().is_empty() {
+                    advance_past_newline(content, next_end)
+                } else {
+                    after_close
+                }
+            } else {
+                after_close
+            };
+            return Ok(&content[body_start..]);
+        }
+        scan = advance_past_newline(content, line_end);
+    }
+
+    bail!("release notes frontmatter opened with `---` but never closed");
+}
+
+/// Return the byte offset of the end of the line starting at `start`
+/// (pointing at the `\n`, the `\r`, or `content.len()` at EOF).
+fn find_line_end(content: &str, start: usize) -> usize {
+    match content[start..].find(['\n', '\r']) {
+        Some(offset) => start + offset,
+        None => content.len(),
+    }
+}
+
+/// Return the byte offset just past the newline sequence at `end`
+/// (handles `\n`, `\r`, `\r\n`).
+fn advance_past_newline(content: &str, end: usize) -> usize {
+    let bytes = content.as_bytes();
+    if end >= bytes.len() {
+        return end;
+    }
+    match bytes[end] {
+        b'\r' if bytes.get(end + 1) == Some(&b'\n') => end + 2,
+        b'\r' | b'\n' => end + 1,
+        _ => end,
+    }
+}
+
+/// Return `true` if the line at byte offset `start` is exactly `---`
+/// (trimmed of trailing whitespace).
+fn line_is_fence(content: &str, start: usize) -> bool {
+    let end = find_line_end(content, start);
+    content[start..end].trim_end() == "---"
+}
+
+/// Normalize a tag argument to the `vX.Y.Z` form used by the note filenames.
+///
+/// Accepts both `v0.12.4` and `0.12.4`; anything else is passed through
+/// unchanged so obviously-wrong tags surface as "file not found" errors.
+fn normalize_tag(tag: &str) -> String {
+    let trimmed = tag.trim();
+    if trimmed.starts_with('v') || trimmed.starts_with('V') {
+        trimmed.to_string()
+    } else {
+        format!("v{trimmed}")
+    }
+}
+
+/// Resolve the canonical note-file path for `tag` under `root`.
+pub fn note_path(root: &Path, tag: &str) -> PathBuf {
+    let normalized = normalize_tag(tag);
+    root.join("docs").join("releases").join(format!("{normalized}.md"))
+}
+
+/// Run the `release-notes` task: read `docs/releases/<tag>.md`, strip its
+/// frontmatter, and emit the body to stdout or the `--output` file.
+///
+/// `root` is optional; when `None`, falls back to [`project_root`]. Tests use
+/// an explicit `root` so they can operate on a throwaway tempdir instead of
+/// the repo's shipped notes.
+pub fn run(tag: String, output: Option<PathBuf>, root: Option<PathBuf>) -> Result<()> {
+    let root = match root {
+        Some(r) => r,
+        None => project_root()?,
+    };
+    let path = note_path(&root, &tag);
+    if !path.exists() {
+        bail!(
+            "release notes file missing: {}\n\
+             Every release must ship a curated note file. See RELEASE.md \
+             \"Release History Updates\" for the template.",
+            path.display()
+        );
+    }
+
+    let content = fs::read_to_string(&path)
+        .with_context_msg(|| format!("failed to read {}", path.display()))?;
+    let body = extract_body(&content)
+        .with_context_msg(|| format!("failed to parse frontmatter in {}", path.display()))?;
+
+    match output {
+        Some(dest) => {
+            if let Some(parent) = dest.parent()
+                && !parent.as_os_str().is_empty()
+            {
+                fs::create_dir_all(parent).with_context_msg(|| {
+                    format!("failed to create parent dir {}", parent.display())
+                })?;
+            }
+            fs::write(&dest, body)
+                .with_context_msg(|| format!("failed to write {}", dest.display()))?;
+            eprintln!("Wrote release body to {}", dest.display());
+        }
+        None => {
+            let stdout = std::io::stdout();
+            let mut handle = stdout.lock();
+            handle.write_all(body.as_bytes()).context("failed to write release body to stdout")?;
+        }
+    }
+
+    Ok(())
+}
+
+// Small local trait so we can use `.with_context_msg(|| ...)` without pulling
+// extra eyre traits into every caller — mirrors the pattern used elsewhere
+// in xtask with `WrapErr`.
+trait ResultExt<T> {
+    fn with_context_msg<F, S>(self, f: F) -> Result<T>
+    where
+        F: FnOnce() -> S,
+        S: Into<String>;
+}
+
+impl<T, E> ResultExt<T> for std::result::Result<T, E>
+where
+    E: Into<color_eyre::eyre::Report>,
+{
+    fn with_context_msg<F, S>(self, f: F) -> Result<T>
+    where
+        F: FnOnce() -> S,
+        S: Into<String>,
+    {
+        self.map_err(Into::into).wrap_err_with(|| f().into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_body_strips_frontmatter() {
+        let input =
+            "---\nversion: \"1.2.3\"\ntag: \"v1.2.3\"\n---\n\n# v1.2.3\n\n## Summary\n\nhi\n";
+        let body = extract_body(input).expect("extraction should succeed");
+        assert_eq!(body, "# v1.2.3\n\n## Summary\n\nhi\n");
+    }
+
+    #[test]
+    fn extract_body_handles_no_trailing_blank_line_after_fence() {
+        let input = "---\nversion: \"1.2.3\"\n---\n# v1.2.3\nhi\n";
+        let body = extract_body(input).expect("extraction should succeed");
+        // No blank-line between closing fence and body — body starts immediately.
+        assert_eq!(body, "# v1.2.3\nhi\n");
+    }
+
+    #[test]
+    fn extract_body_handles_crlf_line_endings() {
+        let input = "---\r\nversion: \"1.2.3\"\r\n---\r\n\r\n# v1.2.3\r\nhi\r\n";
+        let body = extract_body(input).expect("extraction should succeed");
+        assert_eq!(body, "# v1.2.3\r\nhi\r\n");
+    }
+
+    #[test]
+    fn extract_body_skips_leading_bom() {
+        let input = "\u{feff}---\nversion: \"1\"\n---\n\nbody\n";
+        let body = extract_body(input).expect("extraction should succeed");
+        assert_eq!(body, "body\n");
+    }
+
+    #[test]
+    fn extract_body_returns_content_when_no_frontmatter() {
+        let input = "# v1.2.3\n\nhello\n";
+        let body = extract_body(input).expect("extraction should succeed");
+        assert_eq!(body, input);
+    }
+
+    #[test]
+    fn extract_body_errors_on_unterminated_frontmatter() {
+        let input = "---\nversion: \"1.2.3\"\nno closing fence\n";
+        let err = extract_body(input).expect_err("should fail on unterminated frontmatter");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("never closed"), "message was: {msg}");
+    }
+
+    #[test]
+    fn extract_body_tolerates_leading_blank_lines() {
+        let input = "\n\n---\nversion: \"1\"\n---\n\nbody\n";
+        let body = extract_body(input).expect("extraction should succeed");
+        assert_eq!(body, "body\n");
+    }
+
+    #[test]
+    fn extract_body_preserves_fence_inside_body() {
+        // A `---` horizontal rule inside the body must not be mistaken for a
+        // closing fence; only the *first* closing fence after the opener counts.
+        let input = "---\nversion: \"1\"\n---\n\nIntro.\n\n---\n\nMore.\n";
+        let body = extract_body(input).expect("extraction should succeed");
+        assert_eq!(body, "Intro.\n\n---\n\nMore.\n");
+    }
+
+    #[test]
+    fn normalize_tag_prepends_v_when_missing() {
+        assert_eq!(normalize_tag("0.12.4"), "v0.12.4");
+        assert_eq!(normalize_tag("v0.12.4"), "v0.12.4");
+        assert_eq!(normalize_tag(" v0.12.4 "), "v0.12.4");
+    }
+
+    #[test]
+    fn note_path_targets_docs_releases_file() {
+        let path = note_path(Path::new("/repo"), "v1.2.3");
+        assert_eq!(path, PathBuf::from("/repo/docs/releases/v1.2.3.md"));
+        // Bare version gets the `v` prefix.
+        let path = note_path(Path::new("/repo"), "1.2.3");
+        assert_eq!(path, PathBuf::from("/repo/docs/releases/v1.2.3.md"));
+    }
+
+    #[test]
+    fn extract_body_against_real_release_note() {
+        // Snapshot-ish check against the real v0.12.4 note shipped in the repo.
+        // The test only asserts structural invariants so it stays stable even
+        // if the human-written prose is tweaked.
+        let root = project_root().expect("project_root should resolve");
+        let path = root.join("docs/releases/v0.12.4.md");
+        let content = fs::read_to_string(&path).expect("v0.12.4 note must exist");
+        let body = extract_body(&content).expect("extraction should succeed");
+
+        assert!(!body.starts_with("---"), "frontmatter leaked into body: {body:.40?}");
+        assert!(body.starts_with("# v0.12.4"), "body should start with H1 header: {body:.40?}");
+        assert!(body.contains("## Summary"), "body should carry the summary heading");
+    }
+}

--- a/xtask/tests/release_notes_cli.rs
+++ b/xtask/tests/release_notes_cli.rs
@@ -1,0 +1,151 @@
+//! End-to-end CLI tests for `cargo xtask release-notes`.
+//!
+//! These exercise the same extraction code as the in-module unit tests, but
+//! through the compiled binary — verifying argument parsing, exit codes, and
+//! stdout/file output wiring. The hidden `--root` flag points the command at
+//! a throwaway tempdir so tests never depend on the repo's shipped notes.
+
+use anyhow::Result;
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::fs;
+use tempfile::TempDir;
+
+fn write_note(root: &std::path::Path, tag: &str, contents: &str) -> Result<()> {
+    let dir = root.join("docs").join("releases");
+    fs::create_dir_all(&dir)?;
+    fs::write(dir.join(format!("{tag}.md")), contents)?;
+    Ok(())
+}
+
+fn root_arg(root: &std::path::Path) -> &str {
+    use perl_tdd_support::must_some;
+    must_some(root.to_str())
+}
+
+const SAMPLE_NOTE: &str = "---\n\
+version: \"9.9.9\"\n\
+tag: \"v9.9.9\"\n\
+notes_status: canonical\n\
+---\n\
+\n\
+# v9.9.9\n\
+\n\
+## Summary\n\
+\n\
+Sample body used by release-notes CLI tests.\n";
+
+const SAMPLE_BODY: &str =
+    "# v9.9.9\n\n## Summary\n\nSample body used by release-notes CLI tests.\n";
+
+#[test]
+fn release_notes_cli_emits_body_to_stdout() -> Result<()> {
+    let temp = TempDir::new()?;
+    write_note(temp.path(), "v9.9.9", SAMPLE_NOTE)?;
+
+    let assert = cargo_bin_cmd!("xtask")
+        .args(["release-notes", "--root", root_arg(temp.path()), "--tag", "v9.9.9"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())?;
+    assert_eq!(stdout, SAMPLE_BODY);
+    Ok(())
+}
+
+#[test]
+fn release_notes_cli_writes_output_file() -> Result<()> {
+    let temp = TempDir::new()?;
+    write_note(temp.path(), "v9.9.9", SAMPLE_NOTE)?;
+    let out = temp.path().join("notes.out.md");
+    let out_str = root_arg(&out);
+
+    cargo_bin_cmd!("xtask")
+        .args([
+            "release-notes",
+            "--root",
+            root_arg(temp.path()),
+            "--tag",
+            "v9.9.9",
+            "--output",
+            out_str,
+        ])
+        .assert()
+        .success();
+
+    let body = fs::read_to_string(&out)?;
+    assert_eq!(body, SAMPLE_BODY);
+    Ok(())
+}
+
+#[test]
+fn release_notes_cli_accepts_bare_version() -> Result<()> {
+    let temp = TempDir::new()?;
+    // Note lives at v9.9.9 but caller passes bare `9.9.9`.
+    write_note(temp.path(), "v9.9.9", SAMPLE_NOTE)?;
+
+    let assert = cargo_bin_cmd!("xtask")
+        .args(["release-notes", "--root", root_arg(temp.path()), "--tag", "9.9.9"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())?;
+    assert_eq!(stdout, SAMPLE_BODY);
+    Ok(())
+}
+
+#[test]
+fn release_notes_cli_fails_when_file_missing() -> Result<()> {
+    let temp = TempDir::new()?;
+    // Intentionally write no release notes file.
+    fs::create_dir_all(temp.path().join("docs").join("releases"))?;
+
+    let assert = cargo_bin_cmd!("xtask")
+        .args(["release-notes", "--root", root_arg(temp.path()), "--tag", "v0.0.0-missing"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone())?;
+    assert!(
+        stderr.contains("release notes file missing"),
+        "expected clear 'release notes file missing' error, got: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn release_notes_cli_fails_on_unterminated_frontmatter() -> Result<()> {
+    let temp = TempDir::new()?;
+    write_note(
+        temp.path(),
+        "v9.9.9",
+        "---\nversion: \"9.9.9\"\nno closing fence in sight\n# v9.9.9\nbody\n",
+    )?;
+
+    let assert = cargo_bin_cmd!("xtask")
+        .args(["release-notes", "--root", root_arg(temp.path()), "--tag", "v9.9.9"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone())?;
+    assert!(
+        stderr.contains("never closed"),
+        "expected 'never closed' frontmatter error, got: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn release_notes_cli_without_frontmatter_returns_full_file() -> Result<()> {
+    let temp = TempDir::new()?;
+    let raw = "# v9.9.9\n\nPlain body, no frontmatter.\n";
+    write_note(temp.path(), "v9.9.9", raw)?;
+
+    let assert = cargo_bin_cmd!("xtask")
+        .args(["release-notes", "--root", root_arg(temp.path()), "--tag", "v9.9.9"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())?;
+    assert_eq!(stdout, raw);
+    Ok(())
+}


### PR DESCRIPTION
Closes #4340.

## Problem

GitHub Release bodies were auto-generated "What's Changed" PR lists. Since PR #4337, the repo also ships curated per-release notes at `docs/releases/vX.Y.Z.md` with structured summaries, highlights, install instructions, and channel status — but the release workflow never consumed them. Two surfaces diverged:

- **In the repo:** human-written narrative (`# vX.Y.Z` → Summary → Highlights → Install → Links).
- **On GitHub Releases:** a raw PR dump.

That made GitHub Releases the lowest-quality surface — a one-click destination for users evaluating the project, staring at a list of 70 PR titles instead of the headline features.

## What this PR does

Wires `release.yml` and `release-orchestration.yml` to consume `docs/releases/<tag>.md` as the GitHub Release body, with the auto-generated "What's Changed" list appended below.

### 1. New xtask command — `cargo xtask release-notes`

`xtask/src/tasks/release_notes.rs` implements body extraction: read `docs/releases/<tag>.md`, strip its YAML frontmatter, emit the body. Used by the workflow, reusable locally for previews.

```bash
# Print the curated body (what GitHub will show above "What's Changed")
cargo xtask release-notes --tag v0.12.4

# Or redirect to a file for the release action's body_path
cargo xtask release-notes --tag v0.12.4 --output release_notes.md

# Bare version also accepted
cargo xtask release-notes --tag 0.12.4
```

**Failure modes are loud:**
- Missing file → `release notes file missing: docs/releases/v0.12.4.md` + pointer to RELEASE.md template.
- Unterminated frontmatter → `frontmatter opened with `---` but never closed`.

Both surface as annotated `::error::` lines in the Actions UI.

### 2. `release.yml` — generate body from curated notes

Replaced the inline heredoc that generated a generic "install & links" body with:

1. **Preflight existence check** — fail fast with an annotated error if `docs/releases/${TAG}.md` is missing.
2. **`cargo xtask release-notes --tag "$TAG" --output release_notes.md`** — write the extracted body.
3. **`softprops/action-gh-release` continues to set `body_path: release_notes.md` and `generate_release_notes: true`** — so the curated body appears above the auto-generated "What's Changed" PR list.

### 3. `release-orchestration.yml` — fail before tagging

The orchestration workflow now verifies the curated note exists *and* has a YAML frontmatter block before creating the tag. That saves a botched release: tagging before noticing the notes file is missing requires manual tag cleanup.

### 4. `RELEASE.md` — documents the new flow

- Marks `docs/releases/vX.Y.Z.md` as **required** (orchestration refuses to tag without it).
- Adds a local preview step to the pre-publishing checklist: `cargo xtask release-notes --tag vX.Y.Z` shows exactly what will become the release body.
- Adds a post-publish verification that the release body starts with `# vX.Y.Z` (not a PR dump).

## Tests — 17 new, all passing

**Unit tests (11)** — `xtask/src/tasks/release_notes.rs`:
- Strip frontmatter from a typical note.
- Handle no trailing blank line after closing fence.
- Handle CRLF line endings.
- Skip leading UTF-8 BOM.
- Return full content when no frontmatter present.
- Error on unterminated frontmatter.
- Tolerate leading blank lines before the opening fence.
- Preserve `---` horizontal rules *inside* the body (don't confuse with closing fence).
- `normalize_tag` prepends `v` when missing and trims whitespace.
- `note_path` targets `docs/releases/<tag>.md`.
- Structural check against the real `docs/releases/v0.12.4.md` (body starts with `# v0.12.4`, no frontmatter leak, contains `## Summary`).

**CLI integration tests (6)** — `xtask/tests/release_notes_cli.rs`:
- Emit body to stdout.
- Write body to `--output` file.
- Accept bare version (`9.9.9` → reads `v9.9.9.md`).
- Clear error on missing file.
- Clear error on unterminated frontmatter.
- No-frontmatter files pass through unchanged.

All 17 tests run from the xtask test target (`cargo test -p xtask`). Tests use a hidden `--root` flag (registered with `hide = true`, excluded from user-facing help) that points `project_root()` at a tempdir — so tests never depend on the repo's shipped release notes and can't mutate them.

## Acceptance criteria from #4340

- [x] `gh release view vX.Y.Z` body matches `docs/releases/vX.Y.Z.md` content — `body_path: release_notes.md` is populated from `cargo xtask release-notes --tag "$TAG"`, which strips only the YAML frontmatter and emits the rest byte-for-byte.
- [x] Release workflow fails if `docs/releases/vX.Y.Z.md` doesn't exist at tag time — orchestration validate job fails before tagging; release job also fails at preflight if it somehow slipped through.
- [x] Auto-generated "What's Changed" section can optionally be appended below the curated notes — `generate_release_notes: true` is kept on the `softprops/action-gh-release` step, which appends GitHub's auto-notes below `body_path`.

## Local verification

```bash
# Unit + CLI tests
cargo test -p xtask --bins release_notes            # 11 unit tests
cargo test -p xtask --test release_notes_cli        # 6 CLI tests

# Smoke-test against a real shipped note
cargo xtask release-notes --tag v0.12.4 | head -5
# # v0.12.4
#
# ## Summary
#
# Major patch release shipping inherited/role method navigation...

# Smoke-test missing-file error
cargo xtask release-notes --tag v99.99.99
# Error: release notes file missing: /repo/docs/releases/v99.99.99.md
```

## Files changed

| File | Purpose |
|------|---------|
| `xtask/src/tasks/release_notes.rs` | Extraction logic + 11 unit tests (new) |
| `xtask/tests/release_notes_cli.rs` | 6 CLI integration tests (new) |
| `xtask/src/tasks/mod.rs` | Register `release_notes` module |
| `xtask/src/main.rs` | New `ReleaseNotes` subcommand |
| `.github/workflows/release.yml` | Preflight + extract-via-xtask; drop hardcoded heredoc |
| `.github/workflows/release-orchestration.yml` | Pre-tag file-exists + frontmatter check |
| `RELEASE.md` | Document the new flow in pre-/post-publish checklists |

## Compatibility / risk

- **No behavior change** on any release that already ships a `docs/releases/vX.Y.Z.md` file. Every release since v0.8.3 has one (checked via `ls docs/releases/`).
- **Intentional breaking change**: a release without a curated note file now fails at the orchestration validate step (previously it would silently publish a generic release body). This matches the issue's acceptance criterion and is already required by `RELEASE.md`'s pre-publishing checklist.
- **Rollback**: revert this PR; release workflow returns to inline heredoc body. The note files stay in the repo either way.
