### PR TITLE
fix(dap-inline-values): clamp EOF range handling (#0000)

### DIFF
--- a/crates/perl-dap/src/inline_values.rs
+++ b/crates/perl-dap/src/inline_values.rs
@@ -33,8 +33,8 @@ fn is_special_variable_name(name: &str) -> bool {
 
 /// Convert 1-based line bounds into inclusive 0-based indexes.
 ///
-/// Non-positive line inputs are clamped to line 1, and the end index is
-/// rejected when either bound is past the available line count.
+/// Non-positive line inputs are clamped to line 1. The end line is clamped to
+/// the available line count, while a start line past EOF is rejected.
 fn normalize_line_bounds(
     start_line: i64,
     end_line: i64,
@@ -45,10 +45,10 @@ fn normalize_line_bounds(
     }
 
     let start_1_based = start_line.max(1) as usize;
-    let end_1_based = end_line.max(1) as usize;
-    if start_1_based > line_count || end_1_based > line_count {
+    if start_1_based > line_count {
         return None;
     }
+    let end_1_based = (end_line.max(1) as usize).min(line_count);
 
     let start_idx = start_1_based.saturating_sub(1);
     let end_idx = end_1_based.saturating_sub(1);
@@ -450,6 +450,24 @@ mod tests {
         assert!(extract_variable_names(source, 3, 3).is_empty());
         assert!(collect_inline_values_with_runtime(source, 3, 3, None).is_empty());
         assert!(collect_inline_values(source, 3, 3).is_empty());
+    }
+
+    #[test]
+    fn test_end_line_past_eof_is_clamped() {
+        let source = "my $x = 1;\nmy $y = 2;";
+
+        let names = extract_variable_names(source, 1, 999);
+        assert_eq!(names, vec!["$x".to_string(), "$y".to_string()]);
+
+        let runtime_values = collect_inline_values_with_runtime(source, 1, 999, None);
+        assert_eq!(runtime_values.len(), 2);
+        assert!(runtime_values.iter().any(|v| v.text == "$x = ?"));
+        assert!(runtime_values.iter().any(|v| v.text == "$y = ?"));
+
+        let legacy_values = collect_inline_values(source, 1, 999);
+        assert_eq!(legacy_values.len(), 2);
+        assert!(legacy_values.iter().any(|v| v.text == "$x = ?"));
+        assert!(legacy_values.iter().any(|v| v.text == "$y = ?"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- DAP clients may request ranges where `endLine` extends past EOF, and the previous logic rejected such requests resulting in no inline values for otherwise-valid `startLine` values.

### Description
- Change `normalize_line_bounds` in `crates/perl-dap/src/inline_values.rs` to clamp `end_line` to the file's last line instead of rejecting when `end_line` > file length while preserving rejection when `start_line` is past EOF.
- Update the function comment to document the new clamping behavior and keep existing inverted-range safety logic via `start_idx <= end_idx`.
- Add a regression test `test_end_line_past_eof_is_clamped` in `crates/perl-dap/src/inline_values.rs` that validates clamped behavior across `extract_variable_names`, `collect_inline_values_with_runtime`, and the legacy `collect_inline_values`.

### Testing
- Ran `cargo test -p perl-dap test_end_line_past_eof_is_clamped --lib` and the test passed.
- Ran `cargo test -p perl-dap inline_values::tests::test_out_of_range_line_bounds_return_empty --lib` and the test passed.
- Ran `cargo xtask fmt` to ensure formatting and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c957b6083339f637b4d2f744440)