### PR TITLE
perf(incremental): reduce affected-node scan overhead via coalesced ranges (#4994)

### DIFF
--- a/crates/perl-incremental-parsing/src/incremental/incremental_advanced_reuse.rs
+++ b/crates/perl-incremental-parsing/src/incremental/incremental_advanced_reuse.rs
@@ -288,8 +288,8 @@ impl AdvancedReuseAnalyzer {
 
     /// Identify nodes affected by edits
     fn identify_affected_nodes(&mut self, tree: &Node, edits: &EditSet) {
-        for edit in edits.edits() {
-            self.mark_affected_nodes_in_range(tree, edit.start_byte, edit.old_end_byte);
+        for range in edits.coalesced_affected_ranges() {
+            self.mark_affected_nodes_in_range(tree, range.start.byte, range.end.byte);
         }
     }
 
@@ -298,9 +298,10 @@ impl AdvancedReuseAnalyzer {
         let node_range = Range::from(node.location);
         let edit_range = Range::new(Position::new(start, 0, 0), Position::new(end, 0, 0));
 
-        if node_range.overlaps(&edit_range) {
-            self.affected_nodes.insert(node.location.start);
+        if !node_range.overlaps(&edit_range) {
+            return;
         }
+        self.affected_nodes.insert(node.location.start);
 
         // Recurse into children
         match &node.kind {

--- a/crates/perl-parser-core/src/syntax/edit.rs
+++ b/crates/perl-parser-core/src/syntax/edit.rs
@@ -171,6 +171,34 @@ impl EditSet {
             .map(|edit| Range::new(edit.start_position, edit.old_end_position))
             .collect()
     }
+
+    /// Get affected ranges with overlapping and adjacent regions coalesced.
+    ///
+    /// This is useful for incremental parsing workflows that only need the
+    /// minimal set of invalidation windows.
+    pub fn coalesced_affected_ranges(&self) -> Vec<Range> {
+        let mut ranges = self.affected_ranges();
+        if ranges.len() <= 1 {
+            return ranges;
+        }
+
+        ranges.sort_by_key(|range| range.start.byte);
+
+        let mut merged = Vec::with_capacity(ranges.len());
+        let mut current = ranges[0];
+        for range in ranges.into_iter().skip(1) {
+            if range.start.byte <= current.end.byte {
+                if range.end.byte > current.end.byte {
+                    current.end = range.end;
+                }
+            } else {
+                merged.push(current);
+                current = range;
+            }
+        }
+        merged.push(current);
+        merged
+    }
 }
 
 #[cfg(test)]
@@ -252,5 +280,41 @@ mod tests {
 
         // Check cumulative shift
         assert_eq!(edits.byte_shift_at(50), 7); // +2 from first, +5 from second
+    }
+
+    #[test]
+    fn test_coalesced_affected_ranges() {
+        let mut edits = EditSet::new();
+        edits.add(Edit::new(
+            10,
+            15,
+            17,
+            Position::new(10, 1, 0),
+            Position::new(15, 1, 5),
+            Position::new(17, 1, 7),
+        ));
+        edits.add(Edit::new(
+            14,
+            20,
+            21,
+            Position::new(14, 1, 4),
+            Position::new(20, 1, 10),
+            Position::new(21, 1, 11),
+        ));
+        edits.add(Edit::new(
+            30,
+            35,
+            36,
+            Position::new(30, 2, 0),
+            Position::new(35, 2, 5),
+            Position::new(36, 2, 6),
+        ));
+
+        let ranges = edits.coalesced_affected_ranges();
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0].start.byte, 10);
+        assert_eq!(ranges[0].end.byte, 20);
+        assert_eq!(ranges[1].start.byte, 30);
+        assert_eq!(ranges[1].end.byte, 35);
     }
 }

--- a/crates/perl-parser/src/incremental/incremental_advanced_reuse.rs
+++ b/crates/perl-parser/src/incremental/incremental_advanced_reuse.rs
@@ -288,8 +288,8 @@ impl AdvancedReuseAnalyzer {
 
     /// Identify nodes affected by edits
     fn identify_affected_nodes(&mut self, tree: &Node, edits: &EditSet) {
-        for edit in edits.edits() {
-            self.mark_affected_nodes_in_range(tree, edit.start_byte, edit.old_end_byte);
+        for range in edits.coalesced_affected_ranges() {
+            self.mark_affected_nodes_in_range(tree, range.start.byte, range.end.byte);
         }
     }
 
@@ -298,9 +298,10 @@ impl AdvancedReuseAnalyzer {
         let node_range = Range::from(node.location);
         let edit_range = Range::new(Position::new(start, 0, 0), Position::new(end, 0, 0));
 
-        if node_range.overlaps(&edit_range) {
-            self.affected_nodes.insert(node.location.start);
+        if !node_range.overlaps(&edit_range) {
+            return;
         }
+        self.affected_nodes.insert(node.location.start);
 
         // Recurse into children
         match &node.kind {
@@ -933,5 +934,40 @@ mod tests {
 
         // Different type nodes should not be compatible
         assert!(!analyzer.are_compatible_for_content_update(&num1, &str1));
+    }
+
+    #[test]
+    fn test_identify_affected_nodes_marks_only_overlapping_regions() {
+        let mut analyzer = AdvancedReuseAnalyzer::new();
+        let tree = Node::new(
+            NodeKind::Program {
+                statements: vec![
+                    Node::new(
+                        NodeKind::Number { value: "1".to_string() },
+                        SourceLocation { start: 0, end: 1 },
+                    ),
+                    Node::new(
+                        NodeKind::Number { value: "2".to_string() },
+                        SourceLocation { start: 20, end: 21 },
+                    ),
+                ],
+            },
+            SourceLocation { start: 0, end: 21 },
+        );
+
+        let mut edits = EditSet::new();
+        edits.add(perl_parser_core::edit::Edit::new(
+            0,
+            2,
+            2,
+            Position::new(0, 0, 0),
+            Position::new(2, 0, 2),
+            Position::new(2, 0, 2),
+        ));
+
+        analyzer.identify_affected_nodes(&tree, &edits);
+
+        assert!(analyzer.affected_nodes.contains(&0));
+        assert!(!analyzer.affected_nodes.contains(&20));
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce work done during incremental parsing by collapsing overlapping edit windows into minimal invalidation ranges.
- Avoid recursing into subtrees that do not overlap any edit range to speed up affected-node discovery.

### Description
- Added `EditSet::coalesced_affected_ranges()` in `crates/perl-parser-core/src/syntax/edit.rs` to merge overlapping/adjacent edit ranges into a minimal set of `Range` windows.
- Updated `AdvancedReuseAnalyzer::identify_affected_nodes` in both `crates/perl-parser/src/incremental/incremental_advanced_reuse.rs` and `crates/perl-incremental-parsing/src/incremental/incremental_advanced_reuse.rs` to consume coalesced ranges instead of per-edit ranges.
- Short-circuited `mark_affected_nodes_in_range` so traversal returns immediately when a node/subtree does not overlap the current edit range and only inserts affected nodes when overlap exists.
- Added focused unit tests: `test_coalesced_affected_ranges` (coalescing behavior) and `test_identify_affected_nodes_marks_only_overlapping_regions` (affected-node selection), and ran formatter.

### Testing
- Ran `cargo xtask fmt` to format changes and it completed successfully.
- Ran `cargo test -p perl-parser-core test_coalesced_affected_ranges` and the test passed.
- Ran `cargo test -p perl-parser test_identify_affected_nodes_marks_only_overlapping_regions` and the test passed.
- Ran `cargo test -p perl-incremental-parsing test_advanced_reuse_analyzer_creation` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9adfaeac883338dc032e4d48a918c)