### PR TITLE
chore(devex): extend xtask doctor with git hook diagnostics (#4826)

### DIFF
--- a/xtask/src/tasks/devex_doctor.rs
+++ b/xtask/src/tasks/devex_doctor.rs
@@ -3,7 +3,7 @@
 
 use color_eyre::eyre::{Context, Result, bail};
 use std::{
-    env,
+    env, fs,
     path::Path,
     process::{Command, Stdio},
 };
@@ -50,6 +50,10 @@ pub fn run() -> Result<()> {
     } else {
         warn("rustup unavailable; cannot verify components");
     }
+
+    println!();
+    println!("== Git hooks ==");
+    check_pre_push_hook();
 
     println!();
     if Path::new("rust-toolchain.toml").exists() {
@@ -166,6 +170,89 @@ fn show_version(program: &str, command: &str, args: &[&str]) {
     }
 }
 
+fn check_pre_push_hook() {
+    if !has_command("git") {
+        warn("git unavailable; cannot verify pre-push hook");
+        return;
+    }
+
+    let repo_root = git_output(&["rev-parse", "--show-toplevel"]);
+    let git_common_dir = git_output(&["rev-parse", "--git-common-dir"]);
+    let (repo_root, git_common_dir) = match (repo_root, git_common_dir) {
+        (Some(root), Some(common)) => (root, common),
+        _ => {
+            warn("not in a git repository; cannot verify pre-push hook");
+            return;
+        }
+    };
+
+    let hook_path = Path::new(&git_common_dir).join("hooks").join("pre-push");
+    let expected_hook = Path::new(&repo_root).join("hooks").join("pre-push");
+
+    if !hook_path.is_file() {
+        warn("pre-push hook not installed (fix: cargo xtask ci-hygiene install-githooks)");
+        return;
+    }
+
+    if !is_executable(&hook_path) {
+        warn(&format!("pre-push hook present but not executable: {}", hook_path.display()));
+        return;
+    }
+
+    if expected_hook.is_file() {
+        let installed = fs::read_to_string(&hook_path);
+        let expected = fs::read_to_string(&expected_hook);
+        match (installed, expected) {
+            (Ok(installed), Ok(expected)) => {
+                if normalize_hook_text(&installed) == normalize_hook_text(&expected) {
+                    pass("pre-push hook installed and current");
+                } else {
+                    warn(&format!(
+                        "pre-push hook installed but stale: {} (fix: cargo xtask ci-hygiene install-githooks)",
+                        hook_path.display()
+                    ));
+                }
+            }
+            _ => {
+                warn("unable to read pre-push hook content for staleness check");
+            }
+        }
+        return;
+    }
+
+    pass("pre-push hook installed");
+}
+
+fn git_output(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() { None } else { Some(value) }
+}
+
+fn normalize_hook_text(content: &str) -> String {
+    let mut lines: Vec<String> =
+        content.lines().map(|line| line.trim_end_matches('\r').to_string()).collect();
+    while lines.last().is_some_and(|line| line.is_empty()) {
+        lines.pop();
+    }
+    lines.join("\n")
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    fs::metadata(path).is_ok_and(|metadata| metadata.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}
+
 fn pass(message: &str) {
     println!("✅ {message}");
 }
@@ -176,4 +263,23 @@ fn warn(message: &str) {
 
 fn fail(message: &str) {
     println!("❌ {message}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_hook_text;
+
+    #[test]
+    fn normalize_hook_text_removes_crlf_and_trailing_blank_lines() {
+        let input = "#!/usr/bin/env bash\r\nset -eu\r\n\r\n\r\n";
+        let normalized = normalize_hook_text(input);
+        assert_eq!(normalized, "#!/usr/bin/env bash\nset -eu");
+    }
+
+    #[test]
+    fn normalize_hook_text_preserves_internal_blank_lines() {
+        let input = "line1\n\nline3\n";
+        let normalized = normalize_hook_text(input);
+        assert_eq!(normalized, "line1\n\nline3");
+    }
 }


### PR DESCRIPTION
### Motivation
- Surface pre-push hook health during environment checks so developers get immediate, actionable devex feedback. 
- Reduce false stale-hook warnings caused by line-ending or trailing-blank differences.

### Description
- Add a new `== Git hooks ==` section to `cargo xtask devex-doctor` that runs `check_pre_push_hook()` during `run()`.
- Implement `check_pre_push_hook()` which verifies `git` presence, repository context, whether the pre-push hook is installed, executable, and whether it is stale versus `hooks/pre-push`.
- Add helpers `git_output()`, `normalize_hook_text()`, and a platform-aware `is_executable()` to support the hook checks and robust text comparison.
- Include focused unit tests for `normalize_hook_text()` to ensure CRLF normalization and trailing-blank-line trimming do not produce false positives.

### Testing
- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo test -p xtask devex_doctor` and the unit tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99afee94083338fe082825abe29ab)