### PR TITLE
ci(perl): add visible 5.8-5.40 runtime matrix (#0000)

### DIFF
--- a/.github/workflows/perl-version-matrix.yml
+++ b/.github/workflows/perl-version-matrix.yml
@@ -1,0 +1,69 @@
+name: Perl Version Matrix
+
+on:
+  pull_request:
+    branches: [ main, master ]
+  push:
+    branches: [ main, master ]
+  schedule:
+    - cron: '15 4 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  perl-version-matrix:
+    name: Perl ${{ matrix.perl-version }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+          - '5.8'
+          - '5.10'
+          - '5.12'
+          - '5.14'
+          - '5.16'
+          - '5.18'
+          - '5.20'
+          - '5.22'
+          - '5.24'
+          - '5.26'
+          - '5.28'
+          - '5.30'
+          - '5.32'
+          - '5.34'
+          - '5.36'
+          - '5.38'
+          - '5.40'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Perl ${{ matrix.perl-version }}
+        uses: shogo82148/actions-setup-perl@0f12f8929f8062f1f7795f8a89e9f2f88c5f6ce2 # v1.34.0
+        with:
+          perl-version: ${{ matrix.perl-version }}
+
+      - name: Report Perl runtime
+        run: |
+          perl -e 'print "$^V\n";'
+          perl -v | head -n 2
+
+      - name: Syntax smoke
+        run: |
+          cat > smoke.pl <<'PL'
+          use strict;
+          use warnings;
+
+          package Smoke;
+          sub hello {
+              my ($name) = @_;
+              return "hello $name";
+          }
+
+          print Smoke::hello('world'), "\n";
+          PL
+          perl -c smoke.pl
+          perl smoke.pl

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml"><img src="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/perl-version-matrix.yml"><img src="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/perl-version-matrix.yml/badge.svg" alt="Perl Version Matrix" /></a>
   <a href="https://crates.io/crates/perl-lsp-rs"><img src="https://img.shields.io/crates/v/perl-lsp-rs.svg" alt="crates.io" /></a>
   <a href="https://crates.io/crates/perl-lsp-rs"><img src="https://img.shields.io/crates/d/perl-lsp-rs.svg" alt="Downloads" /></a>
   <a href="https://docs.rs/perl-lsp-rs"><img src="https://docs.rs/perl-lsp-rs/badge.svg" alt="docs.rs" /></a>


### PR DESCRIPTION
### Motivation
- The repository claims support for Perl 5.8–5.40 but had no dedicated, visible CI lane proving which Perl runtimes actually boot and run; an authoritative signal is needed. 
- Provide a simple, reproducible smoke check so the project and contributors can observe which Perl versions install and execute successfully in CI.

### Description
- Add `.github/workflows/perl-version-matrix.yml` that runs on `pull_request`, `push`, scheduled, and manual dispatch with a matrix for Perl `5.8` through `5.40`, installs each runtime via `shogo82148/actions-setup-perl`, prints the runtime (`perl -v`), and runs a strict/warnings smoke script (`perl -c smoke.pl` / `perl smoke.pl`).
- Add a README badge linking to the new `perl-version-matrix.yml` workflow so the matrix is visible from the project front page.

### Testing
- Ran `cargo xtask fmt --check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e8ff3f348333ab51cd8cf8364f73)