### PR TITLE
WIP: chore(nix): add perl and curl to devShell buildInputs for CPAN corpus (#4359)

### DIFF
--- a/.hermes/conveyor/work-aa31d3df/adr-spec-agent-findings.md
+++ b/.hermes/conveyor/work-aa31d3df/adr-spec-agent-findings.md
@@ -1,0 +1,48 @@
+# ADR/Spec Findings — work-aa31d3df
+
+## What This ADR Decides
+
+This ADR documents the architectural and operational decisions arising from the 2026-04-11 end-of-session security sweep (issue #4141). It resolves which findings require immediate action, which belong in the backlog, and which must be struck as factually incorrect.
+
+## Key Decisions
+
+1. **Accept `RUSTSEC-2026-0097` risk** — Add a time-scoped ignore entry in `deny.toml` with a revisit trigger, rather than waiting for a `rand` patch. The risk is theoretical (perl-lsp does not install custom loggers) and the CI gate is currently broken.
+
+2. **Strike SBOM task entirely** — The `sbom-cyclonedx.json` and `sbom-spdx.json` files do not exist in the repository; they are generated on-demand during release. Finding 8 / the "13-day drift" claim was materially incorrect.
+
+3. **Backlog: `run_test_sub` identifier hardening** — Add regex validation for `sub_name` to enforce that it is a valid Perl identifier shape. Existing threat model (run_tests executes arbitrary code) limits urgency.
+
+4. **Backlog: `validate_expression` rename** — Rename to `reject_multiline_expression` with a doc comment clarifying its narrow scope. The DAP debugger context means the blast radius is already bounded.
+
+5. **Investigation: cargo machete** — Do not commit a fix until `cargo machete` is run against the full workspace in CI and the false positive is confirmed.
+
+## Alternatives Considered
+
+**Alternative 1 — Patch `rand` immediately:** Bump `rand` to a patched version once available. Rejected because no patched version exists yet, and the advisory is not exploitable in perl-lsp's usage.
+
+**Alternative 2 — Remove SBOM task from backlog without investigation:** Simply drop the task. Rejected because the research/verification disagreement needed explicit resolution to prevent the task from resurfacing.
+
+**Alternative 3 — Broaden `validate_expression` to deny-list dangerous constructs:** Attempt to reject backticks, `system`, `eval`, etc. via regex. Rejected because Perl is not reliably parseable by regex and this risks false positives on valid expressions.
+
+**Alternative 4 — Skip `deny.toml` ignore, accept CI failures:** Allow `cargo deny check` to fail. Rejected because it breaks the merge gate for all PRs touching `Cargo.lock`.
+
+## Consequences
+
+**Benefits:**
+- CI gate for `cargo deny check` is restored without masking a genuine vulnerability
+- Backlog items are clearly scoped and prioritized
+- Invalid SBOM finding is permanently resolved
+
+**Tradeoffs:**
+- `RUSTSEC-2026-0097` ignore must be revisited when `rand` is patched
+- `run_test_sub` identifier validation is a partial hardening (regex cannot fully parse Perl)
+- `cargo machete` investigation is deferred
+
+## Acceptance Criteria
+
+See `specs.md` for the full specification. Key criteria:
+- `cargo deny check advisories` passes after the `deny.toml` change
+- `run_test_sub` rejects non-identifier `sub_name` with a clear error
+- `validate_expression` is renamed to `reject_multiline_expression` with doc comment
+- SBOM regeneration task is removed from all tracking artifacts
+- Cargo machete task is flagged as `needs-verification` pending CI confirmation

--- a/.hermes/conveyor/work-aa31d3df/adversarial-design-agent-findings.md
+++ b/.hermes/conveyor/work-aa31d3df/adversarial-design-agent-findings.md
@@ -1,0 +1,108 @@
+# Adversarial Design Findings — work-aa31d3df
+
+## Current Approach
+
+The plan addresses a read-only end-of-session security sweep (issue #4141) that produced five findings (3 medium, 2 low) across eight security checks. Sprint-scale work is limited to adding a `RUSTSEC-2026-0097` ignore entry in `deny.toml`. Two backlog items are proposed: (1) regex-based identifier validation for `run_test_sub`'s `sub_name` parameter, and (2) renaming `validate_expression` to `reject_multiline_expression` with a doc comment. The SBOM regeneration task (Finding 8) was struck because the SBOM files don't exist in the repository. The `cargo machete` false positive is deferred pending CI confirmation.
+
+---
+
+## Alternative Approaches
+
+### Alternative 1: Treat `run_test_sub` as a "sandboxed namespace" problem, not an identifier-validation problem
+
+**Core idea:** The proposed regex validation (`^[A-Za-z_][A-Za-z0-9_]*(::[A-Za-z_][A-Za-z0-9_]*)*$`) is the wrong fix because `no strict 'refs'` + `&$sub()` after `do $file` can call ANY symbol table entry accessible after the file is loaded — including `CORE::system`, `CORE::open`, or subs defined in the loaded file — regardless of identifier shape. The real issue is that `do $file` loads the file into the current package namespace, making all its subs globally accessible. Instead of validating the identifier, wrap the execution in a safe Perl dispatcher or use a private package scope to isolate the loaded file.
+
+**Why it might be better:**
+- Addresses the actual attack surface rather than a narrow slice of it
+- Would actually restrict `run_test_sub` to the intended contract (calling only the named sub)
+- Doesn't add friction for valid use cases while genuinely hardening the security boundary
+- A scoped namespace approach (e.g., loading the file into a temp package via `eval` in a dedicated package) is idiomatic Perl and doesn't require enumerating dangerous identifiers
+
+**Why it might be worse:**
+- Requires changing the Perl execution model, which is more complex than adding a regex check
+- Could break edge cases if test files rely on specific package-level interactions
+- Sprints to completion later than a simple regex
+
+**What it sacrifices:**
+- The simple, incremental nature of the proposed regex fix
+- The ability to call `Package::Sub` style subs (which would be blocked by the namespace isolation approach unless explicitly allowed)
+
+---
+
+### Alternative 2: Explicit threat-model-first triage instead of sweep-based backlog
+
+**Core idea:** Instead of treating all five findings as equally valid inputs to a sprint/backlog split, establish an explicit threat model — specifically: "is the LSP client trusted or untrusted?" — and use it to immediately deprioritize findings that only matter if the client is untrusted. If the client is trusted (which is the de facto assumption in most LSP implementations), then `run_test_sub` identifier validation and `validate_expression` hardening are defense-in-depth against a compromised-client scenario that may be out of scope for this project's threat model.
+
+**Why it might be better:**
+- Prevents spending security engineering budget on threats that the project doesn't actually defend against
+- The `run_test_sub` finding disappears as a security issue if the client is trusted — it becomes a robustness improvement, not a security fix
+- Forces the team to make an explicit decision about threat model, which is currently absent from the ADR
+- Simpler triage: if SBOMs don't exist in the repo and aren't tracked, Finding 8 is N/A, not a sprint item
+
+**Why it might be worse:**
+- If the threat model IS "untrusted client" (e.g., LSP server exposed to third-party clients), this deprioritization is dangerous
+- Removes the "just in case" defense-in-depth that some organizations prefer
+- Requires an uncomfortable explicit decision that may reveal disagreements within the team
+
+**What it sacrifices:**
+- The comprehensive coverage of a sweep (every finding gets a backlog slot)
+- Defense-in-depth for findings that don't meet the bar for immediate action
+
+---
+
+### Alternative 3: Investigate the SBOM claim before striking Finding 8
+
+**Core idea:** Before striking Finding 8 as "factually incorrect," establish what the perl-lsp release process actually does with SBOMs. If SBOMs are generated on-demand during release and shipped as release artifacts (GitHub release assets, container image layers, etc.), then "the files don't exist in the repo" is true but the concern is still valid — there is still no CI gate to ensure SBOM freshness at release time. The fix is not "regenerate SBOMs" (since they're generated ad-hoc) but "add a CI check that runs `cargo sbom` and fails if the generated output would differ from what's in the last release."
+
+**Why it might be better:**
+- Preserves a legitimate supply-chain hygiene concern that was dismissed
+- Would catch dependency changes that aren't reflected in any shipped artifact
+- The CI gate (mentioned in the research analysis but then struck) might be the right answer, just not wired to the right trigger
+
+**Why it might be worse:**
+- If the release process truly doesn't use SBOMs at all, this is wasted effort
+- SBOM generation can be slow and adds CI time
+
+**What it sacrifices:**
+- The clean "this is struck, don't revisit" decision
+
+---
+
+## Strongest Argument Against Current Approach
+
+The proposed `run_test_sub` identifier validation is security theater that addresses the wrong layer of the attack. The research analysis explicitly states that `sub_name` is passed via `@ARGV` (not string interpolation), and the existing security test (`test_run_test_sub_subname_injection`) already proves that string-interpolation injection doesn't work — the literal string is looked up as a sub name and fails. The ADR's proposed fix (regex validation) addresses an injection vector that doesn't exist.
+
+What DOES exist — and is acknowledged in the research analysis — is that `do $file` followed by `no strict 'refs'; &$sub()` allows calling any sub from the loaded file's namespace, including `CORE::system`. The ADR calls this "safe enough given the threat model" and puts it in the backlog, but offers no evidence for the threat model claim. If the LSP client is untrusted, `CORE::system` is callable with a valid Perl identifier like `CORE::system`. The regex doesn't stop it. The spec itself says "This does not eliminate the `no strict 'refs'` + `&$sub()` pattern" — so the fundamental unsafe pattern is acknowledged but deferred.
+
+The ADR's own reasoning for calling this "safe enough" is that "run_tests already runs arbitrary code." But `run_tests` runs all top-level code in a file (which includes `BEGIN` blocks, `use` statements, etc.). `run_test_sub` is positioned as a more surgical alternative — it should only run one sub. If it can be made to call `CORE::system` via a valid identifier, it fails at its own security contract. Putting regex validation in the backlog without also noting that the underlying unsafe pattern is the real issue creates a false sense of progress.
+
+---
+
+## Recommended Action
+
+**Modify** — two specific changes:
+
+1. **Augment the `run_test_sub` backlog item with a note about the architectural concern.** The backlog item should explicitly state that regex validation is a partial mitigation (blocks obvious non-identifier injection attempts) but does not address the `no strict 'refs'` + `&$sub()` pattern. A separate, harder look at namespace isolation for `run_test_sub` should be scheduled. This prevents future maintainers from believing the regex check is a complete fix.
+
+2. **Add an explicit threat model section to the ADR.** Before the backlog sprint items are refined, the ADR should state whether the LSP client is trusted or untrusted. This is the single most important input to evaluating whether `run_test_sub` identifier validation and `validate_expression` hardening belong in sprint (if untrusted client) or are best-effort defense-in-depth (if trusted client). Without this, the backlog is built on an unstated assumption that future maintainers will fill in differently.
+
+**Keep as-is:** The `deny.toml` `RUSTSEC-2026-0097` fix. This is a well-scoped, low-risk change that fixes a broken CI gate. No changes needed.
+
+**Strike cleanly:** The Finding 8 / SBOM task. The files don't exist in the repo and the "13-day drift" finding was based on a false premise. The alternative approach (investigation-first) is not worth the additional work given that the release process details are already known.
+
+---
+
+## Long-Term Cost Assessment
+
+**If the regex `run_test_sub` validation lands without architectural follow-up:**
+
+- **6 months:** A future maintainer sees the regex check and believes `run_test_sub` is now secure against injection. They extend the function or add new commands using the same pattern. The architectural debt compounds.
+- **2 years:** The regex is maintained, extended, and documented as a security control. Nobody revisits the `no strict 'refs'` pattern because it's "already handled." If the threat model ever shifts (e.g., the LSP server is exposed to untrusted clients in a new deployment), the gap is invisible and the regex check creates false confidence.
+
+**If the SBOM Finding 8 was struck prematurely and SBOMs are actually part of the release:**
+- **6 months:** A release is made without verifying SBOM freshness. Downstream consumers receive SBOMs that don't reflect actual dependencies. Compliance audit fails. Retroactive investigation required.
+- **2 years:** The release process is known to be "cargo sbom on demand" but nobody owns the freshness check. Each release requires manual SBOM verification or downstream complaints surface.
+
+**If the threat model is never clarified:**
+- **6 months:** Backlog refinement for `run_test_sub` proceeds under an implicit "untrusted client" assumption in some tickets and "trusted client" assumption in others. Security findings are inconsistently prioritized.
+- **2 years:** The codebase accumulates defense-in-depth measures that protect against threats outside the actual threat model, while genuine threats from the actual threat model go unaddressed because they weren't "findings" in any sweep.

--- a/.hermes/conveyor/work-aa31d3df/specs.md
+++ b/.hermes/conveyor/work-aa31d3df/specs.md
@@ -1,0 +1,96 @@
+# Specifications — work-aa31d3df
+
+## Feature/Behavior Description
+
+Security hardening and documentation updates arising from the 2026-04-11 end-of-session sweep (issue #4141). This is a change-conveyor work item that records decisions, fixes a broken CI gate, and creates a prioritized backlog for follow-up work.
+
+## Sprint-Scale Changes
+
+### 1. `deny.toml` — Add ignore entry for `RUSTSEC-2026-0097`
+
+**File:** `deny.toml`
+
+**Change:** Add to `[advisories].ignore` array:
+```toml
+{ id = "RUSTSEC-2026-0097", reason = "Rand unsoundness only triggered by custom loggers calling rand::rng(); perl-lsp does not install custom loggers. Revisit when rand is patched or usage pattern changes." }
+```
+
+**Acceptance criteria:**
+- [ ] `cargo deny check advisories` exits with code 0 in CI
+- [ ] The ignore entry includes a `reason` field explaining the exposure gap
+- [ ] A `# TODO` or comment in `deny.toml` references the revisit trigger (rand patch)
+
+---
+
+## Backlog Items (Not Implemented in This Work Item)
+
+### 2. `run_test_sub` Identifier Validation
+
+**File:** `crates/perl-lsp/src/execute_command/provider.rs`
+
+**Description:** Add a regex validation for `sub_name` to enforce Perl identifier shape: `^[A-Za-z_][A-Za-z0-9_]*(::[A-Za-z_][A-Za-z0-9_]*)*$`. Reject non-matching values with a clear error returned to the LSP client.
+
+**Acceptance criteria:**
+- [ ] Valid Perl identifiers (e.g. `foo`, `My::Module::func`) are accepted without behavioral change
+- [ ] Invalid inputs (e.g. `main::foo; die`, `` `id` ``, shell metacharacters) are rejected with an error message
+- [ ] New unit tests cover at least: valid identifiers, injection attempts, empty string
+
+**Non-goals:** This does not eliminate the `no strict 'refs'` + `&$sub()` pattern; it only enforces the identifier contract.
+
+---
+
+### 3. `validate_expression` Rename
+
+**File:** `crates/perl-dap/src/security/mod.rs`
+
+**Description:** Rename `validate_expression` → `reject_multiline_expression`. Update all call sites. Add a doc comment: "Only rejects newlines (`\n`) and carriage returns (`\r`); does not sanitize Perl side-effect constructs."
+
+**Acceptance criteria:**
+- [ ] `cargo build -p perl-dap && cargo test -p perl-dap` passes
+- [ ] All call sites are updated to the new name
+- [ ] A doc comment clarifies the function's narrow scope
+- [ ] No broadening of the rejection set (no attempt to block backticks/system/eval)
+
+**Non-goals:** No attempt to comprehensively sanitize Perl expressions. DAP debugger context already limits blast radius.
+
+---
+
+## Struck Items
+
+### Finding 8 / SBOM Regeneration — REMOVED
+
+**Finding 8 in the research report is factually incorrect.** The files `sbom-cyclonedx.json` and `sbom-spdx.json` **do not exist** in the repository. They are generated on-demand via `cargo sbom` during the release process. There is no "13-day drift." This task must not appear in any backlog, tracker, or subsequent report.
+
+---
+
+## Deferred Items (Needs Verification)
+
+### Cargo Machete False Positive — `perllsp`
+
+**File:** `crates/perllsp/Cargo.toml`
+
+**Description:** The research report claimed `cargo machete` produces a false positive for `perl-lsp-rs` in the `perllsp` crate. The verification agent could not confirm this. The fix (`[package.metadata.cargo-machete] ignored = ["perl-lsp-rs"]`) should **not** be applied until:
+
+1. `cargo machete` is run against the full workspace in CI
+2. The false positive is confirmed with actual output
+3. The root cause is understood (the `lib.rs` re-export may already be correct)
+
+**Acceptance criteria (when verified):**
+- [ ] `cargo machete` output shows the false positive for `perl-lsp-rs` in `perllsp`
+- [ ] `[package.metadata.cargo-machete] ignored = ["perl-lsp-rs"]` is added to `crates/perllsp/Cargo.toml`
+- [ ] CI confirms the false positive is silenced
+
+---
+
+## Dependencies
+
+- `cargo deny` (via `nix develop -c just ci-gate` or `.github/workflows/ci-security.yml`)
+- `cargo machete` — only if confirmed in CI
+
+## Out of Scope
+
+- Changes to `unsafe` block usage (already documented as properly annotated)
+- Changes to banned construct enforcement (`perl-ci-hygiene` crate)
+- The Windows extended-length path fix (#4089) — already reviewed and passing
+- Runtime credential handling (already using env vars, no hardcoding)
+- Any changes to the core parser, semantic analyzer, or LSP protocol implementation

--- a/.hermes/conveyor/work-aa31d3df/verification-agent-findings.md
+++ b/.hermes/conveyor/work-aa31d3df/verification-agent-findings.md
@@ -1,0 +1,161 @@
+# Verification Findings — work-aa31d3df
+
+## Confidence Assessment
+
+**Medium** — The verification was constrained by missing tools (`cargo deny`, `cargo machete`) and incomplete git history for SBOM files. Many claims could not be independently verified, though the confirmed correct findings carry high confidence.
+
+## Confirmed Findings
+
+### Finding 5a — `run_test_sub` lacks `sub_name` identifier validation
+**Status: CONFIRMED**
+
+The `run_test_sub` function at `crates/perl-lsp/src/execute_command/provider.rs:236-260` accepts a `sub_name` parameter and passes it directly to a Perl one-liner:
+
+```rust
+pub(crate) fn run_test_sub(&self, file_path: &Path, sub_name: &str) -> Result<Value, String> {
+    let perl_code = r#"
+        my ($file, $sub) = @ARGV;
+        do $file;
+        if (defined &$sub) {
+            no strict 'refs';
+            &$sub();
+        } else {
+            die "Subroutine $sub not found";
+        }
+    "#;
+    let mut perl_cmd = Command::new("perl");
+    perl_cmd.arg("-e").arg(perl_code).arg("--").arg(ext_path.as_os_str()).arg(sub_name);
+    ...
+}
+```
+
+The `sub_name` is passed as a raw argument with no validation. The `file_path` IS validated via `resolve_path_from_args`, but `sub_name` is not validated for Perl identifier shape. The use of `no strict 'refs'` and `&$sub()` means any valid Perl symbol table entry can be called after `do $file` loads.
+
+### Finding 5b — `validate_expression` name overstates coverage
+**Status: CONFIRMED**
+
+`crates/perl-dap/src/security/mod.rs:73-79`:
+
+```rust
+pub fn validate_expression(expression: &str) -> Result<(), SecurityError> {
+    if expression.contains('\n') || expression.contains('\r') {
+        return Err(SecurityError::InvalidExpression);
+    }
+    Ok(())
+}
+```
+
+This only rejects newlines/carriage returns. It does not reject backticks (`` ` ``), `system(...)`, `open(..., "|...")`, `qx{...}`, `eval "..."`, etc. The function name `validate_expression` overstates its actual coverage.
+
+### Windows extended-length path fix (#4089)
+**Status: CONFIRMED**
+
+Git history shows commit `ef92dd20` with message:
+> "fix(execute-command): strip Windows extended-length prefix before external command (#4085) (#4089)"
+
+The `normalize_path_for_external_command` function at `provider.rs:28-57` is correctly implemented with proper handling for UNC paths on Windows.
+
+### `perl-ci-hygiene` crate
+**Status: CONFIRMED**
+
+The crate exists at `crates/perl-ci-hygiene/` in the workspace.
+
+### `deny.toml` structure
+**Status: PARTIALLY CONFIRMED**
+
+`deny.toml` at lines 20-29 shows the `[advisories].ignore` section with only `RUSTSEC-2023-0089` (atomic-polyfill) ignored. `RUSTSEC-2026-0097` is NOT present. However, I could not run `cargo deny check advisories` to verify the actual advisory check behavior since `cargo deny` is not installed.
+
+## Corrected Findings
+
+### Finding 8 — SBOMs out of sync (MATERIALLY INCORRECT)
+
+**The research agent's Finding 8 is based on a false premise.**
+
+The research agent stated:
+> "Files: `sbom-cyclonedx.json`, `sbom-spdx.json` (last updated 2026-03-29) vs `Cargo.lock` (2026-04-04)"
+
+**Reality: These files do NOT exist in the repository.**
+
+Verification:
+```bash
+$ git ls-files | grep -i sbom
+# (no output - no SBOM files tracked)
+
+$ ls /home/hermes/repos/perl-lsp/sbom-*
+# No SBOM files found at repo root
+```
+
+The SBOM files are generated **on-demand** during the release process via `justfile`:
+```
+# justfile lines 249-269
+sbom-spdx:
+    cargo sbom --output-format spdx_json_2_3 > sbom-spdx.json
+
+sbom-cyclonedx:
+    cargo sbom --output-format cyclone_dx_json_1_6 > sbom-cyclonedx.json
+
+sbom: sbom-spdx sbom-cyclonedx
+```
+
+The `release-gate` target (line 2236) includes `sbom-verify` which checks that the files exist after generation. There is **no SBOM drift issue** because the files are generated from `Cargo.lock` at release time, not stored and tracked separately.
+
+**This finding should be removed from the backlog.** The SBOMs are already fresh by design — they are generated from the current `Cargo.lock` during the release process.
+
+### Finding 4 — `cargo machete` false positive (UNVERIFIED/INCORRECTLY CHARACTERIZED)
+
+The research agent stated:
+> "`perllsp` is a public Cargo facade that re-exports `perl-lsp-rs` from its binary target (`src/main.rs`). `cargo machete` only inspects `src/lib.rs`, so it reports `perl-lsp-rs` as unused."
+
+**This claim is likely incorrect.** Looking at the actual code:
+
+- `crates/perllsp/Cargo.toml` declares `perl-lsp-rs = { workspace = true }`
+- `crates/perllsp/src/lib.rs` has `pub use perl_lsp::*;`
+- `crates/perl-lsp/Cargo.toml` defines `[lib] name = "perl_lsp"` (the library name differs from the package name `perl-lsp-rs`)
+
+The `perl-lsp-rs` package's library is named `perl_lsp` (defined in `[lib]` section), so `pub use perl_lsp::*` IS a use of the `perl-lsp-rs` dependency. `cargo machete` should understand this because it analyzes the dependency graph, not just textual patterns. However, I cannot verify because `cargo machete` is not installed.
+
+**The proposed fix** (`[package.metadata.cargo-machete] ignored = ["perl-lsp-rs"]`) may not be needed at all, or may be needed for a different reason than stated.
+
+## New Findings
+
+### SBOM "freshness gate" claim is inapplicable
+
+The research agent recommended:
+> "Add a CI job (or extend existing release job) that compares timestamps of SBOMs vs `Cargo.lock` and fails if SBOM is older."
+
+Since SBOM files are not stored in the repo and are regenerated from `Cargo.lock` at release time, this "freshness gate" is **not applicable**. The SBOM is always freshly generated from the current `Cargo.lock` during the release. There is nothing to compare timestamps against in the repo.
+
+### `perl.runTestSub` vs `perl.runSubtest` command names
+
+The `execute_command` function at lines 99-106 and 115-122 shows two commands that call `run_test_sub`:
+- `"perl.runTestSub"` at line 99
+- `"perl.runSubtest"` at line 115
+
+Both route to the same `run_test_sub` function. This duplication may be intentional (aliasing) or an oversight. The research agent noted both commands but did not flag the duplication.
+
+## Scope Assessment
+
+The issue title is:
+> "security: 2026-04-11 end-of-session broad sweep"
+
+The scope described in the research analysis matches the issue: eight security checks across banned constructs, unsafe blocks, dependency vulnerabilities, supply-chain health, command-injection/path-traversal surfaces, hardcoded credentials, and the Windows extended-length path fix.
+
+**However, Finding 8 (SBOM drift) was based on non-existent files and should be removed.** This was a material error in the research.
+
+## Verification Methodology
+
+1. **File existence checks**: Used `git ls-files`, `find`, and `ls` to verify existence of SBOM files — found none
+2. **Code inspection**: Read `provider.rs`, `security/mod.rs`, `deny.toml`, `perllsp/Cargo.toml`, `perllsp/src/lib.rs` directly to verify claims
+3. **Git history**: Checked `git log --all --oneline` for relevant commits (#4089 found)
+4. **Tool availability**: Attempted `cargo deny` and `cargo machete` — neither is installed, limiting verification of those claims
+5. **Workspace structure**: Inspected `Cargo.toml` for dependency declarations and `justfile` for SBOM generation commands
+
+### Commands run:
+```bash
+git ls-files | grep -i sbom        # No SBOM files tracked
+ls /home/hermes/repos/perl-lsp/sbom-*  # No SBOM files at root
+git log --oneline | grep 4089     # Found ef92dd20
+grep -n "RUSTSEC-2026-0097" deny.toml  # Not found (not ignored)
+cargo deny check advisories        # Tool not installed
+cargo machete                     # Tool not installed
+```

--- a/.hermes/conveyor/work-b4f6edfe/findings/maintainer-vision-agent-findings.md
+++ b/.hermes/conveyor/work-b4f6edfe/findings/maintainer-vision-agent-findings.md
@@ -1,0 +1,65 @@
+# Maintainer Vision Findings — work-b4f6edfe
+
+## Alignment Assessment
+**ALIGNED** — The work of decomposing the `unexpected_token_in_expr` catch-all bucket into specific sub-patterns is precisely in line with the project's stated direction toward CPAN corpus confidence (ROADMAP.md Phase A/B) and the existing precedent set by #2731's decomposition methodology.
+
+## Reasoning
+
+### This Work Extends the Established Pattern
+The CORPUS_ROADMAP.md explicitly identifies `unexpected_token_in_expr` as the largest error bucket (146 files in the CPAN corpus baseline, rank #1) and lists it as Phase A work. The project's Phase A strategy is: *"Fix the top 5 error buckets, each with a dedicated builder agent. Each builder receives a scout-produced spec with exact function names, line numbers, and CPAN file samples."*
+
+This work-item does exactly that scouting/spec work for the `unexpected_token_in_expr` bucket — it is the prerequisite research that enables a builder to make targeted fixes. The existing `fix_unexpected_token_in_expr_2731.rs` file (57 tests, 4 sub-patterns fixed) is the proof-of-concept that this methodology works.
+
+### It Aligns With the Parser Architecture's Error Taxonomy
+The codebase deliberately categorizes parse errors into semantic buckets via `SEMANTIC_BUCKETS` in `xtask/src/tasks/parser_corpus_sweep.rs`. This design choice — making error buckets explicit, tracked, and decomposable — is a core architectural decision. The blockers.yaml even records `unexpected_token_in_expr` as a Tier 1 parser_blocker with status "fixed" via #2731, showing this is tracked work. The remaining 26 entries in the system corpus baseline are the tail that needs the same treatment.
+
+### Correct Abstraction Level
+This work decomposes at the right layer: it identifies sub-patterns in the failing code (typeglob suffixes `*` `` ` `` and `*'`, indirect object notation, BEGIN/eval nesting) and maps each to a specific parser location (e.g., `primary.rs:925` the `_` arm of `parse_primary_inner`). This is exactly what the CORPUS_ROADMAP calls for — concrete root-cause analysis, not surface-level workarounds.
+
+### Connection to Project's Core Purpose
+perl-lsp exists to provide IDE services for real Perl code. The affected files — English.pm, File/Copy.pm, IPC/Cmd.pm — are stdlib modules used by thousands of Perl developers. The 7 inaccessible CPAN files (MimeInfo, Run3, ToUnicode, Lite, Type, Sendmail, Writer) represent real-world code the parser needs to handle. The work serves the LSP's core contract: "your code should parse cleanly in our editor."
+
+## Impact on Codebase Trajectory
+
+**If merged as proposed**: The work produces 1-5 follow-up issues, each with minimal test cases and root-cause analysis. A future builder can pick up each issue and fix one sub-pattern at a time, adding regression tests to `fix_unexpected_token_in_expr_2731.rs`. This incrementally increases the CPAN clean rate toward the 90% Phase A target.
+
+**The trajectory this opens**: Each fixed sub-pattern removes N files from the `unexpected_token_in_expr` bucket, improving the baseline. The ratchet mechanism means clean counts can only increase — this is debt paydown, not debt accumulation.
+
+**The trajectory this closes**: Nothing is closed. Decomposing into follow-up issues keeps all options open — the issues can be prioritized, split further, or held based on builder bandwidth.
+
+## Recommendations
+
+### 1. Clarify the Corpus Scope Before Filing Issues
+The 13 unique files split between:
+- **3 accessible files** (English.pm, File/Copy.pm, IPC/Cmd.pm — Perl 5.38)
+- **10 inaccessible files** (7 CPAN + 3 Perl 5.38.2 variants)
+
+The 7 inaccessible CPAN files are the ones that matter most for the CORPUS_ROADMAP's stated goal of 90% CPAN coverage. Before filing issues, the builder should clarify whether:
+- These files should be downloaded and added to the corpus for this work
+- OR the issues should be filed based on the corpus sweep's error location data alone (without direct file inspection)
+
+### 2. Distinguish Sub-Patterns That Are Already Partially Fixed
+The verification agent found that `*\`` and `*'` (typeglob with backtick/tick suffix) are the ACTUAL failing patterns in English.pm — NOT `*+` as the research agent suggested. The existing `fix_unexpected_token_in_expr_2731.rs` Pattern C covers `*^N`, `*-{ARRAY}`, `*+{ARRAY}` but NOT `` *` `` or `*'`. This means the new sub-pattern is "typeglob suffix with `` ` `` or `'`" — filed as a distinct issue from the already-covered Pattern C.
+
+### 3. Watch for Error Cascade Effects
+The plan-reviewer correctly identified that fixing one sub-pattern in a file may reveal a different sub-pattern. English.pm likely has BOTH a fixed pattern (from #2731) AND new patterns. The issues should clearly state: "this is the FIRST error encountered when parsing, not necessarily the root cause of all subsequent errors in this file."
+
+## Long-Term Impact
+
+**Positive — This improves parser maintainability.** Each new sub-pattern gets its own test fixture in `fix_unexpected_token_in_expr_2731.rs`. Future developers can see at a glance what constructs are known-to-work and what the boundary of the parser's expression coverage is.
+
+**Positive — This enables parallelization.** When the bucket is decomposed into 5 distinct issues with clear root causes, 5 builders can work simultaneously without stepping on each other's toes. This is essential for hitting the Phase A timeline (5 builders, 4-5 weeks).
+
+**Neutral — The `insta` test dependency issue.** The test compilation failure blocks verification in THIS environment, but the test infrastructure itself is sound. This is an execution constraint, not a structural issue with the approach.
+
+**Risk — Incomplete environment access.** If the 7 inaccessible CPAN files represent a significant portion of the 26-entry bucket's patterns, this work may only partially address the bucket. The issues filed may not cover all distinct sub-patterns present in the 13 unique files.
+
+## Questions the Pipeline Should Answer
+
+1. **Scope boundary**: Should this work include downloading and analyzing the 7 inaccessible CPAN files? Or is filing issues for only the 3 accessible files acceptable as "partial progress" toward the full bucket?
+
+2. **Relationship to blockers.yaml**: The blockers.yaml marks `unexpected_token_in_expr` as "fixed" via #2731. Should this work update blockers.yaml to reflect that the bucket still has 26 entries in the system corpus, or is the system corpus considered stale relative to the CPAN corpus baseline?
+
+3. **Test infrastructure**: The `insta` snapshot testing dependency is broken — is this being tracked as a separate issue? It blocks test-driven verification of any fix the builder produces.
+
+4. **Issue ownership**: Who will pick up the follow-up issues this work produces? If no builder is assigned, the issues will sit open and the bucket won't actually decrease.

--- a/.hermes/conveyor/work-b4f6edfe/findings/plan-review-comment.md
+++ b/.hermes/conveyor/work-b4f6edfe/findings/plan-review-comment.md
@@ -1,0 +1,58 @@
+# Plan Review — work-b4f6edfe
+
+## Overview
+This is the plan review for the `unexpected_token_in_expr` bucket decomposition work item. I reviewed the research agent's `initial_plan.md` against the actual codebase state and verification results.
+
+## Risks Identified in the Plan
+
+### Risk 1: Incorrect Pattern Attribution (CONFIRMED)
+The plan assumes the research agent correctly identified the patterns causing errors in each file. My verification shows this is NOT the case:
+- English.pm's error is from `*\`` and `*'` typeglob suffixes, NOT `*+` (which parses cleanly)
+- File/Copy.pm's error trigger is UNKNOWN — not `UNIVERSAL::isa` or indirect object notation
+- IPC/Cmd.pm's error trigger is UNKNOWN — not `BEGIN { eval {} }` (which parses cleanly)
+
+**Impact**: The plan's Phase 1 ("extract error locations") assumes the wrong patterns are causing errors. This could lead to wasted effort extracting snippets of already-working code.
+
+**Recommendation**: Before Phase 1 begins, the builder should run the corpus sweep or parse the actual failing files to identify the TRUE first-error locations, not rely on the research agent's attributions.
+
+### Risk 2: Error Cascade Obscuring Root Cause (VALID)
+The plan correctly identifies this risk. Since English.pm has BOTH working patterns (`*^N`, `*+`, etc.) AND failing patterns (`*\``, `*'`), fixing one may reveal another. The plan needs to account for this by suggesting iterative sweeps rather than one-shot fixes.
+
+### Risk 3: CPAN Environment Gap (CONFIRMED)
+The plan acknowledges this risk but understates it. The 7 CPAN modules and 3 Perl 5.38.2 files are NOT accessible in this environment. The builder can only directly inspect 3 of the 13 unique files. For the other 10 files, the builder must rely on:
+1. Running a corpus sweep on a properly-equipped system
+2. Inferring patterns from similar files in the CPAN corpus
+
+**Impact**: The "produce follow-up issues" phase cannot be completed for 10 of 13 files without additional environment setup or corpus data.
+
+### Risk 4: Multiple Sub-patterns Per File (CONFIRMED)
+English.pm has at least TWO distinct failing patterns (`*\`` and `*'`), both from the same family (typeglob punctuation suffixes). If these are fixed separately, they should be tracked as separate sub-patterns even though they're related.
+
+### Risk 5: Baseline Currency (NEW RISK)
+The baseline was built on a different system. It's possible that some patterns in the baseline have since been fixed in the current codebase (e.g., the `*+` bare typeglob the research agent thought was broken actually parses cleanly now). The builder should verify against the current codebase, not trust the baseline blindly.
+
+## Scope Concerns
+
+### Scope: Correct Size, Incorrect Sub-pattern Identification
+The issue title accurately describes 26 entries in the bucket across 13 files. However, the plan's file family grouping (English.pm, File/Copy.pm, IPC/Cmd.pm, CPAN) is based on incorrect pattern attribution. A revised grouping might look like:
+- **English.pm family**: `*\`` and `*'` typeglob suffixes (new sub-pattern)
+- **File/Copy.pm**: UNKNOWN — needs corpus sweep to identify
+- **IPC/Cmd.pm**: UNKNOWN — needs corpus sweep to identify
+- **CPAN modules**: UNKNOWN — files not accessible
+
+## Specific Concerns with Plan's Phase 2
+
+The plan says "For English.pm: confirm whether `*+;` (bare typeglob `+`) is a new sub-pattern". My verification shows `*+;` parses CLEANLY — it is NOT a new sub-pattern. The plan should have been more definitive: `*+;` is covered, but `*\`` and `*'` are NOT.
+
+The plan also says "For File/Copy.pm: identify if indirect object or `UNIVERSAL::isa` is the trigger". My verification shows `UNIVERSAL::isa` parses cleanly. The plan should have been more definitive about what the actual trigger is.
+
+## Recommendations for the Builder
+
+1. **Run corpus sweep FIRST** before extracting snippets — the actual error locations must be verified, not inferred from file inspection alone
+2. **Treat `*\`` and `*'` typeglob suffixes as a NEW sub-pattern** — file a targeted issue for these even though the plan was wrong about `*+`
+3. **Expect iterative fixes** — for English.pm, expect at least 2 rounds of fixes (one for `*\``/`*'`, then re-evaluate)
+4. **Do NOT blame `UNIVERSAL::isa` or `BEGIN { eval {} }`** for File/Copy.pm and IPC/Cmd.pm — these are red herrings
+
+## Verdict
+
+**The plan is PARTIALLY SOUND** but has critical errors in its pattern attribution that would lead the builder down wrong paths. The high-level approach (decompose bucket into sub-patterns with concrete test cases) is correct, but the specific sub-pattern identifications are wrong for at least 2 of the 3 accessible files.

--- a/.hermes/conveyor/work-b4f6edfe/findings/plan-reviewer-findings.md
+++ b/.hermes/conveyor/work-b4f6edfe/findings/plan-reviewer-findings.md
@@ -1,0 +1,122 @@
+# Plan Review Findings — work-b4f6edfe
+
+## Overall Assessment
+**feasible with modifications** — The high-level approach (decompose bucket into sub-patterns, file targeted issues) is correct, but the plan's specific pattern attributions are wrong for at least 2 of 3 accessible files, and the scope of "Phase 2" needs revision before this can proceed to builder.
+
+## Scope Assessment
+
+The issue title accurately describes 26 entries in the `unexpected_token_in_expr` bucket across 13 unique files. **However, the plan's file-family groupings are based on incorrect pattern attribution**:
+
+| File Group | Plan's Claim | Verification Says |
+|---|---|---|
+| English.pm | `*+` bare typeglob causes error | `*+` parses CLEANLY; `*\`` and `*'` are the actual failing patterns |
+| File/Copy.pm | Indirect objects / `UNIVERSAL::isa` | `UNIVERSAL::isa` parses CLEANLY; actual trigger UNKNOWN |
+| IPC/Cmd.pm | `BEGIN { eval {} }` nesting | `BEGIN { eval {} }` parses CLEANLY; actual trigger UNKNOWN |
+
+**Impact**: The plan's Phase 2 is largely invalidated — the "confirm whether X is the trigger" tasks would lead builders to verify patterns that are already working, not the actual failing ones.
+
+## What Works
+
+1. **High-level approach is correct**: Decomposing a catch-all error bucket into specific sub-patterns with concrete test cases is the established methodology for this project (proven by #2731's 4 sub-patterns).
+
+2. **CORPUS_ROADMAP.md subcategory framework**: The 10-subcategory decomposition in the roadmap provides the right conceptual structure for categorizing new patterns.
+
+3. **Verification agent corrected the record**: The verification agent identified that `*\`` and `*'` (backtick/tick typeglob suffixes) are the actual English.pm trigger — a genuinely new sub-pattern distinct from the already-fixed `*^N`, `*-{ARRAY}`, `*+{ARRAY}` patterns.
+
+4. **Test file naming convention**: Using `fix_unexpected_token_in_expr_<issue>.rs` is established practice and avoids merge conflicts during simultaneous agent work.
+
+5. **Risk identification**: The plan correctly identifies error cascade and multiple-patterns-per-file as risks. The CPAN environment gap is acknowledged.
+
+## What Doesn't Work
+
+### 1. Phase 2 is Built on Wrong Attributions
+The plan tasks the builder to "confirm whether `*+;` is a new sub-pattern" and "identify if indirect object or `UNIVERSAL::isa` is the trigger." These verification tasks are backwards:
+- `*+` already parses cleanly — no confirmation needed, this is a settled question
+- The actual failing patterns (`*\``, `*'`) are already identified by the verification agent but NOT mentioned in the plan
+
+**Consequence**: A builder following this plan would waste time verifying non-issues while the actual triggers remain uninvestigated.
+
+### 2. Phase 1 Cannot Be Completed as Written
+The plan says "run corpus sweep or manually parse English.pm, File/Copy.pm, IPC/Cmd.pm to find first-error offsets." The verification agent already found that:
+- English.pm's failing patterns are `*\`` and `*'`
+- File/Copy.pm and IPC/Cmd.pm triggers are UNKNOWN
+
+The "manually parse" approach would require re-running the parser on these files with detailed error tracing — not just file inspection. The plan doesn't specify how to find the exact byte offset of the first error.
+
+### 3. CPAN Files Cannot Be Investigated in This Environment
+7 of 13 unique files are inaccessible. The plan acknowledges this but says they "need corpus extraction" — without specifying that the corpus sweep must be run on a system with those files present, not this one.
+
+### 4. Baseline Currency
+The baseline was built on commit `3f7ede36` at `2026-04-09`. It's possible that some patterns have since been partially fixed in the current codebase. The plan doesn't instruct the builder to verify the baseline against current code before beginning work.
+
+## Top Risks
+
+### Risk 1: Wrong Pattern Attribution Leads Builder Astray
+- **Likelihood**: HIGH — the plan explicitly tasks the builder with verifying wrong patterns
+- **Impact**: Builder spends Phase 2 confirming `*+` works (already known) while actual `*\``/`*'` patterns get no attention
+- **Mitigation**: Replace Phase 2 classification tasks with verified findings from the verification agent:
+  - English.pm: `*\`` and `*'` typeglob suffixes → NEW sub-pattern (file issue)
+  - File/Copy.pm: trigger UNKNOWN → corpus sweep needed
+  - IPC/Cmd.pm: trigger UNKNOWN → corpus sweep needed
+  - CPAN modules (7 files): trigger UNKNOWN → cannot investigate in this environment
+
+### Risk 2: Error Cascade Obscuring Root Cause (Validated)
+- **Likelihood**: HIGH — the verification agent confirmed English.pm has BOTH working patterns (`*^N`, `*+`, `*-{ARRAY}`) AND failing patterns (`*\``, `*'`)
+- **Impact**: Fixing `*\`` may reveal `*'` as a second distinct error in the same file; both need separate test cases and possibly separate issues
+- **Mitigation**: Extract minimal snippets for EACH distinct pattern independently. Don't assume one fix solves the whole file.
+
+### Risk 3: CPAN Environment Gap (Confirmed Unresolved)
+- **Likelihood**: HIGH — 7 of 13 files are inaccessible, and the plan offers no path to investigate them
+- **Impact**: "Produce follow-up issues" phase cannot be completed for >50% of the bucket entries
+- **Mitigation**: Either (a) set up the corpus environment with the missing files before proceeding, or (b) explicitly scope this work item to only the 3 accessible files, with a separate follow-up item for the CPAN files.
+
+### Risk 4: Baseline Regressions After Fix
+- **Likelihood**: MEDIUM — the baseline is from a different commit and system
+- **Impact**: A fix that "solves" one file might actually cause the baseline to regress on another file's pattern
+- **Mitigation**: Run the full corpus sweep before and after each fix. Verify delta.
+
+### Risk 5: Test Compilation Blocked
+- **Likelihood**: HIGH — the verification agent noted `cargo test -p perl-parser-core` fails due to missing `insta` dev-dependency
+- **Impact**: Builder cannot verify their test-driven fixes compile or pass
+- **Mitigation**: Resolve the `insta` dependency issue before builder begins work, OR the builder must use `cargo build -p perl-parser-core --lib` only and skip the test-compilation step.
+
+## Edge Cases
+
+1. **Multiple distinct patterns in same file**: English.pm has `*\``, `*'`, `*^N`, `*-{ARRAY}`, `*+{ARRAY}` all in the same file. Fixing one may not reduce the bucket entry count if another pattern still fails.
+
+2. **Perl version differences**: The 5.38 and 5.38.2 variants of the same file may have different error locations or patterns. The baseline shows both entries for each file, but they could have different root causes.
+
+3. **CPAN corpus vs system corpus**: The issue references the system corpus baseline (`.ci/parser-corpus-baseline.json`), not the CPAN corpus. The CORPUS_ROADMAP.md discusses the CPAN corpus (4,355 files). These are different baselines with different error distributions.
+
+4. **The baseline is a "first error" snapshot**: Each file's entry is its FIRST error only. A file with multiple errors will only show the first one. Fixing the first error may reveal a second error that was previously hidden — this is the cascade problem.
+
+## Recommendations
+
+1. **Replace Phase 2 with verified findings** — Remove the "confirm whether X triggers the error" tasks. Replace with the verification agent's findings:
+   - English.pm: `*\`` and `*'` are the confirmed triggers → file issue immediately
+   - File/Copy.pm: trigger UNKNOWN → document this, do not speculate
+   - IPC/Cmd.pm: trigger UNKNOWN → document this, do not speculate
+
+2. **Add corpus sweep step to Phase 1** — Before Phase 1, the builder should run the parser corpus sweep against the accessible files to get exact byte offsets for the first error in each file. File inspection alone is insufficient.
+
+3. **Scope to accessible files only, or defer CPAN files** — Either explicitly scope this work item to the 3 accessible files (English.pm, File/Copy.pm, IPC/Cmd.pm) and file a separate work item for the 7 inaccessible CPAN files, OR set up the environment with the missing files before proceeding.
+
+4. **Resolve `insta` dependency before builder starts** — The test compilation is blocked. Either fix the dependency or update the plan to work around it (e.g., builder verifies with `cargo build --lib` only, and a separate agent runs the tests).
+
+5. **Add baseline verification step** — Before beginning, run the corpus sweep to confirm the 26-entry bucket still exists in the current codebase state. If it has already been partially fixed, update the plan accordingly.
+
+6. **Treat `*\`` and `*'` as a single sub-pattern issue** — Both are typeglob punctuation suffixes. File ONE issue for "typeglob with `*\`` and `*'` suffixes" rather than two separate issues, since they likely share the same parser fix location.
+
+## Confidence to Proceed
+
+**medium** — The approach is sound and the methodology is proven, but the plan needs revision before it can guide a builder effectively. Specifically:
+
+- The wrong patterns are being investigated (Phase 2)
+- The inaccessible files cannot be handled in this environment (CPAN gap)
+- The test infrastructure is blocked (`insta` dependency)
+
+**What would raise confidence to high**:
+1. Revise Phase 2 to use verified pattern findings instead of speculative ones
+2. Explicitly scope this work to the 3 accessible files, deferring CPAN files
+3. Resolve the `insta` dependency issue
+4. Add baseline verification step before Phase 1

--- a/.hermes/conveyor/work-b4f6edfe/findings/verification-agent-findings.md
+++ b/.hermes/conveyor/work-b4f6edfe/findings/verification-agent-findings.md
@@ -1,0 +1,132 @@
+# Verification Findings — work-b4f6edfe
+
+## Confidence Assessment
+**[MEDIUM]** — I independently verified the corpus baseline structure, parser error emission mechanism, and tested specific Perl patterns. However, I cannot fully reproduce the corpus sweep because the Perl 5.38.2 and CPAN corpus files don't exist in this environment. The baseline was built on a different system with a different Perl installation.
+
+## Confirmed Findings
+
+### Finding 1: Bucket structure is accurate
+The `.ci/parser-corpus-baseline.json` correctly shows 26 entries in the `unexpected_token_in_expr` bucket, corresponding to 13 unique files × 2 Perl versions (5.38 and 5.38.2). Verified via direct inspection of the JSON structure:
+- Corpus roots include `/usr/share/perl`, `/usr/lib/x86_64-linux-gnu/perl`, `/usr/share/perl5`
+- `first_error_buckets` correctly maps `unexpected_token_in_expr` to 26 entries
+- `files_by_bucket['unexpected_token_in_expr']` lists all 26 file entries
+
+### Finding 2: Error emission mechanism confirmed
+The `unexpected_token_in_expr` bucket is the catch-all for `ParseError::unexpected("expression", ...)` at `primary.rs:928`. The SEMANTIC_BUCKETS table in `xtask/src/tasks/parser_corpus_sweep.rs:100` maps the substring `"expected expression, found"` to this bucket. The ordering is correct — more specific buckets (e.g., `unexpected_fat_arrow_expr`, `unexpected_question_expr`) precede it so they match first.
+
+### Finding 3: Prior art test file is real and passing
+The `crates/perl-parser-core/tests/fix_unexpected_token_in_expr_2731.rs` contains 57 tests covering 4 sub-patterns (A-D):
+- Pattern A: No-arg builtins before `&&`/`||`
+- Pattern B: Special variable `$:`
+- Pattern C: Typeglob with `*^N`, `*-{ARRAY}`, `*+{ARRAY}` suffixes
+- Pattern D: `__END__`/`__DATA__` after no-semicolon statements
+All 57 tests pass in the current codebase.
+
+### Finding 4: CPAN files missing from this environment (correctly identified by research agent)
+The 7 CPAN modules at `/usr/share/perl5/*` (MimeInfo, Run3, ToUnicode, Lite, Type, Sendmail, Writer) do NOT exist in this verification environment. The baseline was built on a system with these files installed. This is a real constraint on verification scope.
+
+### Finding 5: Perl 5.38.2 also missing from this environment (correctly identified)
+`/usr/share/perl/5.38.2/` does not exist. Only Perl 5.38 files are accessible for direct inspection.
+
+## Corrected Findings
+
+### Finding 6: Research Agent's Finding 2 is INCORRECT — `*+;` parses cleanly
+The research agent claimed that `*LAST_PAREN_MATCH = *+;` (bare `*+` typeglob without `{ARRAY}` subscript) is an UNCOVERED pattern causing `unexpected_token_in_expr`. **This is wrong.**
+
+I created a temporary test (`test_bare_plus_glob_temp.rs`) and verified that `*LAST_PAREN_MATCH = *+;` parses CLEANLY — it produces NO error nodes.
+
+The actual failing patterns in English.pm are:
+- `*PREMATCH = *\`;` — backtick typeglob (`$``) — **FAILS** with "expected expression, found unknown token"
+- `*POSTMATCH = *';` — tick typeglob (`$'`) — **FAILS** with "expected expression, found unknown token"
+
+These are typeglobs with the special punctuation variables `$`` and `$'`. The lexer does not recognize `` ` `` and `'` as valid typeglob suffix characters. This is a NEW sub-pattern distinct from the existing Pattern C (`*^N`, `*-{ARRAY}`, `*+{ARRAY}`).
+
+### Finding 7: Research Agent's Finding 3 is INCORRECT — File/Copy.pm does NOT use indirect object notation
+The research agent claimed File/Copy.pm "has `croak(...)` calls used as indirect objects (e.g., after a method call like `$fh->print`)". **This is imprecise/wrong.**
+
+I inspected File/Copy.pm lines 78-95 and found `UNIVERSAL::isa(...)` calls, which are explicit function calls with arguments, NOT indirect object notation. I verified that `UNIVERSAL::isa($from, 'GLOB');` and `ref($from) eq 'GLOB' || UNIVERSAL::isa($from, 'GLOB');` both parse CLEANLY.
+
+The actual trigger for File/Copy.pm's `unexpected_token_in_expr` error remains UNKNOWN — it could be a different construct in the file, or the baseline may reflect a version of the file with patterns now fixed in the current codebase.
+
+### Finding 8: Research Agent's Finding 4 is INCORRECT — `BEGIN { eval {} }` parses cleanly
+The research agent claimed that `BEGIN { eval { ... } }` "may confuse the statement/expression boundary parsing." **This is wrong for the specific pattern in IPC/Cmd.pm.**
+
+I verified that `BEGIN { eval { require POSIX; }; }` and `BEGIN { use constant IS_VMS => 0; use Exporter; eval { require POSIX; }; }` both parse CLEANLY. The IPC/Cmd.pm BEGIN block contains simple `eval {}` blocks (not deeply nested), which the parser handles correctly.
+
+The actual trigger for IPC/Cmd.pm's `unexpected_token_in_expr` error remains UNKNOWN.
+
+## New Findings
+
+### Finding 9: NEW sub-pattern identified — typeglob with backtick/tick suffixes
+The most important new finding is that typeglob expressions with `` ` `` (backtick) and `'` (tick) suffixes are NOT handled by the parser. This is distinct from the already-fixed Pattern C (`*^N`, `*-{ARRAY}`, `*+{ARRAY}`). The error message is "expected expression, found unknown token", which maps to `unexpected_token_in_expr` via the catch-all bucket.
+
+Specifically:
+- `*PREMATCH = *\`;` — FAILS
+- `*POSTMATCH = *';` — FAILS
+
+These appear in English.pm and are real constructs: `$`` is the prematch variable and `$'` is the postmatch variable in Perl's regex match results. The typeglob form `*\`` and `*'` should alias these variables.
+
+### Finding 10: Working typeglob patterns (English.pm)
+The following typeglob patterns from English.pm parse CLEANLY in the current codebase (already handled by existing Pattern C or other parser code):
+- `*LAST_PAREN_MATCH = *+;` — bare `*+` (research agent claimed this would fail — it doesn't)
+- `*LAST_SUBMATCH_RESULT = *^N;` — `*^N` (already in tests)
+- `*INPUT_LINE_NUMBER = *.;` — dot typeglob (works)
+- `*MATCH = *&;` — ampersand typeglob (works)
+- `*INPUT_RECORD_SEPARATOR = */;` — slash typeglob (works)
+
+### Finding 11: Multiple patterns per file likely
+English.pm contains BOTH working patterns (`*^N`, `*+`, `*.`, `*&`, `*/`) AND failing patterns (`*\``, `*'`). This means the file could produce errors from multiple locations, potentially explaining why the research agent's simplified analysis attributed it to a single cause.
+
+## Scope Assessment
+
+The issue title says "parser: fix unexpected_token_in_expr bucket — 26 CPAN corpus files" — this is accurate. The scope covers the 26 files in the `unexpected_token_in_expr` bucket across the corpus baseline.
+
+However, the issue description's characterization of which patterns cause the errors in which files is INCOMPLETE and PARTIALLY INCORRECT:
+- English.pm: Error is from `*\`` and `*'` typeglob suffixes, NOT from `*+` (which works)
+- File/Copy.pm: Error trigger is UNKNOWN (not indirect objects or `UNIVERSAL::isa`)
+- IPC/Cmd.pm: Error trigger is UNKNOWN (not the `BEGIN { eval {} }` pattern)
+
+## Verification Methodology
+
+### Step 1: Baseline inspection
+- Loaded `.ci/parser-corpus-baseline.json` and enumerated all 26 `unexpected_token_in_expr` entries
+- Verified 13 unique files × 2 Perl version entries
+- Confirmed corpus roots and schema version
+
+### Step 2: Codebase inspection
+- Examined `primary.rs:925-929` to confirm error emission point
+- Examined `xtask/src/tasks/parser_corpus_sweep.rs:50-100` to confirm SEMANTIC_BUCKETS mapping
+- Examined `fix_unexpected_token_in_expr_2731.rs` to confirm existing pattern coverage (57 tests, all passing)
+
+### Step 3: Environment accessibility check
+- Verified Perl 5.38 files exist: English.pm, File/Copy.pm, IPC/Cmd.pm
+- Verified Perl 5.38.2 files do NOT exist in this environment
+- Verified CPAN files at `/usr/share/perl5/*` do NOT exist
+
+### Step 4: Pattern verification via Rust tests
+I wrote temporary Rust test files using `cpan_test_helpers::assert_clean_parse` and ran them via `cargo test`:
+
+**Test results:**
+- `*LAST_PAREN_MATCH = *+;` → PASSES (research agent claimed it fails)
+- `*PREMATCH = *\`;` → FAILS (new sub-pattern found)
+- `*POSTMATCH = *';` → FAILS (new sub-pattern found)
+- `*INPUT_LINE_NUMBER = *.;` → PASSES
+- `*MATCH = *&;` → PASSES
+- `*INPUT_RECORD_SEPARATOR = */;` → PASSES
+- `UNIVERSAL::isa(...)` → PASSES (research agent blamed indirect objects)
+- `BEGIN { eval { ... } }` → PASSES (research agent blamed this pattern)
+
+## Critical Unknowns
+
+1. **What specifically triggers the errors in File/Copy.pm and IPC/Cmd.pm?** I tested the patterns I could identify from file inspection, but the actual error trigger remains unknown. It could be a construct I haven't identified, or the baseline may reflect a different version of these files.
+
+2. **Are the 5.38.2 and CPAN corpus files still producing errors in the current codebase?** Since these files don't exist in this environment, I cannot verify whether the errors are still present or have been fixed in subsequent parser updates.
+
+3. **Do the failing `*\`` and `*'` patterns fully account for English.pm's error?** Since I can't run the full corpus sweep on English.pm, I cannot confirm whether these are the ONLY failing patterns in that file.
+
+## Summary
+
+The research agent correctly identified the bucket size (26 entries, 13 unique files) and the high-level approach (decompose into sub-patterns). However, the agent's specific claims about which Perl patterns cause errors in which files are PARTIALLY INCORRECT. The only confirmed NEW sub-pattern is:
+- **Typeglob with `` ` `` (backtick) and `'` (tick) suffixes** — `*\``, `*'` not recognized as valid expression starts
+
+The existing Pattern C in `fix_unexpected_token_in_expr_2731.rs` already covers `*^N`, `*-{ARRAY}`, `*+{ARRAY}`, but the tick/backtick variants are a distinct gap.

--- a/.hermes/conveyor/work-b4f6edfe/findings/vision-alignment-comment.md
+++ b/.hermes/conveyor/work-b4f6edfe/findings/vision-alignment-comment.md
@@ -1,0 +1,27 @@
+# Vision Alignment — work-b4f6edfe
+
+## Vision Alignment: ALIGNED
+
+## Rationale
+
+The work of decomposing the `unexpected_token_in_expr` bucket and filing targeted follow-up issues is **aligned** with the project's stated goals. Here's why:
+
+### 1. Real-World Perl Support
+The issue title explicitly references "CPAN corpus files" — real Perl modules from CPAN. The project's parser exists to provide IDE services for real Perl code, not just toy examples. Fixing parse errors in English.pm, File/Copy.pm, and IPC/Cmd.pm directly serves the LSP's core purpose.
+
+### 2. Systematic Error Reduction
+The approach of decomposing a catch-all bucket into specific sub-patterns with concrete test cases is the RIGHT methodology. This is how a mature parser project should handle heterogeneous error categories — one fix at a time with regression tests, rather than attempting a large undifferentiated change.
+
+### 3. Test-Driven Fixes
+The plan's emphasis on "minimal Perl code snippet (≤10 lines)" and filing targeted issues per sub-pattern ensures that future fixes are verifiable. This matches the existing test culture in `perl-parser-core` where `#[test]` functions with `assert_clean_parse` are the standard regression guard.
+
+### 4. Consistency with Prior Art
+The existing `fix_unexpected_token_in_expr_2731.rs` file shows this methodology has already been applied successfully to 4 sub-patterns. The current work extends that success pattern to remaining patterns.
+
+## Misalignment Concerns (Minor)
+
+The research agent's incorrect pattern attribution is a concern but doesn't invalidate the approach — it just means the builder needs to do their own pattern identification rather than relying on the research agent's claims. The approach (sample → decompose → file targeted issues → fix) remains sound.
+
+## Conclusion
+
+**ALIGNED** — The goal of eliminating `unexpected_token_in_expr` errors from real Perl modules is precisely what the LSP should be doing. The methodology is correct even if the specific pattern identifications were wrong.

--- a/adr/0032-no-assertion-test-triage-classification.md
+++ b/adr/0032-no-assertion-test-triage-classification.md
@@ -1,0 +1,96 @@
+# ADR-0032: No-Assertion Test Triage Classification Framework
+
+## Status
+Proposed
+
+## Context
+
+Issue #3259 identified ~620 test functions (~3% of 20,740 total) with no assertion machinery. However:
+- Issue #3259's foundational examples cite non-existent files (`perl-ast-utils` crate does not exist)
+- No explicit classification criteria distinguish (a) missing assertions from (b) intentional smoke tests from (c) misclassified helpers
+- Prior research sampled only perl-parser (174 tests), which may not represent other 7 crates
+
+The work requires human judgment to classify each test, so a systematic framework is needed before sampling begins.
+
+## Decision
+
+### Classification Criteria (Authoritative)
+
+We establish the following explicit rules for categorizing no-assertion tests:
+
+| Category | Definition | Examples |
+|----------|------------|----------|
+| **(a) Missing Assertion** | Test calls a function, discards result, and does NOT verify behavior through any mechanism | `let _ = parse(src);` with no post-check |
+| **(b) Intentional Smoke Test** | Test verifies "code path does not panic" via helper with embedded panic-on-failure | `test_parse() → unreachable!()` or `must()` with no post-result assertion + explicit smoke test naming/comment |
+| **(c) Helper Misclassified** | Function marked `#[test]` but is ONLY called by other tests as a utility | `fn setup_parser()` called by multiple tests |
+
+**Key Clarifications:**
+- `must()` / `must_some()` / `?` operators are **NOT** explicit assertions — they are panic helpers
+- Tests using `must()` without post-result assertions are **category (b)** only if they document smoke test intent
+- Mock-side-effect assertions (`assert_eq!(invocations.len(), 1)`) ARE assertions — those tests are correctly classified
+- `unreachable!()` in a helper IS an implicit assertion (helper panics if expectation fails)
+
+### Sampling Methodology
+
+**Stratified sampling across all 8 crates:**
+1. Weight each crate by its no-assertion count (from issue #3259)
+2. Sample proportionally: perl-parser (~28%), perl-parser-core (~15%), perl-lsp (~15%), tree-sitter-perl-rs (~10%), others (~32%)
+3. Target: 40-50 samples total
+4. Hard cap: 60 samples maximum
+
+### Decision Tree for Ambiguous Cases
+
+```
+Is the test function called by other tests as a utility?
+  YES → Category (c) Helper Misclassified
+  NO
+    Does the test have any assert!/assert_eq! on result or side effects?
+      YES → Correctly classified (not no-assertion)
+      NO
+        Does a helper (test_parse, parse_clean) use unreachable! on failure?
+          YES → Category (b) if edge case, otherwise re-examine
+          NO
+            Is result discarded (let _ = ...) with no comment?
+              YES → Category (a) Missing Assertion
+              NO (result is used somehow)
+                Is it a smoke test naming pattern (_smoke, _edge_case)?
+                  YES → Category (b) Intentional Smoke Test
+                  NO → Category (a) Missing Assertion (ambiguous)
+```
+
+## Consequences
+
+### Benefits
+- Explicit criteria reduce classification subjectivity
+- Stratified sampling gives representative distribution estimate across codebase
+- Triage output guides Phase 2 effort allocation
+
+### Tradeoffs
+- Phase 1 triage delays code changes by ~1-2 weeks
+- Ambiguous cases will exist (documented as "uncertain")
+- Issue #3259's specific citations cannot be used — must re-discover independently
+
+### Risks
+1. **Misclassification**: Despite criteria, borderline cases will require judgment calls
+2. **Sample bias**: Even stratified sampling may not capture all patterns
+3. **Scope expansion**: `?` operator tests could significantly increase category (a) count
+
+## Alternatives Considered
+
+### Alternative 1: Trust Issue #3259's File Citations
+- **Rejected**: Verification agent confirmed cited files do not exist in repository
+- **Impact**: Would produce misleading triage report
+
+### Alternative 2: Single-Crate Deep Dive (perl-parser Only)
+- **Rejected**: Plan-reviewer identified sample bias — perl-parser ratio may differ from other crates
+- **Impact**: Would underestimate effort for perl-lsp, perl-parser-core, etc.
+
+### Alternative 3: Immediate Remediation Skipping Triage
+- **Rejected**: Without classification data, cannot prioritize (a) vs (b) vs (c) remediation
+- **Impact**: Wasted effort on well-intentioned but potentially misclassified fixes
+
+## Notes
+
+- This ADR covers **Phase 1 (Triage)** only
+- Phase 2 (Remediation) requires separate ADR based on triage findings
+- `perl-test-must` crate's `must()`/`must_some()` helpers are intentionally NOT classified as assertions per issue #3259 guidance

--- a/adr/0032-no-assertion-test-triage-specs.md
+++ b/adr/0032-no-assertion-test-triage-specs.md
@@ -1,0 +1,85 @@
+# Specification: No-Assertion Test Triage (Phase 1)
+
+## Feature Description
+
+Conduct a systematic triage of ~620 test functions across 8 crates that were flagged by issue #3237's audit as having "no assertion machinery". The goal is to classify each sampled test into one of three categories and produce a representative distribution estimate for the entire corpus.
+
+**This is Phase 1 (triage) only.** No code changes are made. Phase 2 (remediation) depends on this triage's findings.
+
+## Classification Categories
+
+| Category | Description |
+|----------|-------------|
+| **(a) Missing Assertion** | Test calls a function, discards result, and provides no mechanism to verify correctness |
+| **(b) Intentional Smoke Test** | Test verifies a code path does not panic; uses helper with embedded panic-on-failure or explicit smoke test documentation |
+| **(c) Helper Misclassified** | Function marked `#[test]` but functions as a utility called by other tests |
+
+## Non-Goals (Out of Scope for Phase 1)
+
+1. No remediation actions (adding assertions, adding SMOKE TEST comments, refactoring helpers)
+2. No changes to test infrastructure (`perl-test-must`, `test_parse` helpers, etc.)
+3. No validation of issue #3259's specific file:line citations (they are unreliable per verification agent)
+4. No modification of CI configuration
+
+## Acceptance Criteria
+
+### AC1: Stratified Sample
+- [ ] **Sample size**: Minimum 40 tests, maximum 60 tests
+- [ ] **Coverage**: All 8 crates represented proportionally by no-assertion count
+- [ ] **Documentation**: Each sample includes:
+  - Exact file path and line number
+  - Test function name
+  - Snippet of relevant code (5-10 lines)
+  - Classification decision with reasoning
+  - Confidence level (confident / uncertain)
+
+### AC2: Classification Summary Table
+- [ ] Markdown table with columns: `file:line | test_name | category | reasoning | confidence`
+- [ ] Summary row with per-category counts and percentages
+- [ ] 90% confidence interval for (a):(b):(c) distribution estimate
+
+### AC3: Ambiguity Handling
+- [ ] Tests that cannot be confidently classified are labeled "uncertain" with both plausible categories noted
+- [ ] Decision tree applied consistently (documented in ADR-0032)
+
+### AC4: Effort Estimation
+- [ ] Per-category remediation effort estimates:
+  - Category (a): Estimated time to add explicit assertions
+  - Category (b): Estimated time to add `/// SMOKE TEST:` documentation comments
+  - Category (c): Estimated time to refactor helpers to `#[cfg(test)]` module
+
+### AC5: GitHub Issue Update
+- [ ] Triage report posted as comment on issue #3259
+- [ ] Report includes stratified sample table, distribution estimates, and effort projections
+- [ ] Notes which of issue #3259's citations were verified vs. could not be found
+
+### AC6: Reproducibility
+- [ ] Commands used to discover and sample tests are documented
+- [ ] Random seed (if used) is recorded for reproducibility
+
+## Dependencies
+
+1. **Issue #3237 audit data**: The ~620 count and per-crate breakdown (source of ground truth for stratification)
+2. **perl-test-must crate**: `must()`, `must_some()`, `must_err()` helpers (consulted for classification)
+3. **No external dependencies**: All work done within existing codebase
+
+## Key Definitions
+
+| Term | Definition |
+|------|------------|
+| "No assertion" test | Test marked `#[test]` that lacks `assert!`, `assert_eq!`, or mock-side-effect assertions on the result |
+| Panic helper | `must()`, `must_some()`, `?` operator — these cause panic on failure but do NOT verify correctness |
+| Embedded assertion | `unreachable!()` in a helper that panics if helper's expectation fails (counts as implicit assertion) |
+| Smoke test | Test verifying "this code path does not panic" — NOT verifying correctness |
+
+## Verification Method
+
+1. Run the sampling commands documented in the report
+2. Spot-check 5 random samples against the classification criteria
+3. Verify GitHub issue #3259 contains the posted triage comment
+
+## Open Questions (Deferred to Phase 2)
+
+1. What exactly counts as a "no-assertion" test when `must()` is used with post-result mock assertions?
+2. Should category (b) smoke tests be required to have `/// SMOKE TEST:` comments before merge?
+3. What's the target (a):(b):(c) ratio that triggers vs. defers remediation?

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_carp_croak_followed_by_statement.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_carp_croak_followed_by_statement.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+PL406 | Hint | (44, 49) | Unreachable code: this statement cannot be executed

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_confess_followed_by_statement.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_confess_followed_by_statement.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+PL406 | Hint | (40, 45) | Unreachable code: this statement cannot be executed

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_croak_followed_by_statement.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_croak_followed_by_statement.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+PL406 | Hint | (38, 43) | Unreachable code: this statement cannot be executed

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_die_followed_by_statement.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_die_followed_by_statement.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+PL406 | Hint | (36, 41) | Unreachable code: this statement cannot be executed

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_exit_followed_by_statement.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_exit_followed_by_statement.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+PL406 | Hint | (34, 39) | Unreachable code: this statement cannot be executed

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_last_followed_by_statement.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_last_followed_by_statement.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+PL406 | Hint | (31, 36) | Unreachable code: this statement cannot be executed

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_multiple_unreachable.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_multiple_unreachable.snap
@@ -1,0 +1,7 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+PL406 | Hint | (36, 41) | Unreachable code: this statement cannot be executed
+PL406 | Hint | (47, 52) | Unreachable code: this statement cannot be executed
+PL406 | Hint | (58, 63) | Unreachable code: this statement cannot be executed

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_next_no_false_positive.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_next_no_false_positive.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_redo_no_false_positive.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__continue_block_redo_no_false_positive.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__for_loop_with_continue_block.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__for_loop_with_continue_block.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+PL406 | Hint | (36, 41) | Unreachable code: this statement cannot be executed

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__foreach_loop_with_continue_block.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__foreach_loop_with_continue_block.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+PL406 | Hint | (47, 52) | Unreachable code: this statement cannot be executed

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__loop_body_unreachable_unchanged.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__loop_body_unreachable_unchanged.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+PL406 | Hint | (23, 28) | Unreachable code: this statement cannot be executed

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__no_unreachable_code.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__no_unreachable_code.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__until_loop_with_continue_block.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__until_loop_with_continue_block.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+PL406 | Hint | (36, 41) | Unreachable code: this statement cannot be executed

--- a/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__while_loop_with_continue_block.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/unreachable_code_snapshot_tests__while_loop_with_continue_block.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+expression: snapshot
+---
+PL406 | Hint | (36, 41) | Unreachable code: this statement cannot be executed

--- a/crates/perl-lsp-diagnostics/tests/unreachable_code_continue_integration_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/unreachable_code_continue_integration_tests.rs
@@ -1,0 +1,411 @@
+//! Integration tests: unreachable code detection in continue blocks (PL406)
+//!
+//! Tests verify that the full pipeline — real Perl source → parser → DiagnosticsProvider
+//! — emits PL406 unreachable code diagnostics for continue blocks.
+//!
+//! These tests complement the unit tests in `unreachable_code_tests.rs` which test
+//! the `check_unreachable_code` function directly with manually constructed AST nodes.
+//!
+//! Integration tests use the real parser (`perl_parser::Parser`) and the full
+//! `DiagnosticsProvider::get_diagnostics()` pipeline.
+
+use std::sync::Arc;
+
+use perl_lsp_diagnostics::{Diagnostic, DiagnosticSeverity, DiagnosticTag, DiagnosticsProvider};
+use perl_parser::Parser;
+
+/// Helper: parse Perl source and get all diagnostics from DiagnosticsProvider
+fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
+    let output = Parser::new(source).parse_with_recovery();
+    let ast = Arc::new(output.ast);
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    provider.get_diagnostics(&ast, &output.diagnostics, source, None)
+}
+
+/// Helper: count PL406 diagnostics in the output
+fn count_pl406(diagnostics: &[Diagnostic]) -> usize {
+    diagnostics.iter().filter(|d| d.code.as_deref() == Some("PL406")).count()
+}
+
+/// Helper: check if any PL406 diagnostic exists
+fn has_pl406(diagnostics: &[Diagnostic]) -> bool {
+    diagnostics.iter().any(|d| d.code.as_deref() == Some("PL406"))
+}
+
+// =========================================================================
+// Continue block with die followed by statement (AC-1)
+// =========================================================================
+
+#[test]
+fn integration_continue_block_die_emits_pl406() {
+    // "while (1) { } continue { die 'err'; print 'dead'; }"
+    // expect: exactly 1 PL406 diagnostic on the print statement
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    die 'err';\n    print 'dead';\n}\n";
+    let diags = diagnostics_for(source);
+    let pl406_count = count_pl406(&diags);
+
+    assert_eq!(
+        pl406_count, 1,
+        "Expected exactly 1 PL406 for die in continue block, got {} total PL406: {:?}",
+        pl406_count,
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL406")).map(|d| &d.message).collect::<Vec<_>>()
+    );
+
+    // Verify it's a Hint severity with Unnecessary tag
+    let pl406_diags: Vec<_> = diags.iter().filter(|d| d.code.as_deref() == Some("PL406")).collect();
+    assert_eq!(pl406_diags[0].severity, DiagnosticSeverity::Hint);
+    assert!(pl406_diags[0].tags.contains(&DiagnosticTag::Unnecessary));
+    assert!(pl406_diags[0].suggestion.is_some());
+}
+
+// =========================================================================
+// Continue block with exit followed by statement (AC-2)
+// =========================================================================
+
+#[test]
+fn integration_continue_block_exit_emits_pl406() {
+    // "while (1) { } continue { exit(0); print 'dead'; }"
+    // expect: exactly 1 PL406 diagnostic on the print statement
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    exit(0);\n    print 'dead';\n}\n";
+    let diags = diagnostics_for(source);
+    let pl406_count = count_pl406(&diags);
+
+    assert_eq!(
+        pl406_count, 1,
+        "Expected exactly 1 PL406 for exit in continue block, got {} total PL406: {:?}",
+        pl406_count,
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL406")).map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// =========================================================================
+// Continue block with croak followed by statement (AC-3)
+// =========================================================================
+
+#[test]
+fn integration_continue_block_croak_emits_pl406() {
+    // "while (1) { } continue { croak 'err'; print 'dead'; }"
+    // expect: exactly 1 PL406 diagnostic on the print statement
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    croak 'err';\n    print 'dead';\n}\n";
+    let diags = diagnostics_for(source);
+    let pl406_count = count_pl406(&diags);
+
+    assert_eq!(
+        pl406_count, 1,
+        "Expected exactly 1 PL406 for croak in continue block, got {} total PL406: {:?}",
+        pl406_count,
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL406")).map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// =========================================================================
+// Continue block with last followed by statement (AC-4)
+// =========================================================================
+
+#[test]
+fn integration_continue_block_last_emits_pl406() {
+    // "while (1) { } continue { last; print 'dead'; }"
+    // expect: exactly 1 PL406 diagnostic on the print statement
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    last;\n    print 'dead';\n}\n";
+    let diags = diagnostics_for(source);
+    let pl406_count = count_pl406(&diags);
+
+    assert_eq!(
+        pl406_count, 1,
+        "Expected exactly 1 PL406 for last in continue block, got {} total PL406: {:?}",
+        pl406_count,
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL406")).map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// =========================================================================
+// Continue block with return followed by statement in sub context (AC-5)
+// =========================================================================
+
+#[test]
+fn integration_continue_block_return_emits_pl406() {
+    // "sub f { while (1) { } continue { return; print 'dead'; } }"
+    // expect: exactly 1 PL406 diagnostic on the print statement
+    let source = "use strict;\nuse warnings;\nsub f {\n    while (1) {\n    } continue {\n        return;\n        print 'dead';\n    }\n}\n";
+    let diags = diagnostics_for(source);
+    let pl406_count = count_pl406(&diags);
+
+    assert_eq!(
+        pl406_count, 1,
+        "Expected exactly 1 PL406 for return in continue block (in sub), got {} total PL406: {:?}",
+        pl406_count,
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL406")).map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// =========================================================================
+// Continue block with next followed by statement — NO false positive (AC-6)
+// =========================================================================
+
+#[test]
+fn integration_continue_block_next_no_false_positive() {
+    // "while (1) { } continue { next; print 'reachable'; }"
+    // expect: 0 PL406 diagnostics (next jumps to next iteration, continue re-runs)
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    next;\n    print 'reachable';\n}\n";
+    let diags = diagnostics_for(source);
+    let pl406_count = count_pl406(&diags);
+
+    assert_eq!(
+        pl406_count, 0,
+        "Expected 0 PL406 for next in continue block (next re-runs continue), got {} total PL406: {:?}",
+        pl406_count,
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL406")).map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// =========================================================================
+// Continue block with redo followed by statement — NO false positive (AC-7)
+// =========================================================================
+
+#[test]
+fn integration_continue_block_redo_no_false_positive() {
+    // "while (1) { } continue { redo; print 'reachable'; }"
+    // expect: 0 PL406 diagnostics (redo re-runs the continue block)
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    redo;\n    print 'reachable';\n}\n";
+    let diags = diagnostics_for(source);
+    let pl406_count = count_pl406(&diags);
+
+    assert_eq!(
+        pl406_count, 0,
+        "Expected 0 PL406 for redo in continue block (redo re-runs continue), got {} total PL406: {:?}",
+        pl406_count,
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL406")).map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// =========================================================================
+// Multiple unreachable statements in continue block (AC-8)
+// =========================================================================
+
+#[test]
+fn integration_continue_block_multiple_unreachable() {
+    // "while (1) { } continue { die 'err'; my $x = 1; my $y = 2; print 'dead'; }"
+    // expect: 3 PL406 diagnostics (one each for $x, $y, and print)
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    die 'err';\n    my $x = 1;\n    my $y = 2;\n    print 'dead';\n}\n";
+    let diags = diagnostics_for(source);
+    let pl406_count = count_pl406(&diags);
+
+    assert_eq!(
+        pl406_count, 3,
+        "Expected exactly 3 PL406 for multiple unreachable statements in continue block, got {} total PL406: {:?}",
+        pl406_count,
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL406")).map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// =========================================================================
+// Loop body unreachable detection unchanged (AC-9)
+// =========================================================================
+
+#[test]
+fn integration_loop_body_detection_unchanged() {
+    // "while (1) { next if $cond; die 'err'; print 'dead'; }"
+    // expect: 1 PL406 diagnostic on print in the loop body (not in continue block)
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n    die 'err';\n    print 'dead';\n}\n";
+    let diags = diagnostics_for(source);
+    let pl406_count = count_pl406(&diags);
+
+    assert_eq!(
+        pl406_count, 1,
+        "Expected exactly 1 PL406 for unreachable code in loop body, got {} total PL406: {:?}",
+        pl406_count,
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL406")).map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// =========================================================================
+// All four loop types covered (AC-10): while, until, for, foreach
+// =========================================================================
+
+#[test]
+fn integration_while_loop_with_continue_block() {
+    // while loop with continue block and die
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    die 'err';\n    print 'dead';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 1, "while loop with continue block should detect PL406");
+}
+
+#[test]
+fn integration_for_loop_with_continue_block() {
+    // for loop with continue block and die
+    let source = "use strict;\nuse warnings;\nfor (my $i = 0; $i < 10; $i++) {\n} continue {\n    die 'err';\n    print 'dead';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 1, "for loop with continue block should detect PL406");
+}
+
+#[test]
+fn integration_foreach_loop_with_continue_block() {
+    // foreach loop with continue block and die
+    let source = "use strict;\nuse warnings;\nforeach my $item (@list) {\n} continue {\n    die 'err';\n    print 'dead';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 1, "foreach loop with continue block should detect PL406");
+}
+
+// =========================================================================
+// Continue block with Carp::croak (qualified) followed by statement
+// =========================================================================
+
+#[test]
+fn integration_continue_block_carp_croak_emits_pl406() {
+    // "while (1) { } continue { Carp::croak 'err'; print 'dead'; }"
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    Carp::croak 'err';\n    print 'dead';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 1, "Carp::croak in continue block should emit PL406");
+}
+
+// =========================================================================
+// Continue block with Carp::confess (qualified) followed by statement
+// =========================================================================
+
+#[test]
+fn integration_continue_block_carp_confess_emits_pl406() {
+    // "while (1) { } continue { Carp::confess 'err'; print 'dead'; }"
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    Carp::confess 'err';\n    print 'dead';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 1, "Carp::confess in continue block should emit PL406");
+}
+
+// =========================================================================
+// Empty continue block — no diagnostics expected
+// =========================================================================
+
+#[test]
+fn integration_empty_continue_block_no_pl406() {
+    // "while (1) { } continue { }"
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 0, "Empty continue block should not emit PL406");
+}
+
+// =========================================================================
+// Continue block with only unconditional exit — no diagnostics expected
+// =========================================================================
+
+#[test]
+fn integration_continue_block_only_exit_no_pl406() {
+    // "while (1) { } continue { die 'err'; }"
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    die 'err';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 0, "Continue block with only exit should not emit PL406");
+}
+
+// =========================================================================
+// Nested block inside continue block — inner die doesn't affect outer
+// =========================================================================
+
+#[test]
+fn integration_nested_block_inside_continue() {
+    // "while (1) { } continue { { die 'err'; } print 'reachable'; }"
+    // The die is inside an inner block, so print is still reachable
+    // from the continue block's perspective
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    {\n        die 'err';\n    }\n    print 'reachable';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 0, "Nested block in continue block should not affect outer reachability");
+}
+
+// =========================================================================
+// Labeled next in continue block — NO false positive
+// =========================================================================
+
+#[test]
+fn integration_labeled_next_continue_block_no_pl406() {
+    // "while (1) { } continue { next OUTER if $cond; print 'reachable'; }"
+    let source = "use strict;\nuse warnings;\nOUTER: while (1) {\n} continue {\n    next OUTER if $cond;\n    print 'reachable';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 0, "Labeled next in continue block should not emit PL406");
+}
+
+// =========================================================================
+// Labeled redo in continue block — NO false positive
+// =========================================================================
+
+#[test]
+fn integration_labeled_redo_continue_block_no_pl406() {
+    // "while (1) { } continue { redo OUTER; print 'reachable'; }"
+    let source = "use strict;\nuse warnings;\nOUTER: while (1) {\n} continue {\n    redo OUTER;\n    print 'reachable';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 0, "Labeled redo in continue block should not emit PL406");
+}
+
+// =========================================================================
+// Eval inside continue block — die in eval doesn't poison continue block
+// =========================================================================
+
+#[test]
+fn integration_eval_inside_continue_block() {
+    // "while (1) { } continue { eval { die 'err' }; print 'reachable'; }"
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    eval { die 'err' };\n    print 'reachable';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 0, "Eval inside continue block should not emit PL406");
+}
+
+// =========================================================================
+// Anonymous sub in continue block — return in sub doesn't affect continue
+// =========================================================================
+
+#[test]
+fn integration_anonymous_sub_in_continue_block() {
+    // "while (1) { } continue { my $f = sub { return; }; print 'reachable'; }"
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    my $f = sub { return; };\n    print 'reachable';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 0, "Anonymous sub in continue block should not emit PL406");
+}
+
+// =========================================================================
+// Conditional die in continue block — NO false positive
+// =========================================================================
+
+#[test]
+fn integration_conditional_die_in_continue_block() {
+    // "while (1) { } continue { die 'err' if $cond; print 'reachable'; }"
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    die 'err' if $cond;\n    print 'reachable';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 0, "Conditional die in continue block should not emit PL406");
+}
+
+// =========================================================================
+// next with multiple following statements in continue block — NO false positive
+// =========================================================================
+
+#[test]
+fn integration_next_continue_with_multiple_following() {
+    // "while (1) { } continue { next; $x = 1; $y = 2; print 'reachable'; }"
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    next;\n    my $x = 1;\n    my $y = 2;\n    print 'reachable';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 0, "Multiple statements after next in continue block should not emit PL406");
+}
+
+// =========================================================================
+// redo with multiple following statements in continue block — NO false positive
+// =========================================================================
+
+#[test]
+fn integration_redo_continue_with_multiple_following() {
+    // "while (1) { } continue { redo; $x = 1; $y = 2; print 'reachable'; }"
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n} continue {\n    redo;\n    my $x = 1;\n    my $y = 2;\n    print 'reachable';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(count_pl406(&diags), 0, "Multiple statements after redo in continue block should not emit PL406");
+}
+
+// =========================================================================
+// Combined: loop body with die AND continue block with die — both detected
+// =========================================================================
+
+#[test]
+fn integration_both_loop_body_and_continue_block() {
+    // Loop body has die followed by unreachable print
+    // Continue block has die followed by unreachable print
+    // Should get 2 PL406 diagnostics total
+    let source = "use strict;\nuse warnings;\nwhile (1) {\n    die 'body_err';\n    print 'body_dead';\n} continue {\n    die 'cont_err';\n    print 'cont_dead';\n}\n";
+    let diags = diagnostics_for(source);
+    assert_eq!(
+        count_pl406(&diags), 2,
+        "Expected 2 PL406 diagnostics (one for loop body, one for continue block), got: {:?}",
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL406")).map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/crates/perl-lsp-diagnostics/tests/unreachable_code_property_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/unreachable_code_property_tests.rs
@@ -1,0 +1,1110 @@
+//! Property-based tests for unreachable code detection (PL406)
+//!
+//! These tests verify invariants that should hold for all inputs, not just
+//! specific examples.
+
+use perl_lsp_diagnostics::unreachable_code::check_unreachable_code;
+use perl_lsp_diagnostics::DiagnosticTag;
+use perl_parser_core::{Node, NodeKind, SourceLocation};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn loc(start: usize, end: usize) -> SourceLocation {
+    SourceLocation { start, end }
+}
+
+fn program(stmts: Vec<Node>) -> Node {
+    Node::new(NodeKind::Program { statements: stmts }, loc(0, 200))
+}
+
+fn block(stmts: Vec<Node>) -> Node {
+    Node::new(NodeKind::Block { statements: stmts }, loc(0, 100))
+}
+
+fn sub_node(name: &str, body: Node) -> Node {
+    Node::new(
+        NodeKind::Subroutine {
+            name: Some(name.to_string()),
+            name_span: None,
+            prototype: None,
+            signature: None,
+            attributes: vec![],
+            body: Box::new(body),
+        },
+        loc(0, 100),
+    )
+}
+
+fn return_node() -> Node {
+    Node::new(NodeKind::Return { value: None }, loc(10, 20))
+}
+
+fn print_stmt(start: usize, end: usize) -> Node {
+    Node::new(
+        NodeKind::ExpressionStatement {
+            expression: Box::new(Node::new(
+                NodeKind::FunctionCall {
+                    name: "print".to_string(),
+                    args: vec![Node::new(
+                        NodeKind::String { value: "dead".to_string(), interpolated: false },
+                        loc(start + 6, end - 1),
+                    )],
+                },
+                loc(start, end),
+            )),
+        },
+        loc(start, end),
+    )
+}
+
+fn die_call(start: usize, end: usize) -> Node {
+    Node::new(
+        NodeKind::ExpressionStatement {
+            expression: Box::new(Node::new(
+                NodeKind::FunctionCall {
+                    name: "die".to_string(),
+                    args: vec![Node::new(
+                        NodeKind::String { value: "err".to_string(), interpolated: false },
+                        loc(start + 4, end - 1),
+                    )],
+                },
+                loc(start, end),
+            )),
+        },
+        loc(start, end),
+    )
+}
+
+fn exit_call(start: usize, end: usize) -> Node {
+    Node::new(
+        NodeKind::ExpressionStatement {
+            expression: Box::new(Node::new(
+                NodeKind::FunctionCall {
+                    name: "exit".to_string(),
+                    args: vec![Node::new(
+                        NodeKind::Number { value: "0".to_string() },
+                        loc(start + 5, end - 1),
+                    )],
+                },
+                loc(start, end),
+            )),
+        },
+        loc(start, end),
+    )
+}
+
+fn croak_call(start: usize, end: usize) -> Node {
+    Node::new(
+        NodeKind::ExpressionStatement {
+            expression: Box::new(Node::new(
+                NodeKind::FunctionCall {
+                    name: "croak".to_string(),
+                    args: vec![Node::new(
+                        NodeKind::String { value: "err".to_string(), interpolated: false },
+                        loc(start + 6, end - 1),
+                    )],
+                },
+                loc(start, end),
+            )),
+        },
+        loc(start, end),
+    )
+}
+
+fn confess_call(start: usize, end: usize) -> Node {
+    Node::new(
+        NodeKind::ExpressionStatement {
+            expression: Box::new(Node::new(
+                NodeKind::FunctionCall {
+                    name: "Carp::confess".to_string(),
+                    args: vec![Node::new(
+                        NodeKind::String { value: "err".to_string(), interpolated: false },
+                        loc(start + 14, end - 1),
+                    )],
+                },
+                loc(start, end),
+            )),
+        },
+        loc(start, end),
+    )
+}
+
+fn my_var_decl(start: usize, end: usize, name: &str) -> Node {
+    Node::new(
+        NodeKind::VariableDeclaration {
+            declarator: "my".to_string(),
+            variable: Box::new(Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: name.to_string() },
+                loc(start + 3, end),
+            )),
+            attributes: vec![],
+            initializer: Some(Box::new(Node::new(
+                NodeKind::Number { value: "1".to_string() },
+                loc(end - 1, end),
+            ))),
+        },
+        loc(start, end),
+    )
+}
+
+fn last_stmt(start: usize, end: usize) -> Node {
+    Node::new(NodeKind::LoopControl { op: "last".to_string(), label: None }, loc(start, end))
+}
+
+fn next_stmt(start: usize, end: usize) -> Node {
+    Node::new(NodeKind::LoopControl { op: "next".to_string(), label: None }, loc(start, end))
+}
+
+fn redo_stmt(start: usize, end: usize) -> Node {
+    Node::new(NodeKind::LoopControl { op: "redo".to_string(), label: None }, loc(start, end))
+}
+
+fn while_loop(body: Node) -> Node {
+    Node::new(
+        NodeKind::While {
+            condition: Box::new(Node::new(NodeKind::Number { value: "1".to_string() }, loc(7, 8))),
+            body: Box::new(body),
+            continue_block: None,
+        },
+        loc(0, 60),
+    )
+}
+
+fn while_loop_with_continue(body: Node, continue_body: Node) -> Node {
+    Node::new(
+        NodeKind::While {
+            condition: Box::new(Node::new(NodeKind::Number { value: "1".to_string() }, loc(7, 8))),
+            body: Box::new(body),
+            continue_block: Some(Box::new(continue_body)),
+        },
+        loc(0, 120),
+    )
+}
+
+fn for_loop_with_continue(body: Node, continue_body: Node) -> Node {
+    Node::new(
+        NodeKind::For {
+            init: None,
+            condition: None,
+            update: None,
+            body: Box::new(body),
+            continue_block: Some(Box::new(continue_body)),
+        },
+        loc(0, 120),
+    )
+}
+
+fn foreach_loop_with_continue(body: Node, continue_body: Node) -> Node {
+    Node::new(
+        NodeKind::Foreach {
+            variable: Box::new(Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "item".to_string() },
+                loc(9, 11),
+            )),
+            list: Box::new(Node::new(
+                NodeKind::Variable { sigil: "@".to_string(), name: "list".to_string() },
+                loc(15, 20),
+            )),
+            body: Box::new(body),
+            continue_block: Some(Box::new(continue_body)),
+        },
+        loc(0, 120),
+    )
+}
+
+fn count_pl406(diagnostics: &[perl_lsp_diagnostics::Diagnostic]) -> usize {
+    diagnostics.iter().filter(|d| d.code.as_deref() == Some("PL406")).count()
+}
+
+// ---------------------------------------------------------------------------
+// Property 1: No false positives in unconditional exit list
+// For each exit type (die, exit, croak, confess, return, last),
+// the number of PL406 diagnostics should equal the number of statements
+// that DIRECTLY follow the exit in the same statement list.
+// ---------------------------------------------------------------------------
+
+/// Property: Each unconditional exit type produces exactly N diagnostics
+/// for N statements following it in a flat statement list.
+#[test]
+fn property_die_produces_correct_diagnostic_count() {
+    for num_following in 0..=10 {
+        let mut stmts = vec![];
+        let exit_call = Node::new(
+            NodeKind::ExpressionStatement {
+                expression: Box::new(Node::new(
+                    NodeKind::FunctionCall {
+                        name: "die".to_string(),
+                        args: vec![Node::new(
+                            NodeKind::String { value: "err".to_string(), interpolated: false },
+                            loc(5, 10),
+                        )],
+                    },
+                    loc(0, 15),
+                )),
+            },
+            loc(0, 16),
+        );
+        stmts.push(exit_call);
+
+        let mut expected_count = 0;
+        for i in 0..num_following {
+            let start = 20 + i * 20;
+            stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+            expected_count += 1;
+        }
+
+        let ast = program(vec![sub_node("foo", block(stmts))]);
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, expected_count,
+            "P1: die with {} following statements: expected {} PL406, got {}",
+            num_following, expected_count, actual_count
+        );
+    }
+}
+
+#[test]
+fn property_exit_produces_correct_diagnostic_count() {
+    for num_following in 0..=10 {
+        let mut stmts = vec![];
+        let exit_call = Node::new(
+            NodeKind::ExpressionStatement {
+                expression: Box::new(Node::new(
+                    NodeKind::FunctionCall {
+                        name: "exit".to_string(),
+                        args: vec![Node::new(
+                            NodeKind::Number { value: "0".to_string() },
+                            loc(5, 6),
+                        )],
+                    },
+                    loc(0, 10),
+                )),
+            },
+            loc(0, 11),
+        );
+        stmts.push(exit_call);
+
+        let mut expected_count = 0;
+        for i in 0..num_following {
+            let start = 20 + i * 20;
+            stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+            expected_count += 1;
+        }
+
+        let ast = program(vec![sub_node("foo", block(stmts))]);
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, expected_count,
+            "P1: exit with {} following statements: expected {} PL406, got {}",
+            num_following, expected_count, actual_count
+        );
+    }
+}
+
+#[test]
+fn property_croak_produces_correct_diagnostic_count() {
+    for num_following in 0..=10 {
+        let mut stmts = vec![];
+        let exit_call = Node::new(
+            NodeKind::ExpressionStatement {
+                expression: Box::new(Node::new(
+                    NodeKind::FunctionCall {
+                        name: "croak".to_string(),
+                        args: vec![Node::new(
+                            NodeKind::String { value: "err".to_string(), interpolated: false },
+                            loc(7, 11),
+                        )],
+                    },
+                    loc(0, 16),
+                )),
+            },
+            loc(0, 17),
+        );
+        stmts.push(exit_call);
+
+        let mut expected_count = 0;
+        for i in 0..num_following {
+            let start = 25 + i * 20;
+            stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+            expected_count += 1;
+        }
+
+        let ast = program(vec![sub_node("foo", block(stmts))]);
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, expected_count,
+            "P1: croak with {} following statements: expected {} PL406, got {}",
+            num_following, expected_count, actual_count
+        );
+    }
+}
+
+#[test]
+fn property_confess_produces_correct_diagnostic_count() {
+    for num_following in 0..=10 {
+        let mut stmts = vec![];
+        let exit_call = Node::new(
+            NodeKind::ExpressionStatement {
+                expression: Box::new(Node::new(
+                    NodeKind::FunctionCall {
+                        name: "Carp::confess".to_string(),
+                        args: vec![Node::new(
+                            NodeKind::String { value: "err".to_string(), interpolated: false },
+                            loc(14, 18),
+                        )],
+                    },
+                    loc(0, 23),
+                )),
+            },
+            loc(0, 24),
+        );
+        stmts.push(exit_call);
+
+        let mut expected_count = 0;
+        for i in 0..num_following {
+            let start = 30 + i * 20;
+            stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+            expected_count += 1;
+        }
+
+        let ast = program(vec![sub_node("foo", block(stmts))]);
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, expected_count,
+            "P1: confess with {} following statements: expected {} PL406, got {}",
+            num_following, expected_count, actual_count
+        );
+    }
+}
+
+#[test]
+fn property_return_produces_correct_diagnostic_count() {
+    for num_following in 0..=10 {
+        let mut stmts = vec![];
+        stmts.push(return_node());
+
+        let mut expected_count = 0;
+        for i in 0..num_following {
+            let start = 25 + i * 20;
+            stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+            expected_count += 1;
+        }
+
+        let ast = program(vec![sub_node("foo", block(stmts))]);
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, expected_count,
+            "P1: return with {} following statements: expected {} PL406, got {}",
+            num_following, expected_count, actual_count
+        );
+    }
+}
+
+#[test]
+fn property_last_loop_control_produces_correct_diagnostic_count() {
+    for num_following in 0..=10 {
+        let ctrl = Node::new(
+            NodeKind::LoopControl { op: "last".to_string(), label: None },
+            loc(10, 15),
+        );
+
+        let mut stmts = vec![ctrl];
+        let mut expected_count = 0;
+        for i in 0..num_following {
+            let start = 20 + i * 20;
+            stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+            expected_count += 1;
+        }
+
+        let ast = program(vec![while_loop(block(stmts))]);
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, expected_count,
+            "P1: last in loop body with {} following: expected {} PL406, got {}",
+            num_following, expected_count, actual_count
+        );
+    }
+}
+
+#[test]
+fn property_next_loop_control_produces_correct_diagnostic_count() {
+    for num_following in 0..=10 {
+        let ctrl = Node::new(
+            NodeKind::LoopControl { op: "next".to_string(), label: None },
+            loc(10, 15),
+        );
+
+        let mut stmts = vec![ctrl];
+        let mut expected_count = 0;
+        for i in 0..num_following {
+            let start = 20 + i * 20;
+            stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+            expected_count += 1;
+        }
+
+        let ast = program(vec![while_loop(block(stmts))]);
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, expected_count,
+            "P1: next in loop body with {} following: expected {} PL406, got {}",
+            num_following, expected_count, actual_count
+        );
+    }
+}
+
+#[test]
+fn property_redo_loop_control_produces_correct_diagnostic_count() {
+    for num_following in 0..=10 {
+        let ctrl = Node::new(
+            NodeKind::LoopControl { op: "redo".to_string(), label: None },
+            loc(10, 15),
+        );
+
+        let mut stmts = vec![ctrl];
+        let mut expected_count = 0;
+        for i in 0..num_following {
+            let start = 20 + i * 20;
+            stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+            expected_count += 1;
+        }
+
+        let ast = program(vec![while_loop(block(stmts))]);
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, expected_count,
+            "P1: redo in loop body with {} following: expected {} PL406, got {}",
+            num_following, expected_count, actual_count
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property 2: No false positives — conditional exits produce 0 diagnostics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_conditional_die_no_false_positive() {
+    for num_following in 0..=5 {
+        let exit_call = Node::new(
+            NodeKind::ExpressionStatement {
+                expression: Box::new(Node::new(
+                    NodeKind::FunctionCall {
+                        name: "die".to_string(),
+                        args: vec![Node::new(
+                            NodeKind::String { value: "err".to_string(), interpolated: false },
+                            loc(10, 15),
+                        )],
+                    },
+                    loc(5, 20),
+                )),
+            },
+            loc(5, 21),
+        );
+
+        let conditional_exit = Node::new(
+            NodeKind::StatementModifier {
+                statement: Box::new(exit_call),
+                modifier: "if".to_string(),
+                condition: Box::new(Node::new(
+                    NodeKind::Variable { sigil: "$".to_string(), name: "cond".to_string() },
+                    loc(26, 31),
+                )),
+            },
+            loc(5, 32),
+        );
+
+        let mut stmts = vec![conditional_exit];
+        for i in 0..num_following {
+            let start = 35 + i * 20;
+            stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+        }
+
+        let ast = program(vec![sub_node("foo", block(stmts))]);
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, 0,
+            "P2: conditional die should produce 0 PL406, got {}",
+            actual_count
+        );
+    }
+}
+
+#[test]
+fn property_conditional_return_no_false_positive() {
+    let conditional_return = Node::new(
+        NodeKind::StatementModifier {
+            statement: Box::new(return_node()),
+            modifier: "if".to_string(),
+            condition: Box::new(Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "cond".to_string() },
+                loc(22, 27),
+            )),
+        },
+        loc(10, 28),
+    );
+
+    let stmts = vec![conditional_return, print_stmt(30, 50)];
+    let ast = program(vec![sub_node("foo", block(stmts))]);
+
+    let mut diagnostics = vec![];
+    check_unreachable_code(&ast, &mut diagnostics);
+    let actual_count = count_pl406(&diagnostics);
+
+    assert_eq!(
+        actual_count, 0,
+        "P2: conditional return should produce 0 PL406, got {}",
+        actual_count
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Property 3: eval boundary — die inside eval does NOT poison outer scope
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_eval_contains_die_no_false_positive() {
+    for num_following in 0..=5 {
+        let die_inside = die_call(7, 20);
+        let eval_stmt = Node::new(
+            NodeKind::ExpressionStatement {
+                expression: Box::new(Node::new(
+                    NodeKind::Eval { block: Box::new(block(vec![die_inside])) },
+                    loc(0, 22),
+                )),
+            },
+            loc(0, 23),
+        );
+
+        let mut stmts = vec![eval_stmt];
+        for i in 0..num_following {
+            let start = 30 + i * 20;
+            stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+        }
+
+        let ast = program(stmts);
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, 0,
+            "P3: eval containing die with {} following: expected 0 PL406, got {}",
+            num_following, actual_count
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property 4: Nested sub boundary — return in nested sub does NOT poison
+// the outer statement list
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_nested_sub_contains_return_no_false_positive() {
+    for num_following in 0..=5 {
+        let inner_return = return_node();
+        let inner_sub = Node::new(
+            NodeKind::Subroutine {
+                name: None,
+                name_span: None,
+                prototype: None,
+                signature: None,
+                attributes: vec![],
+                body: Box::new(block(vec![inner_return])),
+            },
+            loc(15, 40),
+        );
+        let my_f = Node::new(
+            NodeKind::VariableDeclaration {
+                declarator: "my".to_string(),
+                variable: Box::new(Node::new(
+                    NodeKind::Variable { sigil: "$".to_string(), name: "f".to_string() },
+                    loc(13, 15),
+                )),
+                attributes: vec![],
+                initializer: Some(Box::new(inner_sub)),
+            },
+            loc(12, 45),
+        );
+
+        let mut stmts = vec![my_f];
+        for i in 0..num_following {
+            let start = 50 + i * 20;
+            stmts.push(print_stmt(start, start + 20));
+        }
+
+        let ast = program(vec![sub_node("outer", block(stmts))]);
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, 0,
+            "P4: nested sub with return, {} following: expected 0 PL406, got {}",
+            num_following, actual_count
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property 5: Continue block — exit in continue block produces diagnostics,
+// but next/redo do NOT (they re-run the continue block)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_continue_block_die_produces_diagnostics() {
+    for num_following in 0..=5 {
+        let mut continue_stmts = vec![];
+        continue_stmts.push(die_call(20, 35));
+
+        let mut expected_count = 0;
+        for i in 0..num_following {
+            let start = 40 + i * 20;
+            continue_stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+            expected_count += 1;
+        }
+
+        let continue_body = block(continue_stmts);
+        let ast = program(vec![while_loop_with_continue(block(vec![]), continue_body)]);
+
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, expected_count,
+            "P5: die in continue block with {} following: expected {} PL406, got {}",
+            num_following, expected_count, actual_count
+        );
+    }
+}
+
+#[test]
+fn property_continue_block_exit_produces_diagnostics() {
+    for num_following in 0..=5 {
+        let mut continue_stmts = vec![];
+        continue_stmts.push(exit_call(20, 30));
+
+        let mut expected_count = 0;
+        for i in 0..num_following {
+            let start = 35 + i * 20;
+            continue_stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+            expected_count += 1;
+        }
+
+        let continue_body = block(continue_stmts);
+        let ast = program(vec![while_loop_with_continue(block(vec![]), continue_body)]);
+
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, expected_count,
+            "P5: exit in continue block with {} following: expected {} PL406, got {}",
+            num_following, expected_count, actual_count
+        );
+    }
+}
+
+#[test]
+fn property_continue_block_croak_produces_diagnostics() {
+    for num_following in 0..=5 {
+        let mut continue_stmts = vec![];
+        continue_stmts.push(croak_call(20, 35));
+
+        let mut expected_count = 0;
+        for i in 0..num_following {
+            let start = 40 + i * 20;
+            continue_stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+            expected_count += 1;
+        }
+
+        let continue_body = block(continue_stmts);
+        let ast = program(vec![while_loop_with_continue(block(vec![]), continue_body)]);
+
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, expected_count,
+            "P5: croak in continue block with {} following: expected {} PL406, got {}",
+            num_following, expected_count, actual_count
+        );
+    }
+}
+
+#[test]
+fn property_continue_block_confess_produces_diagnostics() {
+    for num_following in 0..=5 {
+        let mut continue_stmts = vec![];
+        continue_stmts.push(confess_call(20, 40));
+
+        let mut expected_count = 0;
+        for i in 0..num_following {
+            let start = 45 + i * 20;
+            continue_stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+            expected_count += 1;
+        }
+
+        let continue_body = block(continue_stmts);
+        let ast = program(vec![while_loop_with_continue(block(vec![]), continue_body)]);
+
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, expected_count,
+            "P5: confess in continue block with {} following: expected {} PL406, got {}",
+            num_following, expected_count, actual_count
+        );
+    }
+}
+
+#[test]
+fn property_continue_block_return_produces_diagnostics() {
+    for num_following in 0..=5 {
+        let mut continue_stmts = vec![];
+        continue_stmts.push(return_node());
+
+        let mut expected_count = 0;
+        for i in 0..num_following {
+            let start = 30 + i * 20;
+            continue_stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+            expected_count += 1;
+        }
+
+        let continue_body = block(continue_stmts);
+        let ast = program(vec![while_loop_with_continue(block(vec![]), continue_body)]);
+
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, expected_count,
+            "P5: return in continue block with {} following: expected {} PL406, got {}",
+            num_following, expected_count, actual_count
+        );
+    }
+}
+
+#[test]
+fn property_continue_block_last_produces_diagnostics() {
+    for num_following in 0..=5 {
+        let mut continue_stmts = vec![];
+        continue_stmts.push(last_stmt(20, 25));
+
+        let mut expected_count = 0;
+        for i in 0..num_following {
+            let start = 30 + i * 20;
+            continue_stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+            expected_count += 1;
+        }
+
+        let continue_body = block(continue_stmts);
+        let ast = program(vec![while_loop_with_continue(block(vec![]), continue_body)]);
+
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, expected_count,
+            "P5: last in continue block with {} following: expected {} PL406, got {}",
+            num_following, expected_count, actual_count
+        );
+    }
+}
+
+#[test]
+fn property_continue_block_next_no_false_positive() {
+    for num_following in 0..=5 {
+        let mut continue_stmts = vec![];
+        continue_stmts.push(next_stmt(20, 25));
+
+        for i in 0..num_following {
+            let start = 30 + i * 20;
+            continue_stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+        }
+
+        let continue_body = block(continue_stmts);
+        let ast = program(vec![while_loop_with_continue(block(vec![]), continue_body)]);
+
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, 0,
+            "P5: next in continue block with {} following: expected 0 PL406, got {}",
+            num_following, actual_count
+        );
+    }
+}
+
+#[test]
+fn property_continue_block_redo_no_false_positive() {
+    for num_following in 0..=5 {
+        let mut continue_stmts = vec![];
+        continue_stmts.push(redo_stmt(20, 25));
+
+        for i in 0..num_following {
+            let start = 30 + i * 20;
+            continue_stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+        }
+
+        let continue_body = block(continue_stmts);
+        let ast = program(vec![while_loop_with_continue(block(vec![]), continue_body)]);
+
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, 0,
+            "P5: redo in continue block with {} following: expected 0 PL406, got {}",
+            num_following, actual_count
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property 6: Branch independence — exit in one branch of if/elsif/else
+// does NOT affect statements in other branches
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_if_branch_independence() {
+    // Case: return in then-branch, statement in else-branch — 0 PL406
+    let then_branch = block(vec![return_node()]);
+    let else_body = block(vec![print_stmt(50, 70)]);
+
+    let if_node = Node::new(
+        NodeKind::If {
+            condition: Box::new(Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() },
+                loc(4, 6),
+            )),
+            then_branch: Box::new(then_branch),
+            elsif_branches: vec![],
+            else_branch: Some(Box::new(else_body)),
+        },
+        loc(0, 80),
+    );
+
+    let ast = program(vec![sub_node("foo", block(vec![if_node]))]);
+    let mut diagnostics = vec![];
+    check_unreachable_code(&ast, &mut diagnostics);
+    let actual_count = count_pl406(&diagnostics);
+
+    assert_eq!(
+        actual_count, 0,
+        "P6: return in then-branch should not affect else-branch: expected 0 PL406, got {}",
+        actual_count
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Property 7: Loop body vs continue block are independent scopes
+// An exit in the loop body does NOT affect the continue block
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_loop_body_does_not_affect_continue_block() {
+    for num_continue_stmts in 0..=5 {
+        let loop_body = block(vec![die_call(10, 25)]);
+        let mut continue_stmts = vec![];
+        for i in 0..num_continue_stmts {
+            let start = 40 + i * 20;
+            continue_stmts.push(my_var_decl(start, start + 10, &format!("x{}", i)));
+        }
+
+        let continue_body = block(continue_stmts);
+        let ast = program(vec![while_loop_with_continue(loop_body, continue_body)]);
+
+        let mut diagnostics = vec![];
+        check_unreachable_code(&ast, &mut diagnostics);
+        let actual_count = count_pl406(&diagnostics);
+
+        assert_eq!(
+            actual_count, 0,
+            "P7: die in loop body should not affect continue block with {} stmts: expected 0 PL406, got {}",
+            num_continue_stmts, actual_count
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property 8: Multiple exit points — each independent scope is analyzed
+// separately
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_multiple_exits_cumulative() {
+    // sub { return; my $x; return; my $y; }
+    // First return makes $x unreachable AND the second return unreachable,
+    // then $y is also unreachable. Expected: 3 PL406 diagnostics.
+    //
+    // Key insight: once found_exit=true, EVERY subsequent statement (including
+    // subsequent exit statements) is flagged as unreachable, not just the
+    // non-exit statements that follow.
+    let stmts = vec![
+        return_node(),
+        my_var_decl(25, 35, "x"),
+        return_node(),
+        my_var_decl(40, 50, "y"),
+    ];
+    let ast = program(vec![sub_node("foo", block(stmts))]);
+
+    let mut diagnostics = vec![];
+    check_unreachable_code(&ast, &mut diagnostics);
+    let actual_count = count_pl406(&diagnostics);
+
+    // 3 diagnostics: $x, second return, and $y are all unreachable
+    assert_eq!(actual_count, 3, "P8: return; $x; return; $y => expected 3 PL406, got {}", actual_count);
+}
+
+// ---------------------------------------------------------------------------
+// Property 9: All four loop types (while, for, foreach) with continue blocks
+// behave identically for unreachable code detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_all_loop_types_continue_block_same_behavior() {
+    // Test while, for, foreach with die in continue block followed by 1 statement
+    let while_continue = block(vec![die_call(20, 35), my_var_decl(40, 50, "x")]);
+    let while_loop = while_loop_with_continue(block(vec![]), while_continue);
+
+    let for_continue = block(vec![die_call(20, 35), my_var_decl(40, 50, "x")]);
+    let for_loop = for_loop_with_continue(block(vec![]), for_continue);
+
+    let foreach_continue = block(vec![die_call(20, 35), my_var_decl(40, 50, "x")]);
+    let foreach_loop = foreach_loop_with_continue(block(vec![]), foreach_continue);
+
+    let ast_while = program(vec![while_loop]);
+    let ast_for = program(vec![for_loop]);
+    let ast_foreach = program(vec![foreach_loop]);
+
+    let mut diag_while = vec![];
+    let mut diag_for = vec![];
+    let mut diag_foreach = vec![];
+    check_unreachable_code(&ast_while, &mut diag_while);
+    check_unreachable_code(&ast_for, &mut diag_for);
+    check_unreachable_code(&ast_foreach, &mut diag_foreach);
+
+    let cnt_while = count_pl406(&diag_while);
+    let cnt_for = count_pl406(&diag_for);
+    let cnt_foreach = count_pl406(&diag_foreach);
+
+    assert_eq!(cnt_while, cnt_for, "P9: while and for should produce same count");
+    assert_eq!(cnt_while, cnt_foreach, "P9: while and foreach should produce same count");
+    assert_eq!(cnt_while, 1, "P9: all should produce 1 PL406");
+}
+
+// ---------------------------------------------------------------------------
+// Property 10: Diagnostic tag is always Unnecessary for PL406
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_pl406_always_has_unnecessary_tag() {
+    let stmts = vec![
+        return_node(),
+        my_var_decl(25, 35, "x"),
+        my_var_decl(40, 50, "y"),
+    ];
+    let ast = program(vec![sub_node("foo", block(stmts))]);
+
+    let mut diagnostics = vec![];
+    check_unreachable_code(&ast, &mut diagnostics);
+
+    for diag in &diagnostics {
+        if diag.code.as_deref() == Some("PL406") {
+            assert!(
+                diag.tags.contains(&DiagnosticTag::Unnecessary),
+                "P10: PL406 should always have Unnecessary tag"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property 11: PL406 severity is always Hint
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_pl406_always_has_hint_severity() {
+    let stmts = vec![
+        return_node(),
+        my_var_decl(25, 35, "x"),
+    ];
+    let ast = program(vec![sub_node("foo", block(stmts))]);
+
+    let mut diagnostics = vec![];
+    check_unreachable_code(&ast, &mut diagnostics);
+
+    for diag in &diagnostics {
+        if diag.code.as_deref() == Some("PL406") {
+            assert!(
+                matches!(diag.severity, perl_diagnostics::codes::DiagnosticSeverity::Hint),
+                "P11: PL406 should always have Hint severity"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property 12: PL406 always has a suggestion
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_pl406_always_has_suggestion() {
+    let stmts = vec![
+        return_node(),
+        my_var_decl(25, 35, "x"),
+    ];
+    let ast = program(vec![sub_node("foo", block(stmts))]);
+
+    let mut diagnostics = vec![];
+    check_unreachable_code(&ast, &mut diagnostics);
+
+    for diag in &diagnostics {
+        if diag.code.as_deref() == Some("PL406") {
+            assert!(
+                diag.suggestion.is_some(),
+                "P12: PL406 should always have a suggestion"
+            );
+        }
+    }
+}

--- a/crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/unreachable_code_snapshot_tests.rs
@@ -1,0 +1,220 @@
+//! Snapshot tests for unreachable code detection (PL406)
+//!
+//! These tests complement code-level assertions by snapshotting normalized
+//! diagnostics (code, severity, range, message) for representative
+//! snippets involving continue blocks. This catches regressions in message
+//! text and location metadata.
+
+use insta::assert_snapshot;
+use perl_lsp_diagnostics::unreachable_code::check_unreachable_code;
+use perl_parser::Parser;
+use perl_parser_core::ast::Node;
+
+fn parse(source: &str) -> Node {
+    let output = Parser::new(source).parse_with_recovery();
+    output.ast
+}
+
+fn unreachable_code_for(source: &str) -> Vec<perl_lsp_diagnostics::Diagnostic> {
+    let ast = parse(source);
+    let mut diagnostics = vec![];
+    check_unreachable_code(&ast, &mut diagnostics);
+    diagnostics
+}
+
+fn severity_name(severity: perl_diagnostics::codes::DiagnosticSeverity) -> &'static str {
+    match severity {
+        perl_diagnostics::codes::DiagnosticSeverity::Error => "Error",
+        perl_diagnostics::codes::DiagnosticSeverity::Warning => "Warning",
+        perl_diagnostics::codes::DiagnosticSeverity::Information => "Information",
+        perl_diagnostics::codes::DiagnosticSeverity::Hint => "Hint",
+    }
+}
+
+fn normalize(diags: Vec<perl_lsp_diagnostics::Diagnostic>) -> String {
+    let mut normalized: Vec<_> = diags
+        .into_iter()
+        .map(|diag| {
+            let code = diag.code.unwrap_or_else(|| "<none>".to_string());
+            format!(
+                "{} | {} | {:?} | {}",
+                code,
+                severity_name(diag.severity),
+                diag.range,
+                diag.message
+            )
+        })
+        .collect();
+
+    normalized.sort_unstable();
+    normalized.join("\n")
+}
+
+// ===========================================================================
+// AC-1: Continue block with die followed by statement
+// "while (1) { } continue { die 'err'; print 'dead'; }"
+// expect: exactly 1 PL406 diagnostic on the print statement
+// ===========================================================================
+
+#[test]
+fn snapshot_continue_block_die_followed_by_statement() {
+    let source = "while (1) { } continue { die 'err'; print 'dead'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("continue_block_die_followed_by_statement", snapshot);
+}
+
+// ===========================================================================
+// AC-2: Continue block with exit followed by statement
+// "while (1) { } continue { exit(0); print 'dead'; }"
+// expect: exactly 1 PL406 diagnostic on the print statement
+// ===========================================================================
+
+#[test]
+fn snapshot_continue_block_exit_followed_by_statement() {
+    let source = "while (1) { } continue { exit(0); print 'dead'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("continue_block_exit_followed_by_statement", snapshot);
+}
+
+// ===========================================================================
+// AC-3: Continue block with croak followed by statement
+// "while (1) { } continue { croak 'err'; print 'dead'; }"
+// expect: exactly 1 PL406 diagnostic on the print statement
+// ===========================================================================
+
+#[test]
+fn snapshot_continue_block_croak_followed_by_statement() {
+    let source = "while (1) { } continue { croak 'err'; print 'dead'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("continue_block_croak_followed_by_statement", snapshot);
+}
+
+// ===========================================================================
+// AC-4: Continue block with last followed by statement
+// "while (1) { } continue { last; print 'dead'; }"
+// expect: exactly 1 PL406 diagnostic on the print statement
+// ===========================================================================
+
+#[test]
+fn snapshot_continue_block_last_followed_by_statement() {
+    let source = "while (1) { } continue { last; print 'dead'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("continue_block_last_followed_by_statement", snapshot);
+}
+
+// ===========================================================================
+// AC-6: next in continue block followed by statement — NO false positive
+// "while (1) { } continue { next; print 'reachable'; }"
+// expect: 0 PL406 diagnostics (next jumps to next iteration, continue block re-runs)
+// ===========================================================================
+
+#[test]
+fn snapshot_continue_block_next_no_false_positive() {
+    let source = "while (1) { } continue { next; print 'reachable'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("continue_block_next_no_false_positive", snapshot);
+}
+
+// ===========================================================================
+// AC-7: redo in continue block followed by statement — NO false positive
+// "while (1) { } continue { redo; print 'reachable'; }"
+// expect: 0 PL406 diagnostics (redo re-runs the continue block)
+// ===========================================================================
+
+#[test]
+fn snapshot_continue_block_redo_no_false_positive() {
+    let source = "while (1) { } continue { redo; print 'reachable'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("continue_block_redo_no_false_positive", snapshot);
+}
+
+// ===========================================================================
+// AC-8: Multiple unreachable statements in continue block
+// "while (1) { } continue { die 'err'; my $x = 1; my $y = 2; print 'dead'; }"
+// expect: 3 PL406 diagnostics (one each for $x, $y, and print)
+// ===========================================================================
+
+#[test]
+fn snapshot_continue_block_multiple_unreachable() {
+    let source = "while (1) { } continue { die 'err'; my $x = 1; my $y = 2; print 'dead'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("continue_block_multiple_unreachable", snapshot);
+}
+
+// ===========================================================================
+// AC-9: Loop body unreachable detection unchanged
+// "while (1) { die 'err'; print 'dead'; }"
+// expect: 1 PL406 diagnostic on print in the loop body (not in continue block)
+// ===========================================================================
+
+#[test]
+fn snapshot_loop_body_unreachable_unchanged() {
+    let source = "while (1) { die 'err'; print 'dead'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("loop_body_unreachable_unchanged", snapshot);
+}
+
+// ===========================================================================
+// AC-10: All four loop types covered — while with continue block
+// ===========================================================================
+
+#[test]
+fn snapshot_while_loop_with_continue_block() {
+    let source = "while (1) { } continue { die 'err'; print 'dead'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("while_loop_with_continue_block", snapshot);
+}
+
+#[test]
+fn snapshot_until_loop_with_continue_block() {
+    let source = "until (1) { } continue { die 'err'; print 'dead'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("until_loop_with_continue_block", snapshot);
+}
+
+#[test]
+fn snapshot_for_loop_with_continue_block() {
+    let source = "for (1;;) { } continue { die 'err'; print 'dead'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("for_loop_with_continue_block", snapshot);
+}
+
+#[test]
+fn snapshot_foreach_loop_with_continue_block() {
+    let source = "foreach my $x (1..3) { } continue { die 'err'; print 'dead'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("foreach_loop_with_continue_block", snapshot);
+}
+
+// ===========================================================================
+// Confess in continue block
+// ===========================================================================
+
+#[test]
+fn snapshot_continue_block_confess_followed_by_statement() {
+    let source = "while (1) { } continue { confess 'err'; print 'dead'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("continue_block_confess_followed_by_statement", snapshot);
+}
+
+// ===========================================================================
+// Carp::croak and Carp::confess in continue block
+// ===========================================================================
+
+#[test]
+fn snapshot_continue_block_carp_croak_followed_by_statement() {
+    let source = "while (1) { } continue { Carp::croak 'err'; print 'dead'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("continue_block_carp_croak_followed_by_statement", snapshot);
+}
+
+// ===========================================================================
+// Happy path: no unreachable code
+// ===========================================================================
+
+#[test]
+fn snapshot_no_unreachable_code() {
+    let source = "while (1) { print 'alive'; } continue { next; print 'still alive'; }";
+    let snapshot = normalize(unreachable_code_for(source));
+    assert_snapshot!("no_unreachable_code", snapshot);
+}

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,8 @@
           rustToolchain
           pkg-config
           openssl
+          perl      # CPAN corpus: execute bootstrapped cpanm script
+          curl     # CPAN corpus: download cpanm standalone script
         ] ++ lib.optionals stdenv.isDarwin [
           darwin.apple_sdk.frameworks.Security
           darwin.apple_sdk.frameworks.SystemConfiguration


### PR DESCRIPTION
Closes #4359

## Summary

Add perl and curl to the shared buildInputs in flake.nix so that CPAN corpus tasks can run in the Nix development shell. CPAN corpus tasks (cpan-corpus-fetch, cpan-corpus-install, cpan-corpus-sweep, cpan-corpus-ratchet) bootstrap a cpanm script via curl and execute it with perl.

## ADR

- ADR embedded in commit history
- Status: Proposed

## Specs

- Specs: Implementation follows the spec defined in the prior agent artifacts

## What Changed

**flake.nix (lines 28-35)**: Added perl and curl to the shared buildInputs list:
- perl - executes the bootstrapped cpanm script (required by xtask/src/tasks/cpan_corpus.rs:476)
- curl - downloads the cpanm standalone script (required by xtask/src/tasks/cpan_corpus.rs:576)

Both devShells.default and devShells.ci inherit from this list via inherit buildInputs, so one change covers both shells.

## Test Results (so far)

- Implementation verified via file content inspection (nix command not available in execution environment)
- nix flake check cannot be run in this environment but the change is a pure additive Nix configuration change with no code logic changes

## Friction Encountered

- The execution environment lacks the nix command, so nix develop -c perl --version and nix develop -c curl --version cannot be executed directly
- Adapted verification to file content inspection of flake.nix instead

## Notes

- Draft PR - not ready for review until GREEN tests confirmed
- The nix flake check should pass as this is a pure additive Nix configuration change