### PR TITLE
fix(ci): compile integration tests in PR smoke lanes (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,17 @@ jobs:
         run: |
           cargo test --locked --lib ${{ steps.scope.outputs.crates_args }}
 
+      # Compile integration tests for scoped crates so tests in crates/*/tests
+      # cannot silently bit-rot behind --lib-only lanes.
+      - name: Scoped integration-test compile check
+        if: |
+          steps.scope.outputs.scope_ok == 'true' &&
+          steps.scope.outputs.diff_class != 'prose_only' &&
+          steps.scope.outputs.diff_class != 'ci_config' &&
+          steps.scope.outputs.crates_args != ''
+        run: |
+          cargo check --locked --tests ${{ steps.scope.outputs.crates_args }}
+
       # ── Fallback: baseline clippy-core / test-core ────────────────────────
       # Runs when: ci-scope failed (scope_ok=false), OR ci-scope returned no
       # crates to check (empty crates_args on a non-prose diff — shouldn't
@@ -180,6 +191,14 @@ jobs:
            steps.scope.outputs.diff_class != 'ci_config' &&
            steps.scope.outputs.crates_args == '')
         run: just test-core
+
+      - name: Fallback integration-test compile check
+        if: |
+          steps.scope.outputs.scope_ok == 'false' ||
+          (steps.scope.outputs.diff_class != 'prose_only' &&
+           steps.scope.outputs.diff_class != 'ci_config' &&
+           steps.scope.outputs.crates_args == '')
+        run: cargo check --workspace --tests --locked
 
   # ── Merge Gate: full validation on every PR and push to main ─────────
   merge-gate:


### PR DESCRIPTION
### Motivation

- Prevent integration tests under `crates/*/tests/*.rs` from silently bit-rot because PR smoke lanes previously only exercised `--lib` tests.

### Description

- Added a scoped integration-test compile check that runs `cargo check --locked --tests ${{ steps.scope.outputs.crates_args }}` for selected crates in the PR-smoke job in `.github/workflows/ci.yml`.
- Added a fallback compile check that runs `cargo check --workspace --tests --locked` when `ci-scope` fails or no crates are selected, keeping the change confined to the PR-smoke workflow path.

### Testing

- Verified workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ok"'`, which succeeded.
- Started `cargo xtask ci-audit-workflows` to validate workflow policy and observed compilation progress (the run compiled many dependencies but did not finish within the interactive session window).
- Could not run `just ci-workflow-audit` in this environment because `just` is not installed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ef200e648333a2f41a10116ce73c)