### PR TITLE
feat(vscode): broaden Perl file extension support (#0000)

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -186,7 +186,7 @@ Open the command palette (`Ctrl+Shift+P`) and search for "Perl":
 | **Perl: Show Server Version** | Display installed perllsp version |
 | **Perl: Reinstall Server Binary** | Re-download the managed binary |
 | **Perl: Organize Use Statements** | Sort and clean `use` statements |
-| **Perl: Run Tests in Current File** | Run tests in the active `.t` or `.pl` file |
+| **Perl: Run Tests in Current File** | Run tests in the active `.t`, `.pl`, `.plx`, `.cgi`, or `.psgi` file |
 | **Perl: Show Output Channel** | Open the extension output log |
 | **Perl: Show Status Menu** | Quick-access menu for all actions |
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -71,6 +71,8 @@
         ],
         "extensions": [
           ".pl",
+          ".plx",
+          ".cgi",
           ".pm",
           ".xs",
           ".xsi",
@@ -714,7 +716,7 @@
         },
         {
           "command": "perl-lsp.runTests",
-          "when": "editorLangId == perl && resourceExtname =~ /\\.(t|pl)$/"
+          "when": "editorLangId == perl && resourceExtname =~ /\\.(t|pl|plx|cgi|psgi)$/"
         },
         {
           "command": "perl-lsp.runPerlCritic",
@@ -789,7 +791,7 @@
       "editor/title": [
         {
           "command": "perl-lsp.runTests",
-          "when": "editorLangId == perl && resourceExtname =~ /\\.(t|pl)$/",
+          "when": "editorLangId == perl && resourceExtname =~ /\\.(t|pl|plx|cgi|psgi)$/",
           "group": "navigation"
         },
         {


### PR DESCRIPTION
### Motivation
- VS Code integration did not recognize common Perl script extensions (`.plx`, `.cgi`) and the "Run Tests in Current File" command visibility excluded those script types.

### Description
- Register `.plx` and `.cgi` in `vscode-extension/package.json` under the Perl language `extensions` list.
- Broaden `perl-lsp.runTests` visibility `when` expressions in `vscode-extension/package.json` to match `/\.(t|pl|plx|cgi|psgi)$/` for both the Command Palette and editor title menus.
- Update `vscode-extension/README.md` to list the expanded set of file types handled by the "Run Tests in Current File" command.

### Testing
- Verified the `package.json` changes with a Node check that reads `contributes.languages` and the `runTests` menu `when` clauses, which passed.
- Ran `npm run compile --prefix vscode-extension`, which failed due to an unrelated TypeScript `moduleResolution` deprecation in the repo `tsconfig.json` (pre-existing, not caused by this change).
- Ran `npm run lint --prefix vscode-extension`, which reported pre-existing lint errors in the extension source unrelated to the manifest and docs edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b4fdbd483338774d627aa22acc5)