### PR TITLE
docs(collapse): Amendment 6 — perl-lsp-rs-core facade/core split (#4491)

### DIFF
--- a/.spec/microcrate-collapse/ledger.md
+++ b/.spec/microcrate-collapse/ledger.md
@@ -35,7 +35,8 @@ Status legend:
 | current crate | target owner | final status | wave | risk | notes |
 |---|---|---|---:|---:|---|
 | perllsp | perllsp | core-public | — | — | installer façade + binary |
-| perl-lsp-rs | perl-lsp-rs | core-public | — | — | LSP server library + bin (dir: crates/perl-lsp) |
+| perl-lsp-rs | perl-lsp-rs | core-public | — | — | thin UX facade + bin (dir: crates/perl-lsp); re-exports from perl-lsp-rs-core per Amendment 6 |
+| perl-lsp-rs-core | perl-lsp-rs-core (NEW) | core-public | F | — | implementation sibling — absorbs Wave F/G1/G2/G3 crates; see Amendment 6 |
 | perl-dap | perl-dap | core-public | H | — | DAP server; absorbs 11 perl-dap-* |
 | perl-parser | perl-parser | core-public | 3-4 | — | parser facade; absorbs syntax + parser-adjacent |
 | perl-lexer | perl-lexer | core-public | 3 | — | tokenizer; absorbs satellites |
@@ -171,20 +172,32 @@ full semantic analyzer just to get them. `perl-symbol` stays as a separate publi
 | perl-lsp-diagnostic-catalog | perl-diagnostic-catalog | module | E | Low | retired name; content absorbs |
 | perl-lsp-diagnostic-types | perl-diagnostic-catalog | module | E | Low | |
 
-## Wave F — perl-lsp-feature-* → perl-lsp-rs::features
+## Wave F — perl-lsp-feature-* → perl-lsp-rs-core::features
+
+Wave F creates the `perl-lsp-rs-core` implementation crate and moves the 8 feature/capability
+crates into it as modules. `perl-lsp-rs` becomes a thin UX facade that re-exports from
+`perl-lsp-rs-core` (same pattern Wave D established for `perl-parser` / `perl-parser-core`).
+See Amendment 6.
+
+`perl-lsp-feature-profile-cli` had NO `[[bin]]` target on master at Wave F scope time (per
+accuracy-scout on #4489) — drop the "preserve [[bin]]" note; it becomes a plain module.
 
 | current crate | target owner | final status | wave | risk | notes |
 |---|---|---|---:|---:|---|
-| perl-lsp-feature-ids | perl-lsp-rs | module | F | Low | |
-| perl-lsp-feature-contracts | perl-lsp-rs | module | F | Low | |
-| perl-lsp-feature-flags | perl-lsp-rs | module | F | Low | |
-| perl-lsp-feature-profile | perl-lsp-rs | module | F | Low | |
-| perl-lsp-feature-profile-cli | perl-lsp-rs | module | F | Low | preserve [[bin]] as subcommand |
-| perl-lsp-feature-policy | perl-lsp-rs | module | F | Low | |
-| perl-lsp-feature-grid | perl-lsp-rs | module | F | Low | |
-| perl-lsp-capability-map | perl-lsp-rs | module | F | Low | |
+| perl-lsp-feature-ids | perl-lsp-rs-core | module | F | Low | |
+| perl-lsp-feature-contracts | perl-lsp-rs-core | module | F | Low | |
+| perl-lsp-feature-flags | perl-lsp-rs-core | module | F | Low | |
+| perl-lsp-feature-profile | perl-lsp-rs-core | module | F | Low | |
+| perl-lsp-feature-profile-cli | perl-lsp-rs-core | module | F | Low | library-only on master |
+| perl-lsp-feature-policy | perl-lsp-rs-core | module | F | Low | |
+| perl-lsp-feature-grid | perl-lsp-rs-core | module | F | Low | |
+| perl-lsp-capability-map | perl-lsp-rs-core | module | F | Low | |
 
-## Wave G1 — LSP providers → perl-lsp-rs::providers
+## Wave G1 — LSP providers → perl-lsp-rs-core::providers
+
+Per Amendment 6, the target for all Wave G1/G2/G3 rows is `perl-lsp-rs-core` (the implementation
+sibling), not `perl-lsp-rs` (the thin facade). The `perl-lsp-rs` column below reflects the
+pre-Amendment-6 spec — read it as `perl-lsp-rs-core` for the actual absorption target.
 
 | current crate | target owner | final status | wave | risk | notes |
 |---|---|---|---:|---:|---|

--- a/docs/adr/0041-microcrate-collapse.md
+++ b/docs/adr/0041-microcrate-collapse.md
@@ -383,6 +383,40 @@ reasoning that kept `perl-symbol` (Amendment 3), `perl-token` (Amendment 4), and
 
 The 30-crate published target and all other ADR content remain unchanged.
 
+### Amendment 6 — 2026-04-18: `perl-lsp-rs-core` facade/core split for LSP waves
+
+**Source:** Architectural decision made during Wave F scoping (#4489, #4491). Oppositional-planner and advocatus-diaboli both flagged the absence of an implementation sibling as the structural question blocking Wave F and Wave G1/G2/G3.
+
+**The decision:** Apply the same thin UX facade / implementation core pattern established by Wave D (`perl-parser` / `perl-parser-core`) to the LSP lane:
+
+- **`perl-lsp-rs`** — thin user-facing facade (re-exports, ergonomic wrappers, binary entry point in `crates/perl-lsp/src/main.rs`).
+- **`perl-lsp-rs-core`** — implementation home for Wave F/G1/G2/G3 absorptions (features, providers, runtime, governance).
+
+Dependency direction: `perl-lsp-rs → perl-lsp-rs-core` (one-way; no cycle).
+
+**Why this is the right model:**
+
+- **House pattern.** `perl-parser` / `perl-parser-core` (Wave D, #4486), `tree-sitter-perl-rs` (facade over native stack), and now `perl-lsp-rs` / `perl-lsp-rs-core` all follow the same split. Consistent across the codebase.
+- **Preserves compilation unit boundary** during the ~50-crate LSP-side absorption. Modifying feature-level code should not force rebuild of the binary entry point.
+- **Facade stays thin.** `perl-lsp-rs` remains legible as "the LSP server's public API" rather than bloating into a mega-crate with 50+ internal modules.
+- **Unblocks subsequent waves.** Wave F/G1/G2/G3 all land into the same `perl-lsp-rs-core` crate; no mid-program architectural pivots.
+
+**Published target update: 30 → 31.**
+
+`perl-lsp-rs-core` joins the Products (core-public) section alongside `perl-lsp-rs`. This mirrors `perl-parser` / `perl-parser-core`, which already occupy two slots in the published surface. The 30-crate target in the original Decision section becomes **31**.
+
+**Wave execution plan under this amendment:**
+
+| Wave | Scope | Absorption target |
+|---|---|---|
+| F | 8 `perl-lsp-feature-*` + `perl-lsp-capability-map` | `perl-lsp-rs-core::features` + `::capability_map` — creates the crate |
+| G1 | ~25 providers | `perl-lsp-rs-core::providers` |
+| G2 | ~7 runtime crates | `perl-lsp-rs-core::runtime` |
+| G3 | ~6 governance crates | `perl-lsp-rs-core::governance` |
+| Final | `perl-lsp-rs` trims to facade shape | re-exports + binary only |
+
+**Same pattern as:** Amendments 2 (`perl-workspace` naming), 3 (`perl-symbol` kept public), 4 (`perl-token` kept public), 5 (`perl-line-index` / `perl-uri` / `perl-pod` kept public) — each amendment refined the migration based on architectural reality discovered during planning. This amendment applies the already-proven Wave D pattern to the remaining LSP-side waves.
+
 ## References
 
 - [Tracking issue #4410: Microcrate collapse to ~30 published crates](https://github.com/EffortlessMetrics/perl-lsp/issues/4410)


### PR DESCRIPTION
Closes #4491.

## Summary

Amendment 6 locks in the structural decision flagged during Wave F scoping: **`perl-lsp-rs` becomes a thin UX facade and `perl-lsp-rs-core` (new) is the implementation sibling**. Mirrors the Wave D pattern (`perl-parser` / `perl-parser-core`) and the already-established `tree-sitter-perl-rs` facade shape.

Dependency direction: `perl-lsp-rs → perl-lsp-rs-core` (one-way).

## Why now

Oppositional-planner (#4489) and advocatus-diaboli both flagged this as THE structural question blocking Wave F and Wave G1/G2/G3. Diaboli DEFER'd Wave F explicitly pending this decision. User confirmed the thin-UX-facade pattern is the house MO.

## Published target

**30 → 31.** `perl-lsp-rs-core` joins the Products section alongside `perl-lsp-rs` (same way `perl-parser-core` sits alongside `perl-parser`).

## Applies to

| Wave | Scope | Target under this amendment |
|---|---|---|
| F (#4489) | 8 `perl-lsp-feature-*` + `perl-lsp-capability-map` | `perl-lsp-rs-core::features` + `::capability_map` — creates the crate |
| G1 | ~25 providers | `perl-lsp-rs-core::providers` |
| G2 | ~7 runtime | `perl-lsp-rs-core::runtime` |
| G3 | ~6 governance | `perl-lsp-rs-core::governance` |

## Files changed

- `.spec/microcrate-collapse/ledger.md` — new `perl-lsp-rs-core` row, Wave F target updated, Wave G1 prose note
- `docs/adr/0041-microcrate-collapse.md` — Amendment 6 appended

## Same pattern as

#4427 (Amendment 2 — Wave A), #4431 (Amendment 3 — Wave B), #4446 (Amendment 4 — Wave C), #4468 (Amendment 5 — Wave D).

## Test plan

- [x] Lint: `cargo xtask fmt` (no rust changes)
- [x] PR Smoke / validate-title on CI
- [ ] Reviewer confirms ledger + ADR match intent
