### PR TITLE
fix(workspace-index): dedupe qw constant extraction (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -3378,9 +3378,10 @@ fn extract_module_names_from_use_args(args: &[String]) -> Vec<String> {
                 if stripped.is_empty() {
                     return None;
                 }
-                if stripped.chars().all(|c| {
-                    c.is_alphanumeric() || c == '_' || c == ':' || c == '\''
-                }) {
+                if stripped
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '_' || c == ':' || c == '\'')
+                {
                     Some(stripped.to_string())
                 } else {
                     None
@@ -3501,7 +3502,7 @@ fn extract_constant_names_from_use_args(args: &[String]) -> Vec<String> {
         if remainder.trim().is_empty() {
             for word in qw_words {
                 if !word.is_empty() && word.chars().all(|c| c.is_alphanumeric() || c == '_') {
-                    names.push(word);
+                    push_unique(&mut names, &mut seen, &word);
                 }
             }
             return names;


### PR DESCRIPTION
### Motivation
- Fix a correctness bug in constant-name extraction where the fast `qw(...)` path could emit duplicate names (e.g. `qw(FOO BAR FOO)` produced `["FOO","BAR","FOO"]`) causing inconsistent indexing behavior compared with scalar/hash `use constant` forms.

### Description
- Route insertion of words from the fast `qw` extraction through the existing `push_unique` helper in `crates/perl-workspace-index/src/workspace/workspace_index.rs` so `extract_constant_names_from_use_args` returns a deduplicated list for scalar, hash, and `qw` forms.

### Testing
- Ran `cargo test -p perl-workspace constant_names` and `cargo test -p perl-workspace duplicate_names_indexed_once`, both passed, and ran `cargo xtask fmt` to validate formatting successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98e25b6a48333abbc6644fe8dc4bc)