### PR TITLE
docs(helix): use perllsp binary in setup guide (#0000)

### DIFF
--- a/docs/EDITORS/HELIX_SETUP.md
+++ b/docs/EDITORS/HELIX_SETUP.md
@@ -20,7 +20,7 @@ This comprehensive guide helps you set up and configure the Perl Language Server
 ### Required
 
 - **Helix** version 23.03 or later
-- **perl-lsp** server installed (see [Installation](#installation))
+- **perllsp** server installed (see [Installation](#installation))
 
 ### Optional but Recommended
 
@@ -104,7 +104,7 @@ indent = { tab-width = 4, unit = "    " }
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
-command = "perl-lsp"
+command = "perllsp"
 args = ["--stdio"]
 ```
 
@@ -137,7 +137,7 @@ indent = { tab-width = 4, unit = "    " }
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
-command = "perl-lsp"
+command = "perllsp"
 args = ["--stdio"]
 
 [language-server.perl-lsp.config.perl]
@@ -356,8 +356,8 @@ h = { i = ":inlay_hints" }
 
 1. **Verify binary is in PATH**:
    ```bash
-   which perl-lsp
-   # Should output: /usr/local/bin/perl-lsp or similar
+   which perllsp
+   # Should output: /usr/local/bin/perllsp or similar
    ```
 
 2. **Check LSP status**:
@@ -511,7 +511,7 @@ Set environment variables for the LSP server:
 ```toml
 [language-server.perl-lsp]
 command = "env"
-args = ["PERL5LIB=lib", "PERL_MB_OPT=--install_base local", "perl-lsp", "--stdio"]
+args = ["PERL5LIB=lib", "PERL_MB_OPT=--install_base local", "perllsp", "--stdio"]
 ```
 
 ### Custom Formatter
@@ -606,7 +606,7 @@ indent = { tab-width = 4, unit = "    " }
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
-command = "perl-lsp"
+command = "perllsp"
 args = ["--stdio"]
 
 [language-server.perl-lsp.config.perl]


### PR DESCRIPTION
### Motivation
- Fix Helix setup guide to reference the actual shipped CLI `perllsp` so users do not configure Helix with the wrong command name.

### Description
- Updated `docs/EDITORS/HELIX_SETUP.md` to replace `perl-lsp` with `perllsp` in prerequisites, `languages.toml` examples, troubleshooting checks, and environment-variable `args` examples.

### Testing
- Attempted to run the repository fast verification `just pr-fast`, but it could not run in this environment (`just: command not found`), so no automated crate tests were executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b572a2c83339e0a2ba51b040c45)