### PR TITLE
fix(semantic-analyzer): resolve bareword require-import symbols (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1780,6 +1780,19 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             };
             Some(SymbolKey { pkg: pkg.into(), name: bare.into(), sigil: None, kind: SymKind::Sub })
         }
+        NodeKind::Identifier { name } => {
+            let parent = path.get(path.len().saturating_sub(2)).map(|node| &node.kind);
+            if matches!(parent, Some(NodeKind::ExpressionStatement { .. })) {
+                let pkg = find_import_source(ast, name).unwrap_or_else(|| current_pkg.to_string());
+                return Some(SymbolKey {
+                    pkg: pkg.into(),
+                    name: name.clone().into(),
+                    sigil: None,
+                    kind: SymKind::Sub,
+                });
+            }
+            None
+        }
         NodeKind::Subroutine { name: Some(name), .. } => {
             let (pkg, bare) = if let Some(idx) = name.rfind("::") {
                 (&name[..idx], &name[idx + 2..])

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -28,6 +28,20 @@ my $x = load_data();
 }
 
 #[test]
+fn require_import_bareword_call_without_parens_resolves_pkg() {
+    let code = r#"require My::Loader;
+My::Loader->import('load_data');
+load_data;
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data;\n");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "bareword load_data should resolve to My::Loader via require+import, got: {pkg:?}"
+    );
+}
+
+#[test]
 fn require_import_qw_list_resolves_pkg() {
     let code = r#"require My::Tools;
 My::Tools->import(qw(helper_func));


### PR DESCRIPTION
### Motivation

- Go-to-definition did not resolve statement-level bareword subroutine calls (e.g. `load_data;`) that were provided via `require Module; Module->import('sym')`, causing imported symbols to be missed when called without parentheses.

### Description

- Teach `symbol_at_cursor` to treat `NodeKind::Identifier` that lives in an `ExpressionStatement` as a bareword subroutine call and reuse `find_import_source` to infer the provider package.
- Add a regression test `require_import_bareword_call_without_parens_resolves_pkg` to `tests/require_import_resolution.rs` that verifies `require My::Loader; My::Loader->import('load_data'); load_data;` resolves to `My::Loader`.

### Testing

- Ran `cargo test -p perl-semantic-analyzer --test require_import_resolution` and the test suite passed (10 passed; 0 failed).
- Ran `cargo check --all-targets -p perl-semantic-analyzer` and the check completed successfully.
- Ran `cargo clippy -p perl-semantic-analyzer -- -D warnings` and no lints were emitted.
- Ran formatting via `cargo xtask fmt` which completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b877cee88333959cbf69a7cfcfab)