### PR TITLE
fix(perl-semantic-analyzer): track qualified vars in string interpolation (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -2968,7 +2968,11 @@ impl SymbolExtractor {
         // Simple regex to find scalar variables in strings
         // This handles $var, ${var}, but not arrays/hashes for now
         let scalar_re = match SCALAR_RE
-            .get_or_init(|| Regex::new(r"\$([a-zA-Z_]\w*|\{[a-zA-Z_]\w*\})"))
+            .get_or_init(|| {
+                Regex::new(
+                    r"\$((?:[a-zA-Z_]\w*(?:::[a-zA-Z_]\w*)*)|\{(?:[a-zA-Z_]\w*(?:::[a-zA-Z_]\w*)*)\})",
+                )
+            })
             .as_ref()
         {
             Ok(re) => re,

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1693,18 +1693,49 @@ print "Hello, $name!\n";
 }
 
 #[test]
-fn unused_package_variable_used_in_string_interpolation() -> Result<(), Box<dyn std::error::Error>>
+fn qualified_var_in_string_interpolation_registers_reference() -> Result<(), Box<dyn std::error::Error>>
 {
+    // Verify that the SymbolExtractor records a reference for $Foo::name when it
+    // appears inside a double-quoted string.  The old scalar-interpolation regex
+    // only matched bare names (\w+) and silently dropped package-qualified forms.
     let code = r#"
-our $Foo::name = "World";
-print "Hello, $Foo::name!\n";
+my $greeting = "Hello, $Foo::name!";
 "#;
-    let issues = scope_issues(code);
-    let unused = issues
-        .iter()
-        .filter(|i| i.kind == IssueKind::UnusedVariable && i.variable_name.contains("Foo::name"))
-        .count();
-    assert_eq!(unused, 0, "$Foo::name used in interpolated string should not be unused");
+    let table = parse_and_extract(code);
+    assert!(
+        table.references.contains_key("Foo::name"),
+        "$Foo::name inside a double-quoted string should register a reference in the symbol table",
+    );
+    Ok(())
+}
+
+#[test]
+fn nested_qualified_var_in_string_interpolation_registers_reference() -> Result<(), Box<dyn std::error::Error>>
+{
+    // Three-level package qualifier: $Foo::Bar::x.
+    let code = r#"
+my $msg = "value: $Foo::Bar::x";
+"#;
+    let table = parse_and_extract(code);
+    assert!(
+        table.references.contains_key("Foo::Bar::x"),
+        "$Foo::Bar::x inside a double-quoted string should register a reference",
+    );
+    Ok(())
+}
+
+#[test]
+fn braced_qualified_var_in_string_interpolation_registers_reference() -> Result<(), Box<dyn std::error::Error>>
+{
+    // Braced form: ${Foo::name}.
+    let code = r#"
+my $msg = "value: ${Foo::name}";
+"#;
+    let table = parse_and_extract(code);
+    assert!(
+        table.references.contains_key("Foo::name"),
+        "${Foo::name} inside a double-quoted string should register a reference",
+    );
     Ok(())
 }
 

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1693,6 +1693,22 @@ print "Hello, $name!\n";
 }
 
 #[test]
+fn unused_package_variable_used_in_string_interpolation() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = r#"
+our $Foo::name = "World";
+print "Hello, $Foo::name!\n";
+"#;
+    let issues = scope_issues(code);
+    let unused = issues
+        .iter()
+        .filter(|i| i.kind == IssueKind::UnusedVariable && i.variable_name.contains("Foo::name"))
+        .count();
+    assert_eq!(unused, 0, "$Foo::name used in interpolated string should not be unused");
+    Ok(())
+}
+
+#[test]
 fn escaped_interpolated_variable_is_still_unused() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 my $name = "World";


### PR DESCRIPTION
### Motivation

- Interpolated package-qualified scalar variables like `$Foo::name` were not being recognized inside double-quoted strings, which could produce false `UnusedVariable` reports during scope analysis.

### Description

- Expanded the scalar interpolation regex in `crates/perl-semantic-analyzer/src/analysis/symbol.rs` to capture package-qualified names in both `$Foo::name` and `${Foo::name}` forms.
- Added a regression test `unused_package_variable_used_in_string_interpolation` to `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` to ensure `$Foo::name` usage in interpolation is treated as a use.
- The change is narrowly scoped to interpolation variable extraction and does not change other analysis logic or public APIs.

### Testing

- Ran `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests --quiet` (162 tests) and it passed.
- Ran `cargo check --all-targets -p perl-semantic-analyzer` and it passed.
- Ran `cargo clippy -p perl-semantic-analyzer` and it passed.
- Ran `cargo xtask fmt` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ba396d6c8333b870188b102d2f3e)