### PR TITLE
fix(transport): tolerate LF-only LSP header separators (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/transport/framing.rs
+++ b/crates/perl-lsp-rs-core/src/transport/framing.rs
@@ -13,7 +13,8 @@ use std::io::{self, BufRead, Read, Write};
 // ── Absorbed from perl-content-length-framing ─────────────────────────────────
 
 const HEADER_SENTINEL: &[u8] = b"Content-Length:";
-const HEADER_END: &[u8] = b"\r\n\r\n";
+const HEADER_END_CRLF: &[u8] = b"\r\n\r\n";
+const HEADER_END_LF: &[u8] = b"\n\n";
 const RESYNC_TAIL_BYTES: usize = 8 * 1024;
 const MAX_DESYNC_BUFFER_BYTES: usize = 64 * 1024;
 
@@ -81,20 +82,20 @@ impl ContentLengthFramer {
         self.resync_if_needed();
 
         let Some(start) = find_header_start(&self.buf) else {
-            if let Some(header_end) = find_subslice(&self.buf, HEADER_END) {
+            if let Some((header_end, separator_len)) = find_header_end(&self.buf) {
                 match std::str::from_utf8(&self.buf[..header_end]) {
                     Ok(header) => {
                         let has_header_shape = header
-                            .split("\r\n")
+                            .lines()
                             .any(|line| !line.trim().is_empty() && line.contains(':'));
-                        self.consume_header_block(header_end);
+                        self.consume_header_block(header_end, separator_len);
                         if has_header_shape {
                             return Err(FramingError::MissingContentLength);
                         }
                         return Err(FramingError::InvalidHeader);
                     }
                     Err(_) => {
-                        self.consume_header_block(header_end);
+                        self.consume_header_block(header_end, separator_len);
                         return Err(FramingError::InvalidHeaderUtf8);
                     }
                 }
@@ -105,7 +106,7 @@ impl ContentLengthFramer {
             self.buf.drain(..start);
         }
 
-        let Some(header_end) = find_subslice(&self.buf, HEADER_END) else {
+        let Some((header_end, separator_len)) = find_header_end(&self.buf) else {
             return Ok(None);
         };
 
@@ -113,7 +114,7 @@ impl ContentLengthFramer {
         let header_str = match std::str::from_utf8(header_bytes) {
             Ok(header) => header,
             Err(_) => {
-                self.consume_header_block(header_end);
+                self.consume_header_block(header_end, separator_len);
                 return Err(FramingError::InvalidHeaderUtf8);
             }
         };
@@ -121,27 +122,27 @@ impl ContentLengthFramer {
         let length = match parse_content_length(header_str) {
             ContentLengthParse::Found(len) => len,
             ContentLengthParse::Missing => {
-                self.consume_header_block(header_end);
+                self.consume_header_block(header_end, separator_len);
                 return Err(FramingError::MissingContentLength);
             }
             ContentLengthParse::Invalid => {
-                self.consume_header_block(header_end);
+                self.consume_header_block(header_end, separator_len);
                 return Err(FramingError::InvalidContentLength);
             }
             ContentLengthParse::MalformedHeader => {
-                self.consume_header_block(header_end);
+                self.consume_header_block(header_end, separator_len);
                 return Err(FramingError::InvalidHeader);
             }
         };
 
         if length > MAX_FRAME_SIZE {
-            self.consume_header_block(header_end);
+            self.consume_header_block(header_end, separator_len);
             return Err(FramingError::FrameTooLarge { len: length });
         }
 
-        let body_start = header_end + HEADER_END.len();
+        let body_start = header_end + separator_len;
         let Some(body_end) = body_start.checked_add(length) else {
-            self.consume_header_block(header_end);
+            self.consume_header_block(header_end, separator_len);
             return Err(FramingError::InvalidContentLength);
         };
 
@@ -155,8 +156,8 @@ impl ContentLengthFramer {
         Ok(Some(body))
     }
 
-    fn consume_header_block(&mut self, header_end: usize) {
-        let drain_to = (header_end + HEADER_END.len()).min(self.buf.len());
+    fn consume_header_block(&mut self, header_end: usize, separator_len: usize) {
+        let drain_to = (header_end + separator_len).min(self.buf.len());
         self.buf.drain(..drain_to);
         self.resync_if_needed();
     }
@@ -180,10 +181,11 @@ impl ContentLengthFramer {
 /// Build a full `Content-Length` framed message from a payload body.
 #[must_use]
 pub fn frame(body: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(HEADER_SENTINEL.len() + 32 + HEADER_END.len() + body.len());
+    let mut out =
+        Vec::with_capacity(HEADER_SENTINEL.len() + 32 + HEADER_END_CRLF.len() + body.len());
     out.extend_from_slice(b"Content-Length: ");
     out.extend_from_slice(body.len().to_string().as_bytes());
-    out.extend_from_slice(HEADER_END);
+    out.extend_from_slice(HEADER_END_CRLF);
     out.extend_from_slice(body);
     out
 }
@@ -197,7 +199,7 @@ enum ContentLengthParse {
 
 fn parse_content_length(header: &str) -> ContentLengthParse {
     let mut found = None;
-    for line in header.split("\r\n") {
+    for line in header.lines() {
         if line.is_empty() {
             continue;
         }
@@ -227,6 +229,19 @@ fn find_subslice(hay: &[u8], needle: &[u8]) -> Option<usize> {
         return Some(0);
     }
     hay.windows(needle.len()).position(|window| window == needle)
+}
+
+fn find_header_end(hay: &[u8]) -> Option<(usize, usize)> {
+    let crlf = find_subslice(hay, HEADER_END_CRLF).map(|idx| (idx, HEADER_END_CRLF.len()));
+    let lf = find_subslice(hay, HEADER_END_LF).map(|idx| (idx, HEADER_END_LF.len()));
+
+    match (crlf, lf) {
+        (Some(crlf_term), Some(lf_term)) => {
+            Some(if crlf_term.0 <= lf_term.0 { crlf_term } else { lf_term })
+        }
+        (Some(term), None) | (None, Some(term)) => Some(term),
+        (None, None) => None,
+    }
 }
 
 // ── LSP message reader/writer ─────────────────────────────────────────────────
@@ -727,6 +742,21 @@ mod tests {
             .read_next(&mut cursor)?
             .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "expected request"))?;
         assert_eq!(req.method, "test");
+        Ok(())
+    }
+
+    #[test]
+    fn stateful_reader_accepts_lf_only_header_separator() -> io::Result<()> {
+        let body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
+        let mut payload = format!("Content-Length: {}\n\n", body.len()).into_bytes();
+        payload.extend_from_slice(body.as_bytes());
+        let mut cursor = Cursor::new(payload);
+        let mut reader = ContentLengthMessageReader::new();
+
+        let req = reader
+            .read_next(&mut cursor)?
+            .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "expected request"))?;
+        assert_eq!(req.method, "initialize");
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation

- Some non-conformant LSP clients/CLI integrations send `Content-Length` header blocks terminated with LF-only (`\n\n`) instead of the standard CRLF (`\r\n\r\n`), which caused the stateful transport reader to reject frames.

### Description

- Update `crates/perl-lsp-rs-core/src/transport/framing.rs` to accept both CRLF (`\r\n\r\n`) and LF-only (`\n\n`) header terminators by adding `find_header_end` and tracking the separator length. 
- Use line-based header parsing (`header.lines()`) and a `separator_len` parameter to correctly consume header blocks and compute the body start regardless of newline style. 
- Adjust `frame()` to remain CRLF-based for outgoing frames and keep `Content-Length` generation unchanged. 
- Add a focused regression test `stateful_reader_accepts_lf_only_header_separator` that verifies the stateful reader accepts LF-only header separators.

### Testing

- Ran `cargo test -p perl-lsp-rs-core stateful_reader_accepts_lf_only_header_separator`, which passed. 
- Ran `cargo check --all-targets -p perl-lsp-rs-core`, which passed. 
- Ran `cargo clippy -p perl-lsp-rs-core -- -D warnings`, which passed. 
- `cargo fmt --all` was invoked but failed due to an unrelated pre-existing syntax error in another test file and did not block this focused change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea337be6c88333914546cb3b30f87f)