### PR TITLE
fix(navigation): resolve require+import bareword goto-def (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/moniker.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/moniker.rs
@@ -307,7 +307,11 @@ impl LspServer {
     ///
     /// Searches `use` statements for the symbol name, handling both bare imports
     /// and `qw<...>` style import lists with all delimiter types.
-    fn find_import_source(&self, ast: &crate::ast::Node, symbol_name: &str) -> Option<String> {
+    pub(crate) fn find_import_source(
+        &self,
+        ast: &crate::ast::Node,
+        symbol_name: &str,
+    ) -> Option<String> {
         use perl_parser::ast::NodeKind;
 
         fn require_module_name(node: &crate::ast::Node) -> Option<String> {

--- a/crates/perl-lsp-rs/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/navigation.rs
@@ -1352,6 +1352,22 @@ impl LspServer {
                                         return Ok(Some(json!([lsp_location])));
                                     }
                                 }
+
+                                // Resolve bareword calls imported via runtime
+                                // `require Module; Module->import('symbol')`.
+                                if symbol_key.kind == crate::workspace_index::SymKind::Sub
+                                    && symbol_key.sigil.is_none()
+                                    && let Some(import_source_pkg) =
+                                        self.find_import_source(ast, &symbol_key.name)
+                                    && let Some(result) = lookup_workspace_definition(
+                                        self.coordinator(),
+                                        &import_source_pkg,
+                                        &symbol_key.name,
+                                        Some(uri),
+                                    )
+                                {
+                                    return Ok(Some(result));
+                                }
                             }
                         }
                         // No coordinator: fall through to same-file semantic model

--- a/crates/perl-lsp-rs/tests/cross_file_goto_definition_tests.rs
+++ b/crates/perl-lsp-rs/tests/cross_file_goto_definition_tests.rs
@@ -266,6 +266,70 @@ my $result = calculate_sum(1, 2, 3);
 }
 
 #[test]
+fn go_to_definition_on_require_imported_bareword_navigates_to_source_module() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = support::lsp_harness::TempWorkspace::new()?;
+
+    workspace.write(
+        "lib/My/Runtime.pm",
+        r#"package My::Runtime;
+use strict;
+use warnings;
+
+sub runtime_sum {
+    my (@nums) = @_;
+    my $total = 0;
+    $total += $_ for @nums;
+    return $total;
+}
+
+1;
+"#,
+    )?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+
+    let module_uri = workspace.uri("lib/My/Runtime.pm");
+    let module_content = std::fs::read_to_string(workspace.dir.path().join("lib/My/Runtime.pm"))
+        .map_err(|e| format!("failed to read module: {e}"))?;
+    harness.open(&module_uri, &module_content)?;
+
+    let caller = r#"#!/usr/bin/perl
+use strict;
+use warnings;
+require My::Runtime;
+My::Runtime->import('runtime_sum');
+
+my $result = runtime_sum(1, 2, 3);
+"#;
+    harness.open(&workspace.uri("app.pl"), caller)?;
+    harness.barrier();
+
+    let (line, character) = find_line_char(caller, "runtime_sum(1, 2, 3)")?;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("app.pl")},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let locations = result.as_array().ok_or("expected location array")?;
+    assert!(!locations.is_empty(), "expected definition result for runtime require+import symbol");
+
+    let first = &locations[0];
+    assert_valid_location(first);
+    let uri = first["uri"].as_str().ok_or("Expected URI")?;
+    assert!(
+        uri.contains("My/Runtime.pm") || uri.contains("My%2FRuntime.pm"),
+        "Definition should point to My/Runtime.pm, got: {}",
+        uri
+    );
+
+    Ok(())
+}
+
+#[test]
 fn go_to_definition_on_tag_imported_symbol_navigates_to_source_module() -> TestResult {
     let mut harness = LspHarness::new();
     let workspace = support::lsp_harness::TempWorkspace::new()?;


### PR DESCRIPTION
### Motivation
- `textDocument/definition` did not resolve bareword subroutine calls that are imported at runtime via `require Module; Module->import('sym')`, leaving an import-visibility gap for goto-definition.

### Description
- Exposed the existing AST-based import-source resolver as `pub(crate) fn find_import_source(...)` so it can be reused by navigation code.
- Added a navigation fallback in the definition handler that maps unresolved bareword `Sub` symbol keys to the import source package (when `require` + literal `import(...)` is detected) and performs a workspace lookup for the target definition.
- Added a cross-file regression test `go_to_definition_on_require_imported_bareword_navigates_to_source_module` that verifies a `require` + `->import('runtime_sum')` scenario resolves go-to-definition to the module file.

### Testing
- Ran `cargo test -p perl-lsp-rs --test cross_file_goto_definition_tests go_to_definition_on_require_imported_bareword_navigates_to_source_module` and the new test passed.
- Ran `cargo check --all-targets -p perl-lsp-rs` which completed successfully.
- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo clippy -p perl-lsp-rs` which completed (existing warnings remain but no new failures in this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b877cee88333959cbf69a7cfcfab)