### PR TITLE
docs: remove incorrect VS Marketplace deprecation notices (#4768)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@
   <a href="https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs"><img src="https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs" alt="Open VSX Downloads" /></a>
 </p>
 
-> **⚠️ Deprecation Notice:** The VS Marketplace listing is deprecated. Please use the [Open VSX Registry](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs) for VSCodium and open-source VS Code derivatives.
-
 ---
 
 Perl has lacked a proper modern LSP implementation. Other languages — Rust, TypeScript, Go, Python — have mature language servers with fast completions, reliable navigation, and full debugger integration. Perl's existing options were slow, incomplete, or required a working Perl runtime just to get basic editor features. `perl-lsp` fills that gap: a native Rust implementation of the Language Server Protocol and Debug Adapter Protocol for Perl 5, with its own parser and lexer, no Perl runtime required for IDE features.

--- a/vscode-extension/PUBLISHING.md
+++ b/vscode-extension/PUBLISHING.md
@@ -2,15 +2,13 @@
 
 ## Prerequisites
 
-> **⚠️ Deprecation Notice:** The Visual Studio Marketplace listing is deprecated. Please use the [Open VSX Registry](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs) for publishing.
-
 1. **Node.js and npm** installed
 2. **Visual Studio Code** installed
 3. **vsce** (Visual Studio Code Extension manager) and **ovsx** (Open VSX CLI) installed:
    ```bash
    npm install -g @vscode/vsce ovsx
    ```
-4. **Publisher account** on Visual Studio Marketplace (deprecated)
+4. **Publisher account** on Visual Studio Marketplace
 5. **Open VSX access token** for `EffortlessMetrics` publisher
 
 ## Build Process

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -5,8 +5,6 @@
 [![Open VSX Version](https://img.shields.io/open-vsx/v/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
 [![Open VSX Downloads](https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX%20downloads)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
 
-> **⚠️ Deprecation Notice:** The VS Marketplace listing is deprecated. Please use the [Open VSX Registry](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs) for VSCodium and open-source VS Code derivatives.
-
 A fast, native Perl 5 language server extension. Written in Rust for speed and reliability. No runtime dependencies -- just install and code.
 
 > **0.12.3 Public Alpha** -- This extension is under active development. Every feature listed below is wired up and exercised by tests, but as an alpha you will find edge cases where behavior is incomplete or wrong. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose) if you encounter problems. For what the project's headline numbers mean (and do not mean), see the [status overview](https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/project/status/index.md).


### PR DESCRIPTION
Previous revert attempt (#4769) was squash-merged as an empty commit and did not actually remove the deprecation notices. This PR directly edits the 3 README files to remove only the incorrect deprecation language.

## Changes

- `README.md`: Remove deprecation notice block (2 lines)
- `vscode-extension/README.md`: Remove deprecation notice block (2 lines)
- `vscode-extension/PUBLISHING.md`: Remove deprecation notice block + remove `(deprecated)` suffix from "Publisher account on Visual Studio Marketplace"

The VS Marketplace listing is NOT deprecated — only the old badge URL was, and that was already replaced. Open VSX badges are preserved untouched.

Closes #4768.