### PR TITLE
ci: wire ci-scope classifier into pr-smoke for draft-tier scope-aware checks (#4706)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
+          # Fetch enough history so ci-scope can diff against origin/master.
+          # 0 = full history; balances correctness vs. clone cost.
+          fetch-depth: 0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
@@ -87,10 +90,96 @@ jobs:
           cache-all-crates: true
           shared-key: ci-gate-${{ hashFiles('Cargo.lock') }}
 
-      - name: Run PR smoke checks
+      # Compute CI scope: classify the diff and select lanes.
+      # Falls back gracefully — if ci-scope fails, SCOPE_OK=false and we
+      # fall through to the hardcoded clippy-core / test-core baseline.
+      - name: Compute CI scope
+        id: scope
         run: |
-          just clippy-core
-          just test-core
+          SCOPE_OK=true
+          SCOPE_JSON=$(cargo xtask ci-scope --base origin/master --format json 2>/dev/null) || SCOPE_OK=false
+
+          if [ "$SCOPE_OK" = "false" ] || [ -z "$SCOPE_JSON" ]; then
+            echo "::warning::ci-scope failed or emitted empty output — falling back to clippy-core / test-core"
+            echo "scope_ok=false" >> "$GITHUB_OUTPUT"
+            echo "diff_class=unknown" >> "$GITHUB_OUTPUT"
+            echo "crates_args=" >> "$GITHUB_OUTPUT"
+          else
+            echo "scope_ok=true" >> "$GITHUB_OUTPUT"
+
+            # Extract diff_class
+            DIFF_CLASS=$(echo "$SCOPE_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('diff_class','unknown'))")
+            echo "diff_class=$DIFF_CLASS" >> "$GITHUB_OUTPUT"
+
+            # Build -p args from direct_crates + architecture_wideners (unique, non-empty)
+            CRATES_ARGS=$(echo "$SCOPE_JSON" | python3 -c "
+          import sys, json
+          d = json.load(sys.stdin)
+          names = set()
+          for c in d.get('direct_crates', []):
+              n = c.get('name', '').strip()
+              if n: names.add(n)
+          for c in d.get('architecture_wideners', []):
+              n = c.get('name', '').strip()
+              if n: names.add(n)
+          print(' '.join('-p ' + n for n in sorted(names)))
+          ")
+            echo "crates_args=$CRATES_ARGS" >> "$GITHUB_OUTPUT"
+
+            # Log the scope decision for debugging
+            echo "::notice::ci-scope diff_class=$DIFF_CLASS crates=$CRATES_ARGS"
+          fi
+
+      # Skip heavy lanes entirely for prose-only or CI-config-only diffs.
+      - name: Skip notice (prose-only / CI-config diff)
+        if: |
+          steps.scope.outputs.scope_ok == 'true' &&
+          (steps.scope.outputs.diff_class == 'prose_only' ||
+           steps.scope.outputs.diff_class == 'ci_config')
+        run: |
+          echo "::notice::Prose-only / CI-config diff — skipping Rust build lanes (no code changed)"
+
+      # ── Scoped clippy (scope-aware path) ─────────────────────────────────
+      # Runs when ci-scope succeeded AND diff is not prose/CI-config AND
+      # there are crates to check.
+      - name: Scoped clippy
+        if: |
+          steps.scope.outputs.scope_ok == 'true' &&
+          steps.scope.outputs.diff_class != 'prose_only' &&
+          steps.scope.outputs.diff_class != 'ci_config' &&
+          steps.scope.outputs.crates_args != ''
+        run: |
+          cargo clippy --locked ${{ steps.scope.outputs.crates_args }} -- -D warnings -A missing_docs
+
+      # ── Scoped test (scope-aware path) ───────────────────────────────────
+      - name: Scoped test
+        if: |
+          steps.scope.outputs.scope_ok == 'true' &&
+          steps.scope.outputs.diff_class != 'prose_only' &&
+          steps.scope.outputs.diff_class != 'ci_config' &&
+          steps.scope.outputs.crates_args != ''
+        run: |
+          cargo test --locked --lib ${{ steps.scope.outputs.crates_args }}
+
+      # ── Fallback: baseline clippy-core / test-core ────────────────────────
+      # Runs when: ci-scope failed (scope_ok=false), OR ci-scope returned no
+      # crates to check (empty crates_args on a non-prose diff — shouldn't
+      # happen but guards against gaps in the classifier).
+      - name: Fallback clippy-core
+        if: |
+          steps.scope.outputs.scope_ok == 'false' ||
+          (steps.scope.outputs.diff_class != 'prose_only' &&
+           steps.scope.outputs.diff_class != 'ci_config' &&
+           steps.scope.outputs.crates_args == '')
+        run: just clippy-core
+
+      - name: Fallback test-core
+        if: |
+          steps.scope.outputs.scope_ok == 'false' ||
+          (steps.scope.outputs.diff_class != 'prose_only' &&
+           steps.scope.outputs.diff_class != 'ci_config' &&
+           steps.scope.outputs.crates_args == '')
+        run: just test-core
 
   # ── Merge Gate: full validation on every PR and push to main ─────────
   merge-gate:


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `just clippy-core` / `just test-core` (2-crate: `perl-parser` + `perl-lexer`) in `pr-smoke` with a scope-driven approach powered by `cargo xtask ci-scope`
- Adds `fetch-depth: 0` to the `pr-smoke` checkout so `origin/master` is available for `git diff`
- Uses python3 (pre-installed on ubuntu-24.04) to parse JSON and build `-p <crate>` args from `direct_crates` + `architecture_wideners`

## Behavior

| Diff type | Result |
|-----------|--------|
| Touches `perl-dap/src/foo.rs` | ci-scope widens to include DAP + LSP closure; scoped clippy + test runs on that set |
| Docs-only PR (`prose_only`) | Skip notice emitted; Rust build lanes are skipped entirely |
| CI-config-only PR (`ci_config`) | Same — no Rust lanes run |
| ci-scope fails / empty output | Falls back to `just clippy-core` / `just test-core` (original behavior) |

## Fallback mechanism

The `Compute CI scope` step captures `SCOPE_OK` and the downstream steps branch on it:
1. `ci-scope` exits non-zero → `scope_ok=false` → Fallback clippy-core + test-core run
2. `ci-scope` succeeds but returns no crates (classifier gap) → `crates_args=''` → same fallback
3. `ci-scope` succeeds with crates → Scoped clippy + test run on that crate set

## What is NOT touched

- `merge-gate` — stays full-workspace (`just gates`)
- `check-all-targets` — bit-rot guard untouched
- `ux-tests` — regression suite untouched
- `preflight-latest-check` — SHA-freshness gate untouched

## Test plan

- [ ] PR touching `perl-dap/src/` → scoped lanes include DAP crates (verify via Actions log)
- [ ] Docs-only PR → "Prose-only" notice, Rust steps skipped
- [ ] Intentionally break ci-scope (rename binary) → fallback fires, smoke still passes