### PR TITLE
fix(ci-hygiene): improve hash TODO scanning after quoted literals (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3863,17 +3863,54 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
-    if let Some(idx) = line.find('#') {
-        if idx > 0 && line.as_bytes()[idx - 1] == b'!' {
-            return false;
+    for (idx, _) in line.match_indices('#') {
+        if !is_hash_comment_start(line, idx) {
+            continue;
         }
-        if idx > 0 && !line[..idx].chars().next_back().is_some_and(char::is_whitespace) {
-            return false;
+        if has_unlinked_token(&line[idx + 1..], token_re) {
+            return true;
         }
-        has_unlinked_token(&line[idx + 1..], token_re)
-    } else {
-        false
     }
+    false
+}
+
+fn is_hash_comment_start(line: &str, idx: usize) -> bool {
+    if idx > 0 && line.as_bytes()[idx - 1] == b'!' {
+        return false;
+    }
+    if idx > 0 && !line[..idx].chars().next_back().is_some_and(char::is_whitespace) {
+        return false;
+    }
+    !is_inside_simple_quote_context(line, idx)
+}
+
+fn is_inside_simple_quote_context(line: &str, idx: usize) -> bool {
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    for (byte_idx, ch) in line.char_indices() {
+        if byte_idx >= idx {
+            break;
+        }
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' && !in_single {
+            escaped = true;
+            continue;
+        }
+        if ch == '\'' && !in_double {
+            in_single = !in_single;
+            continue;
+        }
+        if ch == '"' && !in_single {
+            in_double = !in_double;
+        }
+    }
+
+    in_single || in_double
 }
 
 fn is_url_like_hash_comment(line: &str, slash_idx: usize) -> bool {
@@ -4174,6 +4211,14 @@ mod tests {
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo '# TODO inside string' # TODO: follow up",
+            &todo_re
+        ));
+        assert!(!has_unlinked_todo_in_hash_line(
+            "echo \"# TODO in string\" # TODO(#77): tracked",
+            &todo_re
+        ));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation

- The TODO/FIXME scanner treated only the first `#` on a line as a potential comment, which missed real unlinked TODOs when an earlier `#` occurred inside a quoted literal. This produced false negatives in hygiene checks for shell/Perl-like files.

### Description

- Updated `has_unlinked_todo_in_hash_line` to iterate all `#` occurrences on a line and consider each as a potential comment start instead of short-circuiting on the first `#` (`crates/perl-ci-hygiene/src/main.rs`).
- Added `is_hash_comment_start` to encapsulate shebang/inline rules and whitespace checks before a `#` is treated as a comment start.
- Added `is_inside_simple_quote_context` to avoid treating `#` characters that appear inside single- or double-quoted literals as comment starts while still allowing later real comments on the same line.
- Extended unit coverage with tests asserting behavior when the first `#` is inside quotes and a trailing `#` introduces the actual comment.

### Testing

- Ran the targeted test: `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and it passed.
- Ran formatting: `cargo fmt -p perl-ci-hygiene` and it succeeded.
- Ran the full crate test suite: `cargo test -p perl-ci-hygiene` which ran and showed the change's tests passing, but the suite failed on a pre-existing hook-sync test (`checked_in_pre_push_hook_matches_generated_hook`) unrelated to this change (test indicates checked-in hooks file drift).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e969ffb010833393f06a7cbe8ad342)