### PR TITLE
feat(tree-sitter-perl-rs): add Tree::walk root cursor API (#0000)

### DIFF
--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -870,4 +870,269 @@ mod tests {
         let at_leaf = !cursor.goto_first_child();
         assert!(at_leaf, "goto_first_child must return false on a leaf node");
     }
+
+    #[test]
+    fn test_tree_cursor_multiple_goto_next_sibling_exhausts() {
+        // When repeatedly calling goto_next_sibling, the cursor must eventually
+        // return false and stay positioned at the last sibling.
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse("1; 2; 3;"));
+        let mut cursor = tree.walk();
+
+        // Navigate to first statement
+        assert!(cursor.goto_first_child());
+        let mut count = 1;
+        // Keep advancing siblings until we can't
+        while cursor.goto_next_sibling() {
+            count += 1;
+        }
+        // After last goto_next_sibling returns false, cursor should still be valid
+        // and still have a node (the last sibling).
+        let node = cursor.node();
+        assert!(!node.kind().is_empty(), "cursor should remain at valid node after exhausting siblings");
+    }
+
+    #[test]
+    fn test_tree_cursor_goto_parent_at_root_repeatedly() {
+        // Calling goto_parent at root should return false every time, keeping cursor at root.
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse("my $x = 1;"));
+        let mut cursor = tree.walk();
+
+        // We should always be at root initially
+        assert_eq!(cursor.node().grammar_kind(), "source_file");
+
+        // Try to go up multiple times — must stay at root
+        for _ in 0..3 {
+            let result = cursor.goto_parent();
+            assert!(!result, "goto_parent at root must return false");
+            assert_eq!(
+                cursor.node().grammar_kind(),
+                "source_file",
+                "cursor must remain at root after failed goto_parent"
+            );
+        }
+    }
+
+    #[test]
+    fn test_tree_cursor_reset_from_deep_nesting() {
+        // reset() must return cursor to root regardless of depth.
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse("sub foo { my $x = 1; }"));
+        let mut cursor = tree.walk();
+
+        // Navigate deep into the tree
+        let mut depth = 0;
+        while cursor.goto_first_child() && depth < 10 {
+            depth += 1;
+        }
+        assert!(depth > 0, "should have navigated at least one level deep");
+
+        // reset() should bring us back to root
+        cursor.reset();
+        assert_eq!(
+            cursor.node().grammar_kind(),
+            "source_file",
+            "reset must return cursor to root"
+        );
+    }
+
+    #[test]
+    fn test_tree_cursor_empty_source_root_is_valid() {
+        // Empty source still produces a (minimal) tree; cursor at root should be valid.
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse(""));
+        let cursor = tree.walk();
+
+        let node = cursor.node();
+        assert_eq!(node.grammar_kind(), "source_file");
+        assert!(node.child_count() == 0, "empty source tree should have no statements");
+    }
+
+    #[test]
+    fn test_tree_cursor_empty_source_goto_first_child_returns_false() {
+        // Empty source root has no children; goto_first_child must return false.
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse(""));
+        let mut cursor = tree.walk();
+
+        let result = cursor.goto_first_child();
+        assert!(!result, "empty tree root should have no first child");
+    }
+
+    #[test]
+    fn test_tree_cursor_single_statement_navigation() {
+        // Single statement: root -> statement -> (children or leaf).
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse("42;"));
+        let mut cursor = tree.walk();
+
+        assert_eq!(cursor.node().grammar_kind(), "source_file");
+        assert!(cursor.goto_first_child(), "root should have exactly one statement");
+
+        // The single statement should have no next sibling
+        assert!(!cursor.goto_next_sibling(), "single statement should be the only child");
+
+        // Going back up should land at root
+        assert!(cursor.goto_parent(), "should be able to return to root");
+        assert_eq!(cursor.node().grammar_kind(), "source_file");
+    }
+
+    #[test]
+    fn test_tree_cursor_sibling_navigation_exact_count() {
+        // Navigate through all siblings and verify the count matches child_count.
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse("1; 2; 3; 4;"));
+        let root = tree.root_node();
+        let child_count = root.child_count();
+
+        let mut cursor = tree.walk();
+        assert!(cursor.goto_first_child());
+
+        let mut sibling_count = 1;
+        while cursor.goto_next_sibling() {
+            sibling_count += 1;
+        }
+
+        assert_eq!(
+            sibling_count, child_count,
+            "sibling count should match root.child_count()"
+        );
+    }
+
+    #[test]
+    fn test_tree_cursor_alternating_parent_child_navigation() {
+        // Test mixed navigation: down, up, down again at different indices.
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse("sub a { 1; } sub b { 2; }"));
+        let mut cursor = tree.walk();
+
+        // Down to first sub
+        assert!(cursor.goto_first_child());
+        let first_kind = cursor.node().grammar_kind().to_string();
+
+        // Back to root
+        assert!(cursor.goto_parent());
+        assert_eq!(cursor.node().grammar_kind(), "source_file");
+
+        // Down again to first sub (should be the same)
+        assert!(cursor.goto_first_child());
+        assert_eq!(
+            cursor.node().grammar_kind(),
+            first_kind,
+            "re-navigating should reach the same node"
+        );
+    }
+
+    #[test]
+    fn test_tree_cursor_complex_traversal_sequence() {
+        // Complex sequence: down, sibling, sibling, up, down, sibling.
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse("my $a = 1; my $b = 2; my $c = 3;"));
+        let mut cursor = tree.walk();
+
+        // Down to first statement
+        assert!(cursor.goto_first_child(), "down to first stmt");
+        assert_eq!(cursor.node().grammar_kind(), "my_declaration");
+
+        // Move to second statement
+        assert!(cursor.goto_next_sibling(), "sibling to second stmt");
+        assert_eq!(cursor.node().grammar_kind(), "my_declaration");
+
+        // Move to third statement
+        assert!(cursor.goto_next_sibling(), "sibling to third stmt");
+        assert_eq!(cursor.node().grammar_kind(), "my_declaration");
+
+        // No fourth statement
+        assert!(!cursor.goto_next_sibling(), "no fourth statement");
+
+        // Back to root
+        assert!(cursor.goto_parent(), "back to root");
+        assert_eq!(cursor.node().grammar_kind(), "source_file");
+
+        // Down to first again
+        assert!(cursor.goto_first_child(), "down to first again");
+        assert_eq!(cursor.node().grammar_kind(), "my_declaration");
+    }
+
+    #[test]
+    fn test_tree_cursor_node_identity_after_traversal() {
+        // A node retrieved at the same path should be equal across separate traversals.
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse("my $x = 1;"));
+        let mut cursor = tree.walk();
+
+        // First traversal: get to first child and extract its kind
+        assert!(cursor.goto_first_child());
+        let first_kind = cursor.node().grammar_kind().to_string();
+
+        // Reset and repeat
+        cursor.reset();
+        assert!(cursor.goto_first_child());
+        let second_kind = cursor.node().grammar_kind().to_string();
+
+        assert_eq!(
+            first_kind, second_kind,
+            "node at the same path should have the same kind in both traversals"
+        );
+    }
+
+    #[test]
+    fn test_tree_cursor_sibling_with_unicode_identifiers() {
+        // Cursor must correctly navigate siblings even when source contains Unicode.
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse("my $café = 1; my $naïve = 2;"));
+        let mut cursor = tree.walk();
+
+        let root = tree.root_node();
+        let expected_count = root.child_count();
+
+        // Count siblings via cursor
+        assert!(cursor.goto_first_child());
+        let mut count = 1;
+        while cursor.goto_next_sibling() {
+            count += 1;
+        }
+
+        assert_eq!(
+            count, expected_count,
+            "sibling count should match even with Unicode identifiers"
+        );
+    }
+
+    #[test]
+    fn test_tree_cursor_deeply_nested_structure() {
+        // Verify cursor can navigate a deeply nested structure without stack overflow.
+        let mut parser = Parser::new();
+        // Create nested blocks: { { { ... } } }
+        let mut code = String::new();
+        for i in 0..5 {
+            code.push_str(&format!("sub level_{} {{ ", i));
+        }
+        code.push_str("1;");
+        for _ in 0..5 {
+            code.push_str(" }");
+        }
+
+        let tree = must_some(parser.parse(&code));
+        let mut cursor = tree.walk();
+
+        // Navigate down as far as possible
+        let mut depth = 0;
+        while cursor.goto_first_child() && depth < 50 {
+            depth += 1;
+        }
+
+        // Should have navigated several levels
+        assert!(depth > 2, "should navigate multiple levels in nested structure");
+
+        // Navigate back up
+        while cursor.goto_parent() {
+            depth -= 1;
+        }
+
+        // Should be back at root
+        assert_eq!(cursor.node().grammar_kind(), "source_file");
+        assert_eq!(depth, 0, "should have gone back up to root (depth 0)");
+    }
 }

--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -220,6 +220,14 @@ impl Tree {
     pub fn edit(&mut self, edit: &InputEdit) {
         self.pending_edits.push(edit.clone());
     }
+
+    /// Returns a cursor positioned at the root node for stateful tree traversal.
+    ///
+    /// This mirrors `tree_sitter::Tree::walk()` and is equivalent to
+    /// `tree.root_node().walk()`.
+    pub fn walk(&self) -> TreeCursor<'_> {
+        self.root_node().walk()
+    }
 }
 
 /// A borrowed reference to a node in the syntax tree.
@@ -816,6 +824,17 @@ mod tests {
         assert!(cursor.goto_next_sibling(), "first statement should have a sibling");
         assert_eq!(cursor.node().grammar_kind(), "my_declaration");
         assert!(!cursor.goto_next_sibling(), "second statement should be the last sibling");
+    }
+
+    #[test]
+    fn test_tree_walk_starts_cursor_at_root() {
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse("my $x = 1;"));
+        let mut cursor = tree.walk();
+
+        assert_eq!(cursor.node().grammar_kind(), "source_file");
+        assert!(cursor.goto_first_child(), "root should have a child");
+        assert_eq!(cursor.node().grammar_kind(), "my_declaration");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Provide a tree-level `walk` entrypoint to match `tree_sitter::Tree::walk()` ergonomics so consumers can start a `TreeCursor` directly from a `Tree` for tree-sitter compatibility.

### Description
- Add `pub fn walk(&self) -> TreeCursor<'_>` to `Tree` as a compatibility alias for `self.root_node().walk()` and add a unit test `test_tree_walk_starts_cursor_at_root` verifying traversal from the root.

### Testing
- Ran `cargo test -p tree-sitter-perl-rs` (passed), `cargo check --all-targets -p tree-sitter-perl-rs` (passed), and `cargo clippy -p tree-sitter-perl-rs --all-targets` (passed); `cargo xtask fmt` was attempted but failed due to unrelated `xtask` compile errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b6deb0c8333a7f6f0e1f292e73b)