### PR TITLE
fix(ci-hygiene): scan all hash comments for unlinked TODOs (#4649)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -4339,6 +4339,11 @@ mod tests {
             "echo \"#not-a-comment\" # TODO: follow up",
             &todo_re,
         ));
+        assert!(!has_unlinked_todo_in_hash_line("echo '# TODO in string' && true", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo '# TODO in string' # TODO: follow up",
+            &todo_re
+        ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
 


### PR DESCRIPTION
### Motivation
- Hash-comment TODO detection skipped scanning after the first `#` on a line, producing false negatives when a non-comment `#` (for example inside a quoted string) appeared before a real trailing comment.

### Description
- Update `has_unlinked_todo_in_hash_line` to iterate over all `#` occurrences using `line.match_indices('#')` and evaluate each candidate rather than returning after the first `#`.
- Preserve existing guards for shebang lines and non-whitespace-prefixed `#` tokens while continuing to scan later `#` markers on the same line.
- Add regression assertions in the unit test `hash_comment_todo_detection_handles_shebang_and_inline_hashes` covering `"echo '# TODO in string' && true"` (should be ignored) and `"echo '# TODO in string' # TODO: follow up"` (should detect TODO).

### Testing
- Ran `cargo xtask fmt` to format changes and it completed successfully. 
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and `cargo test -p perl-ci-hygiene rust_todo_detection_ignores_linked_or_url_like_comments`, both passed. 
- Ran `cargo test -p perl-ci-hygiene` which fails in this workspace due to a pre-existing checked-in hook drift assertion (`checked_in_pre_push_hook_matches_generated_hook`) unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9692136648333b02f4847b61794bf)