### PR TITLE
docs(editors): add OpenCode setup guide (#0000)

### DIFF
--- a/docs/EDITORS/OPENCODE_SETUP.md
+++ b/docs/EDITORS/OPENCODE_SETUP.md
@@ -1,0 +1,58 @@
+# OpenCode Setup Guide for perl-lsp
+
+This guide shows how to run `perllsp` as a custom LSP server in OpenCode.
+
+## Prerequisites
+
+- `perllsp` installed and available on your `PATH`
+- OpenCode installed
+- a Perl project opened in OpenCode
+
+Verify the server first:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Configure OpenCode
+
+Add a project-local `opencode.json` in your repository root (or update an existing
+one) and register `perllsp` as a custom LSP.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "perl-lsp": {
+      "command": ["perllsp", "--stdio"],
+      "extensions": [".pl", ".pm", ".t", ".pod", ".psgi"],
+      "initialization": {
+        "perl": {
+          "workspace": {
+            "includePaths": ["lib", "local/lib/perl5"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Verify It Is Running
+
+1. Open any Perl file (`.pl`, `.pm`, `.t`) in OpenCode.
+2. Trigger a definition lookup or hover on a known symbol.
+3. Confirm diagnostics appear for an intentional syntax error.
+
+If OpenCode does not start the server, confirm `perllsp` is on your shell `PATH`
+and restart OpenCode.
+
+## Troubleshooting
+
+- If no Perl files activate the server, verify your configured file extensions.
+- If the command fails, run `perllsp --stdio` directly in a terminal to confirm
+  the binary is launchable.
+- For server-side behavior and config details, see
+  [docs/reference/CONFIG.md](../reference/CONFIG.md) and
+  [docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| OpenCode | configure a custom `perl-lsp` server in `opencode.json` | [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,12 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### OpenCode
+
+Create or update `opencode.json` and register a custom LSP server with
+`"command": ["perllsp", "--stdio"]` and Perl extensions like `.pl`, `.pm`,
+and `.t`. See [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) for a full example.
 
 ## When Setup Fails
 


### PR DESCRIPTION
### Motivation

- Add documentation so OpenCode users can run `perllsp` as a custom LSP server because the editor setup docs did not include OpenCode guidance.

### Description

- Add `docs/EDITORS/OPENCODE_SETUP.md` and link it from `docs/how-to/EDITOR_SETUP.md` by inserting a table row and a minimal OpenCode configuration section that points to the full guide.

### Testing

- Ran `cargo check -p perl-lsp-rs --lib` which succeeded, and `cargo check --all-targets -p perl-lsp-rs` which failed due to an existing unrelated syntax error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22c4779c8333b96397a82a760d5e)