### PR TITLE
fix(workspace-index): support `use constant +{...}` indexing (#4901)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -3533,10 +3533,24 @@ fn extract_constant_names_from_use_args(args: &[String]) -> Vec<String> {
         return names;
     }
 
-    // Hash form: args start with "{"
-    if first == "{" {
+    // Hash form: args start with "{", "+{", or "+" followed by "{"
+    let starts_hash_form = first == "{"
+        || first == "+{"
+        || (first == "+" && args.get(1).map(String::as_str) == Some("{"));
+    if starts_hash_form {
+        let mut skipped_leading_plus = false;
         let mut iter = args.iter().peekable();
         while let Some(arg) = iter.next() {
+            // Some parser/tokenizer variants can emit "+{" as a single token for
+            // `use constant +{ ... }`. Treat it as structural punctuation.
+            if arg == "+{" {
+                skipped_leading_plus = true;
+                continue;
+            }
+            if arg == "+" && !skipped_leading_plus {
+                skipped_leading_plus = true;
+                continue;
+            }
             if arg == "{" || arg == "}" || arg == "," || arg == "=>" {
                 continue;
             }
@@ -3722,6 +3736,39 @@ use constant {
         ]);
         assert_eq!(names, vec!["FOO", "BAR"]);
     }
+
+    #[test]
+    fn test_extract_constant_names_accepts_plus_hash_form_split_tokens() {
+        let names = extract_constant_names_from_use_args(&[
+            "+".to_string(),
+            "{".to_string(),
+            "FOO".to_string(),
+            "=>".to_string(),
+            "1".to_string(),
+            ",".to_string(),
+            "BAR".to_string(),
+            "=>".to_string(),
+            "2".to_string(),
+            "}".to_string(),
+        ]);
+        assert_eq!(names, vec!["FOO", "BAR"]);
+    }
+
+    #[test]
+    fn test_extract_constant_names_accepts_plus_hash_form_combined_token() {
+        let names = extract_constant_names_from_use_args(&[
+            "+{".to_string(),
+            "FOO".to_string(),
+            "=>".to_string(),
+            "1".to_string(),
+            ",".to_string(),
+            "BAR".to_string(),
+            "=>".to_string(),
+            "2".to_string(),
+            "}".to_string(),
+        ]);
+        assert_eq!(names, vec!["FOO", "BAR"]);
+    }
     #[test]
     fn test_use_constant_duplicate_names_indexed_once() {
         let index = WorkspaceIndex::new();
@@ -3741,6 +3788,23 @@ use constant {
             retry_count_symbols, 1,
             "RETRY_COUNT should be indexed once even when repeated in use constant hash form"
         );
+    }
+
+    #[test]
+    fn test_use_constant_plus_hash_form_indexes_keys() {
+        let index = WorkspaceIndex::new();
+        let uri = "file:///lib/My/PlusHash.pm";
+        let code = r#"package My::PlusHash;
+use constant +{
+    FOO => 1,
+    BAR => 2,
+};
+1;
+"#;
+        must(index.index_file(must(url::Url::parse(uri)), code.to_string()));
+
+        assert!(index.find_definition("My::PlusHash::FOO").is_some());
+        assert!(index.find_definition("My::PlusHash::BAR").is_some());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Parser/tokenizer variants emit `+{` or a split `+` then `{` for `use constant +{ ... }` which previously prevented hash-form constant keys from being indexed and discoverable.
- Ensure the workspace index extracts constant names from all tokenisation variants so navigation and symbol lookup remain robust across real-world Perl code.

### Description
- Update `extract_constant_names_from_use_args` in `crates/perl-workspace-index/src/workspace/workspace_index.rs` to recognise hash-form starts of `{`, `+{`, or `+` followed by `{` and treat `+`/`+{` as structural punctuation when iterating tokens.
- Add handling to skip `+{` and a leading `+` token so existing hash-form parsing logic can detect constant names unchanged.
- Add unit tests for both tokenizer variants: `test_extract_constant_names_accepts_plus_hash_form_split_tokens` and `test_extract_constant_names_accepts_plus_hash_form_combined_token`.
- Add an end-to-end index test `test_use_constant_plus_hash_form_indexes_keys` that verifies `My::PlusHash::FOO` and `My::PlusHash::BAR` are indexed and resolvable via `find_definition`.

### Testing
- Ran `cargo xtask fmt` which completed successfully.
- Ran targeted unit tests: `cargo test -p perl-workspace test_extract_constant_names_accepts_plus_hash_form -- --nocapture` and `cargo test -p perl-workspace plus_hash_form -- --nocapture`, and all added tests passed.
- Ran the crate test-suite during development and the newly added tests passed with no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99a999b7c8333a66da1a06deb5b2d)