### PR TITLE
chore(perl-semantic-analyzer): fix fmt drift (#4812)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
@@ -1722,8 +1722,9 @@ my %config = (key => "value");
     #[test]
     fn test_find_definition_redirects_method_modifier_to_target_method()
     -> Result<(), Box<dyn std::error::Error>> {
-        let code =
-            include_str!("../../../../perl-lsp-rs/tests/fixtures/frameworks/moo_method_modifiers.pl");
+        let code = include_str!(
+            "../../../../perl-lsp-rs/tests/fixtures/frameworks/moo_method_modifiers.pl"
+        );
         let mut parser = Parser::new(code);
         let ast = parser.parse()?;
 


### PR DESCRIPTION
## Summary

- Applies `cargo fmt` to `crates/perl-semantic-analyzer/` to fix accumulated formatting drift
- One file changed: `src/analysis/semantic/mod.rs` — a long `include_str!` macro call wrapped to fit line length
- Purely cosmetic: no logic, behavior, or API changes

## Verification

- `cargo fmt --check -p perl-semantic-analyzer` passes
- `cargo check -p perl-semantic-analyzer --tests` passes clean
- Pre-push single-crate gate: all 21+ tests pass

## Test plan

- [x] `cargo fmt --check -p perl-semantic-analyzer` exits 0
- [x] `cargo check -p perl-semantic-analyzer --tests` clean
- [x] Diff inspected: only whitespace/line-wrap changes (no logic changes)

Closes #4812