### PR TITLE
docs(editors): add Notepad++ setup guide (#0000)

### DIFF
--- a/docs/EDITORS/NOTEPAD_PLUS_PLUS_SETUP.md
+++ b/docs/EDITORS/NOTEPAD_PLUS_PLUS_SETUP.md
@@ -1,0 +1,70 @@
+# Notepad++ Setup Guide for perl-lsp
+
+This guide shows a minimal, reliable Notepad++ setup for `perllsp` using the
+community **LSP Client** plugin.
+
+## Prerequisites
+
+- Notepad++ (Windows)
+- `perllsp` installed and available on `PATH`
+- Notepad++ plugin **LSP Client** installed from Plugins Admin
+
+Verify the language server first from `cmd.exe` or PowerShell:
+
+```powershell
+perllsp --version
+perllsp --health
+```
+
+## 1) Install the LSP Client plugin
+
+1. Open **Plugins → Plugins Admin...**
+2. Search for **LSP Client**
+3. Install and restart Notepad++
+
+## 2) Add a perl-lsp client definition
+
+1. Open **Plugins → LSP Client → Settings**
+2. Add a client entry that launches `perllsp --stdio`
+
+Use this baseline JSON as a starting point:
+
+```json
+{
+  "clients": {
+    "perl-lsp": {
+      "command": ["perllsp", "--stdio"],
+      "languages": ["perl"],
+      "enabled": true
+    }
+  }
+}
+```
+
+If your plugin version uses a different schema, keep the same essentials:
+
+- command: `perllsp --stdio`
+- language/file association: Perl (`.pl`, `.pm`, `.t`, `.psgi`)
+
+## 3) Ensure Perl files map to a Perl language
+
+If `.t` or `.psgi` files do not trigger LSP features automatically, map them to
+Perl in your Notepad++ language associations so the plugin can attach to the
+server.
+
+## 4) Validate end-to-end
+
+1. Open a project folder and a Perl file.
+2. Wait for the plugin status to show the client attached.
+3. Confirm diagnostics and hover/completion are working.
+
+## Troubleshooting
+
+- **Server not found**: restart Notepad++ from a shell where `perllsp` is on
+  `PATH`, or use the absolute path to `perllsp.exe`.
+- **No features in open file**: verify the file is recognized as Perl and that
+  the plugin actually started the `perl-lsp` client entry.
+- **Intermittent startup issues**: enable plugin logging and confirm the launch
+  command is exactly `perllsp --stdio`.
+
+For broader diagnostics, see [Troubleshooting](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| Notepad++ | add a `perllsp --stdio` client in LSP Client | [docs/EDITORS/NOTEPAD_PLUS_PLUS_SETUP.md](../EDITORS/NOTEPAD_PLUS_PLUS_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,12 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### Notepad++
+
+Install the **LSP Client** plugin, then add a Perl client whose command is
+`["perllsp", "--stdio"]`. Ensure `.pl`, `.pm`, `.t`, and `.psgi` files are
+associated with Perl so the LSP client attaches.
 
 ## When Setup Fails
 


### PR DESCRIPTION
### Motivation
- Provide first-party setup instructions so Notepad++ users can reliably connect to `perllsp` using the community LSP Client plugin.

### Description
- Add `docs/EDITORS/NOTEPAD_PLUS_PLUS_SETUP.md` with prerequisites, plugin install steps, a baseline client JSON (`perllsp --stdio`), file-association guidance, validation steps, and troubleshooting, and add a Notepad++ entry + minimal section to `docs/how-to/EDITOR_SETUP.md`.

### Testing
- Ran `git diff --check`, which passed for the docs changes.
- Ran `cargo xtask fmt --check`, which failed due to pre-existing compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` unrelated to this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fdaa2b48333a1f9253cd4098988)