### PR TITLE
docs(collapse): Wave C amendment — perl-token stays published (#4445)

### DIFF
--- a/.spec/microcrate-collapse/ledger.md
+++ b/.spec/microcrate-collapse/ledger.md
@@ -39,6 +39,7 @@ Status legend:
 | perl-dap | perl-dap | core-public | H | — | DAP server; absorbs 11 perl-dap-* |
 | perl-parser | perl-parser | core-public | 3-4 | — | parser facade; absorbs syntax + parser-adjacent |
 | perl-lexer | perl-lexer | core-public | 3 | — | tokenizer; absorbs satellites |
+| perl-token | perl-token | core-public | — | — | foundation primitive — stays published per ADR-0041 (see Amendment 4) |
 | perl-semantic-analyzer | perl-semantic-analyzer | core-public | 5 | — | absorbs incremental/refactor; symbol crates go to perl-symbol (Wave B) |
 | perl-symbol | perl-symbol (NEW) | core-public | B | — | absorbs 4 perl-symbol-*; own published crate (see Wave B) |
 | perl-workspace-index | perl-workspace | core-public | 2 | — | renamed to perl-workspace during Wave 2; absorbs 6 perl-workspace-* |
@@ -98,9 +99,12 @@ not in this ledger PR.
 
 ## Wave 3 — lexer satellites → perl-lexer
 
+`perl-token` is **NOT** absorbed. It remains a separately published foundation primitive per
+ADR-0041 ("Foundation primitives (5): perl-lexer, perl-token, perl-line-index, perl-uri, perl-pod").
+Wave 3 collapses only the 4 satellites below into `perl-lexer`. See Amendment 4.
+
 | current crate | target owner | final status | wave | risk | notes |
 |---|---|---|---:|---:|---|
-| perl-token | perl-lexer | module | 3 | Low | foundation primitive — inline into lexer |
 | perl-tokenizer | perl-lexer | module | 3 | Low | |
 | perl-keywords | perl-lexer | module | 3 | Low | |
 | perl-builtins | perl-lexer | module | 3 | Low | |

--- a/docs/adr/0041-microcrate-collapse.md
+++ b/docs/adr/0041-microcrate-collapse.md
@@ -328,6 +328,30 @@ This is the same reasoning that kept `perl-workspace` as its own crate (Amendmen
 
 The 30-crate published target and all other ADR content remain unchanged.
 
+### Amendment 4 — 2026-04-17: Ledger corrected — perl-token stays published (Wave C)
+
+**Source:** Same pattern as Amendment 3 (perl-symbol, Wave B). Ledger/ADR conflict; ADR wins.
+
+The migration ledger at `.spec/microcrate-collapse/ledger.md` previously listed `perl-token` in
+the Wave 3 lexer-satellites table as a module absorbing into `perl-lexer`. This contradicted the
+Decision section above ("Foundation primitives (5): `perl-lexer`, `perl-token`, `perl-line-index`,
+`perl-uri`, `perl-pod`") and Amendment 1's confirmation of `perl-token` as one of the 5 foundation
+primitives.
+
+**The correction:** Wave C (the lexer collapse) absorbs only the 4 satellites
+(`perl-tokenizer`, `perl-keywords`, `perl-builtins`, `perl-builtins-phf`) into `perl-lexer`.
+`perl-token` remains a separately published foundation primitive per ADR-0041's original design.
+
+**Rationale for keeping perl-token as its own published crate:**
+`perl-token` is a minimal, durable foundation primitive — the token type is consumed across the
+full analysis stack (lexer, parser, semantic analyzer, LSP, DAP). Folding it into `perl-lexer`
+would force every downstream consumer of the token type to depend on the full lexer implementation
+just to get the type. Keeping `perl-token` as a small, focused, published crate preserves clean
+layering and matches the same reasoning that kept `perl-symbol` (Amendment 3) and `perl-workspace`
+(Amendment 2) as their own published crates.
+
+The 30-crate published target and all other ADR content remain unchanged.
+
 ## References
 
 - [Tracking issue #4410: Microcrate collapse to ~30 published crates](https://github.com/EffortlessMetrics/perl-lsp/issues/4410)


### PR DESCRIPTION
Closes #4445.

Prep for Wave C (#4444). Same pattern as #4427 (Wave A) and #4431 (Wave B).

## Problem

- ADR-0041 lists \`perl-token\` as one of 5 foundation primitives to keep published.
- \`.spec/microcrate-collapse/ledger.md\` Wave 3 row said to absorb \`perl-token\` into \`perl-lexer\`.

They disagree. Precedent (Amendment 3 for \`perl-symbol\`): **ADR wins**.

## Decision

\`perl-token\` stays a separately published crate. Wave C (#4444) absorbs only the 4 satellites: \`perl-tokenizer\`, \`perl-keywords\`, \`perl-builtins\`, \`perl-builtins-phf\`.

## Changes

- **\`.spec/microcrate-collapse/ledger.md\`**:
  - Remove \`perl-token\` row from Wave 3.
  - Add \`perl-token\` to the Products (core-public) section.
  - Annotate Wave 3 scope with a note about the exclusion and Amendment 4.
- **\`docs/adr/0041-microcrate-collapse.md\`**:
  - Append **Amendment 4 (2026-04-17)**: Ledger corrected — perl-token stays published (Wave C).

## Rationale

\`perl-token\` is consumed across the full analysis stack (lexer, parser, semantic analyzer, LSP, DAP). Folding it into \`perl-lexer\` would force every downstream consumer of the token type to depend on the full lexer implementation — a layering inversion. Same reasoning as \`perl-symbol\` (Amendment 3) and \`perl-workspace\` (Amendment 2).

## Scope

Docs only — no code changes. No \`cargo\` surface touched.

## Test plan

- [x] Only \`.spec/\` and \`docs/adr/\` files modified
- [x] No Cargo.toml or code changes
- [x] Amendment 4 follows the same structure as Amendment 3
- [x] Ledger Wave 3 and Products sections are internally consistent