### PR TITLE
fix(perl-lsp): reset pull diagnostics critic state on config changes (#9999)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,11 +268,7 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
-    #[allow(dead_code)]
     pub fn reset(&self) {
         *self.critic_analyzer.lock() = None;
         self.warnings_sent.lock().clear();
@@ -286,6 +282,17 @@ impl PullDiagnosticsOrchestrator {
 impl Default for PullDiagnosticsOrchestrator {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+impl PullDiagnosticsOrchestrator {
+    pub(crate) fn test_seed_warning(&self, key: &str) {
+        self.warnings_sent.lock().insert(key.to_string());
+    }
+
+    pub(crate) fn test_warning_count(&self) -> usize {
+        self.warnings_sent.lock().len()
     }
 }
 

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -444,4 +444,25 @@ include_paths = ["other_lib"]
             );
         }
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn did_change_configuration_resets_pull_diagnostics_perlcritic_state() {
+        let server = LspServer::new();
+
+        server.pull_diagnostics_orchestrator.test_seed_warning("missing-binary");
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 1);
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "enabled": true
+                    }
+                }
+            }
+        })));
+
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 0);
+    }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation

- Pull-diagnostics maintained its own cached `CriticAnalyzer` and warning dedupe set which could become stale after `didChangeConfiguration`, producing inconsistent behavior versus push diagnostics.

### Description

- Wire `PullDiagnosticsOrchestrator::reset()` into `handle_did_change_configuration` when perlcritic-related settings change so the pull-diagnostics analyzer and dedupe state are invalidated together with push diagnostics.
- Remove the stale TODO from the orchestrator reset documentation and keep `reset()` as the active invalidation path for pull diagnostics state.
- Add test-only helpers on `PullDiagnosticsOrchestrator` (`test_seed_warning` and `test_warning_count`) and a focused unit test `did_change_configuration_resets_pull_diagnostics_perlcritic_state` to verify the reset behavior.

### Testing

- Ran formatting with `cargo xtask fmt` and the formatter completed successfully.
- Ran the focused unit test with `cargo test -p perl-lsp-rs --lib did_change_configuration_resets_pull_diagnostics_perlcritic_state` and it passed.
- Ran `cargo test -p perl-lsp-rs --lib did_change_configuration_updates_folder_effective_configs` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9577e5a1c83339d96b918501d2c2f)