### PR TITLE
fix(completion): align cancellable completion with editor capability conformance (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -610,6 +610,10 @@ impl LspServer {
                     completion_cap(),
                 );
 
+                // Snapshot capability flag once before the loop to avoid
+                // acquiring client_capabilities lock per completion item.
+                let snippet_support = self.client_capabilities.lock().snippet_support;
+
                 // Convert to JSON format with highly optimized cancellation checks
                 let items: Vec<Value> = completions
                     .into_iter()
@@ -619,6 +623,9 @@ impl LspServer {
                         if idx % 250 == 0 && idx > 0 && token.is_cancelled_relaxed() {
                             return None;
                         }
+
+                        let is_snippet = c.kind == CompletionItemKind::Snippet;
+                        let insert_text_format = if is_snippet && snippet_support { 2 } else { 1 };
 
                         let mut item = json!({
                             "label": c.label,
@@ -632,12 +639,17 @@ impl LspServer {
                                 CompletionItemKind::Constant => 14,
                                 CompletionItemKind::Property => 7,
                             },
+                            "insertTextFormat": insert_text_format,
                         });
 
                         if let Some(detail) = c.detail {
                             item["detail"] = json!(detail);
                         }
-                        if let Some(insert_text) = c.insert_text {
+                        if let Some(mut insert_text) = c.insert_text {
+                            // Degrade snippets to plaintext if client doesn't support snippets.
+                            if is_snippet && !snippet_support {
+                                insert_text = Self::degrade_snippet_to_plaintext(&insert_text);
+                            }
                             item["insertText"] = json!(insert_text);
                         }
                         if let Some(documentation) = c.documentation {

--- a/crates/perl-lsp-rs/tests/lsp_cross_editor_completion_conformance.rs
+++ b/crates/perl-lsp-rs/tests/lsp_cross_editor_completion_conformance.rs
@@ -1,0 +1,216 @@
+//! Cross-editor completion conformance tests.
+//!
+//! These tests emulate completion handshake/request shapes used by
+//! VS Code, Zed, Neovim, and Helix so we can lock down parity in
+//! snippet formatting and commit character behavior.
+
+mod support;
+
+use serde_json::{Value, json};
+use support::lsp_harness::LspHarness;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+#[derive(Clone, Copy)]
+enum CompletionContextShape {
+    Missing,
+    Invoked,
+    Triggered(char),
+}
+
+#[derive(Clone, Copy)]
+struct EditorProfile {
+    name: &'static str,
+    snippet_support: bool,
+    context_shape: CompletionContextShape,
+}
+
+fn editor_profiles() -> [EditorProfile; 4] {
+    [
+        EditorProfile {
+            name: "vscode",
+            snippet_support: true,
+            context_shape: CompletionContextShape::Invoked,
+        },
+        EditorProfile {
+            name: "zed",
+            snippet_support: true,
+            context_shape: CompletionContextShape::Triggered('.'),
+        },
+        EditorProfile {
+            name: "neovim",
+            snippet_support: false,
+            context_shape: CompletionContextShape::Missing,
+        },
+        EditorProfile {
+            name: "helix",
+            snippet_support: false,
+            context_shape: CompletionContextShape::Invoked,
+        },
+    ]
+}
+
+fn capabilities_for(profile: EditorProfile) -> Value {
+    json!({
+        "textDocument": {
+            "completion": {
+                "completionItem": {
+                    "snippetSupport": profile.snippet_support
+                }
+            }
+        }
+    })
+}
+
+fn completion_request(
+    uri: &str,
+    line: u32,
+    character: u32,
+    shape: CompletionContextShape,
+) -> Value {
+    let mut request = json!({
+        "textDocument": { "uri": uri },
+        "position": { "line": line, "character": character },
+    });
+
+    match shape {
+        CompletionContextShape::Missing => {}
+        CompletionContextShape::Invoked => {
+            request["context"] = json!({"triggerKind": 1});
+        }
+        CompletionContextShape::Triggered(ch) => {
+            request["context"] = json!({
+                "triggerKind": 2,
+                "triggerCharacter": ch.to_string(),
+            });
+        }
+    }
+
+    request
+}
+
+fn completion_items(response: Value) -> Result<Vec<Value>, String> {
+    if let Some(items) = response.get("items").and_then(Value::as_array) {
+        return Ok(items.to_vec());
+    }
+
+    if let Some(items) = response.as_array() {
+        return Ok(items.to_vec());
+    }
+
+    Err(format!("expected completion array/list, got: {response}"))
+}
+
+fn completion_item_by_label<'a>(items: &'a [Value], label: &str) -> Result<&'a Value, String> {
+    items
+        .iter()
+        .find(|item| item.get("label").and_then(Value::as_str) == Some(label))
+        .ok_or_else(|| format!("missing completion item '{label}'"))
+}
+
+#[test]
+fn snippet_insert_text_format_matches_client_capabilities() -> TestResult {
+    let uri = "file:///cross_editor_snippets.pl";
+
+    for profile in editor_profiles() {
+        let mut harness = LspHarness::new();
+        harness.initialize(Some(capabilities_for(profile)))?;
+        harness.open(uri, "ife")?;
+
+        let response = harness.request(
+            "textDocument/completion",
+            completion_request(uri, 0, 3, profile.context_shape),
+        )?;
+
+        let items = completion_items(response)?;
+        let ife = completion_item_by_label(&items, "ife")?;
+
+        let insert_text = ife
+            .get("insertText")
+            .and_then(Value::as_str)
+            .ok_or_else(|| format!("{}: missing insertText", profile.name))?;
+
+        if profile.snippet_support {
+            assert!(
+                insert_text.contains("${"),
+                "{} should receive snippet placeholders, got: {insert_text}",
+                profile.name
+            );
+
+            if let Some(insert_text_format) = ife.get("insertTextFormat").and_then(Value::as_u64) {
+                assert_eq!(
+                    insert_text_format, 2,
+                    "{} should use snippet insertTextFormat when present",
+                    profile.name
+                );
+            }
+        } else {
+            assert!(
+                !insert_text.contains("${"),
+                "{} should receive snippet placeholders degraded to plaintext, got: {insert_text}",
+                profile.name
+            );
+
+            if let Some(insert_text_format) = ife.get("insertTextFormat").and_then(Value::as_u64) {
+                assert_eq!(
+                    insert_text_format, 1,
+                    "{} should use plain-text insertTextFormat when present",
+                    profile.name
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn function_commit_characters_are_stable_across_editor_profiles() -> TestResult {
+    let uri = "file:///cross_editor_commit_chars.pl";
+    let mut baseline: Option<Vec<String>> = None;
+
+    for profile in editor_profiles() {
+        let mut harness = LspHarness::new();
+        harness.initialize(Some(capabilities_for(profile)))?;
+        harness.open(uri, "pri")?;
+
+        let response = harness.request(
+            "textDocument/completion",
+            completion_request(uri, 0, 3, profile.context_shape),
+        )?;
+
+        let items = completion_items(response)?;
+        let print_item = completion_item_by_label(&items, "print")?;
+        let commit_chars = print_item
+            .get("commitCharacters")
+            .and_then(Value::as_array)
+            .ok_or_else(|| format!("{}: print missing commitCharacters", profile.name))?
+            .iter()
+            .filter_map(Value::as_str)
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+
+        assert!(
+            commit_chars.iter().any(|ch| ch == "("),
+            "{} profile should include '(' commit character for functions",
+            profile.name
+        );
+        assert!(
+            commit_chars.iter().any(|ch| ch == ";"),
+            "{} profile should include ';' commit character for functions",
+            profile.name
+        );
+
+        if let Some(expected) = &baseline {
+            assert_eq!(
+                &commit_chars, expected,
+                "{} profile diverged from baseline commit characters",
+                profile.name
+            );
+        } else {
+            baseline = Some(commit_chars);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Editors (VS Code, Zed, Neovim, Helix) probe completions/snippets/commit characters differently and the existing LSP-generic path allowed observable divergence. 
- There was no automated test verifying parity across common editor handshake shapes for snippet support and commit characters.

### Description

- Added a cross-editor conformance test suite at `crates/perl-lsp-rs/tests/lsp_cross_editor_completion_conformance.rs` that simulates VS Code, Zed, Neovim, and Helix initialization/request shapes and asserts snippet/commit-char parity. 
- Updated the cancellable completion serialization path in `crates/perl-lsp-rs/src/runtime/language/completion.rs` to snapshot `snippetSupport`, include `insertTextFormat`, and degrade snippet placeholders to plaintext when the client lacks snippet support. 
- Preserved existing commit-character behavior by reusing `commit_chars_for_kind` so function and variable commit characters remain stable across profiles. 

### Testing

- Ran `cargo test -p perl-lsp-rs --test lsp_cross_editor_completion_conformance` and the new tests passed. 
- Ran `cargo check --all-targets -p perl-lsp-rs` and it completed successfully. 
- Ran `cargo xtask fmt` to format changes and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e8da2eac8333aa186ea21cca93d1)