### PR TITLE
fix(dap): remove stale inline identifier helper (#4901)

### DIFF
--- a/crates/perl-dap/src/inline_values.rs
+++ b/crates/perl-dap/src/inline_values.rs
@@ -237,10 +237,6 @@ fn matching_delimiter(open: u8) -> (u8, bool) {
     }
 }
 
-fn is_identifier_byte(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_'
-}
-
 fn collect_line_variables(line: &str, include_non_scalars: bool) -> Vec<(usize, usize, String)> {
     let mut matches = Vec::new();
 


### PR DESCRIPTION
### Motivation

- Remove dead/unused helper code that produced a `dead_code` warning and added maintenance noise in the inline-value extraction module.

### Description

- Deleted the unused `is_identifier_byte` helper from `crates/perl-dap/src/inline_values.rs` and left the inline-value extraction logic intact.
- No functional behavior changes were introduced to `collect_line_variables` or surrounding logic.

### Testing

- Ran `cargo test -p perl-dap --lib inline_values --quiet`, which completed successfully (all tests passed).
- Ran `cargo check -p perl-dap --lib`, which completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99a9c95948333a39769536d5cb9c1)