### PR TITLE
fix(lsp): add Claude Code initialize workspace fallback (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
@@ -27,6 +27,13 @@ impl LspServer {
 
         // Parse client capabilities
         if let Some(params) = &params {
+            let is_claude_code_client = params
+                .get("clientInfo")
+                .and_then(|info| info.get("name"))
+                .and_then(|name| name.as_str())
+                .map(|name| name.to_ascii_lowercase().contains("claude"))
+                .unwrap_or(false);
+
             // Take lock once to write all capabilities
             {
                 let mut caps = self.client_capabilities.lock();
@@ -229,6 +236,21 @@ impl LspServer {
                     root_uri.clone(),
                 ));
                 self.set_root_uri(&root_uri);
+            } else if is_claude_code_client {
+                // Claude Code can start servers without workspaceFolders/rootUri in some modes.
+                // Fall back to the process working directory so workspace-scoped features
+                // (module resolution, project config loading) still behave predictably.
+                if let Ok(root_path) = std::env::current_dir() {
+                    if let Some(path_str) = root_path.to_str() {
+                        let root_uri = root_path_to_file_uri(path_str);
+                        tracing::debug!(root_uri, "Initialized Claude Code fallback workspace");
+                        let mut folders = self.workspace_folders.lock();
+                        folders.push(super::super::workspace_folder::WorkspaceFolderState::new(
+                            root_uri.clone(),
+                        ));
+                        self.set_root_uri(&root_uri);
+                    }
+                }
             }
         }
 
@@ -489,5 +511,20 @@ mod tests {
         let _ = server.handle_initialize(Some(params));
 
         assert!(server.client_capabilities.lock().workspace_configuration_support);
+    }
+
+    #[test]
+    fn initialize_claude_code_falls_back_to_cwd_workspace() {
+        let server = LspServer::new();
+        let params = json!({
+            "clientInfo": {
+                "name": "Claude Code"
+            },
+            "capabilities": {}
+        });
+
+        let _ = server.handle_initialize(Some(params));
+
+        assert_eq!(server.workspace_folders.lock().len(), 1);
     }
 }


### PR DESCRIPTION
### Motivation

- Claude Code sometimes initializes the LSP server without `workspaceFolders`, `rootUri`, or `rootPath`, leaving workspace-scoped features (module resolution, project config loading) under-initialized.

### Description

- Detect `clientInfo.name` containing `claude` in the `initialize` params and set a boolean flag when present.
- When no workspace metadata is provided and the client is Claude Code, fall back to the process current working directory and register it as a workspace folder and root URI.
- Added a focused unit test `initialize_claude_code_falls_back_to_cwd_workspace` to verify the fallback behavior.
- Change is implemented in `crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs`.

### Testing

- Ran `cargo test -p perl-lsp-rs --lib initialize_claude_code_falls_back_to_cwd_workspace` and the new test passed.
- Ran `cargo fmt --all` which reported a pre-existing parse error in an unrelated test file (`mojolicious_navigation_tests.rs`).
- Ran `cargo check --all-targets -p perl-lsp-rs` but the full workspace check did not complete in this environment (long-running build observed and processes were managed during verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2141160c8333bc0bb247573e630b)