### PR TITLE
chore(feature-grid): lock LSP features to BDD coverage sources (#4971)

### DIFF
--- a/features.toml
+++ b/features.toml
@@ -24,7 +24,11 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/lsp_hover_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/lsp_hover_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+  "crates/perl-lsp-ux-tests/tests/ux_scenario_11_hover.rs",
+]
 description = "Hover information with POD markdown rendering, XS::Typemap integration, Moo/Moose attribute display (isa, is, required, predicate, builder, clearer), inherited method resolution across the class hierarchy, pragma documentation, special variable explanations, regex explainer, and file-test operator reference"
 
 [[feature]]
@@ -42,7 +46,11 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/lsp_definition_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/lsp_definition_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+  "crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs",
+]
 description = "Go to definition"
 
 [[feature]]
@@ -51,7 +59,11 @@ spec = "LSP 3.14"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/lsp_definition_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/lsp_definition_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+  "crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs",
+]
 description = "Go to declaration"
 
 [[feature]]
@@ -60,7 +72,10 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/lsp_references_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/lsp_references_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+]
 description = "Find references across workspace"
 
 [[feature]]
@@ -69,7 +84,11 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/lsp_symbols_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/lsp_symbols_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+  "crates/perl-lsp-ux-tests/tests/ux_scenario_13_document_symbols.rs",
+]
 description = "Document symbols with hierarchy"
 
 [[feature]]
@@ -87,7 +106,10 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/lsp_code_lens_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/lsp_code_lens_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+]
 description = "Code lens with reference counts"
 
 [[feature]]
@@ -96,7 +118,10 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/lsp_formatting_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/lsp_formatting_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+]
 description = "Document formatting with Perl::Tidy"
 
 [[feature]]
@@ -105,7 +130,10 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/lsp_formatting_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/lsp_formatting_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+]
 description = "Range formatting (single range)"
 
 [[feature]]
@@ -132,7 +160,10 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/lsp_rename_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/lsp_rename_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+]
 description = "Rename symbol across files"
 
 [[feature]]
@@ -168,7 +199,10 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/lsp_folding_ranges_test.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/lsp_folding_ranges_test.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+]
 description = "Folding ranges with fallback"
 
 [[feature]]
@@ -177,7 +211,10 @@ spec = "LSP 3.15"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/lsp_selection_range_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/lsp_selection_range_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+]
 description = "Smart selection expansion"
 
 [[feature]]
@@ -222,7 +259,11 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/pull_diagnostics_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/pull_diagnostics_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+  "crates/perl-lsp-ux-tests/tests/ux_scenario_12_diagnostics_strict.rs",
+]
 description = "Pull model diagnostics"
 
 [[feature]]
@@ -270,7 +311,11 @@ spec = "perl-lsp"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/pull_diagnostics_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/pull_diagnostics_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+  "crates/perl-lsp-ux-tests/tests/ux_scenario_12_diagnostics_strict.rs",
+]
 description = "Unused variable diagnostics (PL102) via scope analyzer — warns on declared-but-never-used variables, suppressed by underscore prefix"
 
 [[feature]]
@@ -344,7 +389,11 @@ spec = "LSP 3.17"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/pull_diagnostics_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/pull_diagnostics_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+  "crates/perl-lsp-ux-tests/tests/ux_scenario_12_diagnostics_strict.rs",
+]
 description = "Workspace-wide pull diagnostics"
 
 [[feature]]
@@ -847,7 +896,10 @@ spec = "LSP 3.12"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/lsp_rename_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/lsp_rename_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+]
 description = "Validate rename and compute placeholder/range"
 
 [[feature]]
@@ -894,7 +946,10 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["crates/perl-lsp-rs/tests/lsp_code_lens_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/lsp_code_lens_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+]
 description = "Resolve code lens command"
 
 [[feature]]
@@ -1035,7 +1090,11 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["crates/perl-lsp-rs/tests/pull_diagnostics_tests.rs"]
+tests = [
+  "crates/perl-lsp-rs/tests/pull_diagnostics_tests.rs",
+  "crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs",
+  "crates/perl-lsp-ux-tests/tests/ux_scenario_12_diagnostics_strict.rs",
+]
 description = "Push diagnostics via textDocument/publishDiagnostics"
 
 # Window / Telemetry


### PR DESCRIPTION
### Motivation

- Improve BDD-grid evidence traceability by making feature rows point to both focused protocol tests and higher-level behavior-driven scenarios.
- Ensure high-visibility LSP capabilities (hover, goto, document symbols, diagnostics) have UX scenario links so the governance grid reflects observable behavior.
- Tighten consistency across related features so feature-to-test mapping used by reporting and compliance is unambiguous.

### Description

- Expanded the `tests` arrays in `features.toml` for multiple LSP features to include `crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs` alongside their focused protocol test files.
- Added explicit UX scenario mappings for hover, go-to-definition, document symbols, and diagnostics by referencing `crates/perl-lsp-ux-tests/tests/...` scenario files in `features.toml`.
- Applied the same BDD-linkage pattern to resolve-route, diagnostics, and workspace rows so the catalog consistently points at both unit and BDD evidence sources.
- Change is limited to the feature catalog (`features.toml`) and does not modify runtime code or APIs.

### Testing

- Ran `cargo test -p perl-lsp-rs-core features::contracts::tests::bdd_feature_rows_count_matches_all_features -- --nocapture`, and the targeted test passed.
- The `test` profile completed and the invoked unit test reported `ok` (1 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a75d8214833391bad6ef3122e5e6)