### PR TITLE
test(fuzz): add symbol query ranking fuzz target (#4901)

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,11 +12,11 @@ libfuzzer-sys = "0.4"
 
 [dependencies.perl-parser]
 path = "../crates/perl-parser"
-[dependencies.perl-lsp-cancellation]
-path = "../crates/perl-lsp-cancellation"
 
 [dependencies.serde_json]
 version = "1.0.149"
+[dependencies.perl-lsp-rs-core]
+path = "../crates/perl-lsp-rs-core"
 
 [[bin]]
 name = "substitution_parsing"
@@ -78,6 +78,13 @@ bench = false
 [[bin]]
 name = "parser_integration"
 path = "fuzz_targets/fuzz_target_1.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "symbol_query_ranking"
+path = "fuzz_targets/symbol_query_ranking.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/lsp_cancellation_registry.rs
+++ b/fuzz/fuzz_targets/lsp_cancellation_registry.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use perl_lsp_cancellation::{CancellationRegistry, PerlLspCancellationToken};
+use perl_lsp_rs_core::runtime::cancellation::{CancellationRegistry, PerlLspCancellationToken};
 use serde_json::Value;
 
 fn split_u64(data: &[u8], index: usize) -> Option<u64> {

--- a/fuzz/fuzz_targets/symbol_query_ranking.rs
+++ b/fuzz/fuzz_targets/symbol_query_ranking.rs
@@ -1,0 +1,56 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use perl_lsp_rs_core::providers::symbol_query::{compare_names_by_query, matches_query};
+
+const MAX_INPUT_BYTES: usize = 2048;
+const MAX_TOKENS: usize = 64;
+const MAX_TOKEN_CHARS: usize = 64;
+
+fn bounded_utf8_lossy(data: &[u8]) -> std::borrow::Cow<'_, str> {
+    if data.is_empty() {
+        return std::borrow::Cow::Borrowed("");
+    }
+
+    let capped = if data.len() <= MAX_INPUT_BYTES {
+        data
+    } else {
+        &data[..MAX_INPUT_BYTES]
+    };
+
+    String::from_utf8_lossy(capped)
+}
+
+fn split_tokens(input: &str) -> Vec<String> {
+    input
+        .split(['\n', '\0', '|', ',', ';'])
+        .filter(|segment| !segment.is_empty())
+        .map(|segment| segment.chars().take(MAX_TOKEN_CHARS).collect::<String>())
+        .take(MAX_TOKENS)
+        .collect()
+}
+
+fuzz_target!(|data: &[u8]| {
+    let input = bounded_utf8_lossy(data);
+    let mut tokens = split_tokens(&input);
+
+    if tokens.is_empty() {
+        tokens.push("symbol".to_string());
+    }
+
+    for query in &tokens {
+        for name in &tokens {
+            let _ = matches_query(name, query);
+        }
+    }
+
+    for query in &tokens {
+        let mut sorted = tokens.clone();
+        sorted.sort_by(|a, b| compare_names_by_query(a, b, query));
+        sorted.dedup();
+
+        let mut reversed = sorted.clone();
+        reversed.reverse();
+        reversed.sort_by(|a, b| compare_names_by_query(a, b, query));
+    }
+});

--- a/justfile
+++ b/justfile
@@ -311,6 +311,7 @@ fuzz-bounded:
     @cargo +nightly fuzz run lsp_navigation -- -max_total_time=60 || echo "  LSP navigation fuzzing complete"
     @cargo +nightly fuzz run parser_integration -- -max_total_time=60 || echo "  Parser integration fuzzing complete"
     @cargo +nightly fuzz run quote_operators -- -max_total_time=60 || echo "  Quote operators fuzzing complete"
+    @cargo +nightly fuzz run symbol_query_ranking -- -max_total_time=60 || echo "  Symbol query ranking fuzzing complete"
     @cargo +nightly fuzz run substitution_parsing -- -max_total_time=60 || echo "  Substitution fuzzing complete"
     @cargo +nightly fuzz run unicode_positions -- -max_total_time=60 || echo "  Unicode positions fuzzing complete"
     @echo "✅ Fuzz testing complete"
@@ -1932,6 +1933,7 @@ fuzz-regression duration='30':
     @just fuzz lsp_cancellation_registry {{duration}} || true
     @just fuzz parser_integration {{duration}} || true
     @just fuzz quote_operators {{duration}} || true
+    @just fuzz symbol_query_ranking {{duration}} || true
     @just fuzz substitution_parsing {{duration}} || true
     @just fuzz lsp_navigation {{duration}} || true
     @just fuzz unicode_positions {{duration}} || true


### PR DESCRIPTION
### Motivation
- Increase fuzzing coverage for workspace symbol matching and ranking logic to catch regressions in `matches_query` and `compare_names_by_query`.
- Consolidate fuzz dependencies to use the existing runtime crate for cancellation types to avoid missing-path issues when running fuzz harnesses.

### Description
- Add a new cargo-fuzz target `fuzz/fuzz_targets/symbol_query_ranking.rs` that tokenizes bounded UTF-8 inputs and exercises `matches_query` and `compare_names_by_query` across many randomized queries and sort passes.
- Wire the new target into `fuzz/Cargo.toml` and add a workspace dependency on `perl-lsp-rs-core` via `path = "../crates/perl-lsp-rs-core"`.
- Update the cancellation fuzz harness import to use `perl_lsp_rs_core::runtime::cancellation::{CancellationRegistry, PerlLspCancellationToken}` instead of the removed crate path.
- Include the new `symbol_query_ranking` target in the `just` fuzz orchestration by updating `justfile` entries for `fuzz-bounded` and `fuzz-regression`.

### Testing
- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo check --manifest-path fuzz/Cargo.toml` which completed successfully.
- Attempted `cargo +nightly fuzz list` but it could not run in this environment because `cargo-fuzz` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99abb0b588333a95818d075a71733)