### PR TITLE
fix(perl-semantic-analyzer): support CORE:: builtins in semantic docs (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs
@@ -10,10 +10,20 @@ pub struct BuiltinDoc {
     pub description: &'static str,
 }
 
+/// Normalize a built-in name for lookup.
+///
+/// Perl allows calling built-ins with a `CORE::` prefix (for example
+/// `CORE::length`). The semantic analyzer stores the function call text as-is,
+/// so normalize here to keep builtin classification and hover docs consistent.
+fn normalized_builtin_name(name: &str) -> &str {
+    name.strip_prefix("CORE::").unwrap_or(name)
+}
+
 /// Check if a function name is a Perl control-flow keyword.
 ///
 /// Returns `true` if the name is a control-flow keyword like `next`, `last`, etc.
 pub(super) fn is_control_keyword(name: &str) -> bool {
+    let name = normalized_builtin_name(name);
     matches!(name, "next" | "last" | "redo" | "goto" | "return" | "exit" | "die")
 }
 
@@ -21,6 +31,7 @@ pub(super) fn is_control_keyword(name: &str) -> bool {
 ///
 /// Returns `true` if the name matches a known Perl built-in function.
 pub(super) fn is_builtin_function(name: &str) -> bool {
+    let name = normalized_builtin_name(name);
     matches!(
         name,
         "print"
@@ -227,6 +238,7 @@ pub fn get_operator_documentation(op: &str) -> Option<BuiltinDoc> {
 /// semantic analyzer has no symbol-level hit (e.g. bare-word builtins in
 /// fallback path).
 pub fn get_builtin_documentation(name: &str) -> Option<BuiltinDoc> {
+    let name = normalized_builtin_name(name);
     match name {
         // I/O
         "print" => Some(BuiltinDoc {
@@ -1207,7 +1219,10 @@ pub fn get_pragma_documentation(name: &str) -> Option<PragmaDoc> {
 
 #[cfg(test)]
 mod tests {
-    use super::{get_builtin_documentation, get_pragma_documentation};
+    use super::{
+        get_builtin_documentation, get_pragma_documentation, is_builtin_function,
+        is_control_keyword,
+    };
 
     #[test]
     fn test_get_builtin_documentation_begin() -> Result<(), Box<dyn std::error::Error>> {
@@ -1260,6 +1275,21 @@ mod tests {
             doc.description.contains("compilation unit") || doc.description.contains("unit"),
             "UNITCHECK doc should mention compilation unit scope, got: {}",
             doc.description
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_core_prefixed_builtin_lookups() -> Result<(), Box<dyn std::error::Error>> {
+        assert!(is_builtin_function("CORE::length"), "CORE::length should be recognized");
+        assert!(is_control_keyword("CORE::die"), "CORE::die should be recognized as control");
+
+        let doc =
+            get_builtin_documentation("CORE::length").ok_or("CORE::length should have docs")?;
+        assert!(
+            doc.signature.contains("length"),
+            "CORE::length should resolve to length docs, got: {}",
+            doc.signature
         );
         Ok(())
     }

--- a/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
@@ -1431,6 +1431,33 @@ push @items, 5;
     }
 
     #[test]
+    fn test_core_prefixed_builtin_hover_for_function_call() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let code = r#"
+my $value = "abc";
+CORE::length($value);
+"#;
+        let mut parser = Parser::new(code);
+        let ast = parser.parse()?;
+        let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+        let length_pos = code.find("CORE::length").ok_or("CORE::length not found")?;
+        let hover = analyzer
+            .hover_info
+            .iter()
+            .find(|(loc, _)| loc.start <= length_pos && loc.end > length_pos);
+
+        assert!(hover.is_some(), "Should have hover info for CORE::length builtin");
+        let (_, hover) = hover.ok_or("missing hover for CORE::length")?;
+        assert!(
+            hover.signature.contains("length"),
+            "Hover signature should contain 'length', got: {}",
+            hover.signature
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_package_hover_with_pod_name_section() -> Result<(), Box<dyn std::error::Error>> {
         let code = r#"
 =head1 NAME


### PR DESCRIPTION
### Motivation
- Built-ins called with the `CORE::` prefix (e.g. `CORE::length`, `CORE::die`) were not being normalized, causing misclassification and missing hover documentation in the semantic analyzer.
- Normalize names so control-keyword detection, builtin classification, and hover/docs lookup treat `CORE::`-prefixed calls the same as unprefixed builtins.

### Description
- Add `normalized_builtin_name` helper that strips a `CORE::` prefix for lookup and use it in `is_control_keyword`, `is_builtin_function`, and `get_builtin_documentation` in `crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs`.
- Add unit tests in `builtins.rs` to verify `CORE::`-prefixed builtin lookups resolve to the same docs and classification as unprefixed names.
- Add a semantic hover regression test in `crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs` to ensure `CORE::length(...)` produces hover information.

### Testing
- Ran `cargo test -p perl-semantic-analyzer`, which passed (all tests OK).
- Ran `cargo check --all-targets -p perl-semantic-analyzer`, which passed.
- Ran `cargo clippy -p perl-semantic-analyzer`, which passed.
- Ran `cargo xtask fmt` to format sources (completed successfully); `just pr-fast` was unavailable in the environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ba396d6c8333b870188b102d2f3e)