### PR TITLE
fix(perl-uri): accept uppercase file URI scheme (#0000)

### DIFF
--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -42,7 +42,8 @@ pub fn uri_key(uri: &str) -> String {
 /// Check if a URI uses the `file://` scheme.
 #[must_use]
 pub fn is_file_uri(uri: &str) -> bool {
-    uri.starts_with("file://")
+    uri.get(..7)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("file://"))
 }
 
 /// Check if a URI uses a special scheme (not `file://`).
@@ -107,7 +108,7 @@ mod tests {
     fn detects_file_uris() {
         assert!(is_file_uri("file:///tmp/test.pl"));
         assert!(is_file_uri("file://localhost/tmp/test.pl"));
-        assert!(!is_file_uri("FILE:///tmp/test.pl"));
+        assert!(is_file_uri("FILE:///tmp/test.pl"));
         assert!(!is_file_uri("file:test.pl"));
         assert!(!is_file_uri("https://example.com"));
     }

--- a/crates/perl-uri/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-uri/tests/comprehensive_unit_tests.rs
@@ -87,10 +87,9 @@ fn is_file_uri_false_for_plain_path() {
 }
 
 #[test]
-fn is_file_uri_case_sensitive() {
-    // file:// check is case-sensitive via starts_with
-    assert!(!is_file_uri("FILE:///tmp/test.pl"));
-    assert!(!is_file_uri("File:///tmp/test.pl"));
+fn is_file_uri_case_insensitive_for_file_scheme_prefix() {
+    assert!(is_file_uri("FILE:///tmp/test.pl"));
+    assert!(is_file_uri("File:///tmp/test.pl"));
 }
 
 // ── is_special_scheme ───────────────────────────────────────────────


### PR DESCRIPTION
### Motivation

- Some editors and Visual Studio–family clients can emit uppercase or mixed-case `file://` URI schemes, and the previous `is_file_uri` check treated `FILE:///...` as non-file which broke integrations.

### Description

- Change `is_file_uri` to accept the `file://` prefix case-insensitively while still rejecting `file:test.pl`-style bare-scheme values by checking the first seven characters with `eq_ignore_ascii_case("file://")` in `crates/perl-uri/src/classify.rs`.
- Update comprehensive unit tests in `crates/perl-uri/tests/comprehensive_unit_tests.rs` to assert that `FILE:///...` and `File:///...` are treated as file URIs.

### Testing

- Ran `cargo test -p perl-uri` and the crate test-suite passed (all tests OK).
- Ran `cargo check --all-targets -p perl-uri` which completed successfully.
- Ran `cargo clippy -p perl-uri --all-targets -- -D warnings` which completed with no warnings.
- Attempted `cargo xtask fmt` but it failed due to unrelated `xtask` compile errors in pre-existing files (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2136186c8333b8eddd571f55c140)