### PR TITLE
fix(perl-dap): quote all whitespace-delimited args (#0000)

### DIFF
--- a/crates/perl-dap/src/command_args/mod.rs
+++ b/crates/perl-dap/src/command_args/mod.rs
@@ -5,7 +5,7 @@
 pub fn format_command_args(args: &[String]) -> Vec<String> {
     args.iter()
         .map(|arg| {
-            if arg.contains(' ') {
+            if arg.chars().any(char::is_whitespace) {
                 #[cfg(windows)]
                 {
                     format!("\"{}\"", arg.replace('"', "\\\""))
@@ -43,6 +43,24 @@ mod tests {
         assert_eq!(formatted.len(), 1);
         assert!(formatted[0].contains("file with spaces.txt"));
         assert_ne!(formatted[0], "file with spaces.txt");
+    }
+
+    #[test]
+    fn quotes_args_with_tabs() {
+        let args = vec!["column\tseparated".to_string()];
+        let formatted = format_command_args(&args);
+        assert_eq!(formatted.len(), 1);
+        assert!(formatted[0].contains("column\tseparated"));
+        assert_ne!(formatted[0], "column\tseparated");
+    }
+
+    #[test]
+    fn quotes_args_with_newlines() {
+        let args = vec!["line1\nline2".to_string()];
+        let formatted = format_command_args(&args);
+        assert_eq!(formatted.len(), 1);
+        assert!(formatted[0].contains("line1\nline2"));
+        assert_ne!(formatted[0], "line1\nline2");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Shells can split arguments on any whitespace, but `format_command_args` only checked for the literal space character which allowed tab/newline-delimited args to be mis-handled.

### Description

- Change detection from `arg.contains(' ')` to `arg.chars().any(char::is_whitespace)` in `format_command_args` so any Unicode whitespace triggers quoting.
- Preserve existing platform-specific quoting behavior for Windows and non-Windows paths.
- Add unit tests for tab and newline arguments to prevent regressions (`crates/perl-dap/src/command_args/mod.rs`).

### Testing

- Ran `cargo test -p perl-dap command_args` and the command-args unit tests passed.
- Ran `cargo check --all-targets -p perl-dap` and it completed successfully.
- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran `cargo clippy -p perl-dap` and it passed, while `cargo clippy -p perl-dap --all-targets -- -D warnings` fails on unrelated pre-existing `expect()` usage in tests (not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0c28132c8333bfd36133c2d18a6e)