### PR TITLE
docs(emacs): add tree-sitter mode examples (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
 ```elisp
 ;; Emacs (eglot)
 (add-to-list 'eglot-server-programs
-             '((perl-mode cperl-mode) . ("perllsp" "--stdio")))
+             '((perl-mode cperl-mode perl-ts-mode cperl-ts-mode)
+               . ("perllsp" "--stdio")))
 ```
 
 ```text

--- a/docs/EDITORS/EMACS_SETUP.md
+++ b/docs/EDITORS/EMACS_SETUP.md
@@ -32,10 +32,13 @@ Copy this into your Emacs config:
 ```elisp
 (use-package eglot
   :hook ((perl-mode . eglot-ensure)
-         (cperl-mode . eglot-ensure))
+         (cperl-mode . eglot-ensure)
+         (perl-ts-mode . eglot-ensure)
+         (cperl-ts-mode . eglot-ensure))
   :config
   (add-to-list 'eglot-server-programs
-               '((perl-mode cperl-mode) . ("perllsp" "--stdio"))))
+               '((perl-mode cperl-mode perl-ts-mode cperl-ts-mode)
+                 . ("perllsp" "--stdio"))))
 ```
 
 Then:
@@ -85,13 +88,15 @@ If you prefer `lsp-mode`, use this minimal config:
 ```elisp
 (use-package lsp-mode
   :hook ((perl-mode . lsp-deferred)
-         (cperl-mode . lsp-deferred))
+         (cperl-mode . lsp-deferred)
+         (perl-ts-mode . lsp-deferred)
+         (cperl-ts-mode . lsp-deferred))
   :commands lsp
   :config
   (lsp-register-client
    (make-lsp-client
     :new-connection (lsp-stdio-connection '("perllsp" "--stdio"))
-    :major-modes '(perl-mode cperl-mode)
+    :major-modes '(perl-mode cperl-mode perl-ts-mode cperl-ts-mode)
     :server-id 'perllsp)))
 ```
 
@@ -120,7 +125,7 @@ Run these in order:
    M-: major-mode
    ```
 
-   Expected: `perl-mode` or `cperl-mode`.
+   Expected: `perl-mode`, `cperl-mode`, `perl-ts-mode`, or `cperl-ts-mode`.
 
 4. Check client attachment:
 
@@ -141,6 +146,6 @@ This page intentionally focuses on:
 
 - a successful first connection,
 - consistent binary naming (`perllsp`), and
-- consistent mode coverage (`perl-mode` + `cperl-mode`).
+- consistent mode coverage across classic and tree-sitter modes (`perl-mode`, `cperl-mode`, `perl-ts-mode`, and `cperl-ts-mode`).
 
 For broader editor guidance, see [Editor Setup](../how-to/EDITOR_SETUP.md).

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -133,7 +133,8 @@ lspconfig.perl_lsp.setup({
 
 ```elisp
 (add-to-list 'eglot-server-programs
-             '((perl-mode cperl-mode) . ("perllsp" "--stdio")))
+             '((perl-mode cperl-mode perl-ts-mode cperl-ts-mode)
+               . ("perllsp" "--stdio")))
 ```
 
 Then run `M-x eglot` in a Perl buffer.


### PR DESCRIPTION
### Motivation

- Emacs docs only referenced the classic `perl-mode`/`cperl-mode`, which leaves users running Emacs tree-sitter Perl modes without copy-paste-ready examples. 
- Modern Emacs can expose `perl-ts-mode`/`cperl-ts-mode`, so editor snippets and troubleshooting should list those for reliable auto-attachment.

### Description

- Added `perl-ts-mode` and `cperl-ts-mode` to the `eglot` snippet in `README.md` so the quick-start example covers tree-sitter modes. 
- Updated `docs/EDITORS/EMACS_SETUP.md` to add tree-sitter modes to the `eglot` hooks, the `lsp-mode` hooks, the `:major-modes` list, and the troubleshooting/expectations text. 
- Updated `docs/tutorials/GETTING_STARTED.md` to include the same `eglot` server-programs entry so onboarding docs are consistent across entry points. 

### Testing

- Ran `cargo test -p perl-lsp-rs --lib`, which completed successfully (`428 passed; 0 failed; 4 ignored`).
- Ran `cargo xtask fmt`, which failed due to pre-existing `xtask` compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` (unresolved `last_run`/`run` identifiers), and is unrelated to the docs changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b4c84d88333bfae31880a4f4ccc)