### PR TITLE
fix(ci-hygiene): handle C-string TODO parsing edge cases (#4707)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3991,22 +3991,28 @@ fn is_index_in_rust_literal(line: &str, target_idx: usize) -> bool {
             continue;
         }
 
-        if bytes[i] == b'b' && i + 1 < bytes.len() && bytes[i + 1] == b'"' {
+        if (bytes[i] == b'b' || bytes[i] == b'c') && i + 1 < bytes.len() && bytes[i + 1] == b'"' {
             in_string = true;
             i += 2;
             continue;
         }
 
-        if bytes[i] == b'r' || (bytes[i] == b'b' && i + 1 < bytes.len() && bytes[i + 1] == b'r') {
+        if bytes[i] == b'r'
+            || ((bytes[i] == b'b' || bytes[i] == b'c')
+                && i + 1 < bytes.len()
+                && bytes[i + 1] == b'r')
+        {
             let mut j = i + 1;
-            if bytes[i] == b'b' {
+            if bytes[i] == b'b' || bytes[i] == b'c' {
                 j += 1;
             }
             while j < bytes.len() && bytes[j] == b'#' {
                 j += 1;
             }
             if j < bytes.len() && bytes[j] == b'"' {
-                raw_hashes = Some(j.saturating_sub(i + if bytes[i] == b'b' { 2 } else { 1 }));
+                raw_hashes = Some(
+                    j.saturating_sub(i + if bytes[i] == b'b' || bytes[i] == b'c' { 2 } else { 1 }),
+                );
                 i = j + 1;
                 continue;
             }
@@ -4302,6 +4308,23 @@ mod tests {
         assert!(!has_unlinked_todo_in_rust_line("let s = r#\"// TODO in literal\"#;", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line(
             "let s = r#\"/* FIXME in literal */\"#;",
+            &todo_re
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn rust_todo_detection_ignores_c_string_comment_markers() -> Result<()> {
+        let todo_re = Regex::new(r"TODO|FIXME")?;
+
+        assert!(!has_unlinked_todo_in_rust_line("let s = c\"// TODO in literal\";", &todo_re));
+        assert!(!has_unlinked_todo_in_rust_line(
+            "let s = cr#\"/* FIXME in literal */\"#;",
+            &todo_re
+        ));
+        assert!(has_unlinked_todo_in_rust_line(
+            "let s = c\"safe literal\"; // TODO: follow up",
             &todo_re
         ));
 


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner in `perl-ci-hygiene` produced false positives when Rust code used C-style string prefixes like `c"..."` or raw C strings `cr#"..."#` because those prefixes were not recognized as string literals. 
- Recognize these prefixes so comment markers inside such literals are not misinterpreted as real comments.

### Description
- Extend `is_index_in_rust_literal` to treat the `c` prefix like the existing `b` prefix for normal string literals by checking `bytes[i] == b'c'` alongside `b'b'`. 
- Add support for raw C string prefixes (`cr#...#`) by including `c` in the raw-hash detection branch and adjusting the raw-hash length calculation accordingly. 
- Add a unit test `rust_todo_detection_ignores_c_string_comment_markers` covering `c"// ..."`, `cr#"/* ... */"#`, and a control case ensuring trailing `// TODO` is still detected. 
- Run repository formatting with `cargo xtask fmt` on the changed files.

### Testing
- Ran the focused test with `cargo test -p perl-ci-hygiene rust_todo_detection_ignores_c_string_comment_markers` and it passed. 
- Ran the crate test suite with `cargo test -p perl-ci-hygiene` and all tests passed. 
- Ran formatting with `cargo xtask fmt` successfully before tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7ec2e483338e70048e0bc99ce9)