### PR TITLE
fix(ci-scope): classify docs tree config files as docs_as_code (#0000)

### DIFF
--- a/xtask/src/tasks/ci_scope.rs
+++ b/xtask/src/tasks/ci_scope.rs
@@ -141,7 +141,6 @@ pub fn classify_diff(files: &[String]) -> String {
 
 fn is_prose_file(file: &str) -> bool {
     PROSE_EXTENSIONS.iter().any(|ext| file.ends_with(ext))
-        || file.starts_with("docs/")
         || file.starts_with(".github/ISSUE_TEMPLATE/")
         || file == "LICENSE"
         || file == "CHANGELOG"
@@ -920,6 +919,12 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_diff_docs_as_code_inside_docs_tree() {
+        let files = vec!["docs/reference/generated/schema.json".to_string()];
+        assert_eq!(classify_diff(&files), "docs_as_code");
+    }
+
+    #[test]
     fn test_classify_diff_empty_is_prose_only() {
         assert_eq!(classify_diff(&[]), "prose_only");
     }
@@ -941,6 +946,15 @@ mod tests {
         let files = vec![
             "crates/perl-parser/src/lib.rs".to_string(),
             "docs/reference/STABILITY.md".to_string(),
+        ];
+        assert_eq!(classify_diff(&files), "mixed");
+    }
+
+    #[test]
+    fn test_classify_diff_mixed_prose_and_docs_as_code() {
+        let files = vec![
+            "docs/reference/STABILITY.md".to_string(),
+            "docs/reference/generated/schema.json".to_string(),
         ];
         assert_eq!(classify_diff(&files), "mixed");
     }


### PR DESCRIPTION
### Motivation
- The CI scope classifier treated every `docs/**` path as prose, which misclassified config/artifact files (JSON/TOML/YAML) under `docs/` and could skip docs-as-code routing and validation.

### Description
- Stop treating `docs/` as prose by removing the `file.starts_with("docs/")` check in `xtask/src/tasks/ci_scope.rs` so prose detection is driven only by `PROSE_EXTENSIONS`.
- Add regression tests `test_classify_diff_docs_as_code_inside_docs_tree` and `test_classify_diff_mixed_prose_and_docs_as_code` to assert `docs_as_code` detection for `docs/reference/generated/schema.json` and `mixed` behavior when combined with markdown.

### Testing
- Ran `git diff --check`, which passed with no issues.
- Attempted `cargo test -p xtask classify_diff`, but the test run could not complete due to pre-existing, unrelated compile errors in `xtask/src/tasks/metrics/lsp_stats.rs` (unresolved identifiers), so the new classifier tests could not be verified end-to-end in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea380bbc4c8333b5aeeb3d5aa72ee3)