### PR TITLE
docs(readme): link workspace rename slice references (#3522)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The table below is the honest state of v0.13.0 rough edges. None block basic use
 
 #### Must land for v0.13.0
 
-- **Workspace-wide rename slice** — multi-root workspace support shipped in 0.12.x (PR #3984: per-folder config loading, `WorkspaceFolderState`, cross-folder integration); workspace-wide rename and module-move are roughly 30% complete, conditionally in scope pending verification ([#3522](https://github.com/EffortlessMetrics/perl-lsp/issues/3522))
+- **Workspace-wide rename slice** — multi-root workspace support shipped in 0.12.x ([#3984](https://github.com/EffortlessMetrics/perl-lsp/pull/3984): per-folder config loading, `WorkspaceFolderState`, cross-folder integration); workspace-wide rename and module-move are roughly 30% complete, conditionally in scope pending verification ([#3522](https://github.com/EffortlessMetrics/perl-lsp/issues/3522))
 
 #### Nice to land
 


### PR DESCRIPTION
### Motivation

- Clarify README traceability by linking PR #3984 directly from the known-gaps bullet about the workspace-wide rename slice.

### Description

- Replace the plain-text reference to PR #3984 with a direct Markdown link to `https://github.com/EffortlessMetrics/perl-lsp/pull/3984` in the README; this is a docs-only change and touches only `README.md`.

### Testing

- Ran `cargo fmt --all -- --check`, which failed due to unrelated pre-existing formatting drift in `crates/perl-lsp-rs-core/src/feature_catalog.rs` (not introduced by this docs change).
- Ran `git log origin/master --oneline -20` as a workspace pre-check, which failed because the local clone has no `origin/master` revision available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b86bea84833399ffdca63f56e133)