### PR TITLE
ci(workflows): add windows compile bit-rot matrix (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,11 +363,15 @@ jobs:
 
   # ── Compile All Targets: catch integration-test + bench bit-rot ───────
   check-all-targets:
-    name: Compile All Targets (bit-rot guard)
-    runs-on: ubuntu-24.04
+    name: Compile All Targets (${{ matrix.os }}) (bit-rot guard)
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     needs: preflight-latest-check
     if: needs.preflight-latest-check.outputs.is_latest == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-latest]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -379,7 +383,8 @@ jobs:
         with:
           toolchain: 1.92.0
 
-      - name: Install just
+      - name: Install just (Linux only)
+        if: runner.os != 'Windows'
         uses: taiki-e/install-action@cf39a74df4a72510be4e5b63348d61067f11e64a  # v2.75.0
         with:
           tool: just
@@ -391,5 +396,10 @@ jobs:
           cache-all-crates: true
           shared-key: ci-all-targets-${{ hashFiles('Cargo.lock') }}
 
-      - name: Compile all targets (catches integration-test + bench bit-rot)
+      - name: Compile all targets (Linux via just)
+        if: runner.os != 'Windows'
         run: just check-all-targets
+
+      - name: Compile all targets (Windows direct cargo check)
+        if: runner.os == 'Windows'
+        run: cargo check --workspace --all-targets --locked


### PR DESCRIPTION
### Motivation
- Windows-specific regressions (examples: backslash handling, legacy separator compile drift, sandbox behavior) were surfacing after merges because the push CI did not run a Windows compile lane.

### Description
- Convert the existing `check-all-targets` job in `.github/workflows/ci.yml` to a two-OS matrix with `os: [ubuntu-24.04, windows-latest]` and `strategy: fail-fast: false`.
- Make the `just` installation and `just check-all-targets` invocation conditional so they run only on non-Windows runners (`if: runner.os != 'Windows'`).
- Add a Windows-safe compile step that runs `cargo check --workspace --all-targets --locked` on Windows runners (`if: runner.os == 'Windows'`).

### Testing
- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'ok'"` to validate the modified workflow YAML, and it passed.
- Attempted `python3` YAML load (`import yaml`) which failed due to `PyYAML` not being available in the environment, and thus that validation step failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e8e090188333a76a81bf149be001)