### PR TITLE
docs(emacs): add perl-ts-mode setup examples (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
 ```elisp
 ;; Emacs (eglot)
 (add-to-list 'eglot-server-programs
-             '((perl-mode cperl-mode) . ("perllsp" "--stdio")))
+             '((perl-mode cperl-mode perl-ts-mode) . ("perllsp" "--stdio")))
 ```
 
 ```text

--- a/docs/EDITORS/EMACS_SETUP.md
+++ b/docs/EDITORS/EMACS_SETUP.md
@@ -32,10 +32,11 @@ Copy this into your Emacs config:
 ```elisp
 (use-package eglot
   :hook ((perl-mode . eglot-ensure)
-         (cperl-mode . eglot-ensure))
+         (cperl-mode . eglot-ensure)
+         (perl-ts-mode . eglot-ensure))
   :config
   (add-to-list 'eglot-server-programs
-               '((perl-mode cperl-mode) . ("perllsp" "--stdio"))))
+               '((perl-mode cperl-mode perl-ts-mode) . ("perllsp" "--stdio"))))
 ```
 
 Then:
@@ -85,13 +86,14 @@ If you prefer `lsp-mode`, use this minimal config:
 ```elisp
 (use-package lsp-mode
   :hook ((perl-mode . lsp-deferred)
-         (cperl-mode . lsp-deferred))
+         (cperl-mode . lsp-deferred)
+         (perl-ts-mode . lsp-deferred))
   :commands lsp
   :config
   (lsp-register-client
    (make-lsp-client
     :new-connection (lsp-stdio-connection '("perllsp" "--stdio"))
-    :major-modes '(perl-mode cperl-mode)
+    :major-modes '(perl-mode cperl-mode perl-ts-mode)
     :server-id 'perllsp)))
 ```
 
@@ -120,7 +122,7 @@ Run these in order:
    M-: major-mode
    ```
 
-   Expected: `perl-mode` or `cperl-mode`.
+   Expected: `perl-mode`, `cperl-mode`, or `perl-ts-mode`.
 
 4. Check client attachment:
 
@@ -141,6 +143,6 @@ This page intentionally focuses on:
 
 - a successful first connection,
 - consistent binary naming (`perllsp`), and
-- consistent mode coverage (`perl-mode` + `cperl-mode`).
+- consistent mode coverage (`perl-mode`, `cperl-mode`, and `perl-ts-mode`).
 
 For broader editor guidance, see [Editor Setup](../how-to/EDITOR_SETUP.md).


### PR DESCRIPTION
### Motivation
- Ensure Emacs users who use the tree-sitter `perl-ts-mode` get the same out-of-box LSP wiring as `perl-mode`/`cperl-mode` by documenting it in the official Emacs setup guidance.

### Description
- Update `README.md` and `docs/EDITORS/EMACS_SETUP.md` to include `perl-ts-mode` in the `eglot` and `lsp-mode` configuration examples and to mention `perl-ts-mode` in the troubleshooting/expectations text.

### Testing
- No automated tests were run because this is a docs-only change; verification was performed by reviewing the `git diff` showing the intended updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b4c84d88333bfae31880a4f4ccc)