### PR TITLE
feat(quality): track editor UX confidence signals (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | *tracked qualitative signals* | Tracked in `docs/project/status/editor_ux.json`: first-5-minutes workflow scenario count, manual smoke-workflow count, and known-gap issue-link burn-down | Anything about parser breadth, protocol catalog size, or capability count |
 
 The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
 

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -28,6 +28,26 @@
     "release_lane": "just ux-tests-full",
     "status_update": "cargo xtask update-status --only quality"
   },
+  "confidence_signals": [
+    {
+      "name": "ux_workflow_scenarios",
+      "source": "crates/perl-lsp-ux-tests/tests/ux_scenario_*.rs",
+      "status": "tracked",
+      "value": 17
+    },
+    {
+      "name": "manual_smoke_workflows",
+      "source": "docs/project/protocols/verification.md",
+      "status": "tracked",
+      "value": 5
+    },
+    {
+      "name": "open_ux_gap_issue_links",
+      "source": "README.md#known-gaps-toward-solid-ux",
+      "status": "tracked",
+      "value": 4
+    }
+  ],
   "receipt_kind": "planning_scaffold",
   "schema_version": 1,
   "scorecard": "editor_ux",

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -9,7 +9,8 @@
     "scorecard",
     "harness",
     "top_line_metrics",
-    "integration_points"
+    "integration_points",
+    "confidence_signals"
   ],
   "properties": {
     "schema_version": {
@@ -125,6 +126,37 @@
         }
       },
       "additionalProperties": false
+    },
+    "confidence_signals": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": ["name", "value", "source", "status"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "ux_workflow_scenarios",
+              "manual_smoke_workflows",
+              "open_ux_gap_issue_links"
+            ]
+          },
+          "value": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "source": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "const": "tracked"
+          }
+        },
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -122,6 +122,41 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+fn count_manual_smoke_workflows_from_protocol(content: &str) -> usize {
+    content
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Manual editor smoke test:")
+                .map(|items| items.split(',').filter(|item| !item.trim().is_empty()).count())
+        })
+        .unwrap_or(0)
+}
+
+pub(super) fn count_manual_smoke_workflows(root: &Path) -> usize {
+    let protocol_path = root.join("docs/project/protocols/verification.md");
+    let Ok(content) = fs::read_to_string(protocol_path) else {
+        return 0;
+    };
+    count_manual_smoke_workflows_from_protocol(&content)
+}
+
+fn count_known_ux_gaps_from_readme(content: &str) -> usize {
+    let Some(start) = content.find("### Known gaps toward solid UX") else {
+        return 0;
+    };
+    let tail = &content[start..];
+    let section = tail.find("### What shipped this cycle").map_or(tail, |end| &tail[..end]);
+    section.matches("https://github.com/EffortlessMetrics/perl-lsp/issues/").count()
+}
+
+pub(super) fn count_known_ux_gap_issue_links(root: &Path) -> usize {
+    let readme_path = root.join("README.md");
+    let Ok(content) = fs::read_to_string(readme_path) else {
+        return 0;
+    };
+    count_known_ux_gaps_from_readme(&content)
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -169,6 +204,8 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let manual_smoke_workflow_count = count_manual_smoke_workflows(root);
+    let known_ux_gap_issue_count = count_known_ux_gap_issue_links(root);
 
     let receipt = serde_json::json!({
         "schema_version": 1,
@@ -202,6 +239,26 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
             "status_update": "cargo xtask update-status --only quality",
             "quality_surface": "docs/project/status/quality.md",
         },
+        "confidence_signals": [
+            {
+                "name": "ux_workflow_scenarios",
+                "value": scenario_count,
+                "source": "crates/perl-lsp-ux-tests/tests/ux_scenario_*.rs",
+                "status": "tracked",
+            },
+            {
+                "name": "manual_smoke_workflows",
+                "value": manual_smoke_workflow_count,
+                "source": "docs/project/protocols/verification.md",
+                "status": "tracked",
+            },
+            {
+                "name": "open_ux_gap_issue_links",
+                "value": known_ux_gap_issue_count,
+                "source": "README.md#known-gaps-toward-solid-ux",
+                "status": "tracked",
+            },
+        ],
     });
 
     serde_json::to_string_pretty(&receipt).context("serializing editor UX receipt")
@@ -280,6 +337,28 @@ mod tests {
             ])
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        let signals = receipt["confidence_signals"]
+            .as_array()
+            .ok_or_else(|| eyre!("confidence_signals must be an array"))?;
+        assert_eq!(signals.len(), 3, "expected three tracked confidence signals");
         Ok(())
+    }
+
+    #[test]
+    fn test_count_manual_smoke_workflows_from_protocol() {
+        let content = "## Tier C: Real User Confirmation\n\nManual editor smoke test: diagnostics, completion, hover, go-to-definition, rename";
+        assert_eq!(count_manual_smoke_workflows_from_protocol(content), 5);
+    }
+
+    #[test]
+    fn test_count_known_ux_gaps_from_readme() {
+        let content = r#"
+### Known gaps toward solid UX
+- one ([#1](https://github.com/EffortlessMetrics/perl-lsp/issues/1))
+- two ([#2](https://github.com/EffortlessMetrics/perl-lsp/issues/2))
+### What shipped this cycle (v0.12.x)
+- done ([#3](https://github.com/EffortlessMetrics/perl-lsp/issues/3))
+"#;
+        assert_eq!(count_known_ux_gaps_from_readme(content), 2);
     }
 }


### PR DESCRIPTION
### Motivation
- Convert the End-to-end UX confidence row from an ad-hoc qualitative note into machine-tracked signals so UX coverage and known gaps are discoverable and validated by tooling.

### Description
- Add parsers and counters in `xtask/src/tasks/update_status/quality.rs` to extract manual smoke-workflow count and known-UX-gap issue-link count and expose them via `count_manual_smoke_workflows_from_protocol`, `count_manual_smoke_workflows`, `count_known_ux_gaps_from_readme`, and `count_known_ux_gap_issue_links`.
- Wire the new counts into `generate_editor_ux_receipt` so the editor UX receipt includes a `confidence_signals` array with the three named signals and integer values.
- Extend the `docs/project/status/editor_ux.schema.json` schema to require and validate the `confidence_signals` array with the specific signal names and fields.
- Update `docs/project/status/editor_ux.json` with the current signal values and update `README.md` to point at the tracked receipt and mark the UX row as "tracked qualitative signals".
- Add focused unit tests for the new parsers and to assert the updated receipt shape in the `xtask` test suite.

### Testing
- `cargo test -p xtask update_status::quality -- --nocapture` — passed (unit tests covering new parsing helpers and receipt shape).
- `cargo check --all-targets -p xtask` — passed.
- `cargo clippy -p xtask -- -D warnings` — passed.
- `cargo xtask fmt` — ran successfully; `cargo xtask update-status --only quality` was run to regenerate status without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c55a0878833385c7c7172d474c28)