### PR TITLE
docs(editors): add Windsurf setup guide (#0000)

### DIFF
--- a/docs/EDITORS/WINDSURF_SETUP.md
+++ b/docs/EDITORS/WINDSURF_SETUP.md
@@ -1,0 +1,58 @@
+# Windsurf Setup Guide for perl-lsp
+
+Windsurf is VS Code-compatible, so perl-lsp works with the same extension and
+settings model.
+
+## Prerequisites
+
+- `perllsp` installed and on `PATH`
+- Windsurf installed
+
+Verify the binary first:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Recommended: Install the official perl-lsp extension
+
+Install `EffortlessMetrics.perl-lsp-rs` from the Windsurf extensions UI.
+
+If you cannot access marketplace listings directly, install the packaged VSIX
+from the project releases.
+
+## Workspace settings
+
+Create or update `.vscode/settings.json` in your project:
+
+```json
+{
+  "perl-lsp.serverPath": "",
+  "perl-lsp.autoDownload": true,
+  "perl-lsp.trace.server": "off",
+  "perl-lsp.enableDiagnostics": true,
+  "perl-lsp.enableSemanticTokens": true,
+  "perl-lsp.enableFormatting": true,
+  "perl-lsp.enableRefactoring": true
+}
+```
+
+Windsurf reads this VS Code-compatible settings file and forwards those values
+to the extension.
+
+## Manual LSP fallback
+
+If you use a generic LSP client instead of the extension, point it at:
+
+```bash
+perllsp --stdio
+```
+
+## Troubleshooting
+
+- Confirm `perllsp --health` passes in a shell outside Windsurf.
+- Open extension output/log panes and look for startup errors.
+- Validate the workspace root is your project root so indexing can resolve
+  local modules.
+- For common recovery steps, see [TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| Windsurf | install `perl-lsp-rs` extension or use `perllsp --stdio` | [docs/EDITORS/WINDSURF_SETUP.md](../EDITORS/WINDSURF_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,11 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### Windsurf
+
+Windsurf is VS Code-compatible. Install `EffortlessMetrics.perl-lsp-rs` in
+Windsurf, or configure a generic client to run `perllsp --stdio`.
 
 ## When Setup Fails
 


### PR DESCRIPTION
### Motivation

- Provide Windsurf users with explicit setup guidance since Windsurf is VS Code-compatible and lacked a dedicated doc.

### Description

- Add `docs/EDITORS/WINDSURF_SETUP.md` with prerequisites, recommended extension install, `.vscode/settings.json` examples, manual `perllsp --stdio` fallback, and troubleshooting steps.
- Update `docs/how-to/EDITOR_SETUP.md` to include `Windsurf` in the editor matrix and insert a short Windsurf quick-start snippet.

### Testing

- Ran `git diff --check`, which passed for the docs changes.
- Attempted `cargo xtask fmt`; the run failed due to pre-existing compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` unrelated to this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fa3e16c833381fae98285b476ca)