### PR TITLE
docs(vim): add coc.nvim setup and coverage profile (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ The extension auto-downloads the matching `perllsp` binary for your platform.
 require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
 ```
 
+```json
+// Vim/Neovim (coc.nvim): ~/.vim/coc-settings.json or ~/.config/nvim/coc-settings.json
+{
+  "languageserver": {
+    "perl": {
+      "command": "perllsp",
+      "args": ["--stdio"],
+      "filetypes": ["perl"]
+    }
+  }
+}
+```
+
 ```elisp
 ;; Emacs (eglot)
 (add-to-list 'eglot-server-programs
@@ -59,6 +72,7 @@ perllsp --health
 ```
 
 For a full walkthrough, see [docs/tutorials/GETTING_STARTED.md](docs/tutorials/GETTING_STARTED.md).
+For Vim-specific setup details (keymaps, troubleshooting, and advanced coc.nvim config), see [docs/EDITORS/COC_NEOVIM_SETUP.md](docs/EDITORS/COC_NEOVIM_SETUP.md).
 
 > **Note:** Do not use `cargo install perl-lsp` — that name is owned by an unrelated project on crates.io. Use `cargo install --path crates/perllsp` to build from source.
 

--- a/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
@@ -1454,6 +1454,8 @@ fn test_cross_editor_completion_capability_profiles() -> Result<(), Box<dyn std:
         ("vscode", completion_item_caps(true, true), true, true),
         ("zed", completion_item_caps(true, false), true, false),
         ("neovim", completion_item_caps(false, false), false, false),
+        // coc.nvim on Vim/Neovim typically sends a conservative completion capability set.
+        ("vim-coc", completion_item_caps(false, false), false, false),
         ("helix", completion_item_caps(false, false), false, false),
     ];
 

--- a/docs/EDITORS/COC_NEOVIM_SETUP.md
+++ b/docs/EDITORS/COC_NEOVIM_SETUP.md
@@ -53,14 +53,14 @@ Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/re
 
 ```bash
 # Linux (x86_64)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-linux-x86_64.tar.gz
-tar xzf perl-lsp-linux-x86_64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
+curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perllsp-0.12.4-x86_64-unknown-linux-gnu.tar.gz
+tar xzf perllsp-0.12.4-x86_64-unknown-linux-gnu.tar.gz
+sudo mv perllsp /usr/local/bin/
 
 # macOS (Apple Silicon)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-darwin-aarch64.tar.gz
-tar xzf perl-lsp-darwin-aarch64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
+curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perllsp-0.12.4-aarch64-apple-darwin.tar.gz
+tar xzf perllsp-0.12.4-aarch64-apple-darwin.tar.gz
+sudo mv perllsp /usr/local/bin/
 ```
 
 #### Option 3: Build from Source
@@ -79,7 +79,7 @@ perllsp --version
 
 # Quick health check
 perllsp --health
-# Should output: ok 0.10.0
+# Should output: ok 0.12.4
 ```
 
 ### Install coc.nvim
@@ -135,7 +135,7 @@ Create `~/.vim/coc-settings.json` (or `~/.config/nvim/coc-settings.json` for Neo
 {
   "languageserver": {
     "perl": {
-      "command": "perl-lsp",
+      "command": "perllsp",
       "args": ["--stdio"],
       "filetypes": ["perl"],
       "rootPatterns": ["Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"],
@@ -188,7 +188,7 @@ Add to `~/.vim/coc-settings.json`:
 {
   "languageserver": {
     "perl": {
-      "command": "perl-lsp",
+      "command": "perllsp",
       "args": ["--stdio"],
       "filetypes": ["perl"],
       "rootPatterns": ["Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"],
@@ -605,7 +605,7 @@ nnoremap <silent> <space>y  :<C-u>CocList -A --normal yank<cr>
 
 1. **Verify binary is in PATH**:
    ```vim
-   :!which perl-lsp
+   :!which perllsp
    ```
 
 2. **Check coc.nvim info**:
@@ -986,7 +986,7 @@ autocmd FileType perl :CocCommand workspace.toggleDiagnostics
 {
   "languageserver": {
     "perl": {
-      "command": "perl-lsp",
+      "command": "perllsp",
       "args": ["--stdio"],
       "filetypes": ["perl"],
       "rootPatterns": ["Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"],


### PR DESCRIPTION
### Motivation
- Provide an immediate quickstart for Vim/coc.nvim users so they can point `perllsp --stdio` from `coc-settings.json`.
- Ensure test coverage includes a conservative Vim/coc.nvim completion capability profile to prevent editor-specific regressions.

### Description
- Added a `coc-settings.json` example to the top-level `README.md` showing how to configure `perllsp` for Vim/Neovim (coc.nvim) and added a pointer to the dedicated Vim guide at `docs/EDITORS/COC_NEOVIM_SETUP.md`.
- Extended the `test_cross_editor_completion_capability_profiles` matrix in `crates/perl-lsp-rs/tests/lsp_completion_tests.rs` with a `("vim-coc", ...)` profile that models conservative completion capabilities typically sent by coc.nvim.

### Testing
- Ran `cargo test -p perl-lsp-rs --test lsp_completion_tests test_cross_editor_completion_capability_profiles -- --nocapture`, and the targeted test passed (`ok`).
- Ran `cargo check --all-targets -p perl-lsp-rs`, which completed successfully (the run surfaced pre-existing warnings in `multi_root_workspace_tests` unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b5f6ff88333ab9a4a63b1845c5b)