### PR TITLE
fix(ci-hygiene): avoid TODO misses after quoted hashes (#5872)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3863,17 +3863,18 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
-    if let Some(idx) = line.find('#') {
-        if idx > 0 && line.as_bytes()[idx - 1] == b'!' {
+    for (idx, _) in line.match_indices('#') {
+        if idx == 0 && line.as_bytes().get(1) == Some(&b'!') {
             return false;
         }
         if idx > 0 && !line[..idx].chars().next_back().is_some_and(char::is_whitespace) {
-            return false;
+            continue;
         }
-        has_unlinked_token(&line[idx + 1..], token_re)
-    } else {
-        false
+        if has_unlinked_token(&line[idx + 1..], token_re) {
+            return true;
+        }
     }
+    false
 }
 
 fn is_url_like_hash_comment(line: &str, slash_idx: usize) -> bool {
@@ -4174,6 +4175,14 @@ mod tests {
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo \"# not comment\" # TODO: follow up",
+            &todo_re,
+        ));
+        assert!(!has_unlinked_todo_in_hash_line(
+            "echo \"# not comment\" # TODO(#77): tracked",
+            &todo_re,
+        ));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner could miss real trailing `#` comments when an earlier `#` appeared inside non-comment content (e.g., inside quoted strings), causing false negatives for unlinked markers in shell/perl-style files.

### Description
- Update `has_unlinked_todo_in_hash_line` in `crates/perl-ci-hygiene/src/main.rs` to iterate over every `#` occurrence using `line.match_indices('#')` instead of only checking the first `#` found.
- Preserve shebang handling by skipping the leading `#!` case and `continue` when the `#` is not a comment start, and return `true` only when `has_unlinked_token` finds an unlinked marker after a valid comment start.
- Add regression assertions to the `hash_comment_todo_detection_handles_shebang_and_inline_hashes` test to cover cases where a quoted `#` appears before a trailing `# TODO...` comment.

### Testing
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and the test passed (`ok`).
- Ran the package test suite `cargo test -p perl-ci-hygiene` where the change-specific tests passed but one existing unrelated test (`checked_in_pre_push_hook_matches_generated_hook`) still fails in the repository state; this failure is pre-existing and unrelated to the fix.
- Ran `cargo fmt -p perl-ci-hygiene` to ensure formatting and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96a0462ec833396a86db26cfb3a74)