### PR TITLE
fix(perl-module): improve multiline @INC pragma parsing (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/use_lib.rs
+++ b/crates/perl-module/src/resolution/use_lib.rs
@@ -37,8 +37,8 @@ pub enum UseLibAction {
 pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
     let mut paths = Vec::new();
 
-    for line in source.lines() {
-        let trimmed = line.trim();
+    for statement in perl_statements(source) {
+        let trimmed = statement.trim();
         if let Some(rest) = strip_use_lib_prefix(trimmed) {
             extract_paths_from_args(rest, &mut paths);
         }
@@ -52,8 +52,8 @@ pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
 pub fn extract_use_lib_operations(source: &str) -> Vec<UseLibAction> {
     let mut ops = Vec::new();
 
-    for line in source.lines() {
-        let trimmed = line.trim();
+    for statement in perl_statements(source) {
+        let trimmed = statement.trim();
         if let Some(rest) = strip_use_lib_prefix(trimmed) {
             let mut paths = Vec::new();
             extract_paths_from_args(rest, &mut paths);
@@ -312,4 +312,48 @@ fn normalize_findbin_path(base: &Path, relative: &str) -> Option<PathBuf> {
         }
     }
     Some(normalized)
+}
+
+fn perl_statements(source: &str) -> Vec<&str> {
+    let mut statements = Vec::new();
+    let mut start = 0;
+    let mut quote: Option<u8> = None;
+    let bytes = source.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        match quote {
+            Some(q) => {
+                if b == b'\\' {
+                    i = i.saturating_add(2);
+                    continue;
+                }
+                if b == q {
+                    quote = None;
+                }
+            }
+            None => {
+                if b == b'\'' || b == b'"' {
+                    quote = Some(b);
+                } else if b == b';' {
+                    if let Some(stmt) = source.get(start..=i) {
+                        statements.push(stmt);
+                    }
+                    start = i + 1;
+                }
+            }
+        }
+
+        i += 1;
+    }
+
+    if start < source.len()
+        && let Some(stmt) = source.get(start..)
+    {
+        statements.push(stmt);
+    }
+
+    statements
 }

--- a/crates/perl-module/src/resolution/use_lib.rs
+++ b/crates/perl-module/src/resolution/use_lib.rs
@@ -318,11 +318,21 @@ fn perl_statements(source: &str) -> Vec<&str> {
     let mut statements = Vec::new();
     let mut start = 0;
     let mut quote: Option<u8> = None;
+    let mut in_comment = false;
     let bytes = source.as_bytes();
     let mut i = 0;
 
     while i < bytes.len() {
         let b = bytes[i];
+
+        if in_comment {
+            // Comments run to end of line; a `\n` terminates them.
+            if b == b'\n' {
+                in_comment = false;
+            }
+            i += 1;
+            continue;
+        }
 
         match quote {
             Some(q) => {
@@ -335,7 +345,9 @@ fn perl_statements(source: &str) -> Vec<&str> {
                 }
             }
             None => {
-                if b == b'\'' || b == b'"' {
+                if b == b'#' {
+                    in_comment = true;
+                } else if b == b'\'' || b == b'"' {
                     quote = Some(b);
                 } else if b == b';' {
                     if let Some(stmt) = source.get(start..=i) {

--- a/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
+++ b/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
@@ -123,3 +123,19 @@ no lib (\n\
 
     assert!(include_paths.is_empty(), "no lib should cancel multiline use lib");
 }
+
+#[test]
+fn semicolon_inside_comment_does_not_split_statement() {
+    // A `#` comment containing `;` must not trigger a false statement split.
+    let source = "use lib 'mylib'; # do not split; here\nuse lib 'other';\n";
+
+    let ops = extract_use_lib_operations(source);
+    assert_eq!(
+        ops,
+        vec![
+            UseLibAction::Add(vec![UseLibPath { path: "mylib".to_string(), from_findbin: false }]),
+            UseLibAction::Add(vec![UseLibPath { path: "other".to_string(), from_findbin: false }]),
+        ],
+        "comment-embedded semicolon should not create extra use-lib operations"
+    );
+}

--- a/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
+++ b/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
@@ -83,3 +83,43 @@ use Lib::Thing;\n\
 
     assert_eq!(include_paths, vec!["second".to_string()]);
 }
+
+#[test]
+fn multiline_use_lib_is_extracted() {
+    let source = "\
+use lib (\n\
+    'first',\n\
+    'second'\n\
+);\n\
+";
+
+    let ops = extract_use_lib_operations(source);
+    assert_eq!(
+        ops,
+        vec![UseLibAction::Add(vec![
+            UseLibPath { path: "first".to_string(), from_findbin: false },
+            UseLibPath { path: "second".to_string(), from_findbin: false },
+        ])]
+    );
+}
+
+#[test]
+fn multiline_use_and_no_lib_are_ordered() {
+    let source = "\
+use lib (\n\
+    'first'\n\
+);\n\
+no lib (\n\
+    'first'\n\
+);\n\
+";
+
+    let include_paths = resolve_use_lib_paths_from_source_at_offset(
+        source,
+        source.len(),
+        Path::new("/workspace"),
+        None,
+    );
+
+    assert!(include_paths.is_empty(), "no lib should cancel multiline use lib");
+}


### PR DESCRIPTION
### Motivation

- `use lib` / `no lib` extraction scanned source line-by-line which failed to capture multiline pragma forms and could break lexical `@INC` ordering.
- The goal is to reliably extract lexical include-path operations from real-world Perl source that uses parenthesized / multi-line `use lib` forms.

### Description

- Replace per-line scanning with a small statement splitter `perl_statements` that splits on semicolons while honoring single- and double-quoted strings to avoid cutting inside literals.
- Iterate `perl_statements(source)` in `extract_use_lib_paths` and `extract_use_lib_operations` so `use lib (...)` and `no lib (...)` forms spanning multiple lines are parsed correctly.
- Add focused unit tests `multiline_use_lib_is_extracted` and `multiline_use_and_no_lib_are_ordered` to validate multiline extraction and cancellation ordering.
- Changes touch `crates/perl-module/src/resolution/use_lib.rs` and `crates/perl-module/tests/use_lib_resolution_unit_tests.rs` only.

### Testing

- Ran `cargo test -p perl-module --test use_lib_resolution_unit_tests` and all new and existing tests in that test binary passed (6 tests, all ok).
- Ran `cargo check --all-targets -p perl-module` which completed successfully.
- Ran `cargo clippy -p perl-module -- -D warnings` which completed successfully for the modified crate.
- `cargo xtask fmt` hit unrelated compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` outside the scope of this change and is known pre-existing noise.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1da8b36c8333b3d0c594deda972b)