### PR TITLE
fix(completion): include visible constant symbols (#3475)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -1918,7 +1918,9 @@ impl CompletionProvider {
         // Check user-defined functions
         for (name, symbols) in &self.symbol_table.symbols {
             for symbol in symbols {
-                if symbol.kind == SymbolKind::Subroutine && name.starts_with(prefix) {
+                if (symbol.kind == SymbolKind::Subroutine || symbol.kind == SymbolKind::Constant)
+                    && name.starts_with(prefix)
+                {
                     return true;
                 }
             }
@@ -2168,6 +2170,32 @@ proc
 
         assert!(completions.iter().any(|c| c.label == "process_data"));
         assert!(completions.iter().any(|c| c.label == "process_items"));
+    }
+
+    #[test]
+    fn test_constant_symbols_in_visible_table_are_completed() {
+        use perl_semantic_analyzer::SourceLocation;
+        use perl_semantic_analyzer::symbol::Symbol;
+
+        let code = "P";
+        let mut parser = Parser::new("");
+        let ast = must(parser.parse());
+
+        let mut provider = CompletionProvider::new(&ast);
+        provider.symbol_table.symbols.entry("PI".to_string()).or_default().push(Symbol {
+            name: "PI".to_string(),
+            qualified_name: "PI".to_string(),
+            kind: SymbolKind::Constant,
+            location: SourceLocation { start: 0, end: 0 },
+            scope_id: 0,
+            declaration: Some("constant".to_string()),
+            documentation: Some("constant PI".to_string()),
+            attributes: vec![],
+        });
+
+        let completions = provider.get_completions(code, code.len());
+
+        assert!(completions.iter().any(|c| c.label == "PI"));
     }
 
     #[test]

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/functions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/functions.rs
@@ -20,22 +20,38 @@ pub fn add_function_completions(
 
     for (name, symbols) in &symbol_table.symbols {
         for symbol in symbols {
-            if symbol.kind == SymbolKind::Subroutine && name.starts_with(prefix_without_amp) {
-                let distance =
-                    compute_scope_distance(symbol_table, context.cursor_scope_id, symbol.scope_id);
-                completions.push(CompletionItem {
-                    label: name.clone(),
-                    kind: super::items::CompletionItemKind::Function,
-                    detail: Some("sub".to_string()),
-                    documentation: symbol.documentation.clone(),
-                    insert_text: Some(format!("{}()", name)),
-                    sort_text: Some(format!("2{}_{}", distance.sort_key(), name)),
-                    filter_text: Some(name.clone()),
-                    additional_edits: vec![],
-                    text_edit_range: Some((context.prefix_start, context.position)),
-                    commit_characters: None,
-                });
+            if !name.starts_with(prefix_without_amp) {
+                continue;
             }
+
+            let (kind, detail, insert_text) = match symbol.kind {
+                SymbolKind::Subroutine => (
+                    super::items::CompletionItemKind::Function,
+                    Some("sub".to_string()),
+                    Some(format!("{name}()")),
+                ),
+                SymbolKind::Constant => (
+                    super::items::CompletionItemKind::Constant,
+                    Some("constant".to_string()),
+                    Some(name.clone()),
+                ),
+                _ => continue,
+            };
+
+            let distance =
+                compute_scope_distance(symbol_table, context.cursor_scope_id, symbol.scope_id);
+            completions.push(CompletionItem {
+                label: name.clone(),
+                kind,
+                detail,
+                documentation: symbol.documentation.clone(),
+                insert_text,
+                sort_text: Some(format!("2{}_{}", distance.sort_key(), name)),
+                filter_text: Some(name.clone()),
+                additional_edits: vec![],
+                text_edit_range: Some((context.prefix_start, context.position)),
+                commit_characters: None,
+            });
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Completion previously only treated `SymbolKind::Subroutine` (and builtins) as function-like candidates, so constants declared via `use constant` that are tracked in the visible symbol table were not suggested.

### Description

- Treat `SymbolKind::Constant` like a function candidate in prefix gating by updating `could_be_function` to consider constants in addition to subroutines.
- Emit constant completion items from the local symbol table in `add_function_completions` by mapping `SymbolKind::Constant` -> `CompletionItemKind::Constant` with constant-appropriate `insert_text` while preserving scope-distance sorting.
- Add a focused unit test `test_constant_symbols_in_visible_table_are_completed` that injects a visible `PI` constant into the provider's `symbol_table` and verifies it appears in completions.

### Testing

- Ran `cargo test -p perl-lsp-rs-core test_constant_symbols_in_visible_table_are_completed -- --nocapture`, which passed.
- Ran `cargo check --all-targets -p perl-lsp-rs-core`, which passed.
- Ran `cargo clippy -p perl-lsp-rs-core -- -D warnings`, which passed.
- `just pr-fast` was not available in this environment and therefore not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b8b4a1ec8333ba9b3001249adfa4)