### PR TITLE
fix(ci-hygiene): limit TODO scan to block comment bodies (#4707)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3861,7 +3861,8 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
         if is_likely_string_literal_comment_start(line, idx) {
             continue;
         }
-        if has_unlinked_token(&line[idx + 2..], token_re) {
+        let comment_tail = block_comment_text_from(line, idx + 2);
+        if has_unlinked_token(comment_tail, token_re) {
             return true;
         }
     }
@@ -3870,6 +3871,11 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
         return true;
     }
     false
+}
+
+fn block_comment_text_from(line: &str, comment_start: usize) -> &str {
+    let remainder = &line[comment_start..];
+    if let Some(end) = remainder.find("*/") { &remainder[..end] } else { remainder }
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
@@ -4322,6 +4328,26 @@ mod tests {
         ));
         assert!(has_unlinked_todo_in_rust_line(
             "let s = \"safe literal\"; // TODO: follow up",
+            &todo_re
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn rust_todo_detection_scans_only_block_comment_text() -> Result<()> {
+        let todo_re = Regex::new(r"TODO|FIXME")?;
+
+        assert!(!has_unlinked_todo_in_rust_line(
+            "/* tracked */ let s = \"TODO in code string\";",
+            &todo_re
+        ));
+        assert!(has_unlinked_todo_in_rust_line(
+            "/* TODO: follow up */ let s = \"safe\";",
+            &todo_re
+        ));
+        assert!(!has_unlinked_todo_in_rust_line(
+            "/* TODO(#123): tracked */ let s = \"safe\";",
             &todo_re
         ));
 


### PR DESCRIPTION
### Motivation

- The TODO/FIXME scanner flagged tokens that appeared after a closed Rust block comment because it scanned the entire remainder of the line instead of only the block comment body.

### Description

- Update `has_unlinked_todo_in_rust_line` to extract only the `/* ... */` comment slice when scanning block comments by calling a new helper `block_comment_text_from` in `crates/perl-ci-hygiene/src/main.rs`.
- Add the helper function `block_comment_text_from(line: &str, comment_start: usize) -> &str` to return only the text inside the block comment or the remainder if not closed.
- Add a focused regression test `rust_todo_detection_scans_only_block_comment_text` that verifies TODO-like text after a closed block comment is ignored while TODOs inside block comments are still detected.

### Testing

- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo test -p perl-ci-hygiene rust_todo_detection_` and all tests, including the new regression test, passed (`4 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c8ecc78833383ee42832b86263d)