### PR TITLE
feat(status): track editor UX coverage signals (#0000)

### DIFF
--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -47,5 +47,32 @@
       "owner": "perl-lsp-ux-tests",
       "state": "planned"
     }
-  ]
+  ],
+  "tracking_signals": {
+    "ci_tier_distribution": {
+      "nightly_workflows": 1,
+      "pr_workflow_share": 0.9411764705882353,
+      "pr_workflows": 16
+    },
+    "fixture_matrix_loaded": true,
+    "metric_coverage_counts": {
+      "cross_file_definition_success_rate": 1,
+      "module_resolution_workflow_success_rate": 1,
+      "multi_root_workspace_navigation_success_rate": 2,
+      "p95_time_to_first_useful_result_ms": 1,
+      "workflow_pass_rate": 17,
+      "workflow_stability_rate": 17
+    },
+    "subsystem_owner_workflow_counts": {
+      "diagnostics": 1,
+      "editor_intelligence": 4,
+      "engineering_health": 6,
+      "module_resolution": 1,
+      "workspace_indexing": 5
+    },
+    "workflow_inventory": {
+      "expected_outcome_assertions": 32,
+      "total_workflows": 17
+    }
+  }
 }

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -9,7 +9,8 @@
     "scorecard",
     "harness",
     "top_line_metrics",
-    "integration_points"
+    "integration_points",
+    "tracking_signals"
   ],
   "properties": {
     "schema_version": {
@@ -122,6 +123,71 @@
         },
         "quality_surface": {
           "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "tracking_signals": {
+      "type": "object",
+      "required": [
+        "fixture_matrix_loaded",
+        "workflow_inventory",
+        "ci_tier_distribution",
+        "metric_coverage_counts",
+        "subsystem_owner_workflow_counts"
+      ],
+      "properties": {
+        "fixture_matrix_loaded": {
+          "type": "boolean"
+        },
+        "workflow_inventory": {
+          "type": "object",
+          "required": ["total_workflows", "expected_outcome_assertions"],
+          "properties": {
+            "total_workflows": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "expected_outcome_assertions": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        },
+        "ci_tier_distribution": {
+          "type": "object",
+          "required": ["pr_workflows", "nightly_workflows", "pr_workflow_share"],
+          "properties": {
+            "pr_workflows": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "nightly_workflows": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "pr_workflow_share": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "metric_coverage_counts": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "subsystem_owner_workflow_counts": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
         }
       },
       "additionalProperties": false

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -8,7 +8,7 @@
 
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
-- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; planning scaffold at `docs/project/status/editor_ux.json`
+- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; tracking scaffold at `docs/project/status/editor_ux.json` now includes fixture-backed workflow inventory, CI-tier distribution, and metric-coverage counts
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -122,6 +122,74 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+fn collect_editor_ux_tracking_signals(root: &Path) -> serde_json::Value {
+    let matrix_path = root.join("crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json");
+    let Ok(matrix_raw) = fs::read_to_string(&matrix_path) else {
+        return serde_json::json!({
+            "fixture_matrix_loaded": false,
+        });
+    };
+    let Ok(matrix) = serde_json::from_str::<serde_json::Value>(&matrix_raw) else {
+        return serde_json::json!({
+            "fixture_matrix_loaded": false,
+        });
+    };
+
+    let workflows = matrix.get("workflows").and_then(|value| value.as_array());
+    let Some(workflows) = workflows else {
+        return serde_json::json!({
+            "fixture_matrix_loaded": false,
+        });
+    };
+
+    let workflow_total = workflows.len();
+    let mut ci_tier_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut owner_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut metric_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut expected_outcome_assertion_total = 0usize;
+
+    for workflow in workflows {
+        if let Some(ci_tier) = workflow.get("ci_tier").and_then(|value| value.as_str()) {
+            *ci_tier_counts.entry(ci_tier.to_string()).or_default() += 1;
+        }
+        if let Some(owner) = workflow.get("subsystem_owner").and_then(|value| value.as_str()) {
+            *owner_counts.entry(owner.to_string()).or_default() += 1;
+        }
+        if let Some(measures) = workflow.get("measures").and_then(|value| value.as_array()) {
+            for metric in measures {
+                if let Some(metric_name) = metric.as_str() {
+                    *metric_counts.entry(metric_name.to_string()).or_default() += 1;
+                }
+            }
+        }
+        if let Some(expected) = workflow.get("expected_outcomes").and_then(|value| value.as_array()) {
+            expected_outcome_assertion_total += expected.len();
+        }
+    }
+
+    let pr_workflow_count = ci_tier_counts.get("pr").copied().unwrap_or(0);
+    let nightly_workflow_count = ci_tier_counts.get("nightly").copied().unwrap_or(0);
+
+    serde_json::json!({
+        "fixture_matrix_loaded": true,
+        "workflow_inventory": {
+            "total_workflows": workflow_total,
+            "expected_outcome_assertions": expected_outcome_assertion_total,
+        },
+        "ci_tier_distribution": {
+            "pr_workflows": pr_workflow_count,
+            "nightly_workflows": nightly_workflow_count,
+            "pr_workflow_share": if workflow_total == 0 {
+                0.0
+            } else {
+                pr_workflow_count as f64 / workflow_total as f64
+            },
+        },
+        "metric_coverage_counts": metric_counts,
+        "subsystem_owner_workflow_counts": owner_counts,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -142,8 +210,9 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
         "- **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing\n\
          - **UX workflow harness**: {ux_scenarios} scenario files in `perl-lsp-ux-tests`; \
            `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
-           the integration-only 10k-line large-file case; planning scaffold at \
-           `docs/project/status/editor_ux.json`\n\
+           the integration-only 10k-line large-file case; tracking scaffold at \
+           `docs/project/status/editor_ux.json` now includes fixture-backed workflow inventory, \
+           CI-tier distribution, and metric-coverage counts\n\
          - **Mutation testing**: {mutation_note}\n\
          - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
     );
@@ -169,6 +238,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let tracking_signals = collect_editor_ux_tracking_signals(root);
 
     let receipt = serde_json::json!({
         "schema_version": 1,
@@ -202,6 +272,7 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
             "status_update": "cargo xtask update-status --only quality",
             "quality_surface": "docs/project/status/quality.md",
         },
+        "tracking_signals": tracking_signals,
     });
 
     serde_json::to_string_pretty(&receipt).context("serializing editor UX receipt")
@@ -280,6 +351,21 @@ mod tests {
             ])
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        assert_eq!(receipt["tracking_signals"]["fixture_matrix_loaded"], true);
+        let total_workflows = receipt["tracking_signals"]["workflow_inventory"]["total_workflows"]
+            .as_u64()
+            .ok_or_else(|| eyre!("tracking_signals.workflow_inventory.total_workflows missing"))?;
+        assert!(
+            total_workflows >= receipt["harness"]["scenario_count"].as_u64().unwrap_or(0),
+            "workflow inventory should cover at least all executable scenarios"
+        );
+        assert!(
+            receipt["tracking_signals"]["metric_coverage_counts"]["workflow_pass_rate"]
+                .as_u64()
+                .unwrap_or(0)
+                > 0,
+            "workflow_pass_rate should be exercised by fixture workflows"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Editor UX confidence was only a qualitative planning scaffold (`editor_ux.json`) and lacked fixture-derived tracking numbers to show coverage and CI tier distribution.

### Description

- Add `collect_editor_ux_tracking_signals` in `xtask/src/tasks/update_status/quality.rs` to compute fixture-backed signals from `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json`.
- Include a `tracking_signals` block in the editor UX receipt emitted by `generate_editor_ux_receipt` and surface counts for workflow inventory, CI-tier distribution, metric coverage, and subsystem-owner distribution.
- Extend the editor UX schema `docs/project/status/editor_ux.schema.json` to require and validate the new `tracking_signals` structure.
- Update `docs/project/status/quality.md` wording and regenerate `docs/project/status/editor_ux.json` to publish the computed tracking signals.
- Add assertions in the `xtask` receipt unit tests to validate presence and basic properties of the new `tracking_signals` data.

### Testing

- Ran `cargo test -p xtask update_status::quality::tests::` and the unit tests passed (all tests in the `quality` tests group succeeded).
- Ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix` and the fixture-matrix validation test passed.
- Ran the status generator with `target/debug/xtask update-status --only quality --write` which updated the generated status artifacts (`docs/project/status/editor_ux.json` and `docs/project/status/quality.md`) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c55838688333b566777d20ef3741)