### PR TITLE
docs(roadmap): track workspace rename slice status (#3522)

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -109,6 +109,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - Test coverage gaps and broken integration tests
 - VSCode extension lint/quality audit (eslint v10 landed in #3179)
 - AI inline completion (#3018) shipped in the live 0.12.x line — feature wired end-to-end via #3157–#3168, awaiting E2E user validation
+- Workspace-wide rename slice: multi-root support shipped in 0.12.x (#3984); workspace-wide rename/module-move remains roughly 30% complete and only conditionally in scope pending #3522 verification
 - Coroutine support issue #3539 is re-scoped: defer hypothetical core syntax, split upstream-tracking from CPAN-library IDE support planning
 
 ### Next (v0.13.0 — public alpha announcement)


### PR DESCRIPTION
### Motivation
- Make the active roadmap clearer by documenting the current partial state of the workspace-wide rename/module-move work (multi-root groundwork shipped, remaining ~30% pending verification of #3522).

### Description
- Update `docs/project/ROADMAP.md` by adding a focused bullet in the "Now (post-v0.12.3 / pre-v0.13.0)" section that records that multi-root support shipped in 0.12.x (#3984) and that workspace-wide rename/module-move remains roughly 30% complete and conditionally in scope pending #3522 verification.

### Testing
- Attempted to run `just pr-fast` but it could not be executed in this environment because `just` is not installed, so no automated test gate was run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b86bea84833399ffdca63f56e133)