### PR TITLE
docs(perl-lexer): add module-level docs for internal lexer helpers (#0000)

### DIFF
--- a/crates/perl-lexer/src/quote_handler.rs
+++ b/crates/perl-lexer/src/quote_handler.rs
@@ -1,11 +1,15 @@
+//! Quote-like operator helpers used by the lexer.
+//!
+//! This module centralizes small, reusable pieces of quote operator logic so the
+//! main lexer can stay focused on token flow. It covers:
+//! - operator classification (`q`, `qq`, `qw`, `qr`, `qx`, `m`, `s`, `tr`, `y`)
+//! - delimiter pairing helpers (for balanced delimiters such as `(...)` and `{...}`)
+//! - modifier specification tables for operators that accept trailing flags
+//! - token mapping from operator name to [`TokenType`]
+//!
+//! The parser is responsible for final modifier validation; this module keeps
+//! lightweight specs and parsing helpers for lexer-level behavior.
 use crate::TokenType;
-/// Quote operator handling with uniform delimiter processing and modifier attachment
-///
-/// This module provides consistent handling for all Perl quote-like operators:
-/// - q/qq/qw/qr/qx for quote operators
-/// - m for match operators  
-/// - s for substitution operators
-/// - tr/y for transliteration operators
 use std::sync::Arc;
 
 /// Specification for which modifiers are allowed for each operator

--- a/crates/perl-lexer/src/unicode.rs
+++ b/crates/perl-lexer/src/unicode.rs
@@ -1,8 +1,12 @@
+//! Unicode classification helpers for Perl identifier lexing.
+//!
+//! Perl permits a broader identifier character set than plain ASCII. These
+//! helpers combine `unicode-ident` XID checks with Perl-oriented extensions
+//! such as emoji and join/variation code points used in modern source text.
+//!
+//! The module also exposes lightweight counters for debug-only observability of
+//! Unicode-heavy workloads during lexer development and tuning.
 use std::sync::atomic::{AtomicU64, Ordering};
-/// Unicode character classification for Perl identifiers
-///
-/// Perl allows a wide range of Unicode characters in identifiers,
-/// including emoji and other symbols.
 use unicode_ident::{is_xid_continue, is_xid_start};
 
 // Performance tracking for Unicode operations


### PR DESCRIPTION
### Motivation

- Improve crate documentation coverage by adding proper module-level docs for internal lexer helper modules so responsibilities and intended use are clear to readers and rustdoc consumers.

### Description

- Converted file comments to crate-recognized module docs (`//!`) in `crates/perl-lexer/src/quote_handler.rs` and `crates/perl-lexer/src/unicode.rs`, adding concise descriptions of responsibilities, helper APIs, and boundaries without changing runtime behavior.

### Testing

- Ran `cargo check --all-targets -p perl-lexer`, `cargo clippy -p perl-lexer`, and `cargo xtask fmt`, which passed; executed `cargo test -p perl-lexer` where all lexer tests passed locally except a pre-existing workspace-size assertion (`workspace_has_exactly_97_members_after_wave_c`) that failed in this environment and is unrelated to these docs-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e571f4f483339eb2d9f096e32ea6)