### PR TITLE
fix(ci): Windows Guardrails package ID — perl-workspace-index → perl-workspace (#5316)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,7 +428,7 @@ jobs:
               cargo check --locked --all-targets
               -p perl-module
               -p perl-lsp-rs
-              -p perl-workspace-index
+              -p perl-workspace
           - name: module-separator-regressions
             command: >-
               cargo test --locked -p perl-module


### PR DESCRIPTION
Closes #5316. One-line fix: the `compile` lane in `.github/workflows/ci.yml:431` used `-p perl-workspace-index` but the actual Cargo package name in `crates/perl-workspace-index/Cargo.toml` is `perl-workspace`.

Both Windows Guardrails lanes fail with:
```
error: package ID specification `perl-workspace-index` did not match any packages
```

## Impact

Blocks merge-gate on ~25+ in-flight PRs. Unblocks on merge.

## Pattern

6th master bit-rot exposed this session by scope expansion. Sequence: #5016 super path → #5152 clippy/sandbox → #5198 stdout capture → #5212 canonicalize → #5313 snapshot drift → **#5316 Windows Guardrails crate-name drift**.