### PR TITLE
docs(editor-setup): add Trae quick-start guidance (#0000)

### DIFF
--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -24,6 +24,7 @@ perllsp --health
 | Editor | Fast path | Detailed guide |
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
+| Trae (ByteDance) | install the VS Code extension from a `.vsix` and point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
@@ -36,6 +37,15 @@ perllsp --health
 The repo-maintained extension is the easiest route. If you prefer a manual
 configuration, set the command to `perllsp --stdio` and keep the workspace
 root pointed at the project root.
+
+### Trae (ByteDance)
+
+Trae is VS Code-compatible, so the same extension and settings model works.
+If Trae does not expose the VS Code Marketplace entry directly, install the
+extension from the generated `.vsix`, then configure:
+
+- `perl-lsp.serverPath` → absolute path to `perllsp` (or keep default if it is on `PATH`)
+- command/args equivalent to `perllsp --stdio`
 
 ### Neovim
 


### PR DESCRIPTION
### Motivation
- Trae (ByteDance) is VS Code–compatible but lacked explicit setup guidance in the editor matrix, reducing discoverability for Trae users.

### Description
- Add a `Trae (ByteDance)` entry to the editor matrix and a short `Trae (ByteDance)` subsection with VSIX/manual installation guidance and `perllsp --stdio` configuration in `docs/how-to/EDITOR_SETUP.md`.

### Testing
- Documentation-only change; no automated tests were run because no code or tests were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea21360b64833390ec8d72a878a0e0)