### PR TITLE
test(perl-parser): expand BDD parser scenarios (#0000)

### DIFF
--- a/crates/perl-parser/tests/parser_bdd_scenarios.rs
+++ b/crates/perl-parser/tests/parser_bdd_scenarios.rs
@@ -175,7 +175,10 @@ fn bdd_given_unclosed_quote_when_parsed_then_recovery_is_reported_without_panick
         Ok(ast) => {
             let sexp = ast.to_sexp();
             assert!(
-                sexp.contains("ERROR") || sexp.contains("unknown"),
+                sexp.contains("ERROR")
+                    || sexp.contains("(UNKNOWN_REST)")
+                    || sexp.contains("(missing_expression)")
+                    || sexp.contains("(missing_statement)"),
                 "Expected recovery marker for malformed quoted string: {sexp}"
             );
         }
@@ -227,11 +230,16 @@ fn bdd_given_partial_hashref_literal_when_parsed_then_parser_recovers_without_pa
     let result = parser.parse();
 
     // Then: parser should recover (ERROR node) or return a descriptive parse failure.
+    // Note: AST recovery node names are ERROR, (UNKNOWN_REST), (missing_expression),
+    // (missing_statement) — lowercase "unknown" is not a valid sexp token name.
     match result {
         Ok(ast) => {
             let sexp = ast.to_sexp();
             assert!(
-                sexp.contains("ERROR") || sexp.contains("unknown"),
+                sexp.contains("ERROR")
+                    || sexp.contains("(UNKNOWN_REST)")
+                    || sexp.contains("(missing_expression)")
+                    || sexp.contains("(missing_statement)"),
                 "Expected recovery marker for incomplete hashref literal: {sexp}"
             );
         }

--- a/crates/perl-parser/tests/parser_bdd_scenarios.rs
+++ b/crates/perl-parser/tests/parser_bdd_scenarios.rs
@@ -184,3 +184,59 @@ fn bdd_given_unclosed_quote_when_parsed_then_recovery_is_reported_without_panick
         }
     }
 }
+
+#[test]
+fn bdd_given_package_and_constructor_pattern_when_parsed_then_namespace_and_bless_flow_are_preserved()
+-> TestResult {
+    // Given: a developer writes a package with a constructor that blesses a hashref.
+    let code = r#"
+        package My::Service;
+        use strict;
+        use warnings;
+
+        sub new {
+            my ($class, %args) = @_;
+            my $self = bless { %args }, $class;
+            return $self;
+        }
+    "#;
+
+    // When: the parser processes this object-construction pattern.
+    let sexp = parse_sexp(code)?;
+
+    // Then: namespace + constructor flow is represented without recovery artifacts.
+    assert!(sexp.contains("My::Service"), "Expected package name in AST output: {sexp}");
+    assert!(sexp.contains("bless"), "Expected bless call in AST output: {sexp}");
+    assert!(sexp.contains("(return"), "Expected Return node in: {sexp}");
+    assert!(!sexp.contains("ERROR"), "Did not expect recovery ERROR nodes for valid code: {sexp}");
+
+    Ok(())
+}
+
+#[test]
+fn bdd_given_partial_hashref_literal_when_parsed_then_parser_recovers_without_panicking() {
+    // Given: a developer is typing a hashref literal and stops mid-expression.
+    let code = r#"
+        my $cfg = {
+            host => "localhost",
+            port =>
+    "#;
+
+    // When: the parser attempts to process incomplete input.
+    let mut parser = Parser::new(code);
+    let result = parser.parse();
+
+    // Then: parser should recover (ERROR node) or return a descriptive parse failure.
+    match result {
+        Ok(ast) => {
+            let sexp = ast.to_sexp();
+            assert!(
+                sexp.contains("ERROR") || sexp.contains("unknown"),
+                "Expected recovery marker for incomplete hashref literal: {sexp}"
+            );
+        }
+        Err(err) => {
+            assert!(!err.to_string().is_empty(), "Expected non-empty parse failure message");
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve BDD parser coverage by adding scenarios that exercise a common package/constructor (`bless`) pattern and recovery when editing a partial hashref literal.

### Description
- Added two tests to `crates/perl-parser/tests/parser_bdd_scenarios.rs`: `bdd_given_package_and_constructor_pattern_when_parsed_then_namespace_and_bless_flow_are_preserved` and `bdd_given_partial_hashref_literal_when_parsed_then_parser_recovers_without_panicking`.
- The constructor test asserts the AST includes the package name, `bless` call, and `return` node and contains no recovery `ERROR` nodes, and the partial-hashref test verifies the parser either emits recovery markers (`ERROR`/`unknown`) or returns a non-empty parse error without panicking.

### Testing
- Ran `cargo test -p perl-parser --test parser_bdd_scenarios` and the added tests passed (`9 passed; 0 failed`).
- Ran `cargo check --all-targets -p perl-parser`, `cargo xtask fmt`, and `cargo clippy -p perl-parser`, all of which completed successfully.
- `just pr-fast` was not available in this environment (`command not found`), so that gate was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0d27337c833398c07be67a28a8a3)