### PR TITLE
refactor(performance): replace panic helper with Result (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/performance/mod.rs
+++ b/crates/perl-lsp-rs-core/src/performance/mod.rs
@@ -15,20 +15,12 @@ use std::time::Duration;
 
 pub use perl_symbol::SymbolIndex;
 
-/// Assert that a value is `Some` and return it, panicking with `message` if `None`.
+/// Return `Ok(T)` when `value` is `Some`, or a descriptive `Err` otherwise.
 ///
-/// This is a test helper exported for integration tests that do `use performance::*`.
-///
-/// # Panics
-///
-/// Panics with `message` if `value` is `None`. Intended for tests only.
-#[allow(clippy::panic)]
-#[track_caller]
-pub fn assert_some<T>(value: Option<T>, message: &str) -> T {
-    match value {
-        Some(v) => v,
-        None => panic!("{message}"),
-    }
+/// This helper is used by integration tests that do `use performance::*`
+/// and want explicit failure messages without relying on panic helpers.
+pub fn assert_some<T>(value: Option<T>, message: &str) -> Result<T, String> {
+    value.ok_or_else(|| message.to_string())
 }
 
 /// Cache for parsed ASTs with TTL.

--- a/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
+++ b/crates/perl-lsp-rs-core/tests/performance_module_shape.rs
@@ -6,7 +6,7 @@ use perl_lsp_rs_core::performance::*;
 fn performance_module_exposes_ast_cache() {
     // Verify that AstCache is accessible post-absorption
     let cache = AstCache::new(100, 60);
-    assert_some(Some(cache), "AstCache::new should return cache");
+    assert!(assert_some(Some(cache), "AstCache::new should return cache").is_ok());
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn performance_ast_cache_stores_and_retrieves() {
     let _content = "sub foo {}";
     // Note: full integration test would require actual Node construction,
     // which is complex. This test verifies the cache is instantiable.
-    assert_some(Some(cache), "AstCache should be constructible");
+    assert!(assert_some(Some(cache), "AstCache should be constructible").is_ok());
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Remove panic-based behavior from the `performance` helper so production code avoids unexpected process termination and tests can assert results explicitly.

### Description
- Change `performance::assert_some` to return `Result<T, String>` instead of panicking on `None`, and update integration tests to check `.is_ok()` at call sites.

### Testing
- Ran `cargo xtask fmt` to format changes and `cargo test -p perl-lsp-rs-core --test performance_module_shape`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99b1bf7e08333bcda9960f260295d)