### PR TITLE
fix(perl-position-tracking): clamp invalid byte offsets in LineIndex (#0000)

### DIFF
--- a/crates/perl-position-tracking/src/line_index.rs
+++ b/crates/perl-position-tracking/src/line_index.rs
@@ -126,6 +126,7 @@ impl LineIndex {
 
     /// Convert byte offset to position (0-based line and UTF-16 column)
     pub fn offset_to_position(&self, offset: usize) -> (u32, u32) {
+        let offset = self.normalize_offset(offset);
         let line = self.line_starts.binary_search(&offset).unwrap_or_else(|i| i.saturating_sub(1));
 
         let line_start = self.line_starts[line];
@@ -191,6 +192,15 @@ impl LineIndex {
 
         // Check if we're at the end of the line
         if current_utf16 == utf16_offset { Some(line_text.len()) } else { None }
+    }
+
+    /// Normalize a byte offset so it is inside the text and on a UTF-8 codepoint boundary.
+    fn normalize_offset(&self, offset: usize) -> usize {
+        let mut normalized = offset.min(self.text.len());
+        while normalized > 0 && !self.text.is_char_boundary(normalized) {
+            normalized -= 1;
+        }
+        normalized
     }
 
     /// Create a range from byte offsets

--- a/crates/perl-position-tracking/tests/extended_unit_tests.rs
+++ b/crates/perl-position-tracking/tests/extended_unit_tests.rs
@@ -752,6 +752,22 @@ fn line_index_utf16_column_surrogate() {
     assert_eq!(col, 3); // a(1) + 😀(2) = 3 UTF-16 units
 }
 
+#[test]
+fn line_index_offset_to_position_non_boundary_clamps_to_previous_boundary() {
+    let idx = LineIndex::new("a😀b".to_string());
+    let (line, col) = idx.offset_to_position(2); // in the middle of 😀
+    assert_eq!(line, 0);
+    assert_eq!(col, 1); // clamps to byte offset 1 (just after 'a')
+}
+
+#[test]
+fn line_index_offset_to_position_beyond_end_clamps_to_eof() {
+    let idx = LineIndex::new("a😀b".to_string());
+    let (line, col) = idx.offset_to_position(usize::MAX);
+    assert_eq!(line, 0);
+    assert_eq!(col, 4); // a(1) + 😀(2) + b(1)
+}
+
 // ─── convert: offset_to_utf16_line_col ───────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
### Motivation

- `LineIndex::offset_to_position` could be given offsets past EOF or in the middle of a UTF-8 codepoint, which could produce incorrect columns or be inconsistent.

### Description

- Add `normalize_offset` to clamp requested byte offsets to `text.len()` and walk backwards to the nearest UTF-8 codepoint boundary. 
- Call `normalize_offset` at the start of `offset_to_position` so line/column computation always uses a valid byte boundary.
- Add two regression tests covering a mid-codepoint offset (clamps to previous valid boundary) and an out-of-range offset (clamps to EOF).

### Testing

- Ran `cargo test -p perl-position-tracking` and all tests passed.
- Ran `cargo check --all-targets -p perl-position-tracking` and it passed.
- Ran `cargo clippy -p perl-position-tracking --all-targets -- -D warnings` and it passed.
- Ran `cargo xtask fmt` successfully; `just pr-fast` was not run because `just` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf86786c8333b13eeb969e10b94a)