### PR TITLE
test(perl-dap): cover truncation edge cases in renderer (#4971)

### DIFF
--- a/crates/perl-dap/src/variables/renderer.rs
+++ b/crates/perl-dap/src/variables/renderer.rs
@@ -625,6 +625,24 @@ mod tests {
     }
 
     #[test]
+    fn test_string_truncation_zero_max_length() {
+        let renderer = PerlVariableRenderer::new().with_max_string_length(0);
+        let value = PerlValue::Scalar("non-empty".to_string());
+        let rendered = renderer.render("$s", &value);
+
+        assert_eq!(rendered.value, "\"...\"");
+    }
+
+    #[test]
+    fn test_string_truncation_utf8_boundary_safety() {
+        let renderer = PerlVariableRenderer::new().with_max_string_length(1);
+        let value = PerlValue::Scalar("éclair".to_string());
+        let rendered = renderer.render("$s", &value);
+
+        assert_eq!(rendered.value, "\"...\"");
+    }
+
+    #[test]
     fn test_string_escaping() {
         let renderer = PerlVariableRenderer::new();
         let value = PerlValue::Scalar("line1\nline2\ttab".to_string());


### PR DESCRIPTION
### Motivation
- Add test coverage for uncovered truncation boundary behavior in the variable renderer so scalar previews cannot panic or produce invalid slices when `max_string_length` is zero or cuts through a UTF-8 multi-byte character.

### Description
- Add two unit tests to `crates/perl-dap/src/variables/renderer.rs`: `test_string_truncation_zero_max_length` (checks `max_string_length = 0` yields a safe `"..."` preview) and `test_string_truncation_utf8_boundary_safety` (checks truncation at a UTF-8 boundary for `"éclair"` with `max_string_length = 1`).

### Testing
- Ran `cargo test -p perl-dap test_string_truncation -- --nocapture` and observed the new tests `test_string_truncation_zero_max_length` and `test_string_truncation_utf8_boundary_safety` pass along with the existing truncation test, and ran `cargo xtask fmt` to format the workspace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a7edc0608333b55c3d055fa5fea3)