### PR TITLE
fix(metrics): restore editor UX receipt parsing (#0000)

### DIFF
--- a/xtask/src/tasks/metrics/lsp_stats.rs
+++ b/xtask/src/tasks/metrics/lsp_stats.rs
@@ -179,6 +179,7 @@ pub fn run_with_json(json: bool) -> Result<()> {
 
     // Try to load a previous run receipt for pass-rate data
     let receipt_path = root.join(".ci").join("metrics").join("editor_ux.json");
+    let last_run = load_last_run(&receipt_path);
     let observed_rates = load_observed_rates(&receipt_path);
 
     print_table(
@@ -271,6 +272,13 @@ fn load_observed_rates(path: &Path) -> Option<ObservedUxRates> {
     })
 }
 
+fn load_last_run(path: &Path) -> Option<LastRunMetrics> {
+    let raw = fs::read_to_string(path).ok()?;
+    let doc: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let last_run = doc.get("last_run")?;
+    serde_json::from_value(last_run.clone()).ok()
+}
+
 fn write_json_receipt(path: &Path, output: &EditorUxMetrics) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
@@ -315,10 +323,8 @@ fn print_table(
         if let Some(rate) = rates.goto_definition_exact_hit_rate {
             println!("  goto_definition_exact_hit:   {:.1}%", rate * 100.0);
         }
-        if let Some(rate) = run.completion_rate() {
-            println!("  completion_top5_relevance:   {:.1}%", rate * 100.0);
-        }
         if let Some(rate) = rates.completion_top5_usefulness {
+            println!("  completion_top5_relevance:   {:.1}%", rate * 100.0);
             println!("  completion_top5_usefulness:  {:.1}%", rate * 100.0);
         }
         println!("  completion_top1_relevance:   (Phase 2)");
@@ -413,15 +419,18 @@ mod tests {
         assert!((parsed["metrics"]["workflow_pass_rate"].as_f64().unwrap() - 0.91).abs() < 0.001);
         assert!(parsed["metrics"]["rename_success_rate"].is_null());
         // Verify new relevance fields serialize correctly
-        assert!(parsed["metrics"]["completion_top1_relevance"].is_null(),
-            "completion_top1_relevance should be null (Phase 2)");
+        assert!(
+            parsed["metrics"]["completion_top1_relevance"].is_null(),
+            "completion_top1_relevance should be null (Phase 2)"
+        );
         assert!(
             (parsed["metrics"]["completion_top5_relevance"].as_f64().unwrap() - 0.86).abs() < 0.001,
             "completion_top5_relevance should serialize to 0.86"
         );
         // Backward-compat alias should also be present
         assert!(
-            (parsed["metrics"]["completion_top5_usefulness"].as_f64().unwrap() - 0.86).abs() < 0.001,
+            (parsed["metrics"]["completion_top5_usefulness"].as_f64().unwrap() - 0.86).abs()
+                < 0.001,
             "completion_top5_usefulness alias should still serialize"
         );
     }


### PR DESCRIPTION
### Motivation
- Restore correct parsing and preservation of prior editor-UX receipts so `cargo xtask metrics lsp-stats --json` can emit accurate, stable scorecard receipts and avoid compile/runtime failures.

### Description
- Add a `load_last_run` helper and call it to populate `last_run` when building the `EditorUxMetrics` receipt, ensuring prior run numerators/denominators are preserved in `.ci/metrics/editor_ux.json`.
- Fix `print_table` output to read completion relevance from the parsed `observed_rates` instead of referencing an undefined variable.

### Testing
- `cargo check -p xtask` passed.
- `cargo test -p xtask test_load_last_run_from_current_schema -- --nocapture` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b1226888333a5750c92c2df4271)