### PR TITLE
fix(ci): deepen PR smoke verification with pr-fast (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,6 @@ jobs:
         with:
           tool: just
 
-      - name: Check formatting
-        run: cargo xtask fmt --check
-
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
@@ -89,8 +86,7 @@ jobs:
 
       - name: Run PR smoke checks
         run: |
-          just clippy-core
-          just test-core
+          just pr-fast
 
   # ── Merge Gate: full validation on every PR and push to main ─────────
   merge-gate:


### PR DESCRIPTION
### Motivation
- Increase PR smoke depth so the default PR run performs the consolidated `pr-fast` gate (format, README heading checks, publish-closure checks, core clippy/tests and other fast validations) instead of only `clippy-core` and `test-core`.

### Description
- Replace the inline PR smoke steps in `.github/workflows/ci.yml` with a single `just pr-fast` invocation and remove the now-duplicated `cargo xtask fmt --check` step.

### Testing
- Attempted to run `just pr-fast` locally but the container lacks `just`, so the execution could not be performed (failure: `/bin/bash: line 1: just: command not found`).
- Attempted to validate the modified YAML with `python3` and `yaml.safe_load`, but `PyYAML` is not installed so that check also failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ba75bf488333b47c8a5b08ccf24d)