### PR TITLE
feat(quality): track editor UX signal coverage in status receipt (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | `docs/project/status/editor_ux.json` tracked signals | Covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down; published as tracked workflow inventory + metric coverage in `editor_ux.json` | Anything about parser breadth, protocol catalog size, or capability count |
 
 The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
 

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -31,6 +31,35 @@
   "receipt_kind": "planning_scaffold",
   "schema_version": 1,
   "scorecard": "editor_ux",
+  "signal_tracking": {
+    "fixture_matrix_path": "crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json",
+    "measured_top_line_metrics": [
+      {
+        "coverage_rate": 1.0,
+        "measured_workflow_count": 17,
+        "name": "workflow_pass_rate",
+        "state": "tracked"
+      },
+      {
+        "coverage_rate": 1.0,
+        "measured_workflow_count": 17,
+        "name": "workflow_stability_rate",
+        "state": "tracked"
+      },
+      {
+        "coverage_rate": 0.058823529411764705,
+        "measured_workflow_count": 1,
+        "name": "p95_time_to_first_useful_result_ms",
+        "state": "tracked"
+      }
+    ],
+    "workflow_count": 17,
+    "workflow_tier_counts": {
+      "nightly": 1,
+      "pr": 16,
+      "release": 0
+    }
+  },
   "top_line_metrics": [
     {
       "name": "workflow_pass_rate",

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -9,6 +9,7 @@
     "scorecard",
     "harness",
     "top_line_metrics",
+    "signal_tracking",
     "integration_points"
   ],
   "properties": {
@@ -122,6 +123,80 @@
         },
         "quality_surface": {
           "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "signal_tracking": {
+      "type": "object",
+      "required": [
+        "fixture_matrix_path",
+        "workflow_count",
+        "workflow_tier_counts",
+        "measured_top_line_metrics"
+      ],
+      "properties": {
+        "fixture_matrix_path": {
+          "type": "string"
+        },
+        "workflow_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "workflow_tier_counts": {
+          "type": "object",
+          "required": ["pr", "nightly", "release"],
+          "properties": {
+            "pr": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "nightly": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "release": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        },
+        "measured_top_line_metrics": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "state",
+              "measured_workflow_count",
+              "coverage_rate"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "enum": [
+                  "workflow_pass_rate",
+                  "workflow_stability_rate",
+                  "p95_time_to_first_useful_result_ms"
+                ]
+              },
+              "state": {
+                "type": "string",
+                "enum": ["planned", "tracked"]
+              },
+              "measured_workflow_count": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "coverage_rate": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            },
+            "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -8,7 +8,7 @@
 
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
-- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; planning scaffold at `docs/project/status/editor_ux.json`
+- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; tracked signal summary at `docs/project/status/editor_ux.json`
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -11,9 +11,29 @@ use color_eyre::eyre::{Context, Result};
 
 use super::{replace_block, run_cmd};
 
-// ---------------------------------------------------------------------------
-// Metric collectors
-// ---------------------------------------------------------------------------
+const UX_FIXTURE_MATRIX_PATH: &str =
+    "crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json";
+
+#[derive(Debug, serde::Deserialize)]
+struct EditorUxFixtureMatrix {
+    top_line_metrics: Vec<String>,
+    workflows: Vec<EditorUxWorkflow>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct EditorUxWorkflow {
+    ci_tier: String,
+    measures: Vec<String>,
+}
+
+#[derive(Debug)]
+struct UxSignalTracking {
+    workflow_count: usize,
+    pr_workflow_count: usize,
+    nightly_workflow_count: usize,
+    release_workflow_count: usize,
+    measured_top_line_metrics: Vec<serde_json::Value>,
+}
 
 /// Read `mutants.out/mutants.json` and group mutations by crate package name.
 pub(super) fn collect_per_crate_mutation(root: &Path) -> BTreeMap<String, usize> {
@@ -122,9 +142,67 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
-// ---------------------------------------------------------------------------
-// Generators
-// ---------------------------------------------------------------------------
+fn collect_ux_signal_tracking(root: &Path) -> UxSignalTracking {
+    let path = root.join(UX_FIXTURE_MATRIX_PATH);
+    let Ok(raw) = fs::read_to_string(path) else {
+        return UxSignalTracking {
+            workflow_count: 0,
+            pr_workflow_count: 0,
+            nightly_workflow_count: 0,
+            release_workflow_count: 0,
+            measured_top_line_metrics: Vec::new(),
+        };
+    };
+
+    let Ok(matrix) = serde_json::from_str::<EditorUxFixtureMatrix>(&raw) else {
+        return UxSignalTracking {
+            workflow_count: 0,
+            pr_workflow_count: 0,
+            nightly_workflow_count: 0,
+            release_workflow_count: 0,
+            measured_top_line_metrics: Vec::new(),
+        };
+    };
+
+    let workflow_count = matrix.workflows.len();
+    let pr_workflow_count =
+        matrix.workflows.iter().filter(|workflow| workflow.ci_tier == "pr").count();
+    let nightly_workflow_count =
+        matrix.workflows.iter().filter(|workflow| workflow.ci_tier == "nightly").count();
+    let release_workflow_count =
+        matrix.workflows.iter().filter(|workflow| workflow.ci_tier == "release").count();
+
+    let measured_top_line_metrics = matrix
+        .top_line_metrics
+        .iter()
+        .map(|metric| {
+            let measured_workflow_count = matrix
+                .workflows
+                .iter()
+                .filter(|workflow| workflow.measures.iter().any(|measure| measure == metric))
+                .count();
+            let coverage_rate = if workflow_count == 0 {
+                0.0
+            } else {
+                measured_workflow_count as f64 / workflow_count as f64
+            };
+            serde_json::json!({
+                "name": metric,
+                "state": if measured_workflow_count == 0 { "planned" } else { "tracked" },
+                "measured_workflow_count": measured_workflow_count,
+                "coverage_rate": coverage_rate,
+            })
+        })
+        .collect();
+
+    UxSignalTracking {
+        workflow_count,
+        pr_workflow_count,
+        nightly_workflow_count,
+        release_workflow_count,
+        measured_top_line_metrics,
+    }
+}
 
 pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<String> {
     let mutation_by_crate = collect_per_crate_mutation(root);
@@ -142,7 +220,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
         "- **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing\n\
          - **UX workflow harness**: {ux_scenarios} scenario files in `perl-lsp-ux-tests`; \
            `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
-           the integration-only 10k-line large-file case; planning scaffold at \
+           the integration-only 10k-line large-file case; tracked signal summary at \
            `docs/project/status/editor_ux.json`\n\
          - **Mutation testing**: {mutation_note}\n\
          - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
@@ -169,6 +247,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let signal_tracking = collect_ux_signal_tracking(root);
 
     let receipt = serde_json::json!({
         "schema_version": 1,
@@ -196,6 +275,16 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
                 "owner": "perl-lsp-ux-tests",
             },
         ],
+        "signal_tracking": {
+            "fixture_matrix_path": UX_FIXTURE_MATRIX_PATH,
+            "workflow_count": signal_tracking.workflow_count,
+            "workflow_tier_counts": {
+                "pr": signal_tracking.pr_workflow_count,
+                "nightly": signal_tracking.nightly_workflow_count,
+                "release": signal_tracking.release_workflow_count,
+            },
+            "measured_top_line_metrics": signal_tracking.measured_top_line_metrics,
+        },
         "integration_points": {
             "ci_lane": "just ux-tests",
             "release_lane": "just ux-tests-full",
@@ -206,10 +295,6 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
 
     serde_json::to_string_pretty(&receipt).context("serializing editor UX receipt")
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -280,6 +365,20 @@ mod tests {
             ])
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        assert_eq!(receipt["signal_tracking"]["fixture_matrix_path"], UX_FIXTURE_MATRIX_PATH);
+        assert_eq!(receipt["signal_tracking"]["workflow_count"], 17);
+        assert_eq!(receipt["signal_tracking"]["workflow_tier_counts"]["pr"], 16);
+        assert_eq!(receipt["signal_tracking"]["workflow_tier_counts"]["nightly"], 1);
+        assert_eq!(receipt["signal_tracking"]["workflow_tier_counts"]["release"], 0);
+        let tracked_metrics = receipt["signal_tracking"]["measured_top_line_metrics"]
+            .as_array()
+            .ok_or_else(|| eyre!("measured_top_line_metrics must be an array"))?;
+        assert_eq!(tracked_metrics.len(), 3);
+        let first_latency_metric = tracked_metrics
+            .iter()
+            .find(|row| row["name"] == "p95_time_to_first_useful_result_ms")
+            .ok_or_else(|| eyre!("missing latency metric row"))?;
+        assert_eq!(first_latency_metric["measured_workflow_count"], 1);
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- End-to-end UX confidence was described as qualitative and lacked a published, machine-readable signal summary. 
- Emit a small, testable signal summary so tooling and status pages can report workflow inventory and top-line metric coverage derived from the UX fixture matrix.

### Description
- Parse the UX fixture matrix and compute basic signal tracking (workflow count, tier split, and per-top-line-metric coverage) in `xtask/src/tasks/update_status/quality.rs` via `collect_ux_signal_tracking`. 
- Include a new `signal_tracking` object in the `editor_ux` receipt emitted by `generate_editor_ux_receipt`. 
- Extend the `docs/project/status/editor_ux.schema.json` schema to require and validate the new `signal_tracking` fields (fixture path, tier counts, and measured metric coverage rates). 
- Update generated receipt `docs/project/status/editor_ux.json`, the quality status wording in `docs/project/status/quality.md`, and the README to point to the tracked summary; add assertions in `test_editor_ux_receipt_shape` to validate the new fields.

### Testing
- Ran `cargo test -p xtask test_editor_ux_receipt_shape -- --nocapture`, which passed. 
- Ran `cargo test -p xtask -q`, which completed successfully (all xtask unit tests passed). 
- Ran `cargo check --all-targets -p xtask`, `cargo clippy -p xtask`, and `cargo xtask fmt`, all of which passed in this environment. 
- `just pr-fast` was not run here because `just` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c553f1a083338521de2f7bb97ef3)