### PR TITLE
feat(ci): add real-repo first-diagnostics perf gate (#0000)

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -118,6 +118,12 @@ jobs:
         # Extract structured results from Criterion
         python3 ./benchmarks/scripts/extract-criterion.py --output benchmarks/results/latest.json
 
+    - name: Real-repo first-diagnostics perf gate (Catalyst 5000+ lines)
+      run: |
+        cargo test -p perl-lsp-rs --test real_project_latency \
+          real_project_first_diagnostics_catalyst_5000_lines_under_5s \
+          -- --include-ignored --nocapture
+
     - name: Compare against baseline
       id: compare
       continue-on-error: true

--- a/crates/perl-lsp-rs/tests/real_project_latency.rs
+++ b/crates/perl-lsp-rs/tests/real_project_latency.rs
@@ -445,6 +445,47 @@ fn measure_workspace_symbol(fixture: &ProjectFixture, entry_content: &str) -> Ve
     samples
 }
 
+/// Build a synthetic ~5000-line Catalyst-style controller source.
+fn build_large_catalyst_controller() -> String {
+    let mut source = String::from(
+        "package MyApp::Controller::Big;\n\
+use strict;\n\
+use warnings;\n\
+use parent 'Catalyst::Controller';\n\
+\n\
+",
+    );
+
+    // 250 actions × 20 lines ≈ 5000 lines plus header/footer.
+    for idx in 0..250 {
+        source.push_str(&format!(
+            "sub action_{idx} :Path('/action/{idx}') Args(0) {{\n\
+    my ($self, $c) = @_;\n\
+    my $acc = 0;\n\
+    $acc += 1;\n\
+    $acc += 2;\n\
+    $acc += 3;\n\
+    $acc += 4;\n\
+    $acc += 5;\n\
+    $acc += 6;\n\
+    $acc += 7;\n\
+    $acc += 8;\n\
+    $acc += 9;\n\
+    $acc += 10;\n\
+    $acc += 11;\n\
+    $acc += 12;\n\
+    $acc += 13;\n\
+    $acc += 14;\n\
+    $c->stash(action => '{idx}', sum => $acc);\n\
+}}\n\
+\n"
+        ));
+    }
+
+    source.push_str("1;\n");
+    source
+}
+
 // ---- JSON output --------------------------------------------------------------
 
 /// Serialise a LatencySummary to a serde_json Value.
@@ -736,4 +777,45 @@ fn real_project_latency_full_suite() {
     }
     write_baseline(&results);
     eprintln!("\nBaseline written to {OUTPUT_PATH}");
+}
+
+/// Real-repo perf gate: first diagnostics for a 5000+ line Catalyst app should
+/// arrive within 5 seconds.
+#[test]
+#[ignore = "nightly only — performance assertion on representative large file"]
+fn real_project_first_diagnostics_catalyst_5000_lines_under_5s() {
+    let root = workspace_root();
+    let file_path = root.join("test_corpus/real_projects/catalyst_skeleton/lib/BigController.pm");
+    let uri = file_uri(&file_path);
+    let source = build_large_catalyst_controller();
+    let source_line_count = source.lines().count();
+    assert!(source_line_count >= 5000, "expected >=5000 lines, got {source_line_count}");
+
+    let server = start_lsp_server();
+    initialize_lsp(&server);
+
+    let start = Instant::now();
+    open_document(&server, &uri, &source);
+    let maybe_diag = common::read_notification_method(
+        &server,
+        "textDocument/publishDiagnostics",
+        Duration::from_secs(5),
+    );
+    let elapsed = start.elapsed();
+
+    assert!(
+        maybe_diag.is_some(),
+        "did not receive publishDiagnostics within 5s for {source_line_count}-line Catalyst source"
+    );
+    assert!(
+        elapsed <= Duration::from_secs(5),
+        "first diagnostics took {:?} for {source_line_count}-line Catalyst source (target <5s)",
+        elapsed
+    );
+
+    eprintln!(
+        "real_project_first_diagnostics_catalyst_5000_lines_under_5s: {} ms ({} lines)",
+        elapsed.as_millis(),
+        source_line_count
+    );
 }

--- a/docs/project/CI_TEST_LANES.md
+++ b/docs/project/CI_TEST_LANES.md
@@ -33,6 +33,10 @@ The nightly workflow currently uses these labels:
 - `ci:strict`
 - `ci:mutation`
 
+Nightly benchmark runs also execute a real-repo LSP latency assertion:
+`real_project_first_diagnostics_catalyst_5000_lines_under_5s` in
+`crates/perl-lsp-rs/tests/real_project_latency.rs` (`cargo test -p perl-lsp-rs --test real_project_latency ... --include-ignored`).
+
 The broader label catalog lives in [`.github/ci-config.yml`](../../.github/ci-config.yml).
 Use that file as the source of truth when you add or rename labels.
 


### PR DESCRIPTION
### Motivation

- Nightly perf lanes ran micro-benchmarks but lacked a representative real-repo LSP gate that asserts first-diagnostics latency on a large Catalyst-style source, so regressions in real workloads could slip through.

### Description

- Added a synthetic ~5000-line Catalyst controller generator and a nightly-only test `real_project_first_diagnostics_catalyst_5000_lines_under_5s` to `crates/perl-lsp-rs/tests/real_project_latency.rs` that opens the file and asserts the first `textDocument/publishDiagnostics` arrives within 5s.
- Wired the test into the nightly benchmark job in `.github/workflows/ci-nightly.yml` (invoked as a focused `cargo test` call) so nightly benchmark runs exercise this real-repo latency gate.
- Documented the new gate in `docs/project/CI_TEST_LANES.md` so contributors can discover and run the check locally.

### Testing

- Ran `cargo test -p perl-lsp-rs --test real_project_latency test_real_project_fixtures_exist` and it passed.
- Ran `cargo test -p perl-lsp-rs --test real_project_latency real_project_first_diagnostics_catalyst_5000_lines_under_5s -- --include-ignored --nocapture` and it passed (local run printed ~521 ms for a 5006-line generated file).
- Ran `cargo check --all-targets -p perl-lsp-rs`, `cargo xtask fmt`, and `cargo clippy -p perl-lsp-rs` locally and they completed in this environment; `just pr-fast` was not available in the container so it was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e8cfb7548333bce6ae84f0b851ef)