### PR TITLE
docs(collapse): Wave D amendment — line-index, uri, pod stay published (#4467)

### DIFF
--- a/.spec/microcrate-collapse/ledger.md
+++ b/.spec/microcrate-collapse/ledger.md
@@ -40,6 +40,9 @@ Status legend:
 | perl-parser | perl-parser | core-public | 3-4 | — | parser facade; absorbs syntax + parser-adjacent |
 | perl-lexer | perl-lexer | core-public | 3 | — | tokenizer; absorbs satellites |
 | perl-token | perl-token | core-public | — | — | foundation primitive — stays published per ADR-0041 (see Amendment 4) |
+| perl-line-index | perl-line-index | core-public | — | — | foundation primitive — stays published per ADR-0041 (see Amendment 5) |
+| perl-uri | perl-uri | core-public | — | — | foundation primitive — stays published per ADR-0041; absorbs perl-uri-classify during Wave D (see Amendment 5) |
+| perl-pod | perl-pod | core-public | — | — | foundation primitive — stays published per ADR-0041 (see Amendment 5) |
 | perl-semantic-analyzer | perl-semantic-analyzer | core-public | 5 | — | absorbs incremental/refactor; symbol crates go to perl-symbol (Wave B) |
 | perl-symbol | perl-symbol (NEW) | core-public | B | — | absorbs 4 perl-symbol-*; own published crate (see Wave B) |
 | perl-workspace-index | perl-workspace | core-public | 2 | — | renamed to perl-workspace during Wave 2; absorbs 6 perl-workspace-* |
@@ -112,6 +115,12 @@ Wave 3 collapses only the 4 satellites below into `perl-lexer`. See Amendment 4.
 
 ## Wave 4 — parser/AST satellites → perl-parser
 
+`perl-line-index`, `perl-uri`, and `perl-pod` are **NOT** absorbed. They remain separately
+published foundation primitives per ADR-0041 ("Foundation primitives (5): perl-lexer, perl-token,
+perl-line-index, perl-uri, perl-pod"). Wave D collapses only the parser/AST satellites below into
+`perl-parser`. `perl-uri-classify` still folds — but into the retained `perl-uri` crate, not into
+`perl-parser`. See Amendment 5.
+
 | current crate | target owner | final status | wave | risk | notes |
 |---|---|---|---:|---:|---|
 | perl-ast | perl-parser | module | 4 | Med | expose via parser facade |
@@ -125,16 +134,13 @@ Wave 3 collapses only the 4 satellites below into `perl-lexer`. See Amendment 4.
 | perl-refactoring | perl-parser | module | 4 | Med | refactor engine |
 | perl-dead-code | perl-parser | module | 4 | Low | |
 | perl-feature-catalog | perl-parser | module | 4 | Low | codegen build-dep; inline into owner build.rs |
-| perl-line-index | perl-parser | module | 4 | Low | |
 | perl-position-tracking | perl-parser | module | 4 | Low | |
-| perl-pod | perl-parser | module | 4 | Low | |
 | perl-qualified-name | perl-parser | module | 4 | Low | |
 | perl-source-file | perl-parser | module | 4 | Low | |
 | perl-percentile | perl-parser | module | 4 | Low | numeric utility |
 | perl-text-line | perl-parser | module | 4 | Low | |
 | perl-edit | perl-parser | module | 4 | Low | |
-| perl-uri | perl-parser | module | 4 | Low | |
-| perl-uri-classify | perl-parser | module | 4 | Low | fold into perl-uri |
+| perl-uri-classify | perl-uri | module | 4 | Low | folds into the retained perl-uri crate (foundation primitive) |
 | perl-path-normalize | perl-parser | module | 4 | Low | |
 | perl-path-security | perl-parser | module | 4 | Med | security primitive |
 

--- a/docs/adr/0041-microcrate-collapse.md
+++ b/docs/adr/0041-microcrate-collapse.md
@@ -352,6 +352,37 @@ layering and matches the same reasoning that kept `perl-symbol` (Amendment 3) an
 
 The 30-crate published target and all other ADR content remain unchanged.
 
+### Amendment 5 — 2026-04-17: Ledger corrected — perl-line-index, perl-uri, perl-pod stay published (Wave D)
+
+**Source:** Same pattern as Amendments 3 and 4 (perl-symbol, perl-token). Ledger/ADR conflict; ADR wins.
+
+The migration ledger at `.spec/microcrate-collapse/ledger.md` previously listed `perl-line-index`,
+`perl-uri`, and `perl-pod` in the Wave 4 parser/AST satellites table as modules absorbing into
+`perl-parser`. This contradicted the Decision section above ("Foundation primitives (5):
+`perl-lexer`, `perl-token`, `perl-line-index`, `perl-uri`, `perl-pod`") and Amendment 1's
+confirmation of those three crates as members of the 5 foundation primitives.
+
+**The correction:** Wave D (the parser/AST collapse) does **not** absorb `perl-line-index`,
+`perl-uri`, or `perl-pod`. They remain separately published foundation primitives per ADR-0041's
+original design. `perl-uri-classify` still folds — but into the retained `perl-uri` crate, not
+into `perl-parser`.
+
+**Rationale for keeping these three as their own published crates:**
+Each is a minimal, durable foundation primitive consumed across multiple products and layers:
+- `perl-line-index` — line/column <-> byte-offset conversion used by parser, semantic analyzer,
+  LSP providers, DAP.
+- `perl-uri` — Perl-aware URI handling used by LSP navigation, workspace discovery, DAP source
+  location resolution. Absorbs `perl-uri-classify` during Wave D.
+- `perl-pod` — POD documentation parsing used by hover, completion, and parser diagnostics.
+
+Folding any of them into `perl-parser` would force every downstream consumer (LSP providers,
+DAP, workspace index) to depend on the full parser implementation just to get the primitive.
+Keeping them as small, focused, published crates preserves clean layering and matches the same
+reasoning that kept `perl-symbol` (Amendment 3), `perl-token` (Amendment 4), and `perl-workspace`
+(Amendment 2) as their own published crates.
+
+The 30-crate published target and all other ADR content remain unchanged.
+
 ## References
 
 - [Tracking issue #4410: Microcrate collapse to ~30 published crates](https://github.com/EffortlessMetrics/perl-lsp/issues/4410)


### PR DESCRIPTION
Closes #4467.

Prep for Wave D (#4454). Same pattern as #4427 (Wave A), #4431 (Wave B), and #4446 (Wave C).

## Problem

- ADR-0041 Amendment 1 lists 5 foundation primitives to keep published: `perl-lexer`, `perl-token`, `perl-line-index`, `perl-uri`, `perl-pod`.
- `.spec/microcrate-collapse/ledger.md` Wave 4 rows listed `perl-line-index`, `perl-uri`, and `perl-pod` as absorbing into `perl-parser`.

They disagree. Precedent (Amendments 2, 3, 4): **ADR wins.**

## Decision

`perl-line-index`, `perl-uri`, and `perl-pod` stay separately published crates. Wave D (#4454) absorbs only the parser/AST satellites into `perl-parser`. `perl-uri-classify` still folds — but into the retained `perl-uri` crate, not into `perl-parser`.

## Changes

- **`.spec/microcrate-collapse/ledger.md`**:
  - Remove `perl-line-index`, `perl-uri`, `perl-pod` rows from Wave 4.
  - Add them to the Products (core-public) section.
  - Annotate Wave 4 scope with a note about the exclusion and Amendment 5.
  - Re-point `perl-uri-classify` to fold into the retained `perl-uri` crate (not `perl-parser`).
- **`docs/adr/0041-microcrate-collapse.md`**:
  - Append **Amendment 5 (2026-04-17)**: Ledger corrected — perl-line-index, perl-uri, perl-pod stay published (Wave D).

## Rationale

Each of the three primitives is consumed across multiple products and layers — parser, semantic analyzer, LSP providers, DAP, workspace discovery. Folding any of them into `perl-parser` would force every downstream consumer to depend on the full parser implementation just to get the primitive. Same reasoning as `perl-symbol` (Amendment 3), `perl-token` (Amendment 4), and `perl-workspace` (Amendment 2).

## Scope

Docs only — no code changes. No `cargo` surface touched.

## Test plan

- [x] Only `.spec/` and `docs/adr/` files modified
- [x] No Cargo.toml or code changes
- [x] Amendment 5 follows the same structure as Amendments 3 and 4
- [x] Ledger Wave 4 and Products sections are internally consistent
- [x] `perl-uri-classify` still has a fold target (the retained `perl-uri`)