### PR TITLE
ci(scope): compile integration tests in PR smoke (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,8 @@ jobs:
         run: |
           cargo clippy --locked ${{ steps.scope.outputs.crates_args }} -- -D warnings -A missing_docs
 
-      # ── Scoped test (scope-aware path) ───────────────────────────────────
-      - name: Scoped test
+      # ── Scoped unit + integration compile (scope-aware path) ─────────────
+      - name: Scoped test (library unit tests)
         if: |
           steps.scope.outputs.scope_ok == 'true' &&
           steps.scope.outputs.diff_class != 'prose_only' &&
@@ -160,6 +160,15 @@ jobs:
           steps.scope.outputs.crates_args != ''
         run: |
           cargo test --locked --lib ${{ steps.scope.outputs.crates_args }}
+
+      - name: Scoped check (integration tests compile)
+        if: |
+          steps.scope.outputs.scope_ok == 'true' &&
+          steps.scope.outputs.diff_class != 'prose_only' &&
+          steps.scope.outputs.diff_class != 'ci_config' &&
+          steps.scope.outputs.crates_args != ''
+        run: |
+          cargo check --locked --tests ${{ steps.scope.outputs.crates_args }}
 
       # ── Fallback: baseline clippy-core / test-core ────────────────────────
       # Runs when: ci-scope failed (scope_ok=false), OR ci-scope returned no
@@ -180,6 +189,14 @@ jobs:
            steps.scope.outputs.diff_class != 'ci_config' &&
            steps.scope.outputs.crates_args == '')
         run: just test-core
+
+      - name: Fallback check (workspace integration tests compile)
+        if: |
+          steps.scope.outputs.scope_ok == 'false' ||
+          (steps.scope.outputs.diff_class != 'prose_only' &&
+           steps.scope.outputs.diff_class != 'ci_config' &&
+           steps.scope.outputs.crates_args == '')
+        run: cargo check --workspace --tests --locked
 
   # ── Merge Gate: full validation on every PR and push to main ─────────
   merge-gate:


### PR DESCRIPTION
### Motivation
- Integration tests under `crates/*/tests/*.rs` were not compiled in scoped PR smoke lanes, which lets integration-level bit-rot silently accumulate.

### Description
- Added a scope-aware `cargo check --tests` step to the scoped CI path so the selected crates' integration tests are compiled during PR smoke.
- Kept the existing scoped `cargo test --lib` (renamed step to `Scoped test (library unit tests)`) to run unit tests as before.
- Added a fallback `cargo check --workspace --tests --locked` step when `ci-scope` fails or returns no crates to ensure workspace-wide integration compilation coverage.

### Testing
- Ran `cargo check -p xtask --locked` locally and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ef112f1c8333939f5971dfab40ef)