### PR TITLE
feat(status): track editor UX confidence signals (#0000)

### DIFF
--- a/docs/project/metrics/WORKFLOW_SCORECARDS.md
+++ b/docs/project/metrics/WORKFLOW_SCORECARDS.md
@@ -56,7 +56,16 @@ workflow layer exists to answer the narrower product question:
 
 ## Current Scope
 
-The schema and fixture matrix land before a full measured emitter. That keeps
-the contract honest: the workflow inventory is executable today, the current
-component rows are backed by exact scenario assertions today, and the broader
-UX scorecard can expand only when those stronger assertions exist.
+The status receipt now tracks three concrete confidence signals:
+
+- Tier C manual editor smoke workflow count (from
+  `docs/project/protocols/verification.md`)
+- first-5-minutes harness scenario inventory (from
+  `crates/perl-lsp-ux-tests/tests/ux_scenario_*.rs`)
+- UX P0 issue burndown counts (from
+  `docs/project/PRE_ANNOUNCEMENT_CHECKLIST.md`)
+
+This keeps the contract honest: the workflow inventory is executable today, the
+current component rows are backed by exact scenario assertions today, and the
+confidence scaffolding is now tracked as explicit machine-readable counts rather
+than a prose-only qualitative note.

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -1,4 +1,23 @@
 {
+  "confidence_signals": {
+    "first_5_minutes_harness": {
+      "scenario_count": 17,
+      "source": "crates/perl-lsp-ux-tests/tests",
+      "tracking": "counted from ux_scenario_*.rs files"
+    },
+    "manual_editor_smoke": {
+      "source": "docs/project/protocols/verification.md",
+      "tracking": "counted from Tier C workflow list",
+      "workflow_count": 5
+    },
+    "ux_p0_issue_burndown": {
+      "merged": 3,
+      "open": 4,
+      "source": "docs/project/PRE_ANNOUNCEMENT_CHECKLIST.md",
+      "tracked_total": 7,
+      "tracking": "counted from UX P0 status bullets"
+    }
+  },
   "harness": {
     "crate": "crates/perl-lsp-ux-tests",
     "scenario_count": 17,
@@ -28,7 +47,7 @@
     "release_lane": "just ux-tests-full",
     "status_update": "cargo xtask update-status --only quality"
   },
-  "receipt_kind": "planning_scaffold",
+  "receipt_kind": "tracked_signals",
   "schema_version": 1,
   "scorecard": "editor_ux",
   "top_line_metrics": [

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -9,6 +9,7 @@
     "scorecard",
     "harness",
     "top_line_metrics",
+    "confidence_signals",
     "integration_points"
   ],
   "properties": {
@@ -18,7 +19,7 @@
     },
     "receipt_kind": {
       "type": "string",
-      "const": "planning_scaffold"
+      "const": "tracked_signals"
     },
     "scorecard": {
       "type": "string",
@@ -106,6 +107,49 @@
         },
         "additionalProperties": false
       }
+    },
+    "confidence_signals": {
+      "type": "object",
+      "required": [
+        "manual_editor_smoke",
+        "first_5_minutes_harness",
+        "ux_p0_issue_burndown"
+      ],
+      "properties": {
+        "manual_editor_smoke": {
+          "type": "object",
+          "required": ["workflow_count", "source", "tracking"],
+          "properties": {
+            "workflow_count": { "type": "integer", "minimum": 0 },
+            "source": { "type": "string" },
+            "tracking": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "first_5_minutes_harness": {
+          "type": "object",
+          "required": ["scenario_count", "source", "tracking"],
+          "properties": {
+            "scenario_count": { "type": "integer", "minimum": 0 },
+            "source": { "type": "string" },
+            "tracking": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "ux_p0_issue_burndown": {
+          "type": "object",
+          "required": ["tracked_total", "merged", "open", "source", "tracking"],
+          "properties": {
+            "tracked_total": { "type": ["integer", "null"], "minimum": 0 },
+            "merged": { "type": ["integer", "null"], "minimum": 0 },
+            "open": { "type": ["integer", "null"], "minimum": 0 },
+            "source": { "type": "string" },
+            "tracking": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     },
     "integration_points": {
       "type": "object",

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -5,9 +5,11 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result};
+use regex::Regex;
 
 use super::{replace_block, run_cmd};
 
@@ -122,6 +124,64 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UxP0Burndown {
+    total: usize,
+    merged: usize,
+    open: usize,
+}
+
+fn manual_smoke_workflow_count(root: &Path) -> usize {
+    let verification = root.join("docs/project/protocols/verification.md");
+    let Ok(raw) = fs::read_to_string(verification) else {
+        return 0;
+    };
+
+    static MANUAL_SMOKE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"Manual editor smoke test:\s*(?P<steps>[^\n]+)")
+            .expect("manual smoke regex must compile")
+    });
+
+    let Some(caps) = MANUAL_SMOKE_RE.captures(&raw) else {
+        return 0;
+    };
+
+    let Some(steps) = caps.name("steps").map(|m| m.as_str()) else {
+        return 0;
+    };
+
+    steps.split(',').map(str::trim).filter(|step| !step.is_empty()).count()
+}
+
+fn ux_p0_burndown(root: &Path) -> Option<UxP0Burndown> {
+    let checklist = root.join("docs/project/PRE_ANNOUNCEMENT_CHECKLIST.md");
+    let raw = fs::read_to_string(checklist).ok()?;
+
+    static UX_P0_TOTAL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"Current status:\s*⚠\s*—\s*(\d+)\s+UX P0 items tracked")
+            .expect("ux p0 total regex must compile")
+    });
+    static UX_P0_MERGED_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^\s*-\s*✓\s*#\d+").expect("ux p0 merged regex must compile"));
+    static UX_P0_OPEN_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^\s*-\s*⚠\s*#\d+").expect("ux p0 open regex must compile"));
+
+    let total = UX_P0_TOTAL_RE.captures(&raw)?.get(1)?.as_str().parse::<usize>().ok()?;
+
+    let mut merged = 0;
+    let mut open = 0;
+    for line in raw.lines() {
+        if UX_P0_MERGED_RE.is_match(line) {
+            merged += 1;
+        }
+        if UX_P0_OPEN_RE.is_match(line) {
+            open += 1;
+        }
+    }
+
+    Some(UxP0Burndown { total, merged, open })
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -169,10 +229,12 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let manual_smoke_steps = manual_smoke_workflow_count(root);
+    let ux_p0 = ux_p0_burndown(root);
 
     let receipt = serde_json::json!({
         "schema_version": 1,
-        "receipt_kind": "planning_scaffold",
+        "receipt_kind": "tracked_signals",
         "scorecard": "editor_ux",
         "harness": {
             "crate": "crates/perl-lsp-ux-tests",
@@ -196,6 +258,25 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
                 "owner": "perl-lsp-ux-tests",
             },
         ],
+        "confidence_signals": {
+            "manual_editor_smoke": {
+                "workflow_count": manual_smoke_steps,
+                "source": "docs/project/protocols/verification.md",
+                "tracking": "counted from Tier C workflow list",
+            },
+            "first_5_minutes_harness": {
+                "scenario_count": scenario_count,
+                "source": "crates/perl-lsp-ux-tests/tests",
+                "tracking": "counted from ux_scenario_*.rs files",
+            },
+            "ux_p0_issue_burndown": {
+                "tracked_total": ux_p0.as_ref().map(|v| v.total),
+                "merged": ux_p0.as_ref().map(|v| v.merged),
+                "open": ux_p0.as_ref().map(|v| v.open),
+                "source": "docs/project/PRE_ANNOUNCEMENT_CHECKLIST.md",
+                "tracking": "counted from UX P0 status bullets",
+            },
+        },
         "integration_points": {
             "ci_lane": "just ux-tests",
             "release_lane": "just ux-tests-full",
@@ -258,7 +339,7 @@ mod tests {
         let receipt_raw = generate_editor_ux_receipt(&root)?;
         let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
         assert_eq!(receipt["schema_version"], 1);
-        assert_eq!(receipt["receipt_kind"], "planning_scaffold");
+        assert_eq!(receipt["receipt_kind"], "tracked_signals");
         assert_eq!(receipt["scorecard"], "editor_ux");
         assert_eq!(receipt["harness"]["crate"], "crates/perl-lsp-ux-tests");
         assert_eq!(
@@ -280,6 +361,39 @@ mod tests {
             ])
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        assert_eq!(
+            receipt["confidence_signals"]["manual_editor_smoke"]["workflow_count"].as_u64(),
+            Some(manual_smoke_workflow_count(&root) as u64)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_manual_smoke_workflow_count_parses_tier_c_list() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let protocol_path = dir.path().join("docs/project/protocols");
+        fs::create_dir_all(&protocol_path)?;
+        fs::write(
+            protocol_path.join("verification.md"),
+            "## Tier C\nManual editor smoke test: diagnostics, completion, hover, go-to-definition, rename\n",
+        )?;
+        assert_eq!(manual_smoke_workflow_count(dir.path()), 5);
+        Ok(())
+    }
+
+    #[test]
+    fn test_ux_p0_burndown_extracts_counts() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let docs_path = dir.path().join("docs/project");
+        fs::create_dir_all(&docs_path)?;
+        fs::write(
+            docs_path.join("PRE_ANNOUNCEMENT_CHECKLIST.md"),
+            "Current status: ⚠ — 7 UX P0 items tracked; status as of 2026-04-08:\n- ✓ #1 merged\n- ⚠ #2 open\n- ⚠ #3 open\n",
+        )?;
+        let parsed = ux_p0_burndown(dir.path()).ok_or_else(|| eyre!("expected ux p0 parse"))?;
+        assert_eq!(parsed.total, 7);
+        assert_eq!(parsed.merged, 1);
+        assert_eq!(parsed.open, 2);
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Editor UX confidence was described qualitatively and not exposed as machine-readable, testable signals; the goal is to surface concrete counts that can be tracked and validated by CI and status generators.

### Description

- Add parsing helpers to `xtask` to extract a Tier C manual editor smoke workflow count and a UX P0 issue burndown from repository docs (`manual_smoke_workflow_count` and `ux_p0_burndown` in `xtask/src/tasks/update_status/quality.rs`).
- Extend the `generate_editor_ux_receipt` output to include a `confidence_signals` block (manual smoke workflow count, first-5-minutes harness scenario count, and UX P0 burndown counts) and change `receipt_kind` to `tracked_signals` in the same module.
- Update the editor UX receipt schema (`docs/project/status/editor_ux.schema.json`) to require and validate the new `confidence_signals` block and the `tracked_signals` receipt kind.
- Surface the new signals in project docs by updating `docs/project/metrics/WORKFLOW_SCORECARDS.md` and regenerating `docs/project/status/editor_ux.json`; add focused unit tests for the parsers and receipt shape in `xtask`.

### Testing

- Ran `cargo xtask update-status --only quality --write` which completed and updated `docs/project/status/editor_ux.json` successfully.
- Ran unit tests: `cargo test -p xtask test_editor_ux_receipt_shape`, `test_manual_smoke_workflow_count_parses_tier_c_list`, and `test_ux_p0_burndown_extracts_counts`, all of which passed.
- Ran `cargo check --all-targets -p xtask` and `cargo fmt --all`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c55838688333b566777d20ef3741)