### PR TITLE
fix(hooks): pre-tool-use worktree guard (#4464)

### DIFF
--- a/.claude/hooks/pre-tool-use.sh
+++ b/.claude/hooks/pre-tool-use.sh
@@ -19,4 +19,47 @@ if echo "$CMD" | grep -qE 'git stash( |$)'; then
   exit 2
 fi
 
+# Worktree guard (#4464): when CWD is inside a linked worktree, block branch-mutating
+# commands that anchor to the wrong location and cause nested-worktree contamination.
+# Detection: git-dir != git-common-dir means we're inside a linked worktree, not main.
+git_dir=$(git rev-parse --git-dir 2>/dev/null)
+common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
+if [ -n "$git_dir" ] && [ -n "$common_dir" ] && [ "$git_dir" != "$common_dir" ] && [ "$git_dir" != ".git" ]; then
+  # In a linked worktree. Block the subset of git ops that anchor wrong.
+
+  # git worktree add: always block (creates nested worktrees)
+  if echo "$CMD" | grep -qE 'git +worktree +add( |$)'; then
+    echo "Blocked: 'git worktree add' inside a linked worktree creates nested worktrees." >&2
+    echo "Recovery: cd to main checkout first, then re-run. Main checkout: $(git rev-parse --git-common-dir)/.." >&2
+    echo "See #4456 for context." >&2
+    exit 2
+  fi
+
+  # git switch <branch> (without -c/-C): block branch-switch form
+  if echo "$CMD" | grep -qE 'git +switch( +-[-[:alnum:]]+)* +[^-]'; then
+    # Allow -c/-C (create) forms
+    if ! echo "$CMD" | grep -qE 'git +switch +(-c|-C|--create|--force-create)( |$)'; then
+      echo "Blocked: 'git switch <branch>' inside a linked worktree changes the worktree's branch." >&2
+      echo "Recovery: cd to main checkout first, or use 'git switch -c <new-branch>' to create from current." >&2
+      echo "See #4456 for context." >&2
+      exit 2
+    fi
+  fi
+
+  # git checkout <branch>: block branch-switch form (not -b/-B, not -- <file>, not --ours/--theirs)
+  if echo "$CMD" | grep -qE 'git +checkout( |$)'; then
+    # Allow safe forms:
+    #   git checkout -b / -B / --force        → create-and-switch
+    #   git checkout -- <path>                → restore file
+    #   git checkout --ours / --theirs        → rebase conflict
+    #   git checkout HEAD -- <path>           → restore from HEAD
+    if ! echo "$CMD" | grep -qE 'git +checkout +(-b|-B|--force|-f |--ours|--theirs|--detach|-- +|[a-f0-9]+ +-- +|HEAD +-- +)'; then
+      echo "Blocked: 'git checkout <branch>' inside a linked worktree changes the worktree's branch." >&2
+      echo "Recovery: cd to main checkout first. Allowed here: 'git checkout -b/-B <new>', 'git checkout -- <file>', 'git checkout --ours/--theirs'." >&2
+      echo "See #4456 for context." >&2
+      exit 2
+    fi
+  fi
+fi
+
 exit 0

--- a/.claude/hooks/tests/test_pre_tool_use_worktree.sh
+++ b/.claude/hooks/tests/test_pre_tool_use_worktree.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Test the worktree guard in .claude/hooks/pre-tool-use.sh (#4464)
+# Each case simulates a Claude Code pre-tool-use invocation from either the
+# main checkout or a linked worktree and asserts the hook exit code.
+
+set -eu
+
+HOOK="$(git rev-parse --show-toplevel)/.claude/hooks/pre-tool-use.sh"
+FAIL=0
+
+run_case() {
+  local label="$1" cwd="$2" cmd="$3" expected_exit="$4"
+  local actual
+  actual=$(
+    cd "$cwd" && echo "{\"tool_input\":{\"command\":\"$cmd\"}}" | bash "$HOOK" >/dev/null 2>&1
+    echo $?
+  )
+  if [ "$actual" = "$expected_exit" ]; then
+    echo "PASS  $label (exit $actual)"
+  else
+    echo "FAIL  $label (expected $expected_exit, got $actual) CWD=$cwd CMD=$cmd"
+    FAIL=1
+  fi
+}
+
+# Set up a temporary linked worktree for testing
+MAIN="$(git rev-parse --show-toplevel)"
+WORKTREE_TMP="$(mktemp -d)/wt-test-$$"
+git worktree add --detach "$WORKTREE_TMP" HEAD >/dev/null 2>&1
+trap 'git worktree remove --force "$WORKTREE_TMP" >/dev/null 2>&1 || true' EXIT
+
+# --- Main checkout: all git ops allowed ---
+run_case "main checkout: git checkout master"     "$MAIN" "git checkout master"     0
+run_case "main checkout: git checkout -b new"     "$MAIN" "git checkout -b new"     0
+run_case "main checkout: git switch master"       "$MAIN" "git switch master"       0
+run_case "main checkout: git switch -c new"       "$MAIN" "git switch -c new"       0
+run_case "main checkout: git worktree add x y"    "$MAIN" "git worktree add x y"    0
+
+# --- Worktree: branch-switching blocked ---
+run_case "worktree: git checkout master (block)"        "$WORKTREE_TMP" "git checkout master"        2
+run_case "worktree: git switch master (block)"          "$WORKTREE_TMP" "git switch master"          2
+run_case "worktree: git worktree add foo (block)"       "$WORKTREE_TMP" "git worktree add foo"       2
+
+# --- Worktree: safe forms allowed ---
+run_case "worktree: git checkout -b new (allow)"        "$WORKTREE_TMP" "git checkout -b new"        0
+run_case "worktree: git checkout -B new (allow)"        "$WORKTREE_TMP" "git checkout -B new"        0
+run_case "worktree: git checkout -- file.rs (allow)"    "$WORKTREE_TMP" "git checkout -- file.rs"    0
+run_case "worktree: git checkout --ours path (allow)"   "$WORKTREE_TMP" "git checkout --ours path"   0
+run_case "worktree: git switch -c new (allow)"          "$WORKTREE_TMP" "git switch -c new"          0
+
+if [ "$FAIL" -eq 0 ]; then
+  echo
+  echo "All test cases passed."
+  exit 0
+else
+  echo
+  echo "Some test cases failed."
+  exit 1
+fi


### PR DESCRIPTION
Blocks branch-mutating git commands from linked worktrees. Adds detection via git-dir vs git-common-dir comparison. 13 test cases pass. Refs #4464.