### PR TITLE
fix(dap-stack): tighten hash frame heuristic (#4650)

### DIFF
--- a/crates/perl-dap/src/stack/parser.rs
+++ b/crates/perl-dap/src/stack/parser.rs
@@ -314,6 +314,9 @@ impl PerlStackParser {
     #[must_use]
     pub fn looks_like_frame(line: &str) -> bool {
         let line = line.trim();
+        let hash_frame_like = line
+            .strip_prefix('#')
+            .is_some_and(|rest| rest.chars().next().is_some_and(|c| c.is_ascii_digit()));
 
         // Check for common patterns
         line.contains(" at ") && line.contains(" line ")
@@ -321,7 +324,7 @@ impl PerlStackParser {
             || line.starts_with('$') && line.contains(" = ")
             || line.starts_with('@') && line.contains(" = ")
             || line.starts_with('.') && line.contains(" = ")
-            || line.starts_with('#')
+            || hash_frame_like
     }
 }
 

--- a/crates/perl-dap/tests/stack_malformed_debugger_output_tests.rs
+++ b/crates/perl-dap/tests/stack_malformed_debugger_output_tests.rs
@@ -530,19 +530,10 @@ fn classify_all_mixed_with_include_external_true() {
 // ═══════════════════════════════════════════════════════════════════════════
 
 #[test]
-fn looks_like_frame_perl_comments_are_false_positive() {
-    // Perl comments starting with # trigger the starts_with('#') heuristic.
-    // This is a known false positive: looks_like_frame is a quick pre-filter,
-    // and the actual parse_frame() correctly rejects these.
-    assert!(PerlStackParser::looks_like_frame("# This is a comment"));
-    assert!(PerlStackParser::looks_like_frame("# TODO: fix this later"));
-    assert!(PerlStackParser::looks_like_frame("## Section header"));
-
-    // But parse_frame correctly rejects them
-    let mut parser = PerlStackParser::new();
-    assert!(parser.parse_frame("# This is a comment", 0).is_none());
-    assert!(parser.parse_frame("# TODO: fix this later", 0).is_none());
-    assert!(parser.parse_frame("## Section header", 0).is_none());
+fn looks_like_frame_perl_comments_are_negative() {
+    assert!(!PerlStackParser::looks_like_frame("# This is a comment"));
+    assert!(!PerlStackParser::looks_like_frame("# TODO: fix this later"));
+    assert!(!PerlStackParser::looks_like_frame("## Section header"));
 }
 
 #[test]
@@ -610,9 +601,9 @@ fn looks_like_frame_positive_verbose_format() {
 
 #[test]
 fn looks_like_frame_hash_only_is_positive() {
-    // A bare "#" with any content triggers the starts_with('#') check
+    // Hash-prefix frames must start with a numeric frame index.
     assert!(PerlStackParser::looks_like_frame("#0"));
-    assert!(PerlStackParser::looks_like_frame("#anything"));
+    assert!(!PerlStackParser::looks_like_frame("#anything"));
 }
 
 #[test]
@@ -624,26 +615,12 @@ fn looks_like_frame_false_positive_awareness() {
     assert!(PerlStackParser::looks_like_frame(ambiguous));
 }
 
-// Note: The looks_like_frame() heuristic also matches lines starting with '#'.
-// Perl comments start with '#', so they produce false positives.
-// This is a known limitation: looks_like_frame is a quick pre-filter,
-// not a definitive parser. The actual parse_frame() call rejects these.
+// `looks_like_frame` avoids hash-comment false positives while still allowing
+// numbered hash-prefix frames like `#0`.
 #[test]
-fn looks_like_frame_comment_false_positive_rejected_by_parse_frame() {
-    // A comment starting with # will pass looks_like_frame but fail parse_frame
+fn looks_like_frame_comment_is_rejected_before_parse() {
     let comment = "# This is a perl comment";
-    // looks_like_frame triggers on '#' prefix (known false positive)
-    let looks_like = PerlStackParser::looks_like_frame(comment);
-    // But parse_frame correctly rejects it
-    let mut parser = PerlStackParser::new();
-    let parsed = parser.parse_frame(comment, 0);
-    // The comment is rejected by the actual parser even if the heuristic said yes
-    if looks_like {
-        assert!(
-            parsed.is_none(),
-            "parse_frame should reject comments even if looks_like_frame says true"
-        );
-    }
+    assert!(!PerlStackParser::looks_like_frame(comment));
 }
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
### Motivation
- The `looks_like_frame` heuristic was matching any line starting with `#`, causing Perl comments and headers to be pre-filtered as potential stack frames and producing false positives.
- Tightening the heuristic reduces unnecessary parse attempts and avoids treating ordinary comments as frames while preserving valid numbered hash frames.

### Description
- Updated `PerlStackParser::looks_like_frame` to only treat hash-prefixed lines as frame-like when `#` is followed by a numeric frame index by adding a `hash_frame_like` check in `crates/perl-dap/src/stack/parser.rs`.
- Adjusted unit tests in `crates/perl-dap/tests/stack_malformed_debugger_output_tests.rs` to assert that comment lines like `# TODO:` and `## Section header` are rejected while numeric frames like `#0` remain accepted.
- Small test-message/comment cleanups to reflect the new pre-filter behavior and remove the previous false-positive assertions.

### Testing
- Ran `cargo xtask fmt` to format the workspace, which completed successfully.
- Ran the targeted test command `cargo test -p perl-dap looks_like_frame`, and the updated `perl-dap` unit tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96922cca88333b27f07c6c282c10b)