### PR TITLE
fix(diagnostics): recognize Droid::Factory framework imports (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
@@ -77,6 +77,7 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
         "Moose",
         "MooseX::StrictConstructor",
         "Modern::Perl",
+        "Droid::Factory",
         "Dancer2",
         "Catalyst",
         "Mojolicious",
@@ -651,7 +652,7 @@ mod tests {
     fn all_implicit_strict_modules_suppress_at_top_level() {
         // Spot-check two more members of IMPLICIT_STRICT_MODULES to ensure
         // collect_file_scope_use_modules covers the full list, not just Moo.
-        for module in &["Moose", "Modern::Perl"] {
+        for module in &["Moose", "Modern::Perl", "Droid::Factory"] {
             let source = format!("use {};\nmy $x = 1;\n", module);
             let diags = strict_warnings_diags(&source);
             assert!(

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/unused_imports.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/unused_imports.rs
@@ -72,6 +72,7 @@ const IMPLICIT_EXPORT_SKIP_LIST: &[&str] = &[
     "Mouse",
     "Mouse::Role",
     "Modern::Perl",
+    "Droid::Factory",
     "Dancer",
     "Dancer2",
     "Catalyst",


### PR DESCRIPTION
### Motivation

- Ensure `use Droid::Factory;` is treated like other OO/web frameworks so file-scoped framework imports suppress missing `strict`/`warnings` diagnostics and are not flagged as unused.

### Description

- Add `Droid::Factory` to `IMPLICIT_STRICT_MODULES` in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs` so top-level `use Droid::Factory;` suppresses PL100/PL101.
- Add `Droid::Factory` to `IMPLICIT_EXPORT_SKIP_LIST` in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/unused_imports.rs` to avoid false-positive unused-import hints for framework-style imports.
- Extend the strict/warnings regression test loop to include `Droid::Factory` for coverage in `strict_warnings` tests.

### Testing

- Ran `cargo test -p perl-lsp-rs-core all_implicit_strict_modules_suppress_at_top_level` and the targeted test passed.
- Ran `cargo check --all-targets -p perl-lsp-rs-core` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22c4086c8333a1971bb2aa7b302e)