### PR TITLE
test(perl-corpus): add proptest invariants for codegen (#0000)

### DIFF
--- a/crates/perl-corpus/src/codegen.rs
+++ b/crates/perl-corpus/src/codegen.rs
@@ -370,4 +370,78 @@ mod tests {
             "expected unique indices when sampling fewer statements than kinds"
         );
     }
+
+    proptest! {
+        #[test]
+        fn prop_strategy_indices_stay_in_bounds(
+            strategy_len in 1usize..32,
+            statements in 1usize..128,
+            ensure_coverage in any::<bool>(),
+            seed in any::<u64>(),
+        ) {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let indices = build_strategy_indices(strategy_len, statements, ensure_coverage, &mut rng);
+
+            prop_assert_eq!(indices.len(), statements);
+            prop_assert!(indices.iter().all(|idx| *idx < strategy_len));
+        }
+
+        #[test]
+        fn prop_strategy_indices_cover_all_when_requested(
+            strategy_len in 1usize..24,
+            extra_statements in 0usize..48,
+            seed in any::<u64>(),
+        ) {
+            let statements = strategy_len + extra_statements;
+            let mut rng = StdRng::seed_from_u64(seed);
+            let indices = build_strategy_indices(strategy_len, statements, true, &mut rng);
+
+            let mut seen = vec![false; strategy_len];
+            for idx in indices {
+                seen[idx] = true;
+            }
+
+            prop_assert!(seen.into_iter().all(|v| v));
+        }
+
+        #[test]
+        fn prop_seeded_codegen_is_deterministic_for_options(
+            statements in 0usize..40,
+            seed in any::<u64>(),
+            ensure_coverage in any::<bool>(),
+        ) {
+            let options = CodegenOptions {
+                statements,
+                seed,
+                preamble: Some("use strict;\n".to_string()),
+                ensure_coverage,
+                kinds: vec![
+                    StatementKind::Basic,
+                    StatementKind::ControlFlow,
+                    StatementKind::Regex,
+                ],
+            };
+
+            let first = generate_perl_code_with_options(options.clone());
+            let second = generate_perl_code_with_options(options);
+            prop_assert_eq!(first, second);
+        }
+
+        #[test]
+        fn prop_basic_only_codegen_emits_requested_statement_count(
+            statements in 0usize..50,
+            seed in any::<u64>(),
+        ) {
+            let code = generate_perl_code_with_options(CodegenOptions {
+                statements,
+                seed,
+                preamble: None,
+                ensure_coverage: true,
+                kinds: vec![StatementKind::Basic],
+            });
+
+            let non_empty_line_count = code.lines().filter(|line| !line.trim().is_empty()).count();
+            prop_assert_eq!(non_empty_line_count, statements);
+        }
+    }
 }


### PR DESCRIPTION
### Motivation

- Increase property-based test coverage for the randomized code generation path so regressions in index selection, coverage, seeding, and statement-count behavior are caught earlier.

### Description

- Add a suite of `proptest!` invariants to `crates/perl-corpus/src/codegen.rs` that exercise `build_strategy_indices` and `generate_perl_code_with_options`.
- Tests added assert that strategy indices stay in-bounds and that `ensure_coverage` forces each strategy to appear at least once when possible.
- Tests added assert that seeded `CodegenOptions` produce deterministic output and that a single-`Basic` kind generates the requested number of statements.

### Testing

- Ran `cargo test -p perl-corpus` and all tests passed. 
- Ran `cargo check --all-targets -p perl-corpus` and it passed. 
- Ran `cargo clippy -p perl-corpus` and it completed successfully. 
- Ran `cargo xtask fmt`; formatting step completed, and `just pr-fast` is unavailable in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0d3d0a6c8333a614f3b2322de219)