### PR TITLE
fix(diagnostics): reset pull perlcritic state on config changes (#0000)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,11 +268,7 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
-    #[allow(dead_code)]
     pub fn reset(&self) {
         *self.critic_analyzer.lock() = None;
         self.warnings_sent.lock().clear();
@@ -1674,5 +1670,27 @@ mod tests {
         let diagnostic = builtin_violation_to_diagnostic(&violation);
         assert_eq!(diagnostic.severity, InternalDiagnosticSeverity::Error);
         assert_eq!(diagnostic.code.as_deref(), Some("GentlePolicy"));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn did_change_configuration_resets_pull_diagnostic_warning_dedup_state() {
+        let server = LspServer::new();
+        server.pull_diagnostics_orchestrator.warnings_sent.lock().insert("missing-binary".into());
+
+        server.handle_did_change_configuration(Some(json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "enabled": true
+                    }
+                }
+            }
+        })));
+
+        assert!(
+            server.pull_diagnostics_orchestrator.warnings_sent.lock().is_empty(),
+            "pull diagnostics warning dedup cache should reset when perlcritic config changes"
+        );
     }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation
- Pull-diagnostics maintained a cached `CriticAnalyzer` and a warning deduplication set that were not reset when perlcritic-related settings changed, causing stale analyzer state and repeated or missing warnings after config updates.
- The existing `PullDiagnosticsOrchestrator::reset` was implemented but not wired into `workspace/didChangeConfiguration` so it could not perform the needed invalidation.

### Description
- Wire `PullDiagnosticsOrchestrator::reset()` into `handle_did_change_configuration` so the pull-diagnostics analyzer and warning dedup cache are cleared when perlcritic settings change by calling `self.pull_diagnostics_orchestrator.reset()` when `critic_config_changed` is true.
- Remove the stale TODO/allow-dead-code annotation from `PullDiagnosticsOrchestrator::reset` since it is now exercised by configuration changes.
- Add a regression unit test `did_change_configuration_resets_pull_diagnostic_warning_dedup_state` that seeds the dedup cache and asserts it is cleared after `handle_did_change_configuration` with a perlcritic setting change.

### Testing
- Ran formatting with `cargo xtask fmt` which completed successfully.
- Executed the workspace config test with `cargo test -p perl-lsp-rs --lib runtime::lifecycle::workspace::tests::did_change_configuration_updates_folder_effective_configs -- --exact` which passed.
- Executed the new diagnostics test with `cargo test -p perl-lsp-rs --lib runtime::diagnostics::tests::did_change_configuration_resets_pull_diagnostic_warning_dedup_state -- --exact` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894e68e988333bdab3c5e58692a96)