### PR TITLE
docs(diataxis): improve docs routing clarity (#0000)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,6 +2,19 @@
 
 This page is the documentation front door for the `perl-lsp` workspace.
 
+## Diátaxis Quick Chooser
+
+If you are unsure where to look (or where to place new docs), use this table:
+
+| Type | Core question | What belongs here | Avoid |
+|---|---|---|---|
+| Tutorial | "What should I do first to learn this?" | Step-by-step learning paths with expected outcomes | Exhaustive options and edge-case troubleshooting |
+| How-to | "How do I accomplish X right now?" | Goal-driven procedures for one concrete task | Background theory and broad conceptual history |
+| Reference | "What is the exact contract?" | Precise commands, flags, schemas, and capability behavior | Narrative walkthroughs and opinionated workflow advice |
+| Explanation | "Why does it work this way?" | Design rationale, tradeoffs, architecture context | Setup checklists and copy/paste operational recipes |
+
+When adding new content, first pick the user intent (learn, do, look up, or understand), then place the page in the matching section.
+
 ## Start Here
 
 Choose the path that matches what you are trying to do:
@@ -79,8 +92,8 @@ Decision records, project status, and planning documents.
 - [Latency Caps SLO Spec](specs/LATENCY_CAPS_SLO_SPEC.md)
 - [Release Candidate Baseline](specs/RELEASE_CANDIDATE_BASELINE.md)
 
-### Historical Analyses
-Long-form historical writing plus the supporting research notes that fed it.
+### Legacy / Historical (not Diátaxis primary)
+Long-form historical context and research material that supports project memory.
 
 - [Articles and Research Notes](articles/README.md)
 - [Five Eras of AI-Assisted Development](articles/FIVE_ERAS.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,17 @@ Use this directory as the short docs front door. It tells you where to go next
 without making you learn the workspace layout first. For the full Diataxis-style
 map of the docs tree, use [INDEX.md](INDEX.md).
 
+## Diátaxis at a Glance
+
+Use this routing rule when reading or writing documentation:
+
+- **Tutorials**: learning-oriented, end-to-end practice paths.
+- **How-to guides**: task-oriented steps to finish one job quickly.
+- **Reference**: exact behavior, command contracts, and configuration truth.
+- **Explanation**: architecture and rationale behind design choices.
+
+If a page mixes multiple intents, split it so each page has one primary Diátaxis purpose.
+
 ## Canonical Sources
 
 | Topic | Source | Verified By |
@@ -39,12 +50,13 @@ Rule: if a project metric appears outside [project/CURRENT_STATUS.md](project/CU
 | work on the codebase | [../CONTRIBUTING.md](../CONTRIBUTING.md) |
 | browse the full docs map | [INDEX.md](INDEX.md) |
 
-## Docs by Type
+## Docs by Type (Diátaxis)
 
 - Tutorials: [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md), [tutorials/LSP_DEVELOPMENT_GUIDE.md](tutorials/LSP_DEVELOPMENT_GUIDE.md), [tutorials/DAP_USER_GUIDE.md](tutorials/DAP_USER_GUIDE.md), [tutorials/COMPREHENSIVE_TESTING_GUIDE.md](tutorials/COMPREHENSIVE_TESTING_GUIDE.md)
 - How-to: [how-to/INSTALLATION.md](how-to/INSTALLATION.md), [how-to/GITHUB_ACTIONS.md](how-to/GITHUB_ACTIONS.md), [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md), [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md), [how-to/CONTINUOUS_TESTING.md](how-to/CONTINUOUS_TESTING.md), [how-to/UPGRADING.md](how-to/UPGRADING.md), [how-to/PRE_COMMIT.md](how-to/PRE_COMMIT.md), [how-to/PERFORMANCE_TUNING.md](how-to/PERFORMANCE_TUNING.md), [how-to/THREADING_CONFIGURATION_GUIDE.md](how-to/THREADING_CONFIGURATION_GUIDE.md), [how-to/SECURITY_DEVELOPMENT_GUIDE.md](how-to/SECURITY_DEVELOPMENT_GUIDE.md)
 - Reference: [reference/COMMANDS_REFERENCE.md](reference/COMMANDS_REFERENCE.md), [reference/CONFIG.md](reference/CONFIG.md), [reference/LSP_FEATURES.md](reference/LSP_FEATURES.md), [reference/ARCHITECTURE_OVERVIEW.md](reference/ARCHITECTURE_OVERVIEW.md), [reference/CRATE_ARCHITECTURE_GUIDE.md](reference/CRATE_ARCHITECTURE_GUIDE.md), [reference/KNOWN_LIMITATIONS.md](reference/KNOWN_LIMITATIONS.md), [reference/PARSER_FEATURE_MATRIX.md](reference/PARSER_FEATURE_MATRIX.md), [reference/MISSING_DOCUMENTATION_GUIDE.md](reference/MISSING_DOCUMENTATION_GUIDE.md), [reference/API_DOCUMENTATION_STANDARDS.md](reference/API_DOCUMENTATION_STANDARDS.md), [reference/FAQ.md](reference/FAQ.md)
-- Project, specs, and explanations: [INDEX.md](INDEX.md), [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), [project/ROADMAP.md](project/ROADMAP.md), [project/CI.md](project/CI.md), [project/FEATURE_GOVERNANCE.md](project/FEATURE_GOVERNANCE.md), [explanation/LSP_DOCUMENTATION.md](explanation/LSP_DOCUMENTATION.md)
+- Explanation: [explanation/LSP_DOCUMENTATION.md](explanation/LSP_DOCUMENTATION.md), [explanation/CANCELLATION_ARCHITECTURE_GUIDE.md](explanation/CANCELLATION_ARCHITECTURE_GUIDE.md), [explanation/PURE_RUST_PARSER.md](explanation/PURE_RUST_PARSER.md), [explanation/SLASH_DISAMBIGUATION.md](explanation/SLASH_DISAMBIGUATION.md)
+- Project/spec docs (supporting, not primary Diátaxis buckets): [INDEX.md](INDEX.md), [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), [project/ROADMAP.md](project/ROADMAP.md), [project/CI.md](project/CI.md), [project/FEATURE_GOVERNANCE.md](project/FEATURE_GOVERNANCE.md)
 
 ## Maintenance
 


### PR DESCRIPTION
### Motivation

- Clarify where to place and how to read documentation using the Diátaxis framework so contributors can quickly pick the correct document type.
- Reduce friction and inconsistency when adding new pages by giving concise guidance and an explicit taxonomy for docs authors.

### Description

- Add a `Diátaxis Quick Chooser` to `docs/INDEX.md` that maps intent to the four Diátaxis buckets and lists what belongs and what to avoid for each bucket.
- Add a `Diátaxis at a Glance` section to `docs/README.md` with brief routing rules and a rule to split mixed-intent pages.
- Reclassify article-style material as `Legacy / Historical (not Diátaxis primary)` in `docs/INDEX.md` to mark it as supporting project memory rather than a primary Diátaxis bucket.
- Refine `Docs by Type` in `docs/README.md` to list `Explanation` pages explicitly and call out project/spec docs as supporting content outside primary Diátaxis buckets.

### Testing

- Ran `git diff --check` which reported no issues and succeeded.
- Attempted `just status-check` but it could not run in this environment because `just` is not installed, so the canonical doc validation step was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99accea1c833398112c5a72fb3eb0)