### PR TITLE
fix(perl-workspace): ignore .hermes metadata directories (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/discovery/mod.rs
+++ b/crates/perl-workspace-index/src/discovery/mod.rs
@@ -5,7 +5,8 @@
 //! 2. Fall back to filesystem walking with `WalkDir` when git is unavailable.
 //!
 //! The resulting behavior is intentionally conservative: common non-source directories
-//! are skipped in both modes (`.git`, `.hg`, `.svn`, `target`, `node_modules`, `.cache`).
+//! are skipped in both modes (`.git`, `.hg`, `.svn`, `target`, `node_modules`, `.cache`,
+//! `.hermes`).
 
 use crate::ignore::{is_skipped_dir_name, path_contains_skipped_component};
 use perl_parser_core::source_file::is_perl_source_path;

--- a/crates/perl-workspace-index/src/ignore/mod.rs
+++ b/crates/perl-workspace-index/src/ignore/mod.rs
@@ -5,8 +5,18 @@
 
 use std::path::{Component, Path};
 
-const SKIPPED_DIRS: [&str; 9] =
-    [".git", ".hg", ".svn", "target", "node_modules", ".cache", "blib", "local", "vendor"];
+const SKIPPED_DIRS: [&str; 10] = [
+    ".git",
+    ".hg",
+    ".svn",
+    "target",
+    "node_modules",
+    ".cache",
+    ".hermes",
+    "blib",
+    "local",
+    "vendor",
+];
 
 /// Returns true when `name` matches one of the canonical workspace noise directories.
 #[must_use]
@@ -60,6 +70,11 @@ mod tests {
     }
 
     #[test]
+    fn test_skipped_dir_name_hermes_matches() {
+        assert!(is_skipped_dir_name(".hermes"));
+    }
+
+    #[test]
     fn test_skipped_dir_name_blib_matches() {
         assert!(is_skipped_dir_name("blib"));
     }
@@ -84,7 +99,7 @@ mod tests {
 
     #[test]
     fn test_skipped_dir_name_constant_has_expected_count() {
-        assert_eq!(SKIPPED_DIRS.len(), 9);
+        assert_eq!(SKIPPED_DIRS.len(), 10);
     }
 
     // ── is_skipped_dir_name: non-matching names ────────────────────────

--- a/crates/perl-workspace-index/tests/discovery_coverage_tests.rs
+++ b/crates/perl-workspace-index/tests/discovery_coverage_tests.rs
@@ -530,6 +530,7 @@ fn hidden_directories_in_skip_list_are_skipped() -> TestResult {
     // These hidden dirs are in the skip list
     create_file(root, ".git/hooks/hook.pm")?;
     create_file(root, ".cache/fast.pm")?;
+    create_file(root, ".hermes/conveyor/work-1234/session.pm")?;
 
     // Visible file for comparison
     create_file(root, "lib/Visible.pm")?;
@@ -578,11 +579,11 @@ fn hidden_perl_files_at_root_are_discovered() -> TestResult {
 }
 
 #[test]
-fn all_six_skipped_directories_are_excluded_from_walk() -> TestResult {
+fn all_core_skipped_directories_are_excluded_from_walk() -> TestResult {
     let tmp = TempDir::new()?;
     let root = tmp.path();
 
-    let skipped = [".git", ".hg", ".svn", "target", "node_modules", ".cache"];
+    let skipped = [".git", ".hg", ".svn", "target", "node_modules", ".cache", ".hermes"];
     for dir in skipped {
         create_file(root, &format!("{dir}/nested/Module.pm"))?;
     }


### PR DESCRIPTION
### Motivation

- Workspace discovery was indexing Perl files under `.hermes/` (Hermes agent metadata), which pollutes file discovery and indexing with agent worktree artifacts.

### Description

- Added `.hermes` to the canonical skip list `SKIPPED_DIRS` in `crates/perl-workspace-index/src/ignore/mod.rs` so discovery excludes Hermes metadata trees.
- Updated discovery documentation in `crates/perl-workspace-index/src/discovery/mod.rs` to list `.hermes` as a skipped directory.
- Extended/updated tests in `crates/perl-workspace-index/tests/discovery_coverage_tests.rs` to assert `.hermes` directories are skipped and updated the skipped-dir test name/count accordingly.

### Testing

- Ran `cargo test -p perl-workspace` and the workspace-index test suites completed successfully (all tests passed).
- Ran `cargo check --all-targets -p perl-workspace` and `cargo clippy -p perl-workspace`, both completed successfully.
- Attempted `cargo xtask fmt` but it failed due to unrelated pre-existing `xtask` compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` and is not caused by this change.
- `just pr-fast` was not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22c403e88333bb3a25fa9bf4de15)