### PR TITLE
feat(lsp): expand completion trigger characters for path-heavy editing (#4982)

### DIFF
--- a/crates/perl-lsp-rs-core/src/capability_map.rs
+++ b/crates/perl-lsp-rs-core/src/capability_map.rs
@@ -5,6 +5,7 @@
 //! [`lsp_types::ServerCapabilities`] and canonical Perl LSP feature IDs.
 
 use crate::features::ids::*;
+use crate::protocol::capabilities::completion_trigger_characters;
 use lsp_types::ServerCapabilities;
 
 /// Extract feature IDs from LSP `ServerCapabilities`.
@@ -125,13 +126,7 @@ pub fn caps_from_feature_ids(features: &[&str]) -> ServerCapabilities {
         match feature {
             LSP_COMPLETION => {
                 caps.completion_provider = Some(CompletionOptions {
-                    trigger_characters: Some(vec![
-                        "$".to_string(),
-                        "@".to_string(),
-                        "%".to_string(),
-                        ">".to_string(),
-                        ":".to_string(),
-                    ]),
+                    trigger_characters: Some(completion_trigger_characters()),
                     ..Default::default()
                 });
             }

--- a/crates/perl-lsp-rs-core/src/protocol/capabilities.rs
+++ b/crates/perl-lsp-rs-core/src/protocol/capabilities.rs
@@ -19,6 +19,28 @@ use serde_json::Value;
 pub use crate::features::flags::{AdvertisedFeatures, BuildFlags};
 /// Re-export `ServerCapabilities` from `lsp_types` for public access.
 pub use lsp_types::ServerCapabilities;
+
+/// Canonical completion trigger characters advertised to LSP clients.
+///
+/// LSP requires each trigger to be a single character. Multi-character Perl
+/// operators (`->`, `::`) are supported by advertising their component chars.
+#[must_use]
+pub fn completion_trigger_characters() -> Vec<String> {
+    vec![
+        "$".to_string(),
+        "@".to_string(),
+        "%".to_string(),
+        // Method and package separators.
+        "-".to_string(),
+        ">".to_string(),
+        ":".to_string(),
+        // File path completion inside string literals.
+        "/".to_string(),
+        "\\".to_string(),
+        "\"".to_string(),
+        "'".to_string(),
+    ]
+}
 /// Generate server capabilities from build flags
 #[allow(clippy::field_reassign_with_default)]
 pub fn capabilities_for(build: BuildFlags) -> ServerCapabilities {
@@ -66,19 +88,7 @@ pub fn capabilities_for(build: BuildFlags) -> ServerCapabilities {
     if build.completion {
         caps.completion_provider = Some(CompletionOptions {
             resolve_provider: Some(true),
-            trigger_characters: Some(vec![
-                "$".to_string(),
-                "@".to_string(),
-                "%".to_string(),
-                // LSP spec requires single-char trigger characters; ">" fires on the
-                // second character of "->" so method-completion still triggers.
-                ">".to_string(),
-                // ":" fires on the second character of "::" for package member completion.
-                ":".to_string(),
-                // "-" fires on the first character of "->" so method-completion appears
-                // immediately; context detection in completion.rs filters non-arrow uses.
-                "-".to_string(),
-            ]),
+            trigger_characters: Some(completion_trigger_characters()),
             all_commit_characters: None,
             work_done_progress_options: WorkDoneProgressOptions::default(),
             completion_item: None,
@@ -486,5 +496,16 @@ mod tests {
             json["codeLensProvider"]["resolveProvider"].as_bool().unwrap_or(false),
             "codeLensProvider.resolveProvider must be true"
         );
+    }
+
+    #[test]
+    fn completion_trigger_characters_include_file_path_and_perl_tokens() {
+        let triggers = completion_trigger_characters();
+        for expected in ["$", "@", "%", "-", ">", ":", "/", "\\", "\"", "'"] {
+            assert!(
+                triggers.iter().any(|trigger| trigger == expected),
+                "missing completion trigger character: {expected}"
+            );
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Improve editor UX when typing file paths or string-paths by advertising a canonical, expanded set of completion trigger characters to LSP clients so completions are requested earlier and more consistently.

### Description

- Add `completion_trigger_characters()` in `crates/perl-lsp-rs-core/src/protocol/capabilities.rs` as the single canonical trigger-character list used across capability builders.
- Include file/path and string-literal triggers (`/`, `\\`, `"`, `'`) in addition to Perl symbol/operator triggers (`$`, `@`, `%`, `-`, `>`, `:`).
- Wire `capabilities_for()` and `caps_from_feature_ids()` to use `completion_trigger_characters()` to eliminate drift between runtime capability JSON and feature-id mappings.
- Add a unit test `completion_trigger_characters_include_file_path_and_perl_tokens` that locks the expected trigger set to prevent regressions.

### Testing

- Ran formatter with `cargo xtask fmt`, which completed successfully.
- Ran unit tests for the core crate with `cargo test -p perl-lsp-rs-core completion_trigger_characters -- --nocapture`, and the test `protocol::capabilities::tests::completion_trigger_characters_include_file_path_and_perl_tokens` passed.
- Verified `cargo test -p perl-lsp-rs-core caps_from_completion_has_trigger_characters -- --nocapture` passed, confirming existing capability mappings remain valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a7c268388333a1ebd6f26453feea)