### PR TITLE
fix(workspace-folder): preserve file URI rootPath inputs (#4707)

### DIFF
--- a/crates/perl-workspace-index/src/folder/mod.rs
+++ b/crates/perl-workspace-index/src/folder/mod.rs
@@ -74,6 +74,10 @@ pub fn extract_workspace_folder_change(event: &Value) -> WorkspaceFolderChange {
 /// This keeps behavior deterministic across absolute POSIX and Windows-style paths.
 #[must_use]
 pub fn root_path_to_file_uri(root_path: &str) -> String {
+    if root_path.starts_with("file://") {
+        return root_path.to_string();
+    }
+
     let path = std::path::Path::new(root_path);
     url::Url::from_file_path(path).map_or_else(
         |_| {
@@ -135,5 +139,11 @@ mod tests {
     fn converts_legacy_root_path_to_file_uri() {
         let uri = root_path_to_file_uri("/legacy/workspace");
         assert_eq!(uri, "file:///legacy/workspace");
+    }
+
+    #[test]
+    fn preserves_file_uri_root_path_input() {
+        let uri = root_path_to_file_uri("file:///already/uri");
+        assert_eq!(uri, "file:///already/uri");
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent malformed URIs when legacy LSP clients supply `rootPath` already in `file://` form by keeping such inputs unchanged.

### Description
- Short-circuits `root_path_to_file_uri` to return the input unchanged when `root_path` starts with `file://`.
- Adds unit test `preserves_file_uri_root_path_input` to verify the URI-preserving behavior.
- Applied repository formatting via `cargo xtask fmt`.

### Testing
- Ran `cargo test -p perl-workspace preserves_file_uri_root_path_input` and the test passed.
- Executed the crate test suite for `perl-workspace` as part of the run and observed no failures related to this change.
- Ran `cargo xtask fmt` to ensure formatting; the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97cfd75808333ba9ba3383dfb56b3)