### PR TITLE
test(ux): add completion quality scenario coverage (#0000)

### DIFF
--- a/crates/perl-lsp-ux-tests/README.md
+++ b/crates/perl-lsp-ux-tests/README.md
@@ -22,7 +22,8 @@ Scenarios currently include:
 - hover, goto-definition, strict diagnostics, and document symbols flows, and
 - multi-root `workspace/symbol` disambiguation via `workspaceFolderUri`, and
 - workspace-folder removal evicting stale symbols from search results, and
-- deleted-file churn evicting stale search results and definition targets.
+- deleted-file churn evicting stale search results and definition targets, and
+- completion quality checks for lexical and builtin suggestions.
 
 The harness is now also the source of truth for the workflow UX scorecard
 inventory:

--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -362,6 +362,31 @@
       "expected_outcomes": [
         "declaration request returns a location or clean empty result",
         "request does not error"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
+      ]
+    },
+    {
+      "id": "completion_quality_core",
+      "scenario_file": "ux_scenario_19_completion.rs",
+      "subsystem_owner": "editor_intelligence",
+      "ci_tier": "pr",
+      "user_journey": "type local variables and builtin prefixes in a fresh file and rely on completion",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "completion returns lexical suggestions for local symbols",
+        "completion items stay well-formed and include builtin suggestions"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
       ]
     }
   ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion.rs
@@ -1,0 +1,97 @@
+// Test infrastructure — allow test-friendly patterns.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+//! Scenario 19 — Completion quality in first-edit workflows.
+//!
+//! This scenario targets a high-impact UX path: users typing code and relying on
+//! completion to discover local variables and common builtins.
+//!
+//! Acceptance criteria:
+//! - `textDocument/completion` MUST NOT return a JSON-RPC error.
+//! - Local variable completion should include the expected lexical symbol.
+//! - Builtin/keyword completion should return a well-formed item list.
+//! - No crash signatures after completion requests.
+
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use std::time::Duration;
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+#[test]
+fn scenario_19_completion_surfaces_local_variables() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_19: perl-lsp binary not found");
+        return;
+    }
+
+    let source = "use strict;\nuse warnings;\n\nmy $result = 42;\nmy $response = 100;\n\n$res\n";
+    let harness = UxHarness::new(ScenarioConfig::default().with_file("completion.pl", source))
+        .expect("Failed to create UX harness");
+
+    harness.open_file("completion.pl", source).expect("didOpen should succeed");
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Completion on `$res` (line 6, char 4) should include lexical symbols.
+    let items = harness
+        .completion("completion.pl", 6, 4)
+        .expect("completion should not return JSON-RPC error");
+
+    let labels = items
+        .iter()
+        .filter_map(|item| item.get("label").and_then(|label| label.as_str()))
+        .collect::<Vec<_>>();
+
+    assert!(
+        labels.contains(&"$result"),
+        "Expected lexical completion to include $result, got labels: {:?}",
+        labels
+    );
+
+    harness.assert_no_crash();
+}
+
+#[test]
+fn scenario_19_completion_items_have_useful_shape_for_builtins() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_19: perl-lsp binary not found");
+        return;
+    }
+
+    let source = "use strict;\n\npri\n";
+    let harness = UxHarness::new(ScenarioConfig::default().with_file("builtins.pl", source))
+        .expect("Failed to create UX harness");
+
+    harness.open_file("builtins.pl", source).expect("didOpen should succeed");
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let items = harness
+        .completion("builtins.pl", 2, 3)
+        .expect("completion should not return JSON-RPC error");
+
+    assert!(!items.is_empty(), "Expected non-empty completion items for `pri`");
+
+    for item in &items {
+        assert!(
+            item.get("label").and_then(|label| label.as_str()).is_some(),
+            "Completion items must include a string `label`, got: {:?}",
+            item
+        );
+    }
+
+    let labels = items
+        .iter()
+        .filter_map(|item| item.get("label").and_then(|label| label.as_str()))
+        .collect::<Vec<_>>();
+
+    assert!(
+        labels.iter().any(|label| label.contains("print")),
+        "Expected builtin-like completion for `pri` to include `print`, got labels: {:?}",
+        labels
+    );
+
+    harness.assert_no_crash();
+}


### PR DESCRIPTION
### Motivation
- Improve UX test coverage for first-edit completion workflows to catch regressions in lexical and builtin suggestion behavior.
- Keep the editor UX fixture matrix and README in sync with executable scenarios so CI validation remains authoritative.

### Description
- Add `crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion.rs` containing two UX scenarios that validate lexical variable completions and builtin-prefix completion item shape.
- Update `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` to add the `completion_quality_core` workflow and to add missing `confidence_signals` for the `goto_declaration_core` entry required by the matrix validator.
- Update `crates/perl-lsp-ux-tests/README.md` to document the new completion-quality coverage area.

### Testing
- Ran `cargo test -p perl-lsp-ux-tests --test ux_scenario_19_completion` and both tests passed.
- Ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix` and the fixture matrix validation test passed.
- Ran `cargo check --all-targets -p perl-lsp-ux-tests` which completed successfully.
- Ran `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_19_completion -- -D warnings` which passed, while a full crate `clippy --tests` run flagged a pre-existing unrelated lint in `ux_scenario_13_document_symbols.rs` that was not changed by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0d836c0083339f8e266674177fd0)