### PR TITLE
fix(workspace-index): canonicalize legacy ' separators in extract_module_names (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -3380,21 +3380,22 @@ fn extract_module_names_from_use_args(args: &[String]) -> Vec<String> {
     let mut modules = Vec::new();
     let mut seen = HashSet::new();
     for word in qw_words {
-        if let Some(candidate) = normalize_module_name(&word)
-            && seen.insert(candidate.to_string())
-        {
-            modules.push(candidate.to_string());
+        if let Some(candidate) = normalize_module_name(&word) {
+            let canonical = canonicalize_perl_module_name(candidate);
+            if seen.insert(canonical.clone()) {
+                modules.push(canonical);
+            }
         }
     }
 
-    modules.extend(
-        remainder
-            .split_whitespace()
-            .flat_map(|token| token.split(','))
-            .filter_map(normalize_module_name)
-            .filter(|candidate| seen.insert((*candidate).to_string()))
-            .map(str::to_string),
-    );
+    for token in remainder.split_whitespace().flat_map(|t| t.split(',')) {
+        if let Some(candidate) = normalize_module_name(token) {
+            let canonical = canonicalize_perl_module_name(candidate);
+            if seen.insert(canonical.clone()) {
+                modules.push(canonical);
+            }
+        }
+    }
 
     modules
 }


### PR DESCRIPTION
Pre-existing test failure on master caught by the tier-wiring + merge-gate path.

## What

`test_extract_module_names_legacy_separator` expected `"'Foo'Bar'"` to normalize to `"Foo::Bar"`, but the production function was returning `"Foo'Bar"` — the test was RED on master.

## Root cause

`extract_module_names_from_use_args` (crates/perl-workspace-index/src/workspace/workspace_index.rs:3359) was trim-stripping tokens and passing them through directly, without calling `canonicalize_perl_module_name` (which already exists at line 3402 and does exactly `'` → `::`).

## Fix

Apply `canonicalize_perl_module_name` to both branches (qw-words loop and remainder-split loop). Dedup now uses the canonical form as the seen-set key.

## Verify

`cargo test -p perl-workspace --lib` → **233 passed, 0 failed** (was 232 passed, 1 failed on master).

## Exposure

Caught by merge-gate `unit_full` on PR #5086. Unblocks #5086 and any other PR whose scope includes perl-workspace-index.