### PR TITLE
fix(color): correct xterm 256-color cube mapping (#4707)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/color/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/color/mod.rs
@@ -266,6 +266,14 @@ fn parse_ansi_color(code: &str) -> Option<Color> {
 
 /// Convert a 256-color palette index to an RGB Color
 fn color_from_256(n: u8) -> Color {
+    fn xterm_cube_level(index: u8) -> u8 {
+        match index {
+            0 => 0,
+            1..=5 => 55 + index * 40,
+            _ => 255,
+        }
+    }
+
     let (r, g, b) = match n {
         // Standard colors (0-7) -- same as basic ANSI 30-37
         0 => (0, 0, 0),
@@ -291,7 +299,7 @@ fn color_from_256(n: u8) -> Color {
             let ri = idx / 36;
             let gi = (idx % 36) / 6;
             let bi = idx % 6;
-            (ri * 51, gi * 51, bi * 51)
+            (xterm_cube_level(ri), xterm_cube_level(gi), xterm_cube_level(bi))
         }
         // Grayscale (232-255)
         232..=255 => {
@@ -641,6 +649,17 @@ mod tests {
         assert!((colors[0].color.red - 1.0).abs() < 0.01);
         assert!((colors[0].color.green - 0.0).abs() < 0.01);
         assert!((colors[0].color.blue - 0.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_detect_256_color_ansi_uses_xterm_cube_levels() {
+        // 17 maps to (0, 0, 95) in the xterm 256-color cube.
+        let text = r"\e[38;5;17m";
+        let colors = detect_ansi_colors(text);
+        assert_eq!(colors.len(), 1);
+        assert!((colors[0].color.red - 0.0).abs() < 0.01);
+        assert!((colors[0].color.green - 0.0).abs() < 0.01);
+        assert!((colors[0].color.blue - 95.0 / 255.0).abs() < 0.01);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The ANSI 256-color cube was converted using a linear `* 51` mapping which does not match xterm's actual palette levels, causing inaccurate mid-range colors in color previews.
- Improving the mapping ensures color detection and presentations reflect the real terminal palette used by users and tools.

### Description
- Replaced the linear 6-level mapping in `color_from_256` with an `xterm_cube_level` helper that maps cube indices to xterm palette levels (`0, 95, 135, 175, 215, 255`) in `crates/perl-lsp-rs-core/src/providers/color/mod.rs`.
- Updated the 6x6x6 cube branch to use `xterm_cube_level(ri/gi/bi)` instead of `(ri * 51, gi * 51, bi * 51)`.
- Added a regression test `test_detect_256_color_ansi_uses_xterm_cube_levels` verifying that `\e[38;5;17m` resolves to `(0, 0, 95)`.

### Testing
- Ran formatting with `cargo xtask fmt` which completed successfully.
- Executed the provider tests with `cargo test -p perl-lsp-rs-core providers::color` and all color provider tests passed (`15 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c939bb083338af8a5bfd9e9ebf1)