### PR TITLE
feat(status): track editor UX confidence signals (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
+| End-to-end UX confidence | Tracked in `docs/project/status/editor_ux.json` | Aggregates three concrete tracking signals: `perl-lsp-ux-tests` scenario inventory, README known-gap issue links (burn-down), and the manual smoke-playbook reference used for first-5-minutes workflows | Anything about parser breadth, protocol catalog size, or capability count |
 
-The last row is the important one: *none* of the automated metrics above measure whether a real editing session feels good. That's validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below, not by a dashboard.
+The last row is the important one: *none* of the parser/capability metrics above measure whether a real editing session feels good. That confidence is now tracked in `docs/project/status/editor_ux.json` using workflow harness inventory + known-gap burn-down signals, with manual smoke workflows anchored to `docs/reference/UX_TESTING.md`.
 
 Live numbers live in [docs/project/status/parser.md](docs/project/status/parser.md); this table may lag a merge cycle.
 

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -47,5 +47,10 @@
       "owner": "perl-lsp-ux-tests",
       "state": "planned"
     }
-  ]
+  ],
+  "tracking_signals": {
+    "known_gap_issue_links": 8,
+    "manual_smoke_workflow_reference": "docs/reference/UX_TESTING.md",
+    "workflow_harness_scenario_count": 17
+  }
 }

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -8,7 +8,8 @@
 
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
-- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; planning scaffold at `docs/project/status/editor_ux.json`
+- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; tracked scorecard metadata lives in `docs/project/status/editor_ux.json`
+- **UX gap burn-down tracker**: 8 linked issue(s) in the README "Known gaps toward solid UX" section
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -122,6 +122,43 @@ pub(super) fn count_ux_scenarios(root: &Path) -> usize {
     collect_ux_scenario_files(root).len()
 }
 
+pub(super) fn count_known_gap_issue_links(root: &Path) -> usize {
+    let Ok(readme) = fs::read_to_string(root.join("README.md")) else {
+        return 0;
+    };
+
+    let mut in_known_gaps = false;
+    let mut issues = std::collections::BTreeSet::new();
+
+    for line in readme.lines() {
+        if line.starts_with("### Known gaps toward solid UX") {
+            in_known_gaps = true;
+            continue;
+        }
+
+        if in_known_gaps && line.starts_with("## ") {
+            break;
+        }
+
+        if !in_known_gaps {
+            continue;
+        }
+
+        let mut remaining = line;
+        while let Some(idx) = remaining.find("/issues/") {
+            let tail = &remaining[idx + "/issues/".len()..];
+            let digits: String = tail.chars().take_while(|ch| ch.is_ascii_digit()).collect();
+            let digits_len = digits.len();
+            if !digits.is_empty() {
+                issues.insert(digits);
+            }
+            remaining = &tail[digits_len..];
+        }
+    }
+
+    issues.len()
+}
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------
@@ -130,6 +167,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
     let mutation_by_crate = collect_per_crate_mutation(root);
     let tests_by_crate = collect_per_crate_test_counts(root);
     let ux_scenarios = count_ux_scenarios(root);
+    let known_gap_issues = count_known_gap_issue_links(root);
 
     let has_mutation_data = !mutation_by_crate.is_empty();
     let mutation_note = if has_mutation_data {
@@ -142,8 +180,10 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
         "- **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing\n\
          - **UX workflow harness**: {ux_scenarios} scenario files in `perl-lsp-ux-tests`; \
            `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
-           the integration-only 10k-line large-file case; planning scaffold at \
+           the integration-only 10k-line large-file case; tracked scorecard metadata lives in \
            `docs/project/status/editor_ux.json`\n\
+         - **UX gap burn-down tracker**: {known_gap_issues} linked issue(s) in the README \
+           \"Known gaps toward solid UX\" section\n\
          - **Mutation testing**: {mutation_note}\n\
          - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
     );
@@ -169,6 +209,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
 pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
+    let known_gap_issues = count_known_gap_issue_links(root);
 
     let receipt = serde_json::json!({
         "schema_version": 1,
@@ -201,6 +242,11 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
             "release_lane": "just ux-tests-full",
             "status_update": "cargo xtask update-status --only quality",
             "quality_surface": "docs/project/status/quality.md",
+        },
+        "tracking_signals": {
+            "workflow_harness_scenario_count": scenario_count,
+            "known_gap_issue_links": known_gap_issues,
+            "manual_smoke_workflow_reference": "docs/reference/UX_TESTING.md",
         },
     });
 
@@ -280,6 +326,30 @@ mod tests {
             ])
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        assert_eq!(
+            receipt["tracking_signals"]["known_gap_issue_links"].as_u64(),
+            Some(count_known_gap_issue_links(&root) as u64)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_count_known_gap_issue_links_from_readme_slice() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let readme = r#"
+## Status
+irrelevant
+
+### Known gaps toward solid UX
+- one [#100](https://github.com/EffortlessMetrics/perl-lsp/issues/100)
+- dup [#100](https://github.com/EffortlessMetrics/perl-lsp/issues/100)
+- two [#200](https://github.com/EffortlessMetrics/perl-lsp/issues/200)
+
+## Security
+done
+"#;
+        fs::write(dir.path().join("README.md"), readme)?;
+        assert_eq!(count_known_gap_issue_links(dir.path()), 2);
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- End-to-end UX confidence was recorded only as qualitative prose and not published as concrete signals, making harness coverage and issue burn-down hard to track automatically.
- Surface actionable, machine-readable UX signals so status pages and automation can measure scenario inventory and known-gap burn-down.

### Description
- Add `count_known_gap_issue_links(root: &Path) -> usize` to `xtask/src/tasks/update_status/quality.rs` to parse the README `### Known gaps toward solid UX` section and count unique linked issue IDs.
- Wire the new counter into `generate_quality_status` and `generate_editor_ux_receipt` to expose `known_gap_issue_links` and a `tracking_signals` block alongside the existing UX harness `scenario_count` and `scenario_files` output.
- Update generated quality surface text and `docs/project/status/editor_ux.json` to include the new UX gap burn-down tracker and reference the manual smoke-playbook at `docs/reference/UX_TESTING.md`.
- Add unit test `test_count_known_gap_issue_links_from_readme_slice` and extend the editor-UX receipt test to assert the presence of the new tracking signal.

### Testing
- Ran `cargo test -p xtask update_status::quality` and all tests passed (`5 passed, 0 failed`).
- Ran `cargo check --all-targets -p xtask` and it completed successfully.
- Ran `cargo clippy -p xtask -- -D warnings` with no warnings reported.
- Ran `cargo xtask fmt` and `cargo xtask update-status --only quality --write`, which updated `docs/project/status/quality.md` and `docs/project/status/editor_ux.json` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c56b6ac8833383fe92545bcbd978)