### PR TITLE
feat(status): publish editor UX tracked signals (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | Tracked via scorecard signals (see `docs/project/status/editor_ux.json`) | Covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down; the UX scorecard now publishes tracked workflow coverage/tiering/binding counts | Anything about parser breadth, protocol catalog size, or capability count |
 
-The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
+The last row is the important one: *none* of the automated metrics above fully measure whether a real editing session feels good. We still validate through workflow smoke tests, the `perl-lsp-ux-tests` harness, the published UX scorecard signals, and the list of known gaps below.
 
 Live numbers live in [docs/project/status/parser.md](docs/project/status/parser.md); this table may lag a merge cycle.
 

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -22,6 +22,13 @@
       "crates/perl-lsp-ux-tests/tests/ux_scenario_17_deleted_file_churn.rs"
     ]
   },
+  "tracked_signals": {
+    "workflow_count": 17,
+    "scenario_coverage_percent": 100,
+    "pr_tier_workflow_count": 16,
+    "nightly_tier_workflow_count": 1,
+    "top_line_metric_bindings_total": 35
+  },
   "integration_points": {
     "ci_lane": "just ux-tests",
     "quality_surface": "docs/project/status/quality.md",

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -8,6 +8,7 @@
     "receipt_kind",
     "scorecard",
     "harness",
+    "tracked_signals",
     "top_line_metrics",
     "integration_points"
   ],
@@ -41,6 +42,39 @@
           "items": {
             "type": "string"
           }
+        }
+      },
+      "additionalProperties": false
+    },
+    "tracked_signals": {
+      "type": "object",
+      "required": [
+        "workflow_count",
+        "scenario_coverage_percent",
+        "pr_tier_workflow_count",
+        "nightly_tier_workflow_count",
+        "top_line_metric_bindings_total"
+      ],
+      "properties": {
+        "workflow_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "scenario_coverage_percent": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "pr_tier_workflow_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "nightly_tier_workflow_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "top_line_metric_bindings_total": {
+          "type": "integer",
+          "minimum": 0
         }
       },
       "additionalProperties": false

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result};
+use serde::Deserialize;
 
 use super::{replace_block, run_cmd};
 
@@ -122,6 +123,69 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct EditorUxTrackedSignals {
+    pub scenario_count: usize,
+    pub workflows_total: usize,
+    pub scenario_coverage_percent: usize,
+    pub pr_tier_workflows: usize,
+    pub nightly_tier_workflows: usize,
+    pub top_line_metric_bindings_total: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct EditorUxFixtureMatrix {
+    workflows: Vec<EditorUxWorkflow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EditorUxWorkflow {
+    ci_tier: String,
+    measures: Vec<String>,
+}
+
+pub(super) fn collect_editor_ux_tracked_signals(root: &Path) -> EditorUxTrackedSignals {
+    let scenario_count = count_ux_scenarios(root);
+    let fixture_path = root.join("crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json");
+    let matrix = fs::read_to_string(&fixture_path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<EditorUxFixtureMatrix>(&raw).ok());
+
+    let workflows_total = matrix.as_ref().map_or(0, |m| m.workflows.len());
+    let pr_tier_workflows =
+        matrix.as_ref().map_or(0, |m| m.workflows.iter().filter(|w| w.ci_tier == "pr").count());
+    let nightly_tier_workflows = matrix
+        .as_ref()
+        .map_or(0, |m| m.workflows.iter().filter(|w| w.ci_tier == "nightly").count());
+    let top_line_metric_bindings_total = matrix.as_ref().map_or(0, |m| {
+        m.workflows
+            .iter()
+            .map(|w| {
+                w.measures
+                    .iter()
+                    .filter(|name| {
+                        *name == "workflow_pass_rate"
+                            || *name == "workflow_stability_rate"
+                            || *name == "p95_time_to_first_useful_result_ms"
+                    })
+                    .count()
+            })
+            .sum()
+    });
+
+    let scenario_coverage_percent =
+        if scenario_count == 0 { 0 } else { (workflows_total * 100) / scenario_count };
+
+    EditorUxTrackedSignals {
+        scenario_count,
+        workflows_total,
+        scenario_coverage_percent,
+        pr_tier_workflows,
+        nightly_tier_workflows,
+        top_line_metric_bindings_total,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -142,7 +206,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
         "- **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing\n\
          - **UX workflow harness**: {ux_scenarios} scenario files in `perl-lsp-ux-tests`; \
            `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
-           the integration-only 10k-line large-file case; planning scaffold at \
+           the integration-only 10k-line large-file case; tracked signal counts are published in \
            `docs/project/status/editor_ux.json`\n\
          - **Mutation testing**: {mutation_note}\n\
          - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
@@ -168,6 +232,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
+    let tracked_signals = collect_editor_ux_tracked_signals(root);
     let scenario_count = scenario_files.len();
 
     let receipt = serde_json::json!({
@@ -178,6 +243,13 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
             "crate": "crates/perl-lsp-ux-tests",
             "scenario_count": scenario_count,
             "scenario_files": scenario_files,
+        },
+        "tracked_signals": {
+            "workflow_count": tracked_signals.workflows_total,
+            "scenario_coverage_percent": tracked_signals.scenario_coverage_percent,
+            "pr_tier_workflow_count": tracked_signals.pr_tier_workflows,
+            "nightly_tier_workflow_count": tracked_signals.nightly_tier_workflows,
+            "top_line_metric_bindings_total": tracked_signals.top_line_metric_bindings_total,
         },
         "top_line_metrics": [
             {
@@ -257,6 +329,7 @@ mod tests {
         let root = crate::utils::project_root()?;
         let receipt_raw = generate_editor_ux_receipt(&root)?;
         let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
+        let tracked_signals = collect_editor_ux_tracked_signals(&root);
         assert_eq!(receipt["schema_version"], 1);
         assert_eq!(receipt["receipt_kind"], "planning_scaffold");
         assert_eq!(receipt["scorecard"], "editor_ux");
@@ -264,6 +337,14 @@ mod tests {
         assert_eq!(
             receipt["harness"]["scenario_count"].as_u64(),
             Some(count_ux_scenarios(&root) as u64)
+        );
+        assert_eq!(
+            receipt["tracked_signals"]["workflow_count"].as_u64(),
+            Some(tracked_signals.workflows_total as u64)
+        );
+        assert_eq!(
+            receipt["tracked_signals"]["scenario_coverage_percent"].as_u64(),
+            Some(tracked_signals.scenario_coverage_percent as u64)
         );
         let top_line_names = receipt["top_line_metrics"]
             .as_array()
@@ -280,6 +361,43 @@ mod tests {
             ])
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_editor_ux_tracked_signals_from_fixture_matrix() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let tests_dir = dir.path().join("crates/perl-lsp-ux-tests/tests");
+        fs::create_dir_all(&tests_dir)?;
+        fs::write(tests_dir.join("ux_scenario_01_simple_file.rs"), "// scenario 1")?;
+        fs::write(tests_dir.join("ux_scenario_02_missing_perltidy.rs"), "// scenario 2")?;
+
+        let fixtures_dir = dir.path().join("crates/perl-lsp-ux-tests/fixtures");
+        fs::create_dir_all(&fixtures_dir)?;
+        let matrix = serde_json::json!({
+            "workflows": [
+                {
+                    "ci_tier": "pr",
+                    "measures": ["workflow_pass_rate", "workflow_stability_rate"]
+                },
+                {
+                    "ci_tier": "nightly",
+                    "measures": ["workflow_stability_rate", "p95_time_to_first_useful_result_ms"]
+                }
+            ]
+        });
+        fs::write(
+            fixtures_dir.join("editor_ux_fixture_matrix.json"),
+            serde_json::to_string_pretty(&matrix)?,
+        )?;
+
+        let tracked = collect_editor_ux_tracked_signals(dir.path());
+        assert_eq!(tracked.scenario_count, 2);
+        assert_eq!(tracked.workflows_total, 2);
+        assert_eq!(tracked.scenario_coverage_percent, 100);
+        assert_eq!(tracked.pr_tier_workflows, 1);
+        assert_eq!(tracked.nightly_tier_workflows, 1);
+        assert_eq!(tracked.top_line_metric_bindings_total, 4);
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- End-to-end UX confidence was only described qualitatively and not published as machine-checkable signals, making it hard to track UX regressions automatically.
- The goal is to expose a small set of tracked signals from the `perl-lsp-ux-tests` harness so the status generator and downstream tooling can measure UX coverage and tiering.

### Description
- Add `EditorUxTrackedSignals` and `collect_editor_ux_tracked_signals` in `xtask/src/tasks/update_status/quality.rs` to parse `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` and compute `workflow_count`, `scenario_coverage_percent`, PR/nightly workflow counts, and top-line metric binding totals.
- Emit a `tracked_signals` object into the generated editor UX receipt produced by `generate_editor_ux_receipt` and surface the counts in the `docs/project/status/editor_ux.json` planning scaffold.
- Extend `docs/project/status/editor_ux.schema.json` to require and validate the new `tracked_signals` fields.
- Update `README.md` wording to point the “End-to-end UX confidence” row at the published UX scorecard signals.

### Testing
- Ran `cargo test -p xtask test_collect_editor_ux_tracked_signals_from_fixture_matrix -- --test-threads=1` and the unit test passed.
- Ran `cargo test -p xtask test_editor_ux_receipt_shape -- --test-threads=1` and the unit test passed.
- Regenerated status with `cargo xtask update-status --only quality` and verified the receipt file `docs/project/status/editor_ux.json` now contains the `tracked_signals` block.
- Ran `cargo check --all-targets -p xtask`, `cargo xtask fmt`, and `cargo clippy -p xtask`, and these checks completed successfully against the modified code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c566bd9883339a57a8c5ecd579bd)