### PR TITLE
fix(ci-hygiene): make TODO scanner case-insensitive (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3387,7 +3387,7 @@ fn cmd_check_todos(repo_root: &Path, list_mode: bool) -> Result<i32> {
             .join("complex_paren_args_tests.rs"),
     ];
 
-    let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
+    let todo_re = Regex::new(r"(?i)\b(?:TODO|FIXME)\b")?;
     let entries = collect_todo_hits(repo_root, &exclude_dirs, &exclude_files, &todo_re)?;
 
     if list_mode {
@@ -4391,7 +4391,7 @@ mod tests {
 
     #[test]
     fn rust_todo_detection_ignores_linked_or_url_like_comments() -> Result<()> {
-        let todo_re = Regex::new(r"\b(?:TODO|FIXME)\b")?;
+        let todo_re = Regex::new(r"(?i)\b(?:TODO|FIXME)\b")?;
 
         assert!(has_unlinked_todo_in_rust_line("// TODO: investigate", &todo_re));
         assert!(has_unlinked_todo_in_rust_line("// todo: investigate", &todo_re));


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner missed lowercase or mixed-case markers (e.g. `todo`, `FiXmE`), causing undercounting of unlinked TODOs and a failing unit test.
- Align the runtime scanner and tests so BDD-style coverage accurately reflects production behavior when parsing comment markers.

### Description
- Compile the TODO/FIXME token regex case-insensitively by using `(?i)\b(?:TODO|FIXME)\b` in `cmd_check_todos` at `crates/perl-ci-hygiene/src/main.rs`.
- Update the corresponding unit test to use the same case-insensitive regex so test expectations match runtime parsing.

### Testing
- Ran `cargo test -p perl-ci-hygiene --quiet` and all tests passed (`42 passed; 0 failed`).
- Ran `cargo xtask fmt` to format the workspace and finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98e276500833399f23eb9e317c5a6)