### PR TITLE
docs(neovim): improve lspconfig setup guidance (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,16 @@ The extension auto-downloads the matching `perllsp` binary for your platform.
 
 ```lua
 -- Neovim (nvim-lspconfig)
-require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
+local capabilities = vim.lsp.protocol.make_client_capabilities()
+local ok_cmp, cmp_lsp = pcall(require, "cmp_nvim_lsp")
+if ok_cmp then
+  capabilities = cmp_lsp.default_capabilities(capabilities)
+end
+
+require("lspconfig").perl_lsp.setup({
+  cmd = { "perllsp", "--stdio" },
+  capabilities = capabilities,
+})
 ```
 
 ```elisp

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -40,9 +40,16 @@ root pointed at the project root.
 ### Neovim
 
 ```lua
-require('lspconfig').perl_lsp.setup({
-  cmd = { 'perllsp', '--stdio' },
-  filetypes = { 'perl' },
+local capabilities = vim.lsp.protocol.make_client_capabilities()
+local ok_cmp, cmp_lsp = pcall(require, "cmp_nvim_lsp")
+if ok_cmp then
+  capabilities = cmp_lsp.default_capabilities(capabilities)
+end
+
+require("lspconfig").perl_lsp.setup({
+  cmd = { "perllsp", "--stdio" },
+  filetypes = { "perl" },
+  capabilities = capabilities,
 })
 ```
 


### PR DESCRIPTION
### Motivation
- Improve Neovim experience by providing an up-to-date `nvim-lspconfig` snippet that wires client capabilities (and optionally `cmp_nvim_lsp`) and uses the correct `perl_lsp` registration.

### Description
- Updated Neovim examples in `README.md` and `docs/how-to/EDITOR_SETUP.md` to create `capabilities` via `vim.lsp.protocol.make_client_capabilities()`, opt into `cmp_nvim_lsp.default_capabilities` when present, and call `require('lspconfig').perl_lsp.setup({ cmd = { "perllsp", "--stdio" }, capabilities = capabilities })`.

### Testing
- Attempted `cargo xtask fmt`, which failed due to unrelated compile errors in `xtask/src/tasks/metrics/lsp_stats.rs`, so no build or unit tests were changed and the failure is unrelated to this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b4975008333854771d011d374a0)