### PR TITLE
fix(workspace-index): include qualified refs in bare lookups (#4671)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -1891,6 +1891,27 @@ impl WorkspaceIndex {
                     }
                 }
             }
+        } else {
+            // If the symbol is bare, also collect qualified references that end
+            // with the same bare name, e.g. `Pkg::foo` when searching for `foo`.
+            for (name, refs) in global_refs.iter() {
+                if !Self::is_qualified_variant_of(name, symbol_name) {
+                    continue;
+                }
+
+                for loc in refs {
+                    let key = (
+                        loc.uri.clone(),
+                        loc.range.start.line,
+                        loc.range.start.column,
+                        loc.range.end.line,
+                        loc.range.end.column,
+                    );
+                    if seen.insert(key) {
+                        locations.push(Location { uri: loc.uri.clone(), range: loc.range });
+                    }
+                }
+            }
         }
 
         locations
@@ -1931,10 +1952,30 @@ impl WorkspaceIndex {
                         ));
                     }
                 }
+            } else {
+                for (name, refs) in &file_index.references {
+                    if !Self::is_qualified_variant_of(name, symbol_name) {
+                        continue;
+                    }
+
+                    for r in refs.iter().filter(|r| r.kind != ReferenceKind::Definition) {
+                        seen.insert((
+                            r.uri.clone(),
+                            r.range.start.line,
+                            r.range.start.column,
+                            r.range.end.line,
+                            r.range.end.column,
+                        ));
+                    }
+                }
             }
         }
 
         seen.len()
+    }
+
+    fn is_qualified_variant_of(candidate: &str, bare_symbol: &str) -> bool {
+        candidate.rsplit_once("::").is_some_and(|(_, candidate_bare)| candidate_bare == bare_symbol)
     }
 
     /// Find the definition of a symbol
@@ -3596,6 +3637,56 @@ sub test {
 
         let refs = index.find_references("$x");
         assert!(refs.len() >= 2); // Definition + at least one usage
+    }
+
+    #[test]
+    fn test_find_references_bare_name_includes_qualified_calls() {
+        let index = WorkspaceIndex::new();
+        let uri = "file:///refs.pl";
+        let code = r#"
+package RefDemo;
+sub helper {
+    return 1;
+}
+
+helper();
+RefDemo::helper();
+"#;
+
+        must(index.index_file(must(url::Url::parse(uri)), code.to_string()));
+
+        let bare_refs = index.find_references("helper");
+        let qualified_refs = index.find_references("RefDemo::helper");
+
+        assert!(
+            bare_refs.len() >= qualified_refs.len(),
+            "bare-name reference lookup should include qualified calls"
+        );
+    }
+
+    #[test]
+    fn test_count_usages_bare_name_includes_qualified_calls() {
+        let index = WorkspaceIndex::new();
+        let uri = "file:///usage.pl";
+        let code = r#"
+package UsageDemo;
+sub helper {
+    return 1;
+}
+
+helper();
+UsageDemo::helper();
+"#;
+
+        must(index.index_file(must(url::Url::parse(uri)), code.to_string()));
+
+        let bare_usage_count = index.count_usages("helper");
+        let qualified_usage_count = index.count_usages("UsageDemo::helper");
+
+        assert!(
+            bare_usage_count >= qualified_usage_count,
+            "bare-name usage count should include qualified call sites"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Bare-name lookups (e.g. `helper`) did not account for qualified call sites (e.g. `Pkg::helper`), causing undercounted or missing reference/usage results in mixed codebases.
- The workspace index should provide symmetric dual-index behavior so bare and qualified queries return consistent sets of locations.

### Description
- Extend `WorkspaceIndex::find_references` to, when given a bare symbol, also collect qualified reference keys whose suffix matches the bare name while preserving deduplication. 
- Mirror the same behavior in `WorkspaceIndex::count_usages` so usage counts include qualified call sites for bare-name queries.
- Add helper `is_qualified_variant_of` to detect qualified-key suffix matches and two focused unit tests (`test_find_references_bare_name_includes_qualified_calls` and `test_count_usages_bare_name_includes_qualified_calls`) validating the new behavior.
- Ran `cargo xtask fmt` to apply formatting and committed the changes.

### Testing
- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran `cargo test -p perl-workspace test_find_references_bare_name_includes_qualified_calls` and the test passed.
- Ran `cargo test -p perl-workspace test_count_usages_bare_name_includes_qualified_calls` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e969fe3c9c83339011b5c42be811a6)