### PR TITLE
refactor(parser): reduce rename edit grouping friction (#4982)

### DIFF
--- a/crates/perl-parser/src/ide/lsp_compat/rename.rs
+++ b/crates/perl-parser/src/ide/lsp_compat/rename.rs
@@ -337,8 +337,9 @@ impl RenameProvider {
                 new_text: new_name.to_string(),
             };
             
-            file_changes.entry(reference.uri.clone())
-                .or_insert_with(Vec::new)
+            file_changes
+                .entry(reference.uri.clone())
+                .or_default()
                 .push(text_edit);
         }
         


### PR DESCRIPTION
### Motivation
- Simplify and align grouping of `TextEdit`s by file in the rename workspace edit helper to repository coding guidance without changing behavior.

### Description
- Replace `or_insert_with(Vec::new)` with `or_default()` in `create_workspace_edit` in `crates/perl-parser/src/ide/lsp_compat/rename.rs` to reduce verbosity and improve idiomatic usage.

### Testing
- Ran `cargo xtask fmt` and `cargo test -p perl-parser lsp_compat::rename`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9adef931c8333ac8a1d51e7fe2120)