### PR TITLE
chore: add PR template with title-convention reminder (#4819)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,12 @@
+<!--
+PR title convention: end with a real issue ref, e.g.
+  fix(crate): description (#NNNN)
+
+Replace NNNN with the tracking issue number this PR addresses.
+The validate-title CI check enforces this format — placeholder refs
+like (#0000) or (#9999) will fail CI.
+-->
+
 ## Summary
 <!-- What changed and why. Link the issue: Fixes #NNN -->
 


### PR DESCRIPTION
## Summary

Adds a Markdown comment at the top of `.github/PULL_REQUEST_TEMPLATE.md` explaining the `(#NNNN)` title format required by the `validate-title` CI check, and explicitly calling out placeholder refs like `(#0000)` and `(#9999)` as invalid.

This is the #1 noise source identified in the 2026-04-22 continuous Codex review session — contributors use placeholder issue refs and the CI check fails.

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md`: +9 lines — HTML comment at top of template

## Test

No code change — advisory nudge only. The comment is stripped on render and does not block PR creation for contributors who ignore it.

## Verification
- [x] `cargo xtask fmt` — N/A (doc-only)
- [x] Template renders correctly (comments stripped by GitHub on PR form display)

## What I considered but didn't do

- Replacing the entire template body (out of scope — existing sections are fine)
- Adding a regex-enforced pre-commit hook (heavier than needed for an advisory nudge)

## What's next

Monitor validate-title CI failures after merge to see if the nudge reduces placeholder refs.

Closes #4819