### PR TITLE
fix(ci-hygiene): keep generated pre-push hook in sync with crate/package mapping (#4512)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -1984,8 +1984,12 @@ fi
 # Falls back to the full gate if classification is ambiguous.
 SINGLE_CRATE_COUNT="$(printf '%s' "$SINGLE_CRATE_NAMES" | grep -c . 2>/dev/null || echo 0)"
 if [ "$SINGLE_CRATE_ALL_UNDER_CRATES" = true ] && [ "$SINGLE_CRATE_COUNT" = "1" ]; then
-    SINGLE_CRATE_NAME="$(printf '%s' "$SINGLE_CRATE_NAMES" | tr -d '[:space:]')"
-    echo "Single-crate push (${SINGLE_CRATE_NAME}) — running targeted gate"
+    SINGLE_CRATE_DIR="$(printf '%s' "$SINGLE_CRATE_NAMES" | tr -d '[:space:]')"
+    # Resolve the Cargo package name from Cargo.toml, not the directory basename.
+    # This fixes the perl-lsp -> perl-lsp-rs mismatch (issue #4512).
+    # Falls back to directory name if cargo xtask is unavailable.
+    SINGLE_CRATE_NAME="$(cargo xtask resolve-package-name "crates/${SINGLE_CRATE_DIR}" 2>/dev/null || printf '%s' "$SINGLE_CRATE_DIR")"
+    echo "Single-crate push (${SINGLE_CRATE_DIR} -> ${SINGLE_CRATE_NAME}) — running targeted gate"
     echo "   (Skip with: git push --no-verify)"
     echo ""
     run_single_crate_gate() {


### PR DESCRIPTION
### Motivation
- Ensure the generated `pre_push_hook_script()` matches the checked-in `hooks/pre-push` logic so the single-crate fast-path resolves the actual Cargo package name (fixes mismatch like `perl-lsp` dir vs `perl-lsp-rs` package) and prevents the sync-guard test from failing.

### Description
- Update the single-crate block in `pre_push_hook_script()` to compute `SINGLE_CRATE_DIR`, resolve the package name via `cargo xtask resolve-package-name "crates/${SINGLE_CRATE_DIR}"` (falling back to the dir name), and update the log to show `crate-dir -> package-name` before running the targeted gate.

### Testing
- Ran `cargo test -p perl-ci-hygiene --quiet` and all tests passed (35 passed, 0 failed). 
- Ran `cargo fmt -p perl-ci-hygiene -- --check` and formatting check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96a035ae88333b171e72e1ecdeda7)