### PR TITLE
fix(semantic-analyzer): resolve bareword import symbols (#3472)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1289,6 +1289,7 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
                 matches!(
                     node.kind,
                     NodeKind::Variable { .. }
+                        | NodeKind::Identifier { .. }
                         | NodeKind::FunctionCall { .. }
                         | NodeKind::Subroutine { .. }
                         | NodeKind::MethodCall { .. }
@@ -1770,6 +1771,17 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             })
         }
         NodeKind::FunctionCall { name, .. } => {
+            let (pkg, bare) = if let Some(idx) = name.rfind("::") {
+                (name[..idx].to_string(), name[idx + 2..].to_string())
+            } else {
+                (
+                    find_import_source(ast, name).unwrap_or_else(|| current_pkg.to_string()),
+                    name.clone(),
+                )
+            };
+            Some(SymbolKey { pkg: pkg.into(), name: bare.into(), sigil: None, kind: SymKind::Sub })
+        }
+        NodeKind::Identifier { name } => {
             let (pkg, bare) = if let Some(idx) = name.rfind("::") {
                 (name[..idx].to_string(), name[idx + 2..].to_string())
             } else {

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -55,6 +55,32 @@ croak("error");
 }
 
 #[test]
+fn use_import_qw_bareword_resolves_pkg() {
+    let code = r#"use Carp qw(croak);
+my $err = croak;
+"#;
+    let pkg = parse_and_symbol_at(code, "croak;");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("Carp"),
+        "bareword croak should resolve to Carp via use+qw import, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn use_import_tag_bareword_resolves_pkg() {
+    let code = r#"use POSIX qw(:sys_wait_h);
+my $ok = WIFEXITED;
+"#;
+    let pkg = parse_and_symbol_at(code, "WIFEXITED;");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("POSIX"),
+        "bareword WIFEXITED should resolve to POSIX via tag import, got: {pkg:?}"
+    );
+}
+
+#[test]
 fn require_import_multiple_symbols_both_resolve() {
     let code = r#"require My::Utils;
 My::Utils->import('alpha', 'beta');


### PR DESCRIPTION
### Motivation

- `symbol_at_cursor` did not resolve bareword identifiers imported via `use Module qw(...)` or tag imports, causing go-to-definition to miss imported symbols.

### Description

- Treat `Identifier` nodes as symbol candidates in `symbol_at_cursor` so barewords are considered for resolution (`crates/perl-semantic-analyzer/src/analysis/declaration.rs`).
- Resolve those identifiers using the existing `find_import_source` / import-scan logic so `use Module qw(...)` and tag imports correctly claim symbol ownership.
- Add regression tests for bareword cases: `use Carp qw(croak); my $err = croak;` and `use POSIX qw(:sys_wait_h); my $ok = WIFEXITED;` (`crates/perl-semantic-analyzer/tests/require_import_resolution.rs`).

### Testing

- Ran `cargo test -p perl-semantic-analyzer --test require_import_resolution`, and all tests passed (`11 passed`).
- Ran `cargo check --all-targets -p perl-semantic-analyzer` and `cargo clippy -p perl-semantic-analyzer -- -D warnings`, both completed without errors.
- Ran formatting via `cargo xtask fmt`; it completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b8aae34c83339cb2546c05adf79b)