### PR TITLE
fix(diagnostics): reset pull-diagnostic perlcritic state on config changes (#0000)

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -268,9 +268,6 @@ impl PullDiagnosticsOrchestrator {
     fn emit_warning(&self, _server: &LspServer, _key: String, _message: &str) {}
 
     /// Reset the orchestrator state (e.g., on configuration change).
-    ///
-    /// TODO: Wire into `handle_did_change_configuration` so pull-diagnostics
-    /// CriticAnalyzer is also invalidated on config changes.
     #[cfg(not(target_arch = "wasm32"))]
     #[allow(dead_code)]
     pub fn reset(&self) {
@@ -281,6 +278,16 @@ impl PullDiagnosticsOrchestrator {
     /// No-op stub for WASM targets.
     #[cfg(target_arch = "wasm32")]
     pub fn reset(&self) {}
+
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_insert_warning_key(&self, key: &str) {
+        self.warnings_sent.lock().insert(key.to_string());
+    }
+
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) fn test_warning_count(&self) -> usize {
+        self.warnings_sent.lock().len()
+    }
 }
 
 impl Default for PullDiagnosticsOrchestrator {

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -444,4 +444,33 @@ include_paths = ["other_lib"]
             );
         }
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn did_change_configuration_resets_pull_diagnostics_critic_warning_dedupe() {
+        let server = LspServer::new();
+        server.test_configure_perlcritic(true, 5, None);
+
+        server.pull_diagnostics_orchestrator.test_insert_warning_key("perlcritic-missing");
+        server
+            .critic_workspace_warnings_sent
+            .lock()
+            .insert("workspace-perlcritic-missing".to_string());
+
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 1);
+        assert_eq!(server.critic_workspace_warnings_sent.lock().len(), 1);
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "severity": 3
+                    }
+                }
+            }
+        })));
+
+        assert_eq!(server.pull_diagnostics_orchestrator.test_warning_count(), 0);
+        assert_eq!(server.critic_workspace_warnings_sent.lock().len(), 0);
+    }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -749,6 +749,7 @@ impl LspServer {
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
                         self.critic_workspace_warnings_sent.lock().clear();
+                        self.pull_diagnostics_orchestrator.reset();
                     }
 
                     // Update workspace config (include paths, @INC)


### PR DESCRIPTION
### Motivation

- Pull-based diagnostics retained Perl::Critic analyzer and warning-dedupe state when user settings changed, producing stale behavior after `workspace/didChangeConfiguration` updates.
- The push-diagnostic path already cleared its analyzer and warnings, so pull diagnostics should be invalidated the same way to keep both flows consistent.

### Description

- Wire `handle_did_change_configuration` to call `pull_diagnostics_orchestrator.reset()` when Perl::Critic settings change so the pull-diagnostics analyzer and warning dedupe are cleared (`crates/perl-lsp/src/runtime/workspace.rs`).
- Add test-only hooks `test_insert_warning_key` and `test_warning_count` to `PullDiagnosticsOrchestrator` to allow seeding and asserting warning-dedupe state in unit tests (`crates/perl-lsp/src/runtime/diagnostics.rs`).
- Add a regression unit test that seeds both the pull and push warning caches, triggers `handle_did_change_configuration`, and asserts both caches are cleared (`crates/perl-lsp/src/runtime/lifecycle/workspace.rs`).

### Testing

- Ran formatting with `cargo xtask fmt` and it completed successfully.
- Executed `cargo test -p perllsp` (wrong package name) which did not exercise the intended tests; this was then corrected.
- Ran `cargo test -p perl-lsp-rs --lib runtime::lifecycle::workspace::tests::did_change_configuration_resets_pull_diagnostics_critic_warning_dedupe` and the test passed.
- Ran `cargo test -p perl-lsp-rs --lib runtime::lifecycle::workspace::tests::did_change_configuration_updates_folder_effective_configs` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9577ca45883338b876bfe8f6f28b9)