### PR TITLE
feat(perl-regex): improve modifier hover details (#0000)

### DIFF
--- a/crates/perl-regex/src/lib.rs
+++ b/crates/perl-regex/src/lib.rs
@@ -561,15 +561,29 @@ impl RegexAnalyzer {
         }
 
         // Modifier explanations.
+        // Preserve the input order while suppressing duplicate modifier notes.
+        let mut seen_modifiers = Vec::new();
         let modifier_notes: Vec<&str> = modifiers
             .chars()
-            .filter_map(|m| match m {
-                'i' => Some("case-insensitive matching"),
-                'm' => Some("multiline mode: ^ and $ match line boundaries"),
-                's' => Some("single-line mode: dot matches newline"),
-                'x' => Some("extended mode: whitespace and comments allowed"),
-                'g' => Some("global: match all occurrences"),
-                _ => None,
+            .filter_map(|m| {
+                if seen_modifiers.contains(&m) {
+                    return None;
+                }
+                seen_modifiers.push(m);
+                match m {
+                    'i' => Some("case-insensitive matching"),
+                    'm' => Some("multiline mode: ^ and $ match line boundaries"),
+                    's' => Some("single-line mode: dot matches newline"),
+                    'x' => Some("extended mode: whitespace and comments allowed"),
+                    'g' => Some("global: match all occurrences"),
+                    'a' => Some("ASCII-safe mode: character classes are ASCII-only"),
+                    'd' => Some("native charset mode (legacy default semantics)"),
+                    'l' => Some("locale mode: character classes follow locale rules"),
+                    'u' => Some("Unicode mode: character classes follow Unicode semantics"),
+                    'n' => Some("non-capturing mode: unnamed (...) groups do not capture"),
+                    'p' => Some("preserve matched-string variables for ${^MATCH} family"),
+                    _ => None,
+                }
             })
             .collect();
 

--- a/crates/perl-regex/tests/named_capture_tests.rs
+++ b/crates/perl-regex/tests/named_capture_tests.rs
@@ -279,6 +279,28 @@ fn test_hover_text_empty_pattern() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn test_hover_text_modifier_u_explained() -> Result<(), Box<dyn std::error::Error>> {
+    let text = RegexAnalyzer::hover_text_for_regex(r"\w+", "u");
+    assert!(text.to_lowercase().contains("unicode"));
+    Ok(())
+}
+
+#[test]
+fn test_hover_text_modifier_n_explained() -> Result<(), Box<dyn std::error::Error>> {
+    let text = RegexAnalyzer::hover_text_for_regex("(foo)(?<bar>baz)", "n");
+    assert!(text.to_lowercase().contains("non-capturing"));
+    Ok(())
+}
+
+#[test]
+fn test_hover_text_duplicate_modifiers_are_deduplicated() -> Result<(), Box<dyn std::error::Error>>
+{
+    let text = RegexAnalyzer::hover_text_for_regex("hello", "iiigg");
+    let count = text.match_indices("case-insensitive matching").count();
+    assert_eq!(count, 1, "duplicate modifiers should produce one note");
+    Ok(())
+}
+#[test]
 fn test_hover_text_unknown_modifier_ignored_gracefully() -> Result<(), Box<dyn std::error::Error>> {
     // Unknown modifier letters should not panic
     let text = RegexAnalyzer::hover_text_for_regex("\\d+", "z");


### PR DESCRIPTION
### Motivation

- Hover text for Perl regex modifiers only documented a small subset of flags and repeated notes when the same flag appeared multiple times, reducing usefulness.

### Description

- Expand `RegexAnalyzer::hover_text_for_regex` to document additional Perl modifiers (`a`, `d`, `l`, `u`, `n`, `p`) and keep existing ones (`i`, `m`, `s`, `x`, `g`).
- Deduplicate repeated modifier letters while preserving the user-specified order by tracking seen modifiers with `seen_modifiers` and filtering duplicates.
- Add unit tests in `crates/perl-regex/tests/named_capture_tests.rs` for `u` and `n` modifiers and for duplicate-modifier de-duplication.

### Testing

- Ran `cargo test -p perl-regex` and all tests passed.
- Ran `cargo check --all-targets -p perl-regex`, `cargo xtask fmt`, and `cargo clippy -p perl-regex` and they completed successfully.
- Attempted `just pr-fast` but it could not be executed in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0c31d6c88333a7eb4e025c582167)