### PR TITLE
fix(workspace-index): reject stale document store updates (#4707)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/document_store.rs
+++ b/crates/perl-workspace-index/src/workspace/document_store.rs
@@ -71,6 +71,9 @@ impl DocumentStore {
             return false;
         };
         if let Some(doc) = docs.get_mut(&key) {
+            if version < doc.version {
+                return false;
+            }
             doc.update(version, text);
             true
         } else {
@@ -224,5 +227,18 @@ mod tests {
 
         let doc = must_some(store.get(&uri));
         assert_eq!(doc.text, "# test");
+    }
+
+    #[test]
+    fn test_update_rejects_stale_version() {
+        let store = DocumentStore::new();
+        let uri = "file:///versioned.pl".to_string();
+
+        store.open(uri.clone(), 3, "current".to_string());
+        assert!(!store.update(&uri, 2, "stale".to_string()));
+
+        let doc = must_some(store.get(&uri));
+        assert_eq!(doc.version, 3);
+        assert_eq!(doc.text, "current");
     }
 }

--- a/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
@@ -460,6 +460,17 @@ fn test_document_store_update_nonexistent() {
 }
 
 #[test]
+fn test_document_store_rejects_stale_update_version() {
+    let store = DocumentStore::new();
+    store.open("file:///stale.pl".to_string(), 10, "latest".to_string());
+    assert!(!store.update("file:///stale.pl", 9, "older".to_string()));
+
+    let doc = must_some(store.get("file:///stale.pl"));
+    assert_eq!(doc.version, 10);
+    assert_eq!(doc.text, "latest");
+}
+
+#[test]
 fn test_document_store_close_nonexistent() {
     let store = DocumentStore::new();
     assert!(!store.close("file:///never_opened.pl"));


### PR DESCRIPTION
### Motivation
- Prevent out-of-order LSP `didChange` notifications from overwriting newer in-memory document content by enforcing monotonic version updates in the document store.

### Description
- Added a version guard in `DocumentStore::update` so an update is ignored when the incoming `version` is less than the stored document's `version`.
- Added a focused unit test `test_update_rejects_stale_version` in `crates/perl-workspace-index/src/workspace/document_store.rs` to validate the guard.
- Added broader coverage `test_document_store_rejects_stale_update_version` in `crates/perl-workspace-index/tests/comprehensive_unit_tests.rs` to lock the behavior into the workspace-index test grid.

### Testing
- Ran `cargo xtask fmt` to ensure formatting, which completed successfully.
- Ran `cargo test -p perl-workspace stale_version` and the new unit test `test_update_rejects_stale_version`, both of which passed.
- Ran `cargo test -p perl-workspace stale_update_version` and the added comprehensive test `test_document_store_rejects_stale_update_version`, which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97cf88ad483339f428c51fa6fa9fe)