### PR TITLE
test(rename): add package-scoped BDD coverage and guard workspace rename edits (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/features/workspace_rename.rs
+++ b/crates/perl-lsp-rs/src/features/workspace_rename.rs
@@ -138,7 +138,7 @@ fn is_sub_declaration_line(line_text: &str, name: &str) -> bool {
 
     let tail = trimmed.trim_start_matches("sub ").trim_start();
     let declared_name = tail
-        .split(|ch: char| ch.is_whitespace() || ch == '(' || ch == '{')
+        .split(|ch: char| ch.is_whitespace() || ch == '(' || ch == '{' || ch == ';')
         .next()
         .unwrap_or_default();
 
@@ -158,18 +158,23 @@ fn is_non_target_package_declaration(
         return false;
     };
 
-    let Some(start_off) = doc.line_index.position_to_offset(start_line, start_char) else {
-        return false;
-    };
-    let Some(end_off) = doc.line_index.position_to_offset(end_line, end_char) else {
-        return false;
-    };
-    let Some(original) = doc.text.get(start_off..end_off) else {
-        return false;
-    };
+    // Try to read the original source span to detect a qualified name like "Bar::process_data".
+    // When the index returns an inverted range (end < start, a known indexer edge case), we fall
+    // through to the package-context check below rather than conservatively returning false.
+    let maybe_original = doc
+        .line_index
+        .position_to_offset(start_line, start_char)
+        .and_then(|start_off| {
+            doc.line_index
+                .position_to_offset(end_line, end_char)
+                .and_then(|end_off| doc.text.get(start_off..end_off))
+        });
 
-    if let Some((qualifier, _)) = original.rsplit_once("::") {
-        return qualifier != key.pkg.as_ref();
+    if let Some(original) = maybe_original {
+        if let Some((qualifier, _)) = original.rsplit_once("::") {
+            return qualifier != key.pkg.as_ref();
+        }
+        // Unqualified bare name — rely on package context below.
     }
 
     let package_at_line = package_name_for_line(&doc.text, start_line);
@@ -377,6 +382,57 @@ $var;
                 );
             }
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn is_sub_declaration_line_handles_forward_declaration() {
+        // "sub foo;" is a valid Perl forward declaration — semicolon must be treated
+        // as a delimiter so the name is extracted correctly.
+        assert!(
+            is_sub_declaration_line("sub process_data;", "process_data"),
+            "forward declaration 'sub process_data;' should match name 'process_data'"
+        );
+        assert!(
+            is_sub_declaration_line("sub process_data ;", "process_data"),
+            "forward declaration with space before semicolon should match"
+        );
+        // A declaration in another package must still not match a different name
+        assert!(
+            !is_sub_declaration_line("sub process_data;", "other_name"),
+            "forward decl with wrong name must not match"
+        );
+    }
+
+    #[test]
+    fn rename_skips_forward_decl_in_other_package() -> Result<(), Box<dyn std::error::Error>> {
+        // If package Bar has a forward declaration "sub process_data;" and we rename
+        // Foo::process_data, the forward decl in Bar must not be touched.
+        let idx = WorkspaceIndex::new();
+
+        let foo_text = "package Foo;\nsub process_data { return 1; }\n1;\n";
+        let bar_text = "package Bar;\nsub process_data;\nsub process_data { return 2; }\n1;\n";
+
+        index_text(&idx, "file:///Foo.pm", foo_text)?;
+        index_text(&idx, "file:///Bar.pm", bar_text)?;
+
+        let key = SymbolKey {
+            pkg: Arc::from("Foo"),
+            name: Arc::from("process_data"),
+            sigil: None,
+            kind: SymKind::Sub,
+        };
+
+        let edits = build_rename_edit(&idx, &key, "process_records");
+
+        // Bar.pm must not appear in the edit list
+        let bar_edit = edits.iter().find(|e| e.uri.contains("Bar.pm"));
+        assert!(
+            bar_edit.is_none(),
+            "renaming Foo::process_data must not touch Bar.pm; got edits: {:?}",
+            edits.iter().map(|e| (&e.uri, &e.edits)).collect::<Vec<_>>()
+        );
 
         Ok(())
     }

--- a/crates/perl-lsp-rs/src/features/workspace_rename.rs
+++ b/crates/perl-lsp-rs/src/features/workspace_rename.rs
@@ -51,6 +51,15 @@ pub fn build_rename_edit(
         let end_line = loc.range.end.line;
         let end_char = loc.range.end.column;
 
+        if key.kind == SymKind::Sub
+            && key.pkg.as_ref() != "main"
+            && is_non_target_package_declaration(
+                idx, key, &loc.uri, start_line, start_char, end_line, end_char,
+            )
+        {
+            continue;
+        }
+
         // Compute replacement text based on symbol kind
         let replacement = match key.kind {
             SymKind::Var => {
@@ -92,6 +101,84 @@ pub fn build_rename_edit(
 
     // Convert to RenameEdit structs
     grouped.into_iter().map(|(uri, edits)| RenameEdit { uri, edits }).collect()
+}
+
+fn package_name_for_line(text: &str, target_line: u32) -> &str {
+    let mut current_pkg = "main";
+
+    for (line_index, raw_line) in text.lines().enumerate() {
+        if (line_index as u32) > target_line {
+            break;
+        }
+
+        let trimmed = raw_line.trim_start();
+        if !trimmed.starts_with("package ") {
+            continue;
+        }
+
+        let package_decl = trimmed.trim_start_matches("package ").trim_start();
+        let package_name = package_decl
+            .split(|ch: char| ch.is_whitespace() || ch == ';')
+            .next()
+            .unwrap_or_default();
+
+        if !package_name.is_empty() {
+            current_pkg = package_name;
+        }
+    }
+
+    current_pkg
+}
+
+fn is_sub_declaration_line(line_text: &str, name: &str) -> bool {
+    let trimmed = line_text.trim_start();
+    if !trimmed.starts_with("sub ") {
+        return false;
+    }
+
+    let tail = trimmed.trim_start_matches("sub ").trim_start();
+    let declared_name = tail
+        .split(|ch: char| ch.is_whitespace() || ch == '(' || ch == '{')
+        .next()
+        .unwrap_or_default();
+
+    declared_name == name || declared_name.rsplit_once("::").is_some_and(|(_, bare)| bare == name)
+}
+
+fn is_non_target_package_declaration(
+    idx: &WorkspaceIndex,
+    key: &SymbolKey,
+    uri: &str,
+    start_line: u32,
+    start_char: u32,
+    end_line: u32,
+    end_char: u32,
+) -> bool {
+    let Some(doc) = idx.document_store().get(uri) else {
+        return false;
+    };
+
+    let Some(start_off) = doc.line_index.position_to_offset(start_line, start_char) else {
+        return false;
+    };
+    let Some(end_off) = doc.line_index.position_to_offset(end_line, end_char) else {
+        return false;
+    };
+    let Some(original) = doc.text.get(start_off..end_off) else {
+        return false;
+    };
+
+    if let Some((qualifier, _)) = original.rsplit_once("::") {
+        return qualifier != key.pkg.as_ref();
+    }
+
+    let package_at_line = package_name_for_line(&doc.text, start_line);
+    if package_at_line == key.pkg.as_ref() {
+        return false;
+    }
+
+    let line_text = doc.text.lines().nth(start_line as usize).unwrap_or_default();
+    is_sub_declaration_line(line_text, key.name.as_ref())
 }
 
 /// Convert RenameEdit to LSP WorkspaceEdit JSON.

--- a/crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs
+++ b/crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs
@@ -565,6 +565,100 @@ my $also = process_data();
 
 #[test]
 #[serial]
+fn bdd_rename_is_scoped_to_target_package_symbol() -> Result<(), Box<dyn std::error::Error>> {
+    let scenario = BddScenario::new("Rename stays scoped to the selected package symbol");
+
+    let foo_module = r#"package Foo;
+use strict;
+use warnings;
+
+sub process_data {
+    return "foo";
+}
+
+1;
+"#;
+
+    let bar_module = r#"package Bar;
+use strict;
+use warnings;
+
+sub process_data {
+    return "bar";
+}
+
+1;
+"#;
+
+    let main = r#"use strict;
+use warnings;
+use lib './lib';
+use Foo;
+use Bar;
+
+my $foo = Foo::process_data();
+my $bar = Bar::process_data();
+"#;
+
+    scenario.given("a workspace where two packages expose subroutines with the same name");
+    let (mut harness, workspace) = setup_workspace(&[
+        ("lib/Foo.pm", foo_module),
+        ("lib/Bar.pm", bar_module),
+        ("main.pl", main),
+    ])?;
+
+    let foo_uri = workspace.uri("lib/Foo.pm");
+    let bar_uri = workspace.uri("lib/Bar.pm");
+    let main_uri = workspace.uri("main.pl");
+
+    harness.open(&foo_uri, foo_module)?;
+    harness.open(&bar_uri, bar_module)?;
+    harness.open(&main_uri, main)?;
+
+    harness.wait_for_symbol("process_data", Some(&foo_uri), Duration::from_secs(10))?;
+    harness.wait_for_symbol("process_data", Some(&bar_uri), Duration::from_secs(10))?;
+    harness.barrier();
+
+    scenario.when("renaming Foo::process_data from the declaration in Foo.pm");
+    let (def_line, def_char) = find_position(foo_module, "process_data");
+    let edit = wait_for_rename_edit_uris(
+        &mut harness,
+        &foo_uri,
+        def_line,
+        def_char,
+        "process_records",
+        &[&foo_uri, &main_uri],
+        Duration::from_secs(10),
+    )?;
+
+    scenario.then("rename edits target Foo.pm and main.pl only");
+    let touched_uris = workspace_edit_uris(&edit);
+    assert!(touched_uris.contains(&foo_uri), "rename should edit Foo.pm");
+    assert!(touched_uris.contains(&main_uri), "rename should edit main.pl");
+    assert!(!touched_uris.contains(&bar_uri), "rename should not edit Bar.pm");
+
+    scenario.then("the edit payload rewrites Foo call sites but not Bar call sites");
+    let foo_texts = workspace_edit_new_texts_for_uri(&edit, &foo_uri);
+    let main_texts = workspace_edit_new_texts_for_uri(&edit, &main_uri);
+
+    assert!(
+        foo_texts.iter().any(|text| text.contains("process_records")),
+        "Foo edits should include the renamed symbol; got {foo_texts:?}"
+    );
+    assert!(
+        main_texts.iter().any(|text| text.contains("process_records")),
+        "main edits should include the renamed Foo call; got {main_texts:?}"
+    );
+    assert!(
+        !main_texts.iter().any(|text| text.contains("Bar::process_records")),
+        "main edits should not rename Bar::process_data call sites; got {main_texts:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+#[serial]
 fn bdd_workspace_symbols_expose_module_api() -> Result<(), Box<dyn std::error::Error>> {
     let scenario = BddScenario::new("Workspace symbol search surfaces module APIs");
 


### PR DESCRIPTION
### Motivation
- Rename workflows could incorrectly include same-named subroutines from a different package and this behavior lacked BDD coverage.
- Add a deterministic BDD scenario to protect against regressions in package-scoped renames.
- Tighten workspace rename edit generation to avoid touching declarations or qualified references that belong to a non-target package.

### Description
- Added a BDD test `bdd_rename_is_scoped_to_target_package_symbol` in `crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs` that sets up `Foo` and `Bar` packages exposing the same `process_data` sub and asserts renaming `Foo::process_data` does not affect `Bar`.
- Hardened `build_rename_edit` in `crates/perl-lsp-rs/src/features/workspace_rename.rs` to skip non-target-package hits for `SymKind::Sub` by filtering qualified references whose qualifier does not match the target package and by skipping same-named `sub` declarations in other package scopes.
- Introduced helpers `package_name_for_line`, `is_sub_declaration_line`, and `is_non_target_package_declaration` to detect package context and declaration lines when deciding whether to include an edit.

### Testing
- Ran `cargo test -p perl-lsp-rs --test lsp_bdd_workflows bdd_rename_` and the new BDD tests passed locally (both `bdd_rename_updates_workspace_edits` and `bdd_rename_is_scoped_to_target_package_symbol` reported OK).
- Ran `cargo check --all-targets -p perl-lsp-rs` which completed successfully.
- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo clippy -p perl-lsp-rs --all-targets -- -D warnings` which surfaced many pre-existing `expect!/panic!` lints in unrelated files (not introduced by this change) and therefore failed; these warnings are outside the scope of this focused change.
- Note: `just pr-fast` is not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0d3524588333b230bfcd7f0b9495)