### PR TITLE
docs(helix): correct perllsp command and TOML table syntax (#0000)

### DIFF
--- a/docs/EDITORS/HELIX_SETUP.md
+++ b/docs/EDITORS/HELIX_SETUP.md
@@ -104,7 +104,7 @@ indent = { tab-width = 4, unit = "    " }
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
-command = "perl-lsp"
+command = "perllsp"
 args = ["--stdio"]
 ```
 
@@ -137,7 +137,7 @@ indent = { tab-width = 4, unit = "    " }
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
-command = "perl-lsp"
+command = "perllsp"
 args = ["--stdio"]
 
 [language-server.perl-lsp.config.perl]
@@ -606,7 +606,7 @@ indent = { tab-width = 4, unit = "    " }
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
-command = "perl-lsp"
+command = "perllsp"
 args = ["--stdio"]
 
 [language-server.perl-lsp.config.perl]

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -54,7 +54,7 @@ editor-specific guide has the full snippets for both.
 ### Helix
 
 ```toml
-[[language-server.perl-lsp]]
+[language-server.perl-lsp]
 command = "perllsp"
 args = ["--stdio"]
 ```


### PR DESCRIPTION
### Motivation

- Helix setup docs used an inconsistent server command name (`perl-lsp`) which can confuse users who should run the `perllsp` binary.
- A minimal Helix snippet used the wrong TOML table-array form (`[[language-server.perl-lsp]]`) which is invalid for the intended `language-server.perl-lsp` table.

### Description

- Updated the minimal Helix example in `docs/how-to/EDITOR_SETUP.md` to use `[language-server.perl-lsp]` instead of `[[language-server.perl-lsp]]`.
- Replaced `command = "perl-lsp"` with `command = "perllsp"` in all Helix `languages.toml` examples in `docs/EDITORS/HELIX_SETUP.md`.
- Kept the change scoped to documentation only and did not modify runtime code or tests.

### Testing

- Ran `cargo check --all-targets -p perl-lsp-rs`, which completed successfully but emitted a small number of unrelated warnings.
- Attempted `just pr-fast` but it was not available in the environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b572a2c83339e0a2ba51b040c45)