### PR TITLE
docs: add AGENTS.md — agent-facing operating manual (#4931)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,108 +1,182 @@
-# AGENTS.md
+# AGENTS.md — Implementation Agent Operating Manual
 
-Guidance for coding agents working in this repository.
+You are an **implementation agent** (Codex, Jules, or similar). Your job is to make a
+scoped change, test it, and open a PR. You are not the orchestrator. You will not be
+routing work or reading CI pipelines — just implement the thing you were asked to implement.
 
-## Start From Current Truth
+The orchestrator reads `CLAUDE.md`. This file is for you.
 
-Use these files as the primary sources of truth before you restate project facts:
+---
 
-- [`Cargo.toml`](Cargo.toml): workspace members, package version, published crate line
-- [`docs/project/CURRENT_STATUS.md`](docs/project/CURRENT_STATUS.md): evidence-backed metrics and receipts
-- [`docs/project/ROADMAP.md`](docs/project/ROADMAP.md): canonical roadmap and active milestone
-- [`features.toml`](features.toml): LSP capability catalog
-- [`docs/README.md`](docs/README.md): documentation index
+## Context you can read
 
-Do not hardcode workspace counts, release numbers, or performance metrics in new docs unless you regenerated or verified them in the same change.
+| Resource | Purpose |
+|----------|---------|
+| `README.md` | What this project is |
+| `CLAUDE.md` | Orchestrator pipeline model (routing, labels, merge rules) |
+| `docs/project/ROADMAP.md` | Active waves and priorities |
+| `docs/project/FRICTION_LOG.md` | Platform quirks and known workarounds |
+| `docs/articles/CONTINUOUS_REVIEW_PATTERNS.md` | The orchestration pattern used here |
+| `docs/articles/ORCHESTRATION_COUNTERINTUITIONS.md` | Lessons where the obvious rule was wrong |
 
-## Project Shape
+**Before starting:** run `git log origin/master --oneline -20`. The orchestrator
+frequently merges fixes between sessions — your task may already be done.
 
-This repository is a large Rust workspace that ships editor tooling, parser infrastructure, and supporting libraries for Perl 5.
+**Before stating facts** about workspace counts, release numbers, or metrics, verify
+against the truth sources below — do not hardcode them:
 
-### Main entry points
+- [`Cargo.toml`](Cargo.toml) — workspace members, package version
+- [`docs/project/CURRENT_STATUS.md`](docs/project/CURRENT_STATUS.md) — evidence-backed metrics
+- [`docs/project/ROADMAP.md`](docs/project/ROADMAP.md) — canonical roadmap
+- [`features.toml`](features.toml) — LSP capability catalog
+
+---
+
+## Project shape
 
 | Path | Purpose |
-| --- | --- |
-| `/crates/perl-lsp-rs/` | LSP binary and server host |
-| `/crates/perl-dap/` | Debug Adapter Protocol server |
-| `/crates/perl-parser/` | Native recursive-descent parser |
-| `/crates/perl-lexer/` | Context-aware tokenizer |
-| `/crates/perl-parser-core/` | Shared parser infrastructure |
-| `/crates/perl-semantic-analyzer/` | Semantic analysis and resolution |
-| `/crates/perl-workspace-index/` | Cross-file indexing and lookup |
-| `/crates/perl-corpus/` | Corpus and regression fixtures |
+|------|---------|
+| `crates/perl-lsp-rs/` | LSP binary and server host |
+| `crates/perl-dap/` | Debug Adapter Protocol server |
+| `crates/perl-parser/` | Native recursive-descent parser |
+| `crates/perl-lexer/` | Context-aware tokenizer |
+| `crates/perl-parser-core/` | Shared parser infrastructure |
+| `crates/perl-semantic-analyzer/` | Semantic analysis and resolution |
+| `crates/perl-workspace-index/` | Cross-file indexing and lookup |
 
-### Where to work
+Families: `perl-module-*` (module resolution), `perl-lsp-*` (LSP providers),
+`perl-lsp-feature-*` (feature governance), `perl-dap-*` (DAP), `perl-workspace-*`
+(workspace discovery).
 
-1. Parser behavior: `/crates/perl-parser/`, `/crates/perl-parser-core/`, `/crates/perl-lexer/`
-2. LSP features: `/crates/perl-lsp-rs/` and `/crates/perl-lsp-*/`
-3. DAP features: `/crates/perl-dap/` and `/crates/perl-dap-*/`
-4. Semantic resolution: `/crates/perl-semantic-analyzer/`, `/crates/perl-workspace-index/`
-5. Corpus and regressions: `/crates/perl-corpus/`, `/crates/*/tests/`, `/test_corpus/`
+---
 
-## Validation Commands
+## Scoping your PR
 
-AI tools can run bare `cargo build` and `cargo test`; `.cargo/config.toml` handles the repo defaults.
+- Touch **one concern**. One fix, one feature, one refactor.
+- Do NOT bundle unrelated cleanup — "while I'm here" creates review burden and scope drift.
+- Do NOT drop, `#[ignore]`, or comment out existing tests — that is named debt.
+- Do NOT rewrite files you did not need to touch.
+- If your branch contains tool metadata (`.hermes/conveyor/work-<id>/`), that is fine
+  to include — but do NOT mix multiple work IDs in one PR.
+- Do NOT commit top-level `adr.md`, `specs.md`, or `task_list.md` — those belong in
+  `.hermes/conveyor/work-<id>/`.
 
-### Fast feedback
+---
 
-```bash
-just devex
-just pr-fast
+## Commit and PR conventions
+
+**Commit:** Single focused commit. Squash locally before pushing.
+
+**Title format:** `type(scope): description (#NNNN)`
+
+- If you cannot read the issue tracker, use `(#0000)` — the orchestrator will retitle
+  before merge. The CI `validate-title` check enforces the `(#NNNN)` suffix.
+- Valid types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`.
+
+**PR body template (keep it short):**
+
+```
+Problem: <one sentence>
+Fix: <one sentence>
+Verification: `cargo test -p <crate>` passes / `just pr-fast` passes
 ```
 
-### Canonical local gate
+---
+
+## Code quality bar
+
+These rules apply to **all** production code and tests. CI and reviewers enforce them.
+
+**Banned — use `?`, pattern matching, or `Result`/`Option` instead:**
+
+```
+panic!()    unwrap()    expect()    todo!()    unimplemented!()
+dbg!()      println!()  eprintln!()  (in library code — use `tracing`)
+```
+
+**Tests** must return `Result<()>` or use `perl_tdd_support::must` / `must_some`.
+No bare `unwrap()` in tests.
+
+**Regex:** declare as `static LazyLock<Regex>` — never call `Regex::new()` per invocation.
+
+**Public API on facade crates:** add `#[non_exhaustive]` to enums and structs.
+
+**Async:** do not hold a lock across `.await` — clippy `await_holding_lock` is denied.
+
+**Every `#[allow(...)]`** must have a justification comment on the same or preceding line.
+
+**Prefer:**
+- `.first()` over `.get(0)`
+- `.push(ch)` over `.push_str("x")` for single chars
+- `.or_default()` over `.or_insert_with(Vec::new)`
+- Avoid unnecessary `.clone()` on `Copy` types
+
+---
+
+## Verification before pushing
+
+```bash
+cargo test -p <crate>            # crate under change
+cargo check --all-targets -p <crate>  # catches integration test bit-rot (--lib misses this)
+cargo xtask fmt                  # format (Windows-safe, per-crate)
+cargo clippy -p <crate>          # lint
+just pr-fast                     # full fast gate (required before opening PR)
+```
+
+For the canonical local merge gate (before a reviewer merges):
 
 ```bash
 nix develop -c just ci-gate
 ```
 
-### Status and documentation drift
+---
 
-```bash
-just status-update
-just status-check
-```
+## Platform awareness
 
-Run `just status-update` and `just status-check` when you change capability docs, generated status sections, or other docs that depend on computed project metrics.
+- CI runs on Linux. Code must be cross-platform — Windows CRLF and Unix LF both occur
+  in the corpus.
+- You cannot read GitHub issues directly. Placeholder issue refs (`#0000`) are OK;
+  the orchestrator retitles before merge.
+- If the pre-push hook fails on pre-existing fmt drift in unrelated files, you may use
+  `--no-verify` but must note it explicitly in the PR body.
+- `git stash` is **shared across all worktrees** — never use it. Use `git restore <file>`
+  to discard changes, or `git commit -m "wip"` to save in-progress work.
+- Pre-push hook may hit a file-lock race on Windows; API-push workaround is acceptable.
+  See `docs/project/FRICTION_LOG.md` for details.
 
-### Verification Ladder
+---
 
-Prefer cheap, orthogonal passes over one broad gate:
+## Anti-patterns (explicit DON'T list)
 
-1. Check recent merged/open PRs and issues for the area before scoping new work.
-2. Use the narrowest truth-check first for claims: targeted repro/test for behavior, history/doc verification for attribution or status claims.
-3. Escalate to `just pr-fast` or `nix develop -c just ci-gate` only after the narrow pass is green.
+| Pattern | Why |
+|---------|-----|
+| Multiple `.hermes/conveyor/work-<id>/` dirs in one PR | Cross-work-id contamination |
+| Committing `adr.md` / `specs.md` at repo root | Belongs in conveyor dir |
+| Rewriting files you did not need to touch | Creates spurious review surface |
+| Dropping or `#[ignore]`-ing tests | Debt with a name |
+| Guessing issue numbers | Placeholder `#0000` is fine; wrong ref misleads reviewers |
+| Bundling unrelated changes in one PR | Scope drift kills reviewability |
+| Using `git stash` | Shared across worktrees — use `git restore` or `git commit -m "wip"` |
+| Hardcoding metrics in new docs | Metrics drift; link to truth sources instead |
 
-## PR Hygiene
+---
 
-- Use isolated worktrees and focused branches for agent-driven PR work.
-- Give PRs a CI-compliant title before opening them: `type(scope): summary (#1234)`.
-- The `validate-title` check rejects titles that do not include an issue reference.
-- Put the issue reference in the PR title, not just in the body.
+## Documentation discipline
 
-## Documentation Discipline
+- `docs/project/CURRENT_STATUS.md` is the evidence document. Do not duplicate its tables.
+- `docs/project/ROADMAP.md` is the planning document. Keep "shipped" and "targeted" separate.
+- Prefer links to canonical docs over copying the same table into multiple files.
+- After adding tests: no manual status update needed — `docs/project/status/*.md` files
+  are auto-regenerated post-merge via `just status-update`.
 
-- [`docs/project/CURRENT_STATUS.md`](docs/project/CURRENT_STATUS.md) is the evidence document.
-- [`docs/project/ROADMAP.md`](docs/project/ROADMAP.md) is the planning document.
-- [`ROADMAP.md`](ROADMAP.md) and [`NOW_NEXT_LATER.md`](NOW_NEXT_LATER.md) should stay short and point back to the canonical project docs.
-- Keep the current release line separate from the next milestone. Do not blur “shipped” and “targeted”.
-- Prefer links to canonical docs over copying the same table into multiple places.
+---
 
-## Coding Expectations
+## Further reading
 
-- Run `cargo xtask fmt` for formatting (per-crate invocation, Windows-safe).
-- Run the narrowest relevant tests first, then the broader gate when the change is ready.
-- `unwrap()`, `expect()`, `panic!()`, `todo!()`, and `unimplemented!()` are banned in production code.
-- In tests, prefer `Result<()>` and helpers such as `perl_tdd_support::must` and `must_some`.
-- Prefer `.first()` over `.get(0)`.
-- Use `.push(char)` instead of `.push_str("x")` for single characters.
-- Use `or_default()` instead of `or_insert_with(Vec::new)`.
-- Avoid unnecessary `.clone()` on `Copy` types.
-
-## Useful References
-
-- [`CONTRIBUTING.md`](CONTRIBUTING.md)
-- [`docs/reference/COMMANDS_REFERENCE.md`](docs/reference/COMMANDS_REFERENCE.md)
-- [`docs/reference/LSP_IMPLEMENTATION_GUIDE.md`](docs/reference/LSP_IMPLEMENTATION_GUIDE.md)
-- [`docs/reference/CRATE_ARCHITECTURE_GUIDE.md`](docs/reference/CRATE_ARCHITECTURE_GUIDE.md)
-- [`docs/tutorials/DAP_USER_GUIDE.md`](docs/tutorials/DAP_USER_GUIDE.md)
+- `CLAUDE.md` — full orchestrator model, pipeline stages, label semantics
+- `CONTRIBUTING.md` — human contributor workflow
+- `docs/project/FRICTION_LOG.md` — platform quirks and workarounds
+- `docs/reference/COMMANDS_REFERENCE.md` — all `just` and `cargo xtask` commands
+- `docs/reference/LSP_IMPLEMENTATION_GUIDE.md` — LSP provider patterns
+- `docs/reference/CRATE_ARCHITECTURE_GUIDE.md` — microcrate layering rules
+- `docs/articles/ORCHESTRATION_COUNTERINTUITIONS.md` — where the obvious rule was wrong

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-**Latest Release**: 0.12.4 | **Metrics**: [status/index.md](docs/project/status/index.md) | **API Stability**: [STABILITY.md](docs/reference/STABILITY.md)
+**Latest Release**: 0.12.4 | **Metrics**: [status/index.md](docs/project/status/index.md) | **API Stability**: [STABILITY.md](docs/reference/STABILITY.md) | **Implementation agents**: [AGENTS.md](AGENTS.md)
 
 ## Orchestration Model
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Find beginner-friendly issues:
 gh issue list --label "good-first-issue" --state open
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow. If you are an AI implementation agent (Codex, Jules), read [AGENTS.md](AGENTS.md) first.
 
 ## Status
 


### PR DESCRIPTION
## Summary

- Expands existing `AGENTS.md` stub into a full implementation-agent operating manual (182 lines)
- Covers: framing, context sources, project shape, PR scoping rules, commit/title conventions, code quality bar, verification commands, platform gotchas, anti-pattern table, documentation discipline, and further reading
- Cross-links added: `CLAUDE.md` header line + `README.md` Contributing section

## Problem

`CLAUDE.md` is orchestrator-first. Implementation agents (Codex, Jules) picking up scoped work had no single doc covering scope rules, quality bar, platform quirks, and PR conventions.

## Fix

Rewrote `AGENTS.md` with actionable, terse sections synthesized from session learnings (`FRICTION_LOG.md`, `ORCHESTRATION_COUNTERINTUITIONS.md`, memory docs). Added one-line cross-references in `CLAUDE.md` and `README.md`.

## Verification

Docs-only change — no code modified. Pre-push hook failed on pre-existing fmt drift in `crates/perl-lsp-rs-core/src/feature_catalog.rs` (unrelated crate, not touched by this PR). Pushed with `--no-verify` per the bypass policy for pre-existing drift.