### PR TITLE
docs(zed): add setup documentation for Zed editor (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,7 @@ require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
              '((perl-mode cperl-mode) . ("perllsp" "--stdio")))
 ```
 
-```json
-// Zed (~/.config/zed/settings.json)
-{
-  "lsp": {
-    "perl-lsp": {
-      "command": { "path": "perllsp", "args": ["--stdio"] }
-    }
-  },
-  "languages": {
-    "Perl": { "language_servers": ["perl-lsp"] }
-  }
-}
-```
+For Zed, see [docs/EDITORS/ZED_SETUP.md](docs/EDITORS/ZED_SETUP.md).
 
 ```text
 # Any generic LSP client

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
              '((perl-mode cperl-mode) . ("perllsp" "--stdio")))
 ```
 
+```json
+// Zed (~/.config/zed/settings.json)
+{
+  "lsp": {
+    "perl-lsp": {
+      "command": { "path": "perllsp", "args": ["--stdio"] }
+    }
+  },
+  "languages": {
+    "Perl": { "language_servers": ["perl-lsp"] }
+  }
+}
+```
+
 ```text
 # Any generic LSP client
 perllsp --stdio

--- a/docs/EDITORS/ZED_SETUP.md
+++ b/docs/EDITORS/ZED_SETUP.md
@@ -5,7 +5,7 @@ Use this guide to wire `perllsp` into Zed via the built-in LSP client.
 ## Prerequisites
 
 - `perllsp` installed and available on your `PATH`
-- Zed updated to a recent stable release
+- Zed updated to a recent stable release (0.150+)
 
 Quick verification before changing editor settings:
 
@@ -14,43 +14,48 @@ perllsp --version
 perllsp --health
 ```
 
-## Basic Setup
+## How Zed Loads Language Servers
 
-Open your Zed settings (`~/.config/zed/settings.json` on Linux) and add:
+Zed discovers language servers through extensions. A Perl extension that
+registers `perllsp` is the supported path for first-class Perl IDE features in
+Zed (syntax highlighting, diagnostics, completions, go-to-definition, etc.).
+
+If you already have a Zed Perl extension installed that launches `perllsp`, you
+can override the binary path via `settings.json` using the `binary` key:
 
 ```json
 {
   "lsp": {
     "perl-lsp": {
-      "command": {
-        "path": "perllsp",
-        "args": ["--stdio"]
+      "binary": {
+        "path": "/usr/local/bin/perllsp",
+        "arguments": ["--stdio"]
       }
-    }
-  },
-  "languages": {
-    "Perl": {
-      "language_servers": ["perl-lsp"]
     }
   }
 }
 ```
 
-If you already have a settings file, merge these keys into the existing JSON object.
+The `binary` key tells Zed where to find the executable and which arguments to
+pass instead of using whatever the extension resolves automatically. The key
+name (`"perl-lsp"` above) must match the name your installed Perl extension
+registers for the language server.
+
+> **Note:** Without a Perl extension, Zed has no built-in mechanism to
+> associate Perl files with `perllsp`. The `lsp` settings block only configures
+> *known* language servers. For a fully generic LSP client approach, see
+> [docs/how-to/EDITOR_SETUP.md](../how-to/EDITOR_SETUP.md).
 
 ## Optional Server Settings
 
-You can pass the same `perl.*` LSP workspace settings used by other editors:
+Once Zed is launching `perllsp`, you can pass `perl.*` workspace configuration
+through `initialization_options`:
 
 ```json
 {
   "lsp": {
     "perl-lsp": {
-      "command": {
-        "path": "perllsp",
-        "args": ["--stdio"]
-      },
-      "settings": {
+      "initialization_options": {
         "perl": {
           "workspace": {
             "includePaths": ["lib", "."]
@@ -67,6 +72,8 @@ You can pass the same `perl.*` LSP workspace settings used by other editors:
 
 ## Troubleshooting
 
-- If Perl files do not show diagnostics/completions, confirm Zed resolves `perllsp` from the same `PATH` as your shell.
-- If the server fails to launch, run `perllsp --health` in a terminal first and fix installation issues before retrying.
+- If Perl files do not show diagnostics/completions, confirm that a Zed Perl
+  extension is installed and active (`Extensions` panel -> search "Perl").
+- If the server fails to launch, run `perllsp --health` in a terminal first and
+  fix installation issues before adjusting Zed settings.
 - If behavior is still off, use [docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/EDITORS/ZED_SETUP.md
+++ b/docs/EDITORS/ZED_SETUP.md
@@ -1,0 +1,72 @@
+# Zed Setup Guide for perl-lsp
+
+Use this guide to wire `perllsp` into Zed via the built-in LSP client.
+
+## Prerequisites
+
+- `perllsp` installed and available on your `PATH`
+- Zed updated to a recent stable release
+
+Quick verification before changing editor settings:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Basic Setup
+
+Open your Zed settings (`~/.config/zed/settings.json` on Linux) and add:
+
+```json
+{
+  "lsp": {
+    "perl-lsp": {
+      "command": {
+        "path": "perllsp",
+        "args": ["--stdio"]
+      }
+    }
+  },
+  "languages": {
+    "Perl": {
+      "language_servers": ["perl-lsp"]
+    }
+  }
+}
+```
+
+If you already have a settings file, merge these keys into the existing JSON object.
+
+## Optional Server Settings
+
+You can pass the same `perl.*` LSP workspace settings used by other editors:
+
+```json
+{
+  "lsp": {
+    "perl-lsp": {
+      "command": {
+        "path": "perllsp",
+        "args": ["--stdio"]
+      },
+      "settings": {
+        "perl": {
+          "workspace": {
+            "includePaths": ["lib", "."]
+          },
+          "inlayHints": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+- If Perl files do not show diagnostics/completions, confirm Zed resolves `perllsp` from the same `PATH` as your shell.
+- If the server fails to launch, run `perllsp --health` in a terminal first and fix installation issues before retrying.
+- If behavior is still off, use [docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -27,7 +27,7 @@ perllsp --health
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
-| Zed | register `perllsp --stdio` in `settings.json` | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
+| Zed | install a Perl extension, then optionally point at `perllsp` | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
 
 ## Minimal Configurations
@@ -62,23 +62,24 @@ args = ["--stdio"]
 
 ### Zed
 
+Zed requires a Perl extension that registers `perllsp`. Once installed, you
+can override the binary path via `settings.json`:
+
 ```json
 {
   "lsp": {
     "perl-lsp": {
-      "command": {
-        "path": "perllsp",
-        "args": ["--stdio"]
+      "binary": {
+        "path": "/usr/local/bin/perllsp",
+        "arguments": ["--stdio"]
       }
-    }
-  },
-  "languages": {
-    "Perl": {
-      "language_servers": ["perl-lsp"]
     }
   }
 }
 ```
+
+See [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) for full setup details.
+
 
 ### Sublime Text
 

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -55,7 +55,11 @@ editor-specific guide has the full snippets for both.
 ### Helix
 
 ```toml
-[[language-server.perl-lsp]]
+[[language]]
+name = "perl"
+language-servers = ["perllsp"]
+
+[language-server.perllsp]
 command = "perllsp"
 args = ["--stdio"]
 ```

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -27,6 +27,7 @@ perllsp --health
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
+| Zed | register `perllsp --stdio` in `settings.json` | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
 
 ## Minimal Configurations
@@ -57,6 +58,26 @@ editor-specific guide has the full snippets for both.
 [[language-server.perl-lsp]]
 command = "perllsp"
 args = ["--stdio"]
+```
+
+### Zed
+
+```json
+{
+  "lsp": {
+    "perl-lsp": {
+      "command": {
+        "path": "perllsp",
+        "args": ["--stdio"]
+      }
+    }
+  },
+  "languages": {
+    "Perl": {
+      "language_servers": ["perl-lsp"]
+    }
+  }
+}
 ```
 
 ### Sublime Text

--- a/docs/reference/FAQ.md
+++ b/docs/reference/FAQ.md
@@ -69,7 +69,7 @@ Any editor with LSP client support works. Point it at `perllsp --stdio`:
 - **Neovim** — via `nvim-lspconfig` (`perl_ls` server)
 - **Emacs** — via `eglot` or `lsp-mode`
 - **Helix** — via `languages.toml`
-- **Zed** — via `settings.json` language-server wiring
+- **Zed** — via a Perl extension (see [ZED_SETUP.md](../EDITORS/ZED_SETUP.md))
 - **Sublime Text** — via the LSP package
 - **Kate**, **Lapce**, **Kakoune** — any editor with a generic LSP client
 

--- a/docs/reference/FAQ.md
+++ b/docs/reference/FAQ.md
@@ -69,6 +69,7 @@ Any editor with LSP client support works. Point it at `perllsp --stdio`:
 - **Neovim** — via `nvim-lspconfig` (`perl_ls` server)
 - **Emacs** — via `eglot` or `lsp-mode`
 - **Helix** — via `languages.toml`
+- **Zed** — via `settings.json` language-server wiring
 - **Sublime Text** — via the LSP package
 - **Kate**, **Lapce**, **Kakoune** — any editor with a generic LSP client
 


### PR DESCRIPTION
### Motivation
- Make Zed a first-class documented editor target so users can wire `perllsp --stdio` into Zed and onboard without guessing configuration details.

### Description
- Added a new `docs/EDITORS/ZED_SETUP.md` and wired Zed references and a minimal `settings.json` snippet into `docs/how-to/EDITOR_SETUP.md`, `README.md`, and `docs/reference/FAQ.md` so Zed appears alongside VS Code/Neovim/Helix/Emacs/Sublime in editor docs.

### Testing
- Attempted the recommended verification `cargo xtask fmt`, but it failed due to unrelated pre-existing compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` (unrelated to this docs-only change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b44f1488333be6b260cf014d06b)