### PR TITLE
fix(ci-hygiene): handle escaped single-quoted strings in TODO scanner (#4707)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3933,12 +3933,27 @@ fn find_hash_comment_start(line: &str, perl_mode: bool) -> Option<usize> {
     let mut in_single_ansi_c = false;
     let mut in_double = false;
     let mut in_backtick = false;
+    let mut prev_single_was_escape = false;
     let mut prev_was_escape = false;
     let mut prev_was_escape_double = false;
     let mut prev_was_escape_single = false;
 
     for (idx, ch) in line.char_indices() {
         if in_single {
+            if prev_single_was_escape {
+                prev_single_was_escape = false;
+                continue;
+            }
+            if ch == '\\' {
+                prev_single_was_escape = true;
+                continue;
+            }
+            if ch == '\'' {
+                in_single = false;
+            }
+            continue;
+        }
+        if in_double {
             if prev_was_escape {
                 prev_was_escape = false;
                 continue;
@@ -3987,6 +4002,7 @@ fn find_hash_comment_start(line: &str, perl_mode: bool) -> Option<usize> {
                 in_single = true;
                 in_single_ansi_c = idx > 0 && line.as_bytes().get(idx - 1) == Some(&b'$');
                 prev_was_escape_single = false;
+                prev_single_was_escape = false;
             }
             '"' => {
                 in_double = true;
@@ -4691,6 +4707,7 @@ mod tests {
             &todo_re,
         ));
         assert!(!has_unlinked_todo_in_hash_line("echo '# TODO in string' && true", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line(r"print 'it\'s # TODO in string';", &todo_re));
         assert!(has_unlinked_todo_in_hash_line(
             "echo '# TODO in string' # TODO: follow up",
             &todo_re
@@ -4698,6 +4715,10 @@ mod tests {
         assert!(!has_unlinked_todo_in_hash_line("print 'it\\'s # TODO in string';", &todo_re,));
         assert!(has_unlinked_todo_in_hash_line(
             "print 'it\\'s # TODO in string'; # TODO: follow up",
+            &todo_re
+        ));
+        assert!(has_unlinked_todo_in_hash_line(
+            r"print 'it\'s # TODO in string'; # TODO: follow up",
             &todo_re
         ));
         assert!(has_unlinked_todo_in_hash_line("echo ok&&# TODO: follow up", &todo_re));


### PR DESCRIPTION
### Motivation
- Prevent false-positive TODO/FIXME detections where `#` appears inside escaped single-quoted string literals (e.g. `print 'it\'s # TODO in string';`) so the hygiene scanner does not treat embedded `#` as a comment start.

### Description
- Teach `find_hash_comment_start` to track an escape state inside single-quoted literals by adding `prev_single_was_escape` and skipping `#` when the quote was escaped. 
- Update the single-quote entry/exit logic to reset and honor that escape state.
- Add regression assertions to `hash_comment_todo_detection_handles_shebang_and_inline_hashes` covering both the no-comment and trailing-comment variants of escaped single-quoted strings.

### Testing
- Ran `cargo xtask fmt` and it completed successfully. 
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes -- --nocapture` and the test passed. 
- Ran `cargo test -p perl-ci-hygiene` and the full crate test suite passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7cbf5483339ec369e0a17c618b)