### PR TITLE
fix(perl-module): normalize @INC entries in URI resolution (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/uri.rs
+++ b/crates/perl-module/src/resolution/uri.rs
@@ -65,7 +65,9 @@ pub fn resolve_module_uri(
     timeout: Duration,
 ) -> ModuleUriResolution {
     let mut effective_inc_roots = Vec::new();
-    for (idx, include_path) in include_paths.iter().enumerate() {
+    let mut precedence = 0usize;
+
+    for include_path in normalized_unique_include_paths(include_paths) {
         let path = PathBuf::from(include_path);
         let kind = if path.is_absolute() {
             IncRootKind::ExternalAbsolute
@@ -75,18 +77,20 @@ pub fn resolve_module_uri(
         effective_inc_roots.push(IncRoot {
             kind,
             path,
-            precedence: idx,
+            precedence,
             source: "includePaths".to_string(),
         });
+        precedence += 1;
     }
     if use_system_inc {
-        for (offset, path) in system_inc.iter().enumerate() {
+        for path in normalized_unique_system_inc(system_inc) {
             effective_inc_roots.push(IncRoot {
                 kind: IncRootKind::InterpreterStartup,
-                path: path.clone(),
-                precedence: include_paths.len() + offset,
+                path,
+                precedence,
                 source: "interpreter-startup-inc".to_string(),
             });
+            precedence += 1;
         }
     }
     resolve_module_uri_with_effective_inc(
@@ -96,6 +100,34 @@ pub fn resolve_module_uri(
         &effective_inc_roots,
         timeout,
     )
+}
+
+fn normalized_unique_include_paths(include_paths: &[String]) -> Vec<&str> {
+    let mut normalized = Vec::new();
+    for include_path in include_paths {
+        let trimmed = include_path.trim();
+        if trimmed.is_empty() || normalized.contains(&trimmed) {
+            continue;
+        }
+        normalized.push(trimmed);
+    }
+    normalized
+}
+
+fn normalized_unique_system_inc(system_inc: &[PathBuf]) -> Vec<PathBuf> {
+    let mut normalized = Vec::new();
+    for path in system_inc {
+        let trimmed = path.to_string_lossy().trim().to_string();
+        if trimmed.is_empty() || trimmed == "." {
+            continue;
+        }
+        let normalized_path = PathBuf::from(trimmed);
+        if normalized.contains(&normalized_path) {
+            continue;
+        }
+        normalized.push(normalized_path);
+    }
+    normalized
 }
 
 /// Resolve a module name to a `file://` URI using an ordered effective `@INC` model.

--- a/crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs
+++ b/crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs
@@ -566,6 +566,59 @@ fn empty_include_paths_skips_workspace_search() -> Result<(), Box<dyn std::error
 }
 
 #[test]
+fn whitespace_include_path_entries_are_ignored() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp, workspace_uri) = setup_workspace_with_module("lib/Trim/Me.pm")?;
+
+    let result = resolve_module_uri(
+        "Trim::Me",
+        &[],
+        &[workspace_uri],
+        &["  ".to_string(), "\t".to_string(), "lib".to_string(), " lib ".to_string()],
+        false,
+        &[],
+        Duration::from_millis(100),
+    );
+
+    match result {
+        ModuleUriResolution::Resolved(uri) => {
+            assert!(uri.ends_with("Trim/Me.pm"));
+        }
+        other => return Err(format!("expected Resolved, got {other:?}").into()),
+    }
+    Ok(())
+}
+
+#[test]
+fn duplicate_system_inc_entries_do_not_change_resolution_order()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let first_inc = temp.path().join("inc-1");
+    let second_inc = temp.path().join("inc-2");
+    std::fs::create_dir_all(first_inc.join("Sys"))?;
+    std::fs::create_dir_all(second_inc.join("Sys"))?;
+    std::fs::write(first_inc.join("Sys").join("Dup.pm"), "# first")?;
+    std::fs::write(second_inc.join("Sys").join("Dup.pm"), "# second")?;
+
+    let result = resolve_module_uri(
+        "Sys::Dup",
+        &[],
+        &[],
+        &[],
+        true,
+        &[PathBuf::from("  "), PathBuf::from("."), first_inc.clone(), first_inc, second_inc],
+        Duration::from_millis(100),
+    );
+
+    match result {
+        ModuleUriResolution::Resolved(uri) => {
+            assert!(uri.contains("inc-1"), "first unique @INC should win, got: {uri}");
+        }
+        other => return Err(format!("expected Resolved, got {other:?}").into()),
+    }
+    Ok(())
+}
+
+#[test]
 fn empty_workspace_folders_skips_to_system_inc() -> Result<(), Box<dyn std::error::Error>> {
     let temp = tempfile::tempdir()?;
     let inc_dir = temp.path().join("perl5");


### PR DESCRIPTION
### Motivation

- Module URI resolution accepted raw include/system `@INC` inputs which allowed whitespace-only entries and duplicates to affect deterministic search precedence.

### Description

- Trimmed and deduplicated `include_paths` before building effective `IncRoot` entries and assigned stable `precedence` ordering after normalization.
- Filtered, trimmed, and deduplicated system `@INC` entries, dropping `"."` and empty entries, and preserved deterministic ordering when adding them to effective roots.
- Reworked precedence bookkeeping so normalized entries keep a single monotonic `precedence` sequence across include and system roots.
- Added regression tests in `crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs` that assert whitespace-only `includePaths` are ignored and duplicate system `@INC` entries do not change resolution order.

### Testing

- Ran `cargo test -p perl-module` and all tests passed.
- Ran `cargo check --all-targets -p perl-module` which completed successfully.
- Noted unrelated workspace tooling checks: `cargo xtask fmt` failed due to pre-existing `xtask` compile errors and `cargo clippy` surfaced a pre-existing test warning in another file; these issues are external to the `perl-module` changes and were not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1da8b36c8333b3d0c594deda972b)