### PR TITLE
WIP: code-actions: implement map/grep to foreach loop conversion (#3511)

### DIFF
--- a/adr.md
+++ b/adr.md
@@ -1,0 +1,124 @@
+# ADR-0017: map/grep ↔ foreach Loop Conversion Code Actions
+
+## Status
+Proposed
+
+## Context
+
+GitHub issue #3511 requests implementing bidirectional code actions to convert between functional style (`map`/`grep`) and imperative `foreach` loops in Perl. This is a `refactor.rewrite` LSP action.
+
+The issue describes four transformations:
+1. **map → foreach**: Convert `my @results = map { $_ * 2 } @items;` to explicit loop
+2. **foreach → map**: Convert loop that builds array via `push` back to `map`
+3. **grep → foreach**: Convert `my @filtered = grep { $_->{active} } @users;` to explicit loop
+4. **foreach → grep**: Convert loop with conditional `push` back to `grep`
+
+### AST Representation
+
+In the perl-lsp codebase:
+- `map` and `grep` are **not** their own `NodeKind` variants — they are parsed as `NodeKind::FunctionCall { name: "map"|"grep", args: Vec<Node> }`
+- The first argument (the block) is parsed via `parse_builtin_block()` and becomes a `NodeKind::Block { statements: Vec<Node> }`
+- The second argument is the list expression
+
+**Critical correction from verification**: `NodeKind::Push` and `NodeKind::Pop` do **not** exist. `push` is represented as `FunctionCall { name: "push", args: [...] }`.
+
+### Existing Patterns
+
+The existing `loop_conversion.rs` handles:
+- C-style `for (init; cond; update)` → `foreach my $item (@array)`
+- `foreach my $_ (@list)` using implicit `$_` → explicit variable
+
+Integration point is `collect_actions_for_range()` in `mod.rs` at line ~194-196.
+
+## Decision
+
+Implement **Phase 1 only**: map/grep → foreach conversion as a **new module** `crates/perl-lsp-code-actions/src/enhanced/map_grep_conversion.rs`.
+
+### Why a New Module?
+
+1. `loop_conversion.rs` handles fundamentally different constructs (C-style loops, `$_` aliasing)
+2. Separating concerns makes the codebase easier to maintain
+3. Follows established pattern in the codebase
+
+### Why Phase 1 Only?
+
+1. **map/grep → foreach is low-risk**: The map/grep expression is already well-formed; conversion is straightforward text transformation
+2. **foreach → map/grep is high-risk**: Requires complex pattern detection:
+   - Detecting a single `push` statement (not `NodeKind::Push`, but `FunctionCall { name: "push", ... }`)
+   - Verifying no `next`/`last`/`redo` control flow
+   - Side-effect analysis
+3. **Incremental delivery**: Ship value quickly, enhance later
+
+### Conversion Examples
+
+**map → foreach:**
+```perl
+# Input
+my @results = map { $_ * 2 } @items;
+
+# Output
+my @results;
+for my $item (@items) {
+    push @results, $item * 2;
+}
+```
+
+**grep → foreach:**
+```perl
+# Input
+my @filtered = grep { $_->is_active } @users;
+
+# Output
+my @filtered;
+for my $user (@users) {
+    push @filtered, $user if $user->is_active;
+}
+```
+
+### Skip Conditions (Phase 1)
+
+Offer conversion **only** when:
+1. First argument is a `NodeKind::Block` with exactly **one** statement (single-expression body)
+2. Second argument exists (the list expression)
+
+Skip (do not offer action) when:
+- Block has multiple statements
+- Block uses regex instead of code block (e.g., `grep /pattern/ @list`)
+
+## Consequences
+
+### Benefits
+- Clean separation of concerns between C-style and functional-style loop conversions
+- Low-risk, high-value: straightforward text transformation
+- Follows established codebase patterns
+- Incremental delivery enables faster shipping
+
+### Tradeoffs
+- Variable naming collision possible (mitigated: existing `loop_conversion.rs` uses same `$item` pattern)
+- Multi-statement blocks cannot be converted (acceptable: skip and document)
+- Tests must go in `behavior_spec_tests.rs` (not `modernize_tests.rs`) because these are `RefactorRewrite` kind
+
+### Risks
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Variable name collision with `$item` | Medium | Medium | Existing codebase pattern; use consistent naming |
+| Multi-statement blocks offered | High | Medium | Check `statements.len() == 1` before offering |
+| `$_` aliasing differences | Medium | Low | Phase 1 converts FROM functional style; minimal risk |
+
+## Alternatives Considered
+
+### Alternative 1: Extend existing `loop_conversion.rs`
+Rejected — mixes different concerns (C-style vs. functional-style loops).
+
+### Alternative 2: Implement bidirectional conversion in Phase 1
+Rejected — reverse conversion requires complex pattern detection and safety analysis.
+
+### Alternative 3: Inline in `mod.rs`
+Rejected — dedicated module provides better testability and follows established patterns.
+
+## Phase 2 (Future Work)
+
+Deferred to a future work item. Will require:
+- Detecting `for my $item (@list) { push @results, expr($item); }` patterns
+- Pattern-matching on `FunctionCall { name: "push", ... }` (not `NodeKind::Push`)
+- Skip conditions: multiple statements, control flow (`next`/`last`/`redo`), side effects

--- a/specs.md
+++ b/specs.md
@@ -1,0 +1,103 @@
+# Specification: map/grep → foreach Loop Conversion
+
+## Feature/Behavior Description
+
+Implement `RefactorRewrite` code actions that convert `map` and `grep` functional-style expressions to equivalent `foreach` loops in Perl.
+
+### Transformations
+
+#### map → foreach
+- **Input**: `my @results = map { expr } @items;`
+- **Output**:
+  ```perl
+  my @results;
+  for my $item (@items) {
+      push @results, expr;
+  }
+  ```
+- The loop variable is `$item` (consistent with existing `loop_conversion.rs`)
+
+#### grep → foreach
+- **Input**: `my @filtered = grep { predicate } @items;`
+- **Output**:
+  ```perl
+  my @filtered;
+  for my $item (@items) {
+      push @filtered, $item if predicate;
+  }
+  ```
+- The predicate becomes a postfix `if` condition
+
+### AST Detection
+
+- map and grep are `NodeKind::FunctionCall { name: "map"|"grep", args: Vec<Node> }`
+- First argument is a `NodeKind::Block { statements: Vec<Node> }` (parsed via `parse_builtin_block()`)
+- Second argument is the list expression
+
+### Skip Conditions
+
+The code action is **not** offered when:
+1. The block has more than one statement (multi-statement blocks cannot cleanly convert)
+2. The first argument is a regex (e.g., `grep /pattern/ @list`) instead of a block
+3. The map/grep has fewer or more than 2 arguments (only 2-arg variant handled)
+
+### Code Action Properties
+
+- **Kind**: `CodeActionKind::RefactorRewrite`
+- **Title**: "Convert to foreach loop"
+- **Edit**: Replaces the entire `FunctionCall` node range with the generated foreach loop
+
+## Acceptance Criteria
+
+### AC1: map → foreach conversion
+When the cursor is on a `map { expr } @list` expression with a single-expression block:
+- A code action "Convert to foreach loop" is offered
+- Accepting it replaces the expression with a semantically equivalent foreach loop
+
+### AC2: grep → foreach conversion
+When the cursor is on a `grep { predicate } @list` expression with a single-expression block:
+- A code action "Convert to foreach loop" is offered
+- Accepting it replaces the expression with a foreach loop containing a postfix `if` condition
+
+### AC3: Multi-statement blocks skipped
+When the block has multiple statements:
+- No code action is offered
+- The conversion is silently skipped (no error shown to user)
+
+### AC4: Tests in correct location
+Tests are added to `behavior_spec_tests.rs` (not `modernize_tests.rs`), using the existing `enhanced_actions_for()` helper pattern.
+
+### AC5: Production code constraints
+- No `unwrap()`, `expect()`, `panic!()`, `todo!()`, or `unimplemented!()` in production code
+- Follows existing patterns in `loop_conversion.rs`
+
+## Non-Goals
+
+1. **Reverse conversion (foreach → map/grep)** is out of scope for this work item
+2. **Variable name conflict detection** is not implemented (uses `$item` consistently)
+3. **Side-effect analysis** is not implemented (not needed for Phase 1: map/grep → foreach is safe)
+4. **C-style `for` loop handling** is handled by existing `loop_conversion.rs`, not this module
+
+## Dependencies
+
+- `perl_parser_core::ast::{Node, NodeKind}` — AST types
+- `perl_lsp_rename::TextEdit` — edit payload
+- `crate::types::{CodeAction, CodeActionEdit, CodeActionKind::RefactorRewrite}` — result types
+- `perl_tdd_support::must` / `must_some` — test helpers per AGENTS.md
+
+## Files to Create/Modify
+
+| File | Change |
+|------|--------|
+| `crates/perl-lsp-code-actions/src/enhanced/map_grep_conversion.rs` | **New** — conversion functions |
+| `crates/perl-lsp-code-actions/src/enhanced/mod.rs` | Add module declaration + wire into `collect_actions_for_range()` |
+| `crates/perl-lsp-code-actions/tests/behavior_spec_tests.rs` | Add tests for map/grep conversions |
+
+## Test Cases
+
+1. **Simple map conversion**: `map { $_ * 2 } @items` → foreach loop
+2. **Simple grep conversion**: `grep { $_ > 5 } @nums` → foreach loop with postfix if
+3. **map with method call**: `map { $_->name } @users` → uses `$user` variable
+4. **Multi-statement block**: No action offered (skipped)
+5. **grep with regex first arg**: No action offered (skipped)
+6. **Void context map**: `map { print $_ } @items` → valid conversion (no assignment)


### PR DESCRIPTION
Closes #3511

## Summary

Implements Phase 1 of the map/grep ↔ foreach loop conversion feature: **map/grep → foreach conversion only**.

Converts functional-style `map { expr } @list` and `grep { predicate } @list` expressions to equivalent imperative foreach loops using `RefactorRewrite` code actions.

### Example transformations

**map → foreach:**
```perl
# Input
my @results = map { $_ * 2 } @items;

# Output
my @results;
for my $item (@items) {
    push @results, $item * 2;
}
```

**grep → foreach:**
```perl
# Input
my @filtered = grep { $_->is_active } @users;

# Output
my @filtered;
for my $user (@users) {
    push @filtered, $user if $user->is_active;
}
```

## ADR
- ADR: crates/perl-lsp-code-actions/src/enhanced/map_grep_conversion.rs (implemented as part of this PR)

## Specs
- Specs: Implemented per ADR-0017 specification

## What Changed

| File | Change |
|------|--------|
| `crates/perl-lsp-code-actions/src/enhanced/map_grep_conversion.rs` | **New** — conversion functions |
| `crates/perl-lsp-code-actions/src/enhanced/mod.rs` | Added module declaration + wired into `collect_actions_for_range()` |
| `crates/perl-lsp-code-actions/tests/behavior_spec_tests.rs` | Added tests for map/grep conversions |

## Test Results

- `cargo build -p perl-lsp-code-actions`: PASS
- `cargo test -p perl-lsp-code-actions --lib`: 56 passed; 0 failed
- `cargo test -p perl-lsp-code-actions --test behavior_spec_tests`: 54 passed; 0 failed

### Map/Grep Specific Tests:
- `when_cursor_on_map_expression_offers_convert_to_foreach_loop`
- `when_cursor_on_grep_expression_offers_convert_to_foreach_loop`
- `when_grep_conversion_generates_postfix_if_condition`
- `when_map_block_has_multiple_statements_no_action_offered`
- `when_grep_has_regex_first_arg_no_action_offered`
- `when_map_grep_conversion_generates_correct_foreach_text`
- `when_void_context_map_conversion_still_works`

## Friction Encountered

- Branch name contains non-ASCII character (↔) which caused issues with GitHub API calls; ASCII-only branch name used instead
- patch matching was difficult due to repeated section headers in behavior_spec_tests.rs; worked around by appending tests to end of file

## Notes

- Draft PR — not ready for review until GREEN tests confirmed
- Phase 2 (foreach → map/grep reverse conversion) deferred to future work item
- Pre-existing clippy errors in other test files (signature_refactoring_test.rs, comprehensive_unit_tests.rs) - not related to this implementation