### PR TITLE
fix(parser-core): parse local lvalue before assignment (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -162,8 +162,10 @@ impl<'a> Parser<'a> {
         let declarator_token = self.consume_token()?; // consume 'local'
         let declarator = declarator_token.text.to_string();
 
-        // Parse the lvalue expression that's being localized
-        let variable = Box::new(self.parse_expression()?);
+        // Parse the localizable lvalue target without consuming assignment operators.
+        // `local $SIG{__WARN__} = sub { ... };` must leave `=` for the initializer branch
+        // so anonymous sub expressions parse as the RHS, not as a separate statement.
+        let variable = Box::new(self.parse_ternary()?);
 
         let initializer = if self.peek_kind() == Some(TokenKind::Assign) {
             self.tokens.next()?; // consume =


### PR DESCRIPTION
### Motivation
- Fix a parsing bug where `local` targets could consume the `=` as part of the lvalue parse, producing a `MissingExpression` and splitting anonymous `sub` initializers (e.g. `local $SIG{__WARN__} = sub { ... };`).

### Description
- Change `parse_local_statement` to parse the localized lvalue with ternary-level precedence (`parse_ternary`) instead of `parse_expression`, so assignment operators are not consumed by the lvalue parse (file: `crates/perl-parser-core/src/engine/parser/variables.rs`).

### Testing
- Ran `cargo test -p perl-parser-core --test cpan_error_handling`, `cargo check --all-targets -p perl-parser-core`, `cargo clippy -p perl-parser-core`, and `cargo xtask fmt`, all of which completed successfully (note: `just pr-fast` was not available in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b915000c8333ada7dfd5e9c2428c)