### PR TITLE
fix(workspace-rename): apply target package on qualified renames (#4651)

### DIFF
--- a/crates/perl-refactoring/src/refactor/workspace_rename.rs
+++ b/crates/perl-refactoring/src/refactor/workspace_rename.rs
@@ -379,7 +379,7 @@ impl WorkspaceRename {
 
         // Extract the bare name and optional package qualifier from old_name
         let (old_package, old_bare) = split_qualified_name(old_name);
-        let (_new_package, new_bare) = split_qualified_name(new_name);
+        let (new_package, new_bare) = split_qualified_name(new_name);
 
         // AC:AC2 - Name conflict validation
         // Check if any symbol already exists with the new name
@@ -514,19 +514,13 @@ impl WorkspaceRename {
 
                     if in_scope {
                         // Also replace the package qualifier if it precedes the match
-                        let (edit_start, replacement) = if let Some(ref pkg) = scope_package {
-                            let prefix = format!("{}::", pkg);
-                            if match_start >= prefix.len()
-                                && text[match_start - prefix.len()..match_start] == *prefix
-                            {
-                                // Replace "Package::old_bare" with "Package::new_bare"
-                                (match_start - prefix.len(), format!("{}::{}", pkg, new_bare))
-                            } else {
-                                (match_start, new_bare.to_string())
-                            }
-                        } else {
-                            (match_start, new_bare.to_string())
-                        };
+                        let (edit_start, replacement) = build_replacement_text(
+                            text,
+                            match_start,
+                            &scope_package,
+                            new_package,
+                            new_bare,
+                        );
 
                         let (start_line, start_col) = line_index.offset_to_position(edit_start);
                         let (end_line, end_col) = line_index.offset_to_position(match_end);
@@ -813,6 +807,24 @@ impl WorkspaceRename {
     }
 }
 
+fn build_replacement_text(
+    text: &str,
+    match_start: usize,
+    scope_package: &Option<String>,
+    new_package: Option<&str>,
+    new_bare: &str,
+) -> (usize, String) {
+    if let Some(pkg) = scope_package {
+        let prefix = format!("{pkg}::");
+        if match_start >= prefix.len() && text[match_start - prefix.len()..match_start] == *prefix {
+            let target_package = new_package.unwrap_or(pkg.as_str());
+            return (match_start - prefix.len(), format!("{target_package}::{new_bare}"));
+        }
+    }
+
+    (match_start, new_bare.to_string())
+}
+
 /// Check if a byte is a valid Perl identifier character
 fn is_identifier_char(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_'
@@ -882,5 +894,38 @@ mod tests {
         assert_eq!(find_package_at_offset(text, 20), Some("Foo".to_string()));
         assert_eq!(find_package_at_offset(text, 45), Some("Bar".to_string()));
         assert_eq!(find_package_at_offset(text, 0), None);
+    }
+
+    #[test]
+    fn test_build_replacement_text_qualified_uses_new_package_when_provided() {
+        let text = "Old::process()";
+        let scope_package = Some("Old".to_string());
+        let (start, replacement) =
+            build_replacement_text(text, "Old::".len(), &scope_package, Some("New"), "execute");
+
+        assert_eq!(start, 0);
+        assert_eq!(replacement, "New::execute");
+    }
+
+    #[test]
+    fn test_build_replacement_text_qualified_keeps_old_package_when_new_is_unqualified() {
+        let text = "Old::process()";
+        let scope_package = Some("Old".to_string());
+        let (start, replacement) =
+            build_replacement_text(text, "Old::".len(), &scope_package, None, "execute");
+
+        assert_eq!(start, 0);
+        assert_eq!(replacement, "Old::execute");
+    }
+
+    #[test]
+    fn test_build_replacement_text_unqualified_replaces_bare_symbol_only() {
+        let text = "process()";
+        let scope_package = Some("Old".to_string());
+        let (start, replacement) =
+            build_replacement_text(text, 0, &scope_package, Some("New"), "execute");
+
+        assert_eq!(start, 0);
+        assert_eq!(replacement, "execute");
     }
 }


### PR DESCRIPTION
### Motivation
- Qualified rename operations were preserving the original package qualifier even when `new_name` specified a different package, resulting in incorrect replacement text for edits.
- The goal is to make workspace-wide renames honor the destination package when present and make replacement logic explicit and testable.

### Description
- Parse the `new_name` package component with `split_qualified_name` and thread the `new_package` into the replacement logic so a rename like `Old::foo` -> `New::bar` produces `New::bar`.
- Extracted inline replacement construction into a dedicated helper `build_replacement_text(text, match_start, &scope_package, new_package, new_bare)` and replaced the ad-hoc logic with calls to this helper.
- Updated the scope-aware replacement flow in `rename_symbol_impl` to call the helper when building `TextEdit` entries.
- Added focused unit tests for `build_replacement_text` to cover qualified renames to a new package, qualified renames with an unqualified target, and unqualified bare-symbol replacements.

### Testing
- Ran formatting with `cargo xtask fmt` which completed successfully.
- Ran unit tests with `cargo test -p perl-refactoring workspace_rename` and all relevant tests passed (`7 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9691bc760833392c8cbdb038b7372)