### PR TITLE
fix(hooks): block refspec force-push forms (#4481)

### DIFF
--- a/.claude/hooks/pre-tool-use.sh
+++ b/.claude/hooks/pre-tool-use.sh
@@ -11,6 +11,15 @@ if echo "$CMD" | grep -qE 'git push --force|git push -f |git checkout \.|git res
   exit 2
 fi
 
+# Block refspec force-push forms: `git push <remote> +branch`, `git push origin +refs/heads/main`,
+# `git push <remote> +HEAD:branch`. The `+` prefix on a refspec bypasses non-fast-forward checks
+# the same way --force does.
+if echo "$CMD" | grep -qE 'git +push( +[^ ]+)*[[:space:]]\+[^[:space:]]'; then
+  echo "Blocked: refspec '+<ref>' in git push forces non-fast-forward the same as --force." >&2
+  echo "Remove the leading '+' or use a safer alternative." >&2
+  exit 2
+fi
+
 # Block git stash commands -- stash is shared across all worktrees and causes cross-contamination.
 # Use git restore <file> to discard changes, or git commit -m wip to save work in progress.
 if echo "$CMD" | grep -qE 'git stash( |$)'; then


### PR DESCRIPTION
Closes #4481.

## Summary

- Adds a regex in `.claude/hooks/pre-tool-use.sh` that blocks the refspec-force form (`+<ref>`) of push, which bypassed the existing `--force`/`-f` flag check.
- Follow-up hardening to #4469 (worktree guard).

## Tests

Manually verified:

- Refspec-force → blocked (rc=2)
- Normal push → allowed
- Bare push → allowed
- Commit → allowed

## Test plan

- [x] CI smoke + CI Gate on the branch
- [ ] Reviewer confirms the regex covers the three forms in #4481
