### PR TITLE
fix(text-sync): accept embedded Perl template language ids (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -2119,6 +2119,30 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_template_file_guard_parses_mojolicious_language_id()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let uri = "file:///app/templates/index.html.ep";
+
+        server.did_open(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "mojolicious",
+                "version": 1,
+                "text": "% my $title = 'Hello';"
+            }
+        }))?;
+
+        let docs = server.documents.lock();
+        let doc = docs.get(uri).ok_or("template document not stored after didOpen")?;
+        assert!(
+            doc.ast.is_some(),
+            "template with mojolicious languageId should be parsed as Perl"
+        );
+        Ok(())
+    }
+
     /// Semantic analyzer cache must accumulate at most one entry per document
     /// version across multiple hover calls at different offsets.
     ///

--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -31,7 +31,10 @@ fn is_embedded_template_uri(uri: &str) -> bool {
 }
 
 fn is_perl_language_id(language_id: &str) -> bool {
-    matches!(language_id.to_ascii_lowercase().as_str(), "perl" | "perl5" | "perl-cpanfile")
+    matches!(
+        language_id.to_ascii_lowercase().as_str(),
+        "perl" | "perl5" | "perl-cpanfile" | "embedded-perl" | "mojolicious"
+    )
 }
 
 #[cfg(feature = "incremental")]
@@ -2089,6 +2092,30 @@ mod tests {
             "template should remain in no-parse mode after didChange"
         );
         assert!(doc.ast.is_none(), "template should continue skipping parse on didChange");
+        Ok(())
+    }
+
+    #[test]
+    fn test_template_file_guard_parses_embedded_perl_language_id()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let uri = "file:///app/templates/welcome.html.ep";
+
+        server.did_open(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "embedded-perl",
+                "version": 1,
+                "text": "<%= my $name = 'world'; %>"
+            }
+        }))?;
+
+        let docs = server.documents.lock();
+        let doc = docs.get(uri).ok_or("template document not stored after didOpen")?;
+        assert!(
+            doc.ast.is_some(),
+            "template with embedded-perl languageId should be parsed as Perl"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation

- Some editors open template files (e.g. `.ep`) with language IDs like `embedded-perl` or `mojolicious`, and the server's template guard treated those as non-Perl and skipped parsing, reducing diagnostics and other editor features.
- Improving recognition of common embedded-template language IDs restores parsing and diagnostics for those editor workflows.

### Description

- Extend `is_perl_language_id` to accept `embedded-perl` and `mojolicious` in addition to the existing `perl`, `perl5`, and `perl-cpanfile` checks.
- Add a focused unit test `test_template_file_guard_parses_embedded_perl_language_id` that verifies a `.ep` template opened with `languageId: "embedded-perl"` is parsed (AST present).

### Testing

- Ran `cargo test -p perl-lsp-rs --lib runtime::text_sync::tests::test_template_file_guard_parses_embedded_perl_language_id -- --exact` which passed.
- Ran `cargo test -p perl-lsp-rs --lib test_template_file_guard -- --list` which listed the updated tests successfully.
- Ran `cargo check --all-targets -p perl-lsp-rs` which completed successfully (build produced existing test warnings unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b64ae0c83338c29f7ee32194949)