### PR TITLE
fix(ci-hygiene): accept /Users/user placeholder in doc-path checks (#4707)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3355,7 +3355,10 @@ fn has_machine_specific_home_path(line: &str, home_user_path: &Regex) -> bool {
 
 fn has_machine_specific_users_path(line: &str, users_name_path: &Regex) -> bool {
     users_name_path.captures_iter(line).any(|captures| {
-        captures.get(1).is_some_and(|name| !name.as_str().eq_ignore_ascii_case("name"))
+        captures.get(1).is_some_and(|name| {
+            let value = name.as_str();
+            !(value.eq_ignore_ascii_case("name") || value.eq_ignore_ascii_case("user"))
+        })
     })
 }
 
@@ -4373,6 +4376,10 @@ mod tests {
 
         assert!(!has_machine_specific_users_path(
             "Template: /Users/Name/project",
+            &users_name_path,
+        ));
+        assert!(!has_machine_specific_users_path(
+            "Template: /Users/user/project",
             &users_name_path,
         ));
         assert!(has_machine_specific_users_path(


### PR DESCRIPTION
### Motivation
- Avoid false positives from the documentation path scanner by treating `/Users/user/...` as a generic example (like `/Users/Name/...`) rather than a machine-specific username.

### Description
- Update `has_machine_specific_users_path` in `crates/perl-ci-hygiene/src/main.rs` to treat `user` the same as `Name`, and add a regression test `users_path_detection_only_allows_generic_name_examples` to lock the behavior.

### Testing
- Ran `cargo xtask fmt` and `cargo test -p perl-ci-hygiene users_path_detection_only_allows_generic_name_examples --quiet` and `cargo test -p perl-ci-hygiene --quiet`, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c939bb083338af8a5bfd9e9ebf1)