### PR TITLE
fix(perl-incremental-parsing): improve checkpoint capture thresholds (#0000)

### DIFF
--- a/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
+++ b/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
@@ -488,19 +488,22 @@ impl CheckpointedIncrementalParser {
         let mut raw_tokens = Vec::new();
         let mut relexed_tokens = 0usize;
         let mut relexed_bytes = 0usize;
-        let mut checkpoint_positions = vec![0, 100, 500, 1000, 5000];
+        let checkpoint_positions = [0, 100, 500, 1000, 5000];
+        let mut next_checkpoint_idx = 0;
 
         // Collect raw lexer tokens and save checkpoints at specific positions
-        let mut position = 0;
+        let mut position;
         while let Some(token) = lexer.next_token() {
-            // Save checkpoint at specific positions
-            if checkpoint_positions.first() == Some(&position) {
-                checkpoint_positions.remove(0);
+            position = token.end;
+
+            // Save checkpoints once we have lexed past configured byte positions.
+            while next_checkpoint_idx < checkpoint_positions.len()
+                && position >= checkpoint_positions[next_checkpoint_idx]
+            {
                 let checkpoint = lexer.checkpoint();
                 self.checkpoint_cache.add(checkpoint);
+                next_checkpoint_idx += 1;
             }
-
-            position = token.end;
 
             // Stop at EOF
             if matches!(token.token_type, perl_lexer::TokenType::EOF) {
@@ -869,5 +872,28 @@ mod tests {
             let full_after = full.checkpoint_cache.find_after(query).map(|cp| cp.position);
             assert_eq!(incremental_after, full_after, "mismatched right checkpoint at {query}");
         }
+    }
+
+    #[test]
+    fn test_parse_records_early_checkpoint() {
+        let mut parser = CheckpointedIncrementalParser::new();
+        must(parser.parse("my $x = 1;\n".to_string()));
+
+        assert!(
+            parser.checkpoint_cache.find_before(10).is_some(),
+            "expected parser to record an early checkpoint during lexing"
+        );
+    }
+
+    #[test]
+    fn test_parse_records_checkpoint_after_crossing_threshold() {
+        let mut parser = CheckpointedIncrementalParser::new();
+        let source = format!("my ${} = 1;\n", "long_identifier_".repeat(10));
+        must(parser.parse(source));
+
+        assert!(
+            parser.checkpoint_cache.find_after(100).is_some(),
+            "expected a checkpoint to be recorded once lexing crossed byte 100"
+        );
     }
 }


### PR DESCRIPTION
### Motivation

- The previous checkpoint collection logic relied on exact byte-position matches and `Vec::remove(0)`, which could miss checkpoints when token boundaries jump past configured thresholds and incurred front-removal overhead. 

### Description

- Replace front-removal-based checkpoint matching with index-based threshold tracking using `checkpoint_positions` and `next_checkpoint_idx`, recording checkpoints once lexing crosses configured byte offsets. 
- Ensure an early/start checkpoint is recorded by including `0` in the configured checkpoint positions so cache lookups are anchored at document start. 
- Remove the old exact-match logic and add two focused unit tests `test_parse_records_early_checkpoint` and `test_parse_records_checkpoint_after_crossing_threshold` to validate early and threshold-crossing checkpoint capture. 

### Testing

- Ran `cargo test -p perl-incremental-parsing` and all tests passed. 
- Ran `cargo check --all-targets -p perl-incremental-parsing` and it completed successfully. 
- Ran `cargo xtask fmt` and `cargo clippy -p perl-incremental-parsing --lib` which completed successfully; `cargo clippy --all-targets` flags unrelated `expect()` uses in benchmarks (pre-existing) causing failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf86786c8333b13eeb969e10b94a)