### PR TITLE
chore(release): enforce release-history surface checks (#0000)

### DIFF
--- a/.github/pull_request_template_release.md
+++ b/.github/pull_request_template_release.md
@@ -1,0 +1,8 @@
+## Release PR checklist
+
+- [ ] Version bump included
+- [ ] `CHANGELOG.md` updated with `vX.Y.Z` section + compare link
+- [ ] `docs/releases/vX.Y.Z.md` created (curated notes + links)
+- [ ] `RELEASE_HISTORY.md` row added/updated for `vX.Y.Z`
+- [ ] Release workflow run/scheduled
+- [ ] Post-release: `gh release view vX.Y.Z` verified assets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
         with:
           tool: just
 
+      - name: Check release-history drift
+        run: just ci-release-history
+
       - name: Check formatting
         run: cargo xtask fmt --check
 

--- a/justfile
+++ b/justfile
@@ -48,6 +48,7 @@ pr-fast: _check-tools-basic
     echo "=============================================="
     START=$(date +%s)
     just _timed "fmt-check" "just fmt-check" && \
+    just _timed "release-history-check" "just ci-release-history" && \
     just _timed "readme-heading-check" "just readme-heading-check" && \
     just _timed "clippy-core" "just clippy-core" && \
     just _timed "test-core" "just test-core" && \
@@ -1266,6 +1267,10 @@ ci-publication-facts:
     @echo "📊 Checking publication facts (strict mode)..."
     @cargo xtask verify-publication-facts --strict
     @echo "✅ Publication facts check passed"
+
+# Verify release-history surfaces are in sync with git tags and changelog.
+ci-release-history:
+    @bash scripts/check_release_history.sh
 
 # Update derived metrics in docs/project/status/ subsystem files and ROADMAP.md.
 # Optionally pass a subsystem name to regenerate only that one (e.g. just status-update lsp).


### PR DESCRIPTION
### Motivation

- Ensure the repo can detect and block drift between Git tags, the curated per-release notes, and the release ledger so release documentation remains authoritative and auditable. 
- Provide a concise release-PR checklist to make required release artifacts discoverable and consistent for maintainers.

### Description

- Add a reusable `ci-release-history` just target that runs `scripts/check_release_history.sh` to validate the release-history surface. 
- Wire `ci-release-history` into the `pr-fast` just target so quick PR validation includes release-history drift checks. 
- Run `just ci-release-history` in the PR smoke job of `.github/workflows/ci.yml` to enforce the check in CI. 
- Add `.github/pull_request_template_release.md` containing a focused Release PR checklist (version bump, changelog links, `docs/releases/vX.Y.Z.md`, `RELEASE_HISTORY.md` row, workflow run, and post-release asset verification).

### Testing

- Executed the release-history validator directly: `bash scripts/check_release_history.sh` returned exit 0 and printed a single warning (`No non-RC tags found`) indicating the check ran and found no blocking drift. 
- Attempted `just ci-release-history` in this environment but `just` is not available here; CI runners that install `just` will execute the same target and exercise the same script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e85699fc8333af298d5220007460)