### PR TITLE
docs(editors): add Windsurf setup guide (#0000)

### DIFF
--- a/docs/EDITORS/WINDSURF_SETUP.md
+++ b/docs/EDITORS/WINDSURF_SETUP.md
@@ -1,0 +1,82 @@
+# Windsurf Setup Guide for perl-lsp
+
+Windsurf is VS Code-compatible, so `perl-lsp` setup is nearly identical to VS Code.
+Use this guide when you want a direct Windsurf configuration path.
+
+## Prerequisites
+
+- `perllsp` installed and available on your `PATH`
+- Windsurf installed
+- A Perl project folder opened as the workspace root
+
+Verify your install before configuring the editor:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Option 1: Use the perl-lsp Extension
+
+If your Windsurf build can install the `perl-lsp-rs` extension, that is the
+lowest-maintenance setup.
+
+1. Open **Extensions** in Windsurf.
+2. Search for `perl-lsp`.
+3. Install the `perl-lsp-rs` extension when available.
+4. Reload the window.
+
+Then set the server path if needed:
+
+```json
+{
+  "perl-lsp.serverPath": "",
+  "perl-lsp.trace.server": "off"
+}
+```
+
+Leave `perl-lsp.serverPath` empty to use the extension's default resolution.
+Set it to an absolute path if Windsurf cannot find `perllsp` on `PATH`.
+
+## Option 2: Configure a Generic LSP Client
+
+If extension marketplace access is restricted, configure a generic LSP client in
+Windsurf and point it at `perllsp --stdio`.
+
+Use this command tuple:
+
+```json
+{
+  "command": "perllsp",
+  "args": ["--stdio"]
+}
+```
+
+Make sure the client is enabled for Perl file types (`.pl`, `.pm`, `.t`).
+
+## Recommended Workspace Settings
+
+Create or edit `.vscode/settings.json` in your project root:
+
+```json
+{
+  "perl-lsp.includePaths": ["lib", "local/lib/perl5"],
+  "perl-lsp.enableDiagnostics": true,
+  "perl-lsp.enableSemanticTokens": true,
+  "perl-lsp.enableFormatting": true,
+  "perl-lsp.formatOnSave": false,
+  "perl-lsp.trace.server": "off"
+}
+```
+
+## Troubleshooting
+
+- **Server not found**: set `perl-lsp.serverPath` to the absolute path for
+  `perllsp`.
+- **No diagnostics/completions**: verify the workspace root is the project root
+  and Perl files are recognized by the LSP client.
+- **Need deeper debugging**: set `perl-lsp.trace.server` to `"verbose"` and
+  inspect Windsurf's LSP output panel.
+
+For server-level issues, continue with
+[docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| Windsurf | install `perl-lsp-rs` or point a generic LSP client at `perllsp --stdio` | [docs/EDITORS/WINDSURF_SETUP.md](../EDITORS/WINDSURF_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,11 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### Windsurf
+
+Use the `perl-lsp-rs` extension when available. If extension installation is
+restricted, configure a generic LSP client with command `perllsp --stdio`.
 
 ## When Setup Fails
 


### PR DESCRIPTION
### Motivation

- Provide first-party setup guidance for Windsurf editors so users have a direct, discoverable path rather than relying on VS Code assumptions or ad-hoc configuration.

### Description

- Add `docs/EDITORS/WINDSURF_SETUP.md` with extension and generic LSP-client instructions and link it from the central editor matrix in `docs/how-to/EDITOR_SETUP.md`.

### Testing

- Ran `cargo xtask fmt`, which failed due to pre-existing `xtask` compile errors unrelated to this docs-only change. 
- Ran `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix`, which failed due to a pre-existing fixture/test mismatch unrelated to these documentation edits. 
- Ran `cargo test -p perl-lsp-ux-tests --lib`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fa3e16c833381fae98285b476ca)