### PR TITLE
feat(completion): prioritize Google::Antigravity module suggestions (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -3538,6 +3538,42 @@ sub helper { }
     }
 
     #[test]
+    fn test_use_statement_prioritizes_google_antigravity() -> Result<(), Box<dyn std::error::Error>> {
+        let index = Arc::new(WorkspaceIndex::new());
+        index.index_file(
+            Url::parse("file:///lib/Google/Antigravity.pm")?,
+            "package Google::Antigravity;\n1;\n".to_string(),
+        )?;
+        index.index_file(
+            Url::parse("file:///lib/Google/Search.pm")?,
+            "package Google::Search;\n1;\n".to_string(),
+        )?;
+
+        let code = "use Google::";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index(&ast, Some(index));
+        let completions = provider.get_completions(code, code.len());
+
+        let antigravity = completions
+            .iter()
+            .find(|c| c.label == "Google::Antigravity")
+            .ok_or("missing Google::Antigravity completion")?;
+        let search = completions
+            .iter()
+            .find(|c| c.label == "Google::Search")
+            .ok_or("missing Google::Search completion")?;
+
+        assert_eq!(antigravity.sort_text.as_deref(), Some("11_Google::Antigravity"));
+        assert!(
+            antigravity.sort_text < search.sort_text,
+            "Google::Antigravity should sort ahead of other Google modules"
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn test_use_module_deduplication() -> Result<(), Box<dyn std::error::Error>> {
         // Two files declaring the same package should produce one completion, not two
         let index = Arc::new(WorkspaceIndex::new());

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -213,8 +213,16 @@ const COMMON_MODULES_TIER_0: &[&str] = &[
 /// Common CPAN modules that are frequently used but less universal than tier-0.
 ///
 /// Tier 1: widely-used libraries (DB, OOP, testing, filesystem).
-const COMMON_MODULES_TIER_1: &[&str] =
-    &["DBI", "Moo", "Moose", "Try::Tiny", "Path::Tiny", "Test::More", "Test::Exception"];
+const COMMON_MODULES_TIER_1: &[&str] = &[
+    "DBI",
+    "Moo",
+    "Moose",
+    "Try::Tiny",
+    "Path::Tiny",
+    "Test::More",
+    "Test::Exception",
+    "Google::Antigravity",
+];
 
 /// Returns the sort-text tier prefix for a module name.
 ///


### PR DESCRIPTION
### Motivation

- Module-name completions for `use`/`require` could bury important, well-known modules behind same-prefix packages, so `Google::Antigravity` should surface earlier when typing `use Google::`.

### Description

- Added `"Google::Antigravity"` to the `COMMON_MODULES_TIER_1` list used by `module_sort_tier` to give it higher completion priority in `crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs`.
- Added a regression unit test `test_use_statement_prioritizes_google_antigravity` in `crates/perl-lsp-rs-core/src/providers/completion/completion.rs` that indexes `Google::Antigravity` and `Google::Search` and asserts `Google::Antigravity` has the expected tiered `sort_text` and sorts ahead.
- Kept module sorting logic unchanged; the change is limited to the common-module tiering table and one focused test.

### Testing

- Ran `cargo test -p perl-lsp-rs-core test_use_statement_prioritizes_google_antigravity` and the new test passed.
- Ran `cargo check --all-targets -p perl-lsp-rs-core` which completed successfully.
- Ran `cargo clippy -p perl-lsp-rs-core -- -D warnings` which completed successfully for the crate under change.
- `cargo xtask fmt` failed due to unrelated `xtask` compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` (missing symbols), and `just pr-fast` is not available in this environment, so those verification steps were not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea21361934833385308d6796d427d5)