### PR TITLE
fix(ci-hygiene): reduce TODO/FIXME scanner false positives (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3384,7 +3384,7 @@ fn cmd_check_todos(repo_root: &Path, list_mode: bool) -> Result<i32> {
             .join("complex_paren_args_tests.rs"),
     ];
 
-    let todo_re = Regex::new(r"TODO|FIXME")?;
+    let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
     let entries = collect_todo_hits(repo_root, &exclude_dirs, &exclude_files, &todo_re)?;
 
     if list_mode {
@@ -4281,7 +4281,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_linked_or_url_like_comments() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(has_unlinked_todo_in_rust_line("// TODO: investigate", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line("// TODO(#123): tracked", &todo_re));
@@ -4297,7 +4297,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_raw_string_comment_markers() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_rust_line("let s = r#\"// TODO in literal\"#;", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line(
@@ -4310,7 +4310,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_non_raw_string_comment_markers() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_rust_line(
             "let s = \"not a comment // TODO in literal\";",
@@ -4324,13 +4324,15 @@ mod tests {
             "let s = \"safe literal\"; // TODO: follow up",
             &todo_re
         ));
+        assert!(!has_unlinked_todo_in_rust_line("// TODOs are tracked elsewhere", &todo_re));
+        assert!(!has_unlinked_todo_in_rust_line("// FIXMEd by refactor", &todo_re));
 
         Ok(())
     }
 
     #[test]
     fn hash_comment_todo_detection_handles_shebang_and_inline_hashes() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
@@ -4346,6 +4348,7 @@ mod tests {
         ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line("echo hi # TODOs addressed in ticket", &todo_re));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation

- The TODO scanner treated any substring match of `TODO`/`FIXME` as a violation, which produced false positives for inflected or plural forms like `TODOs` and `FIXMEd`.

### Description

- Tighten the token matcher in `cmd_check_todos` from `TODO|FIXME` to the word-boundary pattern `\b(?:TODO|FIXME)\b` in `crates/perl-ci-hygiene/src/main.rs`.
- Update test cases in the same file to use the stricter regex and add regression assertions that confirm plural/inflected tokens (e.g. `// TODOs`, `// FIXMEd`, `# TODOs addressed in ticket`) are not flagged.
- Run project formatting to keep code style consistent (`cargo xtask fmt`).

### Testing

- Ran `cargo test -p perl-ci-hygiene --quiet`, all tests passed (`running 36 tests … test result: ok. 36 passed; 0 failed`).
- Ran `cargo xtask fmt` to ensure formatting, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c8d3ee083338f918a57ddd94f27)