### PR TITLE
fix(lsp): reset pull diagnostics critic cache on config updates (#0000)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,9 +268,6 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
     #[allow(dead_code)]
     pub fn reset(&self) {
@@ -281,6 +278,16 @@ impl PullDiagnosticsOrchestrator {
     /// No-op stub for WASM targets.
     #[cfg(target_arch = "wasm32")]
     pub fn reset(&self) {}
+
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_insert_warning_key(&self, key: &str) {
+        self.warnings_sent.lock().insert(key.to_string());
+    }
+
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_warning_count(&self) -> usize {
+        self.warnings_sent.lock().len()
+    }
 }
 
 impl Default for PullDiagnosticsOrchestrator {

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -444,4 +444,24 @@ include_paths = ["other_lib"]
             );
         }
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn did_change_configuration_resets_pull_diagnostics_orchestrator_on_critic_change() {
+        let server = LspServer::new();
+        server.pull_diagnostics_orchestrator.test_insert_warning_key("perlcritic-not-found");
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 1);
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "enabled": true
+                    }
+                }
+            }
+        })));
+
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 0);
+    }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation

- Pull-diagnostics kept stale Perl::Critic analyzer / warning-dedup state after `didChangeConfiguration` updates to perlcritic settings, leading to stale workspace warnings and incorrect diagnostic behavior.

### Description

- Wire `handle_did_change_configuration` to call `PullDiagnosticsOrchestrator::reset()` when perlcritic-related settings change so the orchestrator's analyzer and warning cache are invalidated.
- Add test-only helpers `test_insert_warning_key` and `test_warning_count` to `PullDiagnosticsOrchestrator` to seed and inspect the warning dedupe set for unit tests.
- Add a unit test `did_change_configuration_resets_pull_diagnostics_orchestrator_on_critic_change` in `runtime/lifecycle/workspace.rs` that verifies the orchestrator's warning state is cleared after a perlcritic config change.

### Testing

- Ran `cargo test -p perl-lsp-rs --lib runtime::lifecycle::workspace::tests::did_change_configuration_resets_pull_diagnostics_orchestrator_on_critic_change -- --exact` and the test passed.
- Ran `cargo test -p perl-lsp-rs --lib runtime::lifecycle::workspace::tests::did_change_configuration_updates_folder_effective_configs -- --exact` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e895133d588333b48e3b933935d2ed)