### PR TITLE
ci(workflows): compile scoped integration tests in PR smoke (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,8 @@ jobs:
         run: |
           cargo clippy --locked ${{ steps.scope.outputs.crates_args }} -- -D warnings -A missing_docs
 
-      # ── Scoped test (scope-aware path) ───────────────────────────────────
-      - name: Scoped test
+      # ── Scoped tests (scope-aware path) ──────────────────────────────────
+      - name: Scoped tests
         if: |
           steps.scope.outputs.scope_ok == 'true' &&
           steps.scope.outputs.diff_class != 'prose_only' &&
@@ -160,6 +160,7 @@ jobs:
           steps.scope.outputs.crates_args != ''
         run: |
           cargo test --locked --lib ${{ steps.scope.outputs.crates_args }}
+          cargo check --locked --tests ${{ steps.scope.outputs.crates_args }}
 
       # ── Fallback: baseline clippy-core / test-core ────────────────────────
       # Runs when: ci-scope failed (scope_ok=false), OR ci-scope returned no


### PR DESCRIPTION
### Motivation
- Scoped PR smoke only ran `cargo test --locked --lib`, which does not compile integration tests under `crates/*/tests/*.rs` and can allow integration tests to silently rot.

### Description
- Update `./github/workflows/ci.yml` to run `cargo check --locked --tests` for the same scoped crate set in the PR-smoke scoped test lane in addition to the existing `cargo test --locked --lib`, and rename the step to `Scoped tests`.

### Testing
- Attempted to run `just ci-audit-workflows` to validate workflow changes but `just` is not installed in this environment so the full workflow audit could not be executed; the CI YAML change is committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ef148aa88333b6b325454628d861)