### PR TITLE
fix(runtime): reset pull-diagnostics perlcritic orchestrator state on config updates (#0000)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -289,6 +289,17 @@ impl Default for PullDiagnosticsOrchestrator {
     }
 }
 
+#[cfg(test)]
+impl PullDiagnosticsOrchestrator {
+    pub(crate) fn test_insert_warning_key(&self, key: &str) {
+        self.warnings_sent.lock().insert(key.to_string());
+    }
+
+    pub(crate) fn test_warning_count(&self) -> usize {
+        self.warnings_sent.lock().len()
+    }
+}
+
 impl LspServer {
     /// Convert internal diagnostic tags to LSP tag values
     ///

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -444,4 +444,23 @@ include_paths = ["other_lib"]
             );
         }
     }
+
+    #[test]
+    fn did_change_configuration_resets_pull_diagnostics_orchestrator_state() {
+        let server = LspServer::new();
+        server.pull_diagnostics_orchestrator.test_insert_warning_key("missing-binary");
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 1);
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "severity": 5
+                    }
+                }
+            }
+        })));
+
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 0);
+    }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation
- Prevent stale perlcritic analyzer / dedupe warning state in the pull-diagnostics path after users update perlcritic-related settings via `workspace/didChangeConfiguration`.

### Description
- Call `self.pull_diagnostics_orchestrator.reset()` when perlcritic-related settings change in `handle_did_change_configuration` so orchestrator-local analyzer and warning state are invalidated.
- Add test-only helper methods `test_insert_warning_key` and `test_warning_count` on `PullDiagnosticsOrchestrator` to seed and inspect dedupe warning state in unit tests (`#[cfg(test)]`).
- Add a regression test `did_change_configuration_resets_pull_diagnostics_orchestrator_state` that seeds a warning key, triggers `handle_did_change_configuration` with a perlcritic setting change, and asserts the orchestrator warning state is cleared.
- Files modified: `crates/perl-lsp/src/runtime/workspace.rs`, `crates/perl-lsp/src/runtime/diagnostics.rs`, and `crates/perl-lsp/src/runtime/lifecycle/workspace.rs`.

### Testing
- Ran formatter with `cargo xtask fmt`, which completed successfully.
- Ran the focused unit test `cargo test -p perl-lsp-rs --lib runtime::lifecycle::workspace::tests::did_change_configuration_resets_pull_diagnostics_orchestrator_state -- --exact`, which passed.
- Ran the existing config merge test `cargo test -p perl-lsp-rs --lib runtime::lifecycle::workspace::tests::did_change_configuration_updates_folder_effective_configs -- --exact`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8951619e88333b6eb3d8ffc1e34ed)