### PR TITLE
fix(ci-hygiene): handle TODO comments after URL-like markers (#4600)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3829,23 +3829,24 @@ fn collect_todo_hits(
 }
 
 fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
-    let mut has_hit = false;
-    if let Some(idx) = line.find("//")
-        && !is_url_like_hash_comment(line, idx)
-        && has_unlinked_token(&line[idx + 2..], token_re)
-    {
-        has_hit = true;
+    for (idx, _) in line.match_indices("//") {
+        if is_url_like_hash_comment(line, idx) {
+            continue;
+        }
+        if has_unlinked_token(&line[idx + 2..], token_re) {
+            return true;
+        }
     }
-    if let Some(idx) = line.find("/*")
-        && has_unlinked_token(&line[idx + 2..], token_re)
-    {
-        has_hit = true;
+    for (idx, _) in line.match_indices("/*") {
+        if has_unlinked_token(&line[idx + 2..], token_re) {
+            return true;
+        }
     }
     let trimmed = line.trim_start();
     if trimmed.starts_with('*') && has_unlinked_token(trimmed, token_re) {
-        has_hit = true;
+        return true;
     }
-    has_hit
+    false
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
@@ -4123,6 +4124,10 @@ mod tests {
         assert!(has_unlinked_todo_in_rust_line("// TODO: investigate", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line("// TODO(#123): tracked", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line("let u = \"http://TODO\";", &todo_re));
+        assert!(has_unlinked_todo_in_rust_line(
+            "let u = \"http://TODO\"; // TODO: investigate",
+            &todo_re
+        ));
         assert!(has_unlinked_todo_in_rust_line("/* FIXME: needs fix */", &todo_re));
 
         Ok(())


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner produced false negatives when a URL-like token such as `http://...` appeared before a real trailing `// TODO` on the same line. 
- The intent is to robustly detect unlinked TODO markers by evaluating every comment marker on a line rather than only the first match.

### Description
- Update `has_unlinked_todo_in_rust_line` to iterate over all `//` occurrences via `match_indices("//")` and over all `/*` occurrences and return early when an unlinked token is found. 
- Preserve URL-like detection with `is_url_like_hash_comment` so `http://...` does not mask a subsequent real `// TODO`. 
- Add a regression test asserting that `let u = "http://TODO"; // TODO: investigate` is detected as an unlinked TODO and run `cargo xtask fmt` for formatting.

### Testing
- Ran `cargo xtask fmt`, which completed successfully. 
- Ran the targeted unit `cargo test -p perl-ci-hygiene rust_todo_detection_ignores_linked_or_url_like_comments`, which passed. 
- Ran the full crate tests `cargo test -p perl-ci-hygiene`, which showed `31 passed; 1 failed` where the failing test `checked_in_pre_push_hook_matches_generated_hook` appears to be an existing checked-in pre-push hook drift assertion unrelated to the TODO-scanner change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9578797b083338f56ddebd3d98514)