### PR TITLE
fix(ffi-checklib): support hash-literal lib/libpath args (#4707)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/ffi_checklib.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/ffi_checklib.rs
@@ -123,6 +123,20 @@ fn collect_checklib_arguments(args: &[Node]) -> (Vec<String>, Vec<String>) {
         index += 1;
     }
 
+    for arg in args {
+        if let NodeKind::HashLiteral { pairs } = &arg.kind {
+            for (key, value) in pairs {
+                if let Some(key) = literal_text(key) {
+                    match key.as_str() {
+                        "lib" => libs.extend(extract_literal_strings(value)),
+                        "libpath" => libpaths.extend(extract_literal_strings(value)),
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
     dedup_strings(&mut libs);
     dedup_strings(&mut libpaths);
     (libs, libpaths)
@@ -374,6 +388,34 @@ mod tests {
         assert!(
             diags[0].message.contains("ffi_checklib_missing_3574"),
             "expected the missing library to be named in the diagnostic"
+        );
+    }
+
+    #[test]
+    fn hash_literal_arguments_are_checked_for_missing_libraries() {
+        let source = "use FFI::CheckLib;\nfind_lib({ lib => 'ffi_checklib_missing_3574_hash' });\n";
+
+        let diags = diagnostics_for(source);
+        assert!(
+            diags.iter().any(|d| d.message.contains("ffi_checklib_missing_3574_hash")),
+            "expected missing-library diagnostic for hash-literal arguments, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn hash_literal_libpath_array_suppresses_missing_library() {
+        let tempdir = tempdir().unwrap();
+        write_library(tempdir.path(), "ffi_checklib_present_3574_hash");
+
+        let source = format!(
+            "use FFI::CheckLib;\nfind_lib({{ lib => 'ffi_checklib_present_3574_hash', libpath => ['{}'] }});\n",
+            tempdir.path().display()
+        );
+
+        let diags = diagnostics_for(&source);
+        assert!(
+            diags.is_empty(),
+            "expected no diagnostics for hash-literal libpath, got: {diags:?}"
         );
     }
 


### PR DESCRIPTION
### Motivation
- `FFI::CheckLib` calls passed as hash-literal arguments (e.g. `find_lib({ lib => 'foo', libpath => [...] })`) were not being inspected, causing missing diagnostics or missed suppressions. 
- The change aims to make the diagnostics conservative and more useful by recognizing common hash-literal call forms used in Perl code. 
- This improves the linter's coverage for realistic call shapes without altering existing flat key/value handling.

### Description
- Extend `collect_checklib_arguments` in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/ffi_checklib.rs` to scan `NodeKind::HashLiteral` argument pairs and extract `lib` and `libpath` values. 
- Preserve the existing flat key/value parsing logic while adding hash-literal compatibility by using `literal_text`, `extract_literal_strings`, and existing dedup logic. 
- Add two regression tests in the same file to cover missing-library diagnostics for hash-literal `lib` usage and suppression when `libpath` is provided as an array in a hash literal.

### Testing
- Ran formatter with `cargo xtask fmt` which completed successfully. 
- Ran the targeted tests with `cargo test -p perl-lsp-rs-core ffi_checklib` and the suite covering the updated behavior passed (`9 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7fc3d88333a9deb3d280656c5e)