### PR TITLE
feat(vscode): one-click creation for missing include paths (#4954)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1542,9 +1542,22 @@ export async function validateIncludePaths(context: vscode.ExtensionContext): Pr
                 ? ` ${missingPaths.length} include paths are missing.`
                 : '';
 
+        const creatablePaths = missingPaths.filter(includePath => {
+            if (path.isAbsolute(includePath)) {
+                return false;
+            }
+            const resolved = path.resolve(folder.uri.fsPath, includePath);
+            const relative = path.relative(folder.uri.fsPath, resolved);
+            return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+        });
+        const actions = ['Open Settings'];
+        if (creatablePaths.length > 0) {
+            actions.push('Create Missing Directories');
+        }
+
         const choice = await vscode.window.showWarningMessage(
             `Perl LSP: include path "${firstMissing}" (${relativeNote}) does not exist.${suffix}`,
-            'Open Settings'
+            ...actions
         );
 
         if (choice === 'Open Settings') {
@@ -1552,6 +1565,23 @@ export async function validateIncludePaths(context: vscode.ExtensionContext): Pr
                 'workbench.action.openSettings',
                 '@ext:EffortlessMetrics.perl-lsp-rs perl-lsp.includePaths'
             );
+        } else if (choice === 'Create Missing Directories') {
+            const createdPaths: string[] = [];
+            for (const includePath of creatablePaths) {
+                const resolved = path.resolve(folder.uri.fsPath, includePath);
+                if (!fs.existsSync(resolved)) {
+                    fs.mkdirSync(resolved, { recursive: true });
+                    createdPaths.push(includePath);
+                }
+            }
+
+            if (createdPaths.length > 0) {
+                vscode.window.showInformationMessage(
+                    `Created ${createdPaths.length} include director${createdPaths.length === 1 ? 'y' : 'ies'}: ${createdPaths.join(', ')}.`
+                );
+                await context.globalState.update(cacheKey, undefined);
+                continue;
+            }
         }
 
         await context.globalState.update(cacheKey, missingSignature);

--- a/vscode-extension/src/test/extensionUx.test.ts
+++ b/vscode-extension/src/test/extensionUx.test.ts
@@ -94,7 +94,8 @@ describe('extension UX warnings', () => {
 
     expect(showWarningMessage).toHaveBeenCalledWith(
       expect.stringContaining('src/libx'),
-      'Open Settings'
+      'Open Settings',
+      'Create Missing Directories'
     );
     expect(globalState.update).toHaveBeenCalledWith(
       expect.stringContaining('perl-lsp.includePathsWarning.'),
@@ -109,7 +110,43 @@ describe('extension UX warnings', () => {
     await validateIncludePaths(context);
     expect(showWarningMessage).toHaveBeenCalledWith(
       expect.stringContaining('vendorx'),
-      'Open Settings'
+      'Open Settings',
+      'Create Missing Directories'
+    );
+  });
+
+  test('can create missing relative include paths directly from the warning', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-ux-create-'));
+    const context = makeContext();
+    context.globalState = {
+      get: jest.fn(() => undefined),
+      update: jest.fn(async () => undefined),
+    };
+
+    const getConfiguration = vscode.workspace.getConfiguration as jest.Mock;
+    getConfiguration.mockImplementation(() => ({
+      get: jest.fn(() => ['lib', 'vendor/perl']),
+    }));
+
+    (vscode.workspace as any).workspaceFolders = [
+      {
+        name: 'workspace',
+        uri: {
+          fsPath: workspaceDir,
+          toString: () => `file://${workspaceDir}`,
+        },
+      },
+    ];
+
+    const showWarningMessage = vscode.window.showWarningMessage as jest.Mock;
+    showWarningMessage.mockResolvedValue('Create Missing Directories');
+
+    await validateIncludePaths(context);
+
+    expect(fs.existsSync(path.join(workspaceDir, 'lib'))).toBe(true);
+    expect(fs.existsSync(path.join(workspaceDir, 'vendor/perl'))).toBe(true);
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Created 2 include directories')
     );
   });
 


### PR DESCRIPTION
### Motivation

- Users encountering missing include-path warnings currently must open settings and create directories manually, which is friction for common setup issues.

### Description

- Add a `Create Missing Directories` action to the include-path validation prompt in `validateIncludePaths`, offering a one-click fix for eligible paths. 
- Only auto-create relative paths that resolve inside the workspace to avoid creating absolute or parent-traversal locations, and create directories with `fs.mkdirSync(..., { recursive: true })` when selected. 
- Show an information confirmation after creation and clear the cached warning state so users are not re-prompted for paths they just fixed. 
- Update and extend the UX tests in `vscode-extension/src/test/extensionUx.test.ts` to expect the new action and to verify that directories are created when the action is chosen.

### Testing

- Ran `cd vscode-extension && npm test -- --runInBand src/test/extensionUx.test.ts`, but the TypeScript/Jest environment in this runner failed to resolve Jest globals so the test suite did not execute successfully. 
- Ran `cd vscode-extension && npx eslint src/extension.ts src/test/extensionUx.test.ts`, which completed but reported pre-existing `no-floating-promises` errors in `src/extension.ts` unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a734527c833396b2fd47060cf4ee)