### PR TITLE
fix(workspace-index): include skipped dirs in walk discovery excluded metrics (#4707)

### DIFF
--- a/crates/perl-workspace-index/src/discovery/mod.rs
+++ b/crates/perl-workspace-index/src/discovery/mod.rs
@@ -126,12 +126,15 @@ fn parse_git_ls_files_output(root: &Path, stdout: &[u8]) -> (Vec<PathBuf>, usize
 fn walk_discovery(root: &Path, start: Instant) -> DiscoveryResult {
     let mut files = Vec::new();
     let mut excluded_count: usize = 0;
+    let mut skipped_dir_count: usize = 0;
 
-    for entry in WalkDir::new(root)
-        .follow_links(false)
-        .into_iter()
-        .filter_entry(|entry| !should_skip_dir(entry))
-    {
+    for entry in WalkDir::new(root).follow_links(false).into_iter().filter_entry(|entry| {
+        if should_skip_dir(entry) {
+            skipped_dir_count += 1;
+            return false;
+        }
+        true
+    }) {
         let entry = match entry {
             Ok(entry) => entry,
             Err(_) => continue,
@@ -147,6 +150,7 @@ fn walk_discovery(root: &Path, start: Instant) -> DiscoveryResult {
             excluded_count += 1;
         }
     }
+    excluded_count += skipped_dir_count;
 
     let result = DiscoveryResult {
         files,
@@ -244,6 +248,25 @@ mod tests {
         assert_eq!(result.method, DiscoveryMethod::Walk);
         assert_eq!(result.files.len(), 1);
         assert!(result.files[0].ends_with("lib/Foo.pm"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn walk_discovery_counts_skipped_directories_as_excluded() -> TestResult {
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path();
+
+        create_file(root, "lib/Foo.pm")?;
+        create_file(root, "node_modules/pkg.pm")?;
+        create_file(root, "target/build/generated.pm")?;
+        create_file(root, ".cache/precompiled.pm")?;
+
+        let result = walk_discovery(root, Instant::now());
+        assert_eq!(result.method, DiscoveryMethod::Walk);
+        assert_eq!(result.files.len(), 1);
+        assert!(result.files[0].ends_with("lib/Foo.pm"));
+        assert_eq!(result.excluded_count, 3);
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- `walk_discovery` previously filtered skipped directories via `filter_entry` without counting them, causing `DiscoveryResult.excluded_count` to underreport excluded entries compared to git-based discovery.
- Make discovery observability consistent by counting directories skipped by the canonical skip rules (e.g. `.git`, `target`, `node_modules`, `.cache`).

### Description
- Add a `skipped_dir_count` counter and increment it from the `filter_entry` closure when `should_skip_dir` returns `true`.
- Add the `skipped_dir_count` to `excluded_count` after traversal so skipped directories contribute to `DiscoveryResult.excluded_count` while returned files remain unchanged.
- Add a regression test `walk_discovery_counts_skipped_directories_as_excluded` that verifies skipped directories are counted as excluded in walk-mode discovery.
- Run repository formatting via `cargo xtask fmt` as part of the change.

### Testing
- Ran `cargo xtask fmt` which completed successfully.
- Ran the focused test `cargo test -p perl-workspace --lib discovery::tests::walk_discovery_counts_skipped_directories_as_excluded` and it passed.
- Ran the broader discovery test group `cargo test -p perl-workspace --lib discovery::tests::walk_discovery_` which executed the walk-discovery tests (10 tests) and all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c90f54c8333b8b3a485642f33ee)