### PR TITLE
docs(config): clarify v0.13 workspace config mechanism (#3515)

### DIFF
--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -60,6 +60,8 @@ All LSP workspace settings live under the `perl` namespace:
 
 `.perl-lsp.toml` is an optional, editor-agnostic project configuration file that you commit to your repository. It lets you share settings with your whole team without requiring each developer to configure their own editor. The file lives at the **workspace root** (the directory containing your `.git` folder or `Makefile.PL` / `cpanfile`).
 
+For v0.13, this per-folder `.perl-lsp.toml` model is the supported multi-root mechanism. Fully dynamic per-folder scoping through the `workspace/configuration` reverse-request flow is deferred (see [#3515](https://github.com/EffortlessMetrics/perl-lsp/issues/3515)).
+
 The server silently skips the file if it does not exist. If the file exists but contains invalid TOML, the server emits a `window/showMessage` warning and continues with defaults.
 
 Unknown keys and sections are silently ignored for forward compatibility.


### PR DESCRIPTION
### Motivation
- Clarify that in v0.13 the supported multi-root configuration mechanism is per-folder `.perl-lsp.toml` and that fully dynamic per-folder scoping via `workspace/configuration` is deferred (see issue `#3515`).

### Description
- Add a concise note to the "Project Configuration File (.perl-lsp.toml)" section of `docs/reference/CONFIG.md` stating the v0.13-supported per-folder TOML model and linking the deferred dynamic scoping to `#3515`.

### Testing
- Ran `cargo xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b88a7480833386e54298c52a20a5)