### PR TITLE
fix(parser): parse typed lexical declarations (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -127,6 +127,24 @@ fn test_list_declarations() {
 }
 
 #[test]
+fn test_typed_lexical_declaration_parses_without_error_nodes() {
+    let mut parser = Parser::new("sub pump { my IPC::Run $self = shift; return $self; }");
+    let ast = must(parser.parse());
+    let sexp = ast.to_sexp();
+
+    assert!(
+        !sexp.contains("ERROR"),
+        "typed lexical declaration should parse without ERROR nodes: {}",
+        sexp
+    );
+    assert!(
+        sexp.contains("(my_declaration"),
+        "typed lexical declaration should remain a declaration node: {}",
+        sexp
+    );
+}
+
+#[test]
 fn test_qw_delimiters() {
     // Test qw with parentheses
     let mut parser = Parser::new("qw(one two three)");

--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -1,4 +1,73 @@
 impl<'a> Parser<'a> {
+    /// Consume an optional lexical type annotation in declarations like:
+    /// `my IPC::Run $self = shift;`
+    ///
+    /// This keeps the existing AST shape (type is currently ignored) while
+    /// accepting typed declarations used by modern Perl code.
+    fn consume_optional_lexical_type_annotation(&mut self, declarator: &str) -> ParseResult<()> {
+        if !matches!(declarator, "my" | "our" | "state") {
+            return Ok(());
+        }
+
+        let first = match self.tokens.peek() {
+            Ok(token) => token.clone(),
+            Err(_) => return Ok(()),
+        };
+
+        if first.kind != TokenKind::Identifier
+            || first.text.starts_with('$')
+            || first.text.starts_with('@')
+            || first.text.starts_with('%')
+            || first.text.starts_with('&')
+            || first.text.starts_with('*')
+        {
+            return Ok(());
+        }
+
+        let second = match self.tokens.peek_second() {
+            Ok(token) => token.clone(),
+            Err(_) => return Ok(()),
+        };
+
+        if second.kind != TokenKind::DoubleColon && !Self::token_starts_variable(&second) {
+            return Ok(());
+        }
+
+        // Consume initial type identifier.
+        self.consume_token()?;
+
+        // Consume `::Identifier` segments.
+        while self.peek_kind() == Some(TokenKind::DoubleColon) {
+            self.consume_token()?; // ::
+            if self.peek_kind() == Some(TokenKind::Identifier) {
+                self.consume_token()?; // type segment
+            } else {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn token_starts_variable(token: &Token) -> bool {
+        matches!(
+            token.kind,
+            TokenKind::ScalarSigil
+                | TokenKind::ArraySigil
+                | TokenKind::HashSigil
+                | TokenKind::SubSigil
+                | TokenKind::GlobSigil
+                | TokenKind::Percent
+                | TokenKind::BitwiseAnd
+                | TokenKind::Star
+        ) || (token.kind == TokenKind::Identifier
+            && (token.text.starts_with('$')
+                || token.text.starts_with('@')
+                || token.text.starts_with('%')
+                || token.text.starts_with('&')
+                || token.text.starts_with('*')))
+    }
+
     /// Parse variable declaration (my, our, local, state)
     fn parse_variable_declaration(&mut self) -> ParseResult<Node> {
         let start = self.current_position();
@@ -94,6 +163,7 @@ impl<'a> Parser<'a> {
                 self.parse_assignment()?
             } else {
                 // For my/our/state, parse a simple variable
+                self.consume_optional_lexical_type_annotation(&declarator)?;
                 let var = self.parse_variable()?;
                 // If -> follows the declared variable, treat it as an lvalue subscript chain
                 // e.g. my $cache->{key} = expr  or  my $foo->method()


### PR DESCRIPTION
### Motivation

- Modern Perl code sometimes uses typed lexical declarations like `my IPC::Run $self = shift;` which the parser previously treated as a syntax error, inflating parser-corpus failure counts against the Ubuntu system Perl baseline.

### Description

- Add `consume_optional_lexical_type_annotation` to accept and skip an optional type path (including `::` segments) before the declared variable for `my`/`our`/`state` declarations while preserving the existing declaration AST shape. 
- Add helper `token_starts_variable` to detect token forms that begin a variable and use it to disambiguate types vs variables. 
- Invoke the new consumer from `parse_variable_declaration` before calling `parse_variable` for single-variable declarations. 
- Add a regression test `test_typed_lexical_declaration_parses_without_error_nodes` to assert typed lexical declarations parse without `ERROR` nodes and remain a declaration node.

### Testing

- Ran `cargo test -p perl-parser-core test_typed_lexical_declaration_parses_without_error_nodes` which passed. 
- Ran full `cargo test -p perl-parser-core` which exposed two pre-existing, unrelated failures in `cpan_error_handling` (`local_sig_die`, `local_sig_warn`).
- Ran `cargo check --all-targets -p perl-parser-core` which passed. 
- Ran `cargo clippy -p perl-parser-core -- -D warnings` which passed. 
- Ran the corpus sweep `cargo run -p xtask -- parser-corpus-sweep --output /tmp/sweep_after.json` which produced an improved corpus result (clean files increased to `2825/2990`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b90e4e8483339eecacac7e8a3351)