### PR TITLE
fix(diagnostics): reset pull cache on config change (#0000)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,11 +268,7 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
-    #[allow(dead_code)]
     pub fn reset(&self) {
         *self.critic_analyzer.lock() = None;
         self.warnings_sent.lock().clear();
@@ -281,6 +277,16 @@ impl PullDiagnosticsOrchestrator {
     /// No-op stub for WASM targets.
     #[cfg(target_arch = "wasm32")]
     pub fn reset(&self) {}
+
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_insert_warning_key(&self, key: &str) {
+        self.warnings_sent.lock().insert(key.to_string());
+    }
+
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_warning_count(&self) -> usize {
+        self.warnings_sent.lock().len()
+    }
 }
 
 impl Default for PullDiagnosticsOrchestrator {

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -418,9 +418,15 @@ include_paths = ["other_lib"]
                 .with_path(folder2.clone()),
         );
 
+        server.pull_diagnostics_orchestrator.test_insert_warning_key("stale-warning");
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 1);
+
         server.handle_did_change_configuration(Some(serde_json::json!({
             "settings": {
                 "perl": {
+                    "perlcritic": {
+                        "profile": ".perlcriticrc"
+                    },
                     "workspace": {
                         "includePaths": ["client_lib"],
                         "useSystemInc": true
@@ -443,5 +449,10 @@ include_paths = ["other_lib"]
                 folder.uri
             );
         }
+        assert_eq!(
+            server.pull_diagnostics_orchestrator.test_warning_count(),
+            0,
+            "pull diagnostics warning cache should reset after perlcritic config change"
+        );
     }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation

- Pull-mode diagnostics could retain stale perlcritic state across `workspace/didChangeConfiguration` updates because only the shared CriticAnalyzer was being reset, leaving the pull diagnostics orchestrator cache intact.

### Description

- Wire `PullDiagnosticsOrchestrator::reset()` into the configuration-change path so the orchestrator state is cleared when perlcritic-related settings change.
- Remove the stale dead-code marker on `reset()` and add test-only helpers `test_insert_warning_key` and `test_warning_count` to assert warning-cache behavior from unit tests.
- Extend `did_change_configuration_updates_folder_effective_configs` to seed the pull-diagnostics warning cache, apply a perlcritic config change, and verify the cache is cleared.
- Modified files: `crates/perl-lsp/src/runtime/workspace.rs`, `crates/perl-lsp/src/runtime/diagnostics.rs`, and `crates/perl-lsp/src/runtime/lifecycle/workspace.rs`.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran the targeted unit test `cargo test -p perl-lsp-rs --lib runtime::lifecycle::workspace::tests::did_change_configuration_updates_folder_effective_configs -- --exact`, which passed.
- Broader test/invocation attempts hit an environment `No space left on device` error during heavy builds, after which `target/` was removed to recover space and the targeted test was re-run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8951619e88333b6eb3d8ffc1e34ed)