### PR TITLE
fix(ci-hygiene): improve hash-comment TODO detection (#4649)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3863,17 +3863,61 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
-    if let Some(idx) = line.find('#') {
-        if idx > 0 && line.as_bytes()[idx - 1] == b'!' {
-            return false;
+    let Some(idx) = find_hash_comment_start(line) else {
+        return false;
+    };
+    has_unlinked_token(&line[idx + 1..], token_re)
+}
+
+fn find_hash_comment_start(line: &str) -> Option<usize> {
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut prev_was_escape = false;
+
+    for (idx, ch) in line.char_indices() {
+        if in_single {
+            if ch == '\'' {
+                in_single = false;
+            }
+            continue;
         }
-        if idx > 0 && !line[..idx].chars().next_back().is_some_and(char::is_whitespace) {
-            return false;
+        if in_double {
+            if prev_was_escape {
+                prev_was_escape = false;
+                continue;
+            }
+            if ch == '\\' {
+                prev_was_escape = true;
+                continue;
+            }
+            if ch == '"' {
+                in_double = false;
+            }
+            continue;
         }
-        has_unlinked_token(&line[idx + 1..], token_re)
-    } else {
-        false
+
+        match ch {
+            '\'' => in_single = true,
+            '"' => in_double = true,
+            '#' => {
+                if idx == 0 && line.as_bytes().get(1) == Some(&b'!') {
+                    return None;
+                }
+                if idx == 0 {
+                    return Some(idx);
+                }
+                if let Some(prev) = line[..idx].chars().next_back() {
+                    if prev.is_whitespace()
+                        || matches!(prev, ';' | '{' | '}' | '(' | ')' | '[' | ']')
+                    {
+                        return Some(idx);
+                    }
+                }
+            }
+            _ => {}
+        }
     }
+    None
 }
 
 fn is_url_like_hash_comment(line: &str, slash_idx: usize) -> bool {
@@ -4172,6 +4216,11 @@ mod tests {
 
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line("echo hi;# TODO: follow up", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo \"#not-a-comment\" # TODO: follow up",
+            &todo_re,
+        ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
 


### PR DESCRIPTION
### Motivation
- The existing hash-comment heuristic missed TODO/FIXME markers when a `#` appeared inside quoted strings or immediately followed common token separators (for example `echo "#not-a-comment" # TODO...` or `echo hi;# TODO...`).
- The scanner also needed to keep correct shebang handling while improving robustness for a wider set of shell-like lines.

### Description
- Replaced the simple `line.find('#')` heuristic with a small parser `find_hash_comment_start` that skips `#` inside single and double quotes, preserves shebang detection, and recognizes comment starts after common separators like `;`, parentheses, and braces.
- Routed `has_unlinked_todo_in_hash_line` through `find_hash_comment_start` and left token/link detection logic (`has_unlinked_token`) unchanged.
- Added regression assertions covering separator-prefixed comments and quoted-`#` content followed by a real comment in `crates/perl-ci-hygiene/src/main.rs`.

### Testing
- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and the targeted test passed (`ok`).
- Ran `cargo test -p perl-ci-hygiene` where the crate unit test suite mostly passed but a pre-existing test `checked_in_pre_push_hook_matches_generated_hook` failed due to checked-in hook drift unrelated to this change (34 passed, 1 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9691647e8833385be82c5378f23da)