### PR TITLE
test(perl-module): remove panic-based assertions in facade tests (#0000)

### DIFF
--- a/crates/perl-module/tests/facade_api_completeness.rs
+++ b/crates/perl-module/tests/facade_api_completeness.rs
@@ -118,13 +118,12 @@ fn test_import_module_types_are_accessible() {
 
 /// Verify parse_module_import_head works correctly (end-to-end).
 #[test]
-fn test_parse_module_import_head_function() {
-    if let Some(head) = parse_module_import_head("use My::Module;") {
-        assert_eq!(head.token, "My::Module");
-        assert_eq!(head.kind, ModuleImportKind::Use);
-    } else {
-        panic!("Failed to parse module import head");
-    }
+fn test_parse_module_import_head_function() -> Result<(), Box<dyn std::error::Error>> {
+    let head = parse_module_import_head("use My::Module;")
+        .ok_or("expected import head for `use My::Module;`")?;
+    assert_eq!(head.token, "My::Module");
+    assert_eq!(head.kind, ModuleImportKind::Use);
+    Ok(())
 }
 
 /// Verify boundary module functions work end-to-end.
@@ -152,13 +151,12 @@ fn test_token_module_functions() {
 
 /// Verify token_parser can parse module tokens.
 #[test]
-fn test_token_parser_function() {
-    if let Some(token) = parse_module_token("My::Module", 0) {
-        assert_eq!(token.start, 0);
-        assert_eq!(token.end, "My::Module".len());
-    } else {
-        panic!("Failed to parse module token");
-    }
+fn test_token_parser_function() -> Result<(), Box<dyn std::error::Error>> {
+    let token =
+        parse_module_token("My::Module", 0).ok_or("expected to parse canonical module token")?;
+    assert_eq!(token.start, 0);
+    assert_eq!(token.end, "My::Module".len());
+    Ok(())
 }
 
 /// Verify import_match functions work correctly.
@@ -170,13 +168,12 @@ fn test_import_match_module_function() {
 
 /// Verify reference module functions work end-to-end.
 #[test]
-fn test_reference_module_functions() {
+fn test_reference_module_functions() -> Result<(), Box<dyn std::error::Error>> {
     let source = "use My::Module;";
-    if let Some(module_name) = extract_module_reference(source, 4) {
-        assert_eq!(module_name, "My::Module");
-    } else {
-        panic!("Failed to extract module reference");
-    }
+    let module_name = extract_module_reference(source, 4)
+        .ok_or("expected module reference at offset 4 in `use My::Module;`")?;
+    assert_eq!(module_name, "My::Module");
+    Ok(())
 }
 
 /// Verify rename module functions work correctly.
@@ -310,14 +307,13 @@ fn test_legacy_package_separator_preservation() {
 
 /// Regression: verify token parsing roundtrip.
 #[test]
-fn test_token_parsing_roundtrip() {
+fn test_token_parsing_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
     let name = "Complex::Nested::Module::Name";
-    if let Some(token) = parse_module_token(name, 0) {
-        assert_eq!(token.start, 0);
-        assert_eq!(token.end, name.len());
-    } else {
-        panic!("Failed to parse module token");
-    }
+    let token =
+        parse_module_token(name, 0).ok_or("expected token parse to succeed for nested module")?;
+    assert_eq!(token.start, 0);
+    assert_eq!(token.end, name.len());
+    Ok(())
 }
 
 /// Regression: verify multi-line handling in rename edits.


### PR DESCRIPTION
### Motivation
- Replace manual `panic!` fallback branches in facade API tests with idiomatic `Result`-returning tests to conform to the repository test-style and eliminate panic-based assertions.

### Description
- Converted four tests (`test_parse_module_import_head_function`, `test_token_parser_function`, `test_reference_module_functions`, and `test_token_parsing_roundtrip`) to return `Result<(), Box<dyn std::error::Error>>` and replaced `if let ... { } else { panic!(...) }` with `ok_or(...)?` error propagation.
- No functional logic of the tests was changed; only the failure signaling/style was adjusted to match project guidelines.

### Testing
- Ran `cargo test -p perl-module` and all tests in the `perl-module` crate passed.
- Ran `cargo check --all-targets -p perl-module` and `cargo clippy -p perl-module`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0d0e03d483339424d87ce2d1663f)