### PR TITLE
fix(quality): publish UX confidence indicators (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | scenario + backlog indicators | Tracked by executable `perl-lsp-ux-tests` first-5-minutes scenario coverage and the README known-gap issue backlog (published in `docs/project/status/quality.md`) | Anything about parser breadth, protocol catalog size, or capability count |
 
-The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
+The last row is the important one: *none* of the parser/capability metrics above measure whether a real editing session feels good. UX confidence is now published as tracked indicators (executable first-5-minutes scenario inventory + known-gap backlog) alongside manual workflow smoke validation.
 
 Live numbers live in [docs/project/status/parser.md](docs/project/status/parser.md); this table may lag a merge cycle.
 

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -8,7 +8,8 @@
 
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
-- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; planning scaffold at `docs/project/status/editor_ux.json`
+- **UX confidence indicators**: 17 executable first-5-minutes scenarios in `perl-lsp-ux-tests`; README tracks 3 current known-gap items linked to 4 issue references
+- **UX workflow harness**: `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; planning scaffold at `docs/project/status/editor_ux.json`
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -122,6 +122,44 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+fn parse_known_ux_gaps_from_readme_text(readme: &str) -> (usize, usize) {
+    let mut in_known_gaps = false;
+    let mut gap_entries = 0usize;
+    let mut issue_refs = 0usize;
+
+    for line in readme.lines() {
+        if line.trim() == "### Known gaps toward solid UX" {
+            in_known_gaps = true;
+            continue;
+        }
+
+        if !in_known_gaps {
+            continue;
+        }
+
+        if line.trim_start().starts_with("#### What shipped this cycle") {
+            break;
+        }
+
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("- **") {
+            gap_entries += 1;
+            issue_refs +=
+                trimmed.split("https://github.com/EffortlessMetrics/perl-lsp/issues/").count() - 1;
+        }
+    }
+
+    (gap_entries, issue_refs)
+}
+
+pub(super) fn collect_known_ux_gaps(root: &Path) -> (usize, usize) {
+    let readme_path = root.join("README.md");
+    let Ok(readme_text) = fs::read_to_string(readme_path) else {
+        return (0, 0);
+    };
+    parse_known_ux_gaps_from_readme_text(&readme_text)
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -130,6 +168,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
     let mutation_by_crate = collect_per_crate_mutation(root);
     let tests_by_crate = collect_per_crate_test_counts(root);
     let ux_scenarios = count_ux_scenarios(root);
+    let (known_gap_entries, known_gap_issue_refs) = collect_known_ux_gaps(root);
 
     let has_mutation_data = !mutation_by_crate.is_empty();
     let mutation_note = if has_mutation_data {
@@ -140,8 +179,9 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 
     let bullets_content = format!(
         "- **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing\n\
-         - **UX workflow harness**: {ux_scenarios} scenario files in `perl-lsp-ux-tests`; \
-           `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
+         - **UX confidence indicators**: {ux_scenarios} executable first-5-minutes scenarios in `perl-lsp-ux-tests`; \
+           README tracks {known_gap_entries} current known-gap items linked to {known_gap_issue_refs} issue references\n\
+         - **UX workflow harness**: `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
            the integration-only 10k-line large-file case; planning scaffold at \
            `docs/project/status/editor_ux.json`\n\
          - **Mutation testing**: {mutation_note}\n\
@@ -281,5 +321,32 @@ mod tests {
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
         Ok(())
+    }
+
+    #[test]
+    fn test_parse_known_ux_gaps_from_readme_text_counts_bullets_and_issue_refs() {
+        let readme = r#"
+### Known gaps toward solid UX
+
+#### Must land for v0.13.0
+
+- **Workspace-wide rename slice** ([#3522](https://github.com/EffortlessMetrics/perl-lsp/issues/3522))
+
+#### Nice to land
+
+- **Dynamic require / literal import** ([#3476](https://github.com/EffortlessMetrics/perl-lsp/issues/3476), tracked by umbrella [#4246](https://github.com/EffortlessMetrics/perl-lsp/issues/4246))
+
+#### Deferred to v0.14.0
+
+- **Dynamic workspace configuration** ([#3515](https://github.com/EffortlessMetrics/perl-lsp/issues/3515))
+
+#### What shipped this cycle (v0.12.x)
+
+- closed item that should not be counted
+"#;
+
+        let (gap_entries, issue_refs) = parse_known_ux_gaps_from_readme_text(readme);
+        assert_eq!(gap_entries, 3, "expected 3 known-gap entries");
+        assert_eq!(issue_refs, 4, "expected 4 known-gap issue refs");
     }
 }


### PR DESCRIPTION
### Motivation
- End-to-end UX confidence was recorded as *qualitative* despite existing signals (executable UX scenarios and a known-gap backlog) that should be surfaced as tracked indicators.
- Make the UX signals machine-readable and visible in the generated quality status so UX confidence moves from undocumented to published and testable.

### Description
- Add a `parse_known_ux_gaps_from_readme_text` helper and `collect_known_ux_gaps` to extract known-gap bullet counts and linked issue references from `README.md` and wire them into quality status generation in `xtask/src/tasks/update_status/quality.rs`.
- Integrate the extracted UX indicators (scenario count + known-gap backlog) into the `generate_quality_status` output so the generated `docs/project/status/quality.md` includes these counts.
- Add a unit test `test_parse_known_ux_gaps_from_readme_text_counts_bullets_and_issue_refs` validating the README parsing logic.
- Update `README.md` wording to reflect that UX confidence is now published as "scenario + backlog indicators" and regenerate `docs/project/status/quality.md` so the new indicators are visible.

### Testing
- Ran `cargo test -p xtask update_status::quality`, and the focused quality tests passed (`5 passed; 0 failed`).
- Ran `cargo xtask update-status --only quality --write`, which updated `docs/project/status/quality.md` successfully.
- Ran `cargo xtask fmt` and `cargo clippy -p xtask -- -D warnings`, and formatting and lints passed.
- Note: `cargo test -p xtask` shows two failing tests in `publish_closure_edge_cases` that are unrelated to the quality changes; the focused tests for this change passed as listed above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c566bd9883339a57a8c5ecd579bd)