### PR TITLE
fix(perl-ci-hygiene): detect inline Perl TODO comments without whitespace (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3788,6 +3788,12 @@ struct IgnoredDetail {
     test_name: String,
 }
 
+#[derive(Clone, Copy)]
+enum HashCommentStyle {
+    ShellLike,
+    PerlLike,
+}
+
 fn collect_todo_hits(
     root: &Path,
     exclude_dirs: &[&str],
@@ -3820,6 +3826,10 @@ fn collect_todo_hits(
         let is_hash_file = file_name == "Justfile"
             || file_name == "justfile"
             || hash_ext.iter().any(|ext| path.extension().is_some_and(|e| e == *ext));
+        let hash_comment_style = match path.extension().and_then(|ext| ext.to_str()) {
+            Some("pl" | "pm" | "t") => HashCommentStyle::PerlLike,
+            _ => HashCommentStyle::ShellLike,
+        };
         if !is_rust && !is_hash_file {
             continue;
         }
@@ -3828,7 +3838,7 @@ fn collect_todo_hits(
             let match_line = if is_rust {
                 has_unlinked_todo_in_rust_line(line, todo_re)
             } else {
-                has_unlinked_todo_in_hash_line(line, todo_re)
+                has_unlinked_todo_in_hash_line(line, todo_re, hash_comment_style)
             };
             if !match_line {
                 continue;
@@ -3872,14 +3882,14 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
     false
 }
 
-fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
-    let Some(idx) = find_hash_comment_start(line) else {
+fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex, style: HashCommentStyle) -> bool {
+    let Some(idx) = find_hash_comment_start(line, style) else {
         return false;
     };
     has_unlinked_token(&line[idx + 1..], token_re)
 }
 
-fn find_hash_comment_start(line: &str) -> Option<usize> {
+fn find_hash_comment_start(line: &str, style: HashCommentStyle) -> Option<usize> {
     let mut in_single = false;
     let mut in_double = false;
     let mut prev_was_escape = false;
@@ -3913,7 +3923,7 @@ fn find_hash_comment_start(line: &str) -> Option<usize> {
                 if idx == 0 && line.as_bytes().get(1) == Some(&b'!') {
                     return None;
                 }
-                if idx == 0 {
+                if idx == 0 || matches!(style, HashCommentStyle::PerlLike) {
                     return Some(idx);
                 }
                 if let Some(prev) = line[..idx].chars().next_back() {
@@ -4332,20 +4342,64 @@ mod tests {
     fn hash_comment_todo_detection_handles_shebang_and_inline_hashes() -> Result<()> {
         let todo_re = Regex::new(r"TODO|FIXME")?;
 
-        assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
-        assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
-        assert!(has_unlinked_todo_in_hash_line("echo hi;# TODO: follow up", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line(
+            "#!/usr/bin/env bash",
+            &todo_re,
+            HashCommentStyle::ShellLike,
+        ));
+        assert!(!has_unlinked_todo_in_hash_line(
+            "echo# TODO not a comment",
+            &todo_re,
+            HashCommentStyle::ShellLike,
+        ));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo hi;# TODO: follow up",
+            &todo_re,
+            HashCommentStyle::ShellLike,
+        ));
         assert!(has_unlinked_todo_in_hash_line(
             "echo \"#not-a-comment\" # TODO: follow up",
             &todo_re,
+            HashCommentStyle::ShellLike,
         ));
-        assert!(!has_unlinked_todo_in_hash_line("echo '# TODO in string' && true", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line(
+            "echo '# TODO in string' && true",
+            &todo_re,
+            HashCommentStyle::ShellLike,
+        ));
         assert!(has_unlinked_todo_in_hash_line(
             "echo '# TODO in string' # TODO: follow up",
-            &todo_re
+            &todo_re,
+            HashCommentStyle::ShellLike,
         ));
-        assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
-        assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo hi # TODO: follow up",
+            &todo_re,
+            HashCommentStyle::ShellLike,
+        ));
+        assert!(!has_unlinked_todo_in_hash_line(
+            "echo hi # TODO(#77): tracked",
+            &todo_re,
+            HashCommentStyle::ShellLike,
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn perl_hash_comment_todo_detection_allows_no_whitespace_before_hash() -> Result<()> {
+        let todo_re = Regex::new(r"TODO|FIXME")?;
+
+        assert!(has_unlinked_todo_in_hash_line(
+            "my $x = 1# TODO: tighten this assertion",
+            &todo_re,
+            HashCommentStyle::PerlLike,
+        ));
+        assert!(!has_unlinked_todo_in_hash_line(
+            "my $x = 1# TODO(#77): tracked",
+            &todo_re,
+            HashCommentStyle::PerlLike,
+        ));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation

- The TODO/FIXME scanner missed inline Perl-style comments like `1# TODO` because hash-comment detection assumed shell-like spacing rules. 
- We need to detect unlinked TODOs in Perl sources while preserving shell-script heuristics to avoid false positives in files like `Justfile` and `sh`.

### Description

- Introduce `HashCommentStyle` (`PerlLike` / `ShellLike`) and choose style based on file extension (`.pl`, `.pm`, `.t` use `PerlLike`).
- Thread the chosen style through `has_unlinked_todo_in_hash_line` into `find_hash_comment_start` and make Perl style treat `#` as a comment start even without preceding whitespace (except for shebang handling).
- Keep existing shell-like heuristics for `ShellLike` files to avoid flagging constructs such as `echo#...` as comments.
- Add focused unit tests verifying both shell-style behavior and Perl inline-comment detection, and update existing assertions to exercise the new API.

### Testing

- Ran formatter with `cargo xtask fmt` and it completed successfully.
- Ran the focused test with `cargo test -p perl-ci-hygiene hash_comment_todo_detection -- --nocapture` and it passed.
- Ran the crate test suite with `cargo test -p perl-ci-hygiene` and all tests passed (37 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97cf74f948333866534d04d944d4e)