### PR TITLE
docs(workspace): clarify v0.13 config deferral (#0000)

### DIFF
--- a/docs/project/status/workspace.md
+++ b/docs/project/status/workspace.md
@@ -68,7 +68,7 @@ This scorecard measures three properties of the index substrate:
 - PR 3 of 3 (per plan-reviewer option A): stale-index defect harness with realistic LSP session replay (didOpen → didChange → didSave → delete → assert)
 - Promote `ci-workspace-multiroot` from nightly to merge gate once 10 consecutive nightly passes are confirmed
 - Surface real P50/P95 latency numbers from benchmarks (`perl-workspace-index/benches/workspace_index_benchmark.rs`) into this file via `xtask update-status --only workspace`
-- `workspace/configuration` handler (#3515) will add a direct signal row once implemented
+- Dynamic workspace configuration remains deferred for v0.13: per-folder `.perl-lsp.toml` is the supported mechanism, and fully dynamic per-folder scoping via `workspace/configuration` reverse requests is tracked in #3515
 
 ## How to Update
 


### PR DESCRIPTION
### Motivation
- The workspace scorecard's Open Work note implied dynamic per-folder scoping via `workspace/configuration` would arrive in v0.13, but the project instead supports per-folder `.perl-lsp.toml` and defers the `workspace/configuration` reverse-request flow (tracked in #3515).

### Description
- Updated the Open Work bullet in `docs/project/status/workspace.md` to state that per-folder `.perl-lsp.toml` is the supported v0.13 mechanism and that fully dynamic per-folder scoping via `workspace/configuration` reverse requests remains deferred and is tracked in #3515.

### Testing
- Documentation-only change; verified with `git diff -- docs/project/status/workspace.md` and committed as `docs(workspace): clarify v0.13 config deferral (#0000)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b88a7480833386e54298c52a20a5)