### PR TITLE
feat(status): track UX confidence signals in receipts (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | *mixed* (qualitative + tracked receipts) | Covered by manual editor smoke workflows plus tracked receipts: `perl-lsp-ux-tests` first-5-minutes scenario inventory, editor-UX metric state (`workflow_pass_rate`, `workflow_stability_rate`, `p95_time_to_first_useful_result_ms`), and known-gap issue burn-down references in `docs/project/status/editor_ux.json` | Anything about parser breadth, protocol catalog size, or capability count |
 
 The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
 

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -28,7 +28,7 @@
     "release_lane": "just ux-tests-full",
     "status_update": "cargo xtask update-status --only quality"
   },
-  "receipt_kind": "planning_scaffold",
+  "receipt_kind": "tracking_receipt",
   "schema_version": 1,
   "scorecard": "editor_ux",
   "top_line_metrics": [
@@ -47,5 +47,15 @@
       "owner": "perl-lsp-ux-tests",
       "state": "planned"
     }
-  ]
+  ],
+  "ux_gap_burndown": {
+    "issue_reference_count": 4,
+    "issue_references": [
+      "https://github.com/EffortlessMetrics/perl-lsp/issues/3476",
+      "https://github.com/EffortlessMetrics/perl-lsp/issues/3515",
+      "https://github.com/EffortlessMetrics/perl-lsp/issues/3522",
+      "https://github.com/EffortlessMetrics/perl-lsp/issues/4246"
+    ],
+    "source": "README.md#known-gaps-toward-solid-ux"
+  }
 }

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -9,6 +9,7 @@
     "scorecard",
     "harness",
     "top_line_metrics",
+    "ux_gap_burndown",
     "integration_points"
   ],
   "properties": {
@@ -18,7 +19,7 @@
     },
     "receipt_kind": {
       "type": "string",
-      "const": "planning_scaffold"
+      "const": "tracking_receipt"
     },
     "scorecard": {
       "type": "string",
@@ -122,6 +123,27 @@
         },
         "quality_surface": {
           "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ux_gap_burndown": {
+      "type": "object",
+      "required": ["source", "issue_reference_count", "issue_references"],
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "issue_reference_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "issue_references": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
         }
       },
       "additionalProperties": false

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -9,6 +9,7 @@
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
 - **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; planning scaffold at `docs/project/status/editor_ux.json`
+- **Known UX gap burn-down**: 4 tracked issue references from `README.md` “Known gaps toward solid UX” (must-land + nice-to-land + deferred)
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -5,11 +5,17 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result};
 
 use super::{replace_block, run_cmd};
+
+static KNOWN_UX_GAP_ISSUE_RE: LazyLock<std::result::Result<regex::Regex, regex::Error>> =
+    LazyLock::new(|| {
+        regex::Regex::new(r"https://github\.com/EffortlessMetrics/perl-lsp/issues/\d+")
+    });
 
 // ---------------------------------------------------------------------------
 // Metric collectors
@@ -122,6 +128,56 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+#[derive(Debug, serde::Deserialize)]
+struct EditorUxMetricsReceipt {
+    metrics: EditorUxMetricValues,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct EditorUxMetricValues {
+    workflow_pass_rate: Option<f64>,
+    workflow_stability_rate: Option<f64>,
+    p95_time_to_first_useful_result_ms: Option<u64>,
+}
+
+fn read_editor_ux_metrics(root: &Path) -> Option<EditorUxMetricValues> {
+    let path = root.join(".ci").join("metrics").join("editor_ux.json");
+    let raw = fs::read_to_string(path).ok()?;
+    let receipt: EditorUxMetricsReceipt = serde_json::from_str(&raw).ok()?;
+    Some(receipt.metrics)
+}
+
+fn extract_known_ux_gap_issues(root: &Path) -> Vec<String> {
+    let readme_path = root.join("README.md");
+    let Ok(readme) = fs::read_to_string(readme_path) else {
+        return Vec::new();
+    };
+
+    let mut in_known_gaps_section = false;
+    let mut issues = std::collections::BTreeSet::new();
+    let Ok(issue_re) = &*KNOWN_UX_GAP_ISSUE_RE else {
+        return Vec::new();
+    };
+
+    for line in readme.lines() {
+        if line.starts_with("### Known gaps toward solid UX") {
+            in_known_gaps_section = true;
+            continue;
+        }
+        if in_known_gaps_section && line.starts_with("### ") {
+            break;
+        }
+        if !in_known_gaps_section {
+            continue;
+        }
+        for m in issue_re.find_iter(line) {
+            issues.insert(m.as_str().to_string());
+        }
+    }
+
+    issues.into_iter().collect()
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -130,6 +186,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
     let mutation_by_crate = collect_per_crate_mutation(root);
     let tests_by_crate = collect_per_crate_test_counts(root);
     let ux_scenarios = count_ux_scenarios(root);
+    let known_ux_gap_issues = extract_known_ux_gap_issues(root);
 
     let has_mutation_data = !mutation_by_crate.is_empty();
     let mutation_note = if has_mutation_data {
@@ -144,8 +201,11 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
            `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
            the integration-only 10k-line large-file case; planning scaffold at \
            `docs/project/status/editor_ux.json`\n\
+         - **Known UX gap burn-down**: {known_gap_count} tracked issue references from \
+           `README.md` “Known gaps toward solid UX” (must-land + nice-to-land + deferred)\n\
          - **Mutation testing**: {mutation_note}\n\
-         - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
+         - **Production Status**: LSP server public alpha (`just ci-gate` passing)",
+        known_gap_count = known_ux_gap_issues.len()
     );
 
     let crate_table = format_crate_quality_table(&mutation_by_crate, &tests_by_crate);
@@ -169,10 +229,29 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let known_ux_gap_issues = extract_known_ux_gap_issues(root);
+    let measured = read_editor_ux_metrics(root);
+    let workflow_pass_state = if measured.as_ref().and_then(|m| m.workflow_pass_rate).is_some() {
+        "measured"
+    } else {
+        "planned"
+    };
+    let workflow_stability_state =
+        if measured.as_ref().and_then(|m| m.workflow_stability_rate).is_some() {
+            "measured"
+        } else {
+            "planned"
+        };
+    let p95_state =
+        if measured.as_ref().and_then(|m| m.p95_time_to_first_useful_result_ms).is_some() {
+            "measured"
+        } else {
+            "planned"
+        };
 
     let receipt = serde_json::json!({
         "schema_version": 1,
-        "receipt_kind": "planning_scaffold",
+        "receipt_kind": "tracking_receipt",
         "scorecard": "editor_ux",
         "harness": {
             "crate": "crates/perl-lsp-ux-tests",
@@ -182,20 +261,25 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
         "top_line_metrics": [
             {
                 "name": "workflow_pass_rate",
-                "state": "planned",
+                "state": workflow_pass_state,
                 "owner": "perl-lsp-ux-tests",
             },
             {
                 "name": "workflow_stability_rate",
-                "state": "planned",
+                "state": workflow_stability_state,
                 "owner": "perl-lsp-ux-tests",
             },
             {
                 "name": "p95_time_to_first_useful_result_ms",
-                "state": "planned",
+                "state": p95_state,
                 "owner": "perl-lsp-ux-tests",
             },
         ],
+        "ux_gap_burndown": {
+            "source": "README.md#known-gaps-toward-solid-ux",
+            "issue_reference_count": known_ux_gap_issues.len(),
+            "issue_references": known_ux_gap_issues,
+        },
         "integration_points": {
             "ci_lane": "just ux-tests",
             "release_lane": "just ux-tests-full",
@@ -258,7 +342,7 @@ mod tests {
         let receipt_raw = generate_editor_ux_receipt(&root)?;
         let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
         assert_eq!(receipt["schema_version"], 1);
-        assert_eq!(receipt["receipt_kind"], "planning_scaffold");
+        assert_eq!(receipt["receipt_kind"], "tracking_receipt");
         assert_eq!(receipt["scorecard"], "editor_ux");
         assert_eq!(receipt["harness"]["crate"], "crates/perl-lsp-ux-tests");
         assert_eq!(
@@ -279,7 +363,30 @@ mod tests {
                 "p95_time_to_first_useful_result_ms",
             ])
         );
+        assert!(
+            receipt["ux_gap_burndown"]["issue_reference_count"].as_u64().unwrap_or(0) > 0,
+            "expected at least one known UX gap issue reference"
+        );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        Ok(())
+    }
+
+    #[test]
+    fn test_extract_known_ux_gap_issues_reads_readme_section() -> Result<()> {
+        let root = crate::utils::project_root()?;
+        let issues = extract_known_ux_gap_issues(&root);
+        assert!(
+            issues.iter().any(|issue| issue.ends_with("/3522")),
+            "must-land issue should be tracked"
+        );
+        assert!(
+            issues.iter().any(|issue| issue.ends_with("/3476")),
+            "nice-to-land issue should be tracked"
+        );
+        assert!(
+            issues.iter().any(|issue| issue.ends_with("/3515")),
+            "deferred issue should be tracked"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- End-to-end UX confidence was documented as a qualitative-only signal with no structured machine-readable receipt tying together measured metrics and known-gap burn‑down. 
- Consumers and CI need a concrete tracking surface so the project can surface when editor UX top-line metrics are instrumented and which UX gaps remain open. 

### Description
- Emit a tracking-focused editor-UX receipt from the status generator by changing `generate_editor_ux_receipt` to produce `receipt_kind: "tracking_receipt"` and add a new `ux_gap_burndown` object. (edited: `xtask/src/tasks/update_status/quality.rs`, `docs/project/status/editor_ux.json`)
- Read optional measured metrics from `.ci/metrics/editor_ux.json` and reflect measurement state (`planned` vs `measured`) for `workflow_pass_rate`, `workflow_stability_rate`, and `p95_time_to_first_useful_result_ms`. (added helpers in `xtask/src/tasks/update_status/quality.rs`)
- Extract known UX-gap issue references from the README “Known gaps toward solid UX” section and include the issue list + count in the receipt and the generated `quality.md` bullets. (added parsing + integration in `xtask/src/tasks/update_status/quality.rs`, updated `docs/project/status/quality.md` and `README.md` to document the change)
- Update the editor UX JSON schema to require the new `ux_gap_burndown` object and the receipt kind change. (`docs/project/status/editor_ux.schema.json`)
- Add unit tests validating the new receipt shape and README-backed issue extraction and format the code. (tests in `xtask/src/tasks/update_status/quality.rs`)

### Testing
- Ran `cargo test -p xtask test_editor_ux_receipt_shape`, which passed. 
- Ran `cargo test -p xtask test_extract_known_ux_gap_issues_reads_readme_section`, which passed. 
- Ran `cargo check --all-targets -p xtask` and `cargo clippy -p xtask -- -D warnings`, both of which completed successfully. 
- A full `cargo test -p xtask` run exposed unrelated, pre-existing failures in other `xtask` edge-case tests (two failing `publish_closure_*` tests); those failures are not caused by these changes and the focused tests above (the ones added here) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c53b7b6c8333ae549fb7ada1c133)