### PR TITLE
fix(perl-corpus): preserve token boundaries in whitespace generator (#0000)

### DIFF
--- a/crates/perl-corpus/src/gen/whitespace.rs
+++ b/crates/perl-corpus/src/gen/whitespace.rs
@@ -25,7 +25,7 @@ pub fn sprinkle_whitespace(src: &str, seed: u64) -> String {
         result.push(ch);
 
         // Don't insert whitespace inside strings or regexes
-        if !in_string && !in_regex {
+        if !in_string && !in_regex && can_insert_after(ch) {
             // Randomly insert whitespace or comments
             let choice = rng.random_range(0..20);
             match choice {
@@ -41,6 +41,13 @@ pub fn sprinkle_whitespace(src: &str, seed: u64) -> String {
     }
 
     result
+}
+
+fn can_insert_after(ch: char) -> bool {
+    matches!(
+        ch,
+        ';' | ',' | '(' | ')' | '{' | '}' | '[' | ']' | '=' | '+' | '-' | '*' | '/' | '%' | ':'
+    )
 }
 
 /// Generate various whitespace patterns
@@ -141,11 +148,9 @@ mod tests {
             })
             .collect();
 
-        // Whitespace insertion can split tokens (e.g., "my" → "m\ty"), so we verify
-        // that the combined tokens preserve the original content
         assert!(
-            trans_tokens.len() >= orig_tokens.len(),
-            "Whitespace insertion should not lose tokens: expected at least {} tokens, got {}",
+            trans_tokens.len() == orig_tokens.len(),
+            "Whitespace insertion should preserve token boundaries: expected {} tokens, got {}",
             orig_tokens.len(),
             trans_tokens.len()
         );


### PR DESCRIPTION
### Motivation
- `sprinkle_whitespace` could insert whitespace/comments after any character, which sometimes split identifiers and altered token boundaries in generated corpus snippets.
- The change aims to avoid producing invalid or confusing metamorphic examples by only injecting whitespace at safe punctuation/operator boundaries.

### Description
- Add a `can_insert_after` helper that enumerates safe characters (punctuation/operators) where whitespace/comments may be inserted. 
- Use `can_insert_after` in `sprinkle_whitespace` to guard insertion points so identifiers are not split. 
- Tighten the `whitespace_preserves_tokens` unit test to assert that token counts are preserved (`trans_tokens.len() == orig_tokens.len()`).

### Testing
- Ran `cargo test -p perl-corpus`, which passed (all tests green). 
- Ran `cargo check --all-targets -p perl-corpus`, which completed successfully. 
- Ran `cargo xtask fmt`, which completed successfully. 
- Ran `cargo clippy -p perl-corpus --all-targets -- -D warnings`, which completed successfully. 
- Attempted `just pr-fast` in the environment but `just` was not available (command not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf8bd8608333b45028c1519c19cc)