### PR TITLE
feat(perl-test-generators): broaden module segment coverage (#0000)

### DIFF
--- a/crates/perl-test-generators/src/module.rs
+++ b/crates/perl-test-generators/src/module.rs
@@ -14,6 +14,14 @@ fn module_segment() -> impl Strategy<Value = String> {
         Just("IO".to_string()),
         (
             prop::char::range('A', 'Z'),
+            prop::collection::vec(
+                prop_oneof![prop::char::range('A', 'Z'), prop::char::range('0', '9'), Just('_'),],
+                0..=7_usize,
+            ),
+        )
+            .prop_map(|(first, rest)| std::iter::once(first).chain(rest).collect::<String>()),
+        (
+            prop::char::range('A', 'Z'),
             prop::collection::vec(prop::char::range('a', 'z'), 0..=7_usize),
         )
             .prop_map(|(first, rest)| std::iter::once(first).chain(rest).collect::<String>()),
@@ -54,6 +62,24 @@ mod tests {
             prop_assert!(!segs.is_empty());
             for s in &segs {
                 prop_assert!(!s.is_empty());
+            }
+        }
+
+        #[test]
+        fn segments_use_module_identifier_charset(segs in module_path_segments()) {
+            for seg in &segs {
+                let mut chars = seg.chars();
+                let Some(first) = chars.next() else {
+                    prop_assert!(false, "segment cannot be empty");
+                    continue;
+                };
+                prop_assert!(first.is_ascii_uppercase(), "segment must start uppercase: {seg}");
+                for ch in chars {
+                    prop_assert!(
+                        ch.is_ascii_alphanumeric() || ch == '_',
+                        "invalid module segment char '{ch}' in {seg}",
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
### Motivation

- The module path generator mostly produced PascalCase segments and did not exercise `UPPER_CASE`-style identifiers containing digits or underscores.
- Tests did not explicitly assert the allowed character set for module identifier segments, reducing confidence that generated names match expected Perl module-name shapes.

### Description

- Expanded `module_segment()` to include an `UPPER_CASE`-style branch that produces segments starting with an uppercase letter and followed by uppercase letters, digits, or underscores.
- Added a property test `segments_use_module_identifier_charset` that asserts each segment starts with an ASCII uppercase letter and subsequent characters are alphanumeric or underscore.
- Changes are confined to `crates/perl-test-generators/src/module.rs` and committed as a single focused change.

### Testing

- Ran `cargo test -p perl-test-generators` and the test suite passed.
- Ran `cargo check --all-targets -p perl-test-generators` and it succeeded.
- Ran `cargo clippy -p perl-test-generators` and it completed without failures.
- Ran `cargo xtask fmt` to format the workspace and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf7a20d883339868f7c6022e852f)