### PR TITLE
fix(performance): treat zero-width edits as insertions (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/performance/mod.rs
+++ b/crates/perl-lsp-rs-core/src/performance/mod.rs
@@ -127,9 +127,12 @@ impl IncrementalParser {
     pub fn mark_changed(&mut self, start: usize, end: usize) {
         let (start, end) = if start <= end { (start, end) } else { (end, start) };
 
-        // Ignore zero-length spans to keep the tracking set focused on
-        // meaningful byte ranges.
+        // Treat zero-length edits (insertions) as touching a single-byte window
+        // so callers that report insertion-only ranges still trigger reparsing
+        // for overlapping nodes.
         if start == end {
+            self.changed_regions.push((start, start.saturating_add(1)));
+            self.merge_overlapping_regions();
             return;
         }
 

--- a/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
+++ b/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
@@ -49,12 +49,15 @@ fn incremental_parser_given_reversed_change_range_when_marked_then_reparse_is_de
 }
 
 #[test]
-fn incremental_parser_given_zero_width_change_when_marked_then_no_nodes_require_reparse() {
+fn incremental_parser_given_zero_width_change_when_marked_then_insertion_region_requires_reparse() {
     let mut parser = IncrementalParser::new();
 
     parser.mark_changed(10, 10);
 
-    assert!(!parser.needs_reparse(0, 100));
+    assert!(parser.needs_reparse(10, 11));
+    assert!(parser.needs_reparse(10, 10));
+    assert!(!parser.needs_reparse(11, 11));
+    assert!(!parser.needs_reparse(0, 9));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Some incremental-edit callers represent insertions using zero-width ranges (`start == end`) which were previously ignored by `IncrementalParser::mark_changed`, causing reparsing at the insertion location to be missed.
- The change tracking should observe insertion-only edits without broadening reparsing beyond the immediate insertion span.

### Description
- Update `IncrementalParser::mark_changed` to record a one-byte window `(start, start + 1)` for zero-length edits and call `merge_overlapping_regions()` so insertion edits participate in overlap checking.
- Update the BDD-style integration test in `crates/perl-lsp-rs-core/tests/performance_module_shape.rs` to assert reparsing is required at the insertion point and not outside it.
- Files modified: `crates/perl-lsp-rs-core/src/performance/mod.rs` and `crates/perl-lsp-rs-core/tests/performance_module_shape.rs`.

### Testing
- Ran `cargo test -p perl-lsp-rs-core --test performance_module_shape` and all tests passed (`11 passed; 0 failed`).
- Ran `cargo xtask fmt` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98e0cc998833380ffeb0f9032adda)