### PR TITLE
test(perl-corpus): cover case-insensitive corpus extensions (#0000)

### DIFF
--- a/crates/perl-corpus/src/files.rs
+++ b/crates/perl-corpus/src/files.rs
@@ -261,4 +261,36 @@ mod tests {
         fs::remove_dir_all(&root)?;
         Ok(())
     }
+
+    #[test]
+    fn collect_files_matches_extensions_case_insensitively()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let root = temp_root("perl_corpus_case_insensitive_ext")?;
+        let fixtures = [
+            root.join("upper.PL"),
+            root.join("mixed.Pm"),
+            root.join("suite.T"),
+            root.join("app.PsGi"),
+            root.join("legacy.CgI"),
+        ];
+
+        for fixture in &fixtures {
+            fs::write(fixture, "print 1;\n")?;
+        }
+
+        let files = collect_files(&root, TEST_EXTENSIONS);
+        let mut names: Vec<_> = files
+            .iter()
+            .map(|path| {
+                path.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_default()
+            })
+            .collect();
+        names.sort();
+
+        let expected = vec!["app.PsGi", "legacy.CgI", "mixed.Pm", "suite.T", "upper.PL"];
+        assert_eq!(names, expected);
+
+        fs::remove_dir_all(&root)?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
Problem: Corpus file discovery lacked a regression test for mixed/uppercase Perl file extensions.

Fix: Added a unit test `collect_files_matches_extensions_case_insensitively` in `crates/perl-corpus/src/files.rs` which creates fixtures with extensions `.PL`, `.Pm`, `.T`, `.PsGi`, and `.CgI` and asserts `collect_files` collects them.

Verification: `cargo test -p perl-corpus` passes; `cargo check --all-targets -p perl-corpus` passes; `cargo clippy -p perl-corpus` passes; `cargo xtask fmt` passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf7bc5bc8333b79fb2d0c032d6e1)