### PR TITLE
fix(ci-hygiene): accept punctuated TODO issue links (#4707)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -4041,7 +4041,11 @@ fn has_unlinked_token(comment: &str, token_re: &Regex) -> bool {
 }
 
 fn linked_marker(suffix: &str) -> bool {
-    let suffix = suffix.trim_start();
+    let mut suffix = suffix.trim_start();
+    while let Some(next) = suffix.strip_prefix(':').or_else(|| suffix.strip_prefix('-')) {
+        suffix = next.trim_start();
+    }
+
     let Some(rest) = suffix.strip_prefix("(#") else {
         return false;
     };
@@ -4273,6 +4277,9 @@ mod tests {
     fn linked_marker_requires_parenthesized_issue_number() {
         assert!(linked_marker("(#123)"));
         assert!(linked_marker("   (#42) trailing text"));
+        assert!(linked_marker(": (#42) trailing text"));
+        assert!(linked_marker(" - (#42) trailing text"));
+        assert!(linked_marker(":- (#42) trailing text"));
         assert!(!linked_marker("#123"));
         assert!(!linked_marker("(#)"));
         assert!(!linked_marker("(#12"));


### PR DESCRIPTION
### Motivation
- The TODO scanner falsely treated linked markers like `TODO: (#123)` or `TODO - (#123)` as unlinked debt, creating CI noise and discouraging the linked-TODO policy.

### Description
- Relax `linked_marker` parsing in `crates/perl-ci-hygiene/src/main.rs` to iteratively strip leading `:` and `-` punctuation before checking for a parenthesized `(#123)` marker.
- Add regression assertions to `linked_marker_requires_parenthesized_issue_number` to cover `:`, `-`, and combined `:-` punctuation forms.

### Testing
- Ran `cargo test -p perl-ci-hygiene linked_marker_requires_parenthesized_issue_number` and the test passed.
- Ran `cargo test -p perl-ci-hygiene --quiet` and all crate tests passed (`36` tests).
- Ran `cargo xtask fmt` to format changes and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c8ecc78833383ee42832b86263d)