### PR TITLE
feat(tree-sitter-perl-rs): add previous-sibling tree cursor navigation (#0000)

### DIFF
--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -433,6 +433,25 @@ impl<'tree> TreeCursor<'tree> {
         true
     }
 
+    /// Moves to the previous sibling of the current node.
+    ///
+    /// Returns `true` on success. Returns `false` if the cursor is at root or if
+    /// the current node is already the first sibling.
+    pub fn goto_previous_sibling(&mut self) -> bool {
+        if self.path.is_empty() {
+            return false;
+        }
+
+        let current_index = self.path[self.path.len() - 1];
+        if current_index == 0 {
+            return false;
+        }
+
+        let last_pos = self.path.len() - 1;
+        self.path[last_pos] = current_index - 1;
+        true
+    }
+
     /// Moves to the parent node.
     ///
     /// Returns `true` when movement succeeds, `false` when already at root.
@@ -816,6 +835,23 @@ mod tests {
         assert!(cursor.goto_next_sibling(), "first statement should have a sibling");
         assert_eq!(cursor.node().grammar_kind(), "my_declaration");
         assert!(!cursor.goto_next_sibling(), "second statement should be the last sibling");
+    }
+
+    #[test]
+    fn test_tree_cursor_goto_previous_sibling_behavior() {
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse("my $x = 1; my $y = 2;"));
+        let root = tree.root_node();
+        let mut cursor = root.walk();
+
+        assert!(!cursor.goto_previous_sibling(), "root has no siblings");
+        assert!(cursor.goto_first_child(), "root should have a child");
+        assert!(!cursor.goto_previous_sibling(), "first child has no previous sibling");
+        assert!(cursor.goto_next_sibling(), "first child should have a sibling");
+        assert_eq!(cursor.node().grammar_kind(), "my_declaration");
+        assert!(cursor.goto_previous_sibling(), "second child should move back to first child");
+        assert_eq!(cursor.node().grammar_kind(), "my_declaration");
+        assert!(!cursor.goto_previous_sibling(), "moved back to first child already");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Provide parity with tree-sitter cursor navigation by adding backward sibling traversal to `TreeCursor` so callers can move to the previous sibling without manipulating the internal `path` manually.

### Description
- Added `TreeCursor::goto_previous_sibling()` which returns `false` when the cursor is at the root or already at the first sibling and otherwise moves the cursor one sibling to the left.
- Added a focused unit test `test_tree_cursor_goto_previous_sibling_behavior` validating root/first-child guards and bi-directional sibling movement.
- Ran formatting (`cargo fmt`) and kept the change limited to `crates/tree-sitter-perl-rs/src/lib.rs` with a single focused commit.

### Testing
- Ran `cargo test -p tree-sitter-perl-rs` and the crate test-suite passed (all unit, behavior, incremental, snapshot, and doctests succeeded).
- Ran `cargo check --all-targets -p tree-sitter-perl-rs` and `cargo clippy -p tree-sitter-perl-rs --all-targets` and both completed successfully. 
- Attempted `just pr-fast` but the `just` tool is not available in this environment (`/bin/bash: line 1: just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0c38172c83339437350826acc649)