### PR TITLE
test(perl-dap): remove unwrap in protocol compliance tests (#0000)

### DIFF
--- a/crates/perl-dap/tests/dap_protocol_compliance_tests.rs
+++ b/crates/perl-dap/tests/dap_protocol_compliance_tests.rs
@@ -211,7 +211,7 @@ fn test_restart_frame_always_fails_with_message() -> Result<(), Box<dyn std::err
     let response = adapter.handle_request(1, "restartFrame", None);
     let msg = assert_response_message(response, "restartFrame");
     assert!(msg.is_some(), "restartFrame must include an error message");
-    let msg = msg.unwrap();
+    let msg = msg.ok_or("restartFrame must include an error message")?;
     assert!(
         msg.contains("Perl") || msg.contains("stack frame"),
         "message should explain why restartFrame is unsupported: {msg}"
@@ -284,7 +284,7 @@ fn test_terminate_threads_always_fails_with_message() -> Result<(), Box<dyn std:
     let response = adapter.handle_request(1, "terminateThreads", None);
     let msg = assert_response_message(response, "terminateThreads");
     assert!(msg.is_some(), "terminateThreads must include an error message");
-    let msg = msg.unwrap();
+    let msg = msg.ok_or("terminateThreads must include an error message")?;
     assert!(
         msg.contains("thread") || msg.contains("Perl"),
         "message should explain threading limitation: {msg}"


### PR DESCRIPTION
### Motivation
- Tests used `unwrap()` in places that return `Result`, which prevents idiomatic error propagation and violates the repository's test quality guidance.

### Description
- Replaced two `unwrap()` calls with `ok_or(...)?` in `crates/perl-dap/tests/dap_protocol_compliance_tests.rs` for the `restartFrame` and `terminateThreads` assertions.

### Testing
- Ran `cargo test -p perl-dap --test dap_protocol_compliance_tests` (all tests passed), `cargo check --all-targets -p perl-dap` (passed), and `cargo clippy -p perl-dap` (passed); `just pr-fast` was unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0c28132c8333bfd36133c2d18a6e)