### PR TITLE
feat(perl-test-generators): broaden package-qualified variable generation (#0000)

### DIFF
--- a/crates/perl-test-generators/src/variable.rs
+++ b/crates/perl-test-generators/src/variable.rs
@@ -33,11 +33,16 @@ fn identifier() -> impl Strategy<Value = String> {
     ]
 }
 
+/// Generate a Perl package path (`Foo`, `Foo::Bar`, ...).
+fn package_path() -> impl Strategy<Value = String> {
+    prop::collection::vec(identifier(), 1..=4_usize).prop_map(|segments| segments.join("::"))
+}
+
 /// Generate a full Perl variable name including sigil.
 ///
 /// Covers scalar (`$x`), array (`@x`), hash (`%x`), special variables
 /// (`$_`, `@_`, `$1`–`$9`), and optionally package-qualified names
-/// (`$Foo::bar`).
+/// (`$Foo::Bar::baz`).
 pub fn variable() -> impl Strategy<Value = String> {
     prop_oneof![
         // Special variables
@@ -51,7 +56,7 @@ pub fn variable() -> impl Strategy<Value = String> {
         (prop_oneof![Just('$'), Just('@'), Just('%')], identifier())
             .prop_map(|(sigil, name)| format!("{}{}", sigil, name)),
         // Package-qualified
-        (prop_oneof![Just('$'), Just('@'), Just('%')], identifier(), identifier())
+        (prop_oneof![Just('$'), Just('@'), Just('%')], package_path(), identifier())
             .prop_map(|(sigil, pkg, name)| format!("{}{}::{}", sigil, pkg, name)),
     ]
 }
@@ -75,6 +80,13 @@ mod tests {
         #[test]
         fn identifier_is_ascii(id in identifier()) {
             prop_assert!(id.is_ascii(), "identifier must be ASCII: {}", id);
+        }
+
+        #[test]
+        fn package_path_has_no_empty_segments(pkg in package_path()) {
+            for segment in pkg.split("::") {
+                prop_assert!(!segment.is_empty(), "empty package segment in {pkg}");
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation

- The existing variable generator only produced package-qualified variables with a single package segment, reducing coverage for nested namespace cases.
- Broader package paths better exercise parsers and LSP components that handle multi-segment Perl package names.

### Description

- Added a new `package_path()` proptest strategy that generates 1–4 `identifier()` segments joined by `::`.
- Updated `variable()` to use `package_path()` for package-qualified variables so generated values can be `Foo::Bar::Baz`-style names.
- Expanded the documentation comment for package-qualified examples and added a property test to assert no empty `::` segments are produced.

### Testing

- Ran `cargo test -p perl-test-generators` and all unit and proptest checks passed.
- Ran `cargo check --all-targets -p perl-test-generators` which completed successfully.
- Ran `cargo xtask fmt` and `cargo clippy -p perl-test-generators` which both completed without errors.
- Attempted `just pr-fast` but the `just` tool was not available in this environment (not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf7bc5bc8333b79fb2d0c032d6e1)