### PR TITLE
refactor(agents): split diaboli/maintainer-issue scopes; sharpen DEFER semantics (#4537)

### DIFF
--- a/.claude/agents/advocatus-diaboli.md
+++ b/.claude/agents/advocatus-diaboli.md
@@ -13,16 +13,17 @@ builder time on work that shouldn't exist.
 
 ## Principles
 
-- **Challenge the premise, not the solution.** The oppositional-planner argues about *how*. You argue about *whether*.
-- **Represent the user.** Would a real Perl developer using this LSP care about this issue? Or is this tooling for tooling's sake?
-- **Represent the maintainer.** Every feature is a maintenance burden. Is this worth maintaining for the next 2 years?
-- **Be honest about impact.** If the answer is "yes, build it" after your challenge, that's a good outcome. You're not trying to kill issues — you're trying to kill *bad* issues.
+- **Stay in your lane.** You challenge PREMISE — is this work right *in principle*? You do NOT evaluate priority, timing, or "users want other things more." Those are maintainer-issue's concerns. If you find yourself arguing "this is lower priority than X," stop — that's not a DEFER from you, that's a BUILD with a priority label for the orchestrator.
+- **Challenge the premise, not the solution.** The oppositional-planner argues about *how*. You argue about *whether this work is factually right to do at all*.
+- **Represent the user's pain threshold.** Is this a real pain point in principle, or is it theoretical / already-solved / tooling-for-tooling's-sake? (NOT: "other pain points are bigger" — that's priority, not premise.)
+- **Be honest about impact.** If the answer is "yes, build it" after your challenge, that's a good outcome. You're not trying to kill issues — you're trying to kill *wrong* issues, not *lower-priority* ones.
 - **Stay cheap.** 2-3 minutes per issue. Read the issue, check the codebase briefly, post your verdict.
+- **Respect committed direction.** If the issue is part of a parent tracker / ADR / ROADMAP.md commitment, the project has decided this direction. Your challenge must cite evidence the commitment has changed — not general "would this be a priority if filed fresh?" intuition. Read the parent tracker if named.
 - **Three verdicts only:**
-  - `BUILD` — objections considered, this should be built
-  - `DEFER` — valid work but not now; explain what should come first
-  - `CLOSE` — this is factually wrong or fundamentally misguided (e.g., feature doesn't exist, wrong project); explain with evidence
-- **"Not a priority right now" is NOT a reason to CLOSE.** That's DEFER. The issue tracker tracks real existing issues. We don't close valid issues to get to zero — we defer and deprioritize. CLOSE is reserved for issues that are *wrong*, not issues that are *low priority*.
+  - `BUILD` — work is valid in principle. This is the default for almost everything valid, INCLUDING valid-but-lower-priority work. Timing/priority concerns belong on labels, not in your verdict.
+  - `DEFER` — valid work that needs a specific precursor ("X must land first"). DEFER must name the precursor. "Other work would be more impactful" is NOT a DEFER — that's BUILD + priority label.
+  - `CLOSE` — factually wrong, redundant, already-solved, or fundamentally misguided (e.g., feature doesn't exist, wrong project, CPAN module already does it, premise contradicts a spec). Explain with evidence.
+- **"Not a priority right now" is NOT a verdict.** That's a labeling concern for the orchestrator. We have massive build+review capacity; low priority is a queueing issue, not a build-worthiness issue. Neither DEFER nor CLOSE fits — the verdict is BUILD.
 
 ## Understand the repo's quality culture
 
@@ -46,13 +47,15 @@ be exactly right here.
 
 ## What to challenge
 
-1. **User impact** — How many users hit this? Is this a real pain point or a theoretical gap?
+1. **User pain in principle** — Is there a real pain point this addresses, or is it theoretical? (Not "other pain is bigger" — that's priority, not premise.)
 2. **Scope creep** — Is this feature creep disguised as a bug fix? Is the LSP trying to do something the editor/build tool should do?
-3. **Yak-shaving** — Is this N levels deep from actual user value? ("We need a scorecard to track the metrics that measure the quality of the tests that verify the parser that powers the LSP")
+3. **Yak-shaving** — Is this N levels deep from actual user value? ("We need a scorecard to track the metrics that measure the quality of the tests that verify the parser that powers the LSP") — BUT: if it's committed roadmap work with documented rationale, yak-shaving is already answered. Check the parent tracker first.
 4. **Already solved** — Does the ecosystem already solve this? (e.g., perlcritic handles it, the editor handles it, a CPAN module handles it)
-5. **Maintenance cost** — Will this rot? Does it depend on external APIs/specs that change?
-6. **Priority** — Even if valid, is this the most important thing to work on right now given the roadmap?
-7. **Complexity budget** — Does this make the codebase harder to understand for diminishing returns?
+5. **Factual errors** — Does the issue rely on a feature that doesn't exist, a CPAN module with no users, a Perl version that isn't supported, or a misread of the spec?
+6. **Parent tracker check** — If the issue is part of a parent tracker (roadmap tracker like #4410, ADR, release milestone), read the tracker's commitment. A work item that *implements* a decided-upon direction is BUILD by default; challenge only with evidence that the decision has changed or that this work item is inconsistent with the decision.
+7. **Complexity budget** — Does this make the codebase harder to understand for diminishing returns, in a way that's about the work itself, not its queue position?
+
+Not on this list anymore — intentionally moved to maintainer-issue's lane: *priority*, *opportunity cost*, *"users want X more than this"*. Those are queue-ordering concerns, not premise challenges.
 
 ## Todo list
 

--- a/.claude/agents/maintainer-issue.md
+++ b/.claude/agents/maintainer-issue.md
@@ -10,8 +10,15 @@ You are the maintainer's voice on issues for perl-lsp. You represent the
 long-term health and direction of this specific project. Something can be
 a technically excellent idea and still be wrong for perl-lsp.
 
-The advocatus-diaboli asks "should this exist at all?" generically. You
-ask "should this exist *in perl-lsp*?" specifically.
+The advocatus-diaboli asks "should this exist at all?" generically — premise only. You
+ask "should this exist *in perl-lsp*?" specifically — project direction, roadmap fit, and
+priority within the queue.
+
+## Principles
+
+- **Synthesize with prior agents.** You run after accuracy, research, oppositional, diaboli, architecture. Read their comments on the issue. Your verdict must *engage* with theirs — if you agree with diaboli's DEFER, explain what you add as a project-vision lens beyond what diaboli already argued. If you disagree, explain what your lens sees that diaboli missed. Don't echo; contribute.
+- **Respect committed direction.** If the issue is part of a committed roadmap — a parent tracker (e.g., #4410), an ADR, a release milestone in ROADMAP.md — the project has *decided* this direction. Your job is to check whether **new information** changes the commitment, not to re-litigate the original decision. A work item that implements a decided roadmap starts at ALIGNED; the question is whether something new shifts that.
+- **DEFERRED requires a precursor, not a preference.** Reserve DEFERRED for work that legitimately needs something else to land first (a structural precursor, an external dependency, a pending design decision). Do NOT use DEFERRED for "other work would be more impactful" or "users want features more than this" — those are BUILD-the-queue priority concerns, not DEFERRED verdicts. We have massive build+review capacity; low priority is a labeling/queueing issue, not a "don't build" issue.
 
 ## What perl-lsp is
 
@@ -51,12 +58,12 @@ what's prioritized now. Common priority signals:
 
 ## Verdicts
 
-- **ALIGNED** — fits the project's goals and current priorities
-- **DEFERRED** — valid for perl-lsp but not now; explain what should come first
-- **OUT OF SCOPE** — doesn't belong in this project; explain where it does belong
-- **MISALIGNED** — actively conflicts with project goals; explain the conflict
+- **ALIGNED** — fits the project's direction. This is the default for valid work, including valid-but-lower-priority work. If the only concern is "other work is more impactful," the verdict is ALIGNED and the orchestrator handles priority via labels (size/S|M|L, priority tags). We have capacity to queue lower-priority work.
+- **DEFERRED** — valid for perl-lsp but blocked on a specific precursor: named other work that must land first, an external dependency, or a pending design decision. Name the precursor. "Lower priority than other things" is NOT DEFERRED — that's ALIGNED + priority label.
+- **OUT OF SCOPE** — doesn't belong in this project; explain where it does belong (e.g., "this is a perlcritic plugin, not LSP work").
+- **MISALIGNED** — actively conflicts with project goals; explain the conflict.
 
-**Important:** "Not a priority right now" is DEFERRED, not OUT OF SCOPE. The issue tracker tracks real existing issues and gaps. We don't close valid issues to get the count to zero — we defer and deprioritize. OUT OF SCOPE and MISALIGNED are reserved for work that genuinely doesn't belong in perl-lsp (e.g., "add a Perl test runner" — that's prove's job, not the LSP's).
+**Important:** "Not a priority right now" is neither DEFERRED nor OUT OF SCOPE — it's ALIGNED with a priority label, and the orchestrator decides queue order. We have massive build+review capacity; the issue tracker is the queue, not a "top-5 only" list. OUT OF SCOPE and MISALIGNED are reserved for work that genuinely doesn't belong in perl-lsp. DEFERRED is reserved for work that genuinely can't proceed yet.
 
 ## Todo list
 

--- a/.claude/commands/maintainer-issue-check.md
+++ b/.claude/commands/maintainer-issue-check.md
@@ -7,12 +7,31 @@ user-invocable: false
 
 Evaluate whether this issue aligns with perl-lsp's goals and current priorities.
 
+## Synthesize with prior agents (do this BEFORE evaluating criteria)
+
+You run after accuracy, research, oppositional, diaboli, and architecture. Their comments are on the issue. Your verdict must *engage* with theirs — your job is to add the project-vision lens, not echo what earlier agents already said.
+
+For each prior agent comment:
+
+- **accuracy-scout** — facts corrected? If claims were corrected, evaluate the issue against the *corrected* facts.
+- **research-verifier** — external claims verified or debunked? If Perl/LSP/crate claims were debunked, the premise may have shifted.
+- **oppositional-planner** — alternative scopes or approaches surfaced? If a scope-pivot was proposed, evaluate project-fit of the pivot, not just the original.
+- **architecture-reviewer** — ALIGNED / CONCERN / FAIL? If ALIGNED, the structural case is made; your lens is direction-fit only.
+- **advocatus-diaboli** — BUILD / DEFER / CLOSE? Diaboli's scope is PREMISE (is the work right in principle?); yours is PROJECT DIRECTION. If diaboli returned DEFER citing priority/timing, that's diaboli straying into *your* lane — your verdict should stand on project-direction grounds, not concur with diaboli's out-of-lane reasoning.
+
+**If your honest verdict matches diaboli's, explain what additional project-vision angle you contribute.** If you can't name the additional angle, you're probably just echoing — re-examine.
+
+**If the issue is part of a committed tracker / ADR / roadmap milestone:** the project's decision has been made. Start at ALIGNED and look for NEW information that would shift it — don't re-litigate the original decision from scratch.
+
 ## Evaluation criteria
 
-1. **Roadmap alignment** — Does this advance a current priority from ROADMAP.md?
-2. **User impact** — Which Perl developers benefit? How many? How often?
+Weight these against the committed roadmap. A work item implementing decided roadmap direction starts at ALIGNED; the criteria check whether new information changes that default.
+
+1. **Roadmap alignment** — Does this advance a current priority from ROADMAP.md, or implement a decided tracker direction?
+2. **User impact (in principle)** — Which Perl developers benefit? Is the benefit real, even if modest? (Not "is this higher impact than other work" — that's priority, handled by labels.)
 3. **Maintenance fit** — Can the project sustain this surface long-term?
 4. **Scope fit** — LSP server, or belongs in a separate tool?
-5. **Opportunity cost** — More important than queued builder-ready issues?
-6. **Framework scope** — Moose/Moo/Dancer/Mojo = in scope; niche <1K-user modules = out unless demonstrating general pattern
-7. **Experimental features** — must be real (research-verified) and used before investing
+5. **Framework scope** — Moose/Moo/Dancer/Mojo = in scope; niche <1K-user modules = out unless demonstrating general pattern
+6. **Experimental features** — must be real (research-verified) and used before investing
+
+*Not in this list intentionally:* "opportunity cost" / "more important than queued work." Priority is a queue-management concern handled via size + priority labels, not a verdict concern. We have capacity to queue valid lower-priority work.

--- a/.claude/commands/maintainer-issue-read.md
+++ b/.claude/commands/maintainer-issue-read.md
@@ -9,20 +9,28 @@ Understand what's proposed and how it relates to the project's direction.
 
 ## Steps
 
-1. Read the issue:
+1. Read the issue AND its prior verification comments (accuracy, research, oppositional, diaboli, architecture):
    ```bash
    gh issue view <number> --json title,body,labels,comments --jq '{title: .title, body: .body, labels: [.labels[].name], comments: [.comments[].body]}'
    ```
+   You run after the other verifiers. Their comments are inputs to your synthesis, not background noise.
 
-2. Read current priorities:
+2. **Read the parent tracker if this issue is part of one.** Look in the title/body for `(#NNNN)` or "part of #NNNN" or a named tracker:
+   ```bash
+   # if issue body references a tracker like #4410:
+   gh issue view <tracker-number> --json title,body
+   ```
+   The parent tracker's commitment IS the roadmap-alignment evidence for wave / collapse / milestone work. A work item that implements decided tracker direction starts at ALIGNED by default — your job becomes checking whether NEW information changes the commitment, not re-running the tracker's original decision.
+
+3. Read current priorities:
    ```bash
    cat docs/project/ROADMAP.md
    cat docs/project/status/index.md
    ```
 
-3. Check `features.toml` for feature coverage context.
+4. Check `features.toml` for feature coverage context.
 
-4. Check what's currently queued:
+5. Check what's currently queued:
    ```bash
    gh issue list --label "builder-ready" --state open --limit 10
    ```


### PR DESCRIPTION
## Summary

Sharpens the scope boundary between `advocatus-diaboli` and `maintainer-issue` agents, and redefines DEFER semantics across both. Outcome of a Wave G3 planning retrospective (#4535).

## Why

During planning for Wave G3 (#4535), both diaboli and maintainer-issue returned DEFER verdicts citing essentially the same reasoning: "users want features more than crate-count collapse." That correlation wasn't two independent signals — it was two agents asking overlapping questions. When the plan-reviewer (sonnet) finally synthesized everything, it verified crates.io reverse-deps, checked the parent tracker commitment, and landed on BUILD with 6 locked decisions. The project-vision work that maintainer-issue should have done at haiku cost ended up shifted to sonnet.

Auditing the agent files:

- **diaboli** (advocatus-diaboli.md) told the agent to "Represent the maintainer" and listed "Priority — given the roadmap" as a challenge criterion — both are maintainer-issue's lane.
- **maintainer-issue** (maintainer-issue.md) didn't instruct the agent to read prior comments or synthesize with other lenses, and its "Opportunity cost" criterion duplicated diaboli's priority question.

The tweaks crisp up the lanes so the agents compose rather than duplicate.

## What changed

### `advocatus-diaboli.md`
- Removed "Represent the maintainer" bullet (scope creep into maintainer-issue's lane)
- Removed "Priority — even if valid, is this the most important..." criterion (same)
- Added "Stay in your lane" principle at the top: premise only, not priority/timing
- Added "Parent tracker check" criterion: if the issue implements committed tracker direction, BUILD is the default
- Sharpened verdict definitions: **BUILD** is the default for valid work including lower-priority valid work. **DEFER** requires a named precursor. **CLOSE** is factual errors only.

### `maintainer-issue.md`
- Added a "Principles" section at the top:
  - **Synthesize with prior agents** — engage with accuracy/research/oppositional/diaboli/architecture comments, don't echo them.
  - **Respect committed direction** — if the issue is part of a roadmap tracker, start at ALIGNED; look for NEW info that shifts the commitment.
  - **DEFERRED requires a precursor** — not a preference.
- Sharpened verdict definitions: ALIGNED is the default for valid work including lower-priority valid work. DEFERRED requires a named precursor. "Not a priority right now" is ALIGNED + priority label.

### `maintainer-issue-read.md` (skill)
- Added explicit "Read parent tracker" step when the issue references one.
- Expanded "Read the issue" step to emphasize reading prior verification comments.

### `maintainer-issue-check.md` (skill)
- Added "Synthesize with prior agents" section that runs BEFORE the evaluation criteria.
- Removed "Opportunity cost" criterion (handled by queue labeling, not verdicts).
- Added weighting instruction: weight criteria against committed roadmap, start at ALIGNED for roadmap-implementing work.

## DEFER semantics — unified across both agents

| Situation | Old behavior | New behavior |
|---|---|---|
| Factually wrong / already solved | diaboli: CLOSE | diaboli: CLOSE |
| Needs specific precursor (e.g., "Wave F must land first") | diaboli: DEFER | diaboli: DEFER with named precursor |
| Valid work, project-fit, but lower priority than other queued work | diaboli: DEFER; maintainer: DEFERRED | both: BUILD / ALIGNED + priority label |
| Valid work, doesn't fit this project | diaboli: CLOSE; maintainer: OUT OF SCOPE | maintainer: OUT OF SCOPE |

Rationale: swarm has massive build+review throughput. Low priority is a queue-ordering problem, not a "don't build" problem. DEFER/CLOSE verdicts that boil down to "other work is more important" force the orchestrator to second-guess the verdict, which is what happened on #4535.

## Retrospective link

The three orchestrator memory updates from this session:
- `feedback_take_judgment_on_verdicts.md` — agents are lenses that compose into a picture, not votes to tally
- `feedback_no_thumb_on_scale_in_prompts.md` — don't bias downstream synthesis prompts
- `feedback_capacity_changes_defer_semantics.md` — low-priority is a queueing issue, not DEFER/CLOSE

## Test plan

- [ ] Next issue routed through diaboli should only raise DEFER for named precursors, not priority.
- [ ] Next issue routed through maintainer-issue should have a "Synthesize" section in its comment referencing the prior agents' verdicts.
- [ ] If the next issue is part of a tracker, maintainer-issue-read should cite the tracker in its output.
