### PR TITLE
fix(perl-dap): harden inline value masking for quote-like literals (#0000)

### DIFF
--- a/crates/perl-dap/src/inline_values.rs
+++ b/crates/perl-dap/src/inline_values.rs
@@ -97,6 +97,14 @@ fn code_byte_mask(line: &str) -> Vec<bool> {
             continue;
         }
 
+        if let Some(end_idx) = scan_quote_like_literal(bytes, i) {
+            for byte in mask.iter_mut().take(end_idx).skip(i) {
+                *byte = false;
+            }
+            i = end_idx;
+            continue;
+        }
+
         match b {
             b'#' => {
                 for byte in mask.iter_mut().take(bytes.len()).skip(i) {
@@ -105,6 +113,14 @@ fn code_byte_mask(line: &str) -> Vec<bool> {
                 break;
             }
             b'\'' => {
+                let prev = i.checked_sub(1).and_then(|idx| bytes.get(idx)).copied();
+                let next = bytes.get(i + 1).copied();
+                let looks_like_legacy_namespace_sep =
+                    prev.is_some_and(is_ident_byte) && next.is_some_and(is_ident_byte);
+                if looks_like_legacy_namespace_sep {
+                    i += 1;
+                    continue;
+                }
                 mask[i] = false;
                 in_single = true;
             }
@@ -119,6 +135,84 @@ fn code_byte_mask(line: &str) -> Vec<bool> {
     }
 
     mask
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+fn scan_quote_like_literal(bytes: &[u8], start: usize) -> Option<usize> {
+    let op_len = match bytes.get(start)? {
+        b'q' => match bytes.get(start + 1) {
+            Some(b'q' | b'w' | b'r' | b'x') => 2,
+            _ => 1,
+        },
+        _ => return None,
+    };
+
+    if start > 0 {
+        let prev = bytes[start - 1];
+        if is_ident_byte(prev) {
+            return None;
+        }
+    }
+
+    let mut delim_start = start + op_len;
+    while let Some(b) = bytes.get(delim_start) {
+        if b.is_ascii_whitespace() {
+            delim_start += 1;
+        } else {
+            break;
+        }
+    }
+
+    let open = *bytes.get(delim_start)?;
+    if open.is_ascii_alphanumeric() || open.is_ascii_whitespace() {
+        return None;
+    }
+
+    let (close, nested) = match open {
+        b'(' => (b')', true),
+        b'{' => (b'}', true),
+        b'[' => (b']', true),
+        b'<' => (b'>', true),
+        other => (other, false),
+    };
+
+    let mut depth = usize::from(nested);
+    let mut escaped = false;
+    let mut i = delim_start + 1;
+
+    while let Some(&cur) = bytes.get(i) {
+        if escaped {
+            escaped = false;
+            i += 1;
+            continue;
+        }
+
+        if cur == b'\\' {
+            escaped = true;
+            i += 1;
+            continue;
+        }
+
+        if nested {
+            if cur == open {
+                depth += 1;
+            } else if cur == close {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(i + 1);
+                }
+            }
+        } else if cur == close {
+            return Some(i + 1);
+        }
+
+        i += 1;
+    }
+
+    Some(bytes.len())
 }
 
 /// Extract unique variable names from source code within a line range.
@@ -490,5 +584,26 @@ mod tests {
         let values = collect_inline_values_with_runtime(source, 1, 1, None);
         assert_eq!(values.len(), 1);
         assert_eq!(values[0].text, "$real = ?");
+    }
+
+    #[test]
+    fn test_quote_like_literals_mask_variable_like_tokens() {
+        let source = "my $real = 1; my $single = q{$fake}; my $double = qq/$also_fake/;";
+        let values = collect_inline_values_with_runtime(source, 1, 1, None);
+        assert_eq!(values.len(), 3);
+        assert!(values.iter().any(|v| v.text == "$real = ?"));
+        assert!(values.iter().any(|v| v.text == "$single = ?"));
+        assert!(values.iter().any(|v| v.text == "$double = ?"));
+        assert!(!values.iter().any(|v| v.text == "$fake = ?"));
+        assert!(!values.iter().any(|v| v.text == "$also_fake = ?"));
+    }
+
+    #[test]
+    fn test_non_quote_like_identifiers_are_not_masked() {
+        let source = "my $qvar = 1; my $qqsize = 2;";
+        let values = collect_inline_values_with_runtime(source, 1, 1, None);
+        assert_eq!(values.len(), 2);
+        assert!(values.iter().any(|v| v.text == "$qvar = ?"));
+        assert!(values.iter().any(|v| v.text == "$qqsize = ?"));
     }
 }


### PR DESCRIPTION
### Motivation
- Lightweight regex scans for inline values were producing false positives when Perl quote-like operators (e.g. `q`, `qq`, `qw`, `qr`, `qx`) contained variable-like tokens.
- Non-nesting quote-like delimiters were not scanned correctly, allowing quoted variable-like tokens to leak into inline value extraction.
- Apostrophes used as legacy namespace separators (e.g. `$Foo'bar`) were being treated as string delimiters and caused regressions for legacy-qualified symbols.

### Description
- Added a `scan_quote_like_literal` helper and integrated it into `code_byte_mask` to recognize and mask Perl quote-like literals so variables inside them are ignored. 
- Fixed delimiter scanning so non-nesting quote-like delimiters (e.g. `qq/.../`) scan from after the opening delimiter and nested delimiters (e.g. `q(...)`) handle depth correctly.
- Preserved legacy apostrophe namespace support by detecting apostrophes between identifier bytes and skipping them as string delimiters via an `is_ident_byte` helper.
- Added focused regression tests and assertions in `crates/perl-dap/src/inline_values.rs` to validate quote-like masking and to ensure non-quote-like identifiers remain detectable.

### Testing
- Ran `cargo xtask fmt` successfully to apply repository formatting rules.
- Ran `cargo test -p perl-dap inline_values::tests:: --lib` and all inline value tests passed (22 tests passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c90f54c8333b8b3a485642f33ee)