### PR TITLE
fix(ci-hygiene): ignore TODO/FIXME inside c/cr literals (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3991,22 +3991,26 @@ fn is_index_in_rust_literal(line: &str, target_idx: usize) -> bool {
             continue;
         }
 
-        if bytes[i] == b'b' && i + 1 < bytes.len() && bytes[i + 1] == b'"' {
+        if (bytes[i] == b'b' || bytes[i] == b'c') && i + 1 < bytes.len() && bytes[i + 1] == b'"' {
             in_string = true;
             i += 2;
             continue;
         }
 
-        if bytes[i] == b'r' || (bytes[i] == b'b' && i + 1 < bytes.len() && bytes[i + 1] == b'r') {
+        if bytes[i] == b'r'
+            || ((bytes[i] == b'b' || bytes[i] == b'c')
+                && i + 1 < bytes.len()
+                && bytes[i + 1] == b'r')
+        {
             let mut j = i + 1;
-            if bytes[i] == b'b' {
+            if bytes[i] == b'b' || bytes[i] == b'c' {
                 j += 1;
             }
             while j < bytes.len() && bytes[j] == b'#' {
                 j += 1;
             }
             if j < bytes.len() && bytes[j] == b'"' {
-                raw_hashes = Some(j.saturating_sub(i + if bytes[i] == b'b' { 2 } else { 1 }));
+                raw_hashes = Some(j.saturating_sub(i + if bytes[i] == b'r' { 1 } else { 2 }));
                 i = j + 1;
                 continue;
             }
@@ -4322,6 +4326,23 @@ mod tests {
         ));
         assert!(has_unlinked_todo_in_rust_line(
             "let s = \"safe literal\"; // TODO: follow up",
+            &todo_re
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn rust_todo_detection_ignores_c_string_comment_markers() -> Result<()> {
+        let todo_re = Regex::new(r"TODO|FIXME")?;
+
+        assert!(!has_unlinked_todo_in_rust_line("let s = c\"// TODO in literal\";", &todo_re));
+        assert!(!has_unlinked_todo_in_rust_line(
+            "let s = cr#\"/* FIXME in literal */\"#;",
+            &todo_re
+        ));
+        assert!(has_unlinked_todo_in_rust_line(
+            "let s = c\"safe literal\"; // TODO: follow up",
             &todo_re
         ));
 


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner in `perl-ci-hygiene` produced false positives when `TODO`/`FIXME` appeared inside Rust C-style string literals like `c"..."` and raw `cr#"..."#` forms.
- Treating these as string literals preserves CI hygiene signal by ignoring tokens that are not actual comments.

### Description
- Extend `is_index_in_rust_literal` to recognize `c"..."` and `cr#"..."#` literal prefixes alongside existing `b`, `r`, and `br` forms (file: `crates/perl-ci-hygiene/src/main.rs`).
- Adjust raw-hash handling so raw C-style literals compute `raw_hashes` correctly and don't mark comment markers inside them as comments.
- Add a focused unit test `rust_todo_detection_ignores_c_string_comment_markers` that asserts `TODO`/`FIXME` inside `c` and `cr` literals are ignored while trailing comments are still detected.

### Testing
- Ran `cargo test -p perl-ci-hygiene rust_todo_detection` which completed successfully with the relevant tests passing (`4 passed`).
- Ran `cargo fmt --all -- crates/perl-ci-hygiene/src/main.rs` to format the change, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c8b4a2883338ee54f58096064ac)