### PR TITLE
feat(perl-token): add token span length helpers (#0000)

### DIFF
--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -68,6 +68,37 @@ impl Token {
     pub fn new(kind: TokenKind, text: impl Into<Arc<str>>, start: usize, end: usize) -> Self {
         Token { kind, text: text.into(), start, end }
     }
+
+    /// Return the token span length in bytes.
+    ///
+    /// This uses saturating subtraction so malformed spans (where `end < start`)
+    /// are treated as zero-length instead of underflowing.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use perl_token::{Token, TokenKind};
+    ///
+    /// let tok = Token::new(TokenKind::Identifier, "foo", 10, 13);
+    /// assert_eq!(tok.len(), 3);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// Return whether the token span is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use perl_token::{Token, TokenKind};
+    ///
+    /// let tok = Token::new(TokenKind::Eof, "", 8, 8);
+    /// assert!(tok.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 /// Token classification for Perl parsing.

--- a/crates/perl-token/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-token/tests/comprehensive_unit_tests.rs
@@ -54,6 +54,21 @@ fn token_new_empty_text() {
 fn token_new_zero_length_span() {
     let t = Token::new(TokenKind::Semicolon, ";", 42, 42);
     assert_eq!(t.start, t.end);
+    assert!(t.is_empty());
+}
+
+#[test]
+fn token_len_reports_span_width() {
+    let t = Token::new(TokenKind::Identifier, "hello", 7, 12);
+    assert_eq!(t.len(), 5);
+    assert!(!t.is_empty());
+}
+
+#[test]
+fn token_len_saturates_for_malformed_span() {
+    let t = Token::new(TokenKind::Unknown, "?", 12, 7);
+    assert_eq!(t.len(), 0);
+    assert!(t.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- Callers repeatedly compute token byte-span widths and risk underflow when `end < start` on malformed spans. 
- Providing small helpers centralizes the logic and improves ergonomics for consumers of `Token`.

### Description

- Add `Token::len()` which returns `end.saturating_sub(start)` to compute span width safely and include a rustdoc example. 
- Add `Token::is_empty()` which returns `self.len() == 0` and include a rustdoc example. 
- Add focused unit tests in `crates/perl-token/tests/comprehensive_unit_tests.rs` for zero-length spans, normal width reporting, and saturated behavior for malformed spans.

### Testing

- Ran `cargo test -p perl-token` and all unit tests and doctests passed. 
- Ran `cargo check --all-targets -p perl-token` which completed successfully. 
- Ran `cargo clippy -p perl-token` which completed successfully. 
- Ran `cargo xtask fmt` to format changes which completed successfully; `just pr-fast` was not available in the environment and did not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf7bc5bc8333b79fb2d0c032d6e1)