### PR TITLE
docs(diataxis): clarify documentation taxonomy guidance (#4901)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,6 +2,23 @@
 
 This page is the documentation front door for the `perl-lsp` workspace.
 
+## Diataxis Quick Guide
+
+Use this quick classifier when you are reading or adding docs:
+
+| If your question sounds like... | Doc type | Primary docs folder |
+|---|---|---|
+| "Can you teach me this from scratch?" | Tutorial | `docs/tutorials/` |
+| "How do I complete a specific task?" | How-to | `docs/how-to/` |
+| "What is the exact behavior/contract?" | Reference | `docs/reference/` |
+| "Why is it designed this way?" | Explanation | `docs/explanation/` |
+
+Rule of thumb:
+- Tutorials optimize for learning flow.
+- How-to guides optimize for successful outcomes.
+- Reference docs optimize for completeness and lookup speed.
+- Explanation docs optimize for understanding tradeoffs and rationale.
+
 ## Start Here
 
 Choose the path that matches what you are trying to do:
@@ -26,7 +43,7 @@ Choose the path that matches what you are trying to do:
 ## Documentation Map
 
 ### Tutorials
-Hands-on guides for learning the system by doing.
+Hands-on guides for learning the system by doing (learning-oriented).
 
 - [Getting Started](tutorials/GETTING_STARTED.md)
 - [LSP Development Guide](tutorials/LSP_DEVELOPMENT_GUIDE.md)
@@ -35,7 +52,7 @@ Hands-on guides for learning the system by doing.
 - [AI Build Guide](tutorials/AI_BUILD_GUIDE.md)
 
 ### How-to Guides
-Task-focused instructions for common operational and development workflows.
+Task-focused instructions for common workflows (goal-oriented).
 
 - [Installation Guide](how-to/INSTALLATION.md)
 - [GitHub Actions Integration](how-to/GITHUB_ACTIONS.md)
@@ -49,7 +66,7 @@ Task-focused instructions for common operational and development workflows.
 - [Security Development Guide](how-to/SECURITY_DEVELOPMENT_GUIDE.md)
 
 ### Reference
-Authoritative descriptions of configuration, architecture, commands, and feature contracts.
+Authoritative descriptions of commands, options, data, and feature contracts (information-oriented).
 
 - [Commands Reference](reference/COMMANDS_REFERENCE.md)
 - [Configuration Reference](reference/CONFIG.md)
@@ -62,7 +79,7 @@ Authoritative descriptions of configuration, architecture, commands, and feature
 - [Known Limitations](reference/KNOWN_LIMITATIONS.md)
 
 ### Explanation
-Background material that explains why the system is designed the way it is.
+Background material that explains why the system is designed the way it is (understanding-oriented).
 
 - [LSP Documentation](explanation/LSP_DOCUMENTATION.md)
 - [Cancellation Architecture Guide](explanation/CANCELLATION_ARCHITECTURE_GUIDE.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,19 @@ Use this directory as the short docs front door. It tells you where to go next
 without making you learn the workspace layout first. For the full Diataxis-style
 map of the docs tree, use [INDEX.md](INDEX.md).
 
+## Diataxis in This Repository
+
+When adding or moving docs, choose the content type first, then the file:
+
+| Content intent | Place it under | Writing focus |
+| --- | --- | --- |
+| Teach by doing | `docs/tutorials/` | step-by-step learning journey |
+| Solve a concrete task | `docs/how-to/` | shortest reliable path to an outcome |
+| Describe the contract | `docs/reference/` | exact behavior, options, and constraints |
+| Explain rationale | `docs/explanation/` | design tradeoffs and mental models |
+
+If a doc starts mixing multiple intents, split it and cross-link the parts.
+
 ## Canonical Sources
 
 | Topic | Source | Verified By |
@@ -57,3 +70,4 @@ just status-check
 - Put computed metrics in [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), not scattered through the docs tree.
 - Update [project/ROADMAP.md](project/ROADMAP.md) when the active milestone or release framing changes.
 - Keep top-level summary docs short and link back to the canonical project docs.
+- Keep each doc in the correct Diataxis category; prefer cross-links over hybrid docs that try to do everything.


### PR DESCRIPTION
### Motivation
- Make it easier for contributors to classify and place documentation by Diataxis intent before writing. 
- Reduce hybrid/mixed-intent docs and encourage clearer, linkable documentation pieces.

### Description
- Added a **Diataxis Quick Guide** to `docs/INDEX.md` with a classifier table and a short rule-of-thumb for Tutorial/How-to/Reference/Explanation placement. 
- Clarified the Documentation Map entries in `docs/INDEX.md` to label each quadrant with its primary orientation (learning/goal/information/understanding). 
- Added **Diataxis in This Repository** to `docs/README.md` with a placement matrix and guidance to split mixed-intent docs and cross-link instead. 
- Extended `docs/README.md` maintenance notes to include a Diataxis hygiene reminder and normalized the Diataxis spelling in the changed files.

### Testing
- Attempted to run `just status-check` but it failed in this environment because `just` is not installed. 
- Verified the updated files (`docs/INDEX.md`, `docs/README.md`) were added and committed locally via `git` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99accea1c833398112c5a72fb3eb0)