### PR TITLE
fix(ci-hygiene): sync generated pre-push hook package-name resolution (#4512)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -1984,8 +1984,12 @@ fi
 # Falls back to the full gate if classification is ambiguous.
 SINGLE_CRATE_COUNT="$(printf '%s' "$SINGLE_CRATE_NAMES" | grep -c . 2>/dev/null || echo 0)"
 if [ "$SINGLE_CRATE_ALL_UNDER_CRATES" = true ] && [ "$SINGLE_CRATE_COUNT" = "1" ]; then
-    SINGLE_CRATE_NAME="$(printf '%s' "$SINGLE_CRATE_NAMES" | tr -d '[:space:]')"
-    echo "Single-crate push (${SINGLE_CRATE_NAME}) — running targeted gate"
+    SINGLE_CRATE_DIR="$(printf '%s' "$SINGLE_CRATE_NAMES" | tr -d '[:space:]')"
+    # Resolve the Cargo package name from Cargo.toml, not the directory basename.
+    # This fixes the perl-lsp -> perl-lsp-rs mismatch (issue #4512).
+    # Falls back to directory name if cargo xtask is unavailable.
+    SINGLE_CRATE_NAME="$(cargo xtask resolve-package-name "crates/${SINGLE_CRATE_DIR}" 2>/dev/null || printf '%s' "$SINGLE_CRATE_DIR")"
+    echo "Single-crate push (${SINGLE_CRATE_DIR} -> ${SINGLE_CRATE_NAME}) — running targeted gate"
     echo "   (Skip with: git push --no-verify)"
     echo ""
     run_single_crate_gate() {


### PR DESCRIPTION
### Motivation
- A parity regression test was failing because the generated pre-push hook used the crate directory name instead of the Cargo package name, breaking the single-crate fast path for directories whose package name differs from the directory name (e.g. `crates/perl-lsp` -> `perl-lsp-rs`).

### Description
- Updated `pre_push_hook_script()` in `crates/perl-ci-hygiene/src/main.rs` to compute `SINGLE_CRATE_DIR` and resolve the real Cargo package name via `cargo xtask resolve-package-name "crates/${SINGLE_CRATE_DIR}"`, falling back to the directory name if resolution fails. 
- Adjusted the generated hook status message to display the directory-to-package mapping (`${SINGLE_CRATE_DIR} -> ${SINGLE_CRATE_NAME}`) to match the checked-in `hooks/pre-push` behavior and preserve the intended single-crate gate semantics.
- Change is scoped to the generated hook string; no runtime behavior outside of the generated pre-push content was modified.

### Testing
- Ran `cargo test -p perl-ci-hygiene tests::checked_in_pre_push_hook_matches_generated_hook --quiet` and it passed. 
- Ran the full crate test suite with `cargo test -p perl-ci-hygiene --quiet` and all tests passed. 
- Formatted with `cargo fmt -p perl-ci-hygiene` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e969fe3c9c83339011b5c42be811a6)