### PR TITLE
fix(lsp): preserve post-dispatch cancellation responses (#4982)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
@@ -119,6 +119,7 @@ impl LspServer {
                     | "workspace/symbol"
                     | "callHierarchy/incomingCalls"
                     | "callHierarchy/outgoingCalls"
+                    | "textDocument/inlayHint"
             );
 
             if needs_cancellation {
@@ -333,12 +334,9 @@ impl LspServer {
             }
         };
 
-        // Clean up cancellation token after request processing
-        if let Some(ref request_id) = id {
-            GLOBAL_CANCELLATION_REGISTRY.remove_request(request_id);
-        }
-
-        // Check for enhanced cancellation with provider context
+        // Check for enhanced cancellation with provider context before cleanup.
+        // This preserves cancelled responses for requests that are interrupted while
+        // handlers are already running.
         if let Some(ref request_id) = id {
             if let Some(token) = GLOBAL_CANCELLATION_REGISTRY.get_token(request_id) {
                 if token.is_cancelled() {
@@ -346,9 +344,12 @@ impl LspServer {
                         GLOBAL_CANCELLATION_REGISTRY.cancel_request(request_id).map_err(|e| {
                             tracing::trace!(error = %e, "cancellation: failed to cancel request (post-dispatch)");
                         }).ok().flatten();
+                    GLOBAL_CANCELLATION_REGISTRY.remove_request(request_id);
                     return Some(enhanced_cancelled_response(&token, cleanup_context.as_ref()));
                 }
             }
+            // Clean up cancellation token after request processing.
+            GLOBAL_CANCELLATION_REGISTRY.remove_request(request_id);
         }
 
         match result {


### PR DESCRIPTION
### Motivation

- Avoid losing a proper cancelled response when a request is cancelled while its handler is running by checking cancelled state before cleaning up registry entries. 
- Ensure `textDocument/inlayHint` participates in the same enhanced cancellation path as other potentially long-running language requests. 

### Description

- Register `textDocument/inlayHint` in the `needs_cancellation` match so inlay hint requests get a cancellation token and provider cleanup context (`crates/perl-lsp-rs/src/runtime/dispatch/mod.rs`).
- Reorder post-dispatch logic to check for an enhanced cancellation (via `GLOBAL_CANCELLATION_REGISTRY.get_token` / `cancel_request`) before calling `remove_request`, and call `remove_request` in both the cancelled and non-cancelled paths to preserve cleanup semantics. 
- Keep existing fallback behaviour and logging while tightening the cleanup ordering so cancelled requests can still return `enhanced_cancelled_response` when interrupted during execution. 

### Testing

- Ran `cargo check -p perl-lsp-rs` and it completed successfully. 
- Ran `cargo check -p perl-lsp-rs --quiet` and it completed successfully. 
- Ran `cargo xtask fmt` to format the workspace and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a75124d0833389d57daae6ac1c08)