### PR TITLE
docs(editors): add Eclipse setup guidance (#0000)

### DIFF
--- a/docs/EDITORS/ECLIPSE_SETUP.md
+++ b/docs/EDITORS/ECLIPSE_SETUP.md
@@ -1,0 +1,43 @@
+# Eclipse Setup Guide for perl-lsp
+
+This guide configures `perllsp` in Eclipse using an LSP-capable plugin.
+
+## Prerequisites
+
+- Eclipse IDE (current release recommended)
+- An installed LSP client plugin (for example: **Wild Web Developer** or another plugin that allows custom language servers)
+- `perllsp` on your `PATH`
+
+Validate the server in a terminal first:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Configure a Perl Language Server in Eclipse
+
+1. Open Eclipse preferences.
+2. Go to the plugin's language server configuration page.
+3. Add a new server definition for Perl files.
+4. Set the server command to:
+
+   ```text
+   perllsp --stdio
+   ```
+
+5. Associate the server with Perl file patterns (for example `*.pl`, `*.pm`, `*.t`, `*.psgi`).
+6. Apply changes and restart Eclipse if prompted.
+
+## Workspace Recommendations
+
+- Open the project root as the Eclipse workspace root so cross-file features can index properly.
+- Keep Perl modules and test files inside the opened workspace tree.
+
+## Troubleshooting
+
+- If the server does not start, verify Eclipse can find `perllsp` from its environment.
+- If diagnostics/completions do not appear, open the LSP plugin logs and confirm initialization succeeded.
+- If indexing appears incomplete, reopen the project root and restart the language server session.
+
+For general debugging steps, see [docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| Eclipse | configure an LSP plugin to run `perllsp --stdio` | [docs/EDITORS/ECLIPSE_SETUP.md](../EDITORS/ECLIPSE_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,11 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### Eclipse
+
+Use any Eclipse LSP-capable plugin and register `perllsp --stdio` for Perl file
+patterns (`*.pl`, `*.pm`, `*.t`, `*.psgi`).
 
 ## When Setup Fails
 


### PR DESCRIPTION
### Motivation
- Provide explicit setup instructions for Eclipse users so they can run `perllsp` via any LSP-capable Eclipse plugin and get cross-file features and diagnostics working.

### Description
- Add `docs/EDITORS/ECLIPSE_SETUP.md` with prerequisites, `perllsp --stdio` wiring, workspace recommendations, and troubleshooting, and update `docs/how-to/EDITOR_SETUP.md` to link Eclipse in the editor matrix and minimal config.

### Testing
- Ran `cargo check --all-targets -p perl-lsp-rs` as the primary verification step, which completed compilation of many crates but failed due to a pre-existing syntax error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs` unrelated to these documentation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2118fc808333b3b757e6a5c26e4f)