### PR TITLE
feat(vscode-extension): activate on perl5 language id (#0000)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -57,6 +57,7 @@
   "main": "./out/extension.js",
   "activationEvents": [
     "onLanguage:perl",
+    "onLanguage:perl5",
     "onLanguage:gherkin",
     "onWalkthrough:perl-lsp.gettingStarted"
   ],

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -194,8 +194,9 @@ describe('package.json contributes', () => {
   });
 
   describe('activation events', () => {
-    test('activates on perl language', () => {
+    test('activates on perl language ids', () => {
       expect(pkg.activationEvents).toContain('onLanguage:perl');
+      expect(pkg.activationEvents).toContain('onLanguage:perl5');
     });
 
     test('activates on gherkin language', () => {


### PR DESCRIPTION
### Motivation
- Ensure the VS Code extension activates in workspaces/editors that report Perl as the `perl5` language id in addition to `perl` so features are available when files use that id.

### Description
- Added `onLanguage:perl5` to the `activationEvents` in `vscode-extension/package.json` and updated the configuration contract test in `vscode-extension/src/test/configuration.test.ts` to assert both `onLanguage:perl` and `onLanguage:perl5` are present.

### Testing
- Ran `npm test -- configuration.test.ts` which failed in this environment due to TypeScript/Jest global typing errors (`Cannot find name 'describe'`), and ran `npm run compile` which failed due to a TypeScript deprecation gate (`TS5107: moduleResolution=node10`); both failures are pre-existing environment/typechain issues and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2136186c8333b8eddd571f55c140)