### PR TITLE
docs(emacs): add perl-ts-mode server mappings (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
 ```elisp
 ;; Emacs (eglot)
 (add-to-list 'eglot-server-programs
-             '((perl-mode cperl-mode) . ("perllsp" "--stdio")))
+             '((perl-mode cperl-mode perl-ts-mode) . ("perllsp" "--stdio")))
 ```
 
 ```text

--- a/docs/EDITORS/EMACS_SETUP.md
+++ b/docs/EDITORS/EMACS_SETUP.md
@@ -32,10 +32,11 @@ Copy this into your Emacs config:
 ```elisp
 (use-package eglot
   :hook ((perl-mode . eglot-ensure)
-         (cperl-mode . eglot-ensure))
+         (cperl-mode . eglot-ensure)
+         (perl-ts-mode . eglot-ensure))
   :config
   (add-to-list 'eglot-server-programs
-               '((perl-mode cperl-mode) . ("perllsp" "--stdio"))))
+               '((perl-mode cperl-mode perl-ts-mode) . ("perllsp" "--stdio"))))
 ```
 
 Then:
@@ -85,13 +86,14 @@ If you prefer `lsp-mode`, use this minimal config:
 ```elisp
 (use-package lsp-mode
   :hook ((perl-mode . lsp-deferred)
-         (cperl-mode . lsp-deferred))
+         (cperl-mode . lsp-deferred)
+         (perl-ts-mode . lsp-deferred))
   :commands lsp
   :config
   (lsp-register-client
    (make-lsp-client
     :new-connection (lsp-stdio-connection '("perllsp" "--stdio"))
-    :major-modes '(perl-mode cperl-mode)
+    :major-modes '(perl-mode cperl-mode perl-ts-mode)
     :server-id 'perllsp)))
 ```
 
@@ -120,7 +122,7 @@ Run these in order:
    M-: major-mode
    ```
 
-   Expected: `perl-mode` or `cperl-mode`.
+   Expected: `perl-mode`, `cperl-mode`, or `perl-ts-mode`.
 
 4. Check client attachment:
 
@@ -141,6 +143,6 @@ This page intentionally focuses on:
 
 - a successful first connection,
 - consistent binary naming (`perllsp`), and
-- consistent mode coverage (`perl-mode` + `cperl-mode`).
+- consistent mode coverage (`perl-mode` + `cperl-mode` + `perl-ts-mode`).
 
 For broader editor guidance, see [Editor Setup](../how-to/EDITOR_SETUP.md).

--- a/docs/how-to/FEATURE_SELECTION.md
+++ b/docs/how-to/FEATURE_SELECTION.md
@@ -159,7 +159,7 @@ args = ["--stdio", "--feature-profile", "production"]
 
 ```elisp
 (add-to-list 'eglot-server-programs
-  '((perl-mode cperl-mode) . ("perllsp" "--stdio" "--feature-profile" "production")))
+  '((perl-mode cperl-mode perl-ts-mode) . ("perllsp" "--stdio" "--feature-profile" "production")))
 ```
 
 ---

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -133,7 +133,7 @@ lspconfig.perl_lsp.setup({
 
 ```elisp
 (add-to-list 'eglot-server-programs
-             '((perl-mode cperl-mode) . ("perllsp" "--stdio")))
+             '((perl-mode cperl-mode perl-ts-mode) . ("perllsp" "--stdio")))
 ```
 
 Then run `M-x eglot` in a Perl buffer.


### PR DESCRIPTION
### Motivation

- Emacs snippets only referenced `perl-mode`/`cperl-mode`, which leaves tree-sitter-based buffers (`perl-ts-mode`) without example server mappings and auto-attach guidance.
- Add explicit examples so users running `perl-ts-mode` get the same `perllsp` integration guidance as other Emacs Perl modes.

### Description

- Updated the top-level README Emacs example to register `perl-ts-mode` in `eglot-server-programs`.
- Updated `docs/tutorials/GETTING_STARTED.md` to include `perl-ts-mode` in the `eglot` example.
- Updated `docs/EDITORS/EMACS_SETUP.md` to add `perl-ts-mode` to both `eglot` and `lsp-mode` examples, adjusted troubleshooting text to list `perl-ts-mode`, and updated the scope wording.
- Updated `docs/how-to/FEATURE_SELECTION.md` to include `perl-ts-mode` in the feature-profile Emacs example.

### Testing

- Ran `git diff --check` and it completed with no issues.
- Ran `cargo xtask fmt`, which failed due to pre-existing compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` (unresolved `last_run` and `run`), unrelated to these documentation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b4c84d88333bfae31880a4f4ccc)