### PR TITLE
fix(ci-hygiene): ignore TODO tokens inside quoted hash strings (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3863,17 +3863,46 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
-    if let Some(idx) = line.find('#') {
-        if idx > 0 && line.as_bytes()[idx - 1] == b'!' {
-            return false;
+    let Some(idx) = find_hash_comment_start(line) else {
+        return false;
+    };
+    has_unlinked_token(&line[idx + 1..], token_re)
+}
+
+fn find_hash_comment_start(line: &str) -> Option<usize> {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    let mut in_single = false;
+    let mut in_double = false;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'\\' && (in_single || in_double) {
+            i += 2;
+            continue;
         }
-        if idx > 0 && !line[..idx].chars().next_back().is_some_and(char::is_whitespace) {
-            return false;
+        if b == b'\'' && !in_double {
+            in_single = !in_single;
+            i += 1;
+            continue;
         }
-        has_unlinked_token(&line[idx + 1..], token_re)
-    } else {
-        false
+        if b == b'"' && !in_single {
+            in_double = !in_double;
+            i += 1;
+            continue;
+        }
+        if b == b'#' && !in_single && !in_double {
+            if i > 0 && bytes[i - 1] == b'!' {
+                return None;
+            }
+            if i > 0 && !line[..i].chars().next_back().is_some_and(char::is_whitespace) {
+                i += 1;
+                continue;
+            }
+            return Some(i);
+        }
+        i += 1;
     }
+    None
 }
 
 fn is_url_like_hash_comment(line: &str, slash_idx: usize) -> bool {
@@ -4172,6 +4201,12 @@ mod tests {
 
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line("echo \"# TODO in string\"", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line("echo '# TODO in single string'", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo \"# TODO in string\" # TODO: follow up",
+            &todo_re
+        ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
 


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner for hash-comment files produced false positives when a `#` appeared inside quoted strings (e.g., `echo "# TODO in string"`).
- The goal is to only treat `#` as a comment start when it is actually outside single- or double-quoted string literals so we don't flag string contents as unlinked TODOs.

### Description
- Replaced the simple `line.find('#')` approach with a new helper `find_hash_comment_start` and updated `has_unlinked_todo_in_hash_line` to call it, where `find_hash_comment_start` scans bytes and tracks single/double-quote state and backslash escapes. 
- The new scanner still preserves existing shebang and inline-hash heuristics and rejects `#!` shebangs while ignoring `#` embedded in non-comment contexts. 
- Added regression coverage for double-quoted, single-quoted, and mixed cases that combine quoted `#` with a trailing real comment in `crates/perl-ci-hygiene/src/main.rs` tests.

### Testing
- Ran `cargo fmt -p perl-ci-hygiene` which completed successfully. 
- Ran `cargo test -p perl-ci-hygiene todo_detection -- --nocapture` and the targeted todo-detection tests passed. 
- Ran the full `cargo test -p perl-ci-hygiene` where all modified tests passed but an existing checked-in hook drift assertion (`checked_in_pre_push_hook_matches_generated_hook`) failed unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9691bc760833392c8cbdb038b7372)