### PR TITLE
fix(status): track editor UX confidence signals (#0000)

### DIFF
--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -31,21 +31,28 @@
   "receipt_kind": "planning_scaffold",
   "schema_version": 1,
   "scorecard": "editor_ux",
+  "supporting_signals": {
+    "known_gap_issue_refs": 4,
+    "tracked_from": "README.md#known-gaps-toward-solid-ux"
+  },
   "top_line_metrics": [
     {
       "name": "workflow_pass_rate",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "planned",
+      "value": null
     },
     {
       "name": "workflow_stability_rate",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "planned",
+      "value": null
     },
     {
       "name": "p95_time_to_first_useful_result_ms",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "planned",
+      "value": null
     }
   ]
 }

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -9,6 +9,7 @@
     "scorecard",
     "harness",
     "top_line_metrics",
+    "supporting_signals",
     "integration_points"
   ],
   "properties": {
@@ -102,10 +103,27 @@
           },
           "owner": {
             "type": "string"
+          },
+          "value": {
+            "type": ["number", "integer", "null"]
           }
         },
         "additionalProperties": false
       }
+    },
+    "supporting_signals": {
+      "type": "object",
+      "required": ["known_gap_issue_refs", "tracked_from"],
+      "properties": {
+        "known_gap_issue_refs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tracked_from": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     },
     "integration_points": {
       "type": "object",

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -9,6 +9,7 @@
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
 - **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; planning scaffold at `docs/project/status/editor_ux.json`
+- **UX confidence tracking**: top-line scorecard metrics measured 0/3 from `.ci/metrics/editor_ux.json`; known-gap burn-down currently tracks 4 linked issue references in README's UX gaps section
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -122,6 +122,66 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+fn parse_editor_ux_metric_values(root: &Path) -> BTreeMap<String, serde_json::Value> {
+    let receipt_path = root.join(".ci").join("metrics").join("editor_ux.json");
+    let Ok(raw) = fs::read_to_string(receipt_path) else {
+        return BTreeMap::new();
+    };
+    let Ok(doc) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return BTreeMap::new();
+    };
+    let Some(metrics) = doc.get("metrics").and_then(serde_json::Value::as_object) else {
+        return BTreeMap::new();
+    };
+
+    metrics.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+}
+
+fn count_known_gap_issue_refs(root: &Path) -> usize {
+    static ISSUE_LINK_RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"https://github\.com/[^)\s]+/issues/\d+")
+            .expect("issue link regex must compile")
+    });
+
+    let readme = root.join("README.md");
+    let Ok(content) = fs::read_to_string(readme) else {
+        return 0;
+    };
+
+    let mut in_known_gaps = false;
+    let mut in_shipped = false;
+    let mut count = 0usize;
+
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed == "### Known gaps toward solid UX" {
+            in_known_gaps = true;
+            continue;
+        }
+        if in_known_gaps && trimmed == "#### What shipped this cycle (v0.12.x)" {
+            in_shipped = true;
+        }
+        if in_shipped {
+            break;
+        }
+        if in_known_gaps {
+            count += ISSUE_LINK_RE.find_iter(line).count();
+        }
+    }
+    count
+}
+
+fn measured_top_line_metric_count(metric_values: &BTreeMap<String, serde_json::Value>) -> usize {
+    [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms",
+    ]
+    .into_iter()
+    .filter(|name| metric_values.get(*name).is_some_and(|v| !v.is_null()))
+    .count()
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -130,6 +190,9 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
     let mutation_by_crate = collect_per_crate_mutation(root);
     let tests_by_crate = collect_per_crate_test_counts(root);
     let ux_scenarios = count_ux_scenarios(root);
+    let ux_metric_values = parse_editor_ux_metric_values(root);
+    let measured_top_line = measured_top_line_metric_count(&ux_metric_values);
+    let known_gap_issue_refs = count_known_gap_issue_refs(root);
 
     let has_mutation_data = !mutation_by_crate.is_empty();
     let mutation_note = if has_mutation_data {
@@ -144,6 +207,9 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
            `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
            the integration-only 10k-line large-file case; planning scaffold at \
            `docs/project/status/editor_ux.json`\n\
+         - **UX confidence tracking**: top-line scorecard metrics measured {measured_top_line}/3 \
+           from `.ci/metrics/editor_ux.json`; known-gap burn-down currently tracks \
+           {known_gap_issue_refs} linked issue references in README's UX gaps section\n\
          - **Mutation testing**: {mutation_note}\n\
          - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
     );
@@ -169,6 +235,8 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let metric_values = parse_editor_ux_metric_values(root);
+    let known_gap_issue_refs = count_known_gap_issue_refs(root);
 
     let receipt = serde_json::json!({
         "schema_version": 1,
@@ -182,20 +250,27 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
         "top_line_metrics": [
             {
                 "name": "workflow_pass_rate",
-                "state": "planned",
+                "state": if metric_values.get("workflow_pass_rate").is_some_and(|v| !v.is_null()) { "measured" } else { "planned" },
+                "value": metric_values.get("workflow_pass_rate").cloned().unwrap_or(serde_json::Value::Null),
                 "owner": "perl-lsp-ux-tests",
             },
             {
                 "name": "workflow_stability_rate",
-                "state": "planned",
+                "state": if metric_values.get("workflow_stability_rate").is_some_and(|v| !v.is_null()) { "measured" } else { "planned" },
+                "value": metric_values.get("workflow_stability_rate").cloned().unwrap_or(serde_json::Value::Null),
                 "owner": "perl-lsp-ux-tests",
             },
             {
                 "name": "p95_time_to_first_useful_result_ms",
-                "state": "planned",
+                "state": if metric_values.get("p95_time_to_first_useful_result_ms").is_some_and(|v| !v.is_null()) { "measured" } else { "planned" },
+                "value": metric_values.get("p95_time_to_first_useful_result_ms").cloned().unwrap_or(serde_json::Value::Null),
                 "owner": "perl-lsp-ux-tests",
             },
         ],
+        "supporting_signals": {
+            "known_gap_issue_refs": known_gap_issue_refs,
+            "tracked_from": "README.md#known-gaps-toward-solid-ux",
+        },
         "integration_points": {
             "ci_lane": "just ux-tests",
             "release_lane": "just ux-tests-full",
@@ -279,7 +354,28 @@ mod tests {
                 "p95_time_to_first_useful_result_ms",
             ])
         );
+        assert!(
+            receipt["supporting_signals"]["known_gap_issue_refs"].as_u64().is_some(),
+            "known gap issue refs should be tracked as an integer"
+        );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        Ok(())
+    }
+
+    #[test]
+    fn test_count_known_gap_issue_refs_from_readme_excerpt() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::write(
+            dir.path().join("README.md"),
+            "\
+### Known gaps toward solid UX
+- First ([#1](https://github.com/org/repo/issues/1))
+- Second ([#2](https://github.com/org/repo/issues/2))
+#### What shipped this cycle (v0.12.x)
+- historical ([#3](https://github.com/org/repo/issues/3))
+",
+        )?;
+        assert_eq!(count_known_gap_issue_refs(dir.path()), 2);
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- The repository described end-to-end UX confidence as qualitative and “not a published number”, leaving no generated status surface for whether top-line UX metrics are measured. 
- The goal is to surface machine-readable scorecard state and a simple supporting signal for known-gap burn-down so UX confidence becomes testable and trackable.

### Description
- Read `.ci/metrics/editor_ux.json` and extract top-line metric values so the status generator can mark each top-line metric as `measured` or `planned` and include an explicit `value` when available via `parse_editor_ux_metric_values` and `measured_top_line_metric_count` in `xtask/src/tasks/update_status/quality.rs`.
- Compute a supporting signal by counting GitHub issue links in the README’s “Known gaps toward solid UX” section via `count_known_gap_issue_refs` and publish that count as `supporting_signals.known_gap_issue_refs`.
- Extend the editor UX receipt schema (`docs/project/status/editor_ux.schema.json`) to allow an optional per-metric `value` and require a `supporting_signals` object with `known_gap_issue_refs` and `tracked_from`.
- Wire these signals into the generated artifacts and update generated files: `docs/project/status/editor_ux.json` and `docs/project/status/quality.md`, and add unit tests for the new receipt shape and README counting logic.

### Testing
- Ran `cargo test -p xtask update_status::quality::tests:: -- --nocapture` and all `xtask` unit tests in the quality module passed.
- Ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix` and the UX fixture matrix test passed.
- Ran `cargo check --all-targets -p xtask` and `cargo clippy -p xtask -- -D warnings` and both succeeded with no issues.
- Ran `cargo xtask update-status --only quality --write` which updated `docs/project/status/quality.md` and `docs/project/status/editor_ux.json` to include the new UX confidence signals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c55838688333b566777d20ef3741)