### PR TITLE
test(perl-uri): add file URI classification coverage (#0000)

### DIFF
--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -101,6 +101,9 @@ mod tests {
     #[test]
     fn detects_file_uris() {
         assert!(is_file_uri("file:///tmp/test.pl"));
+        assert!(is_file_uri("file://localhost/tmp/test.pl"));
+        assert!(!is_file_uri("FILE:///tmp/test.pl"));
+        assert!(!is_file_uri("file:test.pl"));
         assert!(!is_file_uri("https://example.com"));
     }
 


### PR DESCRIPTION
### Motivation
- Improve `is_file_uri` test coverage for edge cases involving `file://localhost` authority, scheme case-sensitivity, and the bare `file:` form.

### Description
- Added focused assertions to `crates/perl-uri/src/classify.rs` verifying that `file://localhost/...` is treated as a file URI while `FILE:///...` (uppercase scheme) and `file:...` (no `//`) are not, with no changes to production logic.

### Testing
- Ran `cargo test -p perl-uri` and all crate tests passed; `cargo check --all-targets -p perl-uri` passed; `cargo clippy -p perl-uri` passed; and `cargo xtask fmt` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf7a20d883339868f7c6022e852f)