### PR TITLE
fix(runtime): reset pull-diagnostics perlcritic cache on config updates (#0000)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -1675,4 +1675,43 @@ mod tests {
         assert_eq!(diagnostic.severity, InternalDiagnosticSeverity::Error);
         assert_eq!(diagnostic.code.as_deref(), Some("GentlePolicy"));
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn did_change_configuration_resets_pull_diagnostics_orchestrator_state() {
+        let server = LspServer::new();
+
+        {
+            let mut analyzer = server.pull_diagnostics_orchestrator.critic_analyzer.lock();
+            *analyzer = Some(crate::perl_critic::CriticAnalyzer::new(
+                crate::perl_critic::CriticConfig { severity: 3, ..Default::default() },
+                std::sync::Arc::new(perl_subprocess_runtime::OsSubprocessRuntime::new()),
+            ));
+        }
+        server
+            .pull_diagnostics_orchestrator
+            .warnings_sent
+            .lock()
+            .insert("missing-binary".to_string());
+
+        server.handle_did_change_configuration(Some(json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "enabled": true,
+                        "severity": 5
+                    }
+                }
+            }
+        })));
+
+        assert!(
+            server.pull_diagnostics_orchestrator.critic_analyzer.lock().is_none(),
+            "pull-diagnostics critic analyzer should be reset after perlcritic config changes"
+        );
+        assert!(
+            server.pull_diagnostics_orchestrator.warnings_sent.lock().is_empty(),
+            "pull-diagnostics warning dedupe set should be cleared after perlcritic config changes"
+        );
+    }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation
- Pull-based Perl::Critic diagnostics retained stale analyzer/cache after `workspace/didChangeConfiguration` updates to perlcritic settings, causing inconsistent diagnostics.
- Ensure pull-diagnostics honors `perl.perlcritic.enabled`, `perl.perlcritic.severity`, and `perl.perlcritic.profile` changes immediately.

### Description
- Reset the pull-diagnostics orchestrator when perlcritic-related settings change by calling `self.pull_diagnostics_orchestrator.reset()` in `handle_did_change_configuration` so the analyzer and dedupe cache are cleared.
- Added a regression unit test `did_change_configuration_resets_pull_diagnostics_orchestrator_state` that seeds the pull-diagnostics critic analyzer and warning set, invokes `handle_did_change_configuration`, and asserts both analyzer and warning set are cleared.
- Minor test helper changes: the test constructs a `CriticConfig` and uses `OsSubprocessRuntime::new()` when seeding the analyzer.

### Testing
- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran `cargo test -p perl-lsp-rs --lib runtime::diagnostics::tests::did_change_configuration_resets_pull_diagnostics_orchestrator_state -- --exact` and the test passed.
- Ran `cargo test -p perl-lsp-rs --lib runtime::lifecycle::workspace::tests::did_change_configuration_updates_folder_effective_configs -- --exact` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e895133d588333b48e3b933935d2ed)