### PR TITLE
fix(lsp): set root uri from workspace folders (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
@@ -4,7 +4,7 @@
 
 use super::super::*;
 use perl_workspace::folder::{extract_workspace_folder_uris, root_path_to_file_uri};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 impl LspServer {
     /// Handle initialize request
@@ -198,8 +198,13 @@ impl LspServer {
             if let Some(workspace_folders) =
                 params.get("workspaceFolders").and_then(|f| f.as_array())
             {
+                let uris = extract_workspace_folder_uris(workspace_folders);
+                if let Some(first_uri) = uris.first() {
+                    self.set_root_uri(first_uri);
+                }
+
                 let mut folders = self.workspace_folders.lock();
-                for uri in extract_workspace_folder_uris(workspace_folders) {
+                for uri in uris {
                     tracing::debug!(uri, "Initialized with workspace folder");
                     let mut folder =
                         super::super::workspace_folder::WorkspaceFolderState::new(uri.clone());
@@ -412,8 +417,8 @@ pub(crate) fn apply_disabled_feature_id(
 #[cfg(test)]
 mod tests {
     use super::apply_disabled_feature_id;
-    use crate::LspServer;
     use crate::protocol::capabilities::BuildFlags;
+    use crate::LspServer;
     use serde_json::json;
 
     #[test]
@@ -473,6 +478,27 @@ mod tests {
                  apply_disabled_feature_id — add one to keep the two in sync"
             );
         }
+    }
+
+    #[test]
+    fn initialize_with_workspace_folders_sets_root_path_from_first_folder() {
+        let server = LspServer::new();
+        let params = json!({
+            "workspaceFolders": [
+                { "uri": "file:///primary", "name": "primary" },
+                { "uri": "file:///secondary", "name": "secondary" }
+            ],
+            "capabilities": {}
+        });
+
+        let result = server.handle_initialize(Some(params));
+        assert!(result.is_ok(), "initialize should succeed");
+
+        let root_path = server.root_path.lock();
+        assert!(
+            root_path.as_ref().is_some_and(|path| path.ends_with("primary")),
+            "root path should come from first workspace folder"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Some LSP clients (CLI-style integrations) send `workspaceFolders` but omit `rootUri`, which left `root_path` unset and broke workspace/module-resolution flows.
- Improve handshake compatibility so CLI-driven consumers (including Codex CLI integration scenarios) get a sensible workspace root without requiring `rootUri`.

### Description

- When `initialize` contains `workspaceFolders`, extract the folder URIs once and call `self.set_root_uri()` with the first URI so the server `root_path` is seeded from the first workspace folder.
- Iterate the extracted URIs to populate `workspace_folders` as before (avoids double-parsing and keeps behavior consistent).
- Add a regression unit test `initialize_with_workspace_folders_sets_root_path_from_first_folder` that verifies `root_path` is derived from the first workspace folder during initialize.

### Testing

- Ran `cargo test -p perl-lsp-rs --lib initialize_with_workspace_folders_sets_root_path_from_first_folder`, which passed.
- Ran `cargo clippy -p perl-lsp-rs --lib -- -D warnings`, which completed successfully for the changed crate.
- Ran `rustfmt` on the modified file to ensure style consistency.
- `cargo check --all-targets -p perl-lsp-rs` encountered a pre-existing unrelated parse error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs` (not caused by this change) and therefore did not fully complete across all tests in the crate workspace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3375217c83339aeb5fddce081231)