### PR TITLE
docs(editors): add Roo Code setup guidance (#0000)

### DIFF
--- a/docs/EDITORS/VS_CODE_SETUP.md
+++ b/docs/EDITORS/VS_CODE_SETUP.md
@@ -1,6 +1,6 @@
 # VS Code Setup Guide for perl-lsp
 
-This guide helps you set up and configure the Perl Language Server in Visual Studio Code.
+This guide helps you set up and configure the Perl Language Server in Visual Studio Code and VS Code-compatible forks such as Roo Code.
 
 ## Table of Contents
 
@@ -95,6 +95,15 @@ code --install-extension EffortlessMetrics.perl-lsp-rs
 # 2. Search for "perl-lsp"
 # 3. Click "Install"
 ```
+
+#### Roo Code Notes
+
+Roo Code is VS Code-compatible, so the same extension settings and commands in this guide apply.
+
+- If the VS Code Marketplace is unavailable in your Roo Code build, install from Open VSX:
+  `EffortlessMetrics.perl-lsp-rs`.
+- If your environment is offline or policy-restricted, sideload the release `.vsix` from:
+  <https://github.com/EffortlessMetrics/perl-lsp/releases>.
 
 ### Option 2: Generic LSP Client
 

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -24,6 +24,7 @@ perllsp --health
 | Editor | Fast path | Detailed guide |
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
+| Roo Code | install the `perl-lsp-rs` VSIX/OpenVSX package, then use the VS Code flow | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -197,6 +197,7 @@ The `perllsp` binary works with any editor that supports the Language Server Pro
 | Editor | How to connect |
 |--------|---------------|
 | **VS Code / VSCodium** | This extension (auto-configured) |
+| **Roo Code** | This extension (install via Marketplace/Open VSX/VSIX) |
 | **Cursor** | This extension |
 | **Neovim** | `nvim-lspconfig` with `perl_lsp` server |
 | **Emacs** | `lsp-mode` or `eglot` |


### PR DESCRIPTION
### Motivation
- Make editor docs explicit about Roo Code so users of VS Code-compatible forks have clear install and configuration guidance.

### Description
- Added Roo Code references and install notes to the editor quick-reference (`docs/how-to/EDITOR_SETUP.md`), the VS Code guide with Roo-specific Open VSX/VSIX instructions (`docs/EDITORS/VS_CODE_SETUP.md`), and the extension compatibility table (`vscode-extension/README.md`).

### Testing
- Ran `git diff --check`, which passed, and verified Roo Code references with `rg -n "Roo Code|Roo" docs/how-to/EDITOR_SETUP.md docs/EDITORS/VS_CODE_SETUP.md vscode-extension/README.md`, which located the new entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea213634208333a13cd377f7132dde)