### PR TITLE
fix(pragma): conditional no semantics and conservative eval string handling (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -654,6 +654,94 @@ impl PragmaTracker {
                 }
             }
             NodeKind::No { module, args, .. } => {
+                if (module == "if" || module == "unless")
+                    && let Some((conditional_module, conditional_args)) =
+                        conditional_pragma_target(args)
+                {
+                    match conditional_module {
+                        "strict" => {
+                            if conditional_args.is_empty() {
+                                current_state.strict_vars = false;
+                                current_state.strict_subs = false;
+                                current_state.strict_refs = false;
+                            } else {
+                                for arg in conditional_args {
+                                    match normalized_pragma_token(arg) {
+                                        "vars" => current_state.strict_vars = false,
+                                        "subs" => current_state.strict_subs = false,
+                                        "refs" => current_state.strict_refs = false,
+                                        _ => {}
+                                    }
+                                }
+                            }
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
+                        "warnings" => {
+                            if conditional_args.is_empty() {
+                                current_state.warnings = false;
+                                current_state.disabled_warning_categories.clear();
+                            } else {
+                                for arg in conditional_args {
+                                    let category = normalized_pragma_token(arg);
+                                    if !current_state
+                                        .disabled_warning_categories
+                                        .iter()
+                                        .any(|c| c == category)
+                                    {
+                                        current_state
+                                            .disabled_warning_categories
+                                            .push(category.to_string());
+                                    }
+                                }
+                            }
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
+                        "utf8" => {
+                            current_state.utf8 = false;
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
+                        "encoding" => {
+                            current_state.encoding = None;
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
+                        "locale" => {
+                            current_state.locale = false;
+                            current_state.locale_scope = None;
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
+                        "feature" => {
+                            if apply_feature_state(current_state, conditional_args, false) {
+                                ranges.push((
+                                    node.location.start..node.location.end,
+                                    current_state.clone(),
+                                ));
+                            }
+                            return;
+                        }
+                        _ => return,
+                    }
+                }
+
                 // Handle no statements
                 match module.as_str() {
                     "strict" => {
@@ -784,7 +872,12 @@ impl PragmaTracker {
                     Self::build_scoped_body(continue_block, current_state, ranges);
                 }
             }
-            NodeKind::Eval { block } | NodeKind::Do { block } | NodeKind::Defer { block } => {
+            NodeKind::Eval { block } => {
+                if matches!(block.kind, NodeKind::Block { .. }) {
+                    Self::build_scoped_body(block, current_state, ranges);
+                }
+            }
+            NodeKind::Do { block } | NodeKind::Defer { block } => {
                 Self::build_scoped_body(block, current_state, ranges);
             }
             NodeKind::PhaseBlock { block, .. } => {

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -281,6 +281,34 @@ fn use_if_encoding_targets_encoding_not_argument() -> Result<(), Box<dyn std::er
 }
 
 #[test]
+fn no_if_strict_conditionally_disables_strict() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        no_node("if", &["$cond", "'strict'"], 13, 33),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 25);
+
+    assert!(!state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(!state.strict_refs);
+    Ok(())
+}
+
+#[test]
+fn no_unless_feature_conditionally_disables_feature() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("feature", &["'say'"], 0, 20),
+        no_node("unless", &["$cond", "feature", "'say'"], 21, 50),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 40);
+
+    assert!(!state.has_feature("say"));
+    Ok(())
+}
+
+#[test]
 fn no_strict_disables_all() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("strict", &[], 0, 12), no_node("strict", &[], 13, 23)]);
     let map = PragmaTracker::build(&ast);
@@ -908,6 +936,19 @@ fn eval_string_call_is_handled_conservatively() -> Result<(), Box<dyn std::error
         !state_after_eval_string.warnings,
         "string eval content must not be treated as lexical `use warnings`"
     );
+    Ok(())
+}
+
+#[test]
+fn eval_string_expression_is_handled_conservatively() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        eval_node(use_node("warnings", &[], 20, 32), 15, 40),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 30);
+
+    assert!(!state.warnings, "eval STRING should not be interpreted as a lexical pragma scope");
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Pragma tracking previously handled `use if` conditional targets but did not apply the same conditional semantics to `no if` / `no unless`, allowing conditional disabling to be missed.
- `eval` expression forms (e.g. `eval "..."`) were being treated like scoped blocks in traversal, risking pragma leakage from runtime-evaluated strings.
- Implement consistent conditional `no` semantics and conservative handling of `eval STRING` to match lexical scoping expectations and close the pragma-scoping gaps tracked by related issues.

### Description
- Added conditional `no` handling for `if`/`unless` targets in `PragmaTracker::build_ranges`, applying the same target-resolution logic used for conditional `use` and updating state for tracked pragmas (`strict`, `warnings`, `utf8`, `encoding`, `locale`, `feature`).
- Limited `Eval` traversal so only `eval { ... }` block forms are treated as lexical scoped bodies; non-block `eval` expressions are no longer traversed for pragma effects.
- Added regression tests: `no_if_strict_conditionally_disables_strict`, `no_unless_feature_conditionally_disables_feature`, and `eval_string_expression_is_handled_conservatively` to assert the new behaviors.

### Testing
- Ran `cargo test -p perl-pragma`, which passed (`100` tests passed including new regressions).
- Ran `cargo check --all-targets -p perl-pragma`, which completed successfully.
- Ran `cargo clippy -p perl-pragma --all-targets` and `cargo xtask fmt`, both completed without blocking errors; `just pr-fast` was unavailable in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c4d8d238833396a5115021104fa8)