### PR TITLE
fix(dap-platform): normalize quoted PATH entries during Perl discovery (#4901)

### DIFF
--- a/crates/perl-dap/src/platform/mod.rs
+++ b/crates/perl-dap/src/platform/mod.rs
@@ -71,7 +71,8 @@ fn find_all_perl_on_path(path_env: &str) -> Vec<PathBuf> {
     #[allow(unused_mut)]
     let mut found: Vec<PathBuf> = path_env
         .split(PATH_SEPARATOR)
-        .map(|dir| PathBuf::from(dir).join(PERL_EXECUTABLE))
+        .filter_map(normalize_path_entry)
+        .map(|dir| dir.join(PERL_EXECUTABLE))
         .filter(|p| p.exists() && p.is_file())
         .collect();
 
@@ -79,6 +80,16 @@ fn find_all_perl_on_path(path_env: &str) -> Vec<PathBuf> {
     found.sort_by_key(|p| windows_perl_rank(p));
 
     found
+}
+
+/// Normalize a single PATH segment by trimming whitespace/quotes and dropping empties.
+fn normalize_path_entry(entry: &str) -> Option<PathBuf> {
+    let trimmed = entry.trim().trim_matches('"');
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    Some(PathBuf::from(trimmed))
 }
 
 /// Canonical OS-specific fallback paths to probe when Perl is not on PATH.
@@ -172,8 +183,8 @@ pub fn find_perl_interpreter(configured_path: Option<&str>) -> PerlInterpreterRe
 
 #[cfg(test)]
 fn resolve_perl_path_from_path_env(path_env: &str) -> anyhow::Result<PathBuf> {
-    for path_dir in path_env.split(PATH_SEPARATOR) {
-        let perl_path = PathBuf::from(path_dir).join(PERL_EXECUTABLE);
+    for path_dir in path_env.split(PATH_SEPARATOR).filter_map(normalize_path_entry) {
+        let perl_path = path_dir.join(PERL_EXECUTABLE);
         if perl_path.exists() && perl_path.is_file() {
             return Ok(perl_path);
         }
@@ -311,6 +322,38 @@ mod tests {
         let path_str = tempdir.path().to_string_lossy().to_string();
         let result = resolve_perl_path_from_path_env(&path_str);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_from_path_env_handles_quoted_path_segment() {
+        use std::fs;
+        let tempdir = must(tempfile::tempdir());
+        let bin = tempdir.path().join(PERL_EXECUTABLE);
+        must(fs::write(&bin, ""));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = must(fs::metadata(&bin)).permissions();
+            perms.set_mode(0o755);
+            must(fs::set_permissions(&bin, perms));
+        }
+        let quoted_path = format!("\"{}\"", tempdir.path().to_string_lossy());
+        let result = resolve_perl_path_from_path_env(&quoted_path);
+        assert_eq!(must(result), bin);
+    }
+
+    #[test]
+    fn normalize_path_entry_trims_whitespace_and_quotes() {
+        let raw = "  \"/tmp/perl path\"  ";
+        let normalized = normalize_path_entry(raw);
+        assert_eq!(normalized, Some(PathBuf::from("/tmp/perl path")));
+    }
+
+    #[test]
+    fn normalize_path_entry_rejects_empty_segments() {
+        assert_eq!(normalize_path_entry(""), None);
+        assert_eq!(normalize_path_entry("   "), None);
+        assert_eq!(normalize_path_entry("\"\""), None);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Some environments emit quoted or whitespace-padded `PATH` segments (commonly when paths contain spaces) which caused Perl discovery to miss valid interpreters.
- The PATH scanning code treated segments literally and did not ignore empty segments, reducing robustness of `perl-dap` platform detection.

### Description
- Add a small helper `normalize_path_entry` that trims whitespace, strips surrounding quotes, and rejects empty segments, and use it when scanning `PATH` in `find_all_perl_on_path`.
- Apply the same normalization to the test helper `resolve_perl_path_from_path_env` so production and test logic match.
- Add regression tests `resolve_from_path_env_handles_quoted_path_segment`, `normalize_path_entry_trims_whitespace_and_quotes`, and `normalize_path_entry_rejects_empty_segments` in `crates/perl-dap/src/platform/mod.rs` to cover quoted and empty PATH segments.
- Change surface area is limited to `crates/perl-dap/src/platform/mod.rs` and does not alter discovery precedence or fallback logic.

### Testing
- Ran formatting with `cargo xtask fmt` and it completed successfully.
- Executed the platform unit tests with `cargo test -p perl-dap platform::tests:: -- --nocapture`, and the relevant tests passed (17 passed, 0 failed).
- Verified the new regression tests exercise both the production scan and the test helper, and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99aa0998c8333b38375b727cd95ac)