### PR TITLE
fix(perl-parser): correct super path in incremental_document test import (#5016)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_document.rs
+++ b/crates/perl-parser/src/incremental/incremental_document.rs
@@ -1077,7 +1077,7 @@ impl SubtreeCache {
 
 #[cfg(test)]
 mod tests {
-    use super::incremental_edit::IncrementalEdit;
+    use super::super::incremental_edit::IncrementalEdit;
     use super::*;
 
     #[test]


### PR DESCRIPTION
Closes #5016.

## Root cause

`crates/perl-parser/src/incremental/incremental_document.rs` line 1080 inside `#[cfg(test)] mod tests` had:
```rust
use super::incremental_edit::IncrementalEdit;
```

From inside `tests` (a child of `incremental_document`), `super` resolves to `incremental_document` itself — not to the `incremental` parent module. The sibling-module `incremental_edit` lives one level up, so the correct path is `super::super::incremental_edit`.

## Why only visible with feature unification

The whole `incremental` module in `perl-parser` is gated behind `feature = "incremental"`. When `cargo check --workspace --all-targets` runs, the feature is unified via `perl-lsp-rs/default = ["workspace", "incremental"]`, which enables the test mod to compile.

The existing top-level import at line 6 works because it's in the `incremental_document` module scope, where `super` correctly points to `incremental`.

## Verification

```bash
cargo check -p perl-parser --features incremental --tests --locked    # green
cargo check --workspace --all-targets --locked                         # green
```

## Caught by

The compile-all-targets gate (#4988) on #5005 surfaced this; the fix is one-line.