### PR TITLE
fix(perl-lsp-rs-core): expand built-in Perl::Critic open checks (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs
@@ -1,5 +1,8 @@
-use super::{QuickFix, Severity, Violation, built_in_quick_fix, insertion_range};
+use super::{built_in_quick_fix, insertion_range, QuickFix, Severity, Violation};
+use perl_parser_core::position::Position;
 use perl_parser_core::Node;
+use regex::Regex;
+use std::sync::LazyLock;
 
 /// Built-in policy analyzer that works without external perlcritic
 pub struct BuiltInAnalyzer {
@@ -61,9 +64,96 @@ impl Policy for RequireUseWarnings {
     }
 }
 
+/// Require three-argument `open`.
+struct RequireThreeArgOpen;
+
+impl Policy for RequireThreeArgOpen {
+    fn name(&self) -> &str {
+        "InputOutput::RequireThreeArgOpen"
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Harsh
+    }
+
+    fn analyze(&self, _ast: &Node, content: &str) -> Vec<Violation> {
+        static TWO_ARG_OPEN_RE: LazyLock<Result<Regex, regex::Error>> = LazyLock::new(|| {
+            Regex::new(r"(?m)^\s*open\s*(?:\(\s*)?[^,\n)]+\s*,\s*[^,\n)]+\s*(?:\)|;)")
+        });
+
+        let Ok(two_arg_open_re) = &*TWO_ARG_OPEN_RE else {
+            return Vec::new();
+        };
+
+        two_arg_open_re
+            .find_iter(content)
+            .map(|m| {
+                let start = byte_to_position(content, m.start());
+                let end = byte_to_position(content, m.end());
+                Violation {
+                    policy: self.name().to_string(),
+                    description: "Use three-argument open".to_string(),
+                    explanation: "Always use three-argument open for safer file handling"
+                        .to_string(),
+                    severity: self.severity(),
+                    range: perl_parser_core::position::Range { start, end },
+                    file: String::new(),
+                }
+            })
+            .collect()
+    }
+}
+
+/// Prohibit bareword filehandles in `open`.
+struct ProhibitBarewordFileHandles;
+
+impl Policy for ProhibitBarewordFileHandles {
+    fn name(&self) -> &str {
+        "InputOutput::ProhibitBarewordFileHandles"
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Harsh
+    }
+
+    fn analyze(&self, _ast: &Node, content: &str) -> Vec<Violation> {
+        static BAREWORD_OPEN_RE: LazyLock<Result<Regex, regex::Error>> =
+            LazyLock::new(|| Regex::new(r"(?m)^\s*open\s*(?:\(\s*)?([A-Za-z_]\w*)\s*,"));
+
+        let Ok(bareword_open_re) = &*BAREWORD_OPEN_RE else {
+            return Vec::new();
+        };
+
+        bareword_open_re
+            .captures_iter(content)
+            .filter_map(|caps| {
+                let matched = caps.get(1)?;
+                let start = byte_to_position(content, matched.start());
+                let end = byte_to_position(content, matched.end());
+                Some(Violation {
+                    policy: self.name().to_string(),
+                    description: "Bareword filehandle used".to_string(),
+                    explanation: "Use lexical filehandles (my $fh) instead of bareword handles"
+                        .to_string(),
+                    severity: self.severity(),
+                    range: perl_parser_core::position::Range { start, end },
+                    file: String::new(),
+                })
+            })
+            .collect()
+    }
+}
+
 impl Default for BuiltInAnalyzer {
     fn default() -> Self {
-        Self { policies: vec![Box::new(RequireUseStrict), Box::new(RequireUseWarnings)] }
+        Self {
+            policies: vec![
+                Box::new(RequireUseStrict),
+                Box::new(RequireUseWarnings),
+                Box::new(RequireThreeArgOpen),
+                Box::new(ProhibitBarewordFileHandles),
+            ],
+        }
     }
 }
 
@@ -106,4 +196,53 @@ fn missing_use_statement_violation(
         range: insertion_range(),
         file: String::new(),
     }]
+}
+
+fn byte_to_position(content: &str, byte: usize) -> Position {
+    let byte = byte.min(content.len());
+    let mut line: u32 = 0;
+    let mut column: u32 = 0;
+
+    for ch in content[..byte].chars() {
+        if ch == '\n' {
+            line = line.saturating_add(1);
+            column = 0;
+        } else {
+            column = column.saturating_add(1);
+        }
+    }
+
+    Position { byte, line, column }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BuiltInAnalyzer;
+    use perl_parser_core::Parser;
+
+    #[test]
+    fn detects_two_arg_open_without_external_perlcritic() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let source = "use strict;\nuse warnings;\nopen($fh, $path);\n";
+        let mut parser = Parser::new(source);
+        let ast = parser.parse()?;
+        let analyzer = BuiltInAnalyzer::new();
+        let violations = analyzer.analyze(&ast, source);
+
+        assert!(violations.iter().any(|v| v.policy == "InputOutput::RequireThreeArgOpen"));
+        Ok(())
+    }
+
+    #[test]
+    fn detects_bareword_filehandle_without_external_perlcritic(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let source = "use strict;\nuse warnings;\nopen(FH, '<', $path);\n";
+        let mut parser = Parser::new(source);
+        let ast = parser.parse()?;
+        let analyzer = BuiltInAnalyzer::new();
+        let violations = analyzer.analyze(&ast, source);
+
+        assert!(violations.iter().any(|v| v.policy == "InputOutput::ProhibitBarewordFileHandles"));
+        Ok(())
+    }
 }


### PR DESCRIPTION
### Motivation

- Provide Rust-native diagnostics for common Perl::Critic policies so editor UX works when external `perlcritic` is not present.

### Description

- Added two new built-in policies: `InputOutput::RequireThreeArgOpen` and `InputOutput::ProhibitBarewordFileHandles` implemented as `Policy` structs using cached `Regex` detectors. 
- Registered both policies in `BuiltInAnalyzer::default()` so they run alongside the existing strict/warnings checks. 
- Added `byte_to_position` utility to convert regex byte offsets into `perl_parser_core::position::Position` so violations carry accurate LSP ranges. 
- Added focused unit tests that assert the new policies fire on representative source snippets (`two-arg open` and `bareword` filehandle cases).

### Testing

- Ran `cargo test -p perl-lsp-rs-core built_in -- --nocapture`, which passed (2 tests ran and succeeded). 
- Ran `cargo check --all-targets -p perl-lsp-rs-core`, which completed successfully. 
- Ran `cargo clippy -p perl-lsp-rs-core --all-targets -- -D warnings`, which failed due to pre-existing `expect()` usage in unrelated tests (no failures introduced by this change). 
- Ran `cargo xtask fmt` / `cargo fmt --all` which failed due to unrelated pre-existing issues in other workspace crates, and `just pr-fast` was unavailable in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2cdf20bc83339fc38d80aa785977)