### PR TITLE
fix(ci-hygiene): detect TODO/FIXME markers case-insensitively (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3384,7 +3384,7 @@ fn cmd_check_todos(repo_root: &Path, list_mode: bool) -> Result<i32> {
             .join("complex_paren_args_tests.rs"),
     ];
 
-    let todo_re = Regex::new(r"TODO|FIXME")?;
+    let todo_re = Regex::new(r"(?i)\b(?:TODO|FIXME)\b")?;
     let entries = collect_todo_hits(repo_root, &exclude_dirs, &exclude_files, &todo_re)?;
 
     if list_mode {
@@ -4281,9 +4281,10 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_linked_or_url_like_comments() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"(?i)\b(?:TODO|FIXME)\b")?;
 
         assert!(has_unlinked_todo_in_rust_line("// TODO: investigate", &todo_re));
+        assert!(has_unlinked_todo_in_rust_line("// todo: investigate", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line("// TODO(#123): tracked", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line("let u = \"http://TODO\";", &todo_re));
         assert!(has_unlinked_todo_in_rust_line(
@@ -4297,7 +4298,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_raw_string_comment_markers() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"(?i)\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_rust_line("let s = r#\"// TODO in literal\"#;", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line(
@@ -4310,7 +4311,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_non_raw_string_comment_markers() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"(?i)\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_rust_line(
             "let s = \"not a comment // TODO in literal\";",
@@ -4330,7 +4331,7 @@ mod tests {
 
     #[test]
     fn hash_comment_todo_detection_handles_shebang_and_inline_hashes() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"(?i)\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
@@ -4346,6 +4347,7 @@ mod tests {
         ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line("echo hi # fixme: follow up", &todo_re));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner only matched uppercase markers and could miss lowercase variants such as `todo` or `fixme`, reducing coverage of the unlinked-TODO audit.
- The scanner should match whole tokens (word boundaries) while preserving existing linked-marker behavior like `TODO(#123)` so tracked items remain excluded.

### Description
- Updated the scanner regex in `cmd_check_todos` to `(?i)\b(?:TODO|FIXME)\b` to enable case-insensitive, token-boundary matching.
- Updated unit tests in the `perl-ci-hygiene` test module to exercise lowercase detection in both Rust comment paths and hash-comment files and to assert existing exclusions still hold.
- No behavioral change to linked-marker handling or other TODO filtering logic was introduced.

### Testing
- Ran `cargo xtask fmt` to format the workspace, which completed successfully.
- Ran `cargo test -p perl-ci-hygiene rust_todo_detection -- --nocapture` and the tests passed.
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes -- --nocapture` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c957b6083339f637b4d2f744440)