### PR TITLE
fix(runtime): reset pull diagnostics cache on perlcritic config updates (#0000)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -281,6 +281,18 @@ impl PullDiagnosticsOrchestrator {
     /// No-op stub for WASM targets.
     #[cfg(target_arch = "wasm32")]
     pub fn reset(&self) {}
+
+    /// Test helper: seed warning deduplication state.
+    #[cfg(test)]
+    pub(crate) fn test_seed_warning_key(&self, key: &str) {
+        self.warnings_sent.lock().insert(key.to_string());
+    }
+
+    /// Test helper: current warning deduplication cache size.
+    #[cfg(test)]
+    pub(crate) fn test_warning_key_count(&self) -> usize {
+        self.warnings_sent.lock().len()
+    }
 }
 
 impl Default for PullDiagnosticsOrchestrator {

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -444,4 +444,24 @@ include_paths = ["other_lib"]
             );
         }
     }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn did_change_configuration_resets_pull_diagnostics_orchestrator_cache() {
+        let server = LspServer::new();
+        server.pull_diagnostics_orchestrator.test_seed_warning_key("execution-failed:stale");
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_key_count(), 1);
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "severity": 4
+                    }
+                }
+            }
+        })));
+
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_key_count(), 0);
+    }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation

- Pull-diagnostics kept stale analyzer/warning state when Perl::Critic-related settings changed, causing misleading/deduplicated warnings to persist after configuration updates.

### Description

- Call `self.pull_diagnostics_orchestrator.reset()` when `critic_config_changed` in `handle_did_change_configuration` to invalidate the pull-diagnostics orchestrator cache (`crates/perl-lsp/src/runtime/workspace.rs`).
- Add test-only helpers `test_seed_warning_key` and `test_warning_key_count` to `PullDiagnosticsOrchestrator` to allow seeding and inspecting the warning deduplication cache (`crates/perl-lsp/src/runtime/diagnostics.rs`).
- Add a regression unit test `did_change_configuration_resets_pull_diagnostics_orchestrator_cache` to assert the orchestrator cache is cleared on relevant config changes (`crates/perl-lsp/src/runtime/lifecycle/workspace.rs`).

### Testing

- Ran `cargo fmt --all` to format the workspace and it completed successfully.
- Ran `cargo test -p perl-lsp-rs --lib did_change_configuration_resets_pull_diagnostics_orchestrator_cache` and the test passed (`ok`).
- Ran `cargo test -p perl-lsp-rs --lib did_change_configuration_updates_folder_effective_configs` and the test passed (`ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e895133d588333b48e3b933935d2ed)