### PR TITLE
fix(ci-hygiene): ignore TODO matches in C-string literals (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3991,22 +3991,26 @@ fn is_index_in_rust_literal(line: &str, target_idx: usize) -> bool {
             continue;
         }
 
-        if bytes[i] == b'b' && i + 1 < bytes.len() && bytes[i + 1] == b'"' {
+        if (bytes[i] == b'b' || bytes[i] == b'c') && i + 1 < bytes.len() && bytes[i + 1] == b'"' {
             in_string = true;
             i += 2;
             continue;
         }
 
-        if bytes[i] == b'r' || (bytes[i] == b'b' && i + 1 < bytes.len() && bytes[i + 1] == b'r') {
+        if bytes[i] == b'r'
+            || ((bytes[i] == b'b' || bytes[i] == b'c')
+                && i + 1 < bytes.len()
+                && bytes[i + 1] == b'r')
+        {
             let mut j = i + 1;
-            if bytes[i] == b'b' {
+            if bytes[i] == b'b' || bytes[i] == b'c' {
                 j += 1;
             }
             while j < bytes.len() && bytes[j] == b'#' {
                 j += 1;
             }
             if j < bytes.len() && bytes[j] == b'"' {
-                raw_hashes = Some(j.saturating_sub(i + if bytes[i] == b'b' { 2 } else { 1 }));
+                raw_hashes = Some(j.saturating_sub(i + if bytes[i] == b'r' { 1 } else { 2 }));
                 i = j + 1;
                 continue;
             }
@@ -4324,6 +4328,20 @@ mod tests {
             "let s = \"safe literal\"; // TODO: follow up",
             &todo_re
         ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn rust_todo_detection_ignores_c_string_literals() -> Result<()> {
+        let todo_re = Regex::new(r"TODO|FIXME")?;
+
+        assert!(!has_unlinked_todo_in_rust_line("let s = c\"// TODO in c string\";", &todo_re));
+        assert!(!has_unlinked_todo_in_rust_line(
+            "let s = cr#\"/* FIXME in raw c string */\"#;",
+            &todo_re
+        ));
+        assert!(has_unlinked_todo_in_rust_line("let s = c\"value\"; // TODO: follow up", &todo_re));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner in `perl-ci-hygiene` produced false positives when `//` or `/*` sequences appeared inside Rust-style C string literals such as `c"..."` and raw `cr#"..."#` forms.
- Tests did not cover these C-prefixed string literal forms, leaving the detection logic incomplete for Rust source scanning.

### Description
- Extend `is_index_in_rust_literal` to recognize `c"..."` and raw `cr#"..."#` style C string prefixes and treat them as string literals rather than comment starts.
- Adjust raw-hash counting logic to account for the new `c` prefix alongside existing `b` and `r` prefixes when parsing raw string delimiters.
- Add a focused unit test `rust_todo_detection_ignores_c_string_literals` that verifies TODO/FIXME tokens inside `c` and `cr#...#` literals are ignored while a real trailing comment is still detected.

### Testing
- Ran `cargo xtask fmt` to format changes, which completed successfully.
- Ran `cargo test -p perl-ci-hygiene rust_todo_detection_ignores_c_string_literals`, which passed (`1 passed`).
- Ran `cargo test -p perl-ci-hygiene rust_todo_detection_`, which ran the related TODO-detection tests and all passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97cfeaf7083339315aa1b8f979936)