### PR TITLE
fix(lsp): reset pull diagnostics critic cache on config changes (#0000)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,9 +268,6 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
     #[allow(dead_code)]
     pub fn reset(&self) {
@@ -281,6 +278,12 @@ impl PullDiagnosticsOrchestrator {
     /// No-op stub for WASM targets.
     #[cfg(target_arch = "wasm32")]
     pub fn reset(&self) {}
+
+    /// Test-only probe for whether pull-diagnostics currently has a cached analyzer.
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_has_cached_critic_analyzer(&self) -> bool {
+        self.critic_analyzer.lock().is_some()
+    }
 }
 
 impl Default for PullDiagnosticsOrchestrator {

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -444,4 +444,53 @@ include_paths = ["other_lib"]
             );
         }
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn did_change_configuration_resets_pull_diagnostics_critic_analyzer() {
+        use perl_subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use std::sync::Arc;
+
+        let server = LspServer::new();
+        let temp = tempfile::tempdir().expect("failed to create temp dir");
+        let file_path = temp.path().join("critic_reset_test.pl");
+        std::fs::write(&file_path, "my $x = 1;\n").expect("failed to write test perl file");
+        let uri = url::Url::from_file_path(&file_path)
+            .expect("failed to convert file path to uri")
+            .to_string();
+
+        server.test_configure_perlcritic(true, 5, None);
+        server.test_bypass_perlcritic_command_check();
+        let runtime = Arc::new(MockSubprocessRuntime::new());
+        runtime.add_response(MockResponse::success("[]\n"));
+        server.test_install_mock_critic_runtime(runtime);
+
+        let mut diagnostics = Vec::new();
+        server.pull_diagnostics_orchestrator.collect_perlcritic_diagnostics(
+            &server,
+            &uri,
+            "my $x = 1;\n",
+            &mut diagnostics,
+        );
+
+        assert!(
+            server.pull_diagnostics_orchestrator.test_has_cached_critic_analyzer(),
+            "pull diagnostics analyzer should be initialized after a collection pass"
+        );
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "severity": 4
+                    }
+                }
+            }
+        })));
+
+        assert!(
+            !server.pull_diagnostics_orchestrator.test_has_cached_critic_analyzer(),
+            "pull diagnostics analyzer should be reset when perlcritic config changes"
+        );
+    }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation
- Pull-diagnostics maintained its own cached `CriticAnalyzer` which was not invalidated when perlcritic-related settings changed, potentially leaving stale analyzer state after a configuration update.

### Description
- Wire `PullDiagnosticsOrchestrator::reset()` into `workspace/didChangeConfiguration` when perlcritic settings change so pull-diagnostics invalidates its cached analyzer (change in `workspace.rs`).
- Add a test-only probe `test_has_cached_critic_analyzer()` to `PullDiagnosticsOrchestrator` to deterministically observe cached analyzer state in unit tests (`diagnostics.rs`).
- Add a focused unit test `did_change_configuration_resets_pull_diagnostics_critic_analyzer` that initializes the analyzer (via `test_install_mock_critic_runtime`) and verifies `handle_did_change_configuration` clears the cache (`lifecycle/workspace.rs`).

### Testing
- Ran formatter with `cargo xtask fmt` which completed successfully.
- Ran the new focused unit test with `cargo test -p perl-lsp-rs did_change_configuration_resets_pull_diagnostics_critic_analyzer --lib` which passed.
- Ran the existing config propagation test with `cargo test -p perl-lsp-rs did_change_configuration_updates_folder_effective_configs --lib` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9577b5c1c833382d9becaf1a9f3bc)