### PR TITLE
docs(editors): add Amazon Kiro setup guide (#0000)

### DIFF
--- a/docs/EDITORS/KIRO_SETUP.md
+++ b/docs/EDITORS/KIRO_SETUP.md
@@ -1,0 +1,64 @@
+# Amazon Kiro Setup Guide for perl-lsp
+
+Amazon Kiro is built on Code OSS and can run VS Code-compatible extensions and
+LSP settings. This guide gives the shortest path to getting `perllsp` running
+reliably in Kiro.
+
+## Prerequisites
+
+- `perllsp` is installed and on your `PATH`
+- Kiro can open your Perl workspace folder
+
+Verify first:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Option 1 (Recommended): Use the perl-lsp extension
+
+If Kiro can install VS Code/Open VSX extensions in your environment, install the
+`perl-lsp-rs` extension and keep defaults.
+
+Then confirm:
+
+1. Open any `.pl` or `.pm` file.
+2. Trigger **Go to Definition** on a known symbol.
+3. Confirm diagnostics appear for an intentional syntax error.
+
+## Option 2: Configure a generic LSP server entry
+
+If extension install is restricted, configure Kiro's LSP client so Perl files use
+this command:
+
+```text
+perllsp --stdio
+```
+
+Use these initialization options (workspace settings or user settings):
+
+```json
+{
+  "perl": {
+    "workspace": {
+      "includePaths": ["lib", ".", "local/lib/perl5"],
+      "useSystemInc": false
+    },
+    "inlayHints": {
+      "enabled": true
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+- If the language server fails to start, run `perllsp --health` in the same shell
+  Kiro uses.
+- If startup works but features are missing, open the Kiro LSP logs and confirm
+  the process command is exactly `perllsp --stdio`.
+- If module resolution is wrong, tune `perl.workspace.includePaths` first.
+
+For broader diagnostics and recovery steps, see
+[docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| Amazon Kiro | use `perllsp --stdio` via extension or generic LSP config | [docs/EDITORS/KIRO_SETUP.md](../EDITORS/KIRO_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,12 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### Amazon Kiro
+
+Kiro can use the same server command (`perllsp --stdio`) as other LSP clients.
+If extension install is available in your environment, use the `perl-lsp-rs`
+extension path; otherwise configure a generic LSP entry.
 
 ## When Setup Fails
 


### PR DESCRIPTION
### Motivation
- Provide concise onboarding for Amazon Kiro (a Code OSS-based editor) so users have a clear path to run `perllsp` either via the extension or a generic LSP client configuration.

### Description
- Add `docs/EDITORS/KIRO_SETUP.md` with recommended extension and generic `perllsp --stdio` configuration and troubleshooting, and update `docs/how-to/EDITOR_SETUP.md` to link and surface the Kiro guidance.

### Testing
- Ran `cargo check --lib -p perl-lsp-rs` which succeeded and ran `cargo xtask fmt` which completed successfully.
- Ran `cargo check --all-targets -p perl-lsp-rs` which failed due to a pre-existing syntax error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea212447c883338b783c5906988be2)