### PR TITLE
test(pragma): lock conservative eval STRING handling (#3489)

### DIFF
--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -848,6 +848,38 @@ fn modern_container_bodies_are_traversed_and_scoped() -> Result<(), Box<dyn std:
     Ok(())
 }
 
+#[test]
+fn eval_string_call_is_handled_conservatively() -> Result<(), Box<dyn std::error::Error>> {
+    let eval_string_call = function_call(
+        "eval",
+        vec![Node {
+            kind: NodeKind::String {
+                value: "use warnings; no strict 'refs';".to_string(),
+                interpolated: true,
+            },
+            location: loc(20, 58),
+        }],
+        15,
+        59,
+    );
+    let ast = program(vec![use_node("strict", &[], 0, 12), eval_string_call]);
+
+    let map = PragmaTracker::build(&ast);
+    let state_after_eval_string = PragmaTracker::state_for_offset(&map, 60);
+
+    assert!(
+        state_after_eval_string.strict_vars
+            && state_after_eval_string.strict_subs
+            && state_after_eval_string.strict_refs,
+        "eval STRING should not be interpreted as compile-time pragma state"
+    );
+    assert!(
+        !state_after_eval_string.warnings,
+        "string eval content must not be treated as lexical `use warnings`"
+    );
+    Ok(())
+}
+
 // ===========================================================================
 // state_for_offset edge cases
 // ===========================================================================


### PR DESCRIPTION
### Motivation
- Ensure the pragma tracker treats `eval STRING` conservatively so `use`/`no` inside a string-eval do not leak into file-level lexical pragma state.

### Description
- Add `eval_string_call_is_handled_conservatively` to `crates/perl-pragma/tests/comprehensive_unit_tests.rs` which builds an `eval` `FunctionCall` with a `String` argument and asserts that outer `use strict` remains active while `use warnings` inside the string is not applied to the surrounding scope.

### Testing
- Ran `cargo test -p perl-pragma` and all tests passed.
- Ran `cargo check --all-targets -p perl-pragma` and it passed.
- Ran `cargo clippy -p perl-pragma --all-targets -- -D warnings` and it passed.
- `just pr-fast` could not be run in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b8c091088333b06efc0bbf33580e)