### PR TITLE
chore(docs): add docs-as-code gate to pr-fast (#0000)

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,6 +50,7 @@ pr-fast: _check-tools-basic
     just _timed "fmt-check" "just fmt-check" && \
     just _timed "release-history" "just ci-release-history" && \
     just _timed "readme-heading-check" "just readme-heading-check" && \
+    just _timed "docs-as-code" "just docs-as-code" && \
     just _timed "clippy-core" "just clippy-core" && \
     just _timed "test-core" "just test-core" && \
     just _timed "publish-closure" "just ci-publish-closure" && \
@@ -1233,6 +1234,14 @@ ci-docs-check:
     @echo "📝 Checking missing docs baseline..."
     @cargo xtask ci-hygiene check-missing-docs
     @echo "✅ Missing docs check passed"
+
+# Docs-as-code hygiene checks (fast, content-focused)
+docs-as-code:
+    @echo "📚 Running docs-as-code checks..."
+    @just ci-docs-check
+    @just ci-doc-paths
+    @just ci-doc-claims
+    @echo "✅ Docs-as-code checks passed"
 
 # Policy and governance checks
 ci-policy:


### PR DESCRIPTION
### Motivation
- Ensure documentation hygiene is exercised early in the PR fast gate by grouping existing docs checks into a single, fast docs-as-code target so docs drift is caught during `pr-fast`.

### Description
- Add a new `docs-as-code` `just` target that runs `ci-docs-check`, `ci-doc-paths`, and `ci-doc-claims`, and wire `docs-as-code` into the `pr-fast` recipe.

### Testing
- Ran `just docs-as-code` (failed: `just` not installed in this environment) and attempted `cargo xtask ci-hygiene check-missing-docs` (failed due to unrelated `xtask` compile errors in `xtask/src/tasks/metrics/lsp_stats.rs`), so no passing automated tests were produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea380bbc4c8333b5aeeb3d5aa72ee3)