### PR TITLE
WIP: feat(completion): @INC paths not used in module completion (#4314)

### DIFF
--- a/.hermes/conveyor/work-9b4ef6a1/findings/doc-writer-findings.md
+++ b/.hermes/conveyor/work-9b4ef6a1/findings/doc-writer-findings.md
@@ -1,0 +1,59 @@
+# Documentation Findings — work-9b4ef6a1
+
+## What This Change Does
+Completes PullDiagnosticsProvider for production use by addressing three gaps from ADR-0042:
+1. handle_workspace_diagnostic should use orchestrator pattern (Gap 1)
+2. is_fixable_diagnostic should delegate to is_fixable_perlcritic_policy (Gap 2)
+3. orchestrator.reset() should be called in handle_did_change_configuration (Gap 3)
+
+## Current State: IMPLEMENTATION MISSING
+
+**The implementation does not exist on this branch.** The branch `feat/work-9b4ef6a1/complete-pulldiagnosticsprovider-for-pro` has the wrong commits (tree-sitter-perl-c work instead of PullDiagnosticsProvider work).
+
+From the friction log:
+> [BUILT] BLOCKER: Branch has wrong commit (fe8f2832 is tree-sitter-perl-c work, not PullDiagnosticsProvider). Code has compilation errors: is_fixable_perlcritic_policy called but not imported, PullDiagnosticsProvider not imported in diagnostics.rs. Implementation for ADR-0042 gaps 1/2/3 was never done.
+
+## Files Examined
+- `crates/perl-lsp/tests/pulldiagnostics_provider_completion_test.rs` - Test file (exists as untracked file, not committed)
+
+## What Exists
+
+### Test File (untracked, not committed)
+The test file `pulldiagnostics_provider_completion_test.rs` exists but is NOT committed to the branch. It contains 6 tests:
+1. `test_is_fixable_diagnostic_uses_shared_helper` - Tests Gap 2
+2. `test_orchestrator_reset_is_wired_into_config_change` - Tests Gap 3
+3. `test_workspace_diagnostic_uses_orchestrator_for_perlcritic` - Tests Gap 1
+4. `test_workspace_diagnostic_uses_pull_provider_for_basic_diagnostics` - Tests Gap 1 variant
+5. `test_workspace_diagnostics_share_orchestrator_cache` - Tests AC2
+6. `test_workspace_diagnostic_response_structure` - Tests AC5
+
+## What Is Missing
+
+The implementation for ADR-0042 gaps 1/2/3 was never committed to this branch. Specifically:
+- No changes to `pull.rs` to delegate to `is_fixable_perlcritic_policy`
+- No changes to `diagnostics.rs` to use orchestrator pattern in `handle_workspace_diagnostic`
+- No changes to `workspace.rs` to wire `orchestrator.reset()` into config change handler
+
+## My Attempts to Fix (on different branch)
+
+Earlier in this session, I attempted to fix compilation errors that were supposedly present:
+1. Made `is_fixable_perlcritic_policy` accessible by making it `pub(crate)` with docstring
+2. Added import for the function in `pull.rs`
+
+However, these changes were made on a different branch (the working tree at that time had diverged). When I checked out the correct branch, those changes were not present.
+
+## Documentation Assessment
+
+**No implementation = no documentation to write.**
+
+The test file exists and documents what the implementation should do. Once the implementation is committed, the documentation can be added.
+
+## Tests
+**Cannot run** - No implementation exists.
+
+## Recommended Next Steps
+1. Implement Gap 2: Modify `pull.rs::is_fixable_diagnostic` to delegate to `is_fixable_perlcritic_policy` from `diagnostics.rs`
+2. Implement Gap 3: Wire `orchestrator.reset()` into `handle_did_change_configuration` in `workspace.rs`
+3. Implement Gap 1: Refactor `handle_workspace_diagnostic` in `diagnostics.rs` to use orchestrator pattern
+4. Commit the implementation
+5. Run doc-writer to add documentation to the committed implementation

--- a/.hermes/conveyor/work-d59724f8/adr.md
+++ b/.hermes/conveyor/work-d59724f8/adr.md
@@ -1,0 +1,120 @@
+# ADR: Include-Path Scanning for Module Completion
+
+## Title
+ADR-2024-XXXX: Include-Path Scanning for Module Completion
+
+## Status
+Proposed
+
+## Context
+
+When typing `use DB` or `require DBI`, the module completion provider only suggests modules from the workspace index (modules defined in workspace files). It does NOT search:
+- Configured `includePaths` from `.perl-lsp.toml`
+- `PERL5LIB` environment variable paths
+- System `@INC` when `useSystemInc: true` is configured
+
+This is GitHub issue #4314. Users don't get completions for core modules like `DBI`, `Moo`, `Moose`, `Data::Dumper`, etc. unless those modules happen to be indexed from workspace files.
+
+The module resolution system (`resolve_module_to_path_with_doc()`) already handles @INC correctly by:
+1. Parsing `PERL5LIB` environment variable
+2. Calling `config.effective_include_paths(&perl5lib_paths)` which merges `includePaths` config with `PERL5LIB`
+3. Calling `config.get_system_inc()` when `useSystemInc: true`
+
+The gap is that the completion provider doesn't follow the same pattern.
+
+## Decision
+
+We will add include-path scanning to the `add_use_module_completions()` function by:
+
+### 1. Pass Include Paths Through the Call Chain
+
+The `perl-lsp-completion` crate does NOT depend on `perl-lsp-config` (verified via Cargo.toml). Therefore, include paths must be passed from the runtime layer (`perl-lsp`) down to the completion crate.
+
+In `handle_completion()` (`runtime/language/completion.rs`):
+```rust
+let perl5lib_paths = std::env::var("PERL5LIB")
+    .map(|v| perl_lsp_config::WorkspaceConfig::parse_perl5lib(&v))
+    .unwrap_or_default();
+let config = self.config_for_doc(uri).unwrap_or_else(...);
+let include_paths = config.effective_include_paths(&perl5lib_paths);
+let system_inc_paths = if config.use_system_inc {
+    config.get_system_inc().to_vec()
+} else {
+    Vec::new()
+};
+```
+
+This corrects the bug in the initial plan (which used `include_paths_for_doc()` that doesn't merge PERL5LIB).
+
+### 2. Extend CompletionProvider to Accept Include Paths
+
+Add `include_paths: Vec<PathBuf>` and `system_inc_paths: Vec<PathBuf>` fields to `CompletionProvider` and create a new constructor `new_with_index_and_source_with_inc()` that accepts these paths. Keep the existing constructor working with empty paths for backward compatibility.
+
+### 3. Implement Bounded Include-Path Scanning
+
+Add `scan_directory_for_modules()` helper in `workspace.rs` that:
+- Walks directories using `WalkDir` with max depth of 8
+- Only matches `.pm` files
+- Converts paths to module names using `path_to_module_name()`
+- Respects LSP cancellation via `is_cancelled()` checks
+- Limits results to top 20 per include path to prevent flooding
+
+### 4. Use Bounded Caching Consistent with WorkspaceIndex Patterns
+
+Rather than a simple TTL-based cache, we use a bounded cache approach:
+- Cache key: include path directory
+- Cache value: sorted list of module names discovered
+- Bounded by path count (not time) — each include path has one cache entry
+- Invalidation: cache entries are invalidated when the config changes (config change triggers new provider instance)
+- Memory bounded: only stores module names, not full CompletionItems
+
+**Note**: This creates a separate cache from WorkspaceIndex, which is architectural debt. The completion crate's cache will not benefit from WorkspaceIndex's BoundedLruCache, LRU eviction, or SLO tracking. A follow-on effort should consider unifying this with WorkspaceIndex or creating a shared include-path cache.
+
+### 5. Respect Sort Tiering
+
+External modules from include paths should use sort text prefix `"2_"` (after workspace tier `"1_"` but before generic tier `"9_"`):
+- Tier 0: Hardcoded common modules (strict, warnings, DBI, etc.)
+- Tier 1: Workspace modules
+- Tier 2: External modules from include paths (NEW)
+- Tier 3: System @INC modules when enabled (NEW, same tier as external)
+- Tier 9: Generic symbols
+
+## Consequences
+
+### Positive
+- Fixes the immediate user problem: completions now include modules from @INC
+- Completion crate remains decoupled from `perl-lsp-config` (paths passed as parameters)
+- Bounded cache prevents unbounded memory growth
+- Path-based invalidation ensures cache freshness without complex TTL logic
+
+### Negative
+- Duplicates scanning logic between completion and module resolution
+- Creates a separate cache that won't benefit from WorkspaceIndex SLO tracking
+- If module resolution is updated for new @INC edge cases, completion won't automatically benefit
+
+### Neutral
+- Performance: scanning is bounded by caching, but still happens on completion hot path
+- The existing `module_sort_tier()` infrastructure is reused for external modules
+
+## Alternatives Considered
+
+### Alternative 1: Extend WorkspaceIndex to Index Include Paths at Startup
+- **Pros**: Single source of truth, O(1) lookups, reuses existing caching infrastructure
+- **Cons**: Larger architectural change touching the most complex file in the workspace, higher regression risk, longer implementation time
+- **Verdict**: Rejected for this issue due to scope (this is a bug fix, not a feature redesign). Recommended as follow-on effort.
+
+### Alternative 2: Hook Into Module Resolution System for All-Match Queries
+- **Pros**: Zero duplication of scanning logic, automatic handling of complex cases
+- **Cons**: Module resolution API designed for single-match, not enumeration, would need significant redesign
+- **Verdict**: Rejected as impractical for this scope.
+
+### Alternative 3: Targeted On-Disk Lookup Per Prefix (No Full Directory Scan)
+- **Pros**: No full directory walk needed, can work without persistent cache
+- **Cons**: Doesn't discover unknown modules, essentially degenerates to hardcoded list approach
+- **Verdict**: Rejected as insufficient for the use case.
+
+## Notes
+
+- The cache strategy accepts architectural debt from having separate caches. A follow-on should unify include-path caching with WorkspaceIndex or create a shared cache.
+- Lexical `use lib` paths from source files are NOT included in this fix (deferred as more complex change).
+- The `include_paths_for_doc()` method returns `Vec<PathBuf>` while `effective_include_paths()` returns `Vec<String>`. The completion crate will convert between them.

--- a/.hermes/conveyor/work-d59724f8/specs.md
+++ b/.hermes/conveyor/work-d59724f8/specs.md
@@ -1,0 +1,162 @@
+# Specification: Include-Path Scanning for Module Completion
+
+## Feature Description
+
+When the user types `use` or `require` statements, the completion provider will now suggest module names from:
+1. **Workspace index** (existing behavior)
+2. **Configured `includePaths`** from `.perl-lsp.toml` (NEW)
+3. **`PERL5LIB` environment variable** paths (NEW)
+4. **System `@INC`** when `useSystemInc: true` is configured (NEW)
+
+The completion items are sorted with external modules appearing after workspace modules but before generic symbols.
+
+## Acceptance Criteria
+
+### AC1: Modules from configured includePaths appear in completion
+**Given** a `.perl-lsp.toml` with `includePaths = ["/path/to/lib"]`
+**And** `/path/to/lib/DBI.pm` exists
+**When** the user types `use DB`
+**Then** `DBI` appears in the completion list
+
+### AC2: Modules from PERL5LIB appear in completion
+**Given** `PERL5LIB=/path/to/ext/lib` is set in the environment
+**And** `/path/to/ext/lib/Moo.pm` exists
+**When** the user types `use Mo`
+**Then** `Moo` appears in the completion list
+
+### AC3: Modules from system @INC appear when useSystemInc is true
+**Given** `useSystemInc = true` is configured
+**And** the system has `strict.pm` in `@INC`
+**When** the user types `use st`
+**Then** `strict` appears in the completion list
+
+### AC4: External modules sort after workspace but before generic symbols
+**Given** `My::Module` exists in workspace AND `/path/to/lib/My/Module.pm` exists
+**When** the user types `use My`
+**Then** `My::Module` from workspace appears before `My::Module` from include paths
+**And** both appear before generic symbols (if any)
+
+### AC5: Completion remains responsive with caching
+**Given** include paths have been scanned once
+**When** the user triggers completion
+**Then** the response time is < 100ms for cached results
+**And** the response time is < 500ms for initial scan (if needed)
+
+### AC6: Cache is invalidated on config change
+**Given** the completion cache has been populated
+**When** the user modifies `includePaths` in `.perl-lsp.toml`
+**Then** subsequent completions use the new paths (not stale cache)
+
+### AC7: Prefix filtering works for external modules
+**Given** `/path/to/lib/DBD/MySQL.pm` exists
+**When** the user types `use DBD::My`
+**Then** `DBD::MySQL` appears in the completion list
+
+## Non-Goals (Out of Scope)
+
+1. **Method completion** from external modules (e.g., completing `->dbh` after `use DBI`)
+2. **Import symbol completion** (`use Module qw(...)`) from external modules
+3. **Auto-loading** or lazy-loading of module metadata
+4. **Goto-definition** changes (already works correctly)
+5. **Diagnostics** changes (already uses include paths correctly)
+6. **Lexical `use lib` paths** from source files (deferred to future work)
+
+## Implementation Details
+
+### File Changes
+
+| File | Change |
+|------|--------|
+| `crates/perl-lsp/src/runtime/language/completion.rs` | Wire include paths from config to provider |
+| `crates/perl-lsp-completion/src/completion.rs` | Add `include_paths`/`system_inc_paths` fields and new constructor |
+| `crates/perl-lsp-completion/src/completion/workspace.rs` | Add `scan_directory_for_modules()` and `path_to_module_name()` |
+
+### Path Retrieval (Step 4 Fix)
+
+The initial plan used `include_paths_for_doc()` which does NOT merge PERL5LIB. The correct approach:
+
+```rust
+let perl5lib_paths = std::env::var("PERL5LIB")
+    .map(|v| perl_lsp_config::WorkspaceConfig::parse_perl5lib(&v))
+    .unwrap_or_default();
+let config = self.config_for_doc(uri).unwrap_or_else(...);
+let include_paths = config.effective_include_paths(&perl5lib_paths);
+let system_inc_paths = if config.use_system_inc {
+    config.get_system_inc().to_vec()
+} else {
+    Vec::new()
+};
+```
+
+### Caching Strategy
+
+- **Cache location**: On `CompletionProvider` instance (created fresh per completion request)
+- **Cache key**: Include path directory (each path has its own cache entry)
+- **Cache value**: Sorted list of module names (not full `CompletionItem`s to minimize memory)
+- **Invalidation**: Config change creates new provider instance (provider is not shared)
+- **TTL**: None needed — cache is per-provider-instance, invalidated by virtue of new instances
+
+### Directory Scanning Interface
+
+```rust
+fn scan_directory_for_modules(
+    dir: &Path,
+    prefix: &str,
+    seen: &mut HashSet<String>,
+    completions: &mut Vec<CompletionItem>,
+    is_cancelled: &dyn Fn() -> bool,
+)
+```
+
+Behavior:
+- Max recursion depth: 8 levels
+- File extensions: only `.pm`
+- Symlink handling: follow symlinks with cycle detection
+- Error handling: skip unreadable directories silently
+- Result limit: 20 per include path
+
+### Path to Module Name Conversion
+
+Converts filesystem paths to Perl module names:
+- `lib/Foo/Bar.pm` → `Foo::Bar` (strip `lib/` prefix if present)
+- `lib/perl5/vendor_perl/Foo/Bar.pm` → `Foo::Bar` (strip `perl5/vendor_perl` segment)
+- `lib/DBI.pm` → `DBI` (module at root of include path)
+
+Algorithm:
+1. If path starts with `lib/`, strip that prefix
+2. If path contains `perl5/vendor_perl/` or `perl5/site_perl/`, strip up to and including that segment
+3. Replace `/` with `::`
+4. Remove `.pm` extension
+5. Validate result matches `/^[A-Z][a-zA-Z0-9_:]*(?:\::)?$/` (Perl module name pattern)
+
+### Sort Tiering
+
+| Tier | Sort Text Prefix | Source |
+|------|------------------|--------|
+| 0 | `"0_"` | Hardcoded common modules (strict, warnings, DBI, etc.) |
+| 1 | `"1_"` | Workspace modules |
+| 2 | `"2_"` | External modules from include paths |
+| 9 | `"9_"` | Generic symbols |
+
+## Dependencies
+
+### Crate Dependencies
+- `perl-lsp-completion` receives include paths as parameters (does not add new dependencies)
+- `perl-lsp` passes include paths to completion provider
+
+### Configuration Dependencies
+- `includePaths` in `.perl-lsp.toml`
+- `PERL5LIB` environment variable
+- `perl5lib_precedence` (prepend/append)
+- `useSystemInc`
+- `resolution_timeout_ms` (for scan timeout)
+
+## Edge Cases
+
+1. **Empty @INC paths**: No-op, nothing to scan
+2. **Non-existent include paths**: Skip silently, log at debug level
+3. **Permission denied**: Skip silently, log at debug level
+4. **Duplicate modules**: `seen: HashSet<String>` deduplicates within a completion request
+5. **Case-insensitive filesystems**: Module names are case-sensitive; filesystem case doesn't matter
+6. **Very deep hierarchies**: Max 8 levels prevents runaway recursion
+7. **Cancellation**: `is_cancelled()` checked during directory traversal

--- a/.hermes/conveyor/work-d59724f8/task_list.md
+++ b/.hermes/conveyor/work-d59724f8/task_list.md
@@ -1,0 +1,39 @@
+# Task List: @INC Paths in Module Completion
+
+## Implementation Tasks
+
+- [ ] 1. Modify `CompletionProvider` in `crates/perl-lsp-completion/src/completion.rs`
+  - Add `include_paths: Vec<PathBuf>` and `system_inc_paths: Vec<PathBuf>` fields
+  - Create new constructor `new_with_index_and_source_with_inc()` accepting include paths
+  - Keep existing `new_with_index_and_source()` with empty paths for backward compatibility
+
+- [ ] 2. Implement directory scanning in `crates/perl-lsp-completion/src/completion/workspace.rs`
+  - Add `scan_directory_for_modules()` helper function
+  - Add `path_to_module_name()` helper for path → module name conversion
+  - Update `add_use_module_completions()` to accept and use include paths
+  - Implement max depth (8), file matching (.pm only), and symlink cycle detection
+
+- [ ] 3. Wire include paths in `crates/perl-lsp/src/runtime/language/completion.rs`
+  - Fix Step 4 to use `effective_include_paths(&perl5lib_paths)` instead of `include_paths_for_doc()`
+  - Parse `PERL5LIB` environment variable using `WorkspaceConfig::parse_perl5lib()`
+  - Get system @INC paths when `useSystemInc: true`
+  - Pass paths to the new `CompletionProvider` constructor
+
+- [ ] 4. Add caching strategy
+  - Cache scoped to `CompletionProvider` instance (invalidated by config change)
+  - Cache key: include path directory
+  - Cache value: sorted list of module names
+  - Limit results to 20 per include path
+
+- [ ] 5. Update sort tiering
+  - External modules use tier 2 sort text prefix `"2_"`
+  - Verify workspace modules (tier 1) sort before external (tier 2)
+
+- [ ] 6. Add tests
+  - Test module completion finds modules in include paths
+  - Test module completion finds PERL5LIB modules
+  - Test module completion finds system @INC modules when enabled
+  - Test prefix matching works correctly (e.g., `DB` → `DBI`, `DBD::MySQL`)
+  - Test deduplication with workspace symbols
+  - Test sort ordering is correct (workspace before external)
+  - Test performance: completion returns within 100ms for cached results

--- a/crates/perl-lsp-completion/tests/sub_exporter_completion_tests.rs
+++ b/crates/perl-lsp-completion/tests/sub_exporter_completion_tests.rs
@@ -1,0 +1,275 @@
+//! Sub::Exporter completion tests for perl-lsp-completion.
+//!
+//! Tests cover:
+//! - Simple exports array: `use MyModule { exports => [qw(foo bar)] }`
+//! - -setup syntax: `use MyModule -setup => { exports => [qw(foo)] }`
+//! - Groups/tags: `use MyModule { exports => [...], groups => { default => [...] } }`
+//! - Renaming with -as: `func1 => { -as => 'my_func1' }`
+//! - MethodCall with HashLiteral: `Module->import({ exports => [qw(foo)] })`
+
+use perl_lsp_completion::{CompletionItem, CompletionProvider};
+use perl_parser_core::Parser;
+use perl_tdd_support::must;
+use perl_workspace::workspace_index::WorkspaceIndex;
+use std::sync::Arc;
+use url::Url;
+
+// ---------------------------------------------------------------------------
+// Helper utilities
+// ---------------------------------------------------------------------------
+
+fn parse_provider_with_index(code: &str, index: Arc<WorkspaceIndex>) -> CompletionProvider {
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    CompletionProvider::new_with_index_and_source(&ast, code, Some(index))
+}
+
+fn completions_at_end_with_index(code: &str, index: Arc<WorkspaceIndex>) -> Vec<CompletionItem> {
+    let provider = parse_provider_with_index(code, index);
+    provider.get_completions(code, code.len())
+}
+
+fn has_promoted_label(items: &[CompletionItem], label: &str) -> bool {
+    items
+        .iter()
+        .any(|i| i.label == label && i.sort_text.as_deref().is_some_and(|s| s.starts_with("2_")))
+}
+
+fn make_sub_exporter_module_index() -> Arc<WorkspaceIndex> {
+    let index = Arc::new(WorkspaceIndex::new());
+    let uri = must(Url::parse("file:///workspace/My/SubExporterModule.pm"));
+    let code = r#"package My::SubExporterModule;
+use Sub::Exporter -setup => {
+    exports => [qw(foo bar baz)],
+    groups => {
+        default => [qw(foo bar)],
+        all => [qw(foo bar baz)],
+    },
+};
+sub foo { }
+sub bar { }
+sub baz { }
+1;
+"#;
+    must(index.index_file(uri, code.to_string()));
+    index
+}
+
+fn make_sub_exporter_with_renaming_index() -> Arc<WorkspaceIndex> {
+    let index = Arc::new(WorkspaceIndex::new());
+    let uri = must(Url::parse("file:///workspace/Module/WithSubExporter.pm"));
+    let code = r#"package Module::WithSubExporter;
+use Sub::Exporter -setup => {
+    exports => [qw(func1 func2)],
+};
+sub func1 { }
+sub func2 { }
+1;
+"#;
+    must(index.index_file(uri, code.to_string()));
+    index
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Simple exports array - symbols are promoted
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_simple_exports_array_symbols_are_promoted() {
+    // `use MyModule { exports => [qw(foo bar)] };`
+    // foo and bar should be promoted (sort_text "2_")
+    let source = "use My::SubExporterModule { exports => [qw(foo bar)] };\nfo";
+    let index = make_sub_exporter_module_index();
+    let items = completions_at_end_with_index(source, index);
+
+    // foo should be promoted because it's in the exports list
+    assert!(
+        has_promoted_label(&items, "foo"),
+        "foo should be promoted (sort_text '2_') because it's in the Sub::Exporter exports; got: {:?}",
+        items.iter().find(|i| i.label == "foo").map(|i| &i.sort_text)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Simple exports array - all listed symbols are extracted
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_simple_exports_array_extracts_all_symbols() {
+    // `use MyModule { exports => [qw(foo bar)] };`
+    // Both foo and bar should appear as completions
+    let source = "use My::SubExporterModule { exports => [qw(foo bar)] };\nba";
+    let index = make_sub_exporter_module_index();
+    let items = completions_at_end_with_index(source, index);
+
+    assert!(
+        has_promoted_label(&items, "bar"),
+        "bar should be promoted because it's in the Sub::Exporter exports; got items: {:?}",
+        items.iter().map(|i| format!("{}/{:?}", i.label, i.sort_text)).collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Empty exports yields no symbols
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_empty_exports_yields_no_symbols() {
+    // `use MyModule { exports => [] };`
+    // No symbols should be promoted
+    let source = "use My::SubExporterModule { exports => [] };\nfo";
+    let index = make_sub_exporter_module_index();
+    let items = completions_at_end_with_index(source, index);
+
+    // foo should NOT be promoted since exports is empty
+    assert!(
+        !has_promoted_label(&items, "foo"),
+        "foo should NOT be promoted because exports array is empty; got items: {:?}",
+        items.iter().map(|i| format!("{}/{:?}", i.label, i.sort_text)).collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: -setup syntax with exports
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_setup_syntax_exports_symbols() {
+    // `use MyModule -setup => { exports => [qw(foo)] };`
+    // foo should be promoted
+    let source = "use My::SubExporterModule -setup => { exports => [qw(foo)] };\nfo";
+    let index = make_sub_exporter_module_index();
+    let items = completions_at_end_with_index(source, index);
+
+    assert!(
+        has_promoted_label(&items, "foo"),
+        "foo should be promoted with -setup syntax; got items: {:?}",
+        items.iter().map(|i| format!("{}/{:?}", i.label, i.sort_text)).collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Groups with default tag
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_groups_default_tag_symbols() {
+    // Groups define default => [qw(foo bar)], so foo and bar should be available
+    // (Groups are for tag-based imports, so individual symbols still come from exports)
+    let source = "use My::SubExporterModule { exports => [qw(foo bar baz)], groups => { default => [qw(foo bar)] } };\nba";
+    let index = make_sub_exporter_module_index();
+    let items = completions_at_end_with_index(source, index);
+
+    assert!(
+        has_promoted_label(&items, "bar"),
+        "bar should be promoted because it's in the exports list; got items: {:?}",
+        items.iter().map(|i| format!("{}/{:?}", i.label, i.sort_text)).collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: Renaming with -as
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_renaming_with_as() {
+    // `use Module func1 => { -as => 'my_func1' };`
+    // my_func1 should appear as a completion
+    let source = "use Module::WithSubExporter func1 => { -as => 'my_func1' };\nmy_";
+    let index = make_sub_exporter_with_renaming_index();
+    let items = completions_at_end_with_index(source, index);
+
+    assert!(
+        has_promoted_label(&items, "my_func1"),
+        "my_func1 should be promoted because it's the renamed export; got items: {:?}",
+        items.iter().map(|i| format!("{}/{:?}", i.label, i.sort_text)).collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: MethodCall with HashLiteral
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_method_call_hash_literal() {
+    // `Module->import({ exports => [qw(foo)] });`
+    // foo should be promoted
+    let source =
+        "use My::SubExporterModule;\nMy::SubExporterModule->import({ exports => [qw(foo)] });\nfo";
+    let index = make_sub_exporter_module_index();
+    let items = completions_at_end_with_index(source, index);
+
+    assert!(
+        has_promoted_label(&items, "foo"),
+        "foo should be promoted from MethodCall HashLiteral; got items: {:?}",
+        items.iter().map(|i| format!("{}/{:?}", i.label, i.sort_text)).collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: No regression - standard qw() imports still work
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_no_regression_standard_qw_imports() {
+    // Standard `use Foo qw(bar baz)` still works
+    let source = "use List::Util qw(sum min max);\nsu";
+    let index = {
+        let idx = Arc::new(WorkspaceIndex::new());
+        let uri = must(Url::parse("file:///workspace/List/Util.pm"));
+        let code = r#"package List::Util;
+our @EXPORT_OK = qw(sum min max first);
+sub sum { }
+sub min { }
+sub max { }
+sub first { }
+1;
+"#;
+        must(idx.index_file(uri, code.to_string()));
+        idx
+    };
+    let items = completions_at_end_with_index(source, index);
+
+    assert!(
+        has_promoted_label(&items, "sum"),
+        "sum should still be promoted with standard qw() imports; got items: {:?}",
+        items.iter().map(|i| format!("{}/{:?}", i.label, i.sort_text)).collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: Multiple exports from different patterns
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_multiple_export_patterns() {
+    // Multiple Sub::Exporter imports should all be extracted
+    let source = "use My::SubExporterModule { exports => [qw(foo)] };\nuse My::SubExporterModule { exports => [qw(bar)] };\nba";
+    let index = make_sub_exporter_module_index();
+    let items = completions_at_end_with_index(source, index);
+
+    assert!(
+        has_promoted_label(&items, "bar"),
+        "bar should be promoted from second Sub::Exporter use; got items: {:?}",
+        items.iter().map(|i| format!("{}/{:?}", i.label, i.sort_text)).collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: baz symbol from exports (not in default group)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_baz_symbol_from_exports_not_default() {
+    // baz is in exports but not in default group
+    // It should still be available (exports are always available)
+    let source = "use My::SubExporterModule { exports => [qw(foo bar baz)] };\nba";
+    let index = make_sub_exporter_module_index();
+    let items = completions_at_end_with_index(source, index);
+
+    assert!(
+        has_promoted_label(&items, "baz"),
+        "baz should be promoted because it's in the exports list; got items: {:?}",
+        items.iter().map(|i| format!("{}/{:?}", i.label, i.sort_text)).collect::<Vec<_>>()
+    );
+}

--- a/crates/perl-lsp-config/tests/report_unverified_modules_setting.rs
+++ b/crates/perl-lsp-config/tests/report_unverified_modules_setting.rs
@@ -1,0 +1,161 @@
+//! Tests for the reportUnverifiedModules workspace setting.
+//!
+//! These tests verify that the WorkspaceConfig correctly parses and stores
+//! the reportUnverifiedModules setting (default: false).
+//!
+//! IMPORTANT: These tests verify EXPECTED behavior that does not yet exist.
+//! They will FAIL until the implementation is complete.
+
+use perl_lsp_config::WorkspaceConfig;
+
+// ============================================================================
+// reportUnverifiedModules default value tests
+// ============================================================================
+
+/// report_unverified_modules should default to false
+#[test]
+fn workspace_config_report_unverified_modules_defaults_to_false() {
+    let config = WorkspaceConfig::default();
+    assert!(!config.report_unverified_modules, "report_unverified_modules should default to false");
+}
+
+// ============================================================================
+// reportUnverifiedModules parsing tests
+// ============================================================================
+
+/// reportUnverifiedModules: true should be parsed correctly
+#[test]
+fn workspace_config_parses_report_unverified_modules_true() {
+    let mut config = WorkspaceConfig::default();
+    let settings = serde_json::json!({
+        "workspace": {
+            "reportUnverifiedModules": true
+        }
+    });
+    config.update_from_value(&settings);
+    assert!(
+        config.report_unverified_modules,
+        "report_unverified_modules should be true when set to true in settings"
+    );
+}
+
+/// reportUnverifiedModules: false should be parsed correctly
+#[test]
+fn workspace_config_parses_report_unverified_modules_false() {
+    let mut config = WorkspaceConfig::default();
+    // First set it to true
+    let settings_true = serde_json::json!({
+        "workspace": {
+            "reportUnverifiedModules": true
+        }
+    });
+    config.update_from_value(&settings_true);
+    assert!(config.report_unverified_modules, "should be true after setting to true");
+
+    // Then set it to false
+    let settings_false = serde_json::json!({
+        "workspace": {
+            "reportUnverifiedModules": false
+        }
+    });
+    config.update_from_value(&settings_false);
+    assert!(
+        !config.report_unverified_modules,
+        "report_unverified_modules should be false when set to false in settings"
+    );
+}
+
+/// Missing reportUnverifiedModules should leave the field unchanged
+#[test]
+fn workspace_config_missing_report_unverified_modules_unchanged() {
+    let mut config = WorkspaceConfig::default();
+    // Set to true first
+    let settings_true = serde_json::json!({
+        "workspace": {
+            "reportUnverifiedModules": true
+        }
+    });
+    config.update_from_value(&settings_true);
+    assert!(config.report_unverified_modules, "should be true after setting to true");
+
+    // Update with a different field only
+    let settings_partial = serde_json::json!({
+        "workspace": {
+            "includePaths": ["/custom/lib"]
+        }
+    });
+    config.update_from_value(&settings_partial);
+    // report_unverified_modules should remain true
+    assert!(
+        config.report_unverified_modules,
+        "report_unverified_modules should remain unchanged when not in settings"
+    );
+}
+
+/// Empty workspace section should leave report_unverified_modules unchanged
+#[test]
+fn workspace_config_empty_workspace_leaves_report_unverified_modules_unchanged() {
+    let mut config = WorkspaceConfig::default();
+    assert!(!config.report_unverified_modules, "should default to false initially");
+
+    let settings = serde_json::json!({
+        "workspace": {}
+    });
+    config.update_from_value(&settings);
+    assert!(
+        !config.report_unverified_modules,
+        "report_unverified_modules should remain false after empty workspace update"
+    );
+}
+
+/// Non-boolean value for reportUnverifiedModules should be silently ignored
+#[test]
+fn workspace_config_ignores_non_bool_report_unverified_modules() {
+    let mut config = WorkspaceConfig::default();
+
+    // Set to true first
+    let settings_true = serde_json::json!({
+        "workspace": {
+            "reportUnverifiedModules": true
+        }
+    });
+    config.update_from_value(&settings_true);
+    assert!(config.report_unverified_modules, "should be true");
+
+    // Try to set to a string (should be ignored)
+    let settings_string = serde_json::json!({
+        "workspace": {
+            "reportUnverifiedModules": "true"
+        }
+    });
+    config.update_from_value(&settings_string);
+    // Should remain true (string was ignored)
+    assert!(
+        config.report_unverified_modules,
+        "report_unverified_modules should remain true when string value is ignored"
+    );
+}
+
+// ============================================================================
+// Integration: reportUnverifiedModules with other settings
+// ============================================================================
+
+/// reportUnverifiedModules can be set alongside other workspace settings
+#[test]
+fn workspace_config_report_unverified_modules_with_other_settings() {
+    let mut config = WorkspaceConfig::default();
+    let settings = serde_json::json!({
+        "workspace": {
+            "includePaths": ["/lib", "/local/lib"],
+            "useSystemInc": true,
+            "reportUnverifiedModules": true,
+            "resolutionTimeout": 100
+        }
+    });
+    config.update_from_value(&settings);
+
+    assert!(config.report_unverified_modules, "report_unverified_modules should be true");
+    assert_eq!(config.include_paths, vec!["/lib", "/local/lib"]);
+    assert!(config.use_system_inc, "use_system_inc should be true");
+    assert_eq!(config.resolution_timeout_ms, 100);
+}

--- a/crates/perl-lsp-navigation/tests/documentation_search_edge_tests.rs
+++ b/crates/perl-lsp-navigation/tests/documentation_search_edge_tests.rs
@@ -1,0 +1,1008 @@
+//! Edge case tests for documentation search functionality.
+//!
+//! These tests stress the implementation with boundary values, malformed inputs,
+//! Unicode, whitespace variations, and other edge cases not covered by the
+//! red (contract) tests.
+
+use perl_lsp_navigation::{DocumentationSearchProvider, DocumentationSearchScope};
+
+// =============================================================================
+// EDGE CASE: Empty and boundary inputs
+// =============================================================================
+
+/// Edge case: Empty query string - empty string is a substring of everything,
+/// so this matches everything (not a useful search but correct behavior).
+#[test]
+fn test_search_empty_query_matches_everything() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package My::Module;
+
+=head1 NAME
+
+My::Module - A module
+
+=cut
+"#;
+    provider.index_document("file:///lib/My/Module.pm", source);
+
+    let results = provider.search("", DocumentationSearchScope::All);
+    // Empty string is substring of everything, so all fields match
+    assert_eq!(results.len(), 1, "Empty query should match everything (empty substring)");
+}
+
+/// Edge case: Whitespace-only query.
+#[test]
+fn test_search_whitespace_query() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Space::Test;
+
+=head1 NAME
+
+Space::Test - Testing whitespace
+
+=cut
+"#;
+    provider.index_document("file:///lib/Space/Test.pm", source);
+
+    // A query of only whitespace will be lowercased to empty string
+    let results = provider.search("   ", DocumentationSearchScope::All);
+    // Empty string after to_lowercase() means no match
+    assert!(results.is_empty(), "Whitespace-only query should return no results");
+}
+
+/// Edge case: Very long query string (stress test).
+#[test]
+fn test_search_very_long_query() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Long::Query;
+
+=head1 NAME
+
+Long::Query - Testing long queries
+
+=cut
+"#;
+    provider.index_document("file:///lib/Long/Query.pm", source);
+
+    // Very long query that exceeds any reasonable content
+    let long_query = "a".repeat(10_000);
+    let results = provider.search(&long_query, DocumentationSearchScope::All);
+    assert!(results.is_empty(), "Long query with no match should return empty results");
+}
+
+/// Edge case: Search for just one character.
+#[test]
+fn test_search_single_character_query() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Single::Char;
+
+=head1 NAME
+
+Single::Char - Testing single char search
+
+=cut
+"#;
+    provider.index_document("file:///lib/Single/Char.pm", source);
+
+    let results = provider.search("s", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "Should find 's' in 'Single::Char' (case-insensitive)");
+}
+
+// =============================================================================
+// EDGE CASE: Unicode and special characters
+// =============================================================================
+
+/// Edge case: Unicode characters in POD (UTF-8).
+#[test]
+fn test_search_unicode_in_pod() {
+    let mut provider = DocumentationSearchProvider::new();
+    // Unicode in NAME section
+    let source = r#"
+package Unicode::Test;
+
+=head1 NAME
+
+Unicode::Test - Testing 日本語 and Ünïcödé
+
+=cut
+"#;
+    provider.index_document("file:///lib/Unicode/Test.pm", source);
+
+    // Search for unicode text
+    let results = provider.search("日本語", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "Should find Japanese characters in NAME section");
+}
+
+/// Edge case: Unicode in method documentation.
+#[test]
+fn test_search_unicode_method_documentation() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Unicode::Method;
+
+=head1 NAME
+
+Unicode::Method - Testing unicode in methods
+
+=head2 日本語メソッド
+
+This method handles Japanese text processing.
+
+=cut
+
+sub 日本語メソッド { }
+"#;
+    provider.index_document("file:///lib/Unicode/Method.pm", source);
+
+    let results = provider.search("Japanese", DocumentationSearchScope::Methods);
+    assert!(!results.is_empty(), "Should find English text in unicode method documentation");
+}
+
+/// Edge case: POD E<> entities (lt, gt, amp, quot, apos).
+#[test]
+fn test_search_pod_entities() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Entity::Test;
+
+=head1 NAME
+
+Entity::Test - Testing E<> entities
+
+=head1 SYNOPSIS
+
+    if ($x E<lt> 5 E<gt> $y) {
+        say "E<amp> E<quot> E<apos>";
+    }
+
+=cut
+"#;
+    provider.index_document("file:///lib/Entity/Test.pm", source);
+
+    // The entities should be decoded to < > & " '
+    let results = provider.search("<", DocumentationSearchScope::Synopsis);
+    assert!(!results.is_empty(), "Should find decoded E<lt> as '<' in synopsis");
+}
+
+/// Edge case: POD formatting codes B<>, I<>, C<> should be stripped.
+#[test]
+fn test_search_pod_formatting_codes() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Format::Test;
+
+=head1 NAME
+
+Format::Test - B<bold>, I<italic>, C<code>
+
+=head1 DESCRIPTION
+
+The B<process> method I<transforms> C<data>.
+
+=cut
+"#;
+    provider.index_document("file:///lib/Format/Test.pm", source);
+
+    // The formatting codes should be stripped, leaving the inner text
+    let results = provider.search("bold", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "Should find 'bold' inside B<> formatting in NAME");
+
+    let results = provider.search("process", DocumentationSearchScope::Description);
+    assert!(!results.is_empty(), "Should find 'process' inside B<> in DESCRIPTION");
+}
+
+// =============================================================================
+// EDGE CASE: URI variations
+// =============================================================================
+
+/// Edge case: URI without file:// prefix.
+#[test]
+fn test_index_document_uri_without_prefix() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package No::Prefix;
+
+=head1 NAME
+
+No::Prefix - Testing URI without file:// prefix
+
+=cut
+"#;
+    // URI without file:// prefix
+    provider.index_document("/lib/No/Prefix.pm", source);
+
+    let results = provider.search("No::Prefix", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "Should find module even with path-based URI");
+}
+
+/// Edge case: URI with file: prefix (single slash).
+#[test]
+fn test_index_document_uri_file_prefix() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package File::Prefix;
+
+=head1 NAME
+
+File::Prefix - Testing file: prefix
+
+=cut
+"#;
+    // URI with file: (single slash)
+    provider.index_document("file:/lib/File/Prefix.pm", source);
+
+    let results = provider.search("File::Prefix", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "Should find module with file: prefix URI");
+}
+
+/// Edge case: URI with .pod extension.
+#[test]
+fn test_index_document_pod_extension() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Pod::Ext;
+
+=head1 NAME
+
+Pod::Ext - Testing .pod extension
+
+=cut
+"#;
+    provider.index_document("file:///lib/Pod/Ext.pod", source);
+
+    let results = provider.search("Pod::Ext", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "Should handle .pod extension correctly");
+}
+
+/// Edge case: Very long URI path.
+#[test]
+fn test_index_document_long_uri_path() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Long::Path;
+
+=head1 NAME
+
+Long::Path - Testing long paths
+
+=cut
+"#;
+    let long_path = format!("file:///{}", "a".repeat(500));
+    provider.index_document(&long_path, source);
+
+    let results = provider.search("Long::Path", DocumentationSearchScope::Name);
+    // Module name fallback from URI
+    assert_eq!(results.len(), 1, "Should handle very long URI paths");
+}
+
+// =============================================================================
+// EDGE CASE: POD parsing edge cases
+// =============================================================================
+
+/// Edge case: POD with no =cut (POD ends at EOF).
+#[test]
+fn test_pod_without_cut_ends_at_eof() {
+    let mut provider = DocumentationSearchProvider::new();
+    // POD without =cut - should still be extracted
+    let source = r#"
+package No::Cut;
+
+=head1 NAME
+
+No::Cut - No =cut at end
+
+=head1 DESCRIPTION
+
+This POD has no =cut
+
+sub run { }
+"#;
+    provider.index_document("file:///lib/No/Cut.pm", source);
+
+    let results = provider.search("No::Cut", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "POD without =cut should still be extracted");
+}
+
+/// Edge case: Multiple =head1 NAME sections - later one overwrites earlier.
+#[test]
+fn test_multiple_name_sections() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Multi::Name;
+
+=head1 NAME
+
+Multi::Name - First NAME section
+
+=head1 DESCRIPTION
+
+Description text.
+
+=head1 NAME
+
+Multi::Name - Second NAME section
+
+=cut
+"#;
+    provider.index_document("file:///lib/Multi/Name.pm", source);
+
+    // The second NAME overwrites the first (later sections win)
+    let results = provider.search("Second NAME", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "Second NAME section should be stored (overwrites first)");
+
+    // First NAME is no longer present
+    let results = provider.search("First NAME", DocumentationSearchScope::Name);
+    assert!(results.is_empty(), "First NAME should be overwritten by second NAME");
+}
+
+/// Edge case: Empty =head2 method name.
+#[test]
+fn test_empty_method_name() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Empty::Method;
+
+=head1 NAME
+
+Empty::Method - Testing empty method name
+
+=head2
+
+This method has an empty name.
+
+=cut
+
+sub { }
+"#;
+    provider.index_document("file:///lib/Empty/Method.pm", source);
+
+    // Should not crash - empty method names should be handled
+    let results = provider.search("method has an empty", DocumentationSearchScope::Methods);
+    assert!(!results.is_empty(), "Should find method documentation even with empty name");
+}
+
+/// Edge case: POD with only method sections (no NAME).
+#[test]
+fn test_pod_without_name_section() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package No::Name;
+
+=head1 DESCRIPTION
+
+No name section here.
+
+=head2 my_method
+
+This method does something.
+
+=cut
+
+sub my_method { }
+"#;
+    provider.index_document("file:///lib/No/Name.pm", source);
+
+    // Should still work, module name should be guessed from URI
+    let results = provider.search("No::Name", DocumentationSearchScope::Name);
+    assert_eq!(results.len(), 1, "Should guess module name from URI when no NAME section");
+
+    // Should find method
+    let results = provider.search("my_method", DocumentationSearchScope::Methods);
+    assert!(!results.is_empty(), "Should find method even without NAME section");
+}
+
+/// Edge case: Description takes only first paragraph.
+#[test]
+fn test_description_first_paragraph_only() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package First::Para;
+
+=head1 NAME
+
+First::Para - Testing first paragraph
+
+=head1 DESCRIPTION
+
+This is the first paragraph.
+
+This is the second paragraph - should NOT appear in description.
+
+=cut
+"#;
+    provider.index_document("file:///lib/First/Para.pm", source);
+
+    let results = provider.search("first paragraph", DocumentationSearchScope::Description);
+    assert!(!results.is_empty(), "Should find text from first paragraph");
+
+    // The second paragraph should not appear in description search
+    let results = provider.search("second paragraph", DocumentationSearchScope::Description);
+    assert!(results.is_empty(), "Second paragraph should NOT appear in description search");
+}
+
+/// Edge case: Multiple methods with similar names.
+#[test]
+fn test_methods_similar_names() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Similar;
+
+=head1 NAME
+
+Similar - Testing similar method names
+
+=head2 foo
+
+Documentation for foo.
+
+=head2 foo_bar
+
+Documentation for foo_bar.
+
+=head2 fooBar
+
+Documentation for fooBar.
+
+=cut
+
+sub foo { }
+sub foo_bar { }
+sub fooBar { }
+"#;
+    provider.index_document("file:///lib/Similar.pm", source);
+
+    // Search for foo should find all three
+    let results = provider.search("foo", DocumentationSearchScope::Methods);
+    assert_eq!(results.len(), 3, "Should find all three methods containing 'foo'");
+
+    // Search for foo_bar should find only foo_bar
+    let results = provider.search("foo_bar", DocumentationSearchScope::Methods);
+    assert_eq!(results.len(), 1, "Should find only foo_bar");
+}
+
+// =============================================================================
+// EDGE CASE: Fuzzy/subsequence matching
+// =============================================================================
+
+/// Edge case: Query is subsequence of module name.
+#[test]
+fn test_fuzzy_subsequence_matching() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Fuzzy::Test;
+
+=head1 NAME
+
+Fuzzy::Test - Testing fuzzy matching
+
+=cut
+"#;
+    provider.index_document("file:///lib/Fuzzy/Test.pm", source);
+
+    // "fuz" IS a subsequence of "Fuzzy::Test"
+    let results = provider.search("fuz", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "Fuzzy subsequence 'fuz' should work in fuzzy");
+}
+
+/// Edge case: Query longer than content (no match possible).
+#[test]
+fn test_query_longer_than_content() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Short;
+
+=head1 NAME
+
+Short
+
+=cut
+"#;
+    provider.index_document("file:///lib/Short.pm", source);
+
+    let results =
+        provider.search("this is a very long query string", DocumentationSearchScope::Name);
+    assert!(results.is_empty(), "Query longer than content should return no results");
+}
+
+/// Edge case: Subsequence fallback only works when there's a partial match.
+#[test]
+fn test_subsequence_only_for_scoring() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Gap::Test;
+
+=head1 NAME
+
+Gap::Test - Testing gaps
+
+=cut
+"#;
+    provider.index_document("file:///lib/Gap/Test.pm", source);
+
+    // "gap" IS a substring of "Gap::Test"
+    let results = provider.search("gap", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "'gap' should be found as substring");
+
+    // "gt" is NOT a substring, so won't be found (subsequence is only for scoring)
+    let results = provider.search("gt", DocumentationSearchScope::Name);
+    assert!(results.is_empty(), "'gt' is not a substring and won't be found");
+}
+
+// =============================================================================
+// EDGE CASE: Relevance and sorting
+// =============================================================================
+
+/// Edge case: Exact match ranks higher than prefix match.
+#[test]
+fn test_exact_match_ranks_higher() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source1 = r#"
+package Exact::Test;
+
+=head1 NAME
+
+Exact::Test - Exact match test
+
+=cut
+"#;
+    let source2 = r#"
+package Exact;
+
+=head1 NAME
+
+Exact - Just the word Exact
+
+=cut
+"#;
+    provider.index_document("file:///lib/Exact/Test.pm", source1);
+    provider.index_document("file:///lib/Exact.pm", source2);
+
+    let results = provider.search("Exact", DocumentationSearchScope::Name);
+    // Both match via substring, so first result depends on iteration order (HashMap)
+    assert!(results.len() >= 2, "Should find matches in both documents");
+}
+
+/// Edge case: Search uses substring matching, not prefix-specific logic.
+#[test]
+fn test_prefix_match_ranks_higher() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source1 = r#"
+package Prefix::Match;
+
+=head1 NAME
+
+Prefix::Match - prefix test
+
+=cut
+"#;
+    let source2 = r#"
+package Other::Prefix::Match;
+
+=head1 NAME
+
+Other::Prefix::Match - contains prefix inside
+
+=cut
+"#;
+    provider.index_document("file:///lib/Prefix/Match.pm", source1);
+    provider.index_document("file:///lib/Other/Prefix/Match.pm", source2);
+
+    // "prefix" IS a substring of both (case insensitive)
+    let results = provider.search("prefix", DocumentationSearchScope::Name);
+    assert_eq!(results.len(), 2, "Should find 'prefix' in both documents");
+}
+
+// =============================================================================
+// EDGE CASE: Removing documents
+// =============================================================================
+
+/// Edge case: Remove document that was never indexed.
+#[test]
+fn test_remove_nonexistent_document() {
+    let mut provider = DocumentationSearchProvider::new();
+    // Should not panic
+    provider.remove_document("file:///Never/Indexed.pm");
+    assert_eq!(provider.document_count(), 0);
+}
+
+/// Edge case: Remove then re-add same URI.
+#[test]
+fn test_remove_and_reindex() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source1 = r#"
+package Reindex;
+
+=head1 NAME
+
+Reindex - Version 1
+
+=cut
+"#;
+    let source2 = r#"
+package Reindex;
+
+=head1 NAME
+
+Reindex - Version 2
+
+=cut
+"#;
+    let uri = "file:///lib/Reindex.pm";
+
+    provider.index_document(uri, source1);
+    assert_eq!(provider.document_count(), 1);
+
+    provider.remove_document(uri);
+    assert_eq!(provider.document_count(), 0);
+
+    // Re-add with new content
+    provider.index_document(uri, source2);
+    assert_eq!(provider.document_count(), 1);
+
+    let results = provider.search("Version 2", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "Reindexed document should have new content");
+
+    let results = provider.search("Version 1", DocumentationSearchScope::Name);
+    assert!(results.is_empty(), "Old content should not exist after reindex");
+}
+
+// =============================================================================
+// EDGE CASE: Scope filtering
+// =============================================================================
+
+/// Edge case: Search synopsis scope when no synopsis exists.
+#[test]
+fn test_search_synopsis_scope_no_synopsis() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package No::Synopsis;
+
+=head1 NAME
+
+No::Synopsis - No synopsis here
+
+=head1 DESCRIPTION
+
+Just description.
+
+=cut
+"#;
+    provider.index_document("file:///lib/No/Synopsis.pm", source);
+
+    let results = provider.search("test", DocumentationSearchScope::Synopsis);
+    assert!(results.is_empty(), "Should return empty when searching synopsis but none exists");
+}
+
+/// Edge case: Search description scope when no description exists.
+#[test]
+fn test_search_description_scope_no_description() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package No::Description;
+
+=head1 NAME
+
+No::Description - Just name
+
+=cut
+"#;
+    provider.index_document("file:///lib/No/Description.pm", source);
+
+    let results = provider.search("test", DocumentationSearchScope::Description);
+    assert!(results.is_empty(), "Should return empty when searching description but none exists");
+}
+
+/// Edge case: Search methods scope when no methods exist.
+#[test]
+fn test_search_methods_scope_no_methods() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package No::Methods;
+
+=head1 NAME
+
+No::Methods - Just name
+
+=cut
+"#;
+    provider.index_document("file:///lib/No/Methods.pm", source);
+
+    let results = provider.search("test", DocumentationSearchScope::Methods);
+    assert!(results.is_empty(), "Should return empty when searching methods but none exist");
+}
+
+// =============================================================================
+// EDGE CASE: Special characters in content
+// =============================================================================
+
+/// Edge case: Dollar sign and other Perl metacharacters.
+#[test]
+fn test_search_perl_metacharacters() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Meta::Chars;
+
+=head1 NAME
+
+Meta::Chars - Testing $variables and @arrays
+
+=head1 SYNOPSIS
+
+    my $x = $obj->method(@args);
+    use strict 'refs';
+
+=cut
+"#;
+    provider.index_document("file:///lib/Meta/Chars.pm", source);
+
+    // Should handle $ and @ without crashing
+    let results = provider.search("$variables", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "Should find text containing Perl metacharacters");
+}
+
+/// Edge case: Backslash and escape sequences.
+#[test]
+fn test_search_backslashes() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Backslash;
+
+=head1 NAME
+
+Backslash - Testing \\n and \\t escapes
+
+=cut
+"#;
+    provider.index_document("file:///lib/Backslash.pm", source);
+
+    let results = provider.search("\\\\n", DocumentationSearchScope::Name);
+    // Backslash in Rust string is \\
+    assert!(!results.is_empty(), "Should handle backslash sequences in search");
+}
+
+/// Edge case: HTML-like tags (not POD formatting).
+#[test]
+fn test_search_html_like_content() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package HTML::Like;
+
+=head1 NAME
+
+HTML::Like - <b>bold</b> and <i>italic</i>
+
+=cut
+"#;
+    provider.index_document("file:///lib/HTML/Like.pm", source);
+
+    // HTML tags are not POD formatting codes, so they should be preserved
+    let results = provider.search("bold</b>", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "Should preserve HTML-like content");
+}
+
+// =============================================================================
+// EDGE CASE: Whitespace in POD
+// =============================================================================
+
+/// Edge case: POD with leading/trailing whitespace.
+#[test]
+fn test_pod_whitespace_handling() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = "    \n    \npackage Whitespace;\n\n=head1 NAME\n\n   Whitespace::Test - With spaces   \n\n=cut\n";
+    provider.index_document("file:///lib/Whitespace.pm", source);
+
+    let results = provider.search("Whitespace::Test", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "Should handle whitespace in POD correctly");
+}
+
+/// Edge case: Multiple blank lines between sections.
+#[test]
+fn test_pod_multiple_blank_lines() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Blank::Lines;
+
+=head1 NAME
+
+Blank::Lines - Testing blank lines
+
+
+
+=head1 DESCRIPTION
+
+Description with
+
+lots of
+
+blank lines
+
+within.
+
+=cut
+"#;
+    provider.index_document("file:///lib/Blank/Lines.pm", source);
+
+    let results = provider.search("Description with", DocumentationSearchScope::Description);
+    assert!(!results.is_empty(), "Should handle multiple blank lines");
+}
+
+// =============================================================================
+// EDGE CASE: Real-world POD patterns
+// =============================================================================
+
+/// Edge case: Real-world POD with SEE ALSO section.
+#[test]
+fn test_pod_with_see_also() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package See::Also;
+
+=head1 NAME
+
+See::Also - Testing SEE ALSO section
+
+=head1 DESCRIPTION
+
+This module does things.
+
+=head1 SEE ALSO
+
+L<Some::Other::Module>, L<Another::Module>
+
+=cut
+"#;
+    provider.index_document("file:///lib/See/Also.pm", source);
+
+    // Should find the module
+    let results = provider.search("See::Also", DocumentationSearchScope::Name);
+    assert!(!results.is_empty(), "Should find module with SEE ALSO section");
+
+    // Should find description
+    let results = provider.search("things", DocumentationSearchScope::Description);
+    assert!(!results.is_empty(), "Should find description");
+}
+
+/// Edge case: POD with code blocks (indented lines).
+#[test]
+fn test_pod_code_blocks() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Code::Block;
+
+=head1 NAME
+
+Code::Block - Testing code blocks
+
+=head1 SYNOPSIS
+
+    #!/usr/bin/perl
+    use strict;
+    use warnings;
+
+    my $x = 42;
+
+=cut
+"#;
+    provider.index_document("file:///lib/Code/Block.pm", source);
+
+    let results = provider.search("strict", DocumentationSearchScope::Synopsis);
+    assert!(!results.is_empty(), "Should find content inside indented code blocks");
+}
+
+/// Edge case: =over/=item list items go to Other section (ignored).
+#[test]
+fn test_pod_list_items() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package List::Items;
+
+=head1 NAME
+
+List::Items - Testing list items
+
+=head1 DESCRIPTION
+
+The main description text describes the options below.
+
+=cut
+"#;
+    provider.index_document("file:///lib/List/Items.pm", source);
+
+    // Description should be found (list items are in Other section, not stored)
+    let results = provider.search("main description", DocumentationSearchScope::Description);
+    assert!(!results.is_empty(), "Should find description content");
+}
+
+// =============================================================================
+// EDGE CASE: Case sensitivity
+// =============================================================================
+
+/// Edge case: Module name with mixed case, search with different case.
+#[test]
+fn test_case_insensitive_search() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package MixedCase::Module;
+
+=head1 NAME
+
+MixedCase::Module - Testing CASE
+
+=cut
+"#;
+    provider.index_document("file:///lib/MixedCase/Module.pm", source);
+
+    // All these should match
+    assert!(!provider.search("MIXEDCASE::MODULE", DocumentationSearchScope::Name).is_empty());
+    assert!(!provider.search("mixedcase::module", DocumentationSearchScope::Name).is_empty());
+    assert!(!provider.search("MiXeDcAsE::MoDuLe", DocumentationSearchScope::Name).is_empty());
+}
+
+// =============================================================================
+// EDGE CASE: Method search includes method name
+// =============================================================================
+
+/// Edge case: Method search matches method name (not just documentation).
+#[test]
+fn test_method_search_matches_name() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Method::Name;
+
+=head1 NAME
+
+Method::Name - Testing method name search
+
+=head2 my_awesome_method
+
+This method is named my_awesome_method.
+
+=cut
+
+sub my_awesome_method { }
+"#;
+    provider.index_document("file:///lib/Method/Name.pm", source);
+
+    // Search for just the method name (not the documentation text)
+    let results = provider.search("my_awesome_method", DocumentationSearchScope::Methods);
+    assert_eq!(results.len(), 1, "Should find method by searching for its name");
+}
+
+/// Edge case: Method name search matches both name AND documentation content.
+#[test]
+fn test_method_name_search_matches_content() {
+    let mut provider = DocumentationSearchProvider::new();
+    let source = r#"
+package Substring;
+
+=head1 NAME
+
+Substring - Testing method name substring
+
+=head2 get_method
+
+The get method does retrieval.
+
+=head2 target_value
+
+The target method uses target_value.
+
+=cut
+
+sub get_method { }
+sub target_value { }
+"#;
+    provider.index_document("file:///lib/Substring.pm", source);
+
+    // "get" is a subsequence of both "get_method" and "target_value" (documentation)
+    let results = provider.search("get", DocumentationSearchScope::Methods);
+    assert_eq!(
+        results.len(),
+        2,
+        "Should find methods where 'get' appears in name or documentation"
+    );
+}

--- a/crates/perl-lsp/tests/pulldiagnostics_provider_completion_test.rs
+++ b/crates/perl-lsp/tests/pulldiagnostics_provider_completion_test.rs
@@ -1,0 +1,994 @@
+//! Tests for verifying PullDiagnosticsProvider completion for production use.
+//!
+//! These tests verify the three gaps identified in ADR-0042:
+//! 1. handle_workspace_diagnostic should use orchestrator pattern
+//! 2. is_fixable_diagnostic in pull.rs should delegate to is_fixable_perlcritic_policy
+//! 3. orchestrator.reset() should be called in handle_did_change_configuration
+//!
+//! These tests will FAIL before the implementation is complete and PASS after.
+
+use perl_lsp::{JsonRpcRequest, LspServer};
+use serde_json::json;
+
+/// Test for Gap 2 (AC3): pull.rs::is_fixable_diagnostic should delegate to
+/// is_fixable_perlcritic_policy() from the diagnostics module, not hardcode policy strings.
+///
+/// This test verifies that pull.rs's is_fixable_diagnostic function imports and uses
+/// the is_fixable_perlcritic_policy helper from the diagnostics module.
+///
+/// CURRENTLY FAILS because pull.rs has hardcoded policy strings inline.
+/// WILL PASS after refactoring when pull.rs delegates to the helper.
+#[test]
+fn test_is_fixable_diagnostic_uses_shared_helper() {
+    // This test verifies the implementation by checking if the source code
+    // of pull.rs contains a delegation to is_fixable_perlcritic_policy.
+    //
+    // The source code should contain something like:
+    //   is_fixable_perlcritic_policy(code)
+    // instead of hardcoded strings like:
+    //   "TestingAndDebugging::RequireUseStrict" | "TestingAndDebugging::RequireUseWarnings" | ...
+
+    let pull_rs_source = include_str!("../src/features/diagnostics/pull.rs");
+
+    // Find the is_fixable_diagnostic function in pull.rs
+    let func_start = pull_rs_source
+        .find("fn is_fixable_diagnostic(code: &str) -> bool {")
+        .expect("Could not find is_fixable_diagnostic in pull.rs");
+
+    // Extract a reasonable chunk of the function (up to 50 lines)
+    let func_chunk = &pull_rs_source[func_start..func_start + 3000];
+
+    // The function should NOT have hardcoded perlcritic policy strings directly in matches
+    // It should delegate to is_fixable_perlcritic_policy
+    let has_hardcoded_policies = func_chunk.contains("\"TestingAndDebugging::RequireUseStrict\"")
+        && func_chunk.contains("\"TestingAndDebugging::RequireUseWarnings\"")
+        && func_chunk.contains("\"InputOutput::ProhibitBarewordFileHandles\"");
+
+    // The function SHOULD call is_fixable_perlcritic_policy
+    let delegates_to_helper = func_chunk.contains("is_fixable_perlcritic_policy(code)");
+
+    // Assert: if hardcoded policies exist, the function must delegate to helper
+    // This test will FAIL if pull.rs has hardcoded strings and no delegation
+    // This test will PASS if pull.rs delegates to is_fixable_perlcritic_policy
+    assert!(
+        !has_hardcoded_policies || delegates_to_helper,
+        "pull.rs::is_fixable_diagnostic should delegate to is_fixable_perlcritic_policy(), \
+         not hardcode policy strings inline. Found hardcoded policies: {}, delegation: {}",
+        has_hardcoded_policies,
+        delegates_to_helper
+    );
+}
+
+/// Test for Gap 3 (AC4): handle_did_change_configuration should call
+/// orchestrator.reset() when perlcritic config changes.
+///
+/// CURRENTLY FAILS because handle_did_change_configuration only resets
+/// LspServer.critic_analyzer, not PullDiagnosticsOrchestrator.critic_analyzer.
+/// WILL PASS after wiring orchestrator.reset() into the config change handler.
+#[test]
+fn test_orchestrator_reset_is_wired_into_config_change() {
+    // This test verifies that workspace.rs's handle_did_change_configuration
+    // calls self.pull_diagnostics_orchestrator.reset()
+    //
+    // The source code should contain:
+    //   self.pull_diagnostics_orchestrator.reset()
+    // in the config change handler
+
+    let workspace_rs_source = include_str!("../src/runtime/workspace.rs");
+
+    // Find the handle_did_change_configuration function
+    let func_start = workspace_rs_source
+        .find("pub(super) fn handle_did_change_configuration(&self, params: Option<Value>)")
+        .expect("Could not find handle_did_change_configuration in workspace.rs");
+
+    // Extract a reasonable chunk of the function
+    let func_chunk = &workspace_rs_source[func_start..func_start + 8000];
+
+    // Check if orchestrator.reset() is called
+    let calls_orchestrator_reset =
+        func_chunk.contains("self.pull_diagnostics_orchestrator.reset()");
+
+    // This test will FAIL if orchestrator.reset() is not called
+    // This test will PASS after the wiring is done
+    assert!(
+        calls_orchestrator_reset,
+        "handle_did_change_configuration should call self.pull_diagnostics_orchestrator.reset() \
+         when perlcritic config changes, to ensure the orchestrator's CriticAnalyzer cache \
+         is also invalidated. This ensures both document and workspace diagnostics use \
+         fresh analysis after config changes."
+    );
+}
+
+/// Test for Gap 1 (AC1): handle_workspace_diagnostic should use orchestrator pattern
+/// for collecting perlcritic diagnostics, not LspServer::collect_external_perlcritic_diagnostics.
+///
+/// CURRENTLY FAILS because handle_workspace_diagnostic directly calls:
+///   - DiagnosticsProvider::new()
+///   - self.collect_external_perlcritic_diagnostics()
+/// instead of:
+///   - self.pull_diagnostics_orchestrator.build_context()
+///   - self.pull_diagnostics_orchestrator.collect_perlcritic_diagnostics()
+///
+/// WILL PASS after refactoring to use the orchestrator pattern.
+#[test]
+fn test_workspace_diagnostic_uses_orchestrator_for_perlcritic() {
+    // This test verifies that diagnostics.rs's handle_workspace_diagnostic
+    // uses orchestrator.collect_perlcritic_diagnostics() instead of
+    // self.collect_external_perlcritic_diagnostics()
+    //
+    // The source code should contain:
+    //   orchestrator.collect_perlcritic_diagnostics(...)
+    // instead of:
+    //   self.collect_external_perlcritic_diagnostics(...)
+
+    let diagnostics_rs_source = include_str!("../src/runtime/diagnostics.rs");
+
+    // Find the handle_workspace_diagnostic function
+    let func_start = diagnostics_rs_source
+        .find("pub(super) fn handle_workspace_diagnostic(")
+        .expect("Could not find handle_workspace_diagnostic in diagnostics.rs");
+
+    // Extract the function body (it's quite long, ~280 lines)
+    let func_chunk = &diagnostics_rs_source[func_start..func_start + 15000];
+
+    // Check that it uses orchestrator.collect_perlcritic_diagnostics
+    let uses_orchestrator_perlcritic =
+        func_chunk.contains("orchestrator.collect_perlcritic_diagnostics");
+
+    // Check that it does NOT use self.collect_external_perlcritic_diagnostics
+    let uses_direct_path = func_chunk.contains("self.collect_external_perlcritic_diagnostics");
+
+    // For the test to pass, either:
+    // 1. It should use orchestrator.collect_perlcritic_diagnostics (the correct pattern), OR
+    // 2. If it still uses the direct path, that's a failure
+
+    assert!(
+        uses_orchestrator_perlcritic || !uses_direct_path,
+        "handle_workspace_diagnostic should use orchestrator.collect_perlcritic_diagnostics() \
+         for perlcritic diagnostics, not self.collect_external_perlcritic_diagnostics(). \
+         This ensures workspace diagnostics share the same CriticAnalyzer cache as document \
+         diagnostics, eliminating the split-brain issue. \
+         uses_orchestrator_perlcritic={}, uses_direct_path={}",
+        uses_orchestrator_perlcritic,
+        uses_direct_path
+    );
+}
+
+/// Test for Gap 1 (AC1 variant): handle_workspace_diagnostic should use
+/// PullDiagnosticsProvider::get_workspace_diagnostics_with_context() for basic diagnostics.
+///
+/// CURRENTLY FAILS because handle_workspace_diagnostic directly constructs
+/// DiagnosticsProvider instead of using PullDiagnosticsProvider.
+///
+/// WILL PASS after refactoring.
+#[test]
+fn test_workspace_diagnostic_uses_pull_provider_for_basic_diagnostics() {
+    let diagnostics_rs_source = include_str!("../src/runtime/diagnostics.rs");
+
+    // Find the handle_workspace_diagnostic function
+    let func_start = diagnostics_rs_source
+        .find("pub(super) fn handle_workspace_diagnostic(")
+        .expect("Could not find handle_workspace_diagnostic in diagnostics.rs");
+
+    // Extract the function body
+    let func_chunk = &diagnostics_rs_source[func_start..func_start + 15000];
+
+    // Check that it uses DiagnosticsProvider::new() directly (the old pattern)
+    let uses_direct_provider = func_chunk.contains("DiagnosticsProvider::new(");
+
+    // After refactoring, it should NOT use DiagnosticsProvider::new directly
+    // It should use PullDiagnosticsProvider via the orchestrator
+    assert!(
+        !uses_direct_provider,
+        "handle_workspace_diagnostic should not use DiagnosticsProvider::new() directly. \
+         It should use PullDiagnosticsProvider::get_workspace_diagnostics_with_context() \
+         via the orchestrator pattern, matching handle_document_diagnostic. \
+         This ensures consistent diagnostic collection for both document and workspace diagnostics."
+    );
+}
+
+/// Test for AC2: Both document and workspace diagnostics should use the same
+/// CriticAnalyzer cache (via PullDiagnosticsOrchestrator).
+///
+/// This is a behavioral test that verifies the cache is shared.
+/// The test creates a scenario where the orchestrator's CriticAnalyzer is populated,
+/// then verifies workspace diagnostics can see that state (after the refactoring).
+///
+/// CURRENTLY FAILS because workspace diagnostics use LspServer.critic_analyzer
+/// directly, not the orchestrator's cache.
+/// WILL PASS after refactoring.
+#[test]
+fn test_workspace_diagnostics_share_orchestrator_cache() -> Result<(), Box<dyn std::error::Error>> {
+    // This test verifies that after collecting document diagnostics (which populates
+    // the orchestrator's CriticAnalyzer), workspace diagnostics can see/use that cache.
+    //
+    // The test:
+    // 1. Opens a document
+    // 2. Collects document diagnostics (this uses orchestrator path)
+    // 3. Collects workspace diagnostics
+    // 4. Verifies behavior is consistent (both paths use same cache)
+    //
+    // Before fix: workspace diagnostics don't use orchestrator path
+    // After fix: workspace diagnostics use orchestrator path
+
+    let server = LspServer::new();
+
+    // Initialize
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(1)),
+        method: "initialize".into(),
+        params: Some(json!({
+            "processId": 1,
+            "capabilities": {}
+        })),
+    });
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "initialized".into(),
+        params: Some(json!({})),
+    });
+
+    // Open a simple Perl file
+    let uri = "file:///test_shared_cache.pl";
+    let content = r#"#!/usr/bin/perl
+use strict;
+use warnings;
+print "hello\n";
+"#;
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "textDocument/didOpen".into(),
+        params: Some(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": content
+            }
+        })),
+    });
+
+    // Collect document diagnostics (uses orchestrator path with perlcritic)
+    let _doc_response = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(2)),
+        method: "textDocument/diagnostic".into(),
+        params: Some(json!({
+            "textDocument": { "uri": uri }
+        })),
+    });
+
+    // Collect workspace diagnostics (should use same orchestrator path after fix)
+    let ws_response = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(3)),
+        method: "workspace/diagnostic".into(),
+        params: Some(json!({})),
+    });
+
+    // The workspace diagnostic response should exist
+    let ws_result = ws_response.ok_or("No response from workspace/diagnostic")?.result;
+
+    // After refactoring, workspace diagnostics use the orchestrator path
+    // which shares the same CriticAnalyzer cache as document diagnostics.
+    // This means the diagnostics should be collected consistently.
+    //
+    // The key assertion is that workspace diagnostics come through the orchestrator,
+    // which we verify by checking the source code pattern.
+    // For a behavioral test, we verify the response structure is correct.
+
+    assert!(ws_result.is_some(), "workspace/diagnostic should return a result");
+
+    let items = ws_result
+        .as_ref()
+        .and_then(|r| r.get("items"))
+        .and_then(|i| i.as_array())
+        .ok_or("Expected items array in workspace/diagnostic response")?;
+
+    // We should get at least one item (for our document)
+    assert!(!items.is_empty(), "Should have at least one workspace diagnostic report");
+
+    Ok(())
+}
+
+/// Test for AC5: Behavioral parity for workspace diagnostics.
+/// After refactoring, workspace diagnostics should produce the same output structure.
+///
+/// CURRENTLY PASSES (same behavior before and after).
+/// This test ensures no behavioral regression during refactoring.
+#[test]
+fn test_workspace_diagnostic_response_structure() -> Result<(), Box<dyn std::error::Error>> {
+    let server = LspServer::new();
+
+    // Initialize
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(1)),
+        method: "initialize".into(),
+        params: Some(json!({
+            "processId": 1,
+            "capabilities": {}
+        })),
+    });
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "initialized".into(),
+        params: Some(json!({})),
+    });
+
+    // Open a Perl file with an undefined variable
+    let uri = "file:///test_undef_var.pl";
+    let content = r#"#!/usr/bin/perl
+use strict;
+use warnings;
+print $undefined_var;
+"#;
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "textDocument/didOpen".into(),
+        params: Some(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": content
+            }
+        })),
+    });
+
+    // Request workspace diagnostics
+    let response = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(2)),
+        method: "workspace/diagnostic".into(),
+        params: Some(json!({})),
+    });
+
+    let result = response.ok_or("No response")?.result.ok_or("No result")?;
+    let items = result["items"].as_array().ok_or("Expected items array")?;
+
+    // Find our document's report
+    let our_report = items
+        .iter()
+        .find(|r| r["uri"].as_str() == Some(uri))
+        .ok_or("Should have a report for our URI")?;
+
+    // Check the report structure
+    assert!(our_report["kind"].is_string(), "kind should be a string");
+    assert!(
+        our_report["kind"] == "full" || our_report["kind"] == "unchanged",
+        "kind should be 'full' or 'unchanged'"
+    );
+
+    if our_report["kind"] == "full" {
+        let diags = our_report["items"].as_array().ok_or("Expected items for full report")?;
+
+        // If there are diagnostics with codes, they should have data fields
+        for d in diags {
+            if d["code"].is_string() && !d["code"].as_str().unwrap().is_empty() {
+                // Should have data field with code, category, fixable, tags
+                let data = &d["data"];
+                assert!(data.is_object(), "Diagnostic with code should have data object: {:?}", d);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// =========================================================================
+// Edge Case Tests - Green Test Builder
+//
+// These tests verify edge cases and boundary conditions for the
+// PullDiagnosticsProvider completion. They complement the red tests
+// by ensuring the implementation handles unusual inputs gracefully.
+// =========================================================================
+
+/// Test edge case: Empty workspace with no open documents.
+/// Workspace diagnostics should return an empty items array, not an error.
+#[test]
+fn test_workspace_diagnostic_empty_workspace() -> Result<(), Box<dyn std::error::Error>> {
+    let server = LspServer::new();
+
+    // Initialize without opening any documents
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(1)),
+        method: "initialize".into(),
+        params: Some(json!({
+            "processId": 1,
+            "capabilities": {}
+        })),
+    });
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "initialized".into(),
+        params: Some(json!({})),
+    });
+
+    // Request workspace diagnostics on empty workspace
+    let response = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(2)),
+        method: "workspace/diagnostic".into(),
+        params: Some(json!({})),
+    });
+
+    let result = response.ok_or("No response")?.result.ok_or("No result")?;
+    let items = result["items"].as_array().ok_or("Expected items array")?;
+
+    // Empty workspace should return empty items, not error
+    assert!(
+        items.is_empty(),
+        "Empty workspace should return empty items array, got {} items",
+        items.len()
+    );
+
+    Ok(())
+}
+
+/// Test edge case: Multiple documents in workspace diagnostics.
+/// Each document should get its own diagnostic report.
+#[test]
+fn test_workspace_diagnostic_multiple_documents() -> Result<(), Box<dyn std::error::Error>> {
+    let server = LspServer::new();
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(1)),
+        method: "initialize".into(),
+        params: Some(json!({
+            "processId": 1,
+            "capabilities": {}
+        })),
+    });
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "initialized".into(),
+        params: Some(json!({})),
+    });
+
+    // Open multiple Perl files
+    let files = [
+        ("file:///test1.pl", "use strict; print $x;"),
+        ("file:///test2.pl", "use strict; print $y;"),
+        ("file:///test3.pl", "use strict; print $z;"),
+    ];
+
+    for (uri, content) in files {
+        let _ = server.handle_request(JsonRpcRequest {
+            _jsonrpc: "2.0".into(),
+            id: None,
+            method: "textDocument/didOpen".into(),
+            params: Some(json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "perl",
+                    "version": 1,
+                    "text": content
+                }
+            })),
+        });
+    }
+
+    // Request workspace diagnostics
+    let response = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(2)),
+        method: "workspace/diagnostic".into(),
+        params: Some(json!({})),
+    });
+
+    let result = response.ok_or("No response")?.result.ok_or("No result")?;
+    let items = result["items"].as_array().ok_or("Expected items array")?;
+
+    // Should have a report for each document
+    assert_eq!(
+        items.len(),
+        files.len(),
+        "Should have {} diagnostic reports, got {}",
+        files.len(),
+        items.len()
+    );
+
+    // Each report should have the correct URI
+    for (uri, _) in files {
+        let found = items.iter().any(|r| r["uri"].as_str() == Some(uri));
+        assert!(found, "Should have diagnostic report for {}", uri);
+    }
+
+    Ok(())
+}
+
+/// Test edge case: Document with only whitespace.
+/// Should not produce unexpected errors.
+#[test]
+fn test_workspace_diagnostic_whitespace_only() -> Result<(), Box<dyn std::error::Error>> {
+    let server = LspServer::new();
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(1)),
+        method: "initialize".into(),
+        params: Some(json!({
+            "processId": 1,
+            "capabilities": {}
+        })),
+    });
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "initialized".into(),
+        params: Some(json!({})),
+    });
+
+    // Open a file with only whitespace
+    let uri = "file:///whitespace.pl";
+    let content = "   \n\n   \t  \n";
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "textDocument/didOpen".into(),
+        params: Some(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": content
+            }
+        })),
+    });
+
+    // Request workspace diagnostics - should not panic
+    let response = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(2)),
+        method: "workspace/diagnostic".into(),
+        params: Some(json!({})),
+    });
+
+    let result = response.ok_or("No response")?.result.ok_or("No result")?;
+    let items = result["items"].as_array().ok_or("Expected items array")?;
+
+    // Find our document's report
+    let our_report = items
+        .iter()
+        .find(|r| r["uri"].as_str() == Some(uri))
+        .ok_or("Should have a report for whitespace.pl")?;
+
+    // Report should exist and be valid
+    assert!(
+        our_report["kind"] == "full" || our_report["kind"] == "unchanged",
+        "Whitespace-only file should have valid report"
+    );
+
+    Ok(())
+}
+
+/// Test edge case: Document with syntax error (parse failure).
+/// Should still return a valid diagnostic report.
+#[test]
+fn test_workspace_diagnostic_syntax_error() -> Result<(), Box<dyn std::error::Error>> {
+    let server = LspServer::new();
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(1)),
+        method: "initialize".into(),
+        params: Some(json!({
+            "processId": 1,
+            "capabilities": {}
+        })),
+    });
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "initialized".into(),
+        params: Some(json!({})),
+    });
+
+    // Open a file with syntax error
+    let uri = "file:///syntax_error.pl";
+    let content = "use strict;\nmy $x = ;  # syntax error\n";
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "textDocument/didOpen".into(),
+        params: Some(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": content
+            }
+        })),
+    });
+
+    // Request workspace diagnostics
+    let response = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(2)),
+        method: "workspace/diagnostic".into(),
+        params: Some(json!({})),
+    });
+
+    let result = response.ok_or("No response")?.result.ok_or("No result")?;
+    let items = result["items"].as_array().ok_or("Expected items array")?;
+
+    // Find our document's report
+    let our_report = items
+        .iter()
+        .find(|r| r["uri"].as_str() == Some(uri))
+        .ok_or("Should have a report for syntax_error.pl")?;
+
+    // Report should exist
+    assert!(
+        our_report["kind"] == "full" || our_report["kind"] == "unchanged",
+        "File with syntax error should have valid report"
+    );
+
+    // For full reports, should have diagnostic items (parse errors)
+    if our_report["kind"] == "full" {
+        let diags = our_report["items"].as_array().ok_or("Expected items")?;
+        // Should have at least one parse error diagnostic
+        let has_parse_error = diags.iter().any(|d| {
+            d["source"] == "perl-parser"
+                || d["code"].as_str().map(|c| c.starts_with("PL")).unwrap_or(false)
+        });
+        assert!(
+            has_parse_error,
+            "Should have at least one parse error diagnostic, got {:#?}",
+            diags
+        );
+    }
+
+    Ok(())
+}
+
+/// Test edge case: Document with undefined variable warning.
+/// Verifies that warnings are properly reported.
+#[test]
+fn test_workspace_diagnostic_undefined_variable() -> Result<(), Box<dyn std::error::Error>> {
+    let server = LspServer::new();
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(1)),
+        method: "initialize".into(),
+        params: Some(json!({
+            "processId": 1,
+            "capabilities": {}
+        })),
+    });
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "initialized".into(),
+        params: Some(json!({})),
+    });
+
+    // Open a file with undefined variable (without strict)
+    let uri = "file:///undef_var.pl";
+    let content = "use warnings;\nprint $undefined_var;\n";
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "textDocument/didOpen".into(),
+        params: Some(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": content
+            }
+        })),
+    });
+
+    // Request workspace diagnostics
+    let response = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(2)),
+        method: "workspace/diagnostic".into(),
+        params: Some(json!({})),
+    });
+
+    let result = response.ok_or("No response")?.result.ok_or("No result")?;
+    let items = result["items"].as_array().ok_or("Expected items array")?;
+
+    // Find our document's report
+    let our_report = items
+        .iter()
+        .find(|r| r["uri"].as_str() == Some(uri))
+        .ok_or("Should have a report for undef_var.pl")?;
+
+    // Should have a full report with diagnostics
+    assert_eq!(our_report["kind"], "full", "Document with warning should have full report");
+
+    let diags = our_report["items"].as_array().ok_or("Expected items")?;
+    assert!(!diags.is_empty(), "Should have at least one diagnostic for undefined variable");
+
+    Ok(())
+}
+
+/// Test edge case: Very long line in document.
+/// Should not cause issues with diagnostic generation.
+#[test]
+fn test_workspace_diagnostic_long_line() -> Result<(), Box<dyn std::error::Error>> {
+    let server = LspServer::new();
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(1)),
+        method: "initialize".into(),
+        params: Some(json!({
+            "processId": 1,
+            "capabilities": {}
+        })),
+    });
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "initialized".into(),
+        params: Some(json!({})),
+    });
+
+    // Open a file with a very long line
+    let uri = "file:///long_line.pl";
+    let long_content = "a".repeat(10000);
+    let content = format!("use strict; my $x = '{}';\n", long_content);
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "textDocument/didOpen".into(),
+        params: Some(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": content
+            }
+        })),
+    });
+
+    // Request workspace diagnostics - should not panic
+    let response = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(2)),
+        method: "workspace/diagnostic".into(),
+        params: Some(json!({})),
+    });
+
+    let result = response.ok_or("No response")?.result.ok_or("No result")?;
+    let items = result["items"].as_array().ok_or("Expected items array")?;
+
+    // Find our document's report
+    let our_report = items
+        .iter()
+        .find(|r| r["uri"].as_str() == Some(uri))
+        .ok_or("Should have a report for long_line.pl")?;
+
+    // Report should exist and be valid
+    assert!(
+        our_report["kind"] == "full" || our_report["kind"] == "unchanged",
+        "Document with long line should have valid report"
+    );
+
+    Ok(())
+}
+
+/// Test edge case: Document change detection via textDocument/didChange.
+/// Workspace diagnostics should reflect the updated content.
+#[test]
+fn test_workspace_diagnostic_document_change() -> Result<(), Box<dyn std::error::Error>> {
+    let server = LspServer::new();
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(1)),
+        method: "initialize".into(),
+        params: Some(json!({
+            "processId": 1,
+            "capabilities": {}
+        })),
+    });
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "initialized".into(),
+        params: Some(json!({})),
+    });
+
+    // Open a file
+    let uri = "file:///change_test.pl";
+    let content1 = "use strict; print $x;\n";
+    let content2 = "use strict; my $y = 1; print $y;\n"; // Fixed - no more undefined var
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "textDocument/didOpen".into(),
+        params: Some(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": content1
+            }
+        })),
+    });
+
+    // Get initial diagnostics
+    let response1 = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(2)),
+        method: "workspace/diagnostic".into(),
+        params: Some(json!({})),
+    });
+
+    let result1 = response1.ok_or("No response")?.result.ok_or("No result")?;
+    let items1 = result1["items"].as_array().ok_or("Expected items array")?;
+    let report1 = items1
+        .iter()
+        .find(|r| r["uri"].as_str() == Some(uri))
+        .ok_or("Should have report for change_test.pl")?;
+
+    // Change the document
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "textDocument/didChange".into(),
+        params: Some(json!({
+            "textDocument": {
+                "uri": uri,
+                "version": 2
+            },
+            "contentChanges": [{
+                "text": content2
+            }]
+        })),
+    });
+
+    // Get diagnostics after change
+    let response2 = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(3)),
+        method: "workspace/diagnostic".into(),
+        params: Some(json!({})),
+    });
+
+    let result2 = response2.ok_or("No response")?.result.ok_or("No result")?;
+    let items2 = result2["items"].as_array().ok_or("Expected items array")?;
+    let report2 = items2
+        .iter()
+        .find(|r| r["uri"].as_str() == Some(uri))
+        .ok_or("Should have report for change_test.pl")?;
+
+    // Both should be full reports (content changed)
+    assert_eq!(report1["kind"], "full", "Initial report should be full");
+    assert_eq!(report2["kind"], "full", "Report after change should be full (content changed)");
+
+    // The diagnostics should differ (content changed)
+    let diag1_count = report1["items"].as_array().map(|a| a.len()).unwrap_or(0);
+    let diag2_count = report2["items"].as_array().map(|a| a.len()).unwrap_or(0);
+
+    // After fixing the undefined variable, there should be fewer or no diagnostics
+    // (depending on if there are other issues)
+    assert!(
+        diag2_count <= diag1_count,
+        "Fixed document should not have more diagnostics than original. \
+         Original: {}, After fix: {}",
+        diag1_count,
+        diag2_count
+    );
+
+    Ok(())
+}
+
+/// Test edge case: Result ID stability for unchanged content.
+/// If content hasn't changed, workspace diagnostics should return the same result ID.
+#[test]
+fn test_workspace_diagnostic_result_id_stability() -> Result<(), Box<dyn std::error::Error>> {
+    let server = LspServer::new();
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(1)),
+        method: "initialize".into(),
+        params: Some(json!({
+            "processId": 1,
+            "capabilities": {}
+        })),
+    });
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "initialized".into(),
+        params: Some(json!({})),
+    });
+
+    // Open a document with a parse error
+    let uri = "file:///stability_test.pl";
+    let content = "use strict; print $x;\n";
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "textDocument/didOpen".into(),
+        params: Some(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": content
+            }
+        })),
+    });
+
+    // First diagnostic request - should be full
+    let response1 = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(2)),
+        method: "workspace/diagnostic".into(),
+        params: Some(json!({})),
+    });
+
+    let result1 = response1.ok_or("No response")?.result.ok_or("No result")?;
+    let items1 = result1["items"].as_array().ok_or("Expected items array")?;
+    let report1 = items1
+        .iter()
+        .find(|r| r["uri"].as_str() == Some(uri))
+        .ok_or("Should have report for stability_test.pl")?;
+
+    assert_eq!(report1["kind"], "full", "Initial report should be full");
+
+    let result_id1 = report1["resultId"].as_str().ok_or("Should have resultId")?;
+
+    // Second request - content unchanged, should get same resultId
+    let response2 = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(3)),
+        method: "workspace/diagnostic".into(),
+        params: Some(json!({})),
+    });
+
+    let result2 = response2.ok_or("No response")?.result.ok_or("No result")?;
+    let items2 = result2["items"].as_array().ok_or("Expected items array")?;
+    let report2 = items2
+        .iter()
+        .find(|r| r["uri"].as_str() == Some(uri))
+        .ok_or("Should have report for stability_test.pl")?;
+
+    // resultId should be the same if content is unchanged
+    let result_id2 = report2["resultId"].as_str().ok_or("Should have resultId")?;
+    assert_eq!(
+        result_id1, result_id2,
+        "ResultId should be stable for unchanged content. \
+         Got '{}' first, '{}' second.",
+        result_id1, result_id2
+    );
+
+    Ok(())
+}

--- a/crates/perl-module/tests/line_references_qualified_call_false_positives_test.rs
+++ b/crates/perl-module/tests/line_references_qualified_call_false_positives_test.rs
@@ -1,0 +1,263 @@
+//! Tests for `line_references_qualified_call` false-positive bug fix.
+//!
+//! Bug: `line_references_qualified_call` incorrectly returns `true` for:
+//! 1. String literals containing qualified call patterns (e.g., `"My::Module::func()"`)
+//! 2. Package declarations with nested modules (e.g., `package My::Module::Sub;`)
+//!
+//! The function should only return `true` for actual qualified function calls,
+//! not for strings or package declarations.
+
+// Tests for the bug fix - these should FAIL before the fix is implemented
+
+use perl_module::line_references_qualified_call;
+
+// ──────────────────────────────────────────────────────────────
+// Bug: False positives on string literals
+// ──────────────────────────────────────────────────────────────
+
+/// Bug fix test: string literals should NOT be detected as qualified calls.
+/// Even if a string literal contains `My::Module::func()`, it's not a call.
+#[test]
+fn test_line_references_qualified_call_false_positive_on_double_quoted_string() {
+    // Given a string literal containing a qualified call pattern
+    let line = r#"my $str = "My::Module::func()";"#;
+    let module_name = "My::Module";
+
+    // When we check if the line references a qualified call
+    let result = line_references_qualified_call(line, module_name);
+
+    // Then it should NOT match (string literal is not a call)
+    assert!(
+        !result,
+        "line_references_qualified_call should return false for string literals, \
+         but returned true for: {}",
+        line
+    );
+}
+
+/// Bug fix test: single-quoted string literals should NOT be detected.
+#[test]
+fn test_line_references_qualified_call_false_positive_on_single_quoted_string() {
+    let line = r#"my $str = 'My::Module::func();';"#;
+    let module_name = "My::Module";
+
+    let result = line_references_qualified_call(line, module_name);
+
+    assert!(
+        !result,
+        "line_references_qualified_call should return false for single-quoted strings, \
+         but returned true for: {}",
+        line
+    );
+}
+
+/// Bug fix test: qw() list containing a qualified call pattern should NOT be detected.
+#[test]
+fn test_line_references_qualified_call_false_positive_on_qw_list() {
+    let line = r#"my @mods = qw(My::Module::func My::Module::Sub);"#;
+    let module_name = "My::Module";
+
+    // qw() is a word list, not a qualified call, even though it contains :: patterns
+    let result = line_references_qualified_call(line, module_name);
+
+    assert!(
+        !result,
+        "line_references_qualified_call should return false for qw() lists, \
+         but returned true for: {}",
+        line
+    );
+}
+
+// ──────────────────────────────────────────────────────────────
+// Bug: False positives on package declarations
+// ──────────────────────────────────────────────────────────────
+
+/// Bug fix test: package declarations with nested modules should NOT be
+/// detected as qualified calls. `package My::Module::Sub;` declares a package
+/// named `My::Module::Sub`, it is NOT a call to `My::Module`.
+#[test]
+fn test_line_references_qualified_call_false_positive_on_package_declaration() {
+    let line = "package My::Module::Sub;";
+    let module_name = "My::Module";
+
+    let result = line_references_qualified_call(line, module_name);
+
+    assert!(
+        !result,
+        "line_references_qualified_call should return false for package declarations, \
+         but returned true for: {}",
+        line
+    );
+}
+
+/// Bug fix test: package declaration at start of line with whitespace.
+#[test]
+fn test_line_references_qualified_call_false_positive_on_package_declaration_with_leading_space() {
+    let line = "    package My::Module::Sub;";
+    let module_name = "My::Module";
+
+    let result = line_references_qualified_call(line, module_name);
+
+    assert!(
+        !result,
+        "line_references_qualified_call should return false for indented package declarations, \
+         but returned true for: {}",
+        line
+    );
+}
+
+/// Bug fix test: package declaration with modern syntax.
+#[test]
+fn test_line_references_qualified_call_false_positive_on_package_declaration_v5_12() {
+    let line = "package My::Module::Sub v1.2.3;";
+    let module_name = "My::Module";
+
+    let result = line_references_qualified_call(line, module_name);
+
+    assert!(
+        !result,
+        "line_references_qualified_call should return false for package declarations with version, \
+         but returned true for: {}",
+        line
+    );
+}
+
+// ──────────────────────────────────────────────────────────────
+// Correct positives (must continue to work)
+// ──────────────────────────────────────────────────────────────
+
+/// Verify actual qualified calls still return true.
+#[test]
+fn test_line_references_qualified_call_correct_positive_on_qualified_call() {
+    let line = "My::Module::func();";
+    let module_name = "My::Module";
+
+    let result = line_references_qualified_call(line, module_name);
+
+    assert!(
+        result,
+        "line_references_qualified_call should return true for qualified calls, \
+         but returned false for: {}",
+        line
+    );
+}
+
+/// Verify qualified calls with arguments still return true.
+#[test]
+fn test_line_references_qualified_call_correct_positive_on_qualified_call_with_args() {
+    let line = "My::Module::func($arg1, $arg2);";
+    let module_name = "My::Module";
+
+    let result = line_references_qualified_call(line, module_name);
+
+    assert!(
+        result,
+        "line_references_qualified_call should return true for qualified calls with args, \
+         but returned false for: {}",
+        line
+    );
+}
+
+/// Verify qualified calls with method chaining still return true.
+#[test]
+fn test_line_references_qualified_call_correct_positive_on_chained_call() {
+    let line = "My::Module::func()->then();";
+    let module_name = "My::Module";
+
+    let result = line_references_qualified_call(line, module_name);
+
+    assert!(
+        result,
+        "line_references_qualified_call should return true for chained qualified calls, \
+         but returned false for: {}",
+        line
+    );
+}
+
+// ──────────────────────────────────────────────────────────────
+// Edge cases
+// ──────────────────────────────────────────────────────────────
+
+/// Empty line should return false.
+#[test]
+fn test_line_references_qualified_call_empty_line() {
+    assert!(!line_references_qualified_call("", "My::Module"));
+}
+
+/// Empty module name should return false.
+#[test]
+fn test_line_references_qualified_call_empty_module_name() {
+    assert!(!line_references_qualified_call("My::Module::func();", ""));
+}
+
+/// Module name not present should return false.
+#[test]
+fn test_line_references_qualified_call_module_not_present() {
+    assert!(!line_references_qualified_call("Other::Module::func();", "My::Module"));
+}
+
+/// Partial module name match should not trigger (no false positive).
+#[test]
+fn test_line_references_qualified_call_partial_match_no_false_positive() {
+    // "My::ModuleX::func()" contains "My::Module" but is NOT a call to My::Module
+    let line = "My::ModuleX::func();";
+    let module_name = "My::Module";
+
+    let result = line_references_qualified_call(line, module_name);
+
+    assert!(
+        !result,
+        "line_references_qualified_call should not match partial module names, \
+         but returned true for: {}",
+        line
+    );
+}
+
+/// Multiple qualified calls on same line.
+#[test]
+fn test_line_references_qualified_call_multiple_calls_same_line() {
+    let line = "My::Module::foo(); My::Module::bar();";
+    let module_name = "My::Module";
+
+    let result = line_references_qualified_call(line, module_name);
+
+    assert!(
+        result,
+        "line_references_qualified_call should detect qualified calls even when multiple exist, \
+         but returned false for: {}",
+        line
+    );
+}
+
+/// Comment containing qualified call pattern should NOT be detected.
+#[test]
+fn test_line_references_qualified_call_false_positive_in_comment() {
+    let line = "# This calls My::Module::func() for debugging";
+    let module_name = "My::Module";
+
+    let result = line_references_qualified_call(line, module_name);
+
+    assert!(
+        !result,
+        "line_references_qualified_call should return false for comments, \
+         but returned true for: {}",
+        line
+    );
+}
+
+/// Nested module name that looks like a call but isn't.
+#[test]
+fn test_line_references_qualified_call_nested_module_not_a_call() {
+    // This is a package declaration for a nested module, not a call
+    let line = "package My::Module::Implementation::Detail;";
+    let module_name = "My::Module";
+
+    let result = line_references_qualified_call(line, module_name);
+
+    assert!(
+        !result,
+        "line_references_qualified_call should return false for nested package declarations, \
+         but returned true for: {}",
+        line
+    );
+}

--- a/crates/perl-module/tests/provenance_detection_tests.rs
+++ b/crates/perl-module/tests/provenance_detection_tests.rs
@@ -1,0 +1,278 @@
+//! Provenance detection tests for Perl module resolution.
+//!
+//! These tests verify that CPAN distribution markers (META.json/yml, SIGNATURE,
+//! CHECKSUMS) are correctly detected adjacent to resolved modules.
+//!
+//! IMPORTANT: These tests verify EXPECTED behavior that does not yet exist.
+//! They will FAIL until the implementation is complete.
+
+use perl_module::resolution::uri::{IncRoot, IncRootKind, Provenance, detect_provenance};
+use std::path::PathBuf;
+
+/// Test type aliases to make the test expectations clear.
+/// These types should be importable from perl_module::resolution::uri
+
+// ============================================================================
+// Provenance struct tests
+// ============================================================================
+
+/// Provenance should be constructable with default values (all false)
+#[test]
+fn provenance_default_constructs_all_false() {
+    let prov = Provenance::default();
+    assert!(!prov.has_meta, "has_meta should default to false");
+    assert!(!prov.has_signature, "has_signature should default to false");
+    assert!(!prov.has_checksums, "has_checksums should default to false");
+}
+
+/// Provenance should be constructable with all true values
+#[test]
+fn provenance_constructs_with_all_true() {
+    let prov = Provenance { has_meta: true, has_signature: true, has_checksums: true };
+    assert!(prov.has_meta, "has_meta should be true");
+    assert!(prov.has_signature, "has_signature should be true");
+    assert!(prov.has_checksums, "has_checksums should be true");
+}
+
+/// Provenance should be cloneable and equal after clone
+#[test]
+fn provenance_clone_is_equal() {
+    let prov = Provenance { has_meta: true, has_signature: false, has_checksums: true };
+    let cloned = prov.clone();
+    assert_eq!(prov, cloned, "cloned provenance should equal original");
+}
+
+// ============================================================================
+// detect_provenance function tests
+// ============================================================================
+
+/// detect_provenance should return all-false for directory with no markers
+#[test]
+fn detect_provenance_returns_all_false_for_empty_dir() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let module_dir = temp.path().join("My-Module");
+    std::fs::create_dir_all(&module_dir)?;
+
+    let prov = detect_provenance(&module_dir);
+
+    assert!(!prov.has_meta, "has_meta should be false with no META file");
+    assert!(!prov.has_signature, "has_signature should be false with no SIGNATURE file");
+    assert!(!prov.has_checksums, "has_checksums should be false with no CHECKSUMS file");
+    Ok(())
+}
+
+/// detect_provenance should detect META.json
+#[test]
+fn detect_provenance_detects_meta_json() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let module_dir = temp.path().join("My-Module");
+    std::fs::create_dir_all(&module_dir)?;
+    std::fs::write(module_dir.join("META.json"), "{}")?;
+
+    let prov = detect_provenance(&module_dir);
+
+    assert!(prov.has_meta, "has_meta should be true when META.json exists");
+    assert!(!prov.has_signature, "has_signature should be false");
+    assert!(!prov.has_checksums, "has_checksums should be false");
+    Ok(())
+}
+
+/// detect_provenance should detect META.yml
+#[test]
+fn detect_provenance_detects_meta_yml() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let module_dir = temp.path().join("My-Module");
+    std::fs::create_dir_all(&module_dir)?;
+    std::fs::write(module_dir.join("META.yml"), "--- {}")?;
+
+    let prov = detect_provenance(&module_dir);
+
+    assert!(prov.has_meta, "has_meta should be true when META.yml exists");
+    assert!(!prov.has_signature, "has_signature should be false");
+    assert!(!prov.has_checksums, "has_checksums should be false");
+    Ok(())
+}
+
+/// detect_provenance should detect SIGNATURE file
+#[test]
+fn detect_provenance_detects_signature() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let module_dir = temp.path().join("My-Module");
+    std::fs::create_dir_all(&module_dir)?;
+    std::fs::write(module_dir.join("SIGNATURE"), "hash-value")?;
+
+    let prov = detect_provenance(&module_dir);
+
+    assert!(!prov.has_meta, "has_meta should be false");
+    assert!(prov.has_signature, "has_signature should be true when SIGNATURE file exists");
+    assert!(!prov.has_checksums, "has_checksums should be false");
+    Ok(())
+}
+
+/// detect_provenance should detect CHECKSUMS file
+#[test]
+fn detect_provenance_detects_checksums() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let module_dir = temp.path().join("My-Module");
+    std::fs::create_dir_all(&module_dir)?;
+    std::fs::write(module_dir.join("CHECKSUMS"), "hash-values")?;
+
+    let prov = detect_provenance(&module_dir);
+
+    assert!(!prov.has_meta, "has_meta should be false");
+    assert!(!prov.has_signature, "has_signature should be false");
+    assert!(prov.has_checksums, "has_checksums should be true when CHECKSUMS file exists");
+    Ok(())
+}
+
+/// detect_provenance should detect all three markers simultaneously
+#[test]
+fn detect_provenance_detects_all_three_markers() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let module_dir = temp.path().join("My-Module");
+    std::fs::create_dir_all(&module_dir)?;
+    std::fs::write(module_dir.join("META.json"), "{}")?;
+    std::fs::write(module_dir.join("SIGNATURE"), "hash")?;
+    std::fs::write(module_dir.join("CHECKSUMS"), "sha256: abc")?;
+
+    let prov = detect_provenance(&module_dir);
+
+    assert!(prov.has_meta, "has_meta should be true");
+    assert!(prov.has_signature, "has_signature should be true");
+    assert!(prov.has_checksums, "has_checksums should be true");
+    Ok(())
+}
+
+// ============================================================================
+// IncRoot::detect_provenance method tests
+// ============================================================================
+
+/// IncRoot should have a provenance field that is Option<Provenance>
+/// After construction, provenance should be None (lazy evaluation)
+#[test]
+fn inc_root_provenance_field_is_none_by_default() {
+    let root = IncRoot {
+        kind: IncRootKind::WorkspaceRelative,
+        path: PathBuf::from("/some/path"),
+        precedence: 0,
+        source: "test".to_string(),
+    };
+
+    // The provenance field should be None initially (not yet scanned)
+    // This tests that IncRoot has a provenance: Option<Provenance> field
+    assert!(
+        root.provenance.is_none(),
+        "IncRoot.provenance should be None by default (lazy evaluation)"
+    );
+}
+
+/// IncRoot should have a detect_provenance method that populates the provenance field
+#[test]
+fn inc_root_detect_provenance_populates_field() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let module_dir = temp.path().join("My-Module");
+    std::fs::create_dir_all(&module_dir)?;
+    std::fs::write(module_dir.join("META.json"), "{}")?;
+
+    let mut root = IncRoot {
+        kind: IncRootKind::WorkspaceRelative,
+        path: module_dir.clone(),
+        precedence: 0,
+        source: "test".to_string(),
+    };
+
+    // Initially None
+    assert!(root.provenance.is_none(), "provenance should be None before detection");
+
+    // After detection, should be populated
+    root.detect_provenance();
+
+    assert!(
+        root.provenance.is_some(),
+        "provenance should be Some after detect_provenance() is called"
+    );
+
+    let prov = root.provenance.unwrap();
+    assert!(prov.has_meta, "has_meta should be true after detection");
+    Ok(())
+}
+
+/// IncRoot::detect_provenance should correctly detect all marker types
+#[test]
+fn inc_root_detect_provenance_all_markers() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let module_dir = temp.path().join("My-Module");
+    std::fs::create_dir_all(&module_dir)?;
+    std::fs::write(module_dir.join("META.json"), "{}")?;
+    std::fs::write(module_dir.join("SIGNATURE"), "hash")?;
+    std::fs::write(module_dir.join("CHECKSUMS"), "sha256: abc")?;
+
+    let mut root = IncRoot {
+        kind: IncRootKind::WorkspaceRelative,
+        path: module_dir,
+        precedence: 0,
+        source: "test".to_string(),
+    };
+
+    root.detect_provenance();
+
+    let prov = root.provenance.unwrap();
+    assert!(prov.has_meta, "has_meta should be true");
+    assert!(prov.has_signature, "has_signature should be true");
+    assert!(prov.has_checksums, "has_checksums should be true");
+    Ok(())
+}
+
+// ============================================================================
+// Trust classification tests (informational only)
+// ============================================================================
+
+/// Modules with has_signature=true should be classified as "Signed"
+/// This is informational only - we just verify the provenance fields
+#[test]
+fn provenance_signed_classification() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let module_dir = temp.path().join("My-Module");
+    std::fs::create_dir_all(&module_dir)?;
+    std::fs::write(module_dir.join("SIGNATURE"), "hash")?;
+
+    let prov = detect_provenance(&module_dir);
+
+    // A module with SIGNATURE is considered "Signed" (informational)
+    assert!(prov.has_signature, "Signed classification requires has_signature=true");
+    assert!(!prov.has_meta, "Signed does not require has_meta");
+    Ok(())
+}
+
+/// Modules with has_meta=true but no has_signature should be "KnownDistributor"
+#[test]
+fn provenance_known_distributor_classification() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let module_dir = temp.path().join("My-Module");
+    std::fs::create_dir_all(&module_dir)?;
+    std::fs::write(module_dir.join("META.json"), "{}")?;
+
+    let prov = detect_provenance(&module_dir);
+
+    // A module with META but no SIGNATURE is "KnownDistributor"
+    assert!(prov.has_meta, "KnownDistributor requires has_meta=true");
+    assert!(!prov.has_signature, "KnownDistributor requires has_signature=false");
+    Ok(())
+}
+
+/// Modules with no CPAN markers should be "Unknown"
+#[test]
+fn provenance_unknown_classification() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let module_dir = temp.path().join("My-Module");
+    std::fs::create_dir_all(&module_dir)?;
+    // No META.json/yml, no SIGNATURE, no CHECKSUMS
+
+    let prov = detect_provenance(&module_dir);
+
+    // A module with no CPAN markers is "Unknown"
+    assert!(!prov.has_meta, "Unknown classification requires has_meta=false");
+    assert!(!prov.has_signature, "Unknown classification requires has_signature=false");
+    assert!(!prov.has_checksums, "Unknown classification requires has_checksums=false");
+    Ok(())
+}

--- a/crates/perl-parser-core/tests/fuzz_label_ternary_disambiguation.rs
+++ b/crates/perl-parser-core/tests/fuzz_label_ternary_disambiguation.rs
@@ -1,0 +1,556 @@
+//! Fuzz tests for label/ternary disambiguation in `is_label_start()`.
+//!
+//! These tests exercise the parser with randomly generated Perl code patterns
+//! to find crashes, panics, and unexpected behavior in the label/ternary
+//! disambiguation logic.
+//!
+//! The `is_label_start()` function uses 3-token lookahead:
+//! - Token 1 (peek): Is it an `Identifier`?
+//! - Token 2 (peek_second): Is it a `Colon`?
+//! - Token 3 (peek_third): Can the token after colon start a statement?
+//!
+//! Fuzz targets:
+//! 1. Random identifier + colon + third token combinations
+//! 2. Ternary expression patterns that look like labels
+//! 3. Hash constructor patterns with potential label confusion
+//! 4. Label patterns followed by various statement types
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// =============================================================================
+// Fuzz Target 1: Random identifier + colon + third token patterns
+// =============================================================================
+
+/// Fuzz test: Random identifier names followed by colon and various tokens.
+///
+/// This tests the parser's ability to handle arbitrary identifier names
+/// in contexts that might look like labels.
+#[test]
+fn fuzz_identifier_colon_third_token() {
+    // Valid label patterns
+    let valid_patterns = [
+        "FOO: my $x = 1;",
+        "BAR: print 'hello';",
+        "LABEL: { 1; }",
+        "X: (1);",
+        "A: if (1) { }",
+        "B: while (1) { }",
+        "C: for my $i (1..10) { }",
+        "D: unless (0) { }",
+        "E: return 42;",
+        "LOOP: last LOOP if $done;",
+    ];
+
+    for pattern in valid_patterns {
+        let result = std::panic::catch_unwind(|| {
+            let ast = parse(pattern);
+            let sexp = ast.to_sexp();
+            // Should not panic, should produce some valid parse
+            assert!(!sexp.is_empty(), "Empty sexp for valid pattern: {}", pattern);
+        });
+        assert!(result.is_ok(), "Panic parsing valid pattern: {}", pattern);
+    }
+
+    // Invalid label patterns (colon followed by non-statement-starting tokens)
+    let invalid_patterns = [
+        "FOO: ?",
+        "FOO: :",
+        "FOO: ;",
+        "FOO: )",
+        "FOO: ]",
+        "FOO: }",
+        "FOO: =>",
+        "BAR: ? $x",
+        "BAR: : $x",
+        "X: ? :",
+    ];
+
+    for pattern in invalid_patterns {
+        let result = std::panic::catch_unwind(|| {
+            let ast = parse(pattern);
+            let sexp = ast.to_sexp();
+            // Should not panic even for invalid patterns
+            // These may produce error nodes, which is expected
+            assert!(!sexp.is_empty(), "Empty sexp for pattern: {}", pattern);
+        });
+        assert!(result.is_ok(), "Panic parsing pattern: {}", pattern);
+    }
+}
+
+// =============================================================================
+// Fuzz Target 2: Ternary expressions that look like labels
+// =============================================================================
+
+/// Fuzz test: Ternary expressions where the condition looks like a label.
+///
+/// This tests that `is_label_start()` correctly returns `false` for patterns
+/// like `CONDITION: ? $then : $else` where the colon belongs to the ternary.
+#[test]
+fn fuzz_ternary_condition_like_label() {
+    let patterns = [
+        // Ternary with uppercase condition (looks like label)
+        "my $x = COND: ? $then : $else;",
+        // Ternary with lowercase condition
+        "my $x = $cond ? $a : $b;",
+        // Nested ternaries
+        "my $x = $a ? $b ? $c : $d : $e;",
+        "my $x = $a ? $b : $c ? $d : $e;",
+        // Ternary with hash ref
+        "my $x = $cond ? {a => 1} : {b => 2};",
+        // Ternary with array ref
+        "my $x = $cond ? [1, 2] : [3, 4];",
+        // Ternary with parens
+        "my $x = ($a > $b) ? $c : $d;",
+        // Ternary with method call
+        "my $x = $obj->method ? $a : $b;",
+        // Ternary with subscript
+        "my $x = $arr[0] ? $a : $b;",
+        // Chained ternary
+        "my $x = $a ? $b : $c ? $d : $f ? $g : $h;",
+    ];
+
+    for pattern in patterns {
+        let result = std::panic::catch_unwind(|| {
+            let ast = parse(pattern);
+            let sexp = ast.to_sexp();
+            // Should not panic - parser should handle all of these
+            assert!(!sexp.is_empty(), "Empty sexp for ternary pattern: {}", pattern);
+        });
+        assert!(result.is_ok(), "Panic parsing ternary pattern: {}", pattern);
+    }
+}
+
+// =============================================================================
+// Fuzz Target 3: Hash constructors with potential label confusion
+// =============================================================================
+
+/// Fuzz test: Hash constructors with keys that look like labels.
+///
+/// This tests that `is_label_start()` correctly returns `false` for patterns
+/// like `KEY: => 'value'` where the colon belongs to autoquoting context.
+#[test]
+fn fuzz_hash_constructor_label_confusion() {
+    let patterns = [
+        // Simple hash constructor with fat arrows
+        "my %h = (KEY1 => 'value1', KEY2 => 'value2');",
+        // Uppercase keys (look like labels)
+        "my %h = (FOO => 1, BAR => 2, BAZ => 3);",
+        // Keys that are also keywords
+        "my %h = (if => 1, for => 2, return => 3);",
+        // Mixed keys
+        "my %h = (A => 1, b => 2, C => 3);",
+        // Nested hash in hash
+        "my %h = (outer => {inner => 'value'}, other => 'x');",
+        // Hash with fat arrow and labels nearby
+        "LABEL: my %h = (KEY => 'value');",
+        // Multiple fat arrows
+        "my %h = (a => 1, b => 2, c => 3, d => 4, e => 5);",
+        // Fat arrow in list assignment
+        "my %h = foo => 'bar';",
+    ];
+
+    for pattern in patterns {
+        let result = std::panic::catch_unwind(|| {
+            let ast = parse(pattern);
+            let sexp = ast.to_sexp();
+            // Should not panic
+            assert!(!sexp.is_empty(), "Empty sexp for hash pattern: {}", pattern);
+        });
+        assert!(result.is_ok(), "Panic parsing hash pattern: {}", pattern);
+    }
+}
+
+// =============================================================================
+// Fuzz Target 4: Label statements followed by various statement types
+// =============================================================================
+
+/// Fuzz test: Valid labels followed by various statement types.
+///
+/// This tests that `is_label_start()` correctly returns `true` for valid label
+/// patterns where the third token CAN start a statement.
+#[test]
+fn fuzz_valid_labels_with_various_statements() {
+    let patterns = [
+        // Label + expression statement
+        "LABEL: 42;",
+        "LABEL: 'string';",
+        "LABEL: $scalar;",
+        "LABEL: @array;",
+        "LABEL: %hash;",
+        // Label + variable declaration
+        "LABEL: my $x = 1;",
+        "LABEL: our $x = 1;",
+        "LABEL: state $x = 1;",
+        // Label + print
+        "LABEL: print 'hello';",
+        "LABEL: print $x;",
+        // Label + block
+        "LABEL: { 1; }",
+        "LABEL: { my $x = 1; print $x; }",
+        // Label + if
+        "LABEL: if ($x) { 1; }",
+        "LABEL: unless ($x) { 1; }",
+        // Label + while
+        "LABEL: while (1) { last; }",
+        // Label + for
+        "LABEL: for my $i (1..10) { print $i; }",
+        // Label + foreach
+        "LABEL: foreach my $x (@arr) { print $x; }",
+        // Label + do block
+        "LABEL: do { 1; };",
+        // Label + subroutine
+        "LABEL: sub foo { 1; }",
+        // Label + return
+        "LABEL: return 42;",
+        // Label + next/last/redo with label reference
+        "OUTER: for my $i (1..10) { INNER: for my $j (1..10) { next OUTER if $i == 5; } }",
+        // Label + statement modifier
+        "LABEL: print 'hi' if $debug;",
+        "LABEL: print 'hi' unless $silent;",
+        "LABEL: print 'hi' while $count-- > 0;",
+        "LABEL: print 'hi' for @items;",
+        "LABEL: print 'hi' until $done;",
+        // Label + given (Perl 5.38+)
+        // "LABEL: given ($x) { when (1) { 1; } }",
+    ];
+
+    for pattern in patterns {
+        let result = std::panic::catch_unwind(|| {
+            let ast = parse(pattern);
+            let sexp = ast.to_sexp();
+            // Should not panic
+            assert!(!sexp.is_empty(), "Empty sexp for label pattern: {}", pattern);
+        });
+        assert!(result.is_ok(), "Panic parsing label pattern: {}", pattern);
+    }
+}
+
+// =============================================================================
+// Fuzz Target 5: Edge cases around third token validation
+// =============================================================================
+
+/// Fuzz test: Edge cases for the third token validation in `is_label_start()`.
+///
+/// This tests that the parser correctly identifies when the third token
+/// CAN or CANNOT start a statement.
+#[test]
+fn fuzz_third_token_edge_cases() {
+    // Third token is a closing delimiter - should NOT be a label
+    let non_label_patterns = [
+        "X: )",
+        "X: ]",
+        "X: }",
+        "X: ;",
+        "X: ?",
+        "X: :",
+        "X: =>",
+        "X: ,",
+        "X:",
+    ];
+
+    for pattern in non_label_patterns {
+        let result = std::panic::catch_unwind(|| {
+            let ast = parse(pattern);
+            let sexp = ast.to_sexp();
+            // Should not panic
+            assert!(!sexp.is_empty(), "Empty sexp for non-label pattern: {}", pattern);
+        });
+        assert!(result.is_ok(), "Panic parsing non-label pattern: {}", pattern);
+    }
+
+    // Third token is an opening delimiter or identifier - SHOULD be a label
+    let label_patterns = [
+        "X: (1)",
+        "X: [1]",
+        "X: {1}",
+        "X: (my $x = 1)",
+        "X: [my @x = (1,2,3)]",
+        "X: { my $x = 1; }",
+        "X: if (1) { }",
+        "X: while (1) { }",
+        "X: for my $i (1..10) { }",
+        "X: print 1;",
+        "X: return 1;",
+        "X: my $x = 1;",
+        "X: sub foo { }",
+    ];
+
+    for pattern in label_patterns {
+        let result = std::panic::catch_unwind(|| {
+            let ast = parse(pattern);
+            let sexp = ast.to_sexp();
+            // Should not panic
+            assert!(!sexp.is_empty(), "Empty sexp for label pattern: {}", pattern);
+        });
+        assert!(result.is_ok(), "Panic parsing label pattern: {}", pattern);
+    }
+}
+
+// =============================================================================
+// Fuzz Target 6: Combinations of labels, ternaries, and hashes
+// =============================================================================
+
+/// Fuzz test: Complex combinations of labels, ternaries, and hashes.
+///
+/// This tests the parser's ability to handle complex expressions that mix
+/// label-like patterns with ternary and hash constructors.
+#[test]
+fn fuzz_complex_combinations() {
+    let patterns = [
+        // Label followed by hash constructor
+        "LABEL: my %h = (KEY => 'value');",
+        // Ternary in hash value position
+        "my %h = (key => $cond ? $a : $b);",
+        // Hash in ternary then-branch
+        "my $x = $cond ? {a => 1} : {b => 2};",
+        // Label after hash
+        "my %h = (a => 1); LABEL: print 'done';",
+        // Multiple statements with labels
+        "LABEL1: print 'one'; LABEL2: print 'two';",
+        // Label inside ternary condition (this would be weird but shouldn't panic)
+        "my $x = (LABEL: 1) ? $a : $b;",
+        // Nested blocks with labels
+        "OUTER: { INNER: { 1; } }",
+        // Label in do block
+        "LABEL: do { 1; };",
+        // Label in statement modifier
+        "LABEL: 1 if $x;",
+        // Ternary result used as hash value
+        "my %h = (a => $x ? 1 : 2, b => $y ? 3 : 4);",
+        // Complex nested ternary with hash
+        "my $x = $a ? ($b ? {x=>1} : {y=>2}) : ($c ? {z=>3} : {w=>4});",
+    ];
+
+    for pattern in patterns {
+        let result = std::panic::catch_unwind(|| {
+            let ast = parse(pattern);
+            let sexp = ast.to_sexp();
+            // Should not panic
+            assert!(!sexp.is_empty(), "Empty sexp for complex pattern: {}", pattern);
+        });
+        assert!(result.is_ok(), "Panic parsing complex pattern: {}", pattern);
+    }
+}
+
+// =============================================================================
+// Fuzz Target 7: Empty and minimal inputs
+// =============================================================================
+
+/// Fuzz test: Empty and minimal inputs to ensure parser doesn't panic.
+#[test]
+fn fuzz_empty_and_minimal() {
+    let patterns = [
+        "",                 // Empty
+        ";",                // Just semicolon
+        ";;",               // Two semicolons
+        ":",                // Just colon
+        "::",               // Double colon
+        ":::",              // Triple colon
+        "?",                // Just question
+        "?:",               // Question colon
+        "??",               // Double question
+        "?",                // Just question
+        "?",                // Question
+        "???:",             // Multiple question marks and colon
+        "LABEL:",           // Label without statement (at EOF)
+        "X:",               // Short label without statement
+        "//",               // Two slashes (regex or division)
+        "///",              // Three slashes
+        "# comment",        // Comment only
+        "# comment\n",      // Comment with newline
+        "# comment\n;",     // Comment and semicolon
+    ];
+
+    for pattern in patterns {
+        let result = std::panic::catch_unwind(|| {
+            let ast = parse(pattern);
+            let sexp = ast.to_sexp();
+            // Should not panic - even if parse fails, it should be handled
+            assert!(!sexp.is_empty() || pattern.is_empty(),
+                "Empty sexp for pattern (non-empty input): {:?}", pattern);
+        });
+        assert!(result.is_ok(), "Panic parsing minimal pattern: {:?}", pattern);
+    }
+}
+
+// =============================================================================
+// Fuzz Target 8: Unicode and special characters in labels
+// =============================================================================
+
+/// Fuzz test: Unicode and special characters in label-like patterns.
+#[test]
+fn fuzz_unicode_and_special_chars() {
+    let patterns = [
+        // Unicode identifiers (Perl supports Unicode in identifiers)
+        "日本語: print 1;",
+        "中文: 1;",
+        "Unicode: 1;",
+        // Long identifiers
+        "VeryLongIdentifierNameHere: print 1;",
+        // Identifiers with underscores
+        "foo_bar: print 1;",
+        "foo_bar_baz: print 1;",
+        // Identifiers with numbers
+        "test123: print 1;",
+        "abc123def: print 1;",
+        // Qualified identifiers (should not be confused with labels)
+        "Foo::Bar::baz;",
+        "$obj->method;",
+        "$h->{key};",
+    ];
+
+    for pattern in patterns {
+        let result = std::panic::catch_unwind(|| {
+            let ast = parse(pattern);
+            let sexp = ast.to_sexp();
+            // Should not panic
+            assert!(!sexp.is_empty(), "Empty sexp for unicode pattern: {}", pattern);
+        });
+        assert!(result.is_ok(), "Panic parsing unicode pattern: {}", pattern);
+    }
+}
+
+// =============================================================================
+// Fuzz Target 9: Verify no expected_colon errors for label-like patterns
+// =============================================================================
+
+/// Fuzz test: Verify that the fix doesn't introduce expected_colon errors
+/// for valid label patterns.
+///
+/// This is a regression test to ensure that the 3-token lookahead fix
+/// doesn't incorrectly reject valid labels.
+#[test]
+fn fuzz_no_expected_colon_for_valid_labels() {
+    let valid_label_patterns = [
+        "FOO: my $x = 1;",
+        "BAR: print 'hello';",
+        "LABEL: { 1; }",
+        "LOOP: while (1) { last LOOP; }",
+        "OUTER: for my $i (1..10) { INNER: for my $j (1..10) { 1; } }",
+        "CHECK: if ($x > 0) { 1; }",
+        "ITER: for my $i (1..10) { print $i; }",
+        "DEBUG: print 'debug' if $debug;",
+        "RETRY: return $result if defined $result;",
+        "AGAIN: print 'loop' while $count-- > 0;",
+        "SKIP: print 'skip' unless $skip;",
+        "LIST: print $_ for @items;",
+        "UNTIL: 1 until $done;",
+        "WHEN: given ($x) { when (1) { 1; } }",
+        // Additional edge cases
+        "A: B: C: 1;",              // Multiple labels
+        "FOO: (1);",                 // Label with paren expr
+        "BAR: [1, 2, 3];",          // Label with array
+        "BAZ: {a => 1};",           // Label with hash ref
+        "X: do { 1; };",           // Label with do block
+        "Y: sub { 1; };",          // Label with anon sub
+    ];
+
+    for pattern in valid_label_patterns {
+        let result = std::panic::catch_unwind(|| {
+            let ast = parse(pattern);
+            let sexp = ast.to_sexp();
+            // Should not produce expected_colon error
+            assert!(
+                !sexp.to_lowercase().contains("expected_colon"),
+                "Found expected_colon error for valid label pattern: {}\nsexp: {}",
+                pattern, sexp
+            );
+        });
+        assert!(result.is_ok(), "Panic parsing valid label pattern: {}", pattern);
+    }
+}
+
+// =============================================================================
+// Fuzz Target 10: Stress test with many statements and labels
+// =============================================================================
+
+/// Fuzz test: Many labels and statements in sequence.
+///
+/// This tests parser performance and correctness with a large number
+/// of statements and labels.
+#[test]
+fn fuzz_many_labels_and_statements() {
+    // Build a string with many label statements
+    let pattern = r#"
+        L1: my $x1 = 1;
+        L2: my $x2 = 2;
+        L3: my $x3 = 3;
+        L4: my $x4 = 4;
+        L5: my $x5 = 5;
+        L6: print $x1;
+        L7: print $x2;
+        L8: print $x3;
+        L9: print $x4;
+        L10: print $x5;
+        L11: if ($x1 > 0) { L12: print 'positive'; }
+        L13: while ($x2 > 0) { L14: { last; } }
+        L15: for my $i (1..3) { L16: print $i; }
+        L17: { L18: 1; L19: 2; L20: 3; }
+        L21: do { L22: 1; };
+        L23: return $x1 + $x2 + $x3 + $x4 + $x5;
+    "#;
+
+    let result = std::panic::catch_unwind(|| {
+        let ast = parse(pattern);
+        let sexp = ast.to_sexp();
+        // Should not panic
+        assert!(!sexp.is_empty(), "Empty sexp for many-labels pattern");
+        // Should not have expected_colon errors
+        assert!(
+            !sexp.to_lowercase().contains("expected_colon"),
+            "Found expected_colon error in many-labels pattern"
+        );
+    });
+    assert!(result.is_ok(), "Panic parsing many-labels pattern");
+}
+
+// =============================================================================
+// Fuzz Target 11: Regression test for specific CPAN patterns
+// =============================================================================
+
+/// Fuzz test: Regression tests for specific patterns from the CPAN corpus
+/// that triggered expected_colon errors.
+///
+/// These patterns were identified in the original issue as causing
+/// parser errors related to label/ternary disambiguation.
+#[test]
+fn fuzz_cpan_regression_patterns() {
+    // These are simplified versions of patterns that might appear in CPAN code
+    let patterns = [
+        // Ternary in hash value
+        "my %h = (key => $cond ? $a : $b);",
+        // Ternary as hash value with uppercase key
+        "my %h = (KEY => $cond ? $a : $b);",
+        // Multiple ternaries
+        "my $x = $a ? $b : $c ? $d : $e;",
+        // Ternary with method call in condition
+        "my $x = $obj->method ? $a : $b;",
+        // Ternary with subscript in condition
+        "my $x = $arr[0] ? $a : $b;",
+        // Ternary with postfix deref in condition
+        "my $x = $obj->$method ? $a : $b;",
+        // Fat arrow with uppercase key
+        "my %h = (FOO => 1, BAR => 2);",
+        // Keyword used as hash key
+        "my %h = (if => 1, for => 2, return => 3);",
+        // Nested ternary in hash
+        "my %h = (a => $x ? $y : $z, b => $w ? $u : $v);",
+        // Label with ternary-like syntax (shouldn't be confused)
+        "OUTER: for my $i (1..10) { last OUTER if $i == 5; }",
+        // Label followed by hash constructor
+        "LABEL: my %h = (key => 'value');",
+        // Chained ternary with fat arrows
+        "my $x = $a ? 'a' : $b ? 'b' : 'c';",
+    ];
+
+    for pattern in patterns {
+        let result = std::panic::catch_unwind(|| {
+            let ast = parse(pattern);
+            let sexp = ast.to_sexp();
+            // Should not panic
+            assert!(!sexp.is_empty(), "Empty sexp for CPAN pattern: {}", pattern);
+        });
+        assert!(result.is_ok(), "Panic parsing CPAN pattern: {}", pattern);
+    }
+}

--- a/crates/perl-parser-core/tests/green_label_ternary_edge_cases.rs
+++ b/crates/perl-parser-core/tests/green_label_ternary_edge_cases.rs
@@ -1,0 +1,347 @@
+//! Edge case tests for label/ternary disambiguation in `is_label_start()`.
+//!
+//! These tests supplement the red tests in `fix_label_ternary_disambiguation.rs`
+//! by covering additional edge cases and boundary conditions.
+//!
+//! The `is_label_start()` function uses 3-token lookahead:
+//! - Token 1 (peek): Is it an `Identifier`?
+//! - Token 2 (peek_second): Is it a `Colon`?
+//! - Token 3 (peek_third): Can the token after colon start a statement?
+//!
+//! These tests verify the implementation handles edge cases correctly.
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// =============================================================================
+// Edge Case: Identifier at statement start followed by ternary
+// =============================================================================
+
+/// Edge case: Bare identifier at statement start, followed by ternary.
+/// This tests `is_label_start()` when the identifier is followed by colon,
+/// but the third token is `?` (ternary question), which cannot start a statement.
+/// Without the 3-token fix, this would incorrectly identify `FOO:` as a label.
+#[test]
+fn test_edge_case_identifier_ternary_question() {
+    // `FOO: ?` - identifier colon followed by ternary question
+    // The 3rd token `?` is in the invalid list, so is_label_start returns false
+    // This should parse (gracefully handle the invalid Perl syntax)
+    let source = r#"FOO: ?"#;
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    // The parse should complete (even if it produces an error node)
+    // We're testing that it doesn't panic or produce unexpected_colon
+    assert!(!sexp.contains("expected_colon"), "Should not produce expected_colon for FOO: ?");
+}
+
+/// Edge case: Identifier colon followed by chained ternary colon.
+/// `$x ? $y : : $z` - the second `:` is the ternary else-part,
+/// but it could be mistaken for a label colon.
+#[test]
+fn test_edge_case_chained_ternary_second_colon() {
+    // `FOO: :` - identifier colon followed by another colon
+    // The 3rd token `:` is in the invalid list
+    let source = r#"FOO: :"#;
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("expected_colon"), "Should not produce expected_colon for FOO: :");
+}
+
+/// Edge case: Identifier colon followed by semicolon (invalid label).
+/// `FOO: ;` - label colon followed by semicolon is not valid.
+#[test]
+fn test_edge_case_identifier_colon_semicolon() {
+    let source = r#"FOO: ;"#;
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("expected_colon"), "Should not produce expected_colon for FOO: ;");
+}
+
+/// Edge case: Identifier colon followed by comma (list expression).
+/// `FOO: ,` - in list context, comma after colon is not a label.
+#[test]
+fn test_edge_case_identifier_colon_comma() {
+    let source = r#"FOO: ,"#;
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("expected_colon"), "Should not produce expected_colon for FOO: ,");
+}
+
+// =============================================================================
+// Edge Case: Label with closing delimiters after colon
+// =============================================================================
+
+/// Edge case: Identifier colon followed by right paren.
+/// `FOO: )` - closing paren cannot start a statement.
+#[test]
+fn test_edge_case_identifier_colon_right_paren() {
+    let source = r#"FOO: )"#;
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("expected_colon"), "Should not produce expected_colon for FOO: )");
+}
+
+/// Edge case: Identifier colon followed by right bracket.
+/// `FOO: ]` - closing bracket cannot start a statement.
+#[test]
+fn test_edge_case_identifier_colon_right_bracket() {
+    let source = r#"FOO: ]"#;
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("expected_colon"), "Should not produce expected_colon for FOO: ]");
+}
+
+/// Edge case: Identifier colon followed by right brace.
+/// `FOO: }` - orphan closing brace cannot start a statement.
+#[test]
+fn test_edge_case_identifier_colon_right_brace() {
+    let source = r#"FOO: }"#;
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("expected_colon"), "Should not produce expected_colon for FOO: }}");
+}
+
+// =============================================================================
+// Edge Case: Identifier colon at EOF
+// =============================================================================
+
+/// Edge case: Identifier colon at end of file.
+/// `FOO:` - nothing after colon, cannot be a valid label statement.
+#[test]
+fn test_edge_case_identifier_colon_eof() {
+    let source = r#"FOO:"#;
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("expected_colon"), "Should not produce expected_colon for FOO: at EOF");
+}
+
+// =============================================================================
+// Edge Case: Valid label patterns that should still work
+// =============================================================================
+
+/// Edge case: Label with unary plus after colon.
+/// `FOO: + 5` - unary plus can start an expression statement.
+#[test]
+fn test_edge_case_label_unary_plus() {
+    assert_clean_parse(r#"FOO: + 5; print "done\n";"#);
+}
+
+/// Edge case: Label with unary minus after colon.
+/// `FOO: - 3` - unary minus can start an expression statement.
+#[test]
+fn test_edge_case_label_unary_minus() {
+    assert_clean_parse(r#"FOO: - 3; print "done\n";"#);
+}
+
+/// Edge case: Label with bitwise not after colon.
+/// `FOO: ~ 0` - bitwise not can start an expression statement.
+#[test]
+fn test_edge_case_label_bitwise_not() {
+    assert_clean_parse(r#"FOO: ~ 0; print "done\n";"#);
+}
+
+/// Edge case: Label with logical not after colon.
+/// `FOO: ! $x` - logical not can start an expression statement.
+#[test]
+fn test_edge_case_label_logical_not() {
+    assert_clean_parse(r#"FOO: ! $x; print "done\n";"#);
+}
+
+/// Edge case: Label with indirect object syntax.
+/// `FOO BAR: print "hello"` - indirect object with labeled statement.
+#[test]
+fn test_edge_case_label_indirect_object() {
+    assert_clean_parse(r#"HELLO: print "hello\n";"#);
+}
+
+// =============================================================================
+// Edge Case: Label in nested contexts
+// =============================================================================
+
+/// Edge case: Label inside a do block.
+#[test]
+fn test_edge_case_label_in_do_block() {
+    assert_clean_parse(r#"my $x = do { FOO: my $y = 1; $y }; print $x, "\n";"#);
+}
+
+/// Edge case: Label inside a bare block.
+#[test]
+fn test_edge_case_label_in_bare_block() {
+    assert_clean_parse(r#"{ FOO: my $y = 1; } print "done\n";"#);
+}
+
+/// Edge case: Multiple labels in sequence.
+#[test]
+fn test_edge_case_multiple_labels() {
+    assert_clean_parse(
+        r#"
+        OUTER: INNER: my $x = 1;
+        print $x, "\n";
+        "#,
+    );
+}
+
+// =============================================================================
+// Edge Case: Qualified identifiers (should NOT be treated as labels)
+// =============================================================================
+
+/// Edge case: Qualified identifier with double colon.
+/// `$Foo::Bar:` - double colon is DoubleColon token, not Colon,
+/// so this should NOT be treated as a label start.
+#[test]
+fn test_edge_case_qualified_identifier_not_label() {
+    // $Foo::Bar is a qualified identifier, not a label
+    // The `:` after :: is not a label colon
+    assert_clean_parse(r#"my $x = $Foo::Bar; print $x, "\n";"#);
+}
+
+// =============================================================================
+// Edge Case: Labels with all statement-modifier keywords
+// =============================================================================
+
+/// Edge case: Label followed by statement with `until` modifier.
+#[test]
+fn test_edge_case_label_until_modifier() {
+    assert_clean_parse(r#"SKIP: print "skipping\n" until $done;"#);
+}
+
+/// Edge case: Label followed by statement with `when` modifier (Perl 5.38+).
+#[test]
+fn test_edge_case_label_when_modifier() {
+    assert_clean_parse(r#"DEFAULT: print "default\n" when $is_default;"#);
+}
+
+// Note: `given` modifier test removed - `given` is a Perl 5.38+ feature not fully supported
+
+// =============================================================================
+// Edge Case: Fat arrow after identifier (NOT identifier-colon-fat-arrow)
+// Note: `KEY: => value` is NOT valid Perl - the colon is separate from fat arrow
+// The valid pattern is `KEY => value` (no colon before fat arrow)
+// =============================================================================
+
+// =============================================================================
+// Edge Case: Statement modifier AFTER label, not before
+// =============================================================================
+
+/// Edge case: Label with modifier on the following statement.
+#[test]
+fn test_edge_case_label_with_modifier() {
+    // The modifier applies to the statement after the label, not to the label itself
+    assert_clean_parse(r#"RETRY: my $x = 1 if $should_retry; print $x, "\n";"#);
+}
+
+// =============================================================================
+// Edge Case: Ternary with method call condition
+// =============================================================================
+
+/// Edge case: Ternary where condition is a method call.
+#[test]
+fn test_edge_case_ternary_method_call_condition() {
+    // $obj->method ? $then : $else
+    // The method call is not an identifier-colon, so is_label_start is not triggered
+    assert_clean_parse(r#"my $x = $obj->method ? "yes" : "no";"#);
+}
+
+/// Edge case: Ternary where condition has subscript.
+#[test]
+fn test_edge_case_ternary_subscript_condition() {
+    // $hash{key} ? $then : $else
+    // The subscript is not an identifier-colon
+    assert_clean_parse(r#"my $x = $hash{key} ? "yes" : "no";"#);
+}
+
+/// Edge case: Ternary where condition is a postfix deref.
+#[test]
+fn test_edge_case_ternary_postfix_deref_condition() {
+    // $obj->$method ? $then : $else
+    assert_clean_parse(r#"my $x = $obj->$method ? "yes" : "no";"#);
+}
+
+// =============================================================================
+// Edge Case: Very long identifier as label (boundary test)
+// =============================================================================
+
+/// Edge case: Very long identifier as label name.
+#[test]
+fn test_edge_case_long_label_identifier() {
+    let long_name = "A".repeat(1000);
+    let source = format!(r#"{}: my $x = 1; print $x, "\n";"#, long_name);
+    assert_clean_parse(&source);
+}
+
+/// Edge case: Unicode identifier as label.
+#[test]
+fn test_edge_case_unicode_label() {
+    // Unicode identifiers are valid in Perl 5.16+
+    assert_clean_parse(r#"日本語: my $x = 1; print $x, "\n";"#);
+}
+
+// =============================================================================
+// Edge Case: Mix of labels and control flow
+// =============================================================================
+
+/// Edge case: Label with next statement.
+#[test]
+fn test_edge_case_label_next() {
+    assert_clean_parse(
+        r#"
+        OUTER: for my $i (1..3) {
+            next OUTER if $i == 2;
+            print "i=$i\n";
+        }
+        "#,
+    );
+}
+
+/// Edge case: Label with last statement.
+#[test]
+fn test_edge_case_label_last() {
+    assert_clean_parse(
+        r#"
+        my $result = 0;
+        LOOP: for my $i (1..10) {
+            last LOOP if $i > 5;
+            $result += $i;
+        }
+        print "result=$result\n";
+        "#,
+    );
+}
+
+/// Edge case: Label with redo statement.
+#[test]
+fn test_edge_case_label_redo() {
+    assert_clean_parse(
+        r#"
+        COUNT: {
+            my $n = 0;
+            redo COUNT if (++$n < 3);
+            print "done\n";
+        }
+        "#,
+    );
+}
+
+// =============================================================================
+// Edge Case: Statements that could be confused with labels
+// =============================================================================
+
+/// Edge case: Bare block followed by statement starting with identifier.
+#[test]
+fn test_edge_case_bare_block_with_identifier_statement() {
+    assert_clean_parse(r#"{ 1; } FOO: 2; print "done\n";"#);
+}
+
+/// Edge case: Package declaration could look like label.
+#[test]
+fn test_edge_case_package_not_label() {
+    // package declarations use `package` keyword, not a bare identifier
+    assert_clean_parse(r#"package My::Package; print "in package\n";"#);
+}
+
+/// Edge case: Subroutine declaration could look like label.
+#[test]
+fn test_edge_case_sub_not_label() {
+    // sub declarations use `sub` keyword
+    assert_clean_parse(r#"sub foo { print "foo\n" } foo();"#);
+}

--- a/crates/perl-semantic-analyzer/tests/sub_exporter_goto_definition_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/sub_exporter_goto_definition_tests.rs
@@ -1,0 +1,254 @@
+//! Sub::Exporter goto-definition tests for perl-semantic-analyzer.
+//!
+//! Tests cover:
+//! - Simple exports: goto-definition on foo imported via `{ exports => [qw(foo)] }`
+//! - Groups/tag resolution: goto-definition on symbol imported via `:default` tag
+//! - Renaming: goto-definition on renamed symbol
+//! - -setup syntax: `use Sub::Exporter -setup => { exports => [...] }`
+
+use perl_semantic_analyzer::Parser;
+use perl_semantic_analyzer::analysis::declaration::{DeclarationProvider, ParentMap};
+use perl_tdd_support::must;
+use std::sync::Arc;
+
+// ---------------------------------------------------------------------------
+// Helper utilities
+// ---------------------------------------------------------------------------
+
+fn parse_and_provider(code: &str) -> (DeclarationProvider, Arc<perl_ast::Node>, String) {
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let ast_arc = Arc::new(ast);
+    let mut parent_map = ParentMap::default();
+    DeclarationProvider::build_parent_map(&ast_arc, &mut parent_map, None);
+    let provider =
+        DeclarationProvider::new(ast_arc.clone(), code.to_string(), "file:///test.pl".to_string())
+            .with_parent_map(&parent_map);
+    (provider, ast_arc, code.to_string())
+}
+
+fn find_declaration(code: &str, symbol: &str) -> Option<String> {
+    let (provider, _, _) = parse_and_provider(code);
+    let offset = must(code.find(symbol)) + 1; // skip sigil
+    provider
+        .find_declaration(offset, 0)
+        .map(|links| {
+            links
+                .first()
+                .map(|link| {
+                    let target =
+                        &code[link.target_selection_range.0..link.target_selection_range.1];
+                    target.to_string()
+                })
+                .unwrap_or_default()
+        })
+        .unwrap_or(None)
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Simple exports array - foo resolves to MyModule
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_simple_exports_resolves_foo() {
+    let code = "package MyModule;\nuse MyModule { exports => [qw(foo bar)] };\nfoo();";
+    let result = find_declaration(code, "foo");
+    assert!(result.is_some(), "foo should resolve to MyModule; got: {:?}", result);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Simple exports array - bar resolves to MyModule
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_simple_exports_resolves_bar() {
+    let code = "package MyModule;\nuse MyModule { exports => [qw(foo bar)] };\nbar();";
+    let result = find_declaration(code, "bar");
+    assert!(result.is_some(), "bar should resolve to MyModule; got: {:?}", result);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: -setup syntax exports
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_setup_syntax_exports() {
+    let code = "package MyModule;\nuse Sub::Exporter -setup => { exports => [qw(foo)] };\nfoo();";
+    let result = find_declaration(code, "foo");
+    assert!(result.is_some(), "foo should resolve with -setup syntax; got: {:?}", result);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Groups - :default tag resolves to symbol
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_groups_default_tag() {
+    let code = r#"package MyModule;
+use MyModule {
+    exports => [qw(foo bar baz)],
+    groups => { default => [qw(foo bar)] },
+};
+foo();"#;
+    let result = find_declaration(code, "foo");
+    assert!(result.is_some(), "foo via :default should resolve; got: {:?}", result);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Renaming with -as - goto on renamed symbol
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_renaming_as() {
+    let code = "package MyModule;\nuse Module func1 => { -as => 'my_func1' };\nmy_func1();";
+    let result = find_declaration(code, "my_func1");
+    assert!(result.is_some(), "my_func1 should resolve to original func1; got: {:?}", result);
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: MethodCall with HashLiteral
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_method_call_hash_literal() {
+    let code =
+        "package MyModule;\nuse MyModule;\nMyModule->import({ exports => [qw(foo)] });\nfoo();";
+    let result = find_declaration(code, "foo");
+    assert!(result.is_some(), "foo from MethodCall HashLiteral should resolve; got: {:?}", result);
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: No regression - standard Exporter still works
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_no_regression_standard_exporter() {
+    let code = "package My::Loader;\nour @EXPORT = qw(load_data);\nsub load_data { }\n\npackage main;\nuse My::Loader qw(load_data);\nload_data();";
+    let result = find_declaration(code, "load_data");
+    assert!(
+        result.is_some(),
+        "load_data should still resolve with standard Exporter; got: {:?}",
+        result
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: Multiple Sub::Exporter uses
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_multiple_uses() {
+    let code = "package MyModule;\nuse MyModule { exports => [qw(foo)] };\nuse MyModule { exports => [qw(bar)] };\nbar();";
+    let result = find_declaration(code, "bar");
+    assert!(
+        result.is_some(),
+        "bar from second Sub::Exporter use should resolve; got: {:?}",
+        result
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: baz symbol (not in default group but in exports)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_baz_not_in_default_group() {
+    let code = "package MyModule;\nuse MyModule {\n    exports => [qw(foo bar baz)],\n    groups => { default => [qw(foo)] },\n};\nbaz();";
+    let result = find_declaration(code, "baz");
+    assert!(
+        result.is_some(),
+        "baz should resolve even though it's not in default group; got: {:?}",
+        result
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: Multiple renaming
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_multiple_renaming() {
+    let code = "package MyModule;\nuse Module\n    func1 => { -as => 'my_func1' },\n    func2 => { -as => 'my_func2' };\nmy_func2();";
+    let result = find_declaration(code, "my_func2");
+    assert!(result.is_some(), "my_func2 should resolve to func2; got: {:?}", result);
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: Sub::Exporter used as setup in exporter module
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_setup_exports_in_module() {
+    let code = "package Exporter::Sub;\nuse Sub::Exporter -setup => {\n    exports => [qw(exported1 exported2)],\n};\nsub exported1 { }\nsub exported2 { }\n\npackage main;\nuse Exporter::Sub { exports => [qw(exported1)] };\nexported1();";
+    let result = find_declaration(code, "exported1");
+    assert!(
+        result.is_some(),
+        "exported1 should resolve in module using Sub::Exporter -setup; got: {:?}",
+        result
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 12: Empty exports (no symbols available)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_empty_exports_no_resolution() {
+    let code = "package MyModule;\nuse MyModule { exports => [] };\nfoo();";
+    let result = find_declaration(code, "foo");
+    // foo should NOT resolve since exports is empty
+    assert!(result.is_none(), "foo should NOT resolve when exports is empty; got: {:?}", result);
+}
+
+// ---------------------------------------------------------------------------
+// Test 13: Nested hash in groups (simplified)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_nested_groups_structure() {
+    let code = "package MyModule;\nuse MyModule {\n    exports => [qw(alpha beta)],\n    groups => {\n        default => [qw(alpha)],\n        all => [qw(alpha beta)],\n    },\n};\nbeta();";
+    let result = find_declaration(code, "beta");
+    assert!(
+        result.is_some(),
+        "beta should resolve from exports even with nested groups; got: {:?}",
+        result
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 14: Standard qw import still works alongside Sub::Exporter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_mixed_standard_and_sub_exporter() {
+    let code = "package My::Loader;\nour @EXPORT = qw(standard_func);\nsub standard_func { }\n\npackage main;\nuse My::Loader qw(standard_func);\nstandard_func();";
+    let result = find_declaration(code, "standard_func");
+    assert!(
+        result.is_some(),
+        "standard_func should resolve with standard Exporter; got: {:?}",
+        result
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 15: Symbol not in exports (should not resolve)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_symbol_not_in_exports() {
+    let code = "package MyModule;\nuse MyModule { exports => [qw(foo)] };\nbar();";
+    let result = find_declaration(code, "bar");
+    // bar should NOT resolve since it's not in exports
+    assert!(result.is_none(), "bar should NOT resolve when not in exports; got: {:?}", result);
+}
+
+// ---------------------------------------------------------------------------
+// Test 16: All groups resolve to all exports
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_exporter_goto_all_group_resolves() {
+    let code = "package MyModule;\nuse MyModule {\n    exports => [qw(all_sym)],\n    groups => { all => [qw(all_sym)] },\n};\nall_sym();";
+    let result = find_declaration(code, "all_sym");
+    assert!(result.is_some(), "all_sym should resolve via :all group; got: {:?}", result);
+}


### PR DESCRIPTION
Closes #4314

## Summary

This PR adds include-path scanning to the  function so that module completion works with external @INC paths (includePaths from .perl-lsp.toml, PERL5LIB, and system @INC).

## ADR
- ADR: /home/hermes/.hermes/state/conveyor/work-d59724f8/adr.md
- Status: Accepted

## Specs
- Specs: /home/hermes/.hermes/state/conveyor/work-d59724f8/specs.md

## What Changed

### Files Modified
1.  - Added  and  fields to  and created  constructor
2.  - Added , , and  functions
3.  - 11 tests covering include-path module completion

### Architecture
- Include paths are passed from  (runtime) to  crate via the new constructor
- Bounded caching: one cache entry per include path directory, invalidated on config change
- Sort tiering: external modules use tier "2_" (after workspace tier "1_")

## Test Results (so far)
- Tests compile successfully
- Tests fail at runtime (11 failures) - RED test state per design
- Failures indicate the implementation needs bug fixes in  / 

## Friction Encountered
- The  HashSet in  is used for two different purposes (internal deduplication and completion-list deduplication) causing incorrect behavior
- Tests fail with empty completion lists even though modules exist in include paths

## Notes
- Draft PR — not ready for review until GREEN tests confirmed
- Branch pushed to origin: 