### PR TITLE
feat(xtask): enrich gate receipt for agent consumers (#5020)

### DIFF
--- a/.ci/receipt.schema.json
+++ b/.ci/receipt.schema.json
@@ -29,9 +29,72 @@
     },
     "diff_config": {
       "$ref": "#/$defs/diff_config"
+    },
+    "scope": {
+      "$ref": "#/$defs/agent_scope"
+    },
+    "selected_lanes": {
+      "type": "array",
+      "description": "Selected gate lanes for this run.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "reasons": {
+      "type": "array",
+      "description": "Human-readable reasons for selected lanes.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "failures": {
+      "$ref": "#/$defs/agent_failures"
+    },
+    "baselines": {
+      "type": "array",
+      "description": "Baseline artifacts considered by this run.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_actions": {
+      "type": "array",
+      "description": "Suggested operator follow-up actions.",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "$defs": {
+    "agent_scope": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["tier"],
+      "properties": {
+        "tier": {
+          "type": "string",
+          "description": "Gate tier used for this run."
+        },
+        "gate_filter": {
+          "type": ["string", "null"],
+          "description": "Optional single-gate filter used for this run."
+        }
+      }
+    },
+    "agent_failures": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["repro"],
+      "properties": {
+        "repro": {
+          "type": "array",
+          "description": "Reproduction commands for failed blocking lanes.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "metadata": {
       "type": "object",
       "description": "Execution context and environment information",

--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -210,6 +210,30 @@ pub struct Receipt {
     pub summary: ReceiptSummary,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diff_config: Option<DiffConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<AgentScopeReceipt>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub selected_lanes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reasons: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failures: Option<AgentFailureReceipt>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub baselines: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_actions: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AgentScopeReceipt {
+    pub tier: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gate_filter: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AgentFailureReceipt {
+    pub repro: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -703,12 +727,27 @@ fn run_gates(
         aggregate_metrics: None, // Could aggregate test counts etc.
     };
 
+    let selected_lanes: Vec<String> = gates.iter().map(|gate| gate.name.clone()).collect();
+    let reasons = build_lane_reasons(gates);
+    let failures = build_failure_repro(&results);
+    let baselines = build_baselines(config);
+    let next_actions = build_next_actions(&summary, &results);
+
     Ok(Receipt {
         schema_version: "1.0.0".to_string(),
         metadata,
         gates: results,
         summary,
         diff_config: None,
+        scope: Some(AgentScopeReceipt {
+            tier: config.tier.to_string(),
+            gate_filter: config.gate_filter.clone(),
+        }),
+        selected_lanes,
+        reasons,
+        failures,
+        baselines,
+        next_actions,
     })
 }
 
@@ -1358,10 +1397,57 @@ fn determine_overall_status(failed: u32, blocking_failures: &[String]) -> &'stat
     if blocking_failures.is_empty() { if failed > 0 { "partial" } else { "pass" } } else { "fail" }
 }
 
+fn build_lane_reasons(gates: &[&GateDefinition]) -> Vec<String> {
+    gates.iter().map(|gate| format!("{}: {}", gate.name, gate.description)).collect()
+}
+
+fn build_failure_repro(results: &[GateResult]) -> Option<AgentFailureReceipt> {
+    let repro: Vec<String> = results
+        .iter()
+        .filter(|result| is_blocking_gate_status(&result.status))
+        .map(|result| format!("{} (`{}`)", result.gate_name, result.command))
+        .collect();
+
+    if repro.is_empty() { None } else { Some(AgentFailureReceipt { repro }) }
+}
+
+fn build_baselines(config: &GateRunnerConfig) -> Vec<String> {
+    config.diff_baseline.as_ref().map(|path| vec![path.display().to_string()]).unwrap_or_default()
+}
+
+fn build_next_actions(summary: &ReceiptSummary, results: &[GateResult]) -> Vec<String> {
+    if summary.overall_status == "pass" {
+        return vec!["No blocking failures detected; proceed with merge flow.".to_string()];
+    }
+
+    let mut actions: Vec<String> = results
+        .iter()
+        .filter(|result| is_blocking_gate_status(&result.status))
+        .map(|result| {
+            format!(
+                "Reproduce and fix {} via `{}`; review {}.",
+                result.gate_name,
+                result.command,
+                result.log_path.as_deref().unwrap_or("captured output")
+            )
+        })
+        .collect();
+
+    if actions.is_empty() {
+        actions.push(
+            "Non-blocking failures detected; inspect failing lanes and decide whether to escalate."
+                .to_string(),
+        );
+    }
+
+    actions
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        GateResult, blocking_failure_gate_names, determine_overall_status, is_blocking_gate_status,
+        GateResult, ReceiptSummary, blocking_failure_gate_names, build_failure_repro,
+        build_next_actions, determine_overall_status, is_blocking_gate_status,
     };
 
     fn gate_result(name: &str, status: &str, required: bool) -> GateResult {
@@ -1408,5 +1494,32 @@ mod tests {
     fn overall_status_is_fail_when_required_timeout_exists_even_without_fail_count() {
         let blocking_failures = vec!["req-timeout".to_string()];
         assert_eq!(determine_overall_status(0, &blocking_failures), "fail");
+    }
+
+    #[test]
+    fn failure_repro_is_included_for_blocking_failures() {
+        let results = vec![gate_result("clippy", "fail", true), gate_result("fmt", "pass", true)];
+        let failures = build_failure_repro(&results).expect("blocking failures should be present");
+        assert_eq!(failures.repro, vec!["clippy (`true`)"]);
+    }
+
+    #[test]
+    fn next_actions_is_success_message_when_receipt_passes() {
+        let summary = ReceiptSummary {
+            total_gates: 1,
+            passed: 1,
+            failed: 0,
+            skipped: 0,
+            timeout: None,
+            error: None,
+            total_duration_ms: 1,
+            tier_results: None,
+            overall_status: "pass".to_string(),
+            blocking_failures: None,
+            aggregate_metrics: None,
+        };
+
+        let actions = build_next_actions(&summary, &[]);
+        assert_eq!(actions, vec!["No blocking failures detected; proceed with merge flow."]);
     }
 }


### PR DESCRIPTION
### Motivation
- PR responders repeatedly re-read clippy/test log tails because `target/receipts/receipt.json` lacked lane-selection rationale and actionable follow-ups.
- That extra log parsing is expensive for downstream agents and prevents cheap token savings per-PR.  
- Extend the gate receipt so agent consumers can decide next steps without re-reading full logs.

### Description
- Add agent-facing fields to the gate `Receipt` model in `xtask/src/tasks/gates.rs`: `scope`, `selected_lanes`, `reasons`, `failures`, `baselines`, and `next_actions`, and new types `AgentScopeReceipt` and `AgentFailureReceipt`.
- Populate those fields during `run_gates` using helpers `build_lane_reasons`, `build_failure_repro`, `build_baselines`, and `build_next_actions`, and include `scope` from `GateRunnerConfig`.
- Update the JSON schema at `.ci/receipt.schema.json` to include `agent_scope` and `agent_failures` and the new top-level properties so emitted receipts remain schema-aligned.
- Add unit tests that exercise `build_failure_repro` and the success-path `build_next_actions`, and ensure formatting/linting for the `xtask` crate.

### Testing
- Ran `cargo test -p xtask gates::tests`, and the focused tests passed (`5 passed`).
- Ran `cargo check --all-targets -p xtask`, which completed successfully.
- Ran formatting and lint checks: `cargo xtask fmt --check` and `cargo clippy -p xtask -- -D warnings`, both passed after formatting fixes.
- `just pr-fast` could not be executed in this environment because `just` was not installed (no-op for local verification here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e91153888333a10ec193d68d4727)