### PR TITLE
test(workspace): stabilize proptest integration suites (#4901)

### DIFF
--- a/crates/perl-workspace-index/tests/discovery_property_tests.rs
+++ b/crates/perl-workspace-index/tests/discovery_property_tests.rs
@@ -2,6 +2,7 @@
 
 use perl_workspace::discovery::{discover_perl_files, is_perl_discovery_path};
 use proptest::prelude::*;
+use proptest::test_runner::Config as ProptestConfig;
 use std::collections::HashSet;
 use std::fs;
 
@@ -22,6 +23,11 @@ fn extension_strategy() -> impl Strategy<Value = String> {
 }
 
 proptest! {
+    #![proptest_config(ProptestConfig {
+        failure_persistence: None,
+        ..ProptestConfig::default()
+    })]
+
     #[test]
     fn prop_discovery_returns_all_and_only_perl_files(
         specs in prop::collection::vec(("[a-z]{1,10}", extension_strategy()), 1..24)

--- a/crates/perl-workspace-index/tests/slo_property.rs
+++ b/crates/perl-workspace-index/tests/slo_property.rs
@@ -1,4 +1,5 @@
 use proptest::prelude::*;
+use proptest::test_runner::Config as ProptestConfig;
 
 use perl_workspace::slo::{OperationResult, OperationType, SloTracker};
 
@@ -29,6 +30,11 @@ fn operation_index(operation_type: OperationType) -> usize {
 }
 
 proptest! {
+    #![proptest_config(ProptestConfig {
+        failure_persistence: None,
+        ..ProptestConfig::default()
+    })]
+
     #[test]
     fn prop_generated_operations_record_expected_counts_and_errors(
         ops in prop::collection::vec((0u8..8u8, any::<bool>()), 0..128),

--- a/crates/perl-workspace-index/tests/workspace_folder_prop.rs
+++ b/crates/perl-workspace-index/tests/workspace_folder_prop.rs
@@ -3,6 +3,7 @@ use perl_workspace::folder::{
     workspace_folder_to_path,
 };
 use proptest::prelude::*;
+use proptest::test_runner::Config as ProptestConfig;
 use serde_json::{Value, json};
 
 fn plain_path_strategy() -> impl Strategy<Value = String> {
@@ -26,6 +27,11 @@ fn uri_entry_strategy() -> impl Strategy<Value = (Option<String>, Value)> {
 }
 
 proptest! {
+    #![proptest_config(ProptestConfig {
+        failure_persistence: None,
+        ..ProptestConfig::default()
+    })]
+
     #[test]
     fn prop_plain_paths_are_interpreted_as_filesystem_paths(folder in plain_path_strategy()) {
         let parsed = workspace_folder_to_path(&folder);


### PR DESCRIPTION
### Motivation
- Reduce noisy `proptest` failure-persistence messages emitted by integration/property suites under `tests/` where on-disk persistence targets are not applicable, while preserving all test assertions and behavior.

### Description
- Add `use proptest::test_runner::Config as ProptestConfig;` and apply `#![proptest_config(ProptestConfig { failure_persistence: None, ..ProptestConfig::default() })]` to the `proptest!` blocks in three integration/property test files to disable file persistence.
- Files modified: `crates/perl-workspace-index/tests/slo_property.rs`, `crates/perl-workspace-index/tests/discovery_property_tests.rs`, and `crates/perl-workspace-index/tests/workspace_folder_prop.rs`.

### Testing
- Ran formatter with `cargo xtask fmt` and ensured formatting completed successfully.
- Ran the modified suites with `cargo test -p perl-workspace --test slo_property --test discovery_property_tests --test workspace_folder_prop -- --nocapture` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99a999b7c8333a66da1a06deb5b2d)