### PR TITLE
feat(status): track editor UX confidence signals (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | *qualitative + tracked signals* | Covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down; tracked signal counts now publish in `docs/project/status/editor_ux.json` (`automated_workflow_scenario_count`, `fixture_matrix_workflow_count`, `known_gap_issue_count`) | Anything about parser breadth, protocol catalog size, or capability count |
 
 The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
 

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -1,4 +1,15 @@
 {
+  "confidence_signals": {
+    "automated_workflow_scenario_count": 17,
+    "fixture_matrix_workflow_count": 17,
+    "known_gap_issue_count": 4,
+    "known_gap_issue_refs": [
+      "#3476",
+      "#3515",
+      "#3522",
+      "#4246"
+    ]
+  },
   "harness": {
     "crate": "crates/perl-lsp-ux-tests",
     "scenario_count": 17,

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -9,7 +9,8 @@
     "scorecard",
     "harness",
     "top_line_metrics",
-    "integration_points"
+    "integration_points",
+    "confidence_signals"
   ],
   "properties": {
     "schema_version": {
@@ -122,6 +123,37 @@
         },
         "quality_surface": {
           "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "confidence_signals": {
+      "type": "object",
+      "required": [
+        "automated_workflow_scenario_count",
+        "fixture_matrix_workflow_count",
+        "known_gap_issue_refs",
+        "known_gap_issue_count"
+      ],
+      "properties": {
+        "automated_workflow_scenario_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "fixture_matrix_workflow_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "known_gap_issue_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^#[0-9]+$"
+          }
+        },
+        "known_gap_issue_count": {
+          "type": "integer",
+          "minimum": 0
         }
       },
       "additionalProperties": false

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -122,6 +122,41 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+pub(super) fn count_fixture_matrix_workflows(root: &Path) -> usize {
+    let matrix_path = root.join("crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json");
+    let Ok(raw) = fs::read_to_string(matrix_path) else {
+        return 0;
+    };
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return 0;
+    };
+    parsed.get("workflows").and_then(serde_json::Value::as_array).map_or(0, std::vec::Vec::len)
+}
+
+pub(super) fn collect_known_ux_gap_issue_refs(root: &Path) -> Vec<String> {
+    let readme_path = root.join("README.md");
+    let Ok(readme) = fs::read_to_string(readme_path) else {
+        return Vec::new();
+    };
+
+    let Some(section_start) = readme.find("### Known gaps toward solid UX") else {
+        return Vec::new();
+    };
+    let Some(section_end_rel) = readme[section_start..].find("### What shipped this cycle") else {
+        return Vec::new();
+    };
+    let section = &readme[section_start..section_start + section_end_rel];
+    let Ok(issue_ref_re) = regex::Regex::new(r"/issues/(\d+)") else {
+        return Vec::new();
+    };
+
+    let mut issue_refs: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for captures in issue_ref_re.captures_iter(section) {
+        issue_refs.insert(format!("#{}", &captures[1]));
+    }
+    issue_refs.into_iter().collect()
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -169,6 +204,9 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let workflow_count = count_fixture_matrix_workflows(root);
+    let known_gap_issue_refs = collect_known_ux_gap_issue_refs(root);
+    let known_gap_count = known_gap_issue_refs.len();
 
     let receipt = serde_json::json!({
         "schema_version": 1,
@@ -201,6 +239,12 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
             "release_lane": "just ux-tests-full",
             "status_update": "cargo xtask update-status --only quality",
             "quality_surface": "docs/project/status/quality.md",
+        },
+        "confidence_signals": {
+            "automated_workflow_scenario_count": scenario_count,
+            "fixture_matrix_workflow_count": workflow_count,
+            "known_gap_issue_refs": known_gap_issue_refs,
+            "known_gap_issue_count": known_gap_count,
         },
     });
 
@@ -280,6 +324,25 @@ mod tests {
             ])
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        assert_eq!(
+            receipt["confidence_signals"]["automated_workflow_scenario_count"].as_u64(),
+            Some(count_ux_scenarios(&root) as u64)
+        );
+        assert_eq!(
+            receipt["confidence_signals"]["fixture_matrix_workflow_count"].as_u64(),
+            Some(count_fixture_matrix_workflows(&root) as u64)
+        );
+        let known_gaps = receipt["confidence_signals"]["known_gap_issue_refs"]
+            .as_array()
+            .ok_or_else(|| eyre!("known_gap_issue_refs must be an array"))?;
+        assert!(
+            !known_gaps.is_empty(),
+            "known gap issue list must not be empty while UX confidence remains qualitative"
+        );
+        assert_eq!(
+            receipt["confidence_signals"]["known_gap_issue_count"].as_u64(),
+            Some(known_gaps.len() as u64)
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- End-to-end UX confidence was only documented as qualitative with no published signal counts tying harness coverage, fixture coverage, and known UX-gap tracking to a machine-readable receipt.
- Provide lightweight, repeatable signals so the project can move UX confidence from "not a published number" toward tracked and testable evidence.

### Description
- Added `count_fixture_matrix_workflows` and `collect_known_ux_gap_issue_refs` to `xtask/src/tasks/update_status/quality.rs` and emit a `confidence_signals` object from `generate_editor_ux_receipt` containing `automated_workflow_scenario_count`, `fixture_matrix_workflow_count`, `known_gap_issue_refs`, and `known_gap_issue_count`.
- Extended the receipt schema `docs/project/status/editor_ux.schema.json` to require and validate the new `confidence_signals` object and its fields.
- Updated `README.md` wording for the "End-to-end UX confidence" row to indicate it is now "qualitative + tracked signals" and point readers at `docs/project/status/editor_ux.json` for the new fields.
- Regenerated `docs/project/status/editor_ux.json` to include the new signals and updated the `xtask` unit test `test_editor_ux_receipt_shape` to assert the new fields are present and consistent.

### Testing
- Ran `cargo test -p xtask test_editor_ux_receipt_shape`, which passed.
- Ran `cargo xtask update-status --only quality --write`, which updated `docs/project/status/editor_ux.json` to include the new `confidence_signals` (success).
- Ran formatting and build checks: `cargo xtask fmt` and `cargo check --all-targets -p xtask` (both succeeded).
- `cargo clippy -p xtask --all-targets -- -D warnings` failed due to a pre-existing lint in `xtask/tests/wave1_perl_module_collapse_tests.rs` (`len() > 0` → use `is_empty`); `cargo clippy -p xtask --bin xtask -- -D warnings` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c566bd9883339a57a8c5ecd579bd)