### PR TITLE
fix(subprocess-runtime): kill timed-out subprocesses (#4804)

### DIFF
--- a/crates/perl-subprocess-runtime/src/lib.rs
+++ b/crates/perl-subprocess-runtime/src/lib.rs
@@ -90,9 +90,8 @@ impl OsSubprocessRuntime {
     /// Create a new OS subprocess runtime with the given wall-clock timeout.
     ///
     /// If the subprocess does not complete within `timeout_secs` seconds the
-    /// call returns a `SubprocessError` with a "timed out" message.  The
-    /// spawned process is left for the OS to reap — it is not explicitly
-    /// killed.
+    /// call returns a `SubprocessError` with a "timed out" message and attempts
+    /// to terminate the spawned process before returning.
     ///
     /// # Stdin size caveat
     ///
@@ -165,27 +164,20 @@ impl SubprocessRuntime for OsSubprocessRuntime {
                 })
             }
             Some(secs) => {
-                use std::thread;
                 use std::time::{Duration, Instant};
 
                 let deadline = Instant::now() + Duration::from_secs(secs);
-                let program_name = program.to_string();
-                let handle = thread::spawn(move || child.wait_with_output());
-
                 loop {
-                    // Check completion before the deadline so a process that
-                    // finishes exactly at the deadline boundary is never
-                    // reported as timed out.
-                    if handle.is_finished() {
-                        let output = handle
-                            .join()
-                            .map_err(|_| SubprocessError::new("subprocess thread panicked"))?
-                            .map_err(|e| {
-                                SubprocessError::new(format!(
-                                    "Failed to wait for {}: {}",
-                                    program_name, e
-                                ))
-                            })?;
+                    if child
+                        .try_wait()
+                        .map_err(|e| {
+                            SubprocessError::new(format!("Failed to poll {}: {}", program, e))
+                        })?
+                        .is_some()
+                    {
+                        let output = child.wait_with_output().map_err(|e| {
+                            SubprocessError::new(format!("Failed to wait for {}: {}", program, e))
+                        })?;
                         return Ok(SubprocessOutput {
                             stdout: output.stdout,
                             stderr: output.stderr,
@@ -194,15 +186,33 @@ impl SubprocessRuntime for OsSubprocessRuntime {
                     }
 
                     if Instant::now() >= deadline {
-                        // Background thread may still be running; deliberately do not
-                        // join — the spawned process will be reaped by the OS.
+                        if let Err(kill_err) = child.kill() {
+                            // Best effort: process may have already exited between `try_wait`
+                            // and `kill`.
+                            let already_exited = child
+                                .try_wait()
+                                .map_err(|e| {
+                                    SubprocessError::new(format!(
+                                        "Failed to poll {}: {}",
+                                        program, e
+                                    ))
+                                })?
+                                .is_some();
+                            if !already_exited {
+                                return Err(SubprocessError::new(format!(
+                                    "subprocess timed out after {} seconds and failed to terminate {}: {}",
+                                    secs, program, kill_err
+                                )));
+                            }
+                        }
+                        let _ = child.wait();
                         return Err(SubprocessError::new(format!(
                             "subprocess timed out after {} seconds",
                             secs
                         )));
                     }
 
-                    thread::sleep(Duration::from_millis(50));
+                    std::thread::sleep(Duration::from_millis(50));
                 }
             }
         }

--- a/crates/perl-subprocess-runtime/tests/extended_unit_tests.rs
+++ b/crates/perl-subprocess-runtime/tests/extended_unit_tests.rs
@@ -1000,3 +1000,36 @@ fn os_runtime_completion_before_deadline_always_succeeds() -> Result<(), Box<dyn
     assert_eq!(output.stdout_lossy().trim(), "boundary");
     Ok(())
 }
+
+#[cfg(all(not(target_arch = "wasm32"), not(windows)))]
+#[test]
+fn os_runtime_timeout_kills_slow_process() -> Result<(), Box<dyn std::error::Error>> {
+    use perl_subprocess_runtime::OsSubprocessRuntime;
+    use std::fs;
+    use std::process::Command;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let runtime = OsSubprocessRuntime::with_timeout(1);
+    let unique = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    let pid_file =
+        std::env::temp_dir().join(format!("perl_subprocess_runtime_timeout_{unique}.pid"));
+    let pid_file_string = pid_file.to_string_lossy().into_owned();
+
+    let script = format!("echo $$ > \"{pid_file_string}\"; sleep 30");
+    let timeout_result = runtime.run_command("sh", &["-c", &script], None);
+    assert!(timeout_result.is_err(), "slow process should time out");
+
+    let pid_contents = fs::read_to_string(&pid_file)?;
+    let pid = pid_contents.trim();
+    assert!(!pid.is_empty(), "child shell should record a pid");
+
+    let alive_status =
+        Command::new("kill").args(["-0", pid]).stderr(std::process::Stdio::null()).status()?;
+    assert!(
+        !alive_status.success(),
+        "timed out process should be terminated (pid still alive: {pid})"
+    );
+
+    let _ = fs::remove_file(pid_file);
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Prevent timed-out subprocesses from being left running in the background, which can accumulate resources and stray processes when timeouts occur.  

### Description

- Reworked `OsSubprocessRuntime::run_command` timeout handling to poll the child process with `try_wait()` instead of using a detached wait thread.  
- On timeout the runtime now attempts to `kill()` the child and then `wait()` to reap it before returning a timeout `SubprocessError`.  
- Updated API docs/comments on `OsSubprocessRuntime::with_timeout` to reflect explicit termination behavior.  
- Added a non-Windows regression test `os_runtime_timeout_kills_slow_process` that spawns a long-running shell, records the child PID, triggers a timeout, and asserts the child is no longer alive.  

### Testing

- Ran `cargo test -p perl-subprocess-runtime --quiet`, all tests passed.  
- Ran formatting via `cargo xtask fmt` to ensure style compliance.  
- Re-ran `cargo test -p perl-subprocess-runtime --quiet` after formatting, all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98e276500833399f23eb9e317c5a6)