### PR TITLE
fix(diagnostics): improve @INC handling for pull diagnostics (#4982)

### DIFF
--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -19,6 +19,7 @@ use crate::state::DocumentState;
 use crate::util::uri::parse_uri;
 use perl_diagnostics::codes::DiagnosticCode;
 use perl_lsp_rs_core::providers::diagnostics::{parse_error_code, parse_error_severity};
+use perl_module::resolution::use_lib::resolve_use_lib_paths_from_source;
 use perl_parser::Parser;
 use perl_parser::error::ParseError;
 use perl_parser::position::offset_to_utf16_line_col;
@@ -264,17 +265,19 @@ impl PullDiagnosticsProvider {
                             tracing::warn!(uri = %uri_str, "pull diagnostics: URI is not a file path");
                         }).ok()
                     });
+                let include_paths = self.effective_include_paths(
+                    &context.include_paths,
+                    content,
+                    source_path.as_deref(),
+                    context,
+                );
 
                 // Build module resolver using context include_paths
                 let resolver = |module: &str| {
-                    self.resolve_module_with_paths(
-                        module,
-                        &context.include_paths,
-                        source_path.as_deref(),
-                    )
+                    self.resolve_module_with_paths(module, &include_paths, source_path.as_deref())
                 };
 
-                let search_paths: Vec<String> = context.include_paths.clone();
+                let search_paths: Vec<String> = include_paths.clone();
 
                 let mut diagnostics = provider
                     .get_diagnostics_with_path(
@@ -312,7 +315,17 @@ impl PullDiagnosticsProvider {
 
         // Check include paths
         for path in include_paths {
-            let full_path = std::path::Path::new(path).join(&module_path);
+            let include_root = {
+                let include_path = std::path::Path::new(path);
+                if include_path.is_absolute() {
+                    include_path.to_path_buf()
+                } else if let Some(source_parent) = source_path.and_then(std::path::Path::parent) {
+                    source_parent.join(include_path)
+                } else {
+                    include_path.to_path_buf()
+                }
+            };
+            let full_path = include_root.join(&module_path);
             if full_path.exists() {
                 return true;
             }
@@ -329,6 +342,30 @@ impl PullDiagnosticsProvider {
         }
 
         false
+    }
+
+    fn effective_include_paths(
+        &self,
+        include_paths: &[String],
+        content: &str,
+        source_path: Option<&std::path::Path>,
+        context: &PullDiagnosticsContext,
+    ) -> Vec<String> {
+        let mut effective_paths = include_paths.to_vec();
+        let workspace_root = context
+            .workspace_root
+            .as_deref()
+            .or_else(|| source_path.and_then(std::path::Path::parent))
+            .unwrap_or(std::path::Path::new("."));
+        let file_dir = source_path.and_then(std::path::Path::parent);
+
+        let dynamic_paths = resolve_use_lib_paths_from_source(content, workspace_root, file_dir);
+        for path in dynamic_paths.into_iter().rev() {
+            effective_paths.retain(|existing| existing != &path);
+            effective_paths.insert(0, path);
+        }
+
+        effective_paths
     }
 
     /// Add built-in Perl::Critic policy diagnostics.
@@ -380,17 +417,19 @@ impl PullDiagnosticsProvider {
             let provider = DiagnosticsProvider::new(ast, doc_state.text.clone());
             let source_path =
                 url::Url::parse(&uri.to_string()).ok().and_then(|value| value.to_file_path().ok());
+            let include_paths = self.effective_include_paths(
+                &context.include_paths,
+                &doc_state.text,
+                source_path.as_deref(),
+                context,
+            );
 
             // Build module resolver using context include_paths
             let resolver = |module: &str| {
-                self.resolve_module_with_paths(
-                    module,
-                    &context.include_paths,
-                    source_path.as_deref(),
-                )
+                self.resolve_module_with_paths(module, &include_paths, source_path.as_deref())
             };
 
-            let search_paths: Vec<String> = context.include_paths.clone();
+            let search_paths: Vec<String> = include_paths.clone();
 
             let mut diagnostics = provider
                 .get_diagnostics_with_path(

--- a/crates/perl-lsp-rs/tests/pull_diagnostics_tests.rs
+++ b/crates/perl-lsp-rs/tests/pull_diagnostics_tests.rs
@@ -1,4 +1,6 @@
 use std::env;
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use lsp_types::{DocumentDiagnosticReport, NumberOrString, Uri};
 use perl_lsp::features::diagnostics::PullDiagnosticsProvider;
@@ -388,5 +390,33 @@ fn pl701_pull_diagnostics_empty_inc_paths_shows_fallback_message()
         .into());
     }
 
+    Ok(())
+}
+
+#[test]
+fn pl701_respects_use_lib_paths_from_document() -> Result<(), Box<dyn std::error::Error>> {
+    let provider = PullDiagnosticsProvider::new();
+    let nonce = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    let project_root = env::temp_dir().join(format!("perl_lsp_pull_diag_inc_{nonce}"));
+    let lib_dir = project_root.join("lib").join("My");
+    fs::create_dir_all(&lib_dir)?;
+    fs::write(project_root.join("lib").join("My").join("Test.pm"), "package My::Test; 1;\n")?;
+    let script_path = project_root.join("script.pl");
+    let uri: Uri = Url::from_file_path(&script_path)
+        .map_err(|_| "failed to create script URI for @INC test")?
+        .to_string()
+        .parse()?;
+
+    let content = "use lib 'lib';\nuse My::Test;\n";
+    let items = items_from_report(provider.get_document_diagnostics(&uri, content, None, None))?;
+    let has_pl701 = items.iter().any(|d| has_code(d, "PL701"));
+    if has_pl701 {
+        return Err(format!(
+            "PL701 should not be emitted when module exists via lexical use lib path. Diagnostics: {items:#?}"
+        )
+        .into());
+    }
+
+    let _ = fs::remove_dir_all(&project_root);
     Ok(())
 }


### PR DESCRIPTION
### Motivation

- Pull diagnostics previously did not honor lexical `use lib` paths or resolve relative include paths against the source file, causing false PL701 (module not found) diagnostics for common project layouts. 
- The change aims to compute an effective per-document include-path list and use it consistently for module-existence checks and PL701 messaging.

### Description

- Add `resolve_use_lib_paths_from_source` and an `effective_include_paths` helper that prepends lexical `use lib` paths parsed from the document to the configured include paths for the current resolution pass. 
- Use the computed effective include paths in both `get_document_diagnostics` and the `DocumentState` diagnostics path so resolution behavior is consistent across pull flows. 
- Change `resolve_module_with_paths` to resolve non-absolute include entries relative to the source file directory when checking file existence, so `use lib 'lib'` works in-file-local layouts. 
- Add a regression test `pl701_respects_use_lib_paths_from_document` that creates a temporary `lib/My/Test.pm` and verifies `use lib 'lib'; use My::Test;` does not emit PL701.

### Testing

- Ran `cargo xtask fmt` successfully. 
- Ran `cargo test -p perl-lsp-rs --test pull_diagnostics_tests pl701_respects_use_lib_paths_from_document` and the test passed. 
- Ran `cargo test -p perl-lsp-rs --test pull_diagnostics_tests pl701_pull_diagnostics` and the existing PL701-related tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9adf53760833385bc1ed3b72b716b)