### PR TITLE
feat(status): publish editor UX confidence signals (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | Mixed (quant + qualitative) | Published via `docs/project/status/editor_ux.json` (scenario/workflow coverage + documented UX gap issue count), plus manual editor smoke workflows and `perl-lsp-ux-tests` first-5-minutes regression runs | Anything about parser breadth, protocol catalog size, or capability count |
 
 The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
 

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -28,6 +28,11 @@
     "release_lane": "just ux-tests-full",
     "status_update": "cargo xtask update-status --only quality"
   },
+  "published_signals": {
+    "documented_ux_gap_issue_count": 4,
+    "fixture_workflow_count": 17,
+    "scenario_to_fixture_workflow_delta": 0
+  },
   "receipt_kind": "planning_scaffold",
   "schema_version": 1,
   "scorecard": "editor_ux",

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -8,6 +8,7 @@
     "receipt_kind",
     "scorecard",
     "harness",
+    "published_signals",
     "top_line_metrics",
     "integration_points"
   ],
@@ -41,6 +42,29 @@
           "items": {
             "type": "string"
           }
+        }
+      },
+      "additionalProperties": false
+    },
+    "published_signals": {
+      "type": "object",
+      "required": [
+        "fixture_workflow_count",
+        "documented_ux_gap_issue_count",
+        "scenario_to_fixture_workflow_delta"
+      ],
+      "properties": {
+        "fixture_workflow_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "documented_ux_gap_issue_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "scenario_to_fixture_workflow_delta": {
+          "type": "integer",
+          "minimum": 0
         }
       },
       "additionalProperties": false

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -9,6 +9,7 @@
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
 - **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; planning scaffold at `docs/project/status/editor_ux.json`
+- **Published UX confidence signals**: 17 fixture workflows tracked in `editor_ux_fixture_matrix.json`, 4 documented UX gap issues in README, and top-line metric states published in `docs/project/status/editor_ux.json`
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -5,11 +5,24 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result};
+use regex::Regex;
 
 use super::{replace_block, run_cmd};
+
+static RUNNING_TEST_CRATE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"Running unittests[^\(]*\(target[^\)]*deps[/\\]([a-zA-Z0-9_-]+)-[0-9a-f]+\)")
+        .expect("running test crate regex must compile")
+});
+static TEST_NAME_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r":\s*test\s*$").expect("test-name regex must compile"));
+static README_ISSUE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"https://github\.com/EffortlessMetrics/perl-lsp/issues/(\d+)")
+        .expect("README issue regex must compile")
+});
 
 // ---------------------------------------------------------------------------
 // Metric collectors
@@ -45,23 +58,16 @@ pub(super) fn collect_per_crate_test_counts(root: &Path) -> BTreeMap<String, usi
         return BTreeMap::new();
     }
 
-    let running_re = regex::Regex::new(
-        r"Running unittests[^\(]*\(target[^\)]*deps[/\\]([a-zA-Z0-9_-]+)-[0-9a-f]+\)",
-    )
-    .ok();
-    let test_re = regex::Regex::new(r":\s*test\s*$").ok();
-
     let mut by_crate: BTreeMap<String, usize> = BTreeMap::new();
     let mut current_crate: Option<String> = None;
 
     for line in output.lines() {
-        if let Some(caps) = running_re.as_ref().and_then(|r| r.captures(line)) {
+        if let Some(caps) = RUNNING_TEST_CRATE_RE.captures(line) {
             let name = caps[1].replace('_', "-");
             current_crate = Some(name);
             continue;
         }
-        if let Some(re) = test_re.as_ref()
-            && re.is_match(line)
+        if TEST_NAME_RE.is_match(line)
             && let Some(ref crate_name) = current_crate
         {
             *by_crate.entry(crate_name.clone()).or_default() += 1;
@@ -122,6 +128,46 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+pub(super) fn count_documented_ux_gap_issues(readme: &str) -> usize {
+    let known_gaps_section = readme
+        .split_once("### Known gaps toward solid UX")
+        .map(|(_, rest)| {
+            if let Some((section, _)) = rest.split_once("\n#### What shipped this cycle") {
+                section
+            } else if let Some((section, _)) = rest.split_once("\n## ") {
+                section
+            } else {
+                rest
+            }
+        })
+        .unwrap_or("");
+
+    README_ISSUE_RE
+        .captures_iter(known_gaps_section)
+        .filter_map(|caps| caps.get(1).map(|id| id.as_str().to_string()))
+        .collect::<std::collections::BTreeSet<_>>()
+        .len()
+}
+
+fn collect_documented_ux_gap_issues(root: &Path) -> usize {
+    let readme_path = root.join("README.md");
+    let Ok(readme) = fs::read_to_string(readme_path) else {
+        return 0;
+    };
+    count_documented_ux_gap_issues(&readme)
+}
+
+pub(super) fn count_ux_fixture_workflows(root: &Path) -> usize {
+    let matrix_path = root.join("crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json");
+    let Ok(raw) = fs::read_to_string(matrix_path) else {
+        return 0;
+    };
+    let Ok(doc) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return 0;
+    };
+    doc.get("workflows").and_then(serde_json::Value::as_array).map_or(0, std::vec::Vec::len)
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -130,6 +176,8 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
     let mutation_by_crate = collect_per_crate_mutation(root);
     let tests_by_crate = collect_per_crate_test_counts(root);
     let ux_scenarios = count_ux_scenarios(root);
+    let ux_fixture_workflows = count_ux_fixture_workflows(root);
+    let documented_ux_gap_issues = collect_documented_ux_gap_issues(root);
 
     let has_mutation_data = !mutation_by_crate.is_empty();
     let mutation_note = if has_mutation_data {
@@ -144,6 +192,9 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
            `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
            the integration-only 10k-line large-file case; planning scaffold at \
            `docs/project/status/editor_ux.json`\n\
+         - **Published UX confidence signals**: {ux_fixture_workflows} fixture workflows tracked in \
+           `editor_ux_fixture_matrix.json`, {documented_ux_gap_issues} documented UX gap issues in \
+           README, and top-line metric states published in `docs/project/status/editor_ux.json`\n\
          - **Mutation testing**: {mutation_note}\n\
          - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
     );
@@ -169,6 +220,8 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let fixture_workflow_count = count_ux_fixture_workflows(root);
+    let documented_ux_gap_issue_count = collect_documented_ux_gap_issues(root);
 
     let receipt = serde_json::json!({
         "schema_version": 1,
@@ -178,6 +231,11 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
             "crate": "crates/perl-lsp-ux-tests",
             "scenario_count": scenario_count,
             "scenario_files": scenario_files,
+        },
+        "published_signals": {
+            "fixture_workflow_count": fixture_workflow_count,
+            "documented_ux_gap_issue_count": documented_ux_gap_issue_count,
+            "scenario_to_fixture_workflow_delta": scenario_count.saturating_sub(fixture_workflow_count),
         },
         "top_line_metrics": [
             {
@@ -265,6 +323,11 @@ mod tests {
             receipt["harness"]["scenario_count"].as_u64(),
             Some(count_ux_scenarios(&root) as u64)
         );
+        assert_eq!(
+            receipt["published_signals"]["fixture_workflow_count"].as_u64(),
+            Some(count_ux_fixture_workflows(&root) as u64)
+        );
+        assert_eq!(receipt["published_signals"]["documented_ux_gap_issue_count"].as_u64(), Some(4));
         let top_line_names = receipt["top_line_metrics"]
             .as_array()
             .ok_or_else(|| eyre!("top_line_metrics must be an array"))?
@@ -281,5 +344,18 @@ mod tests {
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
         Ok(())
+    }
+
+    #[test]
+    fn test_count_documented_ux_gap_issues_parses_unique_issue_ids() {
+        let readme = r#"
+### Known gaps toward solid UX
+- [#100](https://github.com/EffortlessMetrics/perl-lsp/issues/100)
+- [#200](https://github.com/EffortlessMetrics/perl-lsp/issues/200)
+- duplicate [#100](https://github.com/EffortlessMetrics/perl-lsp/issues/100)
+
+## Security
+"#;
+        assert_eq!(count_documented_ux_gap_issues(readme), 2);
     }
 }


### PR DESCRIPTION
### Motivation
- End-to-end UX confidence was only described qualitatively and not surfaced as a reproducible, published signal; the goal is to convert more of that qualitative signal into tracked, automatable metrics. 

### Description
- Extended the quality status generator in `xtask/src/tasks/update_status/quality.rs` to compute and publish editor-UX signals: fixture workflow coverage and documented UX gap issue counts, and to include a scenario→fixture delta. 
- Added parsing helpers `count_ux_fixture_workflows` and `count_documented_ux_gap_issues` and made the runtime regexes `LazyLock<Regex>` statics for efficiency and testability. 
- Embedded the new `published_signals` object into the editor-UX receipt produced by `generate_editor_ux_receipt` and updated the JSON schema `docs/project/status/editor_ux.schema.json` to require and validate the new fields. 
- Regenerated and updated surface files: `docs/project/status/editor_ux.json`, `docs/project/status/quality.md`, and `README.md` to show the new mixed quantitative+qualitative UX confidence signal, and added focused unit tests to validate parsing and receipt shape. 

### Testing
- Ran `cargo test -p xtask test_editor_ux_receipt_shape -- --exact` (the `test_editor_ux_receipt_shape` test) which passed. 
- Ran `cargo test -p xtask documented_ux_gap_issues` (the `test_count_documented_ux_gap_issues_parses_unique_issue_ids` unit test) which passed. 
- Verified build and tooling: `cargo check --all-targets -p xtask` passed, `cargo xtask update-status --only quality --write` updated the docs and `cargo xtask update-status --only quality --check` reported files up to date, and `cargo xtask fmt` ran. 
- Linting: `cargo clippy -p xtask` passed, while the stricter `cargo clippy -p xtask --all-targets -- -D warnings` surfaced a pre-existing `clippy::len_zero` warning in unrelated tests (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c5690c948333865a83d663d92eb7)