### PR TITLE
docs(helix): fix perllsp command examples (#0000)

### DIFF
--- a/docs/EDITORS/HELIX_SETUP.md
+++ b/docs/EDITORS/HELIX_SETUP.md
@@ -104,7 +104,7 @@ indent = { tab-width = 4, unit = "    " }
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
-command = "perl-lsp"
+command = "perllsp"
 args = ["--stdio"]
 ```
 
@@ -137,7 +137,7 @@ indent = { tab-width = 4, unit = "    " }
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
-command = "perl-lsp"
+command = "perllsp"
 args = ["--stdio"]
 
 [language-server.perl-lsp.config.perl]
@@ -356,8 +356,8 @@ h = { i = ":inlay_hints" }
 
 1. **Verify binary is in PATH**:
    ```bash
-   which perl-lsp
-   # Should output: /usr/local/bin/perl-lsp or similar
+   which perllsp
+   # Should output: /usr/local/bin/perllsp or similar
    ```
 
 2. **Check LSP status**:
@@ -511,7 +511,7 @@ Set environment variables for the LSP server:
 ```toml
 [language-server.perl-lsp]
 command = "env"
-args = ["PERL5LIB=lib", "PERL_MB_OPT=--install_base local", "perl-lsp", "--stdio"]
+args = ["PERL5LIB=lib", "PERL_MB_OPT=--install_base local", "perllsp", "--stdio"]
 ```
 
 ### Custom Formatter
@@ -606,7 +606,7 @@ indent = { tab-width = 4, unit = "    " }
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
-command = "perl-lsp"
+command = "perllsp"
 args = ["--stdio"]
 
 [language-server.perl-lsp.config.perl]

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -54,7 +54,11 @@ editor-specific guide has the full snippets for both.
 ### Helix
 
 ```toml
-[[language-server.perl-lsp]]
+[[language]]
+name = "perl"
+language-servers = ["perllsp"]
+
+[language-server.perllsp]
 command = "perllsp"
 args = ["--stdio"]
 ```


### PR DESCRIPTION
### Motivation

- Helix documentation referred to the wrong binary name (`perl-lsp`) which prevents users from launching the server with the intended `perllsp` CLI.
- The compact Helix snippet in the general editor setup guide used an invalid shape and omitted the required `[[language]]` → `[language-server.<name>]` mapping, so a minimal quick-start could fail to attach LSP.

### Description

- Replaced `perl-lsp` examples with `perllsp` in `docs/EDITORS/HELIX_SETUP.md`, including basic, full, troubleshooting, env-wrapper, and complete example blocks so copy-paste snippets invoke the actual CLI (`perllsp --stdio`).
- Rewrote the Helix quick-start snippet in `docs/how-to/EDITOR_SETUP.md` to include a valid `[[language]]` block and a `[language-server.perllsp]` mapping that runs `perllsp --stdio`.
- This is a documentation-only change and does not modify runtime code or server behavior.

### Testing

- Ran targeted `rg` checks to ensure no remaining `perl-lsp` command examples remain, and the searches returned no stale matches.
- Performed a textual review of the diffs to confirm the Helix snippets are syntactically correct and reference `perllsp` as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b572a2c83339e0a2ba51b040c45)