### PR TITLE
fix(vscode-extension): improve Droid binary detection (#0000)

### DIFF
--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -117,10 +117,18 @@ export class BinaryDownloader {
                 // Architecture or OS not supported by the release
                 const platformMatch = /platform:\s*([^\s.]+)/.exec(errorMsg);
                 const platformStr = platformMatch ? platformMatch[1] : 'your platform';
-                message =
-                    `perl-lsp: No pre-built binary for ${platformStr}. ` +
-                    'Build from source or download a compatible binary manually. ' +
-                    manualInstallNote;
+                if (this.isAndroidEnvironment()) {
+                    message =
+                        `perl-lsp: Android environment detected (${platformStr}). ` +
+                        'Pre-built Android binaries are not published yet. ' +
+                        'Use Termux package tooling or build from source, then point perl-lsp.serverPath to the binary. ' +
+                        manualInstallNote;
+                } else {
+                    message =
+                        `perl-lsp: No pre-built binary for ${platformStr}. ` +
+                        'Build from source or download a compatible binary manually. ' +
+                        manualInstallNote;
+                }
                 buttons = ['Install Manually'];
             } else if (errorMsg.includes('HTTP 403')) {
                 // GitHub rate limit or auth failure
@@ -579,6 +587,15 @@ export class BinaryDownloader {
         if (platform === 'darwin') {
             return arch === 'arm64' ? 'aarch64-apple-darwin' : 'x86_64-apple-darwin';
         } else if (platform === 'linux') {
+            if (this.isAndroidEnvironment()) {
+                const androidArchMap: Record<string, string> = {
+                    arm64: 'aarch64-linux-android',
+                    x64: 'x86_64-linux-android',
+                    ia32: 'i686-linux-android',
+                    arm: 'armv7-linux-androideabi'
+                };
+                return androidArchMap[arch] ?? `${arch}-linux-android`;
+            }
             const archPrefix = arch === 'arm64' ? 'aarch64' : 'x86_64';
             const libc = this.detectMusl() ? 'musl' : 'gnu';
             return `${archPrefix}-unknown-linux-${libc}`;
@@ -602,6 +619,19 @@ export class BinaryDownloader {
         const rustArch = archMap[arch] || arch;
         
         return `${rustArch}-${rustPlatform}`;
+    }
+
+    private isAndroidEnvironment(): boolean {
+        if (process.platform !== 'linux') {
+            return false;
+        }
+
+        return (
+            typeof process.env.ANDROID_ROOT === 'string' ||
+            typeof process.env.ANDROID_DATA === 'string' ||
+            typeof process.env.TERMUX_VERSION === 'string' ||
+            os.release().toLowerCase().includes('android')
+        );
     }
     
     private detectMusl(): boolean {

--- a/vscode-extension/src/test/downloader.test.ts
+++ b/vscode-extension/src/test/downloader.test.ts
@@ -36,9 +36,21 @@ function makeOutputChannel(): any {
 // ---------------------------------------------------------------------------
 describe('BinaryDownloader.getPlatformTarget', () => {
   let downloader: BinaryDownloader;
+  let androidRootBackup: string | undefined;
+  let androidDataBackup: string | undefined;
+  let termuxVersionBackup: string | undefined;
 
   beforeEach(() => {
     downloader = new BinaryDownloader(makeContext(), makeOutputChannel());
+    androidRootBackup = process.env.ANDROID_ROOT;
+    androidDataBackup = process.env.ANDROID_DATA;
+    termuxVersionBackup = process.env.TERMUX_VERSION;
+  });
+
+  afterEach(() => {
+    process.env.ANDROID_ROOT = androidRootBackup;
+    process.env.ANDROID_DATA = androidDataBackup;
+    process.env.TERMUX_VERSION = termuxVersionBackup;
   });
 
   function getPlatformTarget(dl: any): string {
@@ -60,6 +72,12 @@ describe('BinaryDownloader.getPlatformTarget', () => {
   test('target contains platform component', () => {
     const target = getPlatformTarget(downloader);
     expect(target).toMatch(/(apple-darwin|unknown-linux|pc-windows)/);
+  });
+
+  test('detects Android/Termux and returns android target triple', () => {
+    process.env.TERMUX_VERSION = '0.118.0';
+    const target = getPlatformTarget(downloader);
+    expect(target).toMatch(/linux-android/);
   });
 });
 
@@ -859,6 +877,24 @@ describe('ensureBinary error classification', () => {
     // Must include the platform string and the manual install setting
     expect(call[0]).toMatch(/arm64-unknown-linux-gnu/);
     expect(call[0]).toMatch(/perl-lsp\.serverPath/);
+  });
+
+  test('android/termux no-binary error includes android guidance', async () => {
+    const termuxVersionBackup = process.env.TERMUX_VERSION;
+    try {
+      process.env.TERMUX_VERSION = '0.118.0';
+      setupDownloadError('No binary found for platform: aarch64-linux-android. Available assets: perllsp-x86_64-unknown-linux-gnu.tar.gz');
+      const vscode = require('vscode');
+      vscode.window.showErrorMessage.mockResolvedValue(undefined);
+
+      await downloader.ensureBinary();
+
+      const call = vscode.window.showErrorMessage.mock.calls[0];
+      expect(call[0]).toMatch(/android environment detected/i);
+      expect(call[0]).toMatch(/termux|build from source|serverPath/i);
+    } finally {
+      process.env.TERMUX_VERSION = termuxVersionBackup;
+    }
   });
 
   test('HTTP 403 rate limit shows GitHub rate limit guidance', async () => {


### PR DESCRIPTION
### Motivation
- Android/Termux devices were treated as generic Linux, producing inaccurate cargo target triples and an unhelpful "No binary found for platform" message for Droid users.

### Description
- Add `isAndroidEnvironment()` to detect Android-like hosts via `ANDROID_ROOT`, `ANDROID_DATA`, `TERMUX_VERSION`, or `os.release()` checks.
- Emit Android-specific Rust target triples in `getPlatformTarget()` when an Android environment is detected (e.g. `aarch64-linux-android`).
- Provide Android/Termux-specific guidance in the `ensureBinary()` no-asset error path recommending Termux tooling, building from source, and setting `perl-lsp.serverPath` for manual installs.
- Add unit tests that exercise Android detection and the Android-specific no-binary message while safely backing up and restoring environment variables to avoid test pollution.

### Testing
- Ran `npm test -- --runInBand src/test/downloader.test.ts`, which failed to execute the suite due to the workspace TypeScript/Jest globals typing setup (Jest globals not recognized), so new tests did not run to completion.
- Ran `npm run compile`, which failed with a pre-existing TypeScript config deprecation error (`TS5107`) unrelated to these changes and preventing a clean compile in this environment.
- Noted that `git log origin/master --oneline -20` could not be executed in this checkout (no `origin/master` ref available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea216974e08333b0059dca98637868)