### PR TITLE
fix(dap): support namespace-qualified inline variables (#4601)

### DIFF
--- a/crates/perl-dap/src/inline_values.rs
+++ b/crates/perl-dap/src/inline_values.rs
@@ -13,11 +13,11 @@ use crate::protocol::InlineValueText;
 /// Regex for matching Perl variables (scalars, arrays, hashes).
 /// Stored as Option to avoid panics; if compilation fails, inline values are skipped.
 static PERL_VAR_RE: Lazy<Option<Regex>> =
-    Lazy::new(|| Regex::new(r"[$@%][A-Za-z_][A-Za-z0-9_]*").ok());
+    Lazy::new(|| Regex::new(r"[$@%][A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*").ok());
 
 /// Legacy regex for scalar-only matching (used by `DapDispatcher`).
 static SCALAR_VAR_RE: Lazy<Option<Regex>> =
-    Lazy::new(|| Regex::new(r"\$[A-Za-z_][A-Za-z0-9_]*").ok());
+    Lazy::new(|| Regex::new(r"\$[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*").ok());
 
 /// Special Perl variables that should not be shown inline.
 const SPECIAL_VARS: &[&str] = &[
@@ -306,6 +306,15 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_variable_names_with_namespace_qualifiers() {
+        let source = "our $Foo::bar = 1;\nour @My::Pkg::items = (1);\nour %App::Config::opts = ();";
+        let names = extract_variable_names(source, 1, 3);
+        assert!(names.contains(&"$Foo::bar".to_string()));
+        assert!(names.contains(&"@My::Pkg::items".to_string()));
+        assert!(names.contains(&"%App::Config::opts".to_string()));
+    }
+
+    #[test]
     fn test_no_runtime_fallback() {
         let source = "my $x = 1;";
         let values = collect_inline_values_with_runtime(source, 1, 1, None);
@@ -343,5 +352,16 @@ mod tests {
         assert!(extract_variable_names(source, 2, 1).is_empty());
         assert!(collect_inline_values_with_runtime(source, 2, 1, None).is_empty());
         assert!(collect_inline_values(source, 2, 1).is_empty());
+    }
+
+    #[test]
+    fn test_runtime_inline_value_for_namespaced_scalar() {
+        let source = "our $Foo::bar = 1;";
+        let mut rv = HashMap::new();
+        rv.insert("$Foo::bar".to_string(), "42".to_string());
+
+        let values = collect_inline_values_with_runtime(source, 1, 1, Some(&rv));
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].text, "$Foo::bar = 42");
     }
 }


### PR DESCRIPTION
### Motivation
- Inline-value extraction missed package-qualified globals like `$Foo::bar`, `@My::Pkg::items`, and `%App::Config::opts`, causing incomplete inline overlays during debugging.
- The goal is to broaden variable recognition to include namespace qualifiers while preserving existing runtime-enriched and legacy scalar-only behavior.

### Description
- Updated `PERL_VAR_RE` and `SCALAR_VAR_RE` to accept `::`-qualified identifiers by appending `(?:::[A-Za-z_][A-Za-z0-9_]*)*` to the existing regexes in `crates/perl-dap/src/inline_values.rs`.
- Ensured both the runtime-enriched path (`collect_inline_values_with_runtime`) and the legacy scalar path (`collect_inline_values`) benefit from the improved matching.
- Added focused unit tests `test_extract_variable_names_with_namespace_qualifiers` and `test_runtime_inline_value_for_namespaced_scalar` to lock behavior into the test grid.
- Ran repository formatting via `cargo xtask fmt` to keep code style consistent.

### Testing
- Ran `cargo xtask fmt` and the formatter completed successfully.
- Ran `cargo test -p perl-dap inline_values::tests` and the inline-values test subset passed (13 passed, 0 failed).
- Ran `cargo test -p perl-dap --lib` as an earlier safety check and the package tests passed (331 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9577ca45883338b876bfe8f6f28b9)