### PR TITLE
fix(hover): surface inline POD inside subroutine bodies (#3407)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/semantic/node_analysis.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/node_analysis.rs
@@ -138,7 +138,7 @@ impl SemanticAnalyzer {
 
                     let hover = HoverInfo {
                         signature: signature_str,
-                        documentation: self.extract_documentation(node.location.start),
+                        documentation: self.extract_sub_documentation(node.location.start, body),
                         details: if attributes.is_empty() {
                             vec![]
                         } else {
@@ -173,7 +173,7 @@ impl SemanticAnalyzer {
 
                     let hover = HoverInfo {
                         signature: signature_str,
-                        documentation: self.extract_documentation(node.location.start),
+                        documentation: self.extract_sub_documentation(node.location.start, body),
                         details,
                     };
 
@@ -205,7 +205,7 @@ impl SemanticAnalyzer {
                 // Add hover info
                 let hover = HoverInfo {
                     signature: format!("method {}", name),
-                    documentation: self.extract_documentation(node.location.start),
+                    documentation: self.extract_sub_documentation(node.location.start, body),
                     details: if attributes.is_empty() {
                         vec![]
                     } else {
@@ -908,7 +908,20 @@ impl SemanticAnalyzer {
         }
     }
 
-    /// Extract documentation (POD or comments) preceding a position
+    /// Extract documentation (POD or comments) immediately preceding a
+    /// position.
+    ///
+    /// The returned string is trimmed and corresponds to whichever of POD
+    /// or comments is found first at the very end of `source[..start]`. If
+    /// both kinds appear earlier in the source but neither is *immediately
+    /// before* `start`, this returns `None` — anchoring is intentional so
+    /// that documentation blocks belonging to one declaration do not bleed
+    /// into a later, unrelated declaration.
+    ///
+    /// Anchoring uses `\z` (absolute end of string) rather than `$`. With
+    /// the `m` flag, `$` matches at the end of every line, which made the
+    /// previous regex match POD blocks anywhere in `before` and leak them
+    /// into hover docs for unrelated subs that followed.
     pub(super) fn extract_documentation(&self, start: usize) -> Option<String> {
         static POD_RE: OnceLock<Result<Regex, regex::Error>> = OnceLock::new();
         static COMMENT_RE: OnceLock<Result<Regex, regex::Error>> = OnceLock::new();
@@ -918,9 +931,9 @@ impl SemanticAnalyzer {
         }
         let before = &self.source[..start];
 
-        // Check for POD blocks ending with =cut
+        // Check for POD blocks ending with =cut, anchored at end of string.
         let pod_re = POD_RE
-            .get_or_init(|| Regex::new(r"(?ms)(=[a-zA-Z0-9].*?\n=cut\n?)\s*$"))
+            .get_or_init(|| Regex::new(r"(?s)(=[a-zA-Z0-9].*?\n=cut\n?)\s*\z"))
             .as_ref()
             .ok()?;
         if let Some(caps) = pod_re.captures(before) {
@@ -929,9 +942,9 @@ impl SemanticAnalyzer {
             }
         }
 
-        // Check for consecutive comment lines
+        // Check for consecutive comment lines, anchored at end of string.
         let comment_re =
-            COMMENT_RE.get_or_init(|| Regex::new(r"(?m)(#.*\n)+\s*$")).as_ref().ok()?;
+            COMMENT_RE.get_or_init(|| Regex::new(r"(?m)(#.*\n)+[\t ]*\z")).as_ref().ok()?;
         if let Some(caps) = comment_re.captures(before) {
             if let Some(comment_match) = caps.get(0) {
                 // Strip the # prefix from each comment line
@@ -947,6 +960,55 @@ impl SemanticAnalyzer {
         }
 
         None
+    }
+
+    /// Extract documentation for a subroutine or method, falling back to
+    /// inline POD blocks inside the body when no leading docs are found.
+    ///
+    /// Resolution order:
+    /// 1. Leading docs (POD or comments) immediately preceding `start` —
+    ///    matches `extract_documentation` and preserves the existing
+    ///    "explicit author intent wins" precedence.
+    /// 2. The first POD block inside `body` (between `body.location.start`
+    ///    and `body.location.end`). This handles the inline-POD style of
+    ///    documenting a sub from within its body, e.g.:
+    ///
+    /// ```perl
+    /// sub process_data {
+    ///     =pod
+    ///     Internal documentation for this sub
+    ///     =cut
+    ///     ...
+    /// }
+    /// ```
+    pub(super) fn extract_sub_documentation(&self, start: usize, body: &Node) -> Option<String> {
+        self.extract_documentation(start).or_else(|| self.find_pod_in_node_body(body))
+    }
+
+    /// Find the first POD block inside the source range covered by `body`.
+    ///
+    /// Matches any POD block (`=pod`, `=head1`, `=item`, etc.) that ends
+    /// with a `=cut` directive. The returned string is trimmed of
+    /// surrounding whitespace and includes the opening directive through
+    /// the closing `=cut`, mirroring the format produced by
+    /// `extract_documentation` for leading POD blocks.
+    pub(super) fn find_pod_in_node_body(&self, body: &Node) -> Option<String> {
+        static BODY_POD_RE: OnceLock<Result<Regex, regex::Error>> = OnceLock::new();
+
+        let start = body.location.start;
+        let end = body.location.end;
+        if self.source.is_empty() || end <= start || end > self.source.len() {
+            return None;
+        }
+        let body_src = &self.source[start..end];
+
+        let pod_re = BODY_POD_RE
+            .get_or_init(|| Regex::new(r"(?ms)^\s*(=[a-zA-Z0-9].*?\n=cut)\b"))
+            .as_ref()
+            .ok()?;
+        let caps = pod_re.captures(body_src)?;
+        let pod_text = caps.get(1)?.as_str().trim().to_string();
+        Some(pod_text)
     }
 
     /// Extract the POD `=head1 NAME` section for a package.

--- a/crates/perl-semantic-analyzer/tests/inline_pod_hover_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/inline_pod_hover_tests.rs
@@ -1,0 +1,266 @@
+//! Tests for inline POD hover documentation on subroutines and methods.
+//!
+//! POD blocks may appear inside a subroutine body (e.g. `=pod ... =cut`
+//! between statements) and should be associated with the enclosing
+//! subroutine for hover documentation. The default `extract_documentation`
+//! only scans backwards from a position, so inline POD inside a sub body
+//! is missed without a body-aware fallback.
+//!
+//! Per perlpod, POD directives must start at column 0 — the parser's
+//! tokenizer recognises `=pod`/`=head1`/`=cut` as a trivia block only
+//! when they begin a line. The fixtures below therefore place POD
+//! directives at column 0 inside sub bodies, which is the form real
+//! Perl source uses.
+//!
+//! See: <https://github.com/EffortlessMetrics/perl-lsp/issues/3407>
+
+use perl_semantic_analyzer::Parser;
+use perl_semantic_analyzer::analysis::semantic::SemanticAnalyzer;
+use perl_semantic_analyzer::symbol::SymbolKind;
+use perl_tdd_support::must;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+/// `=pod ... =cut` immediately inside a sub body should be exposed as the
+/// sub's hover documentation.
+#[test]
+fn inline_pod_pod_cut_is_associated_with_subroutine_hover() -> TestResult {
+    let code = "sub process_data {\n\
+                =pod\n\
+                Internal documentation for this sub\n\
+                =cut\n\
+                    my $data = shift;\n\
+                    return $data;\n\
+                }\n";
+
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+    let symbols = analyzer.symbol_table().find_symbol("process_data", 0, SymbolKind::Subroutine);
+    let symbol = symbols.first().ok_or("process_data should be in the symbol table")?;
+    let hover = analyzer.hover_at(symbol.location).ok_or("expected hover info for process_data")?;
+    let doc = hover.documentation.as_deref().unwrap_or("");
+    assert!(
+        doc.contains("Internal documentation for this sub"),
+        "expected inline POD to be surfaced as hover documentation, got: {doc:?}"
+    );
+    Ok(())
+}
+
+/// `=head1` style POD inside a sub body should also be picked up.
+#[test]
+fn inline_pod_head1_inside_sub_body_is_surfaced_in_hover() -> TestResult {
+    let code = "sub greet {\n\
+                =head1 DESCRIPTION\n\
+                \n\
+                Says hello in a friendly way.\n\
+                \n\
+                =cut\n\
+                    return \"hi\";\n\
+                }\n";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+    let symbols = analyzer.symbol_table().find_symbol("greet", 0, SymbolKind::Subroutine);
+    let symbol = symbols.first().ok_or("greet should be in the symbol table")?;
+    let hover = analyzer.hover_at(symbol.location).ok_or("expected hover for greet")?;
+    let doc = hover.documentation.as_deref().unwrap_or("");
+    assert!(
+        doc.contains("Says hello in a friendly way"),
+        "expected =head1 inline POD to be surfaced as hover documentation, got: {doc:?}"
+    );
+    Ok(())
+}
+
+/// Preceding comment documentation should always win over inline POD when
+/// both are present — preserves the existing leading-doc precedence and
+/// matches what users author when they intentionally annotate a sub.
+#[test]
+fn leading_comment_doc_wins_over_inline_pod() -> TestResult {
+    let code = "# Preferred leading documentation\n\
+                sub do_thing {\n\
+                =pod\n\
+                Inline body documentation\n\
+                =cut\n\
+                    return 1;\n\
+                }\n";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+    let symbols = analyzer.symbol_table().find_symbol("do_thing", 0, SymbolKind::Subroutine);
+    let symbol = symbols.first().ok_or("do_thing should be in the symbol table")?;
+    let hover = analyzer.hover_at(symbol.location).ok_or("expected hover for do_thing")?;
+    let doc = hover.documentation.as_deref().unwrap_or("");
+    assert!(
+        doc.contains("Preferred leading documentation"),
+        "leading comment should still take precedence, got: {doc:?}"
+    );
+    assert!(
+        !doc.contains("Inline body documentation"),
+        "inline POD should not override the explicit leading comment, got: {doc:?}"
+    );
+    Ok(())
+}
+
+/// A sub with neither leading docs nor inline POD must yield no hover docs
+/// (no false positives from unrelated nearby POD blocks).
+#[test]
+fn sub_without_any_pod_or_comments_has_no_doc() -> TestResult {
+    let code = "sub plain_sub {\n    return 42;\n}\n";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+    let symbols = analyzer.symbol_table().find_symbol("plain_sub", 0, SymbolKind::Subroutine);
+    let symbol = symbols.first().ok_or("plain_sub should be in the symbol table")?;
+    let hover = analyzer.hover_at(symbol.location).ok_or("expected hover for plain_sub")?;
+    assert!(
+        hover.documentation.is_none(),
+        "expected no documentation, got: {:?}",
+        hover.documentation
+    );
+    Ok(())
+}
+
+/// Each sub must surface its own inline POD — adjacent subs that each
+/// document themselves with inline POD should each get their own docs,
+/// without cross-contamination through the body-aware fallback.
+///
+/// This also guards against the pre-existing bleed where leading-doc
+/// extraction matched POD from earlier in the source — fixed by
+/// anchoring the POD/comment regex to the absolute end of `before`.
+#[test]
+fn inline_pod_attaches_to_each_subs_own_body() -> TestResult {
+    let code = "sub outer {\n\
+                =pod\n\
+                Outer body documentation\n\
+                =cut\n\
+                    return 1;\n\
+                }\n\
+                \n\
+                # Leading docs for inner\n\
+                sub inner {\n\
+                =pod\n\
+                Inner body documentation\n\
+                =cut\n\
+                    return 2;\n\
+                }\n";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+    let outer = analyzer.symbol_table().find_symbol("outer", 0, SymbolKind::Subroutine);
+    let inner = analyzer.symbol_table().find_symbol("inner", 0, SymbolKind::Subroutine);
+    let outer_sym = outer.first().ok_or("outer should be in the symbol table")?;
+    let inner_sym = inner.first().ok_or("inner should be in the symbol table")?;
+
+    let outer_hover = analyzer.hover_at(outer_sym.location).ok_or("expected hover for outer")?;
+    let inner_hover = analyzer.hover_at(inner_sym.location).ok_or("expected hover for inner")?;
+
+    let outer_doc = outer_hover.documentation.as_deref().unwrap_or("");
+    let inner_doc = inner_hover.documentation.as_deref().unwrap_or("");
+
+    assert!(
+        outer_doc.contains("Outer body documentation"),
+        "expected outer to surface its inline POD, got: {outer_doc:?}"
+    );
+    // `inner` has explicit leading docs, so they win — the body-aware
+    // fallback must not override that, and outer's body POD must not bleed.
+    assert!(
+        inner_doc.contains("Leading docs for inner"),
+        "expected inner's leading comment to win, got: {inner_doc:?}"
+    );
+    assert!(
+        !inner_doc.contains("Outer body documentation"),
+        "outer's inline POD must not bleed into inner's hover, got: {inner_doc:?}"
+    );
+    assert!(
+        !inner_doc.contains("Inner body documentation"),
+        "inner's leading docs should win over its inline POD, got: {inner_doc:?}"
+    );
+    Ok(())
+}
+
+/// Regression guard for the pre-existing leading-doc bleed: an earlier
+/// POD block followed by unrelated code must not be returned as docs for
+/// a later sub. Before the `\z` anchor fix, multiline `$` matched
+/// end-of-any-line and pulled in earlier POD blocks.
+#[test]
+fn earlier_pod_does_not_bleed_into_later_undocumented_sub() -> TestResult {
+    let code = "=pod\n\
+                Module-level POD\n\
+                =cut\n\
+                \n\
+                my $x = 1;\n\
+                my $y = 2;\n\
+                \n\
+                sub later {\n\
+                    return $x + $y;\n\
+                }\n";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+    let symbols = analyzer.symbol_table().find_symbol("later", 0, SymbolKind::Subroutine);
+    let symbol = symbols.first().ok_or("later should be in the symbol table")?;
+    let hover = analyzer.hover_at(symbol.location).ok_or("expected hover for later")?;
+    assert!(
+        hover.documentation.is_none(),
+        "earlier POD must not attach to a later, unrelated sub: {:?}",
+        hover.documentation
+    );
+    Ok(())
+}
+
+/// The first inline POD block inside a sub body wins when multiple are
+/// present — matches the convention of putting the descriptive POD first.
+#[test]
+fn first_inline_pod_block_wins_when_multiple_present() -> TestResult {
+    let code = "sub multi_pod {\n\
+                =pod\n\
+                First body doc\n\
+                =cut\n\
+                    my $x = 1;\n\
+                =pod\n\
+                Second body doc\n\
+                =cut\n\
+                    return $x;\n\
+                }\n";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+    let symbols = analyzer.symbol_table().find_symbol("multi_pod", 0, SymbolKind::Subroutine);
+    let symbol = symbols.first().ok_or("multi_pod should be in the symbol table")?;
+    let hover = analyzer.hover_at(symbol.location).ok_or("expected hover for multi_pod")?;
+    let doc = hover.documentation.as_deref().unwrap_or("");
+    assert!(doc.contains("First body doc"), "expected first inline POD to win, got: {doc:?}");
+    assert!(!doc.contains("Second body doc"), "expected only the first inline POD, got: {doc:?}");
+    Ok(())
+}
+
+/// Inline POD inside an anonymous sub should also be surfaced — anonymous
+/// subs commonly carry inline docs in callback-heavy code.
+#[test]
+fn inline_pod_in_anonymous_sub_is_surfaced() -> TestResult {
+    let code = "my $cb = sub {\n\
+                =pod\n\
+                Anonymous callback doc\n\
+                =cut\n\
+                    return 1;\n\
+                };\n";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+    // The anonymous sub's hover is keyed on its node location. Walk all
+    // hovers and assert at least one carries the inline POD.
+    let found = analyzer
+        .all_hover_entries()
+        .any(|h| h.documentation.as_deref().is_some_and(|d| d.contains("Anonymous callback doc")));
+    assert!(found, "expected anonymous sub hover to carry inline POD");
+    Ok(())
+}


### PR DESCRIPTION
Closes #3407.

## Summary

POD blocks placed *inside* a subroutine body — a common idiom for self-documenting subs — were silently dropped on the floor by the hover provider. Hovering over `process_data` in the example below returned no documentation at all:

```perl
sub process_data {
=pod
Internal documentation for this sub
=cut
    my $data = shift;
    return $data;
}
```

This PR fixes that, plus a closely related pre-existing bug in the leading-doc extractor that the new tests exposed.

## What changed

### 1. Body-aware sub documentation (`extract_sub_documentation`)

Adds a new helper in `crates/perl-semantic-analyzer/src/analysis/semantic/node_analysis.rs` that resolves sub docs in a defined precedence:

1. **Leading docs immediately preceding the sub** (POD or comments) — preserves the existing "explicit author intent wins" precedence.
2. **First POD block inside the sub body** — the new fallback. Picked up by a body-bounded regex that scans `source[body.start..body.end]` for the first `^\s*=…\n=cut` block.

The helper is wired into all three sub-like declarations in `node_analysis.rs`:

| Node kind | Was | Now |
|-----------|-----|-----|
| Named subroutine | `extract_documentation(node.location.start)` | `extract_sub_documentation(node.location.start, body)` |
| Anonymous subroutine (closure) | same | same |
| `method` declaration (Object::Pad / Perl class) | same | same |

### 2. Pre-existing leading-doc bleed fix (anchor `\z` instead of `$`)

While writing the cross-sub bleed test I discovered that `extract_documentation` was already misbehaving in a subtle way: the POD and comment regexes used `\s*$` with the `m` flag, so `$` matched the end of *any* line, not the absolute end of `source[..start]`. That meant POD blocks anywhere earlier in the source could leak into hover docs for unrelated subs that followed. Reproducer:

```perl
=pod
Module-level POD
=cut

my $x = 1;

sub later { return $x; }   # hover on "later" returned the module POD
```

Fixed by anchoring with `\z` (absolute end of string) instead of multiline `$`. Comment regex tightened analogously (`[\t ]*\z` so trailing real newlines don't get swallowed). The `extract_documentation` doc comment now explains the anchor choice.

This fix is in scope because (a) it's the same regex the new fallback layers on top of, (b) without it the cross-sub bleed test couldn't pass, and (c) it's a strict improvement — POD/comments that were intended to be "immediately preceding" still resolve, and POD/comments that *weren't* immediately preceding stop falsely attaching.

## Tests

New file `crates/perl-semantic-analyzer/tests/inline_pod_hover_tests.rs` — **8 tests**, all pass:

| Test | What it pins down |
|------|-------------------|
| `inline_pod_pod_cut_is_associated_with_subroutine_hover` | The headline case: `=pod ... =cut` inside a sub body surfaces in hover |
| `inline_pod_head1_inside_sub_body_is_surfaced_in_hover` | Same for `=head1` style POD |
| `leading_comment_doc_wins_over_inline_pod` | Precedence: explicit leading docs beat the body fallback |
| `sub_without_any_pod_or_comments_has_no_doc` | Negative baseline — no spurious docs |
| `inline_pod_attaches_to_each_subs_own_body` | Adjacent subs each get their own docs; body POD doesn't bleed; leading docs still take precedence on the follower |
| `earlier_pod_does_not_bleed_into_later_undocumented_sub` | Regression guard for the `\z` anchor fix |
| `first_inline_pod_block_wins_when_multiple_present` | Defined behaviour when multiple body POD blocks exist |
| `inline_pod_in_anonymous_sub_is_surfaced` | Anonymous subs get the same treatment |

```
running 8 tests
test leading_comment_doc_wins_over_inline_pod ... ok
test earlier_pod_does_not_bleed_into_later_undocumented_sub ... ok
test sub_without_any_pod_or_comments_has_no_doc ... ok
test inline_pod_in_anonymous_sub_is_surfaced ... ok
test inline_pod_attaches_to_each_subs_own_body ... ok
test first_inline_pod_block_wins_when_multiple_present ... ok
test inline_pod_pod_cut_is_associated_with_subroutine_hover ... ok
test inline_pod_head1_inside_sub_body_is_surfaced_in_hover ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### No regressions in the wider crate

```
cargo test -p perl-semantic-analyzer       → 25 binaries, all green
cargo test -p perl-lsp-providers           → all green
cargo test -p perl-parser --lib            → all green
cargo test -p perl-lsp-rs --lib            → 370 passed
cargo clippy -p perl-semantic-analyzer --lib → clean
cargo fmt -p perl-semantic-analyzer        → clean
```

(One pre-existing failure in `perl-parser-core` `test_custom_func_no_parens_ternary` is unrelated — it predates this branch and is in a different crate.)

## Design notes / why this approach

- **POD must start at column 0.** Per `perlpod`, POD directives (`=pod`, `=head1`, `=cut`, …) are only recognized when they begin a line. The original issue's example showed indented POD, but that's actually a parse error in real Perl. The body-POD regex (`^\s*=…`) allows leading whitespace on the directive line for forgiving column-0 detection but still requires line-start placement, which matches the parser's own POD trivia handling.
- **Body bounds, not whole source.** The new fallback uses `body.location.start..body.location.end` so a sub can never accidentally pick up POD from a preceding or following declaration. Combined with the `\z` anchor fix, the docs-resolution rules are now strictly local: leading docs come from the immediate trailing slice of `source[..start]`; body docs come from inside `source[body.start..body.end]`; nothing else can leak.
- **First-block-wins inside the body.** When a sub contains multiple POD blocks, the first one wins — matches the convention of putting descriptive POD first and skipping over later "internal notes" blocks. This is pinned by `first_inline_pod_block_wins_when_multiple_present`.
- **Precedence preserved.** Leading docs still win over body docs (`leading_comment_doc_wins_over_inline_pod`), so this is purely additive for users who already document their subs the conventional way.

## User impact

A real, observable hover gap closes. Anyone who documents subs with body-internal POD — common in legacy CPAN code, Perl modulinos, and tutorial-style code — now gets the same hover experience as authors who put POD immediately before the sub.

## Files changed

- `crates/perl-semantic-analyzer/src/analysis/semantic/node_analysis.rs` — `+62 / -8`. Adds `extract_sub_documentation` and `find_pod_in_node_body`; tightens the two regexes in `extract_documentation`; updates 3 call sites.
- `crates/perl-semantic-analyzer/tests/inline_pod_hover_tests.rs` — new file, `+274`. 8 tests + module docs explaining the column-0 POD requirement.

https://claude.ai/code/session_01WLoj7PZgJf6CzqjJXGj6Fs
