### PR TITLE
fix(tests): repair workspace test compile bit-rot (#4508)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,6 +2021,7 @@ dependencies = [
 name = "perl-tdd-support"
 version = "0.12.4"
 dependencies = [
+ "anyhow",
  "lsp-types",
  "perl-parser-core",
  "perl-test-must",

--- a/crates/perl-lsp/tests/workspace_permission_denied_test.rs
+++ b/crates/perl-lsp/tests/workspace_permission_denied_test.rs
@@ -89,12 +89,12 @@ fn can_create_permission_denied() -> bool {
         Err(_) => return false,
     };
     perms.set_mode(0o000);
-    let _ = std::fs::set_permissions(&probe, &perms);
+    let _ = std::fs::set_permissions(&probe, perms.clone());
     // If we can still read it, we're root
     let readable = std::fs::read_to_string(&probe).is_ok();
     // Restore so tempdir cleanup succeeds
     perms.set_mode(0o644);
-    let _ = std::fs::set_permissions(&probe, &perms);
+    let _ = std::fs::set_permissions(&probe, perms);
     !readable
 }
 

--- a/crates/perl-parser/tests/facade_pattern_edge_cases.rs
+++ b/crates/perl-parser/tests/facade_pattern_edge_cases.rs
@@ -447,17 +447,17 @@ fn test_incremental_parsing_facade() -> Result<(), Box<dyn std::error::Error>> {
     use perl_parser::{Edit, IncrementalState};
 
     let code = "my $x = 1;";
-    let mut state = IncrementalState::new(code);
-    let ast = state.parse()?;
+    let mut state = IncrementalState::new(code.to_string());
+    let ast = state.ast.clone();
 
     assert!(matches!(ast.kind, perl_parser::NodeKind::Program { .. }));
 
     // Apply an edit
-    let edit = Edit { start_byte: 3, old_end_byte: 5, new_end_byte: 5, text: "$y".to_string() };
-    perl_parser::apply_edits(&mut state, vec![edit]);
+    let edit = Edit { start_byte: 3, old_end_byte: 5, new_end_byte: 5, new_text: "$y".to_string() };
+    perl_parser::apply_edits(&mut state, &[edit])?;
 
-    // Re-parse should work
-    let _new_ast = state.parse()?;
+    // Updated AST should remain valid after incremental edit application
+    let _new_ast = state.ast.clone();
 
     Ok(())
 }

--- a/crates/perl-parser/tests/incremental_performance_tests.rs
+++ b/crates/perl-parser/tests/incremental_performance_tests.rs
@@ -7,7 +7,7 @@
 mod incremental_performance_tests {
     use perl_parser::incremental_v2::{IncrementalMetrics, IncrementalParserV2};
     use perl_parser::{edit::Edit, position::Position};
-    use perl_tdd_support::must;
+    use perl_tdd_support::{must, must_some};
     use std::time::{Duration, Instant};
 
     /// Performance test utilities for incremental parsing
@@ -288,10 +288,7 @@ if ($condition) {
             TestSourceGenerator::simple_variable(),
             |source| {
                 let new_source = source.replace("42", "9999");
-                let pos = match source.find("42") {
-                    Some(p) => p,
-                    None => must(Err::<(), _>(format!("Test data should contain '42'"))),
-                };
+                let pos = must_some(source.find("42"));
                 let edit = Edit::new(
                     pos,
                     pos + 2,
@@ -385,10 +382,7 @@ if ($condition) {
             &source,
             |source| {
                 let new_source = source.replace("42", "9999");
-                let pos = match source.find("42") {
-                    Some(p) => p,
-                    None => must(Err::<(), _>(format!("Test data should contain '42'"))),
-                };
+                let pos = must_some(source.find("42"));
                 let edit = Edit::new(
                     pos,
                     pos + 2,

--- a/crates/perl-parser/tests/mutation_hardening_tests.rs
+++ b/crates/perl-parser/tests/mutation_hardening_tests.rs
@@ -1131,10 +1131,10 @@ mod integration_mutation_tests {
         // This test documents a real bug in incremental_document.rs:356
         // where nodes_reused can be larger than count_nodes(), causing underflow
         let source = "package Test; sub test_function { }";
-        let mut doc = match IncrementalDocument::new(source.to_string()) {
-            Ok(d) => d,
-            Err(e) => must(Err::<(), _>(format!("Should create document: {:?}", e))),
-        };
+        let mut doc = must(
+            IncrementalDocument::new(source.to_string())
+                .map_err(|e| format!("Should create document: {:?}", e)),
+        );
 
         // This edit triggers the underflow bug - it's a legitimate bug to fix
         let edit = IncrementalEdit::with_positions(

--- a/crates/perl-parser/tests/support/incremental_test_utils.rs
+++ b/crates/perl-parser/tests/support/incremental_test_utils.rs
@@ -5,6 +5,7 @@
 
 use perl_parser::incremental_v2::{IncrementalMetrics, IncrementalParserV2};
 use perl_parser::{edit::Edit, position::Position};
+use perl_tdd_support::{must, must_some};
 use std::time::{Duration, Instant};
 
 /// Comprehensive performance measurement utilities for incremental parsing

--- a/crates/perl-tdd-support/Cargo.toml
+++ b/crates/perl-tdd-support/Cargo.toml
@@ -30,6 +30,9 @@ serde_json.workspace = true
 lsp-types = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 
+[dev-dependencies]
+anyhow = { workspace = true }
+
 [features]
 default = []
 lsp-compat = ["lsp-types", "url"]
@@ -40,4 +43,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
-


### PR DESCRIPTION
### Motivation
- Fix residual integration-test bit-rot tracked by issue `#4508` which caused `cargo check --workspace --tests --locked` to fail. 
- Restore test scaffolding and small API-usage gaps so workspace test compilation is deterministic and CI-ready.

### Description
- Added missing test helpers import `use perl_tdd_support::{must, must_some};` and replaced inconsistent `match` arms with `must_some(...)` / `must(...)` patterns to keep match-arm types consistent. 
- Updated mutation hardening tests to use `must(...)` on `Result` to avoid returning `()` in an error arm. 
- Aligned incremental-facade test to the current `IncrementalState` / `Edit` API by passing a `String` to `IncrementalState::new`, using `Edit::new_text` (`new_text` field), and calling `apply_edits(&mut state, &[edit])`. 
- Fixed `set_permissions` usages to pass `Permissions` by value (or cloned) in workspace permission-denied tests and added `anyhow` as a `dev-dependency` to `crates/perl-tdd-support/Cargo.toml`; updated `Cargo.lock` accordingly.

### Testing
- Ran `cargo xtask fmt` and the formatter completed successfully. 
- Ran `cargo check --workspace --tests` and it completed successfully. 
- Ran `cargo check --workspace --tests --locked` and it completed successfully. 
- Executed targeted test binaries: `cargo test -p perl-parser --test incremental_performance_tests -- --test-threads=1` (ok, 0 tests ran), `cargo test -p perl-lsp-rs --test workspace_permission_denied_test -- --test-threads=1` (5 passed), and `cargo test -p perl-tdd-support --test guardrail_tests -- --test-threads=1` (4 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e709df2ae08333ae450dfb4901b6d3)