### PR TITLE
fix(ci-hygiene): avoid TODO false positives in Rust literals (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3836,21 +3836,17 @@ fn collect_todo_hits(
 }
 
 fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
-    for (idx, _) in line.match_indices("//") {
-        if is_url_like_hash_comment(line, idx) {
-            continue;
-        }
-        if is_likely_string_literal_comment_start(line, idx) {
+    let scan_line = strip_rust_literals_for_comment_scan(line);
+
+    for (idx, _) in scan_line.match_indices("//") {
+        if is_url_like_hash_comment(&scan_line, idx) {
             continue;
         }
         if has_unlinked_token(&line[idx + 2..], token_re) {
             return true;
         }
     }
-    for (idx, _) in line.match_indices("/*") {
-        if is_likely_string_literal_comment_start(line, idx) {
-            continue;
-        }
+    for (idx, _) in scan_line.match_indices("/*") {
         if has_unlinked_token(&line[idx + 2..], token_re) {
             return true;
         }
@@ -3860,6 +3856,100 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
         return true;
     }
     false
+}
+
+fn strip_rust_literals_for_comment_scan(line: &str) -> String {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    let mut out = String::with_capacity(line.len());
+
+    while i < bytes.len() {
+        if let Some((end, quote_len)) = raw_string_end(bytes, i) {
+            out.push_str(&line[i..i + quote_len]);
+            for _ in (i + quote_len)..end {
+                out.push(' ');
+            }
+            i = end;
+            continue;
+        }
+
+        let (prefix_len, quote) = if bytes[i] == b'"' {
+            (1, b'"')
+        } else if bytes[i] == b'b' && i + 1 < bytes.len() && bytes[i + 1] == b'"' {
+            (2, b'"')
+        } else if bytes[i] == b'\'' {
+            (1, b'\'')
+        } else if bytes[i] == b'b' && i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
+            (2, b'\'')
+        } else {
+            out.push(bytes[i] as char);
+            i += 1;
+            continue;
+        };
+
+        out.push_str(&line[i..i + prefix_len]);
+        i += prefix_len;
+
+        let mut escaped = false;
+        while i < bytes.len() {
+            out.push(' ');
+            if !escaped && bytes[i] == quote {
+                i += 1;
+                break;
+            }
+            escaped = !escaped && bytes[i] == b'\\';
+            i += 1;
+        }
+    }
+
+    out
+}
+
+fn raw_string_end(bytes: &[u8], start: usize) -> Option<(usize, usize)> {
+    let mut idx = start;
+    let mut prefix_len = 0;
+
+    if bytes.get(idx) == Some(&b'b') {
+        prefix_len += 1;
+        idx += 1;
+    }
+    if bytes.get(idx) != Some(&b'r') {
+        return None;
+    }
+    prefix_len += 1;
+    idx += 1;
+
+    let mut hashes = 0;
+    while bytes.get(idx) == Some(&b'#') {
+        hashes += 1;
+        prefix_len += 1;
+        idx += 1;
+    }
+
+    if bytes.get(idx) != Some(&b'"') {
+        return None;
+    }
+    prefix_len += 1;
+    idx += 1;
+
+    let mut i = idx;
+    while i < bytes.len() {
+        if bytes[i] != b'"' {
+            i += 1;
+            continue;
+        }
+        let hashes_end = i + 1 + hashes;
+        if hashes_end > bytes.len() {
+            i += 1;
+            continue;
+        }
+        if bytes[i + 1..hashes_end].iter().all(|&b| b == b'#') {
+            return Some((hashes_end, prefix_len));
+        }
+        i += 1;
+    }
+
+    Some((bytes.len(), prefix_len))
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
@@ -3882,13 +3972,6 @@ fn is_url_like_hash_comment(line: &str, slash_idx: usize) -> bool {
     }
     let before = line.as_bytes()[slash_idx - 1];
     matches!(before, b'/' | b':' | b'"')
-}
-
-fn is_likely_string_literal_comment_start(line: &str, comment_idx: usize) -> bool {
-    if comment_idx == 0 {
-        return false;
-    }
-    matches!(line.as_bytes()[comment_idx - 1], b'"' | b'\'' | b'#')
 }
 
 fn has_unlinked_token(comment: &str, token_re: &Regex) -> bool {
@@ -4160,6 +4243,30 @@ mod tests {
         assert!(!has_unlinked_todo_in_rust_line("let s = r#\"// TODO in literal\"#;", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line(
             "let s = r#\"/* FIXME in literal */\"#;",
+            &todo_re
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn rust_todo_detection_ignores_embedded_markers_in_non_raw_literals() -> Result<()> {
+        let todo_re = Regex::new(r"TODO|FIXME")?;
+
+        assert!(!has_unlinked_todo_in_rust_line(
+            "let s = \"prefix // TODO still inside string\";",
+            &todo_re
+        ));
+        assert!(!has_unlinked_todo_in_rust_line(
+            "let s = b\"bytes /* FIXME in literal */\";",
+            &todo_re
+        ));
+        assert!(!has_unlinked_todo_in_rust_line(
+            "let s = br#\"raw bytes // TODO in literal\"#;",
+            &todo_re
+        ));
+        assert!(has_unlinked_todo_in_rust_line(
+            "let s = \"prefix // TODO in literal\"; // TODO: track",
             &todo_re
         ));
 


### PR DESCRIPTION
### Motivation

- Prevent false-positive detection of `TODO`/`FIXME` tokens when they appear inside Rust string and char literals to reduce noise in TODO audits.
- Improve the robustness of the CI hygiene scanner so comment-scanning reflects actual Rust comment boundaries instead of a fragile preceding-character heuristic.

### Description

- Update `has_unlinked_todo_in_rust_line` to run comment detection against a sanitized line produced by `strip_rust_literals_for_comment_scan` so embedded markers inside literals are ignored. 
- Add `strip_rust_literals_for_comment_scan` and `raw_string_end` helpers to support normal, byte, raw, and raw-byte string/char literal forms and to replace literal contents with spaces for safe scanning. 
- Remove the prior `is_likely_string_literal_comment_start` heuristic and rely on literal-aware scanning instead. 
- Add a regression test `rust_todo_detection_ignores_embedded_markers_in_non_raw_literals` ensuring markers inside literals are ignored while trailing real comments are still detected.

### Testing

- Ran `cargo xtask fmt` which completed successfully. 
- Ran `cargo test -p perl-ci-hygiene rust_todo_detection_ignores` which passed (new and targeted tests green). 
- Ran `cargo test -p perl-ci-hygiene` where the crate test suite mostly passed but a pre-existing test `checked_in_pre_push_hook_matches_generated_hook` failed due to hook drift in this checkout and is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96a0462ec833396a86db26cfb3a74)