### PR TITLE
docs(readme): link parser recovery PR references (#3499)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The table below is the honest state of v0.13.0 rough edges. None block basic use
 
 These items were rough edges in the previous list and have since landed:
 
-- Parser error recovery: unclosed block recovery (PR #4079), symbol extractor descends into partial `Error` nodes (PR #4071) — [#3499](https://github.com/EffortlessMetrics/perl-lsp/issues/3499) closed
+- Parser error recovery: unclosed block recovery ([PR #4079](https://github.com/EffortlessMetrics/perl-lsp/pull/4079)), symbol extractor descends into partial `Error` nodes ([PR #4071](https://github.com/EffortlessMetrics/perl-lsp/pull/4071)) — [#3499](https://github.com/EffortlessMetrics/perl-lsp/issues/3499) closed
 - Import list bareword resolution for `use Module qw(...)` and tag imports — [#3472](https://github.com/EffortlessMetrics/perl-lsp/issues/3472) closed
 - `use constant` symbols tracked in visible symbol table — [#3475](https://github.com/EffortlessMetrics/perl-lsp/issues/3475) closed
 - Pragma tracker: `use if`, feature bundles, eval/sub-scoped pragma leakage (PRs #4050, #4038, #4052), conservative `eval STRING` handling (PR #4052) — [#3489](https://github.com/EffortlessMetrics/perl-lsp/issues/3489) closed


### PR DESCRIPTION
### Motivation
- The README mentioned parser error recovery and the issue that closed (#3499) but did not link the two implementation PRs, which makes auditing changes harder.

### Description
- Update the parser recovery bullet in `README.md` to link `[PR #4079]` and `[PR #4071]` while preserving the `[#3499]` closure note.

### Testing
- Ran `cargo test -p perl-parser-core unclosed_block_recovery_tests` and `cargo test -p perl-semantic-analyzer decl_visible_when_initializer_is_error_node`, and both test runs passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b89dc5a48333a4a7e01fe473f672)