### PR TITLE
test(vscode-extension): cover high-impact UX warning actions (#0000)

### DIFF
--- a/vscode-extension/src/test/extensionUx.test.ts
+++ b/vscode-extension/src/test/extensionUx.test.ts
@@ -150,6 +150,73 @@ describe('extension UX warnings', () => {
     );
   });
 
+  test('does not offer directory creation for absolute or workspace-escaping include paths', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-ux-escape-'));
+    const context = makeContext();
+    context.globalState = {
+      get: jest.fn(() => undefined),
+      update: jest.fn(async () => undefined),
+    };
+
+    (vscode.workspace.getConfiguration as jest.Mock).mockImplementation(() => ({
+      get: jest.fn(() => ['/opt/perl/lib', '../shared-lib']),
+    }));
+
+    (vscode.workspace as any).workspaceFolders = [
+      {
+        name: 'workspace',
+        uri: {
+          fsPath: workspaceDir,
+          toString: () => `file://${workspaceDir}`,
+        },
+      },
+    ];
+
+    const showWarningMessage = vscode.window.showWarningMessage as jest.Mock;
+    showWarningMessage.mockResolvedValue(undefined);
+
+    await validateIncludePaths(context);
+
+    expect(showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('/opt/perl/lib'),
+      'Open Settings'
+    );
+    expect(showWarningMessage.mock.calls[0]).toHaveLength(2);
+  });
+
+  test('opens settings when selected from include path warning', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-ux-settings-'));
+    const context = makeContext();
+    context.globalState = {
+      get: jest.fn(() => undefined),
+      update: jest.fn(async () => undefined),
+    };
+
+    (vscode.workspace.getConfiguration as jest.Mock).mockImplementation(() => ({
+      get: jest.fn(() => ['missing-lib']),
+    }));
+
+    (vscode.workspace as any).workspaceFolders = [
+      {
+        name: 'workspace',
+        uri: {
+          fsPath: workspaceDir,
+          toString: () => `file://${workspaceDir}`,
+        },
+      },
+    ];
+
+    const showWarningMessage = vscode.window.showWarningMessage as jest.Mock;
+    showWarningMessage.mockResolvedValue('Open Settings');
+
+    await validateIncludePaths(context);
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      'workbench.action.openSettings',
+      '@ext:EffortlessMetrics.perl-lsp-rs perl-lsp.includePaths'
+    );
+  });
+
   test('warns once per major version when conflicting Perl extensions are installed', async () => {
     const context = makeContext('0.12.3');
     let warnedMajor: string | undefined;
@@ -193,6 +260,45 @@ describe('extension UX warnings', () => {
     showWarningMessage.mockClear();
     await warnAboutPerlExtensionConflicts(context);
     expect(showWarningMessage).not.toHaveBeenCalled();
+  });
+
+  test('opens coexistence guide when conflict warning action is selected', async () => {
+    const context = makeContext('0.12.3');
+    context.globalState = {
+      get: jest.fn(() => undefined),
+      update: jest.fn(async () => undefined),
+    };
+
+    const showWarningMessage = vscode.window.showWarningMessage as jest.Mock;
+    showWarningMessage.mockResolvedValue('Open Coexistence Guide');
+
+    (vscode.extensions as any).all = [
+      {
+        id: 'EffortlessMetrics.perl-lsp-rs',
+        packageJSON: {
+          publisher: 'EffortlessMetrics',
+          name: 'perl-lsp-rs',
+          version: '0.12.3',
+        },
+      },
+      {
+        id: 'example.perl-navigator',
+        packageJSON: {
+          displayName: 'Perl Navigator',
+          contributes: {
+            languages: [{ id: 'perl' }],
+          },
+        },
+      },
+    ];
+
+    await warnAboutPerlExtensionConflicts(context);
+
+    expect(vscode.env.openExternal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toString: expect.any(Function),
+      })
+    );
   });
 
   test('syncs perlcritic settings to the server', async () => {


### PR DESCRIPTION
### Motivation

- Improve UX test coverage for include-path remediation and extension-conflict guidance, focusing on user-facing decision points that affect safety and recovery.
- Prevent regressions where the extension might offer to create directories for absolute or workspace-escaping include paths, and ensure the settings/guide actions are wired correctly.

### Description

- Added a test that verifies the extension does not offer a "Create Missing Directories" action for absolute or workspace-escaping include paths.
- Added a test that verifies selecting "Open Settings" from the include-path warning triggers `workbench.action.openSettings` with the `perl-lsp.includePaths` target.
- Added a test that verifies selecting the conflict warning action opens the external coexistence guide via `vscode.env.openExternal`.

### Testing

- Ran `npm test -- --runTestsByPath src/test/extensionUx.test.ts`, which attempted to compile and run the modified test file but failed during TypeScript/Jest compilation due to missing Jest globals/type configuration in the local test environment; this is an environment/configuration issue rather than a failure of the new test logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0d5f7d2083338fa3fbfb86c4efb0)