### PR TITLE
fix(lsp): reset pull perlcritic analyzer on config change (#2018)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,11 +268,7 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
-    #[allow(dead_code)]
     pub fn reset(&self) {
         *self.critic_analyzer.lock() = None;
         self.warnings_sent.lock().clear();

--- a/crates/perl-lsp/src/runtime/test_api.rs
+++ b/crates/perl-lsp/src/runtime/test_api.rs
@@ -280,6 +280,14 @@ impl LspServer {
         cfg.perlcritic_profile = profile;
     }
 
+    /// Test-only bridge for `workspace/didChangeConfiguration`.
+    ///
+    /// Allows integration tests to validate config-change side effects such as
+    /// analyzer cache invalidation.
+    pub fn test_handle_did_change_configuration(&self, params: Option<Value>) {
+        self.handle_did_change_configuration(params);
+    }
+
     /// Test-only entrypoint for LSP `textDocument/inlineCompletion`.
     ///
     /// Exercises inline completion functionality in tests.

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)

--- a/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
+++ b/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
@@ -354,3 +354,54 @@ fn test_f_missing_configured_profile_skips_subprocess_and_diagnostics() {
         "subprocess should not run when configured profile path does not exist"
     );
 }
+
+#[test]
+fn test_g_did_change_configuration_rebuilds_pull_diagnostics_analyzer() {
+    let server = LspServer::new();
+    server.test_configure_perlcritic(true, 5, None);
+
+    let runtime = Arc::new(MockSubprocessRuntime::new());
+    runtime.add_response(MockResponse::success(b"".to_vec()));
+    runtime.add_response(MockResponse::success(b"".to_vec()));
+    server.test_install_mock_critic_runtime(runtime.clone());
+    server.test_bypass_perlcritic_command_check();
+
+    #[cfg(windows)]
+    let uri = "file:///C:/tmp/test_rebuild_config.pl";
+    #[cfg(not(windows))]
+    let uri = "file:///tmp/test_rebuild_config.pl";
+
+    let _ = pull_diagnostics(&server, uri, "print 'first';\n");
+
+    server.test_handle_did_change_configuration(Some(json!({
+        "settings": {
+            "perl": {
+                "perlcritic": {
+                    "enabled": true,
+                    "severity": 1
+                }
+            }
+        }
+    })));
+
+    let _ = pull_diagnostics(&server, uri, "print 'second';\n");
+
+    let invocations = runtime.invocations();
+    assert!(
+        invocations.len() >= 2,
+        "expected at least two perlcritic invocations across the config change; got: {invocations:?}"
+    );
+    assert!(
+        invocations[0].args.iter().any(|arg| arg == "--severity=5"),
+        "first invocation should use initial severity=5; args: {:?}",
+        invocations[0].args
+    );
+    assert!(
+        invocations
+            .iter()
+            .skip(1)
+            .any(|invocation| invocation.args.iter().any(|arg| arg == "--severity=1")),
+        "an invocation after didChangeConfiguration should use updated severity=1; invocations: {:?}",
+        invocations
+    );
+}


### PR DESCRIPTION
### Motivation
- Configuration changes to perlcritic (enabled/severity/profile) did not fully invalidate the pull-diagnostics analyzer cache, allowing stale analyzer state to persist after `workspace/didChangeConfiguration`.
- Tests need a way to exercise `didChangeConfiguration` side effects to verify analyzer rebuild without relying on indirect flows.

### Description
- Reset the pull-diagnostics orchestrator from `handle_did_change_configuration` when critic-related settings change by calling `self.pull_diagnostics_orchestrator.reset()` in `workspace.rs` to ensure the analyzer is rebuilt with new config.
- Remove the stale `TODO`/dead-code suppression and keep `PullDiagnosticsOrchestrator::reset` as the canonical invalidation hook in `diagnostics.rs` so it's actively used by config-change handling.
- Add a test-only bridge `test_handle_did_change_configuration` in `test_api.rs` to allow integration tests to invoke the real `didChangeConfiguration` handler.
- Add an integration regression test `test_g_did_change_configuration_rebuilds_pull_diagnostics_analyzer` which verifies that after changing perlcritic `severity` from `5` to `1`, subsequent pull-diagnostics invocations use the updated `--severity=1` argument.

### Testing
- Ran formatting with `cargo xtask fmt` (succeeds).
- Ran the targeted integration test with `cargo test -p perl-lsp-rs --features expose_lsp_test_api --test lsp_perlcritic_diagnostics_tests test_g_did_change_configuration_rebuilds_pull_diagnostics_analyzer` and it passed.
- Confirmed the added test observes multiple perlcritic invocations and the later invocation uses the updated severity value.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9577e5a1c83339d96b918501d2c2f)