### PR TITLE
fix(ci): add Windows compatibility guard on push (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,43 @@ jobs:
           RUST_TEST_THREADS: "1"
         run: just ux-tests
 
+
+  # ── Windows Compatibility Guard: catch Windows-only regressions on push ──
+  windows-compat:
+    name: Windows Compatibility (compile + targeted tests)
+    runs-on: windows-2022
+    timeout-minutes: 20
+    needs: preflight-latest-check
+    if: needs.preflight-latest-check.outputs.is_latest == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
+        with:
+          toolchain: 1.92.0
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          shared-key: ci-windows-compat-${{ hashFiles('Cargo.lock') }}
+
+      - name: Compile all targets on Windows
+        run: cargo check --workspace --all-targets --locked
+
+      - name: Run Windows separator regression tests
+        run: |
+          cargo test --locked -p perl-workspace-index test_extract_module_names_legacy_separator
+          cargo test --locked -p perl-workspace-index test_find_dependents_matches_legacy_separator_queries
+
+      - name: Run Windows sandbox fail-closed regression test
+        run: cargo test --locked -p perl-lsp-rs test_windows_sandbox_fails_closed -- --exact
+
   # ── Compile All Targets: catch integration-test + bench bit-rot ───────
   check-all-targets:
     name: Compile All Targets (bit-rot guard)


### PR DESCRIPTION
### Motivation
- Several Windows-only regressions (backslash handling, legacy package separator behavior, and sandbox fail-closed behavior) were escaping push CI and surfacing later in breakage. 
- Push CI had no Windows lane to catch these platform-specific failures early. 
- Adding a focused Windows job reduces reactive fixes and lets the merge gate surface Windows regressions proactively.

### Description
- Added a `windows-compat` job to `.github/workflows/ci.yml` that runs on `windows-2022` and is gated by the existing preflight latest-SHA check. 
- The job runs `cargo check --workspace --all-targets --locked` and targeted tests for legacy separator handling in `perl-workspace-index` and the Windows sandbox fail-closed test in `perl-lsp-rs`. 
- The job includes cargo dependency caching (shared key `ci-windows-compat`) and reuses the same checkout/toolchain setup as other CI lanes.

### Testing
- Verified the workflow YAML parses with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'ok'"`, which succeeded. 
- No additional local Rust test runs were executed; the new Windows job will run the targeted `cargo test` cases on push/PR in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e8e090188333a76a81bf149be001)