### PR TITLE
docs(editors): add Roo Code setup guide (#0000)

### DIFF
--- a/docs/EDITORS/ROO_CODE_SETUP.md
+++ b/docs/EDITORS/ROO_CODE_SETUP.md
@@ -1,0 +1,54 @@
+# Roo Code Setup
+
+Roo Code is VS Code-compatible, so `perl-lsp` setup is almost identical to
+VS Code.
+
+## Fast Path (Recommended)
+
+1. Open **Extensions** in Roo Code.
+2. Search for **Perl Language Server (perl-lsp-rs)** by `EffortlessMetrics`.
+3. Install the extension.
+4. Open a Perl workspace folder.
+
+The extension downloads and manages the matching `perllsp` binary
+automatically.
+
+## Manual LSP Configuration
+
+If you prefer not to install the extension, configure Roo Code's LSP client to
+run:
+
+```text
+perllsp --stdio
+```
+
+Use your workspace root as the working directory so include paths and
+configuration discovery resolve correctly.
+
+## Settings You May Want
+
+In `.vscode/settings.json` (Roo Code uses the same folder/settings model),
+these are common project-level settings:
+
+```json
+{
+  "perl-lsp.includePaths": [
+    "lib",
+    "local/lib/perl5"
+  ],
+  "perl-lsp.perlcritic.enabled": true,
+  "perl-lsp.features.inlay_hints": true
+}
+```
+
+## Troubleshooting
+
+- Run `perllsp --health` in the same terminal environment Roo Code launches
+  from.
+- If modules do not resolve, verify `perl-lsp.includePaths` and check for a
+  `.perl-lsp.toml` file at your workspace root.
+- If the server does not start, open Roo Code's output/log panel and inspect
+  language client startup errors.
+
+For feature and behavior details, see the VS Code guide:
+[VS_CODE_SETUP.md](./VS_CODE_SETUP.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -25,6 +25,7 @@ perllsp --health
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
 | Trae (ByteDance) | install the VS Code-compatible extension or set command to `perllsp --stdio` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
+| Roo Code | install the VS Code-compatible extension or use `perllsp --stdio` | [docs/EDITORS/ROO_CODE_SETUP.md](../EDITORS/ROO_CODE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
@@ -45,6 +46,12 @@ root pointed at the project root.
 Trae is VS Code-compatible, so the same extension and settings model applies.
 Install the `EffortlessMetrics.perl-lsp-rs` extension from Trae's Extensions
 panel, or configure a generic language server command as `perllsp --stdio`.
+
+### Roo Code
+
+Roo Code uses the same extension/runtime model as VS Code. Install the
+`perl-lsp-rs` extension or configure `perllsp --stdio` manually, then keep the
+workspace root pointed at the project root.
 
 ### Neovim
 


### PR DESCRIPTION
### Motivation
- Make it explicit how to run `perl-lsp` from Roo Code (a VS Code-compatible editor) so Roo Code users can find the same quick-start and troubleshooting guidance as VS Code users.

### Description
- Add `docs/EDITORS/ROO_CODE_SETUP.md` containing extension-based install flow, manual `perllsp --stdio` setup, example `.vscode/settings.json`, troubleshooting tips, and a link to the VS Code deep-dive guide.
- Update `docs/how-to/EDITOR_SETUP.md` to include `Roo Code` in the editor matrix and add a short `Roo Code` minimal configuration section.

### Testing
- Ran `cargo test -p perl-lsp-rs --lib`, which completed successfully (`428 passed, 0 failed, 4 ignored`).
- Ran `cargo xtask fmt`, which failed due to unrelated pre-existing compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` and not caused by these documentation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea213634208333a13cd377f7132dde)