### PR TITLE
docs(readme): refresh workspace rename slice issue link (#3522)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The table below is the honest state of v0.13.0 rough edges. None block basic use
 
 #### Must land for v0.13.0
 
-- **Workspace-wide rename slice** — multi-root workspace support shipped in 0.12.x (PR #3984: per-folder config loading, `WorkspaceFolderState`, cross-folder integration); workspace-wide rename and module-move are roughly 30% complete, conditionally in scope pending verification ([#3522](https://github.com/EffortlessMetrics/perl-lsp/issues/3522))
+- **Workspace-wide rename slice** — multi-root workspace support shipped in 0.12.x (PR #3984: per-folder config loading, `WorkspaceFolderState`, cross-folder integration); workspace-wide rename and module-move are roughly 30% complete and conditionally in scope pending verification ([#3522](https://github.com/perl-lsp/perl-lsp/issues/3522))
 
 #### Nice to land
 


### PR DESCRIPTION
### Motivation
- The README's workspace-wide rename status bullet pointed at the pre-transfer issue URL and had slightly awkward phrasing, so update it for clarity and correct linking.

### Description
- Adjust the bullet wording to read "and conditionally in scope pending verification" and update the `#3522` link to the current `perl-lsp/perl-lsp` issue URL in `README.md`.

### Testing
- Ran `cargo xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b86bea84833399ffdca63f56e133)