### PR TITLE
test(position-tracking): cover LSP URI fallback conversion (#4971)

### DIFF
--- a/crates/perl-position-tracking/src/wire.rs
+++ b/crates/perl-position-tracking/src/wire.rs
@@ -106,3 +106,39 @@ impl From<WireLocation> for lsp_types::Location {
         Self { uri, range: l.range.into() }
     }
 }
+
+#[cfg(all(test, feature = "lsp-compat"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_location_to_lsp_location_preserves_valid_uri() {
+        let wire_location = WireLocation::new(
+            "file:///tmp/example.pl".to_string(),
+            WireRange::new(WirePosition::new(1, 2), WirePosition::new(3, 4)),
+        );
+
+        let location: lsp_types::Location = wire_location.into();
+
+        assert_eq!(location.uri.as_str(), "file:///tmp/example.pl");
+        assert_eq!(location.range.start.line, 1);
+        assert_eq!(location.range.start.character, 2);
+        assert_eq!(location.range.end.line, 3);
+        assert_eq!(location.range.end.character, 4);
+    }
+
+    #[test]
+    fn wire_location_to_lsp_location_uses_fallback_for_invalid_uri() {
+        let wire_location = WireLocation::new(
+            "not a uri".to_string(),
+            WireRange::new(WirePosition::new(0, 0), WirePosition::new(0, 1)),
+        );
+
+        let location: lsp_types::Location = wire_location.into();
+
+        assert_ne!(location.uri.as_str(), "not a uri");
+        assert!(!location.uri.as_str().is_empty());
+        assert_eq!(location.range.start.line, 0);
+        assert_eq!(location.range.end.character, 1);
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure converting `WireLocation` to `lsp_types::Location` does not propagate invalid URIs and remains safe for LSP consumers.
- Add explicit tests for the fallback behavior and range preservation that were previously untested. 

### Description
- Added unit tests under `#[cfg(all(test, feature = "lsp-compat"))]` in `crates/perl-position-tracking/src/wire.rs` to exercise URI conversion. 
- Added `wire_location_to_lsp_location_preserves_valid_uri` to verify a valid `WireLocation.uri` is preserved when converted. 
- Added `wire_location_to_lsp_location_uses_fallback_for_invalid_uri` to verify invalid URIs are replaced by the safe `fallback_lsp_uri()` while the `WireRange` is preserved. 

### Testing
- Ran `cargo xtask fmt` which completed successfully. 
- Ran `cargo test -p perl-position-tracking --features lsp-compat wire_location_to_lsp_location` and both new tests passed (`2 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a7edc0608333b55c3d055fa5fea3)