### PR TITLE
ci(workflows): add scoped integration target check (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,16 @@ jobs:
         run: |
           cargo test --locked --lib ${{ steps.scope.outputs.crates_args }}
 
+      # ── Scoped integration-test compile guard ────────────────────────────
+      - name: Scoped integration-target check
+        if: |
+          steps.scope.outputs.scope_ok == 'true' &&
+          steps.scope.outputs.diff_class != 'prose_only' &&
+          steps.scope.outputs.diff_class != 'ci_config' &&
+          steps.scope.outputs.crates_args != ''
+        run: |
+          cargo check --locked --tests ${{ steps.scope.outputs.crates_args }}
+
       # ── Fallback: baseline clippy-core / test-core ────────────────────────
       # Runs when: ci-scope failed (scope_ok=false), OR ci-scope returned no
       # crates to check (empty crates_args on a non-prose diff — shouldn't


### PR DESCRIPTION
### Motivation
- Close a scoped-lane blind spot where PR-smoke scope-aware checks ran `cargo test --lib` but did not compile integration-test targets for crates selected by `ci-scope`, allowing integration tests to silently rot for affected crates.

### Description
- Add a scope-aware step in `.github/workflows/ci.yml` that runs `cargo check --tests` for the `-p` crate list emitted by `ci-scope`, executed alongside the existing scoped `cargo test --lib` step.

### Testing
- Ran local workflow/format checks and validations; `git diff --check` returned no issues and the workflow file was committed for CI to exercise (note: `git log origin/master` could not be run locally due to missing remote history, CI fetches enough history per workflow configuration).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ecc6fbd08333b9fec6685bd87aa0)