### PR TITLE
fix(feature-grid): lock LSP rows in BDD payload (#4982)

### DIFF
--- a/crates/perl-lsp-rs-core/src/features/contracts.rs
+++ b/crates/perl-lsp-rs-core/src/features/contracts.rs
@@ -169,6 +169,11 @@ pub fn bdd_feature_rows() -> Vec<BddFeatureRow> {
     rows
 }
 
+/// Export only `lsp.*` feature rows for BDD matrices focused on LSP capabilities.
+pub fn lsp_bdd_feature_rows() -> Vec<BddFeatureRow> {
+    bdd_feature_rows().into_iter().filter(|row| row.id.starts_with("lsp.")).collect()
+}
+
 /// Number of BDD rows that participate in coverage accounting.
 pub fn trackable_feature_count_for_grid() -> usize {
     all_features()
@@ -419,6 +424,13 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn lsp_bdd_feature_rows_only_include_lsp_ids() {
+        let rows = lsp_bdd_feature_rows();
+        assert!(!rows.is_empty(), "expected at least one lsp.* feature row");
+        assert!(rows.iter().all(|row| row.id.starts_with("lsp.")));
     }
 
     #[test]

--- a/crates/perl-lsp-rs-core/src/features/grid.rs
+++ b/crates/perl-lsp-rs-core/src/features/grid.rs
@@ -9,7 +9,7 @@
 pub use crate::features::contracts::{
     BddFeatureRow, Feature, FeatureProfileSpec, LSP_VERSION, VERSION, advertised_features,
     all_features, bdd_feature_rows, catalog, compliance_percent, compliance_percent_for_grid,
-    feature_profile_specs, has_feature, trackable_feature_count_for_grid,
+    feature_profile_specs, has_feature, lsp_bdd_feature_rows, trackable_feature_count_for_grid,
 };
 pub use crate::features::policy::{FeatureProfile, catalog_advertised_feature_ids};
 
@@ -146,8 +146,13 @@ fn feature_grid_payload(
             "columns": FEATURE_GRID_COLUMNS,
             "rows": bdd_feature_rows(),
         },
+        "lsp_feature_grid": {
+            "columns": FEATURE_GRID_COLUMNS,
+            "rows": lsp_bdd_feature_rows(),
+        },
         "profiles": profile_summaries,
         "feature_count": all_features().len(),
+        "lsp_feature_count": lsp_bdd_feature_rows().len(),
     });
 
     if let Some(profile) = selected_profile {
@@ -195,10 +200,13 @@ mod tests {
         assert!(value.get("lsp_version").is_some());
         assert!(value.get("compliance_percent").is_some());
         assert!(value.get("feature_grid").is_some());
+        assert!(value.get("lsp_feature_grid").is_some());
         assert!(value.get("feature_profiles").is_some());
         assert!(value.get("profiles").is_some());
         assert!(value["feature_grid"].get("columns").is_some());
         assert!(value["feature_grid"].get("rows").is_some());
+        assert!(value["lsp_feature_grid"].get("columns").is_some());
+        assert!(value["lsp_feature_grid"].get("rows").is_some());
         let profiles = must_some(value.get("profiles").and_then(|profiles| profiles.as_array()));
         assert!(!profiles.is_empty());
         let rows = must_some(
@@ -208,6 +216,16 @@ mod tests {
                 .and_then(|rows| rows.as_array()),
         );
         assert!(!rows.is_empty());
+        let lsp_rows = must_some(
+            value
+                .get("lsp_feature_grid")
+                .and_then(|grid| grid.get("rows"))
+                .and_then(|rows| rows.as_array()),
+        );
+        assert!(!lsp_rows.is_empty());
+        assert!(lsp_rows.iter().all(|row| {
+            row.get("id").and_then(|id| id.as_str()).is_some_and(|id| id.starts_with("lsp."))
+        }));
     }
 
     #[test]
@@ -396,6 +414,15 @@ mod tests {
         let value: serde_json::Value = must(serde_json::from_str(&payload));
         assert_eq!(value["profile"].as_str(), Some("production"));
         assert!(value.get("feature_count").is_some());
+        let lsp_count = must_some(value.get("lsp_feature_count").and_then(|count| count.as_u64()));
+        let lsp_rows_len = must_some(
+            value
+                .get("lsp_feature_grid")
+                .and_then(|grid| grid.get("rows"))
+                .and_then(|rows| rows.as_array())
+                .map(|rows| rows.len() as u64),
+        );
+        assert_eq!(lsp_count, lsp_rows_len);
     }
 
     // ── Default to_json has no profile key ───────────────────────────


### PR DESCRIPTION
### Motivation
- Provide a stable, source-of-truth projection of only LSP capabilities for BDD/tooling so downstream consumers don't have to guess/filter the global catalog.
- Surface LSP-specific rows and a deterministic count in the JSON payload so BDD matrices and compliance reports can lock onto `lsp.*` features reliably.

### Description
- Added `lsp_bdd_feature_rows()` in `crates/perl-lsp-rs-core/src/features/contracts.rs` to emit a sorted projection that only includes `lsp.*` feature rows.
- Exported and used `lsp_bdd_feature_rows()` in `crates/perl-lsp-rs-core/src/features/grid.rs` and extended the payload with `lsp_feature_grid` (columns/rows) and `lsp_feature_count`.
- Added assertions to the feature-grid unit tests to verify `lsp_feature_grid` exists, contains only `lsp.*` IDs, and that `lsp_feature_count` matches the actual LSP row count.
- Ran formatting (`cargo xtask fmt`) and updated the canonical JSON payload generation to include the new LSP-focused fields.

### Testing
- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran `cargo test -p perl-lsp-rs-core lsp_bdd_feature_rows_only_include_lsp_ids` and the test passed.
- Ran `cargo test -p perl-lsp-rs-core payload_is_stable_for_default_catalog_json` and the test passed.
- Ran `cargo test -p perl-lsp-rs-core to_json_for_production_profile` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a75d8214833391bad6ef3122e5e6)