### PR TITLE
fix(ci-hygiene): detect case-insensitive TODO/FIXME markers (#4707)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3384,7 +3384,7 @@ fn cmd_check_todos(repo_root: &Path, list_mode: bool) -> Result<i32> {
             .join("complex_paren_args_tests.rs"),
     ];
 
-    let todo_re = Regex::new(r"TODO|FIXME")?;
+    let todo_re = Regex::new(r"(?i)\b(?:todo|fixme)\b")?;
     let entries = collect_todo_hits(repo_root, &exclude_dirs, &exclude_files, &todo_re)?;
 
     if list_mode {
@@ -4281,10 +4281,13 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_linked_or_url_like_comments() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"(?i)\b(?:todo|fixme)\b")?;
 
         assert!(has_unlinked_todo_in_rust_line("// TODO: investigate", &todo_re));
+        assert!(has_unlinked_todo_in_rust_line("// todo: investigate", &todo_re));
+        assert!(has_unlinked_todo_in_rust_line("// FiXmE: investigate", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line("// TODO(#123): tracked", &todo_re));
+        assert!(!has_unlinked_todo_in_rust_line("// todo(#123): tracked", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line("let u = \"http://TODO\";", &todo_re));
         assert!(has_unlinked_todo_in_rust_line(
             "let u = \"http://TODO\"; // TODO: investigate",
@@ -4297,7 +4300,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_raw_string_comment_markers() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"(?i)\b(?:todo|fixme)\b")?;
 
         assert!(!has_unlinked_todo_in_rust_line("let s = r#\"// TODO in literal\"#;", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line(
@@ -4310,7 +4313,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_non_raw_string_comment_markers() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"(?i)\b(?:todo|fixme)\b")?;
 
         assert!(!has_unlinked_todo_in_rust_line(
             "let s = \"not a comment // TODO in literal\";",
@@ -4330,11 +4333,12 @@ mod tests {
 
     #[test]
     fn hash_comment_todo_detection_handles_shebang_and_inline_hashes() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"(?i)\b(?:todo|fixme)\b")?;
 
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi;# TODO: follow up", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line("echo hi;# fixme: follow up", &todo_re));
         assert!(has_unlinked_todo_in_hash_line(
             "echo \"#not-a-comment\" # TODO: follow up",
             &todo_re,


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner only matched uppercase tokens, allowing lowercase/mixed-case `todo`/`fixme` markers to bypass the unlinked-TODO gate.
- The baseline TODO audit must reliably detect unlinked markers regardless of casing to avoid unnoticed policy regressions.

### Description
- Updated token matching to use a case-insensitive, word-bounded regex `(?i)\b(?:todo|fixme)\b` in `crates/perl-ci-hygiene/src/main.rs` so `todo`/`fixme` in any case are detected.
- Extended unit tests in the same file to assert lowercase and mixed-case variants are detected and that linked markers like `todo(#123)` remain treated as linked.
- Added a hash-style comment test for lowercase `fixme` to improve coverage of non-Rust comment parsing.

### Testing
- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran `cargo test -p perl-ci-hygiene todo_detection` and the targeted tests passed (`4 passed; 0 failed`).
- Confirmed the updated tests exercise both Rust-line and hash-style comment detection and pass under the new regex.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7e24508333b3bacecdee6ec4f5)