### PR TITLE
fix(perl-uri): support vscode notebook cell URIs (#0000)

### DIFF
--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -54,6 +54,7 @@ pub fn is_special_scheme(uri: &str) -> bool {
         uri.starts_with("untitled:")
             || uri.starts_with("git:")
             || uri.starts_with("vscode-notebook:")
+            || uri.starts_with("vscode-notebook-cell:")
             || uri.starts_with("vscode-vfs:")
     }
 }
@@ -116,6 +117,7 @@ mod tests {
     fn detects_special_schemes() {
         assert!(is_special_scheme("untitled:Untitled-1"));
         assert!(is_special_scheme("git:/foo/bar"));
+        assert!(is_special_scheme("vscode-notebook-cell:/nb.ipynb#cell-id"));
         assert!(!is_special_scheme("file:///tmp/test.pl"));
     }
 

--- a/crates/perl-uri/tests/classify_boundary_cases.rs
+++ b/crates/perl-uri/tests/classify_boundary_cases.rs
@@ -67,6 +67,14 @@ fn is_special_scheme_true_for_vscode_notebook() {
 }
 
 #[test]
+fn is_special_scheme_true_for_vscode_notebook_cell() {
+    assert!(
+        is_special_scheme("vscode-notebook-cell:/path/to/nb.ipynb#ch000001"),
+        "vscode-notebook-cell: is special"
+    );
+}
+
+#[test]
 fn is_special_scheme_true_for_vscode_vfs() {
     assert!(is_special_scheme("vscode-vfs:/mount/path"), "vscode-vfs: is special");
 }

--- a/crates/perl-uri/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-uri/tests/comprehensive_unit_tests.rs
@@ -112,6 +112,11 @@ fn is_special_scheme_detects_vscode_notebook() {
 }
 
 #[test]
+fn is_special_scheme_detects_vscode_notebook_cell() {
+    assert!(is_special_scheme("vscode-notebook-cell:/path/to/notebook.ipynb#cell-1"));
+}
+
+#[test]
 fn is_special_scheme_detects_vscode_vfs() {
     assert!(is_special_scheme("vscode-vfs://github/repo/file.pl"));
 }


### PR DESCRIPTION
### Motivation
- VS Code notebook cell documents use the `vscode-notebook-cell:` scheme and the classifier fallback branch did not recognize that prefix, which could cause notebook-cell URIs to be misclassified in some editor integration flows.

### Description
- Added `vscode-notebook-cell:` to the non-parseable fallback path in `crates/perl-uri/src/classify.rs` and expanded unit coverage by adding assertions to `crates/perl-uri/tests/classify_boundary_cases.rs` and `crates/perl-uri/tests/comprehensive_unit_tests.rs` to verify the new behavior.

### Testing
- Ran `cargo test -p perl-uri`, `cargo check --all-targets -p perl-uri`, `cargo clippy -p perl-uri --all-targets -- -D warnings`, and `cargo fmt -p perl-uri`, all of which passed; `cargo xtask fmt` was attempted but failed due to unrelated pre-existing `xtask` compile errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b4fdbd483338774d627aa22acc5)