### PR TITLE
refactor(perl-lsp-rs): simplify timeout wait check (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/util/command_timeout.rs
+++ b/crates/perl-lsp-rs/src/util/command_timeout.rs
@@ -21,13 +21,12 @@ pub fn run_command_with_timeout(mut cmd: Command, timeout_secs: u64) -> Result<O
     loop {
         // Check completion before the deadline so a process that finishes
         // exactly at the deadline boundary is never reported as timed out.
-        match child.try_wait().map_err(|error| format!("failed waiting for command: {error}"))? {
-            Some(_status) => {
-                return child
-                    .wait_with_output()
-                    .map_err(|error| format!("failed collecting command output: {error}"));
-            }
-            None => {}
+        if let Some(_status) =
+            child.try_wait().map_err(|error| format!("failed waiting for command: {error}"))?
+        {
+            return child
+                .wait_with_output()
+                .map_err(|error| format!("failed collecting command output: {error}"));
         }
 
         if start.elapsed() >= timeout {


### PR DESCRIPTION
### Motivation
- `run_command_with_timeout` used a single-pattern `match` which triggers `clippy::single_match` under `-D warnings` and breaks linting.

### Description
- Replace the single-pattern `match` with an `if let` in `crates/perl-lsp-rs/src/util/command_timeout.rs` to preserve behavior while satisfying the lint.

### Testing
- `cargo check --all-targets -p perl-lsp-rs` passed and `cargo clippy -p perl-lsp-rs -- -D warnings` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf765fe483338dce493aacdb8933)