### PR TITLE
fix(parser-core): support typed lexical declarations (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -127,6 +127,29 @@ fn test_list_declarations() {
 }
 
 #[test]
+fn test_typed_variable_declarations() {
+    let mut parser = Parser::new("my Debconf::Question $question = shift;");
+    let result = parser.parse();
+    assert!(result.is_ok());
+    let _ast = must(result);
+    assert!(
+        parser.errors().is_empty(),
+        "typed declaration should parse without recovery errors: {:?}",
+        parser.errors()
+    );
+
+    let mut parser = Parser::new("our IPC::Run::IO $io;");
+    let result = parser.parse();
+    assert!(result.is_ok());
+    let _ast = must(result);
+    assert!(
+        parser.errors().is_empty(),
+        "package-qualified typed declaration should parse cleanly: {:?}",
+        parser.errors()
+    );
+}
+
+#[test]
 fn test_qw_delimiters() {
     // Test qw with parentheses
     let mut parser = Parser::new("qw(one two three)");

--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -1,4 +1,61 @@
 impl<'a> Parser<'a> {
+    /// Consume an optional type prefix in variable declarations.
+    ///
+    /// Perl allows typed lexicals such as:
+    ///   - `my Class $obj`
+    ///   - `my Class::Name $obj`
+    ///
+    /// This parser currently does not model declaration types in the AST, but
+    /// consuming the prefix avoids spurious `Expected variable` recovery errors
+    /// on real-world corpora that use typed declarations.
+    fn consume_optional_declaration_type_prefix(&mut self) -> ParseResult<()> {
+        if self.peek_kind() != Some(TokenKind::Identifier) {
+            return Ok(());
+        }
+
+        // Only engage this path when a declaration-like pattern is visible:
+        // `Type $var` or `Type::Name $var`.
+        let second_token = self.tokens.peek_second().ok();
+        let second_kind = second_token.map(|t| t.kind);
+        let second_is_sigil_identifier = second_token.is_some_and(|t| {
+            t.kind == TokenKind::Identifier
+                && (t.text.starts_with('$')
+                    || t.text.starts_with('@')
+                    || t.text.starts_with('%')
+                    || t.text.starts_with('&')
+                    || t.text.starts_with('*'))
+        });
+        if !matches!(
+            second_kind,
+            Some(
+                TokenKind::DoubleColon
+                    | TokenKind::ScalarSigil
+                    | TokenKind::ArraySigil
+                    | TokenKind::HashSigil
+                    | TokenKind::SubSigil
+                    | TokenKind::GlobSigil
+            )
+        ) && !second_is_sigil_identifier
+        {
+            return Ok(());
+        }
+
+        // Consume leading type identifier.
+        self.consume_token()?;
+
+        // Consume `::Ident` segments for qualified type names.
+        while self.peek_kind() == Some(TokenKind::DoubleColon) {
+            self.consume_token()?; // consume ::
+            if self.peek_kind() == Some(TokenKind::Identifier) {
+                self.consume_token()?;
+            } else {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Parse variable declaration (my, our, local, state)
     fn parse_variable_declaration(&mut self) -> ParseResult<Node> {
         let start = self.current_position();
@@ -93,6 +150,7 @@ impl<'a> Parser<'a> {
                 // For local, parse a general lvalue expression
                 self.parse_assignment()?
             } else {
+                self.consume_optional_declaration_type_prefix()?;
                 // For my/our/state, parse a simple variable
                 let var = self.parse_variable()?;
                 // If -> follows the declared variable, treat it as an lvalue subscript chain


### PR DESCRIPTION
### Motivation

- Real-world Ubuntu system Perl modules use typed lexicals like `my Debconf::Question $q` which produced spurious `Expected variable` recovery errors and reduced the clean-parse compatibility baseline.

### Description

- Add `consume_optional_declaration_type_prefix` to `crates/perl-parser-core/src/engine/parser/variables.rs` to consume an optional type or qualified type prefix (`Type` / `Type::Name`) before parsing `my`/`our`/`state` variables.
- Wire the new consumer into `parse_variable_declaration` so typed declarations do not trigger `Expected variable` recovery.
- Add `test_typed_variable_declarations` in `crates/perl-parser-core/src/engine/parser/tests.rs` to cover simple and package-qualified typed lexical forms.

### Testing

- Ran the focused unit test: `cargo test -p perl-parser-core test_typed_variable_declarations -- --nocapture` which passed.
- Ran full crate unit test: `cargo test -p perl-parser-core` which produced two failing integration tests in `tests/cpan_error_handling.rs` (`local_sig_warn`, `local_sig_die`) (investigation needed); many other unit tests passed.
- Ran `cargo check --all-targets -p perl-parser-core` and `cargo clippy -p perl-parser-core -- -D warnings`, both succeeded.
- Ran `cargo xtask parser-corpus-sweep --output /tmp/sweep-after.json`, which improved local sweep results (clean files increased in this environment from 2813 to 2825 out of 2990).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b90e4e8483339eecacac7e8a3351)