### PR TITLE
fix(vscode): improve Visual Studio Code Perl file detection (#0000)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -71,6 +71,7 @@
         ],
         "extensions": [
           ".pl",
+          ".PL",
           ".pm",
           ".xs",
           ".xsi",
@@ -83,6 +84,10 @@
           ".tt2",
           ".ep",
           ".i"
+        ],
+        "filenames": [
+          "Makefile.PL",
+          "Build.PL"
         ],
         "firstLine": "^#!.*\\bperl\\b",
         "configuration": "./language-configuration.json"


### PR DESCRIPTION
### Motivation
- Some Perl project entrypoints and file name forms (uppercase `.PL`, `Makefile.PL`, `Build.PL`) were not explicitly mapped in the VS Code extension manifest, which prevented those files from being recognized as Perl by the editor.

### Description
- Updated `vscode-extension/package.json` language contribution to add the `.PL` extension and explicit `filenames` entries for `Makefile.PL` and `Build.PL` so VS Code will open those files with Perl language features.

### Testing
- Verified the modified JSON is well-formed with `node -e "JSON.parse(require('fs').readFileSync('vscode-extension/package.json','utf8')); console.log('ok')"`, which printed `ok`.
- Attempted `npm run compile` and `npm test -- --runInBand`, both of which failed in this environment due to pre-existing TypeScript/Jest toolchain issues (TS config deprecation and missing test type declarations) that are unrelated to this tiny manifest change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2136186c8333b8eddd571f55c140)