### PR TITLE
fix(perl-dap): harden context parsing for spaced paths (#4804)

### DIFF
--- a/crates/perl-dap/src/stack/parser.rs
+++ b/crates/perl-dap/src/stack/parser.rs
@@ -30,7 +30,7 @@ pub enum StackParseError {
 /// - `main::(script.pl):42:`
 static CONTEXT_RE: Lazy<Result<Regex, regex::Error>> = Lazy::new(|| {
     Regex::new(
-        r"^(?:(?P<func>[A-Za-z_][\w:]*+?)::(?:\((?P<file>[^:)]+):(?P<line>\d+)\):?|__ANON__)|main::(?:\()?(?P<file2>[^:)\s]+)(?:\))?:(?P<line2>\d+):?)",
+        r"^(?:(?P<func>[A-Za-z_][\w:]*+?)::(?:\((?P<file>[^:)]+):(?P<line>\d+)\):?|__ANON__)|main::(?:\((?P<file2_paren>[^)]+)\)|(?P<file2>[^:)\s]+)):(?P<line2>\d+):?)",
     )
 });
 
@@ -231,7 +231,11 @@ impl PerlStackParser {
         let func = caps.name("func").map_or("main", |m| m.as_str());
 
         // Get file from either capture group
-        let file = caps.name("file").or_else(|| caps.name("file2"))?.as_str();
+        let file = caps
+            .name("file")
+            .or_else(|| caps.name("file2_paren"))
+            .or_else(|| caps.name("file2"))?
+            .as_str();
 
         // Get line from either capture group
         let line_str = caps.name("line").or_else(|| caps.name("line2"))?.as_str();
@@ -321,9 +325,15 @@ impl PerlStackParser {
     ///
     /// A tuple of (function, file, line) if parsed successfully.
     pub fn parse_context(&self, line: &str) -> Option<(String, String, i64)> {
+        let line = line.trim();
         if let Some(caps) = context_re().and_then(|re| re.captures(line)) {
             let func = caps.name("func").map_or("main", |m| m.as_str()).to_string();
-            let file = caps.name("file").or_else(|| caps.name("file2"))?.as_str().to_string();
+            let file = caps
+                .name("file")
+                .or_else(|| caps.name("file2_paren"))
+                .or_else(|| caps.name("file2"))?
+                .as_str()
+                .to_string();
             let line_str = caps.name("line").or_else(|| caps.name("line2"))?.as_str();
             let line: i64 = line_str.parse().ok()?;
 
@@ -412,6 +422,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_context_main_with_spaces_in_file() {
+        use perl_tdd_support::must_some;
+        let mut parser = PerlStackParser::new();
+        let line = "main::(script with space.pl):42:";
+        let frame = must_some(parser.parse_frame(line, 0));
+        assert_eq!(frame.name, "main");
+        assert_eq!(frame.line, 42);
+        assert_eq!(frame.file_path(), Some("script with space.pl"));
+    }
+
+    #[test]
     fn test_parse_eval_context() {
         use perl_tdd_support::must_some;
         let mut parser = PerlStackParser::new();
@@ -454,6 +475,16 @@ $ = main::run() called from file `script.pl' line 5
         let result = must_some(parser.parse_context("main::(file.pm):100:"));
 
         let (func, file, line) = result;
+        assert_eq!(func, "main");
+        assert_eq!(file, "file.pm");
+        assert_eq!(line, 100);
+    }
+
+    #[test]
+    fn test_parse_context_trims_surrounding_whitespace() {
+        use perl_tdd_support::must_some;
+        let parser = PerlStackParser::new();
+        let (func, file, line) = must_some(parser.parse_context("  main::(file.pm):100:  "));
         assert_eq!(func, "main");
         assert_eq!(file, "file.pm");
         assert_eq!(line, 100);

--- a/crates/perl-dap/tests/stack_malformed_debugger_output_tests.rs
+++ b/crates/perl-dap/tests/stack_malformed_debugger_output_tests.rs
@@ -77,12 +77,13 @@ fn parse_context_non_numeric_line_returns_none() {
 
 #[test]
 fn parse_context_extra_whitespace_around_valid_format() {
+    use perl_tdd_support::must_some;
     let parser = PerlStackParser::new();
-    // Leading/trailing whitespace around valid context line
-    // The regex anchors to start of string so leading whitespace should fail
-    let result = parser.parse_context("  main::(file.pm):42:");
-    // Leading whitespace causes the anchored regex to not match
-    assert!(result.is_none());
+    // Leading/trailing whitespace around valid context line should be ignored.
+    let (func, file, line) = must_some(parser.parse_context("  main::(file.pm):42:   "));
+    assert_eq!(func, "main");
+    assert_eq!(file, "file.pm");
+    assert_eq!(line, 42);
 }
 
 #[test]
@@ -97,11 +98,12 @@ fn parse_context_valid_format_recognized() {
 
 #[test]
 fn parse_context_with_path_containing_spaces() {
+    use perl_tdd_support::must_some;
     let parser = PerlStackParser::new();
-    // Paths with spaces may or may not match depending on regex
-    let result = parser.parse_context("main::(my file.pm):10:");
-    // The regex uses [^:)\\s]+ for file2, so spaces will break the match
-    assert!(result.is_none());
+    let (func, file, line) = must_some(parser.parse_context("main::(my file.pm):10:"));
+    assert_eq!(func, "main");
+    assert_eq!(file, "my file.pm");
+    assert_eq!(line, 10);
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- The debug adapter context parsing failed to recognize `main::(...)` context lines when the parenthesized file path contained spaces and also could be rejected by leading/trailing whitespace; this makes stack-frame detection brittle for real-world debugger output.
- Improve robustness of `PerlStackParser` so debugger context lines with common spacing/formatting variations are handled reliably.

### Description

- Broadened the context regex to capture parenthesized `main::(...)` file paths that may contain spaces via a new `file2_paren` capture group and kept the original `file2` capture for non-parenthesized forms by updating `CONTEXT_RE`.
- Updated `build_frame_from_context` to prefer `file`, then `file2_paren`, then `file2` when selecting the file name from regex captures.
- Trim input in `parse_context` before applying the regex to ignore surrounding whitespace that previously caused valid lines to be rejected.
- Added and updated unit/integration tests to cover: parenthesized `main::(...)` file paths with spaces, trimming of surrounding whitespace in `parse_context`, and updated malformed-output tests to assert the new behavior.

### Testing

- Ran formatting with `cargo xtask fmt` which completed successfully.
- Ran targeted tests: `cargo test -p perl-dap --test stack_malformed_debugger_output_tests parse_context_ -- --nocapture` and `cargo test -p perl-dap --lib stack::parser::tests::test_parse_context_trims_surrounding_whitespace` and `cargo test -p perl-dap --lib stack::parser::tests::test_parse_context_main_with_spaces_in_file`, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98e25b6a48333abbc6644fe8dc4bc)