### PR TITLE
feat(tree-sitter-perl-c): add parser-reuse parse helpers (#0000)

### DIFF
--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -78,7 +78,9 @@ for snippet in &["my $x = 1;", "print $x;"] {
 | `try_create_parser()` | Creates a `tree_sitter::Parser` (returns `Result`) |
 | `create_parser()` | Creates a parser, silently ignoring language-set errors |
 | `parse_perl_bytes(code)` | Parses raw bytes (including non-UTF-8 Perl source) |
+| `parse_perl_bytes_with_parser(parser, code)` | Parses bytes using a caller-provided parser (reuse-friendly) |
 | `parse_perl_code(code)` | Parses a `&str` into a `tree_sitter::Tree` |
+| `parse_perl_code_with_parser(parser, code)` | Parses text using a caller-provided parser (reuse-friendly) |
 | `parse_perl_file(path)` | Reads and parses a file (non-UTF-8 safe) |
 | `get_scanner_config()` | Returns `"c-scanner"` |
 

--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -40,7 +40,7 @@
 //! [`tree-sitter-perl-rs`]: https://docs.rs/tree-sitter-perl-rs
 
 use std::path::Path;
-use tree_sitter::{Language, Parser};
+use tree_sitter::{Language, Parser, Tree};
 
 /// Returns the tree-sitter [`Language`] for Perl (C grammar).
 ///
@@ -128,10 +128,24 @@ pub fn create_parser() -> Parser {
 /// if tree-sitter returns `None` from `parse` (cancelled or timed out).
 pub fn parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
     let mut parser = try_create_parser()?;
-    match parser.parse(code, None) {
-        Some(tree) => Ok(tree),
-        None => Err("Failed to parse code".into()),
-    }
+    parse_perl_bytes_with_parser(&mut parser, code)
+}
+
+/// Parses Perl source bytes with a caller-provided parser and returns a
+/// [`tree_sitter::Tree`].
+///
+/// Use this in hot paths where a single [`Parser`] is reused across multiple
+/// files or snippets to avoid repeatedly constructing parser state.
+///
+/// # Errors
+///
+/// Returns an error when tree-sitter returns `None` from `parse` (for example,
+/// if parsing is cancelled).
+pub fn parse_perl_bytes_with_parser(
+    parser: &mut Parser,
+    code: &[u8],
+) -> Result<Tree, Box<dyn std::error::Error>> {
+    parser.parse(code, None).ok_or_else(|| "Failed to parse code".into())
 }
 
 /// Parses a Perl source string and returns the resulting [`tree_sitter::Tree`].
@@ -151,6 +165,22 @@ pub fn parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, Box<dyn std::e
 /// ```
 pub fn parse_perl_code(code: &str) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
     parse_perl_bytes(code.as_bytes())
+}
+
+/// Parses Perl source text with a caller-provided parser and returns a
+/// [`tree_sitter::Tree`].
+///
+/// This is a convenience wrapper over [`parse_perl_bytes_with_parser`].
+///
+/// # Errors
+///
+/// Returns an error when tree-sitter returns `None` from `parse` (for example,
+/// if parsing is cancelled).
+pub fn parse_perl_code_with_parser(
+    parser: &mut Parser,
+    code: &str,
+) -> Result<Tree, Box<dyn std::error::Error>> {
+    parse_perl_bytes_with_parser(parser, code.as_bytes())
 }
 
 /// Reads a file from `path` and parses it as Perl source.
@@ -214,6 +244,26 @@ mod tests {
     fn test_parse_bytes() -> Result<(), Box<dyn std::error::Error>> {
         let code = b"my $var = 'hello';";
         let tree = parse_perl_bytes(code)?;
+        assert!(!tree.root_node().has_error());
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_bytes_with_reused_parser() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = try_create_parser()?;
+        let first = parse_perl_bytes_with_parser(&mut parser, b"my $x = 1;")?;
+        let second = parse_perl_bytes_with_parser(&mut parser, b"my $y = 2;")?;
+
+        assert_eq!(first.root_node().kind(), "source_file");
+        assert_eq!(second.root_node().kind(), "source_file");
+        assert!(!second.root_node().has_error());
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_code_with_reused_parser() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = try_create_parser()?;
+        let tree = parse_perl_code_with_parser(&mut parser, "my $name = 'perl';")?;
         assert!(!tree.root_node().has_error());
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- `parse_perl_bytes` and `parse_perl_code` always constructed a new `Parser`, forcing callers in hot paths to recreate parser state or duplicate `None` handling. 
- Provide reuse-friendly helpers so callers can reuse a configured `Parser` for performance-sensitive loops.

### Description
- Added `parse_perl_bytes_with_parser(parser: &mut Parser, code: &[u8]) -> Result<Tree, Box<dyn std::error::Error>>` and `parse_perl_code_with_parser(parser: &mut Parser, code: &str) -> Result<Tree, Box<dyn std::error::Error>>` to the `tree-sitter-perl-c` crate. 
- Made `parse_perl_bytes` delegate to the new `parse_perl_bytes_with_parser` helper to centralize `None` handling. 
- Updated the crate `README.md` API table to document the new functions and added unit tests `test_parse_bytes_with_reused_parser` and `test_parse_code_with_reused_parser` to validate parser reuse.

### Testing
- Ran `cargo test -p tree-sitter-perl-c`, and all tests passed. 
- Ran `cargo check --all-targets -p tree-sitter-perl-c`, `cargo clippy -p tree-sitter-perl-c`, and `cargo xtask fmt`, and they completed successfully. 
- `just pr-fast` was not available in the environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0c3b2dec833396f650dfda62ff1d)