### PR TITLE
docs(release): enforce release-history drift checks (#0000)

### DIFF
--- a/.github/pull_request_template_release.md
+++ b/.github/pull_request_template_release.md
@@ -1,0 +1,8 @@
+## Release PR checklist
+
+- [ ] Version bump included
+- [ ] `CHANGELOG.md` updated with `vX.Y.Z` section + compare link
+- [ ] `docs/releases/vX.Y.Z.md` created/updated (curated notes + links)
+- [ ] `RELEASE_HISTORY.md` row added/updated for `vX.Y.Z`
+- [ ] Release workflow run / scheduled
+- [ ] Post-release verification completed with `gh release view vX.Y.Z`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Check formatting
         run: cargo xtask fmt --check
 
+      - name: Check release-history drift
+        run: scripts/check_release_history.sh
+
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:

--- a/justfile
+++ b/justfile
@@ -49,6 +49,7 @@ pr-fast: _check-tools-basic
     START=$(date +%s)
     just _timed "fmt-check" "just fmt-check" && \
     just _timed "readme-heading-check" "just readme-heading-check" && \
+    just _timed "release-history" "just ci-release-history" && \
     just _timed "clippy-core" "just clippy-core" && \
     just _timed "test-core" "just test-core" && \
     just _timed "publish-closure" "just ci-publish-closure" && \
@@ -952,6 +953,13 @@ ci-layer-check:
     @echo "🧱 Checking crate layer constraints..."
     @cargo xtask layer-check
     @echo "✅ Layer-check passed"
+
+
+# Release-history drift gate: tags/notes/changelog/ledger must stay aligned
+ci-release-history:
+    @echo "📚 Checking release-history surface drift..."
+    @scripts/check_release_history.sh
+    @echo "✅ Release-history drift check passed"
 
 # Ratchet: published crate count must not increase above baseline (see #4416)
 ci-published-crate-count:


### PR DESCRIPTION
### Motivation

- Release surfaces (tags, `docs/releases`, `CHANGELOG.md`, and `RELEASE_HISTORY.md`) can drift and must be validated early and often to avoid gaps in the canonical ledger.

### Description

- Add a `ci-release-history` recipe to the `justfile` that runs `scripts/check_release_history.sh` and include it in the `pr-fast` gate so quick PR validation covers release-history drift via `just`.
- Run `scripts/check_release_history.sh` as a CI step in `.github/workflows/ci.yml` so GitHub Actions will validate the ledger early in the workflow run.
- Add a release PR template `.github/pull_request_template_release.md` that lists the required release-surface checklist items (version bump, `CHANGELOG.md`, `docs/releases/vX.Y.Z.md`, and `RELEASE_HISTORY.md`).
- Files changed: `justfile`, `.github/workflows/ci.yml`, and `.github/pull_request_template_release.md`.

### Testing

- Ran `scripts/check_release_history.sh` locally and it exited successfully with the message "Release history drift check passed.".
- Attempted `just ci-release-history` but `just` is not installed in this environment so that invocation could not be executed here; the `ci-release-history` recipe is defined for CI and local environments where `just` is available.
- CI integration: the workflow now invokes `scripts/check_release_history.sh` as part of the PR smoke path so GitHub Actions will run the check on PRs (cannot run Actions here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e85699fc8333af298d5220007460)