### PR TITLE
fix(parser-core): support scoped sub declarations (my/state) (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -93,6 +93,15 @@ impl<'a> Parser<'a> {
                 .is_some_and(|t| t.kind == TokenKind::Sub)
     }
 
+    fn is_scoped_sub_start(&mut self) -> bool {
+        matches!(self.peek_kind(), Some(TokenKind::My | TokenKind::State))
+            && self
+                .tokens
+                .peek_second()
+                .ok()
+                .is_some_and(|t| t.kind == TokenKind::Sub)
+    }
+
     fn is_adjust_block_start(&mut self) -> bool {
         self.in_class_body > 0
             && self.peek_kind() == Some(TokenKind::Identifier)
@@ -199,6 +208,17 @@ impl<'a> Parser<'a> {
                 && !attributes.iter().any(|attr| attr == "async")
             {
                 attributes.insert(0, "async".to_string());
+            }
+            self.finish_subroutine_statement(sub_node)
+        } else if self.is_scoped_sub_start() {
+            let scope_token = self.consume_token()?;
+            let mut sub_node = self.parse_subroutine()?;
+            sub_node.location.start = scope_token.start;
+            let scope = scope_token.text.to_string();
+            if let NodeKind::Subroutine { attributes, .. } = &mut sub_node.kind
+                && !attributes.iter().any(|attr| attr == &scope)
+            {
+                attributes.insert(0, scope);
             }
             self.finish_subroutine_statement(sub_node)
         } else {

--- a/crates/perl-parser-core/tests/fix_scoped_sub_declaration.rs
+++ b/crates/perl-parser-core/tests/fix_scoped_sub_declaration.rs
@@ -1,0 +1,17 @@
+//! Regression coverage for scoped subroutine declarations.
+//! Perl allows lexical and persistent scoped sub declarations such as
+//! `my sub` and `state sub`.
+
+mod cpan_test_helpers;
+
+use cpan_test_helpers::assert_clean_parse;
+
+#[test]
+fn parses_state_sub_declaration() {
+    assert_clean_parse("state sub helper { 1 }");
+}
+
+#[test]
+fn parses_my_sub_declaration() {
+    assert_clean_parse("my sub helper { 1 }");
+}


### PR DESCRIPTION
### Motivation
- The parser treated `my`/`state` followed by `sub` as a variable declaration and failed with an error like "Expected variable, found 'sub'", so scoped subroutine declarations (e.g., `my sub ...`, `state sub ...`) were not parsed correctly.

### Description
- Added a statement-level predicate `is_scoped_sub_start` to detect `my sub` / `state sub` before the variable-declaration branch in `parse_statement_inner`.
- Implemented a fast-path that consumes the scope token, calls `parse_subroutine()`, adjusts the `sub` node `location.start` to the scope token, and inserts the scope word into the subroutine `attributes` when it is not already present (`crates/perl-parser-core/src/engine/parser/statements.rs`).
- Added regression tests in `crates/perl-parser-core/tests/fix_scoped_sub_declaration.rs` to assert clean parsing for `state sub helper { 1 }` and `my sub helper { 1 }` using `assert_clean_parse`.
- Ran repository formatting with `cargo xtask fmt` to keep code style consistent.

### Testing
- Ran `cargo xtask fmt` and it completed successfully.
- Ran `cargo test -p perl-parser-core --test fix_scoped_sub_declaration` and both tests passed (2 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a745b5888333bb6b998f53bd0bf8)