### PR TITLE
feat(perl-regex): support apostrophe named captures (#0000)

### DIFF
--- a/crates/perl-regex/src/lib.rs
+++ b/crates/perl-regex/src/lib.rs
@@ -312,9 +312,10 @@ pub struct RegexAnalyzer;
 impl RegexAnalyzer {
     /// Extract all named capture groups from a Perl regex pattern.
     ///
-    /// Scans the pattern for `(?<name>...)` groups and returns them in left-to-right
-    /// order. Non-capturing groups (`(?:...)`), lookaheads, and lookbehinds do not
-    /// increment the capture index. Escaped parentheses (`\(`) are skipped.
+    /// Scans the pattern for `(?<name>...)` and `(?'name'...)` groups and returns
+    /// them in left-to-right order. Non-capturing groups (`(?:...)`), lookaheads,
+    /// and lookbehinds do not increment the capture index. Escaped parentheses
+    /// (`\(`) are skipped.
     ///
     /// # Example
     /// ```
@@ -371,53 +372,33 @@ impl RegexAnalyzer {
                         }
 
                         // Named capture (?<name>...) — collect the name.
-                        capture_index += 1;
-                        let name_start = i;
-                        while i < len && chars[i] != '>' {
-                            i += 1;
+                        if let Some((name, sub_pattern, next_idx)) =
+                            parse_named_capture(chars.as_slice(), i, '>')
+                        {
+                            capture_index += 1;
+                            result.push(CaptureGroup {
+                                name,
+                                index: capture_index,
+                                pattern: sub_pattern,
+                            });
+                            i = next_idx;
                         }
-                        let name: String = chars[name_start..i].iter().collect();
-                        if i < len {
-                            i += 1; // consume '>'
-                        }
+                        continue;
+                    } else if i < len && chars[i] == '\'' {
+                        i += 1; // consume opening '
 
-                        // Collect the sub-pattern up to the matching ')'.
-                        let pattern_start = i;
-                        let mut depth = 1usize;
-                        while i < len && depth > 0 {
-                            if chars[i] == '\\' {
-                                i += 2;
-                                continue;
-                            }
-                            if chars[i] == '[' {
-                                i += 1;
-                                while i < len {
-                                    if chars[i] == '\\' {
-                                        i += 2;
-                                    } else if chars[i] == ']' {
-                                        i += 1;
-                                        break;
-                                    } else {
-                                        i += 1;
-                                    }
-                                }
-                                continue;
-                            }
-                            if chars[i] == '(' {
-                                depth += 1;
-                            } else if chars[i] == ')' {
-                                depth -= 1;
-                            }
-                            i += 1;
+                        // Named capture (?'name'...)
+                        if let Some((name, sub_pattern, next_idx)) =
+                            parse_named_capture(chars.as_slice(), i, '\'')
+                        {
+                            capture_index += 1;
+                            result.push(CaptureGroup {
+                                name,
+                                index: capture_index,
+                                pattern: sub_pattern,
+                            });
+                            i = next_idx;
                         }
-                        // The ')' was consumed above; sub-pattern ends before it.
-                        let sub: String = if i > 0 && pattern_start < i - 1 {
-                            chars[pattern_start..i - 1].iter().collect()
-                        } else {
-                            String::new()
-                        };
-
-                        result.push(CaptureGroup { name, index: capture_index, pattern: sub });
                         continue;
                     } else if i < len && matches!(chars[i], ':' | '=' | '!' | '>' | '|' | 'P' | '#')
                     {
@@ -496,4 +477,62 @@ impl RegexAnalyzer {
 
         parts.join("\n")
     }
+}
+
+fn parse_named_capture(
+    chars: &[char],
+    mut i: usize,
+    name_terminator: char,
+) -> Option<(String, String, usize)> {
+    let len = chars.len();
+    let name_start = i;
+    while i < len && chars[i] != name_terminator {
+        i += 1;
+    }
+
+    if i >= len {
+        return None;
+    }
+
+    let name: String = chars[name_start..i].iter().collect();
+    i += 1; // consume name terminator
+
+    // Collect the sub-pattern up to the matching ')'.
+    let pattern_start = i;
+    let mut depth = 1usize;
+    while i < len && depth > 0 {
+        if chars[i] == '\\' {
+            i += 2;
+            continue;
+        }
+        if chars[i] == '[' {
+            i += 1;
+            while i < len {
+                if chars[i] == '\\' {
+                    i += 2;
+                } else if chars[i] == ']' {
+                    i += 1;
+                    break;
+                } else {
+                    i += 1;
+                }
+            }
+            continue;
+        }
+        if chars[i] == '(' {
+            depth += 1;
+        } else if chars[i] == ')' {
+            depth -= 1;
+        }
+        i += 1;
+    }
+
+    // The ')' was consumed above; sub-pattern ends before it.
+    let sub_pattern = if i > 0 && pattern_start < i - 1 {
+        chars[pattern_start..i - 1].iter().collect()
+    } else {
+        String::new()
+    };
+
+    Some((name, sub_pattern, i))
 }

--- a/crates/perl-regex/tests/named_capture_tests.rs
+++ b/crates/perl-regex/tests/named_capture_tests.rs
@@ -24,6 +24,16 @@ fn test_extract_single_named_capture() -> Result<(), Box<dyn std::error::Error>>
 }
 
 #[test]
+fn test_extract_single_named_capture_apostrophe_syntax() -> Result<(), Box<dyn std::error::Error>> {
+    let captures = RegexAnalyzer::extract_named_captures("(?'id'\\d+)");
+    assert_eq!(captures.len(), 1);
+    assert_eq!(captures[0].name, "id");
+    assert_eq!(captures[0].index, 1);
+    assert_eq!(captures[0].pattern, "\\d+");
+    Ok(())
+}
+
+#[test]
 fn test_extract_multiple_named_captures() -> Result<(), Box<dyn std::error::Error>> {
     let captures =
         RegexAnalyzer::extract_named_captures("(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})");
@@ -150,6 +160,13 @@ fn test_hover_text_no_captures_no_modifiers() -> Result<(), Box<dyn std::error::
 #[test]
 fn test_hover_text_single_named_capture_listed() -> Result<(), Box<dyn std::error::Error>> {
     let text = RegexAnalyzer::hover_text_for_regex("(?<id>\\d+)", "");
+    assert!(text.contains("id"));
+    Ok(())
+}
+
+#[test]
+fn test_hover_text_apostrophe_named_capture_listed() -> Result<(), Box<dyn std::error::Error>> {
+    let text = RegexAnalyzer::hover_text_for_regex("(?'id'\\d+)", "");
     assert!(text.contains("id"));
     Ok(())
 }


### PR DESCRIPTION
### Motivation

- The named-capture extraction only handled the `(?<name>...)` form and missed Perl's alternate `(?'name'...)` syntax, reducing accuracy of capture reporting and hover summaries.

### Description

- Added a shared `parse_named_capture` helper to centralize parsing of named-capture headers and sub-patterns. 
- Extended `RegexAnalyzer::extract_named_captures` to recognize both `(?<name>...)` and `(?'name'...)` forms and to populate `CaptureGroup::pattern` for the apostrophe form. 
- Added focused tests covering the apostrophe-style named capture for both extraction and `hover_text_for_regex` output.

### Testing

- Ran `cargo test -p perl-regex` and all tests passed. 
- Ran `cargo check --all-targets -p perl-regex` and it passed. 
- Ran `cargo clippy -p perl-regex` and it passed. 
- Ran `cargo xtask fmt` and it completed successfully. 
- Attempted `just pr-fast` but it was unavailable in this environment (command not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf88c2848333b60244f8bc9bd51c)