### PR TITLE
docs(stability): define published crate API contract (#5127)

### DIFF
--- a/docs/reference/STABILITY.md
+++ b/docs/reference/STABILITY.md
@@ -1,74 +1,84 @@
 # API Stability and Version Policy
 
-**MSRV:** 1.92 • **Edition:** 2024 • **Status:** Public alpha
+**MSRV:** 1.92 • **Edition:** 2024 • **Status:** Public alpha (`0.12.x`)
 
-This document describes the stability posture for the current public-alpha line. The current release line is `v0.11.x`; stronger compatibility guarantees are still targeted for the `v0.15.0` stability-contract milestone.
+This document defines the current public-API stability contract for published crates in this workspace.
 
-## Current Alpha Stance
+## Scope of This Contract
 
-What public alpha means here:
+The public crate surface is the explicit publish allowlist at `[workspace.metadata.publish.allow]` in `Cargo.toml`. That allowlist is intentionally hand-maintained and topologically ordered for release safety. At the time of writing, it contains **31 published crates**.
 
-- APIs and behaviors are usable today but can still change between minor releases
-- Advertised protocol behavior is tracked carefully, but the formal compatibility contract is not locked yet
-- Packaging and distribution surfaces can still change while the alpha line is being hardened
-- Documentation is being aligned with the actual shipped posture rather than treated as frozen
+This contract applies to:
 
-## What We Ship Today
+- all crates in the publish allowlist
+- public items exported directly by those crates
+- public items re-exported by facade crates (re-exports are part of the API contract)
+
+This contract does **not** guarantee stability for:
+
+- non-allowlisted/internal crates
+- items behind unstable/internal feature flags
+- undocumented implementation details not reachable through public API
+
+## Current Alpha Posture (What `0.x` Means Here)
+
+The project is still pre-1.0. We use semantic versioning conventions with explicit alpha caveats:
+
+- **Patch (`0.Y.Z`)**: no intentional public API breakage for allowlisted crates
+- **Minor (`0.Y+1.0`)**: breaking changes are allowed, but must be deliberate and documented
+- **Major (`1.0+`)**: not active yet; stronger guarantees are targeted for the `v0.15.0` stability-contract milestone
+
+If we intentionally break public API in a minor release, the release notes must include migration guidance.
+
+## Facade and Re-export Policy
+
+Facade crates are treated as first-class API boundaries. If a facade re-exports a symbol, that re-export is considered part of the public contract.
+
+Rules:
+
+1. Moving a type/function between internal crates is non-breaking **only** if facade exports remain source-compatible.
+2. Renaming/removing a re-export is treated as a public API change and must follow the versioning rules above.
+3. Public enums/structs in facade-facing APIs should be `#[non_exhaustive]` where forward-compatibility is required.
+
+## Required Compatibility Checks
+
+Compatibility is enforced by committed baselines plus semver checks:
+
+- `just public-api-check` compares facade/public baselines in `.ci/public-api-baselines/`
+- `just semver-check` runs `cargo-semver-checks` on the published core package set
+- `just release-check` includes semver validation in the pre-release gate
+
+When an intentional API change occurs:
+
+1. update the API baseline (`just public-api-update`)
+2. document the rationale in the PR and release notes
+3. use the correct semver bump level (minor for breaking changes during alpha)
+
+## Distribution Surfaces
 
 | Distribution | Format | Support level |
 | --- | --- | --- |
 | GitHub Releases | Tagged source and binary artifacts | Alpha |
-| crates.io | Published crates | Alpha |
+| crates.io | Published crates from allowlist | Alpha |
 | VS Code extension | Marketplace / Open VSX distribution | Alpha |
 | Source builds | Git checkout + Cargo | Alpha |
 
-Availability can vary by release. Check the release notes and repo documentation for the exact surface shipped in a given version.
+Availability may vary by release; check release notes for exact artifacts.
 
-## Public Crate Line
+## Toward the `v0.15.0` Stability Milestone
 
-These crates define the user-facing alpha line:
+The `v0.15.0` milestone is where the contract tightens further around:
 
-| Crate | Current line | Purpose | Stability posture |
-| --- | --- | --- | --- |
-| `perl-parser` | `0.11.x` | Parser and AST-facing library | Evolving |
-| `perl-lexer` | `0.11.x` | Tokenizer | Evolving |
-| `perl-lsp` | `0.11.x` | LSP server binary | Evolving |
-| `perl-corpus` | `0.11.x` | Corpus and fixtures | Evolving |
-| `perl-dap` | `0.11.x` | Debug adapter | Preview / evolving |
-| `perl-parser-pest` | `0.11.x` | Legacy parser path | Maintenance only |
-
-## Versioning Policy
-
-### Minor releases (`0.Y.0`)
-
-Breaking changes are still allowed in minor public-alpha releases. We aim to document those changes clearly, but full multi-release deprecation cycles are not promised before `v0.15.0`.
-
-### Patch releases (`0.Y.Z`)
-
-Patch releases are intended for fixes, hardening, and documentation updates that do not deliberately reshape the public surface.
-
-## Support Expectations
-
-During the alpha line, the project aims for:
-
-1. Stronger parser and workspace correctness on real-world Perl
-2. A stable enough editor experience for early adopters
-3. Clearer receipts and project-health documentation
-4. Continued hardening of security and validation boundaries
-
-## Toward the Stability Contract (`v0.15.0`)
-
-The `v0.15.0` milestone is where the project intends to tighten the contract around:
-
-1. Public API compatibility expectations
-2. Advertised protocol behavior
-3. Deprecation policy and migration guidance
-4. Platform support commitments
+1. deprecation windows and migration policy
+2. stricter compatibility automation coverage across all published crates
+3. explicit platform/runtime support commitments
+4. protocol-level compatibility guarantees
 
 ## Verification
 
 ```bash
-nix develop -c just ci-gate
+just public-api-check
+just semver-check
 ```
 
 For current receipts and project posture, see:


### PR DESCRIPTION
### Motivation

- Clarify and lock down what counts as the public API after facade consolidation so consumers and release tooling have a single authoritative surface to check.  
- Surface that the publish allowlist is hand-maintained, topologically ordered, and forms the scope of the stability contract (published crate count updated accordingly).

### Description

- Rewrote `docs/reference/STABILITY.md` to define the public-API stability contract scoped to `[workspace.metadata.publish.allow]` and to reflect the current alpha posture.  
- Codified pre-1.0 semver expectations (`patch` = no intentional API breaks, `minor` may include deliberate breaking changes with migration notes).  
- Added facade and re-export rules that treat re-exports as part of the public contract and recommend `#[non_exhaustive]` for forward-compatible types.  
- Documented required compatibility checks and verification commands (`just public-api-check`, `just semver-check`) and updated the published crate count to **31**.

### Testing

- Ran `cargo check -p perl-parser-core --quiet`, which completed successfully.  
- Attempted `just public-api-check`, which failed to run in this environment because `just` is not available.  
- Verified the workspace publish allowlist size with a short Python/TOML check, which reported `31` entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e8f368948333ad0f157d8483c340)