### PR TITLE
fix(rename): improve token detection for prepare rename (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/rename.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/rename.rs
@@ -12,9 +12,19 @@
 use super::super::*;
 use crate::protocol::{invalid_params, req_position, req_uri};
 #[cfg(feature = "workspace")]
-use crate::runtime::routing::{IndexAccessMode, route_index_access};
+use crate::runtime::routing::{route_index_access, IndexAccessMode};
 
 impl LspServer {
+    fn is_symbol_char(ch: char) -> bool {
+        ch.is_alphanumeric()
+            || ch == '_'
+            || ch == '$'
+            || ch == '@'
+            || ch == '%'
+            || ch == ':'
+            || ch == '\''
+    }
+
     /// Handle textDocument/prepareRename request
     pub(crate) fn handle_prepare_rename(
         &self,
@@ -292,24 +302,26 @@ impl LspServer {
     /// Get token at position (simple implementation)
     pub(crate) fn get_token_at_position(&self, content: &str, offset: usize) -> String {
         let chars: Vec<char> = content.chars().collect();
-        if offset >= chars.len() {
+        if chars.is_empty() {
             return String::new();
+        }
+        let mut pos = offset.min(chars.len() - 1);
+        if !Self::is_symbol_char(chars[pos]) {
+            if pos > 0 && Self::is_symbol_char(chars[pos - 1]) {
+                pos -= 1;
+            } else {
+                return String::new();
+            }
         }
 
         // Find word boundaries
-        let mut start = offset;
-        while start > 0
-            && (chars[start - 1].is_alphanumeric()
-                || chars[start - 1] == '_'
-                || chars[start - 1] == '$'
-                || chars[start - 1] == '@'
-                || chars[start - 1] == '%')
-        {
+        let mut start = pos;
+        while start > 0 && Self::is_symbol_char(chars[start - 1]) {
             start -= 1;
         }
 
-        let mut end = offset;
-        while end < chars.len() && (chars[end].is_alphanumeric() || chars[end] == '_') {
+        let mut end = pos;
+        while end < chars.len() && Self::is_symbol_char(chars[end]) {
             end += 1;
         }
 
@@ -319,27 +331,61 @@ impl LspServer {
     /// Get the bounds of the token at the given position
     pub(crate) fn get_token_bounds(&self, content: &str, offset: usize) -> (usize, usize) {
         let chars: Vec<char> = content.chars().collect();
-        if offset >= chars.len() {
+        if chars.is_empty() {
             return (offset, offset);
+        }
+        let mut pos = offset.min(chars.len() - 1);
+        if !Self::is_symbol_char(chars[pos]) {
+            if pos > 0 && Self::is_symbol_char(chars[pos - 1]) {
+                pos -= 1;
+            } else {
+                return (offset, offset);
+            }
         }
 
         // Find word boundaries
-        let mut start = offset;
-        while start > 0
-            && (chars[start - 1].is_alphanumeric()
-                || chars[start - 1] == '_'
-                || chars[start - 1] == '$'
-                || chars[start - 1] == '@'
-                || chars[start - 1] == '%')
-        {
+        let mut start = pos;
+        while start > 0 && Self::is_symbol_char(chars[start - 1]) {
             start -= 1;
         }
 
-        let mut end = offset;
-        while end < chars.len() && (chars[end].is_alphanumeric() || chars[end] == '_') {
+        let mut end = pos;
+        while end < chars.len() && Self::is_symbol_char(chars[end]) {
             end += 1;
         }
 
         (start, end)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_at_position_includes_sigil_when_cursor_on_sigil() {
+        let server = LspServer::new();
+        let content = "my $value = 1;";
+        let offset = content.find('$').unwrap_or(0);
+        let token = server.get_token_at_position(content, offset);
+        assert_eq!(token, "$value");
+    }
+
+    #[test]
+    fn token_bounds_include_sigil_when_cursor_on_sigil() {
+        let server = LspServer::new();
+        let content = "my $value = 1;";
+        let sigil_offset = content.find('$').unwrap_or(0);
+        let (start, end) = server.get_token_bounds(content, sigil_offset);
+        assert_eq!(&content[start..end], "$value");
+    }
+
+    #[test]
+    fn token_at_position_handles_qualified_package_symbols() {
+        let server = LspServer::new();
+        let content = "my $x = Foo::Bar::run();";
+        let offset = content.find("Bar").unwrap_or(0);
+        let token = server.get_token_at_position(content, offset);
+        assert_eq!(token, "Foo::Bar::run");
     }
 }


### PR DESCRIPTION
### Motivation

- `textDocument/prepareRename` missed tokens when the cursor was on or adjacent to sigils and did not treat Perl package separators as part of the same symbol, which produced incorrect null responses for valid rename targets.

### Description

- Added a shared predicate `is_symbol_char` to include alphanumerics, `_`, sigils (`$`, `@`, `%`), package separators (`:`) and the apostrophe (`'`) to treat qualified Perl symbols as a single token.
- Normalized cursor position by falling back to the previous character when the cursor sits immediately after a symbol so token extraction still resolves the intended name.
- Reworked `get_token_at_position` and `get_token_bounds` to use the unified predicate and the position normalization to compute token start/end reliably.
- Added focused unit tests exercising sigil-at-cursor behavior, token bounds with sigils, and qualified package symbol tokenization in `runtime::language::rename.rs`.

### Testing

- Ran the focused unit tests with `cargo test -p perl-lsp-rs --lib runtime::language::rename::tests::` and they all passed.
- Ran `cargo check --all-targets -p perl-lsp-rs` which completed successfully.
- Ran `cargo clippy -p perl-lsp-rs -- -D warnings` which completed without warnings.
- Ran formatting with `cargo xtask fmt` / `rustfmt` locally in the repo; note that `just pr-fast` is unavailable in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea9122998c8333a7c4f52c206e5704)