### PR TITLE
fix(workspace): accept path-based workspace folders (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/folder/mod.rs
+++ b/crates/perl-workspace-index/src/folder/mod.rs
@@ -76,7 +76,16 @@ pub fn extract_workspace_folder_uris(workspace_folders: &[Value]) -> Vec<String>
     workspace_folders
         .iter()
         .filter_map(|folder| {
-            folder.get("uri").and_then(Value::as_str).map(std::string::ToString::to_string)
+            folder
+                .get("uri")
+                .and_then(Value::as_str)
+                .map(std::string::ToString::to_string)
+                .or_else(|| {
+                    folder
+                        .get("path")
+                        .and_then(Value::as_str)
+                        .map(root_path_to_file_uri)
+                })
         })
         .collect()
 }
@@ -170,10 +179,11 @@ mod tests {
         let entries = vec![
             json!({"uri": "file:///one"}),
             json!({"uri": "file:///two"}),
+            json!({"path": "/three"}),
             json!({"name": "invalid"}),
         ];
         let uris = extract_workspace_folder_uris(&entries);
-        assert_eq!(uris, vec!["file:///one", "file:///two"]);
+        assert_eq!(uris, vec!["file:///one", "file:///two", "file:///three"]);
     }
 
     #[test]

--- a/crates/perl-workspace-index/tests/workspace_folder_prop.rs
+++ b/crates/perl-workspace-index/tests/workspace_folder_prop.rs
@@ -20,6 +20,11 @@ fn uri_entry_strategy() -> impl Strategy<Value = (Option<String>, Value)> {
             let uri = format!("file:///{folder}");
             (Some(uri.clone()), json!({"uri": uri}))
         }),
+        plain_path_strategy().prop_map(|folder| {
+            let path = format!("/{folder}");
+            let uri = root_path_to_file_uri(&path);
+            (Some(uri), json!({"path": path}))
+        }),
         any::<i64>().prop_map(|value| (None, json!({"uri": value}))),
         plain_path_strategy().prop_map(|folder| (None, json!({"name": folder}))),
         Just((None, json!(null))),


### PR DESCRIPTION
### Motivation

- Some LSP clients (e.g., Droid-style/mobile integrations) provide workspace folder entries using a `path` field instead of `uri`, which caused folder initialization to be skipped.

### Description

- Extend `extract_workspace_folder_uris` to accept a `path` string and normalize it to a `file://` URI via `root_path_to_file_uri` when `uri` is absent.
- Add a unit test verifying mixed `uri` + `path` entries are extracted and normalized into `file://` URIs.
- Extend the property-based generator in `workspace_folder_prop.rs` to produce `{"path": ...}` entries so the invariant tests cover path-form inputs.

### Testing

- Ran `cargo test -p perl-workspace` and all tests passed.
- Ran `cargo check --all-targets -p perl-workspace` and it passed.
- `cargo clippy -p perl-workspace --all-targets -- -D warnings` failed due to pre-existing clippy violations in unrelated tests, unrelated to this change.
- `cargo xtask fmt` could not complete due to unrelated `xtask` compile errors in this environment.
- `just pr-fast` is not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea216974e08333b0059dca98637868)