### PR TITLE
fix(perl-lsp-rs): accept requests after initialize even if no initialized notification (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
@@ -155,8 +155,10 @@ impl LspServer {
         let result = match request.method.as_str() {
             "initialize" => self.handle_initialize_dispatch(request.params),
             "initialized" => self.handle_initialized_dispatch(),
-            // All other requests require initialization
-            _ if !self.initialized.load(Ordering::Acquire)
+            // Compatibility: some lightweight clients send `initialize` and then
+            // immediately issue requests without an explicit `initialized` notification.
+            // Accept those requests once `initialize` has completed successfully.
+            _ if !self.initialize_requested.load(Ordering::Acquire)
                 && request.method != "shutdown"
                 && request.method != "exit" =>
             {
@@ -384,5 +386,44 @@ impl LspServer {
                 None
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(id: i64, method: &str, params: Option<Value>) -> JsonRpcRequest {
+        JsonRpcRequest {
+            _jsonrpc: "2.0".to_string(),
+            id: Some(json!(id)),
+            method: method.to_string(),
+            params,
+        }
+    }
+
+    #[test]
+    fn requests_are_accepted_after_initialize_even_without_initialized_notification() {
+        let server = LspServer::new();
+
+        let before_initialize = server
+            .handle_request(request(1, "custom/unknown", None))
+            .and_then(|response| response.error)
+            .map(|error| error.code);
+        assert_eq!(before_initialize, Some(-32002));
+
+        let initialize = server.handle_request(request(2, "initialize", Some(json!({}))));
+        assert!(
+            initialize
+                .as_ref()
+                .is_some_and(|response| response.error.is_none()),
+            "initialize request should succeed"
+        );
+
+        let after_initialize = server
+            .handle_request(request(3, "custom/unknown", None))
+            .and_then(|response| response.error)
+            .map(|error| error.code);
+        assert_eq!(after_initialize, Some(-32601));
     }
 }


### PR DESCRIPTION
### Motivation

- Some lightweight LSP clients (eg. Codex CLI-style integrations) send `initialize` and then immediately issue requests without the `initialized` notification, causing the server to reject those requests as "Server not initialized".

### Description

- Relax request gating in `crates/perl-lsp-rs/src/runtime/dispatch/mod.rs` to check `initialize_requested` instead of `initialized`, allowing non-lifecycle requests once `initialize` completed successfully.
- Add a regression test in the same module that verifies before/after error codes for an unknown request around `initialize` (no `initialized`), proving the request is accepted post-initialize.
- Include a short explanatory comment about the compatibility change for lightweight clients.

### Testing

- Ran `cargo test -p perl-lsp-rs --lib requests_are_accepted_after_initialize_even_without_initialized_notification`, and the test passed.
- Ran `cargo clippy -p perl-lsp-rs --lib`, which completed without issues for the changed crate.
- Ran `cargo check --all-targets -p perl-lsp-rs`, which failed due to a pre-existing unrelated syntax error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs` and not because of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3375217c83339aeb5fddce081231)