### PR TITLE
feat(perl-regex): improve hover modifier coverage (#0000)

### DIFF
--- a/crates/perl-regex/src/lib.rs
+++ b/crates/perl-regex/src/lib.rs
@@ -561,17 +561,11 @@ impl RegexAnalyzer {
         }
 
         // Modifier explanations.
-        let modifier_notes: Vec<&str> = modifiers
-            .chars()
-            .filter_map(|m| match m {
-                'i' => Some("case-insensitive matching"),
-                'm' => Some("multiline mode: ^ and $ match line boundaries"),
-                's' => Some("single-line mode: dot matches newline"),
-                'x' => Some("extended mode: whitespace and comments allowed"),
-                'g' => Some("global: match all occurrences"),
-                _ => None,
-            })
-            .collect();
+        // Deduplicate modifiers while preserving first-seen order
+        // so repeated flags (e.g. /iim/) don't duplicate hover lines.
+        let mut seen = std::collections::BTreeSet::new();
+        let modifier_notes: Vec<&str> =
+            modifiers.chars().filter(|m| seen.insert(*m)).filter_map(modifier_note).collect();
 
         if !modifier_notes.is_empty() {
             parts.push("Modifiers:".to_string());
@@ -584,6 +578,24 @@ impl RegexAnalyzer {
     }
 }
 
+fn modifier_note(modifier: char) -> Option<&'static str> {
+    match modifier {
+        'i' => Some("case-insensitive matching"),
+        'm' => Some("multiline mode: ^ and $ match line boundaries"),
+        's' => Some("single-line mode: dot matches newline"),
+        'x' => Some("extended mode: whitespace and comments allowed"),
+        'g' => Some("global: match all occurrences"),
+        'a' => Some("ASCII-safe mode for character classes and case folding"),
+        'u' => Some("Unicode mode for character classes and case folding"),
+        'l' => Some("locale-based character class and case behavior"),
+        'n' => Some("non-capturing mode by default for unnamed groups"),
+        'p' => Some("preserve matched string for special match variables"),
+        'c' => Some("keep current match position on failed /g match"),
+        'e' => Some("evaluate replacement as Perl code (substitution operator)"),
+        'r' => Some("non-destructive substitution: return replaced copy"),
+        _ => None,
+    }
+}
 fn parse_named_capture_name(
     chars: &[char],
     pos: usize,

--- a/crates/perl-regex/tests/named_capture_tests.rs
+++ b/crates/perl-regex/tests/named_capture_tests.rs
@@ -285,3 +285,22 @@ fn test_hover_text_unknown_modifier_ignored_gracefully() -> Result<(), Box<dyn s
     let _ = text;
     Ok(())
 }
+
+#[test]
+fn test_hover_text_deduplicates_repeated_modifiers() -> Result<(), Box<dyn std::error::Error>> {
+    let text = RegexAnalyzer::hover_text_for_regex("hello", "iiig");
+    let case_mentions = text.matches("case-insensitive matching").count();
+    let global_mentions = text.matches("global: match all occurrences").count();
+    assert_eq!(case_mentions, 1);
+    assert_eq!(global_mentions, 1);
+    Ok(())
+}
+
+#[test]
+fn test_hover_text_additional_perl_modifiers_explained() -> Result<(), Box<dyn std::error::Error>> {
+    let text = RegexAnalyzer::hover_text_for_regex("(?<name>foo)", "aun");
+    assert!(text.contains("ASCII-safe mode"));
+    assert!(text.contains("Unicode mode"));
+    assert!(text.contains("non-capturing mode by default"));
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Prevent duplicated hover notes for repeated modifier flags and provide clearer explanations for a wider set of Perl regex modifiers so IDE hover text is more accurate and informative.
- Keep the change focused to hover rendering and associated tests without altering validation logic.

### Description
- Deduplicate modifier letters before rendering hover lines by tracking seen flags and preserving first-seen order in `RegexAnalyzer::hover_text_for_regex`.
- Introduce a shared `modifier_note` mapping function that expands hover explanations to cover additional Perl modifiers (`a`, `u`, `l`, `n`, `p`, `c`, `e`, `r`) while retaining existing ones (`i`, `m`, `s`, `x`, `g`).
- Add regression tests in `crates/perl-regex/tests/named_capture_tests.rs` to validate deduplication and the newly documented modifiers.

### Testing
- `cargo test -p perl-regex` was run and all crate tests passed.
- `cargo check --all-targets -p perl-regex` and `cargo clippy -p perl-regex` were run and completed successfully.
- `cargo xtask fmt` was run to ensure formatting and completed.
- `just pr-fast` was attempted but failed in this environment because `just` is not installed (`/bin/bash: line 1: just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0c31d6c88333a7eb4e025c582167)