### PR TITLE
fix(perl-lsp-rs): drop Result<()> from lifecycle dispatch tests (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -149,37 +149,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn initialized_requires_initialize_request_first() -> Result<()> {
+    fn initialized_requires_initialize_request_first() {
         let server = LspServer::new();
 
         let result = server.handle_initialized_dispatch();
 
         assert!(result.is_err(), "initialized before initialize must error");
         assert!(!server.is_initialized(), "server must remain uninitialized");
-        Ok(())
     }
 
     #[test]
-    fn initialized_can_only_be_sent_once() -> Result<()> {
+    fn initialized_can_only_be_sent_once() {
         let server = LspServer::new();
-        server.handle_initialize(None)?;
+        server.handle_initialize(None).expect("initialize request should succeed");
 
         let first = server.handle_initialized_dispatch();
         let second = server.handle_initialized_dispatch();
 
         assert!(first.is_ok(), "first initialized must succeed");
         assert!(second.is_err(), "second initialized must error");
-        Ok(())
     }
 
     #[test]
-    fn auto_initialize_for_compat_promotes_initialized_state() -> Result<()> {
+    fn auto_initialize_for_compat_promotes_initialized_state() {
         let server = LspServer::new();
-        server.handle_initialize(None)?;
+        server.handle_initialize(None).expect("initialize request should succeed");
 
         server.auto_initialize_for_compat("textDocument/hover");
 
         assert!(server.is_initialized(), "compatibility path should mark server initialized");
-        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Three tests in `crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs` returned `Result<()>` without any `Result` alias in scope. That resolved to `std::result::Result` (two type params) and broke `cargo check --workspace --all-targets` on master with:

```
error[E0107]: enum takes 2 generic arguments but 1 generic argument was supplied
   --> crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs:152:59
   --> crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs:163:47
   --> crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs:176:67
```

Fix: drop the `Result<()>` return type from all three tests and use `.expect(...)` on the `handle_initialize` call, matching the project's tests-allow-expect exception.

Note: original issue description pointed to `xtask/src/tasks/metrics/lsp_stats.rs:318` and an undefined `run` variable — that location actually compiles cleanly (a `println!("\nLast Run — UX Metrics")`, no `run` identifier). The real master-green blocker was in `lifecycle.rs`; that's what this fixes.

## Test plan

- [x] `cargo check --workspace --all-targets` now passes (previously failed with three E0107 errors)
- [x] `RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --lib runtime::dispatch::lifecycle` — 3 passed, 0 failed
- [ ] CI green on this PR