### PR TITLE
docs(perl-lsp-rs-core): add module-level docs for exports (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/lib.rs
+++ b/crates/perl-lsp-rs-core/src/lib.rs
@@ -2,17 +2,31 @@
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
 
+/// Shared capability map utilities used by feature providers.
 pub mod capability_map;
+/// Configuration models and parsing utilities for the core runtime.
 pub mod config;
+/// Integration helpers for Perl::Critic output parsing.
 pub mod critic_parser;
+/// Capability and feature metadata catalog definitions.
 pub mod feature_catalog;
+/// Feature flag, profile, and policy infrastructure.
 pub mod features;
+/// Governance helpers for feature lifecycle and enforcement.
 pub mod governance;
+/// Performance instrumentation and runtime measurement support.
 pub mod performance;
+/// Platform-specific compatibility helpers.
 pub mod platform;
+/// Protocol-level types and glue code for language tooling.
 pub mod protocol;
+/// Language Server Protocol provider implementations.
 pub mod providers;
+/// Runtime support modules (limits, cancellation, launch, and validation).
 pub mod runtime;
+/// Developer tooling utilities used by the core crate.
 pub mod tooling;
+/// Transport abstractions and message handling utilities.
 pub mod transport;
+/// URI parsing and normalization helpers.
 pub mod uri;


### PR DESCRIPTION
### Motivation
- Problem: Public `pub mod` exports in `crates/perl-lsp-rs-core/src/lib.rs` had no rustdoc text, reducing module-level documentation coverage and triggering `missing_docs` noise.

### Description
- Fix: Added concise rustdoc comments for each public `pub mod` declaration in `crates/perl-lsp-rs-core/src/lib.rs` to improve crate-level documentation coverage.

### Testing
- Verification: Ran `cargo check --all-targets -p perl-lsp-rs-core` and `cargo test -p perl-lsp-rs-core`, but both were blocked by a persistent Cargo build-directory / package-cache file lock in this environment and did not complete; `rustfmt --check crates/perl-lsp-rs-core/src/lib.rs` was also run and reported parse errors surfaced from Rust 2024 let-chain syntax in another module rather than issues with the added doc comments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e5650bfc8333a42d7a4e19af62a8)