### PR TITLE
test(fuzz): broaden parser integration fuzz coverage (#4901)

### DIFF
--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -4,17 +4,14 @@ use libfuzzer_sys::fuzz_target;
 use perl_parser::{format_with_trivia, Parser, SymbolExtractor, TriviaPreservingParser};
 
 const MAX_INPUT_BYTES: usize = 1000;
+const MAX_IDENTIFIER_CHARS: usize = 24;
 
 fn bounded_utf8_lossy(data: &[u8]) -> std::borrow::Cow<'_, str> {
     if data.is_empty() {
         return std::borrow::Cow::Borrowed("");
     }
 
-    let capped = if data.len() <= MAX_INPUT_BYTES {
-        data
-    } else {
-        &data[..MAX_INPUT_BYTES]
-    };
+    let capped = if data.len() <= MAX_INPUT_BYTES { data } else { &data[..MAX_INPUT_BYTES] };
 
     String::from_utf8_lossy(capped)
 }
@@ -23,31 +20,78 @@ fn truncate_chars(input: &str, max_chars: usize) -> String {
     input.chars().take(max_chars).collect()
 }
 
+fn sanitize_identifier(input: &str) -> String {
+    let mut identifier = String::new();
+
+    for ch in input.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            identifier.push(ch);
+        }
+
+        if identifier.len() >= MAX_IDENTIFIER_CHARS {
+            break;
+        }
+    }
+
+    if identifier.is_empty() {
+        identifier.push('_');
+    }
+
+    if identifier.chars().next().is_some_and(|ch| ch.is_ascii_digit()) {
+        identifier.insert(0, '_');
+    }
+
+    identifier
+}
+
+fn parse_snippet(snippet: &str) {
+    let mut parser = Parser::new(snippet);
+    let result = parser.parse();
+
+    let trivia_tree = TriviaPreservingParser::new(snippet.to_string()).parse();
+    let _formatted = format_with_trivia(&trivia_tree);
+
+    if let Ok(ast) = &result {
+        let extractor = SymbolExtractor::new_with_source(snippet);
+        let symbol_table = extractor.extract(ast);
+        let _ = symbol_table.symbols.len();
+        let _ = symbol_table.references.len();
+    }
+}
+
 fuzz_target!(|data: &[u8]| {
     let input = bounded_utf8_lossy(data);
     let source = input.as_ref();
 
+    let ident = sanitize_identifier(source);
+    let short_source = truncate_chars(source, 96);
+
     let snippets = [
         source.to_string(),
-        format!("package {}::Pkg; sub handler {{ {} }}", truncate_chars(source, 12), source),
+        format!("package {}::Pkg; sub handler {{ {} }}", ident, source),
         format!("use strict;\n# fuzz\nmy $value = q{{{}}};\n", source),
-        format!("sub {} {{\n    return {}\n}}", truncate_chars(source, 8), source),
-        format!("my @items = map {{ {} }} grep {{ {} }} @ARGV;", source, source),
+        format!("sub {} {{\n    my ($x) = @_;\n    return {}\n}}", ident, short_source),
+        format!("my @items = map {{ {} }} grep {{ {} }} @ARGV;", short_source, short_source),
+        format!(
+            "my $re = qr/{{{}}}/; $text =~ s/{{{}}}/{} /gr;",
+            short_source, short_source, ident
+        ),
+        format!("my $doc = <<'{}';\n{}\n{}\nprint $doc;", ident, short_source, ident),
+        format!("BEGIN {{ package {}::Boot; our $V = '{}'; }} END {{ 1; }}", ident, short_source),
+        format!("=head1 {}\n\n{}\n\n=cut\nsub {} {{ return 1; }}", ident, short_source, ident),
     ];
 
     for snippet in &snippets {
-        let mut parser = Parser::new(snippet);
-        let result = parser.parse();
+        parse_snippet(snippet);
+    }
 
-        let trivia_tree = TriviaPreservingParser::new(snippet.clone()).parse();
-        let _formatted = format_with_trivia(&trivia_tree);
-
-        if let Ok(ast) = &result {
-            let extractor = SymbolExtractor::new_with_source(snippet);
-            let symbol_table = extractor.extract(ast);
-            let _symbol_count = symbol_table.symbols.len();
-            let _reference_count = symbol_table.references.len();
-        }
-
+    if let Some((left, right)) = source.split_once('\n') {
+        let stitched = format!(
+            "package {}::Split;\nsub left {{ {} }}\nsub right {{ {} }}",
+            ident,
+            truncate_chars(left, 80),
+            truncate_chars(right, 80)
+        );
+        parse_snippet(&stitched);
     }
 });


### PR DESCRIPTION
### Motivation
- Increase fuzz coverage of the parser integration pipeline so each generated case exercises parsing, trivia-preserving parsing, formatting, and symbol extraction.
- Produce more syntactically useful package/sub identifiers from arbitrary fuzz bytes to drive deeper grammar paths while preserving input entropy.
- Cover additional Perl grammar surfaces (regex/substitution, heredoc, BEGIN/END, POD, map/grep, stitched multi-line cases) to catch more classes of crashes and regressions.

### Description
- Expanded `fuzz/fuzz_targets/fuzz_target_1.rs` to add a reusable `parse_snippet` helper that calls `Parser::new(...).parse()`, `TriviaPreservingParser::new(...).parse()`, `format_with_trivia(...)`, and `SymbolExtractor::new_with_source(...).extract(...)` for every generated snippet.
- Added a `sanitize_identifier` helper and `MAX_IDENTIFIER_CHARS` constant to produce safe package/sub identifiers from arbitrary fuzz input and avoid spurious invalid-name noise.
- Broadened the snippet families generated by the target to include regex/substitution forms, heredoc templates, `BEGIN`/`END` blocks, POD sections, regex/substitution/qr usages, map/grep expressions, and a stitched split-on-newline case to increase grammar-surface coverage.
- Refactored the target to reuse `parse_snippet` for all cases and to truncate/sanitize inputs (`truncate_chars`, `sanitize_identifier`) so the pipeline exercises parser, trivia formatter, and symbol extraction consistently.

### Testing
- Ran `cargo xtask fmt` to format workspace sources and the fuzz target, which completed successfully.
- Ran `cargo check -p perl-parser --lib` to validate the parser crate build, which succeeded.
- Ran `cargo check --manifest-path fuzz/Cargo.toml --bin parser_integration` which failed due to a preexisting repository issue: the fuzz manifest references a missing path dependency `crates/perl-lsp-cancellation` (this is unrelated to the fuzz target changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99abb0b588333a95818d075a71733)