### PR TITLE
fix(rename): improve token detection around sigils (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/rename.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/rename.rs
@@ -15,6 +15,61 @@ use crate::protocol::{invalid_params, req_position, req_uri};
 use crate::runtime::routing::{IndexAccessMode, route_index_access};
 
 impl LspServer {
+    fn token_span_at(content: &str, offset: usize) -> Option<(usize, usize)> {
+        let chars: Vec<char> = content.chars().collect();
+        if chars.is_empty() {
+            return None;
+        }
+
+        let is_ident_char = |ch: char| ch.is_alphanumeric() || ch == '_';
+        let is_sigil = |ch: char| ch == '$' || ch == '@' || ch == '%';
+
+        // Allow cursor-at-end and cursor-next-to-token positions by probing the
+        // previous character when needed.
+        let mut probe = offset.min(chars.len().saturating_sub(1));
+        if offset == chars.len()
+            || (!is_ident_char(chars[probe])
+                && !is_sigil(chars[probe])
+                && probe > 0
+                && (is_ident_char(chars[probe - 1]) || is_sigil(chars[probe - 1])))
+        {
+            probe = probe.saturating_sub(1);
+        }
+
+        if !is_ident_char(chars[probe]) && !is_sigil(chars[probe]) {
+            return None;
+        }
+
+        // Skip from sigil to identifier body when the cursor is on sigil.
+        let mut start = probe;
+        if is_sigil(chars[start]) && start + 1 < chars.len() && is_ident_char(chars[start + 1]) {
+            start += 1;
+        }
+
+        while start > 0 && is_ident_char(chars[start - 1]) {
+            start -= 1;
+        }
+        if start > 0 && is_sigil(chars[start - 1]) {
+            start -= 1;
+        }
+
+        let mut end = start;
+        if is_sigil(chars[end]) {
+            end += 1;
+        }
+        while end < chars.len() && is_ident_char(chars[end]) {
+            end += 1;
+        }
+
+        // Require at least one identifier character so we don't rename standalone sigils.
+        let body_start = if is_sigil(chars[start]) { start + 1 } else { start };
+        if body_start >= end {
+            return None;
+        }
+
+        Some((start, end))
+    }
+
     /// Handle textDocument/prepareRename request
     pub(crate) fn handle_prepare_rename(
         &self,
@@ -292,54 +347,60 @@ impl LspServer {
     /// Get token at position (simple implementation)
     pub(crate) fn get_token_at_position(&self, content: &str, offset: usize) -> String {
         let chars: Vec<char> = content.chars().collect();
-        if offset >= chars.len() {
+        if chars.is_empty() || offset > chars.len() {
             return String::new();
         }
-
-        // Find word boundaries
-        let mut start = offset;
-        while start > 0
-            && (chars[start - 1].is_alphanumeric()
-                || chars[start - 1] == '_'
-                || chars[start - 1] == '$'
-                || chars[start - 1] == '@'
-                || chars[start - 1] == '%')
-        {
-            start -= 1;
+        match Self::token_span_at(content, offset) {
+            Some((start, end)) => chars[start..end].iter().collect(),
+            None => String::new(),
         }
-
-        let mut end = offset;
-        while end < chars.len() && (chars[end].is_alphanumeric() || chars[end] == '_') {
-            end += 1;
-        }
-
-        chars[start..end].iter().collect()
     }
 
     /// Get the bounds of the token at the given position
     pub(crate) fn get_token_bounds(&self, content: &str, offset: usize) -> (usize, usize) {
         let chars: Vec<char> = content.chars().collect();
-        if offset >= chars.len() {
+        if chars.is_empty() || offset > chars.len() {
             return (offset, offset);
         }
+        Self::token_span_at(content, offset).unwrap_or((offset, offset))
+    }
+}
 
-        // Find word boundaries
-        let mut start = offset;
-        while start > 0
-            && (chars[start - 1].is_alphanumeric()
-                || chars[start - 1] == '_'
-                || chars[start - 1] == '$'
-                || chars[start - 1] == '@'
-                || chars[start - 1] == '%')
-        {
-            start -= 1;
-        }
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        let mut end = offset;
-        while end < chars.len() && (chars[end].is_alphanumeric() || chars[end] == '_') {
-            end += 1;
-        }
+    #[test]
+    fn token_helpers_support_cursor_on_sigil() -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::default();
+        let text = "my $value = 1;";
+        let offset = text.find('$').ok_or("missing sigil")?;
 
-        (start, end)
+        let token = server.get_token_at_position(text, offset);
+        let (start, end) = server.get_token_bounds(text, offset);
+
+        assert_eq!(token, "$value");
+        assert_eq!(
+            &text.chars().collect::<Vec<_>>()[start..end].iter().collect::<String>(),
+            "$value"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn token_helpers_support_cursor_after_identifier() -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::default();
+        let text = "my $value = 1;";
+        let offset = text.find("$value").ok_or("missing variable")? + "$value".len();
+
+        let token = server.get_token_at_position(text, offset);
+        let (start, end) = server.get_token_bounds(text, offset);
+
+        assert_eq!(token, "$value");
+        assert_eq!(
+            &text.chars().collect::<Vec<_>>()[start..end].iter().collect::<String>(),
+            "$value"
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- `prepareRename` and rename token extraction missed valid symbols when the cursor was on a sigil (`$`, `@`, `%`) or immediately after an identifier, causing poor UX for common cursor positions.

### Description

- Add a centralized `token_span_at` helper that recognizes sigils, identifier bodies, and cursor-adjacent positions and returns a `(start, end)` span.
- Reuse `token_span_at` from `get_token_at_position` and `get_token_bounds` to keep token text and ranges consistent.
- Prevent renaming of standalone sigils by requiring at least one identifier character in the token body.
- Add focused unit tests `token_helpers_support_cursor_on_sigil` and `token_helpers_support_cursor_after_identifier` in `crates/perl-lsp-rs/src/runtime/language/rename.rs` and change only that file.

### Testing

- Ran `cargo test -p perl-lsp-rs --lib token_helpers_support`, which passed (2 tests ran and succeeded).
- Ran `cargo check --all-targets -p perl-lsp-rs`, which completed successfully.
- Ran `cargo clippy -p perl-lsp-rs --all-targets -- -D warnings`, which failed due to many pre-existing unrelated lint violations not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea9122998c8333a7c4f52c206e5704)