### PR TITLE
test(perl-semantic-analyzer): satisfy clippy test linting (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/tests/frameworks_catalyst.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_catalyst.rs
@@ -115,7 +115,7 @@ sub helper :Path :Args(0) { }
         "did not expect Catalyst action marker in a non-controller package"
     );
     assert!(
-        helper.documentation.as_deref().map_or(true, |doc| !doc.contains("Catalyst action")),
+        helper.documentation.as_deref().is_none_or(|doc| !doc.contains("Catalyst action")),
         "did not expect Catalyst action documentation in a non-controller package"
     );
 }

--- a/crates/perl-semantic-analyzer/tests/frameworks_web.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_web.rs
@@ -9,7 +9,7 @@ use perl_semantic_analyzer::{
     declaration::{current_package_at, symbol_at_cursor},
     symbol::{SymbolExtractor, SymbolKind, SymbolTable},
 };
-use perl_tdd_support::must;
+use perl_tdd_support::{must, must_some};
 
 fn extract_symbols(code: &str) -> SymbolTable {
     let mut parser = Parser::new(code);
@@ -340,10 +340,9 @@ builder {
     let mut parser = Parser::new(code);
     let ast = must(parser.parse());
 
-    let static_offset = code.find("Static").expect("could not find Static");
+    let static_offset = must_some(code.find("Static"));
     let current_pkg = current_package_at(&ast, static_offset);
-    let symbol = symbol_at_cursor(&ast, static_offset, current_pkg)
-        .expect("expected symbol_at_cursor to resolve Plack middleware");
+    let symbol = must_some(symbol_at_cursor(&ast, static_offset, current_pkg));
 
     assert_eq!(
         symbol.pkg.as_ref(),


### PR DESCRIPTION
### Motivation

- Fix test-code lint failures emitted by `cargo clippy -p perl-semantic-analyzer --all-targets -- -D warnings` related to `unnecessary_map_or` and `expect_used` in framework tests.

### Description

- Replace `helper.documentation.as_deref().map_or(true, |doc| !doc.contains("Catalyst action"))` with `is_none_or(...)` to satisfy the `unnecessary_map_or` lint in `crates/perl-semantic-analyzer/tests/frameworks_catalyst.rs`.
- Replace `expect(...)` uses with `perl_tdd_support::must_some(...)` and import `must_some` in `crates/perl-semantic-analyzer/tests/frameworks_web.rs` to avoid `expect_used` in tests.

### Testing

- Ran `cargo test -p perl-semantic-analyzer`, which completed successfully with all tests passing.
- Ran `cargo check --all-targets -p perl-semantic-analyzer`, `cargo xtask fmt`, and `cargo clippy -p perl-semantic-analyzer --all-targets -- -D warnings`, all of which passed.
- `just pr-fast` was not available in the environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ba396d6c8333b870188b102d2f3e)