### PR TITLE
feat(perl-semantic-analyzer): add OpenClaw web route detection (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -352,6 +352,8 @@ pub enum WebFrameworkKind {
     MojoliciousLite,
     /// `use Plack::Builder;`
     PlackBuilder,
+    /// `use OpenClaw;` or `use OpenClaw::DSL;`
+    OpenClaw,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -388,7 +390,7 @@ pub struct FrameworkFlags {
     pub class_accessor: bool,
     /// Which specific Moo/Moose variant was detected.
     pub kind: Option<FrameworkKind>,
-    /// Web framework variant, if any (Dancer, Dancer2, Mojolicious::Lite).
+    /// Web framework variant, if any (Dancer, Dancer2, Mojolicious::Lite, OpenClaw).
     pub web_framework: Option<WebFrameworkKind>,
     /// Async framework variant, if any (IO::Async).
     pub async_framework: Option<AsyncFrameworkKind>,
@@ -1565,7 +1567,7 @@ impl SymbolExtractor {
         if require_embedded_marker { None } else { Some(attr_expr) }
     }
 
-    /// Detect Dancer/Dancer2/Mojolicious::Lite route declarations and synthesize route symbols.
+    /// Detect Dancer/Dancer2/Mojolicious::Lite/OpenClaw route declarations and synthesize route symbols.
     ///
     /// Pattern (two statements):
     /// 1. `ExpressionStatement(Identifier("get"|"post"|"put"|"del"|"patch"|"any"))`
@@ -1617,7 +1619,11 @@ impl SymbolExtractor {
 
                         if matches!(
                             web_framework,
-                            Some(WebFrameworkKind::Dancer | WebFrameworkKind::Dancer2)
+                            Some(
+                                WebFrameworkKind::Dancer
+                                    | WebFrameworkKind::Dancer2
+                                    | WebFrameworkKind::OpenClaw
+                            )
                         ) && let Some(target_node) = args.get(1)
                         {
                             if let Some(target_name) =
@@ -2144,6 +2150,7 @@ impl SymbolExtractor {
             "Dancer2" | "Dancer2::Core" => Some(WebFrameworkKind::Dancer2),
             "Mojolicious::Lite" => Some(WebFrameworkKind::MojoliciousLite),
             "Plack::Builder" => Some(WebFrameworkKind::PlackBuilder),
+            "OpenClaw" | "OpenClaw::DSL" => Some(WebFrameworkKind::OpenClaw),
             _ => None,
         };
         if let Some(kind) = web_kind {

--- a/crates/perl-semantic-analyzer/tests/frameworks_web.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_web.rs
@@ -291,6 +291,28 @@ sub show_status {
     );
 }
 
+#[test]
+fn openclaw_route_target_string_adds_subroutine_reference() {
+    let code = r#"
+use OpenClaw;
+
+get '/health' => 'show_health';
+
+sub show_health {
+    return 'ok';
+}
+"#;
+    let table = extract_symbols(code);
+    assert!(
+        has_symbol(&table, "/health", SymbolKind::Subroutine),
+        "expected OpenClaw route to synthesize `/health` symbol"
+    );
+    assert!(
+        has_reference(&table, "show_health", SymbolKind::Subroutine),
+        "expected OpenClaw route target string `show_health` to be recorded as a Subroutine reference"
+    );
+}
+
 // === Plack::Builder middleware chain detection ===
 
 #[test]


### PR DESCRIPTION
### Motivation

- Make OpenClaw-based web apps behave like other recognized web frameworks so route symbols and string-target references are synthesized for `get`/`post` style DSL calls.

### Description

- Added `OpenClaw` to `WebFrameworkKind` and updated the `FrameworkFlags` docs to include OpenClaw.
- Treat `OpenClaw` the same as `Dancer`/`Dancer2` when synthesizing route symbols so route-target string references are recorded (changes in `try_extract_web_route_declaration`).
- Recognize `use OpenClaw;` and `use OpenClaw::DSL;` in `update_framework_context` so OpenClaw routes enable the synthesis path.
- Added a unit test `openclaw_route_target_string_adds_subroutine_reference` in `crates/perl-semantic-analyzer/tests/frameworks_web.rs` verifying route symbol creation and target reference recording.

### Testing

- Ran `cargo test -p perl-semantic-analyzer --test frameworks_web`, which passed (`20 passed; 0 failed`).
- Ran `cargo clippy -p perl-semantic-analyzer --test frameworks_web -- -D warnings`, which completed successfully.
- `cargo check --all-targets -p perl-semantic-analyzer` failed due to an unrelated existing test format-string error in `tests/scope_and_symbol_tests.rs` and did not block the focused test; this is pre-existing.
- `cargo xtask fmt` and `just pr-fast` were not fully usable in this environment (`xtask` compile errors and `just: command not found`), both failures are unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22c3f4a08333a6b25179612c3861)