### PR TITLE
docs(editors): add Notepad++ setup guide (#0000)

### DIFF
--- a/docs/EDITORS/NOTEPAD_PLUS_PLUS_SETUP.md
+++ b/docs/EDITORS/NOTEPAD_PLUS_PLUS_SETUP.md
@@ -1,0 +1,44 @@
+# Notepad++ Setup Guide for perl-lsp
+
+This guide shows how to run `perllsp` from Notepad++ via the LSP client plugin.
+
+## Prerequisites
+
+- Notepad++ on Windows
+- `perllsp` installed and available on `PATH`
+- An LSP client plugin for Notepad++ (for example, **NppLspClient**)
+
+Verify the server from a terminal first:
+
+```powershell
+perllsp --version
+perllsp --health
+```
+
+## Configure the LSP client
+
+In your Notepad++ LSP client settings, register a Perl server with:
+
+- **command**: `perllsp`
+- **arguments**: `--stdio`
+- **language id**: `perl`
+- **file extensions / associations**: `.pl`, `.pm`, `.t`, `.pod`, `.psgi`, `.cgi`
+
+Example server command array:
+
+```json
+["perllsp", "--stdio"]
+```
+
+## Verify in editor
+
+1. Restart Notepad++.
+2. Open a Perl file (for example `script.pl`).
+3. Confirm the LSP client reports the Perl server as started.
+4. Try hover, completion, and diagnostics.
+
+## Troubleshooting
+
+- If the server cannot be started, use an absolute path to `perllsp.exe` in the plugin settings.
+- If no features appear, verify the file is associated with Perl and the language id is `perl`.
+- If startup works but features are inconsistent, run `perllsp --health` and then follow [TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| Notepad++ | configure your LSP plugin to run `perllsp --stdio` | [docs/EDITORS/NOTEPAD_PLUS_PLUS_SETUP.md](../EDITORS/NOTEPAD_PLUS_PLUS_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,12 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### Notepad++
+
+Using your Notepad++ LSP plugin (for example NppLspClient), register a Perl
+server command as `["perllsp", "--stdio"]` and map Perl file types (`.pl`,
+`.pm`, `.t`, etc.) to language id `perl`.
 
 ## When Setup Fails
 


### PR DESCRIPTION
### Motivation
- Notepad++ users had no first-party setup instructions, making `perllsp` onboarding inconsistent across supported editors.

### Description
- Add a dedicated `docs/EDITORS/NOTEPAD_PLUS_PLUS_SETUP.md` with prerequisites, `perllsp --stdio` client configuration, verification, and troubleshooting, and link it from `docs/how-to/EDITOR_SETUP.md`.

### Testing
- Ran `cargo xtask fmt` which failed due to pre-existing `xtask` compile errors unrelated to this docs-only change, and ran `cargo check --all-targets -p perl-lsp-rs` which failed due to a pre-existing syntax error in a test (`mojolicious_navigation_tests.rs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fdaa2b48333a1f9253cd4098988)