### PR TITLE
fix(ci-hygiene): avoid quoted-string TODO false positives in hash scanners (#4587)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3864,6 +3864,9 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
     if let Some(idx) = line.find('#') {
+        if is_inside_single_or_double_quotes(line, idx) {
+            return false;
+        }
         if idx > 0 && line.as_bytes()[idx - 1] == b'!' {
             return false;
         }
@@ -3874,6 +3877,35 @@ fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
     } else {
         false
     }
+}
+
+fn is_inside_single_or_double_quotes(line: &str, idx: usize) -> bool {
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    for (byte_idx, ch) in line.char_indices() {
+        if byte_idx >= idx {
+            break;
+        }
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if ch == '\'' && !in_double {
+            in_single = !in_single;
+            continue;
+        }
+        if ch == '"' && !in_single {
+            in_double = !in_double;
+        }
+    }
+
+    in_single || in_double
 }
 
 fn is_url_like_hash_comment(line: &str, slash_idx: usize) -> bool {
@@ -4172,6 +4204,14 @@ mod tests {
 
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line(
+            "echo \"embedded # TODO marker in string\"",
+            &todo_re
+        ));
+        assert!(!has_unlinked_todo_in_hash_line(
+            "print 'embedded # FIXME marker in string';",
+            &todo_re
+        ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
 


### PR DESCRIPTION
### Motivation

- Prevent false-positive TODO/FIXME detections for hash-comment languages when a `#` appears inside a quoted string literal (common in shell/Perl snippets).

### Description

- Updated `has_unlinked_todo_in_hash_line` in `crates/perl-ci-hygiene/src/main.rs` to skip `#` markers that are inside single or double quoted strings. 
- Added a helper `is_inside_single_or_double_quotes(line: &str, idx: usize) -> bool` that tracks single/double quote state and handles escapes when scanning up to the `#` position. 
- Extended unit tests in the same file to cover embedded `# TODO`/`# FIXME` inside both double- and single-quoted strings while preserving existing comment detection behavior.

### Testing

- Ran `cargo xtask fmt` which completed successfully. 
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` which passed. 
- Ran `cargo test -p perl-ci-hygiene` where the new tests pass but the full crate test run reports one pre-existing unrelated failure (`checked_in_pre_push_hook_matches_generated_hook`) and so the package-level test suite returns a failing status unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e969265fc48333ab0ad53da8f9e39e)