### PR TITLE
fix(perl-module): improve @INC use lib parsing (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/use_lib.rs
+++ b/crates/perl-module/src/resolution/use_lib.rs
@@ -37,8 +37,8 @@ pub enum UseLibAction {
 pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
     let mut paths = Vec::new();
 
-    for line in source.lines() {
-        let trimmed = line.trim();
+    for statement in split_perl_statements(source) {
+        let trimmed = statement.trim();
         if let Some(rest) = strip_use_lib_prefix(trimmed) {
             extract_paths_from_args(rest, &mut paths);
         }
@@ -52,8 +52,8 @@ pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
 pub fn extract_use_lib_operations(source: &str) -> Vec<UseLibAction> {
     let mut ops = Vec::new();
 
-    for line in source.lines() {
-        let trimmed = line.trim();
+    for statement in split_perl_statements(source) {
+        let trimmed = statement.trim();
         if let Some(rest) = strip_use_lib_prefix(trimmed) {
             let mut paths = Vec::new();
             extract_paths_from_args(rest, &mut paths);
@@ -73,6 +73,48 @@ pub fn extract_use_lib_operations(source: &str) -> Vec<UseLibAction> {
     }
 
     ops
+}
+
+fn split_perl_statements(source: &str) -> Vec<&str> {
+    let mut statements = Vec::new();
+    let mut start = 0usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    for (idx, ch) in source.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' if in_single || in_double => {
+                escaped = true;
+            }
+            '\'' if !in_double => {
+                in_single = !in_single;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+            }
+            ';' if !in_single && !in_double => {
+                let statement = &source[start..idx];
+                if !statement.trim().is_empty() {
+                    statements.push(statement);
+                }
+                start = idx + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    let trailing = &source[start..];
+    if !trailing.trim().is_empty() {
+        statements.push(trailing);
+    }
+
+    statements
 }
 
 /// Resolve `use lib` paths against a workspace root and optional file directory.

--- a/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
+++ b/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
 use perl_module::resolution::use_lib::{
-    UseLibAction, UseLibPath, extract_use_lib_operations, resolve_use_lib_paths,
-    resolve_use_lib_paths_from_source_at_offset,
+    UseLibAction, UseLibPath, extract_use_lib_operations, extract_use_lib_paths,
+    resolve_use_lib_paths, resolve_use_lib_paths_from_source_at_offset,
 };
 
 #[test]
@@ -77,6 +77,39 @@ use Lib::Thing;\n\
     let include_paths = resolve_use_lib_paths_from_source_at_offset(
         source,
         offset_at_use,
+        Path::new("/workspace"),
+        None,
+    );
+
+    assert_eq!(include_paths, vec!["second".to_string()]);
+}
+
+#[test]
+fn multiline_use_lib_arguments_are_extracted() {
+    let source = "\
+use lib (\n\
+    'lib',\n\
+    'vendor/lib',\n\
+);\n\
+";
+
+    let paths = extract_use_lib_paths(source);
+    assert_eq!(
+        paths,
+        vec![
+            UseLibPath { path: "lib".to_string(), from_findbin: false },
+            UseLibPath { path: "vendor/lib".to_string(), from_findbin: false },
+        ]
+    );
+}
+
+#[test]
+fn same_line_use_and_no_lib_statements_preserve_order() {
+    let source = "use lib 'first'; no lib 'first'; use lib 'second';";
+
+    let include_paths = resolve_use_lib_paths_from_source_at_offset(
+        source,
+        source.len(),
         Path::new("/workspace"),
         None,
     );


### PR DESCRIPTION
### Motivation

- Line-oriented extraction of `use lib`/`no lib` pragmas missed multi-line argument lists and same-line chained statements, causing incorrect effective `@INC` ordering and missed include paths.

### Description

- Add `split_perl_statements(source: &str)` that splits source into semicolon-delimited statements while respecting single- and double-quoted strings and escapes. 
- Use `split_perl_statements` in `extract_use_lib_paths` and `extract_use_lib_operations` so `use lib`/`no lib` extraction is statement-aware instead of line-based. 
- Add targeted regression tests `multiline_use_lib_arguments_are_extracted` and `same_line_use_and_no_lib_statements_preserve_order` to `use_lib_resolution_unit_tests.rs`.
- Modify test imports to expose `extract_use_lib_paths` for the new tests.

### Testing

- Ran `cargo test -p perl-module`, which passed (all unit tests in `perl-module` succeeded). 
- Ran `cargo check --all-targets -p perl-module`, which completed successfully. 
- Ran formatting via `cargo fmt --all`, which completed successfully. 
- Ran `cargo clippy -p perl-module --all-targets -- -D warnings`, which failed due to a pre-existing clippy warning in an unrelated test (`crates/perl-module/tests/import_comprehensive_unit_tests.rs`) and is not caused by this change. 
- Ran `cargo xtask fmt`, which could not finish due to unrelated compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` external to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b1841a08333ae87656c10e621d5)