### PR TITLE
test(perllsp): improve CLI smoke failure diagnostics (#0000)

### DIFF
--- a/crates/perllsp/tests/cli_smoke.rs
+++ b/crates/perllsp/tests/cli_smoke.rs
@@ -5,22 +5,25 @@ fn run_perllsp(args: &[&str]) -> Result<std::process::Output, Box<dyn std::error
     Ok(output)
 }
 
+fn successful_stdout(output: std::process::Output) -> Result<String, Box<dyn std::error::Error>> {
+    if output.status.success() {
+        return String::from_utf8(output.stdout).map_err(Into::into);
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Err(format!("command failed with status {}: {}", output.status, stderr).into())
+}
+
 #[test]
 fn help_mentions_perllsp() -> Result<(), Box<dyn std::error::Error>> {
-    let output = run_perllsp(&["--help"])?;
-    assert!(output.status.success(), "help should succeed");
-
-    let stdout = String::from_utf8(output.stdout)?;
+    let stdout = successful_stdout(run_perllsp(&["--help"])?)?;
     assert!(stdout.contains("Usage: perllsp"), "help should mention the facade name");
     Ok(())
 }
 
 #[test]
 fn version_mentions_facade_name_and_git_tag() -> Result<(), Box<dyn std::error::Error>> {
-    let output = run_perllsp(&["--version"])?;
-    assert!(output.status.success(), "version should succeed");
-
-    let stdout = String::from_utf8(output.stdout)?;
+    let stdout = successful_stdout(run_perllsp(&["--version"])?)?;
     assert!(stdout.contains("perllsp "), "version should print the facade name");
     assert!(stdout.contains("Git tag:"), "version should include the git tag line");
     Ok(())


### PR DESCRIPTION
### Motivation

- CLI smoke tests asserted process success and decoded stdout but did not surface stderr on failure, which made diagnosing test failures harder.
- A small helper that returns stdout on success and includes exit status plus stderr on failure improves developer feedback without changing test semantics.

### Description

- Add a `successful_stdout` helper in `crates/perllsp/tests/cli_smoke.rs` that returns UTF-8 stdout when the command exits successfully and returns an error containing the exit status and decoded stderr when it fails.
- Update both smoke tests (`--help` and `--version`) to use `successful_stdout` and remove duplicated success checks and stdout decoding, with no other files modified.

### Testing

- Ran `cargo test -p perllsp` and the two CLI smoke tests passed (`2 passed`).
- Ran `cargo check --all-targets -p perllsp` and it completed successfully.
- Ran `cargo xtask fmt` and `cargo clippy -p perllsp` and both completed with no blocking failures.
- `just pr-fast` was attempted but not available in the environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf8b51908333921b694a8937e66c)