### PR TITLE
fix(workspace-index): handle delimiter-wrapped `use parent` modules (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -3322,11 +3322,14 @@ fn extract_module_names_from_use_args(args: &[String]) -> Vec<String> {
         if token.starts_with('-') {
             return None;
         }
-        // Strip surrounding single or double quotes
-        let stripped = token.trim_matches('\'').trim_matches('"');
-        // Strip surrounding parentheses (e.g. `use parent ('Foo')`)
-        let stripped = stripped.trim_matches('(').trim_matches(')');
-        let stripped = stripped.trim_matches('\'').trim_matches('"');
+        // Strip common boundary punctuation around module tokens.
+        // This handles forms like:
+        // - use parent 'Foo::Bar', 'Other::Base';
+        // - use parent ('Foo::Bar');
+        // - use base "Foo::Bar";
+        let stripped = token.trim_matches(|c| {
+            matches!(c, '\'' | '"' | '(' | ')' | ',' | ';' | '[' | ']' | '{' | '}')
+        });
         // Accept tokens containing only word characters, `::`, or `'` (legacy separator)
         if stripped.is_empty() {
             return None;
@@ -4709,6 +4712,16 @@ Utils::process_data();
         let names = extract_module_names_from_use_args(&["'Foo'Bar'".to_string()]);
         // After stripping outer quotes the raw token is Foo'Bar — a valid legacy name
         assert_eq!(names, vec!["Foo'Bar"]);
+    }
+
+    #[test]
+    fn test_extract_module_names_comma_separated_and_terminated() {
+        let names = extract_module_names_from_use_args(&[
+            "-norequire".to_string(),
+            "'Foo::Bar',".to_string(),
+            "\"Other::Base\";".to_string(),
+        ]);
+        assert_eq!(names, vec!["Foo::Bar", "Other::Base"]);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Fix a regression when indexing `use parent` / `use base` forms where module tokens serialized with trailing punctuation (commas, semicolons, parentheses, brackets) could be dropped from dependency indexing (regression noted in #2747).

### Description

- Normalize module tokens in `extract_module_names_from_use_args` by trimming common boundary punctuation (`'`, `"`, `(`, `)`, `,`, `;`, `[`, `]`, `{`, `}`) before validating characters.
- Preserve previous behavior of skipping flag tokens starting with `-` and only accepting names made of word characters, `::`, `_`, or legacy `'` separator.
- Add a unit test `test_extract_module_names_comma_separated_and_terminated` that verifies handling of comma-separated and semicolon-terminated module args (including `-norequire`).
- Run repository formatting via `cargo xtask fmt` to keep style consistent.

### Testing

- Ran the targeted unit tests with `cargo test -p perl-workspace test_extract_module_names -- --nocapture`, and the suite passed (9 tests related to `extract_module_names_from_use_args` all succeeded).
- Ran the formatter with `cargo xtask fmt`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7a419c8333a7932ee7d28950de)