### PR TITLE
fix(ci): skip heavy CI jobs for draft PRs (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: preflight-latest-check
-    if: needs.preflight-latest-check.outputs.is_latest == 'true'
+    # Skip expensive jobs for draft PRs; still run on push events.
+    if: needs.preflight-latest-check.outputs.is_latest == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     steps:
       - uses: actions/checkout@v6
         with:
@@ -98,7 +99,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: [pr-smoke, preflight-latest-check]
-    if: needs.preflight-latest-check.outputs.is_latest == 'true'
+    # Skip expensive jobs for draft PRs; still run on push events.
+    if: needs.preflight-latest-check.outputs.is_latest == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     # Run on every PR push and on push to main/master
     # Earlier gating > label-gated gating (see #4675)
     # Frequent commits will queue; preflight skips superseded SHAs.


### PR DESCRIPTION
### Motivation
- Avoid running expensive CI jobs for pull requests marked as draft to save runner time while preserving normal behavior for push events.

### Description
- Update `.github/workflows/ci.yml` to gate the `pr-smoke` and `merge-gate` jobs with an additional condition so they only run when `github.event` is not a draft PR (keeps push event behavior unchanged) and add brief inline comments explaining the intent.

### Testing
- Validated the modified workflow syntax with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'ok'"` which passed, and attempted `python3` `yaml.safe_load` which failed due to `PyYAML` not being available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ba74b5e08333ac7982311e3205b0)