### PR TITLE
fix(vscode-extension): target termux android triples for binary download (#0000)

### DIFF
--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -574,12 +574,20 @@ export class BinaryDownloader {
     private getPlatformTarget(): string {
         const platform = process.platform;
         const arch = process.arch;
+
+        if (platform === 'android') {
+            const archPrefix = arch === 'arm64' ? 'aarch64' : 'x86_64';
+            return `${archPrefix}-linux-android`;
+        }
         
         // Map Node.js platform/arch to exact cargo-dist target triples
         if (platform === 'darwin') {
             return arch === 'arm64' ? 'aarch64-apple-darwin' : 'x86_64-apple-darwin';
         } else if (platform === 'linux') {
             const archPrefix = arch === 'arm64' ? 'aarch64' : 'x86_64';
+            if (this.detectTermux()) {
+                return `${archPrefix}-linux-android`;
+            }
             const libc = this.detectMusl() ? 'musl' : 'gnu';
             return `${archPrefix}-unknown-linux-${libc}`;
         } else if (platform === 'win32') {
@@ -619,6 +627,19 @@ export class BinaryDownloader {
         ];
         
         return muslLibs.some(lib => fs.existsSync(lib));
+    }
+
+    private detectTermux(): boolean {
+        const prefix = process.env.PREFIX ?? '';
+        if (prefix.startsWith('/data/data/com.termux/')) {
+            return true;
+        }
+
+        if ((process.env.TERMUX_VERSION ?? '').length > 0) {
+            return true;
+        }
+
+        return fs.existsSync('/data/data/com.termux/files/usr/bin/pkg');
     }
     
     private getLocalBinaryPath(): string {

--- a/vscode-extension/src/test/downloader.test.ts
+++ b/vscode-extension/src/test/downloader.test.ts
@@ -59,7 +59,22 @@ describe('BinaryDownloader.getPlatformTarget', () => {
 
   test('target contains platform component', () => {
     const target = getPlatformTarget(downloader);
-    expect(target).toMatch(/(apple-darwin|unknown-linux|pc-windows)/);
+    expect(target).toMatch(/(apple-darwin|unknown-linux|pc-windows|linux-android)/);
+  });
+
+  test('linux termux environments resolve to android target triples', () => {
+    if (process.platform !== 'linux') {
+      return;
+    }
+
+    const detectTermux = jest.spyOn(downloader as any, 'detectTermux').mockReturnValue(true);
+    const detectMusl = jest.spyOn(downloader as any, 'detectMusl').mockReturnValue(false);
+
+    const target = getPlatformTarget(downloader);
+    expect(target).toMatch(/-linux-android$/);
+
+    detectTermux.mockRestore();
+    detectMusl.mockRestore();
   });
 });
 


### PR DESCRIPTION
### Motivation
- Ensure the VS Code extension downloads the correct prebuilt binary for Termux/Android environments instead of requesting incompatible GNU/musl Linux assets.

### Description
- Map Node.js `process.platform === 'android'` and Termux-detected Linux environments to `*-linux-android` cargo-dist triples in `BinaryDownloader.getPlatformTarget`.
- Add a `detectTermux()` helper that checks `process.env.PREFIX`, `TERMUX_VERSION`, and the Termux `pkg` path to identify Termux runtime environments in `vscode-extension/src/downloader.ts`.
- Update `vscode-extension/src/test/downloader.test.ts` to accept `linux-android` in the platform assertions and add a Linux-only unit that mocks `detectTermux()` to verify the android triple behavior.

### Testing
- Ran `npm --prefix vscode-extension test -- downloader.test.ts`; the run failed with TypeScript/Jest global-name errors (`Cannot find name 'jest'`, `describe`, `expect`) caused by the test runner/type config in this environment, so the failure is environmental and not indicative of the logic change.
- No Rust crate tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3369341c8333953253f71b46233e)