### PR TITLE
feat(status): track editor UX confidence signals (#0000)

### DIFF
--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -24,6 +24,7 @@
   },
   "integration_points": {
     "ci_lane": "just ux-tests",
+    "metrics_receipt": ".ci/metrics/editor_ux.json",
     "quality_surface": "docs/project/status/quality.md",
     "release_lane": "just ux-tests-full",
     "status_update": "cargo xtask update-status --only quality"
@@ -31,6 +32,23 @@
   "receipt_kind": "planning_scaffold",
   "schema_version": 1,
   "scorecard": "editor_ux",
+  "signals": [
+    {
+      "name": "manual_editor_smoke_workflows",
+      "source": "human release checklist",
+      "tracking": "qualitative"
+    },
+    {
+      "name": "first_5_minutes_harness",
+      "source": "just ux-tests / just ux-tests-full",
+      "tracking": "quantitative"
+    },
+    {
+      "name": "open_issue_burndown",
+      "source": "issue triage backlog",
+      "tracking": "qualitative"
+    }
+  ],
   "top_line_metrics": [
     {
       "name": "workflow_pass_rate",

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -8,6 +8,7 @@
     "receipt_kind",
     "scorecard",
     "harness",
+    "signals",
     "top_line_metrics",
     "integration_points"
   ],
@@ -44,6 +45,68 @@
         }
       },
       "additionalProperties": false
+    },
+    "signals": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "allOf": [
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "const": "manual_editor_smoke_workflows"
+              }
+            },
+            "required": ["name"]
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "const": "first_5_minutes_harness"
+              }
+            },
+            "required": ["name"]
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "const": "open_issue_burndown"
+              }
+            },
+            "required": ["name"]
+          }
+        }
+      ],
+      "items": {
+        "type": "object",
+        "required": ["name", "tracking", "source"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "manual_editor_smoke_workflows",
+              "first_5_minutes_harness",
+              "open_issue_burndown"
+            ]
+          },
+          "tracking": {
+            "type": "string",
+            "enum": ["qualitative", "quantitative"]
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
     },
     "top_line_metrics": {
       "type": "array",
@@ -96,6 +159,10 @@
               "p95_time_to_first_useful_result_ms"
             ]
           },
+          "value": {
+            "type": "number",
+            "minimum": 0
+          },
           "state": {
             "type": "string",
             "enum": ["planned", "measured"]
@@ -109,7 +176,13 @@
     },
     "integration_points": {
       "type": "object",
-      "required": ["ci_lane", "release_lane", "status_update", "quality_surface"],
+      "required": [
+        "ci_lane",
+        "release_lane",
+        "status_update",
+        "quality_surface",
+        "metrics_receipt"
+      ],
       "properties": {
         "ci_lane": {
           "type": "string"
@@ -118,6 +191,9 @@
           "type": "string"
         },
         "status_update": {
+          "type": "string"
+        },
+        "metrics_receipt": {
           "type": "string"
         },
         "quality_surface": {

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -8,8 +8,21 @@ use std::path::Path;
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result};
+use serde::Deserialize;
 
 use super::{replace_block, run_cmd};
+
+#[derive(Debug, Deserialize)]
+struct EditorUxMetricsReceipt {
+    metrics: Option<EditorUxMetricValues>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EditorUxMetricValues {
+    workflow_pass_rate: Option<f64>,
+    workflow_stability_rate: Option<f64>,
+    p95_time_to_first_useful_result_ms: Option<u64>,
+}
 
 // ---------------------------------------------------------------------------
 // Metric collectors
@@ -169,6 +182,21 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let measured_metrics = load_measured_editor_ux_metrics(root)?;
+
+    let top_line_metrics = vec![
+        metric_row("workflow_pass_rate", measured_metrics.workflow_pass_rate, "perl-lsp-ux-tests"),
+        metric_row(
+            "workflow_stability_rate",
+            measured_metrics.workflow_stability_rate,
+            "perl-lsp-ux-tests",
+        ),
+        metric_row(
+            "p95_time_to_first_useful_result_ms",
+            measured_metrics.p95_time_to_first_useful_result_ms.map(|value| value as f64),
+            "perl-lsp-ux-tests",
+        ),
+    ];
 
     let receipt = serde_json::json!({
         "schema_version": 1,
@@ -179,32 +207,72 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
             "scenario_count": scenario_count,
             "scenario_files": scenario_files,
         },
-        "top_line_metrics": [
+        "signals": [
             {
-                "name": "workflow_pass_rate",
-                "state": "planned",
-                "owner": "perl-lsp-ux-tests",
+                "name": "manual_editor_smoke_workflows",
+                "tracking": "qualitative",
+                "source": "human release checklist",
             },
             {
-                "name": "workflow_stability_rate",
-                "state": "planned",
-                "owner": "perl-lsp-ux-tests",
+                "name": "first_5_minutes_harness",
+                "tracking": "quantitative",
+                "source": "just ux-tests / just ux-tests-full",
             },
             {
-                "name": "p95_time_to_first_useful_result_ms",
-                "state": "planned",
-                "owner": "perl-lsp-ux-tests",
-            },
+                "name": "open_issue_burndown",
+                "tracking": "qualitative",
+                "source": "issue triage backlog",
+            }
         ],
+        "top_line_metrics": top_line_metrics,
         "integration_points": {
             "ci_lane": "just ux-tests",
             "release_lane": "just ux-tests-full",
             "status_update": "cargo xtask update-status --only quality",
             "quality_surface": "docs/project/status/quality.md",
+            "metrics_receipt": ".ci/metrics/editor_ux.json",
         },
     });
 
     serde_json::to_string_pretty(&receipt).context("serializing editor UX receipt")
+}
+
+fn metric_row(name: &str, measured_value: Option<f64>, owner: &str) -> serde_json::Value {
+    match measured_value {
+        Some(value) => serde_json::json!({
+            "name": name,
+            "state": "measured",
+            "owner": owner,
+            "value": value,
+        }),
+        None => serde_json::json!({
+            "name": name,
+            "state": "planned",
+            "owner": owner,
+        }),
+    }
+}
+
+fn load_measured_editor_ux_metrics(root: &Path) -> Result<EditorUxMetricValues> {
+    let metrics_path = root.join(".ci/metrics/editor_ux.json");
+    if !metrics_path.exists() {
+        return Ok(EditorUxMetricValues {
+            workflow_pass_rate: None,
+            workflow_stability_rate: None,
+            p95_time_to_first_useful_result_ms: None,
+        });
+    }
+
+    let raw = fs::read_to_string(&metrics_path)
+        .with_context(|| format!("reading {}", metrics_path.display()))?;
+    let parsed: EditorUxMetricsReceipt = serde_json::from_str(&raw)
+        .with_context(|| format!("parsing {}", metrics_path.display()))?;
+
+    Ok(parsed.metrics.unwrap_or(EditorUxMetricValues {
+        workflow_pass_rate: None,
+        workflow_stability_rate: None,
+        p95_time_to_first_useful_result_ms: None,
+    }))
 }
 
 // ---------------------------------------------------------------------------
@@ -279,7 +347,22 @@ mod tests {
                 "p95_time_to_first_useful_result_ms",
             ])
         );
+        let signal_names = receipt["signals"]
+            .as_array()
+            .ok_or_else(|| eyre!("signals must be an array"))?
+            .iter()
+            .map(|row| row["name"].as_str().ok_or_else(|| eyre!("signal name missing")))
+            .collect::<Result<std::collections::BTreeSet<_>>>()?;
+        assert_eq!(
+            signal_names,
+            std::collections::BTreeSet::from([
+                "manual_editor_smoke_workflows",
+                "first_5_minutes_harness",
+                "open_issue_burndown",
+            ])
+        );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        assert_eq!(receipt["integration_points"]["metrics_receipt"], ".ci/metrics/editor_ux.json");
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- End-to-end editor UX confidence lived as narrative and planned-only rows; we need machine-readable signals and a path to mark top-line metrics as measured from the harness so the status can be validated and automated.

### Description
- Added measured-metrics plumbing to `xtask/src/tasks/update_status/quality.rs`, including `EditorUxMetricValues`/`EditorUxMetricsReceipt`, `load_measured_editor_ux_metrics`, and `metric_row` to emit `measured` rows with `value` when `.ci/metrics/editor_ux.json` exists. 
- Extended the generated receipt to include a `signals` array with the three tracked inputs `manual_editor_smoke_workflows`, `first_5_minutes_harness`, and `open_issue_burndown`, and wired `metrics_receipt` integration to `.ci/metrics/editor_ux.json`.
- Bumped the Editor UX JSON schema `docs/project/status/editor_ux.schema.json` to require and validate the new `signals` array and allow a numeric `value` on top-line metric rows, and updated the published scaffold `docs/project/status/editor_ux.json` to match.
- Tightened the unit test `test_editor_ux_receipt_shape` to assert the new `signals` entries and `integration_points.metrics_receipt` to prevent future schema drift.

### Testing
- Ran `cargo test -p xtask test_editor_ux_receipt_shape -- --nocapture`, which passed. 
- Ran `cargo check --all-targets -p xtask`, which passed. 
- Ran formatting and lint gates `cargo xtask fmt` and `cargo clippy -p xtask -- -D warnings`, which passed. 
- Ran `cargo xtask update-status --only quality --write` to regenerate the scaffold and verify output (updated `docs/project/status/editor_ux.json`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c5690c948333865a83d663d92eb7)