### PR TITLE
fix(cli): improve Warp terminal ANSI detection (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/runtime/launcher/mod.rs
+++ b/crates/perl-lsp-rs-core/src/runtime/launcher/mod.rs
@@ -30,6 +30,27 @@ static LOG_FILE_GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = O
 /// Default port used by socket transport.
 pub const DEFAULT_LSP_PORT: u16 = 9257;
 
+/// Determine whether ANSI output should be enabled for terminal-facing output.
+///
+/// Color is disabled when `NO_COLOR` is set, enabled for real terminals, and
+/// also enabled for Warp (`TERM_PROGRAM=WarpTerminal`) because Warp shells can
+/// report non-terminal streams while still supporting ANSI styling.
+pub fn should_use_ansi(stream_is_terminal: bool) -> bool {
+    should_use_ansi_with_env(
+        stream_is_terminal,
+        std::env::var_os("NO_COLOR").is_some(),
+        std::env::var("TERM_PROGRAM").ok().as_deref(),
+    )
+}
+
+fn should_use_ansi_with_env(
+    stream_is_terminal: bool,
+    no_color_set: bool,
+    term_program: Option<&str>,
+) -> bool {
+    !no_color_set && (stream_is_terminal || term_program == Some("WarpTerminal"))
+}
+
 /// Returns whether runtime logging should be enabled.
 ///
 /// Logging activates when the CLI explicitly requests it or when
@@ -74,7 +95,7 @@ pub fn init_logging(default_filter: &str) {
             .or_else(|_| EnvFilter::try_new(default_filter))
             .unwrap_or_else(|_| EnvFilter::new("info"));
 
-        let use_ansi = std::env::var("NO_COLOR").is_err() && io::stderr().is_terminal();
+        let use_ansi = should_use_ansi(io::stderr().is_terminal());
 
         // If PERL_LSP_LOG_FILE is set, add a rolling file appender alongside stderr.
         if let Ok(log_path) = std::env::var("PERL_LSP_LOG_FILE") {
@@ -809,6 +830,23 @@ mod tests {
         // init_logging is guarded by Once, so calling it multiple times is safe.
         // This test verifies the stderr-only path does not panic.
         super::init_logging("warn");
+    }
+
+    #[test]
+    fn should_use_ansi_prefers_tty_without_no_color() {
+        assert!(super::should_use_ansi_with_env(true, false, None));
+        assert!(!super::should_use_ansi_with_env(false, false, None));
+    }
+
+    #[test]
+    fn should_use_ansi_enables_warp_even_without_tty() {
+        assert!(super::should_use_ansi_with_env(false, false, Some("WarpTerminal")));
+    }
+
+    #[test]
+    fn should_use_ansi_honors_no_color_for_warp() {
+        assert!(!super::should_use_ansi_with_env(true, true, Some("WarpTerminal")));
+        assert!(!super::should_use_ansi_with_env(false, true, Some("WarpTerminal")));
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/cli.rs
+++ b/crates/perl-lsp-rs/src/cli.rs
@@ -9,6 +9,7 @@ use perl_lsp_rs_core::runtime::launcher::{
     LaunchAction, LaunchConfig, StartupTimer, TransportMode, format_health_output,
     format_info_output, format_startup_banner, help_text, init_logging, log_server_startup,
     logging_filter, parse_args, port_in_use_message, shell_completion, should_enable_logging,
+    should_use_ansi,
 };
 use std::env;
 use std::path::Path;
@@ -181,7 +182,7 @@ fn run_check(command_name: &str, files: &[String]) -> i32 {
 
 fn is_terminal_stdout() -> bool {
     use std::io::IsTerminal;
-    env::var("NO_COLOR").is_err() && std::io::stdout().is_terminal()
+    should_use_ansi(std::io::stdout().is_terminal())
 }
 
 struct FileError {


### PR DESCRIPTION
### Motivation

- Terminal ANSI styling could be incorrectly disabled in Warp sessions when standard streams report non-TTY, making colored health/info/log output less readable.

### Description

- Add a centralized helper `should_use_ansi(stream_is_terminal: bool)` (and testable helper `should_use_ansi_with_env`) that honors `NO_COLOR` but treats `TERM_PROGRAM=WarpTerminal` as ANSI-capable.
- Wire the new helper into runtime logging via `init_logging` so stderr logging uses the same Warp-aware logic.
- Update the CLI `is_terminal_stdout` path to call the shared `should_use_ansi` so `--health`/`--info` coloring matches logging behavior.
- Add focused unit tests covering TTY, Warp non-TTY, and `NO_COLOR` override cases.

### Testing

- Ran `cargo test -p perl-lsp-rs-core should_use_ansi -- --nocapture` and the focused ANSI tests passed.
- Ran `cargo check --all-targets -p perl-lsp-rs-core` which completed successfully.
- Ran `cargo clippy -p perl-lsp-rs-core -- -D warnings` which completed successfully with no warnings.
- A full `cargo test -p perl-lsp-rs-core` run exposed an unrelated pre-existing repository test failure (`green_tdd_wave_g1b_regression_hardening`) due to a missing `crates/perl-lsp/Cargo.toml`, which is outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea213670208333802f2aca26a5150e)