### PR TITLE
feat(code-actions): broaden parse quick-fix routing and quote extraction (#4954)

### DIFF
--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -135,14 +135,10 @@ impl CodeActionsProvider {
             Some(code) if code.starts_with("parse-error-") => {
                 fixes::fix_parse_error(self, diagnostic, code)
             }
-            // PL001 / PL002 are general parse error codes. When the diagnostic message
-            // indicates a missing semicolon, route through the same fix as
-            // "parse-error-missingsemicolon" so the quick-fix fires correctly.
-            Some("PL001") | Some("PL002")
-                if diagnostic.message.to_ascii_lowercase().contains("missing semicolon") =>
-            {
-                fixes::fix_parse_error(self, diagnostic, "parse-error-missingsemicolon")
-            }
+            // PL001 / PL002 are general parse error codes. Route known parse
+            // message patterns through the same targeted parse quick-fixes.
+            Some("PL001") | Some("PL002") => parse_error_fix_code_from_message(&diagnostic.message)
+                .map_or_else(Vec::new, |code| fixes::fix_parse_error(self, diagnostic, code)),
             _ => Vec::new(),
         }
     }
@@ -150,6 +146,26 @@ impl CodeActionsProvider {
     pub(super) fn source(&self) -> &str {
         &self.source
     }
+}
+
+fn parse_error_fix_code_from_message(message: &str) -> Option<&'static str> {
+    let message_lower = message.to_ascii_lowercase();
+    if message_lower.contains("missing semicolon") {
+        return Some("parse-error-missingsemicolon");
+    }
+    if message_lower.contains("unclosed string") || message_lower.contains("unterminated string") {
+        return Some("parse-error-unclosedstring");
+    }
+    if message_lower.contains("unclosed parenthesis") {
+        return Some("parse-error-unclosedparen");
+    }
+    if message_lower.contains("unclosed brace")
+        || message_lower.contains("missing '}'")
+        || message_lower.contains("unclosed `{`")
+    {
+        return Some("parse-error-unclosedbrace");
+    }
+    None
 }
 
 #[cfg(test)]
@@ -932,6 +948,12 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_quoted_value_double_quotes() {
+        let result = source_utils::extract_quoted_value("Variable \"$baz\" is undefined");
+        assert_eq!(result, Some("$baz".to_string()));
+    }
+
+    #[test]
     fn test_extract_quoted_value_single_quote_preferred_over_backtick() {
         // Single quotes appear first in the message, so they should be extracted
         let result = source_utils::extract_quoted_value("'first' then `second`");
@@ -1138,6 +1160,24 @@ mod tests {
 
         let actions = provider.get_actions_for_diagnostic(&diagnostic);
         assert!(actions.is_empty(), "PL001 with unrelated message must not produce actions");
+    }
+
+    #[test]
+    fn test_pl002_unclosed_brace_message_triggers_fix() {
+        let source = "sub x { print 'ok';\n".to_string();
+        let provider = CodeActionsProvider::new(source);
+
+        let diagnostic = make_diagnostic(
+            (6, 7),
+            DiagnosticSeverity::Error,
+            "PL002",
+            "Unclosed `{` -- check for a missing `}` to close the block",
+        );
+
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Add closing brace");
+        assert_eq!(actions[0].edit.new_text, "}");
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/source_utils.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/source_utils.rs
@@ -5,7 +5,11 @@ pub(super) fn ranges_overlap(r1: (usize, usize), r2: (usize, usize)) -> bool {
 }
 
 pub(super) fn extract_quoted_value(message: &str) -> Option<String> {
-    extract_between(message, '\'').or_else(|| extract_between(message, '`'))
+    ['\'', '`', '"']
+        .into_iter()
+        .filter_map(|delimiter| extract_between(message, delimiter))
+        .min_by_key(|(start, _)| *start)
+        .map(|(_, value)| value)
 }
 
 pub(super) fn find_declaration_position(provider: &CodeActionsProvider, near: usize) -> usize {
@@ -69,10 +73,10 @@ pub(super) fn split_sigil(name: &str) -> (&str, &str) {
     (&name[..sigil_len], bare)
 }
 
-fn extract_between(message: &str, delimiter: char) -> Option<String> {
+fn extract_between(message: &str, delimiter: char) -> Option<(usize, String)> {
     let start = message.find(delimiter)?;
     let end = message[start + 1..].find(delimiter)?;
-    Some(message[start + 1..start + 1 + end].to_string())
+    Some((start, message[start + 1..start + 1 + end].to_string()))
 }
 
 fn declaration_end(source: &str, pos: usize, search_pattern: &str) -> usize {


### PR DESCRIPTION
### Motivation
- Make parser quick-fixes more helpful by routing generic parser diagnostics (`PL001`/`PL002`) to targeted fixes based on the actual diagnostic message instead of only matching one pattern. 
- Improve reliability of quick-fix extraction by supporting double-quoted tokens and preferring the earliest quoted token in diagnostic messages.

### Description
- Added `parse_error_fix_code_from_message` to map common parse-message patterns (missing semicolon, unclosed string, unclosed parenthesis, unclosed brace) to existing `parse-error-*` quick-fix handlers and routed `PL001`/`PL002` through it. (changes in `crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs`)
- Broadened `extract_quoted_value` to examine `' '`, backtick and double-quote delimiters, choose the earliest quoted token, and return its value; refactored `extract_between` to return the match index plus value. (changes in `crates/perl-lsp-rs/src/features/code_actions_provider/source_utils.rs`)
- Added focused unit tests for double-quoted extraction and PL002 unclosed-brace message routing to ensure the new behaviors. (tests in `crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs`)

### Testing
- Ran code formatting with `cargo xtask fmt` which completed successfully. 
- Ran the new and related unit tests individually with `cargo test -p perl-lsp-rs --lib test_extract_quoted_value_double_quotes`, `cargo test -p perl-lsp-rs --lib test_pl002_unclosed_brace_message_triggers_fix`, and `cargo test -p perl-lsp-rs --lib test_pl001_missing_semicolon_message_triggers_fix`, and all passed.
- Note: an earlier combined cargo invocation with multiple test filters is invalid; tests were executed individually and validated as passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a734527c833396b2fd47060cf4ee)