### PR TITLE
fix(ci-hygiene): ignore TODO markers inside backtick literals (#4707)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3882,6 +3882,7 @@ fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
 fn find_hash_comment_start(line: &str) -> Option<usize> {
     let mut in_single = false;
     let mut in_double = false;
+    let mut in_backtick = false;
     let mut prev_was_escape = false;
 
     for (idx, ch) in line.char_indices() {
@@ -3905,10 +3906,25 @@ fn find_hash_comment_start(line: &str) -> Option<usize> {
             }
             continue;
         }
+        if in_backtick {
+            if prev_was_escape {
+                prev_was_escape = false;
+                continue;
+            }
+            if ch == '\\' {
+                prev_was_escape = true;
+                continue;
+            }
+            if ch == '`' {
+                in_backtick = false;
+            }
+            continue;
+        }
 
         match ch {
             '\'' => in_single = true,
             '"' => in_double = true,
+            '`' => in_backtick = true,
             '#' => {
                 if idx == 0 && line.as_bytes().get(1) == Some(&b'!') {
                     return None;
@@ -4346,6 +4362,11 @@ mod tests {
         ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line("echo `printf '# TODO in backticks'`", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo `printf '# TODO in backticks'` # TODO: follow up",
+            &todo_re
+        ));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner for hash-commented files was producing false positives when `#` appeared inside backtick-delimited command substitutions (e.g., shell/Perl snippets). 
- Ignoring `#` tokens inside backtick literals prevents spurious TODO detections in common command-substitution patterns while preserving real comment detection. 

### Description
- Teach `find_hash_comment_start` to track backtick-delimited literals by adding an `in_backtick` state and handling escapes inside backticks. 
- Ensure backtick-literal `#` characters are skipped so `has_unlinked_todo_in_hash_line` only treats real comments as comment starts. 
- Add regression assertions to `hash_comment_todo_detection_handles_shebang_and_inline_hashes` that verify TODOs inside backticks are ignored and that trailing real comments are still detected. 
- Changes are implemented in `crates/perl-ci-hygiene/src/main.rs`. 

### Testing
- Ran `cargo xtask fmt` to format the workspace, which completed successfully. 
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes`, which passed. 
- Ran `cargo test -p perl-ci-hygiene rust_todo_detection_ignores_non_raw_string_comment_markers`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7ec2e483338e70048e0bc99ce9)