### PR TITLE
fix(perl-module): normalize FindBin use lib paths safely (#4707)

### DIFF
--- a/crates/perl-module/src/resolution/use_lib.rs
+++ b/crates/perl-module/src/resolution/use_lib.rs
@@ -3,7 +3,7 @@
 //! Scans Perl source text for `use lib` pragmas and recognizes common
 //! `FindBin` patterns to discover additional module include directories.
 
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 /// A discovered include path from a `use lib` statement.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -92,7 +92,9 @@ pub fn resolve_use_lib_paths(
 
         if ulp.from_findbin {
             let base = file_dir.unwrap_or(workspace_root);
-            let resolved = base.join(path_str);
+            let Some(resolved) = normalize_findbin_path(base, path_str) else {
+                continue;
+            };
             if resolved.strip_prefix(workspace_root).is_err() {
                 continue;
             }
@@ -293,4 +295,21 @@ fn path_to_relative_string(path: &Path, workspace_root: &Path) -> Option<String>
 
 fn normalize_relative_path_string(path: &str) -> String {
     path.replace('\\', "/")
+}
+
+fn normalize_findbin_path(base: &Path, relative: &str) -> Option<PathBuf> {
+    let mut normalized = PathBuf::from(base);
+    for component in Path::new(relative).components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(segment) => normalized.push(segment),
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return None;
+                }
+            }
+            Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    Some(normalized)
 }

--- a/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
+++ b/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
@@ -1,0 +1,85 @@
+use std::path::Path;
+
+use perl_module::resolution::use_lib::{
+    UseLibAction, UseLibPath, extract_use_lib_operations, resolve_use_lib_paths,
+    resolve_use_lib_paths_from_source_at_offset,
+};
+
+#[test]
+fn findbin_parent_traversal_is_rejected() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().join("workspace");
+    let file_dir = workspace.join("project").join("lib");
+
+    std::fs::create_dir_all(&file_dir)?;
+
+    let resolved = resolve_use_lib_paths(
+        &[UseLibPath { path: "../../../outside".to_string(), from_findbin: true }],
+        &workspace,
+        Some(&file_dir),
+    );
+
+    assert!(resolved.is_empty(), "findbin traversal should be dropped");
+    Ok(())
+}
+
+#[test]
+fn findbin_dot_segment_is_normalized_inside_workspace() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().join("workspace");
+    let file_dir = workspace.join("project").join("lib");
+
+    std::fs::create_dir_all(&file_dir)?;
+
+    let resolved = resolve_use_lib_paths(
+        &[UseLibPath { path: "../vendor/./lib".to_string(), from_findbin: true }],
+        &workspace,
+        Some(&file_dir),
+    );
+
+    assert_eq!(resolved, vec!["project/vendor/lib".to_string()]);
+    Ok(())
+}
+
+#[test]
+fn use_and_no_lib_operations_are_extracted_in_order() {
+    let source = "\
+use lib 'first';\n\
+use lib 'second';\n\
+no lib 'first';\n\
+";
+
+    let ops = extract_use_lib_operations(source);
+
+    assert_eq!(
+        ops,
+        vec![
+            UseLibAction::Add(vec![UseLibPath { path: "first".to_string(), from_findbin: false }]),
+            UseLibAction::Add(vec![UseLibPath { path: "second".to_string(), from_findbin: false }]),
+            UseLibAction::Remove(vec![UseLibPath {
+                path: "first".to_string(),
+                from_findbin: false,
+            }]),
+        ]
+    );
+}
+
+#[test]
+fn use_lib_offset_resolution_obeys_lexical_order() {
+    let source = "\
+use lib 'first';\n\
+use lib 'second';\n\
+no lib 'first';\n\
+use Lib::Thing;\n\
+";
+
+    let offset_at_use = source.find("use Lib::Thing;").unwrap_or(source.len());
+    let include_paths = resolve_use_lib_paths_from_source_at_offset(
+        source,
+        offset_at_use,
+        Path::new("/workspace"),
+        None,
+    );
+
+    assert_eq!(include_paths, vec!["second".to_string()]);
+}


### PR DESCRIPTION
### Motivation

- Prevent `$FindBin::Bin`-derived `use lib` paths with traversal-like segments (e.g., `..`) from bypassing workspace-boundary checks by joining them lexically without normalization.

### Description

- Normalize and safely resolve `from_findbin` paths by adding `normalize_findbin_path` and using it before workspace prefix checks. 
- Reject rooted/prefixed path injections and safely process `.`/`..` segments during normalization via `std::path::Component` logic. 
- Update imports to use `Component` and `PathBuf` and modify `resolve_use_lib_paths` to skip entries that fail normalization. 
- Add focused unit tests in `crates/perl-module/tests/use_lib_resolution_unit_tests.rs` covering traversal rejection, dot-segment normalization, operation ordering, and offset-aware lexical resolution.

### Testing

- Ran `cargo test -p perl-module --test use_lib_resolution_unit_tests` and all tests passed. 
- Ran `cargo test -p perl-module --test module_resolution_use_require use_lib_effect` and tested scenarios passed. 
- Ran repository formatting via `cargo xtask fmt` to ensure formatting compliance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c897e8483338b6f73944beb172d)