### PR TITLE
fix(perl-module): avoid rename false positives in package/quoted contexts (#4423)

### DIFF
--- a/crates/perl-module/src/rename/mod.rs
+++ b/crates/perl-module/src/rename/mod.rs
@@ -34,7 +34,6 @@ pub struct ModuleLineEdit {
 /// - Qualified function calls: `Module::Name::func()` → `NewName::func()`
 /// - Static method calls: `Module::Name->method()` → `NewName->method()`
 /// - `@ISA` array assignments
-/// - Package declarations: `package Module::Name;` → `package NewName;`
 ///
 /// Legacy package separators (`Foo'Bar`) are also handled.
 #[must_use]
@@ -94,17 +93,6 @@ pub fn plan_module_rename_edits(
                 }
             }
 
-            // Check package declarations
-            {
-                let current_line = rewritten.as_deref().unwrap_or(line);
-                if line_references_package_declaration(current_line, old_variant) {
-                    let (candidate, changed) =
-                        replace_module_token(current_line, old_variant, new_variant);
-                    if changed {
-                        rewritten = Some(candidate);
-                    }
-                }
-            }
         }
 
         if let Some(new_text) = rewritten {
@@ -140,6 +128,9 @@ pub fn line_references_qualified_call(line: &str, module_name: &str) -> bool {
     if line.is_empty() || module_name.is_empty() {
         return false;
     }
+    if line.trim_start().starts_with("package ") {
+        return false;
+    }
     let needle = format!("{}::", module_name);
     let needle_bytes = needle.as_bytes();
     let line_bytes = line.as_bytes();
@@ -167,7 +158,7 @@ pub fn line_references_qualified_call(line: &str, module_name: &str) -> bool {
             ch.is_alphabetic() || ch == '_'
         };
 
-        if before_ok && after_ok {
+        if before_ok && after_ok && !index_is_in_quote_or_comment(line, abs) {
             return true;
         }
         start = abs + 1;
@@ -193,6 +184,9 @@ pub fn line_references_package_declaration(line: &str, module_name: &str) -> boo
 #[must_use]
 pub fn replace_module_name_prefix(line: &str, old_module: &str, new_module: &str) -> String {
     if old_module.is_empty() || new_module.is_empty() || line.is_empty() {
+        return line.to_string();
+    }
+    if line.trim_start().starts_with("package ") {
         return line.to_string();
     }
 
@@ -226,7 +220,7 @@ pub fn replace_module_name_prefix(line: &str, old_module: &str, new_module: &str
             ch.is_alphabetic() || ch == '_'
         };
 
-        if before_ok && after_ok {
+        if before_ok && after_ok && !index_is_in_quote_or_comment(line, abs) {
             out.push_str(&line[cursor..abs]);
             out.push_str(&replacement);
             cursor = after;
@@ -238,6 +232,66 @@ pub fn replace_module_name_prefix(line: &str, old_module: &str, new_module: &str
 
     out.push_str(&line[cursor..]);
     out
+}
+
+fn index_is_in_quote_or_comment(line: &str, index: usize) -> bool {
+    let bytes = line.as_bytes();
+    if index >= bytes.len() {
+        return false;
+    }
+
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    for (i, &byte) in bytes.iter().enumerate() {
+        if i == index {
+            return in_single || in_double;
+        }
+
+        let ch = byte as char;
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if in_single {
+            if ch == '\\' {
+                escaped = true;
+                continue;
+            }
+            if ch == '\'' {
+                in_single = false;
+            }
+            continue;
+        }
+
+        if in_double {
+            if ch == '\\' {
+                escaped = true;
+                continue;
+            }
+            if ch == '"' {
+                in_double = false;
+            }
+            continue;
+        }
+
+        if ch == '#' {
+            return i < index;
+        }
+
+        if ch == '\'' {
+            in_single = true;
+            continue;
+        }
+
+        if ch == '"' {
+            in_double = true;
+        }
+    }
+
+    false
 }
 
 /// Apply full-line `ModuleLineEdit` replacements to source text.

--- a/crates/perl-module/tests/facade_api_completeness.rs
+++ b/crates/perl-module/tests/facade_api_completeness.rs
@@ -200,8 +200,8 @@ fn test_rename_module_predicates() {
     assert!(line_references_package_declaration("package My::Module;", "My::Module"));
     assert!(!line_references_package_declaration("use My::Module;", "My::Module"));
 
-    // Note: qualified_call is known to have false positives (pre-existing bug tracked separately)
     assert!(line_references_qualified_call("My::Module::func();", "My::Module"));
+    assert!(!line_references_qualified_call("'My::Module::func();'", "My::Module"));
 }
 
 /// Verify resolution module types can be constructed.

--- a/crates/perl-module/tests/rename_comprehensive_unit_tests.rs
+++ b/crates/perl-module/tests/rename_comprehensive_unit_tests.rs
@@ -2,7 +2,10 @@
 //!
 //! Covers: plan_module_rename_edits, apply_module_rename_edits, ModuleLineEdit
 
-use perl_module::rename::{ModuleLineEdit, apply_module_rename_edits, plan_module_rename_edits};
+use perl_module::rename::{
+    ModuleLineEdit, apply_module_rename_edits, line_references_qualified_call,
+    plan_module_rename_edits, replace_module_name_prefix,
+};
 
 // ──────────────────────────────────────────────────────────────
 // plan_module_rename_edits — early-return / empty-input guards
@@ -174,6 +177,34 @@ fn plan_ignores_plain_code_with_module_name() -> Result<(), Box<dyn std::error::
     let source = "my $obj = Foo::Bar->new();";
     let edits = plan_module_rename_edits(source, "Foo::Bar", "X::Y");
     assert!(edits.is_empty());
+    Ok(())
+}
+
+#[test]
+fn qualified_call_ignores_package_declaration_and_string_literals()
+-> Result<(), Box<dyn std::error::Error>> {
+    assert!(!line_references_qualified_call("package Foo::Bar;", "Foo::Bar"));
+    assert!(!line_references_qualified_call("'Foo::Bar::func()'", "Foo::Bar"));
+    assert!(!line_references_qualified_call("\"Foo::Bar::func()\"", "Foo::Bar"));
+    assert!(line_references_qualified_call("Foo::Bar::func()", "Foo::Bar"));
+    Ok(())
+}
+
+#[test]
+fn replace_prefix_skips_package_lines_and_quoted_occurrences()
+-> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(
+        replace_module_name_prefix("package Foo::Bar;", "Foo::Bar", "New::Mod"),
+        "package Foo::Bar;"
+    );
+    assert_eq!(
+        replace_module_name_prefix("'Foo::Bar::func()'", "Foo::Bar", "New::Mod"),
+        "'Foo::Bar::func()'"
+    );
+    assert_eq!(
+        replace_module_name_prefix("Foo::Bar::func()", "Foo::Bar", "New::Mod"),
+        "New::Mod::func()"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- Module-rename planning produced false positives on `package ...;` declarations and qualified-call-looking text inside string literals or comment tails, which could lead to unwanted edits during rename workflows.
- The change tightens detection so only real qualified-call/code contexts are rewritten and non-code contexts are left unchanged.

### Description

- Stop rewriting `package ...;` declarations from `plan_module_rename_edits` by removing the package-declaration rewrite pass and aligning the docs with that scope.
- Add a lightweight context checker `index_is_in_quote_or_comment` and short-circuit package-line checks, and use these guards in `line_references_qualified_call` and `replace_module_name_prefix` to skip matches inside single/double-quoted strings and comment tails. 
- Add unit/regression tests that assert qualified-call detection and replacement ignore package lines and quoted occurrences (`crates/perl-module/tests/rename_comprehensive_unit_tests.rs`) and update the facade-level API test to assert the regression (`crates/perl-module/tests/facade_api_completeness.rs`).

### Testing

- Ran formatting with `cargo xtask fmt` and it completed successfully. 
- Ran targeted tests with `cargo test -p perl-module --test module_rename_bdd --test rename_comprehensive_unit_tests --test facade_api_completeness` and all selected tests passed. 
- Ran the full crate test `cargo test -p perl-module` and the test suite completed with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e709df2ae08333ae450dfb4901b6d3)