### PR TITLE
fix(incremental): restore benchmark build and relex stats (#4533)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,9 +1575,11 @@ name = "perl-incremental-parsing"
 version = "0.12.4"
 dependencies = [
  "anyhow",
+ "criterion",
  "lsp-types",
  "perl-lexer",
  "perl-line-index",
+ "perl-parser",
  "perl-parser-core",
  "perl-tdd-support",
  "ropey",

--- a/crates/perl-incremental-parsing/Cargo.toml
+++ b/crates/perl-incremental-parsing/Cargo.toml
@@ -38,6 +38,8 @@ default = []
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }
+criterion.workspace = true
+perl-parser = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
+++ b/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
@@ -486,6 +486,8 @@ impl CheckpointedIncrementalParser {
 
         let mut lexer = PerlLexer::new(&self.source);
         let mut raw_tokens = Vec::new();
+        let mut relexed_tokens = 0usize;
+        let mut relexed_bytes = 0usize;
         let mut checkpoint_positions = vec![0, 100, 500, 1000, 5000];
 
         // Collect raw lexer tokens and save checkpoints at specific positions
@@ -505,8 +507,13 @@ impl CheckpointedIncrementalParser {
                 break;
             }
 
+            relexed_tokens += 1;
+            relexed_bytes += token.end.saturating_sub(token.start);
             raw_tokens.push(token);
         }
+
+        self.stats.tokens_relexed += relexed_tokens;
+        self.stats.bytes_relexed += relexed_bytes;
 
         // Convert raw lexer tokens to parser tokens (trivia-filtered + kind-mapped)
         // and cache them for reuse in incremental reparses.


### PR DESCRIPTION
### Motivation
- Fix a regression where benchmark targets failed to build under `--all-targets` and full-reparse flows did not account for tokens/bytes relexed, causing some incremental metrics tests to observe `tokens_relexed == 0`.
- Ensure the incremental parser records accurate re-lexing metrics when a full checkpoint rebuild happens so statistics remain meaningful for tests and telemetry.
- Restore the repository state so benchmark-related dev-dependencies are present for local benchmarking and CI when needed.

### Description
- Added missing dev-dependencies `criterion.workspace = true` and `perl-parser = { workspace = true }` to `crates/perl-incremental-parsing/Cargo.toml` so bench targets compile under `--all-targets`.
- Updated `parse_with_checkpoints` in `crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs` to count re-lexed tokens and bytes (`relexed_tokens` / `relexed_bytes`) and add them to `self.stats.tokens_relexed` and `self.stats.bytes_relexed` during a full checkpoint rebuild.
- Refreshed `Cargo.lock` entries affected by the dependency changes and ran formatting via the repo `xtask` formatter.

### Testing
- Ran `cargo test -p perl-incremental-parsing --test comprehensive_unit_tests --test extended_unit_tests` and all tests passed.
- Ran `cargo test -p perl-incremental-parsing --all-targets` (including bench/targets) and the package build/tests completed successfully.
- Ran `cargo xtask fmt` to ensure formatting; the formatting task completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8951211248333a1979cd08934e69a)