### PR TITLE
ci: add ready_for_review + converted_to_draft to pull_request.types (#4813)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: CI
 on:
   pull_request:
     branches: [ main, master ]
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, ready_for_review, converted_to_draft]
   push:
     branches: [ main, master ]
   workflow_dispatch: {}


### PR DESCRIPTION
## Summary

- Adds `ready_for_review` and `converted_to_draft` to the `pull_request.types` trigger list in `.github/workflows/ci.yml`
- Enables tier-gating CI to fire when a PR transitions between draft and ready states (required for the draft-vs-ready CI gating planned in #4706)

## Change

```diff
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, ready_for_review, converted_to_draft]
```

YAML validity confirmed: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` passes.

Closes #4813