### PR TITLE
docs(editors): add dedicated Zed setup guidance (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
              '((perl-mode cperl-mode) . ("perllsp" "--stdio")))
 ```
 
+```json
+// Zed settings.json
+{
+  "lsp": {
+    "perllsp": {
+      "command": { "path": "perllsp", "arguments": ["--stdio"] }
+    }
+  },
+  "languages": {
+    "Perl": {
+      "language_servers": ["perllsp"]
+    }
+  }
+}
+```
+
 ```text
 # Any generic LSP client
 perllsp --stdio

--- a/docs/EDITORS/ZED_SETUP.md
+++ b/docs/EDITORS/ZED_SETUP.md
@@ -1,0 +1,82 @@
+# Zed Setup Guide for perl-lsp
+
+This guide gives you a minimal, reliable setup for using `perllsp` with Zed.
+
+## Prerequisites
+
+- Zed installed
+- `perllsp` available on your `PATH`
+
+Verify the binary first:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## 1) Configure the language server
+
+Open Zed settings and add (or merge) this JSON:
+
+```json
+{
+  "lsp": {
+    "perllsp": {
+      "command": {
+        "path": "perllsp",
+        "arguments": ["--stdio"]
+      }
+    }
+  },
+  "languages": {
+    "Perl": {
+      "language_servers": ["perllsp"]
+    }
+  }
+}
+```
+
+If you keep project-specific Zed settings, use the same `lsp.perllsp` and
+`languages.Perl.language_servers` fields there.
+
+## 2) Verify attach
+
+1. Restart Zed (or reload the window).
+2. Open a `.pl` or `.pm` file.
+3. Confirm language server activity in Zed's LSP logs/panel.
+
+## 3) Optional server settings
+
+You can forward `perllsp` configuration through initialization options:
+
+```json
+{
+  "lsp": {
+    "perllsp": {
+      "command": {
+        "path": "perllsp",
+        "arguments": ["--stdio"]
+      },
+      "initialization_options": {
+        "perl": {
+          "workspace": {
+            "includePaths": ["lib", ".", "local/lib/perl5"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+For full setting names, see [Configuration Reference](../reference/CONFIG.md).
+
+## Troubleshooting
+
+- If Zed cannot start the server, run `perllsp --version` in a shell from the
+  same environment as Zed and fix `PATH`.
+- If the server starts but features are missing, confirm the file is detected
+  as Perl and that `language_servers` includes `perllsp`.
+- If startup fails after config edits, validate JSON formatting in settings.
+
+For deeper diagnostics, see [Troubleshooting](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -27,6 +27,7 @@ perllsp --health
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
+| Zed | register `perllsp` and map it to Perl | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
 
 ## Minimal Configurations
@@ -57,6 +58,26 @@ editor-specific guide has the full snippets for both.
 [[language-server.perl-lsp]]
 command = "perllsp"
 args = ["--stdio"]
+```
+
+### Zed
+
+```json
+{
+  "lsp": {
+    "perllsp": {
+      "command": {
+        "path": "perllsp",
+        "arguments": ["--stdio"]
+      }
+    }
+  },
+  "languages": {
+    "Perl": {
+      "language_servers": ["perllsp"]
+    }
+  }
+}
 ```
 
 ### Sublime Text

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -152,6 +152,30 @@ command = "perllsp"
 args = ["--stdio"]
 ```
 
+### Zed
+
+Add to your Zed settings JSON:
+
+```json
+{
+  "lsp": {
+    "perllsp": {
+      "command": {
+        "path": "perllsp",
+        "arguments": ["--stdio"]
+      }
+    }
+  },
+  "languages": {
+    "Perl": {
+      "language_servers": ["perllsp"]
+    }
+  }
+}
+```
+
+Then open a Perl file and confirm the language server attaches.
+
 ## Your First 5 Minutes
 
 Once installed, open any Perl file and try these features. Each heading describes what you will see in your editor.


### PR DESCRIPTION
### Motivation
- Provide first-class, editor-specific setup guidance for Zed so users can reliably attach `perllsp` and follow the same quick-start pattern already documented for Neovim/Helix/Emacs.

### Description
- Add `docs/EDITORS/ZED_SETUP.md` with a minimal `settings.json` example and troubleshooting notes, and wire Zed into the central editor docs by updating `README.md`, `docs/how-to/EDITOR_SETUP.md`, and `docs/tutorials/GETTING_STARTED.md` to include the Zed snippets and matrix entry.

### Testing
- Ran `git diff --check` which passed and verified the new files are discoverable with `rg` (Zed snippets present); attempted `cargo xtask fmt --check` which failed due to pre-existing, unrelated compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` (unresolved `last_run`/`run`) and not caused by this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b44f1488333be6b260cf014d06b)