### PR TITLE
test(perl-lsp-ux-tests): deepen goto-declaration UX BDD coverage (#5306)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -360,14 +360,14 @@
         "workflow_stability_rate"
       ],
       "expected_outcomes": [
-        "declaration request returns a location or clean empty result",
-        "request does not error"
+        "declaration request resolves local sub/variable bindings when available",
+        "non-symbol positions degrade gracefully without JSON-RPC errors"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
       ]
     }
-  ],
-  "confidence_signals": [
-    "manual_editor_smoke",
-    "first_five_minutes_harness",
-    "issue_burndown_regression_guard"
   ]
 }

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -46,11 +46,16 @@
 
 pub mod client;
 pub mod env;
+pub mod navigation;
 pub mod scorecard;
 pub mod workspace;
 
 pub use client::{LspEvent, UxClient};
 pub use env::{PathGuard, RestrictedPath};
+pub use navigation::{
+    NavigationTarget, all_locations_or_links, collect_navigation_targets, has_target_in_file,
+    has_target_start_line,
+};
 pub use scorecard::{EditorUxScorecard, ScenarioScore, aggregate_editor_ux_scorecard};
 pub use workspace::FakeWorkspace;
 
@@ -403,29 +408,13 @@ impl UxHarness {
 
     /// Request go-to-definition.
     pub fn definition(&self, relative_path: &str, line: u32, character: u32) -> Result<Vec<Value>> {
-        let uri = self.workspace.uri(relative_path);
-        let resp = self.client.request(
+        self.request_locations(
             "textDocument/definition",
-            json!({
-                "textDocument": { "uri": uri },
-                "position": { "line": line, "character": character }
-            }),
-            self.config.timeout,
-        )?;
-        if resp.get("error").is_some() {
-            return Err(anyhow!("definition returned error: {}", resp["error"]));
-        }
-        match resp["result"].as_array() {
-            Some(locs) => Ok(locs.clone()),
-            None => {
-                if resp["result"].is_null() {
-                    Ok(Vec::new())
-                } else {
-                    // Single location object
-                    Ok(vec![resp["result"].clone()])
-                }
-            }
-        }
+            "definition",
+            relative_path,
+            line,
+            character,
+        )
     }
 
     /// Request go-to-declaration.
@@ -435,29 +424,28 @@ impl UxHarness {
         line: u32,
         character: u32,
     ) -> Result<Vec<Value>> {
+        self.request_locations(
+            "textDocument/declaration",
+            "declaration",
+            relative_path,
+            line,
+            character,
+        )
+    }
+
+    /// Request find-references.
+    pub fn references(&self, relative_path: &str, line: u32, character: u32) -> Result<Vec<Value>> {
         let uri = self.workspace.uri(relative_path);
         let resp = self.client.request(
-            "textDocument/declaration",
+            "textDocument/references",
             json!({
                 "textDocument": { "uri": uri },
-                "position": { "line": line, "character": character }
+                "position": { "line": line, "character": character },
+                "context": { "includeDeclaration": true }
             }),
             self.config.timeout,
         )?;
-        if resp.get("error").is_some() {
-            return Err(anyhow!("declaration returned error: {}", resp["error"]));
-        }
-        match resp["result"].as_array() {
-            Some(locs) => Ok(locs.clone()),
-            None => {
-                if resp["result"].is_null() {
-                    Ok(Vec::new())
-                } else {
-                    // Single location object
-                    Ok(vec![resp["result"].clone()])
-                }
-            }
-        }
+        normalize_location_response(&resp, "references")
     }
 
     /// Drain any pending server-initiated messages (window/showMessage, etc.)
@@ -468,6 +456,26 @@ impl UxHarness {
     /// subsequent `assert_no_crash` / `assert_message_contains` calls.
     pub fn collect_notifications(&self) -> Vec<LspEvent> {
         self.client.drain_events()
+    }
+
+    fn request_locations(
+        &self,
+        method: &str,
+        label: &str,
+        relative_path: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Vec<Value>> {
+        let uri = self.workspace.uri(relative_path);
+        let resp = self.client.request(
+            method,
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character }
+            }),
+            self.config.timeout,
+        )?;
+        normalize_location_response(&resp, label)
     }
 
     /// Clone pending server-initiated messages **without** removing them from
@@ -551,6 +559,22 @@ impl UxHarness {
     /// Returns the root URI of the workspace (useful for the `rootUri` initialize param).
     pub fn root_uri(&self) -> &str {
         &self.workspace.root_uri
+    }
+}
+
+fn normalize_location_response(resp: &Value, label: &str) -> Result<Vec<Value>> {
+    if resp.get("error").is_some() {
+        return Err(anyhow!("{label} returned error: {}", resp["error"]));
+    }
+    match resp["result"].as_array() {
+        Some(locs) => Ok(locs.clone()),
+        None => {
+            if resp["result"].is_null() {
+                Ok(Vec::new())
+            } else {
+                Ok(vec![resp["result"].clone()])
+            }
+        }
     }
 }
 

--- a/crates/perl-lsp-ux-tests/src/navigation.rs
+++ b/crates/perl-lsp-ux-tests/src/navigation.rs
@@ -1,0 +1,93 @@
+use serde_json::Value;
+
+/// Canonical navigation target extracted from either `Location` or
+/// `LocationLink` LSP payloads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NavigationTarget {
+    pub uri: String,
+    pub start_line: u64,
+    pub start_character: u64,
+}
+
+/// Return true when every entry is either a `Location` or a `LocationLink`.
+pub fn all_locations_or_links(entries: &[Value]) -> bool {
+    entries.iter().all(|entry| navigation_target_from_value(entry).is_some())
+}
+
+/// Extract all parseable navigation targets from raw LSP response entries.
+pub fn collect_navigation_targets(entries: &[Value]) -> Vec<NavigationTarget> {
+    entries.iter().filter_map(navigation_target_from_value).collect()
+}
+
+/// Return true when any parsed target points to a URI ending with `file_suffix`.
+pub fn has_target_in_file(entries: &[Value], file_suffix: &str) -> bool {
+    collect_navigation_targets(entries).iter().any(|target| target.uri.ends_with(file_suffix))
+}
+
+/// Return true when any parsed target starts at `line` (0-indexed).
+pub fn has_target_start_line(entries: &[Value], line: u64) -> bool {
+    collect_navigation_targets(entries).iter().any(|target| target.start_line == line)
+}
+
+fn navigation_target_from_value(entry: &Value) -> Option<NavigationTarget> {
+    let (uri, range) = if let Some(uri) = entry.get("targetUri").and_then(Value::as_str) {
+        let range = entry.get("targetSelectionRange").or_else(|| entry.get("targetRange"))?;
+        (uri, range)
+    } else {
+        let uri = entry.get("uri").and_then(Value::as_str)?;
+        let range = entry.get("range")?;
+        (uri, range)
+    };
+
+    let start = range.get("start")?;
+    let start_line = start.get("line")?.as_u64()?;
+    let start_character = start.get("character")?.as_u64()?;
+
+    Some(NavigationTarget { uri: uri.to_string(), start_line, start_character })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{all_locations_or_links, has_target_in_file, has_target_start_line};
+    use anyhow::Result;
+    use serde_json::json;
+
+    #[test]
+    fn navigation_helpers_accept_location_and_location_link_shapes() -> Result<()> {
+        let entries = vec![
+            json!({
+                "uri": "file:///workspace/sample.pl",
+                "range": {
+                    "start": {"line": 3, "character": 2},
+                    "end": {"line": 3, "character": 8}
+                }
+            }),
+            json!({
+                "targetUri": "file:///workspace/lib/Sample.pm",
+                "targetRange": {
+                    "start": {"line": 10, "character": 0},
+                    "end": {"line": 12, "character": 1}
+                },
+                "targetSelectionRange": {
+                    "start": {"line": 11, "character": 4},
+                    "end": {"line": 11, "character": 10}
+                }
+            }),
+        ];
+
+        assert!(all_locations_or_links(&entries));
+        assert!(has_target_in_file(&entries, "sample.pl"));
+        assert!(has_target_in_file(&entries, "Sample.pm"));
+        assert!(has_target_start_line(&entries, 3));
+        assert!(has_target_start_line(&entries, 11));
+
+        Ok(())
+    }
+
+    #[test]
+    fn navigation_helpers_reject_malformed_entries() -> Result<()> {
+        let malformed = vec![json!({"uri": "file:///workspace/sample.pl"})];
+        assert!(!all_locations_or_links(&malformed));
+        Ok(())
+    }
+}

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs
@@ -1,16 +1,18 @@
-//! Scenario 18 — Go-to-declaration feature grid coverage.
+//! Scenario 18 — Go-to-declaration UX behavior coverage.
 //!
-//! Verifies that `textDocument/declaration` is wired up end-to-end for the LSP
-//! server process used in UX regression testing.
-//!
-//! Contract:
-//! - `textDocument/declaration` MUST NOT return a JSON-RPC error.
-//! - A declaration result MAY be empty (degraded mode acceptable) but must not crash.
-//! - When non-empty, each result MUST include URI/range shape (`targetUri` +
-//!   `targetRange` for links, or `uri` + `range` for locations).
+//! BDD acceptance focus:
+//! - Given a local symbol declaration, when a user invokes goto-declaration on
+//!   the symbol usage, then the result should resolve to the declaration line.
+//! - Given an unknown position, when goto-declaration runs, then it should
+//!   degrade to an empty result without JSON-RPC errors.
+//! - For all non-empty results, payload entries must be valid Location or
+//!   LocationLink objects.
 
 use anyhow::Result;
-use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::{
+    ScenarioConfig, UxHarness, all_locations_or_links, has_target_in_file, has_target_start_line,
+};
+use std::time::Duration;
 
 const DECLARATION_FIXTURE: &str = r#"use strict;
 use warnings;
@@ -26,18 +28,52 @@ my $result = inc($value);
 print "$result\n";
 "#;
 
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+fn new_harness() -> Result<UxHarness> {
+    UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
+            .with_file("declaration.pl", DECLARATION_FIXTURE),
+    )
+}
+
 #[test]
-fn scenario_18_declaration_request_does_not_error() -> Result<()> {
-    let harness =
-        UxHarness::new(ScenarioConfig::default().with_file("declaration.pl", DECLARATION_FIXTURE))?;
+fn scenario_18_given_sub_call_when_declaration_requested_then_points_to_sub_definition()
+-> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_18 sub declaration: perl-lsp binary not found");
+        return Ok(());
+    }
 
+    let harness = new_harness()?;
+
+    // Given
     harness.open_file("declaration.pl", DECLARATION_FIXTURE)?;
-    let result = harness.declaration("declaration.pl", 9, 13);
 
+    // When: line 10 contains `inc($value)`.
+    let declarations = harness.declaration("declaration.pl", 10, 13)?;
+
+    // Then
     assert!(
-        result.is_ok(),
-        "textDocument/declaration must not return a JSON-RPC error — feature grid regression: {:?}",
-        result
+        !declarations.is_empty(),
+        "Expected goto-declaration on sub call to resolve to a declaration target"
+    );
+    assert!(
+        all_locations_or_links(&declarations),
+        "goto-declaration must return Location/LocationLink entries, got: {:?}",
+        declarations
+    );
+    assert!(
+        has_target_in_file(&declarations, "declaration.pl"),
+        "Expected declaration target to remain in declaration.pl, got: {:?}",
+        declarations
+    );
+    assert!(
+        has_target_start_line(&declarations, 5),
+        "Expected sub declaration to resolve to line 5 (0-indexed), got: {:?}",
+        declarations
     );
 
     harness.assert_no_crash();
@@ -45,20 +81,63 @@ fn scenario_18_declaration_request_does_not_error() -> Result<()> {
 }
 
 #[test]
-fn scenario_18_declaration_result_is_location_or_empty() -> Result<()> {
-    let harness =
-        UxHarness::new(ScenarioConfig::default().with_file("declaration.pl", DECLARATION_FIXTURE))?;
+fn scenario_18_given_variable_usage_when_declaration_requested_then_points_to_variable_binding()
+-> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_18 variable declaration: perl-lsp binary not found");
+        return Ok(());
+    }
 
+    let harness = new_harness()?;
+
+    // Given
     harness.open_file("declaration.pl", DECLARATION_FIXTURE)?;
-    let declarations = harness.declaration("declaration.pl", 9, 13)?;
 
-    for entry in declarations {
-        let is_link = entry.get("targetUri").is_some() && entry.get("targetRange").is_some();
-        let is_location = entry.get("uri").is_some() && entry.get("range").is_some();
+    // When: line 10 contains `inc($value)` and `$value` starts at char 17.
+    let declarations = harness.declaration("declaration.pl", 10, 18)?;
+
+    // Then
+    assert!(
+        !declarations.is_empty(),
+        "Expected goto-declaration on `$value` usage to resolve to its binding"
+    );
+    assert!(
+        all_locations_or_links(&declarations),
+        "goto-declaration must return Location/LocationLink entries, got: {:?}",
+        declarations
+    );
+    assert!(
+        has_target_start_line(&declarations, 3),
+        "Expected `$value` declaration target to start at line 3 (0-indexed), got: {:?}",
+        declarations
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_18_given_non_symbol_position_when_declaration_requested_then_returns_empty_or_wellformed()
+-> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_18 empty declaration: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let harness = new_harness()?;
+
+    // Given
+    harness.open_file("declaration.pl", DECLARATION_FIXTURE)?;
+
+    // When: line 2 is blank.
+    let declarations = harness.declaration("declaration.pl", 2, 0)?;
+
+    // Then: either graceful empty or fully valid entries.
+    if !declarations.is_empty() {
         assert!(
-            is_link || is_location,
-            "declaration result must be LocationLink or Location, got: {:?}",
-            entry
+            all_locations_or_links(&declarations),
+            "Non-empty declaration response must contain only Location/LocationLink entries: {:?}",
+            declarations
         );
     }
 


### PR DESCRIPTION
### Motivation

- Improve editor UX test coverage around `textDocument/declaration` by moving from shape-only checks to concrete BDD-style behavior assertions for local sub and lexical variable declarations.
- Provide small SRP helpers to normalize and reason about `Location` / `LocationLink` payloads so scenarios can assert intent instead of re-parsing ad-hoc JSON shapes.
- Make the UX harness easier to extend (e.g., references grid) and tighten fixture metadata to reflect stronger acceptance criteria.

### Description

- Add a new `navigation` helper module with `NavigationTarget`, `all_locations_or_links`, `collect_navigation_targets`, `has_target_in_file`, and `has_target_start_line` for normalizing and validating LSP navigation payloads (`crates/perl-lsp-ux-tests/src/navigation.rs`).
- Refactor the harness location parsing into `request_locations` and `normalize_location_response` to centralize response normalization and add a `references` helper for future tests (`crates/perl-lsp-ux-tests/src/lib.rs`).
- Replace and expand Scenario 18 into a BDD-style UX scenario that asserts: goto-declaration resolves to the sub definition, resolves lexical variable bindings, and degrades gracefully on non-symbol positions while validating payload shapes (`crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs`).
- Update the UX fixture matrix to reflect the stronger expected outcomes and confidence signals for the goto-declaration workflow (`crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json`).

### Testing

- Ran `cargo test -p perl-lsp-ux-tests` and all tests passed.
- Ran `cargo check --all-targets -p perl-lsp-ux-tests`, `cargo clippy -p perl-lsp-ux-tests`, and `cargo xtask fmt`, and they completed successfully.
- `just pr-fast` was not available in this environment (command not found), so it was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0bd234408333a1332289e94ebd65)