### PR TITLE
docs(changelog): note #3499 closure details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,11 @@ Release notes: [v0.12.4](docs/releases/v0.12.4.md) · [GitHub Release](https://g
 
 ### Fixed
 
+- **Parser error recovery and symbol extraction under partial `Error` nodes**
+  — unclosed block recovery landed in `perl-parser-core` (PR #4079) and
+  symbol extraction now descends into partial `Error` nodes (PR #4071),
+  closing issue [#3499](https://github.com/EffortlessMetrics/perl-lsp/issues/3499).
+
 - **Navigation: inherited and role methods in goto-def, hover, and
   completion** — BFS traversal now chains `model.roles` alongside
   `model.parents` in `inherited_method_definition_location`; hover


### PR DESCRIPTION
### Motivation
- Make the changelog explicit that unclosed-block recovery (PR #4079) and symbol extraction into partial `Error` nodes (PR #4071) together close issue #3499.

### Description
- Add a concise bullet to `CHANGELOG.md` under the `Fixed` section referencing PR #4079 and PR #4071 and linking the closure of issue [#3499](https://github.com/EffortlessMetrics/perl-lsp/issues/3499).

### Testing
- No automated tests were required for this documentation-only change and a quick file inspection confirmed the new changelog entry appears in the `Fixed` section.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b89dc5a48333a4a7e01fe473f672)