### PR TITLE
fix(perl-critic): harden built-in pragma detection (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs
@@ -1,4 +1,4 @@
-use super::{QuickFix, Severity, Violation, built_in_quick_fix, insertion_range};
+use super::{built_in_quick_fix, insertion_range, QuickFix, Severity, Violation};
 use perl_parser_core::Node;
 
 /// Built-in policy analyzer that works without external perlcritic
@@ -94,7 +94,7 @@ fn missing_use_statement_violation(
     feature: &str,
     explanation: &str,
 ) -> Vec<Violation> {
-    if content.contains(&format!("use {feature}")) {
+    if pragma_is_enabled(content, feature) {
         return Vec::new();
     }
 
@@ -106,4 +106,98 @@ fn missing_use_statement_violation(
         range: insertion_range(),
         file: String::new(),
     }]
+}
+
+fn pragma_is_enabled(content: &str, feature: &str) -> bool {
+    let mut enabled = false;
+    let mut in_pod = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+
+        if in_pod {
+            if trimmed.starts_with("=cut") {
+                in_pod = false;
+            }
+            continue;
+        }
+
+        if trimmed.starts_with("=pod")
+            || trimmed.starts_with("=head")
+            || trimmed.starts_with("=over")
+            || trimmed.starts_with("=item")
+            || trimmed.starts_with("=begin")
+            || trimmed.starts_with("=for")
+        {
+            in_pod = true;
+            continue;
+        }
+
+        if trimmed.starts_with("__DATA__") || trimmed.starts_with("__END__") {
+            break;
+        }
+
+        let code_segment = line.split('#').next().unwrap_or_default();
+        let code_segment = code_segment.trim();
+        if code_segment.is_empty() {
+            continue;
+        }
+
+        let mut parts = code_segment.split_whitespace();
+        let Some(directive) = parts.next() else { continue };
+        if directive != "use" && directive != "no" {
+            continue;
+        }
+
+        let Some(pragma_name) = parts.next() else { continue };
+        let pragma_name = pragma_name.trim_end_matches(';');
+        if pragma_name != "strict" && pragma_name != "warnings" {
+            continue;
+        }
+
+        if pragma_name != feature {
+            continue;
+        }
+
+        enabled = directive == "use";
+    }
+
+    enabled
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pragma_is_enabled;
+
+    #[test]
+    fn detects_enabled_pragma() {
+        let content = "use strict;\nuse warnings;\nmy $x = 1;\n";
+        assert!(pragma_is_enabled(content, "strict"));
+        assert!(pragma_is_enabled(content, "warnings"));
+    }
+
+    #[test]
+    fn ignores_comments_and_pod_mentions() {
+        let content = r#"
+# use strict;
+=head1 NAME
+This module mentions use warnings; in docs.
+=cut
+my $x = 1;
+"#;
+        assert!(!pragma_is_enabled(content, "strict"));
+        assert!(!pragma_is_enabled(content, "warnings"));
+    }
+
+    #[test]
+    fn respects_no_directive_over_use() {
+        let content = "use strict;\nno strict;\n";
+        assert!(!pragma_is_enabled(content, "strict"));
+    }
+
+    #[test]
+    fn ignores_data_section() {
+        let content = "my $x = 1;\n__DATA__\nuse strict;\n";
+        assert!(!pragma_is_enabled(content, "strict"));
+    }
 }


### PR DESCRIPTION
### Motivation

- The built-in Rust fallback for Perl::Critic used a naive substring check which could be satisfied by comments, POD, or `__DATA__` content and did not handle `no` overrides.
- Improve accuracy so the analyzer only considers executable Perl code and correctly tracks `use`/`no` state for `strict` and `warnings`.

### Description

- Replaced the substring check in `missing_use_statement_violation` with a new `pragma_is_enabled` function that scans lines of source and determines effective pragma state.
- `pragma_is_enabled` ignores POD sections and lines after `__DATA__`/`__END__`, strips comments, parses `use`/`no` directives, and respects later `no` directives overriding earlier `use` directives.
- Added focused unit tests covering detection of enabled pragmas, ignoring comments/POD, honoring `no` directives, and ignoring pragmas after `__DATA__`.
- Minor reorder of imported symbols in `crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs` to accommodate the change.

### Testing

- Ran `cargo test -p perl-lsp-rs-core built_in` and the new tests passed (4 passed; 0 failed).
- Ran `cargo check --all-targets -p perl-lsp-rs-core` which completed successfully.
- Ran `cargo clippy -p perl-lsp-rs-core` which completed successfully.
- Ran `cargo xtask fmt` which failed due to unrelated pre-existing compile errors in `xtask/src/tasks/metrics/lsp_stats.rs`, so formatting could not be completed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2cdf20bc83339fc38d80aa785977)