### PR TITLE
docs(editors): add nano terminal workflow guide (#0000)

### DIFF
--- a/docs/EDITORS/NANO_SETUP.md
+++ b/docs/EDITORS/NANO_SETUP.md
@@ -1,0 +1,61 @@
+# GNU nano Setup Guide (Terminal Workflow)
+
+`nano` does not have a built-in LSP client, so it cannot talk to `perllsp`
+over `--stdio` like VS Code, Neovim, or Emacs.
+
+This guide gives a pragmatic workflow so `nano` users can still benefit from
+`perl-lsp` checks and troubleshooting commands.
+
+## What You Can Use Today
+
+- `perllsp --health` to verify the language server environment
+- `perllsp --version` to confirm the installed binary
+- Perl compile checks (`perl -c`) for immediate syntax validation while editing
+
+## Quick Start
+
+1. Confirm tooling is installed:
+
+```bash
+perllsp --version
+perllsp --health
+perl -v
+```
+
+2. In another terminal, run syntax checks while editing:
+
+```bash
+perl -c path/to/file.pl
+```
+
+3. If you see parser or indexing issues in downstream tooling, collect logs with:
+
+```bash
+RUST_LOG=perl_lsp=debug perllsp --stdio 2> perllsp-debug.log
+```
+
+Then stop with `Ctrl+C` after reproducing the issue.
+
+## Optional: Lightweight Re-check Loop
+
+Use this shell loop in a second terminal to re-run `perl -c` after saves:
+
+```bash
+while true; do
+  clear
+  date
+  perl -c path/to/file.pl
+  sleep 1
+done
+```
+
+## If You Want Full IDE Features
+
+Features like completion, go-to-definition, hover, rename, and references require
+an editor with an LSP client implementation. For that experience, use one of:
+
+- VS Code: [VS_CODE_SETUP.md](VS_CODE_SETUP.md)
+- Neovim: [NEOVIM_SETUP.md](NEOVIM_SETUP.md)
+- Emacs: [EMACS_SETUP.md](EMACS_SETUP.md)
+- Helix: [HELIX_SETUP.md](HELIX_SETUP.md)
+- Sublime Text: [SUBLIME_SETUP.md](SUBLIME_SETUP.md)

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,6 +28,7 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| GNU nano | use terminal diagnostics workflow (no native LSP client) | [docs/EDITORS/NANO_SETUP.md](../EDITORS/NANO_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -63,6 +64,13 @@ args = ["--stdio"]
 
 Register a client whose command is `["perllsp", "--stdio"]` and scope it to
 Perl source files.
+
+### GNU nano
+
+`nano` does not implement the Language Server Protocol, so it cannot attach to
+`perllsp` directly. Use the terminal workflow in
+[`docs/EDITORS/NANO_SETUP.md`](../EDITORS/NANO_SETUP.md) to get fast syntax
+checks and on-demand diagnostics while staying in nano.
 
 ## When Setup Fails
 


### PR DESCRIPTION
### Motivation
- Provide guidance for `nano` users who cannot attach an LSP client to `perllsp` so they have a documented, practical terminal workflow for syntax checks and diagnostics.

### Description
- Add `docs/EDITORS/NANO_SETUP.md` with a terminal-based workflow (health/version checks, `perl -c` loop, debug log capture) and link it from `docs/how-to/EDITOR_SETUP.md` with a brief note that `nano` has no native LSP client.

### Testing
- Ran `cargo check -p perl-lsp-rs --all-targets`, which was executed as verification but failed due to a pre-existing parse error in `crates/perl-lsp-rs/tests/mojolicious_navigation_tests.rs` unrelated to these docs-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1fe62a408333b889003c0284b46a)