### PR TITLE
fix(ci-hygiene): scan TODO markers case-insensitively (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3384,7 +3384,7 @@ fn cmd_check_todos(repo_root: &Path, list_mode: bool) -> Result<i32> {
             .join("complex_paren_args_tests.rs"),
     ];
 
-    let todo_re = Regex::new(r"TODO|FIXME")?;
+    let todo_re = Regex::new(r"(?i)TODO|FIXME")?;
     let entries = collect_todo_hits(repo_root, &exclude_dirs, &exclude_files, &todo_re)?;
 
     if list_mode {
@@ -4281,10 +4281,12 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_linked_or_url_like_comments() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"(?i)TODO|FIXME")?;
 
         assert!(has_unlinked_todo_in_rust_line("// TODO: investigate", &todo_re));
+        assert!(has_unlinked_todo_in_rust_line("// todo: investigate", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line("// TODO(#123): tracked", &todo_re));
+        assert!(!has_unlinked_todo_in_rust_line("// todo(#123): tracked", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line("let u = \"http://TODO\";", &todo_re));
         assert!(has_unlinked_todo_in_rust_line(
             "let u = \"http://TODO\"; // TODO: investigate",
@@ -4297,7 +4299,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_raw_string_comment_markers() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"(?i)TODO|FIXME")?;
 
         assert!(!has_unlinked_todo_in_rust_line("let s = r#\"// TODO in literal\"#;", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line(
@@ -4310,7 +4312,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_non_raw_string_comment_markers() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"(?i)TODO|FIXME")?;
 
         assert!(!has_unlinked_todo_in_rust_line(
             "let s = \"not a comment // TODO in literal\";",
@@ -4330,7 +4332,7 @@ mod tests {
 
     #[test]
     fn hash_comment_todo_detection_handles_shebang_and_inline_hashes() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"(?i)TODO|FIXME")?;
 
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner only matched uppercase markers and missed lowercase `todo`/`fixme`, allowing unlinked debt to bypass compliance checks.

### Description
- Make the scanner regex case-insensitive by changing `Regex::new(r"TODO|FIXME")` to `Regex::new(r"(?i)TODO|FIXME")` in `cmd_check_todos`.
- Update unit test initializers to use the same case-insensitive regex so tests mirror production behavior.
- Add assertions covering lowercase `todo` and linked `todo(#123)` patterns to prevent regressions.

### Testing
- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran `cargo test -p perl-ci-hygiene todo_detection` and the targeted tests passed.
- Ran `cargo test -p perl-ci-hygiene` and the full crate test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97cfeaf7083339315aa1b8f979936)