### PR TITLE
feat(perl-lsp-perltidy): improve builtin formatter delimiter handling (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -340,23 +340,74 @@ impl BuiltInFormatter {
 
         for line in code.lines() {
             let trimmed = line.trim();
-            if trimmed.starts_with('}') || trimmed.starts_with(')') || trimmed.starts_with(']') {
-                indent_level = indent_level.saturating_sub(1);
+            if trimmed.is_empty() {
+                result.push('\n');
+                continue;
             }
 
-            if !trimmed.is_empty() {
-                for _ in 0..indent_level {
-                    result.push_str(&indent_str);
-                }
-                result.push_str(trimmed);
+            let leading_closers = Self::count_leading_closers(trimmed);
+            let current_indent = (indent_level - leading_closers).max(0);
+
+            for _ in 0..current_indent {
+                result.push_str(&indent_str);
             }
+            result.push_str(trimmed);
             result.push('\n');
 
-            if trimmed.ends_with('{') || trimmed.ends_with('(') || trimmed.ends_with('[') {
-                indent_level += 1;
-            }
+            indent_level = (indent_level + Self::delimiter_delta(trimmed)).max(0);
         }
 
         result
+    }
+
+    fn count_leading_closers(line: &str) -> i32 {
+        let mut closers = 0_i32;
+        for ch in line.chars() {
+            match ch {
+                ')' | '}' | ']' => {
+                    closers += 1;
+                }
+                _ => break,
+            }
+        }
+        closers
+    }
+
+    fn delimiter_delta(line: &str) -> i32 {
+        let mut delta = 0_i32;
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut escaped = false;
+
+        for ch in line.chars() {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+
+            match ch {
+                '\\' if in_single || in_double => {
+                    escaped = true;
+                }
+                '\'' if !in_double => {
+                    in_single = !in_single;
+                }
+                '"' if !in_single => {
+                    in_double = !in_double;
+                }
+                '#' if !in_single && !in_double => {
+                    break;
+                }
+                '{' | '(' | '[' if !in_single && !in_double => {
+                    delta += 1;
+                }
+                '}' | ')' | ']' if !in_single && !in_double => {
+                    delta -= 1;
+                }
+                _ => {}
+            }
+        }
+
+        delta
     }
 }

--- a/crates/perl-lsp-perltidy/tests/config_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/config_tests.rs
@@ -237,3 +237,26 @@ fn builtin_formatter_handles_empty_input() {
     let formatted = formatter.format("");
     assert_eq!(formatted, "");
 }
+
+#[test]
+fn builtin_formatter_indents_after_opening_delimiter_before_comment() {
+    let formatter = BuiltInFormatter::new(PerlTidyConfig::default());
+    let formatted = formatter.format("if ($x) { # comment\nprint $x;\n}\n");
+
+    let lines: Vec<&str> = formatted.lines().collect();
+    assert_eq!(lines[0], "if ($x) { # comment");
+    assert_eq!(lines[1], "    print $x;");
+    assert_eq!(lines[2], "}");
+}
+
+#[test]
+fn builtin_formatter_does_not_count_delimiters_inside_strings_or_comments() {
+    let formatter = BuiltInFormatter::new(PerlTidyConfig::default());
+    let formatted = formatter.format("if ($x) {\nprint \"}\"; # {\nprint q{literal};\n}\n");
+
+    let lines: Vec<&str> = formatted.lines().collect();
+    assert_eq!(lines[0], "if ($x) {");
+    assert_eq!(lines[1], "    print \"}\"; # {");
+    assert_eq!(lines[2], "    print q{literal};");
+    assert_eq!(lines[3], "}");
+}


### PR DESCRIPTION
### Motivation
- The Rust built-in formatter fallback was too naive and produced incorrect indentation for common Perl patterns when `perltidy` is unavailable. 
- Improve robustness so the fallback handles leading closers, per-line delimiter balances, and ignores delimiters inside strings and `#` comments.

### Description
- Replace simple `starts_with`/`ends_with` heuristics in `BuiltInFormatter::format` with logic that preserves empty lines and computes a safe `current_indent` using leading closer counts. 
- Add `count_leading_closers` and `delimiter_delta` helper functions to compute per-line indent adjustments while ignoring delimiters inside single/double-quoted strings and after `#` comments. 
- Update indentation update to `indent_level = (indent_level + Self::delimiter_delta(trimmed)).max(0)` and apply `indent_str` for the computed `current_indent`. 
- Add two focused regression tests in `crates/perl-lsp-perltidy/tests/config_tests.rs` named `builtin_formatter_indents_after_opening_delimiter_before_comment` and `builtin_formatter_does_not_count_delimiters_inside_strings_or_comments`.

### Testing
- Ran `cargo test -p perl-lsp-perltidy` which completed successfully (all unit tests passed). 
- Ran `cargo check --all-targets -p perl-lsp-perltidy` which completed successfully. 
- Ran `cargo clippy -p perl-lsp-perltidy --all-targets` which completed successfully. 
- Ran `cargo xtask fmt` which failed due to pre-existing compile errors in the `xtask` binary unrelated to this change, and `just pr-fast` was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2cd9b1ec8333b0cdf73ee9632d45)