### PR TITLE
fix(cli): improve Warp terminal ANSI detection (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/runtime/launcher/mod.rs
+++ b/crates/perl-lsp-rs-core/src/runtime/launcher/mod.rs
@@ -40,6 +40,23 @@ pub fn should_enable_logging(explicit_flag: bool) -> bool {
     explicit_flag || logging_env_directive().is_some()
 }
 
+/// Returns whether ANSI output should be emitted for a stream.
+///
+/// ANSI is enabled when `NO_COLOR` is not present and either:
+/// - the stream is attached to a terminal, or
+/// - Warp Terminal is detected via `TERM_PROGRAM`.
+pub fn should_use_ansi(stream_is_terminal: bool) -> bool {
+    std::env::var("NO_COLOR").is_err()
+        && (stream_is_terminal
+            || term_program_is_warp(std::env::var("TERM_PROGRAM").ok().as_deref()))
+}
+
+fn term_program_is_warp(term_program: Option<&str>) -> bool {
+    term_program.is_some_and(|program| {
+        program.eq_ignore_ascii_case("WarpTerminal") || program.eq_ignore_ascii_case("Warp")
+    })
+}
+
 fn logging_env_directive() -> Option<String> {
     std::env::var("PERL_LSP_LOG").ok().or_else(|| std::env::var("RUST_LOG").ok())
 }
@@ -74,7 +91,7 @@ pub fn init_logging(default_filter: &str) {
             .or_else(|_| EnvFilter::try_new(default_filter))
             .unwrap_or_else(|_| EnvFilter::new("info"));
 
-        let use_ansi = std::env::var("NO_COLOR").is_err() && io::stderr().is_terminal();
+        let use_ansi = should_use_ansi(io::stderr().is_terminal());
 
         // If PERL_LSP_LOG_FILE is set, add a rolling file appender alongside stderr.
         if let Ok(log_path) = std::env::var("PERL_LSP_LOG_FILE") {
@@ -880,6 +897,20 @@ mod tests {
         let plan = must(parse_args(["perl-lsp", "--help"]));
         assert_eq!(plan.action, LaunchAction::Help);
         assert_eq!(plan.config.transport, TransportMode::Stdio);
+    }
+
+    #[test]
+    fn warp_term_program_detection_accepts_known_values() {
+        assert!(super::term_program_is_warp(Some("WarpTerminal")));
+        assert!(super::term_program_is_warp(Some("warpterminal")));
+        assert!(super::term_program_is_warp(Some("Warp")));
+    }
+
+    #[test]
+    fn warp_term_program_detection_rejects_other_terminals() {
+        assert!(!super::term_program_is_warp(None));
+        assert!(!super::term_program_is_warp(Some("Apple_Terminal")));
+        assert!(!super::term_program_is_warp(Some("iTerm.app")));
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/cli.rs
+++ b/crates/perl-lsp-rs/src/cli.rs
@@ -9,6 +9,7 @@ use perl_lsp_rs_core::runtime::launcher::{
     LaunchAction, LaunchConfig, StartupTimer, TransportMode, format_health_output,
     format_info_output, format_startup_banner, help_text, init_logging, log_server_startup,
     logging_filter, parse_args, port_in_use_message, shell_completion, should_enable_logging,
+    should_use_ansi,
 };
 use std::env;
 use std::path::Path;
@@ -181,7 +182,7 @@ fn run_check(command_name: &str, files: &[String]) -> i32 {
 
 fn is_terminal_stdout() -> bool {
     use std::io::IsTerminal;
-    env::var("NO_COLOR").is_err() && std::io::stdout().is_terminal()
+    should_use_ansi(std::io::stdout().is_terminal())
 }
 
 struct FileError {


### PR DESCRIPTION
### Motivation

- Improve ANSI/color output for users of Warp Terminal where streams may not report as a classic TTY but the terminal supports colors.

### Description

- Add `should_use_ansi(stream_is_terminal: bool)` to the launcher runtime to centralize ANSI decision logic and respect `NO_COLOR` while treating `TERM_PROGRAM=WarpTerminal`/`Warp` as color-capable.
- Add helper `term_program_is_warp` and unit tests for positive and negative detection cases.
- Use `should_use_ansi` in `init_logging` to decide stderr coloring and wire the same helper into CLI stdout detection via `is_terminal_stdout` in `crates/perl-lsp-rs/src/cli.rs`.
- Update imports and small callsites to use the shared helper and add tests covering the new detection logic.

### Testing

- Ran `cargo test -p perl-lsp-rs-core warp_term_program_detection` and it passed.
- Ran `cargo test -p perl-lsp-rs-core` which exercised the crate test suite but reported one pre-existing unrelated failing test (`green_tdd_wave_g1b_regression_hardening::test_perl_lsp_cargo_toml_removed_g1b_imports`).
- Ran `cargo check --all-targets -p perl-lsp-rs-core` which succeeded.
- Ran `cargo check --all-targets -p perl-lsp-rs` which failed due to a pre-existing unrelated parse error in a test file.
- Ran `cargo clippy -p perl-lsp-rs-core -- -D warnings` and `cargo clippy -p perl-lsp-rs -- -D warnings` which both completed successfully.
- Ran `rustfmt --edition 2024` on the touched files and formatting succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea213670208333802f2aca26a5150e)