### PR TITLE
test(features): lock lsp ids into bdd grid invariants (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/features/contracts.rs
+++ b/crates/perl-lsp-rs-core/src/features/contracts.rs
@@ -169,6 +169,13 @@ pub fn bdd_feature_rows() -> Vec<BddFeatureRow> {
     rows
 }
 
+/// Export LSP-only BDD rows for tools that need to ignore DAP/extension entries.
+///
+/// This keeps the lock between `features.toml` LSP rows and the BDD matrix explicit.
+pub fn lsp_bdd_feature_rows() -> Vec<BddFeatureRow> {
+    bdd_feature_rows().into_iter().filter(|row| row.id.starts_with("lsp.")).collect()
+}
+
 /// Number of BDD rows that participate in coverage accounting.
 pub fn trackable_feature_count_for_grid() -> usize {
     all_features()
@@ -369,6 +376,37 @@ mod tests {
     #[test]
     fn bdd_feature_rows_count_matches_all_features() {
         assert_eq!(bdd_feature_rows().len(), all_features().len());
+    }
+
+    #[test]
+    fn lsp_bdd_feature_rows_only_include_lsp_ids() {
+        let rows = lsp_bdd_feature_rows();
+        assert!(!rows.is_empty(), "expected non-empty LSP rows");
+        assert!(rows.iter().all(|row| row.id.starts_with("lsp.")));
+    }
+
+    #[test]
+    fn lsp_bdd_feature_rows_cover_all_lsp_features() {
+        let expected =
+            all_features().iter().filter(|feature| feature.id.starts_with("lsp.")).count();
+        assert_eq!(lsp_bdd_feature_rows().len(), expected);
+    }
+
+    #[test]
+    fn lsp_bdd_feature_rows_sorted_by_area_then_id() {
+        let rows = lsp_bdd_feature_rows();
+        for pair in rows.windows(2) {
+            let lhs = &pair[0];
+            let rhs = &pair[1];
+            assert!(
+                lhs.area < rhs.area || (lhs.area == rhs.area && lhs.id <= rhs.id),
+                "rows are not sorted: ({}, {}) then ({}, {})",
+                lhs.area,
+                lhs.id,
+                rhs.area,
+                rhs.id
+            );
+        }
     }
 
     #[test]

--- a/crates/perl-lsp-rs-core/src/features/grid.rs
+++ b/crates/perl-lsp-rs-core/src/features/grid.rs
@@ -9,7 +9,7 @@
 pub use crate::features::contracts::{
     BddFeatureRow, Feature, FeatureProfileSpec, LSP_VERSION, VERSION, advertised_features,
     all_features, bdd_feature_rows, catalog, compliance_percent, compliance_percent_for_grid,
-    feature_profile_specs, has_feature, trackable_feature_count_for_grid,
+    feature_profile_specs, has_feature, lsp_bdd_feature_rows, trackable_feature_count_for_grid,
 };
 pub use crate::features::policy::{FeatureProfile, catalog_advertised_feature_ids};
 
@@ -396,6 +396,28 @@ mod tests {
         let value: serde_json::Value = must(serde_json::from_str(&payload));
         assert_eq!(value["profile"].as_str(), Some("production"));
         assert!(value.get("feature_count").is_some());
+    }
+
+    #[test]
+    fn bdd_grid_rows_cover_all_lsp_rows() {
+        let payload = to_json();
+        let value: serde_json::Value = must(serde_json::from_str(&payload));
+        let rows = must_some(
+            value
+                .get("feature_grid")
+                .and_then(|grid| grid.get("rows"))
+                .and_then(|rows| rows.as_array()),
+        );
+
+        let payload_lsp_ids: std::collections::BTreeSet<&str> = rows
+            .iter()
+            .filter_map(|row| row.get("id").and_then(|id| id.as_str()))
+            .filter(|id| id.starts_with("lsp."))
+            .collect();
+        let contract_lsp_ids: std::collections::BTreeSet<&str> =
+            super::lsp_bdd_feature_rows().into_iter().map(|row| row.id).collect();
+
+        assert_eq!(payload_lsp_ids, contract_lsp_ids);
     }
 
     // ── Default to_json has no profile key ───────────────────────────


### PR DESCRIPTION
### Motivation

- Ensure the BDD feature grid emitted by the runtime is tightly locked to the LSP-only rows declared in the feature catalog so tooling and reports cannot drift when DAP/extension entries are present.

### Description

- Add `lsp_bdd_feature_rows()` in `crates/perl-lsp-rs-core/src/features/contracts.rs` to expose an explicit LSP-only view of BDD rows (filters `id` by `lsp.`).
- Re-export `lsp_bdd_feature_rows()` from `features::grid` (`crates/perl-lsp-rs-core/src/features/grid.rs`) so downstream callers use the same canonical helper.
- Add contract tests in `contracts.rs` that assert LSP-only rows are non-empty, all IDs start with `lsp.`, row count matches catalog LSP features, and ordering is stable by `(area, id)`.
- Add a grid payload invariant test in `grid.rs` that validates the JSON `feature_grid.rows` LSP IDs exactly match `lsp_bdd_feature_rows()`.

### Testing

- Ran formatting with `cargo xtask fmt` (succeeded).
- Executed `cargo test -p perl-lsp-rs-core lsp_bdd_feature_rows_cover_all_lsp_features` (passed).
- Executed `cargo test -p perl-lsp-rs-core bdd_grid_rows_cover_all_lsp_rows` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a75d8214833391bad6ef3122e5e6)