### PR TITLE
fix(ci-hygiene): ignore TODO tokens inside quoted hash content (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3863,17 +3863,58 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
-    if let Some(idx) = line.find('#') {
-        if idx > 0 && line.as_bytes()[idx - 1] == b'!' {
-            return false;
-        }
-        if idx > 0 && !line[..idx].chars().next_back().is_some_and(char::is_whitespace) {
-            return false;
-        }
-        has_unlinked_token(&line[idx + 1..], token_re)
-    } else {
-        false
+    if line.starts_with("#!") {
+        return false;
     }
+
+    find_unquoted_hash_comment_start(line)
+        .is_some_and(|idx| has_unlinked_token(&line[idx + 1..], token_re))
+}
+
+fn find_unquoted_hash_comment_start(line: &str) -> Option<usize> {
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut escaped = false;
+
+    for (idx, ch) in line.char_indices() {
+        if in_single_quote {
+            if ch == '\'' {
+                in_single_quote = false;
+            }
+            continue;
+        }
+
+        if in_double_quote {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            if ch == '\\' {
+                escaped = true;
+                continue;
+            }
+            if ch == '"' {
+                in_double_quote = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' => in_single_quote = true,
+            '"' => in_double_quote = true,
+            '#' => {
+                if idx > 0 && line[..idx].chars().next_back().is_some_and(|c| c == '\\') {
+                    continue;
+                }
+                if idx == 0 || line[..idx].chars().next_back().is_some_and(char::is_whitespace) {
+                    return Some(idx);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
 }
 
 fn is_url_like_hash_comment(line: &str, slash_idx: usize) -> bool {
@@ -4174,6 +4215,12 @@ mod tests {
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line("echo \"# TODO in string\" # tracked", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo \"# not a comment\" # TODO: follow up",
+            &todo_re
+        ));
+        assert!(!has_unlinked_todo_in_hash_line("echo \\# TODO escaped", &todo_re));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- Avoid false positives where `#` appears inside single- or double-quoted text or when the hash is escaped, so TODO/FIXME detection for hash-comment languages is more accurate.
- Preserve existing shebang (`#!`) behavior and whitespace-delimited inline comment semantics.

### Description
- Replace naive `line.find('#')` logic in `has_unlinked_todo_in_hash_line` with a call to a new helper `find_unquoted_hash_comment_start` that finds the first unquoted, unescaped `#` index.
- Add `find_unquoted_hash_comment_start` which tracks single-quote, double-quote, and escape state to ignore `#` characters inside quoted strings and skip escaped `\#` sequences.
- Keep shebang handling by short-circuiting on lines starting with `#!`.
- Expand the existing unit test `hash_comment_todo_detection_handles_shebang_and_inline_hashes` with assertions covering quoted `#` content and escaped-hash cases.

### Testing
- Ran `cargo xtask fmt` successfully to apply formatting changes.
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and the targeted test passed.
- Ran `cargo test -p perl-ci-hygiene` where most tests passed (34 passed) and one existing snapshot test failed (`checked_in_pre_push_hook_matches_generated_hook`) due to checked-in pre-push hook drift unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9691647e8833385be82c5378f23da)