### PR TITLE
fix(text-sync): ignore stale didChange versions (#4982)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -383,13 +383,17 @@ impl LspServer {
                 .pointer("/textDocument/uri")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| invalid_params("Missing required parameter: textDocument.uri"))?;
-            let version_i64 =
-                params.pointer("/textDocument/version").and_then(|v| v.as_i64()).unwrap_or(0);
-            let version = i32::try_from(version_i64).unwrap_or(0);
+            let incoming_version_i64 =
+                params.pointer("/textDocument/version").and_then(|v| v.as_i64());
+            let incoming_version = incoming_version_i64.and_then(|v| i32::try_from(v).ok());
 
             // Cancel any active streaming inline completion sessions for this URI
             // that are older than the new document version.
-            self.stream_sessions().cancel_for_uri_version(uri, version_i64);
+            if let Some(version) = incoming_version_i64 {
+                self.stream_sessions().cancel_for_uri_version(uri, version);
+            } else {
+                self.stream_sessions().cancel_for_uri(uri);
+            }
 
             if let Some(changes) = params["contentChanges"].as_array() {
                 // Get current document state or create new one
@@ -430,7 +434,7 @@ impl LspServer {
                 let mut doc_state = existing_doc.unwrap_or_else(|| DocumentState {
                     rope: ropey::Rope::new(),
                     text: String::new(),
-                    version,
+                    version: incoming_version.unwrap_or(0),
                     ast: None,
                     parse_errors: vec![],
                     parent_map: ParentMap::default(),
@@ -442,6 +446,26 @@ impl LspServer {
                     #[cfg(feature = "incremental")]
                     incremental_state: None,
                 });
+
+                // Ignore stale didChange notifications that arrive out of order.
+                // We only gate on explicit client-provided versions; if a client omits
+                // the version field we preserve legacy behavior and treat the change as new.
+                if let Some(version) = incoming_version {
+                    if version <= doc_state.version {
+                        tracing::debug!(
+                            "Ignoring stale didChange for {} (incoming version {} <= current {})",
+                            uri,
+                            version,
+                            doc_state.version
+                        );
+                        return Ok(());
+                    }
+                }
+
+                // didChange version is required by LSP, but keep a fallback for tolerant
+                // handling of non-conforming clients in tests/custom integrations.
+                let version =
+                    incoming_version.unwrap_or_else(|| doc_state.version.saturating_add(1));
 
                 // Increment generation counter for this change
                 let next_gen = doc_state.generation.fetch_add(1, Ordering::SeqCst).wrapping_add(1);
@@ -2118,5 +2142,61 @@ mod tests {
                 err.code
             );
         }
+    }
+
+    /// didChange with an out-of-order version must be ignored to avoid document rollback.
+    #[test]
+    fn handle_did_change_ignores_stale_versions() -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let uri = "file:///stale_version.pl";
+
+        server.did_open(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 5,
+                "text": "my $x = 1;\n"
+            }
+        }))?;
+
+        // Incoming didChange version is older than current (4 < 5): ignore.
+        server.handle_did_change(Some(json!({
+            "textDocument": { "uri": uri, "version": 4 },
+            "contentChanges": [{ "text": "my $x = 999;\n" }]
+        })))?;
+
+        let docs = server.documents.lock();
+        let doc = docs.get(uri).ok_or("document missing after stale didChange")?;
+        assert_eq!(doc.version, 5, "stale didChange must not update document version");
+        assert_eq!(doc.text, "my $x = 1;\n", "stale didChange must not modify document text");
+        Ok(())
+    }
+
+    /// didChange without a version field should still be applied for compatibility.
+    #[test]
+    fn handle_did_change_without_version_uses_next_version()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let uri = "file:///missing_version.pl";
+
+        server.did_open(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": "my $x = 1;\n"
+            }
+        }))?;
+
+        server.handle_did_change(Some(json!({
+            "textDocument": { "uri": uri },
+            "contentChanges": [{ "text": "my $x = 2;\n" }]
+        })))?;
+
+        let docs = server.documents.lock();
+        let doc = docs.get(uri).ok_or("document missing after didChange without version")?;
+        assert_eq!(doc.version, 2, "missing-version didChange should advance version by one");
+        assert_eq!(doc.text, "my $x = 2;\n", "didChange without version should apply content");
+        Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Prevent document rollbacks when LSP `textDocument/didChange` notifications arrive out of order with older versions.
- Ensure streaming inline-completion sessions are cancelled correctly when `version` is present, and conservatively cancelled when `version` is omitted.
- Maintain compatibility with non-conforming clients that omit the `textDocument.version` field by providing a safe fallback.

### Description

- Treat `textDocument.version` as optional and parse it into `incoming_version` when present, otherwise preserve legacy behavior.
- Cancel stream sessions by version when a numeric `version` is provided, and cancel all sessions for the URI when the version is absent.
- Ignore stale/out-of-order `didChange` notifications when `incoming_version <= current_document.version` to avoid rolling back state.
- When `version` is omitted, apply the change and advance the stored version by one; added two regression tests for stale-version ignoring and missing-version handling.

### Testing

- Ran formatting: `cargo xtask fmt` (succeeded).
- Ran targeted unit test: `cargo test -p perl-lsp-rs --lib handle_did_change_ignores_stale_versions` (passed).
- Ran targeted unit test: `cargo test -p perl-lsp-rs --lib handle_did_change_without_version_uses_next_version` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a75124d0833389d57daae6ac1c08)