### PR TITLE
fix(lsp): ignore ranged didChange for unopened documents (#4971)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -395,6 +395,17 @@ impl LspServer {
                 // Get current document state or create new one
                 let mut documents = self.documents.lock();
                 let normalized_uri = self.normalize_uri_key(uri);
+                let existing_doc =
+                    documents.get(&normalized_uri).or_else(|| documents.get(uri)).cloned();
+
+                // LSP requires didChange only for opened documents. If we don't
+                // have a document and receive ranged edits, applying them against
+                // an empty buffer can corrupt state. Ignore this notification and
+                // wait for didOpen (or a full-document replace change).
+                if existing_doc.is_none() && changes.iter().all(|c| c.get("range").is_some()) {
+                    tracing::warn!("Ignoring ranged didChange for unopened document {}", uri);
+                    return Ok(());
+                }
 
                 // Invalidate the SemanticAnalyzer cache for this URI — content is changing.
                 {
@@ -416,25 +427,21 @@ impl LspServer {
                     }
                 }
 
-                let mut doc_state = documents
-                    .get(&normalized_uri)
-                    .or_else(|| documents.get(uri))
-                    .cloned()
-                    .unwrap_or_else(|| DocumentState {
-                        rope: ropey::Rope::new(),
-                        text: String::new(),
-                        version,
-                        ast: None,
-                        parse_errors: vec![],
-                        parent_map: ParentMap::default(),
-                        line_starts: LineStartsCache::new(""),
-                        generation: Arc::new(AtomicU32::new(0)),
-                        degradation_tier: DegradationTier::Minimal,
-                        #[cfg(feature = "incremental")]
-                        incremental_doc: None,
-                        #[cfg(feature = "incremental")]
-                        incremental_state: None,
-                    });
+                let mut doc_state = existing_doc.unwrap_or_else(|| DocumentState {
+                    rope: ropey::Rope::new(),
+                    text: String::new(),
+                    version,
+                    ast: None,
+                    parse_errors: vec![],
+                    parent_map: ParentMap::default(),
+                    line_starts: LineStartsCache::new(""),
+                    generation: Arc::new(AtomicU32::new(0)),
+                    degradation_tier: DegradationTier::Minimal,
+                    #[cfg(feature = "incremental")]
+                    incremental_doc: None,
+                    #[cfg(feature = "incremental")]
+                    incremental_state: None,
+                });
 
                 // Increment generation counter for this change
                 let next_gen = doc_state.generation.fetch_add(1, Ordering::SeqCst).wrapping_add(1);
@@ -1296,6 +1303,28 @@ mod tests {
             doc.incremental_doc.is_some(),
             "incremental_doc must be present after no-op change"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_did_change_ranged_edit_ignored_for_unopened_document()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let uri = "file:///not-opened.pl";
+
+        server.handle_did_change(Some(json!({
+            "textDocument": { "uri": uri, "version": 1 },
+            "contentChanges": [{
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end":   { "line": 0, "character": 0 }
+                },
+                "text": "my $x = 1;\n"
+            }]
+        })))?;
+
+        let docs = server.documents.lock();
+        assert!(docs.get(uri).is_none(), "ranged didChange for unopened docs must be ignored");
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation
- Some LSP clients send ranged `textDocument/didChange` notifications before `didOpen`, and applying ranged edits against an unopened (empty) buffer can corrupt server document state. 

### Description
- Pre-fetch existing document state into `existing_doc` from `self.documents` and reuse it to avoid duplicate map lookups. 
- If no existing document exists and all `contentChanges` are ranged edits, log a warning and ignore the notification (`return Ok(())`) to wait for `didOpen` or a full-document replace. 
- Replace the prior `get(...).cloned().unwrap_or_else(...)` pattern with `existing_doc.unwrap_or_else(...)` for cleaner initialization. 
- Add a regression test `test_did_change_ranged_edit_ignored_for_unopened_document` to verify a ranged `didChange` for an unopened URI is ignored and does not create document state. 

### Testing
- Ran formatting via `cargo xtask fmt`, which completed successfully. 
- Ran static check `git diff --check`, which completed successfully. 
- Added unit test `test_did_change_ranged_edit_ignored_for_unopened_document`; an attempt to run `cargo test -p perl-lsp-rs test_did_change_ranged_edit_ignored_for_unopened_document` in this environment was blocked by a Cargo build-lock so the test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a75124d0833389d57daae6ac1c08)