### PR TITLE
fix(performance): track insertion-only edits for incremental reparse (#4804)

### DIFF
--- a/crates/perl-lsp-rs-core/src/performance/mod.rs
+++ b/crates/perl-lsp-rs-core/src/performance/mod.rs
@@ -127,13 +127,11 @@ impl IncrementalParser {
     pub fn mark_changed(&mut self, start: usize, end: usize) {
         let (start, end) = if start <= end { (start, end) } else { (end, start) };
 
-        // Ignore zero-length spans to keep the tracking set focused on
-        // meaningful byte ranges.
-        if start == end {
-            return;
-        }
+        // A zero-length span represents an insertion. Expand to a one-byte
+        // half-open range so overlap checks still detect impacted nodes.
+        let normalized_end = if start == end { end.saturating_add(1) } else { end };
 
-        self.changed_regions.push((start, end));
+        self.changed_regions.push((start, normalized_end));
         self.merge_overlapping_regions();
     }
 
@@ -309,5 +307,40 @@ mod tests {
         });
 
         assert!(result.is_err(), "worker panic should propagate to caller");
+    }
+
+    #[test]
+    fn incremental_parser_treats_insertions_as_changes() {
+        let mut parser = IncrementalParser::new();
+        parser.mark_changed(5, 5);
+
+        assert!(
+            parser.needs_reparse(0, 10),
+            "insertions should trigger reparse for overlapping nodes"
+        );
+        assert!(
+            parser.needs_reparse(5, 5),
+            "zero-length node at insertion point should be reparsed"
+        );
+        assert!(
+            !parser.needs_reparse(6, 6),
+            "non-overlapping zero-length nodes should not be reparsed"
+        );
+    }
+
+    #[test]
+    fn incremental_parser_merges_insertion_with_adjacent_ranges() {
+        let mut parser = IncrementalParser::new();
+        parser.mark_changed(10, 10);
+        parser.mark_changed(11, 20);
+
+        assert!(
+            parser.needs_reparse(10, 20),
+            "adjacent insertion and edit should merge into one reparse region"
+        );
+        assert!(
+            !parser.needs_reparse(21, 30),
+            "regions outside merged range should not be reparsed"
+        );
     }
 }


### PR DESCRIPTION
### Motivation

- The incremental reparse tracker ignored zero-length edit ranges (insertions), which could leave AST nodes stale after text insertions. 
- The `IncrementalParser` must treat insertion-only edits as real changes so overlap logic and downstream reparsing behave correctly.

### Description

- Update `IncrementalParser::mark_changed` to normalize zero-length spans into a one-byte half-open range using `saturating_add(1)` so existing overlap checks detect insertions (file: `crates/perl-lsp-rs-core/src/performance/mod.rs`).
- Keep existing interval merging logic and push the normalized range into `changed_regions` so adjacent ranges merge correctly. 
- Add focused unit tests that assert insertion-only edits trigger reparses and that insertions merge with adjacent edit ranges (tests added to `crates/perl-lsp-rs-core/src/performance/mod.rs`).

### Testing

- Ran `cargo xtask fmt` to format the workspace and it completed successfully.
- Ran `cargo test -p perl-lsp-rs-core performance::tests:: --lib --quiet` and the performance tests passed.
- Ran `cargo test -p perl-lsp-rs-core performance:: --quiet` and the performance test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98e0cc998833380ffeb0f9032adda)