### PR TITLE
test(features): lock LSP feature receipts into BDD grid (#4971)

### DIFF
--- a/crates/perl-lsp-rs-core/src/features/contracts.rs
+++ b/crates/perl-lsp-rs-core/src/features/contracts.rs
@@ -200,6 +200,15 @@ pub fn compliance_percent_for_grid() -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::{Path, PathBuf};
+
+    fn repo_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf())
+    }
 
     // ── FeatureProfileKind ──────────────────────────────────────────
 
@@ -369,6 +378,47 @@ mod tests {
     #[test]
     fn bdd_feature_rows_count_matches_all_features() {
         assert_eq!(bdd_feature_rows().len(), all_features().len());
+    }
+
+    #[test]
+    fn lsp_features_have_bdd_test_receipts() {
+        for feature in all_features().iter().filter(|feature| feature.id.starts_with("lsp.")) {
+            assert!(
+                !feature.tests.is_empty(),
+                "LSP feature '{}' must include at least one test receipt for BDD grid reporting",
+                feature.id
+            );
+        }
+    }
+
+    #[test]
+    fn lsp_feature_test_receipts_exist_in_repo() {
+        let root = repo_root();
+        for feature in all_features().iter().filter(|feature| feature.id.starts_with("lsp.")) {
+            for test_path in feature.tests {
+                let exists = root.join(test_path).exists();
+                assert!(
+                    exists,
+                    "feature '{}' references missing test receipt path '{}'",
+                    feature.id, test_path
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn bdd_rows_preserve_lsp_test_receipts() {
+        for row in bdd_feature_rows().iter().filter(|row| row.id.starts_with("lsp.")) {
+            let source = all_features().iter().find(|feature| feature.id == row.id);
+            assert!(source.is_some(), "BDD row '{}' should map back to a catalog feature", row.id);
+            if let Some(source) = source {
+                assert_eq!(
+                    row.tests, source.tests,
+                    "BDD row '{}' should preserve test receipts from catalog entry",
+                    row.id
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/perl-lsp-rs/features_sot.toml
+++ b/crates/perl-lsp-rs/features_sot.toml
@@ -231,7 +231,7 @@ spec = "perl-lsp"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs"]
+tests = ["crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs"]
 description = "Missing 'use strict' pragma diagnostic (PL100) — warns when .pm/.pl files lack strict enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
 
 [[feature]]
@@ -240,7 +240,7 @@ spec = "perl-lsp"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs"]
+tests = ["crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs"]
 description = "Missing 'use warnings' pragma diagnostic (PL101) — warns when .pm/.pl files lack warnings enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
 
 [[feature]]
@@ -250,8 +250,8 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 tests = [
-  "crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs",
-  "crates/perl-lsp-code-actions/src/code_actions.rs",
+  "crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs",
+  "crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs",
 ]
 description = "Phase-scoped pragma misconception diagnostics (PL502/PL503) — warns when `use strict` or `use warnings` appears only inside BEGIN/END/INIT/CHECK/UNITCHECK and offers a quick fix to move it to file scope"
 
@@ -261,7 +261,7 @@ spec = "perl-lsp"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-diagnostics/tests/unreachable_code_tests.rs"]
+tests = ["crates/perl-lsp-rs-core/tests/unreachable_code_continue_tests.rs"]
 description = "Unreachable code highlighting (PL406) with DiagnosticTag::Unnecessary — detects code after return/die/exit/croak statements"
 
 [[feature]]

--- a/features.toml
+++ b/features.toml
@@ -231,7 +231,7 @@ spec = "perl-lsp"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs"]
+tests = ["crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs"]
 description = "Missing 'use strict' pragma diagnostic (PL100) — warns when .pm/.pl files lack strict enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
 
 [[feature]]
@@ -240,7 +240,7 @@ spec = "perl-lsp"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs"]
+tests = ["crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs"]
 description = "Missing 'use warnings' pragma diagnostic (PL101) — warns when .pm/.pl files lack warnings enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
 
 [[feature]]
@@ -250,8 +250,8 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 tests = [
-  "crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs",
-  "crates/perl-lsp-code-actions/src/code_actions.rs",
+  "crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs",
+  "crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs",
 ]
 description = "Phase-scoped pragma misconception diagnostics (PL502/PL503) — warns when `use strict` or `use warnings` appears only inside BEGIN/END/INIT/CHECK/UNITCHECK and offers a quick fix to move it to file scope"
 
@@ -261,7 +261,7 @@ spec = "perl-lsp"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-diagnostics/tests/unreachable_code_tests.rs"]
+tests = ["crates/perl-lsp-rs-core/tests/unreachable_code_continue_tests.rs"]
 description = "Unreachable code highlighting (PL406) with DiagnosticTag::Unnecessary — detects code after return/die/exit/croak statements"
 
 [[feature]]


### PR DESCRIPTION
### Motivation
- Prevent drift between the feature catalog and the BDD grid by ensuring every `lsp.*` capability has concrete test receipts and that those receipts actually exist in the repo.
- Surface stale paths quickly after crate absorption so the BDD grid and runtime `features_sot` remain accurate and actionable.

### Description
- Added BDD-grid contract tests in `crates/perl-lsp-rs-core/src/features/contracts.rs` that assert every `lsp.*` feature has at least one `tests` receipt, that each referenced path exists in the repository, and that `bdd_feature_rows()` preserves the same `tests` list as the catalog entry.
- Introduced a `repo_root()` helper to resolve repository-relative test paths for the new assertions.
- Updated the canonical `features.toml` and the runtime copy `crates/perl-lsp-rs/features_sot.toml` to point diagnostic-related test receipts to the absorbed `perl-lsp-rs-core` locations (strict/warnings, phase-scoped pragma, unreachable-code tests).
- Committed the changes and aligned `features_sot.toml` to keep the runtime copy consistent with the catalog.

### Testing
- Ran `cargo xtask fmt` to format changes and it completed successfully.
- Executed `cargo test -p perl-lsp-rs-core lsp_feature_test_receipts_exist_in_repo -- --nocapture` and the test passed.
- Executed `cargo test -p perl-lsp-rs-core lsp_features_have_bdd_test_receipts -- --nocapture` and `cargo test -p perl-lsp-rs-core bdd_rows_preserve_lsp_test_receipts -- --nocapture`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a75d8214833391bad6ef3122e5e6)