### PR TITLE
fix(ci-hygiene): avoid false TODO hits in escaped Perl strings (#4707)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -4596,6 +4596,11 @@ mod tests {
         ));
         assert!(has_unlinked_todo_in_hash_line("my @x = (1,# TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("my @x = (1,# TODO(#77): tracked", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line("print 'it\\'s # TODO in string';", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(
+            "print 'it\\'s # TODO in string'; # TODO: follow up",
+            &todo_re
+        ));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- The TODO scanner for hash-comment languages misidentified `# TODO` inside single-quoted strings containing escaped apostrophes (common in Perl), producing false positives.
- The scanner needed to respect escaped single quotes and avoid stale escape-state when entering quoted regions to correctly distinguish real comments from string contents.

### Description
- Update `find_hash_comment_start` in `crates/perl-ci-hygiene/src/main.rs` to track and honor escapes inside single-quoted and double-quoted spans so `#` inside escaped-string content is not treated as the start of a comment.
- Reset the escape tracking flag when entering a quoted section to avoid stale state bleeding across lexical boundaries.
- Add regression assertions to the existing `hash_comment_todo_detection_handles_shebang_and_inline_hashes` test to cover single-quoted strings with escaped apostrophes and a trailing real comment.
- Run formatter so code style changes are applied via `cargo xtask fmt`.

### Testing
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and the test passed.
- Ran the full crate test suite with `cargo test -p perl-ci-hygiene` and all tests passed (36 passed, 0 failed).
- Ran code formatter with `cargo xtask fmt` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97cfa3ad08333809652fecc98133a)