### PR TITLE
test(perl-lsp-ux-tests): expand workspace folder churn UX coverage (#0000)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -362,12 +362,34 @@
       "expected_outcomes": [
         "declaration request returns a location or clean empty result",
         "request does not error"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
+      ]
+    },
+    {
+      "id": "workspace_folder_addition_freshness",
+      "scenario_file": "ux_scenario_19_workspace_folder_addition.rs",
+      "subsystem_owner": "workspace_indexing",
+      "ci_tier": "pr",
+      "user_journey": "add a workspace folder after startup and verify its symbols and definition targets become discoverable",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "cross_file_definition_success_rate",
+        "multi_root_workspace_navigation_success_rate"
+      ],
+      "expected_outcomes": [
+        "newly added folder symbols appear in workspace/symbol",
+        "definition resolves into newly added folder without restart"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
       ]
     }
-  ],
-  "confidence_signals": [
-    "manual_editor_smoke",
-    "first_five_minutes_harness",
-    "issue_burndown_regression_guard"
   ]
 }

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -51,11 +51,11 @@ pub mod workspace;
 
 pub use client::{LspEvent, UxClient};
 pub use env::{PathGuard, RestrictedPath};
-pub use scorecard::{EditorUxScorecard, ScenarioScore, aggregate_editor_ux_scorecard};
+pub use scorecard::{aggregate_editor_ux_scorecard, EditorUxScorecard, ScenarioScore};
 pub use workspace::FakeWorkspace;
 
-use anyhow::{Context, Result, anyhow};
-use serde_json::{Value, json};
+use anyhow::{anyhow, Context, Result};
+use serde_json::{json, Value};
 use std::time::Duration;
 
 /// Configuration for a UX scenario.
@@ -307,6 +307,31 @@ impl UxHarness {
         }
     }
 
+    /// Poll `workspace/symbol` until `predicate` accepts the latest result or
+    /// `timeout` elapses.
+    ///
+    /// Returns the most recent symbol list observed.
+    pub fn wait_for_workspace_symbols_until<F>(
+        &self,
+        query: &str,
+        timeout: std::time::Duration,
+        mut predicate: F,
+    ) -> Result<Vec<Value>>
+    where
+        F: FnMut(&[Value]) -> bool,
+    {
+        let deadline = std::time::Instant::now() + timeout;
+        let mut latest_symbols = Vec::new();
+        while std::time::Instant::now() < deadline {
+            latest_symbols = self.workspace_symbols(query)?;
+            if predicate(&latest_symbols) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+        Ok(latest_symbols)
+    }
+
     /// Notify the server that workspace folders changed.
     ///
     /// Each tuple is `(relative_path, name)` and is resolved relative to the
@@ -426,6 +451,29 @@ impl UxHarness {
                 }
             }
         }
+    }
+
+    /// Poll go-to-definition until at least one location is returned or
+    /// `timeout` elapses.
+    ///
+    /// Returns the most recent definition response.
+    pub fn wait_for_definition(
+        &self,
+        relative_path: &str,
+        line: u32,
+        character: u32,
+        timeout: std::time::Duration,
+    ) -> Result<Vec<Value>> {
+        let deadline = std::time::Instant::now() + timeout;
+        let mut latest = Vec::new();
+        while std::time::Instant::now() < deadline {
+            latest = self.definition(relative_path, line, character)?;
+            if !latest.is_empty() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+        Ok(latest)
     }
 
     /// Request go-to-declaration.
@@ -573,7 +621,11 @@ impl FormatResult {
 
     /// Extract the error message string if this is an error.
     pub fn error_message(&self) -> Option<&str> {
-        if let Self::Error(v) = self { v["message"].as_str() } else { None }
+        if let Self::Error(v) = self {
+            v["message"].as_str()
+        } else {
+            None
+        }
     }
 
     /// True if there are text edits.

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_workspace_folder_addition.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_workspace_folder_addition.rs
@@ -1,0 +1,107 @@
+// Test infrastructure — allow test-friendly patterns.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+//! Scenario 19 — adding a workspace folder updates workspace-symbol and definition results.
+//!
+//! Verifies that adding a new workspace folder via
+//! `workspace/didChangeWorkspaceFolders` makes fresh symbols and definition
+//! targets discoverable without restarting the server.
+
+use anyhow::Result;
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::Value;
+use std::time::Duration;
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+const APP_SOURCE: &str = "\
+use strict;\n\
+use warnings;\n\
+use lib 'svc-a/lib';\n\
+use lib 'svc-b/lib';\n\
+use DynamicAdd;\n\
+\n\
+my $value = DynamicAdd::joined_after_add_5310();\n\
+print \"$value\\n\";\n\
+";
+
+const DYNAMIC_MODULE: &str = "\
+package DynamicAdd;\n\
+\n\
+sub joined_after_add_5310 {\n\
+    return 5310;\n\
+}\n\
+\n\
+1;\n\
+";
+
+fn contains_symbol_in_folder(symbols: &[Value], symbol_name: &str, folder_fragment: &str) -> bool {
+    symbols.iter().any(|symbol| {
+        symbol["name"].as_str() == Some(symbol_name)
+            && symbol
+                .pointer("/location/uri")
+                .and_then(Value::as_str)
+                .is_some_and(|uri| uri.contains(folder_fragment))
+    })
+}
+
+#[test]
+fn scenario_19_added_workspace_folder_symbols_and_definition_appear() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_19: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
+            .env("PERL_LSP_WORKSPACE", "1")
+            .with_workspace_folder("svc-a", "svc-a")
+            .with_file("main.pl", APP_SOURCE)
+            .with_file("svc-b/lib/DynamicAdd.pm", DYNAMIC_MODULE),
+    )?;
+
+    harness.open_file("main.pl", APP_SOURCE)?;
+
+    let symbols_before = harness.wait_for_workspace_symbols_until(
+        "joined_after_add_5310",
+        Duration::from_secs(5),
+        |symbols| symbols.is_empty(),
+    )?;
+    assert!(
+        symbols_before.is_empty(),
+        "Expected symbol to be absent before adding workspace folder, got: {:?}",
+        symbols_before
+    );
+
+    let defs_before = harness.definition("main.pl", 6, 29)?;
+    assert!(
+        defs_before.is_empty(),
+        "Expected definition to be unavailable before adding workspace folder, got: {:?}",
+        defs_before
+    );
+
+    harness.change_workspace_folders(&[("svc-b", "svc-b")], &[])?;
+
+    let symbols_after = harness.wait_for_workspace_symbols_until(
+        "joined_after_add_5310",
+        Duration::from_secs(10),
+        |symbols| contains_symbol_in_folder(symbols, "joined_after_add_5310", "/svc-b/"),
+    )?;
+    assert!(
+        contains_symbol_in_folder(&symbols_after, "joined_after_add_5310", "/svc-b/"),
+        "Expected added workspace folder to publish joined_after_add_5310, got: {:?}",
+        symbols_after
+    );
+
+    let defs_after = harness.wait_for_definition("main.pl", 6, 29, Duration::from_secs(10))?;
+    assert!(
+        !defs_after.is_empty(),
+        "Expected definition to resolve after adding svc-b workspace folder, got: {:?}",
+        defs_after
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- The UX harness covered workspace-folder removal and deleted-file churn but lacked a focused scenario to validate adding a workspace folder mid-session and exercising eventual-consistency UX flows.
- Tests needed reusable polling helpers to avoid duplicated retry loops when asserting on asynchronous `workspace/symbol` and cross-file `definition` freshness.

### Description

- Added two polling helpers to the UX harness: `wait_for_workspace_symbols_until(...)` and `wait_for_definition(...)` to encapsulate retry logic for eventual-consistency assertions in scenarios (`crates/perl-lsp-ux-tests/src/lib.rs`).
- Introduced a new BDD-style scenario `ux_scenario_19_workspace_folder_addition.rs` that verifies adding a workspace folder via `workspace/didChangeWorkspaceFolders` surfaces new workspace symbols and enables goto-definition without restarting the server (`crates/perl-lsp-ux-tests/tests/ux_scenario_19_workspace_folder_addition.rs`).
- Updated the editor UX fixture matrix to register the new scenario and to add missing `confidence_signals` for the existing scenario 18, keeping the matrix in sync with executable scenarios (`crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json`).

### Testing

- Ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix` which passed after the fixture update.
- Ran `cargo test -p perl-lsp-ux-tests --test ux_scenario_19_workspace_folder_addition` which passed.
- Ran `cargo check --all-targets -p perl-lsp-ux-tests` which passed.
- Ran `cargo clippy -p perl-lsp-ux-tests --lib --test ux_scenario_19_workspace_folder_addition -- -D warnings` which passed, while a pre-existing `clippy` warning in an unrelated test (`ux_scenario_13_document_symbols.rs`) surfaced under an all-targets `-D warnings` run and is unrelated to these changes.
- `just pr-fast` was not available in this environment and therefore was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0bc6df6c8333aa57728695089e7e)