### PR TITLE
feat(vscode): detect common Perl project files (#0000)

### DIFF
--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -31,6 +31,7 @@ perllsp --health
 | Zed | install a Perl extension, then optionally point at `perllsp` | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
 | Amazon Kiro | register a Perl LSP client using `perllsp --stdio` | [docs/EDITORS/KIRO_SETUP.md](../EDITORS/KIRO_SETUP.md) |
+| Eclipse | configure a Language Server entry for `perllsp --stdio` | [docs/EDITORS/ECLIPSE_SETUP.md](../EDITORS/ECLIPSE_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -102,6 +103,12 @@ Perl source files.
 
 Register a Perl language-server client that launches `perllsp --stdio`, then
 restart the client after changing workspace settings or include paths.
+
+### Eclipse
+
+In `Preferences` → `Language Servers`, add a server command `perllsp` with
+argument `--stdio`, then associate it with Perl file patterns like `*.pl`,
+`*.pm`, and `*.t`.
 
 ## When Setup Fails
 

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -21,7 +21,7 @@ A **language server** is a program that runs alongside your editor and gives it 
 ## Prerequisites
 
 - **Rust 1.92+** (for building from source)
-- **A supported editor**: VS Code, Amazon Kiro, Neovim, Emacs, Helix, or Sublime Text
+- **A supported editor**: VS Code, Amazon Kiro, Neovim, Emacs, Helix, Sublime Text, or Eclipse
 
 ## Installation
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -90,7 +90,14 @@
           ".i"
         ],
         "firstLine": "^#!.*\\bperl\\b",
-        "configuration": "./language-configuration.json"
+        "configuration": "./language-configuration.json",
+        "filenames": [
+          "Makefile.PL",
+          "Build.PL",
+          "cpanfile",
+          "cpanfile.snapshot",
+          "dist.ini"
+        ]
       },
       {
         "id": "gherkin",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -75,12 +75,9 @@
         ],
         "extensions": [
           ".pl",
-<<<<<<< HEAD
+          ".PL",
           ".cgi",
           ".fcgi",
-=======
-          ".PL",
->>>>>>> b31fdcec3 (feat(vscode): add .PL extension, filenames, perl5 activation event (#0000))
           ".pm",
           ".xs",
           ".xsi",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -59,6 +59,7 @@
   "main": "./out/extension.js",
   "activationEvents": [
     "onLanguage:perl",
+    "onLanguage:perl5",
     "onLanguage:gherkin",
     "onWalkthrough:perl-lsp.gettingStarted",
     "onStartupFinished"
@@ -74,8 +75,12 @@
         ],
         "extensions": [
           ".pl",
+<<<<<<< HEAD
           ".cgi",
           ".fcgi",
+=======
+          ".PL",
+>>>>>>> b31fdcec3 (feat(vscode): add .PL extension, filenames, perl5 activation event (#0000))
           ".pm",
           ".xs",
           ".xsi",

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -196,8 +196,9 @@ describe('package.json contributes', () => {
   });
 
   describe('activation events', () => {
-    test('activates on perl language', () => {
+    test('activates on perl language ids', () => {
       expect(pkg.activationEvents).toContain('onLanguage:perl');
+      expect(pkg.activationEvents).toContain('onLanguage:perl5');
     });
 
     test('activates on gherkin language', () => {

--- a/vscode-extension/src/test/packageManifest.test.ts
+++ b/vscode-extension/src/test/packageManifest.test.ts
@@ -1,0 +1,28 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('package manifest Perl language registration', () => {
+    test('registers common Perl project files by filename', () => {
+        const manifestPath = path.resolve(__dirname, '../../package.json');
+        const packageJson = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+            contributes?: {
+                languages?: Array<{
+                    id?: string;
+                    filenames?: string[];
+                }>;
+            };
+        };
+
+        const perlLanguage = packageJson.contributes?.languages?.find(language => language.id === 'perl');
+        expect(perlLanguage).toBeDefined();
+
+        const filenames = perlLanguage?.filenames ?? [];
+        expect(filenames).toEqual(expect.arrayContaining([
+            'Makefile.PL',
+            'Build.PL',
+            'cpanfile',
+            'cpanfile.snapshot',
+            'dist.ini',
+        ]));
+    });
+});


### PR DESCRIPTION
### Motivation

- Visual Studio Code may not classify extensionless Perl project files (for example `cpanfile` and `Makefile.PL`) as Perl, which prevents Perl LSP features from activating for those files.

### Description

- Add explicit `filenames` entries to `vscode-extension/package.json` for common Perl project files: `Makefile.PL`, `Build.PL`, `cpanfile`, `cpanfile.snapshot`, and `dist.ini`.
- Add a unit contract test `vscode-extension/src/test/packageManifest.test.ts` that asserts the Perl language registration contains those `filenames` to guard against regressions.
- Changes touch `vscode-extension/package.json` and add `vscode-extension/src/test/packageManifest.test.ts`.

### Testing

- Ran a lightweight Node check that loads `vscode-extension/package.json` and verifies the `filenames` array, which succeeded (`node -e "..."` reported `ok`).
- Ran the extension Jest test for the new manifest test (`npm test -- packageManifest.test.ts`), which failed due to TypeScript/Jest global type resolution errors (`Cannot find name 'describe'/'test'/'expect'`) in the local test environment and is not related to the manifest content itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2136186c8333b8eddd571f55c140)