### PR TITLE
test(parser): improve snapshot coverage (#4901)

### DIFF
--- a/crates/perl-parser/tests/ast_snap.rs
+++ b/crates/perl-parser/tests/ast_snap.rs
@@ -113,6 +113,18 @@ fn ast_ternary_operator() {
     assert_snapshot!(parse_sexp("my $x = $cond ? \"yes\" : \"no\";"));
 }
 
+#[test]
+fn ast_postfix_conditionals() {
+    // Postfix conditionals are idiomatic Perl and stress statement/operator precedence.
+    assert_snapshot!(parse_sexp("print $msg if $enabled; warn $msg unless $quiet;"));
+}
+
+#[test]
+fn ast_foreach_keys_iteration() {
+    // Iterating hash keys is a common real-world control-flow/data-access pattern.
+    assert_snapshot!(parse_sexp("for my $k (keys %h) { print $k; }"));
+}
+
 // CPAN edge cases
 #[test]
 fn ast_empty_input() {
@@ -216,6 +228,12 @@ fn recovery_unclosed_quote_then_valid_statement() {
 }
 
 #[test]
+fn recovery_unclosed_hash_subscript_then_followup_statement() {
+    // Missing closing `}` in hash subscript should still allow recovery to next statement.
+    assert_snapshot!(parse_sexp("my $x = $h{foo;\nmy $y = 2;"));
+}
+
+#[test]
 fn recovery_broken_regex_then_followup_statement() {
     // Broken regex delimiters should not prevent parsing later statements.
     assert_snapshot!(parse_sexp("if ($text =~ /abc) { print 1; }\nmy $ok = 1;"));
@@ -248,6 +266,11 @@ fn errors_truncated_hash() {
 #[test]
 fn errors_unterminated_string_and_followup() {
     assert_snapshot!(parse_errors("my $x = \"oops;\nmy $y = 1;"));
+}
+
+#[test]
+fn errors_unclosed_hash_subscript_and_followup() {
+    assert_snapshot!(parse_errors("my $x = $h{foo;\nmy $y = 2;"));
 }
 
 #[test]

--- a/crates/perl-parser/tests/snapshots/ast_snap__ast_foreach_keys_iteration.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__ast_foreach_keys_iteration.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-parser/tests/ast_snap.rs
+expression: "parse_sexp(\"for my $k (keys %h) { print $k; }\")"
+---
+(source_file (foreach (my_declaration (variable $ k)) (call keys ((variable % h))) (block (expression_statement (call print ((variable $ k)))))))

--- a/crates/perl-parser/tests/snapshots/ast_snap__ast_postfix_conditionals.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__ast_postfix_conditionals.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-parser/tests/ast_snap.rs
+expression: "parse_sexp(\"print $msg if $enabled; warn $msg unless $quiet;\")"
+---
+(source_file (statement_modifier_if (expression_statement (call print ((variable $ msg)))) (variable $ enabled)) (statement_modifier_unless (expression_statement (call warn ((variable $ msg)))) (variable $ quiet)))

--- a/crates/perl-parser/tests/snapshots/ast_snap__errors_unclosed_hash_subscript_and_followup.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__errors_unclosed_hash_subscript_and_followup.snap
@@ -1,0 +1,6 @@
+---
+source: crates/perl-parser/tests/ast_snap.rs
+expression: "parse_errors(\"my $x = $h{foo;\\nmy $y = 2;\")"
+---
+expected '}', found ';' at position 14
+expected statement, found 'my' at position 16

--- a/crates/perl-parser/tests/snapshots/ast_snap__recovery_unclosed_hash_subscript_then_followup_statement.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__recovery_unclosed_hash_subscript_then_followup_statement.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-parser/tests/ast_snap.rs
+expression: "parse_sexp(\"my $x = $h{foo;\\nmy $y = 2;\")"
+---
+(source_file (ERROR "expected \'}\', found \';\' at position 14") (my_declaration (variable $ y)(number 2)))


### PR DESCRIPTION
### Motivation
- Increase parser snapshot coverage to exercise postfix conditionals and `for (keys %h)` iteration shapes in the AST snapshots.
- Add recovery and diagnostic snapshots for an unclosed hash subscript followed by a valid statement to strengthen malformed-input coverage.

### Description
- Added two new AST snapshot tests in `crates/perl-parser/tests/ast_snap.rs` for postfix conditionals and `for my $k (keys %h)` iteration.
- Added a recovery test and a matching diagnostic snapshot test for an unclosed hash subscript followed by a valid statement in `ast_snap.rs`.
- Added four new snapshot artifacts under `crates/perl-parser/tests/snapshots/` and ran repository formatting with `cargo xtask fmt`.

### Testing
- Ran `cargo xtask fmt` to format changes, which completed successfully.
- Ran `INSTA_UPDATE=always cargo test -p perl-parser --test ast_snap` and observed `46 passed; 0 failed` with new snapshots created/updated under `crates/perl-parser/tests/snapshots/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99ac75bb08333b8333a90dfc7bb58)