### PR TITLE
ci(pr-smoke): compile integration tests in scoped lanes (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,17 @@ jobs:
         run: |
           cargo test --locked --lib ${{ steps.scope.outputs.crates_args }}
 
+      # Compile integration tests for the scoped crates to prevent
+      # crates/*/tests/*.rs bit-rot from slipping through PR smoke.
+      - name: Scoped integration compile check
+        if: |
+          steps.scope.outputs.scope_ok == 'true' &&
+          steps.scope.outputs.diff_class != 'prose_only' &&
+          steps.scope.outputs.diff_class != 'ci_config' &&
+          steps.scope.outputs.crates_args != ''
+        run: |
+          cargo check --locked --tests ${{ steps.scope.outputs.crates_args }}
+
       # ── Fallback: baseline clippy-core / test-core ────────────────────────
       # Runs when: ci-scope failed (scope_ok=false), OR ci-scope returned no
       # crates to check (empty crates_args on a non-prose diff — shouldn't
@@ -180,6 +191,14 @@ jobs:
            steps.scope.outputs.diff_class != 'ci_config' &&
            steps.scope.outputs.crates_args == '')
         run: just test-core
+
+      - name: Fallback integration compile check
+        if: |
+          steps.scope.outputs.scope_ok == 'false' ||
+          (steps.scope.outputs.diff_class != 'prose_only' &&
+           steps.scope.outputs.diff_class != 'ci_config' &&
+           steps.scope.outputs.crates_args == '')
+        run: cargo check --workspace --tests --locked
 
   # ── Merge Gate: full validation on every PR and push to main ─────────
   merge-gate:


### PR DESCRIPTION
### Motivation
- PR-smoke runs used `cargo test --lib`, which does not compile integration tests under `crates/*/tests/*.rs` and allowed those targets to silently rot.

### Description
- Add a `Scoped integration compile check` step that runs `cargo check --locked --tests ${{ steps.scope.outputs.crates_args }}` for scoped PR-smoke lanes.
- Add a `Fallback integration compile check` step that runs `cargo check --workspace --tests --locked` when `ci-scope` fails or yields no crates.

### Testing
- Confirmed the change by running `git diff -- .github/workflows/ci.yml` to view the patch and `nl -ba .github/workflows/ci.yml | sed -n '148,215p'` to inspect the inserted steps, both showing the new scoped and fallback integration compile checks.
- No runtime CI jobs were executed locally because this modifies GitHub Actions flow; the new steps will be exercised on the next CI run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ef112f1c8333939f5971dfab40ef)