### PR TITLE
fix(ci-hygiene): ignore ${#var} expansions in TODO scanner (#4707)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3994,6 +3994,10 @@ fn find_hash_comment_start(line: &str, perl_mode: bool) -> Option<usize> {
             }
             '`' => in_backtick = true,
             '#' => {
+                // Bash/Perl parameter-length expansion (`${#var}`) is not a comment.
+                if idx >= 2 && line.as_bytes().get(idx - 2..idx) == Some(b"${") {
+                    continue;
+                }
                 if idx == 0 && line.as_bytes().get(1) == Some(&b'!') {
                     return None;
                 }
@@ -4679,6 +4683,7 @@ mod tests {
 
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line("len=${#TODO_COUNT}", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi;# TODO: follow up", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi;# fixme: follow up", &todo_re));
         assert!(has_unlinked_todo_in_hash_line(
@@ -4699,6 +4704,7 @@ mod tests {
         assert!(has_unlinked_todo_in_hash_line("echo ok||# TODO: follow up", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("cat <# TODO: follow up", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("cat ># TODO: follow up", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line("len=${#value} # TODO: follow up", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi&&# TODO: follow up", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi||# TODO: follow up", &todo_re));


### PR DESCRIPTION
### Motivation
- Prevent false-positive TODO/FIXME hits when scanning hash-style comments in shell/Perl-like files where `#` appears inside parameter-length expansions like `${#VAR}` instead of starting a comment.

### Description
- Update `find_hash_comment_start` in `crates/perl-ci-hygiene/src/main.rs` to skip `#` characters that are part of the `${#...}` parameter-length expansion so they are not treated as comment starts.
- Add regression assertions to the test `hash_comment_todo_detection_handles_shebang_and_inline_hashes` to confirm `len=${#TODO_COUNT}` does not produce a TODO hit while trailing `# TODO` comments are still detected.

### Testing
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and the test passed.
- Ran `cargo test -p perl-ci-hygiene` and the full test suite for the crate passed (36 tests OK).
- Ran `cargo xtask fmt` to format the workspace, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7a419c8333a7932ee7d28950de)