### PR TITLE
fix(perl-dap): preserve legacy package vars in inline values (#0000)

### DIFF
--- a/crates/perl-dap/src/inline_values.rs
+++ b/crates/perl-dap/src/inline_values.rs
@@ -61,6 +61,14 @@ fn normalize_line_bounds(
 /// Bytes that belong to Perl comments (`# ...`) or single/double-quoted string
 /// literals are marked `false` and should be ignored by lightweight regex scans.
 fn code_byte_mask(line: &str) -> Vec<bool> {
+    fn is_ident_char(byte: u8) -> bool {
+        byte.is_ascii_alphanumeric() || byte == b'_'
+    }
+
+    fn is_ident_start(byte: u8) -> bool {
+        byte.is_ascii_alphabetic() || byte == b'_'
+    }
+
     let bytes = line.as_bytes();
     let mut mask = vec![true; bytes.len()];
     let mut in_single = false;
@@ -105,8 +113,15 @@ fn code_byte_mask(line: &str) -> Vec<bool> {
                 break;
             }
             b'\'' => {
-                mask[i] = false;
-                in_single = true;
+                let is_legacy_namespace_separator = i > 0
+                    && i + 1 < bytes.len()
+                    && is_ident_char(bytes[i - 1])
+                    && is_ident_start(bytes[i + 1]);
+
+                if !is_legacy_namespace_separator {
+                    mask[i] = false;
+                    in_single = true;
+                }
             }
             b'"' => {
                 mask[i] = false;


### PR DESCRIPTION
### Motivation
- Inline variable extraction in the DAP code was incorrectly treating apostrophes used as legacy Perl namespace separators (e.g. `$Foo'bar`) as the start of single-quoted strings, which caused valid legacy-namespaced variables to be masked and missed by runtime/value-extraction logic.

### Description
- Adjusted `code_byte_mask` in `crates/perl-dap/src/inline_values.rs` to detect apostrophes that act as legacy namespace separators and not enter single-quote masking for those cases.
- Added small helpers `is_ident_char` and `is_ident_start` and use them to recognize an apostrophe as a legacy separator when it sits between identifier characters.
- Preserved original single- and double-quote masking behavior for true string literals while allowing the regex-based extraction and runtime lookup to see legacy namespaced variables.

### Testing
- Ran `cargo test -p perl-dap --lib inline_values::tests` and the targeted inline-values test suite passed (`20 passed; 0 failed`).
- Ran `cargo test -p perl-dap --lib` and the full `perl-dap` library tests passed (`340 passed; 0 failed`).
- Ran `cargo xtask fmt` to ensure formatting and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c919f348333b8357b7e8032ac8a)