### PR TITLE
fix(hooks): allow --force-with-lease in pre-tool-use (#4487)

### DIFF
--- a/.claude/hooks/pre-tool-use.sh
+++ b/.claude/hooks/pre-tool-use.sh
@@ -6,7 +6,7 @@
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-if echo "$CMD" | grep -qE 'git push --force|git push -f |git checkout \.|git reset --hard|rm -rf /|cargo publish|git clean -fd'; then
+if echo "$CMD" | grep -qE 'git push --force($|[[:space:]])|git push -f |git checkout \.|git reset --hard|rm -rf /|cargo publish|git clean -fd'; then
   echo "Blocked: dangerous command '$CMD'. Use safer alternatives." >&2
   exit 2
 fi


### PR DESCRIPTION
Closes #4487.

## Summary

The hook regex `git push --force` matched `--force-with-lease` by substring, blocking the **safe** force-push path that agents rely on for rebases. Fixed by anchoring `--force` to end-of-string or whitespace so the longer-flag variant is allowed through.

```diff
-'git push --force|git push -f |...'
+'git push --force($|[[:space:]])|git push -f |...'
```

## Impact

Unblocks the normal rebase workflow for any agent doing a force-with-lease push. Was the reason green-refactor had to fall back to GitHub API in PR #4486.

## Test plan

- [x] force-with-lease: rc=0 (allowed)
- [x] --force (with args): rc=2 (blocked)
- [x] --force (end-of-string): rc=2 (blocked)
- [x] -f (with args): rc=2 (blocked)
- [x] +refspec: rc=2 (blocked, existing rule)
- [x] normal push: rc=0 (allowed)
- [x] bare push: rc=0 (allowed)
- [x] commit: rc=0 (allowed)
