### PR TITLE
fix(perl-lsp): reset perlcritic caches on config updates (#4012)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,11 +268,7 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
-    #[allow(dead_code)]
     pub fn reset(&self) {
         *self.critic_analyzer.lock() = None;
         self.warnings_sent.lock().clear();
@@ -281,6 +277,16 @@ impl PullDiagnosticsOrchestrator {
     /// No-op stub for WASM targets.
     #[cfg(target_arch = "wasm32")]
     pub fn reset(&self) {}
+
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_seed_warning(&self, key: impl Into<String>) {
+        self.warnings_sent.lock().insert(key.into());
+    }
+
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_warning_count(&self) -> usize {
+        self.warnings_sent.lock().len()
+    }
 }
 
 impl Default for PullDiagnosticsOrchestrator {
@@ -290,6 +296,21 @@ impl Default for PullDiagnosticsOrchestrator {
 }
 
 impl LspServer {
+    /// Reset all perlcritic analyzer caches and warning dedup state.
+    ///
+    /// Push diagnostics and pull diagnostics each maintain their own analyzer/warning cache.
+    /// This keeps both flows consistent after configuration changes.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn reset_perlcritic_state(&self) {
+        *self.critic_analyzer.lock() = None;
+        self.critic_workspace_warnings_sent.lock().clear();
+        self.pull_diagnostics_orchestrator.reset();
+    }
+
+    /// No-op stub for WASM targets.
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) fn reset_perlcritic_state(&self) {}
+
     /// Convert internal diagnostic tags to LSP tag values
     ///
     /// Maps internal `DiagnosticTag` variants to their LSP numeric equivalents:

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -444,4 +444,25 @@ include_paths = ["other_lib"]
             );
         }
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn did_change_configuration_resets_pull_diagnostics_perlcritic_state() {
+        let server = LspServer::new();
+
+        server.pull_diagnostics_orchestrator.test_seed_warning("missing-binary");
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 1);
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "enabled": true
+                    }
+                }
+            }
+        })));
+
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 0);
+    }
 }

--- a/crates/perl-lsp/src/runtime/test_api.rs
+++ b/crates/perl-lsp/src/runtime/test_api.rs
@@ -249,8 +249,8 @@ impl LspServer {
         runtime: std::sync::Arc<dyn perl_subprocess_runtime::SubprocessRuntime>,
     ) {
         *self.critic_runtime_override.lock() = Some(runtime);
-        // Reset any cached analyzer so it is rebuilt with the new runtime.
-        *self.critic_analyzer.lock() = None;
+        // Reset any cached analyzer state so it is rebuilt with the new runtime.
+        self.reset_perlcritic_state();
     }
 
     /// Skip the `command_exists("perlcritic")` guard in

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -747,8 +747,7 @@ impl LspServer {
                     // changed so the next diagnostic cycle rebuilds it with the new config.
                     #[cfg(not(target_arch = "wasm32"))]
                     if critic_config_changed {
-                        *self.critic_analyzer.lock() = None;
-                        self.critic_workspace_warnings_sent.lock().clear();
+                        self.reset_perlcritic_state();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation

- Ensure perlcritic analyzer and warning deduplication state used by both push and pull diagnostic flows are consistently invalidated when Perl-related configuration changes (there was a TODO about wiring this up and pull diagnostics could retain stale state).

### Description

- Add `LspServer::reset_perlcritic_state` (non-WASM) to clear the push-side `critic_analyzer`, `critic_workspace_warnings_sent`, and call `pull_diagnostics_orchestrator.reset()` and provide a no-op stub for WASM targets.
- Extend `PullDiagnosticsOrchestrator` with test helpers `test_seed_warning` and `test_warning_count` and keep its `reset` to clear the orchestrator's analyzer and warning set.
- Call `reset_perlcritic_state` from `handle_did_change_configuration` when perlcritic-related settings change so both push and pull flows are invalidated together.
- Update `test_install_mock_critic_runtime` to use `reset_perlcritic_state` for consistency and add a regression test `did_change_configuration_resets_pull_diagnostics_perlcritic_state` to assert pull-diagnostics warning dedup state is cleared on config change.

### Testing

- Ran `cargo xtask fmt` and it completed successfully.
- Ran the targeted unit test `cargo test -p perl-lsp-rs --lib did_change_configuration_resets_pull_diagnostics_perlcritic_state` and it passed.
- Ran the existing config update test `cargo test -p perl-lsp-rs --lib did_change_configuration_updates_folder_effective_configs` and it passed.
- One earlier automated invocation used the wrong package id (`cargo test -p perl-lsp`) and failed due to an invalid package name, but the corrected test runs above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9577e5a1c83339d96b918501d2c2f)