### PR TITLE
fix(lsp): reset pull diagnostics critic cache on config change (#0000)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,9 +268,6 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
     #[allow(dead_code)]
     pub fn reset(&self) {
@@ -281,6 +278,18 @@ impl PullDiagnosticsOrchestrator {
     /// No-op stub for WASM targets.
     #[cfg(target_arch = "wasm32")]
     pub fn reset(&self) {}
+
+    /// Test helper: seed warning-dedup state.
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_mark_warning_sent(&self, key: &str) {
+        self.warnings_sent.lock().insert(key.to_string());
+    }
+
+    /// Test helper: observe warning-dedup state size.
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_warning_count(&self) -> usize {
+        self.warnings_sent.lock().len()
+    }
 }
 
 impl Default for PullDiagnosticsOrchestrator {

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -444,4 +444,26 @@ include_paths = ["other_lib"]
             );
         }
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn did_change_configuration_resets_pull_diagnostics_warning_dedup() {
+        let server = LspServer::new();
+
+        server.pull_diagnostics_orchestrator.test_mark_warning_sent("seed-warning");
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 1);
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "enabled": true,
+                        "severity": 4
+                    }
+                }
+            }
+        })));
+
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 0);
+    }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation
- `workspace/didChangeConfiguration` updated Perl::Critic settings but only reset the server-scoped critic cache, leaving the pull-diagnostics orchestrator with stale critic cache and warning dedup state.
- Stale pull-diagnostics state could cause clients using pull diagnostics to observe outdated perlcritic results until a server restart.

### Description
- Wire the critic-config change path in `handle_did_change_configuration` to call `pull_diagnostics_orchestrator.reset()` so pull-diagnostics cache/dedup state is invalidated when perlcritic settings change.
- Implement test helpers `test_mark_warning_sent` and `test_warning_count` on `PullDiagnosticsOrchestrator` to seed and observe the warning-dedup state for tests.
- Remove the stale TODO comment and keep `reset()` as the canonical invalidation point in `crates/perl-lsp/src/runtime/diagnostics.rs`.
- Add a regression unit test `did_change_configuration_resets_pull_diagnostics_warning_dedup` in `crates/perl-lsp/src/runtime/lifecycle/workspace.rs` that seeds a warning, triggers `didChangeConfiguration` with a perlcritic change, and asserts the orchestrator dedup state is cleared.

### Testing
- Ran formatter with `cargo xtask fmt` which completed successfully.
- Ran the new regression test with `cargo test -p perl-lsp-rs did_change_configuration_resets_pull_diagnostics_warning_dedup --lib -- --nocapture` and it passed.
- Verified existing related test `did_change_configuration_updates_folder_effective_configs` with `cargo test -p perl-lsp-rs did_change_configuration_updates_folder_effective_configs --lib` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8951490648333a9dd6bc7f0963242)