### PR TITLE
fix(perl-uri): treat dotfiles as extensionless (#0000)

### DIFF
--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -65,6 +65,9 @@ pub fn uri_extension(uri: &str) -> Option<&str> {
         uri.split_once(['?', '#']).map_or(uri, |(path_prefix, _)| path_prefix);
     let path_part = path_without_query_or_fragment.rsplit('/').next()?;
     let dot_pos = path_part.rfind('.')?;
+    if dot_pos == 0 {
+        return None;
+    }
     let ext = &path_part[dot_pos + 1..];
     if ext.is_empty() { None } else { Some(ext) }
 }
@@ -116,6 +119,8 @@ mod tests {
         assert_eq!(uri_extension("file:///tmp/test.pl"), Some("pl"));
         assert_eq!(uri_extension("file:///tmp/file.pl?query=1"), Some("pl"));
         assert_eq!(uri_extension("file:///tmp/file.pl#L10/permalink"), Some("pl"));
+        assert_eq!(uri_extension("file:///tmp/archive.tar.gz"), Some("gz"));
+        assert_eq!(uri_extension("file:///tmp/.perlcriticrc"), None);
         assert_eq!(uri_extension("file:///tmp/no-extension"), None);
     }
 }

--- a/crates/perl-uri/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-uri/tests/comprehensive_unit_tests.rs
@@ -171,8 +171,8 @@ fn uri_extension_handles_multiple_dots() {
 
 #[test]
 fn uri_extension_hidden_file_no_ext() {
-    // .gitignore → extension is "gitignore" (after the single dot)
-    assert_eq!(uri_extension("file:///tmp/.gitignore"), Some("gitignore"));
+    // Dotfiles like `.gitignore` are treated as extensionless.
+    assert_eq!(uri_extension("file:///tmp/.gitignore"), None);
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- `uri_extension` treated leading-dot filenames like `.gitignore` as having an extension, which conflicts with common filesystem semantics and downstream expectations.

### Description
- Return `None` when the found dot is the leading character (added `if dot_pos == 0 { return None; }` in `uri_extension`).
- Expanded/updated tests to cover dotfiles and multi-dot filenames in `crates/perl-uri/src/classify.rs` and `crates/perl-uri/tests/comprehensive_unit_tests.rs`.
- Change is isolated to `crates/perl-uri` and does not modify other crates or public APIs.

### Testing
- Ran `cargo test -p perl-uri`, which passed (all unit and integration tests succeeded).
- Ran `cargo check --all-targets -p perl-uri`, which succeeded.
- Ran formatting via `cargo xtask fmt`, which completed.
- Ran `cargo clippy -p perl-uri`, which completed without issues.
- `just pr-fast` could not be executed in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf77dcc083338958f655d3998698)