### PR TITLE
fix(navigation): support more Mojolicious route forms in goto-definition (#4654)

### DIFF
--- a/crates/perl-lsp/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp/src/runtime/language/navigation.rs
@@ -36,6 +36,10 @@ static MOJO_STRING_ROUTE_RE: OnceLock<Result<regex::Regex, regex::Error>> = Once
 static MOJO_KV_ROUTE_RE: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
 
 #[cfg(feature = "workspace")]
+static MOJO_KV_ROUTE_RE_ACTION_FIRST: OnceLock<Result<regex::Regex, regex::Error>> =
+    OnceLock::new();
+
+#[cfg(feature = "workspace")]
 fn get_fqn_regex() -> Result<&'static regex::Regex, JsonRpcError> {
     FQN_RE
         .get_or_init(|| regex::Regex::new(r"([A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*)"))
@@ -445,7 +449,9 @@ pub(super) fn workspace_document_text(
 fn get_mojo_string_route_regex() -> Result<&'static regex::Regex, JsonRpcError> {
     MOJO_STRING_ROUTE_RE
         .get_or_init(|| {
-            regex::Regex::new(r"->\s*to\s*\(\s*'(?P<controller>[^'#]+)#(?P<action>[^']+)'\s*\)")
+            regex::Regex::new(
+                r##"->\s*to\s*\(\s*['"](?P<controller>[^'"#]+)#(?P<action>[^'"]+)['"]\s*\)"##,
+            )
         })
         .as_ref()
         .map_err(|err| {
@@ -461,6 +467,22 @@ fn get_mojo_kv_route_regex() -> Result<&'static regex::Regex, JsonRpcError> {
         .get_or_init(|| {
             regex::Regex::new(
                 r"->\s*to\s*\(\s*controller\s*=>\s*'(?P<controller>[^']+)'\s*,\s*action\s*=>\s*'(?P<action>[^']+)'\s*\)",
+            )
+        })
+        .as_ref()
+        .map_err(|err| {
+            crate::protocol::internal_error(&format!(
+                "Failed to initialize Mojolicious route regex: {err}"
+            ))
+        })
+}
+
+#[cfg(feature = "workspace")]
+fn get_mojo_kv_route_regex_action_first() -> Result<&'static regex::Regex, JsonRpcError> {
+    MOJO_KV_ROUTE_RE_ACTION_FIRST
+        .get_or_init(|| {
+            regex::Regex::new(
+                r#"->\s*to\s*\(\s*action\s*=>\s*['"](?P<action>[^'"]+)['"]\s*,\s*controller\s*=>\s*['"](?P<controller>[^'"]+)['"]\s*\)"#,
             )
         })
         .as_ref()
@@ -544,27 +566,30 @@ fn resolve_mojolicious_route_definition(
         }
     }
 
-    let kv_re = get_mojo_kv_route_regex().ok()?;
-    for cap in kv_re.captures_iter(text_around) {
-        let Some(full_match) = cap.get(0) else {
-            continue;
-        };
-        if cursor_in_text < full_match.start() || cursor_in_text >= full_match.end() {
-            continue;
-        }
+    for kv_re in [get_mojo_kv_route_regex().ok()?, get_mojo_kv_route_regex_action_first().ok()?] {
+        for cap in kv_re.captures_iter(text_around) {
+            let Some(full_match) = cap.get(0) else {
+                continue;
+            };
+            if cursor_in_text < full_match.start() || cursor_in_text >= full_match.end() {
+                continue;
+            }
 
-        let Some(controller_match) = cap.name("controller") else {
-            continue;
-        };
-        let Some(action_match) = cap.name("action") else {
-            continue;
-        };
+            let Some(controller_match) = cap.name("controller") else {
+                continue;
+            };
+            let Some(action_match) = cap.name("action") else {
+                continue;
+            };
 
-        if (cursor_in_text >= controller_match.start() && cursor_in_text < controller_match.end())
-            || (cursor_in_text >= action_match.start() && cursor_in_text < action_match.end())
-        {
-            if let Some(location) = try_route(controller_match.as_str(), action_match.as_str()) {
-                return Some(location);
+            if (cursor_in_text >= controller_match.start()
+                && cursor_in_text < controller_match.end())
+                || (cursor_in_text >= action_match.start() && cursor_in_text < action_match.end())
+            {
+                if let Some(location) = try_route(controller_match.as_str(), action_match.as_str())
+                {
+                    return Some(location);
+                }
             }
         }
     }

--- a/crates/perl-lsp/tests/mojolicious_navigation_tests.rs
+++ b/crates/perl-lsp/tests/mojolicious_navigation_tests.rs
@@ -67,7 +67,7 @@ sub startup {
 "#,
     )?;
 
-    let app_text = r#"package MyApp::App;
+    let app_text = r##"package MyApp::App;
 use Mojo::Base 'Mojolicious';
 
 sub startup {
@@ -77,7 +77,7 @@ sub startup {
 }
 
 1;
-"#;
+"##;
 
     let mut harness = LspHarness::new();
     harness.initialize_with_root(&workspace.root_uri, None)?;
@@ -174,6 +174,122 @@ sub startup {
     let uri = location["uri"].as_str().ok_or("expected definition URI")?;
     assert!(
         uri.contains("MyApp/Controller/Admin.pm"),
+        "definition should point to controller file, got: {uri}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn mojolicious_string_route_with_double_quotes_definitions_to_controller_method() -> TestResult {
+    let workspace = TempWorkspace::new()?;
+    workspace.write(
+        "lib/MyApp/Controller/Health.pm",
+        r#"package MyApp::Controller::Health;
+use Mojo::Base 'Mojolicious::Controller';
+
+sub check {
+    my $self = shift;
+    return "ok";
+}
+
+1;
+"#,
+    )?;
+    let app_text = r##"package MyApp::App;
+use Mojo::Base 'Mojolicious';
+
+sub startup {
+    my $self = shift;
+    my $r = $self->routes;
+    $r->get('/health')->to("health#check");
+}
+
+1;
+"##;
+    workspace.write("lib/MyApp/App.pm", app_text)?;
+
+    let mut harness = LspHarness::new();
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+    harness.open(
+        &workspace.uri("lib/MyApp/Controller/Health.pm"),
+        &std::fs::read_to_string(workspace.dir.path().join("lib/MyApp/Controller/Health.pm"))?,
+    )?;
+    harness.open(&workspace.uri("lib/MyApp/App.pm"), app_text)?;
+    harness.barrier();
+
+    let (line, character) = position_of(app_text, "health#check")?;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("lib/MyApp/App.pm")},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let location = first_location(&result).ok_or("expected a definition location")?;
+    assert_valid_location(location);
+    let uri = location["uri"].as_str().ok_or("expected definition URI")?;
+    assert!(
+        uri.contains("MyApp/Controller/Health.pm"),
+        "definition should point to controller file, got: {uri}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn mojolicious_kv_route_target_action_first_definitions_to_controller_method() -> TestResult {
+    let workspace = TempWorkspace::new()?;
+    workspace.write(
+        "lib/MyApp/Controller/Audit.pm",
+        r#"package MyApp::Controller::Audit;
+use Mojo::Base 'Mojolicious::Controller';
+
+sub list {
+    my $self = shift;
+    return "ok";
+}
+
+1;
+"#,
+    )?;
+    let app_text = r#"package MyApp::App;
+use Mojo::Base 'Mojolicious';
+
+sub startup {
+    my $self = shift;
+    my $r = $self->routes;
+    $r->get('/audit')->to(action => "list", controller => "audit");
+}
+
+1;
+"#;
+    workspace.write("lib/MyApp/App.pm", app_text)?;
+
+    let mut harness = LspHarness::new();
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+    harness.open(
+        &workspace.uri("lib/MyApp/Controller/Audit.pm"),
+        &std::fs::read_to_string(workspace.dir.path().join("lib/MyApp/Controller/Audit.pm"))?,
+    )?;
+    harness.open(&workspace.uri("lib/MyApp/App.pm"), app_text)?;
+    harness.barrier();
+
+    let (line, character) = position_of(app_text, "list")?;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("lib/MyApp/App.pm")},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let location = first_location(&result).ok_or("expected a definition location")?;
+    assert_valid_location(location);
+    let uri = location["uri"].as_str().ok_or("expected definition URI")?;
+    assert!(
+        uri.contains("MyApp/Controller/Audit.pm"),
         "definition should point to controller file, got: {uri}"
     );
 


### PR DESCRIPTION
### Motivation
- Mojolicious route targets come in multiple syntactic forms (single-quoted, double-quoted, and key/value pairs with varying order) and the LSP goto-definition logic should resolve controller/action targets reliably across them.
- Improve developer UX by making route navigation resilient to common variations in route syntax observed in real projects.

### Description
- Broadened string-route matching in `get_mojo_string_route_regex` to accept both single- and double-quoted targets (e.g. `to("user#list")` and `to('user#list')`).
- Added a new `OnceLock` and helper `get_mojo_kv_route_regex_action_first` to recognize key/value route forms where `action` appears before `controller`.
- Updated `resolve_mojolicious_route_definition` to attempt both `controller=>..., action=>...` and `action=>..., controller=>...` regexes and pick the matching span under the cursor.
- Added focused tests in `crates/perl-lsp/tests/mojolicious_navigation_tests.rs` that cover double-quoted string routes and action-first key/value routes, and adjusted a position-finding expectation to be robust for the new case.

### Testing
- Ran `cargo xtask fmt` with no formatting errors (succeeded).
- Ran `cargo test -p perl-lsp-rs --test mojolicious_navigation_tests` and all tests passed (`4 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9692136648333b02f4847b61794bf)