### PR TITLE
fix(perl-lexer): broaden s/tr/y delimiter detection (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2046,30 +2046,17 @@ impl<'a> PerlLexer<'a> {
             // Check for substitution/transliteration operators
             // Skip if after '->'  -- these are method names, not operators.
             #[allow(clippy::collapsible_if)]
-            if !self.after_arrow && matches!(text, "s" | "tr" | "y") {
+            if !self.after_arrow && self.hash_brace_depth == 0 && matches!(text, "s" | "tr" | "y")
+            {
                 if let Some(next) = self.current_char() {
-                    // Check if followed by a delimiter
-                    if matches!(
-                        next,
-                        '/' | '|'
-                            | '\''
-                            | '{'
-                            | '['
-                            | '('
-                            | '<'
-                            | '!'
-                            | '#'
-                            | '@'
-                            | '$'
-                            | '%'
-                            | '^'
-                            | '&'
-                            | '*'
-                            | '+'
-                            | '='
-                            | '~'
-                            | '`'
-                    ) {
+                    // Check if followed by a valid delimiter while preserving fat-arrow
+                    // autoquoting (`s=>1`, `tr=>2`, `y=>3`).
+                    let following = self
+                        .input
+                        .get(self.position + next.len_utf8()..)
+                        .and_then(|s| s.chars().next());
+                    let is_fat_arrow = next == '=' && following == Some('>');
+                    if Self::is_quote_delim(next) && !is_fat_arrow {
                         match text {
                             "s" => {
                                 return self.parse_substitution(start);

--- a/crates/perl-lexer/tests/tokenizer_edge_case_tests.rs
+++ b/crates/perl-lexer/tests/tokenizer_edge_case_tests.rs
@@ -206,6 +206,22 @@ fn ts_fat_arrow_autoquote_not_substitution() -> Result<(), Box<dyn std::error::E
 }
 
 #[test]
+fn ts_substitution_inside_hash_subscript_not_triggered() -> Result<(), Box<dyn std::error::Error>> {
+    // Inside a hash subscript brace ($h{s}), the bareword `s` must not be
+    // interpreted as the substitution operator.  hash_brace_depth is > 0, so
+    // the s/tr/y detection must be suppressed.
+    let kinds = collect_kinds("$h{s}");
+    // Expected: Scalar variable, opening `{`, bareword key `s`, closing `}`.
+    // There must be NO Substitution token in the stream.
+    assert!(
+        !kinds.contains(&TokenKind::Substitution),
+        "`s` inside {{...}} must remain a bareword, not a substitution operator; got {:?}",
+        kinds
+    );
+    Ok(())
+}
+
+#[test]
 fn ts_qr_angle() -> Result<(), Box<dyn std::error::Error>> {
     let kind = first_kind("qr<pattern>i");
     assert_eq!(kind, TokenKind::Regex, "qr<...> should be Regex");

--- a/crates/perl-lexer/tests/tokenizer_edge_case_tests.rs
+++ b/crates/perl-lexer/tests/tokenizer_edge_case_tests.rs
@@ -171,6 +171,13 @@ fn ts_substitution_with_modifiers() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn ts_substitution_colon_delimiter() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("s:old:new:");
+    assert_eq!(kind, TokenKind::Substitution, "s:...:...: should be Substitution");
+    Ok(())
+}
+
+#[test]
 fn ts_transliteration_pipe() -> Result<(), Box<dyn std::error::Error>> {
     let kind = first_kind("tr|a-z|A-Z|");
     assert_eq!(kind, TokenKind::Transliteration, "tr|...|...| should be Transliteration");
@@ -178,9 +185,23 @@ fn ts_transliteration_pipe() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn ts_transliteration_semicolon_delimiter() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("tr;a-z;A-Z;");
+    assert_eq!(kind, TokenKind::Transliteration, "tr;...;...; should be Transliteration");
+    Ok(())
+}
+
+#[test]
 fn ts_transliteration_y_alias() -> Result<(), Box<dyn std::error::Error>> {
     let kind = first_kind("y/a-z/A-Z/");
     assert_eq!(kind, TokenKind::Transliteration, "y/.../.../ should be Transliteration");
+    Ok(())
+}
+
+#[test]
+fn ts_fat_arrow_autoquote_not_substitution() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("s=>1");
+    assert_eq!(kind, TokenKind::Identifier, "s=> should remain fat-arrow autoquote identifier");
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- The lexer used a hardcoded subset of characters to detect `s`, `tr`, and `y` delimiters which missed valid delimiters and risked misclassifying fat-arrow autoquoting (`=>`).
- Quote-like operator detection should reuse the shared delimiter predicate and respect contextual guards such as hash-subscript braces.

### Description
- Replace the ad-hoc delimiter match with `Self::is_quote_delim(next)` and explicitly detect/preserve fat-arrow autoquoting (`next == '=' && following == Some('>')`) before treating `s`/`tr`/`y` as substitution/transliteration operators. 
- Add a `hash_brace_depth == 0` guard so `s`/`tr`/`y` are not parsed as operators inside hash subscript braces. 
- Add regression tests in `tokenizer_edge_case_tests.rs` for `s:old:new:`, `tr;a-z;A-Z;`, and the fat-arrow autoquote case `s=>1`.

### Testing
- Ran `cargo xtask fmt` which completed successfully. 
- Ran `cargo test -p perl-lexer` (including `lexer_bdd_workflows` and `tokenizer_edge_case_tests`) and all tests passed after the change. 
- Ran `cargo check --all-targets -p perl-lexer` and `cargo clippy -p perl-lexer`, both completed with no errors. 
- `just pr-fast` was not available in the environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0c21e6b483338777a072b7a85b67)