### PR TITLE
fix(incremental-parsing): validate edit bounds and UTF-8 boundaries (#0000)

### DIFF
--- a/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
+++ b/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
@@ -979,4 +979,85 @@ mod tests {
             }) if location == invalid_start && message.contains("UTF-8 character boundary")
         ));
     }
+
+    #[test]
+    fn test_apply_edit_rejects_non_char_boundary_end() {
+        // Tests that `end` splitting a multibyte codepoint is caught even when
+        // `start` lands on a valid char boundary. Uses a 4-byte emoji so three
+        // interior bytes are all invalid landing spots.
+        let mut parser = CheckpointedIncrementalParser::new();
+        // 🎉 is U+1F389, encoded as 4 UTF-8 bytes
+        must(parser.parse("my $x = 1; # \u{1F389}\n".to_string()));
+
+        let source = parser.source.clone();
+        let emoji_pos = must_some(source.find('\u{1F389}'));
+        // start = beginning of emoji (valid boundary), end = 1 byte inside (invalid)
+        let valid_start = emoji_pos;
+        let invalid_end = emoji_pos + 1;
+        let edit = SimpleEdit { start: valid_start, end: invalid_end, new_text: "x".to_string() };
+        let result = parser.apply_edit(&edit);
+
+        assert!(result.is_err(), "edit whose end splits a 4-byte codepoint should return an error");
+        assert!(matches!(
+            result,
+            Err(ParseError::SyntaxError { location, .. }) if location == invalid_end
+        ));
+    }
+
+    #[test]
+    fn test_apply_edit_accepts_full_source_replacement() {
+        // Edge: start=0, end=len replaces the entire document — must succeed.
+        let mut parser = CheckpointedIncrementalParser::new();
+        let original = "my $x = 1;\n".to_string();
+        must(parser.parse(original.clone()));
+
+        let edit = SimpleEdit {
+            start: 0,
+            end: original.len(),
+            new_text: "my $y = 2;\n".to_string(),
+        };
+        let result = parser.apply_edit(&edit);
+        assert!(result.is_ok(), "full-document replacement should succeed: {result:?}");
+    }
+
+    #[test]
+    fn test_apply_edit_accepts_empty_insert_at_end() {
+        // Edge: start=len, end=len (insertion at document end) must succeed.
+        let mut parser = CheckpointedIncrementalParser::new();
+        let original = "my $x = 1;\n".to_string();
+        must(parser.parse(original.clone()));
+
+        let edit = SimpleEdit {
+            start: original.len(),
+            end: original.len(),
+            new_text: "my $y = 2;\n".to_string(),
+        };
+        let result = parser.apply_edit(&edit);
+        assert!(result.is_ok(), "insert-at-end edit should succeed: {result:?}");
+    }
+
+    #[test]
+    fn test_apply_edit_rejects_three_byte_bmp_boundary() {
+        // Tests a 3-byte BMP character (€ = U+20AC) so the interior bytes
+        // trigger the char-boundary check.
+        let mut parser = CheckpointedIncrementalParser::new();
+        // € is U+20AC, encoded as 3 UTF-8 bytes: 0xE2 0x82 0xAC
+        must(parser.parse("my $cost = 1; # \u{20AC}\n".to_string()));
+
+        let source = parser.source.clone();
+        let euro_pos = must_some(source.find('\u{20AC}'));
+        let invalid_start = euro_pos + 1; // inside the 3-byte sequence
+        let edit = SimpleEdit {
+            start: invalid_start,
+            end: invalid_start + 1,
+            new_text: "e".to_string(),
+        };
+        let result = parser.apply_edit(&edit);
+
+        assert!(result.is_err(), "edit splitting a 3-byte BMP codepoint should return an error");
+        assert!(matches!(
+            result,
+            Err(ParseError::SyntaxError { location, .. }) if location == invalid_start
+        ));
+    }
 }

--- a/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
+++ b/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
@@ -59,7 +59,9 @@
 //! These metrics can be accessed via [`CheckpointedIncrementalParser::stats()`]
 //! and formatted using the `Display` implementation for debugging and monitoring.
 
-use crate::{ast::Node, edit::Edit as OriginalEdit, error::ParseResult, parser::Parser};
+use crate::{
+    ast::Node, edit::Edit as OriginalEdit, error::ParseError, error::ParseResult, parser::Parser,
+};
 use perl_lexer::{CheckpointCache, Checkpointable, LexerCheckpoint, PerlLexer};
 use perl_parser_core::token_stream::{Token, TokenStream};
 
@@ -433,6 +435,8 @@ impl CheckpointedIncrementalParser {
 
     /// Apply an edit and reparse incrementally
     pub fn apply_edit(&mut self, edit: &SimpleEdit) -> ParseResult<Node> {
+        self.validate_edit(edit)?;
+
         self.stats.total_parses += 1;
         self.stats.incremental_parses += 1;
 
@@ -470,6 +474,51 @@ impl CheckpointedIncrementalParser {
             // No checkpoint found, full reparse
             self.parse_with_checkpoints()
         }
+    }
+
+    fn validate_edit(&self, edit: &SimpleEdit) -> ParseResult<()> {
+        if edit.start > edit.end {
+            return Err(ParseError::SyntaxError {
+                message: format!(
+                    "invalid edit range: start {} is greater than end {}",
+                    edit.start, edit.end
+                ),
+                location: edit.start,
+            });
+        }
+
+        if edit.end > self.source.len() {
+            return Err(ParseError::SyntaxError {
+                message: format!(
+                    "invalid edit range: end {} exceeds document length {}",
+                    edit.end,
+                    self.source.len()
+                ),
+                location: edit.end,
+            });
+        }
+
+        if !self.source.is_char_boundary(edit.start) {
+            return Err(ParseError::SyntaxError {
+                message: format!(
+                    "invalid edit boundary: start {} is not on a UTF-8 character boundary",
+                    edit.start
+                ),
+                location: edit.start,
+            });
+        }
+
+        if !self.source.is_char_boundary(edit.end) {
+            return Err(ParseError::SyntaxError {
+                message: format!(
+                    "invalid edit boundary: end {} is not on a UTF-8 character boundary",
+                    edit.end
+                ),
+                location: edit.end,
+            });
+        }
+
+        Ok(())
     }
 
     /// Parse with checkpoint collection and parser-token caching.
@@ -732,7 +781,7 @@ impl CheckpointedIncrementalParser {
 mod tests {
     use super::*;
     use crate::NodeKind;
-    use perl_tdd_support::must;
+    use perl_tdd_support::{must, must_some};
 
     #[test]
     fn test_checkpoint_incremental_parsing() {
@@ -895,5 +944,39 @@ mod tests {
             parser.checkpoint_cache.find_after(100).is_some(),
             "expected a checkpoint to be recorded once lexing crossed byte 100"
         );
+    }
+
+    #[test]
+    fn test_apply_edit_rejects_out_of_bounds_range() {
+        let mut parser = CheckpointedIncrementalParser::new();
+        must(parser.parse("my $x = 1;\n".to_string()));
+
+        let edit = SimpleEdit { start: 0, end: 100, new_text: "2".to_string() };
+        let result = parser.apply_edit(&edit);
+
+        assert!(result.is_err(), "out-of-bounds edit should return an error");
+        assert!(matches!(result, Err(ParseError::SyntaxError { location: 100, .. })));
+    }
+
+    #[test]
+    fn test_apply_edit_rejects_non_char_boundary_range() {
+        let mut parser = CheckpointedIncrementalParser::new();
+        must(parser.parse("my $x = \"é\";\n".to_string()));
+
+        let source = parser.source.clone();
+        let char_start = must_some(source.find('é'));
+        let invalid_start = char_start + 1;
+        let edit =
+            SimpleEdit { start: invalid_start, end: invalid_start + 1, new_text: "e".to_string() };
+        let result = parser.apply_edit(&edit);
+
+        assert!(result.is_err(), "non-char-boundary edit should return an error");
+        assert!(matches!(
+            result,
+            Err(ParseError::SyntaxError {
+                location,
+                message,
+            }) if location == invalid_start && message.contains("UTF-8 character boundary")
+        ));
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent panics and undefined behaviour when applying incremental edits that have invalid byte ranges or split UTF-8 codepoints by validating edits before mutating `source`.

### Description
- Add `validate_edit(&self, edit: &SimpleEdit) -> ParseResult<()>` to `CheckpointedIncrementalParser` and invoke it at the start of `apply_edit` to ensure `start <= end`, `end <= source.len()`, and both `start` and `end` are UTF-8 char boundaries. 
- Import `ParseError` and return `ParseError::SyntaxError` for invalid edits so callers receive a proper parse error instead of triggering `replace_range` panics.
- Add focused unit tests `test_apply_edit_rejects_out_of_bounds_range` and `test_apply_edit_rejects_non_char_boundary_range` to validate the new behavior.

### Testing
- Ran `cargo test -p perl-incremental-parsing` for the affected tests; the two new tests passed (`test_apply_edit_rejects_out_of_bounds_range`, `test_apply_edit_rejects_non_char_boundary_range`).
- Ran `cargo check --all-targets -p perl-incremental-parsing` which completed successfully.
- Ran `cargo fmt --all` to format changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1da324288333ab528c32930fc897)