### PR TITLE
fix(perl-lsp): adapt internal code to non-cloneable AiCompletionConfig (#3231)

### DIFF
--- a/crates/perl-lsp/src/runtime/language/misc.rs
+++ b/crates/perl-lsp/src/runtime/language/misc.rs
@@ -672,10 +672,15 @@ impl LspServer {
             let provider = InlineCompletionProvider::new();
 
             // Try AI backend if enabled
-            let ai_config = self.config.lock().ai_completion.clone();
-            if ai_config.enabled {
+            let (ai_enabled, ai_fallback, max_output_tokens, timeout_ms) = {
+                let guard = self.config.lock();
+                let ai = &guard.ai_completion;
+                (ai.enabled, ai.fallback, ai.max_output_tokens, ai.timeout_ms)
+            };
+            if ai_enabled {
                 if let Some(context) = provider.prepare_context(&text, line, character) {
-                    let backend_result = self.try_ai_inline_completion(&context, &ai_config);
+                    let backend_result =
+                        self.try_ai_inline_completion(&context, max_output_tokens, timeout_ms);
                     match backend_result {
                         Ok(ref items) if !items.is_empty() => {
                             let list = perl_lsp_inline_completion::InlineCompletionList {
@@ -690,14 +695,14 @@ impl LspServer {
                         }
                         Err(ref e) => {
                             tracing::debug!("AI inline completion failed: {}", e);
-                            if !ai_config.fallback {
+                            if !ai_fallback {
                                 return Ok(Some(json!({ "items": [] })));
                             }
                             // Fall through to deterministic
                         }
                         _ => {
                             // Ok(empty) — fall through to deterministic if fallback enabled
-                            if !ai_config.fallback {
+                            if !ai_fallback {
                                 return Ok(Some(json!({ "items": [] })));
                             }
                         }
@@ -724,7 +729,8 @@ impl LspServer {
     fn try_ai_inline_completion(
         &self,
         context: &perl_lsp_inline_completion::PreparedInlineCompletionContext,
-        ai_config: &perl_lsp_config::AiCompletionConfig,
+        max_output_tokens: u32,
+        timeout_ms: u64,
     ) -> Result<
         Vec<perl_lsp_inline_completion::InlineCompletionItem>,
         perl_lsp_inline_completion::BackendError,
@@ -738,8 +744,8 @@ impl LspServer {
 
         let req = perl_lsp_inline_completion::BackendRequest {
             context: context.clone(),
-            max_output_tokens: ai_config.max_output_tokens,
-            timeout_ms: ai_config.timeout_ms,
+            max_output_tokens,
+            timeout_ms,
         };
 
         let texts = backend.complete(&req)?;

--- a/crates/perl-lsp/src/runtime/language/streaming.rs
+++ b/crates/perl-lsp/src/runtime/language/streaming.rs
@@ -52,8 +52,12 @@ impl LspServer {
         };
 
         // Check AI config
-        let ai_config = self.config.lock().ai_completion.clone();
-        if !ai_config.enabled || !ai_config.streaming.enabled {
+        let (ai_enabled, streaming_enabled, max_output_tokens, timeout_ms, fallback) = {
+            let guard = self.config.lock();
+            let ai = &guard.ai_completion;
+            (ai.enabled, ai.streaming.enabled, ai.max_output_tokens, ai.timeout_ms, ai.fallback)
+        };
+        if !ai_enabled || !streaming_enabled {
             // Fall back to one-shot
             return self.handle_inline_completion(Some(params));
         }
@@ -75,11 +79,8 @@ impl LspServer {
         };
 
         // Build request
-        let req = perl_lsp_inline_completion::BackendRequest {
-            context,
-            max_output_tokens: ai_config.max_output_tokens,
-            timeout_ms: ai_config.timeout_ms,
-        };
+        let req =
+            perl_lsp_inline_completion::BackendRequest { context, max_output_tokens, timeout_ms };
 
         let session_id = session.session_id.clone();
         let token_clone = token.clone();
@@ -88,7 +89,7 @@ impl LspServer {
         let backend = match self.ai_backend() {
             Some(b) => b,
             None => {
-                if ai_config.fallback {
+                if fallback {
                     return self.handle_inline_completion(Some(params));
                 }
                 // No backend and no fallback -- emit empty final and return

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -384,37 +384,48 @@ impl LspServer {
     /// Called during initialization (after project config is loaded) and on every
     /// `didChangeConfiguration` notification that touches the `aiCompletion` section.
     pub(crate) fn refresh_ai_backend(&self) {
-        let ai_config = self.config.lock().ai_completion.clone();
+        // Copy config values while holding lock, then release lock for slow operations
+        let (enabled, api_key_env, endpoint, model, timeout_ms, rate_limit_rps, max_inflight) = {
+            let guard = self.config.lock();
+            let ai = &guard.ai_completion;
+            (
+                ai.enabled,
+                ai.api_key_env.clone(),
+                ai.endpoint.clone(),
+                ai.model.clone(),
+                ai.timeout_ms,
+                ai.rate_limit_rps,
+                ai.max_inflight,
+            )
+        };
 
-        if !ai_config.enabled {
+        if !enabled {
             *self.ai_inline_backend.lock() = None;
             return;
         }
 
         // Resolve API key from environment variable
-        let api_key = std::env::var(&ai_config.api_key_env).unwrap_or_default();
+        let api_key = std::env::var(&api_key_env).unwrap_or_default();
         if api_key.is_empty() {
-            tracing::warn!(env_var = %ai_config.api_key_env, "AI completion enabled but env var is empty or unset");
+            tracing::warn!(env_var = %api_key_env, "AI completion enabled but env var is empty or unset");
             *self.ai_inline_backend.lock() = None;
             return;
         }
 
-        let provider_config = perl_lsp_ai_provider::OpenAiConfig {
-            endpoint: ai_config.endpoint.clone(),
-            model: ai_config.model.clone(),
-            api_key,
-            timeout_ms: ai_config.timeout_ms,
-        };
+        // Clone endpoint/model for logging before moving into config
+        let endpoint_for_log = endpoint.clone();
+        let model_for_log = model.clone();
 
-        let limiter = Arc::new(perl_lsp_ai_provider::RateLimiter::new(
-            ai_config.rate_limit_rps,
-            ai_config.max_inflight,
-        ));
+        let provider_config =
+            perl_lsp_ai_provider::OpenAiConfig { endpoint, model, api_key, timeout_ms };
+
+        let limiter =
+            Arc::new(perl_lsp_ai_provider::RateLimiter::new(rate_limit_rps, max_inflight));
 
         let provider = perl_lsp_ai_provider::OpenAiProvider::new(provider_config, limiter);
         *self.ai_inline_backend.lock() = Some(Arc::new(provider));
 
-        tracing::info!(endpoint = %ai_config.endpoint, model = %ai_config.model, "AI inline completion backend configured");
+        tracing::info!(endpoint = %endpoint_for_log, model = %model_for_log, "AI inline completion backend configured");
     }
 
     /// Get the subprocess runtime for external tool execution (perltidy, perlcritic).

--- a/xtask/tests/published_crate_count_gate_integration.rs
+++ b/xtask/tests/published_crate_count_gate_integration.rs
@@ -37,12 +37,9 @@ fn load_gate_policy_yaml() -> Value {
 }
 
 fn find_gate<'a>(gates: &'a Vec<Value>, name: &str) -> Option<&'a Value> {
-    gates.iter().find(|g| {
-        g.get("name")
-            .and_then(|n| n.as_str())
-            .map(|n| n == name)
-            .unwrap_or(false)
-    })
+    gates
+        .iter()
+        .find(|g| g.get("name").and_then(|n| n.as_str()).map(|n| n == name).unwrap_or(false))
 }
 
 /// Test that `published_crate_count` gate exists in gate-policy.yaml.
@@ -53,7 +50,8 @@ fn find_gate<'a>(gates: &'a Vec<Value>, name: &str) -> Option<&'a Value> {
 fn published_crate_count_gate_exists_in_policy() {
     let policy = load_gate_policy_yaml();
 
-    let gates = policy.get("gates")
+    let gates = policy
+        .get("gates")
         .expect("gates section not found in gate-policy.yaml")
         .as_sequence()
         .expect("gates must be a sequence");
@@ -76,7 +74,8 @@ fn published_crate_count_gate_exists_in_policy() {
 fn published_crate_count_gate_is_in_merge_gate_tier() {
     let policy = load_gate_policy_yaml();
 
-    let gates = policy.get("gates")
+    let gates = policy
+        .get("gates")
         .expect("gates section not found")
         .as_sequence()
         .expect("gates must be a sequence");
@@ -84,9 +83,7 @@ fn published_crate_count_gate_is_in_merge_gate_tier() {
     let gate = find_gate(gates, GATE_NAME)
         .expect("published_crate_count gate must exist - see test_gate_exists_in_policy");
 
-    let tier = gate.get("tier")
-        .and_then(|t| t.as_str())
-        .expect("gate must have tier field");
+    let tier = gate.get("tier").and_then(|t| t.as_str()).expect("gate must have tier field");
 
     assert_eq!(
         tier, EXPECTED_TIER,
@@ -102,7 +99,8 @@ fn published_crate_count_gate_is_in_merge_gate_tier() {
 fn published_crate_count_gate_has_correct_command() {
     let policy = load_gate_policy_yaml();
 
-    let gates = policy.get("gates")
+    let gates = policy
+        .get("gates")
         .expect("gates section not found")
         .as_sequence()
         .expect("gates must be a sequence");
@@ -110,9 +108,8 @@ fn published_crate_count_gate_has_correct_command() {
     let gate = find_gate(gates, GATE_NAME)
         .expect("published_crate_count gate must exist - see test_gate_exists_in_policy");
 
-    let command = gate.get("command")
-        .and_then(|c| c.as_str())
-        .expect("gate must have command field");
+    let command =
+        gate.get("command").and_then(|c| c.as_str()).expect("gate must have command field");
 
     assert_eq!(
         command, EXPECTED_COMMAND,
@@ -131,7 +128,8 @@ fn published_crate_count_gate_has_correct_command() {
 fn published_crate_count_gate_has_quarantine_enabled() {
     let policy = load_gate_policy_yaml();
 
-    let gates = policy.get("gates")
+    let gates = policy
+        .get("gates")
         .expect("gates section not found")
         .as_sequence()
         .expect("gates must be a sequence");
@@ -139,9 +137,7 @@ fn published_crate_count_gate_has_quarantine_enabled() {
     let gate = find_gate(gates, GATE_NAME)
         .expect("published_crate_count gate must exist - see test_gate_exists_in_policy");
 
-    let quarantine = gate.get("quarantine")
-        .and_then(|q| q.as_bool())
-        .unwrap_or(false); // defaults to false if not present
+    let quarantine = gate.get("quarantine").and_then(|q| q.as_bool()).unwrap_or(false); // defaults to false if not present
 
     assert!(
         quarantine,
@@ -157,7 +153,8 @@ fn published_crate_count_gate_has_quarantine_enabled() {
 fn published_crate_count_gate_has_appropriate_timeout() {
     let policy = load_gate_policy_yaml();
 
-    let gates = policy.get("gates")
+    let gates = policy
+        .get("gates")
         .expect("gates section not found")
         .as_sequence()
         .expect("gates must be a sequence");
@@ -165,7 +162,8 @@ fn published_crate_count_gate_has_appropriate_timeout() {
     let gate = find_gate(gates, GATE_NAME)
         .expect("published_crate_count gate must exist - see test_gate_exists_in_policy");
 
-    let timeout = gate.get("timeout_seconds")
+    let timeout = gate
+        .get("timeout_seconds")
         .and_then(|t| t.as_i64())
         .expect("gate must have timeout_seconds field");
 
@@ -182,7 +180,8 @@ fn published_crate_count_gate_has_appropriate_timeout() {
 fn published_crate_count_gate_is_required() {
     let policy = load_gate_policy_yaml();
 
-    let gates = policy.get("gates")
+    let gates = policy
+        .get("gates")
         .expect("gates section not found")
         .as_sequence()
         .expect("gates must be a sequence");
@@ -190,9 +189,7 @@ fn published_crate_count_gate_is_required() {
     let gate = find_gate(gates, GATE_NAME)
         .expect("published_crate_count gate must exist - see test_gate_exists_in_policy");
 
-    let required = gate.get("required")
-        .and_then(|r| r.as_bool())
-        .unwrap_or(true); // defaults to true
+    let required = gate.get("required").and_then(|r| r.as_bool()).unwrap_or(true); // defaults to true
 
     assert!(
         required,
@@ -206,7 +203,8 @@ fn published_crate_count_gate_is_required() {
 fn published_crate_count_gate_has_ratchet_tags() {
     let policy = load_gate_policy_yaml();
 
-    let gates = policy.get("gates")
+    let gates = policy
+        .get("gates")
         .expect("gates section not found")
         .as_sequence()
         .expect("gates must be a sequence");
@@ -214,13 +212,9 @@ fn published_crate_count_gate_has_ratchet_tags() {
     let gate = find_gate(gates, GATE_NAME)
         .expect("published_crate_count gate must exist - see test_gate_exists_in_policy");
 
-    let tags = gate.get("tags")
-        .and_then(|t| t.as_sequence())
-        .expect("gate must have tags field");
+    let tags = gate.get("tags").and_then(|t| t.as_sequence()).expect("gate must have tags field");
 
-    let tag_names: Vec<&str> = tags.iter()
-        .filter_map(|t| t.as_str())
-        .collect();
+    let tag_names: Vec<&str> = tags.iter().filter_map(|t| t.as_str()).collect();
 
     assert!(
         tag_names.contains(&"ratchet"),
@@ -256,24 +250,23 @@ fn published_crate_count_gate_has_ratchet_tags() {
 fn published_crate_count_gate_is_in_ci_gate_job_mapping() {
     let policy = load_gate_policy_yaml();
 
-    let workflow_integration = policy.get("workflow_integration")
+    let workflow_integration = policy
+        .get("workflow_integration")
         .expect("workflow_integration section not found in gate-policy.yaml");
 
-    let job_mapping = workflow_integration.get("job_mapping")
+    let job_mapping = workflow_integration
+        .get("job_mapping")
         .expect("job_mapping not found in workflow_integration section");
 
-    let ci_gate = job_mapping.get("ci-gate")
-        .expect("ci-gate job not found in job_mapping");
+    let ci_gate = job_mapping.get("ci-gate").expect("ci-gate job not found in job_mapping");
 
-    let gates = ci_gate.get("gates")
+    let gates = ci_gate
+        .get("gates")
         .expect("gates list not found in ci-gate job")
         .as_sequence()
         .expect("ci-gate.gates must be a sequence");
 
-    let gate_names: Vec<&str> = gates
-        .iter()
-        .filter_map(|v| v.as_str())
-        .collect();
+    let gate_names: Vec<&str> = gates.iter().filter_map(|v| v.as_str()).collect();
 
     assert!(
         gate_names.contains(&GATE_NAME),
@@ -289,12 +282,14 @@ fn published_crate_count_gate_is_in_ci_gate_job_mapping() {
 fn published_crate_count_gate_placement_in_merge_gate_tier() {
     let policy = load_gate_policy_yaml();
 
-    let gates = policy.get("gates")
+    let gates = policy
+        .get("gates")
         .expect("gates section not found")
         .as_sequence()
         .expect("gates must be a sequence");
 
-    let nested_lock_idx = gates.iter()
+    let nested_lock_idx = gates
+        .iter()
         .position(|g| {
             g.get("name")
                 .and_then(|n| n.as_str())
@@ -303,12 +298,10 @@ fn published_crate_count_gate_placement_in_merge_gate_tier() {
         })
         .expect("nested_lock_check gate must exist");
 
-    let published_crate_idx = gates.iter()
+    let published_crate_idx = gates
+        .iter()
         .position(|g| {
-            g.get("name")
-                .and_then(|n| n.as_str())
-                .map(|n| n == GATE_NAME)
-                .unwrap_or(false)
+            g.get("name").and_then(|n| n.as_str()).map(|n| n == GATE_NAME).unwrap_or(false)
         })
         .expect("published_crate_count gate must exist - see test_gate_exists_in_policy");
 
@@ -318,6 +311,7 @@ fn published_crate_count_gate_placement_in_merge_gate_tier() {
         "published_crate_count gate should be placed after nested_lock_check gate.\n\
          Expected: nested_lock_check (index {}) < published_crate_count (index {})\n\
          Gate order in the policy should match tier organization.",
-        nested_lock_idx, published_crate_idx
+        nested_lock_idx,
+        published_crate_idx
     );
 }


### PR DESCRIPTION
## Summary

Fix compilation error introduced by semver hygiene changes that removed Clone from AiCompletionConfig and ServerConfig.

The internal perl-lsp code was calling .clone() on these types. This PR adapts the internal usages to extract only the needed fields while holding the lock, then release the lock before doing slow operations.

## Changes

- crates/perl-lsp/src/runtime/mod.rs: Extract fields from AiCompletionConfig before lock release
- crates/perl-lsp/src/runtime/language/streaming.rs: Same adaptation
- crates/perl-lsp/src/runtime/language/misc.rs: Same adaptation
- xtask/tests/published_crate_count_gate_integration.rs: formatting fix

## Test Results

All semver hygiene tests pass:
- perl-diagnostics/semver_hygiene_tests: 4/4 passing
- perl-lsp-config/semver_hygiene_tests: 4/4 passing  
- perl-semantic-analyzer/semver_hygiene_tests: 5/5 passing

## CI Status

- cargo build --workspace: ✓
- cargo clippy: ✓
- cargo fmt: ✓
- semver hygiene tests: ✓

Work item: work-e7f94205