### PR TITLE
docs(vscode-extension): document PearAI compatibility (#0000)

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -75,7 +75,7 @@ media assets and recording notes live in:
 
 ## Installation
 
-Install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs) or [Open VSX Registry](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs).
+Install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs) or [Open VSX Registry](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs). Open VSX packages also work in VS Code derivatives like PearAI.
 
 ```bash
 # VS Code
@@ -83,6 +83,10 @@ code --install-extension EffortlessMetrics.perl-lsp-rs
 
 # VSCodium / Open VSX
 codium --install-extension EffortlessMetrics.perl-lsp-rs
+
+# PearAI (uses Open VSX-compatible extension IDs)
+# Install via PearAI's Extensions UI, then search for:
+#   EffortlessMetrics.perl-lsp-rs
 ```
 
 The extension automatically downloads the correct `perllsp` binary for your platform on first activation:

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -26,7 +26,8 @@
     "code-completion",
     "diagnostics",
     "vscodium",
-    "open-vsx"
+    "open-vsx",
+    "pearai"
   ],
   "extensionKind": [
     "workspace"


### PR DESCRIPTION
### Motivation
- Improve discovery and installation guidance for VS Code derivatives that use Open VSX-compatible extensions (e.g. PearAI) by making support explicit in docs and extension metadata.

### Description
- Added a short PearAI note to `vscode-extension/README.md` installation instructions and added the `pearai` keyword to `vscode-extension/package.json` so extension catalogs and searches surface compatibility.

### Testing
- Ran the extension unit tests via `npm --prefix vscode-extension test -- --runTestsByPath src/test/extensionUx.test.ts` and the TypeScript/Jest compile step failed in this environment due to missing Jest globals/type declarations (test failure is environmental and not caused by the documentation/keyword changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea21364fec8333aa8006bf663cbe63)