### PR TITLE
feat(vscode-extension): recognize CGI Perl files (#0000)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -71,6 +71,8 @@
         ],
         "extensions": [
           ".pl",
+          ".cgi",
+          ".fcgi",
           ".pm",
           ".xs",
           ".xsi",

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -156,6 +156,8 @@ describe('package.json contributes', () => {
       const perl = pkg.contributes.languages.find((l: any) => l.id === 'perl');
       const exts: string[] = perl.extensions;
       expect(exts).toContain('.pl');
+      expect(exts).toContain('.cgi');
+      expect(exts).toContain('.fcgi');
       expect(exts).toContain('.pm');
       expect(exts).toContain('.xs');
       expect(exts).toContain('.xsi');


### PR DESCRIPTION
### Motivation
- Ensure VS Code recognizes common CGI/FastCGI Perl script file extensions so editor features (syntax, hover, completion, formatting) are applied to `.cgi` and `.fcgi` files.

### Description
- Add `.cgi` and `.fcgi` to the `contributes.languages` `extensions` list in `vscode-extension/package.json`.
- Update `vscode-extension/src/test/configuration.test.ts` to assert the new extensions are included in the Perl language registration.

### Testing
- Executed a quick runtime check with `node -e "const pkg=require('./vscode-extension/package.json');const exts=pkg.contributes.languages.find(l=>l.id==='perl').extensions; if(!exts.includes('.cgi')||!exts.includes('.fcgi')){process.exit(1)}; console.log('ok', exts.length);"` which passed.
- Ran `npm test -- configuration.test.ts` in this environment which failed due to missing Jest TypeScript globals/types in the sandbox (environment limitation), so full test validation should be performed by CI or a local dev environment with Jest type definitions installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b64ae0c83338c29f7ee32194949)