### PR TITLE
chore(tooling): add upstream-log helper recipe (#0000)

### DIFF
--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -78,7 +78,9 @@ perl-dap --stdio  # Standard DAP transport
 ```bash
 # Workspace health check (run before any agent-spawning session)
 just doctor         # Detects+fixes core.bare, worktree leaks, stale branches, etc.
-just upstream-log   # Shows recent commits from auto-detected upstream ref
+
+# Developer utilities
+just upstream-log   # Shows recent N commits from auto-detected upstream ref
 
 # Check the local environment (tools, Rust components)
 just devex          # Alias: just doctor-env

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -78,6 +78,7 @@ perl-dap --stdio  # Standard DAP transport
 ```bash
 # Workspace health check (run before any agent-spawning session)
 just doctor         # Detects+fixes core.bare, worktree leaks, stale branches, etc.
+just upstream-log   # Shows recent commits from auto-detected upstream ref
 
 # Check the local environment (tools, Rust components)
 just devex          # Alias: just doctor-env

--- a/justfile
+++ b/justfile
@@ -735,7 +735,7 @@ upstream-log count='20' base='':
     fi
     if [ -z "$base" ]; then
         echo "ERROR: Could not auto-detect base ref."
-        echo "Hint: run 'just upstream-log <count> <base-ref>' (example: just upstream-log 20 HEAD)."
+        echo "Hint: run 'just upstream-log <count> <base-ref>' (example: just upstream-log 20 origin/master)."
         exit 1
     fi
     echo "Showing last $count commits from $base"

--- a/justfile
+++ b/justfile
@@ -707,6 +707,40 @@ devex-targeted base='' mode='all':
     echo "Running targeted checks (base=$base, mode={{mode}})..."
     cargo xtask targeted-checks --base "$base" --mode "{{mode}}"
 
+# Show recent upstream commits using an auto-detected base ref.
+# Helpful in detached or minimal-clone environments where origin/master may not exist.
+upstream-log count='20' base='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    base="{{base}}"
+    count="{{count}}"
+    if ! [[ "$count" =~ ^[1-9][0-9]*$ ]]; then
+        echo "ERROR: count must be a positive integer (received: $count)"
+        exit 1
+    fi
+    if [ -z "$base" ]; then
+        base=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+    fi
+    if [ -z "$base" ] && git rev-parse --verify --quiet origin/main >/dev/null; then
+        base="origin/main"
+    fi
+    if [ -z "$base" ] && git rev-parse --verify --quiet origin/master >/dev/null; then
+        base="origin/master"
+    fi
+    if [ -z "$base" ] && git rev-parse --verify --quiet main >/dev/null; then
+        base="main"
+    fi
+    if [ -z "$base" ] && git rev-parse --verify --quiet master >/dev/null; then
+        base="master"
+    fi
+    if [ -z "$base" ]; then
+        echo "ERROR: Could not auto-detect base ref."
+        echo "Hint: run 'just upstream-log <count> <base-ref>' (example: just upstream-log 20 HEAD)."
+        exit 1
+    fi
+    echo "Showing last $count commits from $base"
+    git log "$base" --oneline -n "$count"
+
 # Tool availability check (basic tools for PR-fast)
 [private]
 _check-tools-basic:


### PR DESCRIPTION
### Motivation
- Contributors in minimal or detached clones can fail when tooling assumes `origin/master`, so a stable helper to show recent upstream commits is useful.

### Description
- Add an `upstream-log` recipe to `justfile` that auto-detects an upstream/base ref (`origin/HEAD`, `origin/main`, `origin/master`, `main`, `master`), validates a positive integer `count`, and prints the last N commits, and add a brief `just upstream-log` entry to `docs/reference/COMMANDS_REFERENCE.md`.

### Testing
- Ran `git diff --check` which passed, and attempted to run `just upstream-log` but the `just` binary is not installed in this environment so the recipe could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1d8ac3348333b5d38fb6ddce896a)