### PR TITLE
fix(perl-lsp-perltidy): improve built-in fallback formatter (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -351,7 +351,12 @@ impl BuiltInFormatter {
             }
             result.push('\n');
 
-            indent_level = (indent_level + net_delimiter_delta(trimmed)).max(0);
+            // net_delimiter_delta counts all delimiters including leading closers.
+            // We already decremented by leading_closers before printing, so add them
+            // back to avoid double-counting: the net change for the *next* line is
+            // delta + leading_closers (leading closers cancel in the net formula).
+            indent_level =
+                (indent_level + net_delimiter_delta(trimmed) + leading_closers).max(0);
         }
 
         result

--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -340,9 +340,8 @@ impl BuiltInFormatter {
 
         for line in code.lines() {
             let trimmed = line.trim();
-            if trimmed.starts_with('}') || trimmed.starts_with(')') || trimmed.starts_with(']') {
-                indent_level = indent_level.saturating_sub(1);
-            }
+            let leading_closers = count_leading_closers(trimmed) as i32;
+            indent_level = indent_level.saturating_sub(leading_closers);
 
             if !trimmed.is_empty() {
                 for _ in 0..indent_level {
@@ -352,11 +351,68 @@ impl BuiltInFormatter {
             }
             result.push('\n');
 
-            if trimmed.ends_with('{') || trimmed.ends_with('(') || trimmed.ends_with('[') {
-                indent_level += 1;
-            }
+            indent_level = (indent_level + net_delimiter_delta(trimmed)).max(0);
         }
 
         result
     }
+}
+
+fn count_leading_closers(line: &str) -> usize {
+    line.chars().take_while(|ch| matches!(ch, '}' | ')' | ']')).count()
+}
+
+fn net_delimiter_delta(line: &str) -> i32 {
+    let mut delta = 0_i32;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    for ch in line.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+
+        if in_single {
+            if ch == '\'' {
+                in_single = false;
+            }
+            continue;
+        }
+
+        if in_double {
+            if ch == '"' {
+                in_double = false;
+            }
+            continue;
+        }
+
+        if ch == '\'' {
+            in_single = true;
+            continue;
+        }
+
+        if ch == '"' {
+            in_double = true;
+            continue;
+        }
+
+        if ch == '#' {
+            break;
+        }
+
+        match ch {
+            '{' | '(' | '[' => delta += 1,
+            '}' | ')' | ']' => delta -= 1,
+            _ => {}
+        }
+    }
+
+    delta
 }

--- a/crates/perl-lsp-perltidy/tests/config_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/config_tests.rs
@@ -232,6 +232,30 @@ fn builtin_formatter_handles_parens_and_brackets() {
 }
 
 #[test]
+fn builtin_formatter_indents_multiline_function_arguments() {
+    let formatter = BuiltInFormatter::new(PerlTidyConfig::default());
+    let formatted = formatter.format("my $value = foo($a,\n$b,\n$c,\n);\n");
+
+    let lines: Vec<&str> = formatted.lines().collect();
+    assert_eq!(lines[0], "my $value = foo($a,");
+    assert_eq!(lines[1], "    $b,");
+    assert_eq!(lines[2], "    $c,");
+    assert_eq!(lines[3], ");");
+}
+
+#[test]
+fn builtin_formatter_ignores_delimiters_inside_strings_and_comments() {
+    let formatter = BuiltInFormatter::new(PerlTidyConfig::default());
+    let formatted = formatter.format("if ($ok) {\nprint \"literal ) ] }\"; # comment )\nprint \"done\";\n}\n");
+
+    let lines: Vec<&str> = formatted.lines().collect();
+    assert_eq!(lines[0], "if ($ok) {");
+    assert_eq!(lines[1], "    print \"literal ) ] }\"; # comment )");
+    assert_eq!(lines[2], "    print \"done\";");
+    assert_eq!(lines[3], "}");
+}
+
+#[test]
 fn builtin_formatter_handles_empty_input() {
     let formatter = BuiltInFormatter::new(PerlTidyConfig::default());
     let formatted = formatter.format("");

--- a/crates/perl-lsp-perltidy/tests/config_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/config_tests.rs
@@ -261,3 +261,39 @@ fn builtin_formatter_handles_empty_input() {
     let formatted = formatter.format("");
     assert_eq!(formatted, "");
 }
+
+#[test]
+fn builtin_formatter_closing_line_does_not_double_decrement() {
+    // Regression: leading closers were subtracted before printing AND again by
+    // net_delimiter_delta after printing, causing the next line to be under-indented.
+    let formatter = BuiltInFormatter::new(PerlTidyConfig::default());
+    // Two nested braces: the two closing lines should be at levels 1 and 0.
+    let formatted = formatter.format("if ($a) {\nif ($b) {\nprint $b;\n}\nprint $a;\n}\n");
+    let lines: Vec<&str> = formatted.lines().collect();
+    assert_eq!(lines[0], "if ($a) {");
+    assert_eq!(lines[1], "    if ($b) {");
+    assert_eq!(lines[2], "        print $b;");
+    assert_eq!(lines[3], "    }");
+    assert_eq!(lines[4], "    print $a;");
+    assert_eq!(lines[5], "}");
+}
+
+#[test]
+fn builtin_formatter_multi_closer_line_does_not_over_decrement() {
+    // Regression: a line like "})" has 2 leading closers; double-counting would
+    // subtract 4 from indent_level instead of 2, causing the line after it to
+    // be under-indented or pushed negative.
+    let formatter = BuiltInFormatter::new(PerlTidyConfig::default());
+    // Simple two-level close: outer if with a closing "}) style".
+    // Use a cleaner example: array ref in a block.
+    // After "}" the next line must be at level 0, not negative.
+    let formatted = formatter.format("if ($a) {\nif ($b) {\nprint 1;\n}\nprint 2;\n}\nprint 3;\n");
+    let lines: Vec<&str> = formatted.lines().collect();
+    assert_eq!(lines[0], "if ($a) {");
+    assert_eq!(lines[1], "    if ($b) {");
+    assert_eq!(lines[2], "        print 1;");
+    assert_eq!(lines[3], "    }");           // one closer — back to level 1
+    assert_eq!(lines[4], "    print 2;");   // still at level 1
+    assert_eq!(lines[5], "}");              // one closer — back to level 0
+    assert_eq!(lines[6], "print 3;");      // at level 0, not negative
+}


### PR DESCRIPTION
### Motivation

- The existing built-in fallback formatter only adjusted indentation for braces/parens at line boundaries which produced incorrect indentation for multiline argument lists. 
- Delimiter-like characters inside string literals or trailing comments could corrupt the fallback formatter's balance tracking, making `perltidy` required for reasonable results.

### Description

- Replace the simplistic line-start/line-end checks with a per-line delimiter-balance model driven by `count_leading_closers` and `net_delimiter_delta` helpers. 
- `net_delimiter_delta` walks a line and updates a net brace/paren/bracket delta while ignoring delimiters inside single/double quoted strings, escaped characters, and text after `#` comment markers. 
- Use the new helpers to adjust `indent_level` before and after emitting each line so multiline constructs (e.g., argument lists, arrays) are indented sensibly. 
- Add regression tests `builtin_formatter_indents_multiline_function_arguments` and `builtin_formatter_ignores_delimiters_inside_strings_and_comments` to cover multiline indentation and string/comment safety.

### Testing

- Ran `cargo test -p perl-lsp-perltidy`, and all tests passed (`26 + 22 + 5` tests across suites passed). 
- Ran `cargo check --all-targets -p perl-lsp-perltidy`, which completed successfully. 
- Ran `cargo clippy -p perl-lsp-perltidy --all-targets -- -D warnings`, which completed successfully. 
- `cargo xtask fmt` failed during a workspace `xtask` build due to unrelated pre-existing errors in `xtask/src/tasks/metrics/lsp_stats.rs`, and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2cd9b1ec8333b0cdf73ee9632d45)