### PR TITLE
docs(emacs): add perl-ts-mode setup snippets (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
 ```
 
 ```elisp
-;; Emacs (eglot)
+;; Emacs (eglot) — perl-ts-mode is a third-party package, omit if not installed
 (add-to-list 'eglot-server-programs
              '((perl-mode cperl-mode perl-ts-mode) . ("perllsp" "--stdio")))
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
 ```elisp
 ;; Emacs (eglot)
 (add-to-list 'eglot-server-programs
-             '((perl-mode cperl-mode) . ("perllsp" "--stdio")))
+             '((perl-mode cperl-mode perl-ts-mode) . ("perllsp" "--stdio")))
 ```
 
 ```text

--- a/docs/EDITORS/EMACS_SETUP.md
+++ b/docs/EDITORS/EMACS_SETUP.md
@@ -33,11 +33,15 @@ Copy this into your Emacs config:
 (use-package eglot
   :hook ((perl-mode . eglot-ensure)
          (cperl-mode . eglot-ensure)
-         (perl-ts-mode . eglot-ensure))
+         (perl-ts-mode . eglot-ensure))  ; remove if perl-ts-mode is not installed
   :config
   (add-to-list 'eglot-server-programs
                '((perl-mode cperl-mode perl-ts-mode) . ("perllsp" "--stdio"))))
 ```
+
+> **Note:** `perl-mode` and `cperl-mode` are built into Emacs. `perl-ts-mode` is a
+> third-party package (not included in Emacs core); remove it from the hook and mode list
+> if you have not installed it separately.
 
 Then:
 
@@ -87,7 +91,7 @@ If you prefer `lsp-mode`, use this minimal config:
 (use-package lsp-mode
   :hook ((perl-mode . lsp-deferred)
          (cperl-mode . lsp-deferred)
-         (perl-ts-mode . lsp-deferred))
+         (perl-ts-mode . lsp-deferred))  ; remove if perl-ts-mode is not installed
   :commands lsp
   :config
   (lsp-register-client
@@ -96,6 +100,9 @@ If you prefer `lsp-mode`, use this minimal config:
     :major-modes '(perl-mode cperl-mode perl-ts-mode)
     :server-id 'perllsp)))
 ```
+
+> **Note:** `perl-ts-mode` is a third-party package (not built into Emacs); remove it
+> from `:hook` and `:major-modes` if you have not installed it separately.
 
 Keep optional packages (`lsp-ui`, custom completion stacks, extra modeline integrations) layered on only after base connectivity works.
 

--- a/docs/EDITORS/EMACS_SETUP.md
+++ b/docs/EDITORS/EMACS_SETUP.md
@@ -32,10 +32,11 @@ Copy this into your Emacs config:
 ```elisp
 (use-package eglot
   :hook ((perl-mode . eglot-ensure)
-         (cperl-mode . eglot-ensure))
+         (cperl-mode . eglot-ensure)
+         (perl-ts-mode . eglot-ensure))
   :config
   (add-to-list 'eglot-server-programs
-               '((perl-mode cperl-mode) . ("perllsp" "--stdio"))))
+               '((perl-mode cperl-mode perl-ts-mode) . ("perllsp" "--stdio"))))
 ```
 
 Then:
@@ -85,13 +86,14 @@ If you prefer `lsp-mode`, use this minimal config:
 ```elisp
 (use-package lsp-mode
   :hook ((perl-mode . lsp-deferred)
-         (cperl-mode . lsp-deferred))
+         (cperl-mode . lsp-deferred)
+         (perl-ts-mode . lsp-deferred))
   :commands lsp
   :config
   (lsp-register-client
    (make-lsp-client
     :new-connection (lsp-stdio-connection '("perllsp" "--stdio"))
-    :major-modes '(perl-mode cperl-mode)
+    :major-modes '(perl-mode cperl-mode perl-ts-mode)
     :server-id 'perllsp)))
 ```
 
@@ -120,7 +122,7 @@ Run these in order:
    M-: major-mode
    ```
 
-   Expected: `perl-mode` or `cperl-mode`.
+   Expected: `perl-mode`, `cperl-mode`, or `perl-ts-mode`.
 
 4. Check client attachment:
 
@@ -141,6 +143,6 @@ This page intentionally focuses on:
 
 - a successful first connection,
 - consistent binary naming (`perllsp`), and
-- consistent mode coverage (`perl-mode` + `cperl-mode`).
+- consistent mode coverage (`perl-mode` + `cperl-mode` + `perl-ts-mode`).
 
 For broader editor guidance, see [Editor Setup](../how-to/EDITOR_SETUP.md).

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -133,7 +133,7 @@ lspconfig.perl_lsp.setup({
 
 ```elisp
 (add-to-list 'eglot-server-programs
-             '((perl-mode cperl-mode) . ("perllsp" "--stdio")))
+             '((perl-mode cperl-mode perl-ts-mode) . ("perllsp" "--stdio")))
 ```
 
 Then run `M-x eglot` in a Perl buffer.


### PR DESCRIPTION
### Motivation
- Emacs documentation only covered `perl-mode`/`cperl-mode`, excluding users who use the Emacs 29 tree-sitter `perl-ts-mode` major mode.

### Description
- Updated `README.md`, `docs/EDITORS/EMACS_SETUP.md`, and `docs/tutorials/GETTING_STARTED.md` to register `perllsp --stdio` for `perl-ts-mode` in both `eglot` and `lsp-mode` examples and adjusted the troubleshooting/scope text to mention `perl-ts-mode`.

### Testing
- Ran `cargo check -p perl-lsp-rs --quiet`, which passed.
- Attempted `just pr-fast` but it could not be run because `just` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b4c84d88333bfae31880a4f4ccc)