### PR TITLE
ci(flakes): include integration tests in flake detection (#0000)

### DIFF
--- a/.github/workflows/flake-detection.yml
+++ b/.github/workflows/flake-detection.yml
@@ -50,7 +50,8 @@ jobs:
         run: |
           set -euo pipefail
           FILTER="${{ github.event.inputs.test_filter }}"
-          cargo test --workspace --lib --locked -Z unstable-options --format json \
+          # Intentionally include integration tests to avoid --lib-only blind spots.
+          cargo test --workspace --locked -Z unstable-options --format json \
             $FILTER > test-results.jsonl 2>&1 || true
 
           python3 .ci/scripts/extract-failed-tests.py \
@@ -80,7 +81,7 @@ jobs:
 
             for i in 1 2 3; do
               echo "::group::Retry $i/3 for $test_name"
-              if cargo test "$test_name" --lib --locked -- --test-threads=1 2>&1 | tee retry-run.log; then
+              if cargo test "$test_name" --locked -- --test-threads=1 2>&1 | tee retry-run.log; then
                 PASSED=true
                 RETRY_LOG=$(cat retry-run.log)
                 echo "::endgroup::"


### PR DESCRIPTION
### Motivation
- Nightly flake detection previously ran `cargo test --workspace --lib`, which excluded integration tests and allowed integration-test flakes to be missed by the auto-detection and retry logic.

### Description
- Remove the `--lib` filter from the initial JSON capture and per-test retries in `.github/workflows/flake-detection.yml` so integration tests are included in detection and retry classification, and add an inline comment documenting the rationale.

### Testing
- Validated the updated workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/flake-detection.yml')"`, which succeeded; an attempted `python3` `PyYAML` validation could not run in this environment because `PyYAML` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ef200e648333a2f41a10116ce73c)