### PR TITLE
fix(ci-hygiene): track multiline C raw string state in TODO scan (#4901)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -4206,22 +4206,20 @@ fn rust_raw_string_state_after_line(
             continue;
         }
 
-        if bytes[i] == b'b' && i + 1 < bytes.len() && bytes[i + 1] == b'"' {
+        if is_prefixed_string_start(bytes, i, b'b') || is_prefixed_string_start(bytes, i, b'c') {
             in_string = true;
             i += 2;
             continue;
         }
 
-        if bytes[i] == b'r' || (bytes[i] == b'b' && i + 1 < bytes.len() && bytes[i + 1] == b'r') {
-            let mut j = i + 1;
-            if bytes[i] == b'b' {
-                j += 1;
-            }
+        let raw_prefix_len = raw_string_prefix_len(bytes, i);
+        if raw_prefix_len > 0 {
+            let mut j = i + raw_prefix_len;
             while j < bytes.len() && bytes[j] == b'#' {
                 j += 1;
             }
             if j < bytes.len() && bytes[j] == b'"' {
-                raw_hashes = Some(j.saturating_sub(i + if bytes[i] == b'b' { 2 } else { 1 }));
+                raw_hashes = Some(j.saturating_sub(i + raw_prefix_len));
                 i = j + 1;
                 continue;
             }
@@ -4562,6 +4560,31 @@ mod tests {
         ));
         assert!(!has_unlinked_todo_in_rust_line_with_state(
             "// TODO in multiline raw literal",
+            &todo_re,
+            &mut raw_state,
+        ));
+        assert!(!has_unlinked_todo_in_rust_line_with_state("\"#;", &todo_re, &mut raw_state,));
+        assert!(has_unlinked_todo_in_rust_line_with_state(
+            "// TODO: actual follow-up comment",
+            &todo_re,
+            &mut raw_state,
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn rust_todo_detection_ignores_multiline_c_raw_string_content() -> Result<()> {
+        let todo_re = Regex::new(r"TODO|FIXME")?;
+        let mut raw_state = None;
+
+        assert!(!has_unlinked_todo_in_rust_line_with_state(
+            "let s = cr#\"",
+            &todo_re,
+            &mut raw_state,
+        ));
+        assert!(!has_unlinked_todo_in_rust_line_with_state(
+            "// TODO in multiline C raw literal",
             &todo_re,
             &mut raw_state,
         ));


### PR DESCRIPTION
### Motivation
- The TODO/FIXME scanner mis-detected `// TODO` markers when they appeared inside multiline C-style raw Rust strings such as `cr#"..."#`, causing false-positive unlinked TODO warnings.
- Improve literal-state tracking so the scanner correctly ignores tokens inside all Rust raw and prefixed string forms (including `c"..."` / `cr#"..."#`).

### Description
- Updated `rust_raw_string_state_after_line` to recognize `c"..."`/`cr...` prefixed strings by reusing `is_prefixed_string_start` and `raw_string_prefix_len` helpers and to calculate `raw_hashes` using the shared prefix length.
- Added a regression test `rust_todo_detection_ignores_multiline_c_raw_string_content` that verifies multiline C raw string content does not produce unlinked TODO hits.
- Ran formatter (`cargo xtask fmt`) and committed changes to `crates/perl-ci-hygiene/src/main.rs`.

### Testing
- Ran targeted unit tests: `cargo test -p perl-ci-hygiene rust_todo_detection_ignores_multiline` — passed.
- Ran new regression test: `cargo test -p perl-ci-hygiene rust_todo_detection_ignores_multiline_c_raw_string_content` — passed.
- Ran formatting: `cargo xtask fmt` — completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99a9b15f883338cc2c28011e76d4e)