### PR TITLE
refactor(performance): remove panic-only helper from public API (#4854)

### DIFF
--- a/crates/perl-lsp-rs-core/src/performance/mod.rs
+++ b/crates/perl-lsp-rs-core/src/performance/mod.rs
@@ -15,22 +15,6 @@ use std::time::Duration;
 
 pub use perl_symbol::SymbolIndex;
 
-/// Assert that a value is `Some` and return it, panicking with `message` if `None`.
-///
-/// This is a test helper exported for integration tests that do `use performance::*`.
-///
-/// # Panics
-///
-/// Panics with `message` if `value` is `None`. Intended for tests only.
-#[allow(clippy::panic)]
-#[track_caller]
-pub fn assert_some<T>(value: Option<T>, message: &str) -> T {
-    match value {
-        Some(v) => v,
-        None => panic!("{message}"),
-    }
-}
-
 /// Cache for parsed ASTs with TTL.
 ///
 /// Stores parsed ASTs with content hashing to avoid re-parsing unchanged files.

--- a/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
+++ b/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
@@ -6,7 +6,7 @@ use perl_lsp_rs_core::performance::*;
 fn performance_module_exposes_ast_cache() {
     // Verify that AstCache is accessible post-absorption
     let cache = AstCache::new(100, 60);
-    assert_some(Some(cache), "AstCache::new should return cache");
+    let _cache = cache;
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn performance_ast_cache_stores_and_retrieves() {
     let _content = "sub foo {}";
     // Note: full integration test would require actual Node construction,
     // which is complex. This test verifies the cache is instantiable.
-    assert_some(Some(cache), "AstCache should be constructible");
+    let _cache = cache;
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Remove a panic-based test helper exported from the `performance` module because production-facing helpers that call `panic!` violate workspace hygiene and can be misused.

### Description
- Deleted the `assert_some` helper from `crates/perl-lsp-rs-core/src/performance/mod.rs` and removed its export from the public API.
- Updated `crates/perl-lsp-rs-core/tests/performance_module_shape.rs` to stop depending on the helper and instead validate cache construction with a normal binding (`let _cache = cache;`).

### Testing
- Ran `cargo xtask fmt` to apply repository formatting rules, which completed successfully.
- Ran `cargo test -p perl-lsp-rs-core --test performance_module_shape` and all tests passed (11 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99b1bf7e08333bcda9960f260295d)