### PR TITLE
docs: add Codex Pro 5-hour session figure to economics writeups (#4805)

### DIFF
--- a/docs/articles/CONTINUOUS_REVIEW_PATTERNS.md
+++ b/docs/articles/CONTINUOUS_REVIEW_PATTERNS.md
@@ -15,7 +15,12 @@ By the close of the 5-hour Claude session window (roughly 1.5 hours of effective
 - **236 dispositions total**
 - **31 tracking issues filed**, 22 closed
 
-Rate: ~150 dispositions per Claude-session-hour. Cost: ~31% of a 5-hour 20× Max window plus ~7% of the Codex Pro weekly budget on the generation side.
+Rate: ~150 dispositions per Claude-session-hour. Cost breakdown (per user at session close):
+
+- **Claude Code 20× Max**: ~31% of a 5-hour session window + ~5% of the weekly budget
+- **Codex Pro**: ~26% of a 5-hour session window + ~7% of the weekly budget
+
+Both sides ran at near-matched session intensity (~26–31%) — a session this intense burns roughly **5–6× a typical day's consumption on each tool simultaneously**, which is how 150 dispositions/hour becomes possible.
 
 The interesting parts aren't the numbers. They're the patterns that emerged for *staying ahead of* a queue that's being pushed to faster than any single reviewer can absorb.
 
@@ -167,11 +172,13 @@ The rule that should have been invoked: **when the user intervenes and the orche
 
 ## Economics snapshot
 
-| Side | Consumption | Output |
-|---|---|---|
-| **Claude Code (orchestrator + agents)** | ~31% of 5h session + ~5% of weekly (20× Max plan) | 116 merges, 120 closes, 31 issues filed |
-| **Codex Pro (generation)** | ~7% of weekly | ~150 PRs generated (50% useful, 50% dup/drift) |
-| **Master CI** | Many cancelled runs (concurrency group) + ~100 successful gate runs | Green master at session close |
+| Side | 5h session | Weekly | Output |
+|---|---|---|---|
+| **Claude Code (orchestrator + agents, 20× Max)** | ~31% | ~5% | 116 merges, 120 closes, 31 issues filed |
+| **Codex Pro (generation)** | ~26% | ~7% | ~150 PRs generated (50% useful, 50% dup/drift) |
+| **Master CI** | — | — | Many cancelled runs (concurrency group) + ~100 successful gate runs; green master at session close |
+
+Both sides ran at near-matched 5-hour session intensity (**~26–31% each**) and near-matched weekly share (**~5–7% each**), which is how 150 dispositions/hour became achievable. The balance is worth naming: a session that's only-Claude or only-Codex won't reach these rates; the **matched-intensity parallel burn on both tools** is what makes spray-and-filter work at this scale.
 
 The ratio that matters: **Codex is cheaper per attempt; Claude is cheaper per decision**. The orchestration pattern exploits this asymmetry by letting Codex spray variation attempts and letting Claude filter to the best one.
 

--- a/docs/articles/ORCHESTRATION_COUNTERINTUITIONS.md
+++ b/docs/articles/ORCHESTRATION_COUNTERINTUITIONS.md
@@ -32,6 +32,8 @@ It's not. Adjusted analysis:
 
 The economic shape: **Codex spray + Claude filter** is profitable specifically *because* generation is cheap enough that a 50% filter ratio is acceptable. If Codex were 10× more expensive per attempt, the calculus would flip toward requiring higher first-pass quality. At current prices, spray-and-filter wins.
 
+**Updated figures** from the session close: Codex Pro consumed **~26% of a 5-hour session budget + ~7% of the weekly budget** for the ~150 attempts. Combined with Claude at **~31% of 5-hour session + ~5% weekly**, both tools ran at near-matched intensity. The 5-hour-session slice suggests one session this intense burns **~5–6× a typical day's consumption simultaneously on each tool** — unusual-but-sustainable for focused review pushes, not a steady-state rate.
+
 ---
 
 ## Counterintuition 3: Context *is* the source of truth

--- a/docs/forensics/2026-04-22-continuous-codex-review-session.md
+++ b/docs/forensics/2026-04-22-continuous-codex-review-session.md
@@ -6,8 +6,10 @@
 - **Scope of analysis:** From session start (master HEAD `0fe9058f1`, 76 open PRs, master CI red on `ci-gate (unit_full)`) through session end (master HEAD `d148636c9`, 2 open PRs in final rebase, master CI recovering with RUSTSEC + fmt drift cleared and full merge-gate now running on every PR).
 - **Cost envelope (per user at session close):**
   - Claude Code (orchestrator + agents, 20× Max plan): **~31% of a 5-hour session budget** + **~5% of weekly budget**
-  - Codex Pro (input PR generation): **~7% of weekly budget**
+  - Codex Pro (input PR generation): **~26% of a 5-hour session budget** + **~7% of weekly budget**
   - Additional non-Codex PR tokens: modest
+
+  Both sides were near-simultaneous 5-hour session intensity (~26–31% each), with the weekly slices matching that ratio roughly 5:1 — i.e. a single session this intense runs ~5–6× a typical day's consumption for each tool.
 
 ---
 


### PR DESCRIPTION
Closes #4805.

Amends the three session writeups merged earlier (#4773 + #4791) with the more-precise Codex Pro consumption figure from the session close: **~26% of a 5-hour session budget** (in addition to the ~7% weekly slice already captured).

Updates:
- `docs/forensics/2026-04-22-continuous-codex-review-session.md` — cost envelope
- `docs/articles/CONTINUOUS_REVIEW_PATTERNS.md` — session-shape header + Economics snapshot table
- `docs/articles/ORCHESTRATION_COUNTERINTUITIONS.md` — Counterintuition 2 (50% throughput) updated figures

Key insight made explicit: **both tools ran at near-matched ~26–31% of a 5-hour session budget**, which is what made 150 dispositions/hour achievable. A session this intense burns ~5–6× typical daily consumption on each tool simultaneously — unusual-but-sustainable for focused review pushes, not a steady-state rate.