### PR TITLE
test(perl-corpus): expand codegen coverage-index tests (#0000)

### DIFF
--- a/crates/perl-corpus/src/codegen.rs
+++ b/crates/perl-corpus/src/codegen.rs
@@ -314,6 +314,7 @@ fn basic_statement() -> impl Strategy<Value = String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     #[test]
     fn generated_code_is_stable_for_seed() {
@@ -333,5 +334,40 @@ mod tests {
         };
         let code = generate_perl_code_with_options(options);
         assert!(code.is_empty());
+    }
+
+    #[test]
+    fn strategy_indices_cover_all_kinds_when_requested() {
+        let mut rng = StdRng::seed_from_u64(7);
+        let strategy_len = 6;
+        let statements = 30;
+
+        let indices = build_strategy_indices(strategy_len, statements, true, &mut rng);
+        assert_eq!(indices.len(), statements);
+
+        let unique: HashSet<usize> = indices.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            strategy_len,
+            "expected all strategy indices to appear at least once"
+        );
+        assert!(unique.iter().all(|idx| *idx < strategy_len));
+    }
+
+    #[test]
+    fn strategy_indices_do_not_repeat_when_budget_is_smaller_than_kind_count() {
+        let mut rng = StdRng::seed_from_u64(11);
+        let strategy_len = 10;
+        let statements = 4;
+
+        let indices = build_strategy_indices(strategy_len, statements, true, &mut rng);
+        assert_eq!(indices.len(), statements);
+
+        let unique: HashSet<usize> = indices.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            statements,
+            "expected unique indices when sampling fewer statements than kinds"
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Improve direct unit test coverage for the index-selection behavior used by randomized code generation so `ensure_coverage` is exercised deterministically.

### Description
- Add two unit tests to `crates/perl-corpus/src/codegen.rs` that exercise `build_strategy_indices` with a seeded `StdRng` to verify (1) all strategy indices are represented at least once when `ensure_coverage` is true and the statement budget exceeds the strategy count, and (2) unique indices are produced when the statement budget is smaller than the number of kinds.

### Testing
- Ran `cargo test -p perl-corpus` which passed; the new tests are included in the suite.
- Ran `cargo check --all-targets -p perl-corpus`, `cargo clippy -p perl-corpus --all-targets`, and `cargo xtask fmt`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0c0501848333850ff5e179f5256a)