### PR TITLE
docs(contributing): clarify git submodule expectations (#0000)

### DIFF
--- a/docs/contributing/FIRST_PR.md
+++ b/docs/contributing/FIRST_PR.md
@@ -12,6 +12,15 @@ cd perl-lsp
 No submodules to init. The `tree-sitter-perl/` directory is legacy C code excluded from the
 default build — you can ignore it.
 
+If you are used to projects that vendor parser grammars as Git submodules, this repo is simpler:
+`git submodule update --init --recursive` is **not** required here. For confirmation, run:
+
+```bash
+git submodule status
+```
+
+No output means there are no configured submodules (expected for this project).
+
 ## 2. Set up the dev environment
 
 **With Nix (recommended — fully reproducible):**


### PR DESCRIPTION
### Motivation
- Prevent new contributors from assuming `git submodule update --init --recursive` is required for this repo and reduce onboarding confusion.

### Description
- Add a short note to `docs/contributing/FIRST_PR.md` stating that submodules are not used here and include the verification command `git submodule status` with the expected "no output" behaviour.

### Testing
- Ran `git submodule status` which exited successfully with no output, matching the documented expectation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e4cc2ccc8333911ba7595b43e501)