### PR TITLE
refactor(folder): harden and deduplicate file URI prefix handling (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/folder/mod.rs
+++ b/crates/perl-workspace-index/src/folder/mod.rs
@@ -10,6 +10,7 @@ use perl_uri::uri_to_fs_path;
 use serde_json::Value;
 
 /// URI lists extracted from an LSP workspace folder change event.
+#[non_exhaustive]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct WorkspaceFolderChange {
     /// Added workspace folder URIs.
@@ -26,10 +27,7 @@ pub struct WorkspaceFolderChange {
 /// interpreted as a path fallback.
 #[must_use]
 pub fn workspace_folder_to_path(workspace_folder: &str) -> PathBuf {
-    let is_file_uri =
-        workspace_folder.get(..7).is_some_and(|prefix| prefix.eq_ignore_ascii_case("file://"));
-
-    if is_file_uri {
+    if has_file_uri_prefix(workspace_folder) {
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(path) = uri_to_fs_path(workspace_folder) {
             return path;
@@ -43,6 +41,10 @@ pub fn workspace_folder_to_path(workspace_folder: &str) -> PathBuf {
     }
 
     PathBuf::from(workspace_folder)
+}
+
+fn has_file_uri_prefix(value: &str) -> bool {
+    value.get(..7).is_some_and(|prefix| prefix.eq_ignore_ascii_case("file://"))
 }
 
 fn parse_file_uri_fallback(workspace_folder: &str) -> Option<PathBuf> {
@@ -102,7 +104,7 @@ pub fn extract_workspace_folder_change(event: &Value) -> WorkspaceFolderChange {
 /// This keeps behavior deterministic across absolute POSIX and Windows-style paths.
 #[must_use]
 pub fn root_path_to_file_uri(root_path: &str) -> String {
-    if root_path.get(..7).is_some_and(|prefix| prefix.eq_ignore_ascii_case("file://")) {
+    if has_file_uri_prefix(root_path) {
         return root_path.to_string();
     }
 


### PR DESCRIPTION
### Motivation
- Remove duplicated `file://` prefix checks and make the public `WorkspaceFolderChange` API forward-compatible to avoid accidental breakage when evolving the type.

### Description
- Add a shared helper `fn has_file_uri_prefix(&str) -> bool` and replace inline `get(..7)` checks in `workspace_folder_to_path` and `root_path_to_file_uri` with calls to this helper.
- Mark the `WorkspaceFolderChange` struct as `#[non_exhaustive]` to allow non-breaking additions to the type in the future.

### Testing
- Ran `cargo test -p perl-workspace folder::tests -- --nocapture`, which passed.
- Ran `cargo check --all-targets -p perl-workspace`, which passed.
- Ran `cargo test -p perl-workspace`, which failed due to an unrelated pre-existing test (`workspace::workspace_index::tests::test_extract_module_names_legacy_separator`).
- Ran `cargo clippy -p perl-workspace --all-targets -- -D warnings`, which failed on unrelated `expect()` usage in existing tests under `tests/collapse_edge_cases_tests.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf8bd8608333b45028c1519c19cc)