### PR TITLE
ci(perl): add nightly runtime version matrix (#0000)

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -412,6 +412,49 @@ jobs:
         run: |
           cargo clippy --workspace --locked -- -D warnings -D clippy::all -A missing_docs
 
+  perl-version-matrix:
+    name: Perl Runtime Matrix (${{ matrix.perl_version }})
+    timeout-minutes: 45
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        perl_version: ['5.8.9', '5.16.3', '5.30.3', '5.40.0']
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
+        with:
+          toolchain: 1.92.0
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          key: ${{ runner.os }}-perl-matrix-${{ matrix.perl_version }}-${{ hashFiles('Cargo.lock') }}
+          cache-on-failure: true
+
+      - name: Install Perl ${{ matrix.perl_version }}
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl_version }}
+
+      - name: Show Perl runtime
+        run: |
+          perl -V:version
+          perl -e 'print "perl-ok\n";'
+
+      - name: Build perllsp
+        run: cargo build --locked -p perllsp --bin perllsp
+
+      - name: Runtime smoke
+        run: |
+          cargo test --locked -p perl-subprocess-runtime --test extended_unit_tests
+          target/debug/perllsp --version
+
   # ============================================================================
   # Fuzz Testing (nightly only)
   # ============================================================================

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml"><img src="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci-nightly.yml"><img src="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci-nightly.yml/badge.svg" alt="Nightly CI" /></a>
   <a href="https://crates.io/crates/perl-lsp-rs"><img src="https://img.shields.io/crates/v/perl-lsp-rs.svg" alt="crates.io" /></a>
   <a href="https://crates.io/crates/perl-lsp-rs"><img src="https://img.shields.io/crates/d/perl-lsp-rs.svg" alt="Downloads" /></a>
   <a href="https://docs.rs/perl-lsp-rs"><img src="https://docs.rs/perl-lsp-rs/badge.svg" alt="docs.rs" /></a>

--- a/docs/reference/FAQ.md
+++ b/docs/reference/FAQ.md
@@ -49,6 +49,11 @@ The parser covers Perl 5.8 through 5.40. This includes:
 - `use v5.38; class ...` object syntax (partial support)
 - Moose, Moo, and common OO frameworks (detection-level support)
 
+The runtime compatibility matrix is now explicitly exercised in nightly CI at:
+Perl **5.8.9**, **5.16.3**, **5.30.3**, and **5.40.0** (`ci-nightly.yml` job
+`perl-version-matrix`). This verifies what actually runs in CI rather than
+relying on an undocumented assumption.
+
 If you encounter a Perl construct that fails to parse, [report it](https://github.com/EffortlessMetrics/perl-lsp/issues) with a minimal example.
 
 ### Does it support Perl 5.8?


### PR DESCRIPTION
### Motivation

- The project claims Perl 5.8–5.40 support but lacked a visible CI runtime matrix proving which Perl versions are actually exercised. 
- Make runtime coverage explicit and discoverable so the documentation claim is tied to a concrete CI job rather than an undocumented assumption.

### Description

- Add a `perl-version-matrix` job to `.github/workflows/ci-nightly.yml` with Perl matrix values `['5.8.9','5.16.3','5.30.3','5.40.0']` that installs Perl via `shogo82148/actions-setup-perl@v1`, builds `perllsp`, and runs a runtime smoke (`cargo test -p perl-subprocess-runtime --test extended_unit_tests` and `target/debug/perllsp --version`).
- Add a Nightly CI badge to `README.md` linking to `ci-nightly.yml` so the matrix is discoverable from the project front page.
- Update `docs/reference/FAQ.md` to explicitly list the Perl versions exercised in CI and reference the `perl-version-matrix` job in `ci-nightly.yml`.

### Testing

- Ran `cargo xtask fmt --check` locally and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e8ff3f348333ab51cd8cf8364f73)