### PR TITLE
fix(ci-hygiene): harden hash comment TODO scan around escaped quotes (#9999)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3882,10 +3882,19 @@ fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
 fn find_hash_comment_start(line: &str) -> Option<usize> {
     let mut in_single = false;
     let mut in_double = false;
+    let mut prev_single_escape = false;
     let mut prev_was_escape = false;
 
     for (idx, ch) in line.char_indices() {
         if in_single {
+            if prev_single_escape {
+                prev_single_escape = false;
+                continue;
+            }
+            if ch == '\\' {
+                prev_single_escape = true;
+                continue;
+            }
             if ch == '\'' {
                 in_single = false;
             }
@@ -4346,6 +4355,14 @@ mod tests {
         ));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line(
+            "echo 'quoted \\'# TODO in string\\'' && true",
+            &todo_re
+        ));
+        assert!(has_unlinked_todo_in_hash_line(
+            "echo 'quoted \\'# TODO in string\\'' # TODO: follow up",
+            &todo_re
+        ));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- Prevent false-positive TODO/FIXME hits when a `#` appears inside single-quoted text that contains escaped single quotes in hash-style files.

### Description
- Teach `find_hash_comment_start` to track escaped single quotes inside single-quoted spans by adding a `prev_single_escape` guard and treating `\'` as literal content instead of quote termination in `crates/perl-ci-hygiene/src/main.rs`.
- Add regression assertions to `hash_comment_todo_detection_handles_shebang_and_inline_hashes` that cover `# TODO` inside escaped single-quoted strings and the same string followed by a real trailing `# TODO` comment.

### Testing
- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and the test passed (`ok`).
- Ran `cargo test -p perl-ci-hygiene` and the full test suite passed (`36 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97cfbb8148333b686f01adcc14026)