### PR TITLE
feat(tree-sitter-perl-rs): add previous-sibling cursor navigation (#0000)

### DIFF
--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -433,6 +433,25 @@ impl<'tree> TreeCursor<'tree> {
         true
     }
 
+    /// Moves to the previous sibling of the current node.
+    ///
+    /// Returns `true` on success. Returns `false` if the cursor is at root or if
+    /// there is no previous sibling.
+    pub fn goto_previous_sibling(&mut self) -> bool {
+        if self.path.is_empty() {
+            return false;
+        }
+
+        let current_index = self.path[self.path.len() - 1];
+        if current_index == 0 {
+            return false;
+        }
+
+        let last_pos = self.path.len() - 1;
+        self.path[last_pos] = current_index - 1;
+        true
+    }
+
     /// Moves to the parent node.
     ///
     /// Returns `true` when movement succeeds, `false` when already at root.
@@ -815,6 +834,13 @@ mod tests {
         assert_eq!(cursor.node().grammar_kind(), "my_declaration");
         assert!(cursor.goto_next_sibling(), "first statement should have a sibling");
         assert_eq!(cursor.node().grammar_kind(), "my_declaration");
+        assert!(cursor.goto_previous_sibling(), "second statement should have a previous sibling");
+        assert_eq!(cursor.node().grammar_kind(), "my_declaration");
+        assert!(
+            !cursor.goto_previous_sibling(),
+            "first statement should not have a previous sibling"
+        );
+        assert!(cursor.goto_next_sibling(), "should be able to move back to second statement");
         assert!(!cursor.goto_next_sibling(), "second statement should be the last sibling");
     }
 


### PR DESCRIPTION
### Motivation

- `TreeCursor` supported forward sibling movement but had no API to move to the previous sibling, making bidirectional cursor traversal awkward for consumers.

### Description

- Add `TreeCursor::goto_previous_sibling()` which returns `true` when moving to a prior sibling and `false` when at root or the first sibling, with proper index bounds handling in `crates/tree-sitter-perl-rs/src/lib.rs`.
- Extend the existing cursor traversal test (`test_tree_cursor_walks_children_and_siblings`) to verify backward movement, boundary behavior, and that forward movement still works after moving back.

### Testing

- Ran `cargo test -p tree-sitter-perl-rs` and all tests passed (unit, behavior, incremental, snapshot, and doctests).
- Ran `cargo check --all-targets -p tree-sitter-perl-rs`, `cargo clippy -p tree-sitter-perl-rs --all-targets -- -D warnings`, and `cargo xtask fmt`, all of which completed successfully.
- `just pr-fast` was not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0c38172c83339437350826acc649)