### PR TITLE
feat(semantic-analyzer): support Builder::IO::Fusion builder DSL (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -352,6 +352,8 @@ pub enum WebFrameworkKind {
     MojoliciousLite,
     /// `use Plack::Builder;`
     PlackBuilder,
+    /// `use Builder::IO::Fusion;`
+    BuilderIoFusion,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1713,7 +1715,12 @@ impl SymbolExtractor {
         let Some(flags) = self.framework_flags.get(&self.table.current_package) else {
             return;
         };
-        if flags.web_framework != Some(WebFrameworkKind::PlackBuilder) || name != "builder" {
+        let framework_name = match flags.web_framework {
+            Some(WebFrameworkKind::PlackBuilder) => "Plack::Builder",
+            Some(WebFrameworkKind::BuilderIoFusion) => "Builder::IO::Fusion",
+            _ => return,
+        };
+        if name != "builder" {
             return;
         }
 
@@ -1738,10 +1745,22 @@ impl SymbolExtractor {
 
             match stmt_name.as_str() {
                 "enable" => {
-                    self.synthesize_plack_enable_symbol(statement, stmt_args, scope_id, &package);
+                    self.synthesize_plack_enable_symbol(
+                        statement,
+                        stmt_args,
+                        scope_id,
+                        &package,
+                        framework_name,
+                    );
                 }
                 "mount" => {
-                    self.synthesize_plack_mount_symbol(statement, stmt_args, scope_id, &package);
+                    self.synthesize_plack_mount_symbol(
+                        statement,
+                        stmt_args,
+                        scope_id,
+                        &package,
+                        framework_name,
+                    );
                 }
                 _ => {}
             }
@@ -1754,6 +1773,7 @@ impl SymbolExtractor {
         args: &[Node],
         scope_id: ScopeId,
         _package: &str,
+        framework_name: &str,
     ) {
         let Some(first) = args.first() else {
             return;
@@ -1792,7 +1812,7 @@ impl SymbolExtractor {
             declaration: Some("enable".to_string()),
             documentation: Some(format!("PSGI middleware {middleware_name}")),
             attributes: vec![
-                "framework=Plack::Builder".to_string(),
+                format!("framework={framework_name}"),
                 format!("middleware={middleware_name}"),
             ],
         });
@@ -1804,6 +1824,7 @@ impl SymbolExtractor {
         args: &[Node],
         scope_id: ScopeId,
         _package: &str,
+        framework_name: &str,
     ) {
         let Some(path_node) = args.first() else {
             return;
@@ -1840,7 +1861,7 @@ impl SymbolExtractor {
             declaration: Some("mount".to_string()),
             documentation: Some(format!("PSGI mount {path} -> {target}")),
             attributes: vec![
-                "framework=Plack::Builder".to_string(),
+                format!("framework={framework_name}"),
                 format!("mount_path={path}"),
                 format!("mount_target={target}"),
             ],
@@ -2144,6 +2165,7 @@ impl SymbolExtractor {
             "Dancer2" | "Dancer2::Core" => Some(WebFrameworkKind::Dancer2),
             "Mojolicious::Lite" => Some(WebFrameworkKind::MojoliciousLite),
             "Plack::Builder" => Some(WebFrameworkKind::PlackBuilder),
+            "Builder::IO::Fusion" => Some(WebFrameworkKind::BuilderIoFusion),
             _ => None,
         };
         if let Some(kind) = web_kind {

--- a/crates/perl-semantic-analyzer/tests/frameworks_web.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_web.rs
@@ -401,3 +401,37 @@ builder {
         "bare `builder` should not synthesize mount symbols"
     );
 }
+
+#[test]
+fn builder_io_fusion_enable_and_mount_are_synthesized() {
+    let code = r#"
+use Builder::IO::Fusion;
+
+builder {
+    enable 'Static';
+    mount '/api' => $api_app;
+};
+"#;
+    let table = extract_symbols(code);
+
+    assert!(
+        has_symbol(&table, "Plack::Middleware::Static", SymbolKind::Package),
+        "expected Fusion `enable` middleware to normalize to Plack middleware package"
+    );
+    assert!(
+        has_symbol(&table, "/api", SymbolKind::Subroutine),
+        "expected Fusion `mount` symbol for /api"
+    );
+
+    let middleware_attrs = symbol_attrs(&table, "Plack::Middleware::Static", SymbolKind::Package);
+    assert!(
+        middleware_attrs.iter().any(|a| a == "framework=Builder::IO::Fusion"),
+        "expected Fusion framework metadata on middleware symbol, got: {middleware_attrs:?}"
+    );
+
+    let mount_attrs = symbol_attrs(&table, "/api", SymbolKind::Subroutine);
+    assert!(
+        mount_attrs.iter().any(|a| a == "framework=Builder::IO::Fusion"),
+        "expected Fusion framework metadata on mount symbol, got: {mount_attrs:?}"
+    );
+}


### PR DESCRIPTION
### Motivation
- The `builder { ... }` DSL symbol synthesis was only activated for `use Plack::Builder;`, so projects using Builder::IO::Fusion did not get middleware/mount symbols or framework metadata.
- Add Fusion detection and reuse the existing builder-block synthesis so Fusion projects receive the same symbol model as Plack projects.

### Description
- Add `BuilderIoFusion` to `WebFrameworkKind` and detect `use Builder::IO::Fusion` in `update_framework_context`.
- Extend `synthesize_plack_builder_symbols` to accept the active framework name (either `Plack::Builder` or `Builder::IO::Fusion`) and early-return otherwise.
- Propagate `framework={...}` on generated symbols for both middleware `enable` and `mount` synthesis paths by passing `framework_name` into `synthesize_plack_enable_symbol` and `synthesize_plack_mount_symbol` and stamping attributes accordingly.
- Add a unit test `builder_io_fusion_enable_and_mount_are_synthesized` in `crates/perl-semantic-analyzer/tests/frameworks_web.rs` that verifies middleware normalization, mount symbol creation, and `framework=Builder::IO::Fusion` attributes.

### Testing
- Ran `cargo test -p perl-semantic-analyzer --test frameworks_web` and the test suite passed (`20` passed, `0` failed). 
- Ran `cargo clippy -p perl-semantic-analyzer -- -D warnings` and it completed successfully with no warnings. 
- Attempted broader checks: `cargo check --all-targets -p perl-semantic-analyzer` and `cargo test -p perl-semantic-analyzer -- --nocapture` were blocked by pre-existing unrelated test formatting issues in `tests/scope_and_symbol_tests.rs` and unrelated `xtask` compile errors, not by the changes in this PR. 
- `just pr-fast` was not available in the execution environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22bb5520833389b64e839a48a7d9)