### PR TITLE
test(perl-lsp-rs): add BDD inline completion UX harness coverage (#5306)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_inline_completion_stream_bdd_workflows.rs
+++ b/crates/perl-lsp-rs/tests/lsp_inline_completion_stream_bdd_workflows.rs
@@ -1,0 +1,143 @@
+//! BDD-style UX workflows for streaming inline completion.
+//!
+//! These scenarios validate user-visible behavior across request sequencing,
+//! document edits, and document lifecycle events.
+
+mod support;
+
+use serde_json::Value;
+use support::lsp_ux_harness::InlineCompletionUxHarness;
+
+struct Scenario {
+    name: &'static str,
+}
+
+impl Scenario {
+    fn new(name: &'static str) -> Self {
+        eprintln!("Scenario: {name}");
+        Self { name }
+    }
+
+    fn given(&self, step: &str) {
+        eprintln!("[{}] Given {}", self.name, step);
+    }
+
+    fn when(&self, step: &str) {
+        eprintln!("[{}] When {}", self.name, step);
+    }
+
+    fn then(&self, step: &str) {
+        eprintln!("[{}] Then {}", self.name, step);
+    }
+}
+
+fn session_id(progress: &Value) -> Option<&str> {
+    progress.pointer("/params/value/sessionId").and_then(Value::as_str)
+}
+
+fn has_inline_items(response: &Value) -> bool {
+    response.get("items").and_then(Value::as_array).is_some_and(|items| !items.is_empty())
+}
+
+#[test]
+fn bdd_streaming_emits_progress_with_session_identity() -> Result<(), Box<dyn std::error::Error>> {
+    let scenario = Scenario::new("Streaming completion emits session-tagged progress");
+    scenario.given("an initialized workspace with AI inline completion enabled");
+
+    let mut ux = InlineCompletionUxHarness::start(
+        "file:///bdd_streaming_progress.pl",
+        "use strict;\nmy $obj = Package->",
+    )?;
+
+    scenario.when("requesting streamed inline completion at the cursor");
+    let response = ux.request_stream(1, 19, "bdd-progress-token")?;
+
+    scenario.then("the server streams progress or returns explicit fallback inline items");
+    let progress = ux.progress_for_token("bdd-progress-token", 600);
+    if progress.is_empty() {
+        assert!(
+            has_inline_items(&response),
+            "expected streaming progress or fallback inline items; response={response}"
+        );
+    } else {
+        let first_sid =
+            progress.first().and_then(session_id).ok_or("progress payload missing sessionId")?;
+        assert!(!first_sid.is_empty(), "sessionId should not be empty");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn bdd_streaming_after_incremental_edit_uses_new_session() -> Result<(), Box<dyn std::error::Error>>
+{
+    let scenario = Scenario::new("Streaming completion after didChange opens a new stream session");
+    scenario.given("an open file with a partially typed symbol");
+
+    let mut ux = InlineCompletionUxHarness::start(
+        "file:///bdd_streaming_edit.pl",
+        "use strict;\nmy $obj = Package->",
+    )?;
+
+    scenario.when("requesting a stream, editing the file, and requesting again");
+    let first_response = ux.request_stream(1, 19, "token-before-edit")?;
+
+    ux.change_full(
+        "use strict;\nmy $obj = Package->
+",
+    )?;
+    let second_response = ux.request_stream(1, 19, "token-after-edit")?;
+
+    let progress = ux.drain_progress(800);
+    let before_progress: Vec<_> = progress
+        .iter()
+        .filter(|n| n.pointer("/params/token").and_then(Value::as_str) == Some("token-before-edit"))
+        .cloned()
+        .collect();
+    let after_progress: Vec<_> = progress
+        .iter()
+        .filter(|n| n.pointer("/params/token").and_then(Value::as_str) == Some("token-after-edit"))
+        .cloned()
+        .collect();
+    let before_covered = !before_progress.is_empty() || has_inline_items(&first_response);
+    let after_covered = !after_progress.is_empty() || has_inline_items(&second_response);
+
+    assert!(before_covered, "expected progress or fallback items before edit");
+    assert!(after_covered, "expected progress or fallback items after edit");
+
+    scenario.then("sequential requests stay isolated by token/session behavior");
+    if !before_progress.is_empty() && !after_progress.is_empty() {
+        let before_sid = before_progress
+            .first()
+            .and_then(session_id)
+            .ok_or("before-edit progress missing sessionId")?;
+        let after_sid = after_progress
+            .first()
+            .and_then(session_id)
+            .ok_or("after-edit progress missing sessionId")?;
+
+        assert_ne!(before_sid, after_sid, "stream sessions should rotate across requests");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn bdd_streaming_request_on_closed_document_is_safe() -> Result<(), Box<dyn std::error::Error>> {
+    let scenario = Scenario::new("Streaming completion gracefully handles closed documents");
+    scenario.given("a document was opened and then closed in the editor");
+
+    let mut ux = InlineCompletionUxHarness::start(
+        "file:///bdd_streaming_closed_doc.pl",
+        "use strict;\nmy $x = 1;\n",
+    )?;
+    ux.close_document()?;
+
+    scenario.when("requesting inline streaming completion for that closed URI");
+    let response = ux.request_stream(1, 5, "token-closed-doc")?;
+
+    scenario.then("the server returns null and avoids protocol-level failure");
+    assert!(response.is_null(), "closed-document streaming should return null");
+
+    Ok(())
+}

--- a/crates/perl-lsp-rs/tests/support/lsp_ux_harness.rs
+++ b/crates/perl-lsp-rs/tests/support/lsp_ux_harness.rs
@@ -1,7 +1,13 @@
+// Test-only helper methods are imported by selected UX suites.
+#![allow(dead_code)]
+
 //! UX-focused LSP test harness helpers.
 //!
-//! This module wraps [`LspHarness`] with a scenario-oriented API so tests can
-//! express Given/When/Then behavior without repeating boilerplate setup.
+//! This module wraps [`LspHarness`] with scenario-oriented APIs so tests can
+//! express Given/When/Then behavior without repeating boilerplate setup, and
+//! provides streaming-focused facades for inline completion workflows.
+
+use std::time::Duration;
 
 use serde_json::{Value, json};
 
@@ -103,5 +109,82 @@ pub fn assert_symbol_results_include_uri(
         Ok(())
     } else {
         Err(format!("expected symbol results to include '{expected_uri}', got: {response}"))
+    }
+}
+
+/// UX-focused facade for streaming inline completion workflows.
+pub struct InlineCompletionUxHarness {
+    harness: LspHarness,
+    uri: String,
+    version: i32,
+}
+
+impl InlineCompletionUxHarness {
+    /// Boot a harness, initialize the server, enable AI streaming, and open a document.
+    pub fn start(uri: &str, text: &str) -> Result<Self, String> {
+        let mut harness = LspHarness::new();
+        harness.initialize_default()?;
+        harness.notify(
+            "workspace/didChangeConfiguration",
+            json!({
+                "settings": {
+                    "perl": {
+                        "aiCompletion": {
+                            "enabled": true,
+                            "streaming": {
+                                "enabled": true
+                            }
+                        }
+                    }
+                }
+            }),
+        );
+        harness.open(uri, text)?;
+        std::thread::sleep(Duration::from_millis(50));
+        harness.wait_for_idle(Duration::from_millis(200));
+        let _ = harness.drain_notifications(None, 100);
+
+        Ok(Self { harness, uri: uri.to_string(), version: 1 })
+    }
+
+    /// Send a streaming inline completion request.
+    pub fn request_stream(
+        &mut self,
+        line: u32,
+        character: u32,
+        partial_result_token: &str,
+    ) -> Result<Value, String> {
+        self.harness.request(
+            "textDocument/perlInlineCompletionStream",
+            json!({
+                "textDocument": { "uri": self.uri, "version": self.version },
+                "position": { "line": line, "character": character },
+                "partialResultToken": partial_result_token
+            }),
+        )
+    }
+
+    /// Apply a full-document edit and increment the tracked document version.
+    pub fn change_full(&mut self, text: &str) -> Result<(), String> {
+        self.version += 1;
+        self.harness.change_full(&self.uri, self.version, text)
+    }
+
+    /// Close the current document.
+    pub fn close_document(&mut self) -> Result<(), String> {
+        self.harness.close(&self.uri)
+    }
+
+    /// Drain all `$\/progress` notifications emitted within the timeout window.
+    pub fn drain_progress(&mut self, timeout_ms: u64) -> Vec<Value> {
+        self.harness.drain_notifications(Some("$/progress"), timeout_ms)
+    }
+
+    /// Drain progress notifications associated with the supplied partial result token.
+    pub fn progress_for_token(&mut self, token: &str, timeout_ms: u64) -> Vec<Value> {
+        self.drain_progress(timeout_ms)
+            .into_iter()
+            .filter(|n| n.pointer("/params/token").and_then(Value::as_str) == Some(token))
+            .collect()
     }
 }


### PR DESCRIPTION
### Motivation
- Streaming inline-completion UX was exercised by low-level assertions but lacked a focused SRP-style harness and BDD workflows to validate editor-visible behavior across request sequencing, edits, and lifecycle events.

### Description
- Add `InlineCompletionUxHarness` (`crates/perl-lsp-rs/tests/support/lsp_ux_harness.rs`) as a small SRP facade that boots a harness, toggles AI/streaming config, opens/edits/closes documents, and drains progress notifications.
- Add a BDD-style test suite (`crates/perl-lsp-rs/tests/lsp_inline_completion_stream_bdd_workflows.rs`) with scenarios validating streamed progress (with session identity), edit-driven session isolation, and closed-document safety (null response).
- Export the new UX helper from the test support facade by adding `pub mod lsp_ux_harness;` to `crates/perl-lsp-rs/tests/support/mod.rs` so tests can import `support::lsp_ux_harness::InlineCompletionUxHarness` consistently.

### Testing
- Ran `cargo xtask fmt` (format) and it completed successfully.
- Ran `cargo test -p perl-lsp-rs --test lsp_inline_completion_stream_bdd_workflows` and the new BDD suite passed (`3 passed`).
- Ran `cargo check --all-targets -p perl-lsp-rs` and it completed successfully.
- Ran `cargo clippy -p perl-lsp-rs --test lsp_inline_completion_stream_bdd_workflows -- -D warnings` and it completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0bc9365c8333bdbdffe04ada0708)