### PR TITLE
fix(mutation): retarget cargo-mutants quote scope (#0000)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,16 +1,17 @@
 timeout_multiplier = 1.25
 
-# Mutation hardening focus area: quote parsing logic now lives in perl-quote.
+# Mutation hardening focus area: quote parsing now lives in perl-parser-core.
 # Keep this subset intentionally narrow so it stays usable in local/CI flows.
 examine_globs = [
-    "crates/perl-quote/src/lib.rs",
+    "crates/perl-parser-core/src/syntax/quote.rs",
 ]
 
-# Exercise both direct crate tests and parser-level integration tests that consume
-# quote parsing helpers via re-exports.
+# Exercise both parser-core regressions and parser-level integration tests that
+# consume quote parsing helpers via re-exports.
 additional_cargo_test_args = [
-    "-p", "perl-quote",
-    "--test", "comprehensive_unit_tests",
+    "-p", "perl-parser-core",
+    "--test", "fix_subst_unusual_delimiters_2732",
+    "--test", "fix_subst_squote_delimiter",
     "-p", "perl-parser",
     "--test", "quote_operator_tests",
     "--test", "quote_parser_mutation_survivors_elimination",


### PR DESCRIPTION
### Motivation
- Restore meaningful mutation-testing coverage for the quote parser by targeting the real implementation at `crates/perl-parser-core/src/syntax/quote.rs` because the previous target (`crates/perl-quote/src/lib.rs`) no longer exists.

### Description
- Update `.cargo/mutants.toml` to set `examine_globs` to `crates/perl-parser-core/src/syntax/quote.rs` and replace the mutation harness `additional_cargo_test_args` to include `-p perl-parser-core --test fix_subst_unusual_delimiters_2732 --test fix_subst_squote_delimiter` while retaining the parser-level quote mutation tests.

### Testing
- Ran `cargo mutants --list --no-times` which now lists 249 mutants, and `cargo test -p perl-parser-core --test fix_subst_unusual_delimiters_2732 --test fix_subst_squote_delimiter` which passed; a longer `cargo test -p perl-parser --test quote_operator_tests --test quote_parser_mutation_survivors_elimination` was attempted but aborted in this environment due to extended compile/test time rather than a test failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0d6db920833384d81f531f34060f)