### PR TITLE
docs(editors): add Cursor setup guide (#0000)

### DIFF
--- a/docs/EDITORS/CURSOR_SETUP.md
+++ b/docs/EDITORS/CURSOR_SETUP.md
@@ -1,0 +1,55 @@
+# Cursor Setup Guide for perl-lsp
+
+This guide explains how to run `perllsp` in Cursor using the same extension
+and settings model used by VS Code.
+
+## Prerequisites
+
+- Cursor installed
+- `perllsp` installed and available on your `PATH`
+
+Verify the server first:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Install the Extension
+
+1. Open **Extensions** in Cursor.
+2. Search for `perl-lsp`.
+3. Install **EffortlessMetrics.perl-lsp-rs**.
+
+## Configure Cursor
+
+Open workspace settings and add:
+
+```json
+{
+  "perl-lsp.serverPath": "",
+  "perl-lsp.autoDownload": true,
+  "perl-lsp.trace.server": "off"
+}
+```
+
+Notes:
+
+- Leave `perl-lsp.serverPath` empty to use extension auto-download.
+- Set `perl-lsp.serverPath` to an absolute binary path if your shell `PATH`
+  differs from Cursor's app environment.
+
+## Validate in Editor
+
+Open a Perl file and confirm:
+
+- diagnostics appear while typing
+- hover information appears on built-ins
+- go-to-definition works with `F12`
+
+## Troubleshooting
+
+- If Cursor cannot find `perllsp`, set `perl-lsp.serverPath` explicitly.
+- If no LSP features appear, confirm the file language mode is Perl.
+- If features are still missing, continue with
+  [docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -24,6 +24,7 @@ perllsp --health
 | Editor | Fast path | Detailed guide |
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
+| Cursor | use VS Code-compatible settings with `perllsp --stdio` | [docs/EDITORS/CURSOR_SETUP.md](../EDITORS/CURSOR_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
@@ -36,6 +37,14 @@ perllsp --health
 The repo-maintained extension is the easiest route. If you prefer a manual
 configuration, set the command to `perllsp --stdio` and keep the workspace
 root pointed at the project root.
+
+### Cursor
+
+Cursor uses the same extension model as VS Code. Install the `perl-lsp`
+extension from the marketplace, then configure `perllsp --stdio` in Cursor's
+workspace settings when you want to use a locally installed server binary.
+See [docs/EDITORS/CURSOR_SETUP.md](../EDITORS/CURSOR_SETUP.md) for a complete
+walkthrough.
 
 ### Neovim
 
@@ -68,6 +77,8 @@ Perl source files.
 
 - If the server is not found, re-run `perllsp --version` in a shell and fix
   `PATH` first.
+- If Cursor is launched from a desktop app and cannot find `perllsp`, set the
+  explicit binary path in Cursor settings (`perl-lsp.serverPath`).
 - If the server starts but the editor stays idle, check the editor's LSP log
   and confirm the workspace root is correct.
 - If completions or diagnostics are missing, move to


### PR DESCRIPTION
### Motivation

- Provide first-class onboarding and troubleshooting for Cursor users who previously had no dedicated documentation. 
- Make Cursor parity explicit with VS Code so editors that follow the VS Code extension model have clear, reproducible steps to run `perllsp`.

### Description

- Add a new guide `docs/EDITORS/CURSOR_SETUP.md` that documents prerequisites, extension installation, workspace settings, validation steps, and basic troubleshooting. 
- Update `docs/how-to/EDITOR_SETUP.md` to include Cursor in the editor matrix, add a minimal `### Cursor` configuration section, and add a Cursor-specific troubleshooting note about setting `perl-lsp.serverPath` when the app environment does not include the expected `PATH`.

### Testing

- Ran `cargo check -p perl-lsp-rs --lib`, which completed successfully. 
- Ran `cargo check --all-targets -p perl-lsp-rs`, which failed due to a pre-existing syntax error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs` (unexpected closing delimiter), unrelated to the documentation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1f891cdc83338d8a81e6f8407ca3)