### PR TITLE
test(parser-core): align paren recovery checks with recovery diagnostics (#4652)

### DIFF
--- a/crates/perl-parser-core/tests/cpan_test_helpers/mod.rs
+++ b/crates/perl-parser-core/tests/cpan_test_helpers/mod.rs
@@ -10,6 +10,15 @@ pub fn parse(source: &str) -> perl_parser_core::Node {
     must(parser.parse())
 }
 
+/// Parse the given source and return both the AST and any parser diagnostics.
+fn parse_with_diagnostics(source: &str) -> (Node, String, bool) {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let diagnostics = format!("{:?}", parser.get_errors());
+    let has_diagnostics = !parser.get_errors().is_empty();
+    (ast, diagnostics, has_diagnostics)
+}
+
 /// Walk the AST recursively and return the kind_name of the first error or
 /// missing node found, or `None` if the tree is clean.
 fn find_first_error(node: &Node) -> Option<&'static str> {
@@ -51,22 +60,32 @@ pub fn assert_clean_parse(source: &str) {
 /// This is the inverse of `assert_clean_parse` — it verifies that the parser
 /// correctly reports an error for malformed input.
 pub fn assert_has_error(source: &str, needle: &str) {
-    let ast = parse(source);
+    let (ast, diagnostics, has_diagnostics) = parse_with_diagnostics(source);
     let sexp = ast.to_sexp();
     let sexp_lower = sexp.to_lowercase();
     let needle_lower = needle.to_lowercase();
+    let diagnostics_lower = diagnostics.to_lowercase();
 
-    // First verify there IS an error node somewhere using AST walk.
+    // First verify there IS an error signal either in AST error nodes or
+    // parser diagnostics from recovery paths (e.g., inserted closers).
     let has_any_error = find_first_error(&ast).is_some();
-    assert!(has_any_error, "Expected an error node for source:\n{}\n\nsexp:\n{}", source, sexp,);
-
-    // Then verify the needle appears (case-insensitive) in the sexp.
     assert!(
-        sexp_lower.contains(&needle_lower),
-        "Expected error containing '{}' for source:\n{}\n\nsexp:\n{}",
+        has_any_error || has_diagnostics,
+        "Expected an error signal for source:\n{}\n\nsexp:\n{}\n\ndiagnostics:\n{}",
+        source,
+        sexp,
+        diagnostics,
+    );
+
+    // Then verify the needle appears (case-insensitive) in either AST output
+    // or parser diagnostics.
+    assert!(
+        sexp_lower.contains(&needle_lower) || diagnostics_lower.contains(&needle_lower),
+        "Expected error containing '{}' for source:\n{}\n\nsexp:\n{}\n\ndiagnostics:\n{}",
         needle,
         source,
         sexp,
+        diagnostics,
     );
 }
 

--- a/crates/perl-parser-core/tests/paren_recovery_tests.rs
+++ b/crates/perl-parser-core/tests/paren_recovery_tests.rs
@@ -10,20 +10,20 @@ use cpan_test_helpers::*;
 
 #[test]
 fn test_unclosed_paren_with_identifier_tail_produces_error() {
-    // Parser should report an error for the unexpected identifier inside parens.
-    assert_has_error("print($foo bar)", "expected");
+    // Perl allows filehandle-style print forms: print($fh EXPR).
+    assert_clean_parse("print($foo bar)");
 }
 
 #[test]
 fn test_unclosed_paren_at_eof_produces_error() {
     // Missing closing paren at end of input.
-    assert_has_error("my @x = (1, 2, 3", "expected");
+    assert_has_error("my @x = (1, 2, 3", "insertedcloser");
 }
 
 #[test]
 fn test_mixed_sigils_in_unclosed_paren_produces_error() {
     // Missing closing paren with mixed variable sigils.
-    assert_has_error("foo($x, @y, %z", "expected");
+    assert_has_error("foo($x, @y, %z", "insertedcloser");
 }
 
 // ── Clean cases: well-formed parenthesized expressions ─────────────────


### PR DESCRIPTION
### Motivation
- Some BDD-style paren-recovery tests expected explicit AST `Error` / `Missing*` nodes while the parser often recovers by inserting closers and records diagnostics instead. 
- Tests should assert on parser diagnostics as well as AST error nodes so recovery paths are treated as valid error signals. 

### Description
- Add a helper `parse_with_diagnostics` that returns the AST plus `Parser::get_errors()` diagnostics and a boolean flag. 
- Update `assert_has_error` to consider both AST error/missing nodes and parser diagnostics, and to search the provided `needle` in either the sexp or diagnostics. 
- Adjust `paren_recovery_tests` expectations: treat `print($foo bar)` as a clean parse and assert the missing-`)` cases for the `insertedcloser` recovery diagnostic instead of the previous generic message. 

### Testing
- Ran `cargo test -p perl-parser-core --test paren_recovery_tests -q`, which passed. 
- Ran `cargo test -p perl-parser-core --tests -q` and observed failures in the unrelated `parser_panic_mode_recovery` suite (pre-existing and not caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e969265fc48333ab0ad53da8f9e39e)