### PR TITLE
fix(performance): stabilize parallel processing order (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/performance/mod.rs
+++ b/crates/perl-lsp-rs-core/src/performance/mod.rs
@@ -201,12 +201,14 @@ pub mod parallel {
             return Vec::new();
         }
 
+        let file_count = files.len();
+
         // Ensure callers cannot accidentally request zero workers and drop all work.
         // This preserves the API contract that every input file is processed once.
-        let effective_workers = num_workers.max(1).min(files.len());
+        let effective_workers = num_workers.max(1).min(file_count);
 
         let (tx, rx) = mpsc::channel();
-        let work_queue = Arc::new(Mutex::new(files));
+        let work_queue = Arc::new(Mutex::new(files.into_iter().enumerate().collect::<Vec<_>>()));
         let processor = Arc::new(processor);
 
         let mut handles = vec![];
@@ -226,9 +228,9 @@ pub mod parallel {
                     };
 
                     match file {
-                        Some(f) => {
-                            let result = processor(f);
-                            if tx.send(result).is_err() {
+                        Some((index, file)) => {
+                            let result = processor(file);
+                            if tx.send((index, result)).is_err() {
                                 break;
                             }
                         }
@@ -246,6 +248,13 @@ pub mod parallel {
             let _ = handle.join();
         }
 
-        rx.into_iter().collect()
+        let mut ordered_results = Vec::with_capacity(file_count);
+        ordered_results.resize_with(file_count, || None);
+
+        for (index, value) in rx {
+            ordered_results[index] = Some(value);
+        }
+
+        ordered_results.into_iter().flatten().collect()
     }
 }

--- a/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
+++ b/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
@@ -61,8 +61,7 @@ fn incremental_parser_given_zero_width_change_when_marked_then_no_nodes_require_
 fn parallel_given_zero_workers_when_processing_then_all_files_are_still_processed() {
     let files = vec!["a.pm".to_string(), "b.pm".to_string(), "c.pm".to_string()];
 
-    let mut processed = parallel::process_files_parallel(files, 0, |file| file);
-    processed.sort();
+    let processed = parallel::process_files_parallel(files, 0, |file| file);
 
     assert_eq!(processed, vec!["a.pm", "b.pm", "c.pm"]);
 }
@@ -71,8 +70,29 @@ fn parallel_given_zero_workers_when_processing_then_all_files_are_still_processe
 fn parallel_given_more_workers_than_files_when_processing_then_each_file_processed_once() {
     let files = vec!["one.pm".to_string(), "two.pm".to_string()];
 
-    let mut processed = parallel::process_files_parallel(files, 16, |file| file);
-    processed.sort();
+    let processed = parallel::process_files_parallel(files, 16, |file| file);
 
     assert_eq!(processed, vec!["one.pm", "two.pm"]);
+}
+
+#[test]
+fn parallel_given_multiple_workers_when_processing_then_input_order_is_preserved() {
+    let files = vec![
+        "first.pm".to_string(),
+        "second.pm".to_string(),
+        "third.pm".to_string(),
+        "fourth.pm".to_string(),
+    ];
+
+    let processed = parallel::process_files_parallel(files.clone(), 4, |file| {
+        std::thread::sleep(std::time::Duration::from_millis(match file.as_str() {
+            "first.pm" => 40,
+            "second.pm" => 30,
+            "third.pm" => 20,
+            _ => 10,
+        }));
+        file
+    });
+
+    assert_eq!(processed, files);
 }


### PR DESCRIPTION
### Motivation
- `process_files_parallel` produced nondeterministic output order due to concurrent worker completion, which can cause upstream consumers and tests to rely on sorted results instead of preserved input order.
- Tests previously sorted results to assert correctness instead of verifying deterministic ordering, masking the original behavior.

### Description
- Change `parallel::process_files_parallel` to tag each input with its original index, send `(index, result)` from workers, and reassemble the final `Vec<T>` in original input order after workers complete in `crates/perl-lsp-rs-core/src/performance/mod.rs`.
- Preserve existing safety behavior for `num_workers == 0` and when `num_workers` exceeds input count by computing `effective_workers` and keeping worker pool semantics.
- Replace the work queue with a vector of `(index, file)` pairs and adjust channel send/receive to carry indices.
- Update tests in `crates/perl-lsp-rs-core/tests/performance_module_shape.rs` to stop sorting outputs and add `parallel_given_multiple_workers_when_processing_then_input_order_is_preserved` to assert ordering under skewed per-file completion times.

### Testing
- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo test -p perl-lsp-rs-core --test performance_module_shape` and all tests passed (`10 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c919f348333b8357b7e8032ac8a)