### PR TITLE
fix(benchmarks): parse grouped criterion names and mixed units (#0000)

### DIFF
--- a/benchmarks/scripts/run-benchmarks.sh
+++ b/benchmarks/scripts/run-benchmarks.sh
@@ -77,6 +77,27 @@ log() {
     fi
 }
 
+# Convert Criterion timing values to integer nanoseconds.
+# Uses awk for floating-point arithmetic to avoid requiring `bc`.
+to_nanoseconds() {
+    local value=$1
+    local unit=$2
+    local multiplier=1
+
+    case $unit in
+        ns) multiplier=1 ;;
+        us) multiplier=1000 ;;
+        ms) multiplier=1000000 ;;
+        s)  multiplier=1000000000 ;;
+        *)
+            echo ""
+            return 1
+            ;;
+    esac
+
+    awk -v value="$value" -v mult="$multiplier" 'BEGIN { printf "%.0f\n", value * mult }'
+}
+
 # Function to run benchmarks and extract results
 run_criterion_bench() {
     local crate=$1
@@ -94,34 +115,28 @@ run_criterion_bench() {
         # Parse criterion output for timing
         # Example: "parse_simple_script  time:   [45.123 us 45.234 us 45.345 us]"
         while IFS= read -r line; do
-            if [[ $line =~ ([a-z_]+)[[:space:]]+time:[[:space:]]+\[([0-9.]+)[[:space:]]+(ns|us|ms|s)[[:space:]]+([0-9.]+)[[:space:]]+(ns|us|ms|s)[[:space:]]+([0-9.]+)[[:space:]]+(ns|us|ms|s)\] ]]; then
+            if [[ $line =~ ([A-Za-z0-9_/-]+)[[:space:]]+time:[[:space:]]+\[([0-9.]+)[[:space:]]+(ns|us|ms|s)[[:space:]]+([0-9.]+)[[:space:]]+(ns|us|ms|s)[[:space:]]+([0-9.]+)[[:space:]]+(ns|us|ms|s)\] ]]; then
                 local bench_name="${BASH_REMATCH[1]}"
                 local low="${BASH_REMATCH[2]}"
+                local low_unit="${BASH_REMATCH[3]}"
                 local mean="${BASH_REMATCH[4]}"
-                local unit="${BASH_REMATCH[5]}"
+                local mean_unit="${BASH_REMATCH[5]}"
                 local high="${BASH_REMATCH[6]}"
-
-                # Convert to nanoseconds
-                local multiplier=1
-                case $unit in
-                    us) multiplier=1000 ;;
-                    ms) multiplier=1000000 ;;
-                    s)  multiplier=1000000000 ;;
-                esac
+                local high_unit="${BASH_REMATCH[7]}"
 
                 local mean_ns
-                mean_ns=$(echo "$mean * $multiplier" | bc | cut -d'.' -f1)
+                mean_ns=$(to_nanoseconds "$mean" "$mean_unit") || continue
                 local low_ns
-                low_ns=$(echo "$low * $multiplier" | bc | cut -d'.' -f1)
+                low_ns=$(to_nanoseconds "$low" "$low_unit") || continue
                 local high_ns
-                high_ns=$(echo "$high * $multiplier" | bc | cut -d'.' -f1)
+                high_ns=$(to_nanoseconds "$high" "$high_unit") || continue
 
                 echo "      \"$bench_name\": {"
                 echo "        \"mean_ns\": $mean_ns,"
                 echo "        \"low_ns\": $low_ns,"
                 echo "        \"high_ns\": $high_ns,"
-                echo "        \"unit\": \"$unit\","
-                echo "        \"display\": \"$mean $unit\""
+                echo "        \"unit\": \"$mean_unit\","
+                echo "        \"display\": \"$mean $mean_unit\""
                 echo "      },"
             fi
         done < "$temp_output"


### PR DESCRIPTION
### Motivation

- Criterion output can emit grouped benchmark names (e.g. `group/bench`) and report interval bounds (`low`, `mean`, `high`) with mixed units, which the JSON extractor previously mishandled.

### Description

- Broadened the regex in `benchmarks/scripts/run-benchmarks.sh` to accept alphanumeric, digit, underscore, dash and slash characters in benchmark names so grouped names are captured correctly.
- Added a `to_nanoseconds` helper that uses `awk` to convert floating-point values into integer nanoseconds, removing the ad-hoc `bc` usage and avoiding float truncation issues.
- Parse and convert each bound (`low`, `mean`, `high`) with its own unit instead of assuming a single shared unit, and preserve the `mean` unit in the `display` field.

### Testing

- Ran `bash -n benchmarks/scripts/run-benchmarks.sh` which produced no syntax errors.
- Verified help output with `benchmarks/scripts/run-benchmarks.sh --help | head -n 20` and confirmed options render correctly.
- Performed a regex sanity check with a representative Criterion line via `bash -lc` to ensure grouped names and units are captured, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1afb0adc833388e02d23fbcab126)