### PR TITLE
fix(perl-semantic-analyzer): support Builder::IO::Fusion builder symbols (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -352,6 +352,8 @@ pub enum WebFrameworkKind {
     MojoliciousLite,
     /// `use Plack::Builder;`
     PlackBuilder,
+    /// `use Builder::IO::Fusion;`
+    BuilderIoFusion,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -388,7 +390,7 @@ pub struct FrameworkFlags {
     pub class_accessor: bool,
     /// Which specific Moo/Moose variant was detected.
     pub kind: Option<FrameworkKind>,
-    /// Web framework variant, if any (Dancer, Dancer2, Mojolicious::Lite).
+    /// Web framework variant, if any (Dancer, Dancer2, Mojolicious::Lite, Plack::Builder, Builder::IO::Fusion).
     pub web_framework: Option<WebFrameworkKind>,
     /// Async framework variant, if any (IO::Async).
     pub async_framework: Option<AsyncFrameworkKind>,
@@ -1713,7 +1715,11 @@ impl SymbolExtractor {
         let Some(flags) = self.framework_flags.get(&self.table.current_package) else {
             return;
         };
-        if flags.web_framework != Some(WebFrameworkKind::PlackBuilder) || name != "builder" {
+        if !matches!(
+            flags.web_framework,
+            Some(WebFrameworkKind::PlackBuilder | WebFrameworkKind::BuilderIoFusion)
+        ) || name != "builder"
+        {
             return;
         }
 
@@ -2144,6 +2150,7 @@ impl SymbolExtractor {
             "Dancer2" | "Dancer2::Core" => Some(WebFrameworkKind::Dancer2),
             "Mojolicious::Lite" => Some(WebFrameworkKind::MojoliciousLite),
             "Plack::Builder" => Some(WebFrameworkKind::PlackBuilder),
+            "Builder::IO::Fusion" => Some(WebFrameworkKind::BuilderIoFusion),
             _ => None,
         };
         if let Some(kind) = web_kind {

--- a/crates/perl-semantic-analyzer/tests/frameworks_web.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_web.rs
@@ -401,3 +401,35 @@ builder {
         "bare `builder` should not synthesize mount symbols"
     );
 }
+
+#[test]
+fn builder_io_fusion_builder_enable_emits_middleware_symbol() {
+    let code = r#"
+use Builder::IO::Fusion;
+
+builder {
+    enable 'Static';
+};
+"#;
+    let table = extract_symbols(code);
+    assert!(
+        has_symbol(&table, "Plack::Middleware::Static", SymbolKind::Package),
+        "expected Fusion builder middleware to normalize to Plack::Middleware::* symbol"
+    );
+}
+
+#[test]
+fn builder_io_fusion_builder_mount_emits_mount_symbol() {
+    let code = r#"
+use Builder::IO::Fusion;
+
+builder {
+    mount '/api' => $api_app;
+};
+"#;
+    let table = extract_symbols(code);
+    assert!(
+        has_symbol(&table, "/api", SymbolKind::Subroutine),
+        "expected Fusion builder mount to synthesize mount symbol"
+    );
+}


### PR DESCRIPTION
### Motivation

- Builder.io Fusion uses `use Builder::IO::Fusion;` and its `builder { ... }` blocks should synthesize middleware (`enable`) and mount (`mount`) symbols the same way `Plack::Builder` files do, but they were previously ignored.

### Description

- Added `BuilderIoFusion` to `WebFrameworkKind` and documented it in `FrameworkFlags` so Fusion is recognized as a web framework variant in the analyzer.  
- Treated `Builder::IO::Fusion` as equivalent to `Plack::Builder` when gating `builder`-block synthesis by updating the `synthesize_plack_builder_symbols` check to accept both variants.  
- Mapped `"Builder::IO::Fusion"` to `WebFrameworkKind::BuilderIoFusion` in `update_framework_context` so traversal records the framework flag.  
- Added two regression tests in `crates/perl-semantic-analyzer/tests/frameworks_web.rs` that verify `enable` middleware and `mount` symbols are synthesized for Fusion `builder` blocks.

### Testing

- Ran `cargo test -p perl-semantic-analyzer --test frameworks_web` and all tests passed.  
- Ran `cargo clippy -p perl-semantic-analyzer --lib` and it completed successfully.  
- `cargo test -p perl-semantic-analyzer` and `cargo check --all-targets -p perl-semantic-analyzer` currently fail due to a pre-existing invalid format string in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs:1737`, which is unrelated to this change.  
- Commit message: `fix(perl-semantic-analyzer): support Builder::IO::Fusion builder symbols (#0000)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22bb5520833389b64e839a48a7d9)