### PR TITLE
fix(ci-hygiene): ignore TODOs inside Rust c-string literals (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3997,16 +3997,27 @@ fn is_index_in_rust_literal(line: &str, target_idx: usize) -> bool {
             continue;
         }
 
-        if bytes[i] == b'r' || (bytes[i] == b'b' && i + 1 < bytes.len() && bytes[i + 1] == b'r') {
+        if bytes[i] == b'c' && i + 1 < bytes.len() && bytes[i + 1] == b'"' {
+            in_string = true;
+            i += 2;
+            continue;
+        }
+
+        if bytes[i] == b'r'
+            || (bytes[i] == b'b' && i + 1 < bytes.len() && bytes[i + 1] == b'r')
+            || (bytes[i] == b'c' && i + 1 < bytes.len() && bytes[i + 1] == b'r')
+        {
             let mut j = i + 1;
-            if bytes[i] == b'b' {
+            if bytes[i] == b'b' || bytes[i] == b'c' {
                 j += 1;
             }
             while j < bytes.len() && bytes[j] == b'#' {
                 j += 1;
             }
             if j < bytes.len() && bytes[j] == b'"' {
-                raw_hashes = Some(j.saturating_sub(i + if bytes[i] == b'b' { 2 } else { 1 }));
+                raw_hashes = Some(
+                    j.saturating_sub(i + if bytes[i] == b'b' || bytes[i] == b'c' { 2 } else { 1 }),
+                );
                 i = j + 1;
                 continue;
             }
@@ -4322,6 +4333,23 @@ mod tests {
         ));
         assert!(has_unlinked_todo_in_rust_line(
             "let s = \"safe literal\"; // TODO: follow up",
+            &todo_re
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn rust_todo_detection_ignores_c_string_comment_markers() -> Result<()> {
+        let todo_re = Regex::new(r"TODO|FIXME")?;
+
+        assert!(!has_unlinked_todo_in_rust_line("let s = c\"// TODO in literal\";", &todo_re));
+        assert!(!has_unlinked_todo_in_rust_line(
+            "let s = cr#\"/* FIXME in literal */\"#;",
+            &todo_re
+        ));
+        assert!(has_unlinked_todo_in_rust_line(
+            "let s = c\"safe literal\"; // TODO: follow up",
             &todo_re
         ));
 


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner in `perl-ci-hygiene` produced false positives when `// TODO` or `/* FIXME */` appeared inside Rust C-style string literals such as `c"..."` and raw variants like `cr#"..."#`.

### Description
- Extend the Rust literal detection state machine in `crates/perl-ci-hygiene/src/main.rs` to recognize `c"..."` C string literals and `cr#"..."#` raw C string literals by treating them as string contexts.
- Adjust raw-hash counting logic to handle the additional `c` prefix when computing `raw_hashes` for raw string literals.
- Add a regression test `rust_todo_detection_ignores_c_string_comment_markers` in the test module of `crates/perl-ci-hygiene/src/main.rs` to assert that `TODO`/`FIXME` inside `c"..."` and `cr#"..."#` are ignored while trailing comments are still detected.

### Testing
- Ran `cargo test -p perl-ci-hygiene rust_todo_detection_ignores_c_string_comment_markers` and the new test passed (`ok`).
- Ran the related test subset `cargo test -p perl-ci-hygiene rust_todo_detection_` and all included tests passed (`4 passed`).
- Ran formatting via `cargo xtask fmt` to ensure code style compliance and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7b4c608333b8bb8c25a060755c)