### PR TITLE
feat(perl-line-index): add bounded position conversion API (#0000)

### DIFF
--- a/crates/perl-line-index/README.md
+++ b/crates/perl-line-index/README.md
@@ -7,3 +7,5 @@ A tiny microcrate that provides a byte-oriented line index used by incremental p
 - `LineIndex::new(&str)` builds a line-start cache.
 - `LineIndex::byte_to_position(usize)` maps byte offset to `(line, column)`.
 - `LineIndex::position_to_byte(line, column)` maps back to byte offsets.
+- `LineIndex::position_to_byte_checked(line, column)` returns `None` if the
+  column crosses the addressed line's byte boundary.

--- a/crates/perl-line-index/src/lib.rs
+++ b/crates/perl-line-index/src/lib.rs
@@ -46,11 +46,22 @@ impl LineIndex {
 
     /// Convert `(line, column)` back to byte offset, returning `None` when
     /// the column crosses the line boundary.
+    ///
+    /// The newline character at the end of a line is the last addressable
+    /// column on that line.  The byte at `next_line_start` belongs to the
+    /// *next* line and is therefore out of range.
     #[must_use]
     pub fn position_to_byte_checked(&self, line: usize, column: usize) -> Option<usize> {
         let start = *self.line_starts.get(line)?;
-        let line_end = self.line_starts.get(line + 1).copied().unwrap_or(self.text_len);
-        if column > line_end.saturating_sub(start) {
+        // Subtract one from next_line_start so the newline byte is reachable
+        // but the first byte of the next line is not.
+        let line_end = self
+            .line_starts
+            .get(line + 1)
+            .map_or(self.text_len, |next_start| next_start.saturating_sub(1));
+        let max_column = line_end.saturating_sub(start);
+
+        if column > max_column {
             return None;
         }
 

--- a/crates/perl-line-index/src/lib.rs
+++ b/crates/perl-line-index/src/lib.rs
@@ -13,6 +13,8 @@
 pub struct LineIndex {
     /// Byte offset of each line start.
     line_starts: Vec<usize>,
+    /// Total byte length of the indexed text.
+    text_len: usize,
 }
 
 impl LineIndex {
@@ -25,7 +27,7 @@ impl LineIndex {
                 line_starts.push(idx + 1);
             }
         }
-        Self { line_starts }
+        Self { line_starts, text_len: text.len() }
     }
 
     /// Convert a byte offset to `(line, column)` using byte columns.
@@ -40,5 +42,18 @@ impl LineIndex {
     #[must_use]
     pub fn position_to_byte(&self, line: usize, column: usize) -> Option<usize> {
         self.line_starts.get(line).map(|&start| start + column)
+    }
+
+    /// Convert `(line, column)` back to byte offset, returning `None` when
+    /// the column crosses the line boundary.
+    #[must_use]
+    pub fn position_to_byte_checked(&self, line: usize, column: usize) -> Option<usize> {
+        let start = *self.line_starts.get(line)?;
+        let line_end = self.line_starts.get(line + 1).copied().unwrap_or(self.text_len);
+        if column > line_end.saturating_sub(start) {
+            return None;
+        }
+
+        Some(start + column)
     }
 }

--- a/crates/perl-line-index/tests/line_index_roundtrip.rs
+++ b/crates/perl-line-index/tests/line_index_roundtrip.rs
@@ -16,10 +16,14 @@ fn out_of_bounds_line_returns_none() {
 
 #[test]
 fn checked_position_rejects_columns_past_line_end() {
+    // "abc\ndef": line 0 = "abc\n" (bytes 0-3), line 1 = "def" (bytes 4-6)
     let index = LineIndex::new("abc\ndef");
+    // column 3 = '\n' byte — last byte on line 0, still addressable
     assert_eq!(index.position_to_byte_checked(0, 3), Some(3));
-    assert_eq!(index.position_to_byte_checked(0, 4), Some(4));
+    // column 4 would be the 'd' on line 1 — NOT accessible via line 0
+    assert_eq!(index.position_to_byte_checked(0, 4), None);
     assert_eq!(index.position_to_byte_checked(0, 5), None);
+    // line 1 = "def" (bytes 4-6), text_len=7 so max col = 7-4 = 3
     assert_eq!(index.position_to_byte_checked(1, 3), Some(7));
     assert_eq!(index.position_to_byte_checked(1, 4), None);
 }

--- a/crates/perl-line-index/tests/line_index_roundtrip.rs
+++ b/crates/perl-line-index/tests/line_index_roundtrip.rs
@@ -13,3 +13,13 @@ fn out_of_bounds_line_returns_none() {
     let index = LineIndex::new("one\ntwo");
     assert_eq!(index.position_to_byte(10, 0), None);
 }
+
+#[test]
+fn checked_position_rejects_columns_past_line_end() {
+    let index = LineIndex::new("abc\ndef");
+    assert_eq!(index.position_to_byte_checked(0, 3), Some(3));
+    assert_eq!(index.position_to_byte_checked(0, 4), Some(4));
+    assert_eq!(index.position_to_byte_checked(0, 5), None);
+    assert_eq!(index.position_to_byte_checked(1, 3), Some(7));
+    assert_eq!(index.position_to_byte_checked(1, 4), None);
+}


### PR DESCRIPTION
### Motivation
- `LineIndex::position_to_byte` always returns `Some(start + column)` for valid lines, so callers cannot detect when a requested column crosses the line boundary.
- Calls that map LSP positions to byte offsets need a safe way to reject out-of-range columns, including on the last line.

### Description
- Added `text_len: usize` to `LineIndex` to record the source text length for last-line checks.
- Added `LineIndex::position_to_byte_checked(line, column)` which returns `None` when the column exceeds the addressed line's byte boundary.
- Added unit tests in `crates/perl-line-index/tests/line_index_roundtrip.rs` covering accepted and rejected columns for the new API.
- Documented the new API in `crates/perl-line-index/README.md`.

### Testing
- Ran `cargo test -p perl-line-index`, which passed.
- Ran `cargo check --all-targets -p perl-line-index`, which passed.
- Ran `cargo clippy -p perl-line-index`, which passed.
- Ran `cargo xtask fmt` (formatting step) which completed successfully in this environment.
- Attempted `just pr-fast` but the `just` binary is not installed in this environment (`/bin/bash: line 1: just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf7a20d883339868f7c6022e852f)