### PR TITLE
fix(ci-hygiene): sync single-crate hook package resolution (#4512)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -1984,8 +1984,12 @@ fi
 # Falls back to the full gate if classification is ambiguous.
 SINGLE_CRATE_COUNT="$(printf '%s' "$SINGLE_CRATE_NAMES" | grep -c . 2>/dev/null || echo 0)"
 if [ "$SINGLE_CRATE_ALL_UNDER_CRATES" = true ] && [ "$SINGLE_CRATE_COUNT" = "1" ]; then
-    SINGLE_CRATE_NAME="$(printf '%s' "$SINGLE_CRATE_NAMES" | tr -d '[:space:]')"
-    echo "Single-crate push (${SINGLE_CRATE_NAME}) — running targeted gate"
+    SINGLE_CRATE_DIR="$(printf '%s' "$SINGLE_CRATE_NAMES" | tr -d '[:space:]')"
+    # Resolve the Cargo package name from Cargo.toml, not the directory basename.
+    # This fixes the perl-lsp -> perl-lsp-rs mismatch (issue #4512).
+    # Falls back to directory name if cargo xtask is unavailable.
+    SINGLE_CRATE_NAME="$(cargo xtask resolve-package-name "crates/${SINGLE_CRATE_DIR}" 2>/dev/null || printf '%s' "$SINGLE_CRATE_DIR")"
+    echo "Single-crate push (${SINGLE_CRATE_DIR} -> ${SINGLE_CRATE_NAME}) — running targeted gate"
     echo "   (Skip with: git push --no-verify)"
     echo ""
     run_single_crate_gate() {


### PR DESCRIPTION
### Motivation
- The generated pre-push hook produced by the `perl-ci-hygiene` generator diverged from the checked-in `hooks/pre-push`, causing the single-crate gate to assume crate directory names equal Cargo package names and break targets like `crates/perl-lsp` (actual package `perl-lsp-rs`).
- The goal is to make generated hook output match the checked-in script and reliably target the correct Cargo package for per-crate `fmt/clippy/test` runs.

### Description
- Updated the generated hook template in `crates/perl-ci-hygiene/src/main.rs` to compute `SINGLE_CRATE_DIR` and resolve the package name via `cargo xtask resolve-package-name "crates/${SINGLE_CRATE_DIR}"` with a fallback to the directory name. 
- Changed the banner to print both the crate directory and resolved package name (`${SINGLE_CRATE_DIR} -> ${SINGLE_CRATE_NAME}`) for clearer diagnostics when the single-crate gate runs. 
- This mirrors the logic present in the checked-in `hooks/pre-push` and preserves correct targeted gate behavior for crates whose package name differs from their directory.

### Testing
- Ran `cargo test -p perl-ci-hygiene` and the full test suite for that package passed (`35 passed; 0 failed`).
- Ran code formatting with `cargo xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96919a58c8333883e2538091d8fde)