### PR TITLE
fix(perl-refactoring): support signature-style subs in inliner (#0000)

### DIFF
--- a/crates/perl-refactoring/src/refactor/inline.rs
+++ b/crates/perl-refactoring/src/refactor/inline.rs
@@ -297,7 +297,7 @@ fn find_sub_start(source: &str, sub_name: &str) -> Option<usize> {
                 // Verify it's a word boundary (not "sub foobar" when looking for "foo")
                 let boundary_ok =
                     after_name.chars().next().is_none_or(|c| !c.is_alphanumeric() && c != '_');
-                if boundary_ok && after_name.trim_start().starts_with('{') {
+                if boundary_ok && is_sub_opening_delimiter(after_name) {
                     return Some(pos + idx);
                 }
             }
@@ -307,6 +307,47 @@ fn find_sub_start(source: &str, sub_name: &str) -> Option<usize> {
         }
     }
     None
+}
+
+/// Returns true if text after a sub name starts a valid body delimiter.
+///
+/// Accepts:
+/// - `sub name { ... }`
+/// - `sub name ($arg1, $arg2) { ... }`
+fn is_sub_opening_delimiter(after_name: &str) -> bool {
+    let trimmed = after_name.trim_start();
+    if trimmed.starts_with('{') {
+        return true;
+    }
+    let Some(rest) = trimmed.strip_prefix('(') else {
+        return false;
+    };
+    let mut depth = 1usize;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut escaped = false;
+    for (i, c) in rest.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match c {
+            '\\' if in_single_quote || in_double_quote => {
+                escaped = true;
+            }
+            '\'' if !in_double_quote => in_single_quote = !in_single_quote,
+            '"' if !in_single_quote => in_double_quote = !in_double_quote,
+            '(' if !in_single_quote && !in_double_quote => depth += 1,
+            ')' if !in_single_quote && !in_double_quote => {
+                depth -= 1;
+                if depth == 0 {
+                    return rest[i + c.len_utf8()..].trim_start().starts_with('{');
+                }
+            }
+            _ => {}
+        }
+    }
+    false
 }
 
 /// Extract the text between a matching pair of braces starting at `open_pos`

--- a/crates/perl-refactoring/tests/subroutine_inline_tests.rs
+++ b/crates/perl-refactoring/tests/subroutine_inline_tests.rs
@@ -348,10 +348,28 @@ fn test_recursion_detection_ignores_sub_name_in_string() {
         "sub name in a string literal must not trigger Recursive rejection; got: {:?}",
         result
     );
-    let inlined = result.unwrap();
+    let inlined = must(result);
     assert!(
         inlined.contains("1 + 2") || inlined.contains("(1 + 2)"),
         "inlined result should contain the substituted expression; got: {inlined}"
+    );
+}
+
+#[test]
+fn test_inline_sub_with_signature_parens() {
+    // Perl signatures can appear between the sub name and body braces.
+    // The inliner should still locate and inline this sub.
+    let source = r#"sub combine ($left, $right) {
+    my ($left, $right) = @_;
+    return $left . $right;
+}
+"#;
+    let inliner = SubInliner::new(source);
+    let result = inliner.inline_call("combine", r#"combine("a", "b")"#);
+    let inlined = must(result);
+    assert!(
+        inlined.contains("\"a\" . \"b\"") || inlined.contains("(\"a\" . \"b\")"),
+        "signature-style sub should inline normally; got: {inlined}"
     );
 }
 


### PR DESCRIPTION
### Motivation

- The text-based subroutine inliner only matched `sub name { ... }` and therefore failed to locate and inline valid Perl subs that include signature parentheses (e.g. `sub name ($a, $b) { ... }`).

### Description

- Add `is_sub_opening_delimiter` to recognize both `{` and signature-style `(...) {` openings and wire it into `find_sub_start` so signature parentheses no longer block locating the body. 
- Make the signature parser handle nested parens, quoted strings, and escaped characters when scanning for the closing `)` before the `{`.
- Add a regression test `test_inline_sub_with_signature_parens` covering inlining of a signature-style sub and replace a remaining bare `unwrap()` in tests with `must(...)` to follow test safety conventions.

### Testing

- Ran `cargo test -p perl-refactoring` and all tests passed.
- Ran `cargo check --all-targets -p perl-refactoring` and it passed.
- Ran `cargo clippy -p perl-refactoring --all-targets -- -D warnings` and it passed.
- Ran `cargo xtask fmt` which completed successfully; `just pr-fast` was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf8bd8608333b45028c1519c19cc)