### PR TITLE
feat(ux-metrics): track UX confidence signals in status receipt (#0000)

### DIFF
--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -28,24 +28,47 @@
     "release_lane": "just ux-tests-full",
     "status_update": "cargo xtask update-status --only quality"
   },
-  "receipt_kind": "planning_scaffold",
+  "receipt_kind": "tracked_signals",
   "schema_version": 1,
   "scorecard": "editor_ux",
+  "signals": {
+    "first_five_minutes_harness": {
+      "default_lane": "just ux-tests",
+      "fixture_matrix": "crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json",
+      "release_lane": "just ux-tests-full",
+      "state": "tracked"
+    },
+    "manual_editor_smoke_workflow": {
+      "source": "docs/project/protocols/verification.md#tier-c-real-user-confirmation",
+      "state": "tracked",
+      "verification_command": "just ci-full"
+    },
+    "open_issue_burndown": {
+      "labels": [
+        "ux",
+        "ux:p0-blocker",
+        "ux:p1-friction",
+        "ux:p2-polish"
+      ],
+      "state": "tracked",
+      "verification_command": "just ux-issue-burndown"
+    }
+  },
   "top_line_metrics": [
     {
       "name": "workflow_pass_rate",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "tracked"
     },
     {
       "name": "workflow_stability_rate",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "tracked"
     },
     {
       "name": "p95_time_to_first_useful_result_ms",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "tracked"
     }
   ]
 }

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -8,6 +8,7 @@
     "receipt_kind",
     "scorecard",
     "harness",
+    "signals",
     "top_line_metrics",
     "integration_points"
   ],
@@ -18,7 +19,53 @@
     },
     "receipt_kind": {
       "type": "string",
-      "const": "planning_scaffold"
+      "const": "tracked_signals"
+    },
+    "signals": {
+      "type": "object",
+      "required": [
+        "manual_editor_smoke_workflow",
+        "first_five_minutes_harness",
+        "open_issue_burndown"
+      ],
+      "properties": {
+        "manual_editor_smoke_workflow": {
+          "type": "object",
+          "required": ["state", "source", "verification_command"],
+          "properties": {
+            "state": { "type": "string", "const": "tracked" },
+            "source": { "type": "string" },
+            "verification_command": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "first_five_minutes_harness": {
+          "type": "object",
+          "required": ["state", "default_lane", "release_lane", "fixture_matrix"],
+          "properties": {
+            "state": { "type": "string", "const": "tracked" },
+            "default_lane": { "type": "string" },
+            "release_lane": { "type": "string" },
+            "fixture_matrix": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "open_issue_burndown": {
+          "type": "object",
+          "required": ["state", "verification_command", "labels"],
+          "properties": {
+            "state": { "type": "string", "const": "tracked" },
+            "verification_command": { "type": "string" },
+            "labels": {
+              "type": "array",
+              "minItems": 4,
+              "items": { "type": "string" }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     },
     "scorecard": {
       "type": "string",
@@ -98,7 +145,7 @@
           },
           "state": {
             "type": "string",
-            "enum": ["planned", "measured"]
+            "enum": ["planned", "tracked", "measured"]
           },
           "owner": {
             "type": "string"

--- a/justfile
+++ b/justfile
@@ -1049,6 +1049,25 @@ ux-tests-full:
         cargo test -p perl-lsp-ux-tests --features integration-test -- --test-threads=1
     @echo "UX tests (full) passed"
 
+# UX issue burn-down snapshot for first-time-user confidence tracking.
+# Uses GitHub issue labels as the source of truth:
+# - `ux` (all UX issues)
+# - `ux:p0-blocker`, `ux:p1-friction`, `ux:p2-polish` (priority buckets)
+ux-issue-burndown:
+    @echo "UX issue burn-down snapshot (open issues):"
+    @if ! command -v gh >/dev/null 2>&1; then \
+        echo "GitHub CLI (gh) not found. Install gh to query open UX issues."; \
+        exit 1; \
+    fi
+    @echo "  Total ux:* open issues"
+    @gh issue list --label "ux" --state open --limit 500 --json number --jq 'length'
+    @echo "  ux:p0-blocker open issues"
+    @gh issue list --label "ux,ux:p0-blocker" --state open --limit 500 --json number --jq 'length'
+    @echo "  ux:p1-friction open issues"
+    @gh issue list --label "ux,ux:p1-friction" --state open --limit 500 --json number --jq 'length'
+    @echo "  ux:p2-polish open issues"
+    @gh issue list --label "ux,ux:p2-polish" --state open --limit 500 --json number --jq 'length'
+
 # @INC consumer-consistency conformance harness.
 # Verifies that goto-definition, hover, and PL701 diagnostic agree on module resolution
 # across 5 resolution modes: relative includePaths, lexical use lib, no lib cancellation,

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -172,27 +172,45 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
 
     let receipt = serde_json::json!({
         "schema_version": 1,
-        "receipt_kind": "planning_scaffold",
+        "receipt_kind": "tracked_signals",
         "scorecard": "editor_ux",
         "harness": {
             "crate": "crates/perl-lsp-ux-tests",
             "scenario_count": scenario_count,
             "scenario_files": scenario_files,
         },
+        "signals": {
+            "manual_editor_smoke_workflow": {
+                "state": "tracked",
+                "source": "docs/project/protocols/verification.md#tier-c-real-user-confirmation",
+                "verification_command": "just ci-full"
+            },
+            "first_five_minutes_harness": {
+                "state": "tracked",
+                "default_lane": "just ux-tests",
+                "release_lane": "just ux-tests-full",
+                "fixture_matrix": "crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json"
+            },
+            "open_issue_burndown": {
+                "state": "tracked",
+                "verification_command": "just ux-issue-burndown",
+                "labels": ["ux", "ux:p0-blocker", "ux:p1-friction", "ux:p2-polish"]
+            }
+        },
         "top_line_metrics": [
             {
                 "name": "workflow_pass_rate",
-                "state": "planned",
+                "state": "tracked",
                 "owner": "perl-lsp-ux-tests",
             },
             {
                 "name": "workflow_stability_rate",
-                "state": "planned",
+                "state": "tracked",
                 "owner": "perl-lsp-ux-tests",
             },
             {
                 "name": "p95_time_to_first_useful_result_ms",
-                "state": "planned",
+                "state": "tracked",
                 "owner": "perl-lsp-ux-tests",
             },
         ],
@@ -258,9 +276,13 @@ mod tests {
         let receipt_raw = generate_editor_ux_receipt(&root)?;
         let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
         assert_eq!(receipt["schema_version"], 1);
-        assert_eq!(receipt["receipt_kind"], "planning_scaffold");
+        assert_eq!(receipt["receipt_kind"], "tracked_signals");
         assert_eq!(receipt["scorecard"], "editor_ux");
         assert_eq!(receipt["harness"]["crate"], "crates/perl-lsp-ux-tests");
+        assert_eq!(
+            receipt["signals"]["open_issue_burndown"]["verification_command"],
+            "just ux-issue-burndown"
+        );
         assert_eq!(
             receipt["harness"]["scenario_count"].as_u64(),
             Some(count_ux_scenarios(&root) as u64)

--- a/xtask/tests/ci_full_ux_lane_tests.rs
+++ b/xtask/tests/ci_full_ux_lane_tests.rs
@@ -66,3 +66,37 @@ fn test_ux_tests_recipe_builds_and_exports_binary() -> Result<(), Box<dyn std::e
 
     Ok(())
 }
+
+#[test]
+fn test_ux_issue_burndown_recipe_tracks_open_priority_buckets()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = project_root();
+    let justfile = fs::read_to_string(root.join("justfile"))?;
+
+    let recipe_start = justfile
+        .find("\nux-issue-burndown:\n")
+        .ok_or("ux-issue-burndown recipe must exist in justfile")?;
+    let recipe_body = &justfile[recipe_start..];
+    let next_recipe = recipe_body
+        .find("\n# @INC consumer-consistency conformance harness.")
+        .ok_or("ux-issue-burndown recipe terminator marker must exist in justfile")?;
+    let recipe_body = &recipe_body[..next_recipe];
+
+    assert!(
+        recipe_body.contains("gh issue list --label \"ux\" --state open"),
+        "ux-issue-burndown must track open ux issues as the burn-down numerator.\n\
+         Current recipe:\n{}",
+        recipe_body
+    );
+    for label in ["ux:p0-blocker", "ux:p1-friction", "ux:p2-polish"] {
+        let query = format!("gh issue list --label \"ux,{label}\" --state open");
+        assert!(
+            recipe_body.contains(&query),
+            "ux-issue-burndown must track `{label}` open issue counts.\n\
+             Current recipe:\n{}",
+            recipe_body
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- End-to-end UX confidence was recorded only as qualitative notes (manual smoke, harness, issue burn-down) and not surfaced as a tracked, testable receipt.
- Surface the same signals the team uses in automation so UX confidence can be programmatically verified and monitored.

### Description
- Add a `just ux-issue-burndown` recipe that snapshots open `ux` issues and priority buckets (`ux:p0-blocker`, `ux:p1-friction`, `ux:p2-polish`) via the GitHub CLI so burn-down is an explicit, runnable signal.
- Promote the editor UX receipt from a `planning_scaffold` to `tracked_signals` in `xtask` and emit a `signals` section that declares `manual_editor_smoke_workflow`, `first_five_minutes_harness`, and `open_issue_burndown` with verification metadata and lanes.
- Update the editor UX JSON schema to require the new `signals` section and allow a `tracked` state for top-line metrics.
- Add xtask unit tests to lock the `justfile` wiring and the receipt shape so recipe and signal wiring regressions are caught (`xtask/tests/ci_full_ux_lane_tests.rs` and `xtask/src/tasks/update_status/quality.rs`).

### Testing
- Ran `cargo test -p xtask test_editor_ux_receipt_shape -- --nocapture` and the test passed.
- Ran `cargo test -p xtask --test ci_full_ux_lane_tests -- --nocapture` and all new/affected tests passed.
- Ran `cargo xtask fmt`, `cargo check --all-targets -p xtask`, and `cargo clippy -p xtask -- -D warnings`, and they all completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c55b418083338bd8563a5006b112)