### PR TITLE
fix(auto-import): anchor import insertion to preamble only (#4804)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/auto_import.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/auto_import.rs
@@ -57,31 +57,33 @@ pub fn module_already_imported(source: &str, module: &str) -> bool {
 pub fn find_use_block_end(source: &str) -> usize {
     let mut last_use_line_end: Option<usize> = None;
     let mut offset = 0usize;
+    let mut in_preamble = true;
 
     for line in source.split_inclusive('\n') {
         let trimmed = line.trim();
         let line_byte_len = line.len();
 
-        let is_use_line = trimmed.starts_with("use ")
-            || trimmed.starts_with("require ")
-            || trimmed == "use strict"
-            || trimmed == "use warnings"
-            || trimmed == "use utf8"
-            || trimmed == "#!/usr/bin/perl"
+        let is_real_use = trimmed.starts_with("use ") || trimmed.starts_with("require ");
+        let is_preamble_line = trimmed == "#!/usr/bin/perl"
             || trimmed.starts_with('#')
-            || trimmed.is_empty();
+            || trimmed.is_empty()
+            || trimmed.starts_with("package ");
 
-        if is_use_line {
-            // We keep tracking: the actual `use`/`require` lines advance the
-            // insertion candidate; blank lines and comments extend the "preamble"
-            // window but we only commit if a real use statement has been seen.
-            let is_real_use = trimmed.starts_with("use ") || trimmed.starts_with("require ");
-            if is_real_use {
+        if is_real_use {
+            if in_preamble {
                 last_use_line_end = Some(offset + line_byte_len);
             }
+        } else if !is_preamble_line {
+            in_preamble = false;
         }
 
         offset += line_byte_len;
+
+        // Once real code starts, later `use` / `require` lines are not part of
+        // the import preamble and should not move the insertion point.
+        if !in_preamble {
+            break;
+        }
     }
 
     // Return the byte offset right after the last use/require line.
@@ -185,6 +187,19 @@ mod tests {
         let src = "use strict;";
         let offset = find_use_block_end(src);
         assert_eq!(offset, src.len());
+    }
+
+    #[test]
+    fn insert_offset_ignores_late_use_after_code() {
+        let src = "my $x = 1;\nuse DBI;\n";
+        assert_eq!(find_use_block_end(src), 0);
+    }
+
+    #[test]
+    fn insert_offset_tracks_use_after_package_header() {
+        let src = "package My::Module;\n\nuse strict;\nuse warnings;\nsub run { }\n";
+        let offset = find_use_block_end(src);
+        assert_eq!(&src[offset..], "sub run { }\n");
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- Auto-import insertion could be shifted by `use`/`require` lines that appear after executable code, resulting in incorrect edits being inserted into the file.
- Files that declare a `package` before their import block should still get auto-imports inserted after that top preamble, so `package` lines must be treated as preamble.

### Description

- Change `find_use_block_end` to track a top-of-file `in_preamble` state and only update the insertion offset for `use`/`require` lines while in that preamble using an `is_real_use` check.
- Treat shebangs, comments, blank lines and `package` declarations as preamble lines via `is_preamble_line` and stop scanning once non-preamble code is seen so late imports do not move the insertion point.
- Add unit tests for the two regression cases: ignoring late `use` after code and tracking `use` lines after a `package` header.

### Testing

- Ran `cargo test -p perl-lsp-rs-core auto_import` and all auto-import related tests passed (18 tests, 0 failures).
- Ran `cargo xtask fmt` to ensure formatting; the formatter completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98e297aa48333b8dd0e22a775b4a6)