### PR TITLE
ci: coalesce-queue-tail pattern — preflight-latest-check instead of cancel-in-progress (#4938)

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -21,10 +21,12 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
-# Cancel in-flight runs on new pushes (saves minutes)
+# Coalesce-queue-tail: let the running CI complete; skip superseded SHAs at a
+# preflight gate instead of cancelling in-flight work mid-run.
+# Note: scheduled runs always pass the preflight gate (no SHA comparison).
 concurrency:
   group: ci-security-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -34,6 +36,36 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # ── Preflight: skip superseded SHAs to save cost ─────────────────────
+  preflight-latest-check:
+    name: Preflight — is this SHA latest?
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      is_latest: ${{ steps.check.outputs.is_latest }}
+    steps:
+      - name: Check if this SHA is latest on the ref
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Scheduled and manual runs always pass through — no SHA to compare.
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Scheduled/manual run — always passing preflight"
+            exit 0
+          fi
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          CURRENT="${{ github.event.pull_request.head.sha || github.sha }}"
+          LATEST=$(git ls-remote "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" "refs/heads/${BRANCH}" | awk '{print $1}')
+          if [ -z "$LATEST" ] || [ "$LATEST" = "$CURRENT" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::This SHA ($CURRENT) is latest on $BRANCH — running full CI"
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Superseded by $LATEST — skipping remaining jobs to save cost"
+          fi
+
   # ============================================================================
   # Rust Security Audits
   # ============================================================================
@@ -42,6 +74,8 @@ jobs:
     name: Cargo Audit (RustSec)
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    needs: preflight-latest-check
+    if: needs.preflight-latest-check.outputs.is_latest == 'true'
     permissions:
       contents: read
       security-events: write
@@ -94,6 +128,8 @@ jobs:
     name: Cargo Deny (Policy Enforcement)
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    needs: preflight-latest-check
+    if: needs.preflight-latest-check.outputs.is_latest == 'true'
     permissions:
       contents: read
 
@@ -127,6 +163,8 @@ jobs:
     name: Trivy Repository Scan
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    needs: preflight-latest-check
+    if: needs.preflight-latest-check.outputs.is_latest == 'true'
     permissions:
       contents: read
       security-events: write
@@ -183,7 +221,8 @@ jobs:
     name: Trivy Docker Image Scan
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: preflight-latest-check
+    if: (needs.preflight-latest-check.outputs.is_latest == 'true') && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,11 @@ on:
     branches: [ main, master ]
   workflow_dispatch: {}
 
-# Cancel in-flight runs on new pushes (saves minutes)
+# Coalesce-queue-tail: let the running CI complete; skip superseded SHAs at a
+# preflight gate instead of cancelling in-flight work mid-run.
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -28,11 +29,37 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  # ── Preflight: skip superseded SHAs to save cost ─────────────────────
+  preflight-latest-check:
+    name: Preflight — is this SHA latest?
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      is_latest: ${{ steps.check.outputs.is_latest }}
+    steps:
+      - name: Check if this SHA is latest on the ref
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          CURRENT="${{ github.event.pull_request.head.sha || github.sha }}"
+          LATEST=$(git ls-remote "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" "refs/heads/${BRANCH}" | awk '{print $1}')
+          if [ -z "$LATEST" ] || [ "$LATEST" = "$CURRENT" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::This SHA ($CURRENT) is latest on $BRANCH — running full CI"
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Superseded by $LATEST — skipping remaining jobs to save cost"
+          fi
+
   # ── PR Smoke: fast feedback for every PR (~1-2 min) ──────────────────
   pr-smoke:
     name: PR Smoke (Fast Feedback)
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    needs: preflight-latest-check
+    if: needs.preflight-latest-check.outputs.is_latest == 'true'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -70,10 +97,11 @@ jobs:
     name: CI Gate (Merge-Blocking)
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: pr-smoke
+    needs: [pr-smoke, preflight-latest-check]
+    if: needs.preflight-latest-check.outputs.is_latest == 'true'
     # Run on every PR push and on push to main/master
     # Earlier gating > label-gated gating (see #4675)
-    # Frequent commits will churn CI; concurrency group cancels in-flight runs.
+    # Frequent commits will queue; preflight skips superseded SHAs.
     steps:
       - uses: actions/checkout@v6
         with:
@@ -209,7 +237,8 @@ jobs:
     name: UX Regression Tests
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    needs: pr-smoke
+    needs: [pr-smoke, preflight-latest-check]
+    if: needs.preflight-latest-check.outputs.is_latest == 'true'
     # Run on every PR push — this is the regression prevention gate.
     steps:
       - uses: actions/checkout@v6

--- a/crates/perl-lsp-rs/src/runtime/language/misc.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/misc.rs
@@ -1233,5 +1233,4 @@ mod tests {
             "inlay_hint_resolve_support must remain None when client sends no resolveSupport"
         );
     }
-
 }


### PR DESCRIPTION
## Summary

Replaces `cancel-in-progress: true` with the **coalesce-queue-tail pattern** across `ci.yml` and `ci-security.yml`.

### The three CI cancellation modes

| Mode | Behaviour | Problem |
|------|-----------|---------|
| `cancel-in-progress: true` | Kill running job when new push arrives | Wastes work already in-flight; noisy failures for the cancelled SHA |
| `cancel-in-progress: false` (naive) | Queue all runs; nothing is skipped | Costs money on every intermediate push; long queue depth |
| **Coalesce-queue-tail** (this PR) | Queue runs; skip superseded SHAs at a lightweight preflight gate | Running job completes; only the latest SHA does full work |

### Changes

**`ci.yml`** — 3 changes:
1. `cancel-in-progress: true` → `false`
2. New `preflight-latest-check` job (first in `jobs:`, 2-min timeout) — calls `git ls-remote` to compare the current SHA against HEAD on the branch
3. `pr-smoke`, `merge-gate`, `ux-tests` all gain `needs: preflight-latest-check` + `if: needs.preflight-latest-check.outputs.is_latest == 'true'`

**`ci-security.yml`** — same three changes, with one extra guard: scheduled (`cron`) and `workflow_dispatch` runs short-circuit to `is_latest=true` before the git ls-remote check, so nightly security scans are never accidentally skipped.

### Guardrails respected

- No job bodies changed — only `needs:` / `if:` gates added
- Nightly workflows (`ci-nightly.yml`) untouched
- Concurrency group keys unchanged — per-ref isolation preserved
- YAML parses: `python3 -c "import yaml; yaml.safe_load(open(...))"` — OK for both files

Closes #4938