### PR TITLE
fix(pragma): scope implicit strict modules lexically (#3489)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
@@ -65,25 +65,13 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
     // This avoids the false-negative from .any() which sees eval-interior ranges.
     // signatures_strict is included to honour `use feature 'signatures'` (#4038).
     let top_level_state = PragmaTracker::state_for_offset(&pragma_map, usize::MAX);
-    let mut has_strict = top_level_state.strict_vars
+    let has_strict = top_level_state.strict_vars
         || top_level_state.strict_subs
         || top_level_state.strict_refs
         || top_level_state.signatures_strict;
-    let mut has_warnings = top_level_state.warnings;
+    let has_warnings = top_level_state.warnings;
 
-    // OO frameworks that implicitly provide strict+warnings
-    const IMPLICIT_STRICT_MODULES: &[&str] = &[
-        "Moo",
-        "Moose",
-        "MooseX::StrictConstructor",
-        "Modern::Perl",
-        "Dancer2",
-        "Catalyst",
-        "Mojolicious",
-        "Mojo::Base",
-    ];
-
-    // Detect OO implicit strict modules and misspelled pragmas.
+    // Detect misspelled pragmas.
     // The strict/warnings arms are intentionally absent: state_for_offset above
     // is the authoritative source of truth. Walking the full AST for strict/warnings
     // would bypass lexical scoping (finding eval-block or sub-scoped pragmas).
@@ -92,9 +80,6 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
             if module.starts_with('v') || module.chars().next().is_some_and(|c| c.is_ascii_digit())
             {
                 // Version pragmas are already reflected in the shared pragma map.
-            } else if IMPLICIT_STRICT_MODULES.contains(&module.as_str()) {
-                has_strict = true;
-                has_warnings = true;
             } else if module != "strict" && module != "warnings" {
                 // Check for misspelled pragmas (strict/warnings are in pragma_map)
                 check_misspelled_pragma(module, n, diagnostics);
@@ -566,20 +551,17 @@ mod tests {
     }
 
     #[test]
-    fn implicit_strict_module_inside_eval_suppresses_diagnostic_known_limitation() {
-        // use Moose inside eval { } — walk_node visits it scope-unaware and sets
-        // has_strict=true even though Moose is only in eval scope.  This is a
-        // pre-existing limitation (walk_node does not model lexical scoping for
-        // implicit-strict OO modules).  The fix in this PR restores correct
-        // behaviour for `use strict` / `use warnings` via PragmaTracker, but
-        // IMPLICIT_STRICT_MODULES remain scope-unaware in walk_node.
-        //
-        // Asserting the current (known-limited) behaviour so any future change is
-        // deliberate: PL100 currently does NOT fire even though Moose is eval-scoped.
+    fn implicit_strict_module_inside_eval_does_not_suppress_diagnostic() {
+        // use Moose inside eval { } is lexically scoped; it must not suppress
+        // missing file-scope strict/warnings diagnostics.
         let diags = strict_warnings_diags("eval { use Moose; };\nmy $x = 1;\n");
         assert!(
-            diags.iter().all(|d| d.code.as_deref() != Some("PL100")),
-            "known limitation: Moose in eval suppresses PL100 (walk_node is scope-unaware for OO modules)"
+            diags.iter().any(|d| d.code.as_deref() == Some("PL100")),
+            "eval-scoped implicit strict module must not suppress missing-strict (PL100)"
+        );
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL101")),
+            "eval-scoped implicit strict module must not suppress missing-warnings (PL101)"
         );
     }
 }

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -371,7 +371,24 @@ fn normalized_pragma_token(arg: &str) -> &str {
 }
 
 fn is_tracked_pragma_module(module: &str) -> bool {
-    matches!(module, "strict" | "warnings" | "utf8" | "encoding" | "locale" | "feature" | "builtin")
+    matches!(
+        module,
+        "strict"
+            | "warnings"
+            | "utf8"
+            | "encoding"
+            | "locale"
+            | "feature"
+            | "builtin"
+            | "Moo"
+            | "Moose"
+            | "MooseX::StrictConstructor"
+            | "Modern::Perl"
+            | "Dancer2"
+            | "Catalyst"
+            | "Mojolicious"
+            | "Mojo::Base"
+    )
 }
 
 fn valid_strict_args(args: &[String]) -> bool {
@@ -639,6 +656,21 @@ impl PragmaTracker {
                     }
                     "builtin" => {
                         apply_builtin_imports(current_state, args);
+                        ranges
+                            .push((node.location.start..node.location.end, current_state.clone()));
+                    }
+                    "Moo"
+                    | "Moose"
+                    | "MooseX::StrictConstructor"
+                    | "Modern::Perl"
+                    | "Dancer2"
+                    | "Catalyst"
+                    | "Mojolicious"
+                    | "Mojo::Base" => {
+                        current_state.strict_vars = true;
+                        current_state.strict_subs = true;
+                        current_state.strict_refs = true;
+                        current_state.warnings = true;
                         ranges
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -523,7 +523,7 @@ fn no_feature_without_args_clears_bundle_features() -> Result<(), Box<dyn std::e
 
 #[test]
 fn unknown_use_module_ignored() -> Result<(), Box<dyn std::error::Error>> {
-    let ast = program(vec![use_node("Moose", &[], 0, 10)]);
+    let ast = program(vec![use_node("Some::Module", &[], 0, 16)]);
     let map = PragmaTracker::build(&ast);
     assert!(map.is_empty());
     Ok(())
@@ -1505,5 +1505,38 @@ fn package_block_pragma_inside_is_visible_at_inner_offset() -> Result<(), Box<dy
 
     let inside = PragmaTracker::state_for_offset(&map, 30);
     assert!(inside.strict_vars, "strict_vars declared inside package block must be visible");
+    Ok(())
+}
+
+#[test]
+fn implicit_strict_module_enables_strict_and_warnings() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("Moose", &[], 0, 10)]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, usize::MAX);
+    assert!(state.strict_vars);
+    assert!(state.strict_subs);
+    assert!(state.strict_refs);
+    assert!(state.warnings);
+    Ok(())
+}
+
+#[test]
+fn implicit_strict_module_in_eval_does_not_leak_out() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        eval_node(block(vec![use_node("Moose", &[], 8, 18)], 6, 20), 0, 22),
+        use_node("strict", &["vars"], 23, 42),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let inside_eval = PragmaTracker::state_for_offset(&map, 12);
+    assert!(inside_eval.strict_vars);
+    assert!(inside_eval.warnings);
+
+    let after_eval = PragmaTracker::state_for_offset(&map, 24);
+    assert!(after_eval.strict_vars);
+    assert!(!after_eval.strict_subs);
+    assert!(!after_eval.strict_refs);
+    assert!(!after_eval.warnings);
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Implicit strict/warnings providers (e.g. `Moose`, `Moo`, `Modern::Perl`) declared via `use` could be treated scope-unaware and therefore incorrectly suppress file-level missing-`use strict`/`use warnings` diagnostics when declared inside scoped bodies like `eval { }`.
- The pragma tracking and diagnostics needed to represent these implicit-framework effects lexically so scope restoration behaves uniformly.

### Description
- Extend `PragmaTracker` to treat OO/framework modules as tracked pragma-affecting modules by updating `is_tracked_pragma_module` and adding explicit handling for those modules in `PragmaTracker::build_ranges` so their `use` (including conditional `use if`) sets `strict_*` and `warnings` in the lexical state.
- Make the strict/warnings lint (`check_strict_warnings`) rely on `PragmaTracker::build` / `state_for_offset` as the authoritative, scope-aware source of truth and remove the prior scope-unaware AST-based implicit-module shortcut.
- Update tests to assert the corrected behaviour: replace the old known-limitation expectation and add `perl-pragma` unit tests that verify implicit-module enablement and that `use Moose` inside `eval { }` does not leak to top-level state.

### Testing
- Ran `cargo test -p perl-pragma` and all tests passed.
- Ran `cargo test -p perl-lsp-rs-core strict_warnings` and the strict/warnings tests passed.
- Ran `cargo check --all-targets -p perl-pragma -p perl-lsp-rs-core` and it completed successfully.
- Ran `cargo clippy -p perl-pragma -p perl-lsp-rs-core -- -D warnings` and `cargo xtask fmt` and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b8c091088333b06efc0bbf33580e)