### PR TITLE
refactor(perl-lexer): deduplicate unterminated string errors (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2972,16 +2972,7 @@ impl<'a> PerlLexer<'a> {
             last_pos = self.position;
         }
 
-        // Unterminated string - return error token consuming rest of input
-        let end = self.input.len();
-        self.position = end;
-
-        Some(Token {
-            token_type: TokenType::Error(Arc::from("unterminated string")),
-            text: Arc::from(&self.input[start..end]),
-            start,
-            end,
-        })
+        Some(self.unterminated_string_error(start))
     }
 
     fn parse_single_quoted_string(&mut self, start: usize) -> Option<Token> {
@@ -3019,16 +3010,7 @@ impl<'a> PerlLexer<'a> {
             last_pos = self.position;
         }
 
-        // Unterminated string - return error token consuming rest of input
-        let end = self.input.len();
-        self.position = end;
-
-        Some(Token {
-            token_type: TokenType::Error(Arc::from("unterminated string")),
-            text: Arc::from(&self.input[start..end]),
-            start,
-            end,
-        })
+        Some(self.unterminated_string_error(start))
     }
 
     fn parse_backtick_string(&mut self, start: usize) -> Option<Token> {
@@ -3066,21 +3048,26 @@ impl<'a> PerlLexer<'a> {
             last_pos = self.position;
         }
 
-        // Unterminated string - return error token consuming rest of input
-        let end = self.input.len();
-        self.position = end;
-
-        Some(Token {
-            token_type: TokenType::Error(Arc::from("unterminated string")),
-            text: Arc::from(&self.input[start..end]),
-            start,
-            end,
-        })
+        Some(self.unterminated_string_error(start))
     }
 
     fn parse_q_string(&mut self, _start: usize) -> Option<Token> {
         // Simplified q-string parsing
         None
+    }
+
+    #[inline]
+    fn unterminated_string_error(&mut self, start: usize) -> Token {
+        // Consume to EOF so the caller receives a single terminal error token.
+        let end = self.input.len();
+        self.position = end;
+
+        Token {
+            token_type: TokenType::Error(Arc::from("unterminated string")),
+            text: Arc::from(&self.input[start..end]),
+            start,
+            end,
+        }
     }
 
     fn parse_substitution(&mut self, start: usize) -> Option<Token> {


### PR DESCRIPTION
### Motivation

- Three string parsing paths duplicated the logic to produce an EOF/unterminated-string error, increasing maintenance surface.

### Description

- Added an internal helper `unterminated_string_error(&mut self, start: usize) -> Token` that consumes to EOF and constructs the error token.
- Replaced duplicated EOF/error construction in the double-quoted, single-quoted, and backtick string parsers with calls to the new helper.
- Kept observable behavior unchanged while centralizing the error creation and EOF consumption logic.

### Testing

- Ran `cargo test -p perl-lexer` and all tests passed.
- Ran `cargo check --all-targets -p perl-lexer` and it completed successfully.
- Ran `cargo clippy -p perl-lexer -- -D warnings` and it completed without warnings.
- Ran `cargo xtask fmt` to format sources; formatting completed in this environment, and `just pr-fast` was not available here (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0c21e6b483338777a072b7a85b67)