### PR TITLE
fix(critic-parser): validate perlcritic coordinates and severity (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/critic_parser/mod.rs
+++ b/crates/perl-lsp-rs-core/src/critic_parser/mod.rs
@@ -66,6 +66,10 @@ pub fn parse_perlcritic_line(line: &str) -> Option<ParsedCriticLine> {
     let column = parts[start + 1].parse::<u32>().ok()?;
     let severity = parts[start + 2].parse::<u8>().ok()?;
 
+    if line_num == 0 || column == 0 || !(1..=5).contains(&severity) {
+        return None;
+    }
+
     let tail = parts[start + 3..].join(":");
     let boundary = find_policy_message_boundary(&tail)?;
 

--- a/crates/perl-lsp-rs-core/tests/critic_parser_module_shape.rs
+++ b/crates/perl-lsp-rs-core/tests/critic_parser_module_shape.rs
@@ -43,3 +43,33 @@ fn critic_parser_handles_empty_input() {
     let lines = parse_perlcritic_output("");
     assert!(lines.is_empty(), "empty input should produce empty output");
 }
+
+#[test]
+fn critic_parser_rejects_zero_line_or_column() {
+    let line_zero = "lib/Foo.pm:0:5:3:Perl::Critic::Policy::ValuesAndExpressions::ProhibitMagicNumbers:no magic numbers";
+    let col_zero = "lib/Foo.pm:4:0:3:Perl::Critic::Policy::ValuesAndExpressions::ProhibitMagicNumbers:no magic numbers";
+
+    assert!(
+        parse_perlcritic_line(line_zero).is_none(),
+        "line number 0 would underflow when converted to 0-indexed ranges"
+    );
+    assert!(
+        parse_perlcritic_line(col_zero).is_none(),
+        "column number 0 is invalid for Perl::Critic diagnostics"
+    );
+}
+
+#[test]
+fn critic_parser_rejects_out_of_range_severity() {
+    let too_low = "lib/Foo.pm:4:2:0:Perl::Critic::Policy::ValuesAndExpressions::ProhibitMagicNumbers:no magic numbers";
+    let too_high = "lib/Foo.pm:4:2:9:Perl::Critic::Policy::ValuesAndExpressions::ProhibitMagicNumbers:no magic numbers";
+
+    assert!(
+        parse_perlcritic_line(too_low).is_none(),
+        "severity 0 is outside Perl::Critic's supported 1..=5 range"
+    );
+    assert!(
+        parse_perlcritic_line(too_high).is_none(),
+        "severity values greater than 5 should be dropped as malformed"
+    );
+}


### PR DESCRIPTION
### Motivation

- Prevent malformed Perl::Critic records from producing invalid LSP diagnostics by refusing entries with `line` or `column` equal to `0` or with severities outside the supported `1..=5` range.

### Description

- Add validation in `parse_perlcritic_line` to reject records where `line == 0` or `column == 0` or `severity` is not in `1..=5`.
- Preserve existing parsing logic and only drop malformed entries early (returns `None`).
- Add unit tests in `crates/perl-lsp-rs-core/tests/critic_parser_module_shape.rs` that assert rejection of zero coordinates and out-of-range severities.
- Changes applied to `crates/perl-lsp-rs-core/src/critic_parser/mod.rs` and the test file mentioned above.

### Testing

- Ran `cargo test -p perl-lsp-rs-core --test critic_parser_module_shape` and all tests passed (`7 passed`).
- Ran `cargo check --all-targets -p perl-lsp-rs-core` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2cc64b548333ace58de19ba3f190)