### PR TITLE
docs(editors): add Codex CLI LSP bridge setup (#0000)

### DIFF
--- a/docs/EDITORS/CODEX_CLI_SETUP.md
+++ b/docs/EDITORS/CODEX_CLI_SETUP.md
@@ -1,0 +1,81 @@
+# Codex CLI + perl-lsp Setup
+
+This guide shows how to wire `perllsp` into Codex CLI so Codex can call real LSP
+operations (`definition`, `hover`, `references`, `rename`, diagnostics) while it
+is editing your Perl workspace.
+
+## Prerequisites
+
+- `perllsp` installed and on `PATH`
+- Codex CLI installed and authenticated
+- A project folder opened as your Codex working directory
+
+Quick sanity checks:
+
+```bash
+perllsp --version
+perllsp --health
+codex --version
+```
+
+## 1) Add an LSP bridge MCP server
+
+Codex CLI does not speak LSP directly; it calls tools via MCP. Configure an MCP
+server that bridges MCP requests to your local language server.
+
+Add/update `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.perl_lsp]
+command = "uvx"
+args = ["lsp-mcp", "--workspace", "/absolute/path/to/project"]
+```
+
+If you do not use `uvx`, replace `command`/`args` with your preferred launcher
+for the bridge server.
+
+## 2) Register perl-lsp with the bridge
+
+Most LSP bridge servers accept a per-language mapping. Add Perl so `.pl`, `.pm`,
+`.t`, and `.pod` files resolve to `perllsp --stdio`.
+
+Example `~/.config/lsp-mcp/config.toml`:
+
+```toml
+[language_servers.perl]
+command = "perllsp"
+args = ["--stdio"]
+filetypes = ["perl"]
+```
+
+If your bridge uses JSON/YAML instead of TOML, keep the same values.
+
+## 3) Validate from Codex
+
+From inside your Perl repo:
+
+```text
+/mcp
+```
+
+Confirm the Perl LSP bridge is connected, then try prompts like:
+
+- "Find all references to `My::Package::run`."
+- "Rename `build_index` to `build_workspace_index` and update call sites."
+- "Show diagnostics for this file and apply the safe fixes."
+
+## Troubleshooting
+
+- **No LSP tools appear in `/mcp`:** verify the bridge process starts outside
+  Codex first, then restart Codex.
+- **Server starts but returns empty results:** ensure Codex is running at the
+  project root so workspace indexing can discover files.
+- **`perllsp` not found:** run `which perllsp` and use an absolute path in the
+  bridge config if needed.
+- **Slow first queries:** this is usually initial indexing; retry after the
+  first warmup pass.
+
+## Notes
+
+- Keep one Codex session per project root for best workspace accuracy.
+- `perllsp --stdio` is the supported transport for editor and bridge clients.

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| Codex CLI | connect an MCP LSP bridge to `perllsp --stdio` | [docs/EDITORS/CODEX_CLI_SETUP.md](../EDITORS/CODEX_CLI_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,13 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### Codex CLI
+
+Configure an MCP LSP bridge that launches `perllsp --stdio`, then verify the
+bridge appears in Codex via `/mcp`. See
+[docs/EDITORS/CODEX_CLI_SETUP.md](../EDITORS/CODEX_CLI_SETUP.md) for a full
+example config and troubleshooting flow.
 
 ## When Setup Fails
 


### PR DESCRIPTION
### Motivation

- Add documentation so Codex CLI users can integrate `perllsp` via an MCP LSP bridge and use real LSP operations from Codex sessions.

### Description

- Create `docs/EDITORS/CODEX_CLI_SETUP.md` with a sample MCP bridge config, registration example for `perllsp --stdio`, validation steps, and troubleshooting, and add a link/short section to `docs/how-to/EDITOR_SETUP.md` pointing to the new guide.

### Testing

- Ran `cargo check -p perl-lsp-rs-core` and `cargo test -p perl-lsp-rs-core --no-run`, both of which completed successfully, and attempted `cargo xtask fmt` which failed due to pre-existing, unrelated compile errors in `xtask/src/tasks/metrics/lsp_stats.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3375217c83339aeb5fddce081231)