### PR TITLE
fix(xtask): track editor UX confidence signals (#0000)

### DIFF
--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -1,4 +1,23 @@
 {
+  "confidence_signals": {
+    "first_5_minutes_harness": {
+      "command": "just ux-tests",
+      "kind": "quantitative",
+      "scenario_count": 17,
+      "status": "tracked"
+    },
+    "manual_editor_smoke_workflows": {
+      "evidence": "Tier C: docs/project/protocols/verification.md",
+      "kind": "qualitative",
+      "status": "tracked"
+    },
+    "open_issue_burn_down": {
+      "kind": "quantitative",
+      "known_issues_count": 0,
+      "source": ".ci/debt-ledger.yaml",
+      "status": "tracked"
+    }
+  },
   "harness": {
     "crate": "crates/perl-lsp-ux-tests",
     "scenario_count": 17,
@@ -35,17 +54,20 @@
     {
       "name": "workflow_pass_rate",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "planned",
+      "value": null
     },
     {
       "name": "workflow_stability_rate",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "planned",
+      "value": null
     },
     {
       "name": "p95_time_to_first_useful_result_ms",
       "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "planned",
+      "value": null
     }
   ]
 }

--- a/docs/project/status/editor_ux.schema.json
+++ b/docs/project/status/editor_ux.schema.json
@@ -9,6 +9,7 @@
     "scorecard",
     "harness",
     "top_line_metrics",
+    "confidence_signals",
     "integration_points"
   ],
   "properties": {
@@ -18,7 +19,7 @@
     },
     "receipt_kind": {
       "type": "string",
-      "const": "planning_scaffold"
+      "enum": ["planning_scaffold", "tracked_scorecard"]
     },
     "scorecard": {
       "type": "string",
@@ -102,10 +103,56 @@
           },
           "owner": {
             "type": "string"
+          },
+          "value": {
+            "type": ["number", "integer", "null"]
           }
         },
         "additionalProperties": false
       }
+    },
+    "confidence_signals": {
+      "type": "object",
+      "required": [
+        "manual_editor_smoke_workflows",
+        "first_5_minutes_harness",
+        "open_issue_burn_down"
+      ],
+      "properties": {
+        "manual_editor_smoke_workflows": {
+          "type": "object",
+          "required": ["kind", "status", "evidence"],
+          "properties": {
+            "kind": { "const": "qualitative" },
+            "status": { "const": "tracked" },
+            "evidence": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "first_5_minutes_harness": {
+          "type": "object",
+          "required": ["kind", "status", "scenario_count", "command"],
+          "properties": {
+            "kind": { "const": "quantitative" },
+            "status": { "const": "tracked" },
+            "scenario_count": { "type": "integer", "minimum": 0 },
+            "command": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "open_issue_burn_down": {
+          "type": "object",
+          "required": ["kind", "status", "source", "known_issues_count"],
+          "properties": {
+            "kind": { "const": "quantitative" },
+            "status": { "enum": ["tracked", "unavailable"] },
+            "source": { "type": "string" },
+            "known_issues_count": { "type": ["integer", "null"], "minimum": 0 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     },
     "integration_points": {
       "type": "object",

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -169,31 +169,72 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let ux_metrics = load_editor_ux_metrics(root);
+    let known_issues = load_known_issues_count(root);
+
+    let workflow_pass_rate = ux_metrics
+        .as_ref()
+        .and_then(|metrics| metrics.get("workflow_pass_rate"))
+        .and_then(serde_json::Value::as_f64);
+    let workflow_stability_rate = ux_metrics
+        .as_ref()
+        .and_then(|metrics| metrics.get("workflow_stability_rate"))
+        .and_then(serde_json::Value::as_f64);
+    let p95_first_result_ms = ux_metrics
+        .as_ref()
+        .and_then(|metrics| metrics.get("p95_time_to_first_useful_result_ms"))
+        .and_then(serde_json::Value::as_u64);
 
     let receipt = serde_json::json!({
         "schema_version": 1,
-        "receipt_kind": "planning_scaffold",
+        "receipt_kind": if workflow_pass_rate.is_some() || workflow_stability_rate.is_some() || p95_first_result_ms.is_some() {
+            "tracked_scorecard"
+        } else {
+            "planning_scaffold"
+        },
         "scorecard": "editor_ux",
         "harness": {
             "crate": "crates/perl-lsp-ux-tests",
             "scenario_count": scenario_count,
             "scenario_files": scenario_files,
         },
+        "confidence_signals": {
+            "manual_editor_smoke_workflows": {
+                "kind": "qualitative",
+                "status": "tracked",
+                "evidence": "Tier C: docs/project/protocols/verification.md",
+            },
+            "first_5_minutes_harness": {
+                "kind": "quantitative",
+                "status": "tracked",
+                "scenario_count": scenario_count,
+                "command": "just ux-tests",
+            },
+            "open_issue_burn_down": {
+                "kind": "quantitative",
+                "status": if known_issues.is_some() { "tracked" } else { "unavailable" },
+                "source": ".ci/debt-ledger.yaml",
+                "known_issues_count": known_issues,
+            },
+        },
         "top_line_metrics": [
             {
                 "name": "workflow_pass_rate",
-                "state": "planned",
+                "state": if workflow_pass_rate.is_some() { "measured" } else { "planned" },
                 "owner": "perl-lsp-ux-tests",
+                "value": workflow_pass_rate,
             },
             {
                 "name": "workflow_stability_rate",
-                "state": "planned",
+                "state": if workflow_stability_rate.is_some() { "measured" } else { "planned" },
                 "owner": "perl-lsp-ux-tests",
+                "value": workflow_stability_rate,
             },
             {
                 "name": "p95_time_to_first_useful_result_ms",
-                "state": "planned",
+                "state": if p95_first_result_ms.is_some() { "measured" } else { "planned" },
                 "owner": "perl-lsp-ux-tests",
+                "value": p95_first_result_ms,
             },
         ],
         "integration_points": {
@@ -205,6 +246,20 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     });
 
     serde_json::to_string_pretty(&receipt).context("serializing editor UX receipt")
+}
+
+fn load_editor_ux_metrics(root: &Path) -> Option<serde_json::Value> {
+    let path = root.join(".ci").join("metrics").join("editor_ux.json");
+    let raw = fs::read_to_string(path).ok()?;
+    let doc: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    doc.get("metrics").cloned()
+}
+
+fn load_known_issues_count(root: &Path) -> Option<usize> {
+    let path = root.join(".ci").join("debt-ledger.yaml");
+    let raw = fs::read_to_string(path).ok()?;
+    let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&raw).ok()?;
+    doc.get("known_issues").and_then(serde_yaml_ng::Value::as_sequence).map(std::vec::Vec::len)
 }
 
 // ---------------------------------------------------------------------------
@@ -258,7 +313,10 @@ mod tests {
         let receipt_raw = generate_editor_ux_receipt(&root)?;
         let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
         assert_eq!(receipt["schema_version"], 1);
-        assert_eq!(receipt["receipt_kind"], "planning_scaffold");
+        assert!(
+            receipt["receipt_kind"] == "planning_scaffold"
+                || receipt["receipt_kind"] == "tracked_scorecard"
+        );
         assert_eq!(receipt["scorecard"], "editor_ux");
         assert_eq!(receipt["harness"]["crate"], "crates/perl-lsp-ux-tests");
         assert_eq!(
@@ -279,7 +337,48 @@ mod tests {
                 "p95_time_to_first_useful_result_ms",
             ])
         );
+        let confidence = receipt["confidence_signals"]
+            .as_object()
+            .ok_or_else(|| eyre!("confidence_signals must be an object"))?;
+        assert!(confidence.contains_key("manual_editor_smoke_workflows"));
+        assert!(confidence.contains_key("first_5_minutes_harness"));
+        assert!(confidence.contains_key("open_issue_burn_down"));
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        Ok(())
+    }
+
+    #[test]
+    fn test_editor_ux_receipt_uses_measured_metrics_when_present() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::create_dir_all(dir.path().join(".ci/metrics"))?;
+        fs::create_dir_all(dir.path().join("crates/perl-lsp-ux-tests/tests"))?;
+        fs::write(
+            dir.path().join("crates/perl-lsp-ux-tests/tests/ux_scenario_01_example.rs"),
+            "#[test]\nfn sample() {}\n",
+        )?;
+        fs::write(
+            dir.path().join(".ci/metrics/editor_ux.json"),
+            r#"{
+              "schema_version": 1,
+              "subsystem": "editor_ux",
+              "metrics": {
+                "workflow_pass_rate": 0.92,
+                "workflow_stability_rate": 0.88,
+                "p95_time_to_first_useful_result_ms": 74
+              }
+            }"#,
+        )?;
+        fs::write(
+            dir.path().join(".ci/debt-ledger.yaml"),
+            "known_issues:\n  - name: sample issue\n",
+        )?;
+
+        let receipt_raw = generate_editor_ux_receipt(dir.path())?;
+        let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
+        assert_eq!(receipt["receipt_kind"], "tracked_scorecard");
+        assert_eq!(receipt["top_line_metrics"][0]["state"], "measured");
+        assert_eq!(receipt["top_line_metrics"][0]["value"], 0.92);
+        assert_eq!(receipt["confidence_signals"]["open_issue_burn_down"]["known_issues_count"], 1);
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- The editor UX signal was only a "planning scaffold" and left end-to-end UX confidence as a qualitative, untracked statement rather than measurable signals.
- Make the first-5-minutes harness, manual smoke evidence, and open-issue burn-down visible and machine-readable so UX confidence can be tracked and promoted from "not a published number" to an instrumented scorecard.

### Description

- Emit a new `confidence_signals` block in the editor UX receipt that includes `manual_editor_smoke_workflows`, `first_5_minutes_harness`, and `open_issue_burn_down` with provenance and basic counts.
- Load optional measured UX metrics from `.ci/metrics/editor_ux.json` and surface them as `value` fields on the `top_line_metrics` entries, flipping `receipt_kind` to `tracked_scorecard` when measurements are present.
- Read `.ci/debt-ledger.yaml` to include a `known_issues_count` for the open-issue burn-down signal.
- Extend the JSON schema `docs/project/status/editor_ux.schema.json` and update tests in `xtask/src/tasks/update_status/quality.rs` to validate the new receipt shape and measured-metric behavior.

### Testing

- Ran `cargo test -p xtask update_status::quality`, and all relevant unit tests passed. 
- Ran `cargo check --all-targets -p xtask`, `cargo clippy -p xtask -- -D warnings`, and `cargo xtask fmt` with no issues. 
- Executed `cargo xtask update-status --only quality --write` which regenerated `docs/project/status/editor_ux.json` to include the new `confidence_signals` and `top_line_metrics.value` fields successfully. 
- Added a unit test that simulates `.ci/metrics/editor_ux.json` and `.ci/debt-ledger.yaml` to verify the receipt becomes `tracked_scorecard` and includes the measured values, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c5690c948333865a83d663d92eb7)