### PR TITLE
fix(parser): support scoped sub declarations (#4954)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -214,13 +214,21 @@ impl<'a> Parser<'a> {
                 ));
             }
 
-            // Variable declarations
+            // Variable declarations (`my $x`, `our @y`, ...) and scoped sub declarations
+            // (`my sub helper { ... }`, `our sub helper { ... }`, `state sub memo { ... }`).
             TokenKind::My | TokenKind::Our | TokenKind::State => {
-                let decl = self.parse_variable_declaration()?;
-                if self.peek_kind() == Some(TokenKind::FatArrow) {
-                    self.finish_expression_from(decl)
+                if matches!(self.tokens.peek_second().map(|t| t.kind), Ok(TokenKind::Sub)) {
+                    let decl_token = self.consume_token()?;
+                    let mut sub_node = self.parse_subroutine()?;
+                    sub_node.location.start = decl_token.start;
+                    self.finish_subroutine_statement(sub_node)
                 } else {
-                    Ok(self.parse_word_or_expr(decl)?)
+                    let decl = self.parse_variable_declaration()?;
+                    if self.peek_kind() == Some(TokenKind::FatArrow) {
+                        self.finish_expression_from(decl)
+                    } else {
+                        Ok(self.parse_word_or_expr(decl)?)
+                    }
                 }
             }
             // `field` is a variable declarator only in Perl 5.38+ class bodies.

--- a/crates/perl-parser-core/tests/fix_scoped_sub_declarations.rs
+++ b/crates/perl-parser-core/tests/fix_scoped_sub_declarations.rs
@@ -1,0 +1,23 @@
+//! Regression tests for scoped subroutine declarations.
+//!
+//! Perl allows `my sub`, `our sub`, and `state sub` declarations.
+//! These should parse as subroutine statements rather than variable declarations.
+
+mod cpan_test_helpers;
+
+use cpan_test_helpers::assert_clean_parse;
+
+#[test]
+fn parses_my_sub_declaration() {
+    assert_clean_parse("my sub helper ($x) { $x }");
+}
+
+#[test]
+fn parses_our_sub_declaration() {
+    assert_clean_parse("our sub helper ($x) { $x }");
+}
+
+#[test]
+fn parses_state_sub_declaration() {
+    assert_clean_parse("state sub memo { state $x = 1; $x }");
+}


### PR DESCRIPTION
### Motivation

- The statement parser routed `my|our|state` followed by `sub` through variable-declaration parsing which caused valid scoped-sub forms like `our sub helper ($x) { $x }` to fail with a syntax error.

### Description

- Detect `my`, `our`, or `state` followed by `sub` in the statement dispatcher and parse the construct as a subroutine statement instead of a variable declaration by peeking at the second token in `statements.rs`.
- Preserve the declarator token start position by adjusting the parsed subnode's `location.start` when parsing the scoped sub form.
- Add regression tests in `crates/perl-parser-core/tests/fix_scoped_sub_declarations.rs` covering `my sub`, `our sub`, and `state sub` forms.

### Testing

- Ran `cargo test -p perl-parser-core --test fix_scoped_sub_declarations` and all 3 new tests passed (3 passed; 0 failed).
- Ran formatting via `cargo xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a745b5888333bb6b998f53bd0bf8)