### PR TITLE
feat(perl-module): support short FindBin exports in use lib parsing (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/use_lib.rs
+++ b/crates/perl-module/src/resolution/use_lib.rs
@@ -32,6 +32,7 @@ pub enum UseLibAction {
 /// - `use lib qw/path1 path2/;`
 /// - `use lib ("path1", "path2");`
 /// - `use lib '$FindBin::Bin/path'` and `"$FindBin::Bin/path"`
+/// - `use lib '$Bin/path'` and `"$RealBin/path"` (from `FindBin` exports)
 ///
 /// Returns extracted paths in order of appearance.
 pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
@@ -267,8 +268,16 @@ fn extract_one_quoted(s: &str) -> Option<(String, bool, &str)> {
 }
 
 fn resolve_findbin_in_string(s: &str) -> (String, bool) {
-    let findbin_vars =
-        ["$FindBin::Bin", "$FindBin::RealBin", "${FindBin::Bin}", "${FindBin::RealBin}"];
+    let findbin_vars = [
+        "$FindBin::Bin",
+        "$FindBin::RealBin",
+        "${FindBin::Bin}",
+        "${FindBin::RealBin}",
+        "$Bin",
+        "$RealBin",
+        "${Bin}",
+        "${RealBin}",
+    ];
 
     for var in &findbin_vars {
         if let Some(rest) = s.strip_prefix(var) {

--- a/crates/perl-module/src/resolution/use_lib.rs
+++ b/crates/perl-module/src/resolution/use_lib.rs
@@ -268,18 +268,46 @@ fn extract_one_quoted(s: &str) -> Option<(String, bool, &str)> {
 }
 
 fn resolve_findbin_in_string(s: &str) -> (String, bool) {
-    let findbin_vars = [
-        "$FindBin::Bin",
-        "$FindBin::RealBin",
-        "${FindBin::Bin}",
-        "${FindBin::RealBin}",
-        "$Bin",
-        "$RealBin",
-        "${Bin}",
-        "${RealBin}",
-    ];
+    // Fully-qualified FindBin variables — no word-boundary ambiguity because `::` terminates
+    // the name and braced forms are unambiguous.
+    let qualified_vars =
+        ["$FindBin::Bin", "$FindBin::RealBin", "${FindBin::Bin}", "${FindBin::RealBin}"];
 
-    for var in &findbin_vars {
+    for var in &qualified_vars {
+        if let Some(rest) = s.strip_prefix(var) {
+            let path = rest.strip_prefix('/').unwrap_or(rest);
+            if path.is_empty() {
+                return (".".to_string(), true);
+            }
+            return (path.to_string(), true);
+        }
+    }
+
+    // Short exported forms: `$Bin`, `$RealBin`, `${Bin}`, `${RealBin}`.
+    // Braced forms (`${Bin}`) are always unambiguous.  Bare forms (`$Bin`,
+    // `$RealBin`) must be followed by `/`, end-of-string, or a non-identifier
+    // character to avoid false-positives on variables like `$BinDir` or
+    // `$RealBinPath`.
+    let bare_short = ["$Bin", "$RealBin"];
+    let braced_short = ["${Bin}", "${RealBin}"];
+
+    for var in &bare_short {
+        if let Some(rest) = s.strip_prefix(var) {
+            // Word-boundary check: the character after the variable name must
+            // not be a Perl identifier character (letter, digit, or `_`).
+            // This prevents `$BinDir` or `$RealBinPath` from matching `$Bin`/`$RealBin`.
+            let next = rest.chars().next();
+            if next.is_none() || next.is_some_and(|c| !c.is_alphanumeric() && c != '_') {
+                let path = rest.strip_prefix('/').unwrap_or(rest);
+                if path.is_empty() {
+                    return (".".to_string(), true);
+                }
+                return (path.to_string(), true);
+            }
+        }
+    }
+
+    for var in &braced_short {
         if let Some(rest) = s.strip_prefix(var) {
             let path = rest.strip_prefix('/').unwrap_or(rest);
             if path.is_empty() {

--- a/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
+++ b/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
@@ -86,6 +86,8 @@ use Lib::Thing;\n\
 
 #[test]
 fn short_findbin_exports_are_treated_as_findbin_paths() {
+    // Both double-quoted (interpolating) and single-quoted (literal in real Perl)
+    // forms are recognised; the extractor is intentionally quote-type-agnostic.
     let source = "\
 use lib '$Bin/../lib';\n\
 use lib \"$RealBin/../vendor\";\n\
@@ -102,5 +104,47 @@ use lib \"$RealBin/../vendor\";\n\
                 from_findbin: true,
             }]),
         ]
+    );
+}
+
+#[test]
+fn short_findbin_prefix_does_not_match_longer_variable_name() {
+    // `$BinDir` and `$RealBinPath` look like they start with `$Bin`/`$RealBin`
+    // but are different variables — word-boundary check must reject them.
+    let source = "\
+use lib \"$BinDir/lib\";\n\
+use lib \"$RealBinPath/vendor\";\n\
+";
+
+    let ops = extract_use_lib_operations(source);
+
+    // Both paths should be treated as plain (non-FindBin) string paths.
+    assert_eq!(
+        ops,
+        vec![
+            UseLibAction::Add(vec![UseLibPath {
+                path: "$BinDir/lib".to_string(),
+                from_findbin: false,
+            }]),
+            UseLibAction::Add(vec![UseLibPath {
+                path: "$RealBinPath/vendor".to_string(),
+                from_findbin: false,
+            }]),
+        ]
+    );
+}
+
+#[test]
+fn braced_short_findbin_exports_are_treated_as_findbin_paths() {
+    let source = "use lib \"${Bin}/../lib\";\n";
+
+    let ops = extract_use_lib_operations(source);
+
+    assert_eq!(
+        ops,
+        vec![UseLibAction::Add(vec![UseLibPath {
+            path: "../lib".to_string(),
+            from_findbin: true,
+        }]),]
     );
 }

--- a/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
+++ b/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
@@ -83,3 +83,24 @@ use Lib::Thing;\n\
 
     assert_eq!(include_paths, vec!["second".to_string()]);
 }
+
+#[test]
+fn short_findbin_exports_are_treated_as_findbin_paths() {
+    let source = "\
+use lib '$Bin/../lib';\n\
+use lib \"$RealBin/../vendor\";\n\
+";
+
+    let ops = extract_use_lib_operations(source);
+
+    assert_eq!(
+        ops,
+        vec![
+            UseLibAction::Add(vec![UseLibPath { path: "../lib".to_string(), from_findbin: true }]),
+            UseLibAction::Add(vec![UseLibPath {
+                path: "../vendor".to_string(),
+                from_findbin: true,
+            }]),
+        ]
+    );
+}


### PR DESCRIPTION
### Motivation

- `use lib` parsing only recognized fully-qualified `FindBin` variables and missed common exported aliases like `$Bin` / `$RealBin`, causing those include paths to be treated as ordinary paths instead of FindBin-derived.

### Description

- Extend `resolve_findbin_in_string` in `crates/perl-module/src/resolution/use_lib.rs` to recognize `$Bin`, `$RealBin` and their braced forms in addition to `$FindBin::Bin`/`$FindBin::RealBin`.
- Update the `use lib` documentation comment to list the short `FindBin` exports as supported patterns.
- Add a unit test `short_findbin_exports_are_treated_as_findbin_paths` in `crates/perl-module/tests/use_lib_resolution_unit_tests.rs` to verify extracted `UseLibAction::Add` entries have `from_findbin: true` for `$Bin`/`$RealBin` inputs.

### Testing

- Ran `cargo test -p perl-module --test use_lib_resolution_unit_tests`, which passed (`5 tests` all OK).
- Ran `cargo check --all-targets -p perl-module`, which completed successfully.
- Ran `cargo clippy -p perl-module -- -D warnings`, which completed successfully.
- Ran `cargo xtask fmt` to format workspace sources; it completed successfully.
- Note: `just pr-fast` is not available in this environment and could not be run (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0d0e03d483339424d87ce2d1663f)