### PR TITLE
feat(xtask): layer-check dev-dep filter + CI wiring (#4415)

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,7 +50,8 @@ pr-fast: _check-tools-basic
     just _timed "fmt-check" "just fmt-check" && \
     just _timed "clippy-core" "just clippy-core" && \
     just _timed "test-core" "just test-core" && \
-    just _timed "publish-closure" "just ci-publish-closure"
+    just _timed "publish-closure" "just ci-publish-closure" && \
+    just _timed "layer-check" "just ci-layer-check"
     RC=$?
     END=$(date +%s)
     echo ""
@@ -762,7 +763,8 @@ ci-gate:
     just hook-check && \
     just hook-registry-check && \
     just hook-tests && \
-    just ci-publish-closure
+    just ci-publish-closure && \
+    just ci-layer-check
     # @START=$$(date +%s); \
 
 # Gate runner with receipt output (Issue #210)
@@ -863,6 +865,13 @@ ci-publish-closure:
     @echo "🔐 Checking publish-closure transitive deps..."
     @cargo xtask publish-closure
     @echo "✅ Publish-closure check passed"
+
+# Layer-check gate: enforce crate dependency direction constraints
+# Normal (runtime) deps only; dev-deps may cross layers freely.
+ci-layer-check:
+    @echo "🧱 Checking crate layer constraints..."
+    @cargo xtask layer-check
+    @echo "✅ Layer-check passed"
 
 # Core tests (fast, essential)
 ci-test-core:

--- a/xtask/src/tasks/layer_check.rs
+++ b/xtask/src/tasks/layer_check.rs
@@ -9,6 +9,13 @@
 //! - `perl-diagnostics` must NOT depend on any `perl-lsp-*` crate.
 //!   Reason: perl-diagnostics is a stable kernel of diagnostic codes and types.
 //!   LSP-specific formatting belongs in the LSP provider layer, not here.
+//!
+//! # Dev-dep filter
+//!
+//! Only **normal** (runtime) dependencies are checked. Dev-dependencies (`kind == "dev"`)
+//! and build-dependencies (`kind == "build"`) are permitted to cross layers freely,
+//! so tests and build scripts may pull in higher-layer crates for fixtures and
+//! integration testing without triggering a violation.
 
 use color_eyre::eyre::{Result, bail};
 use std::process::Command;
@@ -32,18 +39,34 @@ const LAYER_RULES: &[LayerRule] = &[LayerRule {
                     LSP-specific logic belongs in the perl-lsp-* layer above it.",
 }];
 
+/// Entry point used by `cargo xtask layer-check`.
 pub fn run() -> Result<()> {
+    run_with_metadata(None)
+}
+
+/// Run the layer check, optionally against synthetic metadata (for tests).
+///
+/// When `metadata` is `None`, shells out to `cargo metadata --no-deps` to
+/// introspect the real workspace. When `Some(value)` is provided, that value
+/// is used directly in place of the cargo invocation — this is how unit tests
+/// exercise the rule engine without needing to mutate real `Cargo.toml` files.
+pub fn run_with_metadata(metadata: Option<serde_json::Value>) -> Result<()> {
     println!("Checking crate layer constraints...");
 
-    // Collect cargo metadata to inspect dependencies
-    let output =
-        Command::new("cargo").args(["metadata", "--no-deps", "--format-version=1"]).output()?;
+    let metadata: serde_json::Value = match metadata {
+        Some(m) => m,
+        None => {
+            let output = Command::new("cargo")
+                .args(["metadata", "--no-deps", "--format-version=1"])
+                .output()?;
 
-    if !output.status.success() {
-        bail!("cargo metadata failed: {}", String::from_utf8_lossy(&output.stderr));
-    }
+            if !output.status.success() {
+                bail!("cargo metadata failed: {}", String::from_utf8_lossy(&output.stderr));
+            }
 
-    let metadata: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+            serde_json::from_slice(&output.stdout)?
+        }
+    };
 
     let mut violations = Vec::new();
 
@@ -62,6 +85,14 @@ pub fn run() -> Result<()> {
             // Check each dependency for forbidden prefix
             if let Some(deps) = pkg["dependencies"].as_array() {
                 for dep in deps {
+                    // Only enforce on normal (runtime) deps.
+                    // cargo_metadata records `kind` as null for normal deps,
+                    // "dev" for dev-dependencies, and "build" for build-dependencies.
+                    let kind = dep["kind"].as_str();
+                    if kind.is_some() {
+                        continue;
+                    }
+
                     let dep_name = dep["name"].as_str().unwrap_or("");
                     if dep_name.starts_with(rule.forbidden_prefix) {
                         violations.push(format!(
@@ -86,5 +117,72 @@ pub fn run() -> Result<()> {
             eprintln!("{v}");
         }
         bail!("Layer check failed: {} violation(s) found.", violations.len());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Sanity check: running against the real workspace must succeed.
+    ///
+    /// This guards against regressions — if someone reintroduces a
+    /// forbidden dep inside `perl-diagnostics`, this test will fail
+    /// alongside the CI gate.
+    #[test]
+    fn run_passes_on_clean_workspace() {
+        let result = run_with_metadata(None);
+        assert!(
+            result.is_ok(),
+            "layer-check should pass on the real workspace; got: {result:?}"
+        );
+    }
+
+    /// Synthetic metadata: `perl-diagnostics` has a dev-dependency on a
+    /// `perl-lsp-*` crate. The dev-dep filter must skip it and the check
+    /// must pass.
+    #[test]
+    fn kind_filter_skips_dev_deps() {
+        let metadata = json!({
+            "packages": [
+                {
+                    "name": "perl-diagnostics",
+                    "dependencies": [
+                        { "name": "perl-lsp-core", "kind": "dev" },
+                        { "name": "perl-lsp-types", "kind": "dev" }
+                    ]
+                }
+            ]
+        });
+
+        let result = run_with_metadata(Some(metadata));
+        assert!(
+            result.is_ok(),
+            "dev-deps crossing layer boundaries should be allowed; got: {result:?}"
+        );
+    }
+
+    /// Synthetic metadata: `perl-diagnostics` has a **normal** dependency on
+    /// a `perl-lsp-*` crate. The check must fail.
+    #[test]
+    fn kind_filter_enforces_normal_deps() {
+        let metadata = json!({
+            "packages": [
+                {
+                    "name": "perl-diagnostics",
+                    "dependencies": [
+                        // kind: null => normal runtime dep
+                        { "name": "perl-lsp-core", "kind": null }
+                    ]
+                }
+            ]
+        });
+
+        let result = run_with_metadata(Some(metadata));
+        assert!(
+            result.is_err(),
+            "normal deps crossing layer boundaries must be rejected; got: {result:?}"
+        );
     }
 }

--- a/xtask/src/tasks/layer_check.rs
+++ b/xtask/src/tasks/layer_check.rs
@@ -133,10 +133,7 @@ mod tests {
     #[test]
     fn run_passes_on_clean_workspace() {
         let result = run_with_metadata(None);
-        assert!(
-            result.is_ok(),
-            "layer-check should pass on the real workspace; got: {result:?}"
-        );
+        assert!(result.is_ok(), "layer-check should pass on the real workspace; got: {result:?}");
     }
 
     /// Synthetic metadata: `perl-diagnostics` has a dev-dependency on a

--- a/xtask/src/tasks/layer_check.rs
+++ b/xtask/src/tasks/layer_check.rs
@@ -160,6 +160,29 @@ mod tests {
         );
     }
 
+    /// Synthetic metadata: `perl-diagnostics` has a build-dependency on a
+    /// `perl-lsp-*` crate. Build-deps (used by build scripts) may cross layers
+    /// freely, so the check must pass.
+    #[test]
+    fn kind_filter_skips_build_deps() {
+        let metadata = json!({
+            "packages": [
+                {
+                    "name": "perl-diagnostics",
+                    "dependencies": [
+                        { "name": "perl-lsp-core", "kind": "build" }
+                    ]
+                }
+            ]
+        });
+
+        let result = run_with_metadata(Some(metadata));
+        assert!(
+            result.is_ok(),
+            "build-deps crossing layer boundaries should be allowed; got: {result:?}"
+        );
+    }
+
     /// Synthetic metadata: `perl-diagnostics` has a **normal** dependency on
     /// a `perl-lsp-*` crate. The check must fail.
     #[test]


### PR DESCRIPTION
## Summary

Finishes the layer-check guardrail started in Wave E (`xtask/src/tasks/layer_check.rs`):

- **Dev-dep filter**: only enforce layer rules on **normal** (runtime) deps. Dev-deps and build-deps may cross layers freely, so tests and build scripts can pull in higher-layer crates for fixtures without tripping the gate. `cargo_metadata` records `kind` as `null` for normal deps, `"dev"` for dev-dependencies, and `"build"` for build-dependencies — we skip the latter two.
- **Unit tests** (3 new, all in-process via synthetic metadata):
  - `run_passes_on_clean_workspace` — real workspace sanity
  - `kind_filter_skips_dev_deps` — synthetic dev-dep crossing layer => OK
  - `kind_filter_enforces_normal_deps` — synthetic normal-dep crossing layer => Err
- **CI wiring**: new `ci-layer-check` recipe, added to both `pr-fast` and `ci-gate` after `ci-publish-closure`, so the guardrail runs on every PR iteration and the local merge gate.

Rule surface unchanged: still 1 rule (`perl-diagnostics` must not depend on `perl-lsp-*`). Only the enforcement scope narrows from "all deps" to "normal deps only".

## Files changed

- `xtask/src/tasks/layer_check.rs` (+112 / -9) — add `run_with_metadata(Option<Value>)`, `kind` filter, 3 unit tests
- `justfile` (+13 / -2) — `ci-layer-check` recipe, wired into `pr-fast` and `ci-gate`

## Test plan

- [x] `cargo test -p xtask layer_check` — 3 new tests pass
- [x] `cargo xtask layer-check` — passes on real workspace (1 rule satisfied)
- [x] `just ci-layer-check` — recipe runs end-to-end
- [x] `cargo clippy -p xtask --all-targets` — no new warnings (1 pre-existing unrelated warning in `tests/wave1_perl_module_collapse_tests.rs`)
- [ ] CI `pr-fast` and `ci-gate` lanes run the new step