### PR TITLE
fix(parser-core): preserve ternary precedence for bare unary-style calls (#4579)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -307,6 +307,7 @@ impl<'a> Parser<'a> {
                                 | TokenKind::WordAnd
                                 | TokenKind::WordXor
                                 | TokenKind::WordNot
+                                | TokenKind::Question
                                 | TokenKind::Semicolon
                         ) {
                             return false;

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -688,7 +688,12 @@ impl<'a> Parser<'a> {
                             // sigil-starting argument is a bare function call.
                             // Handles `blessed $self`, `reftype $x`, `weaken $ref`, etc.
                             // (imported unary functions that look like builtins at the call site)
-                            let arg = self.parse_ternary()?;
+                            //
+                            // Parse only a high-precedence argument expression here so
+                            // lower-precedence operators remain outside the call.
+                            // Example: `is_ready $obj ? 1 : 0` must parse as
+                            // `(is_ready $obj) ? 1 : 0`, not `is_ready($obj ? 1 : 0)`.
+                            let arg = self.parse_shift()?;
                             let start = expr.location.start;
                             let end = arg.location.end;
                             expr = Node::new(

--- a/crates/perl-parser-core/tests/fix_ternary_stmt_start.rs
+++ b/crates/perl-parser-core/tests/fix_ternary_stmt_start.rs
@@ -162,6 +162,11 @@ fn test_custom_func_no_parens_ternary() {
 }
 
 #[test]
+fn test_custom_func_no_parens_or_fallback() {
+    assert_clean_parse(r#"is_ready $obj or die "not ready";"#);
+}
+
+#[test]
 fn test_ternary_after_not() {
     assert_clean_parse(r#"!$x ? 1 : 0;"#);
 }


### PR DESCRIPTION
### Motivation
- A bare non-builtin unary-style call followed by a ternary (`name $arg ? then : else`) was being mis-parsed as an indirect-object/indirect-call pattern, producing an `ERROR` node at the `?` token.
- The parser should keep lower-precedence operators (ternary, `or`, `and`) outside a one-argument bare call so the conditional/fallback expressions attach at the expression level.

### Description
- Treat `?` as a terminator when heuristically disqualifying indirect-call candidates so `name $arg ? ...` is not considered an indirect-object form (`crates/perl-parser-core/src/engine/parser/expressions/calls.rs`).
- For the sigil-peek bare-call heuristic, consume only a high-precedence argument (`parse_shift()`) instead of a full `parse_ternary()` so lower-precedence operators remain outside the call (`crates/perl-parser-core/src/engine/parser/expressions/postfix.rs`).
- Add a regression test covering a related low-precedence follow-up form (`is_ready $obj or die ...`) alongside the ternary case (`crates/perl-parser-core/tests/fix_ternary_stmt_start.rs`).

### Testing
- Ran `cargo test -p perl-parser-core --test fix_ternary_stmt_start` and the test suite completed with all tests passing.
- Ran `cargo test -p perl-parser-core indirect_call` and the indirect-call tests passed.
- Ran repository formatting via `cargo xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8951211248333a1979cd08934e69a)