### PR TITLE
feat(ci-metrics): add unique-catch and signal-per-dollar telemetry (#4903)

### DIFF
--- a/.ci/scripts/README.md
+++ b/.ci/scripts/README.md
@@ -104,13 +104,18 @@ cargo xtask ci-baseline --branch master --days 30 --limit 200 --output .ci
       "median_duration_seconds": 120,
       "p95_duration_seconds": 300,
       "avg_duration_seconds": 150,
-      "billable_minutes": 200
+      "billable_minutes": 200,
+      "unique_catch_count": 3,
+      "unique_catch_rate_percent": 60.0,
+      "signal_per_dollar": 1.88
     }
   },
   "summary": {
     "total_runs": 500,
     "total_billable_minutes": 1500,
-    "overall_success_rate_percent": 92.5
+    "overall_success_rate_percent": 92.5,
+    "total_unique_catches": 9,
+    "overall_signal_per_dollar": 0.75
   }
 }
 ```

--- a/xtask/src/tasks/ci_metrics.rs
+++ b/xtask/src/tasks/ci_metrics.rs
@@ -94,6 +94,9 @@ struct BaselineWorkflow {
     p95_duration_seconds: u64,
     avg_duration_seconds: u64,
     billable_minutes: u64,
+    unique_catch_count: u64,
+    unique_catch_rate_percent: f64,
+    signal_per_dollar: f64,
 }
 
 #[derive(Serialize)]
@@ -101,6 +104,8 @@ struct BaselineSummary {
     total_runs: u64,
     total_billable_minutes: u64,
     overall_success_rate_percent: f64,
+    total_unique_catches: u64,
+    overall_signal_per_dollar: f64,
 }
 
 #[derive(Serialize)]
@@ -110,6 +115,13 @@ struct BaselineReport {
     days_analyzed: u64,
     workflows: BTreeMap<String, BaselineWorkflow>,
     summary: BaselineSummary,
+}
+
+#[derive(Clone)]
+struct WorkflowOutcome {
+    workflow_key: String,
+    conclusion: String,
+    head_sha: Option<String>,
 }
 
 pub fn run_cost_monitor(days: u64, json_output: bool) -> Result<()> {
@@ -473,6 +485,7 @@ fn build_baseline_report(
     runs: &[Value],
 ) -> Option<BaselineReport> {
     let mut workflow_counters: BTreeMap<String, BaselineCounters> = BTreeMap::new();
+    let mut outcomes: Vec<WorkflowOutcome> = Vec::new();
 
     for run in runs {
         let created = match read_timestamp(run, &["createdAt", "created_at"]) {
@@ -506,7 +519,7 @@ fn build_baseline_report(
         }
 
         let key = workflow_key(workflow_name);
-        let counters = workflow_counters.entry(key).or_default();
+        let counters = workflow_counters.entry(key.clone()).or_default();
         counters.name = workflow_name.to_string();
         counters.total_runs += 1;
 
@@ -520,6 +533,18 @@ fn build_baseline_report(
             continue;
         }
 
+        let head_sha = run
+            .get("headSha")
+            .and_then(Value::as_str)
+            .or_else(|| run.get("head_sha").and_then(Value::as_str))
+            .map(str::to_string);
+
+        outcomes.push(WorkflowOutcome {
+            workflow_key: key.clone(),
+            conclusion: conclusion.to_string(),
+            head_sha,
+        });
+
         if duration_seconds > 0 {
             counters.durations.push(duration_seconds);
             counters.billable_minutes += duration_seconds.div_ceil(60);
@@ -528,6 +553,30 @@ fn build_baseline_report(
 
     if workflow_counters.is_empty() {
         return None;
+    }
+
+    let mut failing_workflows_by_sha: HashMap<&str, usize> = HashMap::new();
+    for outcome in &outcomes {
+        if outcome.conclusion == "success" {
+            continue;
+        }
+        let Some(head_sha) = outcome.head_sha.as_deref() else {
+            continue;
+        };
+        *failing_workflows_by_sha.entry(head_sha).or_default() += 1;
+    }
+
+    let mut unique_catches: HashMap<String, u64> = HashMap::new();
+    for outcome in &outcomes {
+        if outcome.conclusion == "success" {
+            continue;
+        }
+        let Some(head_sha) = outcome.head_sha.as_deref() else {
+            continue;
+        };
+        if failing_workflows_by_sha.get(head_sha).copied() == Some(1) {
+            *unique_catches.entry(outcome.workflow_key.clone()).or_default() += 1;
+        }
     }
 
     let mut workflow_reports = BTreeMap::new();
@@ -551,6 +600,16 @@ fn build_baseline_report(
             0.0
         };
 
+        let unique_catch_count = unique_catches.get(&key).copied().unwrap_or_default();
+        let unique_catch_rate_percent = if counters.failure_count > 0 {
+            (unique_catch_count as f64 * 100.0) / (counters.failure_count as f64)
+        } else {
+            0.0
+        };
+        let workflow_cost = counters.billable_minutes as f64 * COST_PER_MINUTE;
+        let signal_per_dollar =
+            if workflow_cost > 0.0 { unique_catch_count as f64 / workflow_cost } else { 0.0 };
+
         workflow_reports.insert(
             key,
             BaselineWorkflow {
@@ -565,6 +624,9 @@ fn build_baseline_report(
                 p95_duration_seconds: p95_seconds,
                 avg_duration_seconds: avg_seconds,
                 billable_minutes: counters.billable_minutes,
+                unique_catch_count,
+                unique_catch_rate_percent,
+                signal_per_dollar,
             },
         );
     }
@@ -575,6 +637,8 @@ fn build_baseline_report(
         workflow_reports.values().map(|workflow| workflow.billable_minutes).sum();
 
     let total_success: u64 = workflow_reports.values().map(|workflow| workflow.success_count).sum();
+    let total_unique_catches: u64 =
+        workflow_reports.values().map(|workflow| workflow.unique_catch_count).sum();
     let total_completed: u64 = workflow_reports
         .values()
         .map(|workflow| workflow.success_count + workflow.failure_count)
@@ -586,6 +650,10 @@ fn build_baseline_report(
         0.0
     };
 
+    let total_cost = total_billable as f64 * COST_PER_MINUTE;
+    let overall_signal_per_dollar =
+        if total_cost > 0.0 { total_unique_catches as f64 / total_cost } else { 0.0 };
+
     Some(BaselineReport {
         generated_at: generated_at.to_rfc3339(),
         branch: branch.to_string(),
@@ -595,6 +663,8 @@ fn build_baseline_report(
             total_runs,
             total_billable_minutes: total_billable,
             overall_success_rate_percent,
+            total_unique_catches,
+            overall_signal_per_dollar,
         },
     })
 }
@@ -707,20 +777,32 @@ fn build_baseline_markdown(report: &BaselineReport) -> Result<String> {
         "| Total Billable Minutes | {}m |\n\n",
         report.summary.total_billable_minutes
     ));
+    out.push_str(&format!("| Total Unique Catches | {} |\n", report.summary.total_unique_catches));
+    out.push_str(&format!(
+        "| Signal per Dollar | {:.2} unique catches / $ |\n\n",
+        report.summary.overall_signal_per_dollar
+    ));
 
     out.push_str("## Workflow Details\n\n");
-    out.push_str("| Workflow | Runs | Success Rate | Median | P95 | Billable |\n");
-    out.push_str("|----------|------|--------------|--------|-----|----------|\n");
+    out.push_str(
+        "| Workflow | Runs | Success Rate | Median | P95 | Billable | Unique Catches | Unique Catch Rate | Signal / $ |\n",
+    );
+    out.push_str(
+        "|----------|------|--------------|--------|-----|----------|----------------|-------------------|------------|\n",
+    );
 
     for workflow in report.workflows.values() {
         out.push_str(&format!(
-            "| {} | {} | {:.1}% | {}s | {}s | {}m |\n",
+            "| {} | {} | {:.1}% | {}s | {}s | {}m | {} | {:.1}% | {:.2} |\n",
             workflow.name,
             workflow.total_runs,
             workflow.success_rate_percent,
             workflow.median_duration_seconds,
             workflow.p95_duration_seconds,
-            workflow.billable_minutes
+            workflow.billable_minutes,
+            workflow.unique_catch_count,
+            workflow.unique_catch_rate_percent,
+            workflow.signal_per_dollar
         ));
     }
 
@@ -731,6 +813,10 @@ fn build_baseline_markdown(report: &BaselineReport) -> Result<String> {
         "- Billable Minutes: Estimated billable time (each run rounded up to nearest minute)\n",
     );
     out.push_str("- Success Rate: Calculated excluding skipped runs\n\n");
+    out.push_str(
+        "- Unique Catches: Failing runs where this workflow was the only failed workflow for the same commit SHA\n",
+    );
+    out.push_str("- Signal / $: `unique_catch_count / (billable_minutes * $0.008)`\n\n");
 
     out.push_str("## Recommendations\n\n");
     out.push_str("1. Monitor P95 durations for workflow variance.\n");
@@ -772,6 +858,7 @@ mod tests {
             json!({
                 "workflowName": "CI",
                 "conclusion": "success",
+                "headSha": "aaa",
                 "createdAt": "2026-03-25T11:00:00Z",
                 "startedAt": "2026-03-25T11:00:00Z",
                 "updatedAt": "2026-03-25T11:01:30Z"
@@ -779,6 +866,7 @@ mod tests {
             json!({
                 "workflowName": "CI",
                 "conclusion": "skipped",
+                "headSha": "bbb",
                 "createdAt": "2026-03-25T10:00:00Z",
                 "startedAt": "2026-03-25T10:00:00Z",
                 "updatedAt": "2026-03-25T10:00:30Z"
@@ -786,6 +874,7 @@ mod tests {
             json!({
                 "workflowName": "CI",
                 "conclusion": "failure",
+                "headSha": "ccc",
                 "createdAt": "2026-03-25T09:00:00Z",
                 "startedAt": "2026-03-25T09:00:00Z"
             }),
@@ -802,12 +891,59 @@ mod tests {
         assert_eq!(workflow.failure_count, 1);
         assert_eq!(workflow.skipped_count, 1);
         assert_eq!(workflow.billable_minutes, 2);
+        assert_eq!(workflow.unique_catch_count, 1);
+        assert_eq!(workflow.unique_catch_rate_percent, 100.0);
+        assert_eq!(workflow.signal_per_dollar, 62.5);
         assert_eq!(report.summary.total_runs, 3);
         assert_eq!(report.summary.total_billable_minutes, 2);
         assert_eq!(report.summary.overall_success_rate_percent, 50.0);
+        assert_eq!(report.summary.total_unique_catches, 1);
+        assert_eq!(report.summary.overall_signal_per_dollar, 62.5);
 
         let markdown = build_baseline_markdown(&report)?;
-        assert!(markdown.contains("| CI | 3 | 50.0% | 90s | 90s | 2m |"));
+        assert!(markdown.contains("| CI | 3 | 50.0% | 90s | 90s | 2m | 1 | 100.0% | 62.50 |"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn unique_catch_is_zero_when_multiple_workflows_fail_on_same_sha() -> Result<()> {
+        let generated_at =
+            DateTime::parse_from_rfc3339("2026-03-25T12:00:00Z")?.with_timezone(&Utc);
+        let cutoff = DateTime::parse_from_rfc3339("2026-03-24T12:00:00Z")?.with_timezone(&Utc);
+        let runs = vec![
+            json!({
+                "workflowName": "Lane A",
+                "conclusion": "failure",
+                "headSha": "shared-sha",
+                "createdAt": "2026-03-25T11:00:00Z",
+                "startedAt": "2026-03-25T11:00:00Z",
+                "updatedAt": "2026-03-25T11:01:00Z"
+            }),
+            json!({
+                "workflowName": "Lane B",
+                "conclusion": "failure",
+                "headSha": "shared-sha",
+                "createdAt": "2026-03-25T11:00:00Z",
+                "startedAt": "2026-03-25T11:00:00Z",
+                "updatedAt": "2026-03-25T11:01:00Z"
+            }),
+        ];
+
+        let report = build_baseline_report("master", 1, generated_at, cutoff, &runs)
+            .ok_or_else(|| eyre!("expected baseline report"))?;
+        let lane_a = report
+            .workflows
+            .get("Lane_A")
+            .ok_or_else(|| eyre!("expected lane A workflow report"))?;
+        let lane_b = report
+            .workflows
+            .get("Lane_B")
+            .ok_or_else(|| eyre!("expected lane B workflow report"))?;
+
+        assert_eq!(lane_a.unique_catch_count, 0);
+        assert_eq!(lane_b.unique_catch_count, 0);
+        assert_eq!(report.summary.total_unique_catches, 0);
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation

- Provide measurable lane-yield economics so low-yield CI lanes can be demoted with evidence (Issue #4903).

### Description

- Add per-workflow fields `unique_catch_count`, `unique_catch_rate_percent`, and `signal_per_dollar`, and summary fields `total_unique_catches` and `overall_signal_per_dollar` to the `ci-baseline` report (`xtask/src/tasks/ci_metrics.rs`).
- Compute unique catches by grouping non-success workflow outcomes by commit SHA (`headSha`) and counting failures where exactly one workflow failed for the same SHA, and derive `signal_per_dollar` from billable minutes using the existing cost constant.
- Emit the new metrics in both JSON and Markdown outputs and update the `.ci/scripts/README.md` example JSON to document the new fields.
- Add unit tests validating unique-catch attribution, unique-catch rate math, and the zero-unique-catch case when multiple workflows fail on the same SHA.

### Testing

- Ran `cargo test -p xtask ci_metrics` and the new/updated tests passed (all tests in that suite passed).
- Ran `cargo check --all-targets -p xtask` which completed successfully.
- Ran `cargo fmt` to format changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e91621cc8333a88fda05ee84c511)