### PR TITLE
feat(perl-test-generators): add non-empty unicode strategy (#0000)

### DIFF
--- a/crates/perl-test-generators/README.md
+++ b/crates/perl-test-generators/README.md
@@ -7,6 +7,7 @@ This crate provides generators for:
 - Perl variables
 - Perl module paths
 - Unicode strings for UTF-8 / UTF-16 roundtrip tests
+- Non-empty Unicode strings for call sites that require content
 
 See [docs/reference/PROPERTY_TESTING.md](../../docs/reference/PROPERTY_TESTING.md)
 for usage patterns and guidance.

--- a/crates/perl-test-generators/src/lib.rs
+++ b/crates/perl-test-generators/src/lib.rs
@@ -8,12 +8,17 @@
 //!
 //! ```rust
 //! use proptest::prelude::*;
-//! use perl_test_generators::{variable, module_path, unicode_string};
+//! use perl_test_generators::{variable, module_path, non_empty_unicode_string};
 //!
 //! proptest! {
 //!     #[test]
 //!     fn vars_parse(sym in variable()) {
 //!         assert!(sym.starts_with('$') || sym.starts_with('@') || sym.starts_with('%'));
+//!     }
+//!
+//!     #[test]
+//!     fn non_empty_text(text in non_empty_unicode_string()) {
+//!         assert!(!text.is_empty());
 //!     }
 //! }
 //! ```
@@ -23,5 +28,5 @@ mod unicode;
 mod variable;
 
 pub use module::{module_path, module_path_segments};
-pub use unicode::unicode_string;
+pub use unicode::{non_empty_unicode_string, unicode_string};
 pub use variable::variable;

--- a/crates/perl-test-generators/src/unicode.rs
+++ b/crates/perl-test-generators/src/unicode.rs
@@ -48,6 +48,14 @@ pub fn unicode_string() -> impl Strategy<Value = String> {
     ]
 }
 
+/// Generate a non-empty Unicode string.
+///
+/// Useful when call sites need at least one code point and should avoid
+/// separate assumptions/filters in their property tests.
+pub fn non_empty_unicode_string() -> impl Strategy<Value = String> {
+    unicode_string().prop_filter("string must be non-empty", |value| !value.is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -68,6 +76,11 @@ mod tests {
             let encoded: Vec<u16> = s.encode_utf16().collect();
             let from_utf16 = String::from_utf16_lossy(&encoded);
             prop_assert_eq!(s, from_utf16);
+        }
+
+        #[test]
+        fn non_empty_unicode_string_never_empty(s in non_empty_unicode_string()) {
+            prop_assert!(!s.is_empty(), "non-empty strategy produced an empty string");
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Property tests that require text content currently need ad-hoc filters or assumptions to exclude empty Unicode strings, which is repetitive and error-prone.

### Description
- Add `non_empty_unicode_string()` in `crates/perl-test-generators/src/unicode.rs` implemented as `unicode_string().prop_filter(...)`, export it from the crate, add a property test that asserts it never yields an empty string, and update the crate `README.md` and example to document the new strategy.

### Testing
- Ran `cargo test -p perl-test-generators`, `cargo check --all-targets -p perl-test-generators`, `cargo clippy -p perl-test-generators`, and `cargo xtask fmt`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf7a20d883339868f7c6022e852f)