### PR TITLE
refactor(tests): replace panic branches in parser/dap assertions (#4854)

### DIFF
--- a/crates/perl-dap/src/platform/mod.rs
+++ b/crates/perl-dap/src/platform/mod.rs
@@ -362,15 +362,17 @@ mod tests {
     #[test]
     fn find_perl_interpreter_configured_path_missing_returns_not_found() {
         let result = find_perl_interpreter(Some("/nonexistent/path/to/perl"));
-        match result {
-            PerlInterpreterResult::NotFound { searched } => {
-                assert!(
-                    searched.iter().any(|s| s.contains("configured")),
-                    "searched list should mention configured path: {searched:?}"
-                );
-            }
-            other => panic!("expected NotFound, got: {other:?}"),
-        }
+        assert!(
+            matches!(result, PerlInterpreterResult::NotFound { .. }),
+            "expected NotFound, got: {result:?}"
+        );
+        let PerlInterpreterResult::NotFound { searched } = result else {
+            return;
+        };
+        assert!(
+            searched.iter().any(|s| s.contains("configured")),
+            "searched list should mention configured path: {searched:?}"
+        );
     }
 
     #[test]

--- a/crates/perl-parser/src/heredoc_anti_patterns.rs
+++ b/crates/perl-parser/src/heredoc_anti_patterns.rs
@@ -823,8 +823,13 @@ SECOND
         let diagnostics = detector.detect_all(code);
         assert_eq!(diagnostics.len(), 1);
 
+        assert!(
+            matches!(diagnostics[0].pattern, AntiPattern::SourceFilterHeredoc { .. }),
+            "expected SourceFilterHeredoc pattern, got: {:?}",
+            diagnostics[0].pattern
+        );
         let AntiPattern::SourceFilterHeredoc { location, .. } = &diagnostics[0].pattern else {
-            panic!("expected SourceFilterHeredoc pattern");
+            return;
         };
 
         assert_eq!(location.line, 1);

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -4805,31 +4805,36 @@ Utils::process_data();
         use crate::Parser;
         let mut p = Parser::new("package Child;\nuse parent 'MyBase';\n1;\n");
         let ast = p.parse().expect("parse succeeded");
-        if let NodeKind::Program { statements } = &ast.kind {
-            for stmt in statements {
-                if let NodeKind::Use { module, args, .. } = &stmt.kind {
-                    if module == "parent" {
-                        assert_eq!(
-                            args,
-                            &["'MyBase'".to_string()],
-                            "Expected args=[\"'MyBase'\"] for `use parent 'MyBase'`, got: {:?}",
-                            args
-                        );
-                        let extracted = extract_module_names_from_use_args(args);
-                        assert_eq!(
-                            extracted,
-                            vec!["MyBase".to_string()],
-                            "extract_module_names_from_use_args should return [\"MyBase\"], got {:?}",
-                            extracted
-                        );
-                        return; // Test passed
-                    }
+        assert!(
+            matches!(ast.kind, NodeKind::Program { .. }),
+            "Expected Program root, got {:?}",
+            ast.kind
+        );
+        let NodeKind::Program { statements } = &ast.kind else {
+            return;
+        };
+        let mut found_parent_use = false;
+        for stmt in statements {
+            if let NodeKind::Use { module, args, .. } = &stmt.kind {
+                if module == "parent" {
+                    found_parent_use = true;
+                    assert_eq!(
+                        args,
+                        &["'MyBase'".to_string()],
+                        "Expected args=[\"'MyBase'\"] for `use parent 'MyBase'`, got: {:?}",
+                        args
+                    );
+                    let extracted = extract_module_names_from_use_args(args);
+                    assert_eq!(
+                        extracted,
+                        vec!["MyBase".to_string()],
+                        "extract_module_names_from_use_args should return [\"MyBase\"], got {:?}",
+                        extracted
+                    );
                 }
             }
-            panic!("No Use node with module='parent' found in AST");
-        } else {
-            panic!("Expected Program root");
         }
+        assert!(found_parent_use, "No Use node with module='parent' found in AST");
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Replace ad-hoc `panic!` branches and unsafe destructuring in tests with clearer assertions and safe pattern matching to improve failure diagnostics and align with the workspace ban on `panic!` in non-test code paths.
- Make tests explicitly check expected shapes before destructuring so test failures surface useful assertion messages instead of implicit panics.

### Description
- Replaced a `match` fallback that panicked in `perl-dap` interpreter-path test with an assertion and safe `let ... else { return; }` destructure to preserve diagnostic context (`crates/perl-dap/src/platform/mod.rs`).
- Added an explicit `matches!` assertion and converted the destructure in the heredoc anti-pattern test to a guarded `let ... else { return; }` flow (`crates/perl-parser/src/heredoc_anti_patterns.rs`).
- Reworked the `use parent` AST regression test to assert the root node shape, safely extract `statements`, track whether the target `use` node was found, and assert at the end instead of calling `panic!` mid-traversal (`crates/perl-workspace-index/src/workspace/workspace_index.rs`).

### Testing
- Ran formatting with `cargo xtask fmt` and the formatter completed successfully.
- Ran `cargo test -p perl-dap find_perl_interpreter_configured_path_missing_returns_not_found` and the test passed (`1 passed; 0 failed`).
- Ran `cargo test -p perl-parser test_location_column_is_zero_based_for_new_line_matches` and the test passed (`1 passed; 0 failed`).
- Ran `cargo test -p perl-workspace test_parser_produces_correct_args_for_use_parent` and the test passed (`1 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99b1bf7e08333bcda9960f260295d)