### PR TITLE
test(lexer): improve unicode helper coverage (#4854)

### DIFF
--- a/crates/perl-lexer/src/unicode.rs
+++ b/crates/perl-lexer/src/unicode.rs
@@ -102,3 +102,46 @@ pub fn analyze_unicode_complexity(text: &str) -> (usize, usize, usize) {
 
     (char_count, emoji_count, complex_char_count)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        analyze_unicode_complexity, get_unicode_stats, is_perl_identifier_continue,
+        is_perl_identifier_start, reset_unicode_stats,
+    };
+
+    #[test]
+    fn identifier_start_accepts_ascii_xid_and_emoji() {
+        reset_unicode_stats();
+
+        assert!(is_perl_identifier_start('_'));
+        assert!(is_perl_identifier_start('A'));
+        assert!(is_perl_identifier_start('λ'));
+        assert!(is_perl_identifier_start('🚀'));
+        assert!(!is_perl_identifier_start('1'));
+
+        let (checks, emoji_hits) = get_unicode_stats();
+        assert_eq!(checks, 5);
+        assert_eq!(emoji_hits, 1);
+    }
+
+    #[test]
+    fn identifier_continue_accepts_joiners_selectors_and_modifiers() {
+        assert!(is_perl_identifier_continue('\''));
+        assert!(is_perl_identifier_continue('\u{200D}'));
+        assert!(is_perl_identifier_continue('\u{FE0F}'));
+        assert!(is_perl_identifier_continue('\u{1F3FB}'));
+        assert!(!is_perl_identifier_continue(' '));
+    }
+
+    #[test]
+    fn analyze_complexity_counts_chars_emoji_and_non_bmp() {
+        // a + lambda + rocket + FE0F variation selector
+        let (char_count, emoji_count, complex_char_count) =
+            analyze_unicode_complexity("aλ🚀\u{FE0F}");
+
+        assert_eq!(char_count, 4);
+        assert_eq!(emoji_count, 1);
+        assert_eq!(complex_char_count, 2);
+    }
+}


### PR DESCRIPTION
### Motivation

- Increase unit test coverage for Unicode helper utilities to prevent regressions in identifier classification and complexity analysis.

### Description

- Add a `#[cfg(test)]` module in `crates/perl-lexer/src/unicode.rs` with focused unit tests for the unicode helpers.
- Add a test verifying `is_perl_identifier_start` accepts ASCII, XID, and emoji characters and validates the stats counters via `get_unicode_stats`/`reset_unicode_stats`.
- Add a test covering `is_perl_identifier_continue` for joiners, variation selectors, and Fitzpatrick modifiers and a negative whitespace case.
- Add a complexity analysis test for `analyze_unicode_complexity` asserting character, emoji, and complex-character counts for mixed Unicode input.

### Testing

- Ran `cargo xtask fmt` and it completed successfully.
- Ran `cargo test -p perl-lexer unicode` and the new tests passed; the crate tests completed with all relevant unicode/lexer tests green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99b21ee508333b8d0f6bec0862c25)