### PR TITLE
fix(ci-hygiene): avoid broad 'ac' feature bucket matching (#4649)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -4055,7 +4055,8 @@ fn categorize_ignore(reason: &str, context: &str) -> String {
         || reason.contains("pending")
         || reason.contains("when.implemented")
         || reason.contains("remove.when")
-        || reason.contains("ac")
+        || reason.contains("ac:")
+        || reason.contains("ac ")
         || reason.contains("not.yet")
         || reason.contains("tdd.scaffold")
         || reason.contains("scaffold")
@@ -4216,7 +4217,9 @@ mod tests {
         assert_eq!(categorize_ignore("manual: run locally", ""), "manual");
         assert_eq!(categorize_ignore("TODO: requires CI setup", ""), "infra");
         assert_eq!(categorize_ignore("feature: not implemented", ""), "feature");
+        assert_eq!(categorize_ignore("AC: parser behavior", ""), "feature");
         assert_eq!(categorize_ignore("placeholder", "#[ignore] // AC: parser behavior"), "feature");
+        assert_eq!(categorize_ignore("cache invalidation follow-up", ""), "other");
         assert_eq!(categorize_ignore("ignore", ""), "bare");
         assert_eq!(categorize_ignore("some new reason", ""), "other");
     }


### PR DESCRIPTION
### Motivation

- The `categorize_ignore` function in `perl-ci-hygiene` used a plain `reason.contains("ac")` check that accidentally matched substrings (e.g., “cache”), misclassifying unrelated ignore reasons as `feature` and skewing ignored-test metrics.

### Description

- Tighten feature-bucket detection by replacing the broad `reason.contains("ac")` check with explicit `reason.contains("ac:")` and `reason.contains("ac ")` patterns.
- Add regression assertions to ensure `AC: ...` still maps to `feature` and unrelated text like `cache invalidation follow-up` maps to `other`.
- Run formatter to keep code style consistent (`cargo xtask fmt`).

### Testing

- Ran `cargo xtask fmt` and it completed successfully.
- Ran `cargo test -p perl-ci-hygiene categorize_ignore_maps_reasons_to_expected_buckets` and the test passed.
- Ran the full `cargo test -p perl-ci-hygiene` suite which shows the change does not regress tests, but the suite in this environment reports one unrelated pre-existing failure (`checked_in_pre_push_hook_matches_generated_hook`); unit tests otherwise passed (34 passed, 1 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96a00cd348333b8bd9a6ca07bab98)