### PR TITLE
fix(ci-hygiene): detect TODOs after quoted # in hash-comment files (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3863,17 +3863,21 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
-    if let Some(idx) = line.find('#') {
+    for (idx, _) in line.match_indices('#') {
+        if idx == 0 && line.as_bytes().get(1).is_some_and(|byte| *byte == b'!') {
+            continue;
+        }
         if idx > 0 && line.as_bytes()[idx - 1] == b'!' {
-            return false;
+            continue;
         }
         if idx > 0 && !line[..idx].chars().next_back().is_some_and(char::is_whitespace) {
-            return false;
+            continue;
         }
-        has_unlinked_token(&line[idx + 1..], token_re)
-    } else {
-        false
+        if has_unlinked_token(&line[idx + 1..], token_re) {
+            return true;
+        }
     }
+    false
 }
 
 fn is_url_like_hash_comment(line: &str, slash_idx: usize) -> bool {
@@ -4173,6 +4177,10 @@ mod tests {
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo \"# not a comment\" # TODO: follow up",
+            &todo_re
+        ));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
 
         Ok(())


### PR DESCRIPTION
### Motivation
- Fix a false-negative in the TODO/FIXME scanner for hash-comment languages (shell, Perl `#` comments, `Justfile`, etc.) where a `#` character appearing inside quoted strings could prevent detection of a later real comment containing `TODO`/`FIXME`.

### Description
- Update `has_unlinked_todo_in_hash_line` to iterate over every `#` occurrence using `match_indices` instead of only inspecting the first `#` on the line.
- Preserve existing heuristics for shebang (`#!`) and inline non-comment `#` detection and continue scanning rather than returning early. 
- Add a regression test for a mixed-content line (`echo "# not a comment" # TODO: follow up`) to ensure the trailing `TODO` is detected.
- Run formatting via `cargo xtask fmt` as part of the change.

### Testing
- Ran `cargo xtask fmt` which completed successfully. 
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and the test passed (`1 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96a035ae88333b171e72e1ecdeda7)