### PR TITLE
feat(quality): publish tracked editor UX confidence signals (#0000)

### DIFF
--- a/xtask/src/tasks/metrics/lsp_stats.rs
+++ b/xtask/src/tasks/metrics/lsp_stats.rs
@@ -93,6 +93,19 @@ pub struct LastRunMetrics {
     pub completion_total: usize,
 }
 
+#[derive(Debug, Deserialize)]
+struct StoredMetrics {
+    metrics: StoredMetricValues,
+}
+
+#[derive(Debug, Deserialize)]
+struct StoredMetricValues {
+    workflow_pass_rate: Option<f64>,
+    hover_correctness_rate: Option<f64>,
+    completion_top5_usefulness: Option<f64>,
+    goto_definition_exact_hit_rate: Option<f64>,
+}
+
 impl LastRunMetrics {
     fn hover_rate(&self) -> Option<f64> {
         if self.hover_total == 0 {
@@ -215,7 +228,38 @@ fn load_last_run(path: &Path) -> Option<LastRunMetrics> {
     if let Some(last) = doc.get("last_run") {
         return serde_json::from_value(last.clone()).ok();
     }
-    None
+    let stored: StoredMetrics = serde_json::from_value(doc).ok()?;
+    rates_to_last_run(&stored.metrics)
+}
+
+fn rates_to_last_run(metrics: &StoredMetricValues) -> Option<LastRunMetrics> {
+    fn as_counts(rate: Option<f64>) -> Option<(usize, usize)> {
+        let value = rate?;
+        if !(0.0..=1.0).contains(&value) {
+            return None;
+        }
+        // Preserve one decimal place when we print percentages in the table.
+        let passed = (value * 1000.0).round() as usize;
+        Some((passed, 1000))
+    }
+
+    let (hover_passed, hover_total) = as_counts(metrics.hover_correctness_rate)?;
+    let (goto_passed, goto_total) = as_counts(metrics.goto_definition_exact_hit_rate)?;
+    let (completion_passed, completion_total) = as_counts(metrics.completion_top5_usefulness)?;
+    let (workflow_passed, workflow_total) = as_counts(metrics.workflow_pass_rate)?;
+
+    if workflow_total == 0 || workflow_passed > workflow_total {
+        return None;
+    }
+
+    Some(LastRunMetrics {
+        hover_passed,
+        hover_total,
+        goto_passed,
+        goto_total,
+        completion_passed,
+        completion_total,
+    })
 }
 
 fn write_json_receipt(path: &Path, output: &EditorUxMetrics) -> Result<()> {
@@ -280,6 +324,7 @@ fn print_table(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use color_eyre::eyre::{Result, eyre};
 
     #[test]
     fn test_last_run_metrics_zero_total_returns_none() {
@@ -344,5 +389,42 @@ mod tests {
         assert_eq!(parsed["subsystem"], "editor_ux");
         assert!((parsed["metrics"]["workflow_pass_rate"].as_f64().unwrap() - 0.91).abs() < 0.001);
         assert!(parsed["metrics"]["rename_success_rate"].is_null());
+    }
+
+    #[test]
+    fn test_load_last_run_reads_current_schema_rates() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("editor_ux.json");
+        let json = serde_json::json!({
+            "schema_version": 1,
+            "measured_at": "2026-04-23T00:00:00Z",
+            "subsystem": "editor_ux",
+            "metrics": {
+                "workflow_pass_rate": 0.93,
+                "workflow_stability_rate": null,
+                "p95_time_to_first_useful_result_ms": null,
+                "hover_correctness_rate": 0.95,
+                "completion_top5_usefulness": 0.91,
+                "completion_empty_when_should_not_be_empty_rate": null,
+                "goto_definition_exact_hit_rate": 0.9,
+                "rename_success_rate": null,
+                "settled_diagnostics_correctness_after_edit": null,
+                "module_resolution_workflow_success": null,
+                "multi_root_workspace_navigation_success": null,
+                "dap_happy_path_success_rate": null
+            }
+        });
+        fs::write(&path, serde_json::to_string_pretty(&json)?)?;
+
+        let loaded =
+            load_last_run(&path).ok_or_else(|| eyre!("expected metrics from current schema"))?;
+        let hover = loaded.hover_rate().ok_or_else(|| eyre!("missing hover rate"))?;
+        let goto = loaded.goto_rate().ok_or_else(|| eyre!("missing goto rate"))?;
+        let completion =
+            loaded.completion_rate().ok_or_else(|| eyre!("missing completion rate"))?;
+        assert!((hover - 0.95).abs() < 0.001);
+        assert!((goto - 0.9).abs() < 0.001);
+        assert!((completion - 0.91).abs() < 0.001);
+        Ok(())
     }
 }

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -11,6 +11,19 @@ use color_eyre::eyre::{Context, Result};
 
 use super::{replace_block, run_cmd};
 
+#[derive(Debug, serde::Deserialize)]
+struct EditorUxMetricsReceipt {
+    measured_at: String,
+    metrics: EditorUxMetricValues,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct EditorUxMetricValues {
+    workflow_pass_rate: Option<f64>,
+    workflow_stability_rate: Option<f64>,
+    p95_time_to_first_useful_result_ms: Option<u64>,
+}
+
 // ---------------------------------------------------------------------------
 // Metric collectors
 // ---------------------------------------------------------------------------
@@ -122,6 +135,12 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+fn load_editor_ux_metrics(root: &Path) -> Option<EditorUxMetricsReceipt> {
+    let path = root.join(".ci").join("metrics").join("editor_ux.json");
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -130,6 +149,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
     let mutation_by_crate = collect_per_crate_mutation(root);
     let tests_by_crate = collect_per_crate_test_counts(root);
     let ux_scenarios = count_ux_scenarios(root);
+    let ux_metrics = load_editor_ux_metrics(root);
 
     let has_mutation_data = !mutation_by_crate.is_empty();
     let mutation_note = if has_mutation_data {
@@ -138,12 +158,23 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
         "mutation data pending first nightly CI run — run `just mutation-subset` locally to populate"
     };
 
+    let ux_metrics_summary = if let Some(receipt) = ux_metrics
+        && let Some(rate) = receipt.metrics.workflow_pass_rate
+    {
+        format!(
+            "published workflow_pass_rate {:.1}% (measured at {}) in `.ci/metrics/editor_ux.json`",
+            rate * 100.0,
+            receipt.measured_at
+        )
+    } else {
+        "score publication pending — run `cargo xtask metrics lsp-stats --json` after ux lane execution to publish `.ci/metrics/editor_ux.json`".to_string()
+    };
+
     let bullets_content = format!(
         "- **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing\n\
          - **UX workflow harness**: {ux_scenarios} scenario files in `perl-lsp-ux-tests`; \
            `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
-           the integration-only 10k-line large-file case; planning scaffold at \
-           `docs/project/status/editor_ux.json`\n\
+           the integration-only 10k-line large-file case; `{ux_metrics_summary}`\n\
          - **Mutation testing**: {mutation_note}\n\
          - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
     );
@@ -169,6 +200,19 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let measured_metrics = load_editor_ux_metrics(root);
+    let workflow_pass_state = measured_metrics
+        .as_ref()
+        .and_then(|m| m.metrics.workflow_pass_rate)
+        .map_or("planned", |_| "measured");
+    let workflow_stability_state = measured_metrics
+        .as_ref()
+        .and_then(|m| m.metrics.workflow_stability_rate)
+        .map_or("planned", |_| "measured");
+    let p95_state = measured_metrics
+        .as_ref()
+        .and_then(|m| m.metrics.p95_time_to_first_useful_result_ms)
+        .map_or("planned", |_| "measured");
 
     let receipt = serde_json::json!({
         "schema_version": 1,
@@ -182,17 +226,17 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
         "top_line_metrics": [
             {
                 "name": "workflow_pass_rate",
-                "state": "planned",
+                "state": workflow_pass_state,
                 "owner": "perl-lsp-ux-tests",
             },
             {
                 "name": "workflow_stability_rate",
-                "state": "planned",
+                "state": workflow_stability_state,
                 "owner": "perl-lsp-ux-tests",
             },
             {
                 "name": "p95_time_to_first_useful_result_ms",
-                "state": "planned",
+                "state": p95_state,
                 "owner": "perl-lsp-ux-tests",
             },
         ],
@@ -280,6 +324,54 @@ mod tests {
             ])
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        Ok(())
+    }
+
+    #[test]
+    fn test_editor_ux_receipt_marks_measured_metrics_when_receipt_exists() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        let tests_dir = root.join("crates/perl-lsp-ux-tests/tests");
+        fs::create_dir_all(&tests_dir)?;
+        fs::write(tests_dir.join("ux_scenario_01_simple.rs"), "// fixture")?;
+
+        let metrics_dir = root.join(".ci/metrics");
+        fs::create_dir_all(&metrics_dir)?;
+        let metrics_json = serde_json::json!({
+            "schema_version": 1,
+            "measured_at": "2026-04-23T00:00:00Z",
+            "subsystem": "editor_ux",
+            "metrics": {
+                "workflow_pass_rate": 0.92,
+                "workflow_stability_rate": null,
+                "p95_time_to_first_useful_result_ms": 42
+            }
+        });
+        fs::write(
+            metrics_dir.join("editor_ux.json"),
+            serde_json::to_string_pretty(&metrics_json)?,
+        )?;
+
+        let receipt_raw = generate_editor_ux_receipt(root)?;
+        let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
+        let rows = receipt["top_line_metrics"]
+            .as_array()
+            .ok_or_else(|| eyre!("top_line_metrics must be an array"))?;
+        let pass_row = rows
+            .iter()
+            .find(|row| row["name"] == "workflow_pass_rate")
+            .ok_or_else(|| eyre!("missing workflow_pass_rate row"))?;
+        let stability_row = rows
+            .iter()
+            .find(|row| row["name"] == "workflow_stability_rate")
+            .ok_or_else(|| eyre!("missing workflow_stability_rate row"))?;
+        let p95_row = rows
+            .iter()
+            .find(|row| row["name"] == "p95_time_to_first_useful_result_ms")
+            .ok_or_else(|| eyre!("missing p95 row"))?;
+        assert_eq!(pass_row["state"], "measured");
+        assert_eq!(stability_row["state"], "planned");
+        assert_eq!(p95_row["state"], "measured");
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- End-to-end editor UX confidence was only a planning scaffold and not published as machine-readable metrics, so status output could not show measured signals.
- Make published pass-rate signals usable by status generation and downstream tooling so UX confidence moves from "not a published number" toward tracked and tested.

### Description
- Teach `xtask metrics lsp-stats` to read the current `.ci/metrics/editor_ux.json` schema and convert stored rates into `LastRunMetrics` so pass-rate data is consumable by other xtask commands. 
- Teach `xtask update-status::quality` to load `.ci/metrics/editor_ux.json`, surface a short published summary in the `quality.md` bullets, and flip top-line `editor_ux` rows from `planned` to `measured` when receipt values exist.
- Add small adapter types and a conversion helper (`rates_to_last_run`) and add unit tests that validate reading the current receipt schema and the measured/planned state transition logic.

### Testing
- Ran `cargo test -p xtask lsp_stats::tests::test_load_last_run_reads_current_schema_rates` and it passed.
- Ran `cargo test -p xtask quality::tests::test_editor_ux_receipt_marks_measured_metrics_when_receipt_exists` and it passed.
- Ran `cargo xtask fmt` and `cargo check --all-targets -p xtask` and both completed successfully.
- Ran `cargo clippy -p xtask` which completed successfully (a stricter `-D warnings` job hit an existing lint in unrelated test code outside this change).
- `just pr-fast` was not run because `just` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c55875e0833399011f17ec676f62)