### PR TITLE
test(perl-lsp-ux-tests): cover template language-mode UX resilience (#0000)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -371,7 +371,7 @@
     },
     {
       "id": "template_language_mode_resilience",
-      "scenario_file": "ux_scenario_19_template_language_mode.rs",
+      "scenario_file": "ux_scenario_22_template_language_mode.rs",
       "subsystem_owner": "editor_intelligence",
       "ci_tier": "pr",
       "user_journey": "open a template file in html mode and continue navigating in neighboring Perl files",

--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -364,6 +364,28 @@
         "request does not error"
       ],
       "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
+      ]
+    },
+    {
+      "id": "template_language_mode_resilience",
+      "scenario_file": "ux_scenario_19_template_language_mode.rs",
+      "subsystem_owner": "editor_intelligence",
+      "ci_tier": "pr",
+      "user_journey": "open a template file in html mode and continue navigating in neighboring Perl files",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "cross_file_definition_success_rate"
+      ],
+      "expected_outcomes": [
+        "template-like html mode file does not emit Perl parse diagnostics",
+        "goto-definition in adjacent Perl files remains functional"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
         "manual_editor_smoke",
         "issue_burndown_regression_guard"
       ]

--- a/crates/perl-lsp-ux-tests/src/client.rs
+++ b/crates/perl-lsp-ux-tests/src/client.rs
@@ -230,14 +230,19 @@ impl UxClient {
         self.send_raw(&msg)
     }
 
-    /// Send `textDocument/didOpen`.
-    pub fn did_open(&self, uri: &str, text: &str) -> Result<()> {
+    /// Send `textDocument/didOpen` using the provided language identifier.
+    pub fn did_open_with_language_id(
+        &self,
+        uri: &str,
+        text: &str,
+        language_id: &str,
+    ) -> Result<()> {
         self.notify(
             "textDocument/didOpen",
             json!({
                 "textDocument": {
                     "uri": uri,
-                    "languageId": "perl",
+                    "languageId": language_id,
                     "version": 1,
                     "text": text
                 }
@@ -261,6 +266,11 @@ impl UxClient {
                 ]
             }),
         )
+    }
+
+    /// Send `textDocument/didOpen` using Perl as the language identifier.
+    pub fn did_open(&self, uri: &str, text: &str) -> Result<()> {
+        self.did_open_with_language_id(uri, text, "perl")
     }
 
     /// Drain all buffered server-initiated events and decode them.

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -203,6 +203,21 @@ impl UxHarness {
         self.client.did_change_full(&uri, version, updated_content)
     }
 
+    /// Open a file in the LSP server with an explicit language identifier.
+    ///
+    /// Useful for UX regressions where the editor mode intentionally differs
+    /// from the file extension (for example, opening `*.html.ep` as HTML).
+    pub fn open_file_with_language_id(
+        &self,
+        relative_path: &str,
+        content: &str,
+        language_id: &str,
+    ) -> Result<()> {
+        self.workspace.write(relative_path, content)?;
+        let uri = self.workspace.uri(relative_path);
+        self.client.did_open_with_language_id(&uri, content, language_id)
+    }
+
     /// Request hover information at `(line, character)` (0-indexed UTF-16).
     ///
     /// Returns `None` if the server returned a null/empty result (degraded mode is OK).

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_template_language_mode.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_template_language_mode.rs
@@ -1,0 +1,68 @@
+//! Scenario 19 — Template language mode should not poison Perl UX flows.
+//!
+//! Why this is high-impact:
+//! - Mojolicious/TT template files are frequently opened in HTML mode.
+//! - Regressions here can flood users with parse noise or break navigation in
+//!   neighboring Perl files during the first few minutes of editor usage.
+//!
+//! Contract:
+//! - Opening a template-like file (`*.html.ep`) in non-Perl language mode MUST
+//!   not crash.
+//! - Template diagnostics in this mode SHOULD stay empty (parse intentionally skipped).
+//! - Core navigation in normal Perl files in the same workspace MUST still work.
+
+use anyhow::Result;
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use std::time::Duration;
+
+const APP_SOURCE: &str = r#"use strict;
+use warnings;
+
+sub index {
+    return helper();
+}
+
+sub helper {
+    return 'ok';
+}
+
+index();
+"#;
+
+const TEMPLATE_SOURCE: &str = r#"% my $user = shift;
+<h1><%= $user %></h1>
+% if ($user) {
+  <p>Welcome!</p>
+% }
+"#;
+
+#[test]
+fn scenario_19_template_in_html_mode_preserves_neighboring_perl_navigation() -> Result<()> {
+    let harness = UxHarness::new(
+        ScenarioConfig::default()
+            .with_file("app.pl", APP_SOURCE)
+            .with_file("templates/index.html.ep", TEMPLATE_SOURCE),
+    )?;
+
+    harness.open_file_with_language_id("templates/index.html.ep", TEMPLATE_SOURCE, "html")?;
+    harness.open_file("app.pl", APP_SOURCE)?;
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    let template_diags =
+        harness.wait_for_diagnostics("templates/index.html.ep", Duration::from_millis(1200));
+    assert!(
+        template_diags.is_empty(),
+        "template opened as html should skip Perl parse diagnostics, got: {template_diags:?}"
+    );
+
+    // `helper` call in `return helper();` (line 4, character 11).
+    let defs = harness.definition("app.pl", 4, 11)?;
+    assert!(
+        !defs.is_empty(),
+        "expected goto-definition in neighboring Perl file to keep working after template open"
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_22_template_language_mode.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_22_template_language_mode.rs
@@ -1,4 +1,4 @@
-//! Scenario 19 — Template language mode should not poison Perl UX flows.
+//! Scenario 22 — Template language mode should not poison Perl UX flows.
 //!
 //! Why this is high-impact:
 //! - Mojolicious/TT template files are frequently opened in HTML mode.
@@ -37,7 +37,7 @@ const TEMPLATE_SOURCE: &str = r#"% my $user = shift;
 "#;
 
 #[test]
-fn scenario_19_template_in_html_mode_preserves_neighboring_perl_navigation() -> Result<()> {
+fn scenario_22_template_in_html_mode_preserves_neighboring_perl_navigation() -> Result<()> {
     let harness = UxHarness::new(
         ScenarioConfig::default()
             .with_file("app.pl", APP_SOURCE)


### PR DESCRIPTION
### Motivation
- Prevent regressions where opening template-like files (e.g. `*.html.ep`) in a non-Perl editor mode floods parse diagnostics or breaks navigation in neighboring Perl files during the first few minutes of editor usage.
- Add a targeted UX scenario that exercises the real LSP process and verifies language-mode interactions are safe for adjacent workflows.

### Description
- Added a new UX scenario `ux_scenario_19_template_language_mode.rs` which opens a template file as `html`, asserts no Perl diagnostics for that file, and verifies `goto-definition` still works in a neighboring `app.pl` file.
- Extended the LSP test client with `did_open_with_language_id(...)` and retained `did_open(...)` as a Perl-default wrapper so scenarios can simulate files opened with arbitrary language modes (`crates/perl-lsp-ux-tests/src/client.rs`).
- Added `UxHarness::open_file_with_language_id(...)` to expose the new client API to scenarios (`crates/perl-lsp-ux-tests/src/lib.rs`).
- Updated the UX fixture matrix `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` to include Scenario 19 and to add missing `confidence_signals` for Scenario 18 so the matrix validation test remains consistent.

### Testing
- Ran `cargo check --all-targets -p perl-lsp-ux-tests` which passed.
- Ran `cargo clippy -p perl-lsp-ux-tests` which passed.
- Built the server with `cargo build -p perl-lsp-rs` and then ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix` which passed.
- Verified the new scenario end-to-end using the built binary with `PERL_LSP_BIN=/workspace/perl-lsp/target/debug/perl-lsp cargo test -p perl-lsp-ux-tests --test ux_scenario_19_template_language_mode` which passed.
- Ran `cargo xtask fmt`; `just pr-fast` was not available in the environment and therefore was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0d5f7d2083338fa3fbfb86c4efb0)