### PR TITLE
feat(status): track editor UX confidence signals (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | Tracked signal bundle | Published in `docs/project/status/editor_ux.json`: first-5-minutes workflow counts, manual smoke-checklist coverage, and known-gap issue-reference counts | Anything about parser breadth, protocol catalog size, or capability count |
 
-The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
+The last row is the important one: *none* of the parser/protocol counters above fully measure whether a real editing session feels good. The project now publishes a workflow-signal snapshot (`docs/project/status/editor_ux.json`) so this confidence lane is tracked, test-backed, and inspectable instead of purely qualitative.
 
 Live numbers live in [docs/project/status/parser.md](docs/project/status/parser.md); this table may lag a merge cycle.
 

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -20,32 +20,46 @@
       "crates/perl-lsp-ux-tests/tests/ux_scenario_15_workspace_symbols.rs",
       "crates/perl-lsp-ux-tests/tests/ux_scenario_16_workspace_folder_removal.rs",
       "crates/perl-lsp-ux-tests/tests/ux_scenario_17_deleted_file_churn.rs"
-    ]
+    ],
+    "workflow_count": 17
   },
   "integration_points": {
     "ci_lane": "just ux-tests",
+    "measured_metrics_receipt": ".ci/metrics/editor_ux.json",
     "quality_surface": "docs/project/status/quality.md",
     "release_lane": "just ux-tests-full",
     "status_update": "cargo xtask update-status --only quality"
   },
-  "receipt_kind": "planning_scaffold",
+  "receipt_kind": "tracking_snapshot",
   "schema_version": 1,
   "scorecard": "editor_ux",
+  "signals": {
+    "automated_workflows": 17,
+    "ci_tier_workflow_counts": {
+      "nightly": 1,
+      "pr": 16
+    },
+    "known_gap_issue_refs": 8,
+    "manual_smoke_actions": 5
+  },
   "top_line_metrics": [
     {
       "name": "workflow_pass_rate",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "source": "crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json",
+      "state": "tracked"
     },
     {
       "name": "workflow_stability_rate",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "source": "crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json",
+      "state": "tracked"
     },
     {
       "name": "p95_time_to_first_useful_result_ms",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "source": "crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json",
+      "state": "tracked"
     }
   ]
 }

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -9,6 +9,7 @@
     "scorecard",
     "harness",
     "top_line_metrics",
+    "signals",
     "integration_points"
   ],
   "properties": {
@@ -18,7 +19,7 @@
     },
     "receipt_kind": {
       "type": "string",
-      "const": "planning_scaffold"
+      "const": "tracking_snapshot"
     },
     "scorecard": {
       "type": "string",
@@ -26,7 +27,7 @@
     },
     "harness": {
       "type": "object",
-      "required": ["crate", "scenario_count", "scenario_files"],
+      "required": ["crate", "scenario_count", "scenario_files", "workflow_count"],
       "properties": {
         "crate": {
           "type": "string",
@@ -41,6 +42,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "workflow_count": {
+          "type": "integer",
+          "minimum": 0
         }
       },
       "additionalProperties": false
@@ -98,18 +103,62 @@
           },
           "state": {
             "type": "string",
-            "enum": ["planned", "measured"]
+            "enum": ["tracked", "measured"]
           },
           "owner": {
             "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number",
+            "minimum": 0
           }
         },
         "additionalProperties": false
       }
     },
+    "signals": {
+      "type": "object",
+      "required": [
+        "automated_workflows",
+        "manual_smoke_actions",
+        "known_gap_issue_refs",
+        "ci_tier_workflow_counts"
+      ],
+      "properties": {
+        "automated_workflows": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "manual_smoke_actions": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "known_gap_issue_refs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "ci_tier_workflow_counts": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "integration_points": {
       "type": "object",
-      "required": ["ci_lane", "release_lane", "status_update", "quality_surface"],
+      "required": [
+        "ci_lane",
+        "release_lane",
+        "status_update",
+        "quality_surface",
+        "measured_metrics_receipt"
+      ],
       "properties": {
         "ci_lane": {
           "type": "string"
@@ -121,6 +170,9 @@
           "type": "string"
         },
         "quality_surface": {
+          "type": "string"
+        },
+        "measured_metrics_receipt": {
           "type": "string"
         }
       },

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -8,7 +8,8 @@
 
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
-- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; planning scaffold at `docs/project/status/editor_ux.json`
+- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; tracked UX signal snapshot at `docs/project/status/editor_ux.json`
+- **UX confidence signals tracked**: 17 automated workflows + 5 manual smoke actions + 8 linked open-gap references
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -1,19 +1,24 @@
 //! Quality subsystem status generator.
 //!
 //! Owns per-crate mutation and test counts, UX scenario receipt, and quality.md generation.
-
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::Path;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result};
+use serde_json::Value;
 
 use super::{replace_block, run_cmd};
-
-// ---------------------------------------------------------------------------
-// Metric collectors
-// ---------------------------------------------------------------------------
+static RUNNING_TEST_CRATE_RE: LazyLock<Option<regex::Regex>> = LazyLock::new(|| {
+    regex::Regex::new(r"Running unittests[^\(]*\(target[^\)]*deps[/\\]([a-zA-Z0-9_-]+)-[0-9a-f]+\)")
+        .ok()
+});
+static LISTED_TEST_RE: LazyLock<Option<regex::Regex>> =
+    LazyLock::new(|| regex::Regex::new(r":\s*test\s*$").ok());
+static ISSUE_REF_RE: LazyLock<Option<regex::Regex>> =
+    LazyLock::new(|| regex::Regex::new(r"\[#(\d+)\]\(").ok());
 
 /// Read `mutants.out/mutants.json` and group mutations by crate package name.
 pub(super) fn collect_per_crate_mutation(root: &Path) -> BTreeMap<String, usize> {
@@ -45,22 +50,16 @@ pub(super) fn collect_per_crate_test_counts(root: &Path) -> BTreeMap<String, usi
         return BTreeMap::new();
     }
 
-    let running_re = regex::Regex::new(
-        r"Running unittests[^\(]*\(target[^\)]*deps[/\\]([a-zA-Z0-9_-]+)-[0-9a-f]+\)",
-    )
-    .ok();
-    let test_re = regex::Regex::new(r":\s*test\s*$").ok();
-
     let mut by_crate: BTreeMap<String, usize> = BTreeMap::new();
     let mut current_crate: Option<String> = None;
 
     for line in output.lines() {
-        if let Some(caps) = running_re.as_ref().and_then(|r| r.captures(line)) {
+        if let Some(caps) = RUNNING_TEST_CRATE_RE.as_ref().and_then(|r| r.captures(line)) {
             let name = caps[1].replace('_', "-");
             current_crate = Some(name);
             continue;
         }
-        if let Some(re) = test_re.as_ref()
+        if let Some(re) = LISTED_TEST_RE.as_ref()
             && re.is_match(line)
             && let Some(ref crate_name) = current_crate
         {
@@ -121,15 +120,98 @@ pub(super) fn collect_ux_scenario_files(root: &Path) -> Vec<String> {
 pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
+fn fixture_matrix_workflow_count(root: &Path) -> usize {
+    let matrix_path = root.join("crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json");
+    let Ok(raw) = fs::read_to_string(matrix_path) else {
+        return 0;
+    };
+    let Ok(json) = serde_json::from_str::<Value>(&raw) else {
+        return 0;
+    };
+    json.get("workflows").and_then(Value::as_array).map_or(0, std::vec::Vec::len)
+}
 
-// ---------------------------------------------------------------------------
-// Generators
-// ---------------------------------------------------------------------------
+fn fixture_matrix_tier_counts(root: &Path) -> BTreeMap<String, usize> {
+    let matrix_path = root.join("crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json");
+    let Ok(raw) = fs::read_to_string(matrix_path) else {
+        return BTreeMap::new();
+    };
+    let Ok(json) = serde_json::from_str::<Value>(&raw) else {
+        return BTreeMap::new();
+    };
+    let Some(workflows) = json.get("workflows").and_then(Value::as_array) else {
+        return BTreeMap::new();
+    };
+    let mut counts = BTreeMap::new();
+    for workflow in workflows {
+        if let Some(tier) = workflow.get("ci_tier").and_then(Value::as_str) {
+            *counts.entry(tier.to_string()).or_insert(0) += 1;
+        }
+    }
+    counts
+}
+
+fn manual_smoke_action_count(root: &Path) -> usize {
+    let path = root.join("docs/project/protocols/verification.md");
+    let Ok(raw) = fs::read_to_string(path) else {
+        return 0;
+    };
+    let Some(manual_line) = raw.lines().find(|line| line.starts_with("Manual editor smoke test: "))
+    else {
+        return 0;
+    };
+    let Some((_, actions)) = manual_line.split_once(':') else {
+        return 0;
+    };
+    actions.split(',').map(str::trim).filter(|entry| !entry.is_empty()).count()
+}
+
+fn known_gap_issue_ref_count(root: &Path) -> usize {
+    let path = root.join("README.md");
+    let Ok(raw) = fs::read_to_string(path) else {
+        return 0;
+    };
+    let start = raw.find("### Known gaps toward solid UX").unwrap_or(0);
+    let end = raw.find("## Security").unwrap_or(raw.len());
+    let known_gaps_block = &raw[start..end];
+
+    let mut issues = BTreeSet::new();
+    if let Some(re) = ISSUE_REF_RE.as_ref() {
+        for captures in re.captures_iter(known_gaps_block) {
+            issues.insert(captures[1].to_string());
+        }
+    }
+    issues.len()
+}
+
+fn latest_top_line_metric_values(root: &Path) -> BTreeMap<String, f64> {
+    let metrics_path = root.join(".ci/metrics/editor_ux.json");
+    let Ok(raw) = fs::read_to_string(metrics_path) else {
+        return BTreeMap::new();
+    };
+    let Ok(json) = serde_json::from_str::<Value>(&raw) else {
+        return BTreeMap::new();
+    };
+    let Some(metrics) = json.get("metrics").and_then(Value::as_object) else {
+        return BTreeMap::new();
+    };
+    let mut values = BTreeMap::new();
+    for key in
+        ["workflow_pass_rate", "workflow_stability_rate", "p95_time_to_first_useful_result_ms"]
+    {
+        if let Some(value) = metrics.get(key).and_then(Value::as_f64) {
+            values.insert(key.to_string(), value);
+        }
+    }
+    values
+}
 
 pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<String> {
     let mutation_by_crate = collect_per_crate_mutation(root);
     let tests_by_crate = collect_per_crate_test_counts(root);
     let ux_scenarios = count_ux_scenarios(root);
+    let known_gap_issue_refs = known_gap_issue_ref_count(root);
+    let manual_smoke_actions = manual_smoke_action_count(root);
 
     let has_mutation_data = !mutation_by_crate.is_empty();
     let mutation_note = if has_mutation_data {
@@ -142,8 +224,10 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
         "- **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing\n\
          - **UX workflow harness**: {ux_scenarios} scenario files in `perl-lsp-ux-tests`; \
            `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
-           the integration-only 10k-line large-file case; planning scaffold at \
+           the integration-only 10k-line large-file case; tracked UX signal snapshot at \
            `docs/project/status/editor_ux.json`\n\
+         - **UX confidence signals tracked**: {ux_scenarios} automated workflows + \
+           {manual_smoke_actions} manual smoke actions + {known_gap_issue_refs} linked open-gap references\n\
          - **Mutation testing**: {mutation_note}\n\
          - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
     );
@@ -165,51 +249,63 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
     )?;
     Ok(text)
 }
-
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let workflow_count = fixture_matrix_workflow_count(root);
+    let tier_counts = fixture_matrix_tier_counts(root);
+    let metric_values = latest_top_line_metric_values(root);
+    let top_line_metrics: Vec<Value> =
+        ["workflow_pass_rate", "workflow_stability_rate", "p95_time_to_first_useful_result_ms"]
+            .into_iter()
+            .map(|name| {
+                if let Some(value) = metric_values.get(name) {
+                    serde_json::json!({
+                        "name": name,
+                        "state": "measured",
+                        "owner": "perl-lsp-ux-tests",
+                        "value": value,
+                        "source": ".ci/metrics/editor_ux.json",
+                    })
+                } else {
+                    serde_json::json!({
+                        "name": name,
+                        "state": "tracked",
+                        "owner": "perl-lsp-ux-tests",
+                        "source": "crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json",
+                    })
+                }
+            })
+            .collect();
 
     let receipt = serde_json::json!({
         "schema_version": 1,
-        "receipt_kind": "planning_scaffold",
+        "receipt_kind": "tracking_snapshot",
         "scorecard": "editor_ux",
         "harness": {
             "crate": "crates/perl-lsp-ux-tests",
             "scenario_count": scenario_count,
             "scenario_files": scenario_files,
+            "workflow_count": workflow_count,
         },
-        "top_line_metrics": [
-            {
-                "name": "workflow_pass_rate",
-                "state": "planned",
-                "owner": "perl-lsp-ux-tests",
-            },
-            {
-                "name": "workflow_stability_rate",
-                "state": "planned",
-                "owner": "perl-lsp-ux-tests",
-            },
-            {
-                "name": "p95_time_to_first_useful_result_ms",
-                "state": "planned",
-                "owner": "perl-lsp-ux-tests",
-            },
-        ],
+        "top_line_metrics": top_line_metrics,
+        "signals": {
+            "automated_workflows": workflow_count,
+            "manual_smoke_actions": manual_smoke_action_count(root),
+            "known_gap_issue_refs": known_gap_issue_ref_count(root),
+            "ci_tier_workflow_counts": tier_counts,
+        },
         "integration_points": {
             "ci_lane": "just ux-tests",
             "release_lane": "just ux-tests-full",
             "status_update": "cargo xtask update-status --only quality",
             "quality_surface": "docs/project/status/quality.md",
+            "measured_metrics_receipt": ".ci/metrics/editor_ux.json",
         },
     });
 
     serde_json::to_string_pretty(&receipt).context("serializing editor UX receipt")
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -258,13 +354,14 @@ mod tests {
         let receipt_raw = generate_editor_ux_receipt(&root)?;
         let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
         assert_eq!(receipt["schema_version"], 1);
-        assert_eq!(receipt["receipt_kind"], "planning_scaffold");
+        assert_eq!(receipt["receipt_kind"], "tracking_snapshot");
         assert_eq!(receipt["scorecard"], "editor_ux");
         assert_eq!(receipt["harness"]["crate"], "crates/perl-lsp-ux-tests");
         assert_eq!(
             receipt["harness"]["scenario_count"].as_u64(),
             Some(count_ux_scenarios(&root) as u64)
         );
+        assert!(receipt["harness"]["workflow_count"].as_u64().unwrap_or_default() > 0);
         let top_line_names = receipt["top_line_metrics"]
             .as_array()
             .ok_or_else(|| eyre!("top_line_metrics must be an array"))?
@@ -278,6 +375,14 @@ mod tests {
                 "workflow_stability_rate",
                 "p95_time_to_first_useful_result_ms",
             ])
+        );
+        assert!(
+            receipt["signals"]["manual_smoke_actions"].as_u64().unwrap_or_default() >= 1,
+            "manual smoke actions should be tracked from verification protocol"
+        );
+        assert!(
+            receipt["signals"]["known_gap_issue_refs"].as_u64().unwrap_or_default() >= 1,
+            "known-gap issue links should be tracked from README"
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
         Ok(())


### PR DESCRIPTION
### Motivation
- Turn the previously qualitative "End-to-end UX confidence" signal into a published, test-backed snapshot so editor UX signals are tracked and inspectable rather than only validated by ad-hoc smoke checks and issue burn-down.

### Description
- Extend the status generator: `xtask/src/tasks/update_status/quality.rs` now emits a `tracking_snapshot` `editor_ux` receipt that includes `workflow_count`, `signals` (automated workflows, manual smoke actions, known-gap issue refs, CI-tier counts), and `top_line_metrics` that are promoted to `measured` when `.ci/metrics/editor_ux.json` contains values.  New helpers parse the fixture matrix and verification docs to populate these fields and use `LazyLock`d regexes to avoid repeated compilation. 
- Update the editor-UX schema: `docs/project/status/editor_ux.schema.json` now reflects `tracking_snapshot` semantics (adds `signals`, `workflow_count`, optional metric `source`/`value`, and `measured_metrics_receipt`).
- Emit updated status artifacts: regenerate `docs/project/status/editor_ux.json` and `docs/project/status/quality.md` to include the tracked UX signal bundle and summary bullets. 
- Documentation: update `README.md` to document that End-to-end UX confidence is now a tracked signal bundle and point to the published snapshot.

### Testing
- Ran `cargo test -p xtask quality::tests::test_editor_ux_receipt_shape`, which passed. 
- Ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix`, which passed. 
- Ran `cargo xtask update-status --only quality --write`, which updated `docs/project/status/quality.md` and `docs/project/status/editor_ux.json` (succeeded), and `cargo xtask update-status --only quality --check` returned "All files are up to date" (succeeded). 
- Performed `cargo check --all-targets -p xtask`, `cargo clippy -p xtask -- -D warnings`, and `cargo fmt --all`, which completed successfully. 
- Note: an earlier full `cargo test -p xtask` invocation showed unrelated failures in `publish_closure_edge_cases` in one run; targeted status/UX tests above passed and a subsequent full `cargo test -p xtask` run completed successfully in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c556a3288333b2e7685028f203d4)