### PR TITLE
fix(tests): escape/drop brace-form interpolation in assert messages (#5494)

### DIFF
--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1734,7 +1734,7 @@ my $msg = "value: ${Foo::name}";
     let table = parse_and_extract(code);
     assert!(
         table.references.contains_key("Foo::name"),
-        "${Foo::name} inside a double-quoted string should register a reference",
+        "Foo::name inside a double-quoted string should register a reference",
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fire fix for master break #2. The assert message on `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs:1737` contained `${Foo::name}` — `assert!` treats the message as a format string, and `${...}` is an invalid format specifier, causing compile failure.

Changed the message from `"${Foo::name} inside a double-quoted string..."` to `"Foo::name inside a double-quoted string..."` — drops the literal `${...}` visual (still semantically clear), since the braces aren't carrying meaning for the test.

Introduced by a36f79ac9 (PR #5090).

Closes #5494

## Test plan

- [x] `cargo check --workspace --all-targets` passes (no errors)
- [x] `cargo test -p perl-semantic-analyzer` passes (794 tests)