### PR TITLE
fix(ci-hygiene): classify TODO(#issue) ignore reasons as infra (#4649)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3993,6 +3993,7 @@ fn collect_ignored_matches(crates_root: &Path, repo_root: &Path) -> Result<Vec<I
 fn categorize_ignore(reason: &str, context: &str) -> String {
     let reason = reason.trim().to_lowercase();
     let context = context.to_lowercase();
+    let reason_no_space = reason.replace(' ', "");
 
     if reason.starts_with("manual:")
         || reason.contains("manual ")
@@ -4032,6 +4033,7 @@ fn categorize_ignore(reason: &str, context: &str) -> String {
         return "bug".to_string();
     }
     if reason.starts_with("todo:")
+        || reason_no_space.starts_with("todo(#")
         || reason.starts_with("infra:")
         || reason.contains("infra ")
         || reason.contains("fixme")
@@ -4215,6 +4217,8 @@ mod tests {
     fn categorize_ignore_maps_reasons_to_expected_buckets() {
         assert_eq!(categorize_ignore("manual: run locally", ""), "manual");
         assert_eq!(categorize_ignore("TODO: requires CI setup", ""), "infra");
+        assert_eq!(categorize_ignore("TODO(#123): tracked follow-up", ""), "infra");
+        assert_eq!(categorize_ignore("TODO (#123): tracked follow-up", ""), "infra");
         assert_eq!(categorize_ignore("feature: not implemented", ""), "feature");
         assert_eq!(categorize_ignore("placeholder", "#[ignore] // AC: parser behavior"), "feature");
         assert_eq!(categorize_ignore("ignore", ""), "bare");


### PR DESCRIPTION
### Motivation
- Ignore-reason classification was misclassifying issue-linked TODO reasons (e.g. `TODO(#123)` or `TODO (#123)`) and thus could place tracked TODOs in the wrong bucket, harming CI/ignored-test metrics.

### Description
- Normalize and inspect a whitespace-stripped form of the reason (`reason_no_space`) and treat `todo(#...)` as `infra` in `categorize_ignore`.
- Add regression assertions that cover both `TODO(#123): ...` and `TODO (#123): ...` formats in `categorize_ignore_maps_reasons_to_expected_buckets`.

### Testing
- Ran `cargo xtask fmt` successfully.
- Ran targeted unit tests with `cargo test -p perl-ci-hygiene --bin perl-ci-hygiene categorize_ignore_maps_reasons_to_expected_buckets` and the new assertions passed.
- Ran `cargo test -p perl-ci-hygiene`; the suite shows the change does not break classification tests, but the run fails one existing pre-push hook sync test (`checked_in_pre_push_hook_matches_generated_hook`) that is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96a035ae88333b171e72e1ecdeda7)