### PR TITLE
fix(parser): unexpected_comma_expr bucket — hash slice postfix (#3498)

### DIFF
--- a/.hermes/conveyor/work-e5278c16/adr.md
+++ b/.hermes/conveyor/work-e5278c16/adr.md
@@ -1,0 +1,76 @@
+# ADR: Redirect `unexpected_comma_expr` Fix from `hashes.rs` to `postfix.rs`
+
+## Status
+
+**Proposed** — Redirecting fix location based on verification and plan review findings.
+
+## Context
+
+The work item `work-e5278c16` was created to fix `unexpected_comma_expr` errors in 18 CPAN corpus files. The issue title describes it as "list vs hash disambiguation" and the initial plan targets `parse_hash_or_block_inner()` in `crates/perl-parser-core/src/engine/parser/expressions/hashes.rs`.
+
+However, verification and plan review agents found that:
+
+1. **The issue title and description mischaracterize the root cause.** The actual failing pattern in `overload.pm:27` is:
+   ```perl
+   @ops_seen{ map split(/ /), values %ops } = ();
+   ```
+   This is a **hash slice** (`@hash{...}`), not a hash literal vs block disambiguation issue.
+
+2. **The plan targets the wrong file.** The plan focuses on `hashes.rs` but the bug is in `postfix.rs`. The `LeftBrace` handling at line 267 of `postfix.rs` is ONLY inside the `Arrow` match arm. There is no case for `LeftBrace` directly after a variable (like `@hash{...}` or `%hash{...}`).
+
+3. **The scope is smaller than claimed.** The issue claims 18 files but verification found ~6 unique files (10 error instances).
+
+## Decision
+
+**Redirect the fix to `postfix.rs` as a new standalone `LeftBrace` postfix operation.**
+
+The fix should:
+
+1. Add `LeftBrace` (and `RightBrace`) handling as a standalone postfix operation at the top-level loop of `parse_postfix_chain()` (around line 28), NOT inside the `Arrow` arm.
+
+2. When `parse_postfix_chain()` sees `LeftBrace` after a variable with `@` or `%` sigil, treat it as a hash/array slice postfix and delegate to the existing hash parsing logic.
+
+3. Ensure existing `->{...}` (arrow-based hash dereference) behavior remains unchanged — the `Arrow` arm should continue to handle that case.
+
+## Consequences
+
+### Benefits
+
+- Fixes the actual bug: `@hash{...}` and `%hash{...}` will be recognized as postfix subscripts without requiring `->`
+- Aligns with Perl semantics: hash/array slices are standard Perl syntax
+- Advances CPAN coverage goal (90% target)
+- Fixes errors in the 6 affected corpus files
+
+### Tradeoffs / Risks
+
+1. **Conflict with existing `Arrow` arm**: Adding `LeftBrace` at the top level must not interfere with `->{...}` handling inside the `Arrow` arm. The `Arrow` arm's `LeftBrace` handling should take precedence when preceded by `->`.
+
+2. **Sigil checking required**: The fix needs to check the base expression's sigil (`@` or `%`) to distinguish `@hash{...}` (slice) from plain `{...}` (block or hash literal). If the base is a bare `{`, it should still be handled by `hashes.rs`.
+
+3. **CLI build error**: The non-exhaustive match on `ParseError::Recovered` at `perl-parse.rs:332` prevents direct verification. This should be fixed first or an alternative verification method used.
+
+4. **Scope uncertainty**: The issue claims 18 files but only ~6 are affected. If the corpus scope is different, the fix may not address all intended files.
+
+## Alternatives Considered
+
+### Alternative 1: Keep the original plan (target `hashes.rs`)
+
+**Rejected** — The plan review and vision alignment agents confirmed this would be ineffective. The `parse_hash_or_block_inner()` function handles `{expr}` disambiguation, but `@ops_seen{...}` is never parsed as a hash literal because the postfix chain doesn't consume `{`. The `{...}` is parsed as a separate expression by a different code path.
+
+### Alternative 2: Fix `hashes.rs` AND `postfix.rs`
+
+**Partial adoption** — The `hashes.rs` changes may still be valuable for improving hash/block disambiguation generally, but they won't fix the `unexpected_comma_expr` errors caused by hash slices. The `postfix.rs` fix is necessary; `hashes.rs` changes are orthogonal.
+
+### Alternative 3: Improve lookahead in `parse_expression()`
+
+**Rejected** — This would be a more invasive change that could affect many other parsing paths. The postfix chain approach is more targeted and aligns with how other postfix operators are handled.
+
+## Architecture Notes
+
+The postfix chain architecture in `postfix.rs` has a gap: it only handles `{` as a postfix subscript when preceded by `->`. Perl allows `@hash{...}` and `%hash{...}` without the arrow (standard hash/array slice syntax). Adding `LeftBrace` as a standalone postfix op fills this gap.
+
+The fix should:
+- Check if the base expression is a Variable with sigil `@` or `%`
+- If so, consume `{...}` as a hash/array slice postfix
+- Delegate to existing hash parsing infrastructure
+- Ensure the `Arrow` arm's `LeftBrace` handling still works for `->{...}`

--- a/.hermes/conveyor/work-e5278c16/specs.md
+++ b/.hermes/conveyor/work-e5278c16/specs.md
@@ -1,0 +1,107 @@
+# Specification: Hash Slice Parsing Fix (`work-e5278c16`)
+
+## Feature/Behavior Description
+
+Fix the parser to correctly handle hash slices and array slices (`@hash{...}`, `%hash{...}`, `@array{...}`) as postfix subscript operations without requiring an intervening arrow (`->`).
+
+### Problem Statement
+
+The parser produces `unexpected_comma_expr` errors on Perl code like:
+```perl
+@ops_seen{ map split(/ /), values %ops } = ();
+```
+
+This is a **hash slice** (accessing multiple hash values at once). The parser incorrectly treats `@ops_seen` and `{ map split(/ /), values %ops }` as two separate expressions, causing the comma inside `map split(/ /), values %ops` to be flagged as unexpected.
+
+### Root Cause
+
+In `postfix.rs`, the `parse_postfix_chain()` function only handles `LeftBrace` as a subscript inside the `Arrow` arm (line 267). There is no case for `LeftBrace` directly after a variable with `@` or `%` sigil.
+
+### Expected Behavior
+
+| Perl Code | Parsed As | Currently? |
+|----------|-----------|------------|
+| `$ref->{key}` | Arrow hash dereference | ✅ Works |
+| `@hash{key1, key2}` | Hash slice (postfix) | ❌ Treated as separate expressions |
+| `%hash{key1, key2}` | Hash slice (postfix) | ❌ Treated as separate expressions |
+| `@array{0, 1}` | Array hash-slice alias | ❌ Treated as separate expressions |
+| `{ $a => $b }` | Hash literal | ✅ Works |
+
+## Acceptance Criteria
+
+### AC1: Hash Slice Without Arrow
+```perl
+%hash{key1, key2}   # Should parse as HashSlice, not separate expressions
+@array{0, 1}        # Should parse as HashSlice (Perl alias), not separate expressions
+```
+**Test**: Parse these snippets and verify they produce a single postfix operation, not two separate expressions.
+
+### AC2: Complex Hash Slice Expressions
+```perl
+@ops_seen{ map split(/ /), values %ops }
+%seen{$key1, $key2}
+```
+**Test**: Parse these from actual corpus files and verify no `unexpected_comma_expr` errors.
+
+### AC3: Arrow-Based Hash Dereference Unchanged
+```perl
+$ref->{key}         # Should still work via Arrow arm
+$ref->{ $expr }     # Should still work
+```
+**Test**: Verify existing `->{...}` patterns continue to parse correctly.
+
+### AC4: Hash Literal vs Block Unchanged
+```perl
+{ $a => $b }        # Hash literal — should still parse correctly
+{ $a, $b }          # Block with list — should still parse correctly
+{ expr }            # Block — should still parse correctly
+```
+**Test**: Verify existing hash/block parsing is not affected.
+
+### AC5: Corpus Coverage
+The 6 affected files should show 0 `unexpected_comma_expr` errors after the fix:
+- `/usr/share/perl/5.38/App/Cpan.pm`
+- `/usr/share/perl/5.38/overload.pm`
+- `/usr/share/perl/5.38/unicore/Name.pm`
+- `/usr/share/perl/5.38.2/App/Cpan.pm`
+- `/usr/share/perl/5.38.2/overload.pm`
+- `/usr/share/perl/5.38.2/unicore/Name.pm`
+
+## Non-Goals
+
+1. **Do not fix all `unexpected_comma_expr` errors** — this fix addresses only the hash slice pattern. Other `unexpected_comma_expr` errors (e.g., from genuine comma operator issues) are out of scope.
+
+2. **Do not change hash literal vs block disambiguation** — the `hashes.rs` logic should remain unchanged for expressions that start with `{`.
+
+3. **Do not add support for `[]` subscripts without arrow** — array subscript `[]` may have different handling and is out of scope.
+
+4. **Do not fix the CLI build error** — the `non-exhaustive patterns: Recovered` error at `perl-parse.rs:332` is a pre-existing issue unrelated to this fix.
+
+## Dependencies
+
+1. **Parser infrastructure**: The fix requires access to the postfix chain parsing logic in `postfix.rs`.
+
+2. **Token kinds**: Requires `TokenKind::LeftBrace` and `TokenKind::RightBrace` handling.
+
+3. **Expression parsing**: Needs to delegate to existing hash/array parsing logic for the slice contents.
+
+4. **Test infrastructure**: Uses `perl-parser-core` test framework and corpus sweep tooling for verification.
+
+## Implementation Hint
+
+The fix should add a new match arm at the top-level loop of `parse_postfix_chain()` (around line 28 in `postfix.rs`), not inside the `Arrow` arm. When `peek_kind()` returns `LeftBrace` and the base expression has `@` or `%` sigil, consume `{...}` as a hash/array slice postfix.
+
+The existing `Arrow` arm's `LeftBrace` handling (line 267) should remain unchanged — it handles `->{...}` and takes precedence when preceded by arrow.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `crates/perl-parser-core/src/engine/parser/expressions/postfix.rs` | Add `LeftBrace` as standalone postfix op for hash/array slices |
+| `crates/perl-parser-core/tests/` | Add test file for hash slice patterns |
+
+## Files NOT to Modify (for this fix)
+
+- `crates/perl-parser-core/src/engine/parser/expressions/hashes.rs` — hash literal vs block disambiguation is a separate issue
+- `xtask/src/tasks/parser_corpus_sweep.rs` — error bucket mapping is correct
+- `crates/perl-parser-core/src/engine/parser/expressions/precedence.rs` — comma handling is correct

--- a/crates/perl-module/src/rename/mod.rs
+++ b/crates/perl-module/src/rename/mod.rs
@@ -92,7 +92,6 @@ pub fn plan_module_rename_edits(
                     }
                 }
             }
-
         }
 
         if let Some(new_text) = rewritten {

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -1,18 +1,32 @@
 impl<'a> Parser<'a> {
-    /// Parse postfix expression
+    /// Entry point for parsing postfix expressions.
+    ///
+    /// Parses a primary expression first, then applies any postfix operators
+    /// (arrow chains, subscripts, etc.) to form a complete postfix expression.
     fn parse_postfix(&mut self) -> ParseResult<Node> {
         let expr = self.parse_primary()?;
         self.parse_postfix_chain(expr)
     }
 
     /// Apply postfix operators (arrow chains, subscripts, etc.) to an
-    /// already-parsed expression.  Factored out of `parse_postfix` so
-    /// that callers who build an initial node outside the normal
-    /// `parse_primary` path (e.g. typeglobs in `parse_unary`) can still
-    /// participate in postfix chaining.
+    /// already-parsed expression.
+    ///
+    /// This function is factored out of `parse_postfix` so that callers who
+    /// build an initial node outside the normal `parse_primary` path
+    /// (e.g. typeglobs in `parse_unary`) can still participate in postfix chaining.
+    ///
+    /// The loop handles several postfix patterns in order of precedence:
+    /// 1. Hash/array slice without arrow (`@hash{...}`, `%hash{...}`)
+    /// 2. Increment/decrement operators (`++`, `--`)
+    /// 3. Arrow dereference (`->`)
+    /// 4. Array subscript (`[...]`)
+    /// 5. Hash subscript with block handling (`{...}`)
+    /// 6. Function call parentheses (`(...)`)
     pub(crate) fn parse_postfix_chain(&mut self, mut expr: Node) -> ParseResult<Node> {
         let mut postfix_chain_depth = 0usize;
 
+        // Closure to track nesting depth and prevent stack overflow on deeply
+        // nested postfix chains (e.g., `$a->[0]->[1]->[2]->...`).
         let mut record_postfix_layer = || -> ParseResult<()> {
             postfix_chain_depth += 1;
             if postfix_chain_depth > MAX_RECURSION_DEPTH {
@@ -25,6 +39,50 @@ impl<'a> Parser<'a> {
         };
 
         loop {
+            // --------------------------------------------------------------------
+            // Hash/array slice without arrow: @hash{...} or %hash{...}
+            //
+            // In Perl, `@hash{...}` and `%hash{...}` are valid hash/array slice
+            // operations that do NOT require an intervening `->`.
+            //
+            // This must be checked BEFORE the Arrow arm (line 69) because the
+            // Arrow arm's LeftBrace handling (line 295) is only reached when there
+            // is a `->` preceding the `{`. Without this early check, `@hash{...}`
+            // would fall through to the generic hash-element arm at line 428,
+            // which would incorrectly parse `{...}` as a block instead of a subscript.
+            //
+            // The condition checks:
+            // 1. The next token is `{` (not `->`)
+            // 2. The current expression is a variable with `@` or `%` sigil
+            //
+            // Example: `@ops_seen{ map split(/ /), values %ops }` should parse as
+            // a hash slice, not as `@ops_seen` followed by a block.
+            // --------------------------------------------------------------------
+            if self.peek_kind() == Some(TokenKind::LeftBrace) {
+                if let NodeKind::Variable { sigil, .. } = &expr.kind {
+                    if sigil == "@" || sigil == "%" {
+                        // Hash/array slice: @hash{...} or %hash{...}
+                        self.tokens.next()?; // consume {
+                        let key = self.parse_hash_subscript_key()?;
+                        self.expect(TokenKind::RightBrace)?;
+
+                        let start = expr.location.start;
+                        let end = self.previous_position();
+
+                        record_postfix_layer()?;
+                        expr = Node::new(
+                            NodeKind::Binary {
+                                op: "{}".to_string(),
+                                left: Box::new(expr),
+                                right: Box::new(key),
+                            },
+                            SourceLocation { start, end },
+                        );
+                        continue;
+                    }
+                }
+            }
+
             match self.peek_kind() {
                 Some(k) if Self::is_postfix_op(Some(k)) => {
                     let op_token = self.consume_token()?;

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -1256,68 +1256,102 @@ impl<'a> Parser<'a> {
     /// This function builds a proper parse tree node for them, including support
     /// for hash slices like `@h{m, s}` which require a list node.
     fn parse_hash_subscript_key(&mut self) -> ParseResult<Node> {
-        // Classic keyword-as-bareword (not, and, or, xor, do, eval) when directly
-        // before `}`.  These were handled here before this PR and are preserved.
-        if let Some(kind) = self.peek_kind() {
-            let is_simple_keyword_key = matches!(
-                kind,
-                TokenKind::WordNot
-                    | TokenKind::WordAnd
-                    | TokenKind::WordOr
-                    | TokenKind::WordXor
-                    | TokenKind::Do
-                    | TokenKind::Eval
-            );
-            if is_simple_keyword_key {
-                if let Ok(second) = self.tokens.peek_second() {
-                    if second.kind == TokenKind::RightBrace {
-                        let token = self.tokens.next()?;
-                        return Ok(Node::new(
-                            NodeKind::Identifier { name: token.text.to_string() },
-                            SourceLocation { start: token.start, end: token.end },
-                        ));
-                    }
-                }
-            }
+        // Try keyword-as-bareword first (not, and, or, xor, do, eval)
+        if let Some(node) = self.try_parse_keyword_bareword_key()? {
+            return Ok(node);
         }
 
-        // Quote-op names (m, s, q, qq, qw, qr, qx, tr, y) used as bareword hash keys.
-        // The lexer (hash_brace_depth > 0) already emits these as Identifier tokens
-        // rather than triggering quote-op parsing.  Here in the parser we must build
-        // a comma-separated list when multiple such keys appear (hash slice case,
-        // e.g. `@h{m, s}`), since `parse_expression` → `parse_comma` would still
-        // try to interpret `m` as a regex operator at the `parse_primary` level.
-        if self.peek_is_quote_op_bareword() {
-            let first = self.consume_as_bareword_string()?;
-            let start = first.location.start;
-
-            // Single key (common case): `$h{m}` — `}` immediately follows
-            if self.peek_kind() != Some(TokenKind::Comma) {
-                return Ok(first);
-            }
-
-            // Slice case: `@h{m, s, q}` — build a list node from all bareword keys
-            let mut elements = vec![first];
-            while self.peek_kind() == Some(TokenKind::Comma) {
-                self.consume_token()?; // consume `,`
-                if self.peek_kind() == Some(TokenKind::RightBrace) {
-                    break; // trailing comma before `}` is fine
-                }
-                if self.peek_is_quote_op_bareword() {
-                    elements.push(self.consume_as_bareword_string()?);
-                } else {
-                    // Mixed slice like `@h{m, $var}` — parse rest normally
-                    elements.push(self.parse_assignment()?);
-                }
-            }
-
-            let end = elements.last().map(|n| n.location.end).unwrap_or(start);
-            return Ok(Node::new(
-                NodeKind::ArrayLiteral { elements },
-                SourceLocation { start, end },
-            ));
+        // Try quote-op names as bareword hash keys
+        if let Some(node) = self.try_parse_quote_op_bareword_key()? {
+            return Ok(node);
         }
 
+        // Default: parse as a general expression
         self.parse_expression()
+    }
+
+    /// Attempt to parse a keyword (`not`, `and`, `or`, `xor`, `do`, `eval`) as a
+    /// bareword hash key when it appears directly before `}`.
+    ///
+    /// Returns `Some(Node)` if the current token is a keyword followed by `}`,
+    /// otherwise returns `None` to fall through to general expression parsing.
+    fn try_parse_keyword_bareword_key(&mut self) -> ParseResult<Option<Node>> {
+        let Some(kind) = self.peek_kind() else {
+            return Ok(None);
+        };
+
+        let is_simple_keyword_key = matches!(
+            kind,
+            TokenKind::WordNot
+                | TokenKind::WordAnd
+                | TokenKind::WordOr
+                | TokenKind::WordXor
+                | TokenKind::Do
+                | TokenKind::Eval
+        );
+
+        if !is_simple_keyword_key {
+            return Ok(None);
+        }
+
+        let Ok(second) = self.tokens.peek_second() else {
+            return Ok(None);
+        };
+
+        if second.kind != TokenKind::RightBrace {
+            return Ok(None);
+        }
+
+        let token = self.tokens.next()?;
+        Ok(Some(Node::new(
+            NodeKind::Identifier { name: token.text.to_string() },
+            SourceLocation { start: token.start, end: token.end },
+        )))
+    }
+
+    /// Attempt to parse a quote-operator name (`m`, `s`, `q`, `qq`, `qw`, `qr`,
+    /// `qx`, `tr`, `y`) as a bareword hash key when used in a hash subscript.
+    ///
+    /// The lexer suppresses quote-op detection inside hash subscripts
+    /// (hash_brace_depth > 0), emitting them as Identifier tokens.
+    /// This method builds a proper parse tree node, including support for
+    /// hash slices like `@h{m, s}` which require an ArrayLiteral node.
+    ///
+    /// Returns `Some(Node)` if the current token is a quote-op name followed by
+    /// `}` or `,` (indicating it's being used as a bareword key rather than as
+    /// the start of a quote expression). Returns `None` otherwise.
+    fn try_parse_quote_op_bareword_key(&mut self) -> ParseResult<Option<Node>> {
+        if !self.peek_is_quote_op_bareword() {
+            return Ok(None);
+        }
+
+        let first = self.consume_as_bareword_string()?;
+        let start = first.location.start;
+
+        // Single key (common case): `$h{m}` — `}` immediately follows
+        if self.peek_kind() != Some(TokenKind::Comma) {
+            return Ok(Some(first));
+        }
+
+        // Slice case: `@h{m, s, q}` — build a list node from all bareword keys
+        let mut elements = vec![first];
+        while self.peek_kind() == Some(TokenKind::Comma) {
+            self.consume_token()?; // consume `,`
+            if self.peek_kind() == Some(TokenKind::RightBrace) {
+                break; // trailing comma before `}` is fine
+            }
+            if self.peek_is_quote_op_bareword() {
+                elements.push(self.consume_as_bareword_string()?);
+            } else {
+                // Mixed slice like `@h{m, $var}` — parse rest normally
+                elements.push(self.parse_assignment()?);
+            }
+        }
+
+        let end = elements.last().map(|n| n.location.end).unwrap_or(start);
+        Ok(Some(Node::new(
+            NodeKind::ArrayLiteral { elements },
+            SourceLocation { start, end },
+        )))
     }
 }

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -23,6 +23,10 @@ impl<'a> Parser<'a> {
         matches!(kind, Some(TokenKind::Or) | Some(TokenKind::DefinedOr))
     }
 
+    /// Returns true if the token kind is a postfix increment/decrement operator.
+    ///
+    /// These operators (`++` and `--`) can appear after an expression like `$x++`
+    /// unlike prefix operators which appear before.
     #[inline]
     fn is_postfix_op(kind: Option<TokenKind>) -> bool {
         matches!(kind, Some(TokenKind::Increment) | Some(TokenKind::Decrement))


### PR DESCRIPTION
Closes #3498

## Summary

Fix the parser to correctly handle hash slices (at-hash{...}, percent-hash{...}) as postfix subscript operations without requiring an intervening arrow (-greater).

The parser was producing unexpected_comma_expr errors on Perl code like:
  at-ops-seen{ map split(/ /), values %ops } = ();

This is a hash slice (accessing multiple hash values at once). The parser incorrectly treated at-ops-seen and { map split(/ /), values %ops } as two separate expressions.

## ADR

- ADR: .hermes/conveyor/work-e5278c16/adr.md
- Status: Proposed to Accepted (redirecting fix from hashes.rs to postfix.rs)

## Specs

- Specs: .hermes/conveyor/work-e5278c16/specs.md

## What Changed

crates/perl-parser-core/src/engine/parser/expressions/postfix.rs: Added LeftBrace handling at the top-level loop of parse_postfix_chain() to recognize at-hash{...} and percent-hash{...} as hash/array slice postfixes without requiring arrow.

The fix:
1. Checks if peek_kind() returns LeftBrace and base expression is a Variable with sigil at or percent
2. Consumes {...} as a hash/array slice postfix
3. Delegates to existing hash parsing infrastructure (parse_hash_subscript_key())
4. Ensures the Arrow arm's LeftBrace handling still works for arrow-{...}

## Test Results

No parser tests added yet for this specific fix. The pre-existing CLI build error (non-exhaustive patterns: Recovered at perl-parse.rs:332) prevents direct verification.

## Friction Encountered

1. CLI build fails with non-exhaustive patterns error - cannot run parser directly on corpus files to verify error reduction
2. The scope claim (18 files) appears to be inaccurate - only ~6 unique files affected

## Notes

- Draft PR - not ready for review until GREEN tests confirmed
- Hash literal vs block disambiguation (hashes.rs) is a separate concern - not modified here
- The branch includes ADR and specs documentation in .hermes/conveyor/work-e5278c16/
