### PR TITLE
chore(deps): bump rustls-webpki for RUSTSEC-2026-0104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Bumps the transitive dependency `rustls-webpki` from `0.103.12` to `0.103.13` to resolve a security advisory.

- **Advisory:** https://rustsec.org/advisories/RUSTSEC-2026-0104
- **Title:** Reachable panic in certificate revocation list (CRL) parsing
- **Severity:** Denial-of-service
- **Patched versions:** `>=0.103.13, <0.104.0-alpha.1` or `>=0.104.0-alpha.7`

## Change

`Cargo.lock` only — this is a transitive dependency bump. No `Cargo.toml` changes were required; `cargo update -p rustls-webpki --precise 0.103.13` resolved cleanly.

## Verification

- `cargo check --workspace --locked` — clean, all 268 crates compiled
- `grep 'rustls-webpki'` in `Cargo.lock` confirms `version = "0.103.13"`
- Stays on `0.103.x` to minimize risk (does not bump to `0.104.x`)

This should unblock both `Cargo Audit (RustSec)` and `Cargo Deny (Policy Enforcement)` CI checks on master.