### PR TITLE
fix(pre-merge): treat Hermes conveyor artifacts as docs-only metadata (#0000)

### DIFF
--- a/scripts/pre-merge-check.sh
+++ b/scripts/pre-merge-check.sh
@@ -39,6 +39,7 @@ TITLE="$(json_read '.title')"
 is_docs_only_path() {
     local path="$1"
     case "$path" in
+        .hermes/conveyor/work-*/**|.hermes/conveyor/work-*|.hermes/conveyor/work-*-*.md) return 0 ;;
         docs/*) return 0 ;;
         *.md|*.mdx|*.txt|*.rst|*.adoc) return 0 ;;
         *) return 1 ;;

--- a/scripts/tests/test-pre-merge-check.sh
+++ b/scripts/tests/test-pre-merge-check.sh
@@ -291,6 +291,24 @@ test_review_gate_error_message_is_clear() {
     fi
 }
 
+# ── Test 14: Hermes conveyor metadata PR can skip reviewed-deep ─────────────
+
+test_hermes_metadata_pr_passes_without_reviewed_deep() {
+    local json='{"isDraft":false,"labels":[{"name":"merge-ready"}],"title":"docs(agent): attach hermes work artifacts (#4097)","files":[{"path":".hermes/conveyor/work-abc12345/findings.md"},{"path":".hermes/conveyor/work-abc12345-specs.md"}]}'
+    local mock
+    mock="$(make_mock_gh "$json")"
+
+    local code
+    code="$(run_check "$mock")"
+    cleanup "$mock"
+
+    if [[ "$code" -eq 0 ]]; then
+        pass "hermes metadata PR passes without reviewed-deep"
+    else
+        fail "hermes metadata PR without reviewed-deep — expected exit 0, got $code"
+    fi
+}
+
 # ── Run all tests ─────────────────────────────────────────────────────────────
 
 echo "=== pre-merge-check test suite ==="
@@ -309,6 +327,7 @@ test_issue_ref_middle_of_title_passes
 test_docs_only_pr_passes_without_reviewed_deep
 test_non_docs_pr_requires_reviewed_deep
 test_review_gate_error_message_is_clear
+test_hermes_metadata_pr_passes_without_reviewed_deep
 
 echo ""
 echo "=== Results: $PASS_COUNT passed, $FAIL_COUNT failed ==="


### PR DESCRIPTION
### Motivation
- The pre-merge guard treated `.hermes/conveyor/work-*` artifacts as non-doc changes, causing metadata-only PRs to be blocked for missing the `reviewed-deep` label.

### Description
- Classify `.hermes/conveyor/work-*` paths as docs-only in `scripts/pre-merge-check.sh` so Hermes conveyor artifacts are treated as tooling/docs metadata.
- Add a regression test `test_hermes_metadata_pr_passes_without_reviewed_deep` to `scripts/tests/test-pre-merge-check.sh` and wire it into the test suite.

### Testing
- Ran `bash scripts/tests/test-pre-merge-check.sh`; the suite passed with `14 passed, 0 failed`.
- No other automated test changes were made or required for this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22c403e88333bb3a25fa9bf4de15)