### PR TITLE
fix(perl-regex): preserve named-capture pattern when char class contains ')' (#4971)

### DIFF
--- a/crates/perl-regex/src/lib.rs
+++ b/crates/perl-regex/src/lib.rs
@@ -389,6 +389,20 @@ impl RegexAnalyzer {
                                 i += 2;
                                 continue;
                             }
+                            if chars[i] == '[' {
+                                i += 1;
+                                while i < len {
+                                    if chars[i] == '\\' {
+                                        i += 2;
+                                    } else if chars[i] == ']' {
+                                        i += 1;
+                                        break;
+                                    } else {
+                                        i += 1;
+                                    }
+                                }
+                                continue;
+                            }
                             if chars[i] == '(' {
                                 depth += 1;
                             } else if chars[i] == ')' {

--- a/crates/perl-regex/tests/named_capture_tests.rs
+++ b/crates/perl-regex/tests/named_capture_tests.rs
@@ -107,6 +107,18 @@ fn test_capture_group_has_pattern_field() -> Result<(), Box<dyn std::error::Erro
     Ok(())
 }
 
+#[test]
+fn test_capture_pattern_with_char_class_containing_rparen() -> Result<(), Box<dyn std::error::Error>>
+{
+    // A closing paren inside [...] is literal and must not terminate the group pattern scan.
+    let captures = RegexAnalyzer::extract_named_captures(r"(?<tok>[^)]+)");
+    assert_eq!(captures.len(), 1);
+    assert_eq!(captures[0].name, "tok");
+    assert_eq!(captures[0].index, 1);
+    assert_eq!(captures[0].pattern, "[^)]+");
+    Ok(())
+}
+
 // ── CaptureGroup struct ──────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
### Motivation

- A named-capture extraction routine prematurely terminated the captured sub-pattern when a literal `)` appeared inside a character class, producing incorrect `pattern` text for captures like `(?<tok>[^)]+)`.
- Add a targeted regression test to lock behavior and ensure future changes do not reintroduce the bug.

### Description

- Added a regression test `test_capture_pattern_with_char_class_containing_rparen` in `crates/perl-regex/tests/named_capture_tests.rs` that asserts a named capture containing a `[^)]+` character class is extracted with the correct `pattern` value.
- Fixed `RegexAnalyzer::extract_named_captures` in `crates/perl-regex/src/lib.rs` to skip over `[...]` character classes while scanning the sub-pattern for the matching `)`, so a `)` inside a class does not prematurely end the capture scan.

### Testing

- Ran the targeted test with `cargo test -p perl-regex --test named_capture_tests test_capture_pattern_with_char_class_containing_rparen` and it passed.
- Ran the crate test suite with `cargo test -p perl-regex` and all tests passed.
- Ran repository formatting with `cargo xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a7edc0608333b55c3d055fa5fea3)