### PR TITLE
fix(diagnostics): reset pull critic state on config change (#0000)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,11 +268,7 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
-    #[allow(dead_code)]
     pub fn reset(&self) {
         *self.critic_analyzer.lock() = None;
         self.warnings_sent.lock().clear();
@@ -281,6 +277,16 @@ impl PullDiagnosticsOrchestrator {
     /// No-op stub for WASM targets.
     #[cfg(target_arch = "wasm32")]
     pub fn reset(&self) {}
+
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_insert_warning(&self, key: &str) {
+        self.warnings_sent.lock().insert(key.to_string());
+    }
+
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_warning_count(&self) -> usize {
+        self.warnings_sent.lock().len()
+    }
 }
 
 impl Default for PullDiagnosticsOrchestrator {

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -444,4 +444,29 @@ include_paths = ["other_lib"]
             );
         }
     }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn did_change_configuration_resets_pull_diagnostics_orchestrator_state() {
+        let server = LspServer::new();
+
+        server.pull_diagnostics_orchestrator.test_insert_warning("missing-binary");
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 1);
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "severity": 2
+                    }
+                }
+            }
+        })));
+
+        assert_eq!(
+            server.pull_diagnostics_orchestrator.test_warning_count(),
+            0,
+            "didChangeConfiguration with perlcritic changes should invalidate pull-diagnostics tool state",
+        );
+    }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation
- Ensure pull-diagnostics state is invalidated when Perl::Critic-related settings change so stale analyzer/warning state doesn't persist after `workspace/didChangeConfiguration`.
- Keep pull-diagnostics tool state aligned with the existing push-diagnostics critic reset path to avoid inconsistent behavior between push and pull flows.
- Provide test hooks to allow deterministic unit tests that assert the orchestrator warning cache is cleared on config changes.

### Description
- Call `PullDiagnosticsOrchestrator::reset()` from `handle_did_change_configuration` when Perl::Critic settings change so the pull-diagnostics analyzer and warnings are invalidated (change in `crates/perl-lsp/src/runtime/workspace.rs`).
- Add test-only helpers `test_insert_warning` and `test_warning_count` to `PullDiagnosticsOrchestrator` to seed and inspect the warning dedupe cache for unit tests (change in `crates/perl-lsp/src/runtime/diagnostics.rs`).
- Add a regression unit test `did_change_configuration_resets_pull_diagnostics_orchestrator_state` that verifies `didChangeConfiguration` clears the pull-diagnostics warning cache when `perlcritic` config is updated (change in `crates/perl-lsp/src/runtime/lifecycle/workspace.rs`).
- Remove an unnecessary `#[allow(dead_code)]` on `reset` and keep WASM no-op stubs intact.

### Testing
- Ran `cargo xtask fmt` to format the workspace and the command completed successfully.
- Ran `cargo test -p perl-lsp-rs --lib --no-run` to verify test artifacts build successfully and it completed without error.
- Ran `cargo test -p perl-lsp-rs --lib did_change_configuration_resets_pull_diagnostics_orchestrator_state` and the test passed.
- Ran `cargo test -p perl-lsp-rs --lib did_change_configuration_updates_folder_effective_configs` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8951490648333a9dd6bc7f0963242)