### PR TITLE
chore(agents): remove worktree isolation from 19 read-only agents

### DIFF
--- a/.claude/agents/accuracy-scout.md
+++ b/.claude/agents/accuracy-scout.md
@@ -3,7 +3,6 @@ name: accuracy-scout
 description: Accuracy verification agent. Verifies mechanical facts in scout issues before plan-review.
 model: haiku
 color: orange
-isolation: worktree
 ---
 
 You are an accuracy-scout for perl-lsp — a Rust workspace with 134

--- a/.claude/agents/advocatus-diaboli.md
+++ b/.claude/agents/advocatus-diaboli.md
@@ -3,7 +3,6 @@ name: advocatus-diaboli
 description: Devil's advocate agent. Challenges whether an issue should exist at all — is this the right problem, is it in scope, is it yak-shaving, would users care?
 model: haiku
 color: red
-isolation: worktree
 ---
 
 You are the advocatus diaboli — the devil's advocate. You read a

--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -3,7 +3,6 @@ name: architecture-reviewer
 description: Architecture alignment agent. Checks whether the proposed design fits the microcrate architecture, dependency graph, and existing patterns — before plan-reviewer invests sonnet tokens.
 model: haiku
 color: blue
-isolation: worktree
 ---
 
 You are the architecture reviewer for perl-lsp — a Rust workspace with

--- a/.claude/agents/diff-auditor.md
+++ b/.claude/agents/diff-auditor.md
@@ -3,7 +3,6 @@ name: diff-auditor
 description: Final diff audit agent. Reviews the complete PR diff after all agents have touched the branch — checks for coherence, scope, leftover artifacts, and merge readiness.
 model: haiku
 color: white
-isolation: worktree
 ---
 
 You are the diff auditor for perl-lsp. You're the last set of eyes before

--- a/.claude/agents/green-ci.md
+++ b/.claude/agents/green-ci.md
@@ -3,7 +3,6 @@ name: green-ci
 description: CI verification agent. Confirms all CI checks pass on the current HEAD SHA before ops merges — no stale green, no ignored failures.
 model: haiku
 color: green
-isolation: worktree
 ---
 
 You are the green CI agent for perl-lsp. You're the final automated gate

--- a/.claude/agents/maintainer-issue.md
+++ b/.claude/agents/maintainer-issue.md
@@ -3,7 +3,6 @@ name: maintainer-issue
 description: Maintainer vision agent (issues). Checks whether the proposed work aligns with perl-lsp's goals, roadmap, and user base — before plan-reviewer invests sonnet tokens.
 model: haiku
 color: purple
-isolation: worktree
 ---
 
 You are the maintainer's voice on issues for perl-lsp. You represent the

--- a/.claude/agents/maintainer-pr.md
+++ b/.claude/agents/maintainer-pr.md
@@ -3,7 +3,6 @@ name: maintainer-pr
 description: Maintainer vision agent (PRs). Checks whether the built PR aligns with perl-lsp's goals and quality bar — before deep-reviewer invests sonnet tokens on correctness.
 model: haiku
 color: purple
-isolation: worktree
 ---
 
 You are the maintainer's voice on PRs for perl-lsp. The issue-level

--- a/.claude/agents/oppositional-planner.md
+++ b/.claude/agents/oppositional-planner.md
@@ -3,7 +3,6 @@ name: oppositional-planner
 description: Oppositional planning agent. Challenges the proposed approach, surfaces overlooked alternatives, and stress-tests assumptions before the plan-reviewer sees the spec.
 model: haiku
 color: yellow
-isolation: worktree
 ---
 
 You are the oppositional planner. You read a scout-filed (and optionally

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -3,7 +3,6 @@ name: plan-reviewer
 description: Plan review agent. Reads a scout's issue fresh, stress-tests the approach, and refines the spec before anyone builds.
 model: sonnet
 color: green
-isolation: worktree
 ---
 
 You are the plan reviewer for perl-lsp — a Rust LSP server for Perl with

--- a/.claude/agents/refactor-planner.md
+++ b/.claude/agents/refactor-planner.md
@@ -3,7 +3,6 @@ name: refactor-planner
 description: Refactor analysis agent. Reads the builder's diff and identifies simplification, reuse, and code quality opportunities — preps a concrete plan so the sonnet green-refactor agent jumps straight to editing.
 model: haiku
 color: cyan
-isolation: worktree
 ---
 
 You are the refactor planner for perl-lsp. You read the builder's

--- a/.claude/agents/research-verifier.md
+++ b/.claude/agents/research-verifier.md
@@ -3,7 +3,6 @@ name: research-verifier
 description: Fact verification agent. Reads a scout-filed issue, verifies external claims (Perl semantics, LSP/DAP spec, crate APIs) via web search and codebase checks, then posts findings as a structured comment.
 model: haiku
 color: cyan
-isolation: worktree
 ---
 
 You are the research verifier for perl-lsp. You are a cheap fact-check

--- a/.claude/agents/research-web.md
+++ b/.claude/agents/research-web.md
@@ -5,7 +5,6 @@ model: sonnet
 color: green
 tools: WebSearch, WebFetch
 maxTurns: 6
-isolation: worktree
 ---
 
 You are a web researcher. You take a specific question, find the answer online, and return a condensed result. The caller doesn't see your search context — only your answer.

--- a/.claude/agents/reviewer-deep.md
+++ b/.claude/agents/reviewer-deep.md
@@ -3,7 +3,6 @@ name: reviewer-deep
 description: Correctness reviewer. Deep second pass — does the logic actually work? Edge cases? Regressions?
 model: sonnet
 color: green
-isolation: worktree
 ---
 
 You are the correctness reviewer for perl-lsp — a Rust LSP/DAP server

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -3,7 +3,6 @@ name: reviewer
 description: Standards reviewer. Fast first pass on PRs — banned patterns, scope, formatting.
 model: haiku
 color: yellow
-isolation: worktree
 ---
 
 You are the standards reviewer for perl-lsp — a Rust workspace with 134

--- a/.claude/agents/scout-dap.md
+++ b/.claude/agents/scout-dap.md
@@ -3,7 +3,6 @@ name: scout-dap
 description: DAP-focused scout. Knows DAP crate test gaps, protocol compliance areas, and related issues (#420, #435). Read-only.
 model: haiku
 color: green
-isolation: worktree
 ---
 
 You are a DAP scout. You investigate DAP test gaps and protocol compliance.

--- a/.claude/agents/scout-lsp.md
+++ b/.claude/agents/scout-lsp.md
@@ -3,7 +3,6 @@ name: scout-lsp
 description: LSP-focused scout. Investigates LSP feature gaps, provider issues, and spec compliance. Knows features.toml, provider crates, and LSP 3.17 spec.
 model: haiku
 color: yellow
-isolation: worktree
 ---
 
 You are an LSP scout. You investigate LSP features, provider quality,

--- a/.claude/agents/scout-parser.md
+++ b/.claude/agents/scout-parser.md
@@ -3,7 +3,6 @@ name: scout-parser
 description: Parser-focused scout. Knows error buckets, corpus structure, and how to trace specific Perl constructs to parser code. Read-only — returns SLICE definitions.
 model: haiku
 color: green
-isolation: worktree
 ---
 
 You are a parser scout. You investigate parser error buckets and trace

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -3,7 +3,6 @@ name: scout
 description: Discovery agent. Investigates one finding and files a builder-ready GitHub issue.
 model: haiku
 color: yellow
-isolation: worktree
 ---
 
 You are a scout for perl-lsp — a Rust LSP/DAP server for Perl 5 with 134

--- a/.claude/agents/wisdom.md
+++ b/.claude/agents/wisdom.md
@@ -3,7 +3,6 @@ name: wisdom
 description: Synthesis agent. Reads the full trail of an issue→PR→merge cycle and surfaces patterns, learnings, and process improvements.
 model: sonnet
 color: purple
-isolation: worktree
 ---
 
 You are the wisdom agent for perl-lsp. You read the complete history


### PR DESCRIPTION
Small cleanup: read-only agents don't edit code, don't need worktrees. **Does NOT fix #4456 nesting** — that's a separate CWD/allocator issue.