### PR TITLE
fix(dap-inline-values): clamp line ranges and support apostrophe package vars (#4707)

### DIFF
--- a/crates/perl-dap/src/inline_values.rs
+++ b/crates/perl-dap/src/inline_values.rs
@@ -33,8 +33,8 @@ fn is_special_variable_name(name: &str) -> bool {
 
 /// Convert 1-based line bounds into inclusive 0-based indexes.
 ///
-/// Non-positive line inputs are clamped to line 1, and the end index is
-/// rejected when either bound is past the available line count.
+/// Non-positive line inputs are clamped to line 1. End bounds past the
+/// available line count are clamped to the final line.
 fn normalize_line_bounds(
     start_line: i64,
     end_line: i64,
@@ -45,10 +45,10 @@ fn normalize_line_bounds(
     }
 
     let start_1_based = start_line.max(1) as usize;
-    let end_1_based = end_line.max(1) as usize;
-    if start_1_based > line_count || end_1_based > line_count {
+    if start_1_based > line_count {
         return None;
     }
+    let end_1_based = (end_line.max(1) as usize).min(line_count);
 
     let start_idx = start_1_based.saturating_sub(1);
     let end_idx = end_1_based.saturating_sub(1);
@@ -61,6 +61,10 @@ fn normalize_line_bounds(
 /// Bytes that belong to Perl comments (`# ...`) or single/double-quoted string
 /// literals are marked `false` and should be ignored by lightweight regex scans.
 fn code_byte_mask(line: &str) -> Vec<bool> {
+    fn is_ident_byte(byte: u8) -> bool {
+        byte.is_ascii_alphanumeric() || byte == b'_'
+    }
+
     let bytes = line.as_bytes();
     let mut mask = vec![true; bytes.len()];
     let mut in_single = false;
@@ -105,6 +109,14 @@ fn code_byte_mask(line: &str) -> Vec<bool> {
                 break;
             }
             b'\'' => {
+                let prev_is_ident = i > 0 && is_ident_byte(bytes[i - 1]);
+                let next_is_ident = (i + 1) < bytes.len() && is_ident_byte(bytes[i + 1]);
+
+                if prev_is_ident && next_is_ident {
+                    i += 1;
+                    continue;
+                }
+
                 mask[i] = false;
                 in_single = true;
             }
@@ -450,6 +462,22 @@ mod tests {
         assert!(extract_variable_names(source, 3, 3).is_empty());
         assert!(collect_inline_values_with_runtime(source, 3, 3, None).is_empty());
         assert!(collect_inline_values(source, 3, 3).is_empty());
+    }
+
+    #[test]
+    fn test_end_line_past_file_is_clamped() {
+        let source = "my $x = 1;\nmy $y = 2;";
+
+        let names = extract_variable_names(source, 2, 999);
+        assert_eq!(names, vec!["$y".to_string()]);
+
+        let values = collect_inline_values_with_runtime(source, 2, 999, None);
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].text, "$y = ?");
+
+        let legacy_values = collect_inline_values(source, 2, 999);
+        assert_eq!(legacy_values.len(), 1);
+        assert_eq!(legacy_values[0].text, "$y = ?");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Inline-value requests with `end_line` beyond the file previously produced no results, which makes clients that send broad ranges fragile.
- Legacy Perl package separators using apostrophes (e.g. `$Foo'bar`) were being misrecognized as single-quoted string delimiters in the lightweight mask, preventing extraction and runtime rendering of those variables.

### Description
- Clamp the `end_line` in `normalize_line_bounds` to the final line instead of rejecting the request when `end_line` is past file length.
- Preserve legacy apostrophe package separators in `code_byte_mask` by treating apostrophes between identifier bytes as namespace separators rather than string openers, via a small `is_ident_byte` helper and conditional skip logic.
- Add a regression test `test_end_line_past_file_is_clamped` to verify clamped behavior for `extract_variable_names`, `collect_inline_values_with_runtime`, and `collect_inline_values`.

### Testing
- Ran `cargo test -p perl-dap inline_values::tests` and observed all inline-values tests pass (21 passed).
- Ran targeted tests for the earlier regressions (`test_end_line_past_file_is_clamped`, legacy namespace qualifiers and runtime legacy namespaced scalar tests) and they succeeded.
- Ran `cargo xtask fmt` to format changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c8b4a2883338ee54f58096064ac)