### PR TITLE
docs(editors): add Claude Code LSP setup guide (#0000)

### DIFF
--- a/docs/EDITORS/CLAUDE_CODE_SETUP.md
+++ b/docs/EDITORS/CLAUDE_CODE_SETUP.md
@@ -1,0 +1,61 @@
+# Claude Code Setup
+
+This guide shows how to wire `perllsp` into Claude Code as an external Language
+Server Protocol (LSP) backend.
+
+> If `perllsp` is not installed yet, follow [INSTALLATION.md](../how-to/INSTALLATION.md)
+> first.
+
+## 1) Verify the server binary
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+Both commands should succeed before you configure Claude Code.
+
+## 2) Configure Claude Code to launch `perllsp`
+
+Use this command in your Claude Code LSP settings:
+
+```text
+perllsp --stdio
+```
+
+Use your Perl workspace root as the project folder so workspace-scoped features
+(rename, references, symbols, diagnostics) can resolve files correctly.
+
+## 3) Recommended initialize payload fields
+
+If Claude Code lets you customize initialize parameters, include:
+
+- `rootUri` (or `workspaceFolders`)
+- `capabilities` (may be minimal `{}`)
+- `clientInfo` (recommended, optional)
+
+Example payload skeleton:
+
+```json
+{
+  "rootUri": "file:///path/to/project",
+  "capabilities": {},
+  "clientInfo": {
+    "name": "claude-code"
+  }
+}
+```
+
+`perllsp` accepts minimal capabilities and negotiates feature support from what
+the client declares.
+
+## 4) Smoke test after connecting
+
+Open a `.pl` or `.pm` file and validate these quickly:
+
+1. Diagnostics appear for obvious syntax errors.
+2. Hover works on builtins/symbols.
+3. Go to definition resolves local symbols.
+4. Completion appears inside Perl code.
+
+If any step fails, use [TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| Claude Code | configure external LSP command `perllsp --stdio` | [docs/EDITORS/CLAUDE_CODE_SETUP.md](../EDITORS/CLAUDE_CODE_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,16 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### Claude Code
+
+Configure Claude Code to launch an external LSP command with:
+
+```text
+perllsp --stdio
+```
+
+For full setup details, see [docs/EDITORS/CLAUDE_CODE_SETUP.md](../EDITORS/CLAUDE_CODE_SETUP.md).
 
 ## When Setup Fails
 


### PR DESCRIPTION
### Motivation
- Provide explicit setup guidance so Claude Code users can run `perllsp` as an external LSP backend and get workspace-scoped features working correctly.

### Description
- Add `docs/EDITORS/CLAUDE_CODE_SETUP.md` with a short install/initialize checklist and link it from `docs/how-to/EDITOR_SETUP.md`, and add a one-line Claude Code entry and minimal snippet to the central editor setup page.

### Testing
- Ran `git diff --check` which passed, attempted `cargo xtask fmt` and `cargo check --all-targets -p perl-lsp-rs` which were executed but failed due to unrelated pre-existing workspace build/test issues (xtask compile errors and a test syntax error), so the docs-only change itself required no code fixes and produced no diff-check failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2141160c8333bc0bb247573e630b)