### PR TITLE
ci(workflows): compile scoped integration tests in PR smoke (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,17 @@ jobs:
         run: |
           cargo test --locked --lib ${{ steps.scope.outputs.crates_args }}
 
+      # Compile integration tests for scoped crates to catch `crates/*/tests`
+      # bit-rot that `cargo test --lib` does not exercise.
+      - name: Scoped integration-test compile
+        if: |
+          steps.scope.outputs.scope_ok == 'true' &&
+          steps.scope.outputs.diff_class != 'prose_only' &&
+          steps.scope.outputs.diff_class != 'ci_config' &&
+          steps.scope.outputs.crates_args != ''
+        run: |
+          cargo check --locked --tests ${{ steps.scope.outputs.crates_args }}
+
       # ── Fallback: baseline clippy-core / test-core ────────────────────────
       # Runs when: ci-scope failed (scope_ok=false), OR ci-scope returned no
       # crates to check (empty crates_args on a non-prose diff — shouldn't
@@ -180,6 +191,14 @@ jobs:
            steps.scope.outputs.diff_class != 'ci_config' &&
            steps.scope.outputs.crates_args == '')
         run: just test-core
+
+      - name: Fallback integration-test compile
+        if: |
+          steps.scope.outputs.scope_ok == 'false' ||
+          (steps.scope.outputs.diff_class != 'prose_only' &&
+           steps.scope.outputs.diff_class != 'ci_config' &&
+           steps.scope.outputs.crates_args == '')
+        run: cargo check --workspace --tests --locked
 
   # ── Merge Gate: full validation on every PR and push to main ─────────
   merge-gate:


### PR DESCRIPTION
### Motivation
- PR smoke previously ran only `cargo test --lib`, which leaves `crates/*/tests/*.rs` uncompiled and allows integration-test bit-rot to slip through the fast gate.

### Description
- Add a scope-aware `cargo check --locked --tests ${{ steps.scope.outputs.crates_args }}` step and a fallback `cargo check --workspace --tests --locked` step to `.github/workflows/ci.yml` so integration-test targets are compiled during PR smoke.

### Testing
- Verified with `cargo xtask ci-audit-workflows`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ef148aa88333b6b325454628d861)