### PR TITLE
fix(ci-hygiene): keep generated pre-push hook aligned for package-name resolution (#4512)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -1984,8 +1984,12 @@ fi
 # Falls back to the full gate if classification is ambiguous.
 SINGLE_CRATE_COUNT="$(printf '%s' "$SINGLE_CRATE_NAMES" | grep -c . 2>/dev/null || echo 0)"
 if [ "$SINGLE_CRATE_ALL_UNDER_CRATES" = true ] && [ "$SINGLE_CRATE_COUNT" = "1" ]; then
-    SINGLE_CRATE_NAME="$(printf '%s' "$SINGLE_CRATE_NAMES" | tr -d '[:space:]')"
-    echo "Single-crate push (${SINGLE_CRATE_NAME}) — running targeted gate"
+    SINGLE_CRATE_DIR="$(printf '%s' "$SINGLE_CRATE_NAMES" | tr -d '[:space:]')"
+    # Resolve the Cargo package name from Cargo.toml, not the directory basename.
+    # This fixes the perl-lsp -> perl-lsp-rs mismatch (issue #4512).
+    # Falls back to directory name if cargo xtask is unavailable.
+    SINGLE_CRATE_NAME="$(cargo xtask resolve-package-name "crates/${SINGLE_CRATE_DIR}" 2>/dev/null || printf '%s' "$SINGLE_CRATE_DIR")"
+    echo "Single-crate push (${SINGLE_CRATE_DIR} -> ${SINGLE_CRATE_NAME}) — running targeted gate"
     echo "   (Skip with: git push --no-verify)"
     echo ""
     run_single_crate_gate() {


### PR DESCRIPTION
### Motivation
- Prevent generator drift between the checked-in `hooks/pre-push` and the hook produced by `pre_push_hook_script()` so the `checked_in_pre_push_hook_matches_generated_hook` test remains stable.
- Ensure the single-crate fast-path correctly handles cases where the Cargo package name differs from the crate directory (e.g., `crates/perl-lsp` -> `perl-lsp-rs`).

### Description
- Changed the single-crate branch in `pre_push_hook_script()` to derive `SINGLE_CRATE_DIR` and resolve the package name via `cargo xtask resolve-package-name "crates/${SINGLE_CRATE_DIR}"` with a fallback to the directory name.
- Updated the generated status message to include both the crate directory and the resolved package name (`${SINGLE_CRATE_DIR} -> ${SINGLE_CRATE_NAME}`) to match the checked-in hook semantics.
- Modified file: `crates/perl-ci-hygiene/src/main.rs`.

### Testing
- Ran `cargo test -p perl-ci-hygiene --quiet`, which passed (`35 passed; 0 failed`).
- Ran formatting via `cargo xtask fmt`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e969fcbd9483338d2e7a32a11d799c)