### PR TITLE
fix(lsp): reset pull diagnostics critic cache (#0000)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,9 +268,6 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
     #[allow(dead_code)]
     pub fn reset(&self) {
@@ -281,6 +278,16 @@ impl PullDiagnosticsOrchestrator {
     /// No-op stub for WASM targets.
     #[cfg(target_arch = "wasm32")]
     pub fn reset(&self) {}
+
+    #[cfg(test)]
+    pub(crate) fn test_insert_warning_key(&self, key: &str) {
+        self.warnings_sent.lock().insert(key.to_string());
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_warning_count(&self) -> usize {
+        self.warnings_sent.lock().len()
+    }
 }
 
 impl Default for PullDiagnosticsOrchestrator {

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -444,4 +444,28 @@ include_paths = ["other_lib"]
             );
         }
     }
+
+    #[test]
+    fn did_change_configuration_resets_pull_diagnostics_critic_cache() {
+        let server = LspServer::new();
+        server.test_configure_perlcritic(true, 5, None);
+        server.pull_diagnostics_orchestrator.test_insert_warning_key("stale-warning");
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 1);
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "severity": 4
+                    }
+                }
+            }
+        })));
+
+        assert_eq!(
+            server.pull_diagnostics_orchestrator.test_warning_count(),
+            0,
+            "pull-diagnostics warning cache must reset after perlcritic config changes"
+        );
+    }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation
- Configuration changes to Perl::Critic were clearing the push-diagnostics cache but not the pull-diagnostics orchestrator, leaving pull-based diagnostics stale after config updates.
- This change ensures both diagnostic flows are consistent when `perlcritic` settings (severity/profile/enabled) change.

### Description
- Call `self.pull_diagnostics_orchestrator.reset()` from `handle_did_change_configuration` when critic-related settings change so the pull-diagnostics analyzer and warning cache are invalidated.
- Add test-only helpers `test_insert_warning_key` and `test_warning_count` on `PullDiagnosticsOrchestrator` to seed and inspect the warning cache in unit tests.
- Remove a stale TODO comment in `PullDiagnosticsOrchestrator::reset` and add a focused unit test `did_change_configuration_resets_pull_diagnostics_critic_cache` that verifies the pull-diagnostics warning cache is cleared after a `didChangeConfiguration` update.

### Testing
- Ran `cargo xtask fmt` and formatting completed successfully.
- Executed the focused unit test `runtime::lifecycle::workspace::tests::did_change_configuration_resets_pull_diagnostics_critic_cache` from the `perl-lsp-rs` crate with `cargo test` and it passed.
- Listed tests in the `perl-lsp-rs` lib to confirm the new test is present via `cargo test -- --list` which showed the added test entry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9578797b083338f56ddebd3d98514)