### PR TITLE
fix(ci-hygiene): allow generic /Users paths in doc-path audit (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3355,7 +3355,9 @@ fn has_machine_specific_home_path(line: &str, home_user_path: &Regex) -> bool {
 
 fn has_machine_specific_users_path(line: &str, users_name_path: &Regex) -> bool {
     users_name_path.captures_iter(line).any(|captures| {
-        captures.get(1).is_some_and(|name| !name.as_str().eq_ignore_ascii_case("name"))
+        captures.get(1).is_some_and(|name| {
+            !matches!(name.as_str().to_ascii_lowercase().as_str(), "name" | "user" | "shared")
+        })
     })
 }
 
@@ -4373,6 +4375,14 @@ mod tests {
 
         assert!(!has_machine_specific_users_path(
             "Template: /Users/Name/project",
+            &users_name_path,
+        ));
+        assert!(!has_machine_specific_users_path(
+            "Template: /Users/user/project",
+            &users_name_path,
+        ));
+        assert!(!has_machine_specific_users_path(
+            "Shared storage: /Users/Shared/build-cache",
             &users_name_path,
         ));
         assert!(has_machine_specific_users_path(


### PR DESCRIPTION
### Motivation
- Reduce false-positive documentation warnings from `ci-hygiene` when docs reference common macOS shared or example paths under `/Users`.
- Treat known generic segments as non-machine-specific so the docs audit only flags real personal usernames.

### Description
- Update `has_machine_specific_users_path` to treat `/Users/<segment>` as generic when `<segment>` (case-insensitive) is `name`, `user`, or `shared` by using `matches!(... "name" | "user" | "shared")` in `crates/perl-ci-hygiene/src/main.rs`.
- Add regression assertions to the existing test `users_path_detection_only_allows_generic_name_examples` to ensure `/Users/user` and `/Users/Shared` are accepted while `/Users/alice` is still flagged.

### Testing
- Ran `cargo test -p perl-ci-hygiene users_path_detection_only_allows_generic_name_examples` and it passed.
- Ran the full crate test suite with `cargo test -p perl-ci-hygiene` and all tests passed (`36 passed; 0 failed`).
- Ran formatting with `cargo xtask fmt` to ensure style compliance and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c90f54c8333b8b3a485642f33ee)