### PR TITLE
fix(ci-hygiene): support nested Rust block comments in TODO scanner (#9999)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3827,13 +3827,13 @@ fn collect_todo_hits(
             continue;
         }
         let contents = read_lines(path)?;
-        let mut in_rust_block_comment = false;
+        let mut rust_block_comment_depth = 0;
         for (line_no, line) in contents.iter().enumerate() {
             let match_line = if is_rust {
                 has_unlinked_todo_in_rust_line_with_block_context(
                     line,
                     todo_re,
-                    &mut in_rust_block_comment,
+                    &mut rust_block_comment_depth,
                 )
             } else if path
                 .extension()
@@ -3853,80 +3853,77 @@ fn collect_todo_hits(
 }
 
 fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
-    let mut in_block_comment = false;
-    has_unlinked_todo_in_rust_line_with_block_context(line, token_re, &mut in_block_comment)
+    let mut block_comment_depth = 0;
+    has_unlinked_todo_in_rust_line_with_block_context(line, token_re, &mut block_comment_depth)
 }
 
 fn has_unlinked_todo_in_rust_line_with_block_context(
     line: &str,
     token_re: &Regex,
-    in_block_comment: &mut bool,
+    block_comment_depth: &mut usize,
 ) -> bool {
-    if *in_block_comment {
-        if let Some(end_idx) = find_block_comment_end(line, 0) {
-            if has_unlinked_token(&line[..end_idx], token_re) {
-                *in_block_comment = false;
-                return true;
+    let mut found_unlinked = false;
+    let mut idx = 0;
+    let line_len = line.len();
+    let mut comment_segment_start = 0;
+
+    while idx + 1 < line_len {
+        if *block_comment_depth == 0 {
+            if line[idx..].starts_with("//") {
+                if is_index_in_rust_literal(line, idx)
+                    || is_url_like_hash_comment(line, idx)
+                    || is_likely_string_literal_comment_start(line, idx)
+                {
+                    idx += 1;
+                    continue;
+                }
+                return found_unlinked || has_unlinked_token(&line[idx + 2..], token_re);
             }
-            *in_block_comment = false;
-            return has_unlinked_todo_in_rust_line_with_block_context(
-                &line[end_idx + 2..],
-                token_re,
-                in_block_comment,
-            );
+            if line[idx..].starts_with("/*") {
+                if is_index_in_rust_literal(line, idx)
+                    || is_likely_string_literal_comment_start(line, idx)
+                {
+                    idx += 1;
+                    continue;
+                }
+                *block_comment_depth = 1;
+                idx += 2;
+                comment_segment_start = idx;
+                continue;
+            }
+            idx += 1;
+            continue;
         }
-        return has_unlinked_token(line, token_re);
+
+        if line[idx..].starts_with("/*") {
+            found_unlinked |= has_unlinked_token(&line[comment_segment_start..idx], token_re);
+            *block_comment_depth += 1;
+            idx += 2;
+            comment_segment_start = idx;
+            continue;
+        }
+        if line[idx..].starts_with("*/") {
+            found_unlinked |= has_unlinked_token(&line[comment_segment_start..idx], token_re);
+            *block_comment_depth = block_comment_depth.saturating_sub(1);
+            return found_unlinked
+                || has_unlinked_todo_in_rust_line_with_block_context(
+                    &line[idx + 2..],
+                    token_re,
+                    block_comment_depth,
+                );
+        }
+        idx += 1;
     }
 
-    for (idx, _) in line.match_indices("//") {
-        if is_index_in_rust_literal(line, idx) {
-            continue;
-        }
-        if is_url_like_hash_comment(line, idx) {
-            continue;
-        }
-        if is_likely_string_literal_comment_start(line, idx) {
-            continue;
-        }
-        if has_unlinked_token(&line[idx + 2..], token_re) {
-            return true;
-        }
+    if *block_comment_depth > 0 {
+        return found_unlinked || has_unlinked_token(&line[comment_segment_start..], token_re);
     }
-    for (idx, _) in line.match_indices("/*") {
-        if is_index_in_rust_literal(line, idx) {
-            continue;
-        }
-        if is_likely_string_literal_comment_start(line, idx) {
-            continue;
-        }
-        if let Some(end_idx) = find_block_comment_end(line, idx + 2) {
-            if has_unlinked_token(&line[idx + 2..end_idx], token_re) {
-                return true;
-            }
-            continue;
-        }
-        if has_unlinked_token(&line[idx + 2..], token_re) {
-            *in_block_comment = true;
-            return true;
-        }
-        *in_block_comment = true;
-    }
+
     let trimmed = line.trim_start();
     if trimmed.starts_with('*') && has_unlinked_token(trimmed, token_re) {
         return true;
     }
-    false
-}
-
-fn find_block_comment_end(line: &str, start_idx: usize) -> Option<usize> {
-    for (rel_idx, _) in line[start_idx..].match_indices("*/") {
-        let idx = start_idx + rel_idx;
-        if is_index_in_rust_literal(line, idx) {
-            continue;
-        }
-        return Some(idx);
-    }
-    None
+    found_unlinked
 }
 
 fn has_unlinked_todo_in_hash_line(line: &str, token_re: &Regex) -> bool {
@@ -4481,26 +4478,26 @@ mod tests {
     #[test]
     fn rust_todo_detection_tracks_multiline_block_comments_across_lines() -> Result<()> {
         let todo_re = Regex::new(r"TODO|FIXME")?;
-        let mut in_block_comment = false;
+        let mut block_comment_depth = 0;
 
         assert!(!has_unlinked_todo_in_rust_line_with_block_context(
             "/* context",
             &todo_re,
-            &mut in_block_comment,
+            &mut block_comment_depth,
         ));
-        assert!(in_block_comment);
+        assert_eq!(block_comment_depth, 1);
         assert!(has_unlinked_todo_in_rust_line_with_block_context(
             "  TODO: capture this follow-up",
             &todo_re,
-            &mut in_block_comment,
+            &mut block_comment_depth,
         ));
-        assert!(in_block_comment);
+        assert_eq!(block_comment_depth, 1);
         assert!(!has_unlinked_todo_in_rust_line_with_block_context(
             "*/ let x = 1;",
             &todo_re,
-            &mut in_block_comment,
+            &mut block_comment_depth,
         ));
-        assert!(!in_block_comment);
+        assert_eq!(block_comment_depth, 0);
 
         Ok(())
     }
@@ -4508,24 +4505,57 @@ mod tests {
     #[test]
     fn rust_todo_detection_ignores_linked_todos_inside_multiline_block_comments() -> Result<()> {
         let todo_re = Regex::new(r"TODO|FIXME")?;
-        let mut in_block_comment = false;
+        let mut block_comment_depth = 0;
 
         assert!(!has_unlinked_todo_in_rust_line_with_block_context(
             "/* header",
             &todo_re,
-            &mut in_block_comment,
+            &mut block_comment_depth,
         ));
         assert!(!has_unlinked_todo_in_rust_line_with_block_context(
             " * TODO(#123): tracked",
             &todo_re,
-            &mut in_block_comment,
+            &mut block_comment_depth,
         ));
         assert!(!has_unlinked_todo_in_rust_line_with_block_context(
             " */",
             &todo_re,
-            &mut in_block_comment,
+            &mut block_comment_depth,
         ));
-        assert!(!in_block_comment);
+        assert_eq!(block_comment_depth, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn rust_todo_detection_handles_nested_block_comments_across_lines() -> Result<()> {
+        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let mut block_comment_depth = 0;
+
+        assert!(!has_unlinked_todo_in_rust_line_with_block_context(
+            "/* outer",
+            &todo_re,
+            &mut block_comment_depth,
+        ));
+        assert_eq!(block_comment_depth, 1);
+        assert!(!has_unlinked_todo_in_rust_line_with_block_context(
+            "/* inner",
+            &todo_re,
+            &mut block_comment_depth,
+        ));
+        assert_eq!(block_comment_depth, 2);
+        assert!(!has_unlinked_todo_in_rust_line_with_block_context(
+            "TODO(#44): tracked */",
+            &todo_re,
+            &mut block_comment_depth,
+        ));
+        assert_eq!(block_comment_depth, 1);
+        assert!(has_unlinked_todo_in_rust_line_with_block_context(
+            "TODO: still untracked */",
+            &todo_re,
+            &mut block_comment_depth,
+        ));
+        assert_eq!(block_comment_depth, 0);
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner treated Rust block comments as a flat boolean state which mis-handled nested `/* ... */` comments and could misclassify comment text across lines. 
- Rust allows nested block comments, so the scanner needs to track nesting depth to avoid exiting comment context prematurely. 
- Improving the scanner reduces false positives/negatives in the repository TODO audit and strengthens CI hygiene checks.

### Description
- Replaced the boolean `in_block_comment` state with a numeric `block_comment_depth` and threaded it through `collect_todo_hits` so block-comment state persists across lines. 
- Rewrote the block-comment parsing to detect nested `/*` and `*/` sequences, only scan comment segments for TODO tokens, and preserve existing guards for string-literals and URL-like `//` patterns. 
- Reworked related test helpers and updated existing multiline block-comment tests to assert depth transitions. 
- Added a regression unit test `rust_todo_detection_handles_nested_block_comments_across_lines` that verifies nested block comment handling with both tracked (linked) and untracked TODOs.

### Testing
- Ran `cargo fmt -p perl-ci-hygiene` to apply formatting, and it completed successfully. 
- Ran `cargo test -p perl-ci-hygiene rust_todo_detection_handles_nested_block_comments_across_lines` and the new test passed. 
- Ran `cargo test -p perl-ci-hygiene rust_todo_detection_` which executed the related suite; all targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98e058e9c83338d60234e7692d50b)