### PR TITLE
test(perl-workspace): replace unwrap/expect with must in workspace index tests (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -4865,15 +4865,14 @@ Utils::process_data();
         // 3. find_dependents("MyBase") should return child.pl
         let index = WorkspaceIndex::new();
 
-        let base_url = url::Url::parse("file:///test/workspace/lib/MyBase.pm").unwrap();
-        index
-            .index_file(base_url, "package MyBase;\nsub new { bless {}, shift }\n1;\n".to_string())
-            .expect("indexing MyBase.pm");
+        let base_url = must(url::Url::parse("file:///test/workspace/lib/MyBase.pm"));
+        must(index.index_file(
+            base_url,
+            "package MyBase;\nsub new { bless {}, shift }\n1;\n".to_string(),
+        ));
 
-        let child_url = url::Url::parse("file:///test/workspace/child.pl").unwrap();
-        index
-            .index_file(child_url, "package Child;\nuse parent 'MyBase';\n1;\n".to_string())
-            .expect("indexing child.pl");
+        let child_url = must(url::Url::parse("file:///test/workspace/child.pl"));
+        must(index.index_file(child_url, "package Child;\nuse parent 'MyBase';\n1;\n".to_string()));
 
         let dependents = index.find_dependents("MyBase");
         assert!(
@@ -4926,7 +4925,7 @@ Utils::process_data();
         // the quotes and registers the dependency under the bare name "MyBase".
         use crate::Parser;
         let mut p = Parser::new("package Child;\nuse parent 'MyBase';\n1;\n");
-        let ast = p.parse().expect("parse succeeded");
+        let ast = must(p.parse());
         assert!(
             matches!(ast.kind, NodeKind::Program { .. }),
             "Expected Program root, got {:?}",


### PR DESCRIPTION
### Motivation
- Tests in `workspace_index.rs` used `unwrap`/`expect`, which violates the project testing quality bar and produces inconsistent failure reporting, so they were converted to the canonical test helper.

### Description
- Replaced `url::Url::parse(...).unwrap()`, `.expect(...)` and `p.parse().expect(...)` with `must(url::Url::parse(...))` and `must(index.index_file(...))` / `must(p.parse())` in `crates/perl-workspace-index/src/workspace/workspace_index.rs`.
- Changes are limited to test code in `workspace_index.rs` and do not touch production APIs or behavior.

### Testing
- Ran `cargo check --all-targets -p perl-workspace`, which passed.
- Ran `cargo clippy -p perl-workspace`, which passed.
- Ran `cargo xtask fmt`, which completed successfully.
- Ran `cargo test -p perl-workspace`, which executed 233 tests overall and reported `232 passed; 1 failed` where `test_extract_module_names_legacy_separator` failed (failure appears pre-existing and unrelated to these test-helper changes).
- `just pr-fast` was not available in the environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ba4331548333b357cb8edd51d72a)