### PR TITLE
refactor(perl-dap): cache step-in target regex (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/execution.rs
+++ b/crates/perl-dap/src/debug_adapter/execution.rs
@@ -1,6 +1,10 @@
 //! Execution control: continue, next, step in, step out, pause, goto, cancel.
 
 use super::*;
+use std::sync::LazyLock;
+
+static STEP_IN_TARGET_CALL_RE: LazyLock<Option<Regex>> =
+    LazyLock::new(|| Regex::new(r"(\w[\w:]*)\s*\(").ok());
 
 impl DebugAdapter {
     /// Handle continue request
@@ -427,26 +431,14 @@ impl DebugAdapter {
                     let line_idx = frame_line as usize;
                     if let Some(source_line) = content.lines().nth(line_idx.saturating_sub(1)) {
                         // Find function call patterns
-                        let call_re = match Regex::new(r"(\w[\w:]*)\s*\(") {
-                            Ok(re) => re,
-                            Err(_) => {
-                                let body = StepInTargetsResponseBody { targets };
-                                return DapMessage::Response {
-                                    seq,
-                                    request_seq,
-                                    success: true,
-                                    command: "stepInTargets".to_string(),
-                                    body: serde_json::to_value(&body).ok(),
-                                    message: None,
-                                };
-                            }
-                        };
-                        for (idx, cap) in call_re.captures_iter(source_line).enumerate() {
-                            if let Some(name) = cap.get(1) {
-                                targets.push(StepInTarget {
-                                    id: idx as i64,
-                                    label: name.as_str().to_string(),
-                                });
+                        if let Some(call_re) = STEP_IN_TARGET_CALL_RE.as_ref() {
+                            for (idx, cap) in call_re.captures_iter(source_line).enumerate() {
+                                if let Some(name) = cap.get(1) {
+                                    targets.push(StepInTarget {
+                                        id: idx as i64,
+                                        label: name.as_str().to_string(),
+                                    });
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
### Motivation
- The `stepInTargets` handler compiled the same call-detection regex on every request, causing avoidable work on a hot execution path.

### Description
- Hoisted the call-detection regex into a module-level `LazyLock<Option<Regex>>` named `STEP_IN_TARGET_CALL_RE` in `crates/perl-dap/src/debug_adapter/execution.rs` to cache the compiled pattern.
- Replaced the per-request `Regex::new(...)` creation with reuse of the cached regex and preserved the previous behavior of returning an empty `targets` list when regex initialization fails.

### Testing
- Ran `cargo xtask fmt`, `cargo check --all-targets -p perl-dap`, and `cargo clippy -p perl-dap`, all of which completed successfully.
- Ran `cargo test -p perl-dap`, which ran the test suite but `dap_e2e_workflow_tests::test_e2e_multi_breakpoint_sequence` failed with an assertion mismatch (`expected line 5, got 4`).
- `just pr-fast` was not available in the execution environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf87cb80833388c941cfbc66a47c)