### PR TITLE
fix(color): deduplicate overlapping color detections (#4901)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/color/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/color/mod.rs
@@ -5,9 +5,9 @@
 //! options for editors.
 
 use once_cell::sync::Lazy;
-use perl_position_tracking::{offset_to_utf16_line_col, WirePosition, WireRange};
+use perl_position_tracking::{WirePosition, WireRange, offset_to_utf16_line_col};
 use regex::Regex;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Regex for hex color codes: #RGB, #RRGGBB, #RRGGBBAA
 static HEX_COLOR_RE: Lazy<Option<Regex>> =
@@ -93,6 +93,8 @@ pub struct Color {
 /// Scans the text for hex color codes, ANSI escape sequences, named CSS colors
 /// inside quoted strings, and Term::ANSIColor calls.
 pub fn detect_colors(text: &str) -> Vec<ColorInformation> {
+    use std::collections::HashSet;
+
     let mut colors = Vec::new();
 
     // Detect hex color codes in comments: # color: #RRGGBB or #RRGGBBAA
@@ -106,6 +108,24 @@ pub fn detect_colors(text: &str) -> Vec<ColorInformation> {
 
     // Detect Term::ANSIColor calls: color('red'), colored($text, 'blue')
     colors.extend(detect_term_ansicolor(text));
+
+    // Multiple detectors can legitimately discover the same literal (e.g. "red" in
+    // color('red') is found by both named-string and Term::ANSIColor detectors).
+    // Deduplicate by exact range + RGBA payload to avoid duplicate LSP diagnostics.
+    let mut seen = HashSet::new();
+    colors.retain(|entry| {
+        let key = (
+            entry.range.start.line,
+            entry.range.start.character,
+            entry.range.end.line,
+            entry.range.end.character,
+            entry.color.red.to_bits(),
+            entry.color.green.to_bits(),
+            entry.color.blue.to_bits(),
+            entry.color.alpha.to_bits(),
+        );
+        seen.insert(key)
+    });
 
     colors
 }
@@ -753,6 +773,18 @@ mod tests {
             .collect();
         // Should include a named color label "red"
         assert!(labels.iter().any(|l| l == "red"), "Expected 'red' in labels: {:?}", labels);
+    }
+
+    #[test]
+    fn test_detect_colors_deduplicates_term_ansicolor_named_string_overlap() {
+        let text = "print color('red'), 'ok';";
+        let colors = detect_colors(text);
+        assert_eq!(
+            colors.len(),
+            1,
+            "detect_colors should deduplicate overlapping detectors, got {:?}",
+            colors
+        );
     }
 }
 


### PR DESCRIPTION
### Motivation
- Multiple color detectors (e.g. named-string detection and `Term::ANSIColor` call detection) could report the same literal causing duplicate color entries and duplicate LSP diagnostics.
- A small deduplication pass in the aggregation path prevents redundant results and ensures a single, stable color entry per literal.

### Description
- Add a deduplication step to `detect_colors` that retains only the first occurrence of a color entry keyed by text range and RGBA payload (uses `to_bits()` for stable float identity). 
- Construct the dedupe key from `range.start.line`, `range.start.character`, `range.end.line`, `range.end.character`, and the color component `to_bits()` values. 
- Add a regression test `test_detect_colors_deduplicates_term_ansicolor_named_string_overlap` to assert `detect_colors("print color('red'), 'ok';")` yields a single result. 
- Adjust imports/formatting in `crates/perl-lsp-rs-core/src/providers/color/mod.rs` as part of the change.

### Testing
- Ran `cargo xtask fmt` successfully to apply formatting. 
- Ran `cargo test -p perl-lsp-rs-core providers::color::tests::test_detect_colors_deduplicates_term_ansicolor_named_string_overlap` and the test passed. 
- Ran `cargo test -p perl-lsp-rs-core providers::color::tests` and all provider color tests passed (20 passed; 0 failed), with an unrelated `dead_code` warning emitted from `perl-dap` only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99aa0998c8333b38375b727cd95ac)