### PR TITLE
test(rs-core): keep transport deferred regression test warning-free (#4585)

### DIFF
--- a/crates/perl-lsp-rs-core/tests/runtime_g2_transport_deferred.rs
+++ b/crates/perl-lsp-rs-core/tests/runtime_g2_transport_deferred.rs
@@ -64,8 +64,9 @@ fn test_transport_lib_rs_exists() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_runtime_transport_not_absorbed() -> Result<(), Box<dyn std::error::Error>> {
     // Regression guard: transport should be accessible from rs-core::transport.
-    // If this test compiles, it verifies the module is properly re-exported.
-    use perl_lsp_rs_core::transport as _transport;
+    // Touch a concrete transport item so this check stays meaningful and warning-free.
+    let _type_name =
+        std::any::type_name::<perl_lsp_rs_core::transport::ContentLengthMessageReader>();
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Remove an `unused import` warning from the transport regression test while preserving the compile-time guard that `perl_lsp_rs_core::transport` is publicly accessible.

### Description
- Replaced the compile-only import `use perl_lsp_rs_core::transport as _transport;` with a concrete symbol touch via `std::any::type_name::<perl_lsp_rs_core::transport::ContentLengthMessageReader>()` in `crates/perl-lsp-rs-core/tests/runtime_g2_transport_deferred.rs`.
- Ran `cargo fmt` to keep formatting consistent.

### Testing
- Ran `cargo test -p perl-lsp-rs-core --test runtime_g2_transport_deferred` which passed (all tests in that test target succeeded).
- Ran `cargo fmt --all` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8951211248333a1979cd08934e69a)