### PR TITLE
fix(perl-line-index): validate position column bounds (#0000)

### DIFF
--- a/crates/perl-line-index/src/lib.rs
+++ b/crates/perl-line-index/src/lib.rs
@@ -13,6 +13,8 @@
 pub struct LineIndex {
     /// Byte offset of each line start.
     line_starts: Vec<usize>,
+    /// Total byte length of the indexed text.
+    text_len: usize,
 }
 
 impl LineIndex {
@@ -25,7 +27,7 @@ impl LineIndex {
                 line_starts.push(idx + 1);
             }
         }
-        Self { line_starts }
+        Self { line_starts, text_len: text.len() }
     }
 
     /// Convert a byte offset to `(line, column)` using byte columns.
@@ -39,6 +41,17 @@ impl LineIndex {
     /// Convert `(line, column)` back to byte offset.
     #[must_use]
     pub fn position_to_byte(&self, line: usize, column: usize) -> Option<usize> {
-        self.line_starts.get(line).map(|&start| start + column)
+        let start = *self.line_starts.get(line)?;
+        let line_end = self
+            .line_starts
+            .get(line + 1)
+            .map_or(self.text_len, |next_start| next_start.saturating_sub(1));
+        let max_column = line_end.saturating_sub(start);
+
+        if column > max_column {
+            return None;
+        }
+
+        Some(start + column)
     }
 }

--- a/crates/perl-line-index/tests/line_index_comprehensive.rs
+++ b/crates/perl-line-index/tests/line_index_comprehensive.rs
@@ -145,6 +145,15 @@ fn test_multiline_lf_position_to_byte_each_line_start() -> Result<(), Box<dyn st
     Ok(())
 }
 
+#[test]
+fn test_multiline_lf_position_to_byte_out_of_range_column() -> Result<(), Box<dyn std::error::Error>>
+{
+    let index = LineIndex::new("abc\ndef\nghi");
+    assert_eq!(index.position_to_byte(0, 4), None);
+    assert_eq!(index.position_to_byte(1, 4), None);
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Multi-line with CRLF
 // ---------------------------------------------------------------------------
@@ -203,6 +212,15 @@ fn test_crlf_three_lines_positions() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(index.byte_to_position(0), (0, 0)); // 'x'
     assert_eq!(index.byte_to_position(3), (1, 0)); // 'y'
     assert_eq!(index.byte_to_position(6), (2, 0)); // 'z'
+    Ok(())
+}
+
+#[test]
+fn test_position_to_byte_allows_newline_byte_but_not_next_line_start()
+-> Result<(), Box<dyn std::error::Error>> {
+    let index = LineIndex::new("ab\ncd");
+    assert_eq!(index.position_to_byte(0, 2), Some(2));
+    assert_eq!(index.position_to_byte(0, 3), None);
     Ok(())
 }
 
@@ -369,13 +387,10 @@ fn test_position_to_byte_line_out_of_range() -> Result<(), Box<dyn std::error::E
 }
 
 #[test]
-fn test_position_to_byte_large_column_returns_some() -> Result<(), Box<dyn std::error::Error>> {
-    // The implementation returns Some(start + column) without bounds checking
-    // the column against line length, so large columns just produce large offsets.
+fn test_position_to_byte_large_column_returns_none() -> Result<(), Box<dyn std::error::Error>> {
     let index = LineIndex::new("abc\ndef");
     let result = index.position_to_byte(0, 100);
-    // start of line 0 is 0, so 0 + 100 = 100
-    assert_eq!(result, Some(100));
+    assert_eq!(result, None);
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- `LineIndex::position_to_byte` could accept arbitrarily large `column` values and return offsets past the indexed text, which is surprising and unsafe for callers that expect `None` for out-of-range positions.

### Description

- Add a `text_len: usize` field to `LineIndex` and initialize it in `new` to track the total byte length of the indexed text.
- Update `position_to_byte` to compute the end of the requested line, derive a `max_column`, and return `None` when `column > max_column` instead of producing an out-of-range offset.
- Add and update tests in `line_index_comprehensive.rs` to cover out-of-range columns, newline-boundary behavior, and large-column expectations.

### Testing

- Ran `cargo test -p perl-line-index` and all crate tests passed (`42` tests in `line_index_comprehensive` + `2` roundtrip tests; final run succeeded with no failures). 
- Ran `cargo check --all-targets -p perl-line-index` and `cargo clippy -p perl-line-index`, both completed successfully.
- Ran `cargo xtask fmt` to format changes; `just pr-fast` was not available in this environment so it was not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf765fe483338dce493aacdb8933)