### PR TITLE
fix(critic-parser): harden perlcritic line parsing (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/critic_parser/mod.rs
+++ b/crates/perl-lsp-rs-core/src/critic_parser/mod.rs
@@ -134,6 +134,129 @@ mod tests {
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].line, 1);
     }
+
+    #[test]
+    fn parse_perlcritic_line_accepts_severity_boundaries() {
+        for sev in 1u8..=5 {
+            let line = format!("lib/Foo.pm:1:1:{sev}:TestingAndDebugging::RequireUseStrict:msg");
+            let parsed = parse_perlcritic_line(&line)
+                .unwrap_or_else(|| panic!("severity {sev} must parse"));
+            assert_eq!(parsed.severity, sev);
+        }
+    }
+
+    #[test]
+    fn parse_perlcritic_line_rejects_overflow_severity() {
+        // u8 max (255) is out of the 1..=5 range; u8 parse succeeds, range check rejects.
+        let line = "lib/Foo.pm:1:1:255:TestingAndDebugging::RequireUseStrict:msg";
+        assert!(parse_perlcritic_line(line).is_none());
+    }
+
+    #[test]
+    fn parse_perlcritic_line_rejects_u8_overflow_severity() {
+        // 256 overflows u8; parse fails → line skipped entirely (no partial record).
+        let line = "lib/Foo.pm:1:1:256:TestingAndDebugging::RequireUseStrict:msg";
+        assert!(parse_perlcritic_line(line).is_none());
+    }
+
+    #[test]
+    fn parse_perlcritic_line_handles_windows_path_with_crlf() {
+        // Windows drive path + CRLF line ending: the `\r` trim must run before
+        // parse, and the drive colon must still be treated as part of the file path.
+        let line = "C:\\project\\lib\\Foo.pm:10:4:2:TestingAndDebugging::RequireUseStrict:msg\r";
+        let parsed = parse_perlcritic_line(line).expect("windows+CRLF must parse");
+        assert_eq!(parsed.file, "C:\\project\\lib\\Foo.pm");
+        assert_eq!(parsed.line, 10);
+        assert_eq!(parsed.message, "msg");
+    }
+
+    #[test]
+    fn parse_perlcritic_output_handles_crlf_separated_input() {
+        // Whole output in CRLF — str::lines() already splits, but each line still
+        // carries a trailing `\r` that must be trimmed.
+        let output =
+            "lib/Foo.pm:1:1:5:TestingAndDebugging::RequireUseStrict:msg1\r\n\
+             lib/Bar.pm:2:2:3:TestingAndDebugging::RequireUseWarnings:msg2\r\n";
+        let parsed = parse_perlcritic_output(output);
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].message, "msg1");
+        assert_eq!(parsed[1].message, "msg2");
+        assert!(!parsed[0].policy.contains('\r'));
+        assert!(!parsed[1].policy.contains('\r'));
+    }
+
+    #[test]
+    fn parse_perlcritic_line_rejects_empty_policy() {
+        // Empty policy segment (`::` with nothing in between) must not parse.
+        let line = "lib/Foo.pm:1:1:3::msg";
+        assert!(parse_perlcritic_line(line).is_none());
+    }
+
+    #[test]
+    fn parse_perlcritic_line_rejects_malformed_policy_starting_digit() {
+        // Policy segments must start with ASCII letter or `_`, not a digit.
+        let line = "lib/Foo.pm:1:1:3:2BadPolicy:msg";
+        assert!(parse_perlcritic_line(line).is_none());
+    }
+
+    #[test]
+    fn parse_perlcritic_line_accepts_underscore_policy() {
+        // Valid Perl package segment can start with underscore.
+        let line = "lib/Foo.pm:1:1:3:_Private::Policy:msg";
+        let parsed = parse_perlcritic_line(line).expect("underscore policy must parse");
+        assert_eq!(parsed.policy, "_Private::Policy");
+    }
+
+    #[test]
+    fn parse_perlcritic_line_preserves_colons_inside_message() {
+        // The message after the policy may contain colons (e.g. "line: 12").
+        // `tail[boundary + 1..]` should include them verbatim.
+        let line = "lib/Foo.pm:1:1:3:TestingAndDebugging::RequireUseStrict:found at offset: 42";
+        let parsed = parse_perlcritic_line(line).expect("message with colons must parse");
+        assert_eq!(parsed.message, "found at offset: 42");
+    }
+
+    #[test]
+    fn parse_perlcritic_line_handles_unicode_file_path() {
+        // Non-ASCII in file path (char-based iteration, not byte).
+        let line = "lib/日本/Foo.pm:1:1:3:TestingAndDebugging::RequireUseStrict:msg";
+        let parsed = parse_perlcritic_line(line).expect("unicode path must parse");
+        assert_eq!(parsed.file, "lib/日本/Foo.pm");
+    }
+
+    #[test]
+    fn parse_perlcritic_line_rejects_empty_string() {
+        assert!(parse_perlcritic_line("").is_none());
+    }
+
+    #[test]
+    fn parse_perlcritic_line_rejects_whitespace_only() {
+        assert!(parse_perlcritic_line("   ").is_none());
+        assert!(parse_perlcritic_line("\t\r").is_none());
+    }
+
+    #[test]
+    fn parse_perlcritic_line_rejects_truncated_line() {
+        // Missing message and/or policy.
+        assert!(parse_perlcritic_line("lib/Foo.pm:1:1:3").is_none());
+        assert!(parse_perlcritic_line("lib/Foo.pm:1:1:3:TestingAndDebugging::RequireUseStrict").is_none());
+        // Empty message.
+        assert!(parse_perlcritic_line("lib/Foo.pm:1:1:3:TestingAndDebugging::RequireUseStrict:").is_none());
+    }
+
+    #[test]
+    fn parse_perlcritic_line_rejects_negative_numbers() {
+        // `u32::from_str("-1")` fails → line skipped.
+        let line = "lib/Foo.pm:-1:1:3:TestingAndDebugging::RequireUseStrict:msg";
+        assert!(parse_perlcritic_line(line).is_none());
+    }
+
+    #[test]
+    fn parse_perlcritic_output_empty_input_returns_empty_vec() {
+        assert!(parse_perlcritic_output("").is_empty());
+        assert!(parse_perlcritic_output("\n\n\n").is_empty());
+        assert!(parse_perlcritic_output("\r\n\r\n").is_empty());
+    }
 }
 
 fn find_policy_message_boundary(tail: &str) -> Option<usize> {

--- a/crates/perl-lsp-rs-core/src/critic_parser/mod.rs
+++ b/crates/perl-lsp-rs-core/src/critic_parser/mod.rs
@@ -38,6 +38,7 @@ pub fn parse_perlcritic_output(output: &str) -> Vec<ParsedCriticLine> {
 
 /// Parse one Perl::Critic verbose output line.
 pub fn parse_perlcritic_line(line: &str) -> Option<ParsedCriticLine> {
+    let line = line.trim_end_matches('\r');
     if line.trim().is_empty() {
         return None;
     }
@@ -65,6 +66,9 @@ pub fn parse_perlcritic_line(line: &str) -> Option<ParsedCriticLine> {
     let line_num = parts[start].parse::<u32>().ok()?;
     let column = parts[start + 1].parse::<u32>().ok()?;
     let severity = parts[start + 2].parse::<u8>().ok()?;
+    if line_num == 0 || column == 0 || !(1..=5).contains(&severity) {
+        return None;
+    }
 
     let tail = parts[start + 3..].join(":");
     let boundary = find_policy_message_boundary(&tail)?;
@@ -77,6 +81,59 @@ pub fn parse_perlcritic_line(line: &str) -> Option<ParsedCriticLine> {
     }
 
     Some(ParsedCriticLine { file, line: line_num, column, severity, policy, message })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_perlcritic_line, parse_perlcritic_output};
+
+    #[test]
+    fn parse_perlcritic_line_rejects_zero_line_and_column() {
+        let zero_line = "lib/Foo.pm:0:2:3:TestingAndDebugging::RequireUseStrict:msg";
+        assert!(parse_perlcritic_line(zero_line).is_none());
+
+        let zero_col = "lib/Foo.pm:1:0:3:TestingAndDebugging::RequireUseStrict:msg";
+        assert!(parse_perlcritic_line(zero_col).is_none());
+    }
+
+    #[test]
+    fn parse_perlcritic_line_rejects_out_of_range_severity() {
+        let too_low = "lib/Foo.pm:1:1:0:TestingAndDebugging::RequireUseStrict:msg";
+        assert!(parse_perlcritic_line(too_low).is_none());
+
+        let too_high = "lib/Foo.pm:1:1:7:TestingAndDebugging::RequireUseStrict:msg";
+        assert!(parse_perlcritic_line(too_high).is_none());
+    }
+
+    #[test]
+    fn parse_perlcritic_line_trims_crlf_line_endings() {
+        let line = "lib/Foo.pm:1:1:5:TestingAndDebugging::RequireUseStrict:msg\r";
+        let parsed = parse_perlcritic_line(line).expect("valid perlcritic line");
+        assert_eq!(parsed.message, "msg");
+    }
+
+    #[test]
+    fn parse_perlcritic_line_supports_windows_drive_paths() {
+        let line = "C:\\project\\lib\\Foo.pm:10:4:2:TestingAndDebugging::RequireUseStrict:msg";
+        let parsed = parse_perlcritic_line(line).expect("valid windows path");
+        assert_eq!(parsed.file, "C:\\project\\lib\\Foo.pm");
+        assert_eq!(parsed.line, 10);
+        assert_eq!(parsed.column, 4);
+    }
+
+    #[test]
+    fn parse_perlcritic_output_skips_invalid_lines() {
+        let output = [
+            "lib/Foo.pm:1:1:5:TestingAndDebugging::RequireUseStrict:msg",
+            "lib/Foo.pm:0:1:5:TestingAndDebugging::RequireUseStrict:invalid",
+            "",
+        ]
+        .join("\n");
+
+        let parsed = parse_perlcritic_output(&output);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].line, 1);
+    }
 }
 
 fn find_policy_message_boundary(tail: &str) -> Option<usize> {


### PR DESCRIPTION
### Motivation

- Perl::Critic output parsing could accept CRLF artifacts and invalid coordinates/severities, producing bad ranges and noisy diagnostics.
- The parser needed stricter validation and normalization to make external `perlcritic` integration robust across platforms.

### Description

- Normalize per-line input by trimming trailing `\r` characters before parsing to handle CRLF line endings.
- Reject parsed records with `line == 0`, `column == 0`, or `severity` outside the `1..=5` range to avoid producing invalid diagnostics.
- Added focused unit tests exercising CRLF trimming, Windows drive-path parsing, rejection of zero coordinates and out-of-range severities, and filtering mixed valid/invalid output.
- Change is implemented in `crates/perl-lsp-rs-core/src/critic_parser/mod.rs` (parser logic + tests).

### Testing

- Ran `cargo test -p perl-lsp-rs-core critic_parser` and the new parser tests passed (5 passed).
- Ran `cargo check --all-targets -p perl-lsp-rs-core` and it completed successfully.
- Ran `cargo clippy -p perl-lsp-rs-core --all-targets -- -D warnings` which failed due to existing unrelated clippy warnings in `tests/g3_publish_baseline_enforcement.rs` and is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2cc64b548333ace58de19ba3f190)