### PR TITLE
test(perl-lsp-ux-tests): add BDD diagnostics edit lifecycle coverage (#5306)

### DIFF
--- a/crates/perl-lsp-ux-tests/README.md
+++ b/crates/perl-lsp-ux-tests/README.md
@@ -22,7 +22,9 @@ Scenarios currently include:
 - hover, goto-definition, strict diagnostics, and document symbols flows, and
 - multi-root `workspace/symbol` disambiguation via `workspaceFolderUri`, and
 - workspace-folder removal evicting stale symbols from search results, and
-- deleted-file churn evicting stale search results and definition targets.
+- deleted-file churn evicting stale search results and definition targets, and
+- live-edit diagnostics lifecycle coverage (diagnostics appear for broken files
+  and clear after `didChange` fixes syntax).
 
 The harness is now also the source of truth for the workflow UX scorecard
 inventory:

--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -362,6 +362,32 @@
       "expected_outcomes": [
         "declaration request returns a location or clean empty result",
         "request does not error"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
+      ]
+    },
+    {
+      "id": "diagnostics_edit_lifecycle",
+      "scenario_file": "ux_scenario_19_diagnostics_edit_lifecycle.rs",
+      "subsystem_owner": "diagnostics",
+      "ci_tier": "pr",
+      "user_journey": "start with a parse error, then fix the file and confirm diagnostics clear",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "syntax error diagnostics are published for broken content",
+        "diagnostics clear after didChange applies a valid edit",
+        "follow-up hover remains responsive"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
       ]
     }
   ],

--- a/crates/perl-lsp-ux-tests/src/client.rs
+++ b/crates/perl-lsp-ux-tests/src/client.rs
@@ -245,6 +245,24 @@ impl UxClient {
         )
     }
 
+    /// Send `textDocument/didChange` with full-document sync semantics.
+    pub fn did_change(&self, uri: &str, text: &str, version: i32) -> Result<()> {
+        self.notify(
+            "textDocument/didChange",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "version": version
+                },
+                "contentChanges": [
+                    {
+                        "text": text
+                    }
+                ]
+            }),
+        )
+    }
+
     /// Drain all buffered server-initiated events and decode them.
     ///
     /// After this call the internal queue is empty.  Use `peek_events` if you

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -185,6 +185,15 @@ impl UxHarness {
         self.client.did_open(&uri, content)
     }
 
+    /// Replace a file's full contents via `textDocument/didChange`.
+    ///
+    /// The caller provides the next monotonically increasing document version.
+    pub fn replace_file(&self, relative_path: &str, new_content: &str, version: i32) -> Result<()> {
+        self.workspace.write(relative_path, new_content)?;
+        let uri = self.workspace.uri(relative_path);
+        self.client.did_change(&uri, new_content, version)
+    }
+
     /// Request hover information at `(line, character)` (0-indexed UTF-16).
     ///
     /// Returns `None` if the server returned a null/empty result (degraded mode is OK).
@@ -399,6 +408,61 @@ impl UxHarness {
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
         Vec::new()
+    }
+
+    /// Return the latest diagnostics payload currently buffered for `relative_path`.
+    pub fn latest_diagnostics(&self, relative_path: &str) -> Option<Vec<Value>> {
+        let uri = self.workspace.uri(relative_path);
+        let events = self.client.peek_events();
+        events.into_iter().rev().find_map(|event| match event {
+            LspEvent::Diagnostics { uri: diag_uri, diagnostics } if diag_uri == uri => {
+                Some(diagnostics)
+            }
+            _ => None,
+        })
+    }
+
+    /// Wait up to `timeout` for diagnostics with at least `minimum` entries.
+    ///
+    /// Returns `None` if no matching diagnostics are observed before timeout.
+    pub fn wait_for_diagnostics_minimum(
+        &self,
+        relative_path: &str,
+        minimum: usize,
+        timeout: std::time::Duration,
+    ) -> Option<Vec<Value>> {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if let Some(diagnostics) = self.latest_diagnostics(relative_path) {
+                if diagnostics.len() >= minimum {
+                    return Some(diagnostics);
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                return None;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
+    /// Wait up to `timeout` for a diagnostics publication that is explicitly empty.
+    pub fn wait_for_empty_diagnostics(
+        &self,
+        relative_path: &str,
+        timeout: std::time::Duration,
+    ) -> bool {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if let Some(diagnostics) = self.latest_diagnostics(relative_path) {
+                if diagnostics.is_empty() {
+                    return true;
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
     }
 
     /// Request go-to-definition.

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_edit_lifecycle.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_edit_lifecycle.rs
@@ -1,0 +1,71 @@
+//! Scenario 19 — BDD diagnostics lifecycle under live editing.
+//!
+//! User journey:
+//! - Given a file with a syntax error, diagnostics should appear.
+//! - When the user fixes the file via `didChange`, diagnostics should clear.
+//! - Then the server remains responsive for follow-up hover requests.
+
+use anyhow::{Result, anyhow};
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use std::time::Duration;
+
+const BROKEN_SOURCE: &str = "my $value = ;\nprint $value;\n";
+const FIXED_SOURCE: &str = "my $value = 42;\nprint $value;\n";
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+#[test]
+fn scenario_19_given_syntax_error_when_fixed_then_diagnostics_clear_and_hover_still_works()
+-> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_19: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let harness =
+        UxHarness::new(ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() })?;
+
+    harness.open_file("edit_cycle.pl", BROKEN_SOURCE)?;
+
+    let initial_diagnostics = harness
+        .wait_for_diagnostics_minimum("edit_cycle.pl", 1, Duration::from_secs(8))
+        .ok_or_else(|| anyhow!("expected at least one diagnostic for broken source"))?;
+
+    assert!(
+        initial_diagnostics
+            .iter()
+            .all(|diag| { diag.get("range").is_some() && diag.get("message").is_some() }),
+        "diagnostics must have LSP range/message shape"
+    );
+
+    harness.replace_file("edit_cycle.pl", FIXED_SOURCE, 2)?;
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(8);
+    let mut syntax_error_cleared = false;
+    while std::time::Instant::now() < deadline {
+        if let Some(diagnostics) = harness.latest_diagnostics("edit_cycle.pl") {
+            let contains_syntax_error = diagnostics.iter().any(|diag| {
+                diag.get("message")
+                    .and_then(|m| m.as_str())
+                    .map(|m| {
+                        let lower = m.to_ascii_lowercase();
+                        lower.contains("syntax") || lower.contains("parse")
+                    })
+                    .unwrap_or(false)
+            });
+            if !contains_syntax_error {
+                syntax_error_cleared = true;
+                break;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(syntax_error_cleared, "expected syntax diagnostics to clear after fixing source");
+
+    let _hover = harness.hover("edit_cycle.pl", 1, 7)?;
+
+    harness.assert_no_crash();
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Improve LSP UX harness coverage by adding first-class live-edit diagnostics lifecycle tests so we validate that syntax diagnostics appear for broken content and subsequently clear after `didChange` edits.
- Provide SRP-style, reusable helpers in the harness to make BDD-style scenarios for edit-driven UX workflows straightforward and maintainable.

### Description
- Added `did_change` to the low-level `UxClient` to send full-document `textDocument/didChange` notifications from scenarios.
- Added `replace_file`, `latest_diagnostics`, `wait_for_diagnostics_minimum`, and `wait_for_empty_diagnostics` helpers to `UxHarness` to support edit-driven assertions and reuse across scenarios.
- Added a new BDD scenario `ux_scenario_19_diagnostics_edit_lifecycle.rs` that asserts diagnostics appear for broken content, clear after a fix, and that hover remains responsive afterward.
- Updated the UX fixture matrix (`fixtures/editor_ux_fixture_matrix.json`) and README to include the new diagnostics lifecycle workflow and confidence signals.

### Testing
- Ran `cargo build -p perl-lsp-rs` to produce a local server binary for UX tests and then executed `PERL_LSP_BIN=/workspace/perl-lsp/target/debug/perl-lsp cargo test -p perl-lsp-ux-tests`, which completed successfully and exercised the new scenario.
- Verified the new scenario in isolation with `PERL_LSP_BIN=/workspace/perl-lsp/target/debug/perl-lsp cargo test -p perl-lsp-ux-tests --test ux_scenario_19_diagnostics_edit_lifecycle`, which passed.
- Ran `cargo check --all-targets -p perl-lsp-ux-tests` which passed, and `cargo xtask fmt` which completed successfully.
- Ran `cargo clippy -p perl-lsp-ux-tests --all-targets -- -D warnings` which failed due to a pre-existing lint in an unrelated test file (`ux_scenario_13_document_symbols.rs`) and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0bc9365c8333bdbdffe04ada0708)