### PR TITLE
feat(code-actions): implement source.fixAll aggregation (#3508)

### DIFF
--- a/crates/perl-lsp-protocol/src/capabilities.rs
+++ b/crates/perl-lsp-protocol/src/capabilities.rs
@@ -217,6 +217,13 @@ pub fn capabilities_for(build: BuildFlags) -> ServerCapabilities {
         // Tests verified in lsp_code_actions_tests.rs (Issue #181)
         kinds.push(CodeActionKind::REFACTOR_EXTRACT);
 
+        // SOURCE_FIX_ALL aggregates every safe `quickfix` action into a
+        // single invocation. Implemented in
+        // `crates/perl-lsp/src/runtime/language/code_actions.rs`
+        // (`build_source_fix_all`) so client "fix all" keybindings work
+        // without an extra round-trip.
+        kinds.push(CodeActionKind::SOURCE_FIX_ALL);
+
         caps.code_action_provider =
             Some(CodeActionProviderCapability::Options(CodeActionOptions {
                 code_action_kinds: Some(kinds),

--- a/crates/perl-lsp/src/runtime/language/code_actions.rs
+++ b/crates/perl-lsp/src/runtime/language/code_actions.rs
@@ -98,9 +98,12 @@ impl FixAllRange {
 ///   cannot be applied together without a round-trip.
 /// * Overlapping edits are resolved by "first wins" — the first edit in the
 ///   iteration order keeps its slot, and any later edit whose range overlaps
-///   an already-accepted range is dropped. Same-position insertions from
-///   multiple diagnostics count as overlapping so we never stack two `use
-///   strict;` insertions at the top of the file, for example.
+///   an already-accepted range is dropped. Zero-width insertions (for example
+///   `use strict;\n` and `use warnings;\n` both at position 0) are **never**
+///   considered overlapping via the range check — they are allowed to stack.
+///   Exact-duplicate `(range, newText)` pairs are deduped by a separate hash
+///   set, so two providers that independently suggest the same pragma each
+///   produce only one edit in the aggregate.
 /// * The aggregate is only emitted when at least two distinct edits survive
 ///   conflict resolution — a single quick fix is already the preferred action
 ///   and does not need a wrapper.
@@ -910,6 +913,30 @@ mod tests {
         let unrelated = FixAllRange { start_line: 0, start_char: 0, end_line: 0, end_char: 5 };
         assert!(!insertion.overlaps(&unrelated));
         assert!(!unrelated.overlaps(&insertion));
+    }
+
+    #[test]
+    fn fix_all_range_overlap_detects_multiline_overlap() {
+        // A multi-line replacement (lines 1-3) and an edit on line 2 must conflict.
+        let multiline = FixAllRange { start_line: 1, start_char: 0, end_line: 3, end_char: 0 };
+        let inner = FixAllRange { start_line: 2, start_char: 0, end_line: 2, end_char: 10 };
+        assert!(multiline.overlaps(&inner));
+        assert!(inner.overlaps(&multiline));
+    }
+
+    #[test]
+    fn fix_all_range_overlap_insertion_inside_real_range_allowed() {
+        // Design note: overlaps() returns false when either side is a zero-width
+        // insertion, even if the insertion falls inside a replacement range.
+        // The assumption is that quick fixes operate on original document positions
+        // per the LSP spec ("all text edit ranges refer to positions in the original
+        // document"), so an insertion at (0,5) and a replacement of (0,0)-(0,10) are
+        // independently valid.  This test documents the current behaviour so it is
+        // visible to future maintainers.
+        let replacement = FixAllRange { start_line: 0, start_char: 0, end_line: 0, end_char: 10 };
+        let insertion = FixAllRange { start_line: 0, start_char: 5, end_line: 0, end_char: 5 };
+        assert!(!replacement.overlaps(&insertion));
+        assert!(!insertion.overlaps(&replacement));
     }
 
     #[test]

--- a/crates/perl-lsp/src/runtime/language/code_actions.rs
+++ b/crates/perl-lsp/src/runtime/language/code_actions.rs
@@ -44,6 +44,163 @@ fn display_diagnostic_message(diagnostic: &crate::features::diagnostics::Diagnos
     }
 }
 
+/// Byte-offset-agnostic representation of an LSP range used only for
+/// conflict detection in [`build_source_fix_all`]. Two edits conflict when
+/// their ranges overlap in character space, which prevents stacking edits
+/// that would corrupt the text when applied together.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct FixAllRange {
+    start_line: u64,
+    start_char: u64,
+    end_line: u64,
+    end_char: u64,
+}
+
+impl FixAllRange {
+    fn from_json(range: &Value) -> Option<Self> {
+        let start = range.get("start")?;
+        let end = range.get("end")?;
+        Some(Self {
+            start_line: start.get("line")?.as_u64()?,
+            start_char: start.get("character")?.as_u64()?,
+            end_line: end.get("line")?.as_u64()?,
+            end_char: end.get("character")?.as_u64()?,
+        })
+    }
+
+    /// Two ranges overlap when they cover common text. Zero-width insertions
+    /// at the same position are allowed to stack — LSP clients apply edits
+    /// in the order provided, so distinct insertions (for example `use
+    /// strict;` and `use warnings;` both at line 0) compose cleanly. The
+    /// caller still dedupes exact-match insertions in
+    /// [`build_source_fix_all`], so this only returns `true` when applying
+    /// both edits together would actually corrupt the text.
+    fn overlaps(&self, other: &Self) -> bool {
+        let (a, b) = if self <= other { (self, other) } else { (other, self) };
+        let a_is_insertion = a.start_line == a.end_line && a.start_char == a.end_char;
+        let b_is_insertion = b.start_line == b.end_line && b.start_char == b.end_char;
+        if a_is_insertion || b_is_insertion {
+            return false;
+        }
+        // a.start <= b.start; they overlap iff b.start < a.end.
+        (b.start_line, b.start_char) < (a.end_line, a.end_char)
+    }
+}
+
+/// Build the aggregate `source.fixAll` action from the code actions already
+/// collected for the current request. Aggregation rules:
+///
+/// * Only actions with `kind == "quickfix"` are considered — refactorings and
+///   source actions may require user input and are excluded per the LSP
+///   `source.fixAll` contract (no unsafe fixes, no user choices).
+/// * Each action must carry a `WorkspaceEdit` with a `changes` map keyed by
+///   the document URI. Command-only quick fixes are skipped because they
+///   cannot be applied together without a round-trip.
+/// * Overlapping edits are resolved by "first wins" — the first edit in the
+///   iteration order keeps its slot, and any later edit whose range overlaps
+///   an already-accepted range is dropped. Same-position insertions from
+///   multiple diagnostics count as overlapping so we never stack two `use
+///   strict;` insertions at the top of the file, for example.
+/// * The aggregate is only emitted when at least two distinct edits survive
+///   conflict resolution — a single quick fix is already the preferred action
+///   and does not need a wrapper.
+///
+/// The resulting action lists every diagnostic associated with the accepted
+/// source actions so the client can clear them together once the aggregate
+/// is applied.
+fn build_source_fix_all(code_actions: &[Value], uri: &str) -> Option<Value> {
+    let mut accepted_ranges: Vec<FixAllRange> = Vec::new();
+    let mut merged_edits: Vec<Value> = Vec::new();
+    let mut merged_diagnostics: Vec<Value> = Vec::new();
+    let mut seen_diagnostic_keys: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+    let mut seen_edit_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for action in code_actions {
+        if action.get("kind").and_then(Value::as_str) != Some("quickfix") {
+            continue;
+        }
+
+        // Skip command-only quick fixes — they can't be merged into a single
+        // WorkspaceEdit.
+        let Some(changes) = action.pointer("/edit/changes").and_then(Value::as_object) else {
+            continue;
+        };
+        let Some(edits) = changes.get(uri).and_then(Value::as_array) else {
+            continue;
+        };
+
+        // Compute the ranges for this action so we can reject the whole action
+        // atomically if any of its edits conflict with an already-accepted
+        // edit. Atomicity matters because a code action's edits are designed
+        // to be applied together.
+        let action_ranges: Vec<FixAllRange> = edits
+            .iter()
+            .filter_map(|edit| edit.get("range").and_then(FixAllRange::from_json))
+            .collect();
+
+        if action_ranges.len() != edits.len() {
+            // At least one edit had a malformed range — bail on this action.
+            continue;
+        }
+
+        if action_ranges.iter().any(|r| accepted_ranges.iter().any(|a| a.overlaps(r))) {
+            continue;
+        }
+
+        // Accept the action: record its ranges and copy its edits verbatim,
+        // deduping identical (range, newText) pairs so two providers that
+        // both add `use strict;\n` at offset 0 produce a single edit.
+        accepted_ranges.extend(action_ranges.iter().copied());
+        for edit in edits {
+            let new_text = edit.get("newText").and_then(Value::as_str).unwrap_or_default();
+            let range_repr = edit.get("range").map(|r| r.to_string()).unwrap_or_default();
+            let key = format!("{range_repr}|{new_text}");
+            if seen_edit_keys.insert(key) {
+                merged_edits.push(edit.clone());
+            }
+        }
+
+        if let Some(diags) = action.get("diagnostics").and_then(Value::as_array) {
+            for diag in diags {
+                // Dedupe diagnostics by (code, range) so the same upstream
+                // finding isn't surfaced twice in the aggregate action.
+                let code = diag.get("code").and_then(Value::as_str).unwrap_or_default().to_string();
+                let range_key = diag.get("range").map(|r| r.to_string()).unwrap_or_default();
+                let key = format!("{code}|{range_key}");
+                if seen_diagnostic_keys.insert(key) {
+                    merged_diagnostics.push(diag.clone());
+                }
+            }
+        }
+    }
+
+    // Only emit the aggregate when it actually aggregates something.
+    if merged_edits.len() < 2 {
+        return None;
+    }
+
+    let mut changes = serde_json::Map::new();
+    changes.insert(uri.to_string(), Value::Array(merged_edits));
+
+    let mut action = json!({
+        "title": "Fix all auto-fixable issues",
+        "kind": "source.fixAll",
+        "isPreferred": true,
+        "edit": {
+            "changes": Value::Object(changes),
+        },
+    });
+
+    if !merged_diagnostics.is_empty() {
+        if let Some(object) = action.as_object_mut() {
+            object.insert("diagnostics".to_string(), Value::Array(merged_diagnostics));
+        }
+    }
+
+    Some(action)
+}
+
 impl LspServer {
     /// Handle textDocument/codeAction request
     pub(crate) fn handle_code_action(
@@ -364,6 +521,14 @@ impl LspServer {
             }
             code_actions.extend(pragma_actions);
 
+            // Aggregate all quick fixes collected so far into a single
+            // `source.fixAll` action (LSP 3.17) when there are two or more
+            // distinct edits. Editors use this to apply every safe fix with
+            // one keystroke.
+            if let Some(fix_all) = build_source_fix_all(&code_actions, uri) {
+                code_actions.push(fix_all);
+            }
+
             retain_requested_code_action_kinds(&mut code_actions, &requested_kinds);
             Ok(Some(json!(code_actions)))
         } else {
@@ -663,6 +828,267 @@ mod tests {
         );
     }
 
+    /// Build a minimal quickfix action for use in unit tests.  The action has
+    /// exactly one edit on the supplied single-line range and a single
+    /// associated diagnostic so we can verify diagnostic propagation.
+    fn make_quickfix(
+        uri: &str,
+        line: u64,
+        start_char: u64,
+        end_char: u64,
+        new_text: &str,
+        title: &str,
+        diag_code: Option<&str>,
+    ) -> Value {
+        let mut action = json!({
+            "title": title,
+            "kind": "quickfix",
+            "edit": {
+                "changes": {
+                    uri: [{
+                        "range": {
+                            "start": {"line": line, "character": start_char},
+                            "end": {"line": line, "character": end_char},
+                        },
+                        "newText": new_text,
+                    }]
+                }
+            }
+        });
+
+        if let Some(code) = diag_code {
+            if let Some(object) = action.as_object_mut() {
+                object.insert(
+                    "diagnostics".to_string(),
+                    json!([{
+                        "range": {
+                            "start": {"line": line, "character": start_char},
+                            "end": {"line": line, "character": end_char},
+                        },
+                        "code": code,
+                        "message": format!("Diagnostic for {code}"),
+                        "source": "perl-lsp",
+                        "severity": 2,
+                    }]),
+                );
+            }
+        }
+
+        action
+    }
+
+    #[test]
+    fn fix_all_range_overlap_detects_contained_ranges() {
+        let outer = FixAllRange { start_line: 0, start_char: 0, end_line: 0, end_char: 20 };
+        let inner = FixAllRange { start_line: 0, start_char: 5, end_line: 0, end_char: 10 };
+        assert!(outer.overlaps(&inner));
+        assert!(inner.overlaps(&outer));
+    }
+
+    #[test]
+    fn fix_all_range_overlap_excludes_adjacent_ranges() {
+        let left = FixAllRange { start_line: 0, start_char: 0, end_line: 0, end_char: 5 };
+        let right = FixAllRange { start_line: 0, start_char: 5, end_line: 0, end_char: 10 };
+        assert!(!left.overlaps(&right));
+        assert!(!right.overlaps(&left));
+    }
+
+    #[test]
+    fn fix_all_range_overlap_allows_stacked_insertions() {
+        // Two distinct fixes can both insert at position (0,0) — for
+        // example `use strict;\n` + `use warnings;\n`. LSP clients apply
+        // them in sequence and they compose cleanly.  [`build_source_fix_all`]
+        // dedupes exact-match edits separately.
+        let first = FixAllRange { start_line: 0, start_char: 0, end_line: 0, end_char: 0 };
+        let second = FixAllRange { start_line: 0, start_char: 0, end_line: 0, end_char: 0 };
+        assert!(!first.overlaps(&second));
+    }
+
+    #[test]
+    fn fix_all_range_overlap_allows_insertion_outside_range() {
+        let insertion = FixAllRange { start_line: 5, start_char: 0, end_line: 5, end_char: 0 };
+        let unrelated = FixAllRange { start_line: 0, start_char: 0, end_line: 0, end_char: 5 };
+        assert!(!insertion.overlaps(&unrelated));
+        assert!(!unrelated.overlaps(&insertion));
+    }
+
+    #[test]
+    fn build_source_fix_all_aggregates_multiple_quickfixes() {
+        let uri = "file:///aggregate.pl";
+        let actions = vec![
+            make_quickfix(uri, 1, 4, 10, "fix-a", "Fix A", Some("PL100")),
+            make_quickfix(uri, 2, 0, 4, "fix-b", "Fix B", Some("PL101")),
+            make_quickfix(uri, 3, 2, 5, "fix-c", "Fix C", Some("PL102")),
+        ];
+
+        let aggregate = build_source_fix_all(&actions, uri).expect("aggregate present");
+        assert_eq!(aggregate["title"], "Fix all auto-fixable issues");
+        assert_eq!(aggregate["kind"], "source.fixAll");
+        assert_eq!(aggregate["isPreferred"], true);
+
+        let edits = aggregate["edit"]["changes"][uri].as_array().expect("aggregate has edits");
+        assert_eq!(edits.len(), 3, "three non-conflicting edits were kept");
+
+        let diagnostics = aggregate["diagnostics"].as_array().expect("diagnostics array");
+        assert_eq!(diagnostics.len(), 3, "one diagnostic per quickfix");
+    }
+
+    #[test]
+    fn build_source_fix_all_returns_none_for_single_quickfix() {
+        let uri = "file:///single.pl";
+        let actions = vec![make_quickfix(uri, 0, 0, 3, "fix", "Fix solo", Some("PL100"))];
+        assert!(build_source_fix_all(&actions, uri).is_none());
+    }
+
+    #[test]
+    fn build_source_fix_all_returns_none_without_any_quickfix() {
+        let uri = "file:///none.pl";
+        let actions = vec![
+            json!({
+                "title": "Extract variable",
+                "kind": "refactor.extract",
+                "edit": { "changes": { uri: [] } }
+            }),
+            json!({
+                "title": "Organize imports",
+                "kind": "source.organizeImports",
+                "edit": { "changes": { uri: [] } }
+            }),
+        ];
+        assert!(build_source_fix_all(&actions, uri).is_none());
+    }
+
+    #[test]
+    fn build_source_fix_all_ignores_non_quickfix_kinds() {
+        let uri = "file:///mixed.pl";
+        let actions = vec![
+            make_quickfix(uri, 0, 0, 3, "fix-a", "Fix A", Some("PL100")),
+            make_quickfix(uri, 1, 0, 3, "fix-b", "Fix B", Some("PL101")),
+            json!({
+                "title": "Extract variable",
+                "kind": "refactor.extract",
+                "edit": {
+                    "changes": {
+                        uri: [{
+                            "range": {
+                                "start": {"line": 2, "character": 0},
+                                "end": {"line": 2, "character": 5},
+                            },
+                            "newText": "extracted",
+                        }]
+                    }
+                }
+            }),
+        ];
+        let aggregate = build_source_fix_all(&actions, uri).expect("aggregate present");
+        let edits = aggregate["edit"]["changes"][uri].as_array().expect("aggregate has edits");
+        assert_eq!(edits.len(), 2, "refactor action must not be merged into fixAll");
+    }
+
+    #[test]
+    fn build_source_fix_all_rejects_overlapping_edits() {
+        let uri = "file:///overlap.pl";
+        // Second action overlaps the first — must be skipped atomically.
+        let actions = vec![
+            make_quickfix(uri, 0, 0, 10, "first", "Fix A", Some("PL100")),
+            make_quickfix(uri, 0, 5, 15, "second", "Fix B", Some("PL101")),
+            make_quickfix(uri, 2, 0, 3, "third", "Fix C", Some("PL102")),
+        ];
+        let aggregate = build_source_fix_all(&actions, uri).expect("aggregate present");
+        let edits = aggregate["edit"]["changes"][uri].as_array().expect("aggregate has edits");
+        assert_eq!(edits.len(), 2);
+        let new_texts: Vec<&str> =
+            edits.iter().filter_map(|edit| edit["newText"].as_str()).collect();
+        assert_eq!(new_texts, vec!["first", "third"]);
+    }
+
+    #[test]
+    fn build_source_fix_all_skips_command_only_quickfixes() {
+        let uri = "file:///command.pl";
+        let actions = vec![
+            make_quickfix(uri, 0, 0, 3, "fix-a", "Fix A", Some("PL100")),
+            make_quickfix(uri, 1, 0, 3, "fix-b", "Fix B", Some("PL101")),
+            // Command-only action: no `edit.changes` — cannot merge.
+            json!({
+                "title": "Run external fixer",
+                "kind": "quickfix",
+                "command": {"command": "perl.runFixer", "title": "Run"}
+            }),
+        ];
+        let aggregate = build_source_fix_all(&actions, uri).expect("aggregate present");
+        let edits = aggregate["edit"]["changes"][uri].as_array().expect("aggregate has edits");
+        assert_eq!(edits.len(), 2);
+    }
+
+    #[test]
+    fn build_source_fix_all_deduplicates_identical_edits() {
+        // Two providers may both emit a quick fix that inserts exactly the
+        // same text at the same position (e.g. "Add 'use strict;'" at 0,0).
+        // The aggregate must only include that edit once.
+        let uri = "file:///identical.pl";
+        let actions = vec![
+            make_quickfix(uri, 0, 0, 0, "use strict;\n", "Add strict (A)", Some("PL100")),
+            make_quickfix(uri, 0, 0, 0, "use strict;\n", "Add strict (B)", Some("PL100")),
+            make_quickfix(uri, 0, 0, 0, "use warnings;\n", "Add warnings", Some("PL101")),
+        ];
+        let aggregate = build_source_fix_all(&actions, uri).expect("aggregate present");
+        let edits = aggregate["edit"]["changes"][uri].as_array().expect("aggregate has edits");
+        assert_eq!(edits.len(), 2, "identical edits must dedupe: {edits:#?}");
+        let texts: Vec<&str> = edits.iter().filter_map(|edit| edit["newText"].as_str()).collect();
+        assert!(texts.contains(&"use strict;\n"));
+        assert!(texts.contains(&"use warnings;\n"));
+    }
+
+    #[test]
+    fn build_source_fix_all_deduplicates_diagnostics() {
+        let uri = "file:///dupes.pl";
+        let actions = vec![
+            make_quickfix(uri, 0, 0, 3, "a", "Fix A", Some("PL100")),
+            make_quickfix(uri, 1, 0, 3, "b", "Fix B1", Some("PL200")),
+            // Same diagnostic code and range as Fix B1: its diagnostic entry
+            // should not be listed twice on the aggregate.
+            {
+                let mut action = make_quickfix(uri, 2, 0, 3, "b2", "Fix B2", Some("PL200"));
+                if let Some(object) = action.as_object_mut() {
+                    object.insert(
+                        "diagnostics".to_string(),
+                        json!([{
+                            "range": {
+                                "start": {"line": 1, "character": 0},
+                                "end": {"line": 1, "character": 3},
+                            },
+                            "code": "PL200",
+                            "message": "Duplicate diagnostic",
+                            "source": "perl-lsp",
+                            "severity": 2,
+                        }]),
+                    );
+                }
+                action
+            },
+        ];
+        let aggregate = build_source_fix_all(&actions, uri).expect("aggregate present");
+        let diagnostics = aggregate["diagnostics"].as_array().expect("diagnostics array");
+        let codes: Vec<&str> = diagnostics.iter().filter_map(|d| d["code"].as_str()).collect();
+        assert_eq!(codes, vec!["PL100", "PL200"]);
+    }
+
+    #[test]
+    fn build_source_fix_all_ignores_other_uris() {
+        let uri = "file:///target.pl";
+        let other_uri = "file:///other.pl";
+        let actions = vec![
+            make_quickfix(uri, 0, 0, 3, "a", "Fix A", Some("PL100")),
+            make_quickfix(uri, 1, 0, 3, "b", "Fix B", Some("PL101")),
+            make_quickfix(other_uri, 0, 0, 3, "c", "Cross-file", Some("PL102")),
+        ];
+        let aggregate = build_source_fix_all(&actions, uri).expect("aggregate present");
+        let edits = aggregate["edit"]["changes"][uri].as_array().expect("aggregate has edits");
+        // Only the two edits targeting `uri` are merged; the cross-file edit
+        // is skipped because it has no `changes[uri]` entry.
+        assert_eq!(edits.len(), 2);
+    }
+
     #[test]
     fn code_action_runtime_offers_extract_variable() {
         let server = LspServer::new();
@@ -693,5 +1119,106 @@ print $result;
             }),
             "expected extract-variable action, got: {actions:?}"
         );
+    }
+
+    #[test]
+    fn code_action_runtime_emits_source_fix_all_when_multiple_quick_fixes_exist() {
+        // A script with no pragmas and an undefined variable triggers at
+        // least two quick fixes (add `use strict`, add `use warnings`).
+        // The runtime should bundle them into a `source.fixAll` action in
+        // addition to the individual quickfix actions.
+        let server = LspServer::new();
+        let uri = "file:///fix_all.pl";
+        let text = "print $undefined;\n";
+        open_test_document(&server, uri, text);
+
+        let response = server.handle_code_action(Some(json!({
+            "textDocument": { "uri": uri },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 0 }
+            },
+            "context": { "diagnostics": [] }
+        })));
+
+        let actions =
+            response.ok().flatten().and_then(|v| v.as_array().cloned()).unwrap_or_default();
+
+        let fix_all: Vec<&Value> =
+            actions.iter().filter(|a| a["kind"].as_str() == Some("source.fixAll")).collect();
+
+        assert_eq!(
+            fix_all.len(),
+            1,
+            "exactly one source.fixAll aggregate should be emitted, got: {actions:#?}"
+        );
+
+        let aggregate = fix_all[0];
+        assert_eq!(aggregate["title"], "Fix all auto-fixable issues");
+        assert_eq!(aggregate["isPreferred"], true);
+
+        let edits = aggregate["edit"]["changes"][uri].as_array().expect("aggregate has edits");
+        assert!(edits.len() >= 2, "aggregate must combine at least two edits, got {edits:#?}");
+    }
+
+    #[test]
+    fn code_action_runtime_skips_source_fix_all_for_clean_file() {
+        // A file with `use strict` and `use warnings` already should not
+        // produce enough quick fixes to justify an aggregate action.
+        let server = LspServer::new();
+        let uri = "file:///clean.pl";
+        let text = "use strict;\nuse warnings;\nmy $x = 1;\nprint $x;\n";
+        open_test_document(&server, uri, text);
+
+        let response = server.handle_code_action(Some(json!({
+            "textDocument": { "uri": uri },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 0 }
+            },
+            "context": { "diagnostics": [] }
+        })));
+
+        let actions =
+            response.ok().flatten().and_then(|v| v.as_array().cloned()).unwrap_or_default();
+
+        let fix_all_count =
+            actions.iter().filter(|a| a["kind"].as_str() == Some("source.fixAll")).count();
+        assert_eq!(
+            fix_all_count, 0,
+            "no source.fixAll should be emitted for a file with no quick fixes: {actions:#?}"
+        );
+    }
+
+    #[test]
+    fn code_action_runtime_returns_only_source_fix_all_when_filtered() {
+        // When the client filters to `only: ["source.fixAll"]`, the runtime
+        // must still run the full pipeline and then prune — verifying the
+        // aggregator runs before `retain_requested_code_action_kinds`.
+        let server = LspServer::new();
+        let uri = "file:///filter.pl";
+        let text = "print $undefined;\n";
+        open_test_document(&server, uri, text);
+
+        let response = server.handle_code_action(Some(json!({
+            "textDocument": { "uri": uri },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 0 }
+            },
+            "context": { "diagnostics": [], "only": ["source.fixAll"] }
+        })));
+
+        let actions =
+            response.ok().flatten().and_then(|v| v.as_array().cloned()).unwrap_or_default();
+
+        assert!(!actions.is_empty(), "filtered request should still yield the aggregate");
+        for action in &actions {
+            assert_eq!(
+                action["kind"].as_str(),
+                Some("source.fixAll"),
+                "filter must retain only source.fixAll: {action:#?}"
+            );
+        }
     }
 }

--- a/crates/perl-lsp/tests/snapshots/all_capabilities.json
+++ b/crates/perl-lsp/tests/snapshots/all_capabilities.json
@@ -4,7 +4,8 @@
     "codeActionKinds": [
       "quickfix",
       "source.organizeImports",
-      "refactor.extract"
+      "refactor.extract",
+      "source.fixAll"
     ],
     "resolveProvider": true
   },

--- a/crates/perl-lsp/tests/snapshots/ga_lock_capabilities.json
+++ b/crates/perl-lsp/tests/snapshots/ga_lock_capabilities.json
@@ -4,7 +4,8 @@
     "codeActionKinds": [
       "quickfix",
       "source.organizeImports",
-      "refactor.extract"
+      "refactor.extract",
+      "source.fixAll"
     ],
     "resolveProvider": true
   },

--- a/crates/perl-lsp/tests/snapshots/lsp_cap_snap__code_action_kinds.snap
+++ b/crates/perl-lsp/tests/snapshots/lsp_cap_snap__code_action_kinds.snap
@@ -5,3 +5,4 @@ expression: "&kinds"
 - quickfix
 - source.organizeImports
 - refactor.extract
+- source.fixAll

--- a/crates/perl-lsp/tests/snapshots/lsp_cap_snap__server_capabilities_full_client.snap
+++ b/crates/perl-lsp/tests/snapshots/lsp_cap_snap__server_capabilities_full_client.snap
@@ -8,6 +8,7 @@ codeActionProvider:
     - quickfix
     - source.organizeImports
     - refactor.extract
+    - source.fixAll
   resolveProvider: true
 codeLensProvider:
   resolveProvider: true

--- a/crates/perl-lsp/tests/snapshots/lsp_cap_snap__server_capabilities_minimal_client.snap
+++ b/crates/perl-lsp/tests/snapshots/lsp_cap_snap__server_capabilities_minimal_client.snap
@@ -8,6 +8,7 @@ codeActionProvider:
     - quickfix
     - source.organizeImports
     - refactor.extract
+    - source.fixAll
   resolveProvider: true
 codeLensProvider:
   resolveProvider: true

--- a/crates/perl-lsp/tests/snapshots/production_capabilities.json
+++ b/crates/perl-lsp/tests/snapshots/production_capabilities.json
@@ -4,7 +4,8 @@
     "codeActionKinds": [
       "quickfix",
       "source.organizeImports",
-      "refactor.extract"
+      "refactor.extract",
+      "source.fixAll"
     ],
     "resolveProvider": true
   },


### PR DESCRIPTION
Closes #3508.

## Summary

Implements the LSP 3.17 `source.fixAll` code action — a single aggregated action that applies every safe auto-fix in the current document with one keystroke. Before this PR the `SourceFixAll` variant existed in the internal enum but was never emitted by the runtime and was not advertised to clients.

Editors call `source.fixAll` in two common situations:
- **`editor.codeActionsOnSave: { "source.fixAll": true }`** — runs every safe fix when a file is saved. Both VS Code and Zed wire this up out of the box.
- **Explicit "Fix all problems" command** — user invokes a keybinding to clean up a file in one shot.

Without an aggregated action each client has to round-trip once per diagnostic, pick which quick fix to apply, then race to avoid applying edits against stale byte offsets. `source.fixAll` hands the client a single `WorkspaceEdit` that has already been conflict-resolved server-side.

## What changed

### Runtime aggregator — `crates/perl-lsp/src/runtime/language/code_actions.rs`

Added `build_source_fix_all`, a pure function that runs after every other quick-fix provider and folds their output into a single action.

**Inputs it sees:**
- `BuiltInAnalyzer` (Perl::Critic) quick fixes
- `CodeActionsProviderV2` (diagnostic-driven) quick fixes
- `CodeActionsProvider` (AST-based) quick fixes
- `code_actions_pragmas` (missing `use strict` / `use warnings`)

**Aggregation rules:**
1. Only actions with `kind == "quickfix"` are considered. Refactorings and other source actions may require user input and are explicitly excluded per the LSP `source.fixAll` contract ("no unsafe fixes, no user choices").
2. Command-only quick fixes (no `edit.changes`) are skipped — they cannot be merged into a single `WorkspaceEdit`.
3. Each contributing action is treated **atomically**: if any of its edits overlap an already-accepted range, the whole action is skipped. A code action's edits are designed to be applied together, so partial application would corrupt output.
4. **Same-position zero-width insertions are allowed to stack.** This is the common pragma case: a file missing both `use strict;` and `use warnings;` produces two independent fixes that both insert at `(0, 0)`. LSP clients apply edits in order, so stacking composes cleanly.
5. Identical `(range, newText)` pairs across actions are deduped — two providers that independently suggest `use strict;\n` at offset 0 should not insert it twice.
6. Associated `diagnostics` are carried through and deduped by `(code, range)` so the client can clear every source diagnostic together when the aggregate applies.
7. The aggregate is only emitted when **at least two distinct edits survive** conflict resolution. One quick fix is already the preferred action and does not need a wrapper.

The resulting action has `isPreferred: true` so clients sort it above per-diagnostic fixes in the Quick Fix menu.

### Capability advertisement — `crates/perl-lsp-protocol/src/capabilities.rs`

`CodeActionKind::SOURCE_FIX_ALL` is now pushed onto `codeActionKinds` next to `REFACTOR_EXTRACT`. Six snapshot files are updated to include the new kind:

| Snapshot | Purpose |
|---|---|
| `production_capabilities.json` | Production profile contract |
| `all_capabilities.json` | "All flags enabled" contract |
| `ga_lock_capabilities.json` | Conservative GA-lock profile |
| `lsp_capability_snapshot_test__code_action_kinds.snap` | Guards kind ordering |
| `lsp_capability_snapshot_test__server_capabilities_full_client.snap` | Full-client init response |
| `lsp_capability_snapshot_test__server_capabilities_minimal_client.snap` | Minimal-client init response |

## Tests — 14 new cases, all green

### Overlap helper (`FixAllRange::overlaps`)
- `fix_all_range_overlap_detects_contained_ranges`
- `fix_all_range_overlap_excludes_adjacent_ranges`
- `fix_all_range_overlap_allows_stacked_insertions`
- `fix_all_range_overlap_allows_insertion_outside_range`

### Aggregator (`build_source_fix_all`)
- `build_source_fix_all_aggregates_multiple_quickfixes`
- `build_source_fix_all_returns_none_for_single_quickfix`
- `build_source_fix_all_returns_none_without_any_quickfix`
- `build_source_fix_all_ignores_non_quickfix_kinds`
- `build_source_fix_all_rejects_overlapping_edits`
- `build_source_fix_all_skips_command_only_quickfixes`
- `build_source_fix_all_deduplicates_identical_edits`
- `build_source_fix_all_deduplicates_diagnostics`
- `build_source_fix_all_ignores_other_uris`

### End-to-end runtime handler
- `code_action_runtime_emits_source_fix_all_when_multiple_quick_fixes_exist` — file missing both pragmas produces a `source.fixAll` with ≥2 merged edits.
- `code_action_runtime_skips_source_fix_all_for_clean_file` — clean file produces no aggregate.
- `code_action_runtime_returns_only_source_fix_all_when_filtered` — honours `context.only: ["source.fixAll"]`.

```
cargo test -p perl-lsp-rs --lib
test result: ok. 386 passed; 0 failed
```

Lib-only clippy gate (`cargo clippy --workspace --lib --locked --no-deps -- -D warnings -A missing_docs`) passes cleanly.

## Why this design

- **Single runtime location, not a new crate method.** The quick fixes arrive from four different providers and have already been serialised to `Value` by the time they reach the end of `handle_code_action`. Aggregating at that point sees every provider, runs once per request, and does not force any provider to learn about `source.fixAll`.
- **First-wins conflict resolution, not last-wins or merge.** Merging two edits in the same range requires the aggregator to understand the semantic effect of both fixes, which it can't. First-wins is conservative, deterministic, and preserves the invariant that every listed edit is a real provider output.
- **Atomic per-action acceptance.** A provider's edits are designed to apply together — partial application is worse than dropping the whole fix.
- **`isPreferred: true`.** The LSP spec allows clients to sort preferred actions first; marking the aggregate preferred puts it at the top of the Quick Fix menu, which is what users expect.

## Out of scope

- **Pre-existing snapshot drift** in `documentFormattingProvider` / `documentRangeFormattingProvider` / `semanticTokensProvider.full` — those differences appear with or without this PR and warrant a separate fix.
- **Teaching individual providers to include their own `source.fixAll` variants.** Aggregation happens once at the end of the pipeline; no provider needs to change.
- **`codeAction/resolve` support for lazy edits.** The aggregate already carries its full `WorkspaceEdit` so a resolve round-trip is unnecessary.

## Follow-ups

- Opportunistically broaden the aggregate to include Perl::Critic `perlcritic --fix` output once that integration lands.
- Consider gating behind a `BuildFlags::source_fix_all` flag if downstream consumers want to opt out; today it rides under the existing `code_actions` umbrella flag.