### PR TITLE
fix(workspace-index): parse comma-packed use parent/base args (#4707)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -3317,25 +3317,33 @@ fn extract_module_names_from_use_args(args: &[String]) -> Vec<String> {
     let mut modules = Vec::new();
     modules.extend(qw_words);
 
-    modules.extend(remainder.split_whitespace().filter_map(|token| {
+    modules.extend(remainder.split_whitespace().flat_map(|token| {
         // Skip flags like -norequire and bare punctuation from qw() or parens
         if token.starts_with('-') {
-            return None;
+            return Vec::new();
         }
-        // Strip surrounding single or double quotes
-        let stripped = token.trim_matches('\'').trim_matches('"');
-        // Strip surrounding parentheses (e.g. `use parent ('Foo')`)
-        let stripped = stripped.trim_matches('(').trim_matches(')');
-        let stripped = stripped.trim_matches('\'').trim_matches('"');
-        // Accept tokens containing only word characters, `::`, or `'` (legacy separator)
-        if stripped.is_empty() {
-            return None;
-        }
-        if stripped.chars().all(|c| c.is_alphanumeric() || c == '_' || c == ':' || c == '\'') {
-            Some(stripped.to_string())
-        } else {
-            None
-        }
+        token
+            .split(',')
+            .filter_map(|piece| {
+                // Strip surrounding punctuation that may be attached without whitespace:
+                // - quotes (`'Foo::Bar'`, `"Foo::Bar"`)
+                // - parentheses (`('Foo::Bar')`)
+                let stripped = piece
+                    .trim_matches(|c| matches!(c, '\'' | '"' | '(' | ')'))
+                    .trim_matches(|c| matches!(c, '\'' | '"'));
+                // Accept tokens containing only word characters, `::`, or `'` (legacy separator)
+                if stripped.is_empty() {
+                    return None;
+                }
+                if stripped.chars().all(|c| {
+                    c.is_alphanumeric() || c == '_' || c == ':' || c == '\''
+                }) {
+                    Some(stripped.to_string())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
     }));
 
     modules
@@ -4709,6 +4717,22 @@ Utils::process_data();
         let names = extract_module_names_from_use_args(&["'Foo'Bar'".to_string()]);
         // After stripping outer quotes the raw token is Foo'Bar — a valid legacy name
         assert_eq!(names, vec!["Foo'Bar"]);
+    }
+
+    #[test]
+    fn test_extract_module_names_comma_adjacent_tokens() {
+        let names = extract_module_names_from_use_args(&[
+            "'Foo::Bar',".to_string(),
+            "\"Other::Base\",".to_string(),
+            "'Last::One'".to_string(),
+        ]);
+        assert_eq!(names, vec!["Foo::Bar", "Other::Base", "Last::One"]);
+    }
+
+    #[test]
+    fn test_extract_module_names_parenthesized_without_spaces() {
+        let names = extract_module_names_from_use_args(&["('Foo::Bar','Other::Base')".to_string()]);
+        assert_eq!(names, vec!["Foo::Bar", "Other::Base"]);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- `extract_module_names_from_use_args` relied on whitespace tokenization and could miss module names when `use parent`/`use base` arguments were comma-packed or parenthesized without spaces, causing dependencies to be omitted from the workspace index and weakening navigation and `find_dependents` behavior.

### Description
- Hardened `extract_module_names_from_use_args` in `crates/perl-workspace-index/src/workspace/workspace_index.rs` to `split` non-`qw` tokens on commas and normalize surrounding punctuation (quotes and parentheses) before validation, while preserving existing `qw(...)` handling.
- Replaced a single-token `filter_map` pass with a `flat_map` that splits comma-packed pieces and collects valid module names robustly.
- Added focused regression tests `test_extract_module_names_comma_adjacent_tokens` and `test_extract_module_names_parenthesized_without_spaces` in the same test module to lock the behavior.

### Testing
- Ran `cargo xtask fmt` to format code; formatting completed successfully.
- Ran unit tests for the change with `cargo test -p perl-workspace extract_module_names -- --nocapture`; the targeted tests passed (all new and related `extract_module_names_from_use_args` tests succeeded).
- Ran the wider `perl-workspace` test invocation during validation and observed the package tests complete without failures for the modified areas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c939bb083338af8a5bfd9e9ebf1)