### PR TITLE
fix(perl-lsp): reset pull perlcritic analyzer on config change (#2018)

### DIFF
--- a/crates/perl-lsp/src/runtime/test_api.rs
+++ b/crates/perl-lsp/src/runtime/test_api.rs
@@ -231,6 +231,14 @@ impl LspServer {
         self.handle_document_diagnostic(params)
     }
 
+    /// Test-only entrypoint for `workspace/didChangeConfiguration`.
+    ///
+    /// Applies configuration updates exactly as a client notification would,
+    /// including cache invalidation and follow-up workspace config refresh.
+    pub fn test_handle_did_change_configuration(&self, params: Option<Value>) {
+        self.handle_did_change_configuration(params);
+    }
+
     /// Install a mock subprocess runtime for the `CriticAnalyzer`.
     ///
     /// When set, the lazy-init path in `collect_external_perlcritic_diagnostics`

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)

--- a/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
+++ b/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
@@ -354,3 +354,56 @@ fn test_f_missing_configured_profile_skips_subprocess_and_diagnostics() {
         "subprocess should not run when configured profile path does not exist"
     );
 }
+
+#[test]
+fn test_g_did_change_configuration_resets_pull_perlcritic_analyzer() {
+    let server = LspServer::new();
+    server.test_configure_perlcritic(true, 3, None);
+
+    let runtime = Arc::new(MockSubprocessRuntime::new());
+    runtime.add_response(MockResponse::success(b"".to_vec()));
+    runtime.add_response(MockResponse::success(b"".to_vec()));
+    server.test_install_mock_critic_runtime(runtime.clone());
+    server.test_bypass_perlcritic_command_check();
+
+    #[cfg(windows)]
+    let uri = "file:///C:/tmp/test_reconfigure.pl";
+    #[cfg(not(windows))]
+    let uri = "file:///tmp/test_reconfigure.pl";
+
+    pull_diagnostics(&server, uri, "print \"first\";\n");
+
+    server.test_handle_did_change_configuration(Some(json!({
+        "settings": {
+            "perl": {
+                "perlcritic": {
+                    "enabled": true,
+                    "severity": 5
+                }
+            }
+        }
+    })));
+
+    pull_diagnostics(&server, uri, "print \"second\";\n");
+
+    let invocations = runtime.invocations();
+    assert_eq!(
+        invocations.len(),
+        4,
+        "expected exactly four perlcritic invocations (push+pull before and after config change); got {invocations:?}"
+    );
+    assert!(
+        invocations[0..2]
+            .iter()
+            .all(|invocation| invocation.args.iter().any(|arg| arg == "--severity=3")),
+        "first two invocations should use initial severity=3; invocations: {:?}",
+        &invocations[0..2]
+    );
+    assert!(
+        invocations[2..4]
+            .iter()
+            .all(|invocation| invocation.args.iter().any(|arg| arg == "--severity=5")),
+        "last two invocations should rebuild analyzer and use severity=5; invocations: {:?}",
+        &invocations[2..4]
+    );
+}


### PR DESCRIPTION
### Motivation
- Pull-based diagnostics were not invalidating the cached CriticAnalyzer when Perl::Critic settings changed, causing stale perlcritic invocations for `textDocument/diagnostic` requests.

### Description
- Wire `handle_did_change_configuration` to also reset the pull-diagnostics orchestrator by calling `pull_diagnostics_orchestrator.reset()` when critic-related settings change in `crates/perl-lsp/src/runtime/workspace.rs`.
- Add a test-only API `test_handle_did_change_configuration` that forwards to `handle_did_change_configuration` in `crates/perl-lsp/src/runtime/test_api.rs` to let integration tests simulate client config updates.
- Add an integration test `test_g_did_change_configuration_resets_pull_perlcritic_analyzer` in `crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs` which verifies perlcritic invocations use the updated `--severity` after a config change.

### Testing
- Ran `cargo xtask fmt` which completed successfully.
- Ran the focused integration test with `cargo test -p perl-lsp-rs --features expose_lsp_test_api --test lsp_perlcritic_diagnostics_tests test_g_did_change_configuration_resets_pull_perlcritic_analyzer -- --exact` which passed.
- A broader `cargo test -p perl-lsp-rs --features expose_lsp_test_api ...` run hit an environment linker bus error while compiling unrelated test binaries; the verification focused on the affected integration test which demonstrates the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8951619e88333b6eb3d8ffc1e34ed)