### PR TITLE
docs(collapse): add migration ledger + freeze 30-crate target (#4410)

### DIFF
--- a/.spec/microcrate-collapse/ledger.md
+++ b/.spec/microcrate-collapse/ledger.md
@@ -1,0 +1,283 @@
+# Microcrate collapse migration ledger
+
+**Tracking:** #4410
+**ADR:** [docs/adr/0041-microcrate-collapse.md](../../docs/adr/0041-microcrate-collapse.md)
+**Target:** 132 → 30 published crates
+**Last updated:** 2026-04-15
+
+Workboard for every workspace crate. Columns:
+
+- **current crate** — crate name in current workspace
+- **target owner** — crate it absorbs into (or itself if kept public)
+- **final status** — `core-public` / `public-support` / `module` / `internal` / `tree-sitter`
+- **wave** — migration order (0=prereq, 1-H=families, F=final)
+- **risk** — Low / Med / High
+- **notes** — gotchas, facade path, dev-dep re-route, etc.
+
+Status legend:
+- `core-public` — durable external product/primitive, stays published
+- `public-support` — boring shared support crate kept published
+- `module` — absorbs into owner crate as folder-module
+- `internal` — `publish=false` (tooling/test infra)
+- `tree-sitter` — tree-sitter ecosystem, kept published
+
+---
+
+## Prerequisites (waves 0-1)
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| (xtask publish-closure gate) | xtask | internal | 1 | Low | **MERGED** PR #4417 — adds `cargo xtask publish-closure` |
+| (parser→LSP layering) | perl-parser | core-public | 0 | Low | PR #4418 in flight — removes 8 perl-lsp-* re-exports |
+
+## Products (core-public, stay as-is)
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| perllsp | perllsp | core-public | — | — | installer façade + binary |
+| perl-lsp-rs | perl-lsp-rs | core-public | — | — | LSP server library + bin (dir: crates/perl-lsp) |
+| perl-dap | perl-dap | core-public | H | — | DAP server; absorbs 11 perl-dap-* |
+| perl-parser | perl-parser | core-public | 3-4 | — | parser facade; absorbs syntax + parser-adjacent |
+| perl-lexer | perl-lexer | core-public | 3 | — | tokenizer; absorbs satellites |
+| perl-semantic-analyzer | perl-semantic-analyzer | core-public | 5 | — | absorbs symbol/incremental/refactor |
+| perl-workspace-index | perl-workspace-index | core-public | 2 | — | absorbs 6 perl-workspace-* |
+| perl-module | perl-module (NEW name) | core-public | 1 (PILOT) | Med | absorbs 13 perl-module-*; facade not `perl-module-resolution` |
+| perl-pragma | perl-pragma | core-public | 4 | Low | |
+| perl-regex | perl-regex | core-public | 4 | Low | |
+| perl-diagnostics-codes | perl-diagnostic-catalog | core-public | E | Low | renames; absorbs 2 more |
+| tree-sitter-perl-c | tree-sitter-perl-c | tree-sitter | — | — | FFI binding |
+| tree-sitter-perl-rs | tree-sitter-perl-rs | tree-sitter | — | — | ts-style facade |
+
+## Public-support (kept published, small & stable)
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| perl-parser-core | perl-parser-core | public-support | 4 | Low | engine internals — consider collapsing into perl-parser |
+| perl-subprocess-runtime | perl-subprocess-runtime | public-support | G2 | Low | shared LSP+DAP |
+| perl-lsp-perltidy | perl-lsp-perltidy | public-support | G3 | Low | formatter integration; plausibly reusable |
+| perl-lsp-text-utils | perl-lsp-text-utils | public-support | G2 | Low | text edit helpers |
+| perl-corpus | perl-corpus | public-support | — | Low | test corpus + generators for Perl parsers |
+| perl-tdd-support | perl-tdd-support | public-support | — | Low | TDD helpers for Perl LSP ecosystem |
+| perl-test-must | perl-test-must | public-support | — | Low | generic panic-on-failure helpers |
+| perl-test-generators | perl-test-generators | public-support | — | Low | proptest strategies for Perl domain |
+
+## Wave 1 PILOT — perl-module-* → perl-module
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| perl-module-name | perl-module | module | 1 | Low | api.rs facade, pub via crate::name |
+| perl-module-path | perl-module | module | 1 | Low | |
+| perl-module-token | perl-module | module | 1 | Low | |
+| perl-module-token-core | perl-module | module | 1 | Low | |
+| perl-module-token-parser | perl-module | module | 1 | Low | |
+| perl-module-boundary | perl-module | module | 1 | Low | |
+| perl-module-import | perl-module | module | 1 | Low | |
+| perl-module-import-match | perl-module | module | 1 | Low | |
+| perl-module-reference | perl-module | module | 1 | Low | |
+| perl-module-rename | perl-module | module | 1 | Low | |
+| perl-module-resolution | perl-module | module | 1 | Low | internal resolution/ folder |
+| perl-module-resolution-path | perl-module | module | 1 | Low | |
+| perl-module-resolution-uri | perl-module | module | 1 | Low | |
+
+## Wave 2 — perl-workspace-* → perl-workspace-index
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| perl-workspace-folder | perl-workspace-index | module | 2 | Low | |
+| perl-workspace-ignore | perl-workspace-index | module | 2 | Low | |
+| perl-workspace-discovery | perl-workspace-index | module | 2 | Low | |
+| perl-workspace-index-monitoring | perl-workspace-index | module | 2 | Low | internal monitoring/ |
+| perl-workspace-index-state-machine | perl-workspace-index | module | 2 | Low | |
+| perl-workspace-index-slo | perl-workspace-index | module | 2 | Low | |
+
+## Wave 3 — lexer satellites → perl-lexer
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| perl-token | perl-lexer | module | 3 | Low | foundation primitive — inline into lexer |
+| perl-tokenizer | perl-lexer | module | 3 | Low | |
+| perl-keywords | perl-lexer | module | 3 | Low | |
+| perl-builtins | perl-lexer | module | 3 | Low | |
+| perl-builtins-phf | perl-lexer | module | 3 | Low | PHF lookup tables |
+
+## Wave 4 — parser/AST satellites → perl-parser
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| perl-ast | perl-parser | module | 4 | Med | expose via parser facade |
+| perl-ast-v2 | perl-parser | module | 4 | Med | |
+| perl-ast-utils | perl-parser | module | 4 | Low | |
+| perl-quote | perl-parser | module | 4 | Low | |
+| perl-heredoc | perl-parser | module | 4 | Low | |
+| perl-heredoc-anti-patterns | perl-parser | module | 4 | Low | |
+| perl-error | perl-parser | module | 4 | Low | |
+| perl-incremental-parsing | perl-parser | module | 4 | Med | feature-gated |
+| perl-refactoring | perl-parser | module | 4 | Med | refactor engine |
+| perl-dead-code | perl-parser | module | 4 | Low | |
+| perl-feature-catalog | perl-parser | module | 4 | Low | codegen build-dep; inline into owner build.rs |
+| perl-line-index | perl-parser | module | 4 | Low | |
+| perl-position-tracking | perl-parser | module | 4 | Low | |
+| perl-pod | perl-parser | module | 4 | Low | |
+| perl-qualified-name | perl-parser | module | 4 | Low | |
+| perl-source-file | perl-parser | module | 4 | Low | |
+| perl-percentile | perl-parser | module | 4 | Low | numeric utility |
+| perl-text-line | perl-parser | module | 4 | Low | |
+| perl-edit | perl-parser | module | 4 | Low | |
+| perl-uri | perl-parser | module | 4 | Low | |
+| perl-uri-classify | perl-parser | module | 4 | Low | fold into perl-uri |
+| perl-path-normalize | perl-parser | module | 4 | Low | |
+| perl-path-security | perl-parser | module | 4 | Med | security primitive |
+
+## Wave 5 — semantic shards → perl-semantic-analyzer
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| perl-symbol-types | perl-semantic-analyzer | module | 5 | Low | |
+| perl-symbol-cursor | perl-semantic-analyzer | module | 5 | Low | consumed directly by perl-lsp-rs |
+| perl-symbol-index | perl-semantic-analyzer | module | 5 | Med | |
+| perl-symbol-surface | perl-semantic-analyzer | module | 5 | Low | |
+
+## Wave E — diagnostic catalog (NEW crate)
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| perl-diagnostics-codes | perl-diagnostic-catalog | module | E | Low | stays publishable as the NEW name |
+| perl-lsp-diagnostic-catalog | perl-diagnostic-catalog | module | E | Low | retired name; content absorbs |
+| perl-lsp-diagnostic-types | perl-diagnostic-catalog | module | E | Low | |
+
+## Wave F — perl-lsp-feature-* → perl-lsp-rs::features
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| perl-lsp-feature-ids | perl-lsp-rs | module | F | Low | |
+| perl-lsp-feature-contracts | perl-lsp-rs | module | F | Low | |
+| perl-lsp-feature-flags | perl-lsp-rs | module | F | Low | |
+| perl-lsp-feature-profile | perl-lsp-rs | module | F | Low | |
+| perl-lsp-feature-profile-cli | perl-lsp-rs | module | F | Low | preserve [[bin]] as subcommand |
+| perl-lsp-feature-policy | perl-lsp-rs | module | F | Low | |
+| perl-lsp-feature-grid | perl-lsp-rs | module | F | Low | |
+| perl-lsp-capability-map | perl-lsp-rs | module | F | Low | |
+
+## Wave G1 — LSP providers → perl-lsp-rs::providers
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| perl-lsp-providers | perl-lsp-rs | module | G1 | Med | aggregation → module glue |
+| perl-lsp-navigation | perl-lsp-rs | module | G1 | Med | |
+| perl-lsp-completion | perl-lsp-rs | module | G1 | Med | snapshot heavy |
+| perl-lsp-completion-item | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-file-completion | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-inline-completion | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-ai-provider | perl-lsp-rs | module | G1 | Med | gated by feature flags |
+| perl-lsp-code-actions | perl-lsp-rs | module | G1 | Med | |
+| perl-lsp-code-lens | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-document-highlight | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-document-links | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-folding | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-selection-range | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-semantic-tokens | perl-lsp-rs | module | G1 | Med | snapshot heavy |
+| perl-lsp-inlay-hints | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-rename | perl-lsp-rs | module | G1 | Med | |
+| perl-lsp-type-hierarchy | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-workspace-symbols | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-symbol-query | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-formatting | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-formatting-types | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-on-type-formatting | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-color-provider | perl-lsp-rs | module | G1 | Low | |
+| perl-lsp-diagnostics | perl-lsp-rs | module | G1 | Med | |
+| perl-lsp-import-management | perl-lsp-rs | module | G1 | Low | |
+
+## Wave G2 — LSP runtime infra → perl-lsp-rs::runtime
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| perl-lsp-protocol | perl-lsp-rs | module | G2 | Med | OR keep public as wire contract — orchestrator decision |
+| perl-lsp-transport | perl-lsp-rs | module | G2 | Low | |
+| perl-lsp-cancellation | perl-lsp-rs | module | G2 | Low | |
+| perl-lsp-limits | perl-lsp-rs | module | G2 | Low | |
+| perl-lsp-launcher | perl-lsp-rs | module | G2 | Low | lsp-ga-lock feature |
+| perl-lsp-config | perl-lsp-rs | module | G2 | Low | |
+| perl-lsp-uri | perl-lsp-rs | module | G2 | Low | |
+| perl-lsp-input-validation | perl-lsp-rs | module | G2 | Low | |
+| perl-content-length-framing | perl-lsp-rs | module | G2 | Low | duplicate into perl-dap or keep public (~150 LOC, shared) |
+
+## Wave G3 — LSP governance/tooling → perl-lsp-rs
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| perl-lsp-feature-governance | perl-lsp-rs | module | G3 | Low | |
+| perl-lsp-tooling | perl-lsp-rs | module | G3 | Low | |
+| perl-lsp-performance | perl-lsp-rs | module | G3 | Low | |
+| perl-lsp-critic-parser | perl-lsp-rs | module | G3 | Low | perlcritic output parser |
+
+## Wave H — perl-dap-* → perl-dap
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| perl-dap-breakpoint | perl-dap | module | H | Low | |
+| perl-dap-eval | perl-dap | module | H | Low | |
+| perl-dap-config | perl-dap | module | H | Low | |
+| perl-dap-platform | perl-dap | module | H | Med | cfg(unix)/cfg(windows) preserved |
+| perl-dap-command-args | perl-dap | module | H | Low | preserve build.rs if present |
+| perl-dap-shell | perl-dap | module | H | Low | |
+| perl-dap-stack | perl-dap | module | H | Low | |
+| perl-dap-types | perl-dap | module | H | Low | |
+| perl-dap-value | perl-dap | module | H | Low | |
+| perl-dap-security | perl-dap | module | H | Med | security primitive |
+| perl-dap-variables | perl-dap | module | H | Low | |
+
+## Standalone kernels (ADR-named public, deferred evaluation)
+
+These were flagged in ADR-0041 as potential standalone published kernels. Re-evaluate per-wave whether to keep public or collapse:
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| perl-feature-catalog | TBD | TBD | 4 | Low | build-dep; likely collapse to perl-parser or perl-lsp-rs |
+| perl-incremental-parsing | perl-parser | module | 4 | Low | decided: collapse |
+| perl-refactoring | perl-parser | module | 4 | Low | decided: collapse |
+| perl-dead-code | perl-parser | module | 4 | Low | decided: collapse |
+| perl-heredoc-anti-patterns | perl-parser | module | 4 | Low | decided: collapse |
+| perl-path-security | perl-parser | module | 4 | Low | decided: collapse |
+
+## Internal only (publish=false)
+
+| current crate | target owner | final status | wave | risk | notes |
+|---|---|---|---:|---:|---|
+| xtask | xtask | internal | — | — | tooling |
+| perl-ci-hygiene | perl-ci-hygiene | internal | — | — | CI tooling |
+| perl-lsp-ux-tests | perl-lsp-ux-tests | internal | — | — | UX regression harness |
+| perl-parser-pest | perl-parser-pest | core-public | — | — | **keep public per user** — legacy alternate parser |
+| perl-parser-bench | perl-parser-bench | internal | — | — | benchmark binary |
+
+## Final PR
+
+| action | wave | notes |
+|---|---:|---|
+| Shrink `[workspace.metadata.publish].allow` to exactly 30 | F | final PR |
+| Update CLAUDE.md, docs/dependency-tiers.md | F | |
+| Publish `docs/MIGRATION_v0.14.md` with full retired→new import table | F | |
+
+---
+
+## Progress tracker
+
+| Wave | Status | PR | Merged |
+|---|---|---|---|
+| 0 (prereq: ADR + docs) | ✅ MERGED | #4413 | 2026-04-15 |
+| 0 (prereq: publish-closure) | ✅ MERGED | #4417 | 2026-04-15 |
+| 0 (prereq: parser layering) | 🔄 IN REVIEW | #4418 | — |
+| 1 PILOT (perl-module-*) | ⏳ queued | — | — |
+| 2 (perl-workspace-*) | ⏳ queued | — | — |
+| 3 (lexer satellites) | ⏳ queued | — | — |
+| 4 (parser satellites) | ⏳ queued | — | — |
+| 5 (semantic shards) | ⏳ queued | — | — |
+| E (diagnostic catalog) | ⏳ queued | — | — |
+| F (LSP features) | ⏳ queued | — | — |
+| G1 (LSP providers) | ⏳ queued | — | — |
+| G2 (LSP runtime) | ⏳ queued | — | — |
+| G3 (LSP governance) | ⏳ queued | — | — |
+| H (perl-dap-*) | ⏳ queued | — | — |
+| FINAL (publish surface) | ⏳ queued | — | — |
+
+**Current:** 131 workspace members, 131 publish allowlist entries (post #4413 + #4417 merge; -1 from #4387/#4388 counts?). Will recount after truth check.

--- a/.spec/microcrate-collapse/ledger.md
+++ b/.spec/microcrate-collapse/ledger.md
@@ -141,7 +141,7 @@ Status legend:
 
 | current crate | target owner | final status | wave | risk | notes |
 |---|---|---|---:|---:|---|
-| perl-diagnostics-codes | perl-diagnostic-catalog | module | E | Low | stays publishable as the NEW name |
+| perl-diagnostics-codes | perl-diagnostic-catalog | core-public | E | Low | renamed to `perl-diagnostic-catalog`; this row IS the new published crate |
 | perl-lsp-diagnostic-catalog | perl-diagnostic-catalog | module | E | Low | retired name; content absorbs |
 | perl-lsp-diagnostic-types | perl-diagnostic-catalog | module | E | Low | |
 

--- a/docs/MIGRATION_v0.14.md
+++ b/docs/MIGRATION_v0.14.md
@@ -4,7 +4,7 @@ This guide is for downstream users of perl-lsp crates who are upgrading to v0.14
 
 ## What's changing in v0.14.0
 
-v0.14.0 is a **clean break** release. The published crate count drops from 132 to ~30.
+v0.14.0 is a **clean break** release. The published crate count drops from 132 to **30**.
 Approximately 100 product-internal microcrates stop being published. Their code moves
 into subfolder modules inside the owning published crate. There are no bridge crates
 or re-export shims — old crate names will no longer appear on crates.io after this release.
@@ -25,7 +25,7 @@ The same applies to the other 26 crates in the published set:
 - `perl-lexer`, `perl-token`, `perl-line-index`, `perl-uri`, `perl-pod`
 - `perl-diagnostic-catalog`
 - `perl-lsp-protocol`, `perl-content-length-framing`
-- `perl-semantic-analyzer`, `perl-module-resolution`, `perl-workspace-index`
+- `perl-semantic-analyzer`, `perl-module`, `perl-workspace-index`
 - `perl-symbol`
 - `perl-lsp-perltidy`
 - `perl-corpus`, `perl-tdd-support`, `perl-test-must`, `perl-test-generators`
@@ -35,7 +35,7 @@ The same applies to the other 26 crates in the published set:
 ## If you depend on a retired crate
 
 If your `Cargo.toml` lists a dependency on any crate not in the list above, that crate
-has been retired. Its code now lives as a module inside one of the ~30 published crates.
+has been retired. Its code now lives as a module inside one of the 30 published crates.
 
 **Steps to migrate:**
 
@@ -70,7 +70,7 @@ artifact and a semver contract. The full analysis is in
 ## Timeline
 
 - The collapse is running now, before the next release ships.
-- v0.14.0 will be the first release with the new ~30-crate surface.
+- v0.14.0 will be the first release with the new 30-crate surface.
 - Each wave PR updates this migration table as it lands.
 - There is no extended migration window — old crate names are not re-published as shims.
 

--- a/docs/adr/0041-microcrate-collapse.md
+++ b/docs/adr/0041-microcrate-collapse.md
@@ -200,9 +200,75 @@ When promoting, also update these operational artifacts:
 - Add a row to `docs/project/PUBLISHING_AFTER_COLLAPSE.md` in the appropriate category.
 - Verify `cargo xtask published-crate-count` still passes (or raise the ceiling intentionally with a comment).
 
+## Amendments
+
+### Amendment 1 — 2026-04-15: Target count frozen at 30; pilot target corrected; guardrails added
+
+**Source:** Orchestrator refinement following ledger construction in `.spec/microcrate-collapse/ledger.md`.
+
+#### Target count: 30 published (not 31)
+
+The original Decision section listed "~30" informally. After constructing the full per-crate ledger, the precise count is **30 published crates**. The earlier draft that circulated as "~30/31" double-counted `perl-diagnostic-catalog`, which appeared both under the diagnostic surface bullet and as an annotation in the "1 NEW" note. Corrected category breakdown:
+
+| Category | Count | Crates |
+|----------|------:|--------|
+| Products | 4 | perllsp, perl-lsp-rs, perl-dap, perl-parser |
+| Tree-sitter | 2 | tree-sitter-perl-c, tree-sitter-perl-rs |
+| Alternate parser | 1 | perl-parser-pest |
+| Foundation primitives | 5 | perl-lexer, perl-token, perl-line-index, perl-uri, perl-pod |
+| Diagnostic catalog (NEW) | 1 | perl-diagnostic-catalog |
+| Wire protocols | 2 | perl-lsp-protocol, perl-content-length-framing |
+| Semantic kernels | 3 | perl-semantic-analyzer, perl-module, perl-workspace-index |
+| Symbol model | 1 | perl-symbol |
+| Tool integrations | 1 | perl-lsp-perltidy |
+| Test/corpus ecosystem | 4 | perl-corpus, perl-tdd-support, perl-test-must, perl-test-generators |
+| Standalone tooling | 6 | perl-feature-catalog, perl-incremental-parsing, perl-refactoring, perl-dead-code, perl-heredoc-anti-patterns, perl-path-security |
+| **Total** | **30** | |
+
+#### Pilot target: `perl-module` facade (not `perl-module-resolution`)
+
+Wave 1 PILOT absorbs 13 `perl-module-*` crates. The Decision section above named `perl-module-resolution` as the absorption target; that name is retired. The surviving published crate is **`perl-module`** — a better external noun that owns names, imports, references, resolution, rename, and boundary as internal folder families. Facade-first design: the new `perl-module` crate presents a clean `pub use` surface; all 13 absorbed crates become internal `mod` folders.
+
+#### No public `perl-syntax` umbrella crate
+
+An earlier draft discussion proposed a `perl-syntax` umbrella crate. That proposal is rejected. Syntax primitives (AST, quote, heredoc, error) are absorbed into `perl-parser` as a `syntax/` internal folder family. There is no publicly-published `perl-syntax` crate.
+
+#### Wave order locked
+
+The migration wave sequence is fixed as:
+
+```
+1. perl-module-* → perl-module         (PILOT)
+2. perl-workspace-* → perl-workspace-index
+3. lexer satellites → perl-lexer
+4. parser/AST satellites → perl-parser
+5. semantic shards → perl-semantic-analyzer
+E. diagnostic catalog (NEW) → perl-diagnostic-catalog
+F. perl-lsp-feature-* → perl-lsp-rs::features
+G1. LSP providers → perl-lsp-rs::providers
+G2. LSP runtime → perl-lsp-rs::runtime
+G3. LSP governance → perl-lsp-rs
+H. perl-dap-* → perl-dap              (last, after DAP is stable)
+FINAL. Shrink allowlist to 30
+```
+
+Do **not** start with the `perl-lsp-*` forest (waves F/G) before the module/workspace/lexer/parser/semantic trains (waves 1-5) are complete. The LSP forest is the largest and most snapshot-heavy; doing it last reduces rebase pressure.
+
+#### Guardrails added
+
+Two additional CI gates join the three listed in the Decision section:
+
+- **Packaging dry-runs**: `cargo package -p <crate>` and `cargo publish --dry-run -p <crate>` run in CI for each surviving published crate. Catches path-only dep drift before a real publish attempt.
+- **Public API ratchet**: `cargo public-api diff` runs per-published-crate. Fails on unintended public surface expansion between PRs.
+
+#### Migration ledger is authoritative
+
+The per-crate workboard at [`.spec/microcrate-collapse/ledger.md`](../../.spec/microcrate-collapse/ledger.md) is the authoritative source for crate disposition, wave assignment, and progress tracking. It supersedes any comments, draft notes, or memory entries that reference "~30/31" or name `perl-module-resolution` as the Wave 1 target. Agents and humans executing the collapse must read the ledger, not reconstruct from this ADR alone.
+
 ## References
 
 - [Tracking issue #4410: Microcrate collapse to ~30 published crates](https://github.com/EffortlessMetrics/perl-lsp/issues/4410)
+- [Migration ledger](../../.spec/microcrate-collapse/ledger.md) — authoritative per-crate workboard (Amendment 1)
 - [docs/SRP_MICROCRATES.md](../SRP_MICROCRATES.md) — historical record of the microcrate decomposition campaign
 - [docs/PUBLISHING.md](../PUBLISHING.md) — current publishing pipeline; will simplify post-collapse
 - [scripts/publish-topo.py](../../scripts/publish-topo.py) — current topological publish ordering with dev-dep SCC handling

--- a/docs/project/PUBLISHING_AFTER_COLLAPSE.md
+++ b/docs/project/PUBLISHING_AFTER_COLLAPSE.md
@@ -58,7 +58,7 @@ The post-collapse published set, grouped by category and listed in approximate d
 | Crate | Role |
 |-------|------|
 | `perl-module` | Module name → file path resolution; absorbs 13 perl-module-* crates |
-| `perl-workspace-index` | Workspace symbol index and discovery; absorbs 7 perl-workspace-* crates |
+| `perl-workspace-index` | Workspace symbol index and discovery; absorbs 6 perl-workspace-* crates |
 | `perl-semantic-analyzer` | Scope analysis, type inference, variable resolution |
 
 ### Tool integrations (1)

--- a/docs/project/PUBLISHING_AFTER_COLLAPSE.md
+++ b/docs/project/PUBLISHING_AFTER_COLLAPSE.md
@@ -6,7 +6,7 @@ For the current 132-crate pipeline, see [docs/PUBLISHING.md](../PUBLISHING.md).
 
 See [ADR-0041](../adr/0041-microcrate-collapse.md) for the architectural rationale.
 
-## ~30 published crates in topological order
+## 30 published crates in topological order
 
 The post-collapse published set, grouped by category and listed in approximate dependency order
 (leaves first, products last):
@@ -57,7 +57,7 @@ The post-collapse published set, grouped by category and listed in approximate d
 
 | Crate | Role |
 |-------|------|
-| `perl-module-resolution` | Module name → file path resolution; absorbs 13 perl-module-* crates |
+| `perl-module` | Module name → file path resolution; absorbs 13 perl-module-* crates |
 | `perl-workspace-index` | Workspace symbol index and discovery; absorbs 7 perl-workspace-* crates |
 | `perl-semantic-analyzer` | Scope analysis, type inference, variable resolution |
 
@@ -127,20 +127,20 @@ PR #1 of the collapse series (tracked by [issue #4412](https://github.com/Effort
 |---------|----------------|
 | `cargo xtask publish-closure` | Verifies no `publish = false` crate appears in the runtime/build dependency closure of any published crate |
 | `cargo xtask layer-check` | Enforces dependency direction rules from `xtask/layer-rules.toml` at the import level inside crates |
-| `cargo xtask published-crate-count` | Ratchet — fails if the published crate count exceeds the target ceiling (~30), preventing count creep |
+| `cargo xtask published-crate-count` | Ratchet — fails if the published crate count exceeds the target ceiling (30), preventing count creep |
 
 ## Comparison: before vs after
 
-| Metric | Before (132 crates) | After (~30 crates) |
+| Metric | Before (132 crates) | After (30 crates) |
 |--------|--------------------|--------------------|
 | Publish run time | Hours | Minutes |
 | Topo sort complexity | Non-trivial (SCCs) | Trivial (DAG, no cycles) |
-| Allowlist entries | 132 | ~30 |
+| Allowlist entries | 132 | 30 |
 | Rate-limit handling | Required | Not needed |
 | Per-release version bumps | Workspace-wide cascade | Handful of crates |
-| docs.rs pages | 132 | ~30 |
-| crates.io search results | 132 | ~30 |
-| Semver contracts | 132 | ~30 |
+| docs.rs pages | 132 | 30 |
+| crates.io search results | 132 | 30 |
+| Semver contracts | 132 | 30 |
 
 ## Reference
 


### PR DESCRIPTION
## Summary

- **Landing the migration ledger** at `.spec/microcrate-collapse/ledger.md` — the authoritative per-crate workboard for the 132 → 30 collapse program. Every workspace crate is listed with its target owner, final status, wave, risk, and notes. This is the single source of truth that all collapse-wave builders read, not memory or draft comments.
- **Amending ADR-0041** with four refinements from the 2026-04-15 orchestrator review (Amendment 1 section added before References):
  - Target count frozen at **30** (not "~30/31" — the original listed `perl-diagnostic-catalog` twice; corrected breakdown tallied to exactly 30)
  - Wave 1 PILOT target is **`perl-module` facade**, not `perl-module-resolution` (better external noun; facade-first design)
  - **No public `perl-syntax` umbrella crate** (syntax primitives absorb into `perl-parser` as `syntax/` internal folder family)
  - **Wave order locked**: module → workspace → lexer → parser → semantic → DAP → LSP last (lsp-* forest is largest and most snapshot-heavy; doing it last minimizes rebase pressure)
  - Two new **CI guardrails**: packaging dry-runs (`cargo package -p`, `cargo publish --dry-run -p`) + `cargo public-api diff` ratchet per surviving published crate
- **Updating `docs/MIGRATION_v0.14.md`** and **`docs/project/PUBLISHING_AFTER_COLLAPSE.md`**: all `~30` approximations replaced with the frozen `30`; `perl-module-resolution` references replaced with `perl-module` throughout.

## Supersedes

This PR supersedes the "~30/31" drift present in earlier draft comments and the `perl-module-resolution` naming in the original ADR Decision section. Neither was committed on a branch; this is the authoritative correction.

Tracking: #4410

## Test plan

- [ ] No `.rs` or `Cargo.toml` files modified — pure docs
- [ ] `cargo fmt --check` passes (no code changed)
- [ ] All internal links in the ledger and amended ADR resolve within the repo
- [ ] `perl-module-resolution` no longer appears in MIGRATION_v0.14.md or PUBLISHING_AFTER_COLLAPSE.md as the Wave 1 target
- [ ] `~30` no longer appears in MIGRATION_v0.14.md or PUBLISHING_AFTER_COLLAPSE.md (frozen to `30`)
