### PR TITLE
fix(workspace-folder): encode fallback rootPath file URIs (#4901)

### DIFF
--- a/crates/perl-workspace-index/src/folder/mod.rs
+++ b/crates/perl-workspace-index/src/folder/mod.rs
@@ -87,7 +87,12 @@ pub fn root_path_to_file_uri(root_path: &str) -> String {
             if root_path.starts_with('/') {
                 format!("file://{}", root_path)
             } else {
-                format!("file:///{}", root_path.replace('\\', "/"))
+                let normalized = root_path.replace('\\', "/");
+                // Preserve legacy behavior (force an absolute-looking file URI for
+                // non-absolute paths) while ensuring URI-safe percent encoding.
+                let pseudo_absolute = format!("/{normalized}");
+                url::Url::from_file_path(std::path::Path::new(&pseudo_absolute))
+                    .map_or_else(|_| format!("file:///{}", normalized), |uri| uri.to_string())
             }
         },
         |uri| uri.to_string(),
@@ -156,5 +161,11 @@ mod tests {
     fn preserves_file_uri_root_path_input() {
         let uri = root_path_to_file_uri("file:///already/uri");
         assert_eq!(uri, "file:///already/uri");
+    }
+
+    #[test]
+    fn encodes_spaces_in_windows_style_root_path() {
+        let uri = root_path_to_file_uri(r"C:\Users\me\My Project");
+        assert_eq!(uri, "file:///C:/Users/me/My%20Project");
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent legacy `rootPath` fallback from emitting raw-space `file:///...` URIs (e.g. Windows paths with spaces) which can break downstream URI consumers by ensuring fallback URIs are percent-encoded.

### Description
- Update `root_path_to_file_uri` in `crates/perl-workspace-index/src/folder/mod.rs` to normalize non-absolute paths, build a pseudo-absolute path and call `url::Url::from_file_path` to obtain a percent-encoded `file://` URI while preserving the previous legacy fallback when URL conversion fails, and add a focused unit test (`encodes_spaces_in_windows_style_root_path`).

### Testing
- Ran `cargo xtask fmt` and the focused unit tests `cargo test -p perl-workspace encodes_spaces_in_windows_style_root_path` and `cargo test -p perl-workspace workspace_folder`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99a9c95948333a39769536d5cb9c1)