### PR TITLE
chore(devex): improve xtask doctor install guidance (#4826)

### DIFF
--- a/xtask/src/tasks/devex_doctor.rs
+++ b/xtask/src/tasks/devex_doctor.rs
@@ -36,13 +36,15 @@ pub fn run() -> Result<()> {
     println!();
     println!("== Rust components ==");
     if has_command("rustup") {
-        if is_component_installed("rustfmt") {
+        let installed_components = get_installed_rustup_components();
+
+        if is_component_installed("rustfmt", installed_components.as_deref()) {
             pass("rustup component installed: rustfmt");
         } else {
             warn("rustup component missing: rustfmt (install: rustup component add rustfmt)");
         }
 
-        if is_component_installed("clippy") {
+        if is_component_installed("clippy", installed_components.as_deref()) {
             pass("rustup component installed: clippy");
         } else {
             warn("rustup component missing: clippy (install: rustup component add clippy)");
@@ -90,7 +92,7 @@ fn check_command(program: &str, label: &str, missing_required: &mut bool) {
     if has_command(program) {
         pass(&format!("{label}: found ({})", command_path(program).unwrap_or(program.to_string())));
     } else {
-        warn(&format!("{label}: not found"));
+        warn(&format!("{label}: not found{}", install_hint(program)));
         *missing_required = true;
     }
 }
@@ -99,7 +101,18 @@ fn check_command_optional(program: &str, label: &str) {
     if has_command(program) {
         pass(&format!("{label}: found ({})", command_path(program).unwrap_or(program.to_string())));
     } else {
-        warn(&format!("{label}: not found"));
+        warn(&format!("{label}: not found{}", install_hint(program)));
+    }
+}
+
+fn install_hint(program: &str) -> &'static str {
+    match program {
+        "cargo" | "rustfmt" | "rustup" => " (install via https://rustup.rs)",
+        "just" => " (install: cargo install just)",
+        "cargo-audit" => " (install: cargo install cargo-audit)",
+        "rg" => " (install ripgrep via your package manager)",
+        "nix" => " (install from https://nixos.org/download/)",
+        _ => "",
     }
 }
 
@@ -143,12 +156,18 @@ fn command_path(program: &str) -> Option<String> {
     })
 }
 
-fn is_component_installed(component: &str) -> bool {
-    let output = match Command::new("rustup").args(["component", "list", "--installed"]).output() {
-        Ok(output) if output.status.success() => output,
-        _ => return false,
+fn get_installed_rustup_components() -> Option<String> {
+    let output = Command::new("rustup").args(["component", "list", "--installed"]).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn is_component_installed(component: &str, installed_components: Option<&str>) -> bool {
+    let Some(lines) = installed_components else {
+        return false;
     };
-    let lines = String::from_utf8_lossy(&output.stdout);
     lines.lines().any(|line| {
         let value = line.split_whitespace().next().unwrap_or("");
         value == component || value.starts_with(&(format!("{component}-")))


### PR DESCRIPTION
### Motivation

- Make `cargo xtask devex-doctor` output more actionable for first-time contributors by appending targeted install hints when a required or recommended tool is missing. 
- Avoid redundant work and slightly speed up the rust component checks by querying `rustup` once and reusing the output for multiple component checks.

### Description

- Add `install_hint` helper and append contextual install hints to `check_command` and `check_command_optional` warnings for tools such as `rustup`, `just`, `cargo-audit`, `rg`, and `nix`.
- Introduce `get_installed_rustup_components` to fetch `rustup component list --installed` once and return the output for reuse.
- Change `is_component_installed` signature to accept an optional pre-fetched component list and use it for `rustfmt` and `clippy` checks.
- Keep overall behavior and failure semantics unchanged while improving diagnostics and removing repeated `rustup` invocations.

### Testing

- Ran `cargo xtask fmt` and the repository formatter completed successfully.
- Ran `cargo check -p xtask` and the `xtask` crate type-checks cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99afee94083338fe082825abe29ab)