### PR TITLE
docs(vim): improve Vim setup guidance (#0000)

### DIFF
--- a/docs/EDITORS/COC_NEOVIM_SETUP.md
+++ b/docs/EDITORS/COC_NEOVIM_SETUP.md
@@ -135,7 +135,7 @@ Create `~/.vim/coc-settings.json` (or `~/.config/nvim/coc-settings.json` for Neo
 {
   "languageserver": {
     "perl": {
-      "command": "perl-lsp",
+      "command": "perllsp",
       "args": ["--stdio"],
       "filetypes": ["perl"],
       "rootPatterns": ["Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"],
@@ -188,7 +188,7 @@ Add to `~/.vim/coc-settings.json`:
 {
   "languageserver": {
     "perl": {
-      "command": "perl-lsp",
+      "command": "perllsp",
       "args": ["--stdio"],
       "filetypes": ["perl"],
       "rootPatterns": ["Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"],
@@ -605,7 +605,7 @@ nnoremap <silent> <space>y  :<C-u>CocList -A --normal yank<cr>
 
 1. **Verify binary is in PATH**:
    ```vim
-   :!which perl-lsp
+   :!which perllsp
    ```
 
 2. **Check coc.nvim info**:
@@ -986,7 +986,7 @@ autocmd FileType perl :CocCommand workspace.toggleDiagnostics
 {
   "languageserver": {
     "perl": {
-      "command": "perl-lsp",
+      "command": "perllsp",
       "args": ["--stdio"],
       "filetypes": ["perl"],
       "rootPatterns": ["Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"],

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -25,6 +25,7 @@ perllsp --health
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
+| Vim / gVim | use coc.nvim with `"command": "perllsp"` | [docs/EDITORS/COC_NEOVIM_SETUP.md](../EDITORS/COC_NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
@@ -50,6 +51,11 @@ require('lspconfig').perl_lsp.setup({
 
 Use `lsp-mode` or `eglot` with the same `perllsp --stdio` command. The
 editor-specific guide has the full snippets for both.
+
+### Vim / gVim (coc.nvim)
+
+Use `coc.nvim` and register a `languageserver.perl` entry with
+`"command": "perllsp"` and `"args": ["--stdio"]`.
 
 ### Helix
 


### PR DESCRIPTION
### Motivation

- Make Vim/gVim users discover the supported setup path and ensure coc.nvim examples use the current CLI (`perllsp`) so the docs reflect the real command people should run.

### Description

- Added a first-class `Vim / gVim` row to the editor quick-start table and a short `Vim / gVim (coc.nvim)` minimal-configuration snippet in `docs/how-to/EDITOR_SETUP.md`, and replaced outdated `perl-lsp` occurrences with `perllsp` in `docs/EDITORS/COC_NEOVIM_SETUP.md`.

### Testing

- Ran `cargo xtask fmt --check`, which surfaced pre-existing `xtask` compile errors unrelated to these documentation changes (format check did not complete successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b5f6ff88333ab9a4a63b1845c5b)