### PR TITLE
fix(tests): repair workspace test-target compile drift (#4508)

### DIFF
--- a/crates/perl-parser/tests/incremental_performance_tests.rs
+++ b/crates/perl-parser/tests/incremental_performance_tests.rs
@@ -7,7 +7,7 @@
 mod incremental_performance_tests {
     use perl_parser::incremental_v2::{IncrementalMetrics, IncrementalParserV2};
     use perl_parser::{edit::Edit, position::Position};
-    use perl_tdd_support::must;
+    use perl_tdd_support::{must, must_some};
     use std::time::{Duration, Instant};
 
     /// Performance test utilities for incremental parsing
@@ -288,10 +288,7 @@ if ($condition) {
             TestSourceGenerator::simple_variable(),
             |source| {
                 let new_source = source.replace("42", "9999");
-                let pos = match source.find("42") {
-                    Some(p) => p,
-                    None => must(Err::<usize, _>(format!("Test data should contain '42'"))),
-                };
+                let pos = must_some(source.find("42"));
                 let edit = Edit::new(
                     pos,
                     pos + 2,
@@ -385,10 +382,7 @@ if ($condition) {
             &source,
             |source| {
                 let new_source = source.replace("42", "9999");
-                let pos = match source.find("42") {
-                    Some(p) => p,
-                    None => must(Err::<usize, _>(format!("Test data should contain '42'"))),
-                };
+                let pos = must_some(source.find("42"));
                 let edit = Edit::new(
                     pos,
                     pos + 2,

--- a/crates/perl-parser/tests/mutation_hardening_tests.rs
+++ b/crates/perl-parser/tests/mutation_hardening_tests.rs
@@ -1128,12 +1128,7 @@ mod integration_mutation_tests {
     #[test]
     fn test_incremental_arithmetic_underflow_fixed() -> TestResult {
         let source = "package Test; sub test_function { }";
-        let mut doc = match IncrementalDocument::new(source.to_string()) {
-            Ok(d) => d,
-            Err(e) => {
-                must(Err::<IncrementalDocument, _>(format!("Should create document: {:?}", e)))
-            }
-        };
+        let mut doc = must(IncrementalDocument::new(source.to_string()));
 
         let edit = IncrementalEdit::with_positions(
             source.len(),

--- a/crates/perl-tdd-support/tests/guardrail_tests.rs
+++ b/crates/perl-tdd-support/tests/guardrail_tests.rs
@@ -2,11 +2,14 @@
 
 use perl_tdd_support::governance::*;
 use std::collections::HashMap;
+use std::error::Error;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
+type TestResult = Result<(), Box<dyn Error>>;
+
 #[test]
-fn test_ignored_test_guardian_validation() -> Result<(), Box<dyn std::error::Error>> {
+fn test_ignored_test_guardian_validation() -> TestResult {
     // Tests feature spec: SPEC_144_IGNORED_TESTS_ARCHITECTURAL_BLUEPRINT.md#ci-guardrail-system
 
     let governance = IgnoredTestGovernance {
@@ -155,7 +158,7 @@ fn test_ignored_test_guardian_validation() -> Result<(), Box<dyn std::error::Err
 }
 
 #[test]
-fn test_baseline_regression_detection() -> Result<(), Box<dyn std::error::Error>> {
+fn test_baseline_regression_detection() -> TestResult {
     // Tests feature spec: SPEC_144_IGNORED_TESTS_ARCHITECTURAL_BLUEPRINT.md#ci-guardrail-system
 
     let governance = IgnoredTestGovernance {
@@ -266,7 +269,7 @@ fn test_baseline_regression_detection() -> Result<(), Box<dyn std::error::Error>
 }
 
 #[test]
-fn test_ignored_test_trend_reporting() -> Result<(), Box<dyn std::error::Error>> {
+fn test_ignored_test_trend_reporting() -> TestResult {
     // Tests feature spec: SPEC_144_IGNORED_TESTS_ARCHITECTURAL_BLUEPRINT.md#ci-guardrail-system
 
     let governance = IgnoredTestGovernance {
@@ -385,7 +388,7 @@ fn test_ignored_test_trend_reporting() -> Result<(), Box<dyn std::error::Error>>
 }
 
 #[test]
-fn test_test_quality_validation() -> Result<(), Box<dyn std::error::Error>> {
+fn test_test_quality_validation() -> TestResult {
     // Tests feature spec: SPEC_144_IGNORED_TESTS_ARCHITECTURAL_BLUEPRINT.md#ci-guardrail-system
 
     let governance = IgnoredTestGovernance {


### PR DESCRIPTION
### Motivation

- Unblock workspace test-target compilation failures caused by integration test bit-rot detected by `cargo check --workspace --tests --locked` (tracker: #4508). 

### Description

- Repaired incremental parser test helpers by importing `perl_tdd_support::{must, must_some}` and using `must_some(source.find(...))` instead of `match` fallbacks that produced incompatible arm types. 
- Updated incremental/performance and support helpers to construct and use the current incremental API (`IncrementalParserV2::new`/`IncrementalState::new(String)`, `Edit { new_text }`, and `perl_parser::apply_edits(&mut state, &[Edit])`).
- Fixed moved/borrow issues in permission tests by using `perms.clone()` for the first `set_permissions` call and passing `perms` for restore to match the std API. 
- Simplified a `match`-based construction to `must(...)` in mutation hardening tests to align with current test helper style. 
- Removed unresolved `anyhow::Result` import from `perl-tdd-support` integration tests and introduced a local `TestResult` alias (`Result<(), Box<dyn std::error::Error>>`) to avoid missing dev-dependency issues. 
- Applied formatting via `cargo xtask fmt` to keep code style consistent.

### Testing

- Ran `cargo xtask fmt` successfully. 
- Verified workspace compilation with `cargo check --workspace --tests --locked`, which completed without errors. 
- Executed targeted test runs and all passed: `cargo test -p perl-parser --test incremental_performance_tests --features incremental --locked` (ok), `cargo test -p perl-parser --test facade_pattern_edge_cases --features incremental --locked` (24 passed), `cargo test -p perl-tdd-support --test guardrail_tests --locked` (4 passed), and `cargo test -p perl-lsp-rs --test workspace_permission_denied_test --locked` (5 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e709df2ae08333ae450dfb4901b6d3)