### PR TITLE
docs(editors): add Firebase Studio setup guide (#0000)

### DIFF
--- a/docs/EDITORS/FIREBASE_STUDIO_SETUP.md
+++ b/docs/EDITORS/FIREBASE_STUDIO_SETUP.md
@@ -1,0 +1,59 @@
+# Firebase Studio Setup Guide for perl-lsp
+
+Firebase Studio uses a VS Code-compatible editor surface, so perl-lsp works
+through the same LSP wiring (`perllsp --stdio`) used by other VS Code-family
+clients.
+
+## Prerequisites
+
+- `perllsp` installed in the workspace environment
+- Firebase Studio workspace opened at your project root
+- A Perl file (`.pl`, `.pm`, `.t`, etc.) in the workspace
+
+Verify the binary in the integrated terminal:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Recommended Setup (VS Code Extension Path)
+
+1. Open the Extensions view in Firebase Studio.
+2. Install the **Perl Language Server** extension (`EffortlessMetrics.perl-lsp-rs`).
+3. Open a Perl file and confirm diagnostics/completion appear.
+
+The extension auto-manages launch arguments and starts `perllsp` over stdio.
+
+## Manual Setup (Generic LSP Client)
+
+If you prefer a generic client configuration, point it at:
+
+```json
+{
+  "command": "perllsp",
+  "args": ["--stdio"]
+}
+```
+
+Use the project root as workspace root so module resolution and indexing have
+consistent include-path behavior.
+
+## Firebase Studio Tips
+
+- Add `perllsp` to your `.idx/dev.nix` so each imported workspace has the same
+  toolchain.
+- Keep your workspace opened at repository root (the folder containing `lib/`
+  and/or `t/`) to avoid partial indexing.
+- If the language server is not detected after install, reload the workspace and
+  re-run `perllsp --health` in the integrated terminal.
+
+## Troubleshooting
+
+- No diagnostics/completion: confirm `perllsp --stdio` can be launched from the
+  integrated terminal.
+- Slow first response: wait for initial workspace indexing to complete.
+- Missing cross-file navigation: verify the workspace root points at the
+  repository, not a nested subfolder.
+
+For broader troubleshooting, see [docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| Firebase Studio | use the VS Code extension or generic `perllsp --stdio` wiring | [docs/EDITORS/FIREBASE_STUDIO_SETUP.md](../EDITORS/FIREBASE_STUDIO_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,11 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### Firebase Studio
+
+Use the same VS Code-family setup path: either install the Perl Language Server
+extension or configure a generic client with `perllsp --stdio`.
 
 ## When Setup Fails
 

--- a/docs/reference/FAQ.md
+++ b/docs/reference/FAQ.md
@@ -70,6 +70,7 @@ Any editor with LSP client support works. Point it at `perllsp --stdio`:
 - **Emacs** — via `eglot` or `lsp-mode`
 - **Helix** — via `languages.toml`
 - **Sublime Text** — via the LSP package
+- **Firebase Studio** — VS Code-compatible; use the extension or `perllsp --stdio`
 - **Kate**, **Lapce**, **Kakoune** — any editor with a generic LSP client
 
 See [EDITOR_SETUP.md](../how-to/EDITOR_SETUP.md) for editor-specific configuration.


### PR DESCRIPTION
### Motivation

- Provide first-class onboarding for Firebase Studio users by documenting how to run `perllsp` in that VS Code–compatible environment instead of relying on inference.

### Description

- Add `docs/EDITORS/FIREBASE_STUDIO_SETUP.md` with prerequisites, recommended VS Code-extension path, manual `perllsp --stdio` wiring, tips, and troubleshooting notes.
- Add a Firebase Studio row to the editor table in `docs/how-to/EDITOR_SETUP.md` and a short Firebase Studio note in the minimal-config section.
- Call out Firebase Studio in the editor-support list in `docs/reference/FAQ.md`.

### Testing

- Ran `cargo test -p perl-uri --no-run`, which completed successfully (unit test binaries built).
- Ran `cargo xtask fmt --check`, which failed due to pre-existing compile errors in `xtask` unrelated to this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea20315df0833399590f21b031e1b8)