### PR TITLE
fix(ci-hygiene): ignore TODO/FIXME inside quoted hash literals (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3863,17 +3863,50 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
-    if let Some(idx) = line.find('#') {
-        if idx > 0 && line.as_bytes()[idx - 1] == b'!' {
-            return false;
-        }
-        if idx > 0 && !line[..idx].chars().next_back().is_some_and(char::is_whitespace) {
-            return false;
-        }
-        has_unlinked_token(&line[idx + 1..], token_re)
-    } else {
-        false
+    let Some(idx) = find_hash_comment_start(line) else {
+        return false;
+    };
+    if idx == 0 && line.as_bytes().get(1).is_some_and(|next| *next == b'!') {
+        return false;
     }
+    has_unlinked_token(&line[idx + 1..], token_re)
+}
+
+fn find_hash_comment_start(line: &str) -> Option<usize> {
+    let bytes = line.as_bytes();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    for (idx, ch) in line.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' if in_single || in_double => {
+                escaped = true;
+            }
+            '\'' if !in_double => {
+                in_single = !in_single;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+            }
+            '#' if !in_single && !in_double => {
+                if idx == 0 {
+                    return Some(idx);
+                }
+                if bytes[..idx].last().is_some_and(u8::is_ascii_whitespace) {
+                    return Some(idx);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
 }
 
 fn is_url_like_hash_comment(line: &str, slash_idx: usize) -> bool {
@@ -4172,6 +4205,15 @@ mod tests {
 
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line("echo \"# TODO in string literal\"", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line(
+            "echo '# FIXME in single-quoted literal'",
+            &todo_re
+        ));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo \"# TODO in string\" # TODO: real comment",
+            &todo_re
+        ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
 


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner produced false positives when `#` appeared inside quoted string literals in hash-comment languages (shell/Perl/Just), causing noisy hygiene violations.

### Description
- Replace the simple `line.find('#')` logic in `has_unlinked_todo_in_hash_line` with a quote- and escape-aware scanner `find_hash_comment_start` that locates only real comment starts outside single- and double-quoted literals.
- Preserve existing shebang handling (`#!`) and require either start-of-line or whitespace-before-`#` for a valid comment start.
- Extend unit coverage in `hash_comment_todo_detection_handles_shebang_and_inline_hashes` to include double-quoted, single-quoted, and mixed literal+comment cases.
- Changes are implemented in `crates/perl-ci-hygiene/src/main.rs` and formatted with `cargo fmt -p perl-ci-hygiene`.

### Testing
- Ran `cargo fmt -p perl-ci-hygiene`, which succeeded.
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes`, which passed.
- Ran full `cargo test -p perl-ci-hygiene`, where all unit tests passed except an existing repository-specific test `checked_in_pre_push_hook_matches_generated_hook` that failed due to checked-in hook drift unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96a00cd348333b8bd9a6ca07bab98)