### PR TITLE
test(parser-core): re-enable unclosed bracket regression cases (#4652)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_bracket_fixes_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_bracket_fixes_tests.rs
@@ -91,7 +91,6 @@ fn dotted_numbers_in_arrayref() {
 // ==========================================================================
 
 #[test]
-#[ignore] // separate issue: package names (::) inside @{} block derefs
 fn deref_method_call_in_arrayref() {
     assert_clean_parse(
         "return [@{Mojo::Cookie::Response->parse($headers->set_cookie)}] unless @_;",
@@ -103,7 +102,6 @@ fn deref_method_call_in_arrayref() {
 // ==========================================================================
 
 #[test]
-#[ignore] // separate issue: x repetition operator not recognized after )
 fn x_repetition_in_arrayref() {
     assert_clean_parse("my @x = [ (undef) x scalar(@ordered_values) ];");
 }


### PR DESCRIPTION
### Motivation
- Increase regression coverage for nuanced arrayref parsing edge-cases now handled by the parser so future regressions are caught by normal CI runs.

### Description
- Removed `#[ignore]` from two tests in `crates/perl-parser-core/tests/unclosed_bracket_fixes_tests.rs`: `deref_method_call_in_arrayref` and `x_repetition_in_arrayref` so they run in the default test suite.

### Testing
- Ran `cargo test -p perl-parser-core --test unclosed_bracket_fixes_tests -- --ignored` which passed.
- Ran `cargo test -p perl-parser-core --test unclosed_bracket_fixes_tests` which passed (all tests in the file succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9699adc588333a460a7c41f40b318)