### PR TITLE
chore(devex): add ready preflight command (#4901)

### DIFF
--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -61,10 +61,10 @@ just doctor         # Detects+fixes core.bare, worktree leaks, stale branches, e
 # Check the local environment (tools, Rust components)
 just devex          # Alias: just doctor-env
 
-# Fast validation while iterating
-just pr-fast
+# Pre-push preflight (doctor + fast gate)
+just ready
 
-# Canonical fast push guard
+# Fast validation while iterating
 just pr-fast
 
 # Canonical local merge gate

--- a/justfile
+++ b/justfile
@@ -346,6 +346,11 @@ doctor-env:
 # Short alias for the developer environment quick check
 devex: doctor-env
 
+# One-command pre-flight before pushing a branch:
+# 1) repair/report workspace state issues, then 2) run the fast PR gate.
+ready: doctor pr-fast
+    @echo "✅ Workspace is ready to push (doctor + pr-fast passed)"
+
 # Run before any agent-spawning session. Safe to run repeatedly (idempotent).
 # Checks: core.bare corruption (#3205), stale branches, worktree leaks, orphaned
 # worktree dirs, pre-push hook, workspace cleanliness, master fast-forward state.


### PR DESCRIPTION
### Motivation
- Provide a one-command pre-push preflight that repairs/reports workspace state and runs the fast PR gate to reduce friction when pushing branches.

### Description
- Add `ready` recipe to `justfile` that runs `doctor` then `pr-fast` and prints a success message.
- Document the new `just ready` shortcut in `docs/reference/COMMANDS_REFERENCE.md` and remove a duplicated `just pr-fast` line in the workflow snippet.

### Testing
- Attempted `just --list` and `just --dry-run ready` as dry-run checks, but both could not be executed in this environment because `just` is not installed (no runtime validation performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99af7b0748333b88f25c78c831429)