### PR TITLE
feat(perl-lsp-rs-core): add builtin three-arg open critic policy (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs
@@ -1,5 +1,10 @@
-use super::{QuickFix, Severity, Violation, built_in_quick_fix, insertion_range};
+use super::{built_in_quick_fix, insertion_range, QuickFix, Severity, Violation};
 use perl_parser_core::Node;
+use regex::Regex;
+use std::sync::LazyLock;
+
+static TWO_ARG_OPEN_PATTERN: LazyLock<Option<Regex>> =
+    LazyLock::new(|| Regex::new(r"(?m)\bopen\s*(?:\(|\s+)\s*[^,\n]+,\s*[^,\n\)]+\)?\s*;").ok());
 
 /// Built-in policy analyzer that works without external perlcritic
 pub struct BuiltInAnalyzer {
@@ -63,7 +68,57 @@ impl Policy for RequireUseWarnings {
 
 impl Default for BuiltInAnalyzer {
     fn default() -> Self {
-        Self { policies: vec![Box::new(RequireUseStrict), Box::new(RequireUseWarnings)] }
+        Self {
+            policies: vec![
+                Box::new(RequireUseStrict),
+                Box::new(RequireUseWarnings),
+                Box::new(RequireThreeArgOpen),
+            ],
+        }
+    }
+}
+
+/// Require three-argument `open` calls.
+struct RequireThreeArgOpen;
+
+impl Policy for RequireThreeArgOpen {
+    fn name(&self) -> &str {
+        "InputOutput::RequireThreeArgOpen"
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Brutal
+    }
+
+    fn analyze(&self, _ast: &Node, content: &str) -> Vec<Violation> {
+        let Some(pattern) = TWO_ARG_OPEN_PATTERN.as_ref() else {
+            return Vec::new();
+        };
+
+        let Some(mat) = pattern.find(content) else {
+            return Vec::new();
+        };
+
+        let line = content[..mat.start()].bytes().filter(|b| *b == b'\n').count() as u32;
+        let line_start = content[..mat.start()].rfind('\n').map_or(0, |idx| idx + 1);
+        let column = content[line_start..mat.start()].chars().count() as u32;
+
+        vec![Violation {
+            policy: self.name().to_string(),
+            description: "Use three-argument open for safer file handling".to_string(),
+            explanation: "Three-argument open avoids mode/path ambiguities and is easier to audit."
+                .to_string(),
+            severity: self.severity(),
+            range: perl_parser_core::position::Range {
+                start: perl_parser_core::position::Position { byte: mat.start(), line, column },
+                end: perl_parser_core::position::Position {
+                    byte: mat.start() + 4,
+                    line,
+                    column: column + 4,
+                },
+            },
+            file: String::new(),
+        }]
     }
 }
 
@@ -106,4 +161,44 @@ fn missing_use_statement_violation(
         range: insertion_range(),
         file: String::new(),
     }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser_core::{Node, NodeKind, SourceLocation};
+
+    fn dummy_ast() -> Node {
+        Node::new(NodeKind::Program { statements: Vec::new() }, SourceLocation { start: 0, end: 0 })
+    }
+
+    #[test]
+    fn built_in_analyzer_reports_two_arg_open_without_perlcritic() {
+        let analyzer = BuiltInAnalyzer::new();
+        let content = "use strict;\nuse warnings;\nopen my $fh, $path;\n";
+
+        let violations = analyzer.analyze(&dummy_ast(), content);
+
+        assert!(
+            violations
+                .iter()
+                .any(|violation| violation.policy == "InputOutput::RequireThreeArgOpen"),
+            "expected built-in analyzer to flag two-argument open"
+        );
+    }
+
+    #[test]
+    fn built_in_analyzer_allows_three_arg_open() {
+        let analyzer = BuiltInAnalyzer::new();
+        let content = "use strict;\nuse warnings;\nopen my $fh, '<', $path;\n";
+
+        let violations = analyzer.analyze(&dummy_ast(), content);
+
+        assert!(
+            !violations
+                .iter()
+                .any(|violation| violation.policy == "InputOutput::RequireThreeArgOpen"),
+            "expected three-argument open to pass built-in policy"
+        );
+    }
 }


### PR DESCRIPTION
### Motivation

- The Rust-side built-in critic fallback only checked `use strict` and `use warnings`, leaving unsafe two-argument `open` calls detectable only by external `perlcritic`.
- Provide safer diagnostics even when external `perlcritic` is not available by surfacing a lightweight Rust analyzer for a common IO hazard.

### Description

- Add a new built-in policy `InputOutput::RequireThreeArgOpen` implemented as `RequireThreeArgOpen` that flags two-argument `open` usages.
- Use a `static LazyLock<Option<Regex>>` to hold the two-argument `open` detection pattern and compute byte/line/column positions for the reported `Violation` range.
- Register the new policy in `BuiltInAnalyzer::default()` so it runs alongside the existing strict/warnings checks.
- Add unit tests verifying that a two-argument `open` produces a violation and that a three-argument `open` does not.

### Testing

- Ran `cargo test -p perl-lsp-rs-core built_in_analyzer`, which passed (2 tests ran and succeeded).
- Ran `cargo check --all-targets -p perl-lsp-rs-core`, which completed successfully.
- Ran `cargo clippy -p perl-lsp-rs-core --lib -- -D warnings`, which completed successfully for the library target.
- Noted that `cargo clippy --all-targets -p perl-lsp-rs-core` and `cargo xtask fmt` reported unrelated failures in other test/xtask targets (pre-existing, not caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3744e8188333afaa627edab0c16e)