### PR TITLE
test(parser): add clean goto corpus fixture (#0000)

### DIFF
--- a/test_corpus/goto_clean_coverage.pl
+++ b/test_corpus/goto_clean_coverage.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+sub dispatch {
+    return "ok";
+}
+
+my $state = "start";
+
+START:
+if ($state eq "start") {
+    $state = "done";
+    goto FINISH;
+}
+
+FINISH:
+goto &dispatch;


### PR DESCRIPTION
### Motivation
- The corpus coverage check reported `Goto` NodeKind only via recovery parses, indicating fragile coverage; a clean test case is needed to exercise label and sub-target `goto` forms.

### Description
- Add `test_corpus/goto_clean_coverage.pl`, a small Perl fixture that exercises both label-based `goto` and `goto &dispatch` so `NodeKind::Goto` appears in clean parses.

### Testing
- Ran `cargo test -p perl-parser test_corpus_nodekind_coverage -- --nocapture`, `cargo check --all-targets -p perl-parser`, `cargo xtask fmt`, and `cargo clippy -p perl-parser`, all of which passed; `just pr-fast` was unavailable in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0bfe8f7c8333b283723c914f0725)