### PR TITLE
fix(perl-ci-hygiene): detect TODOs after quoted hash literals (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3863,17 +3863,58 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
-    if let Some(idx) = line.find('#') {
-        if idx > 0 && line.as_bytes()[idx - 1] == b'!' {
-            return false;
-        }
-        if idx > 0 && !line[..idx].chars().next_back().is_some_and(char::is_whitespace) {
-            return false;
-        }
-        has_unlinked_token(&line[idx + 1..], token_re)
-    } else {
-        false
+    find_hash_comment_start(line).is_some_and(|idx| has_unlinked_token(&line[idx + 1..], token_re))
+}
+
+fn find_hash_comment_start(line: &str) -> Option<usize> {
+    enum QuoteState {
+        None,
+        Single,
+        Double,
     }
+
+    let mut state = QuoteState::None;
+    let mut escaped = false;
+
+    for (idx, ch) in line.char_indices() {
+        match state {
+            QuoteState::None => match ch {
+                '\'' => state = QuoteState::Single,
+                '"' => state = QuoteState::Double,
+                '#' => {
+                    if idx == 0 && line.starts_with("#!") {
+                        return None;
+                    }
+                    if idx > 0 && !line[..idx].chars().next_back().is_some_and(char::is_whitespace)
+                    {
+                        continue;
+                    }
+                    return Some(idx);
+                }
+                _ => {}
+            },
+            QuoteState::Single => {
+                if ch == '\'' {
+                    state = QuoteState::None;
+                }
+            }
+            QuoteState::Double => {
+                if escaped {
+                    escaped = false;
+                    continue;
+                }
+                if ch == '\\' {
+                    escaped = true;
+                    continue;
+                }
+                if ch == '"' {
+                    state = QuoteState::None;
+                }
+            }
+        }
+    }
+
+    None
 }
 
 fn is_url_like_hash_comment(line: &str, slash_idx: usize) -> bool {
@@ -4174,6 +4215,11 @@ mod tests {
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line("echo \"# TODO in literal\"", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo \"# TODO in literal\" # TODO: follow up",
+            &todo_re
+        ));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner for hash-style comments used `line.find('#')`, which could match a `#` inside a quoted string and miss a later real trailing comment containing an unlinked TODO/FIXME.

### Description
- Replace the simplistic `line.find('#')` usage with a new `find_hash_comment_start` function that scans `char_indices()` and finds the first `#` outside single- and double-quoted literals while honoring escaped characters in double quotes.
- Update `has_unlinked_todo_in_hash_line` to call `find_hash_comment_start` and preserve existing shebang handling and the rule that inline comments must be preceded by whitespace.
- Add regression assertions to the existing `hash_comment_todo_detection_handles_shebang_and_inline_hashes` test to ensure `"# TODO"` inside a quoted literal is ignored while a trailing `# TODO` comment on the same line is still detected.

### Testing
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` which passed successfully.
- Ran `cargo xtask fmt` to format workspace code which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96a0462ec833396a86db26cfb3a74)