### PR TITLE
docs(editors): improve IntelliJ IDEA support (#0000)

### DIFF
--- a/docs/EDITORS/INTELLIJ_IDEA_SETUP.md
+++ b/docs/EDITORS/INTELLIJ_IDEA_SETUP.md
@@ -1,0 +1,67 @@
+# IntelliJ IDEA Setup
+
+Use this guide to wire `perllsp` into IntelliJ IDEA when you are not using VS
+Code.
+
+## Prerequisites
+
+- IntelliJ IDEA installed
+- `perllsp` available on `PATH`
+- the project opened from its workspace root
+
+Validate the binary before configuring IntelliJ:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Option A: LSP Support plugin (recommended)
+
+If your IntelliJ installation includes an LSP client plugin, create a new LSP
+server entry for Perl and point it at `perllsp --stdio`.
+
+Use these values:
+
+- **Name**: `perl-lsp`
+- **Command**: `perllsp`
+- **Arguments**: `--stdio`
+- **File types / patterns**: Perl files (`*.pl`, `*.pm`, `*.t`, `*.pod`)
+- **Working directory**: `$ProjectFileDir$`
+
+After saving the server entry, reopen a Perl file and check the IntelliJ Event
+Log or LSP tool window for a successful initialize handshake.
+
+## Option B: Built-in Perl tooling + external checks
+
+If your IDE flavor does not expose LSP settings, keep IntelliJ for editing and
+run `perllsp` checks from the terminal while using the built-in Perl plugin for
+syntax highlighting/navigation.
+
+Useful commands:
+
+```bash
+perllsp --health
+just dev-watch-tests
+```
+
+## Optional: file watcher for fast feedback
+
+Create a File Watcher or External Tool that runs the repository test loop on
+save:
+
+- **Program**: `just`
+- **Arguments**: `dev-watch-tests`
+- **Working directory**: `$ProjectFileDir$`
+
+This gives IntelliJ users a continuous feedback loop similar to the VS Code
+task setup.
+
+## Troubleshooting
+
+- If IntelliJ reports that `perllsp` is missing, use an absolute path to the
+  binary in the server command.
+- If the server starts but no diagnostics appear, verify the project root in
+  the server entry is `$ProjectFileDir$`.
+- If startup fails silently, run `perllsp --health` in a terminal from the same
+  project directory to confirm runtime dependencies.

--- a/docs/how-to/CONTINUOUS_TESTING.md
+++ b/docs/how-to/CONTINUOUS_TESTING.md
@@ -54,6 +54,9 @@ Use `just dev-watch-tests` if you want the repo defaults, or run
 `cargo nextest run --profile local-fast --workspace` when you want the smaller
 test loop.
 
+For end-to-end IntelliJ setup (including `perllsp --stdio` wiring), see
+[docs/EDITORS/INTELLIJ_IDEA_SETUP.md](../EDITORS/INTELLIJ_IDEA_SETUP.md).
+
 ## When To Use Each Tool
 
 - Use `bacon` when you want a fast feedback loop while editing.

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| IntelliJ IDEA | add an LSP server entry for `perllsp --stdio` | [docs/EDITORS/INTELLIJ_IDEA_SETUP.md](../EDITORS/INTELLIJ_IDEA_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,12 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### IntelliJ IDEA
+
+If your IntelliJ installation has LSP support, register `perllsp --stdio` as a
+Perl language server and keep the working directory at `$ProjectFileDir$`.
+Use the dedicated setup guide for step-by-step instructions.
 
 ## When Setup Fails
 


### PR DESCRIPTION
### Motivation

- Provide a discoverable, end-to-end setup for IntelliJ IDEA so users can wire `perllsp --stdio` into IntelliJ and get the same continuous feedback loop available to other editors.

### Description

- Add `docs/EDITORS/INTELLIJ_IDEA_SETUP.md` and link it from `docs/how-to/EDITOR_SETUP.md` and `docs/how-to/CONTINUOUS_TESTING.md` to document LSP plugin wiring, fallback workflows, optional file-watcher setup, and troubleshooting.

### Testing

- Ran `git diff --check` which passed, and attempted `cargo test -p perl-lsp-rs` and `cargo xtask fmt` but those runs were interrupted by long-running workspace compilation in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1f7ab57883339f4f6bd5b354b503)