### PR TITLE
ci(workflows): compile scoped integration tests on push (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,16 @@ jobs:
         run: |
           cargo test --locked --lib ${{ steps.scope.outputs.crates_args }}
 
+      # Compile integration tests so crates/*/tests stay healthy on push.
+      - name: Scoped integration-test compile
+        if: |
+          steps.scope.outputs.scope_ok == 'true' &&
+          steps.scope.outputs.diff_class != 'prose_only' &&
+          steps.scope.outputs.diff_class != 'ci_config' &&
+          steps.scope.outputs.crates_args != ''
+        run: |
+          cargo check --locked --tests ${{ steps.scope.outputs.crates_args }}
+
       # ── Fallback: baseline clippy-core / test-core ────────────────────────
       # Runs when: ci-scope failed (scope_ok=false), OR ci-scope returned no
       # crates to check (empty crates_args on a non-prose diff — shouldn't
@@ -180,6 +190,14 @@ jobs:
            steps.scope.outputs.diff_class != 'ci_config' &&
            steps.scope.outputs.crates_args == '')
         run: just test-core
+
+      - name: Fallback integration-test compile
+        if: |
+          steps.scope.outputs.scope_ok == 'false' ||
+          (steps.scope.outputs.diff_class != 'prose_only' &&
+           steps.scope.outputs.diff_class != 'ci_config' &&
+           steps.scope.outputs.crates_args == '')
+        run: cargo check --workspace --tests --locked
 
   # ── Merge Gate: full validation on every PR and push to main ─────────
   merge-gate:


### PR DESCRIPTION
### Motivation

- Push-triggered PR smoke previously ran `cargo test --lib` which did not compile integration tests under `crates/*/tests`, allowing integration tests to silently rot on push. 
- Ensure integration tests are compiled for scoped crate changes and in fallback cases so the CI surface retains coverage of integration tests.

### Description

- Add a `Scoped integration-test compile` step to `.github/workflows/ci.yml` that runs `cargo check --locked --tests ${{ steps.scope.outputs.crates_args }}` after the scoped `cargo test` step. 
- Add a `Fallback integration-test compile` step to `.github/workflows/ci.yml` that runs `cargo check --workspace --tests --locked` when `ci-scope` fails or returns no crates. 
- Change is limited to CI workflow wiring and does not alter runtime code or existing tests.

### Testing

- Ran `cargo xtask ci-audit-workflows` which completed successfully. 
- Verified the modified workflow file (`.github/workflows/ci.yml`) parses via the repository audit task with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ef112f1c8333939f5971dfab40ef)