### PR TITLE
fix(perl-module): reject unterminated quoted require paths (#0000)

### DIFF
--- a/crates/perl-module/src/import/mod.rs
+++ b/crates/perl-module/src/import/mod.rs
@@ -195,17 +195,12 @@ fn parse_require_head(line: &str) -> Option<ModuleImportHead<'_>> {
     let rest_trimmed = rest.trim_start();
     let quote_offset = rest.len() - rest_trimmed.len();
 
-    if let Some(inner) = rest_trimmed
-        .strip_prefix('"')
-        .and_then(|s| s.strip_suffix('"').or_else(|| s.split('"').next()))
-        .or_else(|| {
-            rest_trimmed
-                .strip_prefix('\'')
-                .and_then(|s| s.strip_suffix('\'').or_else(|| s.split('\'').next()))
-        })
-    {
-        let quote_char_len = 1usize;
-        let token_start = after_keyword + quote_offset + quote_char_len;
+    if let Some(quote_char) = rest_trimmed.chars().next().filter(|ch| *ch == '"' || *ch == '\'') {
+        let quoted = &rest_trimmed[quote_char.len_utf8()..];
+        let close_idx = quoted.find(quote_char)?;
+        let inner = &quoted[..close_idx];
+
+        let token_start = after_keyword + quote_offset + quote_char.len_utf8();
         let token_end = token_start + inner.len();
         return Some(ModuleImportHead {
             kind: ModuleImportKind::Require,

--- a/crates/perl-module/tests/dispatch_semantics.rs
+++ b/crates/perl-module/tests/dispatch_semantics.rs
@@ -147,6 +147,22 @@ fn test_require_file_path_single_quote_parses() -> Result<(), String> {
 }
 
 #[test]
+fn test_require_file_path_double_quote_without_closing_quote_is_rejected() -> Result<(), String> {
+    if parse_module_import_head(r#"require "Module/File.pm;"#).is_some() {
+        return Err("expected None for unterminated double-quoted require path".into());
+    }
+    Ok(())
+}
+
+#[test]
+fn test_require_file_path_single_quote_without_closing_quote_is_rejected() -> Result<(), String> {
+    if parse_module_import_head("require 'Module/File.pm;").is_some() {
+        return Err("expected None for unterminated single-quoted require path".into());
+    }
+    Ok(())
+}
+
+#[test]
 fn test_require_file_path_is_file_form() -> Result<(), String> {
     let head = parse_module_import_head(r#"require "Module/File.pm";"#)
         .ok_or("expected Some for quoted require")?;

--- a/crates/perl-module/tests/dispatch_semantics.rs
+++ b/crates/perl-module/tests/dispatch_semantics.rs
@@ -163,6 +163,18 @@ fn test_require_file_path_single_quote_without_closing_quote_is_rejected() -> Re
 }
 
 #[test]
+fn test_require_empty_double_quoted_path_is_accepted() -> Result<(), String> {
+    // `require ""` is syntactically valid (though semantically dubious);
+    // the parser should return Some with an empty token, not None.
+    let head = parse_module_import_head(r#"require "";"#)
+        .ok_or("expected Some for empty double-quoted require")?;
+    if head.token != "" {
+        return Err(format!("expected empty token, got {:?}", head.token));
+    }
+    Ok(())
+}
+
+#[test]
 fn test_require_file_path_is_file_form() -> Result<(), String> {
     let head = parse_module_import_head(r#"require "Module/File.pm";"#)
         .ok_or("expected Some for quoted require")?;


### PR DESCRIPTION
### Motivation

- Prevent `parse_module_import_head` from accepting unterminated quoted `require` arguments as valid tokens, which produced false-positive parses on malformed lines.

### Description

- Tightened the `require` quoted-path parsing in `crates/perl-module/src/import/mod.rs` to explicitly detect a leading quote and require a matching closing quote instead of leniently accepting unterminated input via `split`/`strip_suffix` heuristics.
- Added two regression tests in `crates/perl-module/tests/dispatch_semantics.rs` to ensure unterminated single- and double-quoted `require` forms are rejected.

### Testing

- Ran `cargo test -p perl-module`, which passed successfully (all tests green).
- Ran `cargo check --all-targets -p perl-module`, which completed successfully.
- Ran `cargo xtask fmt`, which completed successfully and formatted the workspace.
- Ran `cargo clippy -p perl-module`, which completed successfully with no blocking lints.
- Attempted `just pr-fast`, which failed in this environment because `just` is not installed (command not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0d0e03d483339424d87ce2d1663f)