### PR TITLE
ci: drop auto-format-commit from pr-smoke (#4807)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,18 +50,8 @@ jobs:
         with:
           tool: just
 
-      - name: Auto-fix formatting
-        run: |
-          cargo xtask fmt
-          if ! git diff --quiet; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add -A
-            git commit -m "chore: auto-format with cargo fmt"
-            git push
-            echo "::notice::Auto-formatted code pushed. CI will re-run."
-            exit 0
-          fi
+      - name: Check formatting
+        run: cargo xtask fmt --check
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1

--- a/crates/perl-dap/src/inline_values.rs
+++ b/crates/perl-dap/src/inline_values.rs
@@ -316,7 +316,6 @@ fn collect_line_variables(line: &str, include_non_scalars: bool) -> Vec<(usize, 
     matches
 }
 
-
 /// Extract unique variable names from source code within a line range.
 ///
 /// Lines are 1-based. Returns deduplicated variable names with their sigils.

--- a/crates/perl-lsp-rs-core/src/providers/color/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/color/mod.rs
@@ -5,9 +5,9 @@
 //! options for editors.
 
 use once_cell::sync::Lazy;
-use perl_position_tracking::{offset_to_utf16_line_col, WirePosition, WireRange};
+use perl_position_tracking::{WirePosition, WireRange, offset_to_utf16_line_col};
 use regex::Regex;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Regex for hex color codes: #RGB, #RRGGBB, #RRGGBBAA
 static HEX_COLOR_RE: Lazy<Option<Regex>> =

--- a/crates/perl-lsp-rs/src/runtime/language/code_actions.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/code_actions.rs
@@ -157,11 +157,7 @@ fn quickfix_text_edits_for_uri<'a>(action: &'a Value, uri: &str) -> Option<Vec<&
         collected.extend(edits.iter());
     }
 
-    if collected.is_empty() {
-        None
-    } else {
-        Some(collected)
-    }
+    if collected.is_empty() { None } else { Some(collected) }
 }
 
 fn build_source_fix_all(code_actions: &[Value], uri: &str) -> Option<Value> {


### PR DESCRIPTION
## Summary

- Replaces the 12-line auto-fix block in `pr-smoke` (which ran `cargo xtask fmt`, then conditionally committed and pushed back to the PR branch) with a single `cargo xtask fmt --check` step that fails cleanly on fmt drift.
- Also fixes three pre-existing fmt drift sites surfaced by the new check step (`perl-lsp-rs-core/color/mod.rs`, `perl-lsp-rs/code_actions.rs`, `perl-dap/inline_values.rs`).

## Why

The old behaviour violated CI's verifier role in three ways:
1. It mutated PR branches (CI should verify, not rewrite)
2. The push back triggered `synchronize` events that restarted the entire CI pipeline, wasting wall-clock minutes
3. On master pushes, branch protection rejected the force-push, producing a silent failure (see #4679)

## YAML diff (before → after)

```diff
-      - name: Auto-fix formatting
-        run: |
-          cargo xtask fmt
-          if ! git diff --quiet; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add -A
-            git commit -m "chore: auto-format with cargo fmt"
-            git push
-            echo "::notice::Auto-formatted code pushed. CI will re-run."
-            exit 0
-          fi
+      - name: Check formatting
+        run: cargo xtask fmt --check
```

YAML syntax verified: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` exits 0.

## Test plan

- [ ] Confirm `pr-smoke` job passes on this PR (no auto-commit push)
- [ ] Confirm `pr-smoke` fails on a branch with deliberate fmt drift
- [ ] Verify no mutation of the PR branch by the CI run

Closes #4807. Related: #4679.