### PR TITLE
fix(runtime): reset stale pull perlcritic cache on config change (#0000)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,9 +268,6 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
     #[allow(dead_code)]
     pub fn reset(&self) {
@@ -1654,6 +1651,43 @@ mod tests {
             "fast path must not emit any bytes for pull-diagnostic clients; \
              buffer grew by {} bytes",
             len_after.saturating_sub(len_before)
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn did_change_configuration_resets_pull_perlcritic_warning_dedup() {
+        let server = LspServer::new();
+
+        {
+            let mut cfg = server.config.lock();
+            cfg.perlcritic_severity = 5;
+        }
+
+        server.critic_workspace_warnings_sent.lock().insert("push-warning".to_string());
+        server
+            .pull_diagnostics_orchestrator
+            .warnings_sent
+            .lock()
+            .insert("pull-warning".to_string());
+
+        server.handle_did_change_configuration(Some(json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "severity": 3
+                    }
+                }
+            }
+        })));
+
+        assert!(
+            server.critic_workspace_warnings_sent.lock().is_empty(),
+            "push perlcritic warning dedup set should be cleared on perlcritic config changes"
+        );
+        assert!(
+            server.pull_diagnostics_orchestrator.warnings_sent.lock().is_empty(),
+            "pull perlcritic warning dedup set should be cleared on perlcritic config changes"
         );
     }
 

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation
- Pull-diagnostics maintained a separate `PullDiagnosticsOrchestrator` cache that was not invalidated when perlcritic settings changed, causing stale warning dedup state and analyzer configs to persist after `workspace/didChangeConfiguration` updates.

### Description
- Reset the pull-diagnostics orchestrator from `handle_did_change_configuration` when perlcritic-related settings change by calling `self.pull_diagnostics_orchestrator.reset()` so the analyzer and warning-dedup set are cleared.
- Clear the push-diagnostics perlcritic cache (`critic_analyzer` / `critic_workspace_warnings_sent`) in the same code path so push and pull invalidation behaviors are aligned.
- Remove the stale TODO comment in `PullDiagnosticsOrchestrator::reset` since the reset is now wired.
- Add a regression test `did_change_configuration_resets_pull_perlcritic_warning_dedup` that verifies both push and pull perlcritic warning-dedup sets are cleared after a perlcritic config change.

### Testing
- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo test -p perl-lsp-rs --lib did_change_configuration_resets_pull_perlcritic_warning_dedup` which passed.
- Ran `cargo test -p perl-lsp-rs --lib did_change_configuration_updates_folder_effective_configs` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894e68e988333bdab3c5e58692a96)