### PR TITLE
test(lsp): remove unsafe request-id static from golden test harness (#4982)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_golden_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_golden_tests.rs
@@ -7,6 +7,7 @@ mod support;
 use serde_json::{Value, json};
 use std::fs;
 use std::path::Path;
+use std::sync::atomic::{AtomicI32, Ordering};
 use support::test_helpers::{
     assert_completion_has_items, assert_folding_ranges_valid, assert_hover_has_text,
 };
@@ -28,6 +29,7 @@ struct TestContext {
 
 /// Compile-time path to the perl-lsp binary, set by Cargo when building integration tests.
 const CARGO_BIN_EXE: Option<&str> = option_env!("CARGO_BIN_EXE_perl-lsp");
+static REQUEST_ID: AtomicI32 = AtomicI32::new(1);
 
 impl TestContext {
     /// Find the perl-lsp binary using multiple resolution strategies
@@ -126,12 +128,7 @@ impl TestContext {
     ) -> Result<Option<Value>, Box<dyn std::error::Error>> {
         use std::io::{BufRead, Read, Write};
 
-        static mut REQUEST_ID: i32 = 1;
-        let id = unsafe {
-            let current = REQUEST_ID;
-            REQUEST_ID += 1;
-            current
-        };
+        let id = REQUEST_ID.fetch_add(1, Ordering::Relaxed);
 
         let request = json!({
             "jsonrpc": "2.0",


### PR DESCRIPTION
### Motivation
- Remove an `unsafe` global counter used by the LSP golden test harness to eliminate undefined behavior, reduce clippy noise, and make the test harness thread-friendly to lower developer friction.

### Description
- Replace the `static mut REQUEST_ID` pattern with `static REQUEST_ID: AtomicI32 = AtomicI32::new(1)` and use `REQUEST_ID.fetch_add(1, Ordering::Relaxed)` in `crates/perl-lsp-rs/tests/lsp_golden_tests.rs` to allocate request ids without `unsafe`.

### Testing
- Ran `cargo fmt --all` and it succeeded.
- Ran `cargo test -p perl-lsp-rs --test lsp_golden_tests --no-run` and it completed successfully.
- Ran `cargo test -p perl-lsp-rs --test lsp_golden_tests -- --list` which listed the tests and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9adef931c8333ac8a1d51e7fe2120)