### PR TITLE
test(perl-lsp-ux-tests): add didChange diagnostics refresh UX flow (#0000)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -362,6 +362,31 @@
       "expected_outcomes": [
         "declaration request returns a location or clean empty result",
         "request does not error"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
+      ]
+    },
+    {
+      "id": "live_diagnostics_refresh_after_edit",
+      "scenario_file": "ux_scenario_19_diagnostics_edit_refresh.rs",
+      "subsystem_owner": "diagnostics",
+      "ci_tier": "pr",
+      "user_journey": "fix strict diagnostics via in-editor edits and verify publishDiagnostics refreshes",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "diagnostics are present before edit",
+        "diagnostics clear after didChange-based fix without reopening file"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
       ]
     }
   ],

--- a/crates/perl-lsp-ux-tests/src/client.rs
+++ b/crates/perl-lsp-ux-tests/src/client.rs
@@ -245,6 +245,24 @@ impl UxClient {
         )
     }
 
+    /// Send `textDocument/didChange` with a full-document replacement payload.
+    pub fn did_change(&self, uri: &str, version: i32, text: &str) -> Result<()> {
+        self.notify(
+            "textDocument/didChange",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "version": version
+                },
+                "contentChanges": [
+                    {
+                        "text": text
+                    }
+                ]
+            }),
+        )
+    }
+
     /// Drain all buffered server-initiated events and decode them.
     ///
     /// After this call the internal queue is empty.  Use `peek_events` if you

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -154,7 +154,7 @@ pub struct UxHarness {
     pub client: UxClient,
     pub workspace: FakeWorkspace,
     config: ScenarioConfig,
-    file_versions: Mutex<HashMap<String, i32>>,
+    document_versions: Mutex<HashMap<String, i32>>,
 }
 
 impl UxHarness {
@@ -176,7 +176,7 @@ impl UxHarness {
         let client = UxClient::spawn(&binary_path, &workspace, &config)
             .context("Failed to spawn LSP server")?;
 
-        Ok(Self { client, workspace, config, file_versions: Mutex::new(HashMap::new()) })
+        Ok(Self { client, workspace, config, document_versions: Mutex::new(HashMap::new()) })
     }
 
     /// Open a file in the LSP server (textDocument/didOpen).
@@ -186,7 +186,7 @@ impl UxHarness {
         self.workspace.write(relative_path, content)?;
         let uri = self.workspace.uri(relative_path);
         self.client.did_open(&uri, content)?;
-        self.record_open_version(&uri);
+        self.document_versions.lock().unwrap_or_else(|e| e.into_inner()).insert(uri, 1);
         Ok(())
     }
 
@@ -569,13 +569,8 @@ impl UxHarness {
         &self.workspace.root_uri
     }
 
-    fn record_open_version(&self, uri: &str) {
-        let mut guard = self.file_versions.lock().unwrap_or_else(|e| e.into_inner());
-        guard.insert(uri.to_string(), 1);
-    }
-
     fn bump_file_version(&self, uri: &str) -> Result<i32> {
-        let mut guard = self.file_versions.lock().unwrap_or_else(|e| e.into_inner());
+        let mut guard = self.document_versions.lock().unwrap_or_else(|e| e.into_inner());
         match guard.get_mut(uri) {
             Some(version) => {
                 *version += 1;

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -56,6 +56,8 @@ pub use workspace::FakeWorkspace;
 
 use anyhow::{Context, Result, anyhow};
 use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::sync::Mutex;
 use std::time::Duration;
 
 /// Configuration for a UX scenario.
@@ -152,6 +154,7 @@ pub struct UxHarness {
     pub client: UxClient,
     pub workspace: FakeWorkspace,
     config: ScenarioConfig,
+    file_versions: Mutex<HashMap<String, i32>>,
 }
 
 impl UxHarness {
@@ -173,7 +176,7 @@ impl UxHarness {
         let client = UxClient::spawn(&binary_path, &workspace, &config)
             .context("Failed to spawn LSP server")?;
 
-        Ok(Self { client, workspace, config })
+        Ok(Self { client, workspace, config, file_versions: Mutex::new(HashMap::new()) })
     }
 
     /// Open a file in the LSP server (textDocument/didOpen).
@@ -182,7 +185,20 @@ impl UxHarness {
     pub fn open_file(&self, relative_path: &str, content: &str) -> Result<()> {
         self.workspace.write(relative_path, content)?;
         let uri = self.workspace.uri(relative_path);
-        self.client.did_open(&uri, content)
+        self.client.did_open(&uri, content)?;
+        self.record_open_version(&uri);
+        Ok(())
+    }
+
+    /// Replace the full file contents and notify the server with `didChange`.
+    ///
+    /// This mirrors the common editor UX where users fix diagnostics and expect
+    /// `publishDiagnostics` to refresh quickly without reopening the file.
+    pub fn change_file(&self, relative_path: &str, new_content: &str) -> Result<()> {
+        self.workspace.write(relative_path, new_content)?;
+        let uri = self.workspace.uri(relative_path);
+        let next_version = self.bump_file_version(&uri)?;
+        self.client.did_change(&uri, next_version, new_content)
     }
 
     /// Request hover information at `(line, character)` (0-indexed UTF-16).
@@ -551,6 +567,25 @@ impl UxHarness {
     /// Returns the root URI of the workspace (useful for the `rootUri` initialize param).
     pub fn root_uri(&self) -> &str {
         &self.workspace.root_uri
+    }
+
+    fn record_open_version(&self, uri: &str) {
+        let mut guard = self.file_versions.lock().unwrap_or_else(|e| e.into_inner());
+        guard.insert(uri.to_string(), 1);
+    }
+
+    fn bump_file_version(&self, uri: &str) -> Result<i32> {
+        let mut guard = self.file_versions.lock().unwrap_or_else(|e| e.into_inner());
+        match guard.get_mut(uri) {
+            Some(version) => {
+                *version += 1;
+                Ok(*version)
+            }
+            None => Err(anyhow!(
+                "cannot send didChange for unopened file `{}`; call open_file first",
+                uri
+            )),
+        }
     }
 }
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_edit_refresh.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_edit_refresh.rs
@@ -1,0 +1,53 @@
+//! Scenario 19: BDD coverage for live diagnostics refresh after in-editor fixes.
+//!
+//! User journey:
+//! - Given a file with strict-mode diagnostics.
+//! - When the user edits the file to fix the issue.
+//! - Then diagnostics should refresh and clear for that file.
+
+use anyhow::{Context, Result};
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use std::time::Duration;
+
+const BROKEN_SOURCE: &str = r#"use strict;
+use warnings;
+
+my $value = undef;
+print $missing_variable;
+"#;
+
+const FIXED_SOURCE: &str = r#"use strict;
+use warnings;
+
+my $value = 42;
+print $value;
+"#;
+
+#[test]
+fn scenario_19_diagnostics_refresh_after_fix_uses_did_change() -> Result<()> {
+    // Given: a strict Perl file with a missing variable diagnostic.
+    let harness = UxHarness::new(ScenarioConfig::default())
+        .context("failed to create UX harness for scenario_19")?;
+    harness.open_file("live_diagnostics.pl", BROKEN_SOURCE)?;
+
+    let initial_diagnostics =
+        harness.wait_for_diagnostics("live_diagnostics.pl", Duration::from_secs(5));
+    assert!(
+        !initial_diagnostics.is_empty(),
+        "expected initial diagnostics for broken source before edit"
+    );
+    let _ = harness.collect_notifications();
+
+    // When: the user fixes the file contents in-place.
+    harness.change_file("live_diagnostics.pl", FIXED_SOURCE)?;
+
+    // Then: diagnostics should refresh and settle to empty for the fixed file.
+    let diagnostics_after_fix =
+        harness.wait_for_diagnostics("live_diagnostics.pl", Duration::from_secs(6));
+    assert!(
+        diagnostics_after_fix.is_empty(),
+        "expected diagnostics to clear after fix; got: {diagnostics_after_fix:?}"
+    );
+    harness.assert_no_crash();
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- The UX harness lacked a first-class `textDocument/didChange` path and therefore did not cover live diagnostics refresh after in-editor fixes, which is an important BDD UX flow for diagnostics stability.

### Description

- Add `did_change` to the LSP client to emit `textDocument/didChange` with full-document replacement payload and explicit `version` (in `crates/perl-lsp-ux-tests/src/client.rs`).
- Extend `UxHarness` with per-file version tracking (`file_versions`) and a `change_file(...)` helper that writes the file, bumps version, and sends `didChange`, and make `open_file` record initial version (in `crates/perl-lsp-ux-tests/src/lib.rs`).
- Add a BDD-style scenario `ux_scenario_19_diagnostics_edit_refresh.rs` that verifies diagnostics are present for broken code, performs an in-place fix via `change_file`, and asserts diagnostics clear and the server remains stable (in `crates/perl-lsp-ux-tests/tests/`).
- Register the new scenario in the editor UX fixture matrix and augment confidence signals for alignment (in `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json`).

### Testing

- `cargo test -p perl-lsp-ux-tests --test ux_scenario_19_diagnostics_edit_refresh` (with `PERL_LSP_BIN=/workspace/perl-lsp/target/debug/perl-lsp`) — passed.
- `cargo check --all-targets -p perl-lsp-ux-tests` — passed.
- `cargo clippy -p perl-lsp-ux-tests --all-targets` — completed (no fatal issues; one unrelated clippy suggestion noted in an existing test).
- Note: running the full `cargo test -p perl-lsp-ux-tests` in a fresh environment requires a resolvable `perl-lsp` binary (set `PERL_LSP_BIN` or build `perl-lsp-rs`); environment without the binary will cause spawn failures unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0bc6df6c8333aa57728695089e7e)