### PR TITLE
fix(perl-pragma): normalize conditional feature semantics and effective strictness (#4982)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -442,7 +442,16 @@ impl PragmaTracker {
         // then take the element before it.
         let idx = pragma_map.partition_point(|(range, _)| range.start <= offset);
 
-        if idx > 0 { pragma_map[idx - 1].1.clone() } else { PragmaState::default() }
+        let mut state =
+            if idx > 0 { pragma_map[idx - 1].1.clone() } else { PragmaState::default() };
+
+        if state.signatures_strict {
+            state.strict_vars = true;
+            state.strict_subs = true;
+            state.strict_refs = true;
+        }
+
+        state
     }
 
     /// Process a lexically scoped body and then restore the caller state.
@@ -533,36 +542,7 @@ impl PragmaTracker {
                             return;
                         }
                         "feature" => {
-                            let mut changed = false;
-                            for arg in conditional_args {
-                                for item in pragma_arg_items(arg) {
-                                    match item.as_str() {
-                                        "signatures" => {
-                                            current_state.strict_vars = true;
-                                            current_state.strict_subs = true;
-                                            current_state.strict_refs = true;
-                                            changed = true;
-                                        }
-                                        "unicode_strings" => {
-                                            current_state.unicode_strings = true;
-                                            changed = true;
-                                        }
-                                        item if item.starts_with(':') => {
-                                            if let Some(version) =
-                                                parse_perl_version(item.trim_start_matches(':'))
-                                            {
-                                                if version >= PerlVersion::new(5, 12) {
-                                                    current_state.unicode_strings = true;
-                                                    changed = true;
-                                                }
-                                            }
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                            }
-
-                            if changed {
+                            if apply_feature_state(current_state, conditional_args, true) {
                                 ranges.push((
                                     node.location.start..node.location.end,
                                     current_state.clone(),

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -155,6 +155,28 @@ fn given_use_feature_qw_when_querying_state_then_requested_features_and_unicode_
 }
 
 #[test]
+fn given_use_if_feature_bundle_when_querying_state_then_bundle_features_are_recorded() {
+    let ast = program(vec![use_node("if", &["$]", ">=", "5.036", "feature", "':5.36'"], 0, 44)]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 20);
+    assert!(state.has_feature("say"));
+    assert!(state.has_feature("signatures"));
+    assert!(state.has_feature("isa"));
+}
+
+#[test]
+fn given_use_feature_signatures_when_querying_state_then_effective_strict_modes_are_enabled() {
+    let ast = program(vec![use_node("feature", &["'signatures'"], 0, 24)]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 12);
+    assert!(state.strict_vars);
+    assert!(state.strict_subs);
+    assert!(state.strict_refs);
+}
+
+#[test]
 fn given_use_v5_38_when_querying_state_then_switch_feature_is_not_available_but_modern_features_are()
  {
     let ast = program(vec![use_node("v5.38", &[], 0, 10)]);


### PR DESCRIPTION
### Motivation
- Conditional `use if/unless ... feature ...` paths only partially applied feature semantics resulting in missing bundle/features in some scopes.
- `signatures_strict` implied strictness in `PragmaState` but `PragmaTracker::state_for_offset` did not expose the effective strict flags to callers.
- Add BDD coverage for both conditional feature bundles and signatures-implied strictness to prevent regressions.

### Description
- Route conditional `use if/unless ... feature ...` handling through `apply_feature_state` so conditional feature bundles and explicit features are applied consistently with ordinary `use feature` semantics (changes in `crates/perl-pragma/src/lib.rs`).
- Make `PragmaTracker::state_for_offset` return an effective `PragmaState` that sets `strict_vars`, `strict_subs`, and `strict_refs` when `signatures_strict` is active so callers see signatures-implied strictness (changes in `crates/perl-pragma/src/lib.rs`).
- Add BDD tests covering `use if ... feature ':5.36'` and that `use feature 'signatures'` produces effective strictness observed via `state_for_offset` (added tests in `crates/perl-pragma/tests/behavior_spec_tests.rs`).

### Testing
- Ran `cargo xtask fmt` to format the workspace and it completed successfully.
- Ran `cargo test -p perl-pragma` which executed behavior and unit tests and passed: behavior tests ran (18 passed) and comprehensive unit tests ran (97 passed); overall test-suite passed with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e999c7ca208333914b39e3f9ab4ce1)