### PR TITLE
docs(roadmap): defer dynamic workspace config scope (#0000)

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -117,6 +117,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - Quality cleanup PRs land, version bump to 0.13.0
 - Seamless install story verified across all distribution channels
 - Announcement blog post / release notes
+- Dynamic workspace configuration remains scoped to per-folder `.perl-lsp.toml` for v0.13.0; fully dynamic per-folder scoping through the `workspace/configuration` reverse-request flow is deferred to v0.14.0 ([#3515](https://github.com/EffortlessMetrics/perl-lsp/issues/3515))
 
 ## Milestone Ladder
 


### PR DESCRIPTION
### Motivation
- Make the roadmap explicit that v0.13.0 uses per-folder `.perl-lsp.toml` and that fully dynamic per-folder scoping via the `workspace/configuration` reverse-request flow is deferred to v0.14.0 (see #3515).

### Description
- Added a single bullet to `docs/project/ROADMAP.md` under "Next (v0.13.0)" clarifying the scoped support and the deferral, linking the tracking issue `#3515`.

### Testing
- Ran `cargo check --all-targets -p perl-lsp-rs` which passed; attempted `just pr-fast` could not be run because `just` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b88a7480833386e54298c52a20a5)