### PR TITLE
refactor(xtask-compare): reuse benchmark parsing and fix success count (#0000)

### DIFF
--- a/xtask/src/tasks/compare.rs
+++ b/xtask/src/tasks/compare.rs
@@ -356,6 +356,7 @@ fn run_single_test(
 ) -> Result<Option<serde_json::Value>> {
     let mut times = Vec::new();
     let mut memories = Vec::new();
+    let mut successful_iterations = 0usize;
     let mut parse_success = false;
     let mut parse_error = false;
 
@@ -381,6 +382,7 @@ fn run_single_test(
         times.push(elapsed);
         memories.push(memory);
         if ok {
+            successful_iterations += 1;
             parse_success = true;
         } else {
             parse_error = true;
@@ -416,7 +418,7 @@ fn run_single_test(
 
     Ok(Some(serde_json::json!({
         "iterations": iterations,
-        "successful_iterations": times.len(),
+        "successful_iterations": successful_iterations,
         "avg_time": avg_time,
         "min_time": min_time,
         "max_time": max_time,
@@ -431,16 +433,13 @@ fn run_single_test(
     })))
 }
 
-fn test_c_implementation(file_path: &str) -> Result<(bool, f64)> {
-    let output =
-        std::process::Command::new("./target/debug/bench_parser_c").arg(file_path).output()?;
-    let stdout = String::from_utf8_lossy(&output.stdout);
+fn parse_benchmark_stdout(stdout: &str) -> (bool, f64) {
     let mut has_error = false;
     let mut duration = 0.0;
+
     for line in stdout.lines() {
         if line.starts_with("status=") {
-            let parts: Vec<_> = line.split_whitespace().collect();
-            for part in parts {
+            for part in line.split_whitespace() {
                 if let Some(stripped) = part.strip_prefix("error=") {
                     has_error = stripped.parse::<bool>().unwrap_or(false);
                 }
@@ -450,6 +449,15 @@ fn test_c_implementation(file_path: &str) -> Result<(bool, f64)> {
             }
         }
     }
+
+    (has_error, duration)
+}
+
+fn test_c_implementation(file_path: &str) -> Result<(bool, f64)> {
+    let output =
+        std::process::Command::new("./target/debug/bench_parser_c").arg(file_path).output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let (has_error, duration) = parse_benchmark_stdout(&stdout);
     // Only return an error if the binary itself failed (non-zero exit code)
     // Parse errors (error=true) are valid results to be compared
     if !output.status.success() {
@@ -463,21 +471,7 @@ fn test_rust_implementation(file_path: &str) -> Result<(bool, f64)> {
     let output =
         std::process::Command::new("./target/debug/bench_parser").arg(file_path).output()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut has_error = false;
-    let mut duration = 0.0;
-    for line in stdout.lines() {
-        if line.starts_with("status=") {
-            let parts: Vec<_> = line.split_whitespace().collect();
-            for part in parts {
-                if let Some(stripped) = part.strip_prefix("error=") {
-                    has_error = stripped.parse::<bool>().unwrap_or(false);
-                }
-                if let Some(stripped) = part.strip_prefix("duration_us=") {
-                    duration = stripped.parse::<f64>().unwrap_or(0.0);
-                }
-            }
-        }
-    }
+    let (has_error, duration) = parse_benchmark_stdout(&stdout);
     // Only return an error if the binary itself failed (non-zero exit code)
     // Parse errors (error=true) are valid results to be compared
     if !output.status.success() {
@@ -1170,5 +1164,23 @@ mod tests {
         assert_eq!(avg_memory, 3.0);
         assert_eq!(min_memory, 1.0);
         assert_eq!(max_memory, 5.0);
+    }
+
+    #[test]
+    fn test_parse_benchmark_stdout_extracts_status_fields() {
+        let stdout = "header\nstatus=ok error=true duration_us=123.5\nfooter";
+        let (has_error, duration) = parse_benchmark_stdout(stdout);
+
+        assert!(has_error);
+        assert!((duration - 123.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_parse_benchmark_stdout_defaults_when_missing_values() {
+        let stdout = "status=ok";
+        let (has_error, duration) = parse_benchmark_stdout(stdout);
+
+        assert!(!has_error);
+        assert_eq!(duration, 0.0);
     }
 }


### PR DESCRIPTION
### Motivation

- The compare task duplicated stdout parsing for C/Rust benchmark binaries and reported `successful_iterations` as the total iterations even when some runs failed, which inflated success counts.

### Description

- Extracted a shared helper `parse_benchmark_stdout` to centralize extraction of `error=` and `duration_us=` from benchmark output and reused it in both `test_c_implementation` and `test_rust_implementation`.
- Track `successful_iterations` by incrementing only on actually successful parse runs instead of using the total iterations length.
- Added focused unit tests covering `parse_benchmark_stdout` behavior and updated test assertions accordingly.
- Changes are confined to `xtask/src/tasks/compare.rs` and are implemented as a focused refactor with no external API changes.

### Testing

- Ran `cargo test -p xtask test_parse_benchmark_stdout -- --nocapture`, which passed (2 tests OK).
- Ran `cargo check --all-targets -p xtask`, which passed.
- Ran `cargo xtask fmt`, which completed successfully.
- Ran `cargo clippy -p xtask --bin xtask -- -D warnings`, which passed; a full `cargo clippy -p xtask --all-targets -- -D warnings` failed on a pre-existing unrelated lint in `xtask/tests/wave1_perl_module_collapse_tests.rs` and is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf85837083338f9be840d24f32ea)