### PR TITLE
fix(parser-core): recover missing rhs before statement keywords (#4954)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/error_recovery_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/error_recovery_tests.rs
@@ -58,6 +58,34 @@ fn test_recovery_missing_expression() {
 }
 
 #[test]
+fn test_recovery_missing_rhs_before_sub_declaration_keyword() {
+    // Missing RHS before `sub foo { ... }` should recover at `sub` as a
+    // statement boundary, instead of consuming `sub` as an identifier.
+    let code = "my $x = sub foo { print 1; }";
+    let mut parser = Parser::new(code);
+    let result = parser.parse();
+
+    assert!(result.is_ok(), "Parser should recover missing assignment RHS");
+    let ast = must(result);
+
+    if let NodeKind::Program { statements } = &ast.kind {
+        assert_eq!(statements.len(), 2, "Should recover and keep the following sub declaration");
+        assert!(
+            matches!(statements[0].kind, NodeKind::VariableDeclaration { .. }),
+            "First statement should stay a recovered variable declaration"
+        );
+        assert!(
+            matches!(statements[1].kind, NodeKind::Subroutine { .. }),
+            "Second statement should parse as subroutine declaration"
+        );
+    } else {
+        unreachable!("Expected program root");
+    }
+
+    assert!(!parser.errors().is_empty(), "Recovery should record a missing operand diagnostic");
+}
+
+#[test]
 fn test_recovery_multiple_errors() {
     // Phase 2: `my $x = ;` now produces a VariableDeclaration with MissingExpression
     // instead of an Error node. Each missing RHS emits exactly 1 Recovered error.

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -620,6 +620,25 @@ impl<'a> Parser<'a> {
                 | Some(TokenKind::RightBrace)
                 | Some(TokenKind::RightParen)
                 | Some(TokenKind::RightBracket)
+                // Statement-starter keywords cannot serve as an expression RHS.
+                // Treating them as "missing operand" allows declaration parsing
+                // to recover cleanly and resume at the next statement boundary.
+                | Some(TokenKind::My)
+                | Some(TokenKind::Our)
+                | Some(TokenKind::Local)
+                | Some(TokenKind::State)
+                | Some(TokenKind::Sub)
+                | Some(TokenKind::Package)
+                | Some(TokenKind::Use)
+                | Some(TokenKind::No)
+                | Some(TokenKind::If)
+                | Some(TokenKind::Unless)
+                | Some(TokenKind::Elsif)
+                | Some(TokenKind::Else)
+                | Some(TokenKind::While)
+                | Some(TokenKind::Until)
+                | Some(TokenKind::For)
+                | Some(TokenKind::Foreach)
                 | Some(TokenKind::Eof)
                 | None
         )


### PR DESCRIPTION
### Motivation

- Error recovery could consume statement-starting keywords (e.g. `sub`) as expression tokens when an infix RHS was missing, preventing correct synchronization to the next statement and losing the following declaration.

### Description

- Treat statement-starting keywords as strong followers in `is_infix_rhs_absent`, so they count as a missing-RHS condition and trigger recovery instead of being parsed as an expression token.
- Expanded the match in `crates/perl-parser-core/src/engine/parser/helpers.rs` to include `My`, `Our`, `Local`, `State`, `Sub`, `Package`, `Use`, `No`, `If`, `Unless`, `Elsif`, `Else`, `While`, `Until`, `For`, and `Foreach` as RHS-absent tokens.
- Added a regression test `test_recovery_missing_rhs_before_sub_declaration_keyword` in `crates/perl-parser-core/src/engine/parser/error_recovery_tests.rs` that verifies `my $x = sub foo { ... }` recovers the missing RHS, preserves the recovered `VariableDeclaration`, parses the following `Subroutine`, and records diagnostics.

### Testing

- Ran the targeted regression with `cargo test -p perl-parser-core test_recovery_missing_rhs_before_sub_declaration_keyword`, which passed.
- Ran formatting with `cargo xtask fmt`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a745b5888333bb6b998f53bd0bf8)