### PR TITLE
feat(completion): add typo-tolerant module suggestions (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -3448,6 +3448,30 @@ sub helper { }
     }
 
     #[test]
+    fn test_use_statement_typo_still_suggests_workspace_module()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Typo in the module name should still suggest the intended workspace package.
+        let index = Arc::new(WorkspaceIndex::new());
+        index.index_file(
+            Url::parse("file:///lib/Droid/Factory.pm")?,
+            "package Droid::Factory;\n1;\n".to_string(),
+        )?;
+
+        let code = "use Droid::Facxtory";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index(&ast, Some(index));
+        let completions = provider.get_completions(code, code.len());
+
+        assert!(
+            completions.iter().any(|c| c.label == "Droid::Factory" && c.kind == CompletionItemKind::Module),
+            "use Droid::Facxtory should suggest Droid::Factory; got: {:?}",
+            completions.iter().map(|c| (&c.label, &c.kind)).collect::<Vec<_>>()
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_require_statement_skips_file_path() -> Result<(), Box<dyn std::error::Error>> {
         let index = Arc::new(WorkspaceIndex::new());
         index

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -230,6 +230,55 @@ fn module_sort_tier(name: &str) -> &'static str {
     }
 }
 
+fn levenshtein_distance(left: &str, right: &str) -> usize {
+    if left == right {
+        return 0;
+    }
+    if left.is_empty() {
+        return right.chars().count();
+    }
+    if right.is_empty() {
+        return left.chars().count();
+    }
+
+    let right_chars: Vec<char> = right.chars().collect();
+    let mut prev: Vec<usize> = (0..=right_chars.len()).collect();
+    let mut curr: Vec<usize> = vec![0; right_chars.len() + 1];
+
+    for (i, left_char) in left.chars().enumerate() {
+        curr[0] = i + 1;
+        for (j, right_char) in right_chars.iter().enumerate() {
+            let cost = usize::from(left_char != *right_char);
+            curr[j + 1] = (curr[j] + 1).min(prev[j + 1] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+
+    prev[right_chars.len()]
+}
+
+fn likely_module_typo_match(prefix: &str, candidate: &str) -> bool {
+    if prefix.is_empty() {
+        return false;
+    }
+
+    // Keep typo matching scoped to similarly-namespaced modules to avoid
+    // unrelated noise in `use` completion fallback suggestions.
+    let same_namespace = match (prefix.split("::").next(), candidate.split("::").next()) {
+        (Some(a), Some(b)) => a.eq_ignore_ascii_case(b),
+        _ => false,
+    };
+    if !same_namespace {
+        return false;
+    }
+
+    let prefix_lower = prefix.to_ascii_lowercase();
+    let candidate_lower = candidate.to_ascii_lowercase();
+    let distance = levenshtein_distance(&prefix_lower, &candidate_lower);
+
+    distance <= 2
+}
+
 /// Add module name completions for `use` and `require` statements.
 ///
 /// When the cursor is after `use ` or `require `, suggests package names from the
@@ -251,22 +300,29 @@ pub fn add_use_module_completions(
 
     let mut seen: HashSet<String> = HashSet::new();
 
-    // Search for package symbols matching the prefix
-    let all_symbols = if context.prefix.is_empty() {
-        index.all_symbols()
-    } else {
-        index.find_symbols(&context.prefix)
-    };
+    // Search for package symbols matching the prefix.
+    let all_symbols = index.all_symbols();
+    let package_symbols: Vec<_> = all_symbols
+        .into_iter()
+        .filter(|symbol| symbol.kind == WsSymbolKind::Package)
+        .collect();
 
-    for symbol in all_symbols {
-        if symbol.kind != WsSymbolKind::Package {
-            continue;
-        }
+    let mut matched_symbols: Vec<_> = package_symbols
+        .iter()
+        .filter(|symbol| context.prefix.is_empty() || symbol.name.starts_with(&context.prefix))
+        .cloned()
+        .collect();
 
-        // Match against the module name prefix
-        if !context.prefix.is_empty() && !symbol.name.starts_with(&context.prefix) {
-            continue;
-        }
+    // Typo-tolerant fallback for module names in use/require statements.
+    if matched_symbols.is_empty() && !context.prefix.is_empty() {
+        matched_symbols = package_symbols
+            .iter()
+            .filter(|symbol| likely_module_typo_match(&context.prefix, &symbol.name))
+            .cloned()
+            .collect();
+    }
+
+    for symbol in matched_symbols {
 
         if !seen.insert(symbol.name.clone()) {
             continue;


### PR DESCRIPTION
### Motivation

- `use`/`require` module completion only matched exact prefixes, so small typos (e.g. `Droid::Facxtory`) could hide the intended workspace module suggestion.

### Description

- Added a bounded Levenshtein implementation `levenshtein_distance` and a scoped matcher `likely_module_typo_match` to identify plausible typos within the same top-level namespace.
- Updated `add_use_module_completions` to collect package symbols and fall back to typo-tolerant matching when no exact-prefix matches are found.
- Added a regression test `test_use_statement_typo_still_suggests_workspace_module` verifying that `use Droid::Facxtory` suggests `Droid::Factory`.

### Testing

- Ran `cargo test -p perl-lsp-rs-core test_use_statement_typo_still_suggests_workspace_module`, which passed.
- Ran `cargo check --all-targets -p perl-lsp-rs-core`, which completed successfully.
- Ran `cargo clippy -p perl-lsp-rs-core -- -D warnings`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22c4086c8333a1971bb2aa7b302e)