### PR TITLE
fix(tests): resolve two master-breaking test compile errors (#5494 #5495)

### DIFF
--- a/crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs
+++ b/crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs
@@ -413,9 +413,6 @@ sub startup {
     Ok(())
 }
 
-    Ok(())
-}
-
 #[test]
 fn mojolicious_string_route_snake_case_controller_resolves_to_camelized_package() -> TestResult {
     let workspace = TempWorkspace::new()?;

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1734,7 +1734,7 @@ my $msg = "value: ${Foo::name}";
     let table = parse_and_extract(code);
     assert!(
         table.references.contains_key("Foo::name"),
-        "${Foo::name} inside a double-quoted string should register a reference",
+        "${{Foo::name}} inside a double-quoted string should register a reference",
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Two independent test-file bugs were preventing `cargo check --workspace --all-targets` from succeeding on master, blocking any builder that runs the full workspace gate. Both are test-only changes — no production code touched.

### Fix 1 — closes #5495

**File:** `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs`

**Root cause:** PR #5288 ("fix(perl-lsp-rs): camelize Mojolicious snake_case controllers") introduced a merge-resolution artifact: the closing `Ok(()) }` block of the previous test function was duplicated, producing an orphaned closing delimiter at line 417.

**rustc error before fix:**
```
error: unexpected closing delimiter: `}`
   --> crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs:417:1
```

**Fix:** Delete the 3 stray lines (blank line + `Ok(())` + `}`).

**Diff:**
```diff
     Ok(())
 }
-
-    Ok(())
-}
 
 #[test]
 fn mojolicious_string_route_snake_case_controller_resolves_to_camelized_package()
```

---

### Fix 2 — closes #5494

**File:** `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs`

**Root cause:** Commit `a36f79ac9` (PR #5090, "fix(perl-semantic-analyzer): track qualified vars in string interpolation") added an `assert!` whose message literal contains `${Foo::name}`. Rust's `assert!` macro treats its message argument as a format string, so the unescaped `{` / `}` pair around `Foo::name` triggers an "invalid format string" compile error.

**rustc error before fix:**
```
error: invalid format string: expected `}`, found `:`
  --> crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs:1737:16
   |
   |         "${Foo::name} inside a double-quoted string should register a reference",
   |           -    ^ expected `}` in format string
```

**Fix:** Escape the braces — `{{` and `}}` — so the literal is passed through as `{Foo::name}` at runtime rather than interpreted as a format argument.

```diff
-        "${Foo::name} inside a double-quoted string should register a reference",
+        "${{Foo::name}} inside a double-quoted string should register a reference",
```

---

## Verification

```
cargo check -p perl-semantic-analyzer --tests   # ✓ clean
cargo check -p perl-lsp-rs --tests             # ✓ clean  
cargo test --workspace --lib                   # ✓ all pass (no regressions)
cargo check --workspace --all-targets          # ✓ no errors from these two files
```

The only remaining `--all-targets` errors are pre-existing `xtask` compile issues (unrelated to these files and present on master before this branch).

## Why these slipped through CI

Per issue #5495 analysis: the merge gate runs `cargo check --workspace --lib` (not `--all-targets`), so integration test file syntax errors aren't caught pre-merge. Issue #4507 tracks adding `--all-targets` to the CI gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SryJjZenZ9jrcu5RzZMqin)_