### PR TITLE
fix(lsp): recognize Notepad++ Perl language ids (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -31,7 +31,17 @@ fn is_embedded_template_uri(uri: &str) -> bool {
 }
 
 fn is_perl_language_id(language_id: &str) -> bool {
-    matches!(language_id.to_ascii_lowercase().as_str(), "perl" | "perl5" | "perl-cpanfile")
+    matches!(
+        language_id.to_ascii_lowercase().as_str(),
+        "perl"
+            | "perl5"
+            | "perl-cpanfile"
+            // Notepad++ LSP clients commonly report Perl as "Perl Script"
+            // (with either a space or hyphen).
+            | "perl script"
+            | "perl-script"
+            | "perlscript"
+    )
 }
 
 #[cfg(feature = "incremental")]
@@ -2089,6 +2099,32 @@ mod tests {
             "template should remain in no-parse mode after didChange"
         );
         assert!(doc.ast.is_none(), "template should continue skipping parse on didChange");
+        Ok(())
+    }
+
+    #[test]
+    fn test_template_file_guard_allows_notepad_plus_plus_perl_language_id()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let uri = "file:///app/templates/welcome.html.ep";
+
+        server.did_open(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "Perl Script",
+                "version": 1,
+                "text": "<% my $name = 'world'; %>"
+            }
+        }))?;
+
+        let docs = server.documents.lock();
+        let doc = docs.get(uri).ok_or("template document not stored after didOpen")?;
+        assert_ne!(
+            doc.degradation_tier,
+            DegradationTier::Minimal,
+            "Perl Script languageId should be treated as Perl for template parsing"
+        );
+        assert!(doc.ast.is_some(), "Perl Script template should be parsed");
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation

- Notepad++ LSP clients commonly report Perl files with language ids like `Perl Script` (or `perl-script` / `perlscript`), which caused template files to be treated as non-Perl and forced into no-parse mode.

### Description

- Extend `is_perl_language_id` in `crates/perl-lsp-rs/src/runtime/text_sync.rs` to accept common Notepad++ variants (`Perl Script`, `perl-script`, `perlscript`) in addition to the existing `perl`, `perl5`, and `perl-cpanfile` checks.
- Add a regression unit test `test_template_file_guard_allows_notepad_plus_plus_perl_language_id` in the same file to verify that a template opened with `languageId: "Perl Script"` is parsed (not downgraded to `DegradationTier::Minimal`).

### Testing

- Ran `cargo test -p perl-lsp-rs --lib test_template_file_guard_allows_notepad_plus_plus_perl_language_id`, which passed.
- Ran `cargo clippy -p perl-lsp-rs --lib -- -D warnings`, which completed successfully for the crate.
- Ran `cargo check --all-targets -p perl-lsp-rs`, which failed due to a pre-existing syntax error in an unrelated test file (`crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs`), not caused by this change.
- Ran `cargo xtask fmt`, which could not complete due to pre-existing `xtask` build issues in the environment and is unrelated to this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fdaa2b48333a1f9253cd4098988)