### PR TITLE
fix(perl-parser-core): parse legacy module separators in use/no (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -540,14 +540,27 @@ impl<'a> Parser<'a> {
             }
         };
 
-        // Handle :: in module names
-        // Handle both DoubleColon tokens and separate Colon tokens (in case lexer sends :: as separate colons)
+        // Normalize legacy package separator `'` to modern `::`.
+        if module.contains('\'') {
+            module = module.replace('\'', "::");
+        }
+
+        // Handle package separators in module names.
+        // Accept both modern `::` and legacy `'` separators, canonicalizing both to `::`.
+        // Also handle separate `:` tokens in case the lexer sends `::` as two colons.
         while self.peek_kind() == Some(TokenKind::DoubleColon)
             || (self.peek_kind() == Some(TokenKind::Colon)
                 && self.tokens.peek_second().map(|t| t.kind) == Ok(TokenKind::Colon))
+            || (self.peek_kind() == Some(TokenKind::Unknown)
+                && self.tokens.peek().map(|t| t.text.as_ref() == "'").unwrap_or(false))
         {
             if self.peek_kind() == Some(TokenKind::DoubleColon) {
                 self.consume_token()?; // consume ::
+                module.push_str("::");
+            } else if self.peek_kind() == Some(TokenKind::Unknown)
+                && self.tokens.peek().map(|t| t.text.as_ref() == "'").unwrap_or(false)
+            {
+                self.consume_token()?; // consume legacy separator '
                 module.push_str("::");
             } else {
                 // Handle two separate Colon tokens as ::
@@ -1106,14 +1119,27 @@ impl<'a> Parser<'a> {
             ));
         };
 
-        // Handle :: in module names
-        // Handle both DoubleColon tokens and separate Colon tokens (in case lexer sends :: as separate colons)
+        // Normalize legacy package separator `'` to modern `::`.
+        if module.contains('\'') {
+            module = module.replace('\'', "::");
+        }
+
+        // Handle package separators in module names.
+        // Accept both modern `::` and legacy `'` separators, canonicalizing both to `::`.
+        // Also handle separate `:` tokens in case the lexer sends `::` as two colons.
         while self.peek_kind() == Some(TokenKind::DoubleColon)
             || (self.peek_kind() == Some(TokenKind::Colon)
                 && self.tokens.peek_second().map(|t| t.kind) == Ok(TokenKind::Colon))
+            || (self.peek_kind() == Some(TokenKind::Unknown)
+                && self.tokens.peek().map(|t| t.text.as_ref() == "'").unwrap_or(false))
         {
             if self.peek_kind() == Some(TokenKind::DoubleColon) {
                 self.consume_token()?; // consume ::
+                module.push_str("::");
+            } else if self.peek_kind() == Some(TokenKind::Unknown)
+                && self.tokens.peek().map(|t| t.text.as_ref() == "'").unwrap_or(false)
+            {
+                self.consume_token()?; // consume legacy separator '
                 module.push_str("::");
             } else {
                 // Handle two separate Colon tokens as ::

--- a/crates/perl-parser-core/tests/fix_google_antigravity_module_separator.rs
+++ b/crates/perl-parser-core/tests/fix_google_antigravity_module_separator.rs
@@ -1,0 +1,34 @@
+mod cpan_test_helpers;
+
+use cpan_test_helpers::parse;
+use perl_parser_core::NodeKind;
+
+#[test]
+fn parse_use_with_legacy_quote_package_separator() {
+    let ast = parse("use Google'Antigravity;");
+    let NodeKind::Program { statements } = ast.kind else {
+        assert!(false, "expected Program node");
+        return;
+    };
+    assert_eq!(statements.len(), 1, "expected a single use statement");
+    let NodeKind::Use { module, .. } = &statements[0].kind else {
+        assert!(false, "expected Use node");
+        return;
+    };
+    assert_eq!(module, "Google::Antigravity");
+}
+
+#[test]
+fn parse_no_with_legacy_quote_package_separator() {
+    let ast = parse("no Google'Antigravity;");
+    let NodeKind::Program { statements } = ast.kind else {
+        assert!(false, "expected Program node");
+        return;
+    };
+    assert_eq!(statements.len(), 1, "expected a single no statement");
+    let NodeKind::No { module, .. } = &statements[0].kind else {
+        assert!(false, "expected No node");
+        return;
+    };
+    assert_eq!(module, "Google::Antigravity");
+}


### PR DESCRIPTION
### Motivation

- Some CPAN modules and legacy code use the apostrophe (`'`) as a package separator (e.g. `Google'Antigravity`) and the parser preserved that form, causing downstream consumers to see a non-canonical module name instead of `Google::Antigravity`.

### Description

- Normalize the legacy package separator by replacing `'` with `::` in `parse_use` and `parse_no` before further processing in `crates/perl-parser-core/src/engine/parser/declarations.rs`.
- Accept apostrophe separators when consuming package-separator tokens so sequences like `Foo'Bar` are handled in the same loop that currently accepts `::` and `:`-`:` tokens in `parse_use` and `parse_no`.
- Add regression tests `crates/perl-parser-core/tests/fix_google_antigravity_module_separator.rs` covering both `use Google'Antigravity;` and `no Google'Antigravity;` and asserting the module is canonicalized to `Google::Antigravity`.

### Testing

- Ran `cargo test -p perl-parser-core --test fix_google_antigravity_module_separator` and the new tests passed (2 passed; 0 failed).
- Ran `cargo check --all-targets -p perl-parser-core` which completed successfully.
- Ran `cargo clippy -p perl-parser-core --all-targets -- -D warnings` which failed due to unrelated, pre-existing clippy issues in test code and is not caused by this change.
- Attempted project-wide formatting (`cargo xtask fmt` / `just pr-fast`) but those steps failed due to unrelated workspace/tooling issues and are not required to verify this focused fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea21361934833385308d6796d427d5)