### PR TITLE
feat(workspace): clear pending workspace/configuration on folder changes (#0000)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b349b03f-04c1-437d-861b-98265fb7d80d","pid":261844,"acquiredAt":1776951223223}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"b349b03f-04c1-437d-861b-98265fb7d80d","pid":261844,"acquiredAt":1776951223223}

--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ The table below is the honest state of v0.13.0 rough edges. None block basic use
 
 - **Dynamic require / literal import** — `require Module; Module->import('sym')` with static string names: goto-def on the bareword should resolve to the definition site; `@ISA` / `use parent` / `use base` chains and `use Module qw(...)` list imports already work; this is the remaining slice of the import visibility lane ([#3476](https://github.com/EffortlessMetrics/perl-lsp/issues/3476), tracked by umbrella [#4246](https://github.com/EffortlessMetrics/perl-lsp/issues/4246))
 
+#### Delivered in v0.13.x
+
+- **Dynamic workspace configuration** — per-folder `.perl-lsp.toml` remains supported and the `workspace/configuration` reverse-request flow now refreshes per-folder scoped settings on topology/config changes ([#3515](https://github.com/EffortlessMetrics/perl-lsp/issues/3515))
+
 #### What shipped this cycle (v0.12.x)
 
 These items were rough edges in the previous list and have since landed:
@@ -187,7 +191,7 @@ These items were rough edges in the previous list and have since landed:
   reverse-request flow is now implemented and merged over per-folder
   `.perl-lsp.toml` base config ([#3515](https://github.com/EffortlessMetrics/perl-lsp/issues/3515))
 
-- Parser error recovery: unclosed block recovery ([PR #4079](https://github.com/EffortlessMetrics/perl-lsp/pull/4079)), symbol extractor descends into partial `Error` nodes ([PR #4071](https://github.com/EffortlessMetrics/perl-lsp/pull/4071)) � [#3499](https://github.com/EffortlessMetrics/perl-lsp/issues/3499) closed (docs(readme): mark dynamic workspace config as shipped (#3515))
+- Parser error recovery: unclosed block recovery ([PR #4079](https://github.com/EffortlessMetrics/perl-lsp/pull/4079)), symbol extractor descends into partial `Error` nodes ([PR #4071](https://github.com/EffortlessMetrics/perl-lsp/pull/4071)) � [#3499](https://github.com/EffortlessMetrics/perl-lsp/issues/3499) closed (docs(readme): mark dynamic workspace config as shipped (#3515))
 - Import list bareword resolution for `use Module qw(...)` and tag imports — [#3472](https://github.com/EffortlessMetrics/perl-lsp/issues/3472) closed
 - `use constant` symbols tracked in visible symbol table — [#3475](https://github.com/EffortlessMetrics/perl-lsp/issues/3475) closed
 - Pragma tracker: `use if`, feature bundles, eval/sub-scoped pragma leakage (PRs #4050, #4038, #4052), conservative `eval STRING` handling (PR #4052) — [#3489 Improve](https://github.com/EffortlessMetrics/perl-lsp/issues/3489)

--- a/crates/perl-lsp-rs/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/workspace.rs
@@ -473,4 +473,38 @@ include_paths = ["other_lib"]
         assert!(msg.contains("distro package manager on Linux"));
         Ok(())
     }
+
+    #[test]
+    fn did_change_workspace_folders_clears_pending_scoped_configuration_requests()
+    -> anyhow::Result<()> {
+        let server = LspServer::new();
+        let temp = tempfile::tempdir()?;
+        let folder = temp.path().join("folder");
+        std::fs::create_dir_all(&folder)?;
+        let uri = url::Url::from_directory_path(&folder)
+            .map_err(|()| anyhow::anyhow!("failed to create folder URI"))?
+            .to_string();
+
+        server.pending_workspace_configuration_requests.lock().insert(
+            700,
+            crate::runtime::PendingWorkspaceConfigurationRequest {
+                folder_uris: vec![uri.clone()],
+                includes_global_item: true,
+                created_at: std::time::Instant::now(),
+            },
+        );
+
+        server.handle_did_change_workspace_folders(Some(serde_json::json!({
+            "event": {
+                "added": [{ "uri": uri, "name": "folder" }],
+                "removed": []
+            }
+        })))?;
+
+        assert!(
+            server.pending_workspace_configuration_requests.lock().is_empty(),
+            "workspace folder changes should invalidate stale scoped configuration requests",
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
### Motivation

- Prevent stale `workspace/configuration` reverse-request responses from being applied after workspace-folder topology changes which can mis-apply per-folder scoped settings.

### Description

- Clear `pending_workspace_configuration_requests` when `workspace/didChangeWorkspaceFolders` is handled so any in-flight scoped payloads are invalidated before re-pulling per-folder settings via `request_workspace_configuration_for_folders`.
- Add a regression test `did_change_workspace_folders_clears_pending_scoped_configuration_requests` that seeds a pending request, triggers a workspace-folder change, and asserts the pending map is cleared.
- Update `README.md` status text for issue `#3515` to reflect that the `workspace/configuration` reverse-request flow now refreshes per-folder scoped settings on topology/config changes.

### Testing

- Ran `cargo xtask fmt` which completed successfully.
- Ran the unit test `cargo test -p perl-lsp-rs --lib did_change_workspace_folders_clears_pending_scoped_configuration_requests` which passed.
- Ran `cargo check --all-targets -p perl-lsp-rs` which passed and `cargo clippy -p perl-lsp-rs` which completed with one pre-existing warning; `just pr-fast` was not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf11c9d88333b8291a11208242f5)