### PR TITLE
docs(intellij): add IDEA watch-loop setup guide (#0000)

### DIFF
--- a/docs/examples/intellij/README.md
+++ b/docs/examples/intellij/README.md
@@ -1,0 +1,32 @@
+# IntelliJ IDEA / RustRover Watch Loop Setup
+
+This example gives IntelliJ-family IDE users a copy-paste setup for the same
+continuous-testing loops documented in
+[`docs/how-to/CONTINUOUS_TESTING.md`](../../how-to/CONTINUOUS_TESTING.md).
+
+## Option A: External Tool (recommended)
+
+1. Open **Settings > Tools > External Tools**.
+2. Add a new tool with:
+   - **Name:** `perl-lsp dev-watch-tests`
+   - **Program:** `just`
+   - **Arguments:** `dev-watch-tests`
+   - **Working directory:** `$ProjectFileDir$`
+3. Run it from **Tools > External Tools**.
+
+This gives you the repo-default watcher loop and works on Linux/macOS/Windows.
+
+## Option B: Cargo command (narrower loop)
+
+If you want the smaller direct test loop, create a Cargo command run
+configuration:
+
+- **Command:** `nextest`
+- **Arguments:** `run --profile local-fast --workspace`
+- **Working directory:** `$ProjectFileDir$`
+
+## Notes
+
+- Keep the process running in a dedicated tool window while editing.
+- Stop and rerun when switching between broad (`just dev-watch-tests`) and
+  narrow (`cargo nextest`) loops.

--- a/docs/how-to/CONTINUOUS_TESTING.md
+++ b/docs/how-to/CONTINUOUS_TESTING.md
@@ -47,12 +47,16 @@ The example includes two tasks:
 ## IntelliJ Rust Plugin
 
 IntelliJ and the Rust plugin do not need a perl-lsp-specific integration point
-for this workflow. Configure an external tool or file watcher that runs one of
-the commands above.
+for this workflow, but they benefit from a concrete reusable setup.
 
-Use `just dev-watch-tests` if you want the repo defaults, or run
-`cargo nextest run --profile local-fast --workspace` when you want the smaller
-test loop.
+Use the IntelliJ example at
+[docs/examples/intellij/README.md](../examples/intellij/README.md) for:
+
+- an External Tool profile running `just dev-watch-tests` (recommended)
+- a narrower Cargo `nextest` run configuration
+
+These mirror the same repo-native loops described above while keeping setup
+steps copy-paste friendly for JetBrains IDE users.
 
 ## When To Use Each Tool
 


### PR DESCRIPTION
### Motivation
- Provide a concrete, copy-paste IntelliJ / RustRover setup so JetBrains users can run the repo-native continuous-testing loops without guessing configuration steps.

### Description
- Add `docs/examples/intellij/README.md` containing an External Tool profile for `just dev-watch-tests` and a Cargo `nextest` run-configuration, and update `docs/how-to/CONTINUOUS_TESTING.md` to point to the new example.

### Testing
- Started `cargo xtask fmt` (did not complete in this environment) and `cargo xtask fmt --check` (blocked on a build lock), so formatting checks were initiated but did not finish under the interactive runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1f7ab57883339f4f6bd5b354b503)