### PR TITLE
fix(performance): harden parallel worker bounds (#4653)

### DIFF
--- a/crates/perl-lsp-rs-core/src/performance/mod.rs
+++ b/crates/perl-lsp-rs-core/src/performance/mod.rs
@@ -197,13 +197,21 @@ pub mod parallel {
         T: Send + 'static,
         F: Fn(String) -> T + Send + Sync + 'static,
     {
+        if files.is_empty() {
+            return Vec::new();
+        }
+
+        // Ensure callers cannot accidentally request zero workers and drop all work.
+        // This preserves the API contract that every input file is processed once.
+        let effective_workers = num_workers.max(1).min(files.len());
+
         let (tx, rx) = mpsc::channel();
         let work_queue = Arc::new(Mutex::new(files));
         let processor = Arc::new(processor);
 
         let mut handles = vec![];
 
-        for _ in 0..num_workers {
+        for _ in 0..effective_workers {
             let tx = tx.clone();
             let work_queue = Arc::clone(&work_queue);
             let processor = Arc::clone(&processor);

--- a/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
+++ b/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
@@ -56,3 +56,23 @@ fn incremental_parser_given_zero_width_change_when_marked_then_no_nodes_require_
 
     assert!(!parser.needs_reparse(0, 100));
 }
+
+#[test]
+fn parallel_given_zero_workers_when_processing_then_all_files_are_still_processed() {
+    let files = vec!["a.pm".to_string(), "b.pm".to_string(), "c.pm".to_string()];
+
+    let mut processed = parallel::process_files_parallel(files, 0, |file| file);
+    processed.sort();
+
+    assert_eq!(processed, vec!["a.pm", "b.pm", "c.pm"]);
+}
+
+#[test]
+fn parallel_given_more_workers_than_files_when_processing_then_each_file_processed_once() {
+    let files = vec!["one.pm".to_string(), "two.pm".to_string()];
+
+    let mut processed = parallel::process_files_parallel(files, 16, |file| file);
+    processed.sort();
+
+    assert_eq!(processed, vec!["one.pm", "two.pm"]);
+}


### PR DESCRIPTION
### Motivation
- Prevent a silent failure mode in the parallel file processor where `num_workers == 0` could result in no work being processed, which breaks the API contract that input files are always processed.
- Ensure bounded concurrency semantics so callers who request too many workers do not create duplicate processing or oversubscribe resources.

### Description
- Add early-return for empty `files` and compute `effective_workers = num_workers.max(1).min(files.len())` in `parallel::process_files_parallel` to guarantee at least one worker and at most one worker per file, in `crates/perl-lsp-rs-core/src/performance/mod.rs`.
- Use `effective_workers` for the worker loop instead of the raw `num_workers` to enforce the new bounds.
- Add BDD-style integration tests in `crates/perl-lsp-rs-core/tests/performance_module_shape.rs` that verify zero-worker requests still process all files and that over-provisioned worker counts do not duplicate work.

### Testing
- Ran `cargo xtask fmt` to apply formatting, which completed successfully.
- Ran `cargo test -p perl-lsp-rs-core --test performance_module_shape`, which executed the suite (9 tests) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9699adc588333a460a7c41f40b318)