### PR TITLE
fix(perl-module): improve @INC pragma statement parsing (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/use_lib.rs
+++ b/crates/perl-module/src/resolution/use_lib.rs
@@ -37,8 +37,8 @@ pub enum UseLibAction {
 pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
     let mut paths = Vec::new();
 
-    for line in source.lines() {
-        let trimmed = line.trim();
+    for statement in iter_perl_statements(source) {
+        let trimmed = statement.trim();
         if let Some(rest) = strip_use_lib_prefix(trimmed) {
             extract_paths_from_args(rest, &mut paths);
         }
@@ -52,8 +52,8 @@ pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
 pub fn extract_use_lib_operations(source: &str) -> Vec<UseLibAction> {
     let mut ops = Vec::new();
 
-    for line in source.lines() {
-        let trimmed = line.trim();
+    for statement in iter_perl_statements(source) {
+        let trimmed = statement.trim();
         if let Some(rest) = strip_use_lib_prefix(trimmed) {
             let mut paths = Vec::new();
             extract_paths_from_args(rest, &mut paths);
@@ -186,6 +186,40 @@ fn strip_no_lib_prefix(trimmed: &str) -> Option<&str> {
         return None;
     }
     Some(rest.trim_start())
+}
+
+fn iter_perl_statements(source: &str) -> Vec<&str> {
+    let mut statements = Vec::new();
+    let mut start = 0usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    for (idx, ch) in source.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' if in_single || in_double => escaped = true,
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            ';' if !in_single && !in_double => {
+                if start <= idx {
+                    statements.push(&source[start..idx]);
+                }
+                start = idx + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    if start < source.len() {
+        statements.push(&source[start..]);
+    }
+
+    statements
 }
 
 fn extract_paths_from_args(args: &str, out: &mut Vec<UseLibPath>) {

--- a/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
+++ b/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
@@ -83,3 +83,31 @@ use Lib::Thing;\n\
 
     assert_eq!(include_paths, vec!["second".to_string()]);
 }
+
+#[test]
+fn use_lib_operations_support_multiline_and_same_line_statements() {
+    let source = "\
+use lib qw(\n\
+  first\n\
+  second\n\
+);\n\
+no lib 'first'; use lib 'third';\n\
+";
+
+    let ops = extract_use_lib_operations(source);
+
+    assert_eq!(
+        ops,
+        vec![
+            UseLibAction::Add(vec![
+                UseLibPath { path: "first".to_string(), from_findbin: false },
+                UseLibPath { path: "second".to_string(), from_findbin: false },
+            ]),
+            UseLibAction::Remove(vec![UseLibPath {
+                path: "first".to_string(),
+                from_findbin: false,
+            }]),
+            UseLibAction::Add(vec![UseLibPath { path: "third".to_string(), from_findbin: false }]),
+        ]
+    );
+}


### PR DESCRIPTION
### Motivation
- `use lib`/`no lib` extraction previously scanned source line-by-line which missed multiline pragmas (for example `qw(...)`) and sequences of statements on the same line, causing incorrect lexical `@INC` handling.

### Description
- Replace line-based scanning with a quote-aware, semicolon-delimited statement iterator implemented as `iter_perl_statements` to avoid splitting inside single or double quotes and to honor escapes.
- Update `extract_use_lib_paths` and `extract_use_lib_operations` to iterate over statements produced by `iter_perl_statements` instead of `source.lines()`.
- Add unit test `use_lib_operations_support_multiline_and_same_line_statements` to cover multiline `use lib qw(...)` and same-line `no lib; use lib` cases.
- Preserve existing `FindBin` resolution and normalization behavior with no public API changes.

### Testing
- Ran `cargo test -p perl-module --test use_lib_resolution_unit_tests` and all tests passed (5 passed, 0 failed).
- Ran `cargo check --all-targets -p perl-module` which completed successfully.
- Ran `cargo clippy -p perl-module -- -D warnings` which completed successfully.
- Ran `cargo fmt -p perl-module` successfully, while `cargo xtask fmt` failed due to unrelated `xtask` compile errors in another crate and did not affect this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1da8b36c8333b3d0c594deda972b)