### PR TITLE
fix(dap): stabilize variable paging cache and child refs (#4650)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/parsing.rs
+++ b/crates/perl-dap/src/debug_adapter/parsing.rs
@@ -150,9 +150,11 @@ impl DebugAdapter {
         let mut top_level = Vec::new();
         let mut child_cache = HashMap::new();
         for (idx, (name, value)) in parsed.into_iter().skip(start).take(count).enumerate() {
-            let child_ref = variables_ref.saturating_mul(1000).saturating_add(
-                Self::i64_to_i32_saturating(i64::try_from(idx + 1).unwrap_or(i64::from(i32::MAX))),
-            );
+            let absolute_index = start.saturating_add(idx).saturating_add(1);
+            let child_ref =
+                variables_ref.saturating_mul(1000).saturating_add(Self::i64_to_i32_saturating(
+                    i64::try_from(absolute_index).unwrap_or(i64::from(i32::MAX)),
+                ));
             let rendered = if value.is_expandable() {
                 renderer.render_with_reference(&name, &value, i64::from(child_ref))
             } else {
@@ -376,6 +378,41 @@ mod tests {
             DebugAdapter::parse_scope_variables_from_lines(&lines, 11, 0, 20);
         let names = vars.iter().map(|v| v.name.as_str()).collect::<Vec<_>>();
         assert_eq!(names, vec!["$alpha", "$mid", "$zeta"]);
+        Ok(())
+    }
+
+    #[test]
+    pub(super) fn test_parse_scope_variables_child_refs_stable_across_pages()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let lines = vec![
+            "@alpha = (1, 2)".to_string(),
+            "@beta = (3, 4)".to_string(),
+            "@gamma = (5, 6)".to_string(),
+        ];
+
+        let (page_one, page_one_children) =
+            DebugAdapter::parse_scope_variables_from_lines(&lines, 11, 0, 1);
+        let (page_two, page_two_children) =
+            DebugAdapter::parse_scope_variables_from_lines(&lines, 11, 1, 1);
+
+        let first_ref = page_one
+            .first()
+            .map(|variable| variable.variables_reference)
+            .ok_or("expected first page variable")?;
+        let second_ref = page_two
+            .first()
+            .map(|variable| variable.variables_reference)
+            .ok_or("expected second page variable")?;
+
+        assert_ne!(first_ref, second_ref, "paged variables must not reuse child references");
+        assert!(
+            page_one_children.contains_key(&first_ref),
+            "expected first page child cache for first reference"
+        );
+        assert!(
+            page_two_children.contains_key(&second_ref),
+            "expected second page child cache for second reference"
+        );
         Ok(())
     }
 

--- a/crates/perl-dap/src/debug_adapter/variables.rs
+++ b/crates/perl-dap/src/debug_adapter/variables.rs
@@ -28,6 +28,7 @@ impl DebugAdapter {
         let variables_ref = args.variables_reference as i32;
         let start = args.start.unwrap_or(0) as usize;
         let count = args.count.map(|v| v as usize).unwrap_or(256).clamp(1, 1024);
+        let can_use_root_cache = start == 0 && args.count.is_none();
 
         if variables_ref == 0 {
             return DapMessage::Response {
@@ -47,7 +48,7 @@ impl DebugAdapter {
 
         if let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session") {
             // Return cached variables first for stable references and fast repeated expansion.
-            if let Some(vars) = session.variables.get(&variables_ref) {
+            if can_use_root_cache && let Some(vars) = session.variables.get(&variables_ref) {
                 used_session_cache = true;
                 parsed_from_output = vars.clone();
             } else {
@@ -150,6 +151,7 @@ impl DebugAdapter {
 
         // Cache parsed variables and generated child references for expansion requests.
         if !used_session_cache
+            && can_use_root_cache
             && let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session")
         {
             session.variables.insert(variables_ref, variables.clone());


### PR DESCRIPTION
### Motivation
- Paginated `variables` requests could generate overlapping `variablesReference` IDs because child refs were computed relative to each page, causing collisions and incorrect child expansions across pages.
- Partial/page responses could be cached as if they were full root scope responses, leading to stale or incomplete results for later `variables` requests.

### Description
- Compute child references using the absolute position in the sorted scope (`start + idx + 1`) when building `variablesReference` IDs in `parse_scope_variables_from_lines`, preventing reuse across pages.
- Add a regression test `test_parse_scope_variables_child_refs_stable_across_pages` that verifies paginated responses produce distinct child refs and child-cache keys.
- Gate use and population of the root `session.variables` cache so it only applies when `start == 0` and `count` is not explicitly provided, avoiding caching of partial pages (change in `handle_variables`).

### Testing
- Ran `cargo xtask fmt` to apply repository formatting rules and the run completed successfully.
- Ran `cargo test -p perl-dap parse_scope_variables`, which executed the parsing-related unit tests and returned `3 passed; 0 failed` including the new regression test `test_parse_scope_variables_child_refs_stable_across_pages`.
- The changes were validated locally against the targeted parsing tests and no new failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9691647e8833385be82c5378f23da)