### PR TITLE
fix(metrics): track editor UX confidence signals (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | Tracked signal set | Published in `docs/project/status/editor_ux.json` as manual editor smoke workflow count, first-5-minutes harness workflow count, and open-issue burn-down count (sourced from the fixture matrix and validated by tests) | Anything about parser breadth, protocol catalog size, or capability count |
 
-The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
+The last row is the important one: these are now tracked confidence signals, not a single scalar KPI. The signals still do not replace qualitative editor validation, but they make smoke coverage and open-gap burn-down explicit and versioned.
 
 Live numbers live in [docs/project/status/parser.md](docs/project/status/parser.md); this table may lag a merge cycle.
 

--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -11,6 +11,39 @@
     "module_resolution_workflow_success_rate",
     "multi_root_workspace_navigation_success_rate"
   ],
+  "confidence_signals": {
+    "manual_editor_smoke_workflows": [
+      "simple_file_smoke",
+      "goto_definition_core",
+      "hover_core",
+      "strict_diagnostics",
+      "multi_root_workspace_symbols"
+    ],
+    "first_five_minutes_harness_workflows": [
+      "simple_file_smoke",
+      "missing_perltidy_graceful_degradation",
+      "missing_perl_graceful_degradation",
+      "missing_perlcritic_graceful_degradation",
+      "bad_config_resilience",
+      "large_file_open",
+      "multi_file_workspace_navigation",
+      "shebang_detection",
+      "encoding_and_bom_resilience",
+      "goto_definition_core",
+      "hover_core",
+      "strict_diagnostics",
+      "document_symbols_core",
+      "inc_conformance",
+      "multi_root_workspace_symbols",
+      "workspace_folder_removal_freshness",
+      "deleted_file_churn_freshness"
+    ],
+    "open_issue_burndown_refs": [
+      "https://github.com/EffortlessMetrics/perl-lsp/issues/3522",
+      "https://github.com/EffortlessMetrics/perl-lsp/issues/3476",
+      "https://github.com/EffortlessMetrics/perl-lsp/issues/3515"
+    ]
+  },
   "workflows": [
     {
       "id": "simple_file_smoke",

--- a/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
+++ b/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
@@ -55,7 +55,15 @@ fn editor_ux_fixture_matrix_covers_all_scenarios() -> Result<()> {
 
     let mut scenarios_in_matrix = BTreeSet::new();
     let mut component_metrics_exercised = BTreeSet::new();
+    let mut workflow_ids = BTreeSet::new();
     for workflow in workflows {
+        let workflow_id =
+            workflow.get("id").and_then(Value::as_str).context("workflow missing id")?;
+        assert!(
+            workflow_ids.insert(workflow_id.to_string()),
+            "workflow id `{workflow_id}` must be unique"
+        );
+
         let scenario_file = workflow
             .get("scenario_file")
             .and_then(Value::as_str)
@@ -94,6 +102,52 @@ fn editor_ux_fixture_matrix_covers_all_scenarios() -> Result<()> {
             scenario_path.display()
         );
         scenarios_in_matrix.insert(scenario_file.to_string());
+    }
+
+    let confidence_signals =
+        matrix.get("confidence_signals").context("confidence_signals missing")?;
+    let manual_smoke_workflows = collect_string_set(
+        confidence_signals
+            .get("manual_editor_smoke_workflows")
+            .context("manual_editor_smoke_workflows missing")?,
+        "manual_editor_smoke_workflows",
+    )?;
+    assert!(
+        !manual_smoke_workflows.is_empty(),
+        "manual_editor_smoke_workflows must list at least one workflow id"
+    );
+    for workflow in &manual_smoke_workflows {
+        assert!(
+            workflow_ids.contains(workflow),
+            "manual smoke workflow `{workflow}` must reference a known workflow id"
+        );
+    }
+
+    let first_five_minutes_workflows = collect_string_set(
+        confidence_signals
+            .get("first_five_minutes_harness_workflows")
+            .context("first_five_minutes_harness_workflows missing")?,
+        "first_five_minutes_harness_workflows",
+    )?;
+    assert_eq!(
+        first_five_minutes_workflows, workflow_ids,
+        "first_five_minutes_harness_workflows must cover every workflow id in the fixture matrix"
+    );
+
+    let open_issue_refs = confidence_signals
+        .get("open_issue_burndown_refs")
+        .and_then(Value::as_array)
+        .context("open_issue_burndown_refs missing")?;
+    assert!(
+        !open_issue_refs.is_empty(),
+        "open_issue_burndown_refs must contain at least one issue reference"
+    );
+    for issue_ref in open_issue_refs {
+        let issue_url = issue_ref.as_str().context("open issue refs must be strings")?;
+        assert!(
+            issue_url.starts_with("https://github.com/EffortlessMetrics/perl-lsp/issues/"),
+            "issue reference `{issue_url}` must point at a perl-lsp GitHub issue"
+        );
     }
 
     let scenarios_on_disk = fs::read_dir(workspace_root().join(UX_TESTS_DIR))

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -28,7 +28,13 @@
     "release_lane": "just ux-tests-full",
     "status_update": "cargo xtask update-status --only quality"
   },
-  "receipt_kind": "planning_scaffold",
+  "confidence_signals": {
+    "first_five_minutes_harness_workflow_count": 17,
+    "manual_editor_smoke_workflow_count": 5,
+    "open_issue_burndown_count": 3,
+    "source_fixture": "crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json"
+  },
+  "receipt_kind": "tracked_signals",
   "schema_version": 1,
   "scorecard": "editor_ux",
   "top_line_metrics": [

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -122,6 +122,17 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+fn load_editor_ux_confidence_signals(root: &Path) -> serde_json::Value {
+    let matrix_path = root.join("crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json");
+    let Ok(raw) = fs::read_to_string(&matrix_path) else {
+        return serde_json::json!({});
+    };
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return serde_json::json!({});
+    };
+    parsed.get("confidence_signals").cloned().unwrap_or_else(|| serde_json::json!({}))
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -169,15 +180,30 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let confidence_signals = load_editor_ux_confidence_signals(root);
+    let manual_smoke_count = confidence_signals
+        .get("manual_editor_smoke_workflows")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, std::vec::Vec::len);
+    let issue_burndown_count = confidence_signals
+        .get("open_issue_burndown_refs")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, std::vec::Vec::len);
 
     let receipt = serde_json::json!({
         "schema_version": 1,
-        "receipt_kind": "planning_scaffold",
+        "receipt_kind": "tracked_signals",
         "scorecard": "editor_ux",
         "harness": {
             "crate": "crates/perl-lsp-ux-tests",
             "scenario_count": scenario_count,
             "scenario_files": scenario_files,
+        },
+        "confidence_signals": {
+            "manual_editor_smoke_workflow_count": manual_smoke_count,
+            "first_five_minutes_harness_workflow_count": scenario_count,
+            "open_issue_burndown_count": issue_burndown_count,
+            "source_fixture": "crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json",
         },
         "top_line_metrics": [
             {
@@ -258,13 +284,19 @@ mod tests {
         let receipt_raw = generate_editor_ux_receipt(&root)?;
         let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
         assert_eq!(receipt["schema_version"], 1);
-        assert_eq!(receipt["receipt_kind"], "planning_scaffold");
+        assert_eq!(receipt["receipt_kind"], "tracked_signals");
         assert_eq!(receipt["scorecard"], "editor_ux");
         assert_eq!(receipt["harness"]["crate"], "crates/perl-lsp-ux-tests");
         assert_eq!(
             receipt["harness"]["scenario_count"].as_u64(),
             Some(count_ux_scenarios(&root) as u64)
         );
+        assert!(receipt["confidence_signals"]["manual_editor_smoke_workflow_count"].is_u64());
+        assert_eq!(
+            receipt["confidence_signals"]["first_five_minutes_harness_workflow_count"].as_u64(),
+            Some(count_ux_scenarios(&root) as u64)
+        );
+        assert!(receipt["confidence_signals"]["open_issue_burndown_count"].is_u64());
         let top_line_names = receipt["top_line_metrics"]
             .as_array()
             .ok_or_else(|| eyre!("top_line_metrics must be an array"))?


### PR DESCRIPTION
### Motivation
- The README and UX status receipt treated end-to-end UX confidence as qualitative-only and did not publish concrete signal counts.
- Make smoke-coverage and open-gap burn-down explicit and machine-readable so status generation and automation can surface these confidence signals.

### Description
- Added a new `confidence_signals` section to `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` listing `manual_editor_smoke_workflows`, `first_five_minutes_harness_workflows`, and `open_issue_burndown_refs`.
- Strengthened `crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs` to validate workflow `id` uniqueness, that manual smoke workflows reference known IDs, that the first-5-minutes set covers all workflow IDs, and that open-issue refs are valid repo issue URLs.
- Wired `xtask` status generation to read the fixture matrix and publish concrete counts in the editor UX receipt (`receipt_kind: tracked_signals`) via `xtask/src/tasks/update_status/quality.rs`.
- Updated `README.md` and the checked-in `docs/project/status/editor_ux.json` to reflect the tracked signal set and source fixture.

### Testing
- Ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix` and the test passed.
- Ran `cargo test -p xtask test_editor_ux_receipt_shape` and the test passed.
- Ran `cargo check --all-targets -p xtask` and the check succeeded.
- Ran `cargo fmt --all` to ensure formatting and committed the result.
- `cargo xtask update-status --only quality` was exercised locally but is long-running due to workspace-wide test discovery, so targeted tests were used to validate the changed behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c55875e0833399011f17ec676f62)