### PR TITLE
fix(ci-hygiene): tighten TODO token matching (#9999)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3384,7 +3384,7 @@ fn cmd_check_todos(repo_root: &Path, list_mode: bool) -> Result<i32> {
             .join("complex_paren_args_tests.rs"),
     ];
 
-    let todo_re = Regex::new(r"TODO|FIXME")?;
+    let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
     let entries = collect_todo_hits(repo_root, &exclude_dirs, &exclude_files, &todo_re)?;
 
     if list_mode {
@@ -4281,9 +4281,17 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_linked_or_url_like_comments() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(has_unlinked_todo_in_rust_line("// TODO: investigate", &todo_re));
+        assert!(!has_unlinked_todo_in_rust_line(
+            "// TODONT: this should not count as a marker",
+            &todo_re
+        ));
+        assert!(!has_unlinked_todo_in_rust_line(
+            "// FIXMEsuffix should not count as a marker",
+            &todo_re
+        ));
         assert!(!has_unlinked_todo_in_rust_line("// TODO(#123): tracked", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line("let u = \"http://TODO\";", &todo_re));
         assert!(has_unlinked_todo_in_rust_line(
@@ -4297,7 +4305,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_raw_string_comment_markers() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_rust_line("let s = r#\"// TODO in literal\"#;", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line(
@@ -4310,7 +4318,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_non_raw_string_comment_markers() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_rust_line(
             "let s = \"not a comment // TODO in literal\";",
@@ -4330,7 +4338,7 @@ mod tests {
 
     #[test]
     fn hash_comment_todo_detection_handles_shebang_and_inline_hashes() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));


### PR DESCRIPTION
### Motivation

- The TODO/FIXME scanner produced noisy matches for substrings embedded in other words (e.g. `TODONT`, `FIXMEsuffix`), causing spurious compliance hits.
- Tighten detection so only standalone markers are considered to reduce false positives and make the baseline/test audits more accurate.
- Keep existing linked-marker behavior (e.g. `TODO(#123)`) and URL-like exemptions intact while reducing noise.

### Description

- Replaced the permissive `TODO|FIXME` regex with a word-boundary anchored pattern `\b(?:TODO|FIXME)\b` in `crates/perl-ci-hygiene/src/main.rs` to only match standalone markers.
- Updated unit tests in the same file to assert that substring words like `// TODONT:` and `// FIXMEsuffix` do not trigger detection, while preserving positive cases (including URL and linked-marker exemptions).
- Ensured the tightened regex is used consistently across the Rust- and hash-comment detection test cases.

### Testing

- Ran `cargo test -p perl-ci-hygiene rust_todo_detection` and the targeted tests passed.
- Ran `cargo test -p perl-ci-hygiene` and the full crate test suite passed (`36` tests, all `ok`).
- Ran formatting via `cargo xtask fmt` to ensure code style consistency and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7fc3d88333a9deb3d280656c5e)