### PR TITLE
docs(perl-lexer): expand module-level docs (#0000)

### DIFF
--- a/crates/perl-lexer/src/quote_handler.rs
+++ b/crates/perl-lexer/src/quote_handler.rs
@@ -1,11 +1,12 @@
+//! Shared quote-operator parsing primitives used by the lexer.
+//!
+//! Perl has several quote-like operators (`q`, `qq`, `qw`, `qr`, `qx`, `m`,
+//! `s`, `tr`, `y`) with overlapping delimiter and modifier behavior. This
+//! module provides small reusable helpers for delimiter pairing, operator
+//! classification, and modifier-shape normalization so the core lexer loop can
+//! stay focused on token boundaries.
+
 use crate::TokenType;
-/// Quote operator handling with uniform delimiter processing and modifier attachment
-///
-/// This module provides consistent handling for all Perl quote-like operators:
-/// - q/qq/qw/qr/qx for quote operators
-/// - m for match operators  
-/// - s for substitution operators
-/// - tr/y for transliteration operators
 use std::sync::Arc;
 
 /// Specification for which modifiers are allowed for each operator

--- a/crates/perl-lexer/src/test_format_debug.rs
+++ b/crates/perl-lexer/src/test_format_debug.rs
@@ -1,3 +1,8 @@
+//! Regression test module for format-body lexer behavior.
+//!
+//! These tests ensure malformed `format` bodies fail fast with an error token
+//! instead of stalling tokenization.
+
 #[cfg(test)]
 mod tests {
     use crate::{PerlLexer, TokenType};

--- a/crates/perl-lexer/src/unicode.rs
+++ b/crates/perl-lexer/src/unicode.rs
@@ -1,8 +1,11 @@
+//! Unicode-aware identifier helpers for the Perl lexer.
+//!
+//! This module encapsulates character-class checks used by tokenization when
+//! lexing Perl symbols and barewords. It extends `unicode-ident` behavior with
+//! Perl-specific allowances such as emoji code points and join/variation
+//! characters used in modern identifier-like grapheme clusters.
+
 use std::sync::atomic::{AtomicU64, Ordering};
-/// Unicode character classification for Perl identifiers
-///
-/// Perl allows a wide range of Unicode characters in identifiers,
-/// including emoji and other symbols.
 use unicode_ident::{is_xid_continue, is_xid_start};
 
 // Performance tracking for Unicode operations


### PR DESCRIPTION
### Motivation

- Some `perl-lexer` source modules lacked top-of-file `//!` documentation, reducing rustdoc coverage and making module responsibilities less discoverable.

### Description

- Added focused `//!` module-level rustdoc to `crates/perl-lexer/src/unicode.rs`, `crates/perl-lexer/src/quote_handler.rs`, and `crates/perl-lexer/src/test_format_debug.rs` to document their responsibilities and behavior without changing runtime logic.

### Testing

- Ran `cargo test -p perl-lexer`, which executed the crate test suite; most tests passed but a pre-existing workspace-count assertion `tests::wave_c_collapse_hardening::workspace_has_exactly_97_members_after_wave_c` failed and is unrelated to these docs-only edits. 
- Ran `cargo check --all-targets -p perl-lexer`, which passed. 
- Ran `cargo clippy -p perl-lexer`, which passed. 
- Ran `cargo xtask fmt`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e571f4f483339eb2d9f096e32ea6)