### PR TITLE
fix(devex): auto-detect default branch for local checks (#4901)

### DIFF
--- a/justfile
+++ b/justfile
@@ -611,21 +611,29 @@ doctor:
     fi
 
     # ------------------------------------------------------------------
-    # Check 7: Master is fast-forward-able
-    # Use the cached refs_dump to check origin/master existence (no extra call).
+    # Check 7: Current checkout is fast-forward-able with remote default branch.
+    # Prefer origin/HEAD, then fall back to common branch names.
     # ------------------------------------------------------------------
-    if [ -n "${remote_ref_set[origin/master]:-}" ]; then
-        behind=$(git rev-list --count HEAD..origin/master 2>/dev/null || echo 0)
+    default_remote_ref=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+    if [ -z "$default_remote_ref" ]; then
+        if [ -n "${remote_ref_set[origin/main]:-}" ]; then
+            default_remote_ref="origin/main"
+        elif [ -n "${remote_ref_set[origin/master]:-}" ]; then
+            default_remote_ref="origin/master"
+        fi
+    fi
+    if [ -n "$default_remote_ref" ]; then
+        behind=$(git rev-list --count HEAD.."$default_remote_ref" 2>/dev/null || echo 0)
         if [ "$behind" = "0" ]; then
-            echo "✅ master is up to date with origin/master"
+            echo "✅ branch is up to date with $default_remote_ref"
         else
-            echo "⚠️  HEAD is $behind commits behind origin/master"
+            echo "⚠️  HEAD is $behind commits behind $default_remote_ref"
             echo "   Fix: git pull --ff-only"
             issues=$((issues + 1))
         fi
     else
-        echo "⚠️  origin/master ref not found (cannot check fast-forward state)"
-        echo "   Fix: git fetch origin master:refs/remotes/origin/master"
+        echo "⚠️  could not resolve default remote branch (cannot check fast-forward state)"
+        echo "   Fix: git remote set-head origin -a && git fetch origin"
         issues=$((issues + 1))
     fi
 
@@ -637,10 +645,34 @@ doctor:
     fi
     exit 0
 
-# Targeted checks for changed crates (fast feedback for active branch)
-devex-targeted base='origin/master' mode='all':
-    @echo "Running targeted checks (base={{base}}, mode={{mode}})..."
-    @cargo xtask targeted-checks --base "{{base}}" --mode "{{mode}}"
+# Targeted checks for changed crates (fast feedback for active branch).
+# If `base` is empty, resolve from origin/HEAD, then fall back to common names.
+devex-targeted base='' mode='all':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    base="{{base}}"
+    if [ -z "$base" ]; then
+        base=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+    fi
+    if [ -z "$base" ] && git rev-parse --verify --quiet origin/main >/dev/null; then
+        base="origin/main"
+    fi
+    if [ -z "$base" ] && git rev-parse --verify --quiet origin/master >/dev/null; then
+        base="origin/master"
+    fi
+    if [ -z "$base" ] && git rev-parse --verify --quiet main >/dev/null; then
+        base="main"
+    fi
+    if [ -z "$base" ] && git rev-parse --verify --quiet master >/dev/null; then
+        base="master"
+    fi
+    if [ -z "$base" ]; then
+        echo "ERROR: Could not auto-detect base branch."
+        echo "Hint: run 'just devex-targeted <base-ref>' (example: origin/main)."
+        exit 1
+    fi
+    echo "Running targeted checks (base=$base, mode={{mode}})..."
+    cargo xtask targeted-checks --base "$base" --mode "{{mode}}"
 
 # Tool availability check (basic tools for PR-fast)
 [private]


### PR DESCRIPTION
### Motivation
- `just doctor` and `devex-targeted` assumed `origin/master`, which breaks forks and repos using `main` as the default branch. 
- Make local devex checks robust across both `main`/`master` conventions to reduce onboarding friction.

### Description
- Update `just doctor` fast-forward check to resolve the remote default via `git symbolic-ref refs/remotes/origin/HEAD` and fall back to `origin/main` then `origin/master`, with clearer status and remediation messaging. 
- Replace the hardcoded `devex-targeted base='origin/master'` recipe with a script-style recipe that auto-detects `base` from `origin/HEAD`, `origin/main`, `origin/master`, `main`, and `master`, and provides an actionable error when detection fails. 
- Add `#!/usr/bin/env bash` and `set -euo pipefail` to the `devex-targeted` recipe to make behavior explicit and safer in CI and local runs.

### Testing
- Attempted to list and dry-run recipes with `just --list` and `just -n devex-targeted`, but the `just` binary is not installed in this environment so recipe execution could not be validated here (failure). 
- No other automated tests were run in this environment; CI will exercise formatting, clippy, and test gates after pushing this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99af7b0748333b88f25c78c831429)