### PR TITLE
fix(parser): detect all tied-handle heredoc writes (#4673)

### DIFF
--- a/crates/perl-parser/src/heredoc_anti_patterns.rs
+++ b/crates/perl-parser/src/heredoc_anti_patterns.rs
@@ -394,23 +394,23 @@ impl PatternDetector for TiedHandleDetector {
 
             // Look for usage of this handle with heredoc
             let usage_pattern = format!(r"print\s+{}\s+<<", regex::escape(handle_to_search));
-            if let Ok(re) = Regex::new(&usage_pattern)
-                && let Some(usage_match) = re.find(code)
-            {
-                let location = Location {
-                    line: code[..usage_match.start()].lines().count(),
-                    column: usage_match.start()
-                        - code[..usage_match.start()].rfind('\n').unwrap_or(0),
-                    offset: offset + usage_match.start(),
-                };
+            if let Ok(re) = Regex::new(&usage_pattern) {
+                for usage_match in re.find_iter(code) {
+                    let location = Location {
+                        line: code[..usage_match.start()].lines().count(),
+                        column: usage_match.start()
+                            - code[..usage_match.start()].rfind('\n').unwrap_or(0),
+                        offset: offset + usage_match.start(),
+                    };
 
-                results.push((
-                    AntiPattern::TiedHandleHeredoc {
-                        location: location.clone(),
-                        handle_name: handle_to_search.to_string(),
-                    },
-                    location,
-                ));
+                    results.push((
+                        AntiPattern::TiedHandleHeredoc {
+                            location: location.clone(),
+                            handle_name: handle_to_search.to_string(),
+                        },
+                        location,
+                    ));
+                }
             }
         }
 
@@ -659,5 +659,26 @@ DATA
         let diagnostics = detector.detect_all(code);
         assert_eq!(diagnostics.len(), 1);
         assert!(matches!(diagnostics[0].pattern, AntiPattern::TiedHandleHeredoc { .. }));
+    }
+
+    #[test]
+    fn test_tied_handle_reports_multiple_writes() {
+        let detector = AntiPatternDetector::new();
+        let code = r###"
+tie *FH, 'Tie::Handle';
+print FH <<'FIRST';
+One
+FIRST
+print FH <<'SECOND';
+Two
+SECOND
+"###;
+
+        let diagnostics = detector.detect_all(code);
+        let tied_handle_count = diagnostics
+            .iter()
+            .filter(|diag| matches!(diag.pattern, AntiPattern::TiedHandleHeredoc { .. }))
+            .count();
+        assert_eq!(tied_handle_count, 2);
     }
 }


### PR DESCRIPTION
### Motivation
- The `TiedHandleDetector` previously reported only the first `print <handle> <<` occurrence for a tied handle which under-reports multiple heredoc writes to the same tied handle.
- We need reliable diagnostics for each heredoc write so static analysis and tooling surface all risky writes to tied handles.

### Description
- Change `TiedHandleDetector::detect` in `crates/perl-parser/src/heredoc_anti_patterns.rs` to iterate matches with `Regex::find_iter` instead of using a single `find` so every `print <handle> <<` occurrence is reported.
- Add a regression test `test_tied_handle_reports_multiple_writes` that ties a handle and emits two heredocs, asserting both diagnostics are produced.

### Testing
- Ran formatting with `cargo xtask fmt` which completed successfully.
- Ran targeted tests with `cargo test -p perl-parser heredoc_anti_patterns` and all related tests passed (new test included).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e969ffb010833393f06a7cbe8ad342)