### PR TITLE
fix(runtime): reset pull-diagnostics critic state on config changes (#0000)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,9 +268,6 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
     #[allow(dead_code)]
     pub fn reset(&self) {
@@ -281,6 +278,12 @@ impl PullDiagnosticsOrchestrator {
     /// No-op stub for WASM targets.
     #[cfg(target_arch = "wasm32")]
     pub fn reset(&self) {}
+
+    /// Test-only helper for validating warning deduplication behavior.
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_warning_count(&self) -> usize {
+        self.warnings_sent.lock().len()
+    }
 }
 
 impl Default for PullDiagnosticsOrchestrator {
@@ -1674,5 +1677,58 @@ mod tests {
         let diagnostic = builtin_violation_to_diagnostic(&violation);
         assert_eq!(diagnostic.severity, InternalDiagnosticSeverity::Error);
         assert_eq!(diagnostic.code.as_deref(), Some("GentlePolicy"));
+    }
+
+    #[test]
+    fn did_change_configuration_resets_pull_diagnostics_warning_dedup() {
+        let server = LspServer::new();
+        server.test_bypass_perlcritic_command_check();
+        server.test_configure_perlcritic(
+            true,
+            5,
+            Some("/definitely/missing/perlcriticrc".to_string()),
+        );
+
+        let uri = "file:///tmp/pull_diagnostics_reset_test.pl";
+        let mut diagnostics = Vec::new();
+        server.pull_diagnostics_orchestrator.collect_perlcritic_diagnostics(
+            &server,
+            uri,
+            "my $x = 1;\n",
+            &mut diagnostics,
+        );
+        server.pull_diagnostics_orchestrator.collect_perlcritic_diagnostics(
+            &server,
+            uri,
+            "my $x = 1;\n",
+            &mut diagnostics,
+        );
+        assert_eq!(
+            server.pull_diagnostics_orchestrator.test_warning_count(),
+            1,
+            "warning should be deduplicated before configuration reset"
+        );
+
+        server.handle_did_change_configuration(Some(json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "severity": 4
+                    }
+                }
+            }
+        })));
+
+        server.pull_diagnostics_orchestrator.collect_perlcritic_diagnostics(
+            &server,
+            uri,
+            "my $x = 1;\n",
+            &mut diagnostics,
+        );
+        assert_eq!(
+            server.pull_diagnostics_orchestrator.test_warning_count(),
+            1,
+            "configuration reset should clear pull-diagnostics warning dedup state"
+        );
     }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation

- Pull-based diagnostics kept a stale Perl::Critic analyzer and warning dedup state after `workspace/didChangeConfiguration`, causing pull diagnostics to not reflect updated perlcritic settings.

### Description

- Reset the `PullDiagnosticsOrchestrator` when perlcritic-related settings change in `handle_did_change_configuration` by calling `self.pull_diagnostics_orchestrator.reset()` so pull diagnostics rebuild their analyzer and clear warning dedup cache. (`crates/perl-lsp/src/runtime/workspace.rs`)
- Add a test-only helper `PullDiagnosticsOrchestrator::test_warning_count()` to inspect the warning deduplication set in unit tests. (`crates/perl-lsp/src/runtime/diagnostics.rs`)
- Add a regression unit test `did_change_configuration_resets_pull_diagnostics_warning_dedup` that verifies deduplication occurs before the config change and that `didChangeConfiguration` clears the dedup state so warnings can be emitted again. (`crates/perl-lsp/src/runtime/diagnostics.rs`)
- Remove an outdated TODO comment that referenced wiring the reset into `didChangeConfiguration` (now implemented).

### Testing

- Ran formatter with `cargo xtask fmt` which completed successfully.
- Ran the new regression test with `cargo test -p perl-lsp-rs --lib runtime::diagnostics::tests::did_change_configuration_resets_pull_diagnostics_warning_dedup` and it passed.
- Verified related workspace config test `cargo test -p perl-lsp-rs --lib runtime::lifecycle::workspace::tests::did_change_configuration_updates_folder_effective_configs` also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9578797b083338f56ddebd3d98514)