### PR TITLE
feat(workspace-index): add typo-tolerant symbol search fallback (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -2220,6 +2220,7 @@ impl WorkspaceIndex {
         let query_lower = query.to_lowercase();
         let files = self.files.read();
         let mut results = Vec::new();
+
         for file_index in files.values() {
             for symbol in &file_index.symbols {
                 if symbol.name.to_lowercase().contains(&query_lower)
@@ -2233,7 +2234,85 @@ impl WorkspaceIndex {
                 }
             }
         }
+
+        if !query_lower.is_empty() && results.is_empty() {
+            for file_index in files.values() {
+                for symbol in &file_index.symbols {
+                    let matches_name =
+                        Self::is_approximate_symbol_match(&symbol.name, &query_lower);
+                    let matches_qualified = symbol
+                        .qualified_name
+                        .as_ref()
+                        .map(|qualified_name| {
+                            Self::is_approximate_symbol_match(qualified_name, &query_lower)
+                        })
+                        .unwrap_or(false);
+
+                    if matches_name || matches_qualified {
+                        results.push(symbol.clone());
+                    }
+                }
+            }
+        }
+
         results
+    }
+
+    fn is_approximate_symbol_match(symbol_name: &str, query_lower: &str) -> bool {
+        let symbol_name_lower = symbol_name.to_lowercase();
+        if Self::is_edit_distance_leq_one(&symbol_name_lower, query_lower) {
+            return true;
+        }
+
+        symbol_name_lower
+            .split("::")
+            .any(|segment| Self::is_edit_distance_leq_one(segment, query_lower))
+    }
+
+    fn is_edit_distance_leq_one(lhs: &str, rhs: &str) -> bool {
+        if lhs == rhs {
+            return true;
+        }
+
+        let lhs_chars: Vec<char> = lhs.chars().collect();
+        let rhs_chars: Vec<char> = rhs.chars().collect();
+        let lhs_len = lhs_chars.len();
+        let rhs_len = rhs_chars.len();
+
+        if lhs_len.abs_diff(rhs_len) > 1 {
+            return false;
+        }
+
+        if lhs_len == rhs_len {
+            let mismatches = lhs_chars
+                .iter()
+                .zip(rhs_chars.iter())
+                .filter(|(left, right)| left != right)
+                .count();
+            return mismatches <= 1;
+        }
+
+        let (longer, shorter) =
+            if lhs_len > rhs_len { (&lhs_chars, &rhs_chars) } else { (&rhs_chars, &lhs_chars) };
+
+        let mut long_index = 0;
+        let mut short_index = 0;
+        let mut edits = 0;
+
+        while long_index < longer.len() && short_index < shorter.len() {
+            if longer[long_index] == shorter[short_index] {
+                long_index += 1;
+                short_index += 1;
+            } else {
+                edits += 1;
+                if edits > 1 {
+                    return false;
+                }
+                long_index += 1;
+            }
+        }
+
+        true
     }
 
     /// Find symbols by query (alias for search_symbols for compatibility)

--- a/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
@@ -222,6 +222,25 @@ fn test_search_symbols_case_insensitive() -> Result<(), Box<dyn std::error::Erro
 }
 
 #[test]
+fn test_search_symbols_fuzzy_typo_fallback() -> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let uri = file_url("/droid_factory.pm")?;
+    index.index_file(
+        uri,
+        "package Droid::Factory;
+sub build { 1 }"
+            .to_string(),
+    )?;
+
+    let results = index.search_symbols("Facxtory");
+    assert!(
+        results.iter().any(|symbol| symbol.qualified_name.as_deref() == Some("Droid::Factory")),
+        "expected fuzzy search to return Droid::Factory package"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_find_symbols_alias() -> Result<(), Box<dyn std::error::Error>> {
     let index = WorkspaceIndex::new();
     let uri = file_url("/alias.pl")?;


### PR DESCRIPTION
### Motivation
- Symbol search previously only returned substring matches so small typos in package names (e.g. `Droid::Facxtory`) failed to resolve to the intended symbol (`Droid::Factory`).

### Description
- Add a fallback fuzzy match in `WorkspaceIndex::search_symbols` that runs when the query is non-empty and the substring search returns no results. 
- Implement `is_approximate_symbol_match` and `is_edit_distance_leq_one` helpers to accept matches within one edit and to test both full qualified names and `::`-segmented name parts. 
- Match fuzzy results into the existing `WorkspaceSymbol` result vector so completion/lookup consumers receive the same symbol objects.
- Add a regression test `test_search_symbols_fuzzy_typo_fallback` which indexes `Droid::Factory` and verifies a query for `Facxtory` returns the package.

### Testing
- Ran `cargo test -p perl-workspace test_search_symbols_fuzzy_typo_fallback` and the new test passed. 
- Ran `cargo check --all-targets -p perl-workspace` and it succeeded. 
- Ran `cargo clippy -p perl-workspace -- -D warnings` and it succeeded. 
- Ran `cargo fmt -p perl-workspace` and it completed; `cargo xtask fmt` failed due to unrelated `xtask` compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22c4086c8333a1971bb2aa7b302e)