### PR TITLE
ci(release-history): enforce ledger drift checks (#0000)

### DIFF
--- a/.github/pull_request_template_release.md
+++ b/.github/pull_request_template_release.md
@@ -1,0 +1,8 @@
+## Release PR checklist
+
+- [ ] Version bump included
+- [ ] CHANGELOG.md updated with `vX.Y.Z` section and compare link
+- [ ] `docs/releases/vX.Y.Z.md` created/updated with curated notes and links
+- [ ] `RELEASE_HISTORY.md` row added/updated for `vX.Y.Z`
+- [ ] Release workflow run or scheduled
+- [ ] Post-release: `gh release view vX.Y.Z` verified expected assets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
 
       - name: Check formatting
         run: cargo xtask fmt --check
+      - name: Check release-history surface drift
+        run: ./scripts/check_release_history.sh
+
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -142,6 +142,9 @@ jobs:
           fi
           echo "✅ Found curated release notes: $NOTE_FILE"
 
+      - name: Verify release-history surface consistency
+        run: ./scripts/check_release_history.sh
+
       - name: Summary
         run: |
           echo "## Release Validation Complete :white_check_mark:" >> "$GITHUB_STEP_SUMMARY"

--- a/justfile
+++ b/justfile
@@ -54,7 +54,8 @@ pr-fast: _check-tools-basic
     just _timed "publish-closure" "just ci-publish-closure" && \
     just _timed "publish-manifest-check" "just ci-publish-manifest-check" && \
     just _timed "layer-check" "just ci-layer-check" && \
-    just _timed "published-crate-count" "just ci-published-crate-count"
+    just _timed "published-crate-count" "just ci-published-crate-count" && \
+    just _timed "release-history" "just ci-release-history"
     RC=$?
     END=$(date +%s)
     echo ""
@@ -960,6 +961,11 @@ ci-published-crate-count:
     @echo "✅ Published-crate count ratchet passed"
 
 # Offline manifest validation: allowlist drift + LICENSE present (see #4499)
+ci-release-history:
+    @echo "Checking release history surface for drift..."
+    ./scripts/check_release_history.sh
+    @echo "Release history surface check passed"
+
 ci-publish-manifest-check:
     @echo "Checking publish manifest (allowlist drift + LICENSE)..."
     @cargo xtask publish-manifest-check


### PR DESCRIPTION
### Motivation

- Prevent accidental drift between Git tags, curated per-release notes, CHANGELOG.md, and the canonical ledger by running an automated consistency check in CI and the release path.

### Description

- Add a release-history drift check invocation to PR CI by calling `./scripts/check_release_history.sh` in `.github/workflows/ci.yml` so PR smoke runs validate the ledger early.  
- Add the same drift check to `release-orchestration.yml` validation so release dispatch fails if the release-history surface is inconsistent.  
- Add `ci-release-history` recipe and wire it into `pr-fast` in the `justfile` so local `just ci-release-history` / `just pr-fast` can run the check.  
- Add a release-focused PR template at `.github/pull_request_template_release.md` that lists required release artifacts (`docs/releases/vX.Y.Z.md`, `RELEASE_HISTORY.md`, `CHANGELOG.md` links) to make human review consistent.

Files changed: `.github/workflows/ci.yml`, `.github/workflows/release-orchestration.yml`, `justfile`, and `.github/pull_request_template_release.md`.

### Testing

- Ran `./scripts/check_release_history.sh` locally and it exited successfully (output: "Release history drift check passed.").  
- Attempted `just ci-release-history` but `just` is not available in this execution environment so the `just` invocation could not be executed; the `ci-release-history` recipe itself simply runs `./scripts/check_release_history.sh`.  
- Changes committed with message `ci(release-history): enforce ledger drift checks (#0000)` and a PR was opened for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e85699fc8333af298d5220007460)