### PR TITLE
docs(editors): add Cursor IDE setup guide (#0000)

### DIFF
--- a/docs/EDITORS/CURSOR_SETUP.md
+++ b/docs/EDITORS/CURSOR_SETUP.md
@@ -1,0 +1,66 @@
+# Cursor IDE Setup Guide for perl-lsp
+
+Cursor is a VS Code-derived editor, so `perl-lsp` works with the same LSP wiring model: launch `perllsp --stdio` and keep the project root as the workspace folder.
+
+## Prerequisites
+
+- Cursor installed
+- `perllsp` installed and available on `PATH`
+- a Perl project opened as a folder/workspace in Cursor
+
+Verify the server before configuring the editor:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Installation Paths
+
+Use one of these:
+
+- install `perllsp` from crates.io: `cargo install perllsp`
+- download a release binary from GitHub Releases
+- build from source in this repository
+
+If Cursor cannot find `perllsp`, set an absolute path in your LSP client settings or launch Cursor from a terminal where `perllsp --version` already works.
+
+## Recommended Setup (Official perl-lsp Extension)
+
+Cursor can install compatible VS Code extensions. The easiest setup is the official extension:
+
+- Extension ID: `EffortlessMetrics.perl-lsp-rs`
+- Then open a `.pl`, `.pm`, or `.t` file and confirm LSP features start automatically.
+
+Optional workspace settings (`.vscode/settings.json` in your project):
+
+```json
+{
+  "perl-lsp.enableDiagnostics": true,
+  "perl-lsp.enableSemanticTokens": true,
+  "perl-lsp.enableFormatting": true,
+  "perl-lsp.enableRefactoring": true
+}
+```
+
+## Manual Fallback (Generic LSP Client)
+
+If you prefer a generic LSP client in Cursor, configure the command exactly as:
+
+```json
+{
+  "command": ["perllsp", "--stdio"],
+  "languages": ["perl"]
+}
+```
+
+Use your extension's schema for the exact setting keys; the important part is the process command and Perl file association.
+
+## Quick Validation Checklist
+
+1. Open a Perl file in Cursor.
+2. Trigger hover on `print` (or another built-in) and confirm docs/signature appear.
+3. Place cursor on a symbol and run **Go to Definition**.
+4. Introduce a syntax error and confirm diagnostics appear.
+
+If any step fails, follow [TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md) and compare against the VS Code reference guide at [VS_CODE_SETUP.md](VS_CODE_SETUP.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -24,6 +24,7 @@ perllsp --health
 | Editor | Fast path | Detailed guide |
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
+| Cursor | install the `EffortlessMetrics.perl-lsp-rs` extension or point a generic client at `perllsp --stdio` | [docs/EDITORS/CURSOR_SETUP.md](../EDITORS/CURSOR_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
@@ -36,6 +37,12 @@ perllsp --health
 The repo-maintained extension is the easiest route. If you prefer a manual
 configuration, set the command to `perllsp --stdio` and keep the workspace
 root pointed at the project root.
+
+### Cursor
+
+Cursor is VS Code-compatible. Install the same `EffortlessMetrics.perl-lsp-rs`
+extension or configure a generic client to run `perllsp --stdio`. See the full
+guide at [docs/EDITORS/CURSOR_SETUP.md](../EDITORS/CURSOR_SETUP.md).
 
 ### Neovim
 

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -16,12 +16,12 @@ just editor-specific setup and feature discovery.
 
 ## What is a Language Server?
 
-A **language server** is a program that runs alongside your editor and gives it deep understanding of your code. Instead of each editor re-implementing features like "go to definition" or "show all references," the [Language Server Protocol (LSP)](https://microsoft.github.io/language-server-protocol/) defines a standard way for any editor to talk to a language-specific backend. `perllsp` is the native Perl 5 language server CLI from the perl-lsp project: it parses your code, builds an index of symbols, and responds to editor requests over JSON-RPC -- so you get IDE-grade navigation, completion, diagnostics, and refactoring in VS Code, Neovim, Emacs, Helix, or any other LSP-capable editor. No Perl runtime is required; the server is a single native binary.
+A **language server** is a program that runs alongside your editor and gives it deep understanding of your code. Instead of each editor re-implementing features like "go to definition" or "show all references," the [Language Server Protocol (LSP)](https://microsoft.github.io/language-server-protocol/) defines a standard way for any editor to talk to a language-specific backend. `perllsp` is the native Perl 5 language server CLI from the perl-lsp project: it parses your code, builds an index of symbols, and responds to editor requests over JSON-RPC -- so you get IDE-grade navigation, completion, diagnostics, and refactoring in VS Code, Cursor, Neovim, Emacs, Helix, or any other LSP-capable editor. No Perl runtime is required; the server is a single native binary.
 
 ## Prerequisites
 
 - **Rust 1.92+** (for building from source)
-- **A supported editor**: VS Code, Neovim, Emacs, Helix, or Sublime Text
+- **A supported editor**: VS Code, Cursor, Neovim, Emacs, Helix, or Sublime Text
 
 ## Installation
 


### PR DESCRIPTION
Problem: Cursor IDE users lacked a dedicated setup path in the editor documentation, making configuration discovery inconsistent.

Fix: Add a new Cursor guide at `docs/EDITORS/CURSOR_SETUP.md` and link Cursor from `docs/how-to/EDITOR_SETUP.md` and `docs/tutorials/GETTING_STARTED.md`.

Verification: Ran `cargo check -p perl-lsp-rs --all-targets`, which exercised the workspace but failed due to a pre-existing test compile error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs`; `just pr-fast` was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1f891cdc83338d8a81e6f8407ca3)