### PR TITLE
ci(workflows): pin ux-tests actions to SHAs (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,17 +247,17 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
           toolchain: 1.92.0
 
       - name: Install just
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@cf39a74df4a72510be4e5b63348d61067f11e64a  # v2.75.0
         with:
           tool: just
 
       - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           cache-on-failure: true
           cache-all-crates: true


### PR DESCRIPTION
### Motivation
- The `ux-tests` CI job used floating action tags (`@stable` / `@v2`) which weakens reproducibility and differs from other jobs that pin actions to audited commit SHAs.

### Description
- Pin the three actions used by the `ux-tests` job in `.github/workflows/ci.yml` to audited commit SHAs for `dtolnay/rust-toolchain`, `taiki-e/install-action`, and `Swatinem/rust-cache`.
- No other workflow behavior or jobs were modified.

### Testing
- Ran `cargo xtask ci-audit-workflows`, which passed (`✓ CI workflow spend audit passed`).
- Attempted `just ci-workflow-audit` but `just` is not installed in this environment, so that check could not be executed locally here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ba74b5e08333ac7982311e3205b0)