### PR TITLE
test(ux): add real-repo first-diagnostics perf lane (#0000)

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -110,6 +110,17 @@ jobs:
       with:
         tool: just
 
+    - name: Build perl-lsp binary for real-repo UX perf lane
+      run: cargo build -p perl-lsp-rs --bin perl-lsp --locked
+
+    - name: Run real-repo first-diagnostics perf lane
+      run: |
+        mkdir -p benchmarks/results
+        PERL_LSP_BIN="${{ github.workspace }}/target/debug/perl-lsp" \
+          cargo test -p perl-lsp-ux-tests --features integration-test \
+          --test ux_scenario_18_real_repo_perf -- --test-threads=1 --nocapture \
+          2>&1 | tee benchmarks/results/real-repo-perf.txt
+
     - name: Run benchmarks
       run: |
         # Run full benchmark suite
@@ -191,6 +202,7 @@ jobs:
         path: |
           benchmarks/results/latest.json
           benchmarks/results/raw-output.txt
+          benchmarks/results/real-repo-perf.txt
           benchmark_receipt.txt
           benchmark_report.md
           comparison.txt

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -240,6 +240,10 @@ PRs labeled with `ci:bench` trigger benchmark runs:
 if: contains(github.event.pull_request.labels.*.name, 'ci:bench')
 ```
 
+That lane also runs the UX perf scenario `ux_scenario_18_real_repo_perf`, which
+checks first-`publishDiagnostics` latency against a 5000+ line Catalyst-like
+fixture assembled from `test_corpus/real_world`.
+
 ### Performance Regression Detection
 
 A regression is detected when:

--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -379,6 +379,22 @@
         "publishDiagnostics republish occurs after edit",
         "updated diagnostic payload remains valid"
       ]
+    },
+    {
+      "id": "real_repo_first_diagnostics_budget",
+      "scenario_file": "ux_scenario_18_real_repo_perf.rs",
+      "subsystem_owner": "diagnostics",
+      "ci_tier": "nightly",
+      "user_journey": "open a representative 5000+ line Catalyst-like app fixture and observe first diagnostics latency",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms"
+      ],
+      "expected_outcomes": [
+        "first publishDiagnostics arrives within 5 seconds",
+        "real-repo fixture parsing remains crash-free"
+      ]
     }
   ],
   "confidence_signals": [

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_real_repo_perf.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_real_repo_perf.rs
@@ -1,0 +1,113 @@
+//! Scenario 18 — Real-repo performance validation.
+//!
+//! Builds a representative Catalyst-like corpus from `test_corpus/real_world`
+//! fixtures and validates time-to-first-diagnostics for a 5000+ line file.
+#![cfg(feature = "integration-test")]
+
+use anyhow::{Context, Result, bail};
+use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+const FIRST_DIAGNOSTICS_BUDGET: Duration = Duration::from_secs(5);
+const MIN_LINES: usize = 5_000;
+const REAL_WORLD_FIXTURES: &[&str] = &[
+    "test_corpus/real_world/async_event_patterns.pl",
+    "test_corpus/real_world/cli_text_processing.pl",
+    "test_corpus/real_world/database_integration_patterns.pl",
+    "test_corpus/real_world/enterprise_cpan_patterns.pl",
+    "test_corpus/real_world/modern_oo_frameworks.pl",
+    "test_corpus/real_world/testing_framework_patterns.pl",
+    "test_corpus/real_world/web_framework_patterns.pl",
+    "test_corpus/real_world/medium_module.pl",
+];
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+fn repo_root() -> Result<PathBuf> {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .context("failed to resolve workspace root from CARGO_MANIFEST_DIR")
+}
+
+fn load_real_repo_fixture_source() -> Result<String> {
+    let root = repo_root()?;
+    let mut merged = String::new();
+
+    merged.push_str("package MyApp::CatalystLike;\n");
+    merged.push_str("use strict;\nuse warnings;\n\n");
+
+    for fixture in REAL_WORLD_FIXTURES {
+        let path = root.join(fixture);
+        let content = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read fixture source {}", path.display()))?;
+        merged.push_str(&format!("# BEGIN FIXTURE: {fixture}\n"));
+        merged.push_str(&content);
+        if !content.ends_with('\n') {
+            merged.push('\n');
+        }
+        merged.push_str(&format!("# END FIXTURE: {fixture}\n\n"));
+    }
+
+    merged.push_str("1;\n");
+
+    let line_count = merged.lines().count();
+    if line_count < MIN_LINES {
+        bail!("merged real-world fixture source too small: {line_count} lines (< {MIN_LINES})");
+    }
+
+    Ok(merged)
+}
+
+#[test]
+fn scenario_18_first_diagnostics_under_five_seconds_on_real_repo_fixture() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_18: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let source = load_real_repo_fixture_source()?;
+    let config = ScenarioConfig { timeout: Duration::from_secs(30), ..Default::default() };
+    let harness = UxHarness::new(config).context("failed to create UX harness")?;
+
+    let relative_path = "lib/MyApp/CatalystLike.pm";
+    let expected_uri = harness.workspace.uri(relative_path);
+
+    let start = Instant::now();
+    harness
+        .open_file(relative_path, &source)
+        .context("didOpen failed for real-repo performance fixture")?;
+
+    let deadline = start + FIRST_DIAGNOSTICS_BUDGET;
+    loop {
+        let events = harness.peek_notifications();
+        for event in &events {
+            if let LspEvent::Diagnostics { uri, .. } = event
+                && uri == &expected_uri
+            {
+                let latency = start.elapsed();
+                assert!(
+                    latency <= FIRST_DIAGNOSTICS_BUDGET,
+                    "first diagnostics for {relative_path} exceeded {:?}: {:?}",
+                    FIRST_DIAGNOSTICS_BUDGET,
+                    latency
+                );
+                harness.assert_no_crash();
+                return Ok(());
+            }
+        }
+
+        if Instant::now() >= deadline {
+            break;
+        }
+
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    bail!("no diagnostics notification for {relative_path} within {:?}", FIRST_DIAGNOSTICS_BUDGET);
+}


### PR DESCRIPTION
### Motivation
- Nightly and PR benchmark lanes lacked a representative real-repo UX perf signal for time-to-first-diagnostics on large (≈5k+ line) apps, reducing coverage for real-world latency regressions.
- Provide an automated, artifacted test that validates `didOpen` → first `publishDiagnostics` latency against a Catalyst-like fixture so CI can catch regressions early.

### Description
- Add a new integration-gated UX scenario test `crates/perl-lsp-ux-tests/tests/ux_scenario_18_real_repo_perf.rs` that assembles sources from `test_corpus/real_world` and asserts first-diagnostics arrive within 5s for a 5000+ line merged fixture.
- Wire the scenario into the nightly / `ci:bench` workflow by building `perl-lsp` and running the test in `.github/workflows/ci-nightly.yml`, saving output to `benchmarks/results/real-repo-perf.txt` and uploading it as an artifact.
- Update the UX fixture matrix `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` and `benchmarks/README.md` to document the new nightly UX perf lane and its expected metric.

### Testing
- Ran `cargo xtask fmt` which completed successfully.
- Built the binary with `cargo build -p perl-lsp-rs --bin perl-lsp --locked` and executed the scenario test with `PERL_LSP_BIN=/workspace/perl-lsp/target/debug/perl-lsp cargo test -p perl-lsp-ux-tests --features integration-test --test ux_scenario_18_real_repo_perf -- --test-threads=1`, and the test passed (`ok`).
- Verified `cargo check --all-targets -p perl-lsp-ux-tests` passed and the scenario-specific `cargo clippy -p perl-lsp-ux-tests --features integration-test --test ux_scenario_18_real_repo_perf -- -D warnings` passed, while a workspace-wide `cargo clippy -p perl-lsp-ux-tests --all-targets -- -D warnings` failed due to a pre-existing, unrelated clippy violation in `ux_scenario_13_document_symbols.rs`.
- `just pr-fast` was not executed here due to the environment missing the `just` binary (local limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e8cfb7548333bce6ae84f0b851ef)