### PR TITLE
fix(quality): track editor UX receipt measurements (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | *tracked + qualitative* | Tracked by executable first-5-minutes workflows in `perl-lsp-ux-tests` and the generated `docs/project/status/editor_ux.json` receipt; manual editor smoke workflows and open-issue burn-down remain complementary qualitative checks | Anything about parser breadth, protocol catalog size, or capability count |
 
 The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
 

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -28,6 +28,10 @@
     "release_lane": "just ux-tests-full",
     "status_update": "cargo xtask update-status --only quality"
   },
+  "measurement_input": {
+    "measured_at": null,
+    "source": ".ci/metrics/editor_ux.json"
+  },
   "receipt_kind": "planning_scaffold",
   "schema_version": 1,
   "scorecard": "editor_ux",
@@ -35,17 +39,20 @@
     {
       "name": "workflow_pass_rate",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "planned",
+      "value": null
     },
     {
       "name": "workflow_stability_rate",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "planned",
+      "value": null
     },
     {
       "name": "p95_time_to_first_useful_result_ms",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "planned",
+      "value": null
     }
   ]
 }

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -9,6 +9,7 @@
     "scorecard",
     "harness",
     "top_line_metrics",
+    "measurement_input",
     "integration_points"
   ],
   "properties": {
@@ -96,6 +97,9 @@
               "p95_time_to_first_useful_result_ms"
             ]
           },
+          "value": {
+            "type": ["number", "integer", "null"]
+          },
           "state": {
             "type": "string",
             "enum": ["planned", "measured"]
@@ -106,6 +110,19 @@
         },
         "additionalProperties": false
       }
+    },
+    "measurement_input": {
+      "type": "object",
+      "required": ["source", "measured_at"],
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "measured_at": {
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false
     },
     "integration_points": {
       "type": "object",

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -8,7 +8,7 @@
 
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
-- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; planning scaffold at `docs/project/status/editor_ux.json`
+- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; tracked receipt at `docs/project/status/editor_ux.json` (awaiting first measured receipt in `.ci/metrics/editor_ux.json`)
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result};
+use serde::Deserialize;
 
 use super::{replace_block, run_cmd};
 
@@ -122,6 +123,25 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+#[derive(Debug, Deserialize)]
+struct EditorUxMetricsReceipt {
+    measured_at: String,
+    metrics: EditorUxMetricsValues,
+}
+
+#[derive(Debug, Deserialize)]
+struct EditorUxMetricsValues {
+    workflow_pass_rate: Option<f64>,
+    workflow_stability_rate: Option<f64>,
+    p95_time_to_first_useful_result_ms: Option<u64>,
+}
+
+fn load_editor_ux_metrics(root: &Path) -> Option<EditorUxMetricsReceipt> {
+    let metrics_path = root.join(".ci/metrics/editor_ux.json");
+    let raw = fs::read_to_string(metrics_path).ok()?;
+    serde_json::from_str::<EditorUxMetricsReceipt>(&raw).ok()
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -137,13 +157,17 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
     } else {
         "mutation data pending first nightly CI run — run `just mutation-subset` locally to populate"
     };
+    let ux_metrics_note = if load_editor_ux_metrics(root).is_some() {
+        "tracked receipt at `docs/project/status/editor_ux.json` (with measured values when available)"
+    } else {
+        "tracked receipt at `docs/project/status/editor_ux.json` (awaiting first measured receipt in `.ci/metrics/editor_ux.json`)"
+    };
 
     let bullets_content = format!(
         "- **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing\n\
          - **UX workflow harness**: {ux_scenarios} scenario files in `perl-lsp-ux-tests`; \
            `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
-           the integration-only 10k-line large-file case; planning scaffold at \
-           `docs/project/status/editor_ux.json`\n\
+           the integration-only 10k-line large-file case; {ux_metrics_note}\n\
          - **Mutation testing**: {mutation_note}\n\
          - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
     );
@@ -169,6 +193,14 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let measured = load_editor_ux_metrics(root);
+    let measured_at = measured.as_ref().map(|receipt| receipt.measured_at.clone());
+    let workflow_pass_rate =
+        measured.as_ref().and_then(|receipt| receipt.metrics.workflow_pass_rate);
+    let workflow_stability_rate =
+        measured.as_ref().and_then(|receipt| receipt.metrics.workflow_stability_rate);
+    let p95_time_to_first_useful_result_ms =
+        measured.as_ref().and_then(|receipt| receipt.metrics.p95_time_to_first_useful_result_ms);
 
     let receipt = serde_json::json!({
         "schema_version": 1,
@@ -182,20 +214,31 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
         "top_line_metrics": [
             {
                 "name": "workflow_pass_rate",
-                "state": "planned",
+                "state": if workflow_pass_rate.is_some() { "measured" } else { "planned" },
                 "owner": "perl-lsp-ux-tests",
+                "value": workflow_pass_rate,
             },
             {
                 "name": "workflow_stability_rate",
-                "state": "planned",
+                "state": if workflow_stability_rate.is_some() { "measured" } else { "planned" },
                 "owner": "perl-lsp-ux-tests",
+                "value": workflow_stability_rate,
             },
             {
                 "name": "p95_time_to_first_useful_result_ms",
-                "state": "planned",
+                "state": if p95_time_to_first_useful_result_ms.is_some() {
+                    "measured"
+                } else {
+                    "planned"
+                },
                 "owner": "perl-lsp-ux-tests",
+                "value": p95_time_to_first_useful_result_ms,
             },
         ],
+        "measurement_input": {
+            "source": ".ci/metrics/editor_ux.json",
+            "measured_at": measured_at,
+        },
         "integration_points": {
             "ci_lane": "just ux-tests",
             "release_lane": "just ux-tests-full",
@@ -279,7 +322,70 @@ mod tests {
                 "p95_time_to_first_useful_result_ms",
             ])
         );
+        assert!(
+            receipt["top_line_metrics"]
+                .as_array()
+                .ok_or_else(|| eyre!("top_line_metrics must be an array"))?
+                .iter()
+                .all(|row| row.get("value").is_some()),
+            "top_line_metrics rows must always include a `value` key"
+        );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        assert_eq!(receipt["measurement_input"]["source"], ".ci/metrics/editor_ux.json");
+        Ok(())
+    }
+
+    #[test]
+    fn test_editor_ux_receipt_promotes_measured_metrics_when_ci_receipt_exists() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let tests_dir = dir.path().join("crates/perl-lsp-ux-tests/tests");
+        fs::create_dir_all(&tests_dir)?;
+        fs::write(tests_dir.join("ux_scenario_01_simple_file.rs"), "// fixture")?;
+
+        let metrics_dir = dir.path().join(".ci/metrics");
+        fs::create_dir_all(&metrics_dir)?;
+        fs::write(
+            metrics_dir.join("editor_ux.json"),
+            serde_json::json!({
+                "schema_version": 1,
+                "measured_at": "2026-04-23T10:00:00Z",
+                "subsystem": "editor_ux",
+                "metrics": {
+                    "workflow_pass_rate": 0.92,
+                    "workflow_stability_rate": null,
+                    "p95_time_to_first_useful_result_ms": 187
+                }
+            })
+            .to_string(),
+        )?;
+
+        let receipt_raw = generate_editor_ux_receipt(dir.path())?;
+        let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
+        let rows = receipt["top_line_metrics"]
+            .as_array()
+            .ok_or_else(|| eyre!("top_line_metrics must be an array"))?;
+
+        let workflow_row = rows
+            .iter()
+            .find(|row| row["name"] == "workflow_pass_rate")
+            .ok_or_else(|| eyre!("workflow_pass_rate row missing"))?;
+        assert_eq!(workflow_row["state"], "measured");
+        assert!((workflow_row["value"].as_f64().unwrap_or_default() - 0.92).abs() < 0.001);
+
+        let stability_row = rows
+            .iter()
+            .find(|row| row["name"] == "workflow_stability_rate")
+            .ok_or_else(|| eyre!("workflow_stability_rate row missing"))?;
+        assert_eq!(stability_row["state"], "planned");
+        assert!(stability_row["value"].is_null());
+
+        let p95_row = rows
+            .iter()
+            .find(|row| row["name"] == "p95_time_to_first_useful_result_ms")
+            .ok_or_else(|| eyre!("p95_time_to_first_useful_result_ms row missing"))?;
+        assert_eq!(p95_row["state"], "measured");
+        assert_eq!(p95_row["value"], 187);
+        assert_eq!(receipt["measurement_input"]["measured_at"], "2026-04-23T10:00:00Z");
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- The project documented "End-to-end UX confidence" as qualitative-only and lacked a way to surface measured UX pass/stability/latency values from CI into the status artifacts. 
- Make the UX scorecard traceable from the headless measurement pipeline so measured values can move from `.ci/metrics/editor_ux.json` into the generated status receipt instead of remaining an undocumented qualitative note.

### Description

- Teach the status generator to ingest the CI-produced receipt `.ci/metrics/editor_ux.json` and surface its values when present by adding `load_editor_ux_metrics` and small deserialization types in `xtask/src/tasks/update_status/quality.rs`.
- Promote per-top-line metric rows from `planned` to `measured` and include a `value` field when numeric measurements exist, and add `measurement_input` provenance (`source` and `measured_at`) into the generated `docs/project/status/editor_ux.json` receipt.
- Update the UX receipt JSON schema (`docs/project/status/editor_ux.schema.json`) to allow the new `value` fields and require `measurement_input`, update `README.md` and the generated `docs/project/status/quality.md` text to reflect that UX is now "tracked + qualitative", and regenerate `docs/project/status/editor_ux.json`/`quality.md`.
- Add unit tests in `xtask` that assert the receipt shape always includes a `value` key for top-line rows and that a mocked CI receipt promotes only populated metrics to `measured` and preserves numeric values and timestamp.

### Testing

- Ran `cargo test -p xtask` (targeted tests for the change) which executed the new `test_editor_ux_receipt_shape` and `test_editor_ux_receipt_promotes_measured_metrics_when_ci_receipt_exists` and they passed.
- Ran `cargo check --all-targets -p xtask` which passed to validate integration targets and build-time correctness.
- Ran `cargo clippy -p xtask -- -D warnings` which completed cleanly with no warnings.
- Exercised the status generator via `cargo xtask update-status --only quality --write` to regenerate `docs/project/status/editor_ux.json` and `docs/project/status/quality.md`, and verified `cargo xtask update-status --only quality --check` reports files up-to-date.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c55f84d8833389c17d37c8b2c8f9)