### PR TITLE
ci: run full merge-gate on every PR (#4675)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 # Tiered CI for perl-lsp (see tests/TAXONOMY.md)
 # - PR smoke: fast feedback on every push (~1-2 min)
-# - Merge gate: full validation on merge-ready label or merge (~5-10 min)
-# Cost: ~$0.03 per PR (smoke), ~$0.05 on merge gate
+# - Merge gate: full validation on every PR push and push to main (~5-10 min)
+# Cost: ~$0.05 per PR (smoke + merge gate; see #4675 for rationale)
 
 on:
   pull_request:
@@ -75,17 +75,15 @@ jobs:
           just clippy-core
           just test-core
 
-  # ── Merge Gate: full validation (label-gated or push to main) ────────
+  # ── Merge Gate: full validation on every PR and push to main ─────────
   merge-gate:
     name: CI Gate (Merge-Blocking)
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: pr-smoke
-    # Run on: merge-ready label, push to main/master, or workflow_dispatch
-    if: >-
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'merge-ready'))
+    # Run on every PR push and on push to main/master
+    # Earlier gating > label-gated gating (see #4675)
+    # Frequent commits will churn CI; concurrency group cancels in-flight runs.
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

- Drops the `merge-ready` label gate on the `merge-gate` job so the full CI Gate (Merge-Blocking) runs on every PR `synchronize` event, not only after labeling.
- Today's PR smoke only covers `perl-parser` + `perl-lexer` via `just clippy-core` + `just test-core`. Deeper verification was deferred until the `merge-ready` label was applied — too late in the lifecycle.
- The concurrency group (`ci-${{ github.ref }}`) already cancels in-flight runs on rapid pushes, so churn is bounded.

## Changes (3 lines in `ci.yml`)

- Removed the `if:` condition that gated `merge-gate` on `contains(labels, 'merge-ready')`.
- Updated the top-level comment block and the section header to reflect that the gate now runs on every PR.
- No changes to the job body itself (same `just gates` steps).

## Other `merge-ready` references

- `pipeline-labels.yml` still uses `merge-ready` for label management — untouched (separate concern).
- No other jobs in `ci.yml` were gated on `merge-ready`.

## Test plan

- [ ] Open any PR and push a commit — verify `CI Gate (Merge-Blocking)` triggers without needing the `merge-ready` label.
- [ ] Verify YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` (done locally — valid).