### PR TITLE
fix(perlcritic): resolve relative profiles and discover perlcriticrc (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -11,6 +11,50 @@ use crate::features::diagnostics::{
 };
 use perl_diagnostics::codes::DiagnosticCode;
 
+#[cfg(not(target_arch = "wasm32"))]
+fn resolve_configured_profile_path(
+    configured_profile: &str,
+    workspace_root: Option<&std::path::Path>,
+    file_path: &std::path::Path,
+) -> Option<std::path::PathBuf> {
+    let profile_path = std::path::Path::new(configured_profile);
+    if profile_path.is_absolute() {
+        return profile_path.exists().then(|| profile_path.to_path_buf());
+    }
+
+    let file_dir = file_path.parent();
+    [
+        Some(profile_path.to_path_buf()),
+        workspace_root.map(|root| root.join(profile_path)),
+        file_dir.map(|dir| dir.join(profile_path)),
+    ]
+    .into_iter()
+    .flatten()
+    .find(|candidate| candidate.exists())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn find_workspace_perlcritic_profile(
+    workspace_root: Option<&std::path::Path>,
+    file_path: &std::path::Path,
+) -> Option<String> {
+    let mut dir = file_path.parent().map(|p| p.to_path_buf());
+    while let Some(current) = dir {
+        for profile_name in [".perlcriticrc", "perlcriticrc"] {
+            let candidate = current.join(profile_name);
+            if candidate.exists() {
+                return candidate.to_str().map(|s| s.to_string());
+            }
+        }
+
+        if workspace_root == Some(current.as_path()) || current.parent().is_none() {
+            break;
+        }
+        dir = current.parent().map(|p| p.to_path_buf());
+    }
+    None
+}
+
 /// Orchestrator for pull diagnostics operations.
 ///
 /// Coordinates between LspServer state and the pure-logic PullDiagnosticsProvider.
@@ -125,10 +169,16 @@ impl PullDiagnosticsOrchestrator {
             return;
         }
 
-        // Validate configured profile if present
-        if let Some(ref configured_profile) = profile {
-            let profile_path = std::path::Path::new(configured_profile);
-            if !profile_path.exists() {
+        let workspace_root = server.root_path.lock().clone();
+
+        // Validate configured profile if present.
+        let resolved_configured_profile = if let Some(ref configured_profile) = profile {
+            let resolved = resolve_configured_profile_path(
+                configured_profile,
+                workspace_root.as_deref(),
+                &file_path,
+            );
+            if resolved.is_none() {
                 self.emit_warning(
                     server,
                     format!("missing-profile:{configured_profile}"),
@@ -138,30 +188,22 @@ impl PullDiagnosticsOrchestrator {
                 );
                 return;
             }
-        }
+            resolved
+        } else {
+            None
+        };
 
         // Lazy-init the CriticAnalyzer
         {
             let mut guard = self.critic_analyzer.lock();
             if guard.is_none() {
-                // Walk up directory tree looking for .perlcriticrc
-                let resolved_profile = profile.or_else(|| {
-                    let workspace_root = server.root_path.lock().clone();
-                    let mut dir = file_path.parent().map(|p| p.to_path_buf());
-                    while let Some(current) = dir {
-                        let candidate = current.join(".perlcriticrc");
-                        if candidate.exists() {
-                            return candidate.to_str().map(|s| s.to_string());
-                        }
-                        if workspace_root.as_deref() == Some(current.as_path())
-                            || current.parent().is_none()
-                        {
-                            break;
-                        }
-                        dir = current.parent().map(|p| p.to_path_buf());
-                    }
-                    None
-                });
+                // Walk up directory tree looking for .perlcriticrc / perlcriticrc.
+                let resolved_profile = resolved_configured_profile
+                    .as_ref()
+                    .and_then(|p| p.to_str().map(|s| s.to_string()))
+                    .or_else(|| {
+                        find_workspace_perlcritic_profile(workspace_root.as_deref(), &file_path)
+                    });
 
                 let critic_config =
                     CriticConfig { severity, profile: resolved_profile, ..Default::default() };
@@ -1292,9 +1334,14 @@ impl LspServer {
             return;
         }
 
-        if let Some(ref configured_profile) = profile {
-            let profile_path = std::path::Path::new(configured_profile);
-            if !profile_path.exists() {
+        let workspace_root = self.root_path.lock().clone();
+        let resolved_configured_profile = if let Some(ref configured_profile) = profile {
+            let resolved = resolve_configured_profile_path(
+                configured_profile,
+                workspace_root.as_deref(),
+                &file_path,
+            );
+            if resolved.is_none() {
                 self.emit_perlcritic_workspace_warning(
                     format!("missing-profile:{configured_profile}"),
                     &format!(
@@ -1303,7 +1350,10 @@ impl LspServer {
                 );
                 return;
             }
-        }
+            resolved
+        } else {
+            None
+        };
 
         // Lazy-init the shared CriticAnalyzer.  If the profile or severity
         // changed, `didChangeConfiguration` has already reset the field to
@@ -1319,24 +1369,12 @@ impl LspServer {
                 // workspace root looking for `.perlcriticrc`.  Ensures that a
                 // repo-root config is found even when the file lives in a
                 // sub-directory.  Only runs when the analyzer needs (re-)init.
-                let resolved_profile = profile.or_else(|| {
-                    let workspace_root = self.root_path.lock().clone();
-                    let mut dir = file_path.parent().map(|p| p.to_path_buf());
-                    while let Some(current) = dir {
-                        let candidate = current.join(".perlcriticrc");
-                        if candidate.exists() {
-                            return candidate.to_str().map(|s| s.to_string());
-                        }
-                        // Stop at the workspace root or the filesystem root.
-                        if workspace_root.as_deref() == Some(current.as_path())
-                            || current.parent().is_none()
-                        {
-                            break;
-                        }
-                        dir = current.parent().map(|p| p.to_path_buf());
-                    }
-                    None
-                });
+                let resolved_profile = resolved_configured_profile
+                    .as_ref()
+                    .and_then(|p| p.to_str().map(|s| s.to_string()))
+                    .or_else(|| {
+                        find_workspace_perlcritic_profile(workspace_root.as_deref(), &file_path)
+                    });
                 let critic_config = crate::perl_critic::CriticConfig {
                     severity,
                     profile: resolved_profile,

--- a/crates/perl-lsp-rs/tests/lsp_perlcritic_diagnostics_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_perlcritic_diagnostics_tests.rs
@@ -356,6 +356,92 @@ fn test_f_missing_configured_profile_skips_subprocess_and_diagnostics() {
 }
 
 #[test]
+fn test_f2_relative_configured_profile_resolves_from_workspace_root() {
+    use std::fs;
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    let cfg_dir = root.join("config");
+    fs::create_dir_all(&cfg_dir).expect("create config/");
+
+    let profile_path = cfg_dir.join("perlcriticrc");
+    fs::write(&profile_path, "severity = 3\n").expect("write profile");
+
+    let module_path = root.join("RelativeProfile.pm");
+    fs::write(&module_path, "package RelativeProfile;\n1;\n").expect("write module");
+
+    let server = LspServer::new();
+    server.test_set_root_path(root.clone());
+    server.test_configure_perlcritic(true, 3, Some("config/perlcriticrc".to_string()));
+    server.test_bypass_perlcritic_command_check();
+
+    let runtime = Arc::new(MockSubprocessRuntime::new());
+    runtime.add_response(MockResponse::success(b"".to_vec()));
+    server.test_install_mock_critic_runtime(runtime.clone());
+
+    let uri = url::Url::from_file_path(&module_path).expect("file url").to_string();
+    pull_diagnostics(&server, &uri, "package RelativeProfile;\n1;\n");
+
+    let invocations = runtime.invocations();
+    assert!(
+        !invocations.is_empty(),
+        "expected perlcritic subprocess invocation; got: {invocations:?}"
+    );
+
+    let expected_profile = profile_path.to_string_lossy().to_string();
+    let profile_arg = format!("--profile={expected_profile}");
+    assert!(
+        invocations.last().is_some_and(|invocation| invocation.args.contains(&profile_arg)),
+        "relative configured profile should resolve from workspace root; args: {:?}",
+        invocations.last().map(|invocation| &invocation.args)
+    );
+}
+
+#[test]
+fn test_f3_walkup_finds_perlcriticrc_without_dot_prefix() {
+    use std::fs;
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    let lib_dir = root.join("lib");
+    fs::create_dir_all(&lib_dir).expect("create lib/");
+
+    let rc_path = root.join("perlcriticrc");
+    fs::write(&rc_path, "severity = 3\n").expect("write perlcriticrc");
+
+    let module_path = lib_dir.join("NoDotRc.pm");
+    fs::write(&module_path, "package NoDotRc;\n1;\n").expect("write module");
+
+    let server = LspServer::new();
+    server.test_configure_perlcritic(true, 3, None);
+    server.test_set_root_path(root.clone());
+    server.test_bypass_perlcritic_command_check();
+
+    let runtime = Arc::new(MockSubprocessRuntime::new());
+    runtime.add_response(MockResponse::success(b"".to_vec()));
+    server.test_install_mock_critic_runtime(runtime.clone());
+
+    let uri = url::Url::from_file_path(&module_path).expect("file url").to_string();
+    pull_diagnostics(&server, &uri, "package NoDotRc;\n1;\n");
+
+    let invocations = runtime.invocations();
+    assert!(
+        !invocations.is_empty(),
+        "expected perlcritic subprocess invocation; got: {invocations:?}"
+    );
+
+    let expected_profile = rc_path.to_string_lossy().to_string();
+    let profile_arg = format!("--profile={expected_profile}");
+    assert!(
+        invocations.last().is_some_and(|invocation| invocation.args.contains(&profile_arg)),
+        "walk-up should discover workspace perlcriticrc without dot; args: {:?}",
+        invocations.last().map(|invocation| &invocation.args)
+    );
+}
+
+#[test]
 fn test_g_did_change_configuration_resets_pull_perlcritic_analyzer() {
     use std::fs;
     use tempfile::TempDir;


### PR DESCRIPTION
### Motivation

- Configured Perl::Critic profile resolution only accepted paths that existed as provided and the walk-up logic looked only for `.perlcriticrc`, which caused workspace-relative profiles and `perlcriticrc` (without dot) files to be ignored.

### Description

- Added `resolve_configured_profile_path` to resolve configured profile paths relative to the file directory and workspace root, and to accept absolute paths when present.
- Added `find_workspace_perlcritic_profile` to walk up the directory tree and discover both `.perlcriticrc` and `perlcriticrc` files.
- Wired the new helpers into both the pull-diagnostics orchestrator and the server runtime diagnostics path so configured profiles and walk-up discovery behave consistently.
- Added integration tests to cover workspace-relative configured profiles and discovery of `perlcriticrc` without a leading dot, and adjusted assertions to handle multiple invocations from the mocked runtime.

### Testing

- Ran `cargo clippy -p perl-lsp-rs --lib -- -D warnings`, which passed. 
- Ran targeted integration tests with the test API: `cargo test -p perl-lsp-rs --features expose_lsp_test_api --test lsp_perlcritic_diagnostics_tests test_f2_relative_configured_profile_resolves_from_workspace_root` and `test_f3_walkup_finds_perlcriticrc_without_dot_prefix`, both of which passed. 
- A full `cargo test` / `cargo check --all-targets` run for the crate revealed unrelated pre-existing failures in other test modules (parse/compile errors outside this change); these failures are not caused by the perlcritic profile resolution changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2cc64b548333ace58de19ba3f190)