### PR TITLE
docs(editors): add GNU nano companion workflow (#0000)

### DIFF
--- a/docs/EDITORS/NANO_SETUP.md
+++ b/docs/EDITORS/NANO_SETUP.md
@@ -1,0 +1,71 @@
+# GNU nano + perl-lsp Companion Workflow
+
+`perllsp` is an LSP server, and GNU nano is not an LSP client. That means nano
+cannot directly consume LSP requests/responses over stdio.
+
+You can still improve your nano workflow by pairing editing with fast CLI checks
+from `perllsp`.
+
+## What works with nano
+
+- Syntax and parse validation via `perllsp --check`
+- Project health verification via `perllsp --health`
+- Server/build metadata inspection via `perllsp --info`
+
+## What does not work inside nano
+
+- Live diagnostics while typing
+- Hover, go-to-definition, references, rename
+- Code actions and inlay hints
+
+For those features, use an LSP-capable editor listed in
+[Editor Setup](../how-to/EDITOR_SETUP.md).
+
+## Quick start
+
+1. Verify install:
+
+   ```bash
+   perllsp --version
+   perllsp --health
+   ```
+
+2. Edit in nano as usual:
+
+   ```bash
+   nano lib/My/Module.pm
+   ```
+
+3. Run a check after saving:
+
+   ```bash
+   perllsp --check lib/My/Module.pm
+   ```
+
+4. Check multiple files:
+
+   ```bash
+   perllsp --check lib/My/Module.pm script/tool.pl t/module.t
+   ```
+
+## Optional shell helper
+
+Add this helper to your shell profile for a shorter command:
+
+```bash
+perlcheck() {
+  perllsp --check "$@"
+}
+```
+
+Then run:
+
+```bash
+perlcheck lib/My/Module.pm
+```
+
+## Recommended path for full IDE features
+
+If you want completions, navigation, and refactoring while typing, keep nano for
+quick edits but add one LSP-capable editor (Neovim, Emacs, Helix, Sublime Text,
+or VS Code) for deep code-intelligence workflows.

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| GNU nano | no native LSP client support; use CLI checks alongside editing | [docs/EDITORS/NANO_SETUP.md](../EDITORS/NANO_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,13 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### GNU nano
+
+`nano` does not implement the Language Server Protocol, so it cannot attach to
+`perllsp` for in-editor features (hover, completion, go-to-definition, etc.).
+Use the companion workflow in [docs/EDITORS/NANO_SETUP.md](../EDITORS/NANO_SETUP.md)
+to keep `nano` while running fast CLI validation with `perllsp --check`.
 
 ## When Setup Fails
 


### PR DESCRIPTION
### Motivation

- Provide clear guidance for users who prefer GNU nano since nano is not an LSP client and the existing editor docs implied parity with LSP-capable editors.

### Description

- Add `docs/EDITORS/NANO_SETUP.md` providing a CLI-focused companion workflow (`perllsp --check`, `--health`, `--info`), quick start steps, and an optional shell helper.
- Update `docs/how-to/EDITOR_SETUP.md` to include GNU nano in the editor matrix and add a short `GNU nano` section that links to the new guide.

### Testing

- Verified the new file and links with `rg -n "NANO_SETUP|GNU nano|perllsp --check" docs/how-to/EDITOR_SETUP.md docs/EDITORS/NANO_SETUP.md`, which succeeded.
- Ran `cargo fmt --all -- --check`, which failed due to pre-existing unrelated workspace issues (format/syntax problems in other tests), not changes made by this PR.
- Attempted `just pr-fast`, but the `just` command is not available in this environment and could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fe62a408333b889003c0284b46a)