### PR TITLE
fix(ci-hygiene): require standalone TODO/FIXME tokens (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3384,7 +3384,7 @@ fn cmd_check_todos(repo_root: &Path, list_mode: bool) -> Result<i32> {
             .join("complex_paren_args_tests.rs"),
     ];
 
-    let todo_re = Regex::new(r"TODO|FIXME")?;
+    let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
     let entries = collect_todo_hits(repo_root, &exclude_dirs, &exclude_files, &todo_re)?;
 
     if list_mode {
@@ -4281,7 +4281,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_linked_or_url_like_comments() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(has_unlinked_todo_in_rust_line("// TODO: investigate", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line("// TODO(#123): tracked", &todo_re));
@@ -4296,8 +4296,19 @@ mod tests {
     }
 
     #[test]
+    fn rust_todo_detection_requires_standalone_tokens() -> Result<()> {
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
+
+        assert!(!has_unlinked_todo_in_rust_line("// METHODTODO: not a marker", &todo_re));
+        assert!(!has_unlinked_todo_in_rust_line("// PREFIXFIXME_SUFFIX", &todo_re));
+        assert!(has_unlinked_todo_in_rust_line("// TODO-item should still match TODO", &todo_re));
+
+        Ok(())
+    }
+
+    #[test]
     fn rust_todo_detection_ignores_raw_string_comment_markers() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_rust_line("let s = r#\"// TODO in literal\"#;", &todo_re));
         assert!(!has_unlinked_todo_in_rust_line(
@@ -4310,7 +4321,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_non_raw_string_comment_markers() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_rust_line(
             "let s = \"not a comment // TODO in literal\";",
@@ -4330,7 +4341,7 @@ mod tests {
 
     #[test]
     fn hash_comment_todo_detection_handles_shebang_and_inline_hashes() -> Result<()> {
-        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
 
         assert!(!has_unlinked_todo_in_hash_line("#!/usr/bin/env bash", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo# TODO not a comment", &todo_re));
@@ -4346,6 +4357,16 @@ mod tests {
         ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
+
+        Ok(())
+    }
+
+    #[test]
+    fn hash_comment_todo_detection_requires_standalone_tokens() -> Result<()> {
+        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
+
+        assert!(!has_unlinked_todo_in_hash_line("echo hi # PRETODOPOST", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line("echo hi # FIXME-next", &todo_re));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- Reduce false-positive TODO/FIXME matches from embedded substrings (for example `METHODTODO`) in the repository TODO scanner.

### Description
- Tightened the TODO/FIXME matcher in `crates/perl-ci-hygiene/src/main.rs` to use the standalone-word regex `\b(?:TODO|FIXME)\b` so only standalone tokens are considered.
- Added focused unit tests `rust_todo_detection_requires_standalone_tokens` and `hash_comment_todo_detection_requires_standalone_tokens` to verify behavior for Rust-style and hash-style comments.

### Testing
- Ran `cargo xtask fmt` successfully.
- Ran `cargo test -p perl-ci-hygiene` and all tests passed (38 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97cfbb8148333b686f01adcc14026)