### PR TITLE
fix(diagnostics): reset pull perlcritic analyzer on config changes (#4578)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,11 +268,7 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
-    #[allow(dead_code)]
     pub fn reset(&self) {
         *self.critic_analyzer.lock() = None;
         self.warnings_sent.lock().clear();
@@ -281,6 +277,19 @@ impl PullDiagnosticsOrchestrator {
     /// No-op stub for WASM targets.
     #[cfg(target_arch = "wasm32")]
     pub fn reset(&self) {}
+
+    /// Invalidate cached perlcritic violations for a single file path.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn invalidate_file_cache(&self, file_path: &std::path::Path) {
+        let path_str = file_path.to_string_lossy().to_string();
+        if let Some(ref mut analyzer) = *self.critic_analyzer.lock() {
+            analyzer.invalidate_cache(&path_str);
+        }
+    }
+
+    /// No-op stub for WASM targets.
+    #[cfg(target_arch = "wasm32")]
+    pub fn invalidate_file_cache(&self, _file_path: &std::path::Path) {}
 }
 
 impl Default for PullDiagnosticsOrchestrator {

--- a/crates/perl-lsp/src/runtime/test_api.rs
+++ b/crates/perl-lsp/src/runtime/test_api.rs
@@ -231,6 +231,13 @@ impl LspServer {
         self.handle_document_diagnostic(params)
     }
 
+    /// Test-only entrypoint for `workspace/didChangeConfiguration`.
+    ///
+    /// Applies the same configuration-update path as a real client notification.
+    pub fn test_handle_did_change_configuration(&self, params: Option<Value>) {
+        self.handle_did_change_configuration(params);
+    }
+
     /// Install a mock subprocess runtime for the `CriticAnalyzer`.
     ///
     /// When set, the lazy-init path in `collect_external_perlcritic_diagnostics`

--- a/crates/perl-lsp/src/runtime/text_sync.rs
+++ b/crates/perl-lsp/src/runtime/text_sync.rs
@@ -412,6 +412,7 @@ impl LspServer {
                         if let Some(ref mut analyzer) = *self.critic_analyzer.lock() {
                             analyzer.invalidate_cache(&path_str);
                         }
+                        self.pull_diagnostics_orchestrator.invalidate_file_cache(&path);
                     }
                 }
 

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)

--- a/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
+++ b/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
@@ -354,3 +354,89 @@ fn test_f_missing_configured_profile_skips_subprocess_and_diagnostics() {
         "subprocess should not run when configured profile path does not exist"
     );
 }
+
+#[test]
+fn test_g_did_change_configuration_resets_pull_perlcritic_analyzer() {
+    use std::fs;
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    let profile_a = root.join("profile-a.perlcriticrc");
+    let profile_b = root.join("profile-b.perlcriticrc");
+    fs::write(&profile_a, "severity = 3\n").expect("write profile-a");
+    fs::write(&profile_b, "severity = 3\n").expect("write profile-b");
+
+    let module_path = root.join("ConfigSwitch.pm");
+    fs::write(&module_path, "package ConfigSwitch;\n1;\n").expect("write module");
+
+    let server = LspServer::new();
+    server.test_set_root_path(root);
+    server.test_bypass_perlcritic_command_check();
+
+    let runtime = Arc::new(MockSubprocessRuntime::new());
+    runtime.add_response(MockResponse::success(b"".to_vec()));
+    runtime.add_response(MockResponse::success(b"".to_vec()));
+    server.test_install_mock_critic_runtime(runtime.clone());
+
+    let uri = url::Url::from_file_path(&module_path).expect("file url").to_string();
+    server
+        .test_handle_did_open(Some(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": "package ConfigSwitch;\n1;\n"
+            }
+        })))
+        .expect("didOpen should succeed");
+
+    server.test_handle_did_change_configuration(Some(json!({
+        "settings": {
+            "perl": {
+                "perlcritic": {
+                    "enabled": true,
+                    "severity": 3,
+                    "profile": profile_a.to_string_lossy().to_string()
+                }
+            }
+        }
+    })));
+    must(server.test_handle_document_diagnostic(Some(json!({
+        "textDocument": { "uri": uri }
+    }))));
+
+    server.test_handle_did_change_configuration(Some(json!({
+        "settings": {
+            "perl": {
+                "perlcritic": {
+                    "enabled": true,
+                    "severity": 3,
+                    "profile": profile_b.to_string_lossy().to_string()
+                }
+            }
+        }
+    })));
+    must(server.test_handle_document_diagnostic(Some(json!({
+        "textDocument": { "uri": uri }
+    }))));
+
+    let invocations = runtime.invocations();
+    assert_eq!(
+        invocations.len(),
+        2,
+        "expected two pull perlcritic invocations; got: {invocations:?}"
+    );
+    assert!(
+        invocations
+            .iter()
+            .any(|call| call.args.contains(&format!("--profile={}", profile_a.to_string_lossy()))),
+        "at least one invocation should use profile-a; invocations: {invocations:?}"
+    );
+    let last = invocations.last().expect("at least one invocation recorded");
+    assert!(
+        last.args.contains(&format!("--profile={}", profile_b.to_string_lossy())),
+        "last invocation should use profile-b after didChangeConfiguration; args: {:?}",
+        last.args
+    );
+}


### PR DESCRIPTION
### Motivation

- Pull diagnostics were reusing a stale Perl::Critic analyzer after `workspace/didChangeConfiguration`, causing pull diagnostics to continue using the old severity/profile instead of rebuilding with new settings.
- Document edits did not invalidate the pull-diagnostics per-file cache, so file-local perlcritic results could remain stale after `textDocument/didChange`.
- Tests lacked a way to exercise the real `didChangeConfiguration` path from integration tests, limiting regression coverage for config-driven analyzer resets.

### Description

- Reset `PullDiagnosticsOrchestrator` when critic-related settings change by calling its `reset()` from the `didChangeConfiguration` handler so the pull-diagnostics analyzer is rebuilt with new config.
- Add `PullDiagnosticsOrchestrator::invalidate_file_cache(&Path)` and call it from `text_sync::handle_did_change` so pull-path perlcritic file caches are invalidated on document edits (matching existing push-path invalidation).
- Add a test-only API `test_handle_did_change_configuration` that forwards to `handle_did_change_configuration` so integration tests can exercise the real notification path.
- Add a regression test `test_g_did_change_configuration_resets_pull_perlcritic_analyzer` that verifies pull diagnostics use profile A, then after a real `didChangeConfiguration` call use profile B.
- Files changed: `crates/perl-lsp/src/runtime/diagnostics.rs`, `crates/perl-lsp/src/runtime/text_sync.rs`, `crates/perl-lsp/src/runtime/workspace.rs`, `crates/perl-lsp/src/runtime/test_api.rs`, and `crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs`.

### Testing

- Ran `cargo xtask fmt` successfully to format changes.
- Ran the focused integration test: `cargo test -p perl-lsp-rs --features expose_lsp_test_api --test lsp_perlcritic_diagnostics_tests test_g_did_change_configuration_resets_pull_perlcritic_analyzer`, which passed.
- The updated perlcritic diagnostics test suite was executed and the new regression test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e895133d588333b48e3b933935d2ed)