### PR TITLE
test(lsp): lock double-initialize contract coverage (#4707)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_protocol_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_protocol_tests.rs
@@ -263,6 +263,39 @@ sub test_function {
 }
 
 #[test]
+fn test_double_initialize_is_rejected_per_lsp_spec() {
+    let server = LspServer::new();
+
+    let first = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(1)),
+        method: "initialize".into(),
+        params: Some(json!({
+            "capabilities": {},
+            "rootUri": "file:///test"
+        })),
+    });
+
+    let second = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(2)),
+        method: "initialize".into(),
+        params: Some(json!({
+            "capabilities": {},
+            "rootUri": "file:///test"
+        })),
+    });
+
+    let first_response = first.expect("first initialize should return a response");
+    assert!(first_response.error.is_none(), "first initialize should succeed");
+
+    let second_response = second.expect("second initialize should return an error response");
+    let error = second_response.error.expect("second initialize should error");
+    assert_eq!(error.code, -32600, "second initialize must be InvalidRequest");
+    assert_eq!(error.message, "initialize may only be sent once");
+}
+
+#[test]
 fn test_position_encoding_advertised() -> Result<(), Box<dyn std::error::Error>> {
     // This test verifies that the server advertises UTF-16 position encoding
     let _server = LspServer::new();

--- a/crates/perl-parser/LSP_API_CONTRACTS.md
+++ b/crates/perl-parser/LSP_API_CONTRACTS.md
@@ -230,7 +230,7 @@ These contracts are enforced by the following test categories:
 1. **Initialization Tests**
    - ✅ Basic initialization
    - ✅ Minimal client capabilities
-   - ⚠️ Double initialization rejection (TODO: Fix server)
+   - ✅ Double initialization rejection (InvalidRequest on second call)
 
 2. **Response Shape Tests**
    - ✅ Completion response shapes


### PR DESCRIPTION
### Motivation
- Ensure the LSP lifecycle contract that `initialize` may only be sent once is locked down by integration coverage so regressions are caught by tests.

### Description
- Added an integration test `test_double_initialize_is_rejected_per_lsp_spec` in `crates/perl-lsp/tests/lsp_protocol_tests.rs` that asserts a second `initialize` request returns `InvalidRequest` (`-32600`) with the expected message.
- Updated `crates/perl-parser/LSP_API_CONTRACTS.md` to mark double-initialize rejection as covered (`✅`) instead of TODO.

### Testing
- Ran `cargo test -p perl-lsp-rs --test lsp_protocol_tests` which executed the protocol tests and reported all tests including the new one passed.
- Ran `cargo xtask fmt` to ensure formatting; the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c919f348333b8357b7e8032ac8a)