### PR TITLE
feat(status): track UX confidence signals in editor scorecard (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | *qualitative* | Tracked via manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and known-gap issue burn-down (see `docs/project/status/editor_ux.json#confidence_signals`) — not a single published number | Anything about parser breadth, protocol catalog size, or capability count |
 
 The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
 

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -28,6 +28,21 @@
     "release_lane": "just ux-tests-full",
     "status_update": "cargo xtask update-status --only quality"
   },
+  "confidence_signals": {
+    "manual_editor_smoke_workflows": {
+      "guide": "docs/reference/UX_TESTING.md",
+      "verification_command": "just ux-tests"
+    },
+    "first_five_minutes_harness": {
+      "scenario_count": 17,
+      "scenario_inventory": "docs/project/status/editor_ux.json#/harness/scenario_files"
+    },
+    "open_issue_burndown": {
+      "source_section": "README.md#known-gaps-toward-solid-ux",
+      "tracked_issue_numbers": [3476, 3515, 3522, 4246],
+      "tracked_issue_count": 4
+    }
+  },
   "receipt_kind": "planning_scaffold",
   "schema_version": 1,
   "scorecard": "editor_ux",

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -9,7 +9,8 @@
     "scorecard",
     "harness",
     "top_line_metrics",
-    "integration_points"
+    "integration_points",
+    "confidence_signals"
   ],
   "properties": {
     "schema_version": {
@@ -122,6 +123,48 @@
         },
         "quality_surface": {
           "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "confidence_signals": {
+      "type": "object",
+      "required": [
+        "manual_editor_smoke_workflows",
+        "first_five_minutes_harness",
+        "open_issue_burndown"
+      ],
+      "properties": {
+        "manual_editor_smoke_workflows": {
+          "type": "object",
+          "required": ["guide", "verification_command"],
+          "properties": {
+            "guide": { "type": "string" },
+            "verification_command": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "first_five_minutes_harness": {
+          "type": "object",
+          "required": ["scenario_count", "scenario_inventory"],
+          "properties": {
+            "scenario_count": { "type": "integer", "minimum": 0 },
+            "scenario_inventory": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "open_issue_burndown": {
+          "type": "object",
+          "required": ["source_section", "tracked_issue_numbers", "tracked_issue_count"],
+          "properties": {
+            "source_section": { "type": "string" },
+            "tracked_issue_numbers": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 1 }
+            },
+            "tracked_issue_count": { "type": "integer", "minimum": 0 }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -5,11 +5,24 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result};
+use regex::Regex;
 
 use super::{replace_block, run_cmd};
+
+static RUNNING_UNITTESTS_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"Running unittests[^\(]*\(target[^\)]*deps[/\\]([a-zA-Z0-9_-]+)-[0-9a-f]+\)")
+        .expect("running-unittests regex must compile")
+});
+static TEST_LINE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r":\s*test\s*$").expect("test-line regex must compile"));
+static ISSUE_LINK_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\[#(\d{3,5})\]\(https://github\.com/EffortlessMetrics/perl-lsp/issues/\d+\)")
+        .expect("issue-link regex must compile")
+});
 
 // ---------------------------------------------------------------------------
 // Metric collectors
@@ -45,23 +58,16 @@ pub(super) fn collect_per_crate_test_counts(root: &Path) -> BTreeMap<String, usi
         return BTreeMap::new();
     }
 
-    let running_re = regex::Regex::new(
-        r"Running unittests[^\(]*\(target[^\)]*deps[/\\]([a-zA-Z0-9_-]+)-[0-9a-f]+\)",
-    )
-    .ok();
-    let test_re = regex::Regex::new(r":\s*test\s*$").ok();
-
     let mut by_crate: BTreeMap<String, usize> = BTreeMap::new();
     let mut current_crate: Option<String> = None;
 
     for line in output.lines() {
-        if let Some(caps) = running_re.as_ref().and_then(|r| r.captures(line)) {
+        if let Some(caps) = RUNNING_UNITTESTS_RE.captures(line) {
             let name = caps[1].replace('_', "-");
             current_crate = Some(name);
             continue;
         }
-        if let Some(re) = test_re.as_ref()
-            && re.is_match(line)
+        if TEST_LINE_RE.is_match(line)
             && let Some(ref crate_name) = current_crate
         {
             *by_crate.entry(crate_name.clone()).or_default() += 1;
@@ -122,6 +128,31 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+fn parse_known_gap_issue_numbers(readme: &str) -> Vec<u64> {
+    let Some(gaps_start) = readme.find("### Known gaps toward solid UX") else {
+        return Vec::new();
+    };
+    let section = &readme[gaps_start..];
+    let section_end = section.find("#### What shipped this cycle").unwrap_or(section.len());
+    let relevant = &section[..section_end];
+
+    let mut numbers: Vec<u64> = ISSUE_LINK_RE
+        .captures_iter(relevant)
+        .filter_map(|caps| caps.get(1).and_then(|m| m.as_str().parse::<u64>().ok()))
+        .collect();
+    numbers.sort_unstable();
+    numbers.dedup();
+    numbers
+}
+
+pub(super) fn collect_known_gap_issue_numbers(root: &Path) -> Vec<u64> {
+    let readme_path = root.join("README.md");
+    let Ok(readme) = fs::read_to_string(readme_path) else {
+        return Vec::new();
+    };
+    parse_known_gap_issue_numbers(&readme)
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -169,6 +200,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let known_gap_issue_numbers = collect_known_gap_issue_numbers(root);
 
     let receipt = serde_json::json!({
         "schema_version": 1,
@@ -202,6 +234,21 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
             "status_update": "cargo xtask update-status --only quality",
             "quality_surface": "docs/project/status/quality.md",
         },
+        "confidence_signals": {
+            "manual_editor_smoke_workflows": {
+                "guide": "docs/reference/UX_TESTING.md",
+                "verification_command": "just ux-tests",
+            },
+            "first_five_minutes_harness": {
+                "scenario_count": scenario_count,
+                "scenario_inventory": "docs/project/status/editor_ux.json#/harness/scenario_files",
+            },
+            "open_issue_burndown": {
+                "source_section": "README.md#known-gaps-toward-solid-ux",
+                "tracked_issue_numbers": known_gap_issue_numbers,
+                "tracked_issue_count": known_gap_issue_numbers.len(),
+            },
+        }
     });
 
     serde_json::to_string_pretty(&receipt).context("serializing editor UX receipt")
@@ -280,6 +327,31 @@ mod tests {
             ])
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        assert_eq!(
+            receipt["confidence_signals"]["manual_editor_smoke_workflows"]["guide"],
+            "docs/reference/UX_TESTING.md"
+        );
+        assert_eq!(
+            receipt["confidence_signals"]["open_issue_burndown"]["tracked_issue_numbers"],
+            serde_json::json!([3476, 3515, 3522, 4246])
+        );
         Ok(())
+    }
+
+    #[test]
+    fn test_parse_known_gap_issue_numbers_limits_to_known_gaps_section() {
+        let readme = r#"
+## Status
+
+### Known gaps toward solid UX
+- workspace rename [#3522](https://github.com/EffortlessMetrics/perl-lsp/issues/3522)
+- dynamic require [#3476](https://github.com/EffortlessMetrics/perl-lsp/issues/3476), umbrella [#4246](https://github.com/EffortlessMetrics/perl-lsp/issues/4246)
+- configuration [#3515](https://github.com/EffortlessMetrics/perl-lsp/issues/3515)
+
+#### What shipped this cycle (v0.12.x)
+- shipped fix [#3499](https://github.com/EffortlessMetrics/perl-lsp/issues/3499)
+"#;
+        let issues = parse_known_gap_issue_numbers(readme);
+        assert_eq!(issues, vec![3476, 3515, 3522, 4246]);
     }
 }


### PR DESCRIPTION
### Motivation
- End-to-end UX confidence was recorded only as a qualitative note and not persisted as machine-readable signals, making it hard to track the three underlying confidence inputs programmatically.

### Description
- Add a `confidence_signals` block to the editor-UX receipt generator in `xtask/src/tasks/update_status/quality.rs` and include `manual_editor_smoke_workflows`, `first_five_minutes_harness`, and `open_issue_burndown` entries. 
- Implement extraction of known-gap issue IDs from the README via `parse_known_gap_issue_numbers` / `collect_known_gap_issue_numbers` and wire the result into the receipt as `tracked_issue_numbers`. 
- Replace ad-hoc regex usage with `LazyLock<Regex>` static patterns and update the per-crate test-count parsing to use the compiled regexes. 
- Update the JSON schema `docs/project/status/editor_ux.schema.json`, the generated receipt `docs/project/status/editor_ux.json`, and the README row to reference the new `confidence_signals` output. 
- Add tests to lock the receipt shape and to assert that known-gap issue extraction is limited to the Known Gaps section (`test_editor_ux_receipt_shape` and `test_parse_known_gap_issue_numbers_limits_to_known_gaps_section`).

### Testing
- Ran `cargo test -p xtask editor_ux_receipt_shape` and the test passed. 
- Ran the parser unit test `test_parse_known_gap_issue_numbers_limits_to_known_gaps_section` and it passed. 
- Ran `cargo check --all-targets -p xtask` and `cargo fmt --all` successfully. 
- An earlier attempt to run multiple test filters in one `cargo test` invocation failed due to incorrect CLI usage, but targeted test runs and full `xtask` test runs succeeded after fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c53c8e7c8333b81cef2c7432f73e)