### PR TITLE
fix(parser): avoid indirect-call ternary misparse (#2750)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -308,6 +308,7 @@ impl<'a> Parser<'a> {
                                 | TokenKind::WordXor
                                 | TokenKind::WordNot
                                 | TokenKind::Semicolon
+                                | TokenKind::Question
                         ) {
                             return false;
                         }


### PR DESCRIPTION
### Motivation
- The parser misclassified bare no-paren calls like `is_ready $obj ? 1 : 0;` as an indirect-call pattern, causing the ternary `?` to be parsed incorrectly and producing an `Error` node.
- The heuristic in `is_indirect_call_pattern` inspected the token after a sigiled first-arg but did not treat `?` as a terminator, so ternary-at-statement-start cases were routed through the indirect-call path erroneously.

### Description
- Updated `crates/perl-parser-core/src/engine/parser/expressions/calls.rs` in `is_indirect_call_pattern` to treat `TokenKind::Question` as a terminator when inspecting the token following a sigiled first argument by adding `TokenKind::Question` to the match that returns `false`.
- This is a minimal, targeted change that prevents the indirect-call heuristic from claiming `name $obj ?` forms while leaving other indirect-call logic unchanged.
- Only a single insertion was made; no behavior changes outside the indirect-call detection path were introduced.

### Testing
- Ran `cargo test -p perl-parser-core --test fix_ternary_stmt_start test_custom_func_no_parens_ternary --quiet` and the targeted test passed.
- Ran `cargo test -p perl-parser-core --test fix_ternary_stmt_start --quiet` and the full suite for that test target passed (`79 passed`).
- Ran `cargo test -p perl-parser-core --test fix_indirect_call_rparen_rbracket --quiet` and it passed.
- Ran `cargo test -p perl-parser-core --test named_unary_ternary_tests --quiet` and it passed.
- An attempted `cargo test -p perl-parser-core --test indirect_call_tests --quiet` failed because the test target does not exist (command-level error), not due to parser failures.
- Ran `cargo xtask fmt` to format changes and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8951211248333a1979cd08934e69a)