### PR TITLE
fix(ci-hygiene): handle quoted hash literals in TODO scan (#9999)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3863,17 +3863,49 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
-    if let Some(idx) = line.find('#') {
-        if idx > 0 && line.as_bytes()[idx - 1] == b'!' {
-            return false;
-        }
-        if idx > 0 && !line[..idx].chars().next_back().is_some_and(char::is_whitespace) {
-            return false;
-        }
-        has_unlinked_token(&line[idx + 1..], token_re)
-    } else {
-        false
+    let Some(idx) = find_hash_comment_start(line) else {
+        return false;
+    };
+    if idx > 0 && line.as_bytes()[idx - 1] == b'!' {
+        return false;
     }
+    if idx > 0 && !line[..idx].chars().next_back().is_some_and(char::is_whitespace) {
+        return false;
+    }
+    has_unlinked_token(&line[idx + 1..], token_re)
+}
+
+fn find_hash_comment_start(line: &str) -> Option<usize> {
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    for (idx, ch) in line.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' && !in_single {
+            escaped = true;
+            continue;
+        }
+
+        if ch == '"' && !in_single {
+            in_double = !in_double;
+            continue;
+        }
+        if ch == '\'' && !in_double {
+            in_single = !in_single;
+            continue;
+        }
+
+        if ch == '#' && !in_single && !in_double {
+            return Some(idx);
+        }
+    }
+
+    None
 }
 
 fn is_url_like_hash_comment(line: &str, slash_idx: usize) -> bool {
@@ -4174,6 +4206,12 @@ mod tests {
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line("echo \"# TODO in string\"", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo \"# TODO in string\" # TODO: follow up",
+            &todo_re
+        ));
+        assert!(!has_unlinked_todo_in_hash_line("echo \\# TODO not comment", &todo_re));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation

- The TODO/FIXME scanner for hash-style comments used `line.find('#')`, which could hit `#` characters inside string literals or escaped sequences and miss the real trailing comment, producing false negatives.
- Improve robustness so the scanner inspects only real hash comments outside quoted or escaped contexts.

### Description

- Replace naive `line.find('#')` usage in `has_unlinked_todo_in_hash_line` with a parser-aware helper `find_hash_comment_start` that tracks single/double-quoted spans and escaped characters and returns the real comment start index.
- Update `has_unlinked_todo_in_hash_line` to use `find_hash_comment_start` and keep existing shebang/inline-hash handling.
- Add unit tests covering `#` inside double-quoted strings, a trailing real `#` comment after a string literal, and an escaped `\#` sequence to prevent regressions, and run `cargo xtask fmt` for formatting.

### Testing

- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and the test passed.
- Ran `cargo test -p perl-ci-hygiene` where all modified-related tests passed but the full suite failed due to an unrelated existing test `checked_in_pre_push_hook_matches_generated_hook` mismatch (pre-existing hook content sync test), not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96a01ede08333ba98160833ad9a4e)