### PR TITLE
fix(vscode-extension): register .cgi files as perl (#0000)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -77,6 +77,7 @@
           ".pod",
           ".t",
           ".psgi",
+          ".cgi",
           ".mason",
           ".mas",
           ".tt",

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -162,6 +162,7 @@ describe('package.json contributes', () => {
       expect(exts).toContain('.t');
       expect(exts).toContain('.pod');
       expect(exts).toContain('.psgi');
+      expect(exts).toContain('.cgi');
       expect(exts).toContain('.mason');
       expect(exts).toContain('.mas');
       expect(exts).toContain('.tt');


### PR DESCRIPTION
### Motivation
- Associate `.cgi` files with the Perl language in VS Code so language features activate for CGI-based projects.

### Description
- Added `.cgi` to `vscode-extension/package.json` under the Perl `contributes.languages[*].extensions` list and updated `vscode-extension/src/test/configuration.test.ts` to assert the `.cgi` mapping.

### Testing
- Verified with `node -e "const p=require('./vscode-extension/package.json'); const exts=p.contributes.languages.find(l=>l.id==='perl').extensions; if(!exts.includes('.cgi')) throw new Error('missing .cgi'); console.log('ok');"` which passed.
- Ran `npm test -- configuration.test.ts` which failed in this environment due to pre-existing TypeScript/Jest ambient type errors unrelated to this change.
- Ran `npm run lint` and `npm run compile` which reported pre-existing lint/type configuration issues in the extension unrelated to the `.cgi` addition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b4fdbd483338774d627aa22acc5)