### PR TITLE
feat(editor-ux): publish fixture-backed UX tracking signals (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | Fixture-backed tracking signals + manual review | Workflow coverage is now published in `docs/project/status/editor_ux.json` (workflow inventory, CI-tier distribution, and top-line/component metric mapping coverage), and still complemented by manual editor smoke workflows plus open-issue burn-down | Anything about parser breadth, protocol catalog size, or capability count |
 
-The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
+The last row is the important one: *none* of the automated metrics above fully capture whether a real editing session feels good. Use the published workflow tracking signals and harness coverage in `docs/project/status/editor_ux.json`, then corroborate with manual smoke workflows and the known-gaps list below.
 
 Live numbers live in [docs/project/status/parser.md](docs/project/status/parser.md); this table may lag a merge cycle.
 

--- a/docs/project/metrics/WORKFLOW_SCORECARDS.md
+++ b/docs/project/metrics/WORKFLOW_SCORECARDS.md
@@ -26,6 +26,15 @@ the subsystem scorecards. It is intentionally narrow:
 - `workflow_stability_rate`
 - `p95_time_to_first_useful_result_ms`
 
+## Published Tracking Signals
+
+The status receipt now publishes concrete workflow-inventory signals in
+[`docs/project/status/editor_ux.json`](../status/editor_ux.json):
+
+- total workflow count in the fixture matrix;
+- PR/nightly/release tier workflow counts; and
+- mapped top-line/component metric coverage counts.
+
 ## Current Component Rows
 
 - `cross_file_definition_success_rate`

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -28,6 +28,14 @@
     "release_lane": "just ux-tests-full",
     "status_update": "cargo xtask update-status --only quality"
   },
+  "tracking_signals": {
+    "mapped_component_metric_count": 3,
+    "mapped_top_line_metric_count": 3,
+    "nightly_tier_workflow_count": 1,
+    "pr_tier_workflow_count": 16,
+    "release_tier_workflow_count": 0,
+    "workflow_count": 17
+  },
   "receipt_kind": "planning_scaffold",
   "schema_version": 1,
   "scorecard": "editor_ux",

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -9,7 +9,8 @@
     "scorecard",
     "harness",
     "top_line_metrics",
-    "integration_points"
+    "integration_points",
+    "tracking_signals"
   ],
   "properties": {
     "schema_version": {
@@ -122,6 +123,44 @@
         },
         "quality_surface": {
           "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "tracking_signals": {
+      "type": "object",
+      "required": [
+        "workflow_count",
+        "pr_tier_workflow_count",
+        "nightly_tier_workflow_count",
+        "release_tier_workflow_count",
+        "mapped_top_line_metric_count",
+        "mapped_component_metric_count"
+      ],
+      "properties": {
+        "workflow_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "pr_tier_workflow_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "nightly_tier_workflow_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "release_tier_workflow_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "mapped_top_line_metric_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "mapped_component_metric_count": {
+          "type": "integer",
+          "minimum": 0
         }
       },
       "additionalProperties": false

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -122,6 +122,87 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+#[derive(Debug, Default)]
+struct EditorUxTrackingSignals {
+    workflow_count: usize,
+    pr_tier_workflow_count: usize,
+    nightly_tier_workflow_count: usize,
+    release_tier_workflow_count: usize,
+    mapped_top_line_metric_count: usize,
+    mapped_component_metric_count: usize,
+}
+
+fn collect_editor_ux_tracking_signals(root: &Path) -> EditorUxTrackingSignals {
+    let matrix_path = root.join("crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json");
+    let Ok(raw) = fs::read_to_string(matrix_path) else {
+        return EditorUxTrackingSignals::default();
+    };
+    let Ok(matrix) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return EditorUxTrackingSignals::default();
+    };
+
+    let workflows = matrix.get("workflows").and_then(serde_json::Value::as_array);
+    let top_line_metrics = matrix
+        .get("top_line_metrics")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let component_metrics = matrix
+        .get("component_metrics")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut pr_tier_workflow_count = 0usize;
+    let mut nightly_tier_workflow_count = 0usize;
+    let mut release_tier_workflow_count = 0usize;
+
+    let top_line_set = top_line_metrics
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .collect::<std::collections::BTreeSet<_>>();
+    let component_set = component_metrics
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut mapped_top_line = std::collections::BTreeSet::new();
+    let mut mapped_component = std::collections::BTreeSet::new();
+
+    let workflow_count = workflows.map_or(0, |workflow_rows| {
+        for workflow in workflow_rows {
+            if let Some(ci_tier) = workflow.get("ci_tier").and_then(serde_json::Value::as_str) {
+                match ci_tier {
+                    "pr" => pr_tier_workflow_count += 1,
+                    "nightly" => nightly_tier_workflow_count += 1,
+                    "release" => release_tier_workflow_count += 1,
+                    _ => {}
+                }
+            }
+
+            if let Some(measures) = workflow.get("measures").and_then(serde_json::Value::as_array) {
+                for metric in measures.iter().filter_map(serde_json::Value::as_str) {
+                    if top_line_set.contains(metric) {
+                        mapped_top_line.insert(metric.to_string());
+                    }
+                    if component_set.contains(metric) {
+                        mapped_component.insert(metric.to_string());
+                    }
+                }
+            }
+        }
+        workflow_rows.len()
+    });
+
+    EditorUxTrackingSignals {
+        workflow_count,
+        pr_tier_workflow_count,
+        nightly_tier_workflow_count,
+        release_tier_workflow_count,
+        mapped_top_line_metric_count: mapped_top_line.len(),
+        mapped_component_metric_count: mapped_component.len(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -169,6 +250,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let tracking_signals = collect_editor_ux_tracking_signals(root);
 
     let receipt = serde_json::json!({
         "schema_version": 1,
@@ -201,6 +283,14 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
             "release_lane": "just ux-tests-full",
             "status_update": "cargo xtask update-status --only quality",
             "quality_surface": "docs/project/status/quality.md",
+        },
+        "tracking_signals": {
+            "workflow_count": tracking_signals.workflow_count,
+            "pr_tier_workflow_count": tracking_signals.pr_tier_workflow_count,
+            "nightly_tier_workflow_count": tracking_signals.nightly_tier_workflow_count,
+            "release_tier_workflow_count": tracking_signals.release_tier_workflow_count,
+            "mapped_top_line_metric_count": tracking_signals.mapped_top_line_metric_count,
+            "mapped_component_metric_count": tracking_signals.mapped_component_metric_count,
         },
     });
 
@@ -280,6 +370,12 @@ mod tests {
             ])
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        assert_eq!(receipt["tracking_signals"]["workflow_count"], 17);
+        assert_eq!(receipt["tracking_signals"]["pr_tier_workflow_count"], 16);
+        assert_eq!(receipt["tracking_signals"]["nightly_tier_workflow_count"], 1);
+        assert_eq!(receipt["tracking_signals"]["release_tier_workflow_count"], 0);
+        assert_eq!(receipt["tracking_signals"]["mapped_top_line_metric_count"], 3);
+        assert_eq!(receipt["tracking_signals"]["mapped_component_metric_count"], 3);
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Turn the qualitative “End-to-end UX confidence (not a published number)” signal into a concrete, fixture-backed artifact so workflow inventory and basic coverage signals are discoverable and machine-readable.
- Surface key tracking signals (workflow inventory, CI-tier distribution, and top-line/component mapping coverage) so teams can track progress toward measured UX metrics.

### Description

- Added an `EditorUxTrackingSignals` struct and `collect_editor_ux_tracking_signals` to parse `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` and compute counts for workflows, CI tiers (`pr`/`nightly`/`release`) and mapped metric coverage. (`xtask/src/tasks/update_status/quality.rs`) 
- Included a `tracking_signals` block in the JSON produced by `generate_editor_ux_receipt` so `docs/project/status/editor_ux.json` now contains the published counts. (`xtask/src/tasks/update_status/quality.rs`) 
- Extended the `editor_ux` status schema to require and validate `tracking_signals` as non-negative integers. (`docs/project/status/editor_ux.schema.json`) 
- Updated the published planning-scaffold receipt with the computed example values and adjusted docs to point readers at `docs/project/status/editor_ux.json` for fixture-backed workflow coverage. (`docs/project/status/editor_ux.json`, `README.md`, `docs/project/metrics/WORKFLOW_SCORECARDS.md`)

### Testing

- Ran `cargo xtask update-status --only quality` which produced the updated `docs/project/status/editor_ux.json` containing the new `tracking_signals` fields (receipt visible in repo), validating the generator end-to-end in this environment. (succeeded)
- Attempted `cargo test -p xtask test_editor_ux_receipt_shape -- --nocapture` to exercise the updated receipt assertions but the run was blocked by a persistent Cargo build-directory lock in this environment and did not complete. (blocked)
- Ran `rustfmt`/`rustfmt`-style checks in this environment failed due to edition-specific `let`-chain parsing outside the normal project formatting flow; repository formatting is expected to be enforced by `cargo xtask fmt` / CI in the normal workflow. (not completed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c55b418083338bd8563a5006b112)