### PR TITLE
fix(perl-module): restore package declaration rewrite in plan_module_rename_edits (#4594)

### DIFF
--- a/crates/perl-module/src/rename/mod.rs
+++ b/crates/perl-module/src/rename/mod.rs
@@ -31,6 +31,7 @@ pub struct ModuleLineEdit {
 /// - `use base qw(Module::Name Other);`
 ///
 /// Also rewrites:
+/// - Package declarations: `package Module::Name;` → `package NewName;`
 /// - Qualified function calls: `Module::Name::func()` → `NewName::func()`
 /// - Static method calls: `Module::Name->method()` → `NewName->method()`
 /// - `@ISA` array assignments
@@ -88,6 +89,18 @@ pub fn plan_module_rename_edits(
                     let candidate =
                         replace_module_name_prefix(current_line, old_variant, new_variant);
                     if candidate != current_line {
+                        rewritten = Some(candidate);
+                    }
+                }
+            }
+
+            // Check package declarations
+            {
+                let current_line = rewritten.as_deref().unwrap_or(line);
+                if line_references_package_declaration(current_line, old_variant) {
+                    let (candidate, changed) =
+                        replace_module_token(current_line, old_variant, new_variant);
+                    if changed {
                         rewritten = Some(candidate);
                     }
                 }

--- a/crates/perl-module/tests/module_rename_bdd.rs
+++ b/crates/perl-module/tests/module_rename_bdd.rs
@@ -22,14 +22,17 @@ fn given_parent_and_base_statements_when_module_is_renamed_then_all_references_a
 }
 
 #[test]
-fn given_non_import_lines_when_module_is_renamed_then_source_is_unchanged() {
+fn given_package_declaration_when_module_is_renamed_then_declaration_is_rewritten() {
+    // package declarations in the target file are rewritten (restored in #4594)
     let source = "package My::Module;\nmy $s = 'My::Module';\n";
 
     let edits = plan_module_rename_edits(source, "My::Module", "My::Renamed");
     let rewritten = apply_module_rename_edits(source, &edits);
 
-    assert!(edits.is_empty());
-    assert_eq!(rewritten, source);
+    // The package declaration line should be rewritten; the string literal line should not
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].line, 0);
+    assert_eq!(rewritten, "package My::Renamed;\nmy $s = 'My::Module';\n");
 }
 
 #[test]

--- a/crates/perl-module/tests/rename_comprehensive_unit_tests.rs
+++ b/crates/perl-module/tests/rename_comprehensive_unit_tests.rs
@@ -565,3 +565,23 @@ fn plan_rename_deep_to_shallow() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(edits[0].new_text, "use Foo;");
     Ok(())
 }
+
+// ──────────────────────────────────────────────────────────────
+// Regression: package declaration rewrite (restored in #4594, broken by #4554)
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_rename_rewrites_package_declaration_in_target_file()
+-> Result<(), Box<dyn std::error::Error>> {
+    // The target file's own `package` declaration must be rewritten when renaming.
+    let source = "package Old::Name;\n\nsub new { bless {}, shift }\n";
+    let edits = plan_module_rename_edits(source, "Old::Name", "New::Name");
+    assert_eq!(edits.len(), 1, "expected exactly one edit for the package declaration line");
+    assert_eq!(edits[0].line, 0, "edit should be on line 0 (the package declaration)");
+    assert_eq!(edits[0].new_text, "package New::Name;");
+
+    // Also verify roundtrip via apply
+    let result = apply_module_rename_edits(source, &edits);
+    assert!(result.starts_with("package New::Name;"));
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Restores the `// Check package declarations` block in `plan_module_rename_edits` that was accidentally removed by PR #4554. The deleted block was responsible for rewriting `package Old::Name;` declarations in the target file when performing a module rename — a distinct and independent feature from the false-positive fix that #4554 was addressing.

- Restored the `// Check package declarations` block inside the per-variant loop in `plan_module_rename_edits` (uses existing `line_references_package_declaration` + `replace_module_token` helpers, chaining via the `rewritten` variable)
- Restored the docstring bullet: `- Package declarations: \`package Module::Name;\` → \`package NewName;\``
- Updated the BDD test `given_non_import_lines_when_module_is_renamed_then_source_is_unchanged` in `module_rename_bdd.rs` which was asserting the regressed (broken) behavior — it now correctly asserts that the `package` line IS rewritten and string literal lines are NOT
- Added regression test `test_rename_rewrites_package_declaration_in_target_file` in `rename_comprehensive_unit_tests.rs`

Fixes #4594. Regression introduced by #4554.

## Test plan

- [x] `cargo test -p perl-module` — 902 tests pass (all suites)
- [x] `cargo xtask fmt` — clean
- [x] `cargo clippy -p perl-module --tests` — 0 errors, 0 new warnings (pre-existing warning in unrelated file)
- [x] Only 3 files changed: `src/rename/mod.rs`, `tests/module_rename_bdd.rs`, `tests/rename_comprehensive_unit_tests.rs`