### PR TITLE
docs(collapse): correct target v0.13.0 + rename Wave A owner perl-workspace (#4426)

### DIFF
--- a/.spec/4412-publish-closure/checklist.md
+++ b/.spec/4412-publish-closure/checklist.md
@@ -578,6 +578,6 @@ Expected: All checks pass (long, ~5-10 min).
 
 ## Related Issues
 
-- Parent: #4410 — Microcrate collapse (v0.14.x)
+- Parent: #4410 — Microcrate collapse (v0.13.0)
 - ADR: PR #4413 (ADR-0041)
 - Design pattern source: `scripts/publish-topo.py` (publish order, not closure)

--- a/.spec/4412-publish-closure/context.md
+++ b/.spec/4412-publish-closure/context.md
@@ -1,7 +1,7 @@
 # Context: publish-closure gate implementation
 
 **Issue**: #4412
-**Parent epic**: #4410 (Microcrate collapse, v0.14.x)
+**Parent epic**: #4410 (Microcrate collapse, v0.13.0)
 **Design document**: PR #4413 (ADR-0041, microcrate collapse design)
 **Scope**: `publish-closure` subcommand ONLY
 

--- a/.spec/4414-parser-layering/acceptance.md
+++ b/.spec/4414-parser-layering/acceptance.md
@@ -61,5 +61,5 @@ Each criterion is individually verifiable and must pass before sign-off.
 ## Historical Context
 
 - Tracking issue: #4410 (microcrate collapse roadmap)
-- ADR: ADR-0041 (PR #4413, documents v0.14.0 clean-break decision)
+- ADR: ADR-0041 (PR #4413, documents v0.13.0 clean-break decision)
 - Related: This is the first PR (#0) of the microcrate collapse sequence

--- a/.spec/4414-parser-layering/context.md
+++ b/.spec/4414-parser-layering/context.md
@@ -33,14 +33,14 @@ This convenience came at the cost of architectural inversion.
 
 1. **Microcrate collapse roadmap** (#4410) requires parser to be a pure leaf crate
 2. **Dependency graph correctness** — application (perl-lsp) should not be imported by foundations (perl-parser)
-3. **Timing decision** — ADR-0041 (PR #4413) specifies v0.14.0 as clean-break release, not v0.13.0
+3. **Timing decision** — ADR-0041 (PR #4413) specifies v0.13.0 as clean-break release, not v0.13.0
 4. **Scope clarity** — parser + analysis layers stay focused on language semantics; LSP features become explicit composition in `perl-lsp`
 
 ## Oppositional Planning Objection and Resolution
 
 **Objection raised**: Why not use a feature flag (`cfg(feature = "lsp-compat")`) to gate the re-exports and maintain backward compatibility?
 
-**Decision**: Rejected. ADR-0041 specifies a v0.14.0 clean break, not an incremental migration. Feature-gated re-exports would:
+**Decision**: Rejected. ADR-0041 specifies a v0.13.0 clean break, not an incremental migration. Feature-gated re-exports would:
 - Complicate the parser crate's public API surface (testing two configs)
 - Defer the architectural fix, making follow-up work harder
 - Create confusion about "the right" import path
@@ -126,7 +126,7 @@ Justification:
 ## Related Documents
 
 - **#4410**: Microcrate collapse roadmap — tracks the full sequence of dependency unwinding
-- **ADR-0041** (PR #4413): Architectural Decision Record — v0.14.0 clean break, rationale for timing, alternatives considered
+- **ADR-0041** (PR #4413): Architectural Decision Record — v0.13.0 clean break, rationale for timing, alternatives considered
 - **CLAUDE.md** (perl-lsp): Crate structure diagram showing current dependencies and planned state
 
 ## Precedent in Codebase

--- a/.spec/4420-wave1-perl-module/context.md
+++ b/.spec/4420-wave1-perl-module/context.md
@@ -72,7 +72,7 @@ This is the **pilot wave** of ADR-0041 (microcrate collapse). It establishes the
 
 **Alternative rejected:** Keep 0.12.4. Downside: semver lie; consumers won't realize they need code changes.
 
-**Implementation:** Cargo.toml sets version = "0.14.0" (step 0a). MIGRATION_v0.14.md documents the change (builder responsibility, not spec-planner).
+**Implementation:** Cargo.toml sets version = "0.13.0" (step 0a). MIGRATION_v0.13.md documents the change (builder responsibility, not spec-planner).
 
 ---
 

--- a/.spec/microcrate-collapse/ledger.md
+++ b/.spec/microcrate-collapse/ledger.md
@@ -3,7 +3,7 @@
 **Tracking:** #4410
 **ADR:** [docs/adr/0041-microcrate-collapse.md](../../docs/adr/0041-microcrate-collapse.md)
 **Target:** 132 → 30 published crates
-**Last updated:** 2026-04-15
+**Last updated:** 2026-04-16
 
 Workboard for every workspace crate. Columns:
 
@@ -40,7 +40,7 @@ Status legend:
 | perl-parser | perl-parser | core-public | 3-4 | — | parser facade; absorbs syntax + parser-adjacent |
 | perl-lexer | perl-lexer | core-public | 3 | — | tokenizer; absorbs satellites |
 | perl-semantic-analyzer | perl-semantic-analyzer | core-public | 5 | — | absorbs symbol/incremental/refactor |
-| perl-workspace-index | perl-workspace-index | core-public | 2 | — | absorbs 6 perl-workspace-* |
+| perl-workspace-index | perl-workspace | core-public | 2 | — | renamed to perl-workspace during Wave 2; absorbs 6 perl-workspace-* |
 | perl-module | perl-module (NEW name) | core-public | 1 (PILOT) | Med | absorbs 13 perl-module-*; facade not `perl-module-resolution` |
 | perl-pragma | perl-pragma | core-public | 4 | Low | |
 | perl-regex | perl-regex | core-public | 4 | Low | |
@@ -79,16 +79,21 @@ Status legend:
 | perl-module-resolution-path | perl-module | module | 1 | Low | |
 | perl-module-resolution-uri | perl-module | module | 1 | Low | |
 
-## Wave 2 — perl-workspace-* → perl-workspace-index
+## Wave 2 — perl-workspace-* → perl-workspace
+
+Note: `perl-workspace-index` is **renamed to `perl-workspace`** during this wave. The absorbed
+scope (enumeration: discovery, folder, ignore; observability: index-monitoring, index-slo,
+index-state-machine) is broader than "indexing." The rename happens as part of Wave 2 execution,
+not in this ledger PR.
 
 | current crate | target owner | final status | wave | risk | notes |
 |---|---|---|---:|---:|---|
-| perl-workspace-folder | perl-workspace-index | module | 2 | Low | |
-| perl-workspace-ignore | perl-workspace-index | module | 2 | Low | |
-| perl-workspace-discovery | perl-workspace-index | module | 2 | Low | |
-| perl-workspace-index-monitoring | perl-workspace-index | module | 2 | Low | internal monitoring/ |
-| perl-workspace-index-state-machine | perl-workspace-index | module | 2 | Low | |
-| perl-workspace-index-slo | perl-workspace-index | module | 2 | Low | |
+| perl-workspace-folder | perl-workspace | module | 2 | Low | enumeration satellite |
+| perl-workspace-ignore | perl-workspace | module | 2 | Low | enumeration satellite |
+| perl-workspace-discovery | perl-workspace | module | 2 | Low | enumeration satellite |
+| perl-workspace-index-monitoring | perl-workspace | module | 2 | Low | observability satellite |
+| perl-workspace-index-state-machine | perl-workspace | module | 2 | Low | observability satellite |
+| perl-workspace-index-slo | perl-workspace | module | 2 | Low | observability satellite |
 
 ## Wave 3 — lexer satellites → perl-lexer
 
@@ -256,7 +261,7 @@ These were flagged in ADR-0041 as potential standalone published kernels. Re-eva
 |---|---:|---|
 | Shrink `[workspace.metadata.publish].allow` to exactly 30 | F | final PR |
 | Update CLAUDE.md, docs/dependency-tiers.md | F | |
-| Publish `docs/MIGRATION_v0.14.md` with full retired→new import table | F | |
+| Publish `docs/MIGRATION_v0.13.md` with full retired→new import table | F | |
 
 ---
 

--- a/docs/MIGRATION_v0.13.md
+++ b/docs/MIGRATION_v0.13.md
@@ -1,10 +1,13 @@
-# Migration Guide — v0.14.0
+# Migration Guide — v0.13.0
 
-This guide is for downstream users of perl-lsp crates who are upgrading to v0.14.0.
+This guide is for downstream users of perl-lsp crates who are upgrading to v0.13.0.
 
-## What's changing in v0.14.0
+> **Note (2026-04-16):** This file was previously named `MIGRATION_v0.14.md`. The target release
+> for the microcrate collapse clean break was corrected to v0.13.0. See ADR-0041 Amendment 2.
 
-v0.14.0 is a **clean break** release. The published crate count drops from 132 to **30**.
+## What's changing in v0.13.0
+
+v0.13.0 is a **clean break** release. The published crate count drops from 132 to **30**.
 Approximately 100 product-internal microcrates stop being published. Their code moves
 into subfolder modules inside the owning published crate. There are no bridge crates
 or re-export shims — old crate names will no longer appear on crates.io after this release.
@@ -25,7 +28,7 @@ The same applies to the other 26 crates in the published set:
 - `perl-lexer`, `perl-token`, `perl-line-index`, `perl-uri`, `perl-pod`
 - `perl-diagnostic-catalog`
 - `perl-lsp-protocol`, `perl-content-length-framing`
-- `perl-semantic-analyzer`, `perl-module`, `perl-workspace-index`
+- `perl-semantic-analyzer`, `perl-module`, `perl-workspace`
 - `perl-symbol`
 - `perl-lsp-perltidy`
 - `perl-corpus`, `perl-tdd-support`, `perl-test-must`, `perl-test-generators`
@@ -70,7 +73,7 @@ artifact and a semver contract. The full analysis is in
 ## Timeline
 
 - The collapse is running now, before the next release ships.
-- v0.14.0 will be the first release with the new 30-crate surface.
+- v0.13.0 will be the first release with the new 30-crate surface.
 - Each wave PR updates this migration table as it lands.
 - There is no extended migration window — old crate names are not re-published as shims.
 

--- a/docs/adr/0041-microcrate-collapse.md
+++ b/docs/adr/0041-microcrate-collapse.md
@@ -151,7 +151,7 @@ The ~30-crate target reflects "all the legitimate reusable kernels and products,
 ### Negative
 
 - **One-time migration cost**: 14 PRs across several weeks of focused work.
-- **Downstream breakage for direct microcrate dependents**: addressed via [`docs/MIGRATION_v0.14.md`](../MIGRATION_v0.14.md) and a major-version bump.
+- **Downstream breakage for direct microcrate dependents**: addressed via [`docs/MIGRATION_v0.13.md`](../MIGRATION_v0.13.md) and a major-version bump.
 - **Snapshot test path drift**: per-wave review and regeneration step.
 - **Loss of crate-level test scoping**: `cargo test -p perl-X` becomes `cargo test -p perl-parser X::` for absorbed crates.
 - **Reduced crate-level incremental granularity**: a change to a former microcrate now rebuilds the whole owning crate. Mitigated by larger crates having less per-change overhead.
@@ -161,7 +161,7 @@ The ~30-crate target reflects "all the legitimate reusable kernels and products,
 - **Layer guards** (`cargo xtask layer-check`) enforce dependency direction inside crates, replacing the implicit guard that crate boundaries provided.
 - **Publish-closure guard** (`cargo xtask publish-closure`) prevents `publish = false` crates from re-entering the runtime graph.
 - **Ratchet** (`cargo xtask published-crate-count`) prevents published count creep.
-- **Migration guide** (`docs/MIGRATION_v0.14.md`) maps every retired crate to its new module path.
+- **Migration guide** (`docs/MIGRATION_v0.13.md`) maps every retired crate to its new module path.
 - **Folder discipline preserved**: each former microcrate is a folder with `mod.rs` facade, `pub(crate)` default, preserved tests, optional `CLAUDE.md`. Agents and humans navigating the codebase still see a microcrate-shaped layout.
 - **Wave merge serialization**: same-Cargo.toml waves serialize (parser train: PR #2 → A → B → C → D; LSP train: F → G1 → G2 → G3); cross-train parallelism is allowed (DAP wave H parallel after D).
 
@@ -218,7 +218,7 @@ The original Decision section listed "~30" informally. After constructing the fu
 | Foundation primitives | 5 | perl-lexer, perl-token, perl-line-index, perl-uri, perl-pod |
 | Diagnostic catalog (NEW) | 1 | perl-diagnostic-catalog |
 | Wire protocols | 2 | perl-lsp-protocol, perl-content-length-framing |
-| Semantic kernels | 3 | perl-semantic-analyzer, perl-module, perl-workspace-index |
+| Semantic kernels | 3 | perl-semantic-analyzer, perl-module, perl-workspace (see Amendment 2) |
 | Symbol model | 1 | perl-symbol |
 | Tool integrations | 1 | perl-lsp-perltidy |
 | Test/corpus ecosystem | 4 | perl-corpus, perl-tdd-support, perl-test-must, perl-test-generators |
@@ -239,7 +239,7 @@ The migration wave sequence is fixed as:
 
 ```
 1. perl-module-* → perl-module         (PILOT)
-2. perl-workspace-* → perl-workspace-index
+2. perl-workspace-* → perl-workspace   (perl-workspace-index renamed; see Amendment 2)
 3. lexer satellites → perl-lexer
 4. parser/AST satellites → perl-parser
 5. semantic shards → perl-semantic-analyzer
@@ -265,10 +265,51 @@ Two additional CI gates join the three listed in the Decision section:
 
 The per-crate workboard at [`.spec/microcrate-collapse/ledger.md`](../../.spec/microcrate-collapse/ledger.md) is the authoritative source for crate disposition, wave assignment, and progress tracking. It supersedes any comments, draft notes, or memory entries that reference "~30/31" or name `perl-module-resolution` as the Wave 1 target. Agents and humans executing the collapse must read the ledger, not reconstruct from this ADR alone.
 
+### Amendment 2 — 2026-04-16: Target release is v0.13.0 (not v0.14.x); Wave 2 owner renamed perl-workspace
+
+**Source:** User correction 2026-04-16.
+
+#### Target release: v0.13.0 clean-break (not v0.14.x)
+
+The Decision section and Amendment 1 referenced "v0.14.x" as the release that ships the new
+30-crate surface. This was incorrect. The correct target is **v0.13.0**.
+
+Current workspace version is **0.12.4**. The microcrate collapse ships as **v0.13.0** — a clean
+break that moves directly from the 0.12.x confidence track to the collapsed surface. There is no
+interim pre-collapse v0.13.0 release; v0.13.0 *is* the collapse release.
+
+Any document, spec file, or comment that says "v0.14.x", "v0.14.0", or implies a pre-collapse
+v0.13.0 ship gate is incorrect. The correction is: **v0.13.0 is the clean-break collapse release**.
+
+The migration guide will be published as `docs/MIGRATION_v0.13.md` (not `MIGRATION_v0.14.md`).
+
+#### Wave 2 owner renamed: perl-workspace-index → perl-workspace
+
+Wave 2 (the `perl-workspace-*` collapse) was slotted to absorb 6 satellites into the existing
+`perl-workspace-index` crate. The 6 satellites span two functional families:
+
+- **Enumeration**: `perl-workspace-discovery`, `perl-workspace-folder`, `perl-workspace-ignore`
+- **Observability**: `perl-workspace-index-monitoring`, `perl-workspace-index-slo`, `perl-workspace-index-state-machine`
+
+The absorbed scope is broader than "indexing." The existing `perl-workspace-index` crate will
+be **renamed to `perl-workspace`** during Wave 2 execution. `perl-workspace` is a more accurate
+external noun for a crate that owns workspace enumeration, discovery, and observability alongside
+the index itself.
+
+The Amendment 1 table in this document listed `perl-workspace-index` under "Semantic kernels."
+That entry should now read **`perl-workspace`**:
+
+| Category | Count | Crates |
+|----------|------:|--------|
+| Semantic kernels | 3 | perl-semantic-analyzer, perl-module, **perl-workspace** |
+
+The migration ledger at [`.spec/microcrate-collapse/ledger.md`](../../.spec/microcrate-collapse/ledger.md)
+is the authoritative source and has been updated accordingly.
+
 ## References
 
 - [Tracking issue #4410: Microcrate collapse to ~30 published crates](https://github.com/EffortlessMetrics/perl-lsp/issues/4410)
-- [Migration ledger](../../.spec/microcrate-collapse/ledger.md) — authoritative per-crate workboard (Amendment 1)
+- [Migration ledger](../../.spec/microcrate-collapse/ledger.md) — authoritative per-crate workboard (Amendment 1, updated Amendment 2)
 - [docs/SRP_MICROCRATES.md](../SRP_MICROCRATES.md) — historical record of the microcrate decomposition campaign
 - [docs/PUBLISHING.md](../PUBLISHING.md) — current publishing pipeline; will simplify post-collapse
 - [scripts/publish-topo.py](../../scripts/publish-topo.py) — current topological publish ordering with dev-dep SCC handling

--- a/docs/project/PUBLISHING_AFTER_COLLAPSE.md
+++ b/docs/project/PUBLISHING_AFTER_COLLAPSE.md
@@ -58,7 +58,7 @@ The post-collapse published set, grouped by category and listed in approximate d
 | Crate | Role |
 |-------|------|
 | `perl-module` | Module name → file path resolution; absorbs 13 perl-module-* crates |
-| `perl-workspace-index` | Workspace symbol index and discovery; absorbs 6 perl-workspace-* crates |
+| `perl-workspace` | Workspace symbol index, discovery, and observability; absorbs 6 perl-workspace-* crates (renamed from perl-workspace-index during Wave 2) |
 | `perl-semantic-analyzer` | Scope analysis, type inference, variable resolution |
 
 ### Tool integrations (1)
@@ -147,4 +147,4 @@ PR #1 of the collapse series (tracked by [issue #4412](https://github.com/Effort
 - [ADR-0041](../adr/0041-microcrate-collapse.md) — architectural rationale
 - [Tracking issue #4410](https://github.com/EffortlessMetrics/perl-lsp/issues/4410) — collapse wave progress
 - [docs/PUBLISHING.md](../PUBLISHING.md) — current 132-crate pipeline (superseded post-collapse)
-- [docs/MIGRATION_v0.14.md](../MIGRATION_v0.14.md) — migration guide for downstream users
+- [docs/MIGRATION_v0.13.md](../MIGRATION_v0.13.md) — migration guide for downstream users


### PR DESCRIPTION
## Summary

Two corrections to the microcrate collapse planning docs, per user clarification on 2026-04-16.

### Correction 1 — Target release is v0.13.0 (not v0.14.x)

Current workspace version is **0.12.4**. The collapse ships as **v0.13.0** — a clean break directly from the 0.12.x confidence track. There is no interim pre-collapse v0.13.0 release; v0.13.0 *is* the collapse release.

Updated: ADR-0041 (Amendment 2 appended), collapse ledger, `MIGRATION_v0.14.md` renamed → `MIGRATION_v0.13.md`, PUBLISHING_AFTER_COLLAPSE, and 5 `.spec/` context files.

### Correction 2 — Wave 2 owner renamed `perl-workspace-index` → `perl-workspace`

The 6 absorbed workspace-* satellites span two families:
- **Enumeration**: discovery, folder, ignore
- **Observability**: index-monitoring, index-slo, index-state-machine

Scope is broader than "indexing." `perl-workspace-index` will be renamed to `perl-workspace` during Wave 2 execution. The ledger, ADR Amendment 2, PUBLISHING_AFTER_COLLAPSE, and migration guide now reflect `perl-workspace` as the Wave 2 target owner.

## Files changed

- `.spec/microcrate-collapse/ledger.md` — Wave 2 section header, target owner column, products table, Final PR row
- `docs/adr/0041-microcrate-collapse.md` — Amendment 2 appended (body not rewritten); Amendment 1 table cross-referenced
- `docs/MIGRATION_v0.14.md` → `docs/MIGRATION_v0.13.md` (renamed + updated)
- `docs/project/PUBLISHING_AFTER_COLLAPSE.md` — semantic kernels table + reference link
- `.spec/4412-publish-closure/checklist.md` — parent epic version
- `.spec/4412-publish-closure/context.md` — parent epic version
- `.spec/4414-parser-layering/acceptance.md` — ADR version reference
- `.spec/4414-parser-layering/context.md` — three v0.14.0 → v0.13.0 replacements
- `.spec/4420-wave1-perl-module/context.md` — version + migration guide filename

## Scope

Docs and planning files only. No code changes. No crate renames (those happen in Wave 2).

Closes: not applicable — this is a correction to #4410 tracking docs (leaving a comment on #4410 instead).

Tracking issue: https://github.com/EffortlessMetrics/perl-lsp/issues/4410