### PR TITLE
fix(lsp): satisfy clippy doc comment spacing (#4982)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/code_actions.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/code_actions.rs
@@ -126,7 +126,6 @@ impl FixAllRange {
 /// The resulting action lists every diagnostic associated with the accepted
 /// source actions so the client can clear them together once the aggregate
 /// is applied.
-
 fn quickfix_text_edits_for_uri<'a>(action: &'a Value, uri: &str) -> Option<Vec<&'a Value>> {
     if let Some(edits) = action
         .pointer("/edit/changes")


### PR DESCRIPTION
### Motivation

- Fix a `clippy::empty_line_after_doc_comments` lint that was failing under `-D warnings` in the LSP runtime docs to keep the crate clippy gate green.

### Description

- Remove the single empty line between the doc comment block and the `fn quickfix_text_edits_for_uri` declaration in `crates/perl-lsp-rs/src/runtime/language/code_actions.rs`.

### Testing

- Ran `cargo clippy -p perl-lsp-rs --lib -- -D warnings` (passes), `cargo clippy --workspace --all-targets -- -D warnings` (still reports unrelated benchmark lint failures in `crates/perl-incremental-parsing/benches/incremental_parsing_benchmarks.rs`), and invoked `python3 scripts/update-current-status.py --check` (which started but `xtask update-status --check` did not finish in this environment run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a7fbe3848333ba1857baa6f70da7)