### PR TITLE
docs(contributing): clarify submodule setup guidance (#0000)

### DIFF
--- a/docs/contributing/FIRST_PR.md
+++ b/docs/contributing/FIRST_PR.md
@@ -9,8 +9,10 @@ git clone https://github.com/EffortlessMetrics/perl-lsp.git
 cd perl-lsp
 ```
 
-No submodules to init. The `tree-sitter-perl/` directory is legacy C code excluded from the
-default build — you can ignore it.
+No Git submodules to initialize — this repository does not use a `.gitmodules` file.
+
+The `tree-sitter-perl/` directory is vendored legacy C code and is excluded from the
+default Rust build, so you can ignore it for normal contributor workflows.
 
 ## 2. Set up the dev environment
 


### PR DESCRIPTION
### Motivation
- Make the first-PR onboarding note explicit so contributors don't mistake the terse line as a required setup step and to explain why `tree-sitter-perl/` can be ignored.

### Description
- Update `docs/contributing/FIRST_PR.md` to state that there are no Git submodules (no `.gitmodules` file) and clarify that `tree-sitter-perl/` is vendored legacy C code excluded from the default Rust build.

### Testing
- Documentation-only change; verified the updated file contents with `nl -ba docs/contributing/FIRST_PR.md | sed -n '1,35p'` and no crate tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e4cc2ccc8333911ba7595b43e501)