### PR TITLE
docs(editors): add Amazon Kiro setup guidance (#0000)

### DIFF
--- a/docs/EDITORS/VS_CODE_SETUP.md
+++ b/docs/EDITORS/VS_CODE_SETUP.md
@@ -5,6 +5,7 @@ This guide helps you set up and configure the Perl Language Server in Visual Stu
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)
+- [Amazon Kiro Compatibility](#amazon-kiro-compatibility)
 - [Installation](#installation)
 - [Extension Setup](#extension-setup)
 - [Configuration](#configuration)
@@ -26,6 +27,21 @@ This guide helps you set up and configure the Perl Language Server in Visual Stu
 
 - **Perl** 5.10 or later (for syntax validation)
 - **perltidy** (for code formatting)
+
+## Amazon Kiro Compatibility
+
+Amazon Kiro follows a VS Code-compatible extension/runtime model. In most
+setups, the perl-lsp extension and settings work unchanged.
+
+If extension installation is blocked by your Kiro distribution channel, use a
+generic LSP client entry that launches:
+
+```text
+perllsp --stdio
+```
+
+Use the same `perl-lsp.*` and workspace `.vscode/settings.json` examples in
+this guide for Kiro workspaces.
 
 ---
 

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -24,6 +24,7 @@ perllsp --health
 | Editor | Fast path | Detailed guide |
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
+| Amazon Kiro | use VS Code-compatible extension flow or set `perllsp --stdio` manually | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
@@ -36,6 +37,13 @@ perllsp --health
 The repo-maintained extension is the easiest route. If you prefer a manual
 configuration, set the command to `perllsp --stdio` and keep the workspace
 root pointed at the project root.
+
+### Amazon Kiro
+
+Kiro uses a VS Code-compatible extension/runtime model. Start with the same
+steps as VS Code setup, then fall back to a generic language-server entry with
+`perllsp --stdio` if the extension marketplace path is unavailable in your
+Kiro build.
 
 ### Neovim
 


### PR DESCRIPTION
### Motivation
- Make editor setup docs explicit for Amazon Kiro users by documenting the VS Code-compatible flow and a manual `perllsp --stdio` fallback so Kiro workspaces have a clear, supported onboarding path.

### Description
- Added Kiro guidance to `docs/how-to/EDITOR_SETUP.md` by adding `Amazon Kiro` to the editor matrix and a short `### Amazon Kiro` minimal-configuration snippet that recommends `perllsp --stdio` when extension marketplace flow is unavailable.
- Added an `Amazon Kiro Compatibility` section and TOC entry to `docs/EDITORS/VS_CODE_SETUP.md` explaining compatibility and the generic LSP fallback command.

### Testing
- Ran `cargo xtask fmt` as part of verification and it failed due to unrelated pre-existing compile errors in `xtask/src/tasks/metrics/lsp_stats.rs`, so formatting/xtask verification could not complete for this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea212447c883338b783c5906988be2)