### PR TITLE
fix(perl-lsp-rs): set root path for workspaceFolders-only init (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
@@ -4,7 +4,7 @@
 
 use super::super::*;
 use perl_workspace::folder::{extract_workspace_folder_uris, root_path_to_file_uri};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 impl LspServer {
     /// Handle initialize request
@@ -198,15 +198,22 @@ impl LspServer {
             if let Some(workspace_folders) =
                 params.get("workspaceFolders").and_then(|f| f.as_array())
             {
+                let folder_uris = extract_workspace_folder_uris(workspace_folders);
                 let mut folders = self.workspace_folders.lock();
-                for uri in extract_workspace_folder_uris(workspace_folders) {
+                for uri in &folder_uris {
                     tracing::debug!(uri, "Initialized with workspace folder");
                     let mut folder =
                         super::super::workspace_folder::WorkspaceFolderState::new(uri.clone());
-                    if let Some(path) = super::super::source_path_from_uri(&uri) {
+                    if let Some(path) = super::super::source_path_from_uri(uri) {
                         folder = folder.with_path(path);
                     }
                     folders.push(folder);
+                }
+                if let Some(first_uri) = folder_uris.first() {
+                    // Some clients only send workspaceFolders (no rootUri/rootPath).
+                    // Seed root_path from the first folder so module resolution behaves
+                    // consistently in those integrations.
+                    self.set_root_uri(first_uri);
                 }
             } else if let Some(root_uri) = params.get("rootUri").and_then(|u| u.as_str()) {
                 // Fallback to rootUri if workspaceFolders is not provided
@@ -412,8 +419,8 @@ pub(crate) fn apply_disabled_feature_id(
 #[cfg(test)]
 mod tests {
     use super::apply_disabled_feature_id;
-    use crate::LspServer;
     use crate::protocol::capabilities::BuildFlags;
+    use crate::LspServer;
     use serde_json::json;
 
     #[test]
@@ -489,5 +496,27 @@ mod tests {
         let _ = server.handle_initialize(Some(params));
 
         assert!(server.client_capabilities.lock().workspace_configuration_support);
+    }
+
+    #[test]
+    fn initialize_sets_root_from_workspace_folders_when_root_uri_absent(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let temp = tempfile::tempdir()?;
+        let uri = url::Url::from_directory_path(temp.path())
+            .map_err(|()| std::io::Error::other("failed to build folder URI"))?
+            .to_string();
+
+        let params = json!({
+            "workspaceFolders": [{ "uri": uri, "name": "tmp" }]
+        });
+
+        server.handle_initialize(Some(params))?;
+
+        assert!(
+            server.root_path.lock().is_some(),
+            "workspaceFolders-only initialize should still set root path"
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Some LSP clients send `workspaceFolders` during `initialize` but omit `rootUri`/`rootPath`, leaving `root_path` unset and weakening workspace/module resolution and integration.

### Description

- Seed `root_path` from the first entry of `workspaceFolders` when `rootUri`/`rootPath` are absent so module resolution behaves consistently for those clients.
- Cache the parsed folder URIs before iterating and use them to populate `workspace_folders` and to seed `root_path` via `set_root_uri`.
- Small cleanup to avoid a needless borrow when calling `source_path_from_uri` to satisfy clippy.
- Add a regression test `initialize_sets_root_from_workspace_folders_when_root_uri_absent` that exercises a `workspaceFolders`-only initialize payload and asserts `root_path` is set.

### Testing

- Ran `rustfmt` on the modified file (`crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs`) with no issues.
- Ran `cargo check --all-targets -p perl-lsp-rs` which completed successfully.
- Ran `cargo clippy -p perl-lsp-rs --lib -- -D warnings` which completed successfully.
- Attempted `cargo test -p perl-lsp-rs initialize_sets_root_from_workspace_folders_when_root_uri_absent`; compilation and focused test invocation were exercised but the full test run timed out in this environment; no test failures were observed in the library checks performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fc8b9908333a3343ff7054dce83)