### PR TITLE
docs(editors): add crush setup guide (#0000)

### DIFF
--- a/docs/EDITORS/CRUSH_SETUP.md
+++ b/docs/EDITORS/CRUSH_SETUP.md
@@ -1,0 +1,66 @@
+# Crush Setup (charmbracelet/crush)
+
+Crush can launch `perllsp` as a project LSP and use it as additional context
+for code understanding.
+
+## Prerequisites
+
+- `perllsp` installed and available on `PATH`
+- `crush` installed and available on `PATH`
+- a project root containing Perl files
+
+Verify both CLIs first:
+
+```bash
+perllsp --version
+perllsp --health
+crush --version
+```
+
+## Minimal `.crush.json`
+
+Create `.crush.json` in your project root:
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "lsp": {
+    "perl": {
+      "command": "perllsp",
+      "args": ["--stdio"]
+    }
+  }
+}
+```
+
+This tells Crush to start `perllsp` over stdio for Perl files.
+
+## Optional: Pin a Perl runtime for lint-driven features
+
+If your workflow relies on external Perl tools (`perl`, `perlcritic`, etc.), add
+an explicit `PATH` in the LSP entry so Crush launches `perllsp` with the right
+runtime environment:
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "lsp": {
+    "perl": {
+      "command": "perllsp",
+      "args": ["--stdio"],
+      "env": {
+        "PATH": "/custom/perl/bin:${PATH}"
+      }
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+- If Crush does not appear to use the Perl LSP, run `perllsp --health` in the
+  same shell and fix any missing runtime dependencies first.
+- Enable Crush debug logs (`"options": { "debug_lsp": true }`) and inspect
+  `.crush/logs/crush.log` for LSP startup errors.
+- If `perllsp` works manually but fails in Crush, use an absolute command path
+  (for example `/home/you/.cargo/bin/perllsp`).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| Crush | configure project `lsp.perl` as `perllsp --stdio` | [docs/EDITORS/CRUSH_SETUP.md](../EDITORS/CRUSH_SETUP.md) |
 
 ## Minimal Configurations
 


### PR DESCRIPTION
### Motivation
- Document how to run `perllsp` under charmbracelet/crush so users can easily enable Perl LSP support via project `.crush.json`.

### Description
- Add `docs/EDITORS/CRUSH_SETUP.md` with a minimal `.crush.json` example, optional `PATH` pinning for external Perl tools, verification commands, and troubleshooting tips, and link it from `docs/how-to/EDITOR_SETUP.md`.

### Testing
- Ran `cargo check -p perl-lsp-rs --quiet`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea22c5fd788333aeb077a663d4f747)