### PR TITLE
test(cli): improve helper coverage (#4854)

### DIFF
--- a/crates/perl-lsp-rs/src/cli.rs
+++ b/crates/perl-lsp-rs/src/cli.rs
@@ -505,3 +505,43 @@ fn print_version(command_name: &str) {
     println!("Git tag: {}", env!("GIT_TAG"));
     println!("Perl Language Server using perl-parser v3");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{categorize_error, invocation_name, render_shell_completion};
+    use std::ffi::OsString;
+
+    #[test]
+    fn invocation_name_uses_file_stem_from_first_arg() {
+        let args = vec![OsString::from("/usr/local/bin/perl-lsp-rs"), OsString::from("--help")];
+        assert_eq!(invocation_name(&args), "perl-lsp-rs");
+    }
+
+    #[test]
+    fn invocation_name_falls_back_when_first_arg_is_empty() {
+        let args = vec![OsString::from("")];
+        assert_eq!(invocation_name(&args), "perllsp");
+    }
+
+    #[test]
+    fn render_shell_completion_rewrites_function_and_command_names() {
+        let script =
+            "complete -F _perl_lsp perl-lsp\n# shell completion for perl-lsp and _perl_lsp";
+        let rendered = render_shell_completion(script, "my-perl-lsp");
+
+        assert!(rendered.contains("_my_perl_lsp"));
+        assert!(rendered.contains("my-perl-lsp"));
+        assert!(!rendered.contains("complete -F _perl_lsp perl-lsp"));
+    }
+
+    #[test]
+    fn categorize_error_maps_known_cases() {
+        assert_eq!(categorize_error("Unexpected end of input while parsing"), "Unexpected EOF");
+        assert_eq!(categorize_error("expected ; but found }"), "Unexpected token");
+        assert_eq!(categorize_error("Invalid syntax near token"), "Syntax error");
+        assert_eq!(categorize_error("Lexer error: invalid byte"), "Lexer error");
+        assert_eq!(categorize_error("Recursion depth exceeded"), "Recursion limit");
+        assert_eq!(categorize_error("read error: permission denied"), "IO error");
+        assert_eq!(categorize_error("something new"), "Other");
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve unit-test coverage for small CLI helper functions in `crates/perl-lsp-rs/src/cli.rs` to catch regressions and document expected behavior.

### Description
- Add a `#[cfg(test)] mod tests` in `crates/perl-lsp-rs/src/cli.rs` with focused unit tests for helper functions.
- Add tests for `invocation_name` covering normal extraction of the executable stem and the fallback when the first arg is empty.
- Add a test for `render_shell_completion` to ensure function and command names are rewritten correctly.
- Add tests that exercise all branches of `categorize_error` including the default `Other` case.

### Testing
- Ran `cargo xtask fmt` which completed successfully.
- Ran the crate tests with `cargo test -p perl-lsp-rs --lib 'cli::tests::'` and the added test module ran with all 4 tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99b21ee508333b8d0f6bec0862c25)