### PR TITLE
docs(neovim): fix lspconfig server name in setup snippets (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The extension auto-downloads the matching `perllsp` binary for your platform.
 
 ```lua
 -- Neovim (nvim-lspconfig)
-require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
+require('lspconfig').perl_lsp.setup { cmd = { "perllsp", "--stdio" } }
 ```
 
 ```elisp

--- a/docs/reference/FAQ.md
+++ b/docs/reference/FAQ.md
@@ -66,7 +66,7 @@ Yes. The parser targets Perl 5.8 as the minimum and handles most idioms from tha
 Any editor with LSP client support works. Point it at `perllsp --stdio`:
 
 - **VS Code** — native extension with auto-download, UI settings, and DAP debugging
-- **Neovim** — via `nvim-lspconfig` (`perl_ls` server)
+- **Neovim** — via `nvim-lspconfig` (`perl_lsp` server)
 - **Emacs** — via `eglot` or `lsp-mode`
 - **Helix** — via `languages.toml`
 - **Sublime Text** — via the LSP package


### PR DESCRIPTION
### Motivation
- Neovim setup snippets in the docs used the incorrect `lspconfig` server key `perl_ls`, which is inconsistent with the project’s configured server name and can mislead users during editor setup.

### Description
- Replace `perl_ls` with `perl_lsp` in `README.md` and `docs/reference/FAQ.md` so the `nvim-lspconfig` examples consistently reference the correct server key.

### Testing
- Ran `cargo test -p perl-lsp-rs --test lsp_completion_tests test_cross_editor_completion_capability_profiles -- --exact` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b4975008333854771d011d374a0)