### PR TITLE
fix(ci-hygiene): collapse hash-comment guard condition (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -4122,15 +4122,14 @@ fn find_hash_comment_start(line: &str, perl_mode: bool) -> Option<usize> {
                 if perl_mode {
                     return Some(idx);
                 }
-                if let Some(prev) = line[..idx].chars().next_back() {
-                    if prev.is_whitespace()
+                if let Some(prev) = line[..idx].chars().next_back()
+                    && (prev.is_whitespace()
                         || matches!(
                             prev,
                             ';' | '{' | '}' | '(' | ')' | '[' | ']' | '&' | '|' | '<' | '>' | ','
-                        )
-                    {
-                        return Some(idx);
-                    }
+                        ))
+                {
+                    return Some(idx);
                 }
             }
             _ => {}


### PR DESCRIPTION
### Motivation
- Fix a Clippy `collapsible_if` lint in the hash-comment detection so `perl-ci-hygiene` compiles cleanly with `-D warnings` while preserving existing behavior.

### Description
- Replace a nested `if let` + inner `if` with a let-chain `if let Some(prev) = ... && (prev.is_whitespace() || matches!(...))` in `find_hash_comment_start` to satisfy the lint.

### Testing
- Ran `cargo test -p perl-ci-hygiene`, `cargo check --all-targets -p perl-ci-hygiene`, `cargo clippy -p perl-ci-hygiene -- -D warnings`, and `cargo xtask fmt`, all of which succeeded; `just pr-fast` was not executed because `just` is unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e999c7ca208333914b39e3f9ab4ce1)