### PR TITLE
fix(ci-hygiene): avoid false TODO hits in escaped single-quoted strings (#4707)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3908,6 +3908,14 @@ fn find_hash_comment_start(line: &str, perl_mode: bool) -> Option<usize> {
 
     for (idx, ch) in line.char_indices() {
         if in_single {
+            if prev_was_escape {
+                prev_was_escape = false;
+                continue;
+            }
+            if ch == '\\' {
+                prev_was_escape = true;
+                continue;
+            }
             if ch == '\'' {
                 in_single = false;
             }
@@ -3943,8 +3951,14 @@ fn find_hash_comment_start(line: &str, perl_mode: bool) -> Option<usize> {
         }
 
         match ch {
-            '\'' => in_single = true,
-            '"' => in_double = true,
+            '\'' => {
+                in_single = true;
+                prev_was_escape = false;
+            }
+            '"' => {
+                in_double = true;
+                prev_was_escape = false;
+            }
             '`' => in_backtick = true,
             '#' => {
                 if idx == 0 && line.as_bytes().get(1) == Some(&b'!') {
@@ -4436,6 +4450,11 @@ mod tests {
         assert!(!has_unlinked_todo_in_hash_line("echo '# TODO in string' && true", &todo_re));
         assert!(has_unlinked_todo_in_hash_line(
             "echo '# TODO in string' # TODO: follow up",
+            &todo_re
+        ));
+        assert!(!has_unlinked_todo_in_hash_line("print 'it\\'s # TODO in string';", &todo_re,));
+        assert!(has_unlinked_todo_in_hash_line(
+            "print 'it\\'s # TODO in string'; # TODO: follow up",
             &todo_re
         ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));


### PR DESCRIPTION
### Motivation

- The TODO scanner for hash-comment languages could misclassify `# TODO` inside single-quoted literals that contain escaped apostrophes as real comments, producing false positives.

### Description

- Update `find_hash_comment_start` in `crates/perl-ci-hygiene/src/main.rs` to honor escaped single quotes (`\'`) while inside single-quoted literals so an escaped apostrophe does not prematurely terminate the single-quote state.
- Reset the escape state when entering a single- or double-quoted literal to avoid leaking prior escape state between contexts.
- Add regression assertions to the existing `hash_comment_todo_detection_handles_shebang_and_inline_hashes` test to cover both the no-comment and trailing-comment cases for `print 'it\'s # TODO in string';`.

### Testing

- Ran formatter with `cargo xtask fmt` and it completed successfully.
- Ran the targeted test with `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and it passed.
- Ran the crate test suite with `cargo test -p perl-ci-hygiene` and all tests passed (36 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c8ecc78833383ee42832b86263d)