### PR TITLE
fix(navigation): support Mojolicious spaced controller names (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/navigation.rs
@@ -511,8 +511,11 @@ fn normalize_mojolicious_controller_name(raw: &str) -> Option<String> {
     }
 
     let mut segments = Vec::new();
-    for segment in
-        normalized.split("::").flat_map(|part| part.split('/')).flat_map(|part| part.split('-'))
+    for segment in normalized
+        .split("::")
+        .flat_map(|part| part.split('/'))
+        .flat_map(|part| part.split('-'))
+        .flat_map(str::split_whitespace)
     {
         let segment = segment.trim();
         if segment.is_empty() {

--- a/crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs
+++ b/crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs
@@ -412,10 +412,6 @@ sub startup {
 
     Ok(())
 }
-
-    Ok(())
-}
-
 #[test]
 fn mojolicious_string_route_snake_case_controller_resolves_to_camelized_package() -> TestResult {
     let workspace = TempWorkspace::new()?;
@@ -469,6 +465,66 @@ sub startup {
     assert!(
         uri.contains("MyApp/Controller/AdminUser.pm"),
         "definition should point to camelized controller file, got: {uri}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn mojolicious_string_route_space_separated_controller_resolves_to_nested_package() -> TestResult {
+    let workspace = TempWorkspace::new()?;
+    workspace.write(
+        "lib/MyApp/Controller/Google/Antigravity.pm",
+        r#"package MyApp::Controller::Google::Antigravity;
+use Mojo::Base 'Mojolicious::Controller';
+
+sub launch {
+    my $self = shift;
+    return "ok";
+}
+
+1;
+"#,
+    )?;
+    let app_text = r##"package MyApp::App;
+use Mojo::Base 'Mojolicious';
+
+sub startup {
+    my $self = shift;
+    my $r = $self->routes;
+    $r->get('/google-antigravity')->to('google antigravity#launch');
+}
+
+1;
+"##;
+    workspace.write("lib/MyApp/App.pm", app_text)?;
+
+    let mut harness = LspHarness::new();
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+    harness.open(
+        &workspace.uri("lib/MyApp/Controller/Google/Antigravity.pm"),
+        &std::fs::read_to_string(
+            workspace.dir.path().join("lib/MyApp/Controller/Google/Antigravity.pm"),
+        )?,
+    )?;
+    harness.open(&workspace.uri("lib/MyApp/App.pm"), app_text)?;
+    harness.barrier();
+
+    let (line, character) = position_of(app_text, "google antigravity#launch")?;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("lib/MyApp/App.pm")},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let location = first_location(&result).ok_or("expected a definition location")?;
+    assert_valid_location(location);
+    let uri = location["uri"].as_str().ok_or("expected definition URI")?;
+    assert!(
+        uri.contains("MyApp/Controller/Google/Antigravity.pm"),
+        "definition should point to nested controller file, got: {uri}"
     );
 
     Ok(())


### PR DESCRIPTION
### Motivation
- Mojolicious route controller names that include spaces (for example `google antigravity#launch`) were not being split into nested package segments, which could cause definition navigation to miss the correct controller package.

### Description
- Split controller tokens on whitespace in `normalize_mojolicious_controller_name` in `crates/perl-lsp-rs/src/runtime/language/navigation.rs` so segments like `"google antigravity"` become `Google::Antigravity`.
- Add an integration test `mojolicious_string_route_space_separated_controller_resolves_to_nested_package` in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs` that verifies `google antigravity#launch` resolves to `MyApp::Controller::Google::Antigravity`.
- Update related test scaffolding and ensure normalization still handles `::`, `/`, `-`, and `_` forms.

### Testing
- Ran `cargo test -p perl-lsp-rs --test mojolicious_navigation_tests mojolicious_string_route_space_separated_controller_resolves_to_nested_package` and the new test passed.
- Ran `cargo check --all-targets -p perl-lsp-rs` which completed successfully.
- Attempted `cargo xtask fmt` but it failed due to pre-existing `xtask` compile errors unrelated to these changes (errors in `xtask/src/tasks/metrics/lsp_stats.rs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea21361934833385308d6796d427d5)