### PR TITLE
fix(workspace): accept unwrapped settings for Sublime clients (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/workspace.rs
@@ -453,6 +453,37 @@ include_paths = ["other_lib"]
     }
 
     #[test]
+    fn did_change_configuration_accepts_unwrapped_perl_settings() {
+        let server = LspServer::new();
+        let temp = tempfile::tempdir().expect("failed to create temp dir");
+        let folder = temp.path().join("folder");
+        std::fs::create_dir_all(&folder).expect("failed to create folder");
+
+        let uri = url::Url::from_directory_path(&folder).expect("failed to create uri").to_string();
+
+        server.workspace_folders.lock().push(
+            crate::runtime::workspace_folder::WorkspaceFolderState::new(uri.clone())
+                .with_path(folder),
+        );
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "workspace": {
+                    "includePaths": ["sublime_lib"],
+                    "useSystemInc": true
+                }
+            }
+        })));
+
+        let folders = server.workspace_folders.lock();
+        let folder_state = folders.iter().find(|f| f.uri == uri).expect("missing folder");
+        assert!(
+            folder_state.effective_workspace_config.include_paths.contains(&"sublime_lib".to_string())
+        );
+        assert!(folder_state.effective_workspace_config.use_system_inc);
+    }
+
+    #[test]
     fn perl_not_found_message_without_config_is_actionable() -> Result<(), Box<dyn Error>> {
         let searched = vec!["PATH".to_string(), "/usr/bin/perl".to_string()];
         let msg = perl_not_found_message(None, &searched);

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -163,6 +163,10 @@ impl Drop for IndexingGuard {
 }
 
 impl LspServer {
+    fn extract_perl_settings<'a>(settings: &'a Value) -> Option<&'a Value> {
+        settings.get("perl").or(Some(settings))
+    }
+
     /// Request `workspace/configuration` for each workspace folder (if supported).
     pub(crate) fn request_workspace_configuration_for_folders(&self) {
         if !self.client_capabilities.lock().workspace_configuration_support {
@@ -707,7 +711,7 @@ impl LspServer {
                 tracing::debug!("Configuration changed, updating server settings");
 
                 // Read perl settings once and update both configs
-                if let Some(perl) = settings.get("perl") {
+                if let Some(perl) = Self::extract_perl_settings(settings) {
                     // Check whether any perlcritic-related setting is changing before
                     // updating config so we can decide whether to reset the shared
                     // CriticAnalyzer.  The analyzer is config-bound (severity, profile)


### PR DESCRIPTION
### Motivation
- Some LSP clients (notably Sublime's LSP package) send `workspace/didChangeConfiguration` settings without wrapping them in a top-level `perl` object, causing perl-lsp to ignore those updates.

### Description
- Added `extract_perl_settings` helper in `crates/perl-lsp-rs/src/runtime/workspace.rs` to accept either `{"perl": {...}}` or an unwrapped settings object and used it in `handle_did_change_configuration`.
- Replaced direct `settings.get("perl")` checks with `Self::extract_perl_settings(...)` so server and workspace configs are updated for both payload shapes.
- Added unit test `did_change_configuration_accepts_unwrapped_perl_settings` in `crates/perl-lsp-rs/src/runtime/lifecycle/workspace.rs` that verifies `includePaths` and `useSystemInc` are applied from an unwrapped payload.

### Testing
- Ran `cargo test -p perl-lsp-rs --lib did_change_configuration_accepts_unwrapped_perl_settings`, which passed.
- Ran `cargo check -p perl-lsp-rs --lib`, which passed.
- Observed that `cargo check --all-targets -p perl-lsp-rs` and `cargo xtask fmt` fail due to pre-existing unrelated issues in the repo (a syntax error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs` and an `xtask` compile error), which are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fb9a9e8833398cbb78a86433890)