### PR TITLE
fix(parser): parse local assignment rhs correctly (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -87,11 +87,14 @@ impl<'a> Parser<'a> {
             Ok(node)
         } else {
             // Single variable declaration
-            // For 'local', we need to parse lvalue expressions (not just simple variables)
-            // because local can take complex forms like local $ENV{PATH}
+            // For 'local', parse only the localized target expression, not an
+            // assignment expression. The initializer is handled below via
+            // `assign_op` parsing, and consuming assignment here would swallow
+            // the RHS into `variable` and leave a `MissingExpression`.
+            //
+            // e.g. `local $SIG{__WARN__} = sub { ... };`
             let variable = if declarator == "local" {
-                // For local, parse a general lvalue expression
-                self.parse_assignment()?
+                self.parse_ternary()?
             } else {
                 // For my/our/state, parse a simple variable
                 let var = self.parse_variable()?;
@@ -162,12 +165,14 @@ impl<'a> Parser<'a> {
         let declarator_token = self.consume_token()?; // consume 'local'
         let declarator = declarator_token.text.to_string();
 
-        // Parse the lvalue expression that's being localized
-        let variable = Box::new(self.parse_expression()?);
+        // Parse only the localized target expression (lhs), not an assignment.
+        // `local $SIG{__WARN__} = sub { ... };` should keep the assignment RHS
+        // in `initializer` below.
+        let variable = Box::new(self.parse_ternary()?);
 
         let initializer = if self.peek_kind() == Some(TokenKind::Assign) {
             self.tokens.next()?; // consume =
-            Some(Box::new(self.parse_expression()?))
+            Some(Box::new(self.parse_assignment()?))
         } else {
             None
         };


### PR DESCRIPTION
### Motivation
- `local $SIG{...} = sub { ... };` was being parsed with a `MissingExpression` because an assignment parse consumed the localized target instead of leaving the RHS to the initializer.
- The change ensures the localized target (LHS) is parsed separately so initializer expressions (including anonymous subs) attach correctly.

### Description
- Parse `local` targets as a non-assignment expression by using `parse_ternary()` instead of `parse_assignment()` when reading the localized target in `variables.rs`.
- Parse the initializer RHS for `local` with `parse_assignment()` after consuming `=` so the RHS is preserved as the declaration initializer.
- Changes made in `crates/perl-parser-core/src/engine/parser/variables.rs` to both the single-variable declaration path and `parse_local_statement`.

### Testing
- Ran `cargo test -p perl-parser-core --test cpan_error_handling` and the test suite passed (`8 passed; 0 failed`).
- Ran `cargo check --all-targets -p perl-parser-core` and it completed successfully.
- Ran formatting and lint checks via `cargo xtask fmt` and `cargo clippy -p perl-parser-core -- -D warnings`, both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b915000c8333ada7dfd5e9c2428c)