### PR TITLE
docs(readme): expand non-VS Code editor setup snippets (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,30 @@ require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
              '((perl-mode cperl-mode) . ("perllsp" "--stdio")))
 ```
 
+```toml
+# Helix (~/.config/helix/languages.toml)
+[[language]]
+name = "perl"
+language-servers = ["perllsp"]
+
+[language-server.perllsp]
+command = "perllsp"
+args = ["--stdio"]
+```
+
+```json
+// Sublime Text LSP package settings
+{
+  "clients": {
+    "perllsp": {
+      "enabled": true,
+      "command": ["perllsp", "--stdio"],
+      "selector": "source.perl"
+    }
+  }
+}
+```
+
 ```text
 # Any generic LSP client
 perllsp --stdio
@@ -59,6 +83,7 @@ perllsp --health
 ```
 
 For a full walkthrough, see [docs/tutorials/GETTING_STARTED.md](docs/tutorials/GETTING_STARTED.md).
+For editor-specific setup (Neovim, Emacs, Helix, Sublime), see [docs/specs/PACKAGING_INSTALL_SPEC.md](docs/specs/PACKAGING_INSTALL_SPEC.md).
 
 > **Note:** Do not use `cargo install perl-lsp` — that name is owned by an unrelated project on crates.io. Use `cargo install --path crates/perllsp` to build from source.
 


### PR DESCRIPTION
### Motivation
- Improve discoverability for non‑VS Code users by providing copy‑paste editor configuration examples and a direct link to the full editor installation spec.

### Description
- Added Helix and Sublime Text LSP configuration snippets to the "Other editors" Quick Start in `README.md` and added a pointer to `docs/specs/PACKAGING_INSTALL_SPEC.md` for more detailed editor guidance.

### Testing
- `cargo check --all-targets -p perl-lsp-rs -q` completed successfully; `cargo xtask fmt` was attempted but failed due to unrelated compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` (not impacted by this README-only change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b64ae0c83338c29f7ee32194949)