### PR TITLE
fix(ci-hygiene): stabilize hash-line TODO parsing (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3939,6 +3939,21 @@ fn find_hash_comment_start(line: &str, perl_mode: bool) -> Option<usize> {
     let mut prev_was_escape_single = false;
 
     for (idx, ch) in line.char_indices() {
+        if in_single_ansi_c {
+            if prev_was_escape_single {
+                prev_was_escape_single = false;
+                continue;
+            }
+            if ch == '\\' {
+                prev_was_escape_single = true;
+                continue;
+            }
+            if ch == '\'' {
+                in_single = false;
+                in_single_ansi_c = false;
+            }
+            continue;
+        }
         if in_single {
             if prev_single_was_escape {
                 prev_single_was_escape = false;
@@ -3950,21 +3965,6 @@ fn find_hash_comment_start(line: &str, perl_mode: bool) -> Option<usize> {
             }
             if ch == '\'' {
                 in_single = false;
-            }
-            continue;
-        }
-        if in_double {
-            if prev_was_escape {
-                prev_was_escape = false;
-                continue;
-            }
-            if ch == '\\' {
-                prev_was_escape = true;
-                continue;
-            }
-            if ch == '\'' {
-                in_single = false;
-                in_single_ansi_c = false;
             }
             continue;
         }
@@ -4027,7 +4027,7 @@ fn find_hash_comment_start(line: &str, perl_mode: bool) -> Option<usize> {
                     if prev.is_whitespace()
                         || matches!(
                             prev,
-                            ';' | '{' | '}' | '(' | ')' | '[' | ']' | '&' | '|' | '<' | '>'
+                            ';' | ',' | '{' | '}' | '(' | ')' | '[' | ']' | '&' | '|' | '<' | '>'
                         )
                     {
                         return Some(idx);
@@ -4727,6 +4727,8 @@ mod tests {
         assert!(has_unlinked_todo_in_hash_line("cat ># TODO: follow up", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("len=${#value} # TODO: follow up", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi # TODO: follow up", &todo_re));
+        assert!(has_unlinked_todo_in_hash_line("echo \"quoted\" # TODO: follow up", &todo_re));
+        assert!(!has_unlinked_todo_in_hash_line("echo \"# TODO in string\" && true", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi&&# TODO: follow up", &todo_re));
         assert!(has_unlinked_todo_in_hash_line("echo hi||# TODO: follow up", &todo_re));
         assert!(!has_unlinked_todo_in_hash_line("echo hi # TODO(#77): tracked", &todo_re));
@@ -4748,6 +4750,10 @@ mod tests {
         ));
         assert!(has_unlinked_todo_in_hash_line(
             "printf $'it\\'s # TODO in string' # TODO: follow up",
+            &todo_re,
+        ));
+        assert!(has_unlinked_todo_in_hash_line(
+            "printf \"it\\\"s # TODO in string\" # TODO: follow up",
             &todo_re,
         ));
 


### PR DESCRIPTION
### Motivation
- The hash-comment TODO scanner had a state-machine bug that could fail to exit double-quoted contexts and mishandle ANSI-C single-quoted strings, causing false negatives/positives when detecting unlinked `TODO`/`FIXME` markers.
- Improve accuracy of TODO detection in hash-comment languages (shell/Justfile/other hash-delimited files) to reduce spurious CI failures and match existing test expectations.

### Description
- Fixes the `find_hash_comment_start` state machine to correctly track and exit double-quoted strings and to separate normal single-quote and ANSI-C single-quote (`$'...'`) handling. 
- Restores correct escape-state handling for ANSI-C single-quoted mode and normal single-quoted mode so escaped quotes are respected.
- Extends the allowed prefix characters for hash-comments to include `,` so inline comments like `foo, # comment` are recognized as comments. 
- Adds/adjusts regression assertions to cover TODO detection after closed double-quoted strings and TODO-like tokens inside quoted content; changes are in `crates/perl-ci-hygiene/src/main.rs`.

### Testing
- Ran `cargo test -p perl-ci-hygiene hash_comment_todo_detection_handles_shebang_and_inline_hashes` and the test passed. 
- Ran `cargo test -p perl-ci-hygiene perl_todo_detection_allows_comment_start_without_whitespace` and the test passed. 
- Ran `cargo xtask fmt` to apply formatting, which completed successfully. 
- A prior full run of `cargo test -p perl-ci-hygiene` showed two unrelated failing Rust TODO-detection tests that are not caused by these changes; the targeted tests added/modified by this PR are green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99aa2ad208333ab90094269a8adf6)