### PR TITLE
fix(tests): resolve integration test compilation errors across workspace (#4508)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,6 +2021,7 @@ dependencies = [
 name = "perl-tdd-support"
 version = "0.12.4"
 dependencies = [
+ "anyhow",
  "lsp-types",
  "perl-parser-core",
  "perl-test-must",

--- a/crates/perl-lsp/tests/workspace_permission_denied_test.rs
+++ b/crates/perl-lsp/tests/workspace_permission_denied_test.rs
@@ -89,12 +89,16 @@ fn can_create_permission_denied() -> bool {
         Err(_) => return false,
     };
     perms.set_mode(0o000);
-    let _ = std::fs::set_permissions(&probe, &perms);
+    let _ = std::fs::set_permissions(&probe, perms);
     // If we can still read it, we're root
     let readable = std::fs::read_to_string(&probe).is_ok();
     // Restore so tempdir cleanup succeeds
+    let mut perms = match std::fs::metadata(&probe) {
+        Ok(m) => m.permissions(),
+        Err(_) => return false,
+    };
     perms.set_mode(0o644);
-    let _ = std::fs::set_permissions(&probe, &perms);
+    let _ = std::fs::set_permissions(&probe, perms);
     !readable
 }
 

--- a/crates/perl-parser/tests/facade_pattern_edge_cases.rs
+++ b/crates/perl-parser/tests/facade_pattern_edge_cases.rs
@@ -447,17 +447,17 @@ fn test_incremental_parsing_facade() -> Result<(), Box<dyn std::error::Error>> {
     use perl_parser::{Edit, IncrementalState};
 
     let code = "my $x = 1;";
-    let mut state = IncrementalState::new(code);
-    let ast = state.parse()?;
+    let mut state = IncrementalState::new(code.to_string());
+    let ast = &state.ast;
 
     assert!(matches!(ast.kind, perl_parser::NodeKind::Program { .. }));
 
     // Apply an edit
-    let edit = Edit { start_byte: 3, old_end_byte: 5, new_end_byte: 5, text: "$y".to_string() };
-    perl_parser::apply_edits(&mut state, vec![edit]);
+    let edit = Edit { start_byte: 3, old_end_byte: 5, new_end_byte: 5, new_text: "$y".to_string() };
+    let _result = perl_parser::apply_edits(&mut state, &[edit])?;
 
-    // Re-parse should work
-    let _new_ast = state.parse()?;
+    // After apply_edits, state.ast is updated
+    let _new_ast = &state.ast;
 
     Ok(())
 }

--- a/crates/perl-parser/tests/facade_pattern_edge_cases.rs
+++ b/crates/perl-parser/tests/facade_pattern_edge_cases.rs
@@ -133,8 +133,6 @@ fn test_text_line_facade_functional() -> Result<(), Box<dyn std::error::Error>> 
     use perl_parser_core::text_line::{is_keyword_boundary, line_bounds_at, skip_ascii_whitespace};
 
     let source = "my $x = 1;\nmy $y = 2;\n";
-    let bytes = source.as_bytes();
-
     // line_bounds_at: for a position in the second line, returns the line's byte range
     let second_line_pos = must_some(source.find("$y"));
     let (line_start, line_end) = line_bounds_at(source, second_line_pos);

--- a/crates/perl-parser/tests/incremental_performance_tests.rs
+++ b/crates/perl-parser/tests/incremental_performance_tests.rs
@@ -290,7 +290,7 @@ if ($condition) {
                 let new_source = source.replace("42", "9999");
                 let pos = match source.find("42") {
                     Some(p) => p,
-                    None => must(Err::<(), _>(format!("Test data should contain '42'"))),
+                    None => must(Err::<usize, _>(format!("Test data should contain '42'"))),
                 };
                 let edit = Edit::new(
                     pos,
@@ -387,7 +387,7 @@ if ($condition) {
                 let new_source = source.replace("42", "9999");
                 let pos = match source.find("42") {
                     Some(p) => p,
-                    None => must(Err::<(), _>(format!("Test data should contain '42'"))),
+                    None => must(Err::<usize, _>(format!("Test data should contain '42'"))),
                 };
                 let edit = Edit::new(
                     pos,

--- a/crates/perl-parser/tests/mutation_hardening_tests.rs
+++ b/crates/perl-parser/tests/mutation_hardening_tests.rs
@@ -1123,20 +1123,18 @@ mod integration_mutation_tests {
         Ok(())
     }
 
-    /// Test that documents arithmetic underflow issue in incremental parsing
-    /// This test is currently expected to expose bugs in the incremental parser
+    /// Regression guard: appending a subroutine via incremental edit must not underflow.
+    /// Previously nodes_reused could exceed count_nodes() causing arithmetic underflow.
     #[test]
-    #[should_panic(expected = "attempt to subtract with overflow")]
-    fn test_incremental_arithmetic_underflow_documentation() {
-        // This test documents a real bug in incremental_document.rs:356
-        // where nodes_reused can be larger than count_nodes(), causing underflow
+    fn test_incremental_append_does_not_underflow() {
         let source = "package Test; sub test_function { }";
         let mut doc = match IncrementalDocument::new(source.to_string()) {
             Ok(d) => d,
-            Err(e) => must(Err::<(), _>(format!("Should create document: {:?}", e))),
+            Err(e) => {
+                must(Err::<IncrementalDocument, _>(format!("Should create document: {:?}", e)))
+            }
         };
 
-        // This edit triggers the underflow bug - it's a legitimate bug to fix
         let edit = IncrementalEdit::with_positions(
             source.len(),
             source.len(),
@@ -1145,7 +1143,7 @@ mod integration_mutation_tests {
             Position::new(source.len(), 0, 0),
         );
 
-        // This will panic due to arithmetic underflow - this is the bug we're documenting
-        let _result = doc.apply_edit(edit);
+        let result = doc.apply_edit(edit);
+        assert!(result.is_ok(), "Appending subroutine should succeed without underflow");
     }
 }

--- a/crates/perl-parser/tests/support/incremental_test_utils.rs
+++ b/crates/perl-parser/tests/support/incremental_test_utils.rs
@@ -5,6 +5,7 @@
 
 use perl_parser::incremental_v2::{IncrementalMetrics, IncrementalParserV2};
 use perl_parser::{edit::Edit, position::Position};
+use perl_tdd_support::{must, must_some};
 use std::time::{Duration, Instant};
 
 /// Comprehensive performance measurement utilities for incremental parsing

--- a/crates/perl-tdd-support/Cargo.toml
+++ b/crates/perl-tdd-support/Cargo.toml
@@ -34,6 +34,9 @@ url = { workspace = true, optional = true }
 default = []
 lsp-compat = ["lsp-types", "url"]
 
+[dev-dependencies]
+anyhow = { workspace = true }
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
## Summary

- Fix all compilation errors in `cargo check --workspace --tests --locked` (previously 9+ errors across 4 test files and 2 crates)
- After this PR, the full workspace including all integration tests compiles cleanly, unblocking #4507 (CI `--all-targets` gate)

## Problem

Post-collapse-wave API drift and Rust edition changes left integration tests unable to compile. CI only runs `--lib` so these accumulated silently. Specific failures:

| File | Errors | Root cause |
|------|--------|------------|
| `perl-parser/tests/support/incremental_test_utils.rs` | 3 | Missing `use perl_tdd_support::{must, must_some}` import |
| `perl-parser/tests/facade_pattern_edge_cases.rs` | 5 | `IncrementalState` API changed: `new()` takes `String`, field renamed `text`→`new_text`, `apply_edits` takes `&[Edit]`, no `.parse()` method |
| `perl-parser/tests/incremental_performance_tests.rs` | 2 | `must(Err::<(), _>(...))` used where `usize` expected — type param mismatch |
| `perl-parser/tests/mutation_hardening_tests.rs` | 1 | Same type param issue + `#[should_panic]` test for a bug that's been fixed |
| `perl-lsp/tests/workspace_permission_denied_test.rs` | 2 | `set_permissions` takes `Permissions` by value, not `&Permissions` |
| `perl-tdd-support/tests/guardrail_tests.rs` | 1 | Missing `anyhow` dev-dependency |

## Changes

1. **`incremental_test_utils.rs`** — Added missing import for `must`/`must_some` from `perl_tdd_support`
2. **`facade_pattern_edge_cases.rs`** — Aligned test with current `IncrementalState` API: pass `String`, use `new_text` field, pass `&[Edit]` slice, access `.ast` field directly
3. **`incremental_performance_tests.rs`** — Fixed `must()` generic type from `()` to `usize` to match the match arm's expected type
4. **`mutation_hardening_tests.rs`** — Fixed `must()` generic type, converted stale `#[should_panic]` test into a proper regression guard (the arithmetic underflow bug it documented has been fixed)
5. **`workspace_permission_denied_test.rs`** — Pass `Permissions` by value to `set_permissions()` as the Rust std API requires; re-fetch metadata for the restore step since the value was consumed
6. **`perl-tdd-support/Cargo.toml`** — Added `anyhow` as a dev-dependency (already in workspace, just not wired to this crate's tests)

## Verification

```bash
# Zero compilation errors
cargo check --workspace --tests --locked  # ✅ exits 0

# All affected tests pass
cargo test -p perl-tdd-support --test guardrail_tests  # 4 passed
cargo test -p perl-parser --features incremental --test facade_pattern_edge_cases  # 24 passed
cargo test -p perl-parser --features incremental --test incremental_performance_tests  # 8 passed
cargo test -p perl-parser --features incremental --test mutation_hardening_tests  # 163 passed
cargo test -p perl-lsp-rs --test workspace_permission_denied_test  # 5 passed

# Formatting clean
cargo fmt -- --check  # ✅ no diff
```

## Test plan

- [x] `cargo check --workspace --tests --locked` exits 0
- [x] All modified test files compile and their tests pass
- [x] `cargo fmt -- --check` clean
- [x] No clippy regressions introduced by these changes

Closes #4508

https://claude.ai/code/session_01MgkFn6JyDSEMYCYkjRPLbR