### PR TITLE
test(perl-lsp-ux-tests): add cross-editor completion parity scenario (#0000)

### DIFF
--- a/crates/perl-lsp-ux-tests/README.md
+++ b/crates/perl-lsp-ux-tests/README.md
@@ -22,7 +22,8 @@ Scenarios currently include:
 - hover, goto-definition, strict diagnostics, and document symbols flows, and
 - multi-root `workspace/symbol` disambiguation via `workspaceFolderUri`, and
 - workspace-folder removal evicting stale symbols from search results, and
-- deleted-file churn evicting stale search results and definition targets.
+- deleted-file churn evicting stale search results and definition targets, and
+- cross-editor completion probe parity across VS Code, Zed, Neovim, and Helix trigger contexts.
 
 The harness is now also the source of truth for the workflow UX scorecard
 inventory:

--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -269,6 +269,21 @@
         "deleted symbols disappear from workspace/symbol",
         "definition no longer resolves to deleted targets"
       ]
+    },
+    {
+      "id": "cross_editor_completion_parity",
+      "scenario_file": "ux_scenario_18_cross_editor_completion.rs",
+      "subsystem_owner": "editor_intelligence",
+      "ci_tier": "pr",
+      "user_journey": "request completion through representative VS Code, Zed, Neovim, and Helix trigger contexts",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "completion results remain non-empty across editor probe contexts",
+        "shared lexical completion payload shape stays aligned across editors"
+      ]
     }
   ]
 }

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -205,13 +205,30 @@ impl UxHarness {
 
     /// Request completion at `(line, character)`.
     pub fn completion(&self, relative_path: &str, line: u32, character: u32) -> Result<Vec<Value>> {
+        self.completion_with_context(relative_path, line, character, 1, None)
+    }
+
+    /// Request completion with explicit trigger context.
+    pub fn completion_with_context(
+        &self,
+        relative_path: &str,
+        line: u32,
+        character: u32,
+        trigger_kind: u32,
+        trigger_character: Option<&str>,
+    ) -> Result<Vec<Value>> {
         let uri = self.workspace.uri(relative_path);
+        let mut context = json!({ "triggerKind": trigger_kind });
+        if let Some(trigger_character) = trigger_character {
+            context["triggerCharacter"] = Value::String(trigger_character.to_string());
+        }
+
         let resp = self.client.request(
             "textDocument/completion",
             json!({
                 "textDocument": { "uri": uri },
                 "position": { "line": line, "character": character },
-                "context": { "triggerKind": 1 }
+                "context": context
             }),
             self.config.timeout,
         )?;

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_cross_editor_completion.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_cross_editor_completion.rs
@@ -1,0 +1,98 @@
+//! Scenario 18 — Cross-editor completion parity.
+//!
+//! Editors probe completion with different trigger contexts. This scenario
+//! verifies we keep stable completion payloads across representative editor
+//! request shapes (VS Code, Zed, Neovim, Helix).
+
+use anyhow::{Context, Result};
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::Value;
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+#[derive(Clone, Copy)]
+struct EditorProbe {
+    name: &'static str,
+    trigger_kind: u32,
+    trigger_character: Option<&'static str>,
+}
+
+const EDITOR_PROBES: [EditorProbe; 4] = [
+    EditorProbe { name: "vscode", trigger_kind: 1, trigger_character: None },
+    EditorProbe { name: "zed", trigger_kind: 2, trigger_character: Some("$") },
+    EditorProbe { name: "neovim", trigger_kind: 3, trigger_character: Some("$") },
+    EditorProbe { name: "helix", trigger_kind: 1, trigger_character: None },
+];
+
+#[test]
+fn scenario_18_cross_editor_completion_payloads_stay_aligned() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_18: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let source = "use strict;\nuse warnings;\n\nmy $alpha = 41;\nmy $beta = $alp\n";
+    let harness = UxHarness::new(ScenarioConfig::default().with_file("cross_editor.pl", source))
+        .context("Failed to create UX harness")?;
+
+    harness
+        .open_file("cross_editor.pl", source)
+        .context("didOpen should succeed for cross-editor scenario")?;
+
+    let mut baseline_shape: Option<(Option<String>, Option<u64>, Option<Vec<String>>)> = None;
+
+    for probe in EDITOR_PROBES {
+        let items = harness
+            .completion_with_context(
+                "cross_editor.pl",
+                4,
+                16,
+                probe.trigger_kind,
+                probe.trigger_character,
+            )
+            .with_context(|| format!("completion request failed for {}", probe.name))?;
+
+        assert!(
+            !items.is_empty(),
+            "{} probe should return at least one completion item",
+            probe.name
+        );
+
+        let alpha_item = find_item_by_label(&items, "$alpha").with_context(|| {
+            format!("{} probe should include lexical completion for $alpha", probe.name)
+        })?;
+
+        let current_shape = completion_shape(alpha_item);
+        if let Some(expected_shape) = &baseline_shape {
+            assert_eq!(
+                &current_shape, expected_shape,
+                "{} probe returned divergent completion payload shape for $alpha",
+                probe.name
+            );
+        } else {
+            baseline_shape = Some(current_shape);
+        }
+    }
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+fn find_item_by_label<'a>(items: &'a [Value], label: &str) -> Result<&'a Value> {
+    items
+        .iter()
+        .find(|item| item.get("label").and_then(Value::as_str) == Some(label))
+        .with_context(|| format!("completion item with label `{label}` missing"))
+}
+
+fn completion_shape(item: &Value) -> (Option<String>, Option<u64>, Option<Vec<String>>) {
+    let insert_text = item.get("insertText").and_then(Value::as_str).map(str::to_string);
+    let insert_text_format = item.get("insertTextFormat").and_then(Value::as_u64);
+    let commit_characters = item.get("commitCharacters").and_then(Value::as_array).map(|chars| {
+        chars.iter().filter_map(Value::as_str).map(str::to_string).collect::<Vec<_>>()
+    });
+
+    (insert_text, insert_text_format, commit_characters)
+}


### PR DESCRIPTION
### Motivation
- Different editors (VS Code, Zed, Neovim, Helix) probe completions with different `CompletionContext` shapes and the UX harness previously only exercised a generic LSP completion call, leaving cross-editor parity unverified.

### Description
- Add a new UX scenario `ux_scenario_18_cross_editor_completion.rs` that probes completion with representative trigger contexts and asserts the lexical `$alpha` completion payload shape stays aligned across editors.
- Extend the harness with `completion_with_context(...)` and make the existing `completion(...)` call it so tests can send explicit `triggerKind` and optional `triggerCharacter`.
- Register the new scenario in `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` so the fixture-vs-scenario lockstep validation covers cross-editor parity.
- Update the crate `README.md` to document the added cross-editor completion parity coverage.

### Testing
- Ran `cargo xtask fmt` and the formatting step completed successfully.
- Ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --test ux_scenario_18_cross_editor_completion`, and both tests passed.
- Ran `cargo check --all-targets -p perl-lsp-ux-tests`, which passed.
- Ran `cargo clippy -p perl-lsp-ux-tests --all-targets -- -D warnings` and it failed due to a pre-existing clippy lint in `ux_scenario_13_document_symbols.rs` unrelated to these changes; plain `cargo clippy -p perl-lsp-ux-tests` completed successfully.
- `just pr-fast` was not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e8da2eac8333aa186ea21cca93d1)