### PR TITLE
feat(metrics): publish editor UX tracking signals (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | Tracked via workflow scorecard signals | Published in `docs/project/status/editor_ux.json`: UX scenario inventory, fixture-matrix coverage rate, CI-tier distribution, and component-metric exercise counts; complemented by manual editor smoke workflows and open-issue burn-down | Anything about parser breadth, protocol catalog size, or capability count |
 
-The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
+The last row is the important one: automated parser/protocol coverage still does **not** guarantee a good editing session. We now track concrete UX harness health signals in `docs/project/status/editor_ux.json`, then combine that with workflow smoke tests and known-gap burn-down to evaluate real-world editor confidence.
 
 Live numbers live in [docs/project/status/parser.md](docs/project/status/parser.md); this table may lag a merge cycle.
 

--- a/docs/reference/UX_TESTING.md
+++ b/docs/reference/UX_TESTING.md
@@ -52,8 +52,8 @@ feature-gated 10k-line large-file case from Scenario 06.
 
 ## Workflow Scorecard Contract
 
-The UX harness is also the fixture source for the planned `editor_ux`
-scorecard:
+The UX harness is also the fixture source for the `editor_ux` scorecard
+tracking signals:
 
 - `docs/project/metrics/WORKFLOW_SCORECARDS.md` describes the workflow layer and
   the top-line/current-component rows it owns.
@@ -64,8 +64,11 @@ scorecard:
 - `crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs` prevents the
   matrix from drifting away from the executable scenario files.
 
-This keeps the workflow scorecard grounded in real harness coverage instead of a
-manually curated checklist.
+`cargo xtask update-status --only quality` writes
+`docs/project/status/editor_ux.json`, including concrete tracking signals
+derived from this fixture matrix (scenario coverage, CI-tier split, and
+component-metric exercise counts). This keeps the workflow scorecard grounded
+in real harness coverage instead of a manually curated checklist.
 
 ## How to Add a New Scenario
 

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -7,7 +7,8 @@ use std::fs;
 use std::path::Path;
 use std::time::Duration;
 
-use color_eyre::eyre::{Context, Result};
+use color_eyre::eyre::{Context, ContextCompat, Result};
+use serde_json::Value;
 
 use super::{replace_block, run_cmd};
 
@@ -122,6 +123,68 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+fn collect_editor_ux_fixture_matrix_summary(root: &Path) -> Result<Value> {
+    let matrix_path = root.join("crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json");
+    let matrix_raw = fs::read_to_string(&matrix_path)
+        .with_context(|| format!("reading {}", matrix_path.display()))?;
+    let matrix: Value = serde_json::from_str(&matrix_raw)
+        .with_context(|| format!("parsing {}", matrix_path.display()))?;
+
+    let workflows: &[Value] = matrix
+        .get("workflows")
+        .and_then(Value::as_array)
+        .context("fixture matrix workflows missing")?;
+    let component_metrics: &[Value] = matrix
+        .get("component_metrics")
+        .and_then(Value::as_array)
+        .context("fixture matrix component_metrics missing")?;
+    let component_metric_set: std::collections::BTreeSet<String> =
+        component_metrics.iter().filter_map(Value::as_str).map(ToOwned::to_owned).collect();
+
+    let mut scenario_files = std::collections::BTreeSet::new();
+    let mut component_metrics_exercised = std::collections::BTreeSet::new();
+    let mut pr_workflows = 0usize;
+    let mut nightly_workflows = 0usize;
+    for workflow in workflows {
+        if let Some(scenario_file) = workflow.get("scenario_file").and_then(Value::as_str) {
+            scenario_files.insert(scenario_file.to_string());
+        }
+        match workflow.get("ci_tier").and_then(Value::as_str) {
+            Some("pr") => pr_workflows += 1,
+            Some("nightly") => nightly_workflows += 1,
+            _ => {}
+        }
+        for metric in workflow
+            .get("measures")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+        {
+            if component_metric_set.contains(metric) {
+                component_metrics_exercised.insert(metric.to_string());
+            }
+        }
+    }
+
+    let scenario_count = count_ux_scenarios(root);
+    let covered = scenario_files.len();
+    let scenario_coverage_rate =
+        if scenario_count == 0 { 0.0 } else { covered as f64 / scenario_count as f64 };
+
+    Ok(serde_json::json!({
+        "workflow_count": workflows.len(),
+        "scenario_files_covered": covered,
+        "scenario_coverage_rate": scenario_coverage_rate,
+        "ci_tier_counts": {
+            "pr": pr_workflows,
+            "nightly": nightly_workflows,
+        },
+        "component_metrics_declared": component_metric_set.len(),
+        "component_metrics_exercised": component_metrics_exercised.len(),
+    }))
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -169,6 +232,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let fixture_matrix_summary = collect_editor_ux_fixture_matrix_summary(root)?;
 
     let receipt = serde_json::json!({
         "schema_version": 1,
@@ -196,6 +260,7 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
                 "owner": "perl-lsp-ux-tests",
             },
         ],
+        "tracking_signals": fixture_matrix_summary,
         "integration_points": {
             "ci_lane": "just ux-tests",
             "release_lane": "just ux-tests-full",
@@ -279,6 +344,9 @@ mod tests {
                 "p95_time_to_first_useful_result_ms",
             ])
         );
+        assert_eq!(receipt["tracking_signals"]["scenario_coverage_rate"], 1.0);
+        assert_eq!(receipt["tracking_signals"]["ci_tier_counts"]["pr"], 16);
+        assert_eq!(receipt["tracking_signals"]["ci_tier_counts"]["nightly"], 1);
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
         Ok(())
     }


### PR DESCRIPTION
### Motivation

- End-to-end UX confidence was documented as qualitative and lacked a published, test-validated signal surface to track harness coverage and CI-tier distribution.

### Description

- Add `collect_editor_ux_fixture_matrix_summary` to `xtask/src/tasks/update_status/quality.rs` to parse `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` and produce a fixture-matrix summary (workflow counts, scenario coverage rate, CI-tier split, and component-metric exercise counts).
- Wire the resulting summary into the `editor_ux` receipt as `tracking_signals` emitted by `generate_editor_ux_receipt` so `cargo xtask update-status --only quality` publishes concrete UX tracking signals into `docs/project/status/editor_ux.json`.
- Strengthen the existing xtask unit test `test_editor_ux_receipt_shape` to assert on the new `tracking_signals` fields for deterministic validation.
- Update prose in `README.md` and `docs/reference/UX_TESTING.md` to point readers at the published `editor_ux` receipt and describe the tracked signals.

### Testing

- Ran `cargo test -p xtask test_editor_ux_receipt_shape`, which passed. 
- Ran `cargo check --all-targets -p xtask`, which completed successfully. 
- Ran `cargo xtask fmt`, which completed successfully. 
- Ran `cargo clippy -p xtask -- -D warnings`, which completed successfully. 
- Note: `just pr-fast` was not available in the environment (`just` missing) so the full local `just` gate was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c555d8cc8333b145b9273757637d)