### PR TITLE
test(perl-lsp-ux-tests): add incremental diagnostics UX scenario (#5306)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -362,6 +362,32 @@
       "expected_outcomes": [
         "declaration request returns a location or clean empty result",
         "request does not error"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
+      ]
+    },
+    {
+      "id": "incremental_edit_diagnostics_feedback_loop",
+      "scenario_file": "ux_scenario_19_incremental_diagnostics.rs",
+      "subsystem_owner": "diagnostics",
+      "ci_tier": "pr",
+      "user_journey": "fix a strict-mode error via didChange and verify diagnostics reflect the edit",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "initial diagnostic appears for undeclared variable",
+        "diagnostics clear after the fix is sent",
+        "hover remains responsive after incremental edits"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
       ]
     }
   ],

--- a/crates/perl-lsp-ux-tests/src/client.rs
+++ b/crates/perl-lsp-ux-tests/src/client.rs
@@ -7,8 +7,8 @@
 //! assert on user-visible messages after the fact.
 
 use crate::{FakeWorkspace, ScenarioConfig};
-use anyhow::{Context, Result, anyhow};
-use serde_json::{Value, json};
+use anyhow::{anyhow, Context, Result};
+use serde_json::{json, Value};
 use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, Command, Stdio};
@@ -241,6 +241,24 @@ impl UxClient {
                     "version": 1,
                     "text": text
                 }
+            }),
+        )
+    }
+
+    /// Send `textDocument/didChange` using full-document sync.
+    pub fn did_change(&self, uri: &str, text: &str, version: i32) -> Result<()> {
+        self.notify(
+            "textDocument/didChange",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "version": version
+                },
+                "contentChanges": [
+                    {
+                        "text": text
+                    }
+                ]
             }),
         )
     }

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -51,11 +51,13 @@ pub mod workspace;
 
 pub use client::{LspEvent, UxClient};
 pub use env::{PathGuard, RestrictedPath};
-pub use scorecard::{EditorUxScorecard, ScenarioScore, aggregate_editor_ux_scorecard};
+pub use scorecard::{aggregate_editor_ux_scorecard, EditorUxScorecard, ScenarioScore};
 pub use workspace::FakeWorkspace;
 
-use anyhow::{Context, Result, anyhow};
-use serde_json::{Value, json};
+use anyhow::{anyhow, Context, Result};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::Mutex;
 use std::time::Duration;
 
 /// Configuration for a UX scenario.
@@ -152,6 +154,7 @@ pub struct UxHarness {
     pub client: UxClient,
     pub workspace: FakeWorkspace,
     config: ScenarioConfig,
+    document_versions: Mutex<HashMap<String, i32>>,
 }
 
 impl UxHarness {
@@ -173,7 +176,7 @@ impl UxHarness {
         let client = UxClient::spawn(&binary_path, &workspace, &config)
             .context("Failed to spawn LSP server")?;
 
-        Ok(Self { client, workspace, config })
+        Ok(Self { client, workspace, config, document_versions: Mutex::new(HashMap::new()) })
     }
 
     /// Open a file in the LSP server (textDocument/didOpen).
@@ -182,7 +185,20 @@ impl UxHarness {
     pub fn open_file(&self, relative_path: &str, content: &str) -> Result<()> {
         self.workspace.write(relative_path, content)?;
         let uri = self.workspace.uri(relative_path);
-        self.client.did_open(&uri, content)
+        self.client.did_open(&uri, content)?;
+        self.set_document_version(relative_path, 1);
+        Ok(())
+    }
+
+    /// Apply an in-editor full-document text change (`textDocument/didChange`).
+    ///
+    /// The harness tracks and increments the LSP version for each file so
+    /// scenarios can focus on user intent instead of protocol bookkeeping.
+    pub fn change_file(&self, relative_path: &str, content: &str) -> Result<()> {
+        self.workspace.write(relative_path, content)?;
+        let uri = self.workspace.uri(relative_path);
+        let next_version = self.bump_document_version(relative_path);
+        self.client.did_change(&uri, content, next_version)
     }
 
     /// Request hover information at `(line, character)` (0-indexed UTF-16).
@@ -372,7 +388,7 @@ impl UxHarness {
     }
 
     /// Wait up to `timeout` for a `textDocument/publishDiagnostics` notification
-    /// for the given file, then return all diagnostics collected for it.
+    /// for the given file, then return the latest diagnostics payload observed.
     ///
     /// Returns an empty vec if the deadline expires with no diagnostics published.
     pub fn wait_for_diagnostics(
@@ -385,12 +401,16 @@ impl UxHarness {
         loop {
             {
                 let events = self.client.peek_events();
+                let mut latest = None;
                 for ev in &events {
                     if let LspEvent::Diagnostics { uri: diag_uri, diagnostics } = ev {
                         if diag_uri == &uri {
-                            return diagnostics.clone();
+                            latest = Some(diagnostics.clone());
                         }
                     }
+                }
+                if let Some(diagnostics) = latest {
+                    return diagnostics;
                 }
             }
             if std::time::Instant::now() >= deadline {
@@ -552,6 +572,18 @@ impl UxHarness {
     pub fn root_uri(&self) -> &str {
         &self.workspace.root_uri
     }
+
+    fn set_document_version(&self, relative_path: &str, version: i32) {
+        let mut versions = self.document_versions.lock().unwrap_or_else(|e| e.into_inner());
+        versions.insert(relative_path.to_string(), version);
+    }
+
+    fn bump_document_version(&self, relative_path: &str) -> i32 {
+        let mut versions = self.document_versions.lock().unwrap_or_else(|e| e.into_inner());
+        let next_version = versions.get(relative_path).copied().unwrap_or(0) + 1;
+        versions.insert(relative_path.to_string(), next_version);
+        next_version
+    }
 }
 
 /// Outcome of a formatting request.
@@ -573,7 +605,11 @@ impl FormatResult {
 
     /// Extract the error message string if this is an error.
     pub fn error_message(&self) -> Option<&str> {
-        if let Self::Error(v) = self { v["message"].as_str() } else { None }
+        if let Self::Error(v) = self {
+            v["message"].as_str()
+        } else {
+            None
+        }
     }
 
     /// True if there are text edits.

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_diagnostics.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_diagnostics.rs
@@ -1,0 +1,98 @@
+//! Scenario 19 — incremental edit flow updates diagnostics and keeps UX responsive.
+//!
+//! BDD focus:
+//! - GIVEN a file with an obvious strict-mode diagnostic.
+//! - WHEN the user fixes the file through a didChange edit.
+//! - THEN diagnostics should eventually clear and hover should still respond.
+
+use anyhow::Result;
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use std::time::{Duration, Instant};
+
+const BROKEN_SOURCE: &str = "\
+use strict;\n\
+use warnings;\n\
+\n\
+sub greet {\n\
+    return $missing_name;\n\
+}\n\
+\n\
+1;\n\
+";
+
+const FIXED_SOURCE: &str = "\
+use strict;\n\
+use warnings;\n\
+\n\
+my $missing_name = 'Perl';\n\
+\n\
+sub greet {\n\
+    return $missing_name;\n\
+}\n\
+\n\
+1;\n\
+";
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+fn wait_until_diagnostics(
+    harness: &UxHarness,
+    relative_path: &str,
+    expect_empty: bool,
+    timeout: Duration,
+) -> Vec<serde_json::Value> {
+    let deadline = Instant::now() + timeout;
+    let mut latest = Vec::new();
+    while Instant::now() < deadline {
+        latest = harness.wait_for_diagnostics(relative_path, Duration::from_millis(250));
+        if expect_empty == latest.is_empty() {
+            return latest;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    latest
+}
+
+#[test]
+fn scenario_19_incremental_edit_clears_diagnostics_and_preserves_hover() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_19: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("incremental.pl", BROKEN_SOURCE))?;
+
+    // GIVEN a strict file with an undeclared variable.
+    harness.open_file("incremental.pl", BROKEN_SOURCE)?;
+    let initial_diagnostics =
+        wait_until_diagnostics(&harness, "incremental.pl", false, Duration::from_secs(8));
+    assert!(
+        !initial_diagnostics.is_empty(),
+        "Expected diagnostics for undeclared variable before edit"
+    );
+
+    // WHEN the user applies an in-editor fix through didChange.
+    harness.change_file("incremental.pl", FIXED_SOURCE)?;
+
+    // THEN diagnostics eventually clear for the same document.
+    let final_diagnostics =
+        wait_until_diagnostics(&harness, "incremental.pl", true, Duration::from_secs(8));
+    assert!(
+        final_diagnostics.is_empty(),
+        "Expected diagnostics to clear after fix, got {final_diagnostics:?}"
+    );
+
+    // AND the file remains interactive for follow-up UX actions.
+    let hover = harness.hover("incremental.pl", 7, 12)?;
+    if hover.is_none() {
+        eprintln!(
+            "INFO scenario_19: hover returned null after edits (acceptable degraded behavior)"
+        );
+    }
+
+    harness.assert_no_crash();
+    Ok(())
+}

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_diagnostics.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_diagnostics.rs
@@ -74,6 +74,21 @@ fn scenario_19_incremental_edit_clears_diagnostics_and_preserves_hover() -> Resu
         "Expected diagnostics for undeclared variable before edit"
     );
 
+    // AND at least one diagnostic actually mentions the offending symbol —
+    // otherwise we cannot claim the diagnostic proves the strict-mode bug
+    // (it could be a stray unrelated warning).
+    let mentions_missing_name = initial_diagnostics.iter().any(|diag| {
+        diag.get("message")
+            .and_then(serde_json::Value::as_str)
+            .map(|m| m.contains("missing_name") || m.to_ascii_lowercase().contains("strict"))
+            .unwrap_or(false)
+    });
+    assert!(
+        mentions_missing_name,
+        "expected a diagnostic mentioning `missing_name` or `strict` for the \
+         undeclared-variable case; got: {initial_diagnostics:?}"
+    );
+
     // WHEN the user applies an in-editor fix through didChange.
     harness.change_file("incremental.pl", FIXED_SOURCE)?;
 
@@ -84,9 +99,19 @@ fn scenario_19_incremental_edit_clears_diagnostics_and_preserves_hover() -> Resu
         final_diagnostics.is_empty(),
         "Expected diagnostics to clear after fix, got {final_diagnostics:?}"
     );
+    // AND the clear was a real change, not a coincidence where both sides
+    // happened to be empty (which would imply the GIVEN never held).
+    assert_ne!(
+        final_diagnostics, initial_diagnostics,
+        "diagnostic set did not change across edit; test is vacuous"
+    );
 
-    // AND the file remains interactive for follow-up UX actions.
-    let hover = harness.hover("incremental.pl", 7, 12)?;
+    // AND the file remains interactive for follow-up UX actions. A hover
+    // error (JSON-RPC failure / timeout / crash) is a regression; a null
+    // result is degraded but acceptable for first-session UX.
+    let hover = harness
+        .hover("incremental.pl", 7, 12)
+        .map_err(|e| anyhow::anyhow!("hover errored after didChange fix: {e}"))?;
     if hover.is_none() {
         eprintln!(
             "INFO scenario_19: hover returned null after edits (acceptable degraded behavior)"


### PR DESCRIPTION
### Motivation
- The UX harness lacked a focused BDD workflow for in-editor incremental edits (`didChange`) and there was limited confidence that diagnostics update correctly after edits.
- Tests should exercise real editor feedback loops (edit → reanalysis → hover) so regressions in diagnostics refresh are caught early.

### Description
- Add `did_change` to the LSP client (`UxClient::did_change`) to emit full-document `textDocument/didChange` notifications.  
- Add harness-managed document version tracking (`document_versions`) and a high-level helper `UxHarness::change_file` so scenarios can perform edits without manual LSP version bookkeeping.  
- Update `UxHarness::wait_for_diagnostics` to return the latest diagnostics payload observed for a file instead of the first one seen, which is important for edit→reanalysis flows.  
- Add a new BDD-style scenario `ux_scenario_19_incremental_diagnostics.rs` that verifies: initial strict-mode diagnostic appears, the user fixes the file via `change_file` (didChange), diagnostics clear, and hover remains responsive; and update `editor_ux_fixture_matrix.json` to include the new scenario (and complete `scenario_18` metadata). 

### Testing
- Ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix editor_ux_fixture_matrix_covers_all_scenarios` and it passed.  
- Ran `cargo test -p perl-lsp-ux-tests --test ux_scenario_19_incremental_diagnostics -- --nocapture` which passed (the scenario self-skips when the `perl-lsp` binary is not available in the environment).  
- Ran `cargo check --all-targets -p perl-lsp-ux-tests` which completed successfully.  
- Ran `cargo clippy -p perl-lsp-ux-tests --tests -- -D warnings` which reported a pre-existing lint in an unrelated test file (`ux_scenario_13_document_symbols.rs`) and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0bc88d188333b8727a96103e5fd2)