### PR TITLE
fix(devex): fail doctor when rustup components are missing (#4826)

### DIFF
--- a/xtask/src/tasks/devex_doctor.rs
+++ b/xtask/src/tasks/devex_doctor.rs
@@ -37,18 +37,8 @@ pub fn run() -> Result<()> {
     println!("== Rust components ==");
     if has_command("rustup") {
         let installed_components = get_installed_rustup_components();
-
-        if is_component_installed("rustfmt", installed_components.as_deref()) {
-            pass("rustup component installed: rustfmt");
-        } else {
-            warn("rustup component missing: rustfmt (install: rustup component add rustfmt)");
-        }
-
-        if is_component_installed("clippy", installed_components.as_deref()) {
-            pass("rustup component installed: clippy");
-        } else {
-            warn("rustup component missing: clippy (install: rustup component add clippy)");
-        }
+        check_rust_component("rustfmt", true, &mut missing_required, installed_components.as_deref());
+        check_rust_component("clippy", true, &mut missing_required, installed_components.as_deref());
     } else {
         warn("rustup unavailable; cannot verify components");
     }
@@ -177,6 +167,27 @@ fn is_component_installed(component: &str, installed_components: Option<&str>) -
         let value = line.split_whitespace().next().unwrap_or("");
         value == component || value.starts_with(&(format!("{component}-")))
     })
+}
+
+fn check_rust_component(
+    component: &str,
+    required: bool,
+    missing_required: &mut bool,
+    installed_components: Option<&str>,
+) {
+    if is_component_installed(component, installed_components) {
+        pass(&format!("rustup component installed: {component}"));
+        return;
+    }
+
+    let message = format!(
+        "rustup component missing: {component} (install: rustup component add {component})"
+    );
+
+    warn(&message);
+    if required {
+        *missing_required = true;
+    }
 }
 
 fn show_version(program: &str, command: &str, args: &[&str]) {


### PR DESCRIPTION
### Motivation
- Make the developer environment doctor (`xtask devex-doctor`) surface missing `rustup` components earlier so onboarding feedback is actionable and prevents later `just pr-fast`/`just ci-gate` failures.

### Description
- Refactor duplicated logic into a helper `check_rust_component(...)` and use it to check `rustfmt` and `clippy`.
- Treat missing `rustup` components as required by setting `missing_required = true` when those components are absent so the doctor exits with a failure instead of silently warning.

### Testing
- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo check -p xtask` which completed successfully.
- Ran `cargo run -p xtask -- devex-doctor` which reported installed components and exited successfully in the validated environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99afee94083338fe082825abe29ab)