### PR TITLE
fix(workspace-discovery): deduplicate git ls-files results (#4707)

### DIFF
--- a/crates/perl-workspace-index/src/discovery/mod.rs
+++ b/crates/perl-workspace-index/src/discovery/mod.rs
@@ -9,6 +9,7 @@
 
 use crate::ignore::{is_skipped_dir_name, path_contains_skipped_component};
 use perl_parser_core::source_file::is_perl_source_path;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use walkdir::{DirEntry, WalkDir};
@@ -99,6 +100,7 @@ fn try_git_discovery(root: &Path, start: Instant) -> Result<DiscoveryResult, std
 fn parse_git_ls_files_output(root: &Path, stdout: &[u8]) -> (Vec<PathBuf>, usize) {
     let stdout = String::from_utf8_lossy(stdout);
     let mut files = Vec::new();
+    let mut seen = HashSet::new();
     let mut excluded_count: usize = 0;
 
     for entry in stdout.split('\0') {
@@ -114,7 +116,11 @@ fn parse_git_ls_files_output(root: &Path, stdout: &[u8]) -> (Vec<PathBuf>, usize
 
         let path = root.join(relative_path);
         if is_perl_discovery_path(&path) {
-            files.push(path);
+            if seen.insert(path.clone()) {
+                files.push(path);
+            } else {
+                excluded_count += 1;
+            }
         } else {
             excluded_count += 1;
         }
@@ -355,6 +361,20 @@ mod tests {
 
         assert_eq!(files.len(), 1);
         assert_eq!(files[0], Path::new("/home/user/project/lib/Module.pm"));
+    }
+
+    #[test]
+    fn parse_git_output_deduplicates_duplicate_entries() {
+        let root = Path::new("/tmp/workspace");
+        let payload = b"lib/Foo.pm\0lib/Foo.pm\0script.pl\0script.pl\0README.md\0";
+
+        let (files, excluded_count) = parse_git_ls_files_output(root, payload);
+
+        assert_eq!(files.len(), 2);
+        assert!(files.iter().any(|p| p.ends_with("lib/Foo.pm")));
+        assert!(files.iter().any(|p| p.ends_with("script.pl")));
+        // Two duplicate Perl paths + one non-Perl file.
+        assert_eq!(excluded_count, 3);
     }
 
     // --- Additional coverage: path_contains_skipped_component ---


### PR DESCRIPTION
### Motivation

- `git ls-files` can emit duplicate path entries in some repository/index states, which caused downstream indexing to process files multiple times and inflated discovery metrics.

### Description

- Deduplicated `git ls-files` output in `parse_git_ls_files_output` by tracking absolute paths with a `HashSet` and only appending unseen Perl files to the result vector.
- Treat duplicate entries as excluded (increment `excluded_count`) so discovery metrics remain accurate and stable.
- Added a regression test `parse_git_output_deduplicates_duplicate_entries` to ensure duplicate git records produce unique file results and correct exclusion accounting.

### Testing

- Ran formatter: `cargo xtask fmt` and it completed successfully.
- Ran the new unit test: `cargo test -p perl-workspace discovery::tests::parse_git_output_deduplicates_duplicate_entries --quiet` and it passed.
- Ran the crate test suite: `cargo test -p perl-workspace --quiet` and it passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97cf88ad483339f428c51fa6fa9fe)