### PR TITLE
fix(workspace): accept string workspace folder URIs (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/folder/mod.rs
+++ b/crates/perl-workspace-index/src/folder/mod.rs
@@ -75,8 +75,12 @@ fn parse_file_uri_fallback(workspace_folder: &str) -> Option<PathBuf> {
 pub fn extract_workspace_folder_uris(workspace_folders: &[Value]) -> Vec<String> {
     workspace_folders
         .iter()
-        .filter_map(|folder| {
-            folder.get("uri").and_then(Value::as_str).map(std::string::ToString::to_string)
+        .filter_map(|folder| match folder {
+            Value::String(uri) => Some(uri.clone()),
+            Value::Object(_) => {
+                folder.get("uri").and_then(Value::as_str).map(std::string::ToString::to_string)
+            }
+            _ => None,
         })
         .collect()
 }
@@ -170,10 +174,11 @@ mod tests {
         let entries = vec![
             json!({"uri": "file:///one"}),
             json!({"uri": "file:///two"}),
+            json!("file:///three"),
             json!({"name": "invalid"}),
         ];
         let uris = extract_workspace_folder_uris(&entries);
-        assert_eq!(uris, vec!["file:///one", "file:///two"]);
+        assert_eq!(uris, vec!["file:///one", "file:///two", "file:///three"]);
     }
 
     #[test]

--- a/crates/perl-workspace-index/tests/workspace_folder_prop.rs
+++ b/crates/perl-workspace-index/tests/workspace_folder_prop.rs
@@ -20,6 +20,10 @@ fn uri_entry_strategy() -> impl Strategy<Value = (Option<String>, Value)> {
             let uri = format!("file:///{folder}");
             (Some(uri.clone()), json!({"uri": uri}))
         }),
+        plain_path_strategy().prop_map(|folder| {
+            let uri = format!("file:///{folder}");
+            (Some(uri.clone()), json!(uri))
+        }),
         any::<i64>().prop_map(|value| (None, json!({"uri": value}))),
         plain_path_strategy().prop_map(|folder| (None, json!({"name": folder}))),
         Just((None, json!(null))),


### PR DESCRIPTION
### Motivation
- Some LSP clients send `workspaceFolders` entries as plain URI strings instead of object entries with a `uri` field, which caused those folders to be ignored during initialization.

### Description
- Update `extract_workspace_folder_uris` in `crates/perl-workspace-index/src/folder/mod.rs` to accept both `Value::String` entries and object entries with a `uri` field. 
- Extend the unit test `extracts_workspace_uris` to include a string-form folder URI to ensure mixed payloads are handled. 
- Extend the property-test input generator in `crates/perl-workspace-index/tests/workspace_folder_prop.rs` to produce string-form workspace folder entries for fuzz coverage.

### Testing
- Ran `cargo test -p perl-workspace` and the crate's unit/property tests passed. 
- Ran `cargo check --all-targets -p perl-workspace` which completed successfully. 
- Ran `cargo clippy -p perl-workspace --all-targets -- -D warnings` which failed on pre-existing lint issues in `crates/perl-workspace-index/tests/workspace_scorecard.rs` unrelated to this change. 
- Ran `cargo xtask fmt` which failed due to pre-existing `xtask` compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` unrelated to this change. 
- `just pr-fast` was unavailable in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fc8b9908333a3343ff7054dce83)