### PR TITLE
test(perl-lsp-ux-tests): deepen goto-definition BDD coverage (#5306)

### DIFF
--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -544,6 +544,37 @@ impl UxHarness {
         self.definition(&cursor.relative_path, cursor.line, cursor.character)
     }
 
+    /// Request go-to-definition and optionally retry to absorb asynchronous indexing delays.
+    ///
+    /// Returns immediately when the first non-empty response is observed, or after
+    /// `attempts` tries (minimum 1). This keeps UX scenarios deterministic without
+    /// forcing each test to hand-roll sleep/retry loops.
+    pub fn definition_with_retry(
+        &self,
+        relative_path: &str,
+        line: u32,
+        character: u32,
+        attempts: usize,
+        pause: Duration,
+    ) -> Result<Vec<Value>> {
+        let mut last = Vec::new();
+        let max_attempts = attempts.max(1);
+
+        for idx in 0..max_attempts {
+            let current = self.definition(relative_path, line, character)?;
+            if !current.is_empty() {
+                return Ok(current);
+            }
+
+            last = current;
+            if idx + 1 < max_attempts {
+                std::thread::sleep(pause);
+            }
+        }
+
+        Ok(last)
+    }
+
     /// Request references (`textDocument/references`) at a cursor position.
     pub fn references(
         &self,

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
@@ -84,6 +84,10 @@ fn is_lsp_location_shape(entry: &Value) -> bool {
     is_location || is_location_link
 }
 
+fn entry_uri(entry: &Value) -> Option<&str> {
+    entry.get("uri").or_else(|| entry.get("targetUri")).and_then(Value::as_str)
+}
+
 #[test]
 fn scenario_10_definition_same_file_call_site_resolves() -> Result<()> {
     if !binary_available() {
@@ -99,13 +103,29 @@ fn scenario_10_definition_same_file_call_site_resolves() -> Result<()> {
     // When go-to-definition is requested on `greet('World')`.
     let definitions = scenario.when_requesting_definition_with_retry("greet.pl", 8, 0)?;
 
-    // Then the server returns either a location or degrades cleanly.
+    // Then the server must return at least one result — the `sub greet`
+    // declaration is literally six lines above the call site. An empty list
+    // after retry indicates goto-definition is broken, not degraded UX.
+    assert!(
+        !definitions.is_empty(),
+        "expected at least one definition location for same-file `greet()` call site \
+         (sub defined on line 3) but got empty list after retries"
+    );
     for entry in &definitions {
         assert!(
             is_lsp_location_shape(entry),
             "definition entry must be a Location or LocationLink: {entry:?}"
         );
     }
+    // And at least one location must point back to greet.pl — otherwise the
+    // server resolved the call to some unrelated file (real regression).
+    let points_to_source = definitions.iter().any(|entry| {
+        entry_uri(entry).map(|uri| uri.ends_with("greet.pl")).unwrap_or(false)
+    });
+    assert!(
+        points_to_source,
+        "expected at least one definition result to point back to greet.pl, got: {definitions:?}"
+    );
 
     scenario.then_no_crash_signals_exist();
     Ok(())
@@ -127,7 +147,9 @@ fn scenario_10_definition_cross_file_module_symbol_points_to_module() -> Result<
     // When go-to-definition is requested on `increment` in `Counter->increment`.
     let definitions = scenario.when_requesting_definition_with_retry("main.pl", 5, 23)?;
 
-    // Then results are shape-valid and, if present, include the module file.
+    // Then results are shape-valid. Cross-file module resolution may degrade
+    // if `use lib` handling is incomplete; keep the empty path tolerated but
+    // log it so we notice when it happens in CI.
     for entry in &definitions {
         assert!(
             is_lsp_location_shape(entry),
@@ -135,19 +157,32 @@ fn scenario_10_definition_cross_file_module_symbol_points_to_module() -> Result<
         );
     }
 
-    let points_to_module = definitions.iter().any(|entry| {
-        entry
-            .get("uri")
-            .or_else(|| entry.get("targetUri"))
-            .and_then(Value::as_str)
-            .map(|uri| uri.ends_with("lib/Counter.pm"))
-            .unwrap_or(false)
-    });
-
-    assert!(
-        definitions.is_empty() || points_to_module,
-        "non-empty cross-file definition results should include lib/Counter.pm: {definitions:?}"
-    );
+    if definitions.is_empty() {
+        eprintln!(
+            "INFO scenario_10: cross-file definition returned empty — tolerated \
+             degraded path (cross-file indexing may not have settled)"
+        );
+    } else {
+        let points_to_module = definitions
+            .iter()
+            .any(|entry| entry_uri(entry).map(|uri| uri.ends_with("Counter.pm")).unwrap_or(false));
+        assert!(
+            points_to_module,
+            "non-empty cross-file definition results must include Counter.pm but did not: \
+             {definitions:?}"
+        );
+        // And they must never resolve to an unrelated file (e.g. leaking the
+        // call-site file as the definition would be a real regression).
+        let resolves_outside_workspace = definitions.iter().any(|entry| {
+            entry_uri(entry)
+                .map(|uri| !uri.ends_with("Counter.pm") && !uri.ends_with("main.pl"))
+                .unwrap_or(false)
+        });
+        assert!(
+            !resolves_outside_workspace,
+            "cross-file definition resolved to an unrelated file: {definitions:?}"
+        );
+    }
 
     scenario.then_no_crash_signals_exist();
     Ok(())

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
@@ -119,9 +119,9 @@ fn scenario_10_definition_same_file_call_site_resolves() -> Result<()> {
     }
     // And at least one location must point back to greet.pl — otherwise the
     // server resolved the call to some unrelated file (real regression).
-    let points_to_source = definitions.iter().any(|entry| {
-        entry_uri(entry).map(|uri| uri.ends_with("greet.pl")).unwrap_or(false)
-    });
+    let points_to_source = definitions
+        .iter()
+        .any(|entry| entry_uri(entry).map(|uri| uri.ends_with("greet.pl")).unwrap_or(false));
     assert!(
         points_to_source,
         "expected at least one definition result to point back to greet.pl, got: {definitions:?}"

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
@@ -1,129 +1,182 @@
-// Test infrastructure — allow test-friendly patterns.
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-
-//! Scenario 10 — Go-to-definition feature grid coverage.
+//! Scenario 10 — Go-to-definition UX workflow coverage.
 //!
-//! Verifies that `textDocument/definition` is wired up end-to-end for the LSP
-//! feature advertised in `features.toml`.
-//!
-//! Acceptance criteria:
-//! - `textDocument/definition` MUST NOT return a JSON-RPC error.
-//! - A definition result MAY be empty (degraded mode acceptable) but must not crash.
-//! - When a sub is defined in the same file, the server SHOULD return a location
-//!   pointing back into that file.
-//! - No crash signatures after the request.
+//! Focus area: `textDocument/definition` behavior for first-editing-session UX.
+//! This suite uses a compact BDD-style helper so each test describes intent in
+//! Given/When/Then language and avoids duplicated harness boilerplate.
 
+use anyhow::Result;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
-use serde_json::json;
+use serde_json::Value;
 use std::time::Duration;
+
+const SAME_FILE_FIXTURE: &str = r#"use strict;
+use warnings;
+
+sub greet {
+    my ($name) = @_;
+    return "Hello, $name!";
+}
+
+greet('World');
+"#;
+
+const CROSS_FILE_MODULE: &str = r#"package Counter;
+use strict;
+use warnings;
+
+sub increment {
+    my ($class, $n) = @_;
+    return $n + 1;
+}
+
+1;
+"#;
+
+const CROSS_FILE_SCRIPT: &str = r#"use strict;
+use warnings;
+use lib 'lib';
+use Counter;
+
+my $value = Counter->increment(3);
+print "$value\n";
+"#;
 
 fn binary_available() -> bool {
     perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
-/// Source with a named sub defined near the top and called later.
-/// We will request go-to-definition on the call site at line 8, char 0.
-const GOTO_SOURCE: &str = "\
-use strict;\n\
-use warnings;\n\
-\n\
-sub greet {\n\
-    my ($name) = @_;\n\
-    return \"Hello, $name!\";\n\
-}\n\
-\n\
-greet('World');\n\
-";
+struct DefinitionScenario {
+    harness: UxHarness,
+}
 
-#[test]
-fn scenario_10_definition_request_does_not_error() {
-    if !binary_available() {
-        eprintln!("SKIP scenario_10: perl-lsp binary not found");
-        return;
+impl DefinitionScenario {
+    fn single_file() -> Result<Self> {
+        let harness = UxHarness::new(
+            ScenarioConfig::default()
+                .with_file("greet.pl", SAME_FILE_FIXTURE)
+                .with_file("lib/Counter.pm", CROSS_FILE_MODULE)
+                .with_file("main.pl", CROSS_FILE_SCRIPT),
+        )?;
+        Ok(Self { harness })
     }
 
-    let harness = UxHarness::new(
-        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
-            .with_file("greet.pl", GOTO_SOURCE),
-    )
-    .expect("Failed to create UX harness");
+    fn given_file_is_open(&self, path: &str, content: &str) -> Result<()> {
+        self.harness.open_file(path, content)
+    }
 
-    harness.open_file("greet.pl", GOTO_SOURCE).expect("didOpen should succeed");
+    fn when_requesting_definition_with_retry(
+        &self,
+        path: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Vec<Value>> {
+        self.harness.definition_with_retry(path, line, character, 5, Duration::from_millis(200))
+    }
 
-    // Allow the server to index the file.
-    std::thread::sleep(Duration::from_millis(500));
+    fn then_no_crash_signals_exist(&self) {
+        self.harness.assert_no_crash();
+    }
+}
 
-    // Request definition on the call site `greet('World')` — line 8, char 0.
-    let cursor = harness.position_cursor("greet.pl", 8, 0);
-    let result = harness.definition_at(&cursor);
+fn is_lsp_location_shape(entry: &Value) -> bool {
+    let is_location = entry.get("uri").is_some() && entry.get("range").is_some();
+    let is_location_link = entry.get("targetUri").is_some() && entry.get("targetRange").is_some();
+    is_location || is_location_link
+}
+
+#[test]
+fn scenario_10_definition_same_file_call_site_resolves() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_10: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let scenario = DefinitionScenario::single_file()?;
+
+    // Given a script with an in-file sub definition and call site.
+    scenario.given_file_is_open("greet.pl", SAME_FILE_FIXTURE)?;
+
+    // When go-to-definition is requested on `greet('World')`.
+    let definitions = scenario.when_requesting_definition_with_retry("greet.pl", 8, 0)?;
+
+    // Then the server returns either a location or degrades cleanly.
+    for entry in &definitions {
+        assert!(
+            is_lsp_location_shape(entry),
+            "definition entry must be a Location or LocationLink: {entry:?}"
+        );
+    }
+
+    scenario.then_no_crash_signals_exist();
+    Ok(())
+}
+
+#[test]
+fn scenario_10_definition_cross_file_module_symbol_points_to_module() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_10: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let scenario = DefinitionScenario::single_file()?;
+
+    // Given a module and script opened in the same workspace.
+    scenario.given_file_is_open("lib/Counter.pm", CROSS_FILE_MODULE)?;
+    scenario.given_file_is_open("main.pl", CROSS_FILE_SCRIPT)?;
+
+    // When go-to-definition is requested on `increment` in `Counter->increment`.
+    let definitions = scenario.when_requesting_definition_with_retry("main.pl", 5, 23)?;
+
+    // Then results are shape-valid and, if present, include the module file.
+    for entry in &definitions {
+        assert!(
+            is_lsp_location_shape(entry),
+            "definition entry must be a Location or LocationLink: {entry:?}"
+        );
+    }
+
+    let points_to_module = definitions.iter().any(|entry| {
+        entry
+            .get("uri")
+            .or_else(|| entry.get("targetUri"))
+            .and_then(Value::as_str)
+            .map(|uri| uri.ends_with("lib/Counter.pm"))
+            .unwrap_or(false)
+    });
+
     assert!(
-        result.is_ok(),
-        "textDocument/definition must not return a JSON-RPC error — feature grid regression: {:?}",
-        result
+        definitions.is_empty() || points_to_module,
+        "non-empty cross-file definition results should include lib/Counter.pm: {definitions:?}"
     );
 
-    harness.assert_no_crash();
+    scenario.then_no_crash_signals_exist();
+    Ok(())
 }
 
 #[test]
-fn scenario_10_definition_result_is_location_or_empty() {
+fn scenario_10_definition_unknown_position_is_stable() -> Result<()> {
     if !binary_available() {
         eprintln!("SKIP scenario_10: perl-lsp binary not found");
-        return;
+        return Ok(());
     }
 
-    let harness = UxHarness::new(
-        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
-            .with_file("greet.pl", GOTO_SOURCE),
-    )
-    .expect("Failed to create UX harness");
+    let scenario = DefinitionScenario::single_file()?;
 
-    harness.open_file("greet.pl", GOTO_SOURCE).expect("didOpen should succeed");
+    // Given a tiny script with no resolvable symbol at the cursor position.
+    let unknown_fixture = "use strict;\nmy $x = 1;\n";
+    scenario.given_file_is_open("unknown.pl", unknown_fixture)?;
 
-    std::thread::sleep(Duration::from_millis(500));
+    // When go-to-definition is requested over `strict`.
+    let definitions = scenario.when_requesting_definition_with_retry("unknown.pl", 0, 5)?;
 
-    let cursor = harness.position_cursor("greet.pl", 8, 0);
-    let defs = harness.definition_at(&cursor).expect("definition must not error");
-
-    // If results are returned they must be well-formed Location objects.
-    for loc in &defs {
+    // Then the response is either empty or contains shape-valid locations.
+    for entry in &definitions {
         assert!(
-            loc.get("uri").is_some() && loc.get("range").is_some(),
-            "Definition result must have 'uri' and 'range' fields, got: {:?}",
-            loc
-        );
-        harness.assert_normalized_eq(
-            loc,
-            &json!({
-                "uri": "file://$WORKSPACE/greet.pl",
-                "range": loc["range"].clone(),
-            }),
+            is_lsp_location_shape(entry),
+            "definition entry must be a Location or LocationLink: {entry:?}"
         );
     }
 
-    harness.assert_no_crash();
-}
-
-#[test]
-fn scenario_10_definition_on_unknown_position_returns_empty() {
-    if !binary_available() {
-        eprintln!("SKIP scenario_10: perl-lsp binary not found");
-        return;
-    }
-
-    let source = "use strict;\nmy $x = 1;\n";
-    let harness = UxHarness::new(ScenarioConfig::default().with_file("simple.pl", source))
-        .expect("Failed to create UX harness");
-
-    harness.open_file("simple.pl", source).expect("didOpen should succeed");
-
-    // Position in middle of `strict` string literal — no definition expected.
-    let cursor = harness.position_cursor("simple.pl", 0, 5);
-    let defs =
-        harness.definition_at(&cursor).expect("definition must not error on arbitrary position");
-
-    // Empty is fine; what we are testing is that no crash or error occurs.
-    let _ = defs;
-
-    harness.assert_no_crash();
+    scenario.then_no_crash_signals_exist();
+    Ok(())
 }


### PR DESCRIPTION
### Motivation

- Go-to-definition UX tests were brittle (ad-hoc sleeps) and lacked structured cross-file and shape validation, making first-editing-session behavior hard to verify reliably.

### Description

- Add `UxHarness::definition_with_retry(...)` to perform repeated `textDocument/definition` requests with a small pause until a non-empty result or max attempts, removing ad-hoc sleeps and improving determinism.
- Rework Scenario 10 into a BDD-style `DefinitionScenario` with Given/When/Then helpers to keep tests SRP-friendly and readable.
- Replace the original scenario with three focused workflows: same-file call-site resolution, cross-file module resolution, and unknown-position stability, each validating `Location`/`LocationLink` shape and asserting no crash signatures.
- Tests are gated on `resolve_binary()` so they gracefully skip when the `perl-lsp` binary is not available locally.

### Testing

- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo check --all-targets -p perl-lsp-ux-tests` which passed.
- Ran `cargo test -p perl-lsp-ux-tests` which failed due to a pre-existing unrelated fixture metadata issue (`editor_ux_fixture_matrix` missing `confidence_signals`).
- Ran `cargo clippy -p perl-lsp-ux-tests --all-targets -- -D warnings` which failed due to a pre-existing clippy lint in `ux_scenario_13_document_symbols.rs` unrelated to these changes.
- Ran the focused suite `cargo test -p perl-lsp-ux-tests --test ux_scenario_10_goto_definition` which passed (3 tests OK).
- Note: `just pr-fast` was not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0bc9365c8333bdbdffe04ada0708)