### PR TITLE
fix(actions): add Windows ARM64 setup target (#0000)

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -8,6 +8,11 @@ This directory contains reusable composite actions for perl-lsp CI workflows.
 
 Installs `perllsp` for downstream GitHub Actions workflows.
 
+Supported release binaries auto-resolve for:
+- Linux: `x86_64`, `aarch64`
+- macOS: `x86_64`, `aarch64`
+- Windows: `x86_64`, `aarch64`
+
 **Usage:**
 ```yaml
 - uses: EffortlessMetrics/perl-lsp/.github/actions/setup-perl-lsp@master

--- a/.github/actions/setup-perl-lsp/action.yml
+++ b/.github/actions/setup-perl-lsp/action.yml
@@ -102,6 +102,7 @@ runs:
           Windows)
             case "$RUNNER_ARCH" in
               X64) target="x86_64-pc-windows-msvc" ;;
+              ARM64) target="aarch64-pc-windows-msvc" ;;
               *)
                 if [ "${INPUT_BUILD_FROM_SOURCE:-false}" = "true" ]; then
                   mode="source"


### PR DESCRIPTION
### Motivation
- The `setup-perl-lsp` composite action rejected Windows ARM64 runners even though ARM binaries are published, causing CI consumers on Windows/ARM to hard-fail during platform resolution.

### Description
- Map `RUNNER_ARCH=ARM64` to `aarch64-pc-windows-msvc` in `.github/actions/setup-perl-lsp/action.yml` and document supported auto-resolved architectures in `.github/actions/README.md`.

### Testing
- Verified the updated `action.yml` parses with `ruby -e "require 'yaml'; YAML.safe_load_file('.github/actions/setup-perl-lsp/action.yml', permitted_classes: [], aliases: true); puts 'ok'"` (passes), and attempted `cargo xtask fmt` which failed due to unrelated compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` (pre-existing and not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea336df5b48333bfe5b6c0603fd1c5)