### PR TITLE
feat(metrics): add explicit completion relevance rows (#5154)

### DIFF
--- a/xtask/src/tasks/metrics/lsp_stats.rs
+++ b/xtask/src/tasks/metrics/lsp_stats.rs
@@ -64,6 +64,14 @@ pub struct UxMetrics {
 
     // --- Feature drill-down rows (Phase 1 fills the first three) ---
     pub hover_correctness_rate: Option<f64>,
+    /// Top-1 completion relevance against gold fixtures.
+    /// Phase 2 (ranking-aware fixture assertions).
+    pub completion_top1_relevance: Option<f64>,
+    /// Top-5 completion relevance against gold fixtures.
+    /// Phase 1 currently approximates this from completion pass rate.
+    pub completion_top5_relevance: Option<f64>,
+    /// Backward-compatible alias kept while downstream consumers migrate.
+    /// Prefer `completion_top5_relevance`.
     pub completion_top5_usefulness: Option<f64>,
     pub completion_empty_when_should_not_be_empty_rate: Option<f64>,
     pub goto_definition_exact_hit_rate: Option<f64>,
@@ -195,6 +203,8 @@ fn build_metrics(last_run: Option<&LastRunMetrics>) -> UxMetrics {
         workflow_stability_rate: None,            // Phase 2
         p95_time_to_first_useful_result_ms: None, // Phase 2
         hover_correctness_rate: hover_rate,
+        completion_top1_relevance: None, // Phase 2
+        completion_top5_relevance: completion_rate,
         completion_top5_usefulness: completion_rate,
         completion_empty_when_should_not_be_empty_rate: None, // Phase 2
         goto_definition_exact_hit_rate: goto_rate,
@@ -263,8 +273,10 @@ fn print_table(
             println!("  goto_definition_exact_hit:   {:.1}%", rate * 100.0);
         }
         if let Some(rate) = run.completion_rate() {
+            println!("  completion_top5_relevance:   {:.1}%", rate * 100.0);
             println!("  completion_top5_usefulness:  {:.1}%", rate * 100.0);
         }
+        println!("  completion_top1_relevance:   (Phase 2)");
         println!("  workflow_stability_rate:     (Phase 2)");
         println!("  p95_time_to_first_result_ms: (Phase 2)");
     } else {
@@ -327,6 +339,8 @@ mod tests {
                 workflow_stability_rate: None,
                 p95_time_to_first_useful_result_ms: None,
                 hover_correctness_rate: Some(0.89),
+                completion_top1_relevance: None,
+                completion_top5_relevance: Some(0.86),
                 completion_top5_usefulness: Some(0.86),
                 completion_empty_when_should_not_be_empty_rate: None,
                 goto_definition_exact_hit_rate: Some(0.94),

--- a/xtask/src/tasks/metrics/lsp_stats.rs
+++ b/xtask/src/tasks/metrics/lsp_stats.rs
@@ -358,5 +358,17 @@ mod tests {
         assert_eq!(parsed["subsystem"], "editor_ux");
         assert!((parsed["metrics"]["workflow_pass_rate"].as_f64().unwrap() - 0.91).abs() < 0.001);
         assert!(parsed["metrics"]["rename_success_rate"].is_null());
+        // Verify new relevance fields serialize correctly
+        assert!(parsed["metrics"]["completion_top1_relevance"].is_null(),
+            "completion_top1_relevance should be null (Phase 2)");
+        assert!(
+            (parsed["metrics"]["completion_top5_relevance"].as_f64().unwrap() - 0.86).abs() < 0.001,
+            "completion_top5_relevance should serialize to 0.86"
+        );
+        // Backward-compat alias should also be present
+        assert!(
+            (parsed["metrics"]["completion_top5_usefulness"].as_f64().unwrap() - 0.86).abs() < 0.001,
+            "completion_top5_usefulness alias should still serialize"
+        );
     }
 }


### PR DESCRIPTION
### Motivation

- Align the editor-UX scorecard with the planned top-1 / top-5 completion relevance model while preserving existing consumers of the `completion_top5_usefulness` field.

### Description

- Add `completion_top1_relevance` and `completion_top5_relevance` fields to `xtask` output and the `UxMetrics` struct and keep `completion_top5_usefulness` as a backward-compatible alias in `xtask/src/tasks/metrics/lsp_stats.rs`.
- Wire `completion_top5_relevance` to the current completion pass-rate data as a Phase-1 approximation and leave `completion_top1_relevance` as Phase-2 (pending ranking instrumentation), and update CLI printing and the serialization test to cover the new shape.

### Testing

- Ran `cargo test -p xtask lsp_stats -- --nocapture` and the unit tests for `lsp_stats` passed.
- Verified `cargo check --all-targets -p xtask`, `cargo clippy -p xtask -- -D warnings`, and `cargo xtask fmt` all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ef200e648333a2f41a10116ce73c)