### PR TITLE
fix(ci-hygiene): ignore TODO tokens in backtick literals (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3882,6 +3882,7 @@ fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
 fn find_hash_comment_start(line: &str) -> Option<usize> {
     let mut in_single = false;
     let mut in_double = false;
+    let mut in_backtick = false;
     let mut prev_was_escape = false;
 
     for (idx, ch) in line.char_indices() {
@@ -3905,10 +3906,25 @@ fn find_hash_comment_start(line: &str) -> Option<usize> {
             }
             continue;
         }
+        if in_backtick {
+            if prev_was_escape {
+                prev_was_escape = false;
+                continue;
+            }
+            if ch == '\\' {
+                prev_was_escape = true;
+                continue;
+            }
+            if ch == '`' {
+                in_backtick = false;
+            }
+            continue;
+        }
 
         match ch {
             '\'' => in_single = true,
             '"' => in_double = true,
+            '`' => in_backtick = true,
             '#' => {
                 if idx == 0 && line.as_bytes().get(1) == Some(&b'!') {
                     return None;
@@ -4334,6 +4350,11 @@ mod tests {
 
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line("echo `printf '# TODO in backticks'`", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo `printf '# TODO in backticks'` # TODO: follow up",
+            &todo_re
+        ));
         assert!(has_unlinked_todo_in_hash_line("echo hi;# TODO: follow up", &todo_re));
         assert!(has_unlinked_todo_in_hash_line(
             "echo \"#not-a-comment\" # TODO: follow up",


### PR DESCRIPTION
### Motivation

- The TODO/FIXME scanner treated `#` inside backtick command substitutions as comment starts, producing false positives for shell/perl-style command substitutions.

### Description

- Treat backtick-quoted command substitutions as string-like regions in `find_hash_comment_start` by adding an `in_backtick` state and skipping `#` characters while inside backticks.
- Ensure escaped characters are honored inside backticks similarly to other string states by reusing `prev_was_escape` handling.
- Add unit assertions in the existing `hash_comment_todo_detection_handles_shebang_and_inline_hashes` test to prove that `# TODO` inside backticks is ignored while a trailing real `# TODO` is still detected (changes in `crates/perl-ci-hygiene/src/main.rs`).

### Testing

- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes`, which passed (`1 passed; 0 failed`).
- Ran `cargo xtask fmt` to format the workspace, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c8ecc78833383ee42832b86263d)