### PR TITLE
feat(perl-semantic-analyzer): add OpenClaw framework aliases (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/class_model.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/class_model.rs
@@ -525,7 +525,7 @@ impl ClassModelBuilder {
     fn detect_framework(&mut self, module: &str, args: &[String]) {
         let framework = match module {
             "Moose" | "Moose::Role" => Framework::Moose,
-            "Moo" | "Moo::Role" => Framework::Moo,
+            "Moo" | "Moo::Role" | "OpenClaw" | "OpenClaw::Role" => Framework::Moo,
             "Mouse" | "Mouse::Role" => Framework::Mouse,
             "Class::Accessor" => Framework::ClassAccessor,
             "Object::Pad" => Framework::ObjectPad,
@@ -1363,6 +1363,23 @@ sub greet { }
         assert!(age_attr.required);
 
         assert!(model.methods.iter().any(|m| m.name == "greet"));
+    }
+
+    #[test]
+    fn openclaw_class_is_treated_as_moo_framework() {
+        let models = build_models(
+            r#"
+package MyApp::OpenClawUser;
+use OpenClaw;
+
+has 'name' => (is => 'ro', isa => 'Str');
+"#,
+        );
+
+        let model = find_model(&models, "MyApp::OpenClawUser")
+            .expect("expected ClassModel for OpenClaw class");
+        assert_eq!(model.framework, Framework::Moo);
+        assert_eq!(model.attributes.len(), 1);
     }
 
     #[test]

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -2120,8 +2120,8 @@ impl SymbolExtractor {
         let pkg = self.table.current_package.clone();
 
         let framework_kind = match module {
-            "Moo" | "Mouse" => Some(FrameworkKind::Moo),
-            "Moo::Role" | "Mouse::Role" => Some(FrameworkKind::MooRole),
+            "Moo" | "Mouse" | "OpenClaw" => Some(FrameworkKind::Moo),
+            "Moo::Role" | "Mouse::Role" | "OpenClaw::Role" => Some(FrameworkKind::MooRole),
             "Moose" => Some(FrameworkKind::Moose),
             "Moose::Role" => Some(FrameworkKind::MooseRole),
             _ => None,

--- a/crates/perl-semantic-analyzer/tests/frameworks_moo.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_moo.rs
@@ -249,6 +249,45 @@ use Moo::Role;
 }
 
 #[test]
+fn openclaw_package_emits_class_symbol_kind() {
+    let code = r#"
+package MyApp::OpenClawUser;
+use OpenClaw;
+has 'name' => (is => 'ro');
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        has_symbol(&table, "MyApp::OpenClawUser", SymbolKind::Class),
+        "expected SymbolKind::Class for OpenClaw package"
+    );
+    assert!(
+        !has_symbol(&table, "MyApp::OpenClawUser", SymbolKind::Package),
+        "OpenClaw package should be upgraded from Package to Class"
+    );
+}
+
+#[test]
+fn openclaw_role_package_emits_role_symbol_kind() {
+    let code = r#"
+package MyApp::OpenClawRole;
+use OpenClaw::Role;
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        has_symbol(&table, "MyApp::OpenClawRole", SymbolKind::Role),
+        "expected SymbolKind::Role for OpenClaw::Role package"
+    );
+    assert!(
+        !has_symbol(&table, "MyApp::OpenClawRole", SymbolKind::Package),
+        "OpenClaw::Role package should be upgraded from Package to Role"
+    );
+}
+
+#[test]
 fn plain_package_keeps_package_symbol_kind() {
     let code = r#"
 package MyApp::Utils;


### PR DESCRIPTION
### Motivation
- `use OpenClaw` / `use OpenClaw::Role` were not treated as Moo-family framework imports, so framework-driven symbol synthesis and class-model extraction did not trigger for OpenClaw-based code.

### Description
- Treat `OpenClaw` and `OpenClaw::Role` as aliases for the Moo family in the class-model framework detection by updating `detect_framework` in `crates/perl-semantic-analyzer/src/analysis/class_model.rs`.
- Treat `OpenClaw` and `OpenClaw::Role` as Moo-like in symbol extraction by updating `update_framework_context` in `crates/perl-semantic-analyzer/src/analysis/symbol.rs`.
- Add regression tests exercising package/role symbol-kind upgrades in `crates/perl-semantic-analyzer/tests/frameworks_moo.rs` and a unit test asserting class-model attribute extraction for `use OpenClaw` in `crates/perl-semantic-analyzer/src/analysis/class_model.rs`.

### Testing
- Ran `cargo test -p perl-semantic-analyzer --test frameworks_moo openclaw` and the OpenClaw integration tests passed.
- Ran `cargo test -p perl-semantic-analyzer --lib openclaw_class_is_treated_as_moo_framework` and the class-model unit test passed.
- Ran `cargo clippy -p perl-semantic-analyzer -- -D warnings` which completed successfully for the crate.
- A full `cargo test -p perl-semantic-analyzer` / `cargo check --all-targets -p perl-semantic-analyzer` run failed due to a pre-existing unrelated format-string issue in `tests/scope_and_symbol_tests.rs`, not introduced by this change.
- `cargo xtask fmt` and `just pr-fast` were not fully executed here due to environment/tooling issues (`xtask` compile errors and `just` not available) and did not block the focused test verification above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22c3f4a08333a6b25179612c3861)