### PR TITLE
docs(perl-dap): document BridgeAdapter CPAN fallback install steps (#4804)

### DIFF
--- a/crates/perl-dap/README.md
+++ b/crates/perl-dap/README.md
@@ -30,3 +30,19 @@ perl-dap --stdio
 perl-dap --socket --port 13603
 perl-dap --bridge
 ```
+
+## BridgeAdapter dependency
+
+`--bridge` mode requires the CPAN module `Perl::LanguageServer`.
+Install it with either:
+
+```bash
+cpan Perl::LanguageServer
+cpanm Perl::LanguageServer
+```
+
+You can verify availability with:
+
+```bash
+perl -e "use Perl::LanguageServer::DebuggerInterface; print qq{OK\n};"
+```


### PR DESCRIPTION
### Motivation
- Restore DAP AC18 documentation invariants by documenting the BridgeAdapter dependency and CPAN fallback so repository checks that expect `Perl::LanguageServer` and `cpanm Perl::LanguageServer` find the required guidance.

### Description
- Add a `## BridgeAdapter dependency` section to `crates/perl-dap/README.md` documenting `cpan Perl::LanguageServer`, `cpanm Perl::LanguageServer`, and a verification one-liner (`perl -e "use Perl::LanguageServer::DebuggerInterface; print qq{OK\\n};"`).

### Testing
- Ran `cargo test -p perl-dap --test dap_dependency_tests --features dap-phase3` and the dependency tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98e276500833399f23eb9e317c5a6)