### PR TITLE
feat(status): publish tracked editor UX confidence signals (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | 17 scripted workflows + 4 known-gap issues | Composite confidence proxy from `docs/project/status/editor_ux.json`: first-5-minutes harness breadth and known-gap issue burn-down from this README's tracked UX gap list | Anything about parser breadth, protocol catalog size, or capability count |
 
 The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
 

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -47,5 +47,28 @@
       "owner": "perl-lsp-ux-tests",
       "state": "planned"
     }
+  ],
+  "supporting_signals": [
+    {
+      "name": "first_five_minutes_workflow_count",
+      "owner": "perl-lsp-ux-tests",
+      "source": "crates/perl-lsp-ux-tests/tests/ux_scenario_*.rs",
+      "state": "measured",
+      "unit": "scenarios",
+      "value": 17
+    },
+    {
+      "breakdown": {
+        "deferred": 1,
+        "must_land": 1,
+        "nice_to_land": 2
+      },
+      "name": "open_known_gap_issue_count",
+      "owner": "docs/README known gaps list",
+      "source": "README.md::Known gaps toward solid UX",
+      "state": "measured",
+      "unit": "issues",
+      "value": 4
+    }
   ]
 }

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -9,6 +9,7 @@
     "scorecard",
     "harness",
     "top_line_metrics",
+    "supporting_signals",
     "integration_points"
   ],
   "properties": {
@@ -125,6 +126,76 @@
         }
       },
       "additionalProperties": false
+    },
+    "supporting_signals": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "allOf": [
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "const": "first_five_minutes_workflow_count"
+              }
+            },
+            "required": ["name"]
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "const": "open_known_gap_issue_count"
+              }
+            },
+            "required": ["name"]
+          }
+        }
+      ],
+      "items": {
+        "type": "object",
+        "required": ["name", "state", "owner", "value", "unit", "source"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "first_five_minutes_workflow_count",
+              "open_known_gap_issue_count"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "enum": ["planned", "measured"]
+          },
+          "owner": {
+            "type": "string"
+          },
+          "value": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "unit": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "breakdown": {
+            "type": "object",
+            "required": ["must_land", "nice_to_land", "deferred"],
+            "properties": {
+              "must_land": { "type": "integer", "minimum": 0 },
+              "nice_to_land": { "type": "integer", "minimum": 0 },
+              "deferred": { "type": "integer", "minimum": 0 }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -9,6 +9,7 @@
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
 - **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; planning scaffold at `docs/project/status/editor_ux.json`
+- **UX confidence scorecard**: 17 scripted workflows and 4 active known-gap issues from README (1 must-land / 2 nice-to-land / 1 deferred)
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result};
+use regex::Regex;
 
 use super::{replace_block, run_cmd};
 
@@ -122,6 +123,64 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(super) struct UxGapIssueCounts {
+    must_land: usize,
+    nice_to_land: usize,
+    deferred: usize,
+}
+
+impl UxGapIssueCounts {
+    pub(super) fn total(self) -> usize {
+        self.must_land + self.nice_to_land + self.deferred
+    }
+}
+
+pub(super) fn collect_readme_ux_gap_issue_counts(root: &Path) -> UxGapIssueCounts {
+    let readme_path = root.join("README.md");
+    let Ok(readme) = fs::read_to_string(readme_path) else {
+        return UxGapIssueCounts::default();
+    };
+    let heading_re = Regex::new(r"^####\s+(.+)$").ok();
+    let issue_re = Regex::new(r"\[#\d+\]\(").ok();
+
+    enum GapSection {
+        MustLand,
+        NiceToLand,
+        Deferred,
+        Other,
+    }
+
+    let mut section = GapSection::Other;
+    let mut counts = UxGapIssueCounts::default();
+
+    for line in readme.lines() {
+        if let Some(caps) = heading_re.as_ref().and_then(|re| re.captures(line)) {
+            section = match caps.get(1).map(|m| m.as_str().trim()) {
+                Some("Must land for v0.13.0") => GapSection::MustLand,
+                Some("Nice to land") => GapSection::NiceToLand,
+                Some("Deferred to v0.14.0") => GapSection::Deferred,
+                _ => GapSection::Other,
+            };
+            continue;
+        }
+
+        let issue_count = issue_re.as_ref().map_or(0, |re| re.find_iter(line).count());
+        if issue_count == 0 {
+            continue;
+        }
+
+        match section {
+            GapSection::MustLand => counts.must_land += issue_count,
+            GapSection::NiceToLand => counts.nice_to_land += issue_count,
+            GapSection::Deferred => counts.deferred += issue_count,
+            GapSection::Other => {}
+        }
+    }
+
+    counts
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -130,6 +189,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
     let mutation_by_crate = collect_per_crate_mutation(root);
     let tests_by_crate = collect_per_crate_test_counts(root);
     let ux_scenarios = count_ux_scenarios(root);
+    let ux_gap_issues = collect_readme_ux_gap_issue_counts(root);
 
     let has_mutation_data = !mutation_by_crate.is_empty();
     let mutation_note = if has_mutation_data {
@@ -144,8 +204,15 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
            `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
            the integration-only 10k-line large-file case; planning scaffold at \
            `docs/project/status/editor_ux.json`\n\
+         - **UX confidence scorecard**: {ux_scenarios} scripted workflows and \
+           {ux_gap_total} active known-gap issues from README ({ux_gap_must} must-land / \
+           {ux_gap_nice} nice-to-land / {ux_gap_deferred} deferred)\n\
          - **Mutation testing**: {mutation_note}\n\
-         - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
+         - **Production Status**: LSP server public alpha (`just ci-gate` passing)",
+        ux_gap_total = ux_gap_issues.total(),
+        ux_gap_must = ux_gap_issues.must_land,
+        ux_gap_nice = ux_gap_issues.nice_to_land,
+        ux_gap_deferred = ux_gap_issues.deferred
     );
 
     let crate_table = format_crate_quality_table(&mutation_by_crate, &tests_by_crate);
@@ -169,6 +236,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let ux_gap_issues = collect_readme_ux_gap_issue_counts(root);
 
     let receipt = serde_json::json!({
         "schema_version": 1,
@@ -194,6 +262,29 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
                 "name": "p95_time_to_first_useful_result_ms",
                 "state": "planned",
                 "owner": "perl-lsp-ux-tests",
+            },
+        ],
+        "supporting_signals": [
+            {
+                "name": "first_five_minutes_workflow_count",
+                "state": "measured",
+                "owner": "perl-lsp-ux-tests",
+                "value": scenario_count,
+                "unit": "scenarios",
+                "source": "crates/perl-lsp-ux-tests/tests/ux_scenario_*.rs",
+            },
+            {
+                "name": "open_known_gap_issue_count",
+                "state": "measured",
+                "owner": "docs/README known gaps list",
+                "value": ux_gap_issues.total(),
+                "unit": "issues",
+                "source": "README.md::Known gaps toward solid UX",
+                "breakdown": {
+                    "must_land": ux_gap_issues.must_land,
+                    "nice_to_land": ux_gap_issues.nice_to_land,
+                    "deferred": ux_gap_issues.deferred,
+                },
             },
         ],
         "integration_points": {
@@ -280,6 +371,34 @@ mod tests {
             ])
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        let supporting_signals = receipt["supporting_signals"]
+            .as_array()
+            .ok_or_else(|| eyre!("supporting_signals must be an array"))?;
+        assert_eq!(supporting_signals.len(), 2, "expected two supporting UX signals");
+        assert_eq!(supporting_signals[0]["name"], "first_five_minutes_workflow_count");
+        assert_eq!(supporting_signals[1]["name"], "open_known_gap_issue_count");
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_readme_ux_gap_issue_counts() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let readme = r#"
+#### Must land for v0.13.0
+- Workspace rename ([#3522](https://example.com/3522))
+
+#### Nice to land
+- Dynamic require ([#3476](https://example.com/3476), umbrella [#4246](https://example.com/4246))
+
+#### Deferred to v0.14.0
+- Dynamic workspace configuration ([#3515](https://example.com/3515))
+"#;
+        fs::write(dir.path().join("README.md"), readme)?;
+        let counts = collect_readme_ux_gap_issue_counts(dir.path());
+        assert_eq!(counts.must_land, 1);
+        assert_eq!(counts.nice_to_land, 2);
+        assert_eq!(counts.deferred, 1);
+        assert_eq!(counts.total(), 4);
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- End-to-end UX confidence was previously recorded as a qualitative note and not surfaced as a measurable signal. 
- We need lightweight, reproducible signals (first-5-minutes workflow breadth and known-gap issue burn-down) so progress on UX is trackable and can be automated into status surfaces. 

### Description
- Add `UxGapIssueCounts` and `collect_readme_ux_gap_issue_counts()` in `xtask/src/tasks/update_status/quality.rs` to parse README known-gap sections and count referenced issues (must-land / nice-to-land / deferred). 
- Surface the new counts in the generated editor UX receipt via `generate_editor_ux_receipt()` and include a `supporting_signals` block with `first_five_minutes_workflow_count` and `open_known_gap_issue_count`. 
- Extend `docs/project/status/editor_ux.schema.json` to require and validate the new `supporting_signals` block and update `docs/project/status/editor_ux.json` and `docs/project/status/quality.md` to publish the measured signals. 
- Update the README status table row for "End-to-end UX confidence" to point at the new composite proxy and add unit-tested parsing and receipt-shape checks in `xtask` tests. 

### Testing
- Ran `cargo test -p xtask quality::tests::` and the targeted unit tests passed (`5 passed`).
- Ran `cargo check --all-targets -p xtask` and typechecking succeeded.
- Ran `cargo clippy -p xtask` and `cargo fmt --all` with no blocking issues on the modified crate.
- `just pr-fast` could not be executed in this environment because `just` is not installed, noted in verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c553f1a083338521de2f7bb97ef3)