### PR TITLE
fix(perl-module): improve @INC use lib statement parsing (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/use_lib.rs
+++ b/crates/perl-module/src/resolution/use_lib.rs
@@ -37,9 +37,8 @@ pub enum UseLibAction {
 pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
     let mut paths = Vec::new();
 
-    for line in source.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = strip_use_lib_prefix(trimmed) {
+    for statement in iter_perl_statements(source) {
+        if let Some(rest) = strip_use_lib_prefix(statement) {
             extract_paths_from_args(rest, &mut paths);
         }
     }
@@ -52,9 +51,8 @@ pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
 pub fn extract_use_lib_operations(source: &str) -> Vec<UseLibAction> {
     let mut ops = Vec::new();
 
-    for line in source.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = strip_use_lib_prefix(trimmed) {
+    for statement in iter_perl_statements(source) {
+        if let Some(rest) = strip_use_lib_prefix(statement) {
             let mut paths = Vec::new();
             extract_paths_from_args(rest, &mut paths);
             if !paths.is_empty() {
@@ -63,7 +61,7 @@ pub fn extract_use_lib_operations(source: &str) -> Vec<UseLibAction> {
             continue;
         }
 
-        if let Some(rest) = strip_no_lib_prefix(trimmed) {
+        if let Some(rest) = strip_no_lib_prefix(statement) {
             let mut paths = Vec::new();
             extract_paths_from_args(rest, &mut paths);
             if !paths.is_empty() {
@@ -160,6 +158,10 @@ pub fn resolve_use_lib_paths_from_source_at_offset(
         }
     }
     resolved
+}
+
+fn iter_perl_statements(source: &str) -> impl Iterator<Item = &str> {
+    source.split(';').map(str::trim).filter(|statement| !statement.is_empty())
 }
 
 fn strip_use_lib_prefix(trimmed: &str) -> Option<&str> {

--- a/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
+++ b/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
@@ -83,3 +83,31 @@ use Lib::Thing;\n\
 
     assert_eq!(include_paths, vec!["second".to_string()]);
 }
+
+#[test]
+fn extracts_use_lib_from_multiple_statements_on_same_line() {
+    let source = "use lib 'first'; use lib 'second'; no lib 'first';";
+
+    let include_paths = resolve_use_lib_paths_from_source_at_offset(
+        source,
+        source.len(),
+        Path::new("/workspace"),
+        None,
+    );
+
+    assert_eq!(include_paths, vec!["second".to_string()]);
+}
+
+#[test]
+fn extracts_multiline_use_lib_statement() {
+    let source = "use lib
+  'multi_line';
+use App::Thing;
+";
+
+    let offset = source.find("use App::Thing;").unwrap_or(source.len());
+    let include_paths =
+        resolve_use_lib_paths_from_source_at_offset(source, offset, Path::new("/workspace"), None);
+
+    assert_eq!(include_paths, vec!["multi_line".to_string()]);
+}


### PR DESCRIPTION
### Motivation

- `use lib` / `no lib` extraction previously scanned source line-by-line and missed valid Perl forms split across lines or chained on a single line, causing incorrect effective `@INC` handling.

### Description

- Parse Perl source as semicolon-delimited statements via a new `iter_perl_statements` helper and apply `use lib` / `no lib` extraction against those statements instead of raw lines.
- Wire the statement iterator into `extract_use_lib_paths` and `extract_use_lib_operations` to preserve lexical ordering and multi-statement semantics.
- Add two regression tests covering same-line multi-statements and a multiline `use lib` declaration to validate offset-aware resolution.

### Testing

- Ran `cargo test -p perl-module --test use_lib_resolution_unit_tests --quiet`, which passed.
- Ran `cargo test -p perl-module --quiet`, which passed.
- Ran `cargo check --all-targets -p perl-module`, which passed.
- Ran `cargo clippy -p perl-module --all-targets -- -D warnings`, which failed due to a pre-existing clippy lint in a test (unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1da8b36c8333b3d0c594deda972b)