### PR TITLE
fix(ci-hygiene): detect comma-adjacent hash TODO comments (#4707)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -4015,7 +4015,7 @@ fn find_hash_comment_start(line: &str, perl_mode: bool) -> Option<usize> {
                 }
                 if let Some(prev) = line[..idx].chars().next_back() {
                     if prev.is_whitespace()
-                        || matches!(prev, ';' | '{' | '}' | '(' | ')' | '[' | ']' | '&' | '|')
+                        || matches!(prev, ';' | ',' | '{' | '}' | '(' | ')' | '[' | ']' | '&' | '|')
                     {
                         return Some(idx);
                     }
@@ -4561,6 +4561,8 @@ mod tests {
             "echo `printf '# TODO in backticks'` # TODO: follow up",
             &todo_re
         ));
+        assert!(has_unlinked_todo_in_hash_line("my @x = (1,# TODO: follow up", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line("my @x = (1,# TODO(#77): tracked", &todo_re));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation

- Close a detection gap in the TODO compliance scanner where hash comments that start immediately after a comma (e.g. `my @x = (1,# TODO: ...)`) were not recognized by `find_hash_comment_start` and could be silently skipped.
- Add regression coverage so comma-adjacent unlinked TODOs are detected while linked TODOs remain exempt.

### Description

- Treat `','` as a valid delimiter before `#` in `find_hash_comment_start` by adding `','` to the `matches!(prev, ...)` check in `crates/perl-ci-hygiene/src/main.rs`.
- Extend the unit test `hash_comment_todo_detection_handles_shebang_and_inline_hashes` in `crates/perl-ci-hygiene/src/main.rs` with both an unlinked and a linked comma-adjacent case.
- Applied formatting with `cargo xtask fmt`.

### Testing

- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and the test passed.
- Ran `cargo xtask fmt` to ensure formatting; the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97cfd75808333ba9ba3383dfb56b3)