### PR TITLE
docs(vim): add coc.nvim quick-start wiring (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,20 @@ The extension auto-downloads the matching `perllsp` binary for your platform.
 
 ```lua
 -- Neovim (nvim-lspconfig)
-require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
+require('lspconfig').perl_lsp.setup { cmd = { "perllsp", "--stdio" } }
+```
+
+```json
+// Vim/Neovim (coc.nvim): ~/.vim/coc-settings.json or ~/.config/nvim/coc-settings.json
+{
+  "languageserver": {
+    "perl-lsp": {
+      "command": "perllsp",
+      "args": ["--stdio"],
+      "filetypes": ["perl"]
+    }
+  }
+}
 ```
 
 ```elisp

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -25,6 +25,7 @@ perllsp --health
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
+| Vim / Neovim (coc.nvim) | add a `languageserver.perl-lsp` entry with `command: "perllsp"` | [docs/EDITORS/COC_NEOVIM_SETUP.md](../EDITORS/COC_NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
@@ -50,6 +51,22 @@ require('lspconfig').perl_lsp.setup({
 
 Use `lsp-mode` or `eglot` with the same `perllsp --stdio` command. The
 editor-specific guide has the full snippets for both.
+
+### Vim / Neovim (coc.nvim)
+
+Add this to `~/.vim/coc-settings.json` (or `~/.config/nvim/coc-settings.json`):
+
+```json
+{
+  "languageserver": {
+    "perl-lsp": {
+      "command": "perllsp",
+      "args": ["--stdio"],
+      "filetypes": ["perl"]
+    }
+  }
+}
+```
 
 ### Helix
 

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -21,7 +21,7 @@ A **language server** is a program that runs alongside your editor and gives it 
 ## Prerequisites
 
 - **Rust 1.92+** (for building from source)
-- **A supported editor**: VS Code, Neovim, Emacs, Helix, or Sublime Text
+- **A supported editor**: VS Code, Vim/Neovim (native LSP or coc.nvim), Emacs, Helix, or Sublime Text
 
 ## Installation
 
@@ -128,6 +128,24 @@ lspconfig.perl_lsp.setup({
 ```
 
 **Verify it works**: open a `.pl` file and run `:LspInfo` -- you should see `perl_lsp` attached.
+
+### Vim / Neovim (with coc.nvim)
+
+Add this to `~/.vim/coc-settings.json` (or `~/.config/nvim/coc-settings.json`):
+
+```json
+{
+  "languageserver": {
+    "perl-lsp": {
+      "command": "perllsp",
+      "args": ["--stdio"],
+      "filetypes": ["perl"]
+    }
+  }
+}
+```
+
+**Verify it works**: open a `.pl` file and run `:CocInfo` -- you should see `perl-lsp` running.
 
 ### Emacs (with eglot, Emacs 29+)
 


### PR DESCRIPTION
### Motivation
- Surface a ready-to-copy `coc.nvim` quick-start for Vim/Neovim users and fix an inconsistent Neovim example server identifier so editor setup docs are accurate and actionable.

### Description
- Corrected the Neovim example in `README.md` to use `perl_lsp` as the nvim-lspconfig server key.
- Added a `coc.nvim` `languageserver` JSON snippet (command `perllsp --stdio`) to `README.md` for Vim/Neovim users.
- Expanded `docs/how-to/EDITOR_SETUP.md` and `docs/tutorials/GETTING_STARTED.md` to include the coc.nvim snippet and list "Vim / Neovim (coc.nvim)" in the editor matrix.

### Testing
- Ran `git diff --check`, which passed for the modified files.
- Attempted `cargo xtask fmt`, which failed due to pre-existing unrelated compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` and not caused by these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b5f6ff88333ab9a4a63b1845c5b)