### PR TITLE
fix(ci-hygiene): detect TODO hash-comments after && and || (#4707)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3918,7 +3918,7 @@ fn find_hash_comment_start(line: &str) -> Option<usize> {
                 }
                 if let Some(prev) = line[..idx].chars().next_back() {
                     if prev.is_whitespace()
-                        || matches!(prev, ';' | '{' | '}' | '(' | ')' | '[' | ']')
+                        || matches!(prev, ';' | '{' | '}' | '(' | ')' | '[' | ']' | '&' | '|')
                     {
                         return Some(idx);
                     }
@@ -4345,6 +4345,8 @@ mod tests {
             &todo_re
         ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line("echo hi&&# TODO: follow up", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line("echo hi||# TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
 
         Ok(())


### PR DESCRIPTION
### Motivation

- The TODO/FIXME scanner missed hash-comments that start immediately after shell/perl control operators like `&&` and `||`, allowing unlinked TODOs to slip through CI hygiene checks.

### Description

- Treat `&` and `|` as valid preceding characters for `#` in `find_hash_comment_start`, so patterns like `&&#` and `||#` are recognized as comment starts in `crates/perl-ci-hygiene/src/main.rs`.
- Add regression assertions to the `hash_comment_todo_detection_handles_shebang_and_inline_hashes` test to cover `echo hi&&# TODO: ...` and `echo hi||# TODO: ...` cases.

### Testing

- Ran `cargo xtask fmt` successfully.
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and the test passed.
- Ran `cargo test -p perl-ci-hygiene` and the full crate test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7ec2e483338e70048e0bc99ce9)