### PR TITLE
test(runtime): strengthen outbound writer tests (#4971)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/outbound.rs
+++ b/crates/perl-lsp-rs/src/runtime/outbound.rs
@@ -186,3 +186,131 @@ fn serialize_message(msg: &OutboundMessage) -> Vec<u8> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::error::Error;
+    use std::io::Write;
+    use std::sync::Arc;
+
+    #[derive(Clone, Default)]
+    struct SharedBuffer {
+        inner: Arc<parking_lot::Mutex<Vec<u8>>>,
+    }
+
+    impl SharedBuffer {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn bytes(&self) -> Vec<u8> {
+            self.inner.lock().clone()
+        }
+    }
+
+    impl Write for SharedBuffer {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.inner.lock().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn parse_framed_payloads(raw: &[u8]) -> Result<Vec<serde_json::Value>, Box<dyn Error>> {
+        let mut cursor = 0usize;
+        let mut payloads = Vec::new();
+
+        while cursor < raw.len() {
+            let remainder = &raw[cursor..];
+            let separator = b"\r\n\r\n";
+            let Some(header_end) = remainder.windows(separator.len()).position(|w| w == separator)
+            else {
+                return Err("missing frame header separator".into());
+            };
+            let header_bytes = &remainder[..header_end];
+            let header = std::str::from_utf8(header_bytes)?;
+            let content_length = header
+                .lines()
+                .find_map(|line| line.strip_prefix("Content-Length: "))
+                .ok_or("missing Content-Length header")?
+                .parse::<usize>()?;
+
+            let body_start = cursor + header_end + separator.len();
+            let body_end = body_start + content_length;
+            if body_end > raw.len() {
+                return Err("framed body shorter than declared Content-Length".into());
+            }
+            let body = &raw[body_start..body_end];
+            payloads.push(serde_json::from_slice(body)?);
+            cursor = body_end;
+        }
+
+        Ok(payloads)
+    }
+
+    #[test]
+    fn closed_sender_returns_broken_pipe_for_all_message_types() {
+        let sender = closed_sender();
+        let response_result =
+            sender.send_response(JsonRpcResponse::success(Some(json!(1)), json!({})));
+        let notification_result = sender.send_notification("window/logMessage", json!({"x": 1}));
+        let request_result = sender.send_request(7, "workspace/configuration", json!({}));
+
+        for result in [response_result, notification_result, request_result] {
+            match result {
+                Ok(()) => panic!("expected BrokenPipe error when outbound channel is closed"),
+                Err(err) => assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe),
+            }
+        }
+    }
+
+    #[test]
+    fn spawn_writer_serializes_response_notification_and_request() -> Result<(), Box<dyn Error>> {
+        let buffer = SharedBuffer::new();
+        let (sender, handle) = spawn_writer(Box::new(buffer.clone()));
+
+        sender.send_response(JsonRpcResponse::success(Some(json!(11)), json!({"ok": true})))?;
+        sender.send_notification("window/logMessage", json!({"type": 3, "message": "hello"}))?;
+        sender.send_request(42, "workspace/configuration", json!({"items": []}))?;
+
+        drop(sender);
+        handle.join().map_err(|_| "writer thread panicked")?;
+
+        let payloads = parse_framed_payloads(&buffer.bytes())?;
+        assert_eq!(payloads.len(), 3);
+        assert_eq!(payloads[0]["id"], 11);
+        assert_eq!(payloads[0]["result"]["ok"], true);
+        assert_eq!(payloads[1]["method"], "window/logMessage");
+        assert_eq!(payloads[2]["id"], 42);
+        assert_eq!(payloads[2]["method"], "workspace/configuration");
+
+        Ok(())
+    }
+
+    #[test]
+    fn spawn_writer_shared_serializes_payloads() -> Result<(), Box<dyn Error>> {
+        let buffer = SharedBuffer::new();
+        let shared =
+            Arc::new(parking_lot::Mutex::new(Box::new(buffer.clone()) as Box<dyn Write + Send>));
+
+        let (sender, handle) = spawn_writer_shared(Arc::clone(&shared));
+        sender.send_notification("telemetry/event", json!({"name": "batch"}))?;
+        sender.send_request(9, "client/registerCapability", json!({"registrations": []}))?;
+
+        drop(sender);
+        handle.join().map_err(|_| "writer thread panicked")?;
+
+        let payloads = parse_framed_payloads(&buffer.bytes())?;
+        assert_eq!(payloads.len(), 2);
+        assert_eq!(payloads[0]["method"], "telemetry/event");
+        assert_eq!(payloads[1]["id"], 9);
+        assert_eq!(payloads[1]["method"], "client/registerCapability");
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Motivation

- The outbound writer is a critical JSON-RPC transport path with no focused unit coverage, which increases regression risk for framing/serialization and batching behavior. 

### Description

- Add a new test module to `crates/perl-lsp-rs/src/runtime/outbound.rs` that exercises writer code paths and framing. 
- Introduce `SharedBuffer` test helper that implements `Write` and captures written bytes for inspection. 
- Add `parse_framed_payloads` test helper to decode `Content-Length`-framed LSP payload batches. 
- Add three tests: verify `closed_sender()` returns `BrokenPipe` for response/notification/request; verify `spawn_writer()` emits framed JSON-RPC response/notification/request preserving `id`/`method`/`result`; verify `spawn_writer_shared()` emits framed payloads for the shared-writer variant. 

### Testing

- Ran `cargo xtask fmt` successfully. 
- Ran `cargo test -p perl-lsp-rs --lib outbound::tests -- --nocapture` and observed `3 passed; 0 failed` for the new outbound writer tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a7dba14c83338548cb6d898c924b)