### PR TITLE
fix(performance): normalize incremental parser changed-range handling (#4603)

### DIFF
--- a/crates/perl-lsp-rs-core/src/performance/mod.rs
+++ b/crates/perl-lsp-rs-core/src/performance/mod.rs
@@ -125,6 +125,14 @@ impl IncrementalParser {
     ///
     /// Overlapping regions are automatically merged.
     pub fn mark_changed(&mut self, start: usize, end: usize) {
+        let (start, end) = if start <= end { (start, end) } else { (end, start) };
+
+        // Ignore zero-length spans to keep the tracking set focused on
+        // meaningful byte ranges.
+        if start == end {
+            return;
+        }
+
         self.changed_regions.push((start, end));
         self.merge_overlapping_regions();
     }

--- a/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
+++ b/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
@@ -36,3 +36,23 @@ fn performance_ast_cache_stores_and_retrieves() {
     // which is complex. This test verifies the cache is instantiable.
     assert_some(Some(cache), "AstCache should be constructible");
 }
+
+#[test]
+fn incremental_parser_given_reversed_change_range_when_marked_then_reparse_is_detected() {
+    let mut parser = IncrementalParser::new();
+
+    // Simulate a caller accidentally sending end/start in reverse order.
+    parser.mark_changed(20, 10);
+
+    assert!(parser.needs_reparse(12, 18));
+    assert!(!parser.needs_reparse(0, 9));
+}
+
+#[test]
+fn incremental_parser_given_zero_width_change_when_marked_then_no_nodes_require_reparse() {
+    let mut parser = IncrementalParser::new();
+
+    parser.mark_changed(10, 10);
+
+    assert!(!parser.needs_reparse(0, 100));
+}


### PR DESCRIPTION
### Motivation
- Incremental parsing callers may supply change-region bounds in either order or emit zero-width edits; normalizing and filtering spans prevents missed reparses and noisy tracking.

### Description
- Canonicalize the `(start, end)` order in `IncrementalParser::mark_changed` so reversed inputs are normalized before merging. (`crates/perl-lsp-rs-core/src/performance/mod.rs`)
- Ignore zero-width ranges in `mark_changed` so inert spans do not pollute the changed-region list. (`crates/perl-lsp-rs-core/src/performance/mod.rs`)
- Add BDD-style tests that exercise reversed-range handling and zero-width behavior to lock expectations into the test grid. (`crates/perl-lsp-rs-core/tests/performance_module_shape.rs`)

### Testing
- Ran `cargo test -p perl-lsp-rs-core --test performance_module_shape` and all tests passed (7 passed; 0 failed). 
- Ran `cargo xtask fmt` to ensure formatting consistency and the formatter completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9577ca45883338b876bfe8f6f28b9)