### PR TITLE
test(config): harden workspace update regression coverage (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/mod.rs
+++ b/crates/perl-lsp-rs-core/src/config/mod.rs
@@ -997,4 +997,55 @@ perltidy_extra_args = ["-noll"]
         let paths = config.effective_include_paths(&[]);
         assert_eq!(paths, vec!["lib"]);
     }
+
+    #[test]
+    fn update_from_value_keeps_existing_perl5lib_precedence_on_unknown_value() {
+        let mut config = WorkspaceConfig {
+            perl5lib_precedence: Perl5LibPrecedence::Append,
+            ..WorkspaceConfig::default()
+        };
+
+        let settings = serde_json::json!({
+            "workspace": {
+                "perl5libPrecedence": "sideways"
+            }
+        });
+
+        config.update_from_value(&settings);
+
+        assert!(matches!(config.perl5lib_precedence, Perl5LibPrecedence::Append));
+    }
+
+    #[test]
+    fn update_from_value_clears_system_inc_cache_when_perl_runtime_inputs_change() {
+        let mut config = WorkspaceConfig::default();
+        config.use_system_inc = true;
+        config.system_inc_cache = Some(vec![PathBuf::from("/cached/inc")]);
+
+        let perl_path_change = serde_json::json!({
+            "workspace": {
+                "perlPath": "/usr/bin/perl"
+            }
+        });
+        config.update_from_value(&perl_path_change);
+        assert!(config.system_inc_cache.is_none());
+
+        config.system_inc_cache = Some(vec![PathBuf::from("/cached/inc")]);
+        let perl_args_change = serde_json::json!({
+            "workspace": {
+                "perlArgs": ["-Ilib"]
+            }
+        });
+        config.update_from_value(&perl_args_change);
+        assert!(config.system_inc_cache.is_none());
+
+        config.system_inc_cache = Some(vec![PathBuf::from("/cached/inc")]);
+        let use_system_inc_change = serde_json::json!({
+            "workspace": {
+                "useSystemInc": false
+            }
+        });
+        config.update_from_value(&use_system_inc_change);
+        assert!(config.system_inc_cache.is_none());
+    }
 }


### PR DESCRIPTION
### Motivation
- Protect workspace module-resolution behavior from typos by ensuring an unknown `workspace.perl5libPrecedence` value does not overwrite an explicitly-set precedence.
- Ensure `WorkspaceConfig` invalidates cached system `@INC` when runtime inputs (`perlPath`, `perlArgs`, `useSystemInc`) change to avoid stale include paths.

### Description
- Added unit tests in `crates/perl-lsp-rs-core/src/config/mod.rs`: `update_from_value_keeps_existing_perl5lib_precedence_on_unknown_value` and `update_from_value_clears_system_inc_cache_when_perl_runtime_inputs_change`.
- No production logic was changed; this PR only expands regression coverage for `WorkspaceConfig::update_from_value`.

### Testing
- Ran `cargo test -p perl-lsp-rs-core`, which executed the crate test suite and uncovered one pre-existing unrelated failure in `green_tdd_wave_g1b_regression_hardening::test_perl_lsp_cargo_toml_removed_g1b_imports`, while the new tests passed.
- Ran `cargo check --all-targets -p perl-lsp-rs-core` which completed successfully.
- Ran `cargo clippy -p perl-lsp-rs-core` which completed successfully without new lints.
- Ran `cargo xtask fmt` which completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0d5e52a88333a80a43da64ff3bf3)