### PR TITLE
test(perl-lsp-rs): add BDD semantic tokens incremental workflow (#0000)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs
+++ b/crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs
@@ -1907,9 +1907,13 @@ print $value + $delta;
         before_data, after_data,
         "semantic tokens should change after incremental edit; before={before_data:?} after={after_data:?}"
     );
+    // The after content introduces $delta (appears twice: declaration and use), so the
+    // encoded token stream must be strictly longer — each token is 5 u64 values in
+    // LSP's relative-encoded format. A '>=' allows the degenerate case where tokens
+    // shrink to exactly the same count, so we require strict growth.
     assert!(
-        after_data.len() >= before_data.len(),
-        "adding a local symbol should not shrink semantic token payload; before={} after={}",
+        after_data.len() > before_data.len(),
+        "adding two $delta references must grow the token payload; before={} after={}",
         before_data.len(),
         after_data.len()
     );

--- a/crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs
+++ b/crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs
@@ -405,6 +405,14 @@ fn inlay_labels(response: &Value) -> Vec<String> {
         .unwrap_or_default()
 }
 
+fn semantic_token_data(response: &Value) -> Vec<u64> {
+    response
+        .get("data")
+        .and_then(Value::as_array)
+        .map(|data| data.iter().filter_map(Value::as_u64).collect())
+        .unwrap_or_default()
+}
+
 fn line_span(range: &Value) -> Option<(u64, u64)> {
     let start = range.pointer("/range/start/line").and_then(Value::as_u64)?;
     let end = range.pointer("/range/end/line").and_then(Value::as_u64)?;
@@ -1840,6 +1848,70 @@ my $value = cal
             .iter()
             .any(|label| label == "calculate_total" || label.ends_with("calculate_total")),
         "completion after didChange should include calculate_total; got {after_labels:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn bdd_incremental_semantic_tokens_refresh_after_local_symbol_addition()
+-> Result<(), Box<dyn std::error::Error>> {
+    let scenario = BddScenario::new("Incremental semantic tokens refresh after local symbol edit");
+
+    let before = r#"use strict;
+use warnings;
+
+my $value = 41;
+print $value;
+"#;
+
+    let after = r#"use strict;
+use warnings;
+
+my $value = 41;
+my $delta = $value + 1;
+print $value + $delta;
+"#;
+
+    scenario.given("an opened file with semantic tokens available for baseline content");
+    let (mut harness, workspace) = setup_workspace(&[("incremental_semantic_tokens.pl", before)])?;
+    let uri = workspace.uri("incremental_semantic_tokens.pl");
+    harness.open(&uri, before)?;
+    harness.barrier();
+
+    scenario.when("requesting semantic tokens before the incremental change");
+    let before_tokens = harness.request(
+        "textDocument/semanticTokens/full",
+        json!({
+            "textDocument": { "uri": uri }
+        }),
+    )?;
+    let before_data = semantic_token_data(&before_tokens);
+
+    scenario.when("editing the file to add a new local symbol and requesting tokens again");
+    harness.change_full(&uri, 2, after)?;
+    harness.barrier();
+    let after_tokens = harness.request(
+        "textDocument/semanticTokens/full",
+        json!({
+            "textDocument": { "uri": uri }
+        }),
+    )?;
+    let after_data = semantic_token_data(&after_tokens);
+
+    scenario.then("semantic tokens are recomputed and reflect the richer symbol set");
+    assert!(!before_data.is_empty(), "baseline semantic tokens should not be empty");
+    assert!(!after_data.is_empty(), "updated semantic tokens should not be empty");
+    assert_ne!(
+        before_data, after_data,
+        "semantic tokens should change after incremental edit; before={before_data:?} after={after_data:?}"
+    );
+    assert!(
+        after_data.len() >= before_data.len(),
+        "adding a local symbol should not shrink semantic token payload; before={} after={}",
+        before_data.len(),
+        after_data.len()
     );
 
     Ok(())


### PR DESCRIPTION
### Motivation
- The BDD workflow suite lacked coverage for semantic-token recomputation after incremental edits, leaving editor highlighting/semantic-refresh behavior without end-to-end assertions.

### Description
- Add `semantic_token_data` helper to normalize `textDocument/semanticTokens/full` payloads into a `Vec<u64>` for deterministic comparisons.
- Add a focused BDD test `bdd_incremental_semantic_tokens_refresh_after_local_symbol_addition` that opens a file, requests semantic tokens, applies an incremental `didChange`, re-requests tokens, and asserts tokens are non-empty, changed, and not regressive in size.
- Changes are limited to `crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs` and only introduce test helpers and a single new scenario.

### Testing
- Ran the new test directly: `cargo test -p perl-lsp-rs --test lsp_bdd_workflows bdd_incremental_semantic_tokens_refresh_after_local_symbol_addition -- --test-threads=1` — passed.
- Ran build validation: `cargo check --all-targets -p perl-lsp-rs` — passed.
- Ran lints for the modified test: `cargo clippy -p perl-lsp-rs --test lsp_bdd_workflows -- -D warnings` — passed.
- Ran formatting via `cargo xtask fmt` as part of the verification steps — completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0d3524588333b230bfcd7f0b9495)