### PR TITLE
fix(ci-hygiene): ignore TODO markers inside Rust C-string literals (#9999)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3991,22 +3991,25 @@ fn is_index_in_rust_literal(line: &str, target_idx: usize) -> bool {
             continue;
         }
 
-        if bytes[i] == b'b' && i + 1 < bytes.len() && bytes[i + 1] == b'"' {
+        if matches!(bytes[i], b'b' | b'c') && i + 1 < bytes.len() && bytes[i + 1] == b'"' {
             in_string = true;
             i += 2;
             continue;
         }
 
-        if bytes[i] == b'r' || (bytes[i] == b'b' && i + 1 < bytes.len() && bytes[i + 1] == b'r') {
+        if bytes[i] == b'r'
+            || (matches!(bytes[i], b'b' | b'c') && i + 1 < bytes.len() && bytes[i + 1] == b'r')
+        {
             let mut j = i + 1;
-            if bytes[i] == b'b' {
+            if matches!(bytes[i], b'b' | b'c') {
                 j += 1;
             }
             while j < bytes.len() && bytes[j] == b'#' {
                 j += 1;
             }
             if j < bytes.len() && bytes[j] == b'"' {
-                raw_hashes = Some(j.saturating_sub(i + if bytes[i] == b'b' { 2 } else { 1 }));
+                raw_hashes =
+                    Some(j.saturating_sub(i + if matches!(bytes[i], b'b' | b'c') { 2 } else { 1 }));
                 i = j + 1;
                 continue;
             }
@@ -4302,6 +4305,19 @@ mod tests {
         assert!(!has_unlinked_todo_in_rust_line("let s = r#\"// TODO in literal\"#;", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line(
             "let s = r#\"/* FIXME in literal */\"#;",
+            &todo_re
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn rust_todo_detection_ignores_c_string_comment_markers() -> Result<()> {
+        let todo_re = Regex::new(r"TODO|FIXME")?;
+
+        assert!(!has_unlinked_todo_in_rust_line("let c = c\"// TODO in literal\";", &todo_re));
+        assert!(!has_unlinked_todo_in_rust_line(
+            "let c = cr#\"/* FIXME in literal */\"#;",
             &todo_re
         ));
 


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner incorrectly flagged TODO-like text inside Rust C-string literals as unlinked TODOs, causing false positives.
- The scanner must treat `c"..."` and raw variants as string literals so comment-like contents inside them are ignored.

### Description
- Updated `is_index_in_rust_literal` in `crates/perl-ci-hygiene/src/main.rs` to recognize `c"..."` byte-compatible C-string literals as string contexts.
- Extended raw-literal parsing to accept `cr#"..."#` prefixes so raw C-strings do not generate TODO hits.
- Added a targeted regression test `rust_todo_detection_ignores_c_string_comment_markers` to ensure `c"// TODO ..."` and `cr#"/* FIXME ... */"#` are ignored by the scanner.

### Testing
- Ran `cargo test -p perl-ci-hygiene rust_todo_detection_ignores_c_string_comment_markers`, which passed.
- Ran the full crate tests with `cargo test -p perl-ci-hygiene`, where all tests passed (`37 passed; 0 failed`).
- Ran formatting via `cargo xtask fmt` as part of validation, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97cf88ad483339f428c51fa6fa9fe)