### PR TITLE
fix(dap): honor extended debugger output wait budgets (#4707)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -686,9 +686,12 @@ impl DebugAdapter {
     }
 
     /// Wait briefly for debugger command responses to arrive in the output buffer.
+    fn debugger_output_window_ms(timeout_ms: u32) -> u64 {
+        u64::from(timeout_ms).max(DEBUGGER_QUERY_WAIT_MS)
+    }
+
     fn wait_for_debugger_output_window(timeout_ms: u32) {
-        let wait_ms = u64::from(timeout_ms.min(250)).max(DEBUGGER_QUERY_WAIT_MS);
-        thread::sleep(Duration::from_millis(wait_ms));
+        thread::sleep(Duration::from_millis(Self::debugger_output_window_ms(timeout_ms)));
     }
 
     /// Expand debugger query budgets in heavily instrumented environments.
@@ -738,6 +741,16 @@ mod tests {
         assert_eq!(adapter.next_seq(), 1);
         assert_eq!(adapter.next_seq(), 2);
         assert_eq!(adapter.next_seq(), 3);
+    }
+
+    #[test]
+    fn test_debugger_output_window_ms_enforces_minimum_budget() {
+        assert_eq!(DebugAdapter::debugger_output_window_ms(1), DEBUGGER_QUERY_WAIT_MS);
+    }
+
+    #[test]
+    fn test_debugger_output_window_ms_honors_extended_budget() {
+        assert_eq!(DebugAdapter::debugger_output_window_ms(600), 600);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- The previous implementation of `wait_for_debugger_output_window` silently capped caller requests at 250ms which prevented call sites that requested larger windows (e.g. `DEBUGGER_QUERY_WAIT_MS * 8`) from getting the intended extra time in slow / instrumented environments.

### Description

- Introduced `debugger_output_window_ms(timeout_ms: u32) -> u64` to centralize wait-window computation and make the behavior unit-testable.
- Updated `wait_for_debugger_output_window` to call `debugger_output_window_ms` and removed the hard `250ms` cap so callers requesting larger windows are honored while still enforcing the minimum floor (`DEBUGGER_QUERY_WAIT_MS`).
- Added two unit tests `test_debugger_output_window_ms_enforces_minimum_budget` and `test_debugger_output_window_ms_honors_extended_budget` to lock in the expected behavior.
- Ran repository formatting with `cargo xtask fmt` to apply style fixes.

### Testing

- Ran `cargo xtask fmt` and the formatter completed successfully.
- Ran `cargo test -p perl-dap test_debugger_output_window_ms -- --nocapture` and both new tests passed (`2 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c8d3ee083338f918a57ddd94f27)