### PR TITLE
docs(editors): add ByteDance Trae setup guidance (#0000)

### DIFF
--- a/docs/EDITORS/TRAE_SETUP.md
+++ b/docs/EDITORS/TRAE_SETUP.md
@@ -17,15 +17,19 @@ perllsp --health
 
 ## Option 1: Install the perl-lsp extension (recommended)
 
-If Trae can access Open VSX, install:
+Trae supports extensions from its built-in Extension Store and the VS Code
+Marketplace. Install the Perl LSP extension:
 
-- `EffortlessMetrics.perl-lsp-rs`
+- Extension ID: `EffortlessMetrics.perl-lsp-rs`
 
-Then open Trae settings and confirm the extension is enabled for Perl files.
+Search for `perl-lsp` in Trae's Extensions panel, or install via the command
+palette. Then open Trae settings and confirm the extension is enabled for Perl
+files.
 
 ## Option 2: Generic LSP client configuration
 
-If you prefer manual wiring, configure a generic language server entry:
+If extension marketplace access is unavailable, configure a generic language
+server entry:
 
 - **Command**: `perllsp`
 - **Arguments**: `--stdio`
@@ -44,7 +48,7 @@ If you prefer manual wiring, configure a generic language server entry:
 2. If diagnostics/completion do not appear, verify the active document language
    is Perl and check the LSP output/log panel.
 3. If modules are unresolved, add include paths in `.perl-lsp.toml` (`include_paths`)
-   or editor settings (`perl.includePaths`).
+   or extension settings (`perl-lsp.includePaths`).
 
 See also:
 

--- a/docs/EDITORS/TRAE_SETUP.md
+++ b/docs/EDITORS/TRAE_SETUP.md
@@ -1,0 +1,53 @@
+# Trae (ByteDance) Setup Guide for perl-lsp
+
+Trae is compatible with the VS Code extension ecosystem, so perl-lsp setup is
+nearly identical to VS Code.
+
+## Prerequisites
+
+- `perllsp` available on your `PATH`
+- Trae installed
+
+Verify the server before configuring the editor:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Option 1: Install the perl-lsp extension (recommended)
+
+If Trae can access Open VSX, install:
+
+- `EffortlessMetrics.perl-lsp-rs`
+
+Then open Trae settings and confirm the extension is enabled for Perl files.
+
+## Option 2: Generic LSP client configuration
+
+If you prefer manual wiring, configure a generic language server entry:
+
+- **Command**: `perllsp`
+- **Arguments**: `--stdio`
+- **Filetypes / language IDs**: `perl`, `pl`, `pm`, `t`
+
+## Recommended settings
+
+- Open the project root as your workspace folder (not a nested subdirectory)
+- Keep `perl-lsp.trace.server` at `messages` while debugging setup
+- Put team-shared behavior in `.perl-lsp.toml` at repo root
+
+## Troubleshooting
+
+1. If Trae reports "server not found", run `perllsp --version` in a shell
+   started the same way you launch Trae.
+2. If diagnostics/completion do not appear, verify the active document language
+   is Perl and check the LSP output/log panel.
+3. If modules are unresolved, add include paths in `.perl-lsp.toml` (`include_paths`)
+   or editor settings (`perl.includePaths`).
+
+See also:
+
+- [Editor Setup](../how-to/EDITOR_SETUP.md)
+- [Configuration](../reference/CONFIGURATION.md)
+- [Troubleshooting](../how-to/TROUBLESHOOTING.md)

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -24,6 +24,7 @@ perllsp --health
 | Editor | Fast path | Detailed guide |
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
+| Trae (ByteDance) | install from Open VSX or set command to `perllsp --stdio` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
@@ -36,6 +37,12 @@ perllsp --health
 The repo-maintained extension is the easiest route. If you prefer a manual
 configuration, set the command to `perllsp --stdio` and keep the workspace
 root pointed at the project root.
+
+### Trae (ByteDance)
+
+Trae is VS Code-compatible, so the same extension and settings model applies.
+Use the Perl LSP extension from Open VSX when available, or configure a generic
+language server command as `perllsp --stdio`.
 
 ### Neovim
 

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -24,7 +24,7 @@ perllsp --health
 | Editor | Fast path | Detailed guide |
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
-| Trae (ByteDance) | install from Open VSX or set command to `perllsp --stdio` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
+| Trae (ByteDance) | install the VS Code-compatible extension or set command to `perllsp --stdio` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
@@ -41,8 +41,8 @@ root pointed at the project root.
 ### Trae (ByteDance)
 
 Trae is VS Code-compatible, so the same extension and settings model applies.
-Use the Perl LSP extension from Open VSX when available, or configure a generic
-language server command as `perllsp --stdio`.
+Install the `EffortlessMetrics.perl-lsp-rs` extension from Trae's Extensions
+panel, or configure a generic language server command as `perllsp --stdio`.
 
 ### Neovim
 

--- a/docs/reference/FAQ.md
+++ b/docs/reference/FAQ.md
@@ -66,6 +66,7 @@ Yes. The parser targets Perl 5.8 as the minimum and handles most idioms from tha
 Any editor with LSP client support works. Point it at `perllsp --stdio`:
 
 - **VS Code** — native extension with auto-download, UI settings, and DAP debugging
+- **Trae (ByteDance)** — VS Code-compatible setup (extension or generic LSP command)
 - **Neovim** — via `nvim-lspconfig` (`perl_ls` server)
 - **Emacs** — via `eglot` or `lsp-mode`
 - **Helix** — via `languages.toml`


### PR DESCRIPTION
### Motivation

- Make it explicit that Trae (ByteDance) is supported and give users a short, discoverable setup path rather than relying on VS Code assumptions.

### Description

- Add a new `docs/EDITORS/TRAE_SETUP.md` with prerequisites, Open VSX/extension guidance, generic LSP configuration, recommended settings, and troubleshooting tips.
- Link the new Trae guide from the central editor matrix in `docs/how-to/EDITOR_SETUP.md` and add a short Trae note to the minimal configs section.
- Update `docs/reference/FAQ.md` to list Trae in the editor support overview.

### Testing

- Ran `git diff --check`, which returned clean results (no trailing whitespace or index issues).
- Ran `cargo xtask fmt --check`, which attempted to build `xtask` and failed due to unrelated, pre-existing compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` (symbols `last_run`/`run`), so formatting checks could not complete; this failure is unrelated to the docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea21360b64833390ec8d72a878a0e0)