### PR TITLE
fix(ci-hygiene): require TODO/FIXME word boundaries (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3384,7 +3384,7 @@ fn cmd_check_todos(repo_root: &Path, list_mode: bool) -> Result<i32> {
             .join("complex_paren_args_tests.rs"),
     ];
 
-    let todo_re = Regex::new(r"TODO|FIXME")?;
+    let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
     let entries = collect_todo_hits(repo_root, &exclude_dirs, &exclude_files, &todo_re)?;
 
     if list_mode {
@@ -4281,7 +4281,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_linked_or_url_like_comments() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(has_unlinked_todo_in_rust_line("// TODO: investigate", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line("// TODO(#123): tracked", &todo_re));
@@ -4297,7 +4297,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_raw_string_comment_markers() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_rust_line("let s = r#\"// TODO in literal\"#;", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line(
@@ -4310,7 +4310,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_non_raw_string_comment_markers() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_rust_line(
             "let s = \"not a comment // TODO in literal\";",
@@ -4330,7 +4330,7 @@ mod tests {
 
     #[test]
     fn hash_comment_todo_detection_handles_shebang_and_inline_hashes() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
@@ -4346,6 +4346,21 @@ mod tests {
         ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
+
+        Ok(())
+    }
+
+    #[test]
+    fn todo_detection_requires_word_boundaries() -> Result<()> {
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
+
+        assert!(!has_unlinked_todo_in_rust_line(
+            "// TODOLIST items are tracked elsewhere",
+            &todo_re
+        ));
+        assert!(!has_unlinked_todo_in_hash_line("echo hi # PRETODO is not a marker", &todo_re));
+        assert!(has_unlinked_todo_in_rust_line("// TODO: this is tracked inline", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line("echo hi # FIXME: follow-up needed", &todo_re));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation

- Reduce false positives from the repository TODO/FIXME scanner by ensuring the matcher only flags standalone markers and not substrings like `TODOLIST` or `PRETODO`.

### Description

- Tighten the token matcher in `perl-ci-hygiene` by changing the regex to `\b(?:TODO|FIXME)\b` used by the TODO scanner.
- Update existing unit tests to use the stricter regex so test behavior matches production scanning.
- Add a regression test `todo_detection_requires_word_boundaries` in `crates/perl-ci-hygiene/src/main.rs` that asserts marker-like substrings do not trigger while true `TODO`/`FIXME` markers still do.

### Testing

- Ran `cargo xtask fmt` to apply repository formatting and it completed successfully.
- Ran `cargo test -p perl-ci-hygiene todo_detection_requires_word_boundaries` and the new test passed.
- Ran focused unit tests `hash_comment_todo_detection_handles_shebang_and_inline_hashes` and `rust_todo_detection_ignores_linked_or_url_like_comments` and both passed, confirming no regressions in existing behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7b4c608333b8bb8c25a060755c)