### PR TITLE
fix(diagnostics): reset pull critic cache on config changes (#0)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,11 +268,7 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
-    #[allow(dead_code)]
     pub fn reset(&self) {
         *self.critic_analyzer.lock() = None;
         self.warnings_sent.lock().clear();
@@ -281,6 +277,18 @@ impl PullDiagnosticsOrchestrator {
     /// No-op stub for WASM targets.
     #[cfg(target_arch = "wasm32")]
     pub fn reset(&self) {}
+
+    /// Seed internal state for tests so reset behavior can be verified.
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_seed_state(&self) {
+        self.warnings_sent.lock().insert("pull-diag-test-warning".to_string());
+    }
+
+    /// Expose whether cached state exists (tests only).
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_has_cached_state(&self) -> bool {
+        self.critic_analyzer.lock().is_some() || !self.warnings_sent.lock().is_empty()
+    }
 }
 
 impl Default for PullDiagnosticsOrchestrator {

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -444,4 +444,24 @@ include_paths = ["other_lib"]
             );
         }
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn did_change_configuration_resets_pull_diagnostics_critic_cache() {
+        let server = LspServer::new();
+        server.pull_diagnostics_orchestrator.test_seed_state();
+        assert!(server.pull_diagnostics_orchestrator.test_has_cached_state());
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "severity": 4
+                    }
+                }
+            }
+        })));
+
+        assert!(!server.pull_diagnostics_orchestrator.test_has_cached_state());
+    }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation
- Pull-diagnostics maintained its own cached `CriticAnalyzer`/warning dedupe state which was not invalidated when Perl::Critic-related settings changed, allowing stale critic configuration to be used after a `workspace/didChangeConfiguration` event.

### Description
- Wire `PullDiagnosticsOrchestrator::reset()` into `handle_did_change_configuration` so the pull-diagnostics cache is cleared when Perl::Critic settings change. (change in `crates/perl-lsp/src/runtime/workspace.rs`).
- Add test-only helpers `test_seed_state` and `test_has_cached_state` on `PullDiagnosticsOrchestrator` to allow seeding and inspecting cached state in unit tests. (changes in `crates/perl-lsp/src/runtime/diagnostics.rs`).
- Add a focused non-WASM unit test `did_change_configuration_resets_pull_diagnostics_critic_cache` that seeds orchestrator state, invokes `handle_did_change_configuration`, and asserts the orchestrator state is cleared. (change in `crates/perl-lsp/src/runtime/lifecycle/workspace.rs`).

### Testing
- Ran `cargo xtask fmt` and it completed successfully.
- Ran the targeted unit test with `cargo test -p perl-lsp-rs --lib runtime::lifecycle::workspace::tests::did_change_configuration_resets_pull_diagnostics_critic_cache -- --exact` and it passed.
- Ran the broader related workspace tests `cargo test -p perl-lsp-rs --lib runtime::lifecycle::workspace::tests::did_change_configuration_` and both relevant tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8951490648333a9dd6bc7f0963242)