### PR TITLE
fix(config): normalize and dedupe effective @INC paths (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/mod.rs
+++ b/crates/perl-lsp-rs-core/src/config/mod.rs
@@ -444,7 +444,7 @@ impl WorkspaceConfig {
         const SEP: char = ';';
         #[cfg(not(windows))]
         const SEP: char = ':';
-        value.split(SEP).filter(|s| !s.is_empty()).map(|s| s.to_string()).collect()
+        value.split(SEP).map(str::trim).filter(|s| !s.is_empty()).map(ToString::to_string).collect()
     }
 
     /// Return the effective module-search-path, merging `PERL5LIB` paths with
@@ -453,21 +453,34 @@ impl WorkspaceConfig {
     /// If `self.use_perl5lib` is `false`, or `perl5lib_paths` is empty, the
     /// returned list is identical to `self.include_paths`.
     pub fn effective_include_paths(&self, perl5lib_paths: &[String]) -> Vec<String> {
-        if !self.use_perl5lib || perl5lib_paths.is_empty() {
-            return self.include_paths.clone();
-        }
-        match self.perl5lib_precedence {
-            Perl5LibPrecedence::Prepend => {
-                let mut result = perl5lib_paths.to_vec();
-                result.extend_from_slice(&self.include_paths);
-                result
+        let mut combined = if !self.use_perl5lib || perl5lib_paths.is_empty() {
+            self.include_paths.clone()
+        } else {
+            match self.perl5lib_precedence {
+                Perl5LibPrecedence::Prepend => {
+                    let mut result = perl5lib_paths.to_vec();
+                    result.extend_from_slice(&self.include_paths);
+                    result
+                }
+                Perl5LibPrecedence::Append => {
+                    let mut result = self.include_paths.clone();
+                    result.extend_from_slice(perl5lib_paths);
+                    result
+                }
             }
-            Perl5LibPrecedence::Append => {
-                let mut result = self.include_paths.clone();
-                result.extend_from_slice(perl5lib_paths);
-                result
+        };
+
+        // Normalize by dropping empty/whitespace-only entries and de-duplicating while
+        // preserving the first occurrence. This keeps @INC search order deterministic while
+        // avoiding redundant filesystem probes and duplicate diagnostics context.
+        combined.retain(|entry| !entry.trim().is_empty());
+        let mut deduped = Vec::with_capacity(combined.len());
+        for path in combined {
+            if !deduped.contains(&path) {
+                deduped.push(path);
             }
         }
+        deduped
     }
 
     /// Refresh workspace-native build hints from the selected workspace root.
@@ -785,5 +798,33 @@ impl ProjectConfig {
         if let Some(ref prec) = self.perl.perl5lib_precedence {
             config.perl5lib_precedence = prec.clone();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Perl5LibPrecedence, WorkspaceConfig};
+
+    #[test]
+    fn parse_perl5lib_trims_and_drops_empty_entries() {
+        let parsed = WorkspaceConfig::parse_perl5lib(" lib ::vendor/lib:  :local/lib/perl5 ");
+        assert_eq!(parsed, vec!["lib", "vendor/lib", "local/lib/perl5"]);
+    }
+
+    #[test]
+    fn effective_include_paths_dedupes_preserving_first_precedence() {
+        let config = WorkspaceConfig {
+            include_paths: vec!["lib".to_string(), "vendor/lib".to_string(), "lib".to_string()],
+            use_perl5lib: true,
+            perl5lib_precedence: Perl5LibPrecedence::Prepend,
+            ..WorkspaceConfig::default()
+        };
+        let effective = config.effective_include_paths(&[
+            "vendor/lib".to_string(),
+            "custom/lib".to_string(),
+            "lib".to_string(),
+        ]);
+
+        assert_eq!(effective, vec!["vendor/lib", "custom/lib", "lib"]);
     }
 }


### PR DESCRIPTION
### Motivation
- Make `PERL5LIB` and workspace include-path merging robust to whitespace, empty segments, and duplicate entries so module resolution and diagnostics do not perform redundant probes or produce confusing messages.

### Description
- Trim and drop empty/whitespace-only components when parsing `PERL5LIB` in `WorkspaceConfig::parse_perl5lib()` so entries like `" lib ::vendor/lib:  "` become `"lib"`, `"vendor/lib"`, etc.
- Revise `WorkspaceConfig::effective_include_paths()` to merge `PERL5LIB` and `include_paths`, then normalize by removing empty entries and de-duplicating while preserving the first-seen (precedence) order.
- Add unit tests in `crates/perl-lsp-rs-core/src/config/mod.rs` covering trimmed `PERL5LIB` parsing and deterministic deduplication of effective include paths.

### Testing
- Ran `cargo xtask fmt` (completed successfully).
- Ran `cargo test -p perl-lsp-rs-core parse_perl5lib_trims_and_drops_empty_entries` and the test passed.
- Ran `cargo test -p perl-lsp-rs-core effective_include_paths_dedupes_preserving_first_precedence` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9adf53760833385bc1ed3b72b716b)