### PR TITLE
docs(commands): add `just` prerequisite and Cargo fallbacks (#4982)

### DIFF
--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -12,6 +12,27 @@ just status-check
 just release-check
 ```
 
+## Tooling Prerequisites
+
+`just` is required for the short command forms used throughout this repository.
+
+```bash
+# Install just (https://github.com/casey/just)
+cargo install just
+```
+
+If you are in a constrained environment where `just` is unavailable, you can still
+run the equivalent core checks directly with Cargo:
+
+```bash
+# Fast local validation fallback
+cargo xtask fmt
+cargo test --workspace --lib
+
+# Broader validation fallback
+cargo test --workspace
+```
+
 ## Installation Commands
 
 ### LSP Server


### PR DESCRIPTION
### Motivation

- Reduce first-run setup friction when `just` is not installed in clean or constrained environments by making the prerequisite explicit.
- Provide direct `cargo` fallbacks so contributors can run core validation without `just`.

### Description

- Add a `Tooling Prerequisites` section to `docs/reference/COMMANDS_REFERENCE.md` that documents installing `just` via `cargo install just`.
- Add explicit fallback commands including `cargo xtask fmt`, `cargo test --workspace --lib`, and `cargo test --workspace` for environments where `just` is unavailable.

### Testing

- Ran `git diff --check` which passed.
- Ran `cargo test -p perl-ci-hygiene --no-run -q` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9adef931c8333ac8a1d51e7fe2120)