### PR TITLE
fix(metrics): improve editor UX metric loading (#0000)

### DIFF
--- a/xtask/src/tasks/metrics/lsp_stats.rs
+++ b/xtask/src/tasks/metrics/lsp_stats.rs
@@ -180,6 +180,7 @@ pub fn run_with_json(json: bool) -> Result<()> {
     // Try to load a previous run receipt for pass-rate data
     let receipt_path = root.join(".ci").join("metrics").join("editor_ux.json");
     let observed_rates = load_observed_rates(&receipt_path);
+    let last_run = load_last_run(&receipt_path);
 
     print_table(
         hover_fixtures.len(),
@@ -250,10 +251,10 @@ fn load_observed_rates(path: &Path) -> Option<ObservedUxRates> {
     // where pass-rate data is inside `metrics` as individual rates.
     // Prefer `last_run` when available because it carries numerator/denominator
     // data and avoids rounding loss.
-    if let Some(last) = doc.get("last_run") {
-        if let Ok(parsed) = serde_json::from_value::<LastRunMetrics>(last.clone()) {
-            return Some(ObservedUxRates::from_last_run(&parsed));
-        }
+    if let Some(last) = doc.get("last_run")
+        && let Ok(parsed) = serde_json::from_value::<LastRunMetrics>(last.clone())
+    {
+        return Some(ObservedUxRates::from_last_run(&parsed));
     }
 
     let metrics = doc.get("metrics")?;
@@ -266,9 +267,19 @@ fn load_observed_rates(path: &Path) -> Option<ObservedUxRates> {
             .get("goto_definition_exact_hit_rate")
             .and_then(serde_json::Value::as_f64),
         completion_top5_usefulness: metrics
-            .get("completion_top5_usefulness")
-            .and_then(serde_json::Value::as_f64),
+            .get("completion_top5_relevance")
+            .and_then(serde_json::Value::as_f64)
+            .or_else(|| {
+                metrics.get("completion_top5_usefulness").and_then(serde_json::Value::as_f64)
+            }),
     })
+}
+
+fn load_last_run(path: &Path) -> Option<LastRunMetrics> {
+    let raw = fs::read_to_string(path).ok()?;
+    let doc: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let last = doc.get("last_run")?;
+    serde_json::from_value(last.clone()).ok()
 }
 
 fn write_json_receipt(path: &Path, output: &EditorUxMetrics) -> Result<()> {
@@ -315,10 +326,8 @@ fn print_table(
         if let Some(rate) = rates.goto_definition_exact_hit_rate {
             println!("  goto_definition_exact_hit:   {:.1}%", rate * 100.0);
         }
-        if let Some(rate) = run.completion_rate() {
-            println!("  completion_top5_relevance:   {:.1}%", rate * 100.0);
-        }
         if let Some(rate) = rates.completion_top5_usefulness {
+            println!("  completion_top5_relevance:   {:.1}%", rate * 100.0);
             println!("  completion_top5_usefulness:  {:.1}%", rate * 100.0);
         }
         println!("  completion_top1_relevance:   (Phase 2)");
@@ -413,15 +422,18 @@ mod tests {
         assert!((parsed["metrics"]["workflow_pass_rate"].as_f64().unwrap() - 0.91).abs() < 0.001);
         assert!(parsed["metrics"]["rename_success_rate"].is_null());
         // Verify new relevance fields serialize correctly
-        assert!(parsed["metrics"]["completion_top1_relevance"].is_null(),
-            "completion_top1_relevance should be null (Phase 2)");
+        assert!(
+            parsed["metrics"]["completion_top1_relevance"].is_null(),
+            "completion_top1_relevance should be null (Phase 2)"
+        );
         assert!(
             (parsed["metrics"]["completion_top5_relevance"].as_f64().unwrap() - 0.86).abs() < 0.001,
             "completion_top5_relevance should serialize to 0.86"
         );
         // Backward-compat alias should also be present
         assert!(
-            (parsed["metrics"]["completion_top5_usefulness"].as_f64().unwrap() - 0.86).abs() < 0.001,
+            (parsed["metrics"]["completion_top5_usefulness"].as_f64().unwrap() - 0.86).abs()
+                < 0.001,
             "completion_top5_usefulness alias should still serialize"
         );
     }


### PR DESCRIPTION
### Motivation
- Prevent broken metric generation and console output by carrying forward `last_run` when writing the editor-UX receipt and by making the loader accept modern relevance fields.
- Maintain backward compatibility with legacy receipts so instrumentation continues to surface observed rates after schema evolution.

### Description
- Add `load_last_run(path: &Path) -> Option<LastRunMetrics>` and use it in `run_with_json` so `last_run` is included in the written `EditorUxMetrics` receipt.
- Update `load_observed_rates` to prefer `last_run` numerators/denominators when present and accept either `completion_top5_relevance` or the legacy `completion_top5_usefulness` key.
- Remove the invalid `run.completion_rate()` reference in `print_table` and print relevance/usefulness rows from the parsed `ObservedUxRates` instead.
- Files changed: `xtask/src/tasks/metrics/lsp_stats.rs` (logic + small formatting cleanup); tests already present exercise `last_run` loading and observed-rate parsing.

### Testing
- Ran `cargo test -p xtask lsp_stats -- --nocapture` and all tests passed (6 passed, 0 failed). 
- Ran `cargo check --all-targets -p xtask` which completed successfully. 
- Ran `cargo clippy -p xtask -- -D warnings` with no warnings. 
- Ran `cargo xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b1226888333a5750c92c2df4271)