### PR TITLE
fix(perl-semantic-analyzer): add Builder.io Fusion route detection (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -352,6 +352,8 @@ pub enum WebFrameworkKind {
     MojoliciousLite,
     /// `use Plack::Builder;`
     PlackBuilder,
+    /// `use Fusion;` / `use Builder::IO::Fusion;`
+    BuilderIoFusion,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1617,7 +1619,11 @@ impl SymbolExtractor {
 
                         if matches!(
                             web_framework,
-                            Some(WebFrameworkKind::Dancer | WebFrameworkKind::Dancer2)
+                            Some(
+                                WebFrameworkKind::Dancer
+                                    | WebFrameworkKind::Dancer2
+                                    | WebFrameworkKind::BuilderIoFusion
+                            )
                         ) && let Some(target_node) = args.get(1)
                         {
                             if let Some(target_name) =
@@ -2144,6 +2150,9 @@ impl SymbolExtractor {
             "Dancer2" | "Dancer2::Core" => Some(WebFrameworkKind::Dancer2),
             "Mojolicious::Lite" => Some(WebFrameworkKind::MojoliciousLite),
             "Plack::Builder" => Some(WebFrameworkKind::PlackBuilder),
+            "Fusion" | "Builder::IO::Fusion" | "Builder::IO::Fusion::Lite" => {
+                Some(WebFrameworkKind::BuilderIoFusion)
+            }
             _ => None,
         };
         if let Some(kind) = web_kind {

--- a/crates/perl-semantic-analyzer/tests/frameworks_web.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_web.rs
@@ -291,6 +291,40 @@ sub show_status {
     );
 }
 
+#[test]
+fn fusion_route_emits_subroutine_symbol() {
+    let code = r#"
+use Fusion;
+
+get '/content' => sub {
+    return 'ok';
+};
+"#;
+    let table = extract_symbols(code);
+    assert!(
+        has_symbol(&table, "/content", SymbolKind::Subroutine),
+        "expected route symbol `/content` for Fusion `get` route"
+    );
+}
+
+#[test]
+fn fusion_route_target_string_adds_subroutine_reference() {
+    let code = r#"
+use Builder::IO::Fusion;
+
+get '/content' => 'render_content';
+
+sub render_content {
+    return 'ok';
+}
+"#;
+    let table = extract_symbols(code);
+    assert!(
+        has_reference(&table, "render_content", SymbolKind::Subroutine),
+        "expected Fusion route target string `render_content` to be recorded as a Subroutine reference"
+    );
+}
+
 // === Plack::Builder middleware chain detection ===
 
 #[test]


### PR DESCRIPTION
### Motivation

- Builder.io Fusion routes were not recognized as a web framework, so route symbols and string-target references were missing for `use Fusion` / `use Builder::IO::Fusion` code.

### Description

- Added a `WebFrameworkKind::BuilderIoFusion` variant and mapped `use Fusion`, `use Builder::IO::Fusion`, and `use Builder::IO::Fusion::Lite` to it in `update_framework_context`.
- Treated `BuilderIoFusion` like Dancer/Dancer2 when synthesizing route symbols so target-string handlers (e.g. `get '/x' => 'handler'`) produce subroutine references.
- Added two regression tests in `crates/perl-semantic-analyzer/tests/frameworks_web.rs` to verify Fusion `get` route symbol creation and target-string reference synthesis.

### Testing

- Ran `cargo test -p perl-semantic-analyzer --test frameworks_web fusion_route`, which executed the new Fusion tests and they passed (`2 passed`).
- Attempted `cargo check --all-targets -p perl-semantic-analyzer` and `cargo clippy -p perl-semantic-analyzer --all-targets -- -D warnings`, but those are blocked by a pre-existing invalid format string in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` and unrelated `xtask` compile issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22bb5520833389b64e839a48a7d9)