### PR TITLE
fix(workspace-index): dedupe use constant qw names (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -3378,9 +3378,10 @@ fn extract_module_names_from_use_args(args: &[String]) -> Vec<String> {
                 if stripped.is_empty() {
                     return None;
                 }
-                if stripped.chars().all(|c| {
-                    c.is_alphanumeric() || c == '_' || c == ':' || c == '\''
-                }) {
+                if stripped
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '_' || c == ':' || c == '\'')
+                {
                     Some(stripped.to_string())
                 } else {
                     None
@@ -3501,7 +3502,7 @@ fn extract_constant_names_from_use_args(args: &[String]) -> Vec<String> {
         if remainder.trim().is_empty() {
             for word in qw_words {
                 if !word.is_empty() && word.chars().all(|c| c.is_alphanumeric() || c == '_') {
-                    names.push(word);
+                    push_unique(&mut names, &mut seen, &word);
                 }
             }
             return names;
@@ -3711,6 +3712,24 @@ use constant {
             retry_count_symbols, 1,
             "RETRY_COUNT should be indexed once even when repeated in use constant hash form"
         );
+    }
+
+    #[test]
+    fn test_use_constant_qw_duplicate_names_indexed_once() {
+        let index = WorkspaceIndex::new();
+        let uri = "file:///lib/My/QwDedupConfig.pm";
+        let code = r#"package My::QwDedupConfig;
+use constant qw(FOO BAR FOO);
+1;
+"#;
+        must(index.index_file(must(url::Url::parse(uri)), code.to_string()));
+
+        let symbols = index.file_symbols(uri);
+        let foo_symbols = symbols.iter().filter(|s| s.name == "FOO").count();
+        let bar_symbols = symbols.iter().filter(|s| s.name == "BAR").count();
+
+        assert_eq!(foo_symbols, 1, "FOO should be indexed once in qw form");
+        assert_eq!(bar_symbols, 1, "BAR should be indexed once in qw form");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- `use constant qw(...)` values were being appended without deduplication, causing duplicate symbol entries when indexing qw-form constants and exposing a failing unit test.

### Description
- Route parsed `qw` words through the existing `push_unique` path in `extract_constant_names_from_use_args` so duplicate names are suppressed (file: `crates/perl-workspace-index/src/workspace/workspace_index.rs`).
- Add a regression test `test_use_constant_qw_duplicate_names_indexed_once` that indexes `use constant qw(FOO BAR FOO);` and asserts each constant is indexed exactly once.
- Minor formatting/cleanup applied to the surrounding code to keep style consistent.

### Testing
- Ran `cargo xtask fmt` to format the workspace, which completed successfully.
- Ran the workspace unit tests for the modified crate with `cargo test -p perl-workspace --lib` and targeted tests; the previously failing `test_extract_constant_names_deduplicates_qw_form` now passes and the test suite reports all tests passing (217 passed; 0 failed).
- Also ran targeted tests `test_extract_constant_names_deduplicates_qw_form` and `test_use_constant_qw_duplicate_names_indexed_once` which both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98e0cc998833380ffeb0f9032adda)