### PR TITLE
fix(workspace-index): support spaced `qw` delimiters in `use constant` extraction (#4707)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -3497,8 +3497,19 @@ fn extract_constant_names_from_use_args(args: &[String]) -> Vec<String> {
 
     // qw form: single arg starting with "qw"
     if first.starts_with("qw") {
-        let content = first
-            .trim_start_matches("qw")
+        let (qw_words, remainder) = extract_qw_words(first);
+        if remainder.trim().is_empty() {
+            for word in qw_words {
+                if !word.is_empty() && word.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                    names.push(word);
+                }
+            }
+            return names;
+        }
+
+        // Fallback for odd tokenisation: tolerate `qw` followed by spacing before the opener.
+        let content = first.trim_start_matches("qw").trim_start();
+        let content = content
             .trim_start_matches(|c: char| "([{/<|!".contains(c))
             .trim_end_matches(|c: char| ")]}/|!>".contains(c));
         for word in content.split_whitespace() {
@@ -4881,6 +4892,26 @@ Utils::process_data();
             "'Other::Base')".to_string(),
         ]);
         assert_eq!(names, vec!["Foo::Bar", "Other::Base"]);
+    }
+
+    #[test]
+    fn test_extract_constant_names_qw_with_space_before_delimiter() {
+        let names = extract_constant_names_from_use_args(&["qw [FOO BAR]".to_string()]);
+        assert_eq!(names, vec!["FOO", "BAR"]);
+    }
+
+    #[test]
+    fn test_index_use_constant_qw_with_space_before_delimiter() {
+        let index = WorkspaceIndex::new();
+        let uri = must(url::Url::parse("file:///workspace/lib/My/Config.pm"));
+        let source = "package My::Config;\nuse constant qw [FOO BAR];\n1;\n";
+
+        must(index.index_file(uri, source.to_string()));
+
+        let foo = index.find_definition("My::Config::FOO");
+        let bar = index.find_definition("My::Config::BAR");
+        assert!(foo.is_some(), "Expected My::Config::FOO to be indexed");
+        assert!(bar.is_some(), "Expected My::Config::BAR to be indexed");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- `use constant` `qw` lists with a space before the delimiter (e.g. `qw [FOO BAR]`) were not always parsed correctly, causing constants to be missed during workspace indexing and failing definition lookups.

### Description
- Update `extract_constant_names_from_use_args` to reuse `extract_qw_words` for primary parsing and add a defensive fallback that tolerates a space between `qw` and its opening delimiter.
- Add a unit test `test_extract_constant_names_qw_with_space_before_delimiter` to cover the parsing case.
- Add an indexing-level regression test `test_index_use_constant_qw_with_space_before_delimiter` verifying `use constant qw [FOO BAR];` produces resolvable symbols (`My::Config::FOO` and `My::Config::BAR`).
- Run `cargo xtask fmt` which produced a minor formatting cleanup in `tests/collapse_edge_cases_tests.rs`.

### Testing
- Ran `cargo xtask fmt` successfully to apply formatting changes.
- Ran the `perl-workspace` test suite and targeted tests; `cargo test -p perl-workspace` completed with all tests passing (201 passed in earlier run) and the newly added tests `test_extract_constant_names_qw_with_space_before_delimiter` and `test_index_use_constant_qw_with_space_before_delimiter` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7cbf5483339ec369e0a17c618b)