### PR TITLE
fix(ci-hygiene): gate test-only TODO helpers behind cfg(test) (#4982)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3854,6 +3854,7 @@ fn collect_todo_hits(
     Ok(hits)
 }
 
+#[cfg(test)]
 fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
     let mut raw_string_state = None;
     let mut in_block_comment = false;
@@ -3865,6 +3866,7 @@ fn has_unlinked_todo_in_rust_line(line: &str, token_re: &Regex) -> bool {
     )
 }
 
+#[cfg(test)]
 fn has_unlinked_todo_in_rust_line_with_block_context(
     line: &str,
     token_re: &Regex,
@@ -3879,6 +3881,7 @@ fn has_unlinked_todo_in_rust_line_with_block_context(
     )
 }
 
+#[cfg(test)]
 fn has_unlinked_todo_in_rust_line_with_state(
     line: &str,
     token_re: &Regex,


### PR DESCRIPTION
### Motivation
- Reduce developer friction from dead-code warnings during normal `cargo check` runs by hiding helper wrappers that are only used by unit tests.

### Description
- Added `#[cfg(test)]` to the three TODO-detection helper wrappers `has_unlinked_todo_in_rust_line`, `has_unlinked_todo_in_rust_line_with_block_context`, and `has_unlinked_todo_in_rust_line_with_state` in `crates/perl-ci-hygiene/src/main.rs` so they are compiled only for tests.

### Testing
- Ran `cargo test -q -p perl-ci-hygiene` which completed successfully with `47 passed; 0 failed`.
- Ran `cargo check -q` which completed successfully with no warnings related to these helpers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9adef931c8333ac8a1d51e7fe2120)