### PR TITLE
fix(perl-symbol): improve cursor boundary token detection (#0000)

### DIFF
--- a/crates/perl-symbol/src/cursor/mod.rs
+++ b/crates/perl-symbol/src/cursor/mod.rs
@@ -116,12 +116,27 @@ pub fn token_under_cursor(text: &str, line: usize, col_utf16: usize) -> Option<S
     let byte_pos = byte_offset_utf16(line_text, col_utf16);
     let bytes = line_text.as_bytes();
 
-    if byte_pos >= bytes.len() {
+    if bytes.is_empty() {
         return None;
     }
 
-    let mut start = byte_pos;
-    let mut end = byte_pos;
+    // Cursor positions reported by editors are often *between* characters.
+    // If the cursor is at end-of-line or on a delimiter right after a token,
+    // treat it as selecting the token immediately to the left.
+    let anchor = if byte_pos >= bytes.len() {
+        bytes.len() - 1
+    } else if !is_modchar(bytes[byte_pos]) && byte_pos > 0 && is_modchar(bytes[byte_pos - 1]) {
+        byte_pos - 1
+    } else {
+        byte_pos
+    };
+
+    if !is_modchar(bytes[anchor]) {
+        return None;
+    }
+
+    let mut start = anchor;
+    let mut end = anchor;
 
     while start > 0 && is_modchar(bytes[start - 1]) {
         start -= 1;
@@ -134,7 +149,11 @@ pub fn token_under_cursor(text: &str, line: usize, col_utf16: usize) -> Option<S
         end += 1;
     }
 
-    Some(line_text[start..end].to_string())
+    if start == end {
+        None
+    } else {
+        Some(line_text[start..end].to_string())
+    }
 }
 
 /// Check if a match at `pos..pos+word_len` is bounded by non-word chars.
@@ -165,6 +184,28 @@ mod tests {
     fn token_under_cursor_supports_sigils() {
         let text = "my $value = 1;\n";
         assert_eq!(token_under_cursor(text, 0, 5), Some("$value".to_string()));
+    }
+
+    #[test]
+    fn token_under_cursor_supports_cursor_after_token_boundary() {
+        let text = "use Demo::Worker;\n";
+        let cursor_after_token = "use Demo::Worker".len();
+        assert_eq!(
+            token_under_cursor(text, 0, cursor_after_token),
+            Some("Demo::Worker".to_string())
+        );
+    }
+
+    #[test]
+    fn token_under_cursor_supports_cursor_at_end_of_line() {
+        let text = "my $value";
+        assert_eq!(token_under_cursor(text, 0, text.len()), Some("$value".to_string()));
+    }
+
+    #[test]
+    fn token_under_cursor_returns_none_when_not_on_or_after_token() {
+        let text = "my $value = 1;\n";
+        assert_eq!(token_under_cursor(text, 0, 3), None);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Cursor-based token lookup could miss symbols when the editor caret is placed between characters, at end-of-line, or immediately after a token delimiter, causing LSP features (hover, go-to, references) to fail to find the intended symbol. 
- The intent is to anchor the cursor to the left token when appropriate and otherwise return `None` for non-token anchors to make cursor behavior deterministic.

### Description
- Updated `token_under_cursor` in `crates/perl-symbol/src/cursor/mod.rs` to compute an `anchor` that moves left when the cursor is past the end of a token or at end-of-line, and to return `None` when the anchor is not on a module/name character. 
- Added handling for empty lines and ensured the function only extracts tokens when the anchor is a valid `is_modchar`. 
- Added regression tests exercising cursor-after-token, cursor-at-end-of-line, and non-token-cursor cases in the same module's test block.

### Testing
- Ran `cargo test -p perl-symbol` and all tests passed (`20` unit tests + integration BDD and comprehensive cursor tests; overall: all passed). 
- Ran `cargo check --all-targets -p perl-symbol` which completed successfully. 
- Ran `cargo clippy -p perl-symbol --all-targets -- -D warnings` which completed successfully. 
- Attempted `cargo xtask fmt` but it failed due to unrelated compile errors in the `xtask` binary (unrelated to `perl-symbol` changes), so formatting task could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1f840b5083338e914a9d12c4dbd7)