### PR TITLE
fix(perl-uri): make uri_extension resilient to slashy fragments (#4604)

### DIFF
--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -50,9 +50,9 @@ pub fn is_special_scheme(uri: &str) -> bool {
 /// Extract the file extension from a URI-like string.
 #[must_use]
 pub fn uri_extension(uri: &str) -> Option<&str> {
-    let path_part = uri.rsplit('/').next()?;
-    let path_part = path_part.split('?').next()?;
-    let path_part = path_part.split('#').next()?;
+    let path_without_query_or_fragment =
+        uri.split_once(['?', '#']).map_or(uri, |(path_prefix, _)| path_prefix);
+    let path_part = path_without_query_or_fragment.rsplit('/').next()?;
     let dot_pos = path_part.rfind('.')?;
     let ext = &path_part[dot_pos + 1..];
     if ext.is_empty() { None } else { Some(ext) }
@@ -90,6 +90,7 @@ mod tests {
     fn extracts_extensions() {
         assert_eq!(uri_extension("file:///tmp/test.pl"), Some("pl"));
         assert_eq!(uri_extension("file:///tmp/file.pl?query=1"), Some("pl"));
+        assert_eq!(uri_extension("file:///tmp/file.pl#L10/permalink"), Some("pl"));
         assert_eq!(uri_extension("file:///tmp/no-extension"), None);
     }
 }


### PR DESCRIPTION
### Motivation
- Make extension extraction resilient to query/fragment suffixes that contain slashes so URIs like `file:///tmp/file.pl#L10/permalink` still yield `pl`.

### Description
- Update `crates/perl-uri/src/classify.rs` to strip query/fragment before selecting the final path segment and add a regression unit test covering the `#L10/permalink` style fragment.

### Testing
- Ran `cargo xtask fmt` successfully.
- Ran `cargo test -p perl-uri` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9577b5c1c833382d9becaf1a9f3bc)