### PR TITLE
docs(editors): add Windsurf setup path (#0000)

### DIFF
--- a/docs/EDITORS/WINDSURF_SETUP.md
+++ b/docs/EDITORS/WINDSURF_SETUP.md
@@ -1,0 +1,60 @@
+# Windsurf Setup Guide for perl-lsp
+
+This guide covers the quickest ways to run `perllsp` in Windsurf.
+
+## Prerequisites
+
+- `perllsp` installed and available on `PATH`
+- Windsurf installed
+- a workspace folder opened at your project root
+
+Verify the server first:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Option 1: Use the VS Code Extension Path (Recommended)
+
+Windsurf is VS Code-compatible, so the simplest route is to use the same
+workflow as VS Code:
+
+1. Open the Extensions panel.
+2. Install the `perl-lsp` extension if it is available in your extension
+   catalog.
+3. Open a Perl file (`.pl`, `.pm`, `.t`) and confirm language features start.
+
+If your Windsurf build cannot install the extension from your catalog, use
+Option 2.
+
+## Option 2: Configure a Generic LSP Client
+
+Configure the Perl language server command to:
+
+```json
+["perllsp", "--stdio"]
+```
+
+And scope it to Perl filetypes (`perl`, `.pl`, `.pm`, `.t`).
+
+## Recommended Workspace Settings
+
+Add these to your workspace settings JSON (or the equivalent Windsurf
+settings UI):
+
+```json
+{
+  "perl.perlPath": "perl",
+  "perl.workspace.includePaths": ["lib", "local/lib/perl5"]
+}
+```
+
+## Troubleshooting
+
+- If the server does not start, run `perllsp --version` in a terminal started
+  from Windsurf to confirm `PATH` visibility.
+- If diagnostics/completion do not appear, verify the opened folder is the
+  project root (not a parent directory with no Perl sources).
+- If a specific extension setting does not appear in Windsurf, configure the
+  server via the generic command approach in Option 2.

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| Windsurf | use VS Code-compatible extension flow or generic LSP command | [docs/EDITORS/WINDSURF_SETUP.md](../EDITORS/WINDSURF_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,12 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### Windsurf
+
+Start with the VS Code-compatible extension path. If your extension catalog
+does not provide `perl-lsp`, configure a generic LSP client with
+`["perllsp", "--stdio"]` and Perl filetypes.
 
 ## When Setup Fails
 


### PR DESCRIPTION
### Motivation

- Windsurf (a VS Code-compatible IDE) was not listed in editor setup docs, making onboarding for Windsurf users unclear.
- Provide an explicit Windsurf path (extension-first plus generic LSP fallback) so users can start `perllsp` reliably in that environment.

### Description

- Add `docs/EDITORS/WINDSURF_SETUP.md` which documents two setup options (VS Code-compatible extension flow and a generic `["perllsp", "--stdio"]` client), recommended workspace settings, and troubleshooting steps.
- Update `docs/how-to/EDITOR_SETUP.md` to include Windsurf in the editor matrix and a minimal Windsurf configuration section that links to the new guide.

### Testing

- Ran `cargo xtask fmt` to verify formatting, but it failed due to pre-existing compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` unrelated to the documentation changes.
- No crate unit tests were modified or executed as part of this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fa3e16c833381fae98285b476ca)