### PR TITLE
docs(editors): add Cursor IDE setup guide (#0000)

### DIFF
--- a/docs/EDITORS/CURSOR_SETUP.md
+++ b/docs/EDITORS/CURSOR_SETUP.md
@@ -1,0 +1,62 @@
+# Cursor Setup Guide for perl-lsp
+
+Cursor is VS Code-compatible, so perl-lsp setup is almost identical: install
+`perllsp`, then configure Cursor's language-server settings to launch
+`perllsp --stdio`.
+
+## Prerequisites
+
+- `perllsp` on your `PATH`
+- Cursor installed
+- A Perl workspace folder open in Cursor
+
+Verify the server first:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Minimal Cursor Configuration
+
+Create or update `.vscode/settings.json` in your project:
+
+```json
+{
+  "perl.server": {
+    "command": "perllsp",
+    "args": ["--stdio"]
+  }
+}
+```
+
+If your Cursor setup already uses another LSP extension, configure that client
+to run the same command and args.
+
+## Recommended Project Settings
+
+```json
+{
+  "perl.server": {
+    "command": "perllsp",
+    "args": ["--stdio"]
+  },
+  "perl": {
+    "featureProfile": "auto",
+    "includePaths": ["lib", "local/lib/perl5"]
+  }
+}
+```
+
+## Troubleshooting
+
+- If the server does not start, run `perllsp --version` in the same shell used
+  to launch Cursor and fix `PATH`.
+- If diagnostics or completions are missing, restart the language server from
+  the Command Palette and reopen the workspace folder.
+- For general issues, see [docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).
+
+## Related Guides
+
+- [VS Code setup](VS_CODE_SETUP.md) for extension-specific workflows
+- [Configuration reference](../reference/CONFIGURATION.md) for server settings

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -24,6 +24,7 @@ perllsp --health
 | Editor | Fast path | Detailed guide |
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
+| Cursor | configure Cursor's VS Code-compatible settings to run `perllsp --stdio` | [docs/EDITORS/CURSOR_SETUP.md](../EDITORS/CURSOR_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
@@ -36,6 +37,12 @@ perllsp --health
 The repo-maintained extension is the easiest route. If you prefer a manual
 configuration, set the command to `perllsp --stdio` and keep the workspace
 root pointed at the project root.
+
+### Cursor
+
+Cursor reads the same `.vscode/settings.json` file format as VS Code. Point
+the Perl language server command at `perllsp --stdio`; the dedicated Cursor
+guide includes a copy-paste configuration block.
 
 ### Neovim
 


### PR DESCRIPTION
### Motivation
- Cursor users did not have first-class setup instructions in the editor docs, making configuration discoverability weaker than other supported editors.

### Description
- Add a dedicated Cursor setup guide at `docs/EDITORS/CURSOR_SETUP.md` and link Cursor in the central editor matrix in `docs/how-to/EDITOR_SETUP.md` with a minimal configuration note pointing to the new guide.

### Testing
- Ran `cargo xtask fmt --check`, which failed due to pre-existing compile errors in `xtask` (unrelated to these docs changes); the failure is environmental and pre-existing. 
- Ran `cargo check --all-targets -p perl-lsp-rs`, which failed due to a pre-existing test-source syntax error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs`; this docs-only change did not introduce the failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1f891cdc83338d8a81e6f8407ca3)