### PR TITLE
fix(parser): keep local lvalue parse separate from initializer (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -162,8 +162,13 @@ impl<'a> Parser<'a> {
         let declarator_token = self.consume_token()?; // consume 'local'
         let declarator = declarator_token.text.to_string();
 
-        // Parse the lvalue expression that's being localized
-        let variable = Box::new(self.parse_expression()?);
+        // Parse the lvalue expression that's being localized.
+        // Use parse_ternary() instead of parse_expression()/parse_assignment()
+        // so we stop before `=` in constructs like:
+        //   local $SIG{__WARN__} = sub { ... };
+        // If we parse assignment here, the RHS is consumed too early and can
+        // degrade into a missing-expression recovery node.
+        let variable = Box::new(self.parse_ternary()?);
 
         let initializer = if self.peek_kind() == Some(TokenKind::Assign) {
             self.tokens.next()?; // consume =


### PR DESCRIPTION
### Motivation

- Localization statements like `local $SIG{__WARN__} = sub { ... };` produced a `MissingExpression` recovery node because the parser consumed the assignment RHS when parsing the localized target.

### Description

- In `crates/perl-parser-core/src/engine/parser/variables.rs` `parse_local_statement` now parses the localized lvalue with `parse_ternary()` instead of `parse_expression()` to avoid consuming a trailing `=` and its RHS.
- Added comments explaining why the non-assignment lvalue parse is required so the initializer path can handle `=` and the RHS correctly.
- No other behavioral changes or files were modified.

### Testing

- Ran `cargo test -p perl-parser-core --test cpan_error_handling` and the test suite passed.
- Ran `cargo check --all-targets -p perl-parser-core` and it passed.
- Ran `cargo clippy -p perl-parser-core -- -D warnings` and it passed without warnings.
- Ran `cargo xtask fmt` to format the workspace and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b915000c8333ada7dfd5e9c2428c)