### PR TITLE
fix(folder): harden file URI fallback parsing for workspace folders (#4895)

### DIFF
--- a/crates/perl-workspace-index/src/folder/mod.rs
+++ b/crates/perl-workspace-index/src/folder/mod.rs
@@ -35,10 +35,35 @@ pub fn workspace_folder_to_path(workspace_folder: &str) -> PathBuf {
             return path;
         }
 
+        if let Some(path) = parse_file_uri_fallback(workspace_folder) {
+            return path;
+        }
+
         return PathBuf::from(&workspace_folder[7..]);
     }
 
     PathBuf::from(workspace_folder)
+}
+
+fn parse_file_uri_fallback(workspace_folder: &str) -> Option<PathBuf> {
+    let parsed = url::Url::parse(workspace_folder).ok()?;
+    if parsed.scheme() != "file" {
+        return None;
+    }
+
+    if let Ok(path) = parsed.to_file_path() {
+        return Some(path);
+    }
+
+    let path = parsed.path();
+    if path.is_empty() {
+        return None;
+    }
+
+    match parsed.host_str() {
+        None | Some("") | Some("localhost") => Some(PathBuf::from(path)),
+        Some(host) => Some(PathBuf::from(format!("//{host}{path}"))),
+    }
 }
 
 /// Extract workspace folder URIs from an LSP `workspaceFolders` array.
@@ -122,6 +147,15 @@ mod tests {
         let parsed = workspace_folder_to_path("FILE:///tmp/project");
         assert!(parsed.to_string_lossy().contains("tmp"));
         assert!(parsed.to_string_lossy().contains("project"));
+    }
+
+    #[test]
+    fn parses_localhost_file_uri_without_leaking_host_component() {
+        let parsed = workspace_folder_to_path("file://localhost/tmp/project");
+        let path = parsed.to_string_lossy();
+        assert!(path.contains("tmp"));
+        assert!(path.contains("project"));
+        assert!(!path.contains("localhost/tmp"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Workspace folder inputs may include non-standard or partially-malformed `file://` URIs which previously fell back to a crude `file://` prefix strip and could leak authority text (e.g. `localhost`) into returned paths.
- Some runtime contexts cannot use `perl_uri::uri_to_fs_path`, so a more robust fallback is needed to interpret file URIs correctly without relying on direct filesystem resolution.

### Description
- Add a URL-aware fallback parser `parse_file_uri_fallback` and call it from `workspace_folder_to_path` before using the raw `file://` string-strip fallback, implemented in `crates/perl-workspace-index/src/folder/mod.rs`.
- The fallback uses `url::Url::parse` and `to_file_path` where possible, returns a plain path for `file://localhost/...` or no-host URIs, and constructs a UNC-like `//host/path` for non-local authorities.
- Add a regression unit test `parses_localhost_file_uri_without_leaking_host_component` to lock in correct `file://localhost` behavior.

### Testing
- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran targeted tests with `cargo test -p perl-workspace folder:: -- --nocapture` and the workspace folder unit tests passed (all tests in the module passed).
- Ran grouped workspace folder test suites with `cargo test -p perl-workspace --test workspace_folder_bdd --test workspace_folder_integration --test workspace_folder_prop` and all specified tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99aa2ad208333ab90094269a8adf6)