### PR TITLE
fix(ci-hygiene): handle escaped single-quote literals in TODO hash scan (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3886,6 +3886,14 @@ fn find_hash_comment_start(line: &str) -> Option<usize> {
 
     for (idx, ch) in line.char_indices() {
         if in_single {
+            if prev_was_escape {
+                prev_was_escape = false;
+                continue;
+            }
+            if ch == '\\' {
+                prev_was_escape = true;
+                continue;
+            }
             if ch == '\'' {
                 in_single = false;
             }
@@ -3907,8 +3915,14 @@ fn find_hash_comment_start(line: &str) -> Option<usize> {
         }
 
         match ch {
-            '\'' => in_single = true,
-            '"' => in_double = true,
+            '\'' => {
+                in_single = true;
+                prev_was_escape = false;
+            }
+            '"' => {
+                in_double = true;
+                prev_was_escape = false;
+            }
             '#' => {
                 if idx == 0 && line.as_bytes().get(1) == Some(&b'!') {
                     return None;
@@ -4346,6 +4360,8 @@ mod tests {
         ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line(r#"print 'don\'t # TODO in literal';"#, &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(r#"print 'don\'t'; # TODO: follow up"#, &todo_re));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- The hash-comment TODO scanner could misclassify `# TODO` that appears inside single-quoted literals containing escaped single quotes (for example `print 'don\'t # TODO in literal';`) as a real comment, producing false positives.

### Description
- Update `find_hash_comment_start` in `crates/perl-ci-hygiene/src/main.rs` to track escape state while inside single-quoted literals, mirroring the existing escape handling for double-quoted literals so escaped single quotes do not prematurely terminate the literal.
- Ensure `prev_was_escape` is reset on entering a quote and is checked/updated while scanning inside single or double quotes.
- Add two regression assertions to `hash_comment_todo_detection_handles_shebang_and_inline_hashes` to verify no hit when `# TODO` is inside an escaped single-quoted literal and a hit when `# TODO` appears in a real trailing comment after such a literal.

### Testing
- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and the targeted test passed.
- Ran `cargo test -p perl-ci-hygiene` and the crate test suite passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c939bb083338af8a5bfd9e9ebf1)