### PR TITLE
docs(collapse): align ledger with ADR — perl-symbol as own crate (Wave B) (#4428)

### DIFF
--- a/.spec/microcrate-collapse/ledger.md
+++ b/.spec/microcrate-collapse/ledger.md
@@ -39,7 +39,8 @@ Status legend:
 | perl-dap | perl-dap | core-public | H | — | DAP server; absorbs 11 perl-dap-* |
 | perl-parser | perl-parser | core-public | 3-4 | — | parser facade; absorbs syntax + parser-adjacent |
 | perl-lexer | perl-lexer | core-public | 3 | — | tokenizer; absorbs satellites |
-| perl-semantic-analyzer | perl-semantic-analyzer | core-public | 5 | — | absorbs symbol/incremental/refactor |
+| perl-semantic-analyzer | perl-semantic-analyzer | core-public | 5 | — | absorbs incremental/refactor; symbol crates go to perl-symbol (Wave B) |
+| perl-symbol | perl-symbol (NEW) | core-public | B | — | absorbs 4 perl-symbol-*; own published crate (see Wave B) |
 | perl-workspace-index | perl-workspace | core-public | 2 | — | renamed to perl-workspace during Wave 2; absorbs 6 perl-workspace-* |
 | perl-module | perl-module (NEW name) | core-public | 1 (PILOT) | Med | absorbs 13 perl-module-*; facade not `perl-module-resolution` |
 | perl-pragma | perl-pragma | core-public | 4 | Low | |
@@ -135,12 +136,22 @@ not in this ledger PR.
 
 ## Wave 5 — semantic shards → perl-semantic-analyzer
 
+*(No symbol crates — see Wave B below. The 4 perl-symbol-* crates are NOT absorbed into
+perl-semantic-analyzer; they absorb into the standalone `perl-symbol` published crate instead.)*
+
+## Wave B — perl-symbol-* → perl-symbol (NEW published crate)
+
+`perl-symbol` is its own small published crate (see ADR-0041 "Symbol model (1): perl-symbol").
+Absorbing the 4 satellites into `perl-semantic-analyzer` would invert the dependency layering:
+`perl-workspace-index` and `perl-lsp` both consume symbol types directly and cannot depend on the
+full semantic analyzer just to get them. `perl-symbol` stays as a separate published crate.
+
 | current crate | target owner | final status | wave | risk | notes |
 |---|---|---|---:|---:|---|
-| perl-symbol-types | perl-semantic-analyzer | module | 5 | Low | |
-| perl-symbol-cursor | perl-semantic-analyzer | module | 5 | Low | consumed directly by perl-lsp-rs |
-| perl-symbol-index | perl-semantic-analyzer | module | 5 | Med | |
-| perl-symbol-surface | perl-semantic-analyzer | module | 5 | Low | |
+| perl-symbol-types | perl-symbol | module | B | Low | shared by perl-workspace-index, perl-semantic-analyzer, perl-lsp |
+| perl-symbol-cursor | perl-symbol | module | B | Low | consumed directly by perl-lsp-rs |
+| perl-symbol-index | perl-symbol | module | B | Med | |
+| perl-symbol-surface | perl-symbol | module | B | Low | |
 
 ## Wave E — diagnostic catalog (NEW crate)
 
@@ -276,7 +287,8 @@ These were flagged in ADR-0041 as potential standalone published kernels. Re-eva
 | 2 (perl-workspace-*) | ⏳ queued | — | — |
 | 3 (lexer satellites) | ⏳ queued | — | — |
 | 4 (parser satellites) | ⏳ queued | — | — |
-| 5 (semantic shards) | ⏳ queued | — | — |
+| 5 (semantic shards, no symbol crates) | ⏳ queued | — | — |
+| B (perl-symbol-* → perl-symbol NEW) | ⏳ queued | — | — |
 | E (diagnostic catalog) | ⏳ queued | — | — |
 | F (LSP features) | ⏳ queued | — | — |
 | G1 (LSP providers) | ⏳ queued | — | — |

--- a/docs/adr/0041-microcrate-collapse.md
+++ b/docs/adr/0041-microcrate-collapse.md
@@ -306,6 +306,28 @@ That entry should now read **`perl-workspace`**:
 The migration ledger at [`.spec/microcrate-collapse/ledger.md`](../../.spec/microcrate-collapse/ledger.md)
 is the authoritative source and has been updated accordingly.
 
+### Amendment 3 — 2026-04-16: Ledger corrected — perl-symbol is its own published crate (Wave B)
+
+**Source:** Accuracy-scout finding on issue #4428; user ruling: ADR wins.
+
+The migration ledger at `.spec/microcrate-collapse/ledger.md` previously listed all four
+`perl-symbol-*` satellites as Wave 5 modules absorbing into `perl-semantic-analyzer`. This
+contradicted the Decision section above ("Symbol model (1): `perl-symbol`").
+
+**The correction:** The four satellites (`perl-symbol-types`, `perl-symbol-cursor`,
+`perl-symbol-index`, `perl-symbol-surface`) absorb into **`perl-symbol`** — a standalone
+small published crate — not into `perl-semantic-analyzer`. The ledger now has a dedicated
+**Wave B** section for this family and Wave 5 is annotated to reflect it holds no symbol crates.
+
+**Rationale for keeping perl-symbol as its own published crate:**
+`perl-symbol-types` is consumed directly by `perl-workspace-index`, `perl-semantic-analyzer`,
+and `perl-lsp`. If it folded into `perl-semantic-analyzer`, then `perl-workspace-index` and
+`perl-lsp` would need to depend on the whole analyzer just to get symbol types — a dependency
+inversion. Keeping `perl-symbol` as a small, focused, published crate preserves clean layering.
+This is the same reasoning that kept `perl-workspace` as its own crate (Amendment 2).
+
+The 30-crate published target and all other ADR content remain unchanged.
+
 ## References
 
 - [Tracking issue #4410: Microcrate collapse to ~30 published crates](https://github.com/EffortlessMetrics/perl-lsp/issues/4410)


### PR DESCRIPTION
## Summary

- **ADR-0041 vs ledger disagreement fixed**: The ledger previously routed all 4 `perl-symbol-*` satellites (`perl-symbol-types`, `perl-symbol-cursor`, `perl-symbol-index`, `perl-symbol-surface`) into `perl-semantic-analyzer` as Wave 5 modules. ADR-0041 line 222 specifies "Symbol model (1): `perl-symbol`" as its own published crate.
- **Ledger updated**: Wave 5 annotated (holds no symbol crates); new **Wave B** section added for the `perl-symbol` family; `perl-symbol` added to the Products table with status `core-public`.
- **ADR-0041 amended**: Amendment 3 appended documenting the correction, rationale (dependency inversion), and noting the 30-crate target is unchanged.

## Rationale (from issue #4428 user ruling: ADR wins)

`perl-symbol-types` is consumed directly by `perl-workspace-index`, `perl-semantic-analyzer`, and `perl-lsp`. If it folded into `perl-semantic-analyzer`, then `perl-workspace-index` and `perl-lsp` would need to depend on the whole analyzer just to get symbol types — a dependency inversion. Keeping `perl-symbol` as a small, focused, published crate preserves clean layering. Same pattern as #4427 (perl-workspace rename).

## Scope

- Docs only: `.spec/microcrate-collapse/ledger.md`, `docs/adr/0041-microcrate-collapse.md`
- No code changes, no Cargo.toml changes
- `cargo build --workspace` passes (353 crates, no changes to build graph)

## Test plan

- [x] `cargo build --workspace` passes
- [x] Both files reviewed for correctness against ADR-0041 line 222 and issue #4428 spec
- [x] Wave B section explains the dependency-inversion rationale
- [x] Amendment 3 does not rewrite original ADR body — appended only