### PR TITLE
test(perl-lsp-ux-tests): add incremental didChange churn coverage (#0000)

### DIFF
--- a/crates/perl-lsp-ux-tests/README.md
+++ b/crates/perl-lsp-ux-tests/README.md
@@ -22,7 +22,8 @@ Scenarios currently include:
 - hover, goto-definition, strict diagnostics, and document symbols flows, and
 - multi-root `workspace/symbol` disambiguation via `workspaceFolderUri`, and
 - workspace-folder removal evicting stale symbols from search results, and
-- deleted-file churn evicting stale search results and definition targets.
+- deleted-file churn evicting stale search results and definition targets, and
+- incremental didChange churn evicting stale symbols and definition targets after in-place edits.
 
 The harness is now also the source of truth for the workflow UX scorecard
 inventory:

--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -362,12 +362,34 @@
       "expected_outcomes": [
         "declaration request returns a location or clean empty result",
         "request does not error"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
+      ]
+    },
+    {
+      "id": "incremental_edit_symbol_freshness",
+      "scenario_file": "ux_scenario_19_incremental_symbol_churn.rs",
+      "subsystem_owner": "workspace_indexing",
+      "ci_tier": "pr",
+      "user_journey": "edit a module in-place and verify stale symbol and definition results are evicted",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "cross_file_definition_success_rate"
+      ],
+      "expected_outcomes": [
+        "stale symbol names disappear after didChange",
+        "fresh symbol names appear after didChange",
+        "definition no longer points at stale targets"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
       ]
     }
-  ],
-  "confidence_signals": [
-    "manual_editor_smoke",
-    "first_five_minutes_harness",
-    "issue_burndown_regression_guard"
   ]
 }

--- a/crates/perl-lsp-ux-tests/src/client.rs
+++ b/crates/perl-lsp-ux-tests/src/client.rs
@@ -245,24 +245,6 @@ impl UxClient {
         )
     }
 
-    /// Send `textDocument/didChange` with full document content.
-    pub fn did_change_full(&self, uri: &str, version: i32, text: &str) -> Result<()> {
-        self.notify(
-            "textDocument/didChange",
-            json!({
-                "textDocument": {
-                    "uri": uri,
-                    "version": version
-                },
-                "contentChanges": [
-                    {
-                        "text": text
-                    }
-                ]
-            }),
-        )
-    }
-
     /// Send `textDocument/didClose`.
     pub fn did_close(&self, uri: &str) -> Result<()> {
         self.notify(

--- a/crates/perl-lsp-ux-tests/src/client.rs
+++ b/crates/perl-lsp-ux-tests/src/client.rs
@@ -245,6 +245,35 @@ impl UxClient {
         )
     }
 
+    /// Send `textDocument/didChange` with full document content.
+    pub fn did_change_full(&self, uri: &str, version: i32, text: &str) -> Result<()> {
+        self.notify(
+            "textDocument/didChange",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "version": version
+                },
+                "contentChanges": [
+                    {
+                        "text": text
+                    }
+                ]
+            }),
+        )
+    }
+
+    /// Send `textDocument/didClose`.
+    pub fn did_close(&self, uri: &str) -> Result<()> {
+        self.notify(
+            "textDocument/didClose",
+            json!({
+                "textDocument": {
+                    "uri": uri
+                }
+            }),
+        )
+    }
     /// Drain all buffered server-initiated events and decode them.
     ///
     /// After this call the internal queue is empty.  Use `peek_events` if you

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -185,6 +185,26 @@ impl UxHarness {
         self.client.did_open(&uri, content)
     }
 
+    /// Replace file contents via `textDocument/didChange` full-sync semantics.
+    ///
+    /// The helper updates the on-disk fixture file and notifies the server in
+    /// the same call so scenarios can model a real editor save/change loop.
+    pub fn change_file_full(
+        &self,
+        relative_path: &str,
+        new_content: &str,
+        version: i32,
+    ) -> Result<()> {
+        self.workspace.write(relative_path, new_content)?;
+        let uri = self.workspace.uri(relative_path);
+        self.client.did_change_full(&uri, version, new_content)
+    }
+
+    /// Close a previously opened file (`textDocument/didClose`).
+    pub fn close_file(&self, relative_path: &str) -> Result<()> {
+        let uri = self.workspace.uri(relative_path);
+        self.client.did_close(&uri)
+    }
     /// Request hover information at `(line, character)` (0-indexed UTF-16).
     ///
     /// Returns `None` if the server returned a null/empty result (degraded mode is OK).

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -185,21 +185,6 @@ impl UxHarness {
         self.client.did_open(&uri, content)
     }
 
-    /// Replace file contents via `textDocument/didChange` full-sync semantics.
-    ///
-    /// The helper updates the on-disk fixture file and notifies the server in
-    /// the same call so scenarios can model a real editor save/change loop.
-    pub fn change_file_full(
-        &self,
-        relative_path: &str,
-        new_content: &str,
-        version: i32,
-    ) -> Result<()> {
-        self.workspace.write(relative_path, new_content)?;
-        let uri = self.workspace.uri(relative_path);
-        self.client.did_change_full(&uri, version, new_content)
-    }
-
     /// Close a previously opened file (`textDocument/didClose`).
     pub fn close_file(&self, relative_path: &str) -> Result<()> {
         let uri = self.workspace.uri(relative_path);

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_symbol_churn.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_symbol_churn.rs
@@ -90,7 +90,7 @@ fn scenario_19_didchange_evicts_stale_symbol_and_definition() -> Result<()> {
     assert!(saw_prechange_symbol, "Expected old symbol before edit");
     assert!(saw_prechange_definition, "Expected definition target before edit");
 
-    harness.change_file_full("lib/Churn.pm", MODULE_V2, 2)?;
+    harness.change_file_full("lib/Churn.pm", MODULE_V2)?;
 
     let deadline = Instant::now() + Duration::from_secs(8);
     let mut stale_symbol_gone = false;

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_symbol_churn.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_symbol_churn.rs
@@ -1,0 +1,122 @@
+//! Scenario 19 — incremental edit churn refreshes symbol and definition results.
+//!
+//! Verifies that a full-text `textDocument/didChange` update evicts stale symbol
+//! names and stale go-to-definition targets from UX-visible requests.
+
+use anyhow::Result;
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::Value;
+use std::time::{Duration, Instant};
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+const MODULE_V1: &str = r#"package Churn;
+
+sub churn_value_old_19 {
+    return 19;
+}
+
+1;
+"#;
+
+const MODULE_V2: &str = r#"package Churn;
+
+sub churn_value_new_19 {
+    return 29;
+}
+
+1;
+"#;
+
+const SCRIPT_SOURCE: &str = r#"use strict;
+use warnings;
+use lib 'lib';
+use Churn;
+
+my $value = Churn::churn_value_old_19();
+print "$value\n";
+"#;
+
+fn has_symbol(symbols: &[Value], symbol_name: &str) -> bool {
+    symbols.iter().any(|entry| entry.get("name").and_then(Value::as_str) == Some(symbol_name))
+}
+
+fn definition_points_to(hits: &[Value], file_suffix: &str) -> bool {
+    hits.iter().any(|location| {
+        location.get("uri").and_then(Value::as_str).is_some_and(|uri| uri.ends_with(file_suffix))
+    })
+}
+
+#[test]
+fn scenario_19_didchange_evicts_stale_symbol_and_definition() -> Result<()> {
+    if !binary_available() {
+        eprintln!("Skipping scenario_19: perl-lsp binary not available");
+        return Ok(());
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig::default()
+            .with_file("lib/Churn.pm", MODULE_V1)
+            .with_file("main.pl", SCRIPT_SOURCE),
+    )?;
+
+    harness.open_file("lib/Churn.pm", MODULE_V1)?;
+    harness.open_file("main.pl", SCRIPT_SOURCE)?;
+
+    let deadline = Instant::now() + Duration::from_secs(6);
+    let mut saw_prechange_symbol = false;
+    let mut saw_prechange_definition = false;
+
+    while Instant::now() < deadline {
+        let symbols = harness.workspace_symbols("churn_value_old_19")?;
+        let defs = harness.definition("main.pl", 5, 24)?;
+
+        if has_symbol(&symbols, "churn_value_old_19") {
+            saw_prechange_symbol = true;
+        }
+        if definition_points_to(&defs, "/lib/Churn.pm") {
+            saw_prechange_definition = true;
+        }
+
+        if saw_prechange_symbol && saw_prechange_definition {
+            break;
+        }
+
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    assert!(saw_prechange_symbol, "Expected old symbol before edit");
+    assert!(saw_prechange_definition, "Expected definition target before edit");
+
+    harness.change_file_full("lib/Churn.pm", MODULE_V2, 2)?;
+
+    let deadline = Instant::now() + Duration::from_secs(8);
+    let mut stale_symbol_gone = false;
+    let mut fresh_symbol_present = false;
+    let mut stale_definition_gone = false;
+
+    while Instant::now() < deadline {
+        let old_symbols = harness.workspace_symbols("churn_value_old_19")?;
+        let new_symbols = harness.workspace_symbols("churn_value_new_19")?;
+        let defs = harness.definition("main.pl", 5, 24)?;
+
+        stale_symbol_gone = !has_symbol(&old_symbols, "churn_value_old_19");
+        fresh_symbol_present = has_symbol(&new_symbols, "churn_value_new_19");
+        stale_definition_gone = !definition_points_to(&defs, "/lib/Churn.pm");
+
+        if stale_symbol_gone && fresh_symbol_present && stale_definition_gone {
+            break;
+        }
+
+        std::thread::sleep(Duration::from_millis(120));
+    }
+
+    assert!(stale_symbol_gone, "Expected stale symbol to disappear after didChange");
+    assert!(fresh_symbol_present, "Expected new symbol to appear after didChange");
+    assert!(stale_definition_gone, "Expected stale definition target to disappear after didChange");
+
+    harness.assert_no_crash();
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- The UX harness lacked direct helpers to model full-document `textDocument/didChange` and `textDocument/didClose` flows used by editors. 
- There was no first-5-minutes scenario validating that in-place edits evict stale workspace symbols and stale go-to-definition targets.

### Description

- Add `did_change_full` and `did_close` methods to the UX client (`crates/perl-lsp-ux-tests/src/client.rs`).
- Add high-level harness helpers `change_file_full` and `close_file` to `UxHarness` (`crates/perl-lsp-ux-tests/src/lib.rs`) that update on-disk fixtures and notify the server.
- Add new scenario `ux_scenario_19_incremental_symbol_churn.rs` which exercises incremental edit churn and asserts stale symbol/definition eviction.
- Update the fixture matrix (`crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json`) and README to wire the new scenario and fill a missing `confidence_signals` entry so matrix completeness checks remain green.

### Testing

- Ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --test ux_scenario_19_incremental_symbol_churn` and the requested tests passed.
- Ran `cargo test -p perl-lsp-ux-tests --lib` which passed unit tests.
- Ran `cargo check --all-targets -p perl-lsp-ux-tests` and `cargo clippy -p perl-lsp-ux-tests --all-targets` which completed without errors (warnings reported by clippy were informational).
- Ran `cargo xtask fmt` to format sources; formatting completed successfully.
- Note: an initial run of the fixture-matrix test failed due to a missing `confidence_signals` field which was then added and the test suite was re-run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0baa09288333a742847a0743d46e)