### PR TITLE
feat(status): publish tracked UX confidence signals (#0000)

### DIFF
--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -28,7 +28,7 @@
     "release_lane": "just ux-tests-full",
     "status_update": "cargo xtask update-status --only quality"
   },
-  "receipt_kind": "planning_scaffold",
+  "receipt_kind": "tracked_scaffold",
   "schema_version": 1,
   "scorecard": "editor_ux",
   "top_line_metrics": [
@@ -47,5 +47,54 @@
       "owner": "perl-lsp-ux-tests",
       "state": "planned"
     }
-  ]
+  ],
+  "tracked_signals": {
+    "expected_outcome_density": {
+      "average_expected_outcomes_per_workflow": 1.8823529411764706,
+      "total_expected_outcomes": 32
+    },
+    "metric_coverage": [
+      {
+        "coverage_percent": 100.0,
+        "name": "workflow_pass_rate",
+        "total_workflows": 17,
+        "workflows_covering": 17
+      },
+      {
+        "coverage_percent": 100.0,
+        "name": "workflow_stability_rate",
+        "total_workflows": 17,
+        "workflows_covering": 17
+      },
+      {
+        "coverage_percent": 5.882352941176471,
+        "name": "p95_time_to_first_useful_result_ms",
+        "total_workflows": 17,
+        "workflows_covering": 1
+      },
+      {
+        "coverage_percent": 5.882352941176471,
+        "name": "module_resolution_workflow_success_rate",
+        "total_workflows": 17,
+        "workflows_covering": 1
+      },
+      {
+        "coverage_percent": 11.764705882352942,
+        "name": "multi_root_workspace_navigation_success_rate",
+        "total_workflows": 17,
+        "workflows_covering": 2
+      },
+      {
+        "coverage_percent": 5.882352941176471,
+        "name": "cross_file_definition_success_rate",
+        "total_workflows": 17,
+        "workflows_covering": 1
+      }
+    ],
+    "workflow_ci_tier_breakdown": {
+      "nightly": 1,
+      "pr": 16
+    },
+    "workflow_inventory_total": 17
+  }
 }

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -9,7 +9,8 @@
     "scorecard",
     "harness",
     "top_line_metrics",
-    "integration_points"
+    "integration_points",
+    "tracked_signals"
   ],
   "properties": {
     "schema_version": {
@@ -18,7 +19,7 @@
     },
     "receipt_kind": {
       "type": "string",
-      "const": "planning_scaffold"
+      "const": "tracked_scaffold"
     },
     "scorecard": {
       "type": "string",
@@ -122,6 +123,86 @@
         },
         "quality_surface": {
           "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "tracked_signals": {
+      "type": "object",
+      "required": [
+        "workflow_inventory_total",
+        "workflow_ci_tier_breakdown",
+        "expected_outcome_density",
+        "metric_coverage"
+      ],
+      "properties": {
+        "workflow_inventory_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "workflow_ci_tier_breakdown": {
+          "type": "object",
+          "required": ["pr", "nightly"],
+          "properties": {
+            "pr": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "nightly": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        },
+        "expected_outcome_density": {
+          "type": "object",
+          "required": [
+            "total_expected_outcomes",
+            "average_expected_outcomes_per_workflow"
+          ],
+          "properties": {
+            "total_expected_outcomes": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "average_expected_outcomes_per_workflow": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        },
+        "metric_coverage": {
+          "type": "array",
+          "minItems": 6,
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "workflows_covering",
+              "total_workflows",
+              "coverage_percent"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "workflows_covering": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "total_workflows": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "coverage_percent": {
+                "type": "number",
+                "minimum": 0
+              }
+            },
+            "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -8,7 +8,7 @@
 
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
-- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; planning scaffold at `docs/project/status/editor_ux.json`
+- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `16` PR-tier + `1` nightly-tier workflows; latency signal coverage `1/17` workflows (5.9%); `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; tracked scaffold at `docs/project/status/editor_ux.json`
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -8,6 +8,8 @@ use std::path::Path;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result};
+use serde::Deserialize;
+use serde_json::json;
 
 use super::{replace_block, run_cmd};
 
@@ -122,6 +124,57 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+#[derive(Debug, Deserialize)]
+struct EditorUxFixtureMatrix {
+    workflows: Vec<EditorUxWorkflowRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EditorUxWorkflowRow {
+    ci_tier: String,
+    measures: Vec<String>,
+    expected_outcomes: Vec<String>,
+}
+
+#[derive(Debug)]
+struct EditorUxSignalSnapshot {
+    total_workflows: usize,
+    pr_workflows: usize,
+    nightly_workflows: usize,
+    total_expected_outcomes: usize,
+    metrics_coverage: BTreeMap<String, usize>,
+}
+
+fn collect_editor_ux_signals(root: &Path) -> Option<EditorUxSignalSnapshot> {
+    let matrix_path = root.join("crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json");
+    let raw = fs::read_to_string(matrix_path).ok()?;
+    let matrix = serde_json::from_str::<EditorUxFixtureMatrix>(&raw).ok()?;
+
+    let mut metrics_coverage: BTreeMap<String, usize> = BTreeMap::new();
+    let mut pr_workflows = 0usize;
+    let mut nightly_workflows = 0usize;
+    let mut total_expected_outcomes = 0usize;
+    for workflow in &matrix.workflows {
+        match workflow.ci_tier.as_str() {
+            "pr" => pr_workflows += 1,
+            "nightly" => nightly_workflows += 1,
+            _ => {}
+        }
+        total_expected_outcomes += workflow.expected_outcomes.len();
+        for measure in &workflow.measures {
+            *metrics_coverage.entry(measure.clone()).or_default() += 1;
+        }
+    }
+
+    Some(EditorUxSignalSnapshot {
+        total_workflows: matrix.workflows.len(),
+        pr_workflows,
+        nightly_workflows,
+        total_expected_outcomes,
+        metrics_coverage,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -130,6 +183,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
     let mutation_by_crate = collect_per_crate_mutation(root);
     let tests_by_crate = collect_per_crate_test_counts(root);
     let ux_scenarios = count_ux_scenarios(root);
+    let ux_signals = collect_editor_ux_signals(root);
 
     let has_mutation_data = !mutation_by_crate.is_empty();
     let mutation_note = if has_mutation_data {
@@ -138,11 +192,32 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
         "mutation data pending first nightly CI run — run `just mutation-subset` locally to populate"
     };
 
+    let ux_tracking_line = if let Some(signals) = ux_signals {
+        let p95_covered = signals
+            .metrics_coverage
+            .get("p95_time_to_first_useful_result_ms")
+            .copied()
+            .unwrap_or(0);
+        let coverage_pct = if signals.total_workflows == 0 {
+            0.0
+        } else {
+            (p95_covered as f64 * 100.0) / signals.total_workflows as f64
+        };
+        format!(
+            "{ux_scenarios} scenario files in `perl-lsp-ux-tests`; `{}` PR-tier + `{}` nightly-tier workflows; \
+             latency signal coverage `{p95_covered}/{}` workflows ({coverage_pct:.1}%)",
+            signals.pr_workflows, signals.nightly_workflows, signals.total_workflows
+        )
+    } else {
+        format!(
+            "{ux_scenarios} scenario files in `perl-lsp-ux-tests`; fixture matrix unavailable for signal rollups"
+        )
+    };
+
     let bullets_content = format!(
         "- **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing\n\
-         - **UX workflow harness**: {ux_scenarios} scenario files in `perl-lsp-ux-tests`; \
-           `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
-           the integration-only 10k-line large-file case; planning scaffold at \
+         - **UX workflow harness**: {ux_tracking_line}; `just ux-tests` runs the default release-confidence lane and \
+           `just ux-tests-full` adds the integration-only 10k-line large-file case; tracked scaffold at \
            `docs/project/status/editor_ux.json`\n\
          - **Mutation testing**: {mutation_note}\n\
          - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
@@ -169,10 +244,60 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let ux_signals = collect_editor_ux_signals(root);
+    let signal_rollup = if let Some(signals) = ux_signals {
+        let total_workflows = signals.total_workflows;
+        let average_expected_outcomes_per_workflow = if total_workflows == 0 {
+            0.0
+        } else {
+            signals.total_expected_outcomes as f64 / total_workflows as f64
+        };
+        let metric_names = [
+            "workflow_pass_rate",
+            "workflow_stability_rate",
+            "p95_time_to_first_useful_result_ms",
+            "module_resolution_workflow_success_rate",
+            "multi_root_workspace_navigation_success_rate",
+            "cross_file_definition_success_rate",
+        ];
+        let metric_coverage = metric_names
+            .iter()
+            .map(|name| {
+                let workflows_covering = signals.metrics_coverage.get(*name).copied().unwrap_or(0);
+                let coverage_percent = if total_workflows == 0 {
+                    0.0
+                } else {
+                    (workflows_covering as f64 * 100.0) / total_workflows as f64
+                };
+                json!({
+                    "name": name,
+                    "workflows_covering": workflows_covering,
+                    "total_workflows": total_workflows,
+                    "coverage_percent": coverage_percent,
+                })
+            })
+            .collect::<Vec<_>>();
+        json!({
+            "workflow_inventory_total": total_workflows,
+            "workflow_ci_tier_breakdown": {
+                "pr": signals.pr_workflows,
+                "nightly": signals.nightly_workflows,
+            },
+            "expected_outcome_density": {
+                "total_expected_outcomes": signals.total_expected_outcomes,
+                "average_expected_outcomes_per_workflow": average_expected_outcomes_per_workflow,
+            },
+            "metric_coverage": metric_coverage,
+        })
+    } else {
+        json!({
+            "note": "fixture matrix unavailable; run from repository root with editor UX fixtures checked out",
+        })
+    };
 
     let receipt = serde_json::json!({
         "schema_version": 1,
-        "receipt_kind": "planning_scaffold",
+        "receipt_kind": "tracked_scaffold",
         "scorecard": "editor_ux",
         "harness": {
             "crate": "crates/perl-lsp-ux-tests",
@@ -202,6 +327,7 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
             "status_update": "cargo xtask update-status --only quality",
             "quality_surface": "docs/project/status/quality.md",
         },
+        "tracked_signals": signal_rollup,
     });
 
     serde_json::to_string_pretty(&receipt).context("serializing editor UX receipt")
@@ -258,7 +384,7 @@ mod tests {
         let receipt_raw = generate_editor_ux_receipt(&root)?;
         let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
         assert_eq!(receipt["schema_version"], 1);
-        assert_eq!(receipt["receipt_kind"], "planning_scaffold");
+        assert_eq!(receipt["receipt_kind"], "tracked_scaffold");
         assert_eq!(receipt["scorecard"], "editor_ux");
         assert_eq!(receipt["harness"]["crate"], "crates/perl-lsp-ux-tests");
         assert_eq!(
@@ -280,6 +406,7 @@ mod tests {
             ])
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        assert_eq!(receipt["tracked_signals"]["workflow_inventory_total"].as_u64(), Some(17));
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- End-to-end UX confidence was described qualitatively and not emitted as concrete, machine-readable signals in the status scaffold. 
- The goal is to convert fixture-backed UX planning scaffolds into tracked, testable signals so UX coverage and latency signals can be measured automatically.

### Description
- Add parsing and rollup logic for `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` via `EditorUxFixtureMatrix`/`EditorUxWorkflowRow` and `collect_editor_ux_signals` to compute workflow counts, CI-tier split, expected-outcome density, and per-metric coverage. 
- Emit a `tracked_signals` block from `generate_editor_ux_receipt` (and change `receipt_kind` to `tracked_scaffold`) so `docs/project/status/editor_ux.json` contains measurable UX signal rollups. 
- Surface a compact UX tracking summary in the generated `docs/project/status/quality.md` via `generate_quality_status`. 
- Extend `docs/project/status/editor_ux.schema.json` to validate the new `tracked_signals` shape and update the unit test expectations in `xtask` to assert the tracked receipt kind and presence of the rollup.

### Testing
- Ran `cargo test -p xtask quality::tests::test_editor_ux_receipt_shape -- --nocapture` and it passed. 
- Ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix` and it passed. 
- Ran `target/debug/xtask update-status --only quality --write` and `--check` to regenerate and verify `docs/project/status/quality.md` and `docs/project/status/editor_ux.json`, and the update/check completed successfully. 
- Validated the produced JSON with `python -m json.tool` for `docs/project/status/editor_ux.schema.json` and `docs/project/status/editor_ux.json` with no parse errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c554a5ac8333a0bd9749f63d5c3f)