### PR TITLE
fix(perl-lsp): reset pull diagnostics critic state on config updates (#9999)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,9 +268,6 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
     #[allow(dead_code)]
     pub fn reset(&self) {
@@ -281,6 +278,16 @@ impl PullDiagnosticsOrchestrator {
     /// No-op stub for WASM targets.
     #[cfg(target_arch = "wasm32")]
     pub fn reset(&self) {}
+
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn warning_count_for_test(&self) -> usize {
+        self.warnings_sent.lock().len()
+    }
+
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn seed_warning_for_test(&self, key: &str) {
+        self.warnings_sent.lock().insert(key.to_string());
+    }
 }
 
 impl Default for PullDiagnosticsOrchestrator {

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -444,4 +444,24 @@ include_paths = ["other_lib"]
             );
         }
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn did_change_configuration_resets_pull_diagnostics_orchestrator() {
+        let server = LspServer::new();
+        server.pull_diagnostics_orchestrator.seed_warning_for_test("missing-binary");
+        assert_eq!(server.pull_diagnostics_orchestrator.warning_count_for_test(), 1);
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "enabled": true
+                    }
+                }
+            }
+        })));
+
+        assert_eq!(server.pull_diagnostics_orchestrator.warning_count_for_test(), 0);
+    }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation
- The pull-diagnostics orchestrator cached a `CriticAnalyzer` and a warnings dedupe set but was not being reset when Perl::Critic-related configuration changed, leaving stale analyzer/warning state across config updates.

### Description
- Wire `workspace/didChangeConfiguration` to call `pull_diagnostics_orchestrator.reset()` when Perl::Critic settings change so the cached analyzer and warnings are invalidated (change in `handle_did_change_configuration` in `crates/perl-lsp/src/runtime/workspace.rs`).
- Remove the stale TODO comment in the orchestrator reset docs and keep `reset()` as the canonical invalidation hook (change in `crates/perl-lsp/src/runtime/diagnostics.rs`).
- Add two test-only helpers on `PullDiagnosticsOrchestrator`: `seed_warning_for_test` and `warning_count_for_test` to allow focused tests of the warning dedupe state (in `crates/perl-lsp/src/runtime/diagnostics.rs`).
- Add a focused lifecycle test `did_change_configuration_resets_pull_diagnostics_orchestrator` that verifies the orchestrator warning set is cleared after a config change (in `crates/perl-lsp/src/runtime/lifecycle/workspace.rs`).

### Testing
- Ran `cargo fmt --all --check` and it succeeded.
- Ran `cargo check -p perl-lsp-rs --lib` and it succeeded.
- Attempted `cargo test -p perl-lsp-rs did_change_configuration_resets_pull_diagnostics_orchestrator -- --nocapture` but the run could not complete in this environment due to `No space left on device` while compiling test targets, so the new test was added but could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8951490648333a9dd6bc7f0963242)