### PR TITLE
test(perl-lsp-ux-tests): deepen completion UX editing coverage (#5306)

### DIFF
--- a/crates/perl-lsp-ux-tests/README.md
+++ b/crates/perl-lsp-ux-tests/README.md
@@ -22,7 +22,8 @@ Scenarios currently include:
 - hover, goto-definition, strict diagnostics, and document symbols flows, and
 - multi-root `workspace/symbol` disambiguation via `workspaceFolderUri`, and
 - workspace-folder removal evicting stale symbols from search results, and
-- deleted-file churn evicting stale search results and definition targets.
+- deleted-file churn evicting stale search results and definition targets, and
+- completion stability across `didChange` edits and trigger modes.
 
 The harness is now also the source of truth for the workflow UX scorecard
 inventory:

--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -362,12 +362,32 @@
       "expected_outcomes": [
         "declaration request returns a location or clean empty result",
         "request does not error"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
+      ]
+    },
+    {
+      "id": "completion_editing_stability",
+      "scenario_file": "ux_scenario_19_completion_editing.rs",
+      "subsystem_owner": "editor_intelligence",
+      "ci_tier": "pr",
+      "user_journey": "type within a Perl file, apply didChange updates, and request completion across trigger modes",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "completion remains responsive after didChange",
+        "completion payload shape remains valid across trigger modes"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
       ]
     }
-  ],
-  "confidence_signals": [
-    "manual_editor_smoke",
-    "first_five_minutes_harness",
-    "issue_burndown_regression_guard"
   ]
 }

--- a/crates/perl-lsp-ux-tests/src/client.rs
+++ b/crates/perl-lsp-ux-tests/src/client.rs
@@ -245,6 +245,24 @@ impl UxClient {
         )
     }
 
+    /// Send `textDocument/didChange` using full-document sync payload.
+    pub fn did_change_full(&self, uri: &str, text: &str, version: i32) -> Result<()> {
+        self.notify(
+            "textDocument/didChange",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "version": version
+                },
+                "contentChanges": [
+                    {
+                        "text": text
+                    }
+                ]
+            }),
+        )
+    }
+
     /// Drain all buffered server-initiated events and decode them.
     ///
     /// After this call the internal queue is empty.  Use `peek_events` if you

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -154,6 +154,29 @@ pub struct UxHarness {
     config: ScenarioConfig,
 }
 
+/// Completion trigger mode for `textDocument/completion`.
+#[derive(Debug, Clone)]
+pub enum CompletionTrigger {
+    /// User explicitly invoked completion (`Ctrl+Space` style).
+    Invoked,
+    /// Completion triggered by a character typed in the editor.
+    TriggerCharacter(char),
+    /// Follow-up completion request for incomplete prior results.
+    TriggerForIncompleteCompletions,
+}
+
+impl CompletionTrigger {
+    fn context_value(&self) -> Value {
+        match self {
+            Self::Invoked => json!({ "triggerKind": 1 }),
+            Self::TriggerCharacter(character) => {
+                json!({ "triggerKind": 2, "triggerCharacter": character.to_string() })
+            }
+            Self::TriggerForIncompleteCompletions => json!({ "triggerKind": 3 }),
+        }
+    }
+}
+
 impl UxHarness {
     /// Spawn a fresh LSP server and set up a clean workspace.
     pub fn new(config: ScenarioConfig) -> Result<Self> {
@@ -207,13 +230,24 @@ impl UxHarness {
 
     /// Request completion at `(line, character)`.
     pub fn completion(&self, relative_path: &str, line: u32, character: u32) -> Result<Vec<Value>> {
+        self.completion_with_trigger(relative_path, line, character, CompletionTrigger::Invoked)
+    }
+
+    /// Request completion at `(line, character)` with explicit trigger context.
+    pub fn completion_with_trigger(
+        &self,
+        relative_path: &str,
+        line: u32,
+        character: u32,
+        trigger: CompletionTrigger,
+    ) -> Result<Vec<Value>> {
         let uri = self.workspace.uri(relative_path);
         let resp = self.client.request(
             "textDocument/completion",
             json!({
                 "textDocument": { "uri": uri },
                 "position": { "line": line, "character": character },
-                "context": { "triggerKind": 1 }
+                "context": trigger.context_value()
             }),
             self.config.timeout,
         )?;
@@ -227,6 +261,18 @@ impl UxHarness {
                 None => Ok(Vec::new()),
             },
         }
+    }
+
+    /// Apply a full-document edit and notify the server via `didChange`.
+    pub fn apply_full_change(
+        &self,
+        relative_path: &str,
+        updated_content: &str,
+        version: i32,
+    ) -> Result<()> {
+        self.workspace.write(relative_path, updated_content)?;
+        let uri = self.workspace.uri(relative_path);
+        self.client.did_change_full(&uri, updated_content, version)
     }
 
     /// Request document formatting.

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion_editing.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion_editing.rs
@@ -23,15 +23,33 @@ fn binary_available() -> bool {
 }
 
 fn assert_completion_items_have_labels(items: &[Value], phase: &str) {
+    assert!(
+        !items.is_empty(),
+        "{phase}: completion returned no items — a `$al`/`$alp` prefix with \
+         `$alpha` in scope must surface at least one item; vacuous pass would \
+         hide a real regression."
+    );
     for item in items {
-        if item.is_null() {
-            continue;
-        }
+        // Per LSP spec, completion items are objects. Null entries indicate a
+        // malformed payload, not a tolerated degraded case.
+        assert!(
+            !item.is_null(),
+            "{phase}: completion item is null, expected CompletionItem object"
+        );
         assert!(
             item.get("label").and_then(Value::as_str).is_some(),
             "{phase}: completion item missing string label: {item:?}"
         );
     }
+}
+
+fn labels_contain(items: &[Value], needle: &str) -> bool {
+    items.iter().any(|item| {
+        item.get("label")
+            .and_then(Value::as_str)
+            .map(|label| label.contains(needle))
+            .unwrap_or(false)
+    })
 }
 
 #[test]
@@ -47,10 +65,20 @@ fn scenario_19_completion_remains_stable_across_edit_and_trigger_modes() -> Resu
     // Given an opened Perl document.
     harness.open_file("editing.pl", INITIAL_SOURCE)?;
 
-    // When completion is manually invoked.
+    // When completion is manually invoked after typing `$al`.
     let initial_items =
         harness.completion_with_trigger("editing.pl", 4, 16, CompletionTrigger::Invoked)?;
     assert_completion_items_have_labels(&initial_items, "initial invoke completion");
+    // And the `$alpha` identifier declared on the prior line is surfaced —
+    // this is the concrete UX behaviour the test claims to protect.
+    assert!(
+        labels_contain(&initial_items, "alpha"),
+        "initial invoke completion: expected label containing `alpha`, got labels: {:?}",
+        initial_items
+            .iter()
+            .filter_map(|i| i.get("label").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+    );
 
     // And the user continues typing in the same line.
     harness.apply_full_change("editing.pl", UPDATED_SOURCE, 2)?;
@@ -63,6 +91,13 @@ fn scenario_19_completion_remains_stable_across_edit_and_trigger_modes() -> Resu
         CompletionTrigger::TriggerCharacter('p'),
     )?;
     assert_completion_items_have_labels(&triggered_items, "trigger-character completion");
+    // And `$alpha` is still a valid completion after the edit — proves the
+    // didChange did not desync the server's view of the document.
+    assert!(
+        labels_contain(&triggered_items, "alpha"),
+        "trigger-character completion: expected `alpha` after didChange; server \
+         view of document may be stale"
+    );
 
     // And follow-up incomplete completion requests also remain healthy.
     let incomplete_items = harness.completion_with_trigger(

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion_editing.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion_editing.rs
@@ -1,0 +1,78 @@
+//! Scenario 19 — completion UX during active editing.
+//!
+//! Drives a realistic editor loop:
+//! 1. Open a file.
+//! 2. Request completion by explicit invoke.
+//! 3. Edit the document (`didChange`).
+//! 4. Request completion again with trigger-character and incomplete-result modes.
+//!
+//! Acceptance criteria:
+//! - Completion requests succeed across trigger modes.
+//! - `didChange` does not destabilize subsequent completion requests.
+//! - Returned completion payloads stay structurally valid.
+
+use anyhow::Result;
+use perl_lsp_ux_tests::{CompletionTrigger, ScenarioConfig, UxHarness};
+use serde_json::Value;
+
+const INITIAL_SOURCE: &str = "use strict;\nuse warnings;\n\nmy $alpha = 1;\nmy $value = $al\n";
+const UPDATED_SOURCE: &str = "use strict;\nuse warnings;\n\nmy $alpha = 1;\nmy $value = $alp\n";
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+fn assert_completion_items_have_labels(items: &[Value], phase: &str) {
+    for item in items {
+        if item.is_null() {
+            continue;
+        }
+        assert!(
+            item.get("label").and_then(Value::as_str).is_some(),
+            "{phase}: completion item missing string label: {item:?}"
+        );
+    }
+}
+
+#[test]
+fn scenario_19_completion_remains_stable_across_edit_and_trigger_modes() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_19: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("editing.pl", INITIAL_SOURCE))?;
+
+    // Given an opened Perl document.
+    harness.open_file("editing.pl", INITIAL_SOURCE)?;
+
+    // When completion is manually invoked.
+    let initial_items =
+        harness.completion_with_trigger("editing.pl", 4, 16, CompletionTrigger::Invoked)?;
+    assert_completion_items_have_labels(&initial_items, "initial invoke completion");
+
+    // And the user continues typing in the same line.
+    harness.apply_full_change("editing.pl", UPDATED_SOURCE, 2)?;
+
+    // Then trigger-character completion remains healthy.
+    let triggered_items = harness.completion_with_trigger(
+        "editing.pl",
+        4,
+        17,
+        CompletionTrigger::TriggerCharacter('p'),
+    )?;
+    assert_completion_items_have_labels(&triggered_items, "trigger-character completion");
+
+    // And follow-up incomplete completion requests also remain healthy.
+    let incomplete_items = harness.completion_with_trigger(
+        "editing.pl",
+        4,
+        17,
+        CompletionTrigger::TriggerForIncompleteCompletions,
+    )?;
+    assert_completion_items_have_labels(&incomplete_items, "incomplete completion");
+
+    harness.assert_no_crash();
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Expand UX harness coverage to exercise realistic editor loops (open → edit → re-request) for completion, not just one-off invoke flows. 
- Improve BDD-style coverage and SRP-friendly helpers so scenarios can assert completion behavior across LSP trigger modes and document changes.

### Description
- Add `CompletionTrigger` enum and `completion_with_trigger` to model explicit LSP completion contexts (`Invoked`, `TriggerCharacter`, `TriggerForIncompleteCompletions`).
- Add `UxClient::did_change_full` and `UxHarness::apply_full_change` to send full-document `textDocument/didChange` notifications and persist workspace edits for realistic editing flows.
- Add a new scenario `tests/ux_scenario_19_completion_editing.rs` that validates completion stability across invoke, trigger-character, and incomplete follow-up requests and checks completion item payload shape.
- Wire the scenario into the UX fixture matrix and update the crate README to document the new coverage area.

### Testing
- Ran `cargo test -p perl-lsp-ux-tests --test ux_scenario_19_completion_editing` and the scenario passed (`1 passed`).
- Ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix` and the fixture matrix check passed (`1 passed`).
- Ran `cargo check --all-targets -p perl-lsp-ux-tests` and it succeeded.
- Ran `cargo clippy -p perl-lsp-ux-tests -- -D warnings` and it succeeded; ran `cargo xtask fmt` which completed successfully; `just pr-fast` could not run in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0bcad56c8333890254594d045016)