### PR TITLE
docs(release): add release PR checklist template (#0000)

### DIFF
--- a/.github/pull_request_template_release.md
+++ b/.github/pull_request_template_release.md
@@ -1,0 +1,8 @@
+## Release PR checklist
+
+- [ ] Version bump included
+- [ ] `CHANGELOG.md` updated with `vX.Y.Z` section + compare link
+- [ ] `docs/releases/vX.Y.Z.md` created (curated notes + links)
+- [ ] `RELEASE_HISTORY.md` row added/updated for `vX.Y.Z`
+- [ ] Release workflow run / scheduled
+- [ ] Post-release: `gh release view vX.Y.Z` verified assets

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -422,6 +422,9 @@ gh workflow run version-bump.yml \
 
 This creates a `release/vNEW_VERSION` branch with updated `Cargo.toml` and `CHANGELOG.md`, then opens a PR for review.
 
+For release-scoped PRs, use the dedicated checklist template at
+`.github/pull_request_template_release.md`.
+
 ---
 
 ## Release History Updates


### PR DESCRIPTION
### Motivation
- Provide an in-repo release PR checklist so release-scoped PRs consistently update the release-history surface (per-release notes, ledger, and changelog) and reduce missed post-release steps.

### Description
- Add `.github/pull_request_template_release.md` containing the release checklist and update `RELEASE.md` to reference the template so maintainers see the checklist from the runbook.

### Testing
- Ran `bash scripts/check_release_history.sh`, which exited successfully (the script prints a non-fatal warning about no non-RC tags present in this workspace).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e83ef0f0833387bc8435922a1ed2)