### PR TITLE
chore(perl-lsp-rs-core): fix feature_catalog.rs fmt drift (#4989)

### DIFF
--- a/crates/perl-lsp-rs-core/src/feature_catalog.rs
+++ b/crates/perl-lsp-rs-core/src/feature_catalog.rs
@@ -228,11 +228,7 @@ impl Catalog {
             }
         }
 
-        if issues.is_empty() {
-            Ok(())
-        } else {
-            Err(CatalogError::Validation(issues.join(", ")))
-        }
+        if issues.is_empty() { Ok(()) } else { Err(CatalogError::Validation(issues.join(", "))) }
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix rustfmt drift in `feature_catalog.rs` that was blocking pre-push hooks for all agents
- Purely cosmetic: collapse multi-line `if/else` to single line as rustfmt requires
- Same pattern as resolved #4676 (collapse_edge_cases_tests.rs) and #4812 (perl-semantic-analyzer)

## Changes
- `crates/perl-lsp-rs-core/src/feature_catalog.rs` — 1 insertion, 5 deletions (if/else collapse only)

## Evidence
- **Commits**: 1
- **Tests**: `cargo check -p perl-lsp-rs-core --tests` — clean (57s compile, no errors)
- **Fmt check**: `cargo fmt --check -p perl-lsp-rs-core` — passes
- **Files**: 1 changed, +1/-5 lines (pure whitespace restructure)

## Test Plan
- `cargo fmt --check -p perl-lsp-rs-core` should return exit 0
- `cargo check -p perl-lsp-rs-core --tests` should compile cleanly
- Pre-push hooks on branches touching this crate will no longer block

## Unknowns
- No semantic changes; no logic to test beyond fmt compliance