### PR TITLE
feat(perl-line-index): add checked position conversion (#0000)

### DIFF
--- a/crates/perl-line-index/src/lib.rs
+++ b/crates/perl-line-index/src/lib.rs
@@ -13,6 +13,8 @@
 pub struct LineIndex {
     /// Byte offset of each line start.
     line_starts: Vec<usize>,
+    /// Total number of bytes in the indexed text.
+    text_len: usize,
 }
 
 impl LineIndex {
@@ -25,7 +27,7 @@ impl LineIndex {
                 line_starts.push(idx + 1);
             }
         }
-        Self { line_starts }
+        Self { line_starts, text_len: text.len() }
     }
 
     /// Convert a byte offset to `(line, column)` using byte columns.
@@ -40,5 +42,22 @@ impl LineIndex {
     #[must_use]
     pub fn position_to_byte(&self, line: usize, column: usize) -> Option<usize> {
         self.line_starts.get(line).map(|&start| start + column)
+    }
+
+    /// Convert `(line, column)` to byte offset, returning `None` for out-of-range columns.
+    ///
+    /// This variant validates that the computed byte offset falls within the line's byte range.
+    /// In contrast, [`Self::position_to_byte`] only validates the line number.
+    #[must_use]
+    pub fn position_to_byte_checked(&self, line: usize, column: usize) -> Option<usize> {
+        let start = *self.line_starts.get(line)?;
+        let end = self.line_starts.get(line + 1).copied().unwrap_or(self.text_len);
+        let max_column = end - start;
+
+        if column > max_column {
+            return None;
+        }
+
+        Some(start + column)
     }
 }

--- a/crates/perl-line-index/tests/line_index_roundtrip.rs
+++ b/crates/perl-line-index/tests/line_index_roundtrip.rs
@@ -13,3 +13,17 @@ fn out_of_bounds_line_returns_none() {
     let index = LineIndex::new("one\ntwo");
     assert_eq!(index.position_to_byte(10, 0), None);
 }
+
+#[test]
+fn checked_position_to_byte_rejects_out_of_range_column() {
+    let index = LineIndex::new("one\ntwo");
+    assert_eq!(index.position_to_byte_checked(0, 3), Some(3));
+    assert_eq!(index.position_to_byte_checked(0, 5), None);
+}
+
+#[test]
+fn checked_position_to_byte_accepts_terminal_empty_line() {
+    let index = LineIndex::new("one\n");
+    assert_eq!(index.position_to_byte_checked(1, 0), Some(4));
+    assert_eq!(index.position_to_byte_checked(1, 1), None);
+}


### PR DESCRIPTION
### Motivation

- `position_to_byte` validated only the line number and would happily return byte offsets for columns beyond the end of a line, which can lead to incorrect offsets for callers that expect bounds-checked conversions.

### Description

- Add a `text_len: usize` field to `LineIndex` to record the total byte length of the indexed text.
- Introduce `position_to_byte_checked(&self, line: usize, column: usize) -> Option<usize>` which validates that the computed byte offset falls within the target line's byte range and returns `None` for out-of-range columns.
- Keep the existing `position_to_byte` behavior unchanged to preserve the non-breaking API, and add unit tests exercising valid and invalid column cases and a terminal empty-line case.

### Testing

- Ran `cargo test -p perl-line-index` and all tests passed (previous failing test fixed and re-run successfully). 
- Ran `cargo check --all-targets -p perl-line-index` and it passed. 
- Ran `cargo clippy -p perl-line-index` and it passed. 
- Ran `cargo xtask fmt` to format changes; `just pr-fast` was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf85837083338f9be840d24f32ea)