### PR TITLE
fix(semantic-analyzer): recognize builtin regex/errno hash vars (#4901)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1926,7 +1926,7 @@ fn is_builtin_global(sigil: &str, name: &str) -> bool {
             }
         },
         b'@' => matches!(name, "_" | "+" | "-" | "INC" | "ARGV" | "EXPORT" | "EXPORT_OK" | "ISA"),
-        b'%' => matches!(name, "_" | "+" | "ENV" | "INC" | "SIG" | "EXPORT_TAGS"),
+        b'%' => matches!(name, "_" | "+" | "-" | "!" | "ENV" | "INC" | "SIG" | "EXPORT_TAGS"),
         _ => false,
     }
 }

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -2983,6 +2983,63 @@ if ("hello" =~ /ell/) {
     Ok(())
 }
 
+#[test]
+fn builtin_percent_plus_no_undeclared_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use warnings;
+if ("alpha-beta" =~ /(?<lhs>alpha)-(?<rhs>beta)/) {
+    my %named_caps = %+;
+    print $named_caps{lhs}, "\n";
+}
+"#;
+    let issues = scope_issues_strict(code);
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "+"),
+        "%+ should be a recognized builtin; got issues: {:?}",
+        issues.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn builtin_percent_minus_no_undeclared_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use warnings;
+if ("alpha-beta" =~ /(?<lhs>alpha)-(?<rhs>beta)/) {
+    my %named_cap_hist = %-;
+    print $named_cap_hist{lhs}[0], "\n";
+}
+"#;
+    let issues = scope_issues_strict(code);
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "-"),
+        "%- should be a recognized builtin; got issues: {:?}",
+        issues.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn builtin_percent_bang_no_undeclared_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use warnings;
+my $errno_name = $!{ENOENT};
+my %errno_table = %!;
+print $errno_name, "\n";
+print scalar(keys %errno_table), "\n";
+"#;
+    let issues = scope_issues_strict(code);
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "!"),
+        "%! should be a recognized builtin; got issues: {:?}",
+        issues.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
 // ===========================================================================
 // Builtin globals — ${^MATCH}, ${^PREMATCH}, ${^POSTMATCH} (#3351)
 // ===========================================================================


### PR DESCRIPTION
### Motivation
- Prevent false "undeclared variable" diagnostics for Perl builtin hash globals `%+`, `%-`, and `%!` which represent named regex captures and the errno lookups respectively, so strict-vars analysis treats these like existing special globals.

### Description
- Extend the `%`-sigil match in `is_builtin_global` to include `"+"`, `"-"`, and `"!"` in `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs`.
- Add three regression tests in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` (`builtin_percent_plus_no_undeclared_diagnostic`, `builtin_percent_minus_no_undeclared_diagnostic`, `builtin_percent_bang_no_undeclared_diagnostic`) to lock the behavior into the BDD grid.
- Keep the change minimal and conservative so only the intended builtin hash names are treated as globals.

### Testing
- Ran formatting with `cargo xtask fmt` which completed successfully.
- Ran targeted tests with `cargo test -p perl-semantic-analyzer builtin_percent_` and the filtered tests completed successfully.
- Ran the full test file with `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests` and observed all tests (including the three new regressions) pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99a9b15f883338cc2c28011e76d4e)