### PR TITLE
fix(dap-stack): parse stack paths with spaces (#4804)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -137,7 +137,7 @@ fn prompt_re() -> Option<&'static Regex> {
 fn stack_frame_re() -> Option<&'static Regex> {
     STACK_FRAME_RE
         .get_or_init(|| {
-            Regex::new(r"^\s*#?\s*(?P<frame>\d+)?\s+(?P<func>[A-Za-z_][\w:]*+?)(?:\s+called)?\s+at\s+(?P<file>[^\s]+)\s+line\s+(?P<line>\d+)")
+            Regex::new(r"^\s*#?\s*(?P<frame>\d+)?\s+(?P<func>[A-Za-z_][\w:]*+?)(?:\s+called)?\s+at\s+(?P<file>.+?)\s+line\s+(?P<line>\d+)")
         })
         .as_ref()
         .ok()

--- a/crates/perl-dap/src/debug_adapter/parsing.rs
+++ b/crates/perl-dap/src/debug_adapter/parsing.rs
@@ -763,6 +763,20 @@ mod tests {
         assert_eq!(frames[1].source.name, Some("Foo.pm".to_string()));
     }
 
+    #[test]
+    pub(super) fn test_parse_stack_trace_with_space_in_paths() {
+        let output = r#"# 0 main::test at /tmp/My Project/script.pl line 10
+# 1 Foo::bar called at C:\Work Files\lib\Foo.pm line 25"#;
+
+        let frames = DebugAdapter::parse_stack_trace(output);
+
+        assert_eq!(frames.len(), 2);
+        assert_eq!(frames[0].source.path, "/tmp/My Project/script.pl");
+        assert_eq!(frames[0].source.name, Some("script.pl".to_string()));
+        assert_eq!(frames[1].source.path, r"C:\Work Files\lib\Foo.pm");
+        assert_eq!(frames[1].source.name, Some("Foo.pm".to_string()));
+    }
+
     // AC8.2: Stack trace parsing with empty output
     #[test]
     pub(super) fn test_parse_stack_trace_empty_output() {

--- a/crates/perl-dap/src/stack/parser.rs
+++ b/crates/perl-dap/src/stack/parser.rs
@@ -40,7 +40,7 @@ static CONTEXT_RE: Lazy<Result<Regex, regex::Error>> = Lazy::new(|| {
 /// - `  #0  main::foo at script.pl line 10`
 static STACK_FRAME_RE: Lazy<Result<Regex, regex::Error>> = Lazy::new(|| {
     Regex::new(
-        r"^\s*#?\s*(?P<frame>\d+)?\s+(?P<func>[A-Za-z_][\w:]*+?)(?:\s+called)?\s+at\s+(?P<file>[^\s]+)\s+line\s+(?P<line>\d+)",
+        r"^\s*#?\s*(?P<frame>\d+)?\s+(?P<func>[A-Za-z_][\w:]*+?)(?:\s+called)?\s+at\s+(?P<file>.+?)\s+line\s+(?P<line>\d+)",
     )
 });
 
@@ -549,5 +549,16 @@ $ = main::run() called from file `script.pl' line 5
         assert_eq!(frames.len(), 2);
         assert_eq!(frames[0].name, "DB::DB");
         assert_eq!(frames[1].name, "main::foo");
+    }
+
+    #[test]
+    fn test_parse_standard_frame_with_space_in_file_path() {
+        use perl_tdd_support::must_some;
+        let mut parser = PerlStackParser::new();
+        let line = "  #0  main::foo at /tmp/My Project/script.pl line 10";
+        let frame = must_some(parser.parse_frame(line, 0));
+        assert_eq!(frame.name, "main::foo");
+        assert_eq!(frame.line, 10);
+        assert_eq!(frame.file_path(), Some("/tmp/My Project/script.pl"));
     }
 }


### PR DESCRIPTION
### Motivation
- Stack-frame parsing for the Perl DAP truncated file paths at the first whitespace, losing source mapping for paths that contain spaces (common on Windows and some user directories).

### Description
- Relaxed the `STACK_FRAME_RE` file capture from `[^
\s]+` to `.+?` so the regex captures paths containing spaces until the terminating ` line <n>` token in both the shared stack parser and debug-adapter fallback.
- Added a unit test `test_parse_standard_frame_with_space_in_file_path` to `crates/perl-dap/src/stack/parser.rs` to verify standard frame parsing with spaces in the path.
- Added a parsing test `test_parse_stack_trace_with_space_in_paths` to `crates/perl-dap/src/debug_adapter/parsing.rs` to validate both Unix- and Windows-style paths that include spaces.

### Testing
- Ran `cargo xtask fmt` to format changes and it completed successfully.
- Ran `cargo test -p perl-dap test_parse_standard_frame_with_space_in_file_path` and the test passed.
- Ran `cargo test -p perl-dap test_parse_stack_trace_with_space_in_paths` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98e2b471083338106ca6e9c353dc9)