### PR TITLE
fix(ci): compile integration tests in PR smoke (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,16 @@ jobs:
         run: |
           cargo test --locked --lib ${{ steps.scope.outputs.crates_args }}
 
+      # Compile integration tests to catch crates/*/tests/*.rs bit-rot.
+      # cargo test --lib alone does not build these targets.
+      - name: Compile integration tests
+        if: |
+          steps.scope.outputs.scope_ok == 'true' &&
+          steps.scope.outputs.diff_class != 'prose_only' &&
+          steps.scope.outputs.diff_class != 'ci_config'
+        run: |
+          cargo check --workspace --tests --locked
+
       # ── Fallback: baseline clippy-core / test-core ────────────────────────
       # Runs when: ci-scope failed (scope_ok=false), OR ci-scope returned no
       # crates to check (empty crates_args on a non-prose diff — shouldn't


### PR DESCRIPTION
### Motivation
- PR smoke previously ran `cargo test --lib`, which does not build integration tests under `crates/*/tests/*.rs`, allowing integration-target bit-rot to slip through.

### Description
- Add a scoped PR-smoke step in `.github/workflows/ci.yml` to run `cargo check --workspace --tests --locked` for non-prose / non-CI-config diffs so integration tests are compiled during fast CI.

### Testing
- Ran `cargo check --workspace --tests --locked` locally and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ef112f1c8333939f5971dfab40ef)