### PR TITLE
fix(workspace): deduplicate qw-form constant extraction (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -3378,9 +3378,10 @@ fn extract_module_names_from_use_args(args: &[String]) -> Vec<String> {
                 if stripped.is_empty() {
                     return None;
                 }
-                if stripped.chars().all(|c| {
-                    c.is_alphanumeric() || c == '_' || c == ':' || c == '\''
-                }) {
+                if stripped
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '_' || c == ':' || c == '\'')
+                {
                     Some(stripped.to_string())
                 } else {
                     None
@@ -3501,7 +3502,7 @@ fn extract_constant_names_from_use_args(args: &[String]) -> Vec<String> {
         if remainder.trim().is_empty() {
             for word in qw_words {
                 if !word.is_empty() && word.chars().all(|c| c.is_alphanumeric() || c == '_') {
-                    names.push(word);
+                    push_unique(&mut names, &mut seen, &word);
                 }
             }
             return names;


### PR DESCRIPTION
### Motivation
- The `use constant qw(...)` extraction branch appended names without deduplication, allowing duplicate constants (e.g. `FOO BAR FOO`) to leak into indexing and trigger a failing unit test.

### Description
- Updated `extract_constant_names_from_use_args` in `crates/perl-workspace-index/src/workspace/workspace_index.rs` to use the existing `push_unique` helper for the primary `qw` parsing branch so extracted names are deduplicated.
- This makes `qw(...)` behavior consistent with the scalar and hash `use constant` extraction paths.

### Testing
- Ran the focused test with `cargo test -p perl-workspace test_extract_constant_names_deduplicates_qw_form -- --exact` and it passed.
- Ran the package test suite with `cargo test -p perl-workspace --lib` which resulted in all tests passing (`216 passed; 0 failed`).
- Ran formatting with `cargo xtask fmt` to ensure code style conformance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98e2b471083338106ca6e9c353dc9)