### PR TITLE
docs(contributing): clarify submodule setup guidance (#0000)

### DIFF
--- a/docs/contributing/FIRST_PR.md
+++ b/docs/contributing/FIRST_PR.md
@@ -9,8 +9,18 @@ git clone https://github.com/EffortlessMetrics/perl-lsp.git
 cd perl-lsp
 ```
 
-No submodules to init. The `tree-sitter-perl/` directory is legacy C code excluded from the
-default build — you can ignore it.
+This repo does **not** use Git submodules, so you do not need to run
+`git submodule update --init --recursive`.
+
+If you want to verify your clone is clean, this command should print nothing:
+
+```bash
+git submodule status
+```
+
+The `tree-sitter-perl/` directory is vendored legacy C parser code kept for historical
+reference and migration context. It is excluded from the default Rust build, so most
+first PRs can ignore it safely.
 
 ## 2. Set up the dev environment
 


### PR DESCRIPTION
### Motivation
- Make it explicit that the repository does not use Git submodules and clarify the role of `tree-sitter-perl/` so new contributors do not run unnecessary submodule commands.

### Description
- Edit `docs/contributing/FIRST_PR.md` to state the repo does **not** use submodules, add a `git submodule status` verification example, and explain that `tree-sitter-perl/` is vendored legacy parser code excluded from the default Rust build.

### Testing
- Documentation-only change; no automated crate tests were run because the change does not affect code or the build pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e4cc2ccc8333911ba7595b43e501)