### PR TITLE
fix(ci-hygiene): detect TODO after comma-prefixed hash comments (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3918,7 +3918,7 @@ fn find_hash_comment_start(line: &str) -> Option<usize> {
                 }
                 if let Some(prev) = line[..idx].chars().next_back() {
                     if prev.is_whitespace()
-                        || matches!(prev, ';' | '{' | '}' | '(' | ')' | '[' | ']')
+                        || matches!(prev, ';' | ',' | '{' | '}' | '(' | ')' | '[' | ']')
                     {
                         return Some(idx);
                     }
@@ -4345,6 +4345,7 @@ mod tests {
             &todo_re
         ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line("my @x = (1,# TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
 
         Ok(())


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner for hash-comment languages missed comments that begin immediately after a comma (`,#`), which can occur in list-like Perl/shell code and lead to unreported unlinked TODOs.

### Description
- Add `','` to the delimiter set in `find_hash_comment_start` so `,#` is recognized as a valid inline comment boundary in hash-comment files.
- Add a regression assertion to `hash_comment_todo_detection_handles_shebang_and_inline_hashes` that covers the `"my @x = (1,# TODO: follow up"` case.

### Testing
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` which passed.
- Ran `cargo test -p perl-ci-hygiene` which completed with all tests passing.
- Ran `cargo xtask fmt` to format the workspace successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7b4c608333b8bb8c25a060755c)