### PR TITLE
test(incremental): fuzz apply_edits against ground truth (#4999)

### DIFF
--- a/crates/perl-parser/src/incremental/mod.rs
+++ b/crates/perl-parser/src/incremental/mod.rs
@@ -529,6 +529,20 @@ fn apply_single_edit(state: &mut IncrementalState, edit: &Edit) -> Result<Range<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+
+    #[derive(Clone, Debug)]
+    struct FuzzEdit {
+        start: usize,
+        delete_len: usize,
+        insert_text: String,
+    }
+
+    fn apply_edit_to_ground_truth(source: &mut String, edit: &FuzzEdit) {
+        let start = edit.start.min(source.len());
+        let old_end = (start + edit.delete_len).min(source.len());
+        source.replace_range(start..old_end, &edit.insert_text);
+    }
 
     /// Verify that a small ranged edit re-lexes substantially fewer bytes than
     /// the total document length, confirming the checkpoint fast-path fires.
@@ -613,6 +627,45 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    proptest! {
+        #[test]
+        fn prop_incremental_apply_edits_matches_ground_truth(
+            edits in prop::collection::vec(
+                (
+                    0usize..900usize,
+                    0usize..80usize,
+                    "[a-zA-Z0-9_ \\n;\\$\\(\\)\\{\\}\\[\\],]{0,40}"
+                ),
+                1..60
+            )
+        ) {
+            let mut state = IncrementalState::new("my $seed = 0;\n".repeat(80));
+            let mut expected_source = state.source.clone();
+
+            for (start, delete_len, insert_text) in edits {
+                let fuzz_edit = FuzzEdit { start, delete_len, insert_text };
+                let start_byte = fuzz_edit.start.min(state.source.len());
+                let old_end_byte = (start_byte + fuzz_edit.delete_len).min(state.source.len());
+
+                apply_edit_to_ground_truth(&mut expected_source, &fuzz_edit);
+
+                let incremental_edit = Edit {
+                    start_byte,
+                    old_end_byte,
+                    new_end_byte: start_byte + fuzz_edit.insert_text.len(),
+                    new_text: fuzz_edit.insert_text,
+                };
+
+                let result = apply_edits(&mut state, &[incremental_edit]);
+                prop_assert!(result.is_ok());
+                prop_assert_eq!(&state.source, &expected_source);
+            }
+
+            let reparsed = IncrementalState::new(expected_source);
+            prop_assert_eq!(&state.source, &reparsed.source);
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation

- A silent document-corruption bug (caught manually in #4999) showed we lack a property/fuzz harness that feeds random edit sequences to `apply_edits`, so regressions can go unnoticed.

### Description

- Added a proptest-based property test `prop_incremental_apply_edits_matches_ground_truth` in `crates/perl-parser/src/incremental/mod.rs` that generates random edit sequences and applies them to both the incremental `IncrementalState` (via `apply_edits`) and an independent ground-truth `String` model. 
- Introduced a small `FuzzEdit` model and `apply_edit_to_ground_truth` helper to mirror string edits for comparison.
- The test asserts equality of `state.source` and the ground-truth after every edit and verifies final state by constructing a fresh `IncrementalState` from the expected source and comparing end-state text.

### Testing

- Ran `cargo test -p perl-parser --features incremental prop_incremental_apply_edits_matches_ground_truth`, which passed.
- Ran `cargo check --all-targets -p perl-parser --features incremental`, which passed.
- Ran `cargo clippy -p perl-parser --features incremental -- -D warnings`, which passed.
- Ran `cargo xtask fmt`, which completed successfully.
- Note: `just pr-fast` was not available in this environment (`just: command not found`), so it was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e8d4afcc833387eb632e0dfdf595)