### PR TITLE
fix(semantic-analyzer): track imported barewords via scope_analyzer (#3472)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,6 +1847,7 @@ dependencies = [
 name = "perl-semantic-analyzer"
 version = "0.12.4"
 dependencies = [
+ "perl-module",
  "perl-parser-core",
  "perl-symbol",
  "perl-tdd-support",

--- a/crates/perl-semantic-analyzer/Cargo.toml
+++ b/crates/perl-semantic-analyzer/Cargo.toml
@@ -24,6 +24,7 @@ doctest = false
 
 [dependencies]
 perl-parser-core = { workspace = true }
+perl-module = { workspace = true }
 perl-workspace = { workspace = true }
 perl-symbol = { workspace = true }
 regex.workspace = true
@@ -38,4 +39,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
-

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -51,6 +51,7 @@
 
 use crate::ast::{Node, NodeKind};
 use crate::pragma_tracker::{PragmaState, PragmaTracker};
+use perl_module::import::resolve_known_export_tag;
 use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
 use std::ops::Range;
@@ -357,19 +358,25 @@ enum ExtractedName<'a> {
 struct AnalysisContext<'a> {
     code: &'a str,
     pragma_map: &'a [(Range<usize>, PragmaState)],
+    imported_barewords: std::collections::HashSet<String>,
     line_starts: RefCell<Option<Vec<usize>>>,
     /// Current package name, updated as `package` statements are traversed.
     current_package: RefCell<String>,
 }
 
 impl<'a> AnalysisContext<'a> {
-    fn new(code: &'a str, pragma_map: &'a [(Range<usize>, PragmaState)]) -> Self {
+    fn new(ast: &Node, code: &'a str, pragma_map: &'a [(Range<usize>, PragmaState)]) -> Self {
         Self {
             code,
             pragma_map,
+            imported_barewords: collect_imported_barewords(ast),
             line_starts: RefCell::new(None),
             current_package: RefCell::new("main".to_string()),
         }
+    }
+
+    fn has_imported_bareword(&self, name: &str) -> bool {
+        self.imported_barewords.contains(name)
     }
 
     fn get_line(&self, offset: usize) -> usize {
@@ -558,7 +565,7 @@ impl ScopeAnalyzer {
         // Use a vector as a stack for ancestors to avoid O(N) HashMap allocation
         let mut ancestors: Vec<&Node> = Vec::new();
 
-        let context = AnalysisContext::new(code, pragma_map);
+        let context = AnalysisContext::new(ast, code, pragma_map);
 
         self.analyze_node(ast, &root_scope, &mut ancestors, &mut issues, &context);
 
@@ -978,6 +985,7 @@ impl ScopeAnalyzer {
                     && !self.is_in_hash_key_context(node, ancestors, 1)
                     && !is_known_function(name)
                     && !pragma_state.has_builtin_import(name)
+                    && !context.has_imported_bareword(name)
                     && !self.is_in_hash_key_context(node, ancestors, 10)
                 {
                     issues.push(ScopeIssue {
@@ -1831,6 +1839,57 @@ impl ScopeAnalyzer {
             })
             .collect()
     }
+}
+
+fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
+    fn push_symbol(imported: &mut std::collections::HashSet<String>, module: &str, token: &str) {
+        let symbol = token.trim().trim_matches('\'').trim_matches('"').trim();
+        if symbol.is_empty() || symbol == "," {
+            return;
+        }
+
+        if symbol.starts_with(':') {
+            if let Some(expanded) = resolve_known_export_tag(module, symbol) {
+                imported.extend(expanded.iter().map(|name| (*name).to_string()));
+            }
+            return;
+        }
+
+        let is_bareword = symbol.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+            && symbol
+                .as_bytes()
+                .first()
+                .is_some_and(|first| first.is_ascii_alphabetic() || *first == b'_');
+        if is_bareword {
+            imported.insert(symbol.to_string());
+        }
+    }
+
+    fn visit(node: &Node, imported: &mut std::collections::HashSet<String>) {
+        if let NodeKind::Use { module, args, .. } = &node.kind {
+            for arg in args {
+                if arg.starts_with("qw") {
+                    let content = arg
+                        .trim_start_matches("qw")
+                        .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                        .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                    for token in content.split_whitespace() {
+                        push_symbol(imported, module, token);
+                    }
+                } else {
+                    push_symbol(imported, module, arg);
+                }
+            }
+        }
+
+        for child in node.children() {
+            visit(child, imported);
+        }
+    }
+
+    let mut imported = std::collections::HashSet::new();
+    visit(ast, &mut imported);
+    imported
 }
 
 /// Returns true if `name` (without sigil) is a numbered capture variable.

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1831,6 +1831,42 @@ print PL_sv_undef;
 }
 
 #[test]
+fn strict_subs_allows_qw_imported_barewords() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+use List::Util qw(sum);
+print sum(1, 2, 3);
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "sum"
+        }),
+        "strict 'subs' should not flag qw-imported bareword function names"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_subs_allows_tag_imported_barewords() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+use POSIX qw(:sys_wait_h);
+print WIFEXITED(0);
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "WIFEXITED"
+        }),
+        "strict 'subs' should not flag symbols imported through known export tags"
+    );
+    Ok(())
+}
+
+#[test]
 fn version_pragma_enables_strict_vars_and_subs() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use v5.40;


### PR DESCRIPTION
### Motivation

- `UnquotedBareword` diagnostics under `use strict 'subs'` were incorrectly flagging symbols that were actually imported via `use Module qw(...)` or via export tags (e.g. `:sys_wait_h`).

### Description

- Add `perl-module` workspace dependency and use `resolve_known_export_tag` to expand known export tags. 
- Build an `imported_barewords` set at analysis start via `collect_imported_barewords(ast)` which parses `use` statements, handles `qw(...)` delimiters, parenthesized lists, and export-tag expansion. 
- Exempt names present in the collected `imported_barewords` from the strict `UnquotedBareword` check in `ScopeAnalyzer::analyze_node`. 
- Add regression tests `strict_subs_allows_qw_imported_barewords` and `strict_subs_allows_tag_imported_barewords` to ensure imported symbols are not reported. 
- Update `Cargo.lock` and run formatting/cleanup around the changes.

### Testing

- Ran `cargo test -p perl-semantic-analyzer` and all relevant tests (including the two new regression tests) passed. 
- Ran `cargo check --all-targets -p perl-semantic-analyzer` which completed successfully. 
- Ran `cargo clippy -p perl-semantic-analyzer` and `cargo xtask fmt` which completed without blocking issues. 
- Verified related `perl-lsp-rs` cross-file goto-definition test for parenthesized import list also passes locally. 
- Note: `just pr-fast` was not executed in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b8aae34c83339cb2546c05adf79b)