### PR TITLE
fix(incremental-parsing): reuse shifted nodes in batch edits (#0000)

### DIFF
--- a/crates/perl-incremental-parsing/src/incremental/incremental_document.rs
+++ b/crates/perl-incremental-parsing/src/incremental/incremental_document.rs
@@ -145,7 +145,7 @@ impl IncrementalDocument {
             sorted_edits.iter().map(|e| (e.start_byte, e.old_end_byte)).collect();
 
         // Collect reusable subtrees outside affected ranges
-        let reusable = self.find_reusable_for_ranges(&affected_ranges);
+        let reusable = self.find_reusable_for_ranges(&affected_ranges, &sorted_edits);
 
         // Parse with reuse when possible
         let new_root = if !reusable.is_empty() {
@@ -239,7 +239,11 @@ impl IncrementalDocument {
     }
 
     /// Find reusable subtrees for multiple affected ranges
-    fn find_reusable_for_ranges(&mut self, ranges: &[(usize, usize)]) -> Vec<Arc<Node>> {
+    fn find_reusable_for_ranges(
+        &mut self,
+        ranges: &[(usize, usize)],
+        edits: &[IncrementalEdit],
+    ) -> Vec<Arc<Node>> {
         let mut reusable = Vec::new();
 
         for ((start, end), node) in &self.subtree_cache.by_range {
@@ -249,15 +253,32 @@ impl IncrementalDocument {
             });
 
             if !affected {
-                reusable.push(node.clone());
-                self.metrics.cache_hits += 1;
-                self.metrics.nodes_reused += self.count_nodes(node);
+                let delta = Self::cumulative_shift_before(*start, edits);
+                if delta == 0 {
+                    reusable.push(node.clone());
+                    self.metrics.cache_hits += 1;
+                    self.metrics.nodes_reused += self.count_nodes(node);
+                } else if let Some(adjusted) = self.adjust_node_position(node, delta) {
+                    reusable.push(Arc::new(adjusted));
+                    self.metrics.cache_hits += 1;
+                    self.metrics.nodes_reused += self.count_nodes(node);
+                } else {
+                    self.metrics.cache_misses += 1;
+                }
             } else {
                 self.metrics.cache_misses += 1;
             }
         }
 
         reusable
+    }
+
+    fn cumulative_shift_before(pos: usize, edits: &[IncrementalEdit]) -> isize {
+        edits
+            .iter()
+            .filter(|edit| edit.old_end_byte <= pos)
+            .map(IncrementalEdit::byte_shift)
+            .sum()
     }
 
     /// Incrementally parse with subtree reuse.
@@ -1172,6 +1193,27 @@ mod tests {
             doc.metrics.last_parse_time_ms < 10.0,
             "Incremental parse time was {:.2}ms, which exceeds 10.0ms threshold",
             doc.metrics.last_parse_time_ms
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_batch_edits_reuse_shifted_nodes() -> ParseResult<()> {
+        let source = r#"
+            my $x = 1;
+            my $y = $x + 1;
+        "#;
+        let mut doc = IncrementalDocument::new(source.to_string())?;
+
+        let mut edits = IncrementalEditSet::new();
+        edits.add(IncrementalEdit::new(0, 0, "# inserted header\n".to_string()));
+
+        doc.apply_edits(&edits)?;
+
+        assert!(
+            doc.metrics.nodes_reused > 0,
+            "Batch edits should reuse nodes even when edit shifts all positions"
         );
 
         Ok(())

--- a/crates/perl-incremental-parsing/src/incremental/incremental_document.rs
+++ b/crates/perl-incremental-parsing/src/incremental/incremental_document.rs
@@ -1200,20 +1200,65 @@ mod tests {
 
     #[test]
     fn test_batch_edits_reuse_shifted_nodes() -> ParseResult<()> {
-        let source = r#"
-            my $x = 1;
-            my $y = $x + 1;
-        "#;
+        // Regression test: a batch insert at byte 0 shifts all cached node positions.
+        // After the fix, find_reusable_for_ranges computes cumulative_shift_before and
+        // calls adjust_node_position so nodes splice into the fresh parse correctly.
+        //
+        // NOTE: `nodes_reused > 0` alone is insufficient — on master that metric is
+        // incremented in find_reusable_for_ranges even when the splice later silently
+        // fails due to stale positions.  We additionally verify the root end-position
+        // matches a full re-parse of the new source.
+        let source = "my $x = 1;\nmy $y = $x + 1;";
+        let header = "# inserted header\n";
+        let new_source = format!("{header}{source}");
+
         let mut doc = IncrementalDocument::new(source.to_string())?;
 
         let mut edits = IncrementalEditSet::new();
-        edits.add(IncrementalEdit::new(0, 0, "# inserted header\n".to_string()));
-
+        edits.add(IncrementalEdit::new(0, 0, header.to_string()));
         doc.apply_edits(&edits)?;
 
+        // The root node produced by apply_edits must span the full new source.
+        let full_root = Parser::new(&new_source).parse()?;
+        assert_eq!(
+            doc.root.location.end,
+            full_root.location.end,
+            "incremental root end ({}) must match full-parse root end ({})",
+            doc.root.location.end,
+            full_root.location.end,
+        );
         assert!(
             doc.metrics.nodes_reused > 0,
             "Batch edits should reuse nodes even when edit shifts all positions"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_two_insertions_cumulative_shift() -> ParseResult<()> {
+        // Two insertions at different positions exercise the cumulative_shift_before
+        // summation: nodes after both insertions must be shifted by the total delta.
+        let source = "my $a = 1;\nmy $b = 2;\nmy $c = 3;";
+        let insert1 = "# A\n"; // 4 bytes at position 0
+        let insert2 = "# C\n"; // 4 bytes before "my $c"
+        let pos2 = source.find("my $c").expect("test source must contain 'my $c'");
+        let new_source = format!("{insert1}{}{insert2}{}", &source[..pos2], &source[pos2..]);
+
+        let mut doc = IncrementalDocument::new(source.to_string())?;
+        let mut edits = IncrementalEditSet::new();
+        // Edits in ascending order; apply_edits re-sorts them descending internally.
+        edits.add(IncrementalEdit::new(0, 0, insert1.to_string()));
+        edits.add(IncrementalEdit::new(pos2, pos2, insert2.to_string()));
+        doc.apply_edits(&edits)?;
+
+        let full_root = Parser::new(&new_source).parse()?;
+        assert_eq!(
+            doc.root.location.end,
+            full_root.location.end,
+            "root end after two insertions: incremental={}, full-parse={}",
+            doc.root.location.end,
+            full_root.location.end,
         );
 
         Ok(())


### PR DESCRIPTION
### Motivation
- Batch `apply_edits` only considered cached subtree byte ranges from the original document, so earlier edits in a batch that shift later node positions prevented reuse of otherwise unaffected subtrees.
- The change enables reuse when multiple edits shift node offsets (for example, an insertion at byte 0) to improve incremental parse reuse and metrics.

### Description
- Updated `apply_edits` to pass the sorted edit list into the reusable-subtree collector so reuse decisions can account for cumulative shifts via `find_reusable_for_ranges(&affected_ranges, &sorted_edits)`.
- Extended `find_reusable_for_ranges` to accept `edits: &[IncrementalEdit]` and compute a `cumulative_shift_before` for candidate subtree start positions before deciding reuse or applying `adjust_node_position`.
- Added `cumulative_shift_before` helper that sums `IncrementalEdit::byte_shift()` for edits that end before a given position so nodes can be adjusted to their post-edit offsets.
- Added a regression test `test_batch_edits_reuse_shifted_nodes` that inserts at byte 0 and asserts nodes are still reused after the batch edit.

### Testing
- Ran `cargo test -p perl-incremental-parsing` and all tests passed (multiple unit/extended/integration suites; 48 + 162 + 107 + 13 + 24 tests shown as passing in the run).
- Ran `cargo check --all-targets -p perl-incremental-parsing` and it completed successfully.
- Ran `cargo clippy -p perl-incremental-parsing` which succeeded, while `cargo clippy -p perl-incremental-parsing --all-targets -- -D warnings` produced failures due to pre-existing bench lints in unrelated benchmark code.
- Formatting via `cargo xtask fmt` hit unrelated `xtask` compile errors in `xtask/src/tasks/metrics/lsp_stats.rs`, and `just pr-fast` was not available in this environment, so those gates were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1da324288333ab528c32930fc897)