### PR TITLE
feat(perl-semantic-analyzer): add Droid web-route detection (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -348,6 +348,8 @@ pub enum WebFrameworkKind {
     Dancer,
     /// `use Dancer2;` or `use Dancer2::Core;`
     Dancer2,
+    /// `use Droid;`
+    Droid,
     /// `use Mojolicious::Lite;`
     MojoliciousLite,
     /// `use Plack::Builder;`
@@ -388,7 +390,7 @@ pub struct FrameworkFlags {
     pub class_accessor: bool,
     /// Which specific Moo/Moose variant was detected.
     pub kind: Option<FrameworkKind>,
-    /// Web framework variant, if any (Dancer, Dancer2, Mojolicious::Lite).
+    /// Web framework variant, if any (Dancer, Dancer2, Droid, Mojolicious::Lite).
     pub web_framework: Option<WebFrameworkKind>,
     /// Async framework variant, if any (IO::Async).
     pub async_framework: Option<AsyncFrameworkKind>,
@@ -1565,7 +1567,7 @@ impl SymbolExtractor {
         if require_embedded_marker { None } else { Some(attr_expr) }
     }
 
-    /// Detect Dancer/Dancer2/Mojolicious::Lite route declarations and synthesize route symbols.
+    /// Detect Dancer/Dancer2/Droid/Mojolicious::Lite route declarations and synthesize route symbols.
     ///
     /// Pattern (two statements):
     /// 1. `ExpressionStatement(Identifier("get"|"post"|"put"|"del"|"patch"|"any"))`
@@ -1617,7 +1619,11 @@ impl SymbolExtractor {
 
                         if matches!(
                             web_framework,
-                            Some(WebFrameworkKind::Dancer | WebFrameworkKind::Dancer2)
+                            Some(
+                                WebFrameworkKind::Dancer
+                                    | WebFrameworkKind::Dancer2
+                                    | WebFrameworkKind::Droid
+                            )
                         ) && let Some(target_node) = args.get(1)
                         {
                             if let Some(target_name) =
@@ -2142,6 +2148,7 @@ impl SymbolExtractor {
         let web_kind = match module {
             "Dancer" => Some(WebFrameworkKind::Dancer),
             "Dancer2" | "Dancer2::Core" => Some(WebFrameworkKind::Dancer2),
+            "Droid" => Some(WebFrameworkKind::Droid),
             "Mojolicious::Lite" => Some(WebFrameworkKind::MojoliciousLite),
             "Plack::Builder" => Some(WebFrameworkKind::PlackBuilder),
             _ => None,

--- a/crates/perl-semantic-analyzer/tests/frameworks_web.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_web.rs
@@ -256,6 +256,38 @@ any '/multi' => sub { return 'multi' };
 }
 
 #[test]
+fn droid_get_route_emits_subroutine_symbol() {
+    let code = r#"
+use Droid;
+
+get '/health' => sub { return 'ok' };
+"#;
+    let table = extract_symbols(code);
+    assert!(
+        has_symbol(&table, "/health", SymbolKind::Subroutine),
+        "expected route symbol `/health` for Droid `get '/health' => sub`"
+    );
+}
+
+#[test]
+fn droid_route_target_string_adds_subroutine_reference() {
+    let code = r#"
+use Droid;
+
+get '/status' => 'show_status';
+
+sub show_status {
+    return 'ok';
+}
+"#;
+    let table = extract_symbols(code);
+    assert!(
+        has_reference(&table, "show_status", SymbolKind::Subroutine),
+        "expected Droid route target string `show_status` to be recorded as a Subroutine reference"
+    );
+}
+
+#[test]
 fn dancer_route_target_string_adds_subroutine_reference() {
     let code = r#"
 use Dancer;


### PR DESCRIPTION
### Motivation

- Recognize `use Droid;` as a web framework so Droid route declarations are synthesized for navigation/analysis features.

### Description

- Add `WebFrameworkKind::Droid` and update `FrameworkFlags` docs to include `Droid` in web framework detection.
- Extend route extraction (`try_extract_web_route_declaration`) to treat `Droid` like `Dancer`/`Dancer2` for synthesizing route `Subroutine` symbols and for recording string-target subroutine references.
- Map the module name `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea216974e08333b0059dca98637868)