### PR TITLE
fix(workspace-folder): accept case-insensitive file URI schemes (#4707)

### DIFF
--- a/crates/perl-workspace-index/src/folder/mod.rs
+++ b/crates/perl-workspace-index/src/folder/mod.rs
@@ -26,13 +26,16 @@ pub struct WorkspaceFolderChange {
 /// interpreted as a path fallback.
 #[must_use]
 pub fn workspace_folder_to_path(workspace_folder: &str) -> PathBuf {
-    if workspace_folder.starts_with("file://") {
+    let is_file_uri =
+        workspace_folder.get(..7).is_some_and(|prefix| prefix.eq_ignore_ascii_case("file://"));
+
+    if is_file_uri {
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(path) = uri_to_fs_path(workspace_folder) {
             return path;
         }
 
-        return PathBuf::from(workspace_folder.trim_start_matches("file://"));
+        return PathBuf::from(&workspace_folder[7..]);
     }
 
     PathBuf::from(workspace_folder)
@@ -105,6 +108,14 @@ mod tests {
     #[test]
     fn parses_file_uri_when_possible() {
         let parsed = workspace_folder_to_path("file:///tmp/project");
+        assert!(parsed.to_string_lossy().contains("tmp"));
+        assert!(parsed.to_string_lossy().contains("project"));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn parses_uppercase_file_uri_when_possible() {
+        let parsed = workspace_folder_to_path("FILE:///tmp/project");
         assert!(parsed.to_string_lossy().contains("tmp"));
         assert!(parsed.to_string_lossy().contains("project"));
     }

--- a/crates/perl-workspace-index/tests/collapse_edge_cases_tests.rs
+++ b/crates/perl-workspace-index/tests/collapse_edge_cases_tests.rs
@@ -320,10 +320,7 @@ fn test_workspace_members_match_crates_directory() {
         .collect();
 
     // Parse current workspace members from the manifest.
-    assert!(
-        !members.is_empty(),
-        "Workspace members list must not be empty"
-    );
+    assert!(!members.is_empty(), "Workspace members list must not be empty");
 
     // Discover crate directories that contain a Cargo.toml.
     let crates_dir = workspace_root.join("crates");
@@ -333,9 +330,7 @@ fn test_workspace_members_match_crates_directory() {
         .map(|entry| entry.path())
         .filter(|path| path.is_dir() && path.join("Cargo.toml").exists())
         .filter_map(|path| {
-            path.file_name()
-                .and_then(|name| name.to_str())
-                .map(|name| format!("crates/{name}"))
+            path.file_name().and_then(|name| name.to_str()).map(|name| format!("crates/{name}"))
         })
         .collect();
 


### PR DESCRIPTION
### Motivation
- Workspace folder entries using `FILE://` (uppercase) were not recognized as `file://` URIs causing them to be treated as plain filesystem paths, so detection must be case-insensitive while preserving existing URI resolution behavior.

### Description
- Use a case-insensitive check for the `file://` scheme via `workspace_folder.get(..7).is_some_and(|prefix| prefix.eq_ignore_ascii_case("file://"))` in `workspace_folder_to_path`.
- Preserve the non-`wasm32` fast path using `perl_uri::uri_to_fs_path` and use a deterministic slice `&workspace_folder[7..]` as the fallback payload when URI parsing fails.
- Add a focused unit test `parses_uppercase_file_uri_when_possible` to lock the behavior into the BDD grid and include small `rustfmt`-only adjustments produced by `cargo xtask fmt`.

### Testing
- Ran `cargo xtask fmt` and it completed successfully.
- Ran `cargo test -p perl-workspace parses_uppercase_file_uri_when_possible` and the test passed.
- Ran `cargo test -p perl-workspace workspace_folder_` (workspace-folder related tests) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c8b4a2883338ee54f58096064ac)