### PR TITLE
fix(dap-inline): preserve parsing after $#array markers (#4707)

### DIFF
--- a/crates/perl-dap/src/inline_values.rs
+++ b/crates/perl-dap/src/inline_values.rs
@@ -99,6 +99,10 @@ fn code_byte_mask(line: &str) -> Vec<bool> {
 
         match b {
             b'#' => {
+                if is_perl_array_length_marker(bytes, i) {
+                    i += 1;
+                    continue;
+                }
                 for byte in mask.iter_mut().take(bytes.len()).skip(i) {
                     *byte = false;
                 }
@@ -119,6 +123,13 @@ fn code_byte_mask(line: &str) -> Vec<bool> {
     }
 
     mask
+}
+
+fn is_perl_array_length_marker(bytes: &[u8], idx: usize) -> bool {
+    if idx > 0 && bytes[idx - 1] == b'$' {
+        return true;
+    }
+    idx > 1 && bytes[idx - 1] == b'{' && bytes[idx - 2] == b'$'
 }
 
 /// Extract unique variable names from source code within a line range.
@@ -490,5 +501,27 @@ mod tests {
         let values = collect_inline_values_with_runtime(source, 1, 1, None);
         assert_eq!(values.len(), 1);
         assert_eq!(values[0].text, "$real = ?");
+    }
+
+    #[test]
+    fn test_array_length_marker_does_not_start_comment() {
+        let source = "my $len = $#arr; my $next = 1;";
+
+        let names = extract_variable_names(source, 1, 1);
+        assert!(names.contains(&"$len".to_string()));
+        assert!(names.contains(&"$next".to_string()));
+
+        let values = collect_inline_values_with_runtime(source, 1, 1, None);
+        assert!(values.iter().any(|v| v.text == "$len = ?"));
+        assert!(values.iter().any(|v| v.text == "$next = ?"));
+    }
+
+    #[test]
+    fn test_braced_array_length_marker_does_not_start_comment() {
+        let source = "my $len = ${#arr}; my $next = 1;";
+
+        let names = extract_variable_names(source, 1, 1);
+        assert!(names.contains(&"$len".to_string()));
+        assert!(names.contains(&"$next".to_string()));
     }
 }


### PR DESCRIPTION
### Motivation

- The inline-value scanner treated `#` as an unconditional comment start, causing `$#array` or `${#array}` to mask the remainder of the line and skip valid variables later on the same line.
- This produced incorrect or missing inline values for code that uses Perl array-length syntax.

### Description

- Updated `code_byte_mask` to ignore `#` when it is part of Perl array-length syntax by calling a new helper `is_perl_array_length_marker` before starting comment masking.
- Added `fn is_perl_array_length_marker(bytes: &[u8], idx: usize) -> bool` to detect `$#array` and `${#array}` forms.
- Added regression tests `test_array_length_marker_does_not_start_comment` and `test_braced_array_length_marker_does_not_start_comment` to verify extraction and inline-value collection continue after `$#arr` / `${#arr}`.
- Ran formatting (`cargo xtask fmt`) as part of the change.

### Testing

- Ran `cargo xtask fmt` which completed successfully.
- Ran the targeted test `cargo test -p perl-dap array_length_marker_does_not_start_comment` which passed.
- Ran `cargo test -p perl-dap inline_values` where the new tests pass but the run exposed two pre-existing failures unrelated to this change (legacy namespaced scalar tests); these failures were observed but are not introduced by this patch.
- The change is localized to `crates/perl-dap/src/inline_values.rs` and covered by the added regression tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97cfeaf7083339315aa1b8f979936)