### PR TITLE
fix(pragma): cover conservative eval string scoping (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
@@ -566,6 +566,22 @@ mod tests {
     }
 
     #[test]
+    fn eval_string_with_embedded_pragma_text_does_not_suppress_missing_diagnostics() {
+        // eval STRING is runtime code generation. We do not parse the embedded
+        // source into pragma state, so strict/warnings must still be considered
+        // missing at file scope.
+        let diags = strict_warnings_diags("eval 'use strict; use warnings;';\nmy $x = 1;\n");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL100")),
+            "eval STRING text must not suppress missing-strict (PL100)"
+        );
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL101")),
+            "eval STRING text must not suppress missing-warnings (PL101)"
+        );
+    }
+
+    #[test]
     fn implicit_strict_module_inside_eval_suppresses_diagnostic_known_limitation() {
         // use Moose inside eval { } — walk_node visits it scope-unaware and sets
         // has_strict=true even though Moose is only in eval scope.  This is a

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -48,6 +48,13 @@ fn number_node(value: &str, start: usize, end: usize) -> Node {
     Node { kind: NodeKind::Number { value: value.to_string() }, location: loc(start, end) }
 }
 
+fn string_node(value: &str, interpolated: bool, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::String { value: value.to_string(), interpolated },
+        location: loc(start, end),
+    }
+}
+
 fn program(stmts: Vec<Node>) -> Node {
     let end = stmts.last().map_or(0, |n| n.location.end);
     Node { kind: NodeKind::Program { statements: stmts }, location: loc(0, end) }
@@ -845,6 +852,27 @@ fn modern_container_bodies_are_traversed_and_scoped() -> Result<(), Box<dyn std:
     let after = PragmaTracker::state_for_offset(&map, 285);
     assert!(after.strict_vars && after.strict_subs && after.strict_refs);
     assert!(after.warnings);
+    Ok(())
+}
+
+#[test]
+fn eval_string_is_handled_conservatively_without_pragma_side_effects()
+-> Result<(), Box<dyn std::error::Error>> {
+    let eval_string_stmt = eval_node(string_node("use strict; use warnings;", false, 5, 36), 0, 38);
+    let ast = program(vec![eval_string_stmt, dummy_node(39, 45)]);
+    let map = PragmaTracker::build(&ast);
+
+    let inside_eval = PragmaTracker::state_for_offset(&map, 10);
+    assert!(!inside_eval.strict_vars);
+    assert!(!inside_eval.strict_subs);
+    assert!(!inside_eval.strict_refs);
+    assert!(!inside_eval.warnings);
+
+    let after_eval = PragmaTracker::state_for_offset(&map, 44);
+    assert!(!after_eval.strict_vars);
+    assert!(!after_eval.strict_subs);
+    assert!(!after_eval.strict_refs);
+    assert!(!after_eval.warnings);
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Ensure `eval STRING` payloads are treated conservatively and do not affect lexical pragma state used for file-scope `use strict` / `use warnings` diagnostics as required by #3489.
- Add regression coverage to make the intended conservative behaviour explicit and prevent future regressions that might parse eval string text into pragma state.

### Description
- Add a `string_node` test helper to `crates/perl-pragma/tests/comprehensive_unit_tests.rs` to model `eval STRING` payloads directly in AST-driven tests.
- Add `eval_string_is_handled_conservatively_without_pragma_side_effects` to `crates/perl-pragma/tests/comprehensive_unit_tests.rs` asserting embedded pragma text in a `String` node does not change pragma state inside the eval or after it.
- Add `eval_string_with_embedded_pragma_text_does_not_suppress_missing_diagnostics` to `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs` asserting `eval 'use strict; use warnings;'` does not suppress PL100/PL101 at file scope.

### Testing
- Ran `cargo test -p perl-pragma --test comprehensive_unit_tests eval_string_is_handled_conservatively_without_pragma_side_effects` which passed.
- Ran `cargo test -p perl-lsp-rs-core eval_string_with_embedded_pragma_text_does_not_suppress_missing_diagnostics` which passed.
- Ran `cargo fmt --all` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c4d8d238833396a5115021104fa8)