### PR TITLE
docs(sublime): use perllsp command in setup examples (#0000)

### DIFF
--- a/docs/EDITORS/SUBLIME_SETUP.md
+++ b/docs/EDITORS/SUBLIME_SETUP.md
@@ -120,7 +120,7 @@ perllsp --health
   "clients": {
     "perl-lsp": {
       "enabled": true,
-      "command": ["perl-lsp", "--stdio"],
+      "command": ["perllsp", "--stdio"],
       "selector": "source.perl",
       "initializationOptions": {
         "perl": {
@@ -168,7 +168,7 @@ Open LSP settings (`Preferences: LSP Settings`) and add:
   "clients": {
     "perl-lsp": {
       "enabled": true,
-      "command": ["perl-lsp", "--stdio"],
+      "command": ["perllsp", "--stdio"],
       "selector": "source.perl",
       "priority": 1,
       "initializationOptions": {
@@ -436,8 +436,8 @@ To customize keybindings, edit `Preferences: Key Bindings`:
 
 1. **Verify binary is in PATH**:
    - Open terminal
-   - Run: `which perl-lsp`
-   - Should output: `/usr/local/bin/perl-lsp` or similar
+   - Run: `which perllsp`
+   - Should output: `/usr/local/bin/perllsp` or similar
 
 2. **Check LSP status**:
    - Open Command Palette: `Ctrl+Shift+P`
@@ -739,7 +739,7 @@ Enable detailed logging for troubleshooting:
   "clients": {
     "perl-lsp": {
       "enabled": true,
-      "command": ["perl-lsp", "--stdio"],
+      "command": ["perllsp", "--stdio"],
       "selector": "source.perl",
       "priority": 1,
       "initializationOptions": {


### PR DESCRIPTION
### Motivation
- Fix Sublime Text setup docs that referenced the wrong executable name so users can start the language server with the command demonstrated in the guide.

### Description
- Updated `docs/EDITORS/SUBLIME_SETUP.md` to replace `["perl-lsp", "--stdio"]` with `["perllsp", "--stdio"]` in all Sublime LSP configuration examples and changed the troubleshooting check from `which perl-lsp` to `which perllsp`.

### Testing
- Ran `cargo xtask fmt`, which failed due to unrelated compile errors in `xtask/src/tasks/metrics/lsp_stats.rs`; this is a docs-only change and no code compilation is required for the update to be correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fb9a9e8833398cbb78a86433890)