### PR TITLE
docs(readme): clarify UX confidence metric wording (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | *qualitative* | Tracked through manual editor smoke workflows, pass/fail runs of the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down; intentionally not collapsed into a single published score | Anything about parser breadth, protocol catalog size, or capability count |
 
 The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
 


### PR DESCRIPTION
### Motivation
- Clarify that the "End-to-end UX confidence" entry is a qualitative signal composed of multiple inputs and is intentionally not presented as a single numeric score.

### Description
- Updated the README status table row to explicitly list the qualitative inputs (manual editor smoke workflows, pass/fail runs of the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down) and state it is not collapsed into a single published score.

### Testing
- Ran `cargo xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b8ec915483338c677c23539d0c4e)