### PR TITLE
fix(performance): preserve processing when worker count is zero (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/performance/mod.rs
+++ b/crates/perl-lsp-rs-core/src/performance/mod.rs
@@ -197,6 +197,10 @@ pub mod parallel {
         T: Send + 'static,
         F: Fn(String) -> T + Send + Sync + 'static,
     {
+        if num_workers == 0 {
+            return files.into_iter().map(processor).collect();
+        }
+
         let (tx, rx) = mpsc::channel();
         let work_queue = Arc::new(Mutex::new(files));
         let processor = Arc::new(processor);

--- a/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
+++ b/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
@@ -56,3 +56,22 @@ fn incremental_parser_given_zero_width_change_when_marked_then_no_nodes_require_
 
     assert!(!parser.needs_reparse(0, 100));
 }
+
+#[test]
+fn process_files_parallel_given_zero_workers_when_processing_then_falls_back_to_sequential() {
+    let files = vec!["a.pm".to_string(), "b.pm".to_string(), "c.pm".to_string()];
+
+    let processed = parallel::process_files_parallel(files, 0, |file| format!("ok:{file}"));
+
+    assert_eq!(processed, vec!["ok:a.pm", "ok:b.pm", "ok:c.pm"]);
+}
+
+#[test]
+fn process_files_parallel_given_workers_when_processing_then_returns_all_files() {
+    let files = vec!["a.pm".to_string(), "b.pm".to_string(), "c.pm".to_string()];
+
+    let mut processed = parallel::process_files_parallel(files, 2, |file| format!("ok:{file}"));
+    processed.sort();
+
+    assert_eq!(processed, vec!["ok:a.pm", "ok:b.pm", "ok:c.pm"]);
+}


### PR DESCRIPTION
### Motivation
- Prevent callers from accidentally losing work when `process_files_parallel` is invoked with `num_workers == 0` by providing a safe, deterministic fallback.

### Description
- Add a defensive fallback in `performance::parallel::process_files_parallel` to run the `processor` sequentially when `num_workers == 0` instead of spawning zero workers and returning an empty result.
- Update `crates/perl-lsp-rs-core/src/performance/mod.rs` to include the zero-worker branch before the thread pool logic.
- Add tests in `crates/perl-lsp-rs-core/tests/performance_module_shape.rs` covering the zero-worker fallback (`process_files_parallel_given_zero_workers_when_processing_then_falls_back_to_sequential`) and a multi-worker case (`process_files_parallel_given_workers_when_processing_then_returns_all_files`).

### Testing
- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo test -p perl-lsp-rs-core --test performance_module_shape` and all tests passed (9 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9699adc588333a460a7c41f40b318)