### PR TITLE
docs(editors): add GNU nano workflow guide (#0000)

### DIFF
--- a/docs/EDITORS/NANO_SETUP.md
+++ b/docs/EDITORS/NANO_SETUP.md
@@ -1,0 +1,51 @@
+# GNU nano Setup Guide for perl-lsp
+
+GNU nano does not include a built-in LSP client, so it cannot attach to
+`perllsp --stdio` directly.
+
+This guide gives you the best practical nano workflow today:
+
+1. Keep Perl syntax highlighting in nano.
+2. Run `perllsp` checks from the terminal for diagnostics.
+3. Use a full LSP editor (VS Code, Neovim, Emacs, Helix, Sublime) when you need
+   completions, go-to-definition, rename, and code actions.
+
+## 1) Syntax highlighting in nano
+
+Add this to `~/.nanorc`:
+
+```nanorc
+syntax "perl" "\\.(pl|pm|t|psgi)$"
+color brightgreen "\<(sub|my|our|use|package|if|else|elsif|for|foreach|while|return)\>"
+color brightblue "\$[A-Za-z_][A-Za-z0-9_]*"
+color brightcyan "@[A-Za-z_][A-Za-z0-9_]*"
+color brightmagenta "%[A-Za-z_][A-Za-z0-9_]*"
+color yellow "#.*"
+```
+
+## 2) Run diagnostics with perllsp from terminal
+
+From your project root:
+
+```bash
+perllsp --check path/to/file.pl
+```
+
+For whole-project validation:
+
+```bash
+perllsp --check-project .
+```
+
+## 3) Known limitations in nano
+
+Because nano is not an LSP client, these `perllsp` features are unavailable
+inside nano itself:
+
+- live diagnostics while typing
+- inline completions and snippets
+- go-to-definition and find references
+- rename symbol and code actions
+
+If those workflows are important, keep nano for quick edits and use one of the
+LSP-capable editors from the main setup guide for IDE features.

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| GNU nano | syntax highlighting + terminal `perllsp --check` workflow | [docs/EDITORS/NANO_SETUP.md](../EDITORS/NANO_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,12 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### GNU nano
+
+GNU nano does not expose an LSP client transport, so `perllsp --stdio` cannot
+attach directly. Use nano for editing + syntax colors, then run
+`perllsp --check <file>` or `perllsp --check-project .` from the terminal.
 
 ## When Setup Fails
 


### PR DESCRIPTION
### Motivation

- Users editing Perl in GNU nano had no documented workflow for using `perllsp` and could be confused about what features are available without an LSP-capable editor.

### Description

- Add a new guide `docs/EDITORS/NANO_SETUP.md` describing a practical nano workflow (syntax highlighting + terminal-driven `perllsp --check` / `--check-project`) and listing limitations. 
- Update `docs/how-to/EDITOR_SETUP.md` to include GNU nano in the editor matrix and add a short nano section under minimal configurations. 
- Changes are documentation-only and do not modify runtime code or library APIs.

### Testing

- Ran `cargo check -p perl-lsp-rs --all-targets`, which was executed but failed due to a pre-existing, unrelated test parse error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs` and not due to these docs changes. 
- `just pr-fast` was not available in the environment (`just: command not found`) so the full local fast gate could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fe62a408333b889003c0284b46a)