### PR TITLE
ci: compile integration tests on push to catch bit-rot (#4507)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,3 +271,36 @@ jobs:
           PERL_LSP_BIN: ${{ github.workspace }}/target/debug/perl-lsp
           RUST_TEST_THREADS: "1"
         run: just ux-tests
+
+  # ── Compile All Targets: catch integration-test + bench bit-rot ───────
+  check-all-targets:
+    name: Compile All Targets (bit-rot guard)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: preflight-latest-check
+    if: needs.preflight-latest-check.outputs.is_latest == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
+        with:
+          toolchain: 1.92.0
+
+      - name: Install just
+        uses: taiki-e/install-action@cf39a74df4a72510be4e5b63348d61067f11e64a  # v2.75.0
+        with:
+          tool: just
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          shared-key: ci-all-targets-${{ hashFiles('Cargo.lock') }}
+
+      - name: Compile all targets (catches integration-test + bench bit-rot)
+        run: just check-all-targets

--- a/justfile
+++ b/justfile
@@ -63,6 +63,15 @@ pr-fast: _check-tools-basic
     echo "=============================================="
     exit $RC
 
+# Compile-only gate: catches integration-test and benchmark bit-rot without
+# incurring full test runtime (~30-45 s). Matches the workspace excludes used
+# by the rest of the CI gates (tree-sitter-perl, fuzz, archive are excluded
+# from the workspace Cargo.toml so --workspace picks only the 134 crates).
+check-all-targets:
+    @echo "Compiling all targets (lib, bins, tests, benches) — bit-rot check..."
+    cargo check --workspace --all-targets --locked
+    @echo "All targets compile clean."
+
 # Fail if README.md has duplicate level-2 headings. Helps catch accidental
 # copy/paste doc drift that is otherwise easy to miss during review.
 readme-heading-check:


### PR DESCRIPTION
## Summary

- Add `just check-all-targets` recipe: `cargo check --workspace --all-targets --locked`
- Add `check-all-targets` CI job that runs on every PR push, parallel to `pr-smoke`
- Uses the same pinned action SHAs as other jobs in `ci.yml`
- ~30-45 s overhead per push, compile-only (no test runtime cost)

## Problem

Push-triggered CI ran `cargo test --workspace --lib --locked` — only library targets. Integration tests (`crates/*/tests/*.rs`) and benchmarks were not compiled. Crate moves/collapses silently introduced import rot. Issue #4508 was an instance: 9 errors across 3 test files found only via manual inspection.

## Changes

**`justfile`** — new recipe between `pr-fast` and `readme-heading-check`:
```
check-all-targets:
    cargo check --workspace --all-targets --locked
```

**`.github/workflows/ci.yml`** — new parallel job `check-all-targets` after `ux-tests`, needs only `preflight-latest-check` (runs regardless of `pr-smoke` result to give faster signal).

## Test plan

- [ ] CI passes on this PR with the new `check-all-targets` job visible in the checks list
- [ ] Verify the job name "Compile All Targets (bit-rot guard)" appears in GitHub Actions
- [ ] Confirm `just check-all-targets` runs cleanly locally