### PR TITLE
fix(lsp): reset pull perlcritic cache after config updates (#2018)

### DIFF
--- a/crates/perl-lsp/src/runtime/test_api.rs
+++ b/crates/perl-lsp/src/runtime/test_api.rs
@@ -231,6 +231,14 @@ impl LspServer {
         self.handle_document_diagnostic(params)
     }
 
+    /// Test-only entrypoint for `workspace/didChangeConfiguration`.
+    ///
+    /// Allows tests to exercise config update flows (including cache invalidation)
+    /// without routing through transport-level notification dispatch.
+    pub fn test_handle_did_change_configuration(&self, params: Option<Value>) {
+        self.handle_did_change_configuration(params);
+    }
+
     /// Install a mock subprocess runtime for the `CriticAnalyzer`.
     ///
     /// When set, the lazy-init path in `collect_external_perlcritic_diagnostics`

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)

--- a/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
+++ b/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
@@ -354,3 +354,61 @@ fn test_f_missing_configured_profile_skips_subprocess_and_diagnostics() {
         "subprocess should not run when configured profile path does not exist"
     );
 }
+
+#[test]
+fn test_g_did_change_configuration_resets_pull_diagnostics_perlcritic_cache() {
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let module_path = tmp.path().join("SeverityConfig.pm");
+    std::fs::write(&module_path, "package SeverityConfig;\n1;\n").expect("write module");
+    let uri = url::Url::from_file_path(&module_path).expect("file url").to_string();
+
+    let server = LspServer::new();
+    server.test_configure_perlcritic(true, 5, None);
+
+    let runtime = Arc::new(MockSubprocessRuntime::new());
+    runtime.add_response(MockResponse::success(b"".to_vec()));
+    runtime.add_response(MockResponse::success(b"".to_vec()));
+    server.test_install_mock_critic_runtime(runtime.clone());
+    server.test_bypass_perlcritic_command_check();
+
+    pull_diagnostics(&server, &uri, "package SeverityConfig;\n1;\n");
+    let invocations_before_change = runtime.invocations();
+    assert!(
+        !invocations_before_change.is_empty(),
+        "Expected at least one perlcritic invocation before config change"
+    );
+    assert!(
+        invocations_before_change
+            .iter()
+            .all(|invocation| invocation.args.contains(&"--severity=5".to_string())),
+        "All invocations before config change should use severity=5; got: {invocations_before_change:?}"
+    );
+
+    server.test_handle_did_change_configuration(Some(json!({
+        "settings": {
+            "perl": {
+                "perlcritic": {
+                    "enabled": true,
+                    "severity": 1
+                }
+            }
+        }
+    })));
+
+    pull_diagnostics(&server, &uri, "package SeverityConfig;\n1;\n");
+
+    let invocations_after_change = runtime.invocations();
+    let new_invocations = &invocations_after_change[invocations_before_change.len()..];
+    assert!(
+        !new_invocations.is_empty(),
+        "Expected additional perlcritic invocations after config change; before={invocations_before_change:?}, after={invocations_after_change:?}"
+    );
+    assert!(
+        new_invocations
+            .iter()
+            .all(|invocation| invocation.args.contains(&"--severity=1".to_string())),
+        "All new invocations after didChangeConfiguration should use severity=1; got: {new_invocations:?}"
+    );
+}


### PR DESCRIPTION
### Motivation
- Pull-diagnostics used a cached `CriticAnalyzer` that was not invalidated when perlcritic settings changed, causing stale analyzer configuration to be used for subsequent pull diagnostics.

### Description
- Reset the pull-diagnostics analyzer when perlcritic settings change by calling `self.pull_diagnostics_orchestrator.reset()` from the `didChangeConfiguration` path in `crates/perl-lsp/src/runtime/workspace.rs`.
- Add a test-only helper `test_handle_did_change_configuration` in `crates/perl-lsp/src/runtime/test_api.rs` to exercise the configuration handler in integration tests.
- Add a regression integration test `test_g_did_change_configuration_resets_pull_diagnostics_perlcritic_cache` in `crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs` that verifies perlcritic subprocess invocations reflect the updated `--severity` after a config change.

### Testing
- Ran `cargo xtask fmt` to format changes successfully.
- Ran `cargo test -p perl-lsp-rs --features expose_lsp_test_api --test lsp_perlcritic_diagnostics_tests test_g_did_change_configuration_resets_pull_diagnostics_perlcritic_cache` and the new test passed.
- Ran `cargo test -p perl-lsp-rs --lib did_change_configuration_updates_folder_effective_configs` and the existing config-related unit test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894e68e988333bdab3c5e58692a96)