### PR TITLE
docs(editors): add Windsurf setup guide (#0000)

### DIFF
--- a/docs/EDITORS/WINDSURF_SETUP.md
+++ b/docs/EDITORS/WINDSURF_SETUP.md
@@ -1,0 +1,64 @@
+# Windsurf Setup Guide for perl-lsp
+
+This guide shows the fastest way to use `perllsp` in Windsurf.
+
+## Prerequisites
+
+- Windsurf installed
+- `perllsp` available on your `PATH`
+
+Verify the server first:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Option 1: Install the perl-lsp extension from Open VSX
+
+Windsurf uses Open VSX for extensions. Install `perl-lsp-rs` from publisher
+`EffortlessMetrics` in the Extensions panel.
+
+After installing, open a Perl file (`.pl`, `.pm`, `.t`) and confirm the status
+bar shows the Perl language server is running.
+
+## Option 2: Configure perllsp manually with a generic LSP extension
+
+If you prefer a generic LSP client in Windsurf, configure it to launch:
+
+```text
+perllsp --stdio
+```
+
+Use your project root as the workspace folder so module resolution and
+workspace-wide features behave correctly.
+
+## Recommended settings
+
+In Windsurf settings JSON, keep these defaults unless you have a reason to tune
+behavior:
+
+```json
+{
+  "perl-lsp.autoDownload": true,
+  "perl-lsp.trace.server": "off",
+  "perl-lsp.enableDiagnostics": true,
+  "perl-lsp.enableFormatting": true,
+  "perl-lsp.enableRefactoring": true
+}
+```
+
+If `perllsp` is already installed system-wide, set `perl-lsp.serverPath` to the
+absolute path of your binary.
+
+## Troubleshooting
+
+- If startup fails, run `perllsp --health` in the same shell environment used by
+  Windsurf.
+- If features are missing, make sure the workspace root is the project root and
+  not a nested subdirectory.
+- For deeper diagnostics, temporarily set `"perl-lsp.trace.server": "verbose"`
+  and inspect Windsurf's extension/LSP logs.
+
+See also: [Editor Setup](../how-to/EDITOR_SETUP.md),
+[TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -24,6 +24,7 @@ perllsp --health
 | Editor | Fast path | Detailed guide |
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
+| Windsurf | install `EffortlessMetrics/perl-lsp-rs` from Open VSX | [docs/EDITORS/WINDSURF_SETUP.md](../EDITORS/WINDSURF_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
@@ -36,6 +37,12 @@ perllsp --health
 The repo-maintained extension is the easiest route. If you prefer a manual
 configuration, set the command to `perllsp --stdio` and keep the workspace
 root pointed at the project root.
+
+### Windsurf
+
+Windsurf follows the same setup model as VS Code. Install the
+`EffortlessMetrics/perl-lsp-rs` extension from Open VSX, or point a generic LSP
+client at `perllsp --stdio`.
 
 ### Neovim
 


### PR DESCRIPTION
### Motivation
- Provide first-class, targeted setup documentation for Windsurf so users do not have to infer configuration from VS Code instructions.

### Description
- Add `docs/EDITORS/WINDSURF_SETUP.md` containing prerequisites, Open VSX extension instructions, generic LSP client guidance, recommended settings, and troubleshooting, and link it from `docs/how-to/EDITOR_SETUP.md` by adding a table row and a minimal Windsurf section.

### Testing
- Ran `rg -n "Windsurf|perllsp --stdio|perl-lsp-rs" docs/how-to/EDITOR_SETUP.md docs/EDITORS/WINDSURF_SETUP.md` which located the new entries (pass).
- Ran `cargo xtask fmt` which began formatting but failed due to pre-existing compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` (undefined `last_run`/`run`), which is unrelated to this docs-only change (fail).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fa3e16c833381fae98285b476ca)