### PR TITLE
fix(semantic-analyzer): resolve strict hash-slice sigil bridging (#4707)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1352,6 +1352,17 @@ impl ScopeAnalyzer {
             }
         }
 
+        // Hash slice syntax (`@hash{...}`) reads from `%hash`, not a lexical `@hash`.
+        // Bridge this so strict-vars and usage tracking resolve against the declared hash.
+        if sigil == "@"
+            && let Some(parent) = ancestors.last()
+            && let NodeKind::Binary { op, left, .. } = &parent.kind
+            && op == "{}"
+            && std::ptr::eq(left.as_ref(), node)
+        {
+            return Some(("%", name));
+        }
+
         // When the parser interprets `print $arr[0]` as indirect-object syntax, it produces
         // `IndirectCall { object: Variable($, "arr"), args: [ArrayLiteral([0])] }`.
         // Similarly, `print $hash{a}` produces

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1758,6 +1758,24 @@ print $unknown_var;
 }
 
 #[test]
+fn strict_hash_slice_marks_declared_hash_as_used() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+my %h = (key1 => 1, key2 => 2);
+my @values = @h{qw(key1 key2)};
+print scalar @values;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "h"),
+        "@h{{...}} should resolve through declared %h under strict; issues: {:?}",
+        issues.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
 fn strict_vars_only_checks_undeclared_variables() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'vars';


### PR DESCRIPTION
### Motivation
- Hash-slice reads like `@hash{...}` are semantically accesses of the underlying hash (`%hash`), but the scope analyzer treated them as uses of an `@hash` lexical, causing false `undeclared-variable` diagnostics under `use strict`.
- This produced noisy and incorrect diagnostics in editor workflows that rely on the analyzer for real-time checks.
- The change aligns scope-use resolution with Perl semantics to reduce false positives.

### Description
- Map hash-slice syntax to the hash sigil by returning `Some(("%", name))` for `@name{...}` in `resolve_variable_use_target` in `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs`.
- Add a regression test `strict_hash_slice_marks_declared_hash_as_used` to `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` verifying a declared `%h` is not flagged when accessed via `@h{...}` under `use strict`.
- Preserve existing dereference and indirect-call sigil-bridging behavior while adding the targeted hash-slice bridge.

### Testing
- Ran formatting with `cargo xtask fmt` which completed successfully.
- Ran the focused test `cargo test -p perl-semantic-analyzer strict_hash_slice_marks_declared_hash_as_used -- --exact` which passed after fixing an initial format-string escape in the test assertion.
- Ran the suite pattern `cargo test -p perl-semantic-analyzer hash_slice --test scope_and_symbol_tests` which passed (the new regression test ran and succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7e24508333b3bacecdee6ec4f5)