### PR TITLE
test(ux): codify UX confidence tracking signals (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | *qualitative + fixture-backed signals* | Tracked via the `perl-lsp-ux-tests` first-5-minutes scenario matrix (`ux_confidence_signals`), linked manual smoke runbook coverage, and known-gap issue burn-down inventory | Anything about parser breadth, protocol catalog size, or capability count |
 
 The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
 

--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -270,5 +270,24 @@
         "definition no longer resolves to deleted targets"
       ]
     }
-  ]
+  ],
+  "ux_confidence_signals": {
+    "manual_editor_smoke": {
+      "runbook": "docs/reference/UX_TESTING.md",
+      "cadence": "release_and_regression_triage"
+    },
+    "first_5_minutes_harness": {
+      "harness_crate": "crates/perl-lsp-ux-tests",
+      "scenario_prefix": "ux_scenario_"
+    },
+    "open_issue_burndown": {
+      "tracking_issues": [
+        3522,
+        3476,
+        4246,
+        3515
+      ],
+      "source": "README.md#known-gaps-toward-solid-ux"
+    }
+  }
 }

--- a/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
+++ b/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
@@ -47,15 +47,25 @@ fn editor_ux_fixture_matrix_covers_all_scenarios() -> Result<()> {
         matrix.get("component_metrics").context("component_metrics missing")?,
         "component_metrics",
     )?;
+    let confidence_signals =
+        matrix.get("ux_confidence_signals").context("ux_confidence_signals missing")?;
+    validate_confidence_signals(confidence_signals)?;
     let allowed_metrics =
         top_line_metrics.union(&component_metrics).cloned().collect::<BTreeSet<_>>();
 
     let workflows =
         matrix.get("workflows").and_then(Value::as_array).context("workflows missing")?;
 
+    let mut workflow_ids = BTreeSet::new();
     let mut scenarios_in_matrix = BTreeSet::new();
     let mut component_metrics_exercised = BTreeSet::new();
     for workflow in workflows {
+        let workflow_id =
+            workflow.get("id").and_then(Value::as_str).context("workflow missing id")?;
+        assert!(
+            workflow_ids.insert(workflow_id.to_string()),
+            "workflow id `{workflow_id}` is duplicated"
+        );
         let scenario_file = workflow
             .get("scenario_file")
             .and_then(Value::as_str)
@@ -124,4 +134,29 @@ fn collect_string_set(value: &Value, context_label: &str) -> Result<BTreeSet<Str
         out.insert(item.to_string());
     }
     Ok(out)
+}
+
+fn validate_confidence_signals(value: &Value) -> Result<()> {
+    let signals = value.as_object().context("ux_confidence_signals must be an object")?;
+    for signal_name in ["manual_editor_smoke", "first_5_minutes_harness", "open_issue_burndown"] {
+        assert!(signals.contains_key(signal_name), "missing confidence signal `{signal_name}`");
+    }
+
+    let runbook = signals["manual_editor_smoke"]
+        .get("runbook")
+        .and_then(Value::as_str)
+        .context("manual_editor_smoke.runbook missing")?;
+    assert_eq!(runbook, "docs/reference/UX_TESTING.md");
+
+    let tracking_issues = signals["open_issue_burndown"]
+        .get("tracking_issues")
+        .and_then(Value::as_array)
+        .context("open_issue_burndown.tracking_issues missing")?;
+    assert!(!tracking_issues.is_empty(), "tracking_issues must not be empty");
+    for issue in tracking_issues {
+        let issue_number = issue.as_u64().context("tracking issue IDs must be integers")?;
+        assert!(issue_number > 0, "tracking issue IDs must be positive");
+    }
+
+    Ok(())
 }

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -122,6 +122,39 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+#[derive(Debug, Default, PartialEq, Eq)]
+struct UxConfidenceSignals {
+    tracked_issue_count: usize,
+    has_manual_smoke_runbook: bool,
+}
+
+fn collect_ux_confidence_signals(root: &Path) -> UxConfidenceSignals {
+    let matrix_path = root.join("crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json");
+    let Ok(raw) = fs::read_to_string(matrix_path) else {
+        return UxConfidenceSignals::default();
+    };
+    let Ok(matrix) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return UxConfidenceSignals::default();
+    };
+    let Some(signals) = matrix.get("ux_confidence_signals").and_then(|v| v.as_object()) else {
+        return UxConfidenceSignals::default();
+    };
+
+    let has_manual_smoke_runbook = signals
+        .get("manual_editor_smoke")
+        .and_then(|v| v.get("runbook"))
+        .and_then(|v| v.as_str())
+        .is_some();
+
+    let tracked_issue_count = signals
+        .get("open_issue_burndown")
+        .and_then(|v| v.get("tracking_issues"))
+        .and_then(|v| v.as_array())
+        .map_or(0, |issues| issues.iter().filter(|issue| issue.as_u64().is_some()).count());
+
+    UxConfidenceSignals { tracked_issue_count, has_manual_smoke_runbook }
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -130,6 +163,12 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
     let mutation_by_crate = collect_per_crate_mutation(root);
     let tests_by_crate = collect_per_crate_test_counts(root);
     let ux_scenarios = count_ux_scenarios(root);
+    let ux_signals = collect_ux_confidence_signals(root);
+    let manual_smoke_state = if ux_signals.has_manual_smoke_runbook {
+        "manual smoke runbook linked"
+    } else {
+        "manual smoke runbook missing"
+    };
 
     let has_mutation_data = !mutation_by_crate.is_empty();
     let mutation_note = if has_mutation_data {
@@ -144,8 +183,11 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
            `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
            the integration-only 10k-line large-file case; planning scaffold at \
            `docs/project/status/editor_ux.json`\n\
+         - **UX confidence signals**: {ux_scenarios} executable first-5-minutes workflows, \
+           {tracked_issues} tracked known-gap issues for burn-down, {manual_smoke_state} via fixture matrix\n\
          - **Mutation testing**: {mutation_note}\n\
-         - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
+         - **Production Status**: LSP server public alpha (`just ci-gate` passing)",
+        tracked_issues = ux_signals.tracked_issue_count
     );
 
     let crate_table = format_crate_quality_table(&mutation_by_crate, &tests_by_crate);
@@ -280,6 +322,29 @@ mod tests {
             ])
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_ux_confidence_signals_from_matrix_shape() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let fixture_dir = dir.path().join("crates/perl-lsp-ux-tests/fixtures");
+        fs::create_dir_all(&fixture_dir)?;
+        fs::write(
+            fixture_dir.join("editor_ux_fixture_matrix.json"),
+            r#"{
+              "ux_confidence_signals": {
+                "manual_editor_smoke": { "runbook": "docs/reference/UX_TESTING.md" },
+                "open_issue_burndown": { "tracking_issues": [3522, 3476, 4246] }
+              }
+            }"#,
+        )?;
+
+        let signals = collect_ux_confidence_signals(dir.path());
+        assert_eq!(
+            signals,
+            UxConfidenceSignals { tracked_issue_count: 3, has_manual_smoke_runbook: true }
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Make the qualitative “End-to-end UX confidence” signal machine-observable and testable by encoding the three confidence inputs (manual editor smoke, first-5-minutes harness, open-issue burn-down) in the fixture matrix so tooling and status generators can consume them.

### Description

- Add an explicit `ux_confidence_signals` block to `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` that documents the manual smoke runbook, harness metadata, and tracked known-gap issue IDs.
- Strengthen the fixture validation in `crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs` to require and sanity-check `ux_confidence_signals` and to enforce unique workflow `id` values.
- Surface the signals in status generation by adding `collect_ux_confidence_signals` and related rendering to `xtask/src/tasks/update_status/quality.rs` so `cargo xtask update-status --only quality` can emit concrete UX-confidence bullets.
- Update `README.md` wording to indicate the UX confidence row is now "qualitative + fixture-backed signals".

### Testing

- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix` which passed.
- Ran the xtask unit test `cargo test -p xtask test_collect_ux_confidence_signals_from_matrix_shape` which passed and `cargo check --all-targets -p xtask` which also passed.
- Ran `cargo check --all-targets -p perl-lsp-ux-tests` which passed.
- Noted unrelated failures: `cargo clippy -p perl-lsp-ux-tests --tests -- -D warnings` fails on a pre-existing clippy lint in `ux_scenario_13_document_symbols.rs`, and `cargo test -p xtask` shows unrelated `publish_closure_edge_cases` failures; these are pre-existing and not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c539d6788333b2dc9ae826d7a4fa)