### PR TITLE
fix(execute-command): improve go-to-implementation module path matching (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/execute_command/provider.rs
+++ b/crates/perl-lsp-rs/src/execute_command/provider.rs
@@ -75,6 +75,56 @@ impl Default for ExecuteCommandProvider {
 }
 
 impl ExecuteCommandProvider {
+    fn resolve_local_module_path(
+        workspace_root: &std::path::Path,
+        module_name: &str,
+    ) -> Option<std::path::PathBuf> {
+        let rel_path = module_name.replace("::", std::path::MAIN_SEPARATOR_STR) + ".pm";
+        let candidate = workspace_root.join("lib").join(&rel_path);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+
+        let parts: Vec<&str> = module_name.split("::").filter(|part| !part.is_empty()).collect();
+        if parts.is_empty() {
+            return None;
+        }
+
+        let mut current = workspace_root.join("lib");
+        for part in &parts[..parts.len().saturating_sub(1)] {
+            current = Self::find_case_insensitive_child(&current, part, false)?;
+        }
+
+        let file_name = format!("{}.pm", parts[parts.len() - 1]);
+        Self::find_case_insensitive_child(&current, &file_name, true)
+    }
+
+    fn find_case_insensitive_child(
+        parent: &std::path::Path,
+        wanted_name: &str,
+        require_file: bool,
+    ) -> Option<std::path::PathBuf> {
+        let entries = std::fs::read_dir(parent).ok()?;
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if require_file && !file_type.is_file() {
+                continue;
+            }
+            if !require_file && !file_type.is_dir() {
+                continue;
+            }
+
+            let candidate_name = entry.file_name();
+            let candidate_name = candidate_name.to_string_lossy();
+            if candidate_name.eq_ignore_ascii_case(wanted_name) {
+                return Some(entry.path());
+            }
+        }
+        None
+    }
+
     /// Create a new execute command provider.
     pub fn new() -> Self {
         Self { workspace_roots: Vec::new() }
@@ -661,10 +711,9 @@ impl ExecuteCommandProvider {
                 continue;
             }
 
-            // Map Foo::Bar -> lib/Foo/Bar.pm
-            let rel_path = module_name.replace("::", std::path::MAIN_SEPARATOR_STR) + ".pm";
-            let candidate = workspace_root.join("lib").join(&rel_path);
-            if candidate.exists() {
+            // Map Foo::Bar -> lib/Foo/Bar.pm (with case-insensitive fallback).
+            if let Some(candidate) = Self::resolve_local_module_path(&workspace_root, &module_name)
+            {
                 return json!({
                     "found": true,
                     "path": candidate.to_string_lossy(),

--- a/crates/perl-lsp-rs/src/execute_command/tests.rs
+++ b/crates/perl-lsp-rs/src/execute_command/tests.rs
@@ -336,6 +336,46 @@ fn test_go_to_implementation_skips_version_pragma() -> Result<(), Box<dyn std::e
 }
 
 #[test]
+fn test_go_to_implementation_case_insensitive_module_path() -> Result<(), Box<dyn std::error::Error>>
+{
+    // Some distributions use mixed-case file paths (e.g. AntiGravity.pm) while tests may
+    // reference a normalized module spelling.
+    let temp_dir = tempdir()?;
+    let lib_dir = temp_dir.path().join("lib").join("Google");
+    let t_dir = temp_dir.path().join("t");
+    fs::create_dir_all(&lib_dir)?;
+    fs::create_dir_all(&t_dir)?;
+
+    let pm_file = lib_dir.join("AntiGravity.pm");
+    let t_file = t_dir.join("google-antigravity.t");
+    fs::write(&pm_file, "package Google::AntiGravity;\n1;\n")?;
+    fs::write(&t_file, "use strict;\nuse Google::Antigravity;\ndone_testing;\n")?;
+
+    let provider =
+        ExecuteCommandProvider::with_workspace_roots(vec![temp_dir.path().to_path_buf()]);
+    let result = provider.execute_command(
+        "perl.goToImplementation",
+        vec![Value::String(t_file.to_string_lossy().to_string())],
+    );
+
+    assert!(
+        result.is_ok(),
+        "perl.goToImplementation should support case-insensitive path fallback"
+    );
+    let value = result?;
+    assert!(
+        value["found"].as_bool().unwrap_or(false),
+        "Should resolve Google::Antigravity to AntiGravity.pm"
+    );
+    let impl_path = value["path"].as_str().ok_or("expected path string")?;
+    assert!(
+        impl_path.ends_with("AntiGravity.pm"),
+        "Should navigate to AntiGravity.pm, got: {impl_path}"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_find_workspace_root_prefers_project_marker() -> Result<(), Box<dyn std::error::Error>> {
     // A directory with a cpanfile should be found as the workspace root when walking up.
     // We call go_to_test directly (bypassing execute_command security validation) so we can


### PR DESCRIPTION
### Motivation
- `perl.goToImplementation` only resolved exact-cased `lib/Foo/Bar.pm` paths which can miss mixed-case files (e.g. `Google/AntiGravity.pm`) referenced as `Google::Antigravity` in tests or real projects.
- Provide a robust fallback so implementation lookup works on filesystems or distributions with case variations without changing lookup semantics for normal exact matches.

### Description
- Added `resolve_local_module_path` which first checks the exact `lib/... .pm` path and then falls back to case-insensitive directory/file matching to resolve module components.
- Implemented `find_case_insensitive_child` to scan a directory for a case-insensitive match for either a directory component or a target file and made `file_type` handling more robust.
- Replaced the previous exact-path-only lookup in `go_to_implementation` with the new resolver and added `test_go_to_implementation_case_insensitive_module_path` to cover the mixed-case scenario.

### Testing
- Ran `cargo test -p perl-lsp-rs --lib test_go_to_implementation_case_insensitive_module_path` and it passed.
- Ran `cargo clippy -p perl-lsp-rs --lib -- -D warnings` and it passed.
- Ran `cargo check --all-targets -p perl-lsp-rs` which failed due to a pre-existing parse error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs` unrelated to this change.
- `cargo xtask fmt` / `cargo fmt --all` reported failures due to unrelated pre-existing formatting/compile issues in other workspace targets and not caused by these edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea21361934833385308d6796d427d5)