### PR TITLE
fix(perl-module): support legacy separators in qualified-call rename (#4804)

### DIFF
--- a/crates/perl-module/src/rename/mod.rs
+++ b/crates/perl-module/src/rename/mod.rs
@@ -140,40 +140,47 @@ pub fn line_references_qualified_call(line: &str, module_name: &str) -> bool {
     if line.is_empty() || module_name.is_empty() {
         return false;
     }
-    if line.trim_start().starts_with("package ") {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("package ")
+        || trimmed.starts_with("use ")
+        || trimmed.starts_with("require ")
+        || trimmed.starts_with("no ")
+    {
         return false;
     }
-    let needle = format!("{}::", module_name);
-    let needle_bytes = needle.as_bytes();
-    let line_bytes = line.as_bytes();
-    let needle_len = needle_bytes.len();
+    for separator in ["::", "'"] {
+        let needle = format!("{module_name}{separator}");
+        let needle_bytes = needle.as_bytes();
+        let line_bytes = line.as_bytes();
+        let needle_len = needle_bytes.len();
 
-    if line_bytes.len() < needle_len {
-        return false;
-    }
-
-    let mut start = 0usize;
-    while start + needle_len <= line_bytes.len() {
-        let Some(rel) = line[start..].find(needle.as_str()) else {
-            break;
-        };
-        let abs = start + rel;
-        let after = abs + needle_len;
-
-        let before_ok = abs == 0 || {
-            let ch = line_bytes[abs - 1] as char;
-            !ch.is_alphanumeric() && ch != '_' && ch != ':'
-        };
-
-        let after_ok = after < line_bytes.len() && {
-            let ch = line_bytes[after] as char;
-            ch.is_alphabetic() || ch == '_'
-        };
-
-        if before_ok && after_ok && !index_is_in_quote_or_comment(line, abs) {
-            return true;
+        if line_bytes.len() < needle_len {
+            continue;
         }
-        start = abs + 1;
+
+        let mut start = 0usize;
+        while start + needle_len <= line_bytes.len() {
+            let Some(rel) = line[start..].find(needle.as_str()) else {
+                break;
+            };
+            let abs = start + rel;
+            let after = abs + needle_len;
+
+            let before_ok = abs == 0 || {
+                let ch = line_bytes[abs - 1] as char;
+                !ch.is_alphanumeric() && ch != '_' && ch != ':'
+            };
+
+            let after_ok = after < line_bytes.len() && {
+                let ch = line_bytes[after] as char;
+                ch.is_alphabetic() || ch == '_'
+            };
+
+            if before_ok && after_ok && !index_is_in_quote_or_comment(line, abs) {
+                return true;
+            }
+            start = abs + 1;
+        }
     }
 
     false
@@ -198,51 +205,62 @@ pub fn replace_module_name_prefix(line: &str, old_module: &str, new_module: &str
     if old_module.is_empty() || new_module.is_empty() || line.is_empty() {
         return line.to_string();
     }
-    if line.trim_start().starts_with("package ") {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("package ")
+        || trimmed.starts_with("use ")
+        || trimmed.starts_with("require ")
+        || trimmed.starts_with("no ")
+    {
         return line.to_string();
     }
 
-    let needle = format!("{}::", old_module);
-    let replacement = format!("{}::", new_module);
-    let needle_bytes = needle.as_bytes();
-    let needle_len = needle_bytes.len();
-    let line_bytes = line.as_bytes();
+    let mut out = line.to_string();
 
-    if line_bytes.len() < needle_len {
-        return line.to_string();
-    }
+    for separator in ["::", "'"] {
+        let needle = format!("{old_module}{separator}");
+        let replacement = format!("{new_module}{separator}");
+        let needle_bytes = needle.as_bytes();
+        let needle_len = needle_bytes.len();
+        let line_bytes = out.as_bytes();
 
-    let mut out = String::with_capacity(line.len());
-    let mut cursor = 0usize;
-
-    while cursor + needle_len <= line_bytes.len() {
-        let Some(rel) = line[cursor..].find(needle.as_str()) else {
-            break;
-        };
-        let abs = cursor + rel;
-        let after = abs + needle_len;
-
-        let before_ok = abs == 0 || {
-            let ch = line_bytes[abs - 1] as char;
-            !ch.is_alphanumeric() && ch != '_' && ch != ':'
-        };
-
-        let after_ok = after < line_bytes.len() && {
-            let ch = line_bytes[after] as char;
-            ch.is_alphabetic() || ch == '_'
-        };
-
-        if before_ok && after_ok && !index_is_in_quote_or_comment(line, abs) {
-            out.push_str(&line[cursor..abs]);
-            out.push_str(&replacement);
-            cursor = after;
-        } else {
-            out.push_str(&line[cursor..abs + 1]);
-            cursor = abs + 1;
+        if line_bytes.len() < needle_len {
+            continue;
         }
+
+        let mut replaced = String::with_capacity(out.len());
+        let mut cursor = 0usize;
+
+        while cursor + needle_len <= line_bytes.len() {
+            let Some(rel) = out[cursor..].find(needle.as_str()) else {
+                break;
+            };
+            let abs = cursor + rel;
+            let after = abs + needle_len;
+
+            let before_ok = abs == 0 || {
+                let ch = line_bytes[abs - 1] as char;
+                !ch.is_alphanumeric() && ch != '_' && ch != ':'
+            };
+
+            let after_ok = after < line_bytes.len() && {
+                let ch = line_bytes[after] as char;
+                ch.is_alphabetic() || ch == '_'
+            };
+
+            if before_ok && after_ok && !index_is_in_quote_or_comment(&out, abs) {
+                replaced.push_str(&out[cursor..abs]);
+                replaced.push_str(&replacement);
+                cursor = after;
+            } else {
+                replaced.push_str(&out[cursor..abs + 1]);
+                cursor = abs + 1;
+            }
+        }
+
+        replaced.push_str(&out[cursor..]);
+        out = replaced;
     }
 
-    out.push_str(&line[cursor..]);
     out
 }
 

--- a/crates/perl-module/tests/rename_comprehensive_unit_tests.rs
+++ b/crates/perl-module/tests/rename_comprehensive_unit_tests.rs
@@ -184,9 +184,12 @@ fn plan_ignores_plain_code_with_module_name() -> Result<(), Box<dyn std::error::
 fn qualified_call_ignores_package_declaration_and_string_literals()
 -> Result<(), Box<dyn std::error::Error>> {
     assert!(!line_references_qualified_call("package Foo::Bar;", "Foo::Bar"));
+    assert!(!line_references_qualified_call("use Foo'Bar'Baz;", "Foo'Bar"));
     assert!(!line_references_qualified_call("'Foo::Bar::func()'", "Foo::Bar"));
     assert!(!line_references_qualified_call("\"Foo::Bar::func()\"", "Foo::Bar"));
     assert!(line_references_qualified_call("Foo::Bar::func()", "Foo::Bar"));
+    assert!(line_references_qualified_call("Foo::Bar'func()", "Foo::Bar"));
+    assert!(line_references_qualified_call("Foo'Bar'func()", "Foo'Bar"));
     Ok(())
 }
 
@@ -198,12 +201,24 @@ fn replace_prefix_skips_package_lines_and_quoted_occurrences()
         "package Foo::Bar;"
     );
     assert_eq!(
+        replace_module_name_prefix("use Foo'Bar'Baz;", "Foo'Bar", "New'Path"),
+        "use Foo'Bar'Baz;"
+    );
+    assert_eq!(
         replace_module_name_prefix("'Foo::Bar::func()'", "Foo::Bar", "New::Mod"),
         "'Foo::Bar::func()'"
     );
     assert_eq!(
         replace_module_name_prefix("Foo::Bar::func()", "Foo::Bar", "New::Mod"),
         "New::Mod::func()"
+    );
+    assert_eq!(
+        replace_module_name_prefix("Foo::Bar'func()", "Foo::Bar", "New::Mod"),
+        "New::Mod'func()"
+    );
+    assert_eq!(
+        replace_module_name_prefix("Foo'Bar'func()", "Foo'Bar", "New'Path"),
+        "New'Path'func()"
     );
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Rename planning did not recognize legacy Perl namespace separators (`'`) in qualified calls, causing some renames to miss occurrences like `Foo'Bar'func()`.
- Replacement logic only rewrote canonical `::` prefixes and could produce incorrect partial rewrites on import/declaration lines.

### Description
- Extended qualified-call detection in `perl-module` to check both canonical (`::`) and legacy (`'`) separators by iterating separators when searching for prefix matches in `line_references_qualified_call`.
- Updated prefix replacement logic in `replace_module_name_prefix` to rewrite occurrences for both `::` and `'`, preserving the separator style found in the source line.
- Added guards to skip qualified-call detection/replacement on declaration/import-like lines (`package`, `use`, `require`, `no`) to avoid partial rewrites in import statements.
- Added and updated unit tests in `rename_comprehensive_unit_tests.rs` to cover legacy-qualified patterns and import-line safety cases.
- Modified `crates/perl-module/src/rename/mod.rs` and `crates/perl-module/tests/rename_comprehensive_unit_tests.rs` to implement and validate the change.

### Testing
- Ran formatting with `cargo xtask fmt` successfully.
- Ran targeted tests: `cargo test -p perl-module --test module_rename_bdd --test rename_comprehensive_unit_tests` and all tests in those suites passed.
- Ran full crate tests with `cargo test -p perl-module` and observed success for the crate's test suite.
- Verified the new/updated unit tests exercising legacy separators and import-line guards passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98e297aa48333b8dd0e22a775b4a6)