### PR TITLE
feat(mcp): add .mcp file support across source detection (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/runtime/input_validation/mod.rs
+++ b/crates/perl-lsp-rs-core/src/runtime/input_validation/mod.rs
@@ -15,7 +15,7 @@ use crate::runtime::limits::max_file_size_bytes as limits_max_file_size_bytes;
 const MAX_PATH_LENGTH: usize = 4096;
 
 /// Allowed file extensions for Perl files.
-const ALLOWED_EXTENSIONS: &[&str] = &["pl", "pm", "t", "pod"];
+const ALLOWED_EXTENSIONS: &[&str] = &["pl", "pm", "t", "pod", "mcp"];
 
 /// Validates and sanitizes a file path to prevent path traversal attacks.
 pub fn validate_file_path<P: AsRef<Path>>(path: P, workspace_root: &Path) -> Result<PathBuf> {
@@ -29,7 +29,7 @@ pub fn validate_file_path<P: AsRef<Path>>(path: P, workspace_root: &Path) -> Res
         .map_err(|error| anyhow!("Invalid workspace path {}: {error}", path.display()))?;
 
     if let Some(extension) = validated.extension().and_then(OsStr::to_str)
-        && !ALLOWED_EXTENSIONS.contains(&extension)
+        && !ALLOWED_EXTENSIONS.iter().any(|allowed| allowed.eq_ignore_ascii_case(extension))
     {
         return Err(anyhow!(
             "File extension '{}' not allowed. Allowed: {:?}",
@@ -217,6 +217,18 @@ mod tests {
 
         let result = validate_file_path(malicious_path, workspace_root);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_file_path_mcp_extension() {
+        use perl_tdd_support::must;
+        let temp_dir = must(TempDir::new());
+        let workspace_root = temp_dir.path();
+        let file_path = workspace_root.join("component.mcp");
+        must(fs::write(&file_path, "<%perl> my $x = 1; </%perl>"));
+
+        let result = validate_file_path(&file_path, workspace_root);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
@@ -4,7 +4,7 @@
 
 use super::super::*;
 use perl_workspace::folder::{extract_workspace_folder_uris, root_path_to_file_uri};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 impl LspServer {
     /// Handle initialize request
@@ -310,37 +310,43 @@ impl LspServer {
                     { "pattern": { "glob": "**/*.pl" } },
                     { "pattern": { "glob": "**/*.pm" } },
                     { "pattern": { "glob": "**/*.t" } },
-                    { "pattern": { "glob": "**/*.psgi" } }
+                    { "pattern": { "glob": "**/*.psgi" } },
+                    { "pattern": { "glob": "**/*.mcp" } }
                 ]},
                 "didCreate": { "filters": [
                     { "pattern": { "glob": "**/*.pl" } },
                     { "pattern": { "glob": "**/*.pm" } },
                     { "pattern": { "glob": "**/*.t" } },
-                    { "pattern": { "glob": "**/*.psgi" } }
+                    { "pattern": { "glob": "**/*.psgi" } },
+                    { "pattern": { "glob": "**/*.mcp" } }
                 ]},
                 "willRename": { "filters": [
                     { "pattern": { "glob": "**/*.pl" } },
                     { "pattern": { "glob": "**/*.pm" } },
                     { "pattern": { "glob": "**/*.t" } },
-                    { "pattern": { "glob": "**/*.psgi" } }
+                    { "pattern": { "glob": "**/*.psgi" } },
+                    { "pattern": { "glob": "**/*.mcp" } }
                 ]},
                 "didRename": { "filters": [
                     { "pattern": { "glob": "**/*.pl" } },
                     { "pattern": { "glob": "**/*.pm" } },
                     { "pattern": { "glob": "**/*.t" } },
-                    { "pattern": { "glob": "**/*.psgi" } }
+                    { "pattern": { "glob": "**/*.psgi" } },
+                    { "pattern": { "glob": "**/*.mcp" } }
                 ]},
                 "willDelete": { "filters": [
                     { "pattern": { "glob": "**/*.pl" } },
                     { "pattern": { "glob": "**/*.pm" } },
                     { "pattern": { "glob": "**/*.t" } },
-                    { "pattern": { "glob": "**/*.psgi" } }
+                    { "pattern": { "glob": "**/*.psgi" } },
+                    { "pattern": { "glob": "**/*.mcp" } }
                 ]},
                 "didDelete": { "filters": [
                     { "pattern": { "glob": "**/*.pl" } },
                     { "pattern": { "glob": "**/*.pm" } },
                     { "pattern": { "glob": "**/*.t" } },
-                    { "pattern": { "glob": "**/*.psgi" } }
+                    { "pattern": { "glob": "**/*.psgi" } },
+                    { "pattern": { "glob": "**/*.mcp" } }
                 ]}
             },
             "textDocumentContent": {
@@ -412,8 +418,8 @@ pub(crate) fn apply_disabled_feature_id(
 #[cfg(test)]
 mod tests {
     use super::apply_disabled_feature_id;
-    use crate::LspServer;
     use crate::protocol::capabilities::BuildFlags;
+    use crate::LspServer;
     use serde_json::json;
 
     #[test]

--- a/crates/perl-lsp-rs/src/runtime/lifecycle/watchers.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/watchers.rs
@@ -4,9 +4,9 @@
 
 use super::super::*;
 use lsp_types::{
+    notification::{DidChangeWatchedFiles, Notification},
     DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern, Registration,
     RegistrationParams, WatchKind,
-    notification::{DidChangeWatchedFiles, Notification},
 };
 impl LspServer {
     /// Register file watchers for Perl files
@@ -30,6 +30,10 @@ impl LspServer {
             },
             FileSystemWatcher {
                 glob_pattern: GlobPattern::String("**/*.psgi".into()),
+                kind: Some(WatchKind::Create | WatchKind::Change | WatchKind::Delete),
+            },
+            FileSystemWatcher {
+                glob_pattern: GlobPattern::String("**/*.mcp".into()),
                 kind: Some(WatchKind::Create | WatchKind::Change | WatchKind::Delete),
             },
         ];

--- a/crates/perl-parser-core/src/syntax/source_file.rs
+++ b/crates/perl-parser-core/src/syntax/source_file.rs
@@ -34,8 +34,8 @@ pub fn is_binary_content(text: &str) -> bool {
 /// Includes core Perl script and module extensions as well as common embedded
 /// Perl template formats: `.ep` (Mojolicious), `.tt`/`.tt2` (Template Toolkit),
 /// and `.mason` (Mason/HTML::Mason).
-pub const PERL_SOURCE_EXTENSIONS: [&str; 9] =
-    ["pl", "pm", "t", "psgi", "cgi", "ep", "tt", "tt2", "mason"];
+pub const PERL_SOURCE_EXTENSIONS: [&str; 10] =
+    ["pl", "pm", "t", "psgi", "cgi", "ep", "tt", "tt2", "mason", "mcp"];
 
 /// Returns `true` if `extension` is a recognized Perl source extension.
 ///
@@ -69,8 +69,8 @@ pub fn is_perl_source_uri(uri: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        BINARY_PROBE_BYTES, PERL_SOURCE_EXTENSIONS, is_binary_content, is_perl_source_extension,
-        is_perl_source_path, is_perl_source_uri,
+        is_binary_content, is_perl_source_extension, is_perl_source_path, is_perl_source_uri,
+        BINARY_PROBE_BYTES, PERL_SOURCE_EXTENSIONS,
     };
     use std::path::Path;
 
@@ -78,7 +78,7 @@ mod tests {
     fn exposes_expected_extension_set() {
         assert_eq!(
             PERL_SOURCE_EXTENSIONS,
-            ["pl", "pm", "t", "psgi", "cgi", "ep", "tt", "tt2", "mason"]
+            ["pl", "pm", "t", "psgi", "cgi", "ep", "tt", "tt2", "mason", "mcp"]
         );
     }
 
@@ -159,6 +159,12 @@ mod tests {
         assert!(is_perl_source_extension("MASON"));
         assert!(is_perl_source_path(Path::new("/app/comp/header.mason")));
         assert!(is_perl_source_uri("file:///app/comp/header.mason"));
+
+        // .mcp — Mason component files
+        assert!(is_perl_source_extension("mcp"));
+        assert!(is_perl_source_extension("MCP"));
+        assert!(is_perl_source_path(Path::new("/app/comp/header.mcp")));
+        assert!(is_perl_source_uri("file:///app/comp/header.mcp"));
 
         // Non-template extensions remain unrecognized
         assert!(!is_perl_source_extension("html"));


### PR DESCRIPTION
### Motivation

- `.mcp` (Mason component) files were not consistently recognized as Perl source, causing them to be skipped by source classification, input validation, and LSP file-operation/watcher filters.

### Description

- Add `.mcp` to the canonical source extension list in `crates/perl-parser-core/src/syntax/source_file.rs` so `is_perl_source_extension`/`is_perl_source_path`/`is_perl_source_uri` recognize `.mcp` files.
- Allow `.mcp` in runtime input validation by adding it to `ALLOWED_EXTENSIONS` and making the extension check case-insensitive in `crates/perl-lsp-rs-core/src/runtime/input_validation/mod.rs`, and add a unit test `test_validate_file_path_mcp_extension`.
- Register `**/*.mcp` file watchers in `crates/perl-lsp-rs/src/runtime/lifecycle/watchers.rs` so clients can dynamically register for changes to Mason components.
- Include `**/*.mcp` in the workspace `fileOperations` filters (willCreate/didCreate/willRename/didRename/willDelete/didDelete) in `crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs` so file operation notifications cover `.mcp` files.

### Testing

- Ran `cargo test -p perl-parser-core source_file` and it passed (source-file unit tests including new `.mcp` cases).
- Ran `cargo test -p perl-lsp-rs-core input_validation` and it passed (new validation test for `.mcp`).
- Ran `cargo check -p perl-lsp-rs --lib` and it passed.
- `cargo check --all-targets -p perl-parser-core -p perl-lsp-rs-core -p perl-lsp-rs` was attempted but blocked by an unrelated pre-existing syntax error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs` (not caused by this change).
- `cargo xtask fmt`, `cargo clippy -p ... -- -D warnings`, and `cargo fmt --all` were attempted but blocked by unrelated pre-existing issues in `xtask` and some denied lints in tests; those failures are not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22877c8483338dcc3efbbd7449a8)