### PR TITLE
fix(perl-lexer): justify deprecated re-export allow (#0000)

### DIFF
--- a/crates/perl-lexer/src/api.rs
+++ b/crates/perl-lexer/src/api.rs
@@ -25,5 +25,6 @@ pub use crate::builtins::phf_lookup::{
 // tokenizer module (AST-agnostic slice only; TokenStream lives in
 // perl-parser-core because it depends on perl-error)
 pub use crate::tokenizer::token_wrapper::{PositionTracker, TokenWithPosition};
+// Re-export deprecated helpers for downstream compatibility during tokenizer API migration.
 #[allow(deprecated)]
 pub use crate::tokenizer::util::{code_slice, find_data_marker_byte, find_data_marker_byte_lexed};


### PR DESCRIPTION
### Motivation
- Repository linting policy requires every `#[allow(...)]` to have an adjacent justification comment, and `crates/perl-lexer/src/api.rs` contained an undocumented `#[allow(deprecated)]` for a tokenizer util re-export.

### Description
- Add a one-line justification comment immediately above the `#[allow(deprecated)]` for the deprecated tokenizer helper re-export in `crates/perl-lexer/src/api.rs` to document why the allowance is present during the tokenizer API migration.

### Testing
- Ran `cargo check --all-targets -p perl-lexer` and `cargo clippy -p perl-lexer --all-targets -- -D warnings`, both of which passed; `cargo test -p perl-lexer` exercised the crate but failed due to a pre-existing unrelated assertion in `wave_c_collapse_hardening::workspace_has_exactly_97_members_after_wave_c`; `just pr-fast` could not be run in this environment because `just: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf87cb80833388c941cfbc66a47c)