### PR TITLE
fix(ci): compile scoped integration tests in PR smoke (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,8 @@ jobs:
         run: |
           cargo clippy --locked ${{ steps.scope.outputs.crates_args }} -- -D warnings -A missing_docs
 
-      # ── Scoped test (scope-aware path) ───────────────────────────────────
-      - name: Scoped test
+      # ── Scoped tests (scope-aware path) ──────────────────────────────────
+      - name: Scoped test (library targets)
         if: |
           steps.scope.outputs.scope_ok == 'true' &&
           steps.scope.outputs.diff_class != 'prose_only' &&
@@ -160,6 +160,15 @@ jobs:
           steps.scope.outputs.crates_args != ''
         run: |
           cargo test --locked --lib ${{ steps.scope.outputs.crates_args }}
+
+      - name: Scoped check (integration test compile)
+        if: |
+          steps.scope.outputs.scope_ok == 'true' &&
+          steps.scope.outputs.diff_class != 'prose_only' &&
+          steps.scope.outputs.diff_class != 'ci_config' &&
+          steps.scope.outputs.crates_args != ''
+        run: |
+          cargo check --locked --tests ${{ steps.scope.outputs.crates_args }}
 
       # ── Fallback: baseline clippy-core / test-core ────────────────────────
       # Runs when: ci-scope failed (scope_ok=false), OR ci-scope returned no


### PR DESCRIPTION
### Motivation
- The scope-aware PR smoke path only ran `cargo test --locked --lib`, which did not compile integration tests under `crates/*/tests/*.rs` and allowed integration-test bit-rot to go unnoticed.

### Description
- Added a scope-aware `cargo check --locked --tests ${{ steps.scope.outputs.crates_args }}` lane to `.github/workflows/ci.yml` next to the existing scoped `cargo test --locked --lib` step so integration tests are compiled whenever `ci-scope` selects crates.

### Testing
- Executed `cargo xtask ci-audit-workflows` and the audit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ef200e648333a2f41a10116ce73c)