### PR TITLE
fix(workspace-folder): treat file URI scheme case-insensitively (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/folder/mod.rs
+++ b/crates/perl-workspace-index/src/folder/mod.rs
@@ -77,7 +77,7 @@ pub fn extract_workspace_folder_change(event: &Value) -> WorkspaceFolderChange {
 /// This keeps behavior deterministic across absolute POSIX and Windows-style paths.
 #[must_use]
 pub fn root_path_to_file_uri(root_path: &str) -> String {
-    if root_path.starts_with("file://") {
+    if root_path.get(..7).is_some_and(|prefix| prefix.eq_ignore_ascii_case("file://")) {
         return root_path.to_string();
     }
 
@@ -156,5 +156,11 @@ mod tests {
     fn preserves_file_uri_root_path_input() {
         let uri = root_path_to_file_uri("file:///already/uri");
         assert_eq!(uri, "file:///already/uri");
+    }
+
+    #[test]
+    fn preserves_file_uri_root_path_input_case_insensitively() {
+        let uri = root_path_to_file_uri("FILE:///already/uri");
+        assert_eq!(uri, "FILE:///already/uri");
     }
 }


### PR DESCRIPTION
### Motivation

- LSP clients may emit `file://` URIs with different capitalization and URI schemes are case-insensitive by spec, so existing code that only checked for lowercase `file://` could incorrectly re-encode valid URIs like `FILE:///...`.

### Description

- Update the legacy `rootPath` handler to detect `file://` using ASCII case-insensitive matching in `crates/perl-workspace-index/src/folder/mod.rs` by replacing the `starts_with("file://")` check with `get(..7).is_some_and(|prefix| prefix.eq_ignore_ascii_case("file://"))`.
- Add a regression unit test `preserves_file_uri_root_path_input_case_insensitively` to lock in behavior for uppercase scheme inputs.

### Testing

- Ran the focused unit test with `cargo test -p perl-workspace folder::tests::preserves_file_uri_root_path_input_case_insensitively -- --exact`, which passed.
- Ran workspace folder tests with `cargo test -p perl-workspace workspace_folder -- --nocapture`, which passed.
- Ran the full `perl-workspace` test suite during verification earlier (all package tests executed and passed) and formatted changes with `cargo xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99a9c95948333a39769536d5cb9c1)