### PR TITLE
feat(tree-sitter-perl-rs): add Point position APIs (#0000)

### DIFF
--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -60,6 +60,18 @@ use perl_parser_core::Parser as CoreParser;
 /// Mirrors `tree_sitter::InputEdit` field layout for drop-in compatibility.
 pub use perl_parser_core::edit::Edit as InputEdit;
 
+/// A tree-sitter-compatible source position.
+///
+/// `row` and `column` are both zero-based and `column` is measured in bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Point {
+    /// Zero-based row number.
+    pub row: usize,
+    /// Zero-based byte column within `row`.
+    pub column: usize,
+}
+
 /// A Perl parser with tree-sitter-style ergonomics.
 ///
 /// Wraps the v3 recursive-descent Perl parser. Create one parser instance and call
@@ -337,6 +349,20 @@ impl<'tree> Node<'tree> {
         self.inner.location.end.min(self.tree_source.len())
     }
 
+    /// Returns the start position as a tree-sitter-compatible [`Point`].
+    ///
+    /// `row`/`column` are zero-based and `column` is measured in bytes.
+    pub fn start_position(&self) -> Point {
+        byte_to_point(self.tree_source, self.start_byte())
+    }
+
+    /// Returns the end position as a tree-sitter-compatible [`Point`].
+    ///
+    /// `row`/`column` are zero-based and `column` is measured in bytes.
+    pub fn end_position(&self) -> Point {
+        byte_to_point(self.tree_source, self.end_byte())
+    }
+
     /// Extracts the source text slice covered by this node.
     ///
     /// Returns `Err` only when the byte range contains invalid UTF-8, which is unlikely
@@ -492,6 +518,23 @@ fn pascal_to_snake(s: &str) -> String {
     out
 }
 
+fn byte_to_point(source: &str, byte: usize) -> Point {
+    let clamped = byte.min(source.len());
+    let mut row = 0usize;
+    let mut column = 0usize;
+
+    for b in source.as_bytes().iter().take(clamped) {
+        if *b == b'\n' {
+            row += 1;
+            column = 0;
+        } else {
+            column += 1;
+        }
+    }
+
+    Point { row, column }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -543,6 +586,28 @@ mod tests {
         let root = tree.root_node();
         assert_eq!(root.start_byte(), 0);
         assert_eq!(root.end_byte(), source.len(), "root end_byte should clamp to source length");
+    }
+
+    #[test]
+    fn test_start_and_end_position_are_tree_sitter_compatible() {
+        let source = "my $x = 1;\nmy $y = 2;";
+        let mut p = Parser::new();
+        let tree = must_some(p.parse(source));
+        let root = tree.root_node();
+
+        assert_eq!(root.start_position(), Point { row: 0, column: 0 });
+        assert_eq!(root.end_position(), Point { row: 1, column: 10 });
+    }
+
+    #[test]
+    fn test_end_position_column_uses_bytes_not_chars() {
+        let source = "my $emoji = \"😀\";";
+        let mut p = Parser::new();
+        let tree = must_some(p.parse(source));
+        let root = tree.root_node();
+
+        assert_eq!(root.end_byte(), source.len());
+        assert_eq!(root.end_position(), Point { row: 0, column: source.len() });
     }
 
     /// Verify the end_byte clamp invariant: for every node in the tree,


### PR DESCRIPTION
### Motivation
- Consumers expecting tree-sitter-style coordinates lacked a `Point`/row-column API and could only use byte offsets, making interoperability with tree-sitter tooling awkward.
- Provide zero-based, byte-column `row`/`column` semantics to match tree-sitter expectations and keep the existing byte-offset APIs intact.

### Description
- Added a public, `#[non_exhaustive]` `Point { row, column }` type with zero-based row and byte-measured column semantics.
- Implemented `Node::start_position()` and `Node::end_position()` that return `Point` values derived from `start_byte()`/`end_byte()`.
- Added a `byte_to_point` helper that walks bytes up to the clamped offset to compute row/column and accounts for `\n` line breaks.
- Added unit tests validating multi-line positions and that `column` counts bytes (multi-byte UTF-8) and included regression coverage for the new APIs.

### Testing
- Ran `cargo test -p tree-sitter-perl-rs` and all tests passed (`33 passed`).
- Ran `cargo check --all-targets -p tree-sitter-perl-rs` and it completed successfully.
- Ran `cargo clippy -p tree-sitter-perl-rs --all-targets` with no new lints reported.
- Attempted `cargo xtask fmt`, but it is blocked by pre-existing compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b6deb0c8333a7f6f0e1f292e73b)