### PR TITLE
feat(semantic-analyzer): add Builder::IO::Fusion web framework detection (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -352,6 +352,8 @@ pub enum WebFrameworkKind {
     MojoliciousLite,
     /// `use Plack::Builder;`
     PlackBuilder,
+    /// `use Fusion;` or `use Builder::IO::Fusion;`
+    Fusion,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2144,6 +2146,7 @@ impl SymbolExtractor {
             "Dancer2" | "Dancer2::Core" => Some(WebFrameworkKind::Dancer2),
             "Mojolicious::Lite" => Some(WebFrameworkKind::MojoliciousLite),
             "Plack::Builder" => Some(WebFrameworkKind::PlackBuilder),
+            "Fusion" | "Builder::IO::Fusion" => Some(WebFrameworkKind::Fusion),
             _ => None,
         };
         if let Some(kind) = web_kind {

--- a/crates/perl-semantic-analyzer/tests/frameworks_web.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_web.rs
@@ -239,6 +239,36 @@ post '/submit' => sub { my $c = shift };
     );
 }
 
+#[test]
+fn fusion_route_emits_subroutine_symbol() {
+    let code = r#"
+use Builder::IO::Fusion;
+
+get '/fusion-health' => sub {
+    return 'ok';
+};
+"#;
+    let table = extract_symbols(code);
+    assert!(
+        has_symbol(&table, "/fusion-health", SymbolKind::Subroutine),
+        "expected route symbol `/fusion-health` for Builder::IO::Fusion `get` route"
+    );
+}
+
+#[test]
+fn fusion_route_without_use_is_not_synthesized() {
+    let code = r#"
+get '/fusion-health' => sub {
+    return 'ok';
+};
+"#;
+    let table = extract_symbols(code);
+    assert!(
+        !has_symbol(&table, "/fusion-health", SymbolKind::Subroutine),
+        "bare `get` without `use Builder::IO::Fusion` should NOT produce a route symbol"
+    );
+}
+
 // === any route (Dancer2) ===
 
 #[test]


### PR DESCRIPTION
### Motivation

- Fusion-based apps (for example `use Builder::IO::Fusion` or `use Fusion`) were not being recognized as a web framework, so Fusion-style `get`/`post` route declarations were not synthesized.

### Description

- Add `WebFrameworkKind::Fusion` to represent the Fusion web framework in the semantic analyzer.
- Map `Fusion` and `Builder::IO::Fusion` to `WebFrameworkKind::Fusion` in `update_framework_context` so existing route synthesis is enabled for Fusion projects.
- Add focused regression tests in `crates/perl-semantic-analyzer/tests/frameworks_web.rs` that assert route synthesis when the Fusion framework is imported and no synthesis when it is not.
- Files changed: `crates/perl-semantic-analyzer/src/analysis/symbol.rs` and `crates/perl-semantic-analyzer/tests/frameworks_web.rs`.

### Testing

- Ran `cargo test -p perl-semantic-analyzer --test frameworks_web`, which passed (21 tests, 0 failed). 
- Ran `cargo clippy -p perl-semantic-analyzer`, which completed successfully. 
- `cargo test -p perl-semantic-analyzer` and `cargo check --all-targets -p perl-semantic-analyzer` failed due to a pre-existing invalid format string in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` and are unrelated to this change. 
- `cargo xtask fmt` could not be fully verified here due to existing `xtask` compile errors in this environment, and `just pr-fast` is not available in the runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22bb5520833389b64e839a48a7d9)