### PR TITLE
fix(semantic-analyzer): resolve use qw/tag import barewords (#3472)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1345,6 +1345,41 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         export_tag_members(module, import_token).contains(&symbol_name)
     }
 
+    fn qw_list_imports_symbol(import_arg: &str, module: &str, symbol_name: &str) -> bool {
+        let trimmed = import_arg.trim();
+        let Some(rest) = trimmed.strip_prefix("qw") else {
+            return false;
+        };
+        let mut chars = rest.chars();
+        let Some(open) = chars.next() else {
+            return false;
+        };
+        let close = match open {
+            '(' => ')',
+            '[' => ']',
+            '{' => '}',
+            '<' => '>',
+            '/' => '/',
+            '|' => '|',
+            '!' => '!',
+            _ => return false,
+        };
+        let Some(end_idx) = rest.rfind(close) else {
+            return false;
+        };
+        let content = &rest[open.len_utf8()..end_idx];
+        content
+            .split_whitespace()
+            .any(|tok| tok == symbol_name || tag_imports_symbol(module, tok, symbol_name))
+    }
+
+    fn import_arg_matches_symbol(import_arg: &str, module: &str, symbol_name: &str) -> bool {
+        let bare = import_arg.trim().trim_matches(',').trim_matches('\'').trim_matches('"').trim();
+        bare == symbol_name
+            || tag_imports_symbol(module, bare, symbol_name)
+            || qw_list_imports_symbol(bare, module, symbol_name)
+    }
+
     fn find_import_source(ast: &Node, symbol_name: &str) -> Option<String> {
         /// Extract the module name from a `require Module;` statement node.
         ///
@@ -1423,29 +1458,8 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         /// context).
         fn arg_node_matches_symbol(arg: &Node, module: &str, symbol: &str) -> bool {
             match &arg.kind {
-                NodeKind::String { value, .. } => {
-                    // Strip surrounding single/double quotes that some code
-                    // paths leave in the value (e.g. qw in quotes.rs).
-                    let bare = value.trim_matches('\'').trim_matches('"');
-                    bare == symbol || tag_imports_symbol(module, bare, symbol)
-                }
-                NodeKind::Identifier { name } => {
-                    if name == symbol {
-                        return true;
-                    }
-                    // qw(...) stored as a raw "qw(...)" Identifier string
-                    // (from the Use-node code path that reuses this helper).
-                    if name.starts_with("qw") {
-                        let content = name
-                            .trim_start_matches("qw")
-                            .trim_start_matches(|c: char| "([{/<|!".contains(c))
-                            .trim_end_matches(|c: char| ")]}/|!>".contains(c));
-                        return content
-                            .split_whitespace()
-                            .any(|tok| tok == symbol || tag_imports_symbol(module, tok, symbol));
-                    }
-                    false
-                }
+                NodeKind::String { value, .. } => import_arg_matches_symbol(value, module, symbol),
+                NodeKind::Identifier { name } => import_arg_matches_symbol(name, module, symbol),
                 NodeKind::ArrayLiteral { elements } => {
                     // qw(...) in expression context → ArrayLiteral of String nodes
                     elements.iter().any(|el| arg_node_matches_symbol(el, module, symbol))
@@ -1548,35 +1562,8 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
                     // Fall through to children
                 } else {
                     for arg in args {
-                        if arg == name {
+                        if import_arg_matches_symbol(arg, module, name) {
                             return Some(module.clone());
-                        }
-                        if tag_imports_symbol(module, arg, name) {
-                            return Some(module.clone());
-                        }
-                        if arg.starts_with("qw") {
-                            let content = arg
-                                .trim_start_matches("qw")
-                                .trim_start_matches(|c: char| "([{/<|!".contains(c))
-                                .trim_end_matches(|c: char| ")]}/|!>".contains(c));
-                            for import_token in content.split_whitespace() {
-                                if import_token == name
-                                    || tag_imports_symbol(module, import_token, name)
-                                {
-                                    return Some(module.clone());
-                                }
-                            }
-                        } else {
-                            // Parenthesized import list: use Foo ('bar', 'baz')
-                            // The parser emits each token as a separate arg including commas
-                            // and string literals with their surrounding quotes.
-                            let bare = arg.trim().trim_matches('\'').trim_matches('"').trim();
-                            if bare == name {
-                                return Some(module.clone());
-                            }
-                            if tag_imports_symbol(module, bare, name) {
-                                return Some(module.clone());
-                            }
                         }
                     }
                 }

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -55,6 +55,32 @@ croak("error");
 }
 
 #[test]
+fn use_import_qw_tag_resolves_members() {
+    let code = r#"use POSIX qw(:sys_wait_h);
+my $ok = WIFEXITED($status);
+"#;
+    let pkg = parse_and_symbol_at(code, "WIFEXITED(");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("POSIX"),
+        "WIFEXITED() should resolve to POSIX via use+qw tag import, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn use_import_qw_delimited_list_resolves_pkg() {
+    let code = r#"use List::Util qw/sum min/;
+my $total = sum(1, 2, 3);
+"#;
+    let pkg = parse_and_symbol_at(code, "sum(");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("List::Util"),
+        "sum() should resolve to List::Util via use+qw/.../ import, got: {pkg:?}"
+    );
+}
+
+#[test]
 fn require_import_multiple_symbols_both_resolve() {
     let code = r#"require My::Utils;
 My::Utils->import('alpha', 'beta');


### PR DESCRIPTION
### Motivation

- Symbol resolution for barewords imported via `use Module qw(...)` and tag imports like `:sys_wait_h` was inconsistent, causing `symbol_at_cursor` to miss their source package.

### Description

- Added `qw_list_imports_symbol` to robustly parse `qw` forms with multiple delimiter styles and match tokens against the queried symbol.
- Added `import_arg_matches_symbol` and centralized import-argument matching to handle quoted tokens, commas, tag tokens, and `qw` lists in one place.
- Rewired `arg_node_matches_symbol` and the `Use`-node import scanning to use the new matcher so both `use Module ...` and `Module->import(...)` paths share the same logic.
- Added regression tests covering `use POSIX qw(:sys_wait_h);` and `use List::Util qw/sum min/;` to verify tag and delimited `qw` list resolution.

### Testing

- Ran `cargo test -p perl-semantic-analyzer --test require_import_resolution`, which passed (`11 passed`).
- Ran `cargo check --all-targets -p perl-semantic-analyzer`, which completed successfully.
- Ran `cargo clippy -p perl-semantic-analyzer`, which completed successfully; note that `cargo clippy -p perl-semantic-analyzer --all-targets -- -D warnings` initially failed due to unrelated test `expect()` usages, not changes in this patch.
- Ran `cargo xtask fmt`; formatting completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b8aae34c83339cb2546c05adf79b)