### PR TITLE
fix(performance): normalize incremental parser node spans (#4707)

### DIFF
--- a/crates/perl-lsp-rs-core/src/performance/mod.rs
+++ b/crates/perl-lsp-rs-core/src/performance/mod.rs
@@ -141,6 +141,16 @@ impl IncrementalParser {
     ///
     /// Returns true if the node overlaps with any changed region.
     pub fn needs_reparse(&self, node_start: usize, node_end: usize) -> bool {
+        let (node_start, node_end) =
+            if node_start <= node_end { (node_start, node_end) } else { (node_end, node_start) };
+
+        if node_start == node_end {
+            return self
+                .changed_regions
+                .iter()
+                .any(|(start, end)| node_start >= *start && node_start < *end);
+        }
+
         self.changed_regions.iter().any(|(start, end)| node_start < *end && node_end > *start)
     }
 

--- a/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
+++ b/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
@@ -58,6 +58,24 @@ fn incremental_parser_given_zero_width_change_when_marked_then_no_nodes_require_
 }
 
 #[test]
+fn incremental_parser_given_reversed_node_range_when_checked_then_overlap_is_detected() {
+    let mut parser = IncrementalParser::new();
+    parser.mark_changed(10, 20);
+
+    assert!(parser.needs_reparse(18, 12));
+    assert!(!parser.needs_reparse(9, 0));
+}
+
+#[test]
+fn incremental_parser_given_point_query_inside_change_when_checked_then_reparse_is_required() {
+    let mut parser = IncrementalParser::new();
+    parser.mark_changed(30, 40);
+
+    assert!(parser.needs_reparse(35, 35));
+    assert!(!parser.needs_reparse(40, 40));
+}
+
+#[test]
 fn parallel_given_zero_workers_when_processing_then_all_files_are_still_processed() {
     let files = vec!["a.pm".to_string(), "b.pm".to_string(), "c.pm".to_string()];
 


### PR DESCRIPTION
### Motivation
- Prevent callers from missing overlap detection when passing node ranges in reverse order by normalizing input spans in `IncrementalParser::needs_reparse`.
- Ensure zero-width point queries (cursor/position checks) inside a changed region correctly indicate a reparse is required while preserving end-boundary exclusivity.
- Lock the intended behavior into the BDD grid with focused regression tests for the performance module.

### Description
- Normalize `node_start`/`node_end` in `IncrementalParser::needs_reparse` so reversed ranges are handled correctly in `crates/perl-lsp-rs-core/src/performance/mod.rs`.
- Add explicit handling for zero-width point queries in `needs_reparse` to treat positions inside a changed region as requiring reparse while keeping the region end exclusive.
- Add two regression tests to `crates/perl-lsp-rs-core/tests/performance_module_shape.rs` covering reversed node ranges and point queries at interior/boundary positions.

### Testing
- Ran `cargo xtask fmt` and the formatter completed successfully.
- Ran `cargo test -p perl-lsp-rs-core --test performance_module_shape` and all tests passed (`11 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7e24508333b3bacecdee6ec4f5)