### PR TITLE
fix(vscode-extension): register perl format keybinding (#0000)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -843,6 +843,11 @@
         "when": "editorTextFocus && editorLangId == perl"
       },
       {
+        "command": "editor.action.formatDocument",
+        "key": "shift+alt+f",
+        "when": "editorHasDocumentFormattingProvider && editorTextFocus && !editorReadonly && editorLangId == perl"
+      },
+      {
         "command": "perl-lsp.extractVariable",
         "key": "shift+alt+v",
         "when": "editorTextFocus && editorHasSelection && editorLangId == perl"


### PR DESCRIPTION
### Motivation
- The README and marketplace docs reference `Shift+Alt+F` for formatting but the extension did not explicitly register that keybinding for Perl editor sessions, causing a discrepancy in editor behavior.

### Description
- Add a Perl-scoped keybinding to `vscode-extension/package.json` that maps `shift+alt+f` to `editor.action.formatDocument` with the same availability guards used by VS Code (`editorHasDocumentFormattingProvider && editorTextFocus && !editorReadonly && editorLangId == perl`).

### Testing
- `node -e "JSON.parse(require('fs').readFileSync('vscode-extension/package.json','utf8')); console.log('ok')"` succeeded.
- `npm --prefix vscode-extension run -s compile` was executed and failed with a pre-existing TypeScript deprecation error `TS5107` about `moduleResolution=node10`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b64ae0c83338c29f7ee32194949)