### PR TITLE
docs(editors): add Zed setup guide (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,25 @@ require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
              '((perl-mode cperl-mode) . ("perllsp" "--stdio")))
 ```
 
+```json
+// Zed (~/.config/zed/settings.json)
+{
+  "lsp": {
+    "perl-lsp": {
+      "binary": {
+        "path": "perllsp",
+        "arguments": ["--stdio"]
+      }
+    }
+  },
+  "languages": {
+    "Perl": {
+      "language_servers": ["perl-lsp"]
+    }
+  }
+}
+```
+
 ```text
 # Any generic LSP client
 perllsp --stdio

--- a/docs/EDITORS/ZED_SETUP.md
+++ b/docs/EDITORS/ZED_SETUP.md
@@ -1,0 +1,54 @@
+# Zed Setup Guide for perl-lsp
+
+This guide shows the fastest path to run `perllsp` in Zed.
+
+## Prerequisites
+
+- Zed installed (latest stable recommended)
+- `perllsp` available on your `PATH`
+
+Verify the binary before editing Zed settings:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Configure the language server
+
+Create or edit `~/.config/zed/settings.json` and add a Perl language server entry:
+
+```json
+{
+  "lsp": {
+    "perl-lsp": {
+      "binary": {
+        "path": "perllsp",
+        "arguments": ["--stdio"]
+      }
+    }
+  },
+  "languages": {
+    "Perl": {
+      "language_servers": ["perl-lsp"]
+    }
+  }
+}
+```
+
+If your binary is not on `PATH`, replace `"perllsp"` with an absolute path.
+
+## Validate in Zed
+
+1. Restart Zed.
+2. Open a Perl project folder.
+3. Open a `.pl` or `.pm` file and confirm:
+   - diagnostics appear,
+   - hover works,
+   - completion suggestions appear while typing.
+
+## Troubleshooting
+
+- If Zed cannot launch the server, run `perllsp --health` in the same shell environment Zed inherits.
+- If features are missing, confirm the file is detected as Perl and the project root is correct.
+- See [`docs/how-to/TROUBLESHOOTING.md`](../how-to/TROUBLESHOOTING.md) for deeper debugging.

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -27,6 +27,7 @@ perllsp --health
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
+| Zed | register `perllsp --stdio` in `settings.json` | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
 
 ## Minimal Configurations
@@ -58,6 +59,11 @@ editor-specific guide has the full snippets for both.
 command = "perllsp"
 args = ["--stdio"]
 ```
+
+### Zed
+
+Add an LSP entry in `~/.config/zed/settings.json` that launches
+`perllsp --stdio`, then map it to the `Perl` language.
 
 ### Sublime Text
 


### PR DESCRIPTION
### Motivation
- Provide concrete, discoverable setup instructions for the Zed editor because the repo referenced Zed support but had no dedicated guide or quick-start snippet.

### Description
- Add `docs/EDITORS/ZED_SETUP.md` with a `~/.config/zed/settings.json` example and validation/troubleshooting steps, and link Zed from `docs/how-to/EDITOR_SETUP.md` and the README quick-start snippets.

### Testing
- Ran `cargo fmt --all -- --check` which failed due to pre-existing formatting drift in unrelated files, and started `cargo test -p perl-lsp-rs test_cross_editor_completion_capability_profiles` where compilation progressed but the full test run did not complete within the session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b44f1488333be6b260cf014d06b)