### PR TITLE
fix(perl-uri): canonicalize file://localhost URI keys (#4707)

### DIFF
--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -14,7 +14,18 @@ use url::Url;
 #[must_use]
 pub fn uri_key(uri: &str) -> String {
     if let Ok(parsed) = Url::parse(uri) {
-        let value = parsed.as_str().to_string();
+        let mut value = parsed.as_str().to_string();
+
+        // Canonicalize localhost file authorities (file://localhost/...) to
+        // the standard local form (file:///...) so equivalent URIs map to the
+        // same key.
+        if parsed.scheme() == "file"
+            && parsed.host_str() == Some("localhost")
+            && let Some(path) = value.strip_prefix("file://localhost")
+        {
+            value = format!("file://{path}");
+        }
+
         if let Some(rest) = value.strip_prefix("file:///")
             && rest.len() > 1
             && rest.as_bytes()[1] == b':'
@@ -66,6 +77,20 @@ mod tests {
     fn normalizes_uri_keys() {
         assert_eq!(uri_key("file:///tmp/test.pl"), "file:///tmp/test.pl");
         assert_eq!(uri_key("file:///C:/Users/test.pl"), "file:///c:/Users/test.pl");
+    }
+
+    #[test]
+    fn normalizes_localhost_file_authority() {
+        assert_eq!(uri_key("file://localhost/tmp/test.pl"), uri_key("file:///tmp/test.pl"));
+        assert_eq!(
+            uri_key("file://localhost/C:/Users/test.pl"),
+            uri_key("file:///c:/Users/test.pl")
+        );
+    }
+
+    #[test]
+    fn preserves_non_local_file_authority() {
+        assert_eq!(uri_key("file://server/share/test.pl"), "file://server/share/test.pl");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Equivalent local file URIs using `file://localhost/...` and `file:///...` were treated as different keys, which can cause missed document/cache lookups and inconsistent workspace behavior.

### Description
- Canonicalize local file authorities inside `uri_key` by mapping `file://localhost/...` to the standard `file:///...` form before generating the lookup key in `crates/perl-uri/src/classify.rs`.
- Preserve existing behavior for non-local authorities (e.g., `file://server/...`) so UNC/remote semantics remain unchanged.
- Add focused unit tests to assert localhost normalization and non-local authority preservation in `crates/perl-uri/src/classify.rs`.
- Run repository formatting via `cargo xtask fmt` to keep code style consistent.

### Testing
- Ran `cargo test -p perl-uri`, which executed the unit test suite for the `perl-uri` crate and all tests passed (all new and existing tests succeeded).
- Ran `cargo xtask fmt` to validate formatting, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c7cbf5483339ec369e0a17c618b)