### PR TITLE
docs(editors): add Kilo Code setup guidance (#0000)

### DIFF
--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| Kilo Code | follow the VS Code flow; run `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,15 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### Kilo Code
+
+Kilo Code is VS Code-compatible, so the quickest path is the same as VS Code:
+install the `perl-lsp-rs` extension and ensure the workspace launches
+`perllsp --stdio`.
+
+If you use a generic LSP client inside Kilo Code, set its server command to
+`["perllsp", "--stdio"]` and scope it to Perl files.
 
 ## When Setup Fails
 

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -85,6 +85,16 @@ If `--version` and `--health` work but your editor still cannot connect, jump to
 
 2. Open a `.pl` or `.pm` file - the server starts automatically.
 
+### Kilo Code
+
+Kilo Code is VS Code-compatible, so you can use the same extension and workflow:
+
+1. Install the `EffortlessMetrics.perl-lsp-rs` extension from the extensions UI.
+
+2. Open your Perl project in Kilo Code and confirm `perllsp --health` returns `ok` in an integrated terminal.
+
+3. If you prefer a generic LSP client setup, point it to `perllsp --stdio`.
+
 ### Neovim
 
 Add to your `init.lua`:


### PR DESCRIPTION
### Motivation
- Kilo Code users did not have explicit editor setup guidance, requiring them to infer compatibility from the VS Code docs.

### Description
- Added a `Kilo Code` entry to the editor compatibility table and a `### Kilo Code` subsection in `docs/how-to/EDITOR_SETUP.md` and a quick-start `### Kilo Code` block in `docs/tutorials/GETTING_STARTED.md` that instructs users to install the `EffortlessMetrics.perl-lsp-rs` extension or point their LSP client at `perllsp --stdio`.

### Testing
- Ran `cargo xtask fmt --check`, which failed due to pre-existing compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` (`last_run` / `run` unresolved) that are unrelated to these docs-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2136465883338a4b3b898bd94f68)