### PR TITLE
fix(ci-hygiene): handle quoted # literals in TODO scan (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3863,17 +3863,59 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
-    if let Some(idx) = line.find('#') {
+    if let Some(idx) = find_hash_comment_start(line) {
         if idx > 0 && line.as_bytes()[idx - 1] == b'!' {
-            return false;
-        }
-        if idx > 0 && !line[..idx].chars().next_back().is_some_and(char::is_whitespace) {
             return false;
         }
         has_unlinked_token(&line[idx + 1..], token_re)
     } else {
         false
     }
+}
+
+fn find_hash_comment_start(line: &str) -> Option<usize> {
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+    let mut prev_char: Option<char> = None;
+
+    for (idx, ch) in line.char_indices() {
+        if escaped {
+            escaped = false;
+            prev_char = Some(ch);
+            continue;
+        }
+
+        if ch == '\\' {
+            escaped = true;
+            prev_char = Some(ch);
+            continue;
+        }
+
+        if ch == '\'' && !in_double {
+            in_single = !in_single;
+            prev_char = Some(ch);
+            continue;
+        }
+
+        if ch == '"' && !in_single {
+            in_double = !in_double;
+            prev_char = Some(ch);
+            continue;
+        }
+
+        if ch == '#' && !in_single && !in_double {
+            if idx > 0 && !prev_char.is_some_and(char::is_whitespace) {
+                prev_char = Some(ch);
+                continue;
+            }
+            return Some(idx);
+        }
+
+        prev_char = Some(ch);
+    }
+
+    None
 }
 
 fn is_url_like_hash_comment(line: &str, slash_idx: usize) -> bool {
@@ -4172,6 +4214,14 @@ mod tests {
 
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo \"# TODO not a comment\" # TODO: follow up",
+            &todo_re
+        ));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo '# TODO not a comment' # TODO: follow up",
+            &todo_re
+        ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
 


### PR DESCRIPTION
### Motivation
- Fix false negatives in the TODO/FIXME scanner for hash-comment languages where an earlier quoted `#` (e.g. `"# TODO"` or `'# TODO'`) caused `line.find('#')` to pick the wrong `#` and miss the real trailing comment.

### Description
- Replace the naive `line.find('#')` usage with a new `find_hash_comment_start` helper that tracks single-quoted and double-quoted regions plus escapes to locate the first real comment `#` outside of string literals.
- Update `has_unlinked_todo_in_hash_line` to use `find_hash_comment_start` while preserving existing shebang (`#!`) handling and linked-marker logic.
- Add unit coverage for cases where a quoted `# TODO` appears before an actual trailing `# TODO` (both single- and double-quoted examples).
- Applied code formatting with `cargo xtask fmt`.

### Testing
- Ran `cargo xtask fmt` and it completed successfully.
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and the test passed.
- Ran `cargo test -p perl-ci-hygiene`; the suite reported one failing test `checked_in_pre_push_hook_matches_generated_hook` that is due to checked-in/generated hook drift in this checkout and is unrelated to the change in the TODO scanner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96922cca88333b27f07c6c282c10b)