### PR TITLE
fix(declaration): resolve bareword imports in `use ... qw(...)` lists (#3472)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/moniker.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/moniker.rs
@@ -28,9 +28,12 @@ impl LspServer {
 
                     // Find the symbol at the cursor position
                     let current_pkg = crate::declaration::current_package_at(ast, offset);
-                    if let Some(key) =
-                        crate::declaration::symbol_at_cursor(ast, offset, current_pkg)
-                    {
+                    if let Some(key) = crate::declaration::symbol_at_cursor_with_source(
+                        ast,
+                        offset,
+                        current_pkg,
+                        &doc.text,
+                    ) {
                         let mut monikers = Vec::new();
 
                         // Determine moniker properties based on symbol context

--- a/crates/perl-lsp-rs/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/navigation.rs
@@ -1351,7 +1351,12 @@ impl LspServer {
                             let current_package =
                                 crate::declaration::current_package_at(ast, offset);
                             if let Some(symbol_key) =
-                                crate::declaration::symbol_at_cursor(ast, offset, current_package)
+                                crate::declaration::symbol_at_cursor_with_source(
+                                    ast,
+                                    offset,
+                                    current_package,
+                                    &doc.text,
+                                )
                             {
                                 tracing::debug!(symbol_key = ?symbol_key, "looking for definition");
 

--- a/crates/perl-lsp-rs/src/runtime/language/references.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/references.rs
@@ -60,8 +60,12 @@ impl LspServer {
                         .unwrap_or_default();
 
                     let current_package = crate::declaration::current_package_at(ast, offset);
-                    let symbol_key =
-                        crate::declaration::symbol_at_cursor(ast, offset, current_package);
+                    let symbol_key = crate::declaration::symbol_at_cursor_with_source(
+                        ast,
+                        offset,
+                        current_package,
+                        &doc.text,
+                    );
 
                     // Check index state and use appropriate search strategy
                     #[cfg(feature = "workspace")]

--- a/crates/perl-lsp-rs/src/runtime/language/rename.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/rename.rs
@@ -167,7 +167,12 @@ impl LspServer {
                                 let offset = self.pos16_to_offset(doc, line as u32, ch as u32);
                                 let current_pkg =
                                     crate::declaration::current_package_at(ast, offset);
-                                crate::declaration::symbol_at_cursor(ast, offset, current_pkg)
+                                crate::declaration::symbol_at_cursor_with_source(
+                                    ast,
+                                    offset,
+                                    current_pkg,
+                                    &doc.text,
+                                )
                             })
                         })
                     };

--- a/crates/perl-lsp-rs/tests/cross_file_goto_definition_tests.rs
+++ b/crates/perl-lsp-rs/tests/cross_file_goto_definition_tests.rs
@@ -266,6 +266,66 @@ my $result = calculate_sum(1, 2, 3);
 }
 
 #[test]
+fn go_to_definition_on_use_qw_import_bareword_navigates_to_source_module() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = support::lsp_harness::TempWorkspace::new()?;
+
+    workspace.write(
+        "lib/My/Utils.pm",
+        r#"package My::Utils;
+use strict;
+use warnings;
+
+sub calculate_sum {
+    my (@nums) = @_;
+    my $total = 0;
+    $total += $_ for @nums;
+    return $total;
+}
+
+1;
+"#,
+    )?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+
+    let module_uri = workspace.uri("lib/My/Utils.pm");
+    let module_content = std::fs::read_to_string(workspace.dir.path().join("lib/My/Utils.pm"))
+        .map_err(|e| format!("failed to read module: {e}"))?;
+    harness.open(&module_uri, &module_content)?;
+
+    let caller = r#"#!/usr/bin/perl
+use strict;
+use warnings;
+use My::Utils qw(calculate_sum);
+"#;
+    harness.open(&workspace.uri("app.pl"), caller)?;
+    harness.barrier();
+
+    let (line, character) = find_line_char(caller, "calculate_sum")?;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("app.pl")},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let locations = result.as_array().ok_or("expected location array")?;
+    assert!(!locations.is_empty(), "expected definition result for use qw bareword import");
+
+    let first = &locations[0];
+    assert_valid_location(first);
+    let uri = first["uri"].as_str().ok_or("Expected URI")?;
+    assert!(
+        uri.contains("My/Utils.pm") || uri.contains("My%2FUtils.pm"),
+        "Definition should point to My/Utils.pm, got: {uri}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn go_to_definition_on_tag_imported_symbol_navigates_to_source_module() -> TestResult {
     let mut harness = LspHarness::new();
     let workspace = support::lsp_harness::TempWorkspace::new()?;
@@ -387,6 +447,66 @@ my $result = runtime_sum(1, 2, 3);
         uri.contains("My/Runtime.pm") || uri.contains("My%2FRuntime.pm"),
         "Definition should point to My/Runtime.pm, got: {}",
         uri
+    );
+
+    Ok(())
+}
+
+#[test]
+fn go_to_definition_on_use_qw_tag_expansion_bareword_navigates_to_source_module() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = support::lsp_harness::TempWorkspace::new()?;
+
+    workspace.write(
+        "lib/POSIX.pm",
+        r#"package POSIX;
+use strict;
+use warnings;
+
+sub WIFEXITED {
+    return 1;
+}
+
+1;
+"#,
+    )?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+
+    let module_uri = workspace.uri("lib/POSIX.pm");
+    let module_content = std::fs::read_to_string(workspace.dir.path().join("lib/POSIX.pm"))
+        .map_err(|e| format!("failed to read module: {e}"))?;
+    harness.open(&module_uri, &module_content)?;
+
+    let caller = r#"#!/usr/bin/perl
+use strict;
+use warnings;
+use POSIX qw(:sys_wait_h WIFEXITED);
+"#;
+    harness.open(&workspace.uri("app.pl"), caller)?;
+    harness.barrier();
+
+    let (line, character) = find_line_char(caller, "WIFEXITED")?;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("app.pl")},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let locations = result.as_array().ok_or("expected location array")?;
+    assert!(
+        !locations.is_empty(),
+        "expected definition result for bareword in tag-based use qw import list"
+    );
+
+    let first = &locations[0];
+    assert_valid_location(first);
+    let uri = first["uri"].as_str().ok_or("Expected URI")?;
+    assert!(
+        uri.contains("POSIX.pm") || uri.contains("POSIX%2Epm"),
+        "Definition should point to POSIX.pm, got: {uri}"
     );
 
     Ok(())

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1254,7 +1254,12 @@ impl<'a> DeclarationProvider<'a> {
 ///     println!("Found symbol: {:?}", sym);
 /// }
 /// ```
-pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<SymbolKey> {
+fn symbol_at_cursor_internal(
+    ast: &Node,
+    offset: usize,
+    current_pkg: &str,
+    source_text: &str,
+) -> Option<SymbolKey> {
     fn collect_node_path_at_offset<'a>(
         node: &'a Node,
         offset: usize,
@@ -1309,6 +1314,27 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
     }
 
+    fn token_at_offset_in_text(text: &str, rel_offset: usize) -> Option<String> {
+        let bytes = text.as_bytes();
+        if rel_offset >= bytes.len() {
+            return None;
+        }
+        let is_ident = |b: u8| matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_' | b':');
+        if !is_ident(bytes[rel_offset]) {
+            return None;
+        }
+
+        let mut start = rel_offset;
+        while start > 0 && is_ident(bytes[start - 1]) {
+            start -= 1;
+        }
+        let mut end = rel_offset + 1;
+        while end < bytes.len() && is_ident(bytes[end]) {
+            end += 1;
+        }
+        Some(text[start..end].to_string())
+    }
+
     fn export_tag_members(module: &str, tag: &str) -> &'static [&'static str] {
         match (module, tag) {
             // POSIX tag sets commonly used in system scripts.
@@ -1343,6 +1369,27 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             return false;
         }
         export_tag_members(module, import_token).contains(&symbol_name)
+    }
+
+    fn use_args_import_symbol(module: &str, args: &[String], symbol_name: &str) -> bool {
+        args.iter().any(|arg| {
+            if arg == symbol_name || tag_imports_symbol(module, arg, symbol_name) {
+                return true;
+            }
+
+            if arg.starts_with("qw") {
+                let content = arg
+                    .trim_start_matches("qw")
+                    .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                    .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                return content
+                    .split_whitespace()
+                    .any(|tok| tok == symbol_name || tag_imports_symbol(module, tok, symbol_name));
+            }
+
+            let bare = arg.trim().trim_matches('\'').trim_matches('"').trim();
+            bare == symbol_name || tag_imports_symbol(module, bare, symbol_name)
+        })
     }
 
     fn find_import_source(ast: &Node, symbol_name: &str) -> Option<String> {
@@ -1800,7 +1847,28 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
                 kind: SymKind::Sub,
             })
         }
-        NodeKind::Use { module, .. } => {
+        NodeKind::Use { module, args, .. } => {
+            if module != "constant"
+                && !source_text.is_empty()
+                && offset >= node.location.start
+                && offset <= node.location.end
+            {
+                let rel_offset = offset.saturating_sub(node.location.start);
+                if let Some(stmt_text) = source_text.get(node.location.start..node.location.end)
+                    && let Some(token) = token_at_offset_in_text(stmt_text, rel_offset)
+                    && token != *module
+                    && token != "use"
+                    && use_args_import_symbol(module, args, &token)
+                {
+                    return Some(SymbolKey {
+                        pkg: module.clone().into(),
+                        name: token.into(),
+                        sigil: None,
+                        kind: SymKind::Sub,
+                    });
+                }
+            }
+
             // When cursor is on a `use Module::Name` statement, resolve to the package
             Some(SymbolKey {
                 pkg: module.clone().into(),
@@ -1811,6 +1879,27 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         }
         _ => None,
     }
+}
+
+/// Extract a symbol key at a cursor offset with access to source text.
+///
+/// This variant is used by LSP handlers when additional source-aware
+/// disambiguation is needed (for example, barewords in `use ... qw(...)` lists).
+pub fn symbol_at_cursor_with_source(
+    ast: &Node,
+    offset: usize,
+    current_pkg: &str,
+    source_text: &str,
+) -> Option<SymbolKey> {
+    symbol_at_cursor_internal(ast, offset, current_pkg, source_text)
+}
+
+/// Extract a symbol key at a cursor offset.
+///
+/// This keeps the historical API and defers to [`symbol_at_cursor_with_source`]
+/// without source text-specific disambiguation.
+pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<SymbolKey> {
+    symbol_at_cursor_internal(ast, offset, current_pkg, "")
 }
 
 /// Determines the current package context at the given offset.

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1371,6 +1371,23 @@ fn symbol_at_cursor_internal(
         export_tag_members(module, import_token).contains(&symbol_name)
     }
 
+    /// Pragmas and structural modules whose qw/string arguments are NOT
+    /// imported symbol names. Cursor-on-arg for these should not resolve
+    /// to a bogus `SymbolKey` — they carry inheritance lists, feature names,
+    /// or other non-import semantics.
+    const NON_IMPORT_PRAGMAS: &[&str] = &[
+        "constant", // constant definitions, not imports
+        "parent",   // inheritance: qw/string args are class names
+        "base",     // legacy inheritance
+        "vars",     // variable declarations, not imports
+        "Exporter", // 'import' arg is a proxy method, not an imported symbol
+        "mro",      // method resolution order pragma
+        "if",       // conditional module load
+        "lib",      // adds directories to @INC
+        "feature",  // enables Perl feature flags
+        "utf8",     // encoding pragma
+    ];
+
     fn use_args_import_symbol(module: &str, args: &[String], symbol_name: &str) -> bool {
         args.iter().any(|arg| {
             if arg == symbol_name || tag_imports_symbol(module, arg, symbol_name) {
@@ -1590,8 +1607,8 @@ fn symbol_at_cursor_internal(
 
         fn find(node: &Node, name: &str) -> Option<String> {
             if let NodeKind::Use { module, args, .. } = &node.kind {
-                // Skip `use constant` — constants are not import-list symbols
-                if module == "constant" {
+                // Skip structural pragmas — their args are not import-list symbols
+                if NON_IMPORT_PRAGMAS.contains(&module.as_str()) {
                     // Fall through to children
                 } else {
                     for arg in args {
@@ -1848,7 +1865,7 @@ fn symbol_at_cursor_internal(
             })
         }
         NodeKind::Use { module, args, .. } => {
-            if module != "constant"
+            if !NON_IMPORT_PRAGMAS.contains(&module.as_str())
                 && !source_text.is_empty()
                 && offset >= node.location.start
                 && offset <= node.location.end

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -2,7 +2,9 @@
 //! Issue #3476: literal require + explicit named import tracking.
 
 use perl_semantic_analyzer::Parser;
-use perl_semantic_analyzer::analysis::declaration::symbol_at_cursor;
+use perl_semantic_analyzer::analysis::declaration::{
+    symbol_at_cursor, symbol_at_cursor_with_source,
+};
 
 fn parse_and_symbol_at(code: &str, needle: &str) -> Option<String> {
     // Find the byte offset of needle in the code
@@ -11,6 +13,16 @@ fn parse_and_symbol_at(code: &str, needle: &str) -> Option<String> {
     let ast = parser.parse().ok()?;
     let key = symbol_at_cursor(&ast, offset, "main")?;
     Some(key.pkg.to_string())
+}
+
+/// Helper: parse `code`, find `needle`, call symbol_at_cursor_with_source.
+/// Returns the SymbolKey's (pkg, name) as Strings, or None.
+fn parse_and_symbol_with_source_at(code: &str, needle: &str) -> Option<(String, String)> {
+    let offset = code.find(needle)?;
+    let mut parser = Parser::new(code);
+    let ast = parser.parse().ok()?;
+    let key = symbol_at_cursor_with_source(&ast, offset, "main", code)?;
+    Some((key.pkg.to_string(), key.name.to_string()))
 }
 
 #[test]
@@ -148,4 +160,44 @@ load_data();
         Some("My::Loader"),
         "$loader->import() should resolve back to static use_module target, got: {pkg:?}"
     );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Regression tests for NON_IMPORT_PRAGMAS false-positive fix (PR #5022)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// `use parent qw(Base::Class)` — cursor on `Base` should NOT resolve to a
+/// bogus SymbolKey like `{ pkg: "parent", name: "Base::Class", kind: Sub }`.
+/// `parent` is an inheritance pragma; its args are class names, not imports.
+#[test]
+fn use_parent_qw_does_not_resolve_as_import() {
+    let code = "use parent qw(Base::Class);\n";
+    // Position cursor on "Base" inside the qw list
+    let result = parse_and_symbol_with_source_at(code, "Base");
+    // Must NOT return pkg="parent", name="Base::Class"
+    if let Some((pkg, name)) = &result {
+        assert!(
+            !(pkg == "parent" && name == "Base::Class"),
+            "use parent qw(Base::Class) with cursor on 'Base' produced bogus SymbolKey \
+             {{ pkg: {pkg:?}, name: {name:?} }} — parent args are not imported symbols"
+        );
+    }
+    // Either None or resolved to the package itself (Pack kind) is acceptable.
+}
+
+/// `use Exporter 'import'` — cursor on `import` should NOT resolve to
+/// `SymbolKey { pkg: "Exporter", name: "import", kind: Sub }`.
+/// `'import'` here is a proxy-import method name, not an imported symbol.
+#[test]
+fn use_exporter_import_does_not_resolve_as_import() {
+    let code = "use Exporter 'import';\n";
+    // Position cursor on 'import' (the string literal)
+    let result = parse_and_symbol_with_source_at(code, "import");
+    if let Some((pkg, name)) = &result {
+        assert!(
+            !(pkg == "Exporter" && name == "import"),
+            "use Exporter 'import' with cursor on 'import' produced bogus SymbolKey \
+             {{ pkg: {pkg:?}, name: {name:?} }} — Exporter args are not imported symbols"
+        );
+    }
 }


### PR DESCRIPTION
### Motivation

- Go-to-definition and related features treated barewords inside `use Module qw(...)` import lists as package navigation rather than imported symbols, so imported functions and tag-expanded members did not navigate to their exporter definitions.

### Description

- Add a source-aware internal resolver `symbol_at_cursor_internal(..., source_text)` and a public `symbol_at_cursor_with_source(...)` API to disambiguate barewords inside `use` import lists. 
- Implement `token_at_offset_in_text` and `use_args_import_symbol` helpers and extend `NodeKind::Use` handling to recognize bareword imports (including `qw(...)` and tag expansions) and return `SymbolKey { pkg: module, name: symbol }` when appropriate. 
- Wire LSP handlers to use the new API by passing `&doc.text` in definition/rename/references/moniker paths so editor flows use the source-aware resolution. 
- Add regression tests covering `use Module qw(symbol)` and tag-based `use POSIX qw(:tag SYMBOL)` bareword resolution in `cross_file_goto_definition_tests.rs`.

### Testing

- Ran `cargo test -p perl-lsp-rs --test cross_file_goto_definition_tests use_qw_` and the two new `use qw` tests passed. 
- Ran `cargo check --all-targets -p perl-semantic-analyzer -p perl-lsp-rs` and it completed successfully. 
- Ran `cargo xtask fmt` to format changes successfully. 
- Note: `just pr-fast` is not available in this environment (`/bin/bash: line 1: just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b8aae34c83339cb2546c05adf79b)