### PR TITLE
refactor(language): extract document-link handlers (#4901)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/document_links.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/document_links.rs
@@ -1,0 +1,236 @@
+//! Document link handlers.
+//!
+//! Keeps document-link feature logic isolated from other language handlers.
+
+use super::super::*;
+use crate::protocol::req_uri;
+use std::borrow::Cow;
+
+fn normalize_document_link_file_path(file_path: &str) -> Cow<'_, str> {
+    if !file_path.contains(['\\', '/']) {
+        return Cow::Borrowed(file_path);
+    }
+
+    let preserve_unc_prefix = file_path.starts_with("\\\\") || file_path.starts_with("//");
+    let mut normalized = String::with_capacity(file_path.len());
+    let mut chars = file_path.chars().peekable();
+
+    if preserve_unc_prefix {
+        normalized.push_str("//");
+        while matches!(chars.peek(), Some('\\' | '/')) {
+            chars.next();
+        }
+    }
+
+    let mut saw_separator = false;
+
+    for ch in chars {
+        let is_separator = ch == '\\' || ch == '/';
+        if is_separator {
+            if !saw_separator {
+                normalized.push('/');
+            }
+        } else {
+            normalized.push(ch);
+        }
+        saw_separator = is_separator;
+    }
+
+    Cow::Owned(normalized)
+}
+
+impl LspServer {
+    /// Handle textDocument/documentLink request
+    pub(crate) fn handle_document_links(
+        &self,
+        params: Option<Value>,
+    ) -> Result<Option<Value>, JsonRpcError> {
+        if let Some(p) = params {
+            let uri = p["textDocument"]["uri"].as_str().ok_or_else(|| JsonRpcError {
+                code: INVALID_PARAMS,
+                message: "Missing textDocument.uri".into(),
+                data: None,
+            })?;
+            // Snapshot document text under lock, then release before acquiring
+            // workspace_folders via workspace_roots() to prevent ABBA deadlock.
+            // Path A (here): documents -> workspace_folders
+            // Path B (workspace.rs): workspace_folders -> documents
+            let doc_text = {
+                let documents = self.documents_guard();
+                let doc = self.get_document(&documents, uri).ok_or_else(|| JsonRpcError {
+                    code: INVALID_REQUEST,
+                    message: format!("Document not open: {}", uri),
+                    data: None,
+                })?;
+                doc.text.clone()
+            };
+            // documents lock released here
+
+            let roots = self.workspace_roots();
+            let links = crate::document_links::compute_links(uri, &doc_text, &roots);
+            Ok(Some(json!(links)))
+        } else {
+            Ok(Some(json!([])))
+        }
+    }
+
+    /// Handle documentLink/resolve request
+    ///
+    /// Resolves a document link by filling in the target URI based on the data field.
+    /// This allows the initial documentLink response to defer expensive resolution
+    /// until the user actually hovers over or clicks the link.
+    pub(crate) fn handle_document_link_resolve(
+        &self,
+        params: Option<Value>,
+    ) -> Result<Option<Value>, JsonRpcError> {
+        if let Some(mut link) = params {
+            // Extract data field to determine link type
+            let data = link.get("data").cloned();
+
+            // If link already has a target, return as-is (already resolved)
+            if link.get("target").and_then(|t| t.as_str()).is_some() {
+                return Ok(Some(link));
+            }
+
+            // Resolve based on data field
+            if let Some(data_obj) = data {
+                let link_type = data_obj.get("type").and_then(|t| t.as_str());
+
+                match link_type {
+                    Some("module") => {
+                        // Module reference - resolve to file path or MetaCPAN
+                        let module_name = data_obj
+                            .get("module")
+                            .and_then(|m| m.as_str())
+                            .ok_or_else(|| JsonRpcError {
+                                code: INVALID_PARAMS,
+                                message: "Missing module name in data".into(),
+                                data: None,
+                            })?;
+
+                        // Try to resolve module to local file
+                        if let Some(target) = self.resolve_module_to_path(module_name) {
+                            link["target"] = json!(target);
+                        } else {
+                            // Fallback to MetaCPAN
+                            let target = format!("https://metacpan.org/pod/{}", module_name);
+                            link["target"] = json!(target);
+                        }
+                    }
+                    Some("file") => {
+                        // File reference - resolve to absolute path
+                        let file_path =
+                            data_obj.get("path").and_then(|p| p.as_str()).ok_or_else(|| {
+                                JsonRpcError {
+                                    code: INVALID_PARAMS,
+                                    message: "Missing file path in data".into(),
+                                    data: None,
+                                }
+                            })?;
+                        let normalized_file_path = normalize_document_link_file_path(file_path);
+
+                        let base_uri = data_obj
+                            .get("baseUri")
+                            .and_then(|u| u.as_str())
+                            .ok_or_else(|| JsonRpcError {
+                                code: INVALID_PARAMS,
+                                message: "Missing base URI in data".into(),
+                                data: None,
+                            })?;
+
+                        // Resolve relative to base URI. Prefer URL joins because tests
+                        // and editors may use synthetic file:// roots that are not
+                        // convertible to platform-native absolute paths on Windows.
+                        if let Ok(base_url) = url::Url::parse(base_uri) {
+                            if let Ok(target_url) = base_url.join(&normalized_file_path) {
+                                link["target"] = json!(target_url.to_string());
+                            } else if let Ok(base_path) = base_url.to_file_path() {
+                                if let Some(parent) = base_path.parent() {
+                                    let resolved = parent.join(normalized_file_path.as_ref());
+                                    if let Ok(target_url) = url::Url::from_file_path(&resolved) {
+                                        link["target"] = json!(target_url.to_string());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Some("url") => {
+                        // URL reference - already resolved, just copy from data
+                        if let Some(url) = data_obj.get("url").and_then(|u| u.as_str()) {
+                            link["target"] = json!(url);
+                        }
+                    }
+                    _ => {
+                        // Unknown link type - return error
+                        return Err(JsonRpcError {
+                            code: INVALID_PARAMS,
+                            message: "Unknown link type in data field".into(),
+                            data: Some(json!({"linkType": link_type})),
+                        });
+                    }
+                }
+            }
+
+            Ok(Some(link))
+        } else {
+            Err(JsonRpcError {
+                code: INVALID_PARAMS,
+                message: "Missing parameters for documentLink/resolve".into(),
+                data: None,
+            })
+        }
+    }
+
+    /// Handle documentLink request (alternative)
+    #[allow(dead_code)] // Alternative implementation
+    pub(crate) fn handle_document_link(
+        &self,
+        params: Option<Value>,
+    ) -> Result<Option<Value>, JsonRpcError> {
+        if let Some(params) = params {
+            let uri = req_uri(&params)?;
+
+            let documents = self.documents_guard();
+            if let Some(doc) = self.get_document(&documents, uri) {
+                let uri_parsed = url::Url::parse(uri).map_err(|_| JsonRpcError {
+                    code: -32602,
+                    message: "Invalid URI".to_string(),
+                    data: None,
+                })?;
+                match crate::lsp_document_link::collect_document_links(&doc.text, &uri_parsed) {
+                    Ok(links) => Ok(Some(serde_json::to_value(links).map_err(|e| {
+                        crate::protocol::internal_error(&format!(
+                            "Failed to serialize document links: {}",
+                            e
+                        ))
+                    })?)),
+                    Err(_) => Ok(Some(Value::Null)),
+                }
+            } else {
+                Ok(Some(Value::Null))
+            }
+        } else {
+            Ok(Some(Value::Null))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_document_link_file_path;
+
+    #[test]
+    fn normalize_document_link_file_path_collapses_windows_separators() {
+        assert_eq!(normalize_document_link_file_path(r"lib\\Thing.pm"), "lib/Thing.pm");
+        assert_eq!(normalize_document_link_file_path(r"lib\Thing.pm"), "lib/Thing.pm");
+        assert_eq!(normalize_document_link_file_path("lib/Thing.pm"), "lib/Thing.pm");
+    }
+
+    #[test]
+    fn normalize_document_link_file_path_preserves_unc_prefix() {
+        assert_eq!(
+            normalize_document_link_file_path(r"\\server\share\Thing.pm"),
+            "//server/share/Thing.pm"
+        );
+    }
+}

--- a/crates/perl-lsp-rs/src/runtime/language/misc.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/misc.rs
@@ -16,7 +16,6 @@ use crate::protocol::{invalid_params, req_position, req_uri};
 use crate::state::{code_lens_cap, code_lens_resolve_deadline, inlay_hints_cap};
 use perl_module::import::resolve_known_export_tag;
 use perl_parser_core::source_file::is_perl_source_uri;
-use std::borrow::Cow;
 use std::sync::OnceLock;
 use std::time::Instant;
 
@@ -27,39 +26,6 @@ fn get_inline_value_regex() -> Option<&'static regex::Regex> {
         .get_or_init(|| regex::Regex::new(r"([$@%])([a-zA-Z_][a-zA-Z0-9_]*)"))
         .as_ref()
         .ok()
-}
-
-fn normalize_document_link_file_path(file_path: &str) -> Cow<'_, str> {
-    if !file_path.contains(['\\', '/']) {
-        return Cow::Borrowed(file_path);
-    }
-
-    let preserve_unc_prefix = file_path.starts_with("\\\\") || file_path.starts_with("//");
-    let mut normalized = String::with_capacity(file_path.len());
-    let mut chars = file_path.chars().peekable();
-
-    if preserve_unc_prefix {
-        normalized.push_str("//");
-        while matches!(chars.peek(), Some('\\' | '/')) {
-            chars.next();
-        }
-    }
-
-    let mut saw_separator = false;
-
-    for ch in chars {
-        let is_separator = ch == '\\' || ch == '/';
-        if is_separator {
-            if !saw_separator {
-                normalized.push('/');
-            }
-        } else {
-            normalized.push(ch);
-        }
-        saw_separator = is_separator;
-    }
-
-    Cow::Owned(normalized)
 }
 
 impl LspServer {
@@ -289,180 +255,6 @@ impl LspServer {
             }
         });
         found
-    }
-
-    /// Handle textDocument/documentLink request
-    pub(crate) fn handle_document_links(
-        &self,
-        params: Option<Value>,
-    ) -> Result<Option<Value>, JsonRpcError> {
-        if let Some(p) = params {
-            let uri = p["textDocument"]["uri"].as_str().ok_or_else(|| JsonRpcError {
-                code: INVALID_PARAMS,
-                message: "Missing textDocument.uri".into(),
-                data: None,
-            })?;
-            // Snapshot document text under lock, then release before acquiring
-            // workspace_folders via workspace_roots() to prevent ABBA deadlock.
-            // Path A (here): documents -> workspace_folders
-            // Path B (workspace.rs): workspace_folders -> documents
-            let doc_text = {
-                let documents = self.documents_guard();
-                let doc = self.get_document(&documents, uri).ok_or_else(|| JsonRpcError {
-                    code: INVALID_REQUEST,
-                    message: format!("Document not open: {}", uri),
-                    data: None,
-                })?;
-                doc.text.clone()
-            };
-            // documents lock released here
-
-            let roots = self.workspace_roots();
-            let links = crate::document_links::compute_links(uri, &doc_text, &roots);
-            Ok(Some(json!(links)))
-        } else {
-            Ok(Some(json!([])))
-        }
-    }
-
-    /// Handle documentLink/resolve request
-    ///
-    /// Resolves a document link by filling in the target URI based on the data field.
-    /// This allows the initial documentLink response to defer expensive resolution
-    /// until the user actually hovers over or clicks the link.
-    pub(crate) fn handle_document_link_resolve(
-        &self,
-        params: Option<Value>,
-    ) -> Result<Option<Value>, JsonRpcError> {
-        if let Some(mut link) = params {
-            // Extract data field to determine link type
-            let data = link.get("data").cloned();
-
-            // If link already has a target, return as-is (already resolved)
-            if link.get("target").and_then(|t| t.as_str()).is_some() {
-                return Ok(Some(link));
-            }
-
-            // Resolve based on data field
-            if let Some(data_obj) = data {
-                let link_type = data_obj.get("type").and_then(|t| t.as_str());
-
-                match link_type {
-                    Some("module") => {
-                        // Module reference - resolve to file path or MetaCPAN
-                        let module_name = data_obj
-                            .get("module")
-                            .and_then(|m| m.as_str())
-                            .ok_or_else(|| JsonRpcError {
-                                code: INVALID_PARAMS,
-                                message: "Missing module name in data".into(),
-                                data: None,
-                            })?;
-
-                        // Try to resolve module to local file
-                        if let Some(target) = self.resolve_module_to_path(module_name) {
-                            link["target"] = json!(target);
-                        } else {
-                            // Fallback to MetaCPAN
-                            let target = format!("https://metacpan.org/pod/{}", module_name);
-                            link["target"] = json!(target);
-                        }
-                    }
-                    Some("file") => {
-                        // File reference - resolve to absolute path
-                        let file_path =
-                            data_obj.get("path").and_then(|p| p.as_str()).ok_or_else(|| {
-                                JsonRpcError {
-                                    code: INVALID_PARAMS,
-                                    message: "Missing file path in data".into(),
-                                    data: None,
-                                }
-                            })?;
-                        let normalized_file_path = normalize_document_link_file_path(file_path);
-
-                        let base_uri = data_obj
-                            .get("baseUri")
-                            .and_then(|u| u.as_str())
-                            .ok_or_else(|| JsonRpcError {
-                                code: INVALID_PARAMS,
-                                message: "Missing base URI in data".into(),
-                                data: None,
-                            })?;
-
-                        // Resolve relative to base URI. Prefer URL joins because tests
-                        // and editors may use synthetic file:// roots that are not
-                        // convertible to platform-native absolute paths on Windows.
-                        if let Ok(base_url) = url::Url::parse(base_uri) {
-                            if let Ok(target_url) = base_url.join(&normalized_file_path) {
-                                link["target"] = json!(target_url.to_string());
-                            } else if let Ok(base_path) = base_url.to_file_path() {
-                                if let Some(parent) = base_path.parent() {
-                                    let resolved = parent.join(normalized_file_path.as_ref());
-                                    if let Ok(target_url) = url::Url::from_file_path(&resolved) {
-                                        link["target"] = json!(target_url.to_string());
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    Some("url") => {
-                        // URL reference - already resolved, just copy from data
-                        if let Some(url) = data_obj.get("url").and_then(|u| u.as_str()) {
-                            link["target"] = json!(url);
-                        }
-                    }
-                    _ => {
-                        // Unknown link type - return error
-                        return Err(JsonRpcError {
-                            code: INVALID_PARAMS,
-                            message: "Unknown link type in data field".into(),
-                            data: Some(json!({"linkType": link_type})),
-                        });
-                    }
-                }
-            }
-
-            Ok(Some(link))
-        } else {
-            Err(JsonRpcError {
-                code: INVALID_PARAMS,
-                message: "Missing parameters for documentLink/resolve".into(),
-                data: None,
-            })
-        }
-    }
-
-    /// Handle documentLink request (alternative)
-    #[allow(dead_code)] // Alternative implementation
-    pub(crate) fn handle_document_link(
-        &self,
-        params: Option<Value>,
-    ) -> Result<Option<Value>, JsonRpcError> {
-        if let Some(params) = params {
-            let uri = req_uri(&params)?;
-
-            let documents = self.documents_guard();
-            if let Some(doc) = self.get_document(&documents, uri) {
-                let uri_parsed = url::Url::parse(uri).map_err(|_| JsonRpcError {
-                    code: -32602,
-                    message: "Invalid URI".to_string(),
-                    data: None,
-                })?;
-                match crate::lsp_document_link::collect_document_links(&doc.text, &uri_parsed) {
-                    Ok(links) => Ok(Some(serde_json::to_value(links).map_err(|e| {
-                        crate::protocol::internal_error(&format!(
-                            "Failed to serialize document links: {}",
-                            e
-                        ))
-                    })?)),
-                    Err(_) => Ok(Some(Value::Null)),
-                }
-            } else {
-                Ok(Some(Value::Null))
-            }
-        } else {
-            Ok(Some(Value::Null))
-        }
     }
 
     /// Handle textDocument/selectionRange request
@@ -1859,7 +1651,6 @@ impl LspServer {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_document_link_file_path;
     use crate::LspServer;
     use crate::state::ClientCapabilities;
     use serde_json::json;
@@ -2052,20 +1843,5 @@ mod tests {
             "baz should resolve through use_module+import alias"
         );
         Ok(())
-    }
-
-    #[test]
-    fn normalize_document_link_file_path_collapses_windows_separators() {
-        assert_eq!(normalize_document_link_file_path(r"lib\\Thing.pm"), "lib/Thing.pm");
-        assert_eq!(normalize_document_link_file_path(r"lib\Thing.pm"), "lib/Thing.pm");
-        assert_eq!(normalize_document_link_file_path("lib/Thing.pm"), "lib/Thing.pm");
-    }
-
-    #[test]
-    fn normalize_document_link_file_path_preserves_unc_prefix() {
-        assert_eq!(
-            normalize_document_link_file_path(r"\\server\share\Thing.pm"),
-            "//server/share/Thing.pm"
-        );
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/language/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/mod.rs
@@ -18,6 +18,7 @@
 mod code_actions;
 mod colors;
 mod completion;
+mod document_links;
 mod formatting;
 mod hierarchy;
 mod hover;


### PR DESCRIPTION
### Motivation

- `misc.rs` mixed document-link handling with many unrelated LSP handlers, violating SRP and making the document-link logic harder to test and maintain.
- The document-link code (normalization + request/resolve handlers) is a focused responsibility that is easier to evolve if owned by its own module.

### Description

- Add a new SRP module `crates/perl-lsp-rs/src/runtime/language/document_links.rs` that contains `normalize_document_link_file_path` and the `handle_document_links`, `handle_document_link_resolve`, and alternative `handle_document_link` implementations.
- Remove the document-link helper and handlers (and their tests) from `crates/perl-lsp-rs/src/runtime/language/misc.rs` so `misc.rs` retains only its other miscellaneous handlers.
- Register the new module in `crates/perl-lsp-rs/src/runtime/language/mod.rs` via `mod document_links;` so it is compiled as part of the language feature surface.
- Move the document-link unit tests into the new module so the tests live next to the implementation.

### Testing

- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran `cargo check -p perl-lsp-rs` and the crate checked successfully.
- Ran `cargo test -p perl-lsp-rs --lib normalize_document_link_file_path_collapses_windows_separators` and the test passed.
- Ran `cargo test -p perl-lsp-rs --lib normalize_document_link_file_path_preserves_unc_prefix` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99ae43ba4833396a4ae4aa24b3b53)