### PR TITLE
fix(ci-hygiene): detect inline Perl TODO comments (#4707)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3827,6 +3827,11 @@ fn collect_todo_hits(
         for (line_no, line) in contents.iter().enumerate() {
             let match_line = if is_rust {
                 has_unlinked_todo_in_rust_line(line, todo_re)
+            } else if path
+                .extension()
+                .is_some_and(|ext| matches!(ext.to_str(), Some("pl" | "pm" | "t")))
+            {
+                has_unlinked_todo_in_perl_line(line, todo_re)
             } else {
                 has_unlinked_todo_in_hash_line(line, todo_re)
             };
@@ -3873,13 +3878,20 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
-    let Some(idx) = find_hash_comment_start(line) else {
+    let Some(idx) = find_hash_comment_start(line, false) else {
         return false;
     };
     has_unlinked_token(&line[idx + 1..], token_re)
 }
 
-fn find_hash_comment_start(line: &str) -> Option<usize> {
+fn has_unlinked_todo_in_perl_line(line: &str, token_re: &Regex) -> bool {
+    let Some(idx) = find_hash_comment_start(line, true) else {
+        return false;
+    };
+    has_unlinked_token(&line[idx + 1..], token_re)
+}
+
+fn find_hash_comment_start(line: &str, perl_mode: bool) -> Option<usize> {
     let mut in_single = false;
     let mut in_double = false;
     let mut prev_was_escape = false;
@@ -3914,6 +3926,9 @@ fn find_hash_comment_start(line: &str) -> Option<usize> {
                     return None;
                 }
                 if idx == 0 {
+                    return Some(idx);
+                }
+                if perl_mode {
                     return Some(idx);
                 }
                 if let Some(prev) = line[..idx].chars().next_back() {
@@ -4350,6 +4365,16 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn perl_todo_detection_allows_comment_start_without_whitespace() -> Result<()> {
+        let todo_re = Regex::new(r"TODO|FIXME")?;
+
+        assert!(has_unlinked_todo_in_perl_line("print# TODO: perl comment", &todo_re));
+        assert!(!has_unlinked_todo_in_perl_line("my $s = '# TODO in string';", &todo_re));
+        assert!(!has_unlinked_todo_in_perl_line("print# TODO(#123): tracked", &todo_re));
+
+        Ok(())
+    }
     #[test]
     fn home_path_detection_only_allows_generic_user_examples() -> Result<()> {
         let home_user_path = Regex::new(r"/home/([A-Za-z0-9._-]+)")?;


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner treated all hash-style files with a shell-like heuristic which missed inline Perl comments such as `print# TODO: ...` in `.pl`, `.pm`, and `.t` files.

### Description
- Route files with extensions `.pl`, `.pm`, and `.t` through a Perl-aware scanning path inside `collect_todo_hits` so they are evaluated with Perl semantics.
- Add `has_unlinked_todo_in_perl_line` and extend the hash-comment parser to accept a `perl_mode` flag that treats `#` as a comment start even when it directly follows code.
- Preserve existing behavior for shell/other hash-style files by continuing to use the stricter `has_unlinked_todo_in_hash_line` path for non-Perl hash files.
- Add a unit test that verifies `print# TODO: ...` is detected while TODOs inside Perl string literals and linked TODO markers remain ignored.

### Testing
- Ran formatting with `cargo xtask fmt` which completed successfully.
- Ran the perl-ci-hygiene unit tests for TODO detection with `cargo test -p perl-ci-hygiene todo_detection -- --nocapture` and the suite passed (5 tests passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7ec2e483338e70048e0bc99ce9)