### PR TITLE
fix(execute-command): skip OpenCLAW modules in go-to-implementation (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/execute_command/provider.rs
+++ b/crates/perl-lsp-rs/src/execute_command/provider.rs
@@ -589,6 +589,7 @@ impl ExecuteCommandProvider {
             "Moo",
             "Moose",
             "Mouse",
+            "OpenCLAW",
             // Test modules (exact)
             "Test::More",
             "Test::Simple",
@@ -616,6 +617,7 @@ impl ExecuteCommandProvider {
             "MouseX::",
             "Moo::Role",
             "Moose::Role",
+            "OpenCLAW::",
             "Types::",     // Types::Standard, Types::Path::Tiny, etc.
             "namespace::", // namespace::autoclean, namespace::clean
             "Sub::",       // Sub::Exporter, Sub::Quote, etc.

--- a/crates/perl-lsp-rs/src/execute_command/tests.rs
+++ b/crates/perl-lsp-rs/src/execute_command/tests.rs
@@ -306,6 +306,41 @@ fn test_go_to_implementation_skips_moosex_modules() -> Result<(), Box<dyn std::e
 }
 
 #[test]
+fn test_go_to_implementation_skips_openclaw_modules() -> Result<(), Box<dyn std::error::Error>> {
+    // OpenCLAW modules should be skipped so local modules are preferred.
+    let temp_dir = tempdir()?;
+    let lib_dir = temp_dir.path().join("lib").join("My");
+    let t_dir = temp_dir.path().join("t");
+    fs::create_dir_all(&lib_dir)?;
+    fs::create_dir_all(&t_dir)?;
+
+    let pm_file = lib_dir.join("Class.pm");
+    let t_file = t_dir.join("my-class.t");
+    fs::write(&pm_file, "package My::Class;\n1;\n")?;
+    fs::write(
+        &t_file,
+        "use strict;\nuse OpenCLAW::Types;\nuse OpenCLAW;\nuse My::Class;\ndone_testing;\n",
+    )?;
+
+    let provider =
+        ExecuteCommandProvider::with_workspace_roots(vec![temp_dir.path().to_path_buf()]);
+    let result = provider.execute_command(
+        "perl.goToImplementation",
+        vec![Value::String(t_file.to_string_lossy().to_string())],
+    );
+
+    assert!(result.is_ok(), "perl.goToImplementation should skip OpenCLAW modules");
+    let value = result?;
+    assert!(
+        value["found"].as_bool().unwrap_or(false),
+        "Should find My::Class after skipping OpenCLAW modules"
+    );
+    let impl_path = value["path"].as_str().ok_or("expected path string")?;
+    assert!(impl_path.ends_with("Class.pm"), "Should navigate to Class.pm, got: {impl_path}");
+    Ok(())
+}
+
+#[test]
 fn test_go_to_implementation_skips_version_pragma() -> Result<(), Box<dyn std::error::Error>> {
     // `use v5.20;` and `use 5.010;` must be skipped; My::Module should be found.
     let temp_dir = tempdir()?;


### PR DESCRIPTION
### Motivation

- Avoid treating OpenCLAW imports as local implementations so `perl.goToImplementation` resolves to the real project module when both an OpenCLAW module and a local module are imported.

### Description

- Added `"OpenCLAW"` to the exact-module skip list in `crates/perl-lsp-rs/src/execute_command/provider.rs`.
- Added `"OpenCLAW::"` to the namespace-prefix skip list in `crates/perl-lsp-rs/src/execute_command/provider.rs`.
- Added a focused regression test `test_go_to_implementation_skips_openclaw_modules` in `crates/perl-lsp-rs/src/execute_command/tests.rs` that verifies navigation prefers the local `lib/.../Class.pm` when `OpenCLAW` imports are present.

### Testing

- Ran `cargo test -p perl-lsp-rs --lib test_go_to_implementation_skips_openclaw_modules`, which passed.
- Ran `cargo clippy -p perl-lsp-rs --lib -- -D warnings`, which completed successfully for the changed crate.
- `cargo xtask fmt` could not finish due to pre-existing `xtask` compile errors unrelated to this change (missing identifiers in `xtask/src/tasks/metrics/lsp_stats.rs`).
- `cargo check --all-targets -p perl-lsp-rs` encountered a pre-existing syntax error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs` unrelated to this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22c3f4a08333a6b25179612c3861)