### PR TITLE
fix(lsp): tolerate clients that skip initialized (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -149,34 +149,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn initialized_requires_initialize_request_first() {
+    fn initialized_requires_initialize_request_first() -> Result<()> {
         let server = LspServer::new();
 
         let result = server.handle_initialized_dispatch();
 
         assert!(result.is_err(), "initialized before initialize must error");
         assert!(!server.is_initialized(), "server must remain uninitialized");
+        Ok(())
     }
 
     #[test]
-    fn initialized_can_only_be_sent_once() {
+    fn initialized_can_only_be_sent_once() -> Result<()> {
         let server = LspServer::new();
-        server.handle_initialize(None).expect("initialize request should succeed");
+        server.handle_initialize(None)?;
 
         let first = server.handle_initialized_dispatch();
         let second = server.handle_initialized_dispatch();
 
         assert!(first.is_ok(), "first initialized must succeed");
         assert!(second.is_err(), "second initialized must error");
+        Ok(())
     }
 
     #[test]
-    fn auto_initialize_for_compat_promotes_initialized_state() {
+    fn auto_initialize_for_compat_promotes_initialized_state() -> Result<()> {
         let server = LspServer::new();
-        server.handle_initialize(None).expect("initialize request should succeed");
+        server.handle_initialize(None)?;
 
         server.auto_initialize_for_compat("textDocument/hover");
 
         assert!(server.is_initialized(), "compatibility path should mark server initialized");
+        Ok(())
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -5,6 +5,53 @@
 use super::super::*;
 
 impl LspServer {
+    fn complete_initialization(&self) {
+        if self
+            .initialized
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        tracing::info!("Server initialized");
+
+        // Register file watchers for Perl files only if client supports it
+        if self.client_capabilities.lock().dynamic_registration_support {
+            self.register_file_watchers_async();
+        }
+
+        // Start workspace indexing in the background (if workspace folders exist)
+        #[cfg(feature = "workspace")]
+        self.start_workspace_indexing();
+
+        // Send index-ready notification
+        if let Err(e) = self.send_index_ready_notification() {
+            tracing::warn!(error = %e, "Failed to send index-ready notification");
+        }
+
+        if std::env::var("PERL_LSP_QUIET").is_err() {
+            let folder_count = self.workspace_folders.lock().len();
+            if folder_count == 0 {
+                tracing::info!("perl-lsp ready (single-file mode)");
+            } else {
+                tracing::info!(folder_count, "perl-lsp ready");
+            }
+        }
+    }
+
+    pub(super) fn auto_initialize_for_compat(&self, method: &str) {
+        if self.initialize_requested.load(Ordering::Acquire)
+            && !self.initialized.load(Ordering::Acquire)
+        {
+            tracing::warn!(
+                method,
+                "Client skipped initialized notification; auto-initializing for compatibility"
+            );
+            self.complete_initialization();
+        }
+    }
+
     /// Handle initialize request
     pub(super) fn handle_initialize_dispatch(
         &self,
@@ -91,31 +138,7 @@ impl LspServer {
             });
         }
 
-        self.initialized.store(true, Ordering::Release);
-        tracing::info!("Server initialized");
-
-        // Register file watchers for Perl files only if client supports it
-        if self.client_capabilities.lock().dynamic_registration_support {
-            self.register_file_watchers_async();
-        }
-
-        // Start workspace indexing in the background (if workspace folders exist)
-        #[cfg(feature = "workspace")]
-        self.start_workspace_indexing();
-
-        // Send index-ready notification
-        if let Err(e) = self.send_index_ready_notification() {
-            tracing::warn!(error = %e, "Failed to send index-ready notification");
-        }
-
-        if std::env::var("PERL_LSP_QUIET").is_err() {
-            let folder_count = self.workspace_folders.lock().len();
-            if folder_count == 0 {
-                tracing::info!("perl-lsp ready (single-file mode)");
-            } else {
-                tracing::info!(folder_count, "perl-lsp ready");
-            }
-        }
+        self.complete_initialization();
 
         Ok(None)
     }
@@ -145,5 +168,15 @@ mod tests {
 
         assert!(first.is_ok(), "first initialized must succeed");
         assert!(second.is_err(), "second initialized must error");
+    }
+
+    #[test]
+    fn auto_initialize_for_compat_promotes_initialized_state() {
+        let server = LspServer::new();
+        server.handle_initialize(None).expect("initialize request should succeed");
+
+        server.auto_initialize_for_compat("textDocument/hover");
+
+        assert!(server.is_initialized(), "compatibility path should mark server initialized");
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
@@ -56,7 +56,7 @@ pub(crate) use cancellation::enhanced_cancelled_response;
 
 use super::*;
 use crate::cancellation::{
-    GLOBAL_CANCELLATION_REGISTRY, PerlLspCancellationToken, ProviderCleanupContext,
+    PerlLspCancellationToken, ProviderCleanupContext, GLOBAL_CANCELLATION_REGISTRY,
 };
 use std::time::Instant;
 
@@ -150,6 +150,16 @@ impl LspServer {
                     return Some(cancelled_response_with_method(request_id, &request.method));
                 }
             }
+        }
+
+        if !self.initialized.load(Ordering::Acquire)
+            && self.initialize_requested.load(Ordering::Acquire)
+            && request.method != "initialize"
+            && request.method != "initialized"
+            && request.method != "shutdown"
+            && request.method != "exit"
+        {
+            self.auto_initialize_for_compat(&request.method);
         }
 
         let result = match request.method.as_str() {


### PR DESCRIPTION
### Motivation

- Some LSP clients (notably minimal/CLI-style integrations like Gemini's CLI) call `initialize` but never send the `initialized` notification, leaving the server rejecting subsequent requests with `Server not initialized`; this change aims to improve compatibility for those clients.

### Description

- Introduced a shared `complete_initialization()` helper to centralize the side effects of becoming ready (watchers, indexing, index-ready notification, startup logs) so explicit and compatibility paths behave identically.
- Added `auto_initialize_for_compat()` which promotes the server to initialized when a post-`initialize` request is observed and the client skipped `initialized`.
- Hooked the compatibility auto-init into request dispatch so the first non-lifecycle request after `initialize` triggers the compatibility path, and added a unit test to verify the behavior.

### Testing

- Ran `cargo test -p perl-lsp-rs --lib auto_initialize_for_compat_promotes_initialized_state`, and the targeted unit test passed.
- Ran `cargo check --all-targets -p perl-lsp-rs`, which currently fails due to a pre-existing syntax error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs` that is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea337be6c88333914546cb3b30f87f)