### PR TITLE
fix(perl-workspace): skip .hermes workspace noise in discovery (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/discovery/mod.rs
+++ b/crates/perl-workspace-index/src/discovery/mod.rs
@@ -229,14 +229,14 @@ mod tests {
     #[test]
     fn parses_git_output_and_filters_entries() {
         let root = Path::new("/tmp/workspace");
-        let payload = b"lib/Foo.pm\0README.md\0node_modules/pkg.pm\0script.pl\0";
+        let payload = b"lib/Foo.pm\0README.md\0node_modules/pkg.pm\0.hermes/scripts/tool.pl\0script.pl\0";
 
         let (files, excluded_count) = parse_git_ls_files_output(root, payload);
 
         assert_eq!(files.len(), 2);
         assert!(files.iter().any(|path| path.ends_with("lib/Foo.pm")));
         assert!(files.iter().any(|path| path.ends_with("script.pl")));
-        assert_eq!(excluded_count, 2);
+        assert_eq!(excluded_count, 3);
     }
 
     #[test]
@@ -550,7 +550,7 @@ mod tests {
     }
 
     #[test]
-    fn walk_discovery_skips_all_six_noise_directories() -> TestResult {
+    fn walk_discovery_skips_all_noise_directories() -> TestResult {
         let tmp = tempfile::tempdir()?;
         let root = tmp.path();
 
@@ -560,6 +560,7 @@ mod tests {
         create_file(root, "target/build/out.pm")?;
         create_file(root, "node_modules/dep.pm")?;
         create_file(root, ".cache/fast.pm")?;
+        create_file(root, ".hermes/conveyor/work-1/prompt.pl")?;
         create_file(root, "lib/Visible.pm")?;
 
         let result = walk_discovery(root, Instant::now());

--- a/crates/perl-workspace-index/src/ignore/mod.rs
+++ b/crates/perl-workspace-index/src/ignore/mod.rs
@@ -5,8 +5,18 @@
 
 use std::path::{Component, Path};
 
-const SKIPPED_DIRS: [&str; 9] =
-    [".git", ".hg", ".svn", "target", "node_modules", ".cache", "blib", "local", "vendor"];
+const SKIPPED_DIRS: [&str; 10] = [
+    ".git",
+    ".hg",
+    ".svn",
+    "target",
+    "node_modules",
+    ".cache",
+    "blib",
+    "local",
+    "vendor",
+    ".hermes",
+];
 
 /// Returns true when `name` matches one of the canonical workspace noise directories.
 #[must_use]
@@ -75,6 +85,11 @@ mod tests {
     }
 
     #[test]
+    fn test_skipped_dir_name_hermes_matches() {
+        assert!(is_skipped_dir_name(".hermes"));
+    }
+
+    #[test]
     fn test_skipped_dir_name_all_canonical_patterns() {
         // Verify every entry in the constant is recognized
         for name in &SKIPPED_DIRS {
@@ -84,7 +99,7 @@ mod tests {
 
     #[test]
     fn test_skipped_dir_name_constant_has_expected_count() {
-        assert_eq!(SKIPPED_DIRS.len(), 9);
+        assert_eq!(SKIPPED_DIRS.len(), 10);
     }
 
     // ── is_skipped_dir_name: non-matching names ────────────────────────


### PR DESCRIPTION
### Motivation
- Agent metadata stored under `.hermes/` (Hermes agent output) was being treated as workspace content and could leak non-project Perl files into discovery and indexing.

### Description
- Add `.hermes` to the canonical skipped directory set in `crates/perl-workspace-index/src/ignore/mod.rs` so discovery filters it out.
- Extend `crates/perl-workspace-index/src/discovery/mod.rs` tests to include `.hermes` fixtures exercising both the `git ls-files` parse and the `WalkDir` fallback.
- Add a unit test asserting `.hermes` is recognized by the skip rules and update the expected skip-set size.

### Testing
- Ran `cargo test -p perl-workspace` which passed (unit and integration tests exercised for the crate). 
- Ran `cargo check --all-targets -p perl-workspace` which completed successfully. 
- Ran `cargo xtask fmt` which failed due to pre-existing `xtask` compile errors unrelated to these changes. 
- Ran `cargo clippy -p perl-workspace --all-targets -- -D warnings` which failed due to pre-existing clippy violations in tests unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22c403e88333bb3a25fa9bf4de15)