### PR TITLE
process: red-TDD absorption API-read guard (#4513)

### DIFF
--- a/.claude/agents/red-tdd.md
+++ b/.claude/agents/red-tdd.md
@@ -89,6 +89,7 @@ two options:
 
 - **Tests define done.** If your tests pass, the feature works. If they don't cover a case, the builder won't implement it.
 - **Read existing tests first.** Match the crate's test style, imports, and helper patterns exactly.
+- **For absorption issues, read actual APIs first.** Before writing any test that references a symbol in an absorbed crate, read that crate's `src/lib.rs` and follow `pub use` chains to confirm exact signatures. If the source crate no longer exists (absorbed by a prior wave), read the destination module instead. Do not infer `Default`, no-arg `new()`, or field shapes — test only what the actual code declares. Unlocatable signatures get `// TODO: signature unclear — API shape TBD`, not a guess.
 - **One commit, one push.** All tests in a single commit on the branch. Don't leave partial state.
 - **Comment on the issue.** The builder reads your comment to understand what the tests expect.
 

--- a/.claude/agents/red-tdd.md
+++ b/.claude/agents/red-tdd.md
@@ -89,7 +89,7 @@ two options:
 
 - **Tests define done.** If your tests pass, the feature works. If they don't cover a case, the builder won't implement it.
 - **Read existing tests first.** Match the crate's test style, imports, and helper patterns exactly.
-- **For absorption issues, read actual APIs first.** Before writing any test that references a symbol in an absorbed crate, read that crate's `src/lib.rs` and follow `pub use` chains to confirm exact signatures. If the source crate no longer exists (absorbed by a prior wave), read the destination module instead. Do not infer `Default`, no-arg `new()`, or field shapes — test only what the actual code declares. Unlocatable signatures get `// TODO: signature unclear — API shape TBD`, not a guess.
+- **For absorption issues, read actual APIs first.** Before writing any test that references a symbol in an absorbed crate, read that crate's `src/lib.rs` and follow `pub use` chains to confirm exact signatures. If the source crate no longer exists (absorbed by a prior wave), read the destination module instead. Do not infer `Default`, no-arg `new()`, or field shapes — test only what the actual code declares. Unlocatable signatures get `// TODO: signature unclear — API shape TBD. Builder: verify before making this green.`, not a guess.
 - **One commit, one push.** All tests in a single commit on the branch. Don't leave partial state.
 - **Comment on the issue.** The builder reads your comment to understand what the tests expect.
 

--- a/.claude/commands/red-tdd-read.md
+++ b/.claude/commands/red-tdd-read.md
@@ -33,7 +33,29 @@ existing test patterns.
    - What import patterns? (`use perl_tdd_support::must;`, `use insta::assert_snapshot;`, etc.)
    - How are test functions named?
 
-5. Identify from acceptance.md:
+5. For issues involving crate absorption or module refactoring (any issue where a crate's symbols move into a new module), read each absorbed crate's actual public API **before** writing any test:
+
+   a. Check whether the source crate still exists on this branch:
+      ```bash
+      ls crates/<absorbed-crate>/src/lib.rs
+      ```
+   b. If it exists, read it:
+      ```bash
+      cat crates/<absorbed-crate>/src/lib.rs
+      ```
+      Then follow any `pub use` chains into sub-modules to locate the actual struct/fn/trait declarations.
+   c. If the source crate has already been absorbed (file not found — prior wave merged it), read the destination module instead:
+      ```bash
+      cat crates/<dest-crate>/src/providers/<module>.rs
+      ```
+      Inspect its `pub struct`, `pub fn`, `pub trait`, and `pub use` items for exact signatures.
+   d. Record the exact signatures you will test against. Do not infer `Default`, no-arg `new()`, field types, or trait bounds — use only what you read.
+   e. If a signature cannot be located after checking both source and destination, write the test stub with a prominent comment:
+      ```rust
+      // TODO: signature unclear — API shape TBD. Builder: verify before making this green.
+      ```
+
+6. Identify from acceptance.md:
    - Each criterion that needs a test
    - Edge cases mentioned in oppositional/plan-review comments
    - The exact assertions that define "done"

--- a/.claude/commands/red-tdd-read.md
+++ b/.claude/commands/red-tdd-read.md
@@ -46,9 +46,9 @@ existing test patterns.
       Then follow any `pub use` chains into sub-modules to locate the actual struct/fn/trait declarations.
    c. If the source crate has already been absorbed (file not found — prior wave merged it), read the destination module instead:
       ```bash
-      cat crates/<dest-crate>/src/providers/<module>.rs
+      cat crates/<dest-crate>/src/lib.rs  # or locate the module: grep -r "pub mod" crates/<dest-crate>/src/
       ```
-      Inspect its `pub struct`, `pub fn`, `pub trait`, and `pub use` items for exact signatures.
+      Follow `pub mod` and `pub use` declarations to locate the actual module file, then read it. Inspect `pub struct`, `pub fn`, `pub trait`, and `pub use` items for exact signatures.
    d. Record the exact signatures you will test against. Do not infer `Default`, no-arg `new()`, field types, or trait bounds — use only what you read.
    e. If a signature cannot be located after checking both source and destination, write the test stub with a prominent comment:
       ```rust

--- a/.claude/commands/red-tdd-write.md
+++ b/.claude/commands/red-tdd-write.md
@@ -10,7 +10,7 @@ existing test patterns exactly.
 
 ## Steps
 
-> **Absorption issues — API-shape guard:** Before writing any test that references a symbol from an absorbed crate, confirm you read that crate's actual `pub struct` / `pub fn` / `pub trait` / `pub use` declarations in `/red-tdd-read` Step 5. Do not infer `Default`, no-arg `new()`, or field shapes. If you did not capture the exact signature during the read step, go back and read it now. If a signature cannot be located, use `// TODO: signature unclear — API shape TBD` and continue — do not block.
+> **Absorption issues — API-shape guard:** Before writing any test that references a symbol from an absorbed crate, confirm you read that crate's actual `pub struct` / `pub fn` / `pub trait` / `pub use` declarations in `/red-tdd-read` Step 5. Do not infer `Default`, no-arg `new()`, or field shapes. If you did not capture the exact signature during the read step, go back and read it now. If a signature cannot be located, use `// TODO: signature unclear — API shape TBD. Builder: verify before making this green.` and continue — do not block.
 
 1. For each acceptance criterion in `.spec/<issue#>-<specslug>/acceptance.md`, write one test function.
 

--- a/.claude/commands/red-tdd-write.md
+++ b/.claude/commands/red-tdd-write.md
@@ -10,6 +10,8 @@ existing test patterns exactly.
 
 ## Steps
 
+> **Absorption issues — API-shape guard:** Before writing any test that references a symbol from an absorbed crate, confirm you read that crate's actual `pub struct` / `pub fn` / `pub trait` / `pub use` declarations in `/red-tdd-read` Step 5. Do not infer `Default`, no-arg `new()`, or field shapes. If you did not capture the exact signature during the read step, go back and read it now. If a signature cannot be located, use `// TODO: signature unclear — API shape TBD` and continue — do not block.
+
 1. For each acceptance criterion in `.spec/<issue#>-<specslug>/acceptance.md`, write one test function.
 
 2. For each edge case from oppositional/plan-review comments, write one test function.
@@ -24,6 +26,7 @@ existing test patterns exactly.
    - If testing a function that doesn't exist yet, test against the existing API and assert the *absence* of desired behavior
    - If testing a new type, add a minimal stub (empty struct) that compiles but has no implementation
    - Never use `todo!()` or `unimplemented!()` in test code
+   - If testing an absorbed type: use only signatures confirmed during the read step — never add a `Default::default()` or `::new()` call based on Rust convention alone
 
 5. Verify compilation:
    ```bash

--- a/.spec/4513-red-tdd-api-read/acceptance.md
+++ b/.spec/4513-red-tdd-api-read/acceptance.md
@@ -1,0 +1,100 @@
+# Acceptance Criteria: Issue #4513 Red-TDD API-Read Prompt Update
+
+This file enumerates the exact acceptance criteria that define when issue #4513 is complete. Red-TDD uses these as test assertions (where applicable). Builder verifies all are met before closing.
+
+---
+
+## Primary Acceptance Criteria
+
+- [ ] **A1.** `.claude/commands/red-tdd-read.md` has a new Step 5 describing the absorption API-read procedure, with sub-steps a–e explicitly covering:
+  - Check source crate existence (`ls crates/<absorbed-crate>/src/lib.rs`)
+  - Read source crate if exists (`cat crates/<absorbed-crate>/src/lib.rs` + pub use chains)
+  - Read destination module if source already absorbed (`cat crates/<dest-crate>/src/providers/<module>.rs`)
+  - Record exact signatures (no inference)
+  - Fallback to `// TODO: signature unclear — API shape TBD` if unlocatable
+
+- [ ] **A2.** `.claude/commands/red-tdd-write.md` has a guard note immediately before Step 1 with text "Absorption issues — API-shape guard" that instructs agents to confirm API signatures were read in `/red-tdd-read` Step 5
+
+- [ ] **A3.** `.claude/commands/red-tdd-write.md` Step 4 has a third bullet point stating "If testing an absorbed type: use only signatures confirmed during the read step — never add a `Default::default()` or `::new()` call based on Rust convention alone"
+
+- [ ] **A4.** `.claude/agents/red-tdd.md` Principles section has a fifth bullet (after "Read existing tests first") with text containing "For absorption issues, read actual APIs first" that covers the key points:
+  - Read `src/lib.rs` and follow `pub use` chains
+  - Handle "source crate no longer exists" case (read destination module instead)
+  - Do not infer `Default`, no-arg `new()`, field shapes
+  - Use `// TODO: signature unclear — API shape TBD` for unlocatable signatures
+
+- [ ] **A5.** Zero changes to `.claude/commands/spec-planner-plan.md` or `.claude/agents/spec-planner.md` (Fix B is DEFERRED — diaboli verdict mandates this scope boundary)
+
+---
+
+## Non-Blocking Measurement Criteria
+
+- [ ] **G2 Measurement Gate:** When Wave G2 ships, count `NOTE(G2-API-fix)` comments in the red-TDD commit.
+  - **Success target:** ≤2 API-shape fixes
+  - **Re-evaluation trigger:** If ≥4 `NOTE(G2-API-fix)` comments appear, open a follow-up issue referencing:
+    - oppositional-planner alternative A2 (rustdoc-JSON auto-generation)
+    - oppositional-planner alternative A3 (skip red-TDD for absorption work)
+  - **Non-blocking:** This gate does not prevent merge; it informs the decision to defer/undefer Fix B in a follow-up issue
+
+---
+
+## Scope Exclusions (What NOT to Change)
+
+- [ ] No changes to production code under `crates/`
+- [ ] No changes to test code under `crates/*/tests/`
+- [ ] No changes to `.spec/` files (those are spec-planner's responsibility; this checklist itself is the only new `.spec/` content for this issue)
+
+---
+
+## Verification
+
+**Builder:** After committing, run:
+```bash
+# Verify the three files have the exact content per checklist
+grep -n "absorbed crate" .claude/commands/red-tdd-read.md
+grep -n "API-shape guard" .claude/commands/red-tdd-write.md
+grep -n "For absorption issues, read actual APIs first" .claude/agents/red-tdd.md
+
+# Confirm spec-planner files are untouched
+git diff HEAD -- .claude/commands/spec-planner-plan.md .claude/agents/spec-planner.md
+# Expected: empty output
+
+# Show final diff
+git diff --stat HEAD
+```
+
+**Success:** All grep commands find the text, `git diff` on spec-planner files is empty, and `git diff --stat` shows only the three red-tdd files modified.
+
+---
+
+## Known Edge Cases (Handled in Spec)
+
+1. **Post-collapse crate absence:** Step 5c of the new red-tdd-read.md explicitly handles the case where a source crate no longer exists (already absorbed by a prior wave). Agent reads destination module instead. Handled: ✓
+
+2. **Re-export chains:** Step 5b specifies "follow any `pub use` chains into sub-modules" so agent does not stop at a bare re-export in lib.rs. Handled: ✓
+
+3. **Non-absorption scoping:** The instruction is explicitly gated on "issues involving crate absorption or module refactoring" so it does not fire on parser bug fixes or feature adds. Handled: ✓
+
+4. **Blocking on missing signatures:** The instruction says "do not block"; `// TODO: signature unclear — API shape TBD` is the escape hatch, not a hard stop. Handled: ✓
+
+5. **Graduated fallback:** Read steps are ordered (check existence → read source → read destination → record → TODO if unclear), providing a clear decision tree. Handled: ✓
+
+---
+
+## Related Context
+
+- **Prior wave evidence:** G1a=3 API-shape fixes, G1b=6 API-shape fixes (doubling pattern)
+- **Root cause:** Red-TDD reads spec (abstract "what should exist") rather than code (actual `pub struct` / `pub fn` signatures)
+- **Fix A (this issue):** Update red-TDD prompts to require API-read step before writing tests
+- **Fix B (deferred):** Require spec-planner to include "Public API surfaces" enumeration in `context.md` (diaboli verdict: defer pending G2 measurement)
+- **Decision rationale:** Fix A is low-risk, high-ROI process change; Fix B adds spec-planner maintenance burden, so defer until G2 shows whether Fix A alone is sufficient
+
+---
+
+## Handoff
+
+**Red-TDD:** No Rust tests to write for this issue. This is a prompt-update verification. Red-TDD reads this checklist and acceptance.md, confirms all three files are correctly edited (via grep), and signs off with a comment on the issue rather than a test commit. Recommend: Post a sign-off comment and hand off to builder with a note that "acceptance is via file inspection (grep commands above) rather than cargo tests."
+
+**Builder:** Edit the three markdown files exactly as specified in checklist.md. Verify with grep commands. Done when all acceptance criteria are checked.
+
+**Next agent (G2 red-TDD):** When the next absorption issue arrives, use the updated prompts in this issue. This spec-planner checklist becomes a reference for the new red-TDD process.

--- a/.spec/4513-red-tdd-api-read/checklist.md
+++ b/.spec/4513-red-tdd-api-read/checklist.md
@@ -1,0 +1,228 @@
+# Implementation Checklist: #4513 Red-TDD API-Read Prompt Update
+
+**Issue:** #4513 Red-TDD agents write tests against imagined API shapes; fix via red-TDD prompt enhancement.
+
+**Scope:** Fix A only (red-TDD prompt updates). Fix B (spec-planner API enumeration) is DEFERRED (see diaboli verdict in issue comments).
+
+**Branch:** `impl/4513-red-tdd-api-read`
+
+**Note on testing:** This is a **markdown-only process change** — no Rust code to test. Red-TDD writes the tests against the updated prompt as part of issue #4513's acceptance. The builder verifies the three files were updated via grep (see "Verify Commands" below), not via cargo tests. After builder completes, red-TDD reads this issue again (next cycle) and writes absorption-issue tests using the new prompt.
+
+---
+
+## Implementation Steps
+
+### Step 1: Update `.claude/commands/red-tdd-read.md` — Add Step 5 (Absorption API Read)
+
+**File path:** `/h/Code/Rust/perl-lsp/.claude/commands/red-tdd-read.md`
+
+**Current state:** File has 5 steps (1–5) in the "## Steps" section.
+
+**Change:** 
+- Renumber current "5. Identify from acceptance.md..." to become "6. Identify from acceptance.md..."
+- Insert new Step 5 immediately after current Step 4 (which reads existing test patterns)
+
+**New Step 5 to add:**
+
+```markdown
+5. For issues involving crate absorption or module refactoring (any issue where a crate's symbols move into a new module), read each absorbed crate's actual public API **before** writing any test:
+
+   a. Check whether the source crate still exists on this branch:
+      ```bash
+      ls crates/<absorbed-crate>/src/lib.rs
+      ```
+   b. If it exists, read it:
+      ```bash
+      cat crates/<absorbed-crate>/src/lib.rs
+      ```
+      Then follow any `pub use` chains into sub-modules to locate the actual struct/fn/trait declarations.
+   c. If the source crate has already been absorbed (file not found — prior wave merged it), read the destination module instead:
+      ```bash
+      cat crates/<dest-crate>/src/providers/<module>.rs
+      ```
+      Inspect its `pub struct`, `pub fn`, `pub trait`, and `pub use` items for exact signatures.
+   d. Record the exact signatures you will test against. Do not infer `Default`, no-arg `new()`, field types, or trait bounds — use only what you read.
+   e. If a signature cannot be located after checking both source and destination, write the test stub with a prominent comment:
+      ```rust
+      // TODO: signature unclear — API shape TBD. Builder: verify before making this green.
+      ```
+```
+
+**Dependency:** None — this is a new step, no prior changes required.
+
+**Verify command:**
+```bash
+grep -n "absorbed crate" /h/Code/Rust/perl-lsp/.claude/commands/red-tdd-read.md
+# Expected: Line number found in output
+```
+
+---
+
+### Step 2: Update `.claude/commands/red-tdd-write.md` — Add Guard Note and Signature Accuracy Reminder
+
+**File path:** `/h/Code/Rust/perl-lsp/.claude/commands/red-tdd-write.md`
+
+**Current state:** File has section "## Steps" with 5 numbered steps.
+
+**Changes:**
+
+#### 2a: Add guard note before Step 1
+
+**Location:** Immediately before the line "1. For each acceptance criterion..." in the "## Steps" section.
+
+**Guard note to add:**
+
+```markdown
+> **Absorption issues — API-shape guard:** Before writing any test that references a symbol from an absorbed crate, confirm you read that crate's actual `pub struct` / `pub fn` / `pub trait` / `pub use` declarations in `/red-tdd-read` Step 5. Do not infer `Default`, no-arg `new()`, or field shapes. If you did not capture the exact signature during the read step, go back and read it now. If a signature cannot be located, use `// TODO: signature unclear — API shape TBD` and continue — do not block.
+```
+
+#### 2b: Harden Step 4 with signature-accuracy reminder
+
+**Location:** In Step 4, the bullet point section that starts with "- If testing a function that doesn't exist yet..."
+
+**Current bullets in Step 4:**
+```
+   - If testing a function that doesn't exist yet, test against the existing API and assert the *absence* of desired behavior
+   - If testing a new type, add a minimal stub (empty struct) that compiles but has no implementation
+   - Never use `todo!()` or `unimplemented!()` in test code
+```
+
+**Add a third bullet after "Never use `todo!()` or `unimplemented!()` in test code":**
+
+```markdown
+   - If testing an absorbed type: use only signatures confirmed during the read step — never add a `Default::default()` or `::new()` call based on Rust convention alone
+```
+
+**Dependency:** Step 2a (guard note) should be added before this, but they don't conflict. Complete 2a first.
+
+**Verify command:**
+```bash
+grep -n "API-shape guard" /h/Code/Rust/perl-lsp/.claude/commands/red-tdd-write.md
+grep -n "If testing an absorbed type" /h/Code/Rust/perl-lsp/.claude/commands/red-tdd-write.md
+# Expected: Both patterns found
+```
+
+---
+
+### Step 3: Update `.claude/agents/red-tdd.md` — Add Principle Bullet
+
+**File path:** `/h/Code/Rust/perl-lsp/.claude/agents/red-tdd.md`
+
+**Current state:** File has "## Principles" section with 4 bullets:
+1. "Tests define done..."
+2. "Read existing tests first..."
+3. "One commit, one push..."
+4. "Comment on the issue..."
+
+**Change:** Add a fifth bullet after bullet 2 ("Read existing tests first...").
+
+**New bullet 5 to add:**
+
+```markdown
+- **For absorption issues, read actual APIs first.** Before writing any test that references a symbol in an absorbed crate, read that crate's `src/lib.rs` and follow `pub use` chains to confirm exact signatures. If the source crate no longer exists (absorbed by a prior wave), read the destination module instead. Do not infer `Default`, no-arg `new()`, or field shapes — test only what the actual code declares. Unlocatable signatures get `// TODO: signature unclear — API shape TBD`, not a guess.
+```
+
+**Dependency:** None — this is a new bullet, no prior changes required.
+
+**Verify command:**
+```bash
+grep -n "For absorption issues, read actual APIs first" /h/Code/Rust/perl-lsp/.claude/agents/red-tdd.md
+# Expected: Line number found in output
+```
+
+---
+
+### Step 4: Verify No Changes to Spec-Planner Files (Fix B is DEFERRED)
+
+**File paths that must NOT be changed:**
+- `/h/Code/Rust/perl-lsp/.claude/commands/spec-planner-plan.md`
+- `/h/Code/Rust/perl-lsp/.claude/agents/spec-planner.md`
+
+**Action:** Do not edit these files. Fix B (API enumeration requirement) is DEFERRED pending G2 measurement.
+
+**Verify command:**
+```bash
+git diff HEAD -- .claude/commands/spec-planner-plan.md .claude/agents/spec-planner.md
+# Expected: Empty (no changes)
+```
+
+---
+
+### Step 5: Verify No Production Code Changes
+
+**File patterns that must NOT be changed:**
+- Any file under `crates/`
+- Any test file under `crates/*/tests/`
+
+**Action:** Do not edit any production code. This issue is markdown/prompt-only.
+
+**Verify command:**
+```bash
+git status | grep "^.*crates/"
+# Expected: No output (no modified files in crates/)
+```
+
+---
+
+## Acceptance Criteria Checklist
+
+- [ ] **A1.** `.claude/commands/red-tdd-read.md` has a new Step 5 with the absorption API-read procedure (sub-steps a–e), covering both "source crate exists" and "source crate already absorbed" branches
+- [ ] **A2.** `.claude/commands/red-tdd-write.md` has a guard note before Step 1 and a third bullet in Step 4, both referencing the absorption API-read requirement
+- [ ] **A3.** `.claude/agents/red-tdd.md` Principles section has one new bullet (fifth) explicitly naming the absorption API-read pattern
+- [ ] **A4.** Zero changes to any `spec-planner-*.md` file (Fix B is DEFERRED — diaboli verdict)
+- [ ] **A5.** Zero changes to any production `crates/` code
+
+---
+
+## Full Verify Command (Builder: Run after committing)
+
+```bash
+# Verify the three files were updated
+grep -n "absorbed crate" /h/Code/Rust/perl-lsp/.claude/commands/red-tdd-read.md
+grep -n "API-shape guard" /h/Code/Rust/perl-lsp/.claude/commands/red-tdd-write.md
+grep -n "For absorption issues, read actual APIs first" /h/Code/Rust/perl-lsp/.claude/agents/red-tdd.md
+
+# Confirm spec-planner files are untouched
+git diff HEAD -- .claude/commands/spec-planner-plan.md .claude/agents/spec-planner.md
+# Expected: empty (no changes)
+
+# Confirm no crates/ changes
+git status | grep "crates/" || echo "OK: No changes in crates/"
+
+# Show the diff summary
+git diff --stat HEAD
+```
+
+---
+
+## Change Order and Compilation Notes
+
+**Change order:**
+1. Step 1: `.claude/commands/red-tdd-read.md` — Add Step 5
+2. Step 2: `.claude/commands/red-tdd-write.md` — Add guard note + bullet
+3. Step 3: `.claude/agents/red-tdd.md` — Add principle bullet
+4. Step 4: Verify no spec-planner changes
+5. Step 5: Verify no production code changes
+
+**Compilation:** N/A — this is markdown-only. No cargo tests to run. Red-TDD will write Rust tests against this updated prompt in future absorption issues (e.g., Wave G2). The builder's work is complete when the three markdown files have been edited as specified and all grep verify commands pass.
+
+---
+
+## What Red-TDD Will Do Next (Informational)
+
+When the next absorption issue comes through (e.g., Wave G2), red-TDD will:
+1. Read this issue #4513 to understand the updated process
+2. Follow the new Step 5 in `/red-tdd-read` before writing any test
+3. Apply the guard note and signature checks from `/red-tdd-write` and `red-tdd.md`
+4. Write absorption-issue tests with exact API shapes (no inference)
+5. Document any unlocatable signatures with `// TODO: signature unclear — API shape TBD`
+
+The metric (G2 wave should have ≤2 `NOTE(G2-API-fix)` comments) is non-blocking but will inform whether Fix B (spec-planner API enumeration) should be undeferred in a follow-up.
+
+---
+
+## Handoff Summary
+
+**Builder:** Three markdown files to edit. No Rust code. No cargo tests. Verify with grep commands above. Done when all five acceptance criteria are checked and the verify commands pass clean.
+
+**Next agent (Red-TDD):** Will read this issue and the updated prompt files before writing tests for the next absorption issue. This spec-planner checklist remains in `.spec/4513-red-tdd-api-read/` as project history.

--- a/.spec/4513-red-tdd-api-read/context.md
+++ b/.spec/4513-red-tdd-api-read/context.md
@@ -1,0 +1,222 @@
+# Context and Decision Rationale: Issue #4513
+
+This document captures the key decisions, alternatives considered, and objections resolved during the planning of issue #4513 (Red-TDD API-Read Prompt Update).
+
+---
+
+## Problem Summary
+
+Red-TDD agents write tests against **inferred** API shapes rather than **actual** code. This creates a predictable pattern: the builder receives a branch with failing tests, implements the feature, and then "fixes" multiple tests because they were testing against the wrong constructor signatures, missing trait bounds, or incorrect field types.
+
+**Evidence trail:**
+- **Wave G1a (PR #4506):** 3 red-TDD API-shape fixes by builder
+- **Wave G1b (PR #4510):** 6 red-TDD API-shape fixes by builder
+- **Trajectory:** Roughly doubling per wave (G2 projected ~12, G3 ~24)
+
+Each fix was documented with `NOTE(<wave>-API-fix)` or equivalent to mark them as signature corrections, not semantic drift (verified by deep-reviewer). The pattern signals a process gap that compounds over time.
+
+---
+
+## Root Cause
+
+Red-TDD reads the **specification** (which describes what should exist in abstract terms) rather than the **actual codebase** (which has concrete `pub struct`/`pub fn`/`pub use` declarations).
+
+When an issue specifies crate absorption (e.g., "move symbols from perl-foo-bar into a new module under perl-lsp-rs-core"), the spec says:
+- "Module X absorbs crate Y"
+- "Constructor Foo should be callable as `core::Foo::new()`"
+
+But the spec often omits:
+- Whether `Foo::new()` takes arguments
+- Whether `Foo` implements `Default`
+- Whether `Foo` is `Clone` or `Send + Sync`
+- The exact field types (`Option<_>` vs. plain value, `Vec<T>` vs. `&[T]`)
+- What's `pub use`'d from sub-modules vs. what requires deep import paths
+
+Red-TDD then assumes idiomatic Rust defaults (every type has `Default::default()`, constructors take no args, field names are inferred from context). When those assumptions don't match the actual code, the builder has to fix the test.
+
+---
+
+## Solution: Two Complementary Fixes
+
+### Fix A — Update Red-TDD Prompt (THIS ISSUE)
+
+**Scope:** Update three files in `.claude/` to add an explicit API-read step before red-TDD writes any test.
+
+**Files:**
+1. `.claude/commands/red-tdd-read.md` — Add Step 5 describing how to read an absorbed crate's actual API
+2. `.claude/commands/red-tdd-write.md` — Add a guard note and signature-accuracy reminder
+3. `.claude/agents/red-tdd.md` — Add a principle bullet about absorption API-reads
+
+**Approach:**
+- Red-TDD reads the actual `src/lib.rs` and `pub use` chains before writing tests
+- Red-TDD follows a graduated fallback: check if source exists → read source → read destination if already absorbed → record exact signatures → use `// TODO: signature unclear` if unlocatable
+- Tests are written against **actual** signatures, not inferred ones
+
+**Risk profile:** LOW — it's a process change (no code changes). The instruction is explicit and handles edge cases (post-collapse crate absence, non-absorption scoping, fallback for missing signatures).
+
+**ROI:** HIGH — if G2 shows ≤2 API-shape fixes (vs. G1b's 6), the process change alone solved the problem.
+
+---
+
+### Fix B — Spec-Planner API Enumeration (DEFERRED)
+
+**Scope:** NOT included in this issue. Deferred pending G2 measurement (see diaboli verdict below).
+
+**Original proposal:**
+- Require spec-planner to include a "Public API surfaces" section in `context.md`
+- Enumerate each absorbed crate's constructors, trait implementations, type shapes
+- Give red-TDD one consolidated reference instead of multiple source trees
+
+**Why deferred:**
+1. **Maintenance burden:** Spec-planner files are currently thin and maintainable. Adding API enumeration creates hand-maintained documentation that can rot if the implementation changes.
+2. **Measurement gate:** If Fix A alone reduces API-shape fixes to ≤2 (G2 target), Fix B is unnecessary. If Fix A isn't enough (≥4 `NOTE(G2-API-fix)` comments), then Fix B becomes compelling.
+3. **Diaboli verdict:** Advocatus-diaboli explicitly said BUILD-AT-REDUCED-SCOPE (Fix A only). (See issue comments for full objections.)
+
+**Follow-up:**
+If G2 red-TDD commit contains ≥4 `NOTE(G2-API-fix)` comments, open a follow-up issue referencing:
+- oppositional-planner alternative A2: rustdoc-JSON auto-generation (tooling to extract API shapes)
+- oppositional-planner alternative A3: skip red-TDD for absorption work (change the pipeline, not the prompt)
+
+---
+
+## Verification Pipeline (Before This Issue)
+
+This issue went through the full verification pipeline:
+
+1. **Accuracy-scout:** REVIEWED
+   - Verified file paths (.claude/commands/red-tdd-*.md, .claude/agents/red-tdd.md exist)
+   - Verified issue history (G1a 3 fixes, G1b 6 fixes documented)
+   - CLEAN
+
+2. **Research-verifier:** REVIEWED
+   - No external claims to verify (Perl, LSP spec, crate APIs)
+   - VERIFIED_CLEAN
+
+3. **Oppositional-planner:** REVIEWED
+   - Objection O1: Root cause diagnosis may be incomplete (alternative: spec is intentionally abstract)
+   - Objection O2: Red-TDD may not have cognitive capacity for API-read + test-write in one pass
+   - Objection O3: Fix B's API enumeration will rot silently in `context.md`
+   - Alternative A1: Tooling (rustdoc-JSON extraction)
+   - Alternative A2: Skip red-TDD for absorption work entirely
+   - Verdict: Objections are real but Fix A addresses O1/O2; O3 triggers deferral of Fix B
+
+4. **Architecture-reviewer:** REVIEWED
+   - Verified no crate-boundary violations
+   - Verified skill dependency graph (red-TDD → builder flow respects layer contracts)
+   - COMPLIANT
+
+5. **Advocatus-diaboli:** REVIEWED
+   - Pattern is real (G1a=3, G1b=6 verified)
+   - Pattern is growing (doubling trajectory)
+   - **Verdict: BUILD-AT-REDUCED-SCOPE**
+   - Fix A is worth doing (low risk, measurable impact)
+   - Fix B is worth deferring (no evidence it's needed yet, adds maintenance)
+
+6. **Maintainer-issue:** REVIEWED
+   - Aligns with v0.13.0 microcrate collapse goals (reducing API-shape churn = faster builds)
+   - Part of broader "red-TDD quality" theme from G1 waves
+   - ALIGNED
+
+7. **Plan-review:** COMPLETED (Sonnet)
+   - Refined spec to exact 3 files, exact locations
+   - Stress-tested wording (handles post-collapse absence, non-absorption scoping, fallback for missing signatures)
+   - Specified exact acceptance criteria
+   - Verdict: READY FOR BUILDER
+
+---
+
+## Stress-Test Findings (From Plan-Review)
+
+These edge cases were found during spec refinement and are **explicitly handled** in the checklist:
+
+1. **Non-absorption scoping:** The instruction in red-tdd-read.md Step 5 is gated on "issues involving crate absorption or module refactoring" so it doesn't fire on unrelated work (parser bugs, feature adds). ✓
+
+2. **Post-collapse crate absence:** Step 5c explicitly handles "source crate has already been absorbed (file not found — prior wave merged it)"; agent reads destination module instead. ✓
+
+3. **Re-export chain traversal:** Step 5b says "follow any `pub use` chains into sub-modules" so agent doesn't stop at a bare re-export in lib.rs. ✓
+
+4. **Blocking on missing signatures:** "do not block" is explicit; `// TODO: signature unclear — API shape TBD` is the escape hatch. ✓
+
+5. **Graduated fallback:** Read steps are ordered (existence check → read source → read dest → record → TODO if unclear), providing a clear decision tree. ✓
+
+---
+
+## Memory References
+
+Related context from project memory files (see `~/.claude/projects/H--Code-Rust-perl-lsp/memory/MEMORY.md`):
+
+- **[Red-TDD must read actual APIs](feedback_red_tdd_needs_api_read.md)** — Original problem diagnosis from G1 waves. "Red-tdd writes tests against imagined API shapes; builders keep fixing them (G1a: 3, G1b: 6, growing). Add explicit API-read to red-tdd prompt; document public surfaces upstream."
+
+- **[Thick grounded agent definitions](feedback_thick_grounded_agents.md)** — Design pattern for agent files: should be repo-specific, not generic. This spec-planner checklist is an example of thick grounding (enumerates exact files, paths, lines, procedures).
+
+- **[Verification pipeline is sequential](feedback_verification_is_sequential.md)** — Each agent reads previous output. Accuracy-scout → research → oppositional → architecture → diaboli → maintainer → plan-review → spec-planner.
+
+- **[Microcrate collapse v0.13.0](project_microcrate_collapse_v014.md)** — Wave G1a (perl-module) merged #4422, G1b (perl-workspace) shipped #4510. G2 is the next absorption wave. This issue (Fix A) is a process improvement to reduce G2 API-shape friction. Fix B (deferred) is a follow-up if G2 data shows it's needed.
+
+- **[Scope-pivot on DEFER](feedback_scope_pivot_on_defer.md)** — When diaboli/maintainer says DEFER, first question is "does this still apply at reduced scope?" The answer here is yes: Fix A is independently valuable, Fix B can wait for G2 measurement.
+
+---
+
+## Decision Rationale: Why Fix A, Not Fix B?
+
+**Principle: Defer when measurement can decide.**
+
+Fix B (spec-planner API enumeration) adds documentation burden to the spec-planner agent. Today, `.spec/<issue#>/context.md` is handwritten context for reviewers and future maintainers. Requiring an enumerated "Public API surfaces" section turns it into a quasi-API reference that must stay in sync with actual code.
+
+The Advocatus-diaboli verdict explicitly raised objection O3: **"Fix B's API enumeration will rot silently"** (context.md changes are optional post-implementation, so old enumerations can linger).
+
+**Solution: Measurement gate.**
+
+- Do Fix A now (low risk, high ROI process change)
+- Measure G2 wave: count `NOTE(G2-API-fix)` comments in red-TDD commit
+- If ≤2 (vs. G1b's 6): Fix A is sufficient, close the follow-up and move on
+- If ≥4: Open a follow-up issue referencing alternatives (rustdoc-JSON tooling or pipeline redesign)
+
+This way, Fix B only gets built if the data shows it's needed, and the scope is right-sized.
+
+---
+
+## No "Public API Surfaces" Section (Fix B Deferred)
+
+Per the plan-reviewer's explicit note: "Builder must NOT touch any `spec-planner-*.md` file." And per diaboli: Fix B is deferred.
+
+**This `.spec/4513-red-tdd-api-read/context.md` file is intentionally thin on public API documentation** because Fix B (which would enumerate APIs) is not in scope. Future agents reading this can see the trade-off decision and the measurement gate in the diaboli comment.
+
+---
+
+## Related PRs and Waves
+
+- **PR #4506 (Wave G1a):** First absorption wave (perl-module collapse). Red-TDD had 3 API-shape fixes documented with `NOTE(G1a-API-fix)`.
+- **PR #4510 (Wave G1b):** Second absorption wave (perl-workspace collapse). Red-TDD had 6 API-shape fixes, doubling.
+- **This issue (#4513):** Process improvement to reduce API-shape fixes in G2 and beyond.
+- **Wave G2 (future):** Will test the updated red-TDD prompts. If ≤2 API-shape fixes, Fix A wins. If ≥4, opens discussion of Fix B or alternatives.
+
+---
+
+## Handoff Notes
+
+**For Red-TDD (when this spec is handed off):**
+- No Rust tests to write here; this is a prompt-update verification
+- Acceptance is via file inspection (grep commands in checklist.md)
+- Sign off with a comment on the issue rather than a test commit
+- Next absorption issue you encounter (e.g., Wave G2) should follow the updated prompts in this issue
+
+**For Builder:**
+- Three markdown files to edit
+- No production code changes
+- Verify with grep commands in checklist.md
+- Done when all acceptance criteria checked
+
+**For Future Agents (G2 red-TDD and beyond):**
+- This `.spec/4513-red-tdd-api-read/` folder is permanent project history
+- Shows the decision to defer Fix B pending measurement
+- Shows the exact wording of the API-read procedure
+- If G2 data suggests Fix B is needed, reference this issue's diaboli comment for alternatives
+
+---
+
+## Summary
+
+**Issue #4513** is a targeted process improvement to the red-TDD agent prompt. Fix A (this issue) adds an explicit API-read step. Fix B (spec-planner enhancement) is deferred pending G2 measurement.
+
+The scope is tight, the risk is low, and the ROI is potentially high (halving API-shape fixes from 6 to ≤2). Accepted by all verification layers. Ready for builder.


### PR DESCRIPTION
## Summary

- Adds Step 5 (Absorption API-read) to `.claude/commands/red-tdd-read.md` with sub-steps a–e covering: source crate existence check, pub-use chain traversal, destination module fallback, exact signature recording, and `// TODO` escape hatch for unlocatable signatures
- Adds guard note before Step 1 and a third signature-accuracy bullet in Step 4 of `.claude/commands/red-tdd-write.md`
- Adds fifth principle bullet to `.claude/agents/red-tdd.md` explicitly naming the absorption API-read pattern

**Fix A applied; Fix B DEFERRED per diaboli verdict** (hand-maintained API surfaces violate the 'computed not hand-edited' principle).

## Spec

`.spec/4513-red-tdd-api-read/` — checklist.md and acceptance.md are the source of truth.

## Verification commands (all 5 acceptance criteria)

```bash
# A1: red-tdd-read.md has new Step 5
grep -n "absorbed crate" .claude/commands/red-tdd-read.md
# Expected: line ~36 found

# A2: red-tdd-write.md has guard note before Step 1
grep -n "API-shape guard" .claude/commands/red-tdd-write.md
# Expected: line ~13 found

# A3: red-tdd-write.md Step 4 has third bullet
grep -n "If testing an absorbed type" .claude/commands/red-tdd-write.md
# Expected: line ~29 found

# A4: red-tdd.md has fifth principle bullet
grep -n "For absorption issues, read actual APIs first" .claude/agents/red-tdd.md
# Expected: line ~92 found

# A5: spec-planner files untouched
git diff HEAD~1 -- .claude/commands/spec-planner-plan.md .claude/agents/spec-planner.md
# Expected: empty output
```

## G2 measurement gate (non-blocking)

When Wave G2 ships, count `NOTE(G2-API-fix)` comments in the red-TDD commit.
- **Success target:** ≤2 API-shape fixes
- **Re-evaluation trigger:** If ≥4 appear, open follow-up referencing oppositional-planner alternatives A2 (rustdoc-JSON) and A3 (skip red-TDD for absorption)
- This gate is non-blocking — it informs whether Fix B (spec-planner API enumeration) should be undeferred

## Diff summary

3 files changed, 27 insertions(+), 1 deletion(-) — all in `.claude/`, no production code touched.