### PR TITLE
docs(editors): add Amazon Kiro setup guidance (#0000)

### DIFF
--- a/docs/EDITORS/KIRO_SETUP.md
+++ b/docs/EDITORS/KIRO_SETUP.md
@@ -15,25 +15,40 @@ perllsp --version
 perllsp --health
 ```
 
-## Quick Setup
+## Kiro IDE (Desktop)
 
-Kiro is a desktop editor that can run stdio-based language servers. Configure Perl
-files to launch:
+Kiro IDE is built on VS Code's open-source foundation and uses the OpenVSX
+extension registry. Install the Perl LSP extension from the Extensions panel:
 
-```text
-perllsp --stdio
-```
+- Search for `perl-lsp` in Kiro's Extensions panel
+- Extension ID: `EffortlessMetrics.perl-lsp-rs`
 
-If Kiro supports VS Code-compatible settings in your environment, the minimal
-client shape is:
+If the extension is not available in OpenVSX, download the `.vsix` from
+[GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases) and
+install it via "Install from VSIX..." in the Extensions panel menu.
+
+## Kiro CLI
+
+If you use the Kiro command-line interface, add a custom language server entry
+in `.kiro/settings/lsp.json` at your project root:
 
 ```json
 {
-  "command": "perllsp",
-  "args": ["--stdio"],
-  "filetypes": ["perl"]
+  "languages": {
+    "perl": {
+      "name": "perllsp",
+      "command": "perllsp",
+      "args": ["--stdio"],
+      "file_extensions": ["pl", "pm", "t", "psgi"],
+      "project_patterns": [".perl-lsp.toml", "Makefile.PL", "Build.PL"],
+      "multi_workspace": false
+    }
+  }
 }
 ```
+
+Run `/code init` in the project root first if the `.kiro/settings/` directory
+does not exist, then restart the Kiro CLI to load the new configuration.
 
 ## Recommended Workspace Settings
 

--- a/docs/EDITORS/KIRO_SETUP.md
+++ b/docs/EDITORS/KIRO_SETUP.md
@@ -1,0 +1,58 @@
+# Amazon Kiro Setup Guide for perl-lsp
+
+This guide gives you a reliable setup path for using `perllsp` in Amazon Kiro.
+
+## Prerequisites
+
+- Amazon Kiro installed
+- `perllsp` installed and available on `PATH`
+- A Perl workspace opened in Kiro
+
+Verify the server first:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Quick Setup
+
+Kiro is a desktop editor that can run stdio-based language servers. Configure Perl
+files to launch:
+
+```text
+perllsp --stdio
+```
+
+If Kiro supports VS Code-compatible settings in your environment, the minimal
+client shape is:
+
+```json
+{
+  "command": "perllsp",
+  "args": ["--stdio"],
+  "filetypes": ["perl"]
+}
+```
+
+## Recommended Workspace Settings
+
+- Keep your project root open as the workspace root.
+- Add include/library paths in project settings when your code uses nonstandard
+  module locations.
+- Restart the language server after changing server path or arguments.
+
+## Troubleshooting
+
+1. **Server does not start**
+   - Run `perllsp --health` in an external shell.
+   - Confirm Kiro inherits the same `PATH` as your shell.
+2. **No diagnostics or completions**
+   - Confirm the file is recognized as Perl.
+   - Confirm the LSP client is attached to the current buffer/file.
+3. **Definitions/references incomplete**
+   - Open the repository root, not a nested subfolder.
+   - Ensure local library paths are configured in project settings.
+
+For cross-editor fallback patterns, see [Editor Setup](../how-to/EDITOR_SETUP.md)
+and [Troubleshooting](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| Amazon Kiro | register a Perl LSP client using `perllsp --stdio` | [docs/EDITORS/KIRO_SETUP.md](../EDITORS/KIRO_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,11 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### Amazon Kiro
+
+Register a Perl language-server client that launches `perllsp --stdio`, then
+restart the client after changing workspace settings or include paths.
 
 ## When Setup Fails
 

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -21,7 +21,7 @@ A **language server** is a program that runs alongside your editor and gives it 
 ## Prerequisites
 
 - **Rust 1.92+** (for building from source)
-- **A supported editor**: VS Code, Neovim, Emacs, Helix, or Sublime Text
+- **A supported editor**: VS Code, Amazon Kiro, Neovim, Emacs, Helix, or Sublime Text
 
 ## Installation
 


### PR DESCRIPTION
### Motivation

- Provide first-class documentation for Amazon Kiro users so they have a clear, minimal path to use `perllsp` in that editor.

### Description

- Add a new `docs/EDITORS/KIRO_SETUP.md` with prerequisites, a minimal `perllsp --stdio` client snippet, recommended workspace settings, and troubleshooting guidance.
- Update `docs/how-to/EDITOR_SETUP.md` to include Amazon Kiro in the editor matrix and a short Kiro-specific note, and update `docs/tutorials/GETTING_STARTED.md` to list Amazon Kiro among supported editors.

### Testing

- Ran the project formatting step via `cargo xtask fmt`, which failed due to unrelated pre-existing compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` (missing `last_run` and `run` symbols), so no further automated checks were run for this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea212447c883338b783c5906988be2)