### PR TITLE
chore(devex): split nextest checks from base tool gate (#4901)

### DIFF
--- a/justfile
+++ b/justfile
@@ -650,14 +650,28 @@ _check-tools-basic:
     MISSING=""
     if ! command -v cargo >/dev/null 2>&1; then MISSING="$MISSING cargo"; fi
     if ! command -v rustfmt >/dev/null 2>&1; then MISSING="$MISSING rustfmt"; fi
-    if ! cargo nextest --version >/dev/null 2>&1; then MISSING="$MISSING cargo-nextest"; fi
     if [ -n "$MISSING" ]; then
         echo "ERROR: Missing required tools:$MISSING"
         echo "  Install Rust: https://rustup.rs"
-        echo "  Install nextest: cargo install cargo-nextest --locked"
+        echo "  Install rustfmt: rustup component add rustfmt"
         exit 1
     fi
     cargo xtask check-toolchain
+
+# Tool availability check for Nextest-backed recipes
+[private]
+_check-tools-nextest:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if command -v cargo-nextest >/dev/null 2>&1; then
+        exit 0
+    fi
+    if cargo nextest --version >/dev/null 2>&1; then
+        exit 0
+    fi
+    echo "ERROR: Missing required tool: cargo-nextest"
+    echo "  Install nextest: cargo install cargo-nextest --locked"
+    exit 1
 
 # ============================================================================
 # CI Validation Commands (Issue #211)
@@ -898,6 +912,7 @@ ci-test-core:
 # Library tests only (fastest, for merge gate)
 ci-test-lib:
     @echo "🧪 Running library tests..."
+    @just _check-tools-nextest
     cargo nextest run --workspace --lib --locked --profile ci
     @echo "✅ Library tests passed"
 


### PR DESCRIPTION
### Motivation
- Avoid blocking fast local workflows (`pr-fast`, formatting, clippy, core tests) with optional tooling requirements. 
- `cargo-nextest` is only required for specific test recipes, so the basic preflight should only validate truly baseline tools. 
- Provide clearer, actionable failure messages when Nextest is required so contributors can install it only if needed.

### Description
- Removed the `cargo-nextest` availability check from the private `_check-tools-basic` recipe in `justfile` so baseline checks only validate `cargo` and `rustfmt`. 
- Added a new private recipe `_check-tools-nextest` that verifies Nextest (`cargo-nextest` or `cargo nextest`) and prints an explicit install hint. 
- Wired `ci-test-lib` to call `@just _check-tools-nextest` immediately before invoking `cargo nextest run` so Nextest is enforced only for Nextest-backed recipes.

### Testing
- Ran `cargo run -p xtask -- check-toolchain` which completed successfully and reported the pinned toolchain match. 
- Attempted `just --dry-run ci-test-lib` in the environment and it failed because `just` is not installed (`/bin/bash: line 1: just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99af7b0748333b88f25c78c831429)