### PR TITLE
fix(semantic-analyzer): track use constant symbols in symbol table (#3475)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -814,6 +814,9 @@ impl SymbolExtractor {
                 if module == "Readonly" {
                     self.readonly_enabled = true;
                 }
+                if module == "constant" {
+                    self.add_use_constant_symbols(args, node.location);
+                }
                 if module == "EV" {
                     self.synthesize_ev_framework_symbol(node.location);
                 }
@@ -2894,6 +2897,114 @@ impl SymbolExtractor {
             }
             _ => false,
         }
+    }
+
+    fn add_use_constant_symbols(&mut self, args: &[String], declaration_location: SourceLocation) {
+        let scope_id = self.table.current_scope();
+        let package_name = self.table.current_package.clone();
+
+        for constant_name in Self::extract_constant_names_from_use_args(args) {
+            self.table.add_symbol(Symbol {
+                name: constant_name.clone(),
+                qualified_name: format!("{package_name}::{constant_name}"),
+                kind: SymbolKind::Constant,
+                location: declaration_location,
+                scope_id,
+                declaration: Some("use constant".to_string()),
+                documentation: Some("Compile-time constant via use constant".to_string()),
+                attributes: vec![],
+            });
+        }
+    }
+
+    fn extract_constant_names_from_use_args(args: &[String]) -> Vec<String> {
+        use std::collections::HashSet;
+
+        fn push_unique(out: &mut Vec<String>, seen: &mut HashSet<String>, candidate: &str) {
+            if seen.insert(candidate.to_string()) {
+                out.push(candidate.to_string());
+            }
+        }
+
+        fn normalize_name(token: &str) -> Option<&str> {
+            let trimmed = token.trim_matches(|c: char| {
+                matches!(c, '\'' | '"' | '(' | ')' | '[' | ']' | '{' | '}' | ',' | ';')
+            });
+            if trimmed.is_empty() || trimmed.starts_with('-') {
+                return None;
+            }
+            trimmed.chars().all(|c| c.is_ascii_alphanumeric() || c == '_').then_some(trimmed)
+        }
+
+        fn extract_qw_words(token: &str) -> Vec<String> {
+            let text = token.trim();
+            if !text.starts_with("qw") {
+                return Vec::new();
+            }
+
+            let rest = text[2..].trim_start();
+            let mut chars = rest.chars();
+            let Some(open) = chars.next() else {
+                return Vec::new();
+            };
+
+            let close = match open {
+                '(' => ')',
+                '[' => ']',
+                '{' => '}',
+                '<' => '>',
+                _ => open,
+            };
+
+            let mut body = String::new();
+            for ch in chars {
+                if ch == close {
+                    break;
+                }
+                body.push(ch);
+            }
+            body.split_whitespace().map(ToString::to_string).collect()
+        }
+
+        let mut names = Vec::new();
+        let mut seen = HashSet::new();
+
+        let Some(first) = args.first().map(String::as_str) else {
+            return names;
+        };
+
+        if first.starts_with("qw") {
+            for word in extract_qw_words(first) {
+                if let Some(candidate) = normalize_name(&word) {
+                    push_unique(&mut names, &mut seen, candidate);
+                }
+            }
+            return names;
+        }
+
+        let is_hash_form = first == "{"
+            || first == "+{"
+            || (first == "+" && args.get(1).map(String::as_str) == Some("{"));
+        if is_hash_form {
+            let mut iter = args.iter().peekable();
+            while let Some(token) = iter.next() {
+                if token == "+" || token == "+{" || token == "{" || token == "}" || token == "," {
+                    continue;
+                }
+                if let Some(candidate) = normalize_name(token)
+                    && iter.peek().map(|next| next.as_str()) == Some("=>")
+                {
+                    push_unique(&mut names, &mut seen, candidate);
+                }
+            }
+            return names;
+        }
+
+        if let Some(candidate) = normalize_name(first) {
+            push_unique(&mut names, &mut seen, candidate);
+        }
+
+        names
     }
 
     fn register_catch_variable(&mut self, full_name: &str, catch_block_location: SourceLocation) {

--- a/crates/perl-semantic-analyzer/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/comprehensive_unit_tests.rs
@@ -156,13 +156,41 @@ sub bar { 1 }
 
 #[test]
 fn symbol_extraction_constant() -> Result<(), Box<dyn std::error::Error>> {
-    // `use constant` is a pragma call; the extractor may index the import
-    // rather than a named constant. Verify no crash and some symbols exist.
     let code = "use constant PI => 3.14159;";
     let table = parse_and_extract(code);
-    // The parser should at least produce something from this pragma
-    // (may index "constant" as an Import or not index "PI" at all)
-    let _ = table;
+    assert!(has_symbol(&table, "PI", SymbolKind::Constant));
+    let symbols = table.symbols.get("PI").ok_or("PI not found")?;
+    assert!(
+        symbols.iter().any(|symbol| symbol.qualified_name == "main::PI"),
+        "expected package-qualified constant, got: {:?}",
+        symbols.iter().map(|symbol| &symbol.qualified_name).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn symbol_extraction_constant_hash_form_tracks_all_constants()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+package My::Config;
+use constant {
+    MAX_RETRIES => 3,
+    TIMEOUT => 30,
+};
+"#;
+    let table = parse_and_extract(code);
+    assert!(has_symbol(&table, "MAX_RETRIES", SymbolKind::Constant));
+    assert!(has_symbol(&table, "TIMEOUT", SymbolKind::Constant));
+    Ok(())
+}
+
+#[test]
+fn symbol_extraction_constant_qw_form_tracks_all_constants()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = "use constant qw(FOO BAR);";
+    let table = parse_and_extract(code);
+    assert!(has_symbol(&table, "FOO", SymbolKind::Constant));
+    assert!(has_symbol(&table, "BAR", SymbolKind::Constant));
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- `use constant` declarations were not registered as visible `Constant` symbols in the semantic analyzer, which prevented visibility-based resolution (e.g. `My::Config::PI`) from finding their definitions.
- The change aims to surface compile-time `use constant` names in the semantic symbol table so other analysis and navigation features can resolve them.

### Description

- When visiting `NodeKind::Use` nodes for the `constant` module the traversal now calls `add_use_constant_symbols` to register constants into the visible symbol table as `SymbolKind::Constant` with package-qualified `qualified_name` and declaration metadata.
- Implemented parsing of `use constant` argument forms via `extract_constant_names_from_use_args` supporting scalar form (`FOO => ...`), hash form (`{ FOO => 1, BAR => 2 }`) and `qw(...)` form, with deduplication and identifier normalization.
- Added/updated unit tests in `comprehensive_unit_tests.rs` to assert extraction for scalar, hash, and `qw` forms and to check package-qualified names are present.

### Testing

- Ran `cargo test -p perl-semantic-analyzer symbol_extraction_constant -- --nocapture` and the new/updated tests passed (3 newly-running tests passed).
- Ran `cargo check --all-targets -p perl-semantic-analyzer` and it completed successfully.
- Ran `cargo clippy -p perl-semantic-analyzer -- -D warnings` and `cargo xtask fmt` / `cargo fmt --package perl-semantic-analyzer` and they passed with no warnings or formatting issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b8b4a1ec8333ba9b3001249adfa4)