### PR TITLE
docs(workspace): mark dynamic config as deferred (#3515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,17 +66,14 @@ Release notes: [v0.12.4](docs/releases/v0.12.4.md) · [GitHub Release](https://g
   Multi-file rename batches are merged per-URI via a new `append_workspace_edits`
   helper. (#4056, #4098)
 
-- **`workspace/configuration` reverse-request flow** — the server now parses
-  the client's `workspace.configuration` capability and, when advertised,
-  issues a `workspace/configuration` reverse request per folder after
-  `.perl-lsp.toml` is loaded, merging returned overlays into each folder's
-  `effective_workspace_config` (TOML stays the base layer). Re-fetched on
-  `workspace/didChangeConfiguration`. JSON-RPC responses without `method`
-  are routed as an internal `$/perl-lsp/clientResponse` pseudo-notification
-  through the existing dispatch system. Non-`file://` workspace folder URIs
-  (`vscode-remote://`, `untitled:`, etc.) are tolerated end-to-end —
-  `to_file_path()` calls are routed through a file-only URI helper and
-  non-filesystem folders are skipped during indexing scans. (#4093, #4059)
+- **Dynamic workspace configuration remains deferred** — v0.12.4 keeps
+  per-folder `.perl-lsp.toml` as the supported mechanism. Fully dynamic
+  per-folder scoping via the `workspace/configuration` reverse-request flow
+  remains deferred to follow-up work tracked in #3515. Non-`file://`
+  workspace folder URIs (`vscode-remote://`, `untitled:`, etc.) are still
+  tolerated end-to-end — `to_file_path()` calls are routed through a
+  file-only URI helper and non-filesystem folders are skipped during
+  indexing scans. (#3515, #4059)
 
 - **Windows extended-length path fix for external commands** — `Path::canonicalize`
   on Windows returns paths with the `\\?\` prefix, which Win32 APIs accept but
@@ -93,9 +90,9 @@ Release notes: [v0.12.4](docs/releases/v0.12.4.md) · [GitHub Release](https://g
 
 ### Added
 
-- **Workspace `workspace/configuration` reverse-request flow** with client
-  capability gating, per-folder scoping, and JSON-RPC response routing via
-  `$/perl-lsp/clientResponse` (#4093).
+- **Deferred:** fully dynamic workspace configuration via
+  `workspace/configuration` reverse-request flow remains tracked by #3515;
+  per-folder `.perl-lsp.toml` remains the supported mechanism in v0.12.4.
 
 - **`workspace/willRenameFiles` workspace-wide planning** — reads text from
   open-doc cache, workspace index, or filesystem, and merges multi-URI edits

--- a/docs/releases/v0.12.4.md
+++ b/docs/releases/v0.12.4.md
@@ -30,8 +30,9 @@ assets:
 
 Major patch release shipping inherited/role method navigation, pragma tracker
 correctness sweep, incremental parsing improvements, workspace file-operations
-refactoring, `workspace/configuration` reverse-request flow, Windows
-extended-length path fixes, and Perl::Critic diagnostics UX overhaul.
+refactoring, Windows extended-length path fixes, and Perl::Critic diagnostics
+UX overhaul. Dynamic workspace configuration via
+`workspace/configuration` reverse-request flow remains deferred (#3515).
 
 ~70 PRs merged across two sessions covering navigation, pragma scoping,
 incremental parsing, workspace refactoring, Windows hardening, diagnostics
@@ -50,9 +51,10 @@ polish, hover improvements, completion ranking, and CI hygiene.
 - **Workspace file-operations** — `workspace/willRenameFiles` plans edits across
   unopened files; `workspace/willDeleteFiles` emits warnings for cross-file
   reference breakage.
-- **`workspace/configuration` reverse-request** — server issues
-  `workspace/configuration` requests per folder when the client advertises the
-  capability.
+- **Dynamic workspace configuration deferred** — per-folder
+  `.perl-lsp.toml` remains the supported mechanism; fully dynamic per-folder
+  scoping via `workspace/configuration` reverse requests remains tracked as
+  deferred follow-up work in #3515.
 - **Windows extended-length path fix** — strips `\\?\` prefix before spawning
   external commands (`perl.exe`, `prove`, `yath`).
 - **Perl::Critic diagnostics UX** — policy codes carry `source: "perlcritic"`,

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -16,9 +16,10 @@ All notable changes to the Perl Language Server extension will be documented in 
   `use warnings` placed inside phase blocks (`BEGIN`, `END`, etc.) where they
   have block scope rather than file scope, with quick-fixes that move them to
   file scope. (#4131)
-- **`workspace/configuration` live reload**: server re-fetches per-folder
-  configuration from the client on `workspace/didChangeConfiguration`, merging
-  returned overlays over `.perl-lsp.toml` without a restart. (#4093)
+- **Dynamic workspace configuration remains deferred**: per-folder
+  `.perl-lsp.toml` remains the supported v0.13 mechanism; fully dynamic
+  per-folder scoping via `workspace/configuration` reverse requests is tracked
+  as deferred follow-up work. (#3515)
 - **`workspace/willDeleteFiles` warnings**: deleting a file that is referenced
   by other files in the workspace now surfaces a `Warning` diagnostic before
   the delete completes. (#4056)


### PR DESCRIPTION
### Motivation
- Release-facing notes still described the `workspace/configuration` per-folder reverse-request flow as shipped, but the project currently uses per-folder `.perl-lsp.toml` and fully dynamic per-folder scoping is deferred (tracked in #3515). 

### Description
- Update wording to mark dynamic workspace configuration as deferred and keep `.perl-lsp.toml` as the supported mechanism by editing `CHANGELOG.md`, `docs/releases/v0.12.4.md`, and `vscode-extension/CHANGELOG.md` to reflect the deferred status. 

### Testing
- No crate-level tests were required for this docs-only change; attempted project fast gate `just pr-fast` could not run in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b88a7480833386e54298c52a20a5)