### PR TITLE
test(perl-lsp-ux-tests): add actionable completion UX scenario (#0000)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -362,12 +362,32 @@
       "expected_outcomes": [
         "declaration request returns a location or clean empty result",
         "request does not error"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
+      ]
+    },
+    {
+      "id": "completion_actionable_suggestions",
+      "scenario_file": "ux_scenario_19_completion_quality.rs",
+      "subsystem_owner": "editor_intelligence",
+      "ci_tier": "pr",
+      "user_journey": "type a common Perl prefix in a fresh file and request completion",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "completion returns non-empty suggestions for common prefixes",
+        "suggestions include expected Perl built-ins for high-frequency flows"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
       ]
     }
-  ],
-  "confidence_signals": [
-    "manual_editor_smoke",
-    "first_five_minutes_harness",
-    "issue_burndown_regression_guard"
   ]
 }

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion_quality.rs
@@ -1,0 +1,49 @@
+// Test infrastructure — allow test-friendly patterns.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+//! Scenario 19 — completion quality for first-file editing.
+//!
+//! Verifies that completion is not only crash-free, but returns actionable
+//! suggestions for a high-frequency typing path (`pri` -> `print`).
+
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+#[test]
+fn scenario_19_completion_returns_actionable_builtin_suggestions() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_19: perl-lsp binary not found");
+        return;
+    }
+
+    let source = "use strict;\nuse warnings;\n\npri\n";
+    let harness = UxHarness::new(ScenarioConfig::default().with_file("completion.pl", source))
+        .expect("Failed to create UX harness");
+
+    harness.open_file("completion.pl", source).expect("didOpen should succeed");
+
+    let completion_items =
+        harness.completion("completion.pl", 3, 3).expect("completion request should not error");
+
+    assert!(
+        !completion_items.is_empty(),
+        "Expected completion to return at least one suggestion for `pri`, got empty list"
+    );
+
+    let has_print = completion_items.iter().any(|item| {
+        item.get("label")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|label| label == "print" || label.starts_with("print "))
+    });
+
+    assert!(
+        has_print,
+        "Expected completion suggestions for `pri` to include `print`, got: {:?}",
+        completion_items
+    );
+
+    harness.assert_no_crash();
+}


### PR DESCRIPTION
### Motivation

- The UX harness verified completion was crash-free but did not assert that completions are actionable for common first-file typing flows. 
- A focused test that checks for real, expected suggestions (e.g. `pri` -> `print`) improves regression coverage on a high-frequency editor interaction.

### Description

- Added a new UX scenario `crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion_quality.rs` that opens a fresh file, requests completion for the prefix `pri`, and asserts the results include `print` and are non-empty. 
- Registered the new scenario in `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` including measures, expected outcomes, and confidence signals. 
- Also added missing `confidence_signals` for the existing `ux_scenario_18_goto_declaration.rs` entry so the fixture matrix invariants remain explicit.

### Testing

- Ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --test ux_scenario_19_completion_quality -- --test-threads=1` and the selected tests passed. 
- Ran `cargo check --all-targets -p perl-lsp-ux-tests` and it completed successfully. 
- Ran `cargo clippy -p perl-lsp-ux-tests --tests -- -D warnings` which failed due to a pre-existing clippy lint in `ux_scenario_13_document_symbols.rs` unrelated to this change. 
- Ran `cargo xtask fmt` to ensure formatting consistency and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0d836c0083339f8e266674177fd0)