### PR TITLE
fix(lsp): reset pull diagnostics critic cache on config change (#0000)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,9 +268,6 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
     #[allow(dead_code)]
     pub fn reset(&self) {
@@ -281,6 +278,25 @@ impl PullDiagnosticsOrchestrator {
     /// No-op stub for WASM targets.
     #[cfg(target_arch = "wasm32")]
     pub fn reset(&self) {}
+
+    /// Test helper: pre-populate cached state to verify reset wiring.
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_seed_cached_state(&self) {
+        use perl_lsp_rs_core::tooling::perl_critic::{CriticAnalyzer, CriticConfig};
+
+        *self.critic_analyzer.lock() = Some(CriticAnalyzer::with_os_runtime(CriticConfig {
+            severity: 5,
+            profile: None,
+            ..Default::default()
+        }));
+        self.warnings_sent.lock().insert("seed-warning".to_string());
+    }
+
+    /// Test helper: report whether any cached state is currently present.
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_has_cached_state(&self) -> bool {
+        self.critic_analyzer.lock().is_some() || !self.warnings_sent.lock().is_empty()
+    }
 }
 
 impl Default for PullDiagnosticsOrchestrator {

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -444,4 +444,28 @@ include_paths = ["other_lib"]
             );
         }
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn did_change_configuration_resets_pull_diagnostics_critic_cache() {
+        let server = LspServer::new();
+        server.pull_diagnostics_orchestrator.test_seed_cached_state();
+        assert!(server.pull_diagnostics_orchestrator.test_has_cached_state());
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "enabled": true,
+                        "severity": 4
+                    }
+                }
+            }
+        })));
+
+        assert!(
+            !server.pull_diagnostics_orchestrator.test_has_cached_state(),
+            "pull diagnostics critic cache should be reset when perlcritic config changes"
+        );
+    }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation

- Prevent stale cached `CriticAnalyzer` and workspace warnings in the pull-diagnostics path after user changes to `perl.perlcritic` settings by ensuring the orchestrator's cached state is cleared when configuration changes.

### Description

- Wire `PullDiagnosticsOrchestrator::reset()` into `handle_did_change_configuration` so the pull-diagnostics perlcritic cache is cleared when perlcritic-related settings change.
- Add test-only helpers `test_seed_cached_state` and `test_has_cached_state` on `PullDiagnosticsOrchestrator` to allow unit tests to seed and assert cached state.
- Add a unit test `did_change_configuration_resets_pull_diagnostics_critic_cache` that seeds the cached state, triggers `handle_did_change_configuration`, and asserts the cache was cleared.
- Remove the stale TODO about wiring reset in `diagnostics.rs` now that the reset is implemented.

### Testing

- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo test -p perllsp` which executed successfully but did not include the new test target for that package.
- Attempted `cargo test -p perl-lsp-rs` and `cargo check -p perl-lsp-rs` but those runs failed in this environment due to transient resource/linker issues (disk space / linker bus error) and did not prevent committing the changes locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8951619e88333b6eb3d8ffc1e34ed)