### PR TITLE
ci(release-history): wire drift check and release PR template (#0000)

### DIFF
--- a/.github/pull_request_template_release.md
+++ b/.github/pull_request_template_release.md
@@ -1,0 +1,8 @@
+## Release PR checklist
+
+- [ ] Version bump included
+- [ ] CHANGELOG.md updated with vX.Y.Z section + compare link
+- [ ] docs/releases/vX.Y.Z.md created (curated notes + links)
+- [ ] RELEASE_HISTORY.md row added/updated for vX.Y.Z
+- [ ] Release workflow run / scheduled
+- [ ] Post-release: gh release view vX.Y.Z verified assets

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -427,6 +427,7 @@ This creates a `release/vNEW_VERSION` branch with updated `Cargo.toml` and `CHAN
 ## Release History Updates
 
 Every public release **must** update three surfaces. See [RELEASE_HISTORY.md](RELEASE_HISTORY.md) for the canonical ledger.
+For release-only pull requests, use [.github/pull_request_template_release.md](.github/pull_request_template_release.md).
 
 ### Before publishing
 

--- a/justfile
+++ b/justfile
@@ -54,7 +54,8 @@ pr-fast: _check-tools-basic
     just _timed "publish-closure" "just ci-publish-closure" && \
     just _timed "publish-manifest-check" "just ci-publish-manifest-check" && \
     just _timed "layer-check" "just ci-layer-check" && \
-    just _timed "published-crate-count" "just ci-published-crate-count"
+    just _timed "published-crate-count" "just ci-published-crate-count" && \
+    just _timed "release-history-check" "just ci-release-history-check"
     RC=$?
     END=$(date +%s)
     echo ""
@@ -85,6 +86,10 @@ readme-heading-check:
         exit 1
     fi
     echo "✅ README heading structure looks good"
+
+# Detect drift between tags, release notes files, CHANGELOG, and RELEASE_HISTORY.
+ci-release-history-check:
+    bash scripts/check_release_history.sh
 
 # Pre-merge guard: verify a PR is not draft, has merge-ready label, and title has (#NNN)
 # Usage: just pre-merge-check 3291


### PR DESCRIPTION
### Motivation
- Prevent silent drift between Git tags, per-release notes, and the canonical ledger by making the release-history check part of the standard PR validation flow.
- Provide a clear, focused PR template for release-only changes so maintainers follow the documented release-surface update steps.

### Description
- Add a `ci-release-history-check` `just` recipe that runs the existing `scripts/check_release_history.sh` check and wire it into the `pr-fast` recipe so release-history drift is checked on normal PR validation runs.
- Create `.github/pull_request_template_release.md` with a concise release PR checklist that documents the minimal files to update for a public release.
- Update `RELEASE.md` to point release-only PR authors at the new release PR template for consistent workflow usage.

### Testing
- Ran the release drift checker directly with `bash scripts/check_release_history.sh`, which printed `Release history drift check passed.` (with a `WARN: No non-RC tags found`).
- Attempted to run `just ci-release-history-check` but `just` was not installed in this environment, so the `just`-invoked recipe could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e83ef0f0833387bc8435922a1ed2)