### PR TITLE
fix(goto): resolve goto labels in declaration lookup (#0000)

### DIFF
--- a/crates/perl-parser/tests/declaration_unit_tests.rs
+++ b/crates/perl-parser/tests/declaration_unit_tests.rs
@@ -176,6 +176,32 @@ fn test_unicode_and_crlf() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn test_goto_label_resolves_to_labeled_statement() -> TestResult {
+    let content = r#"
+sub jump {
+    goto TARGET;
+}
+
+TARGET: return 1;
+"#;
+    let mut parser = Parser::new(content);
+    let ast = parser.parse()?;
+
+    let provider =
+        DeclarationProvider::new(Arc::new(ast), content.to_string(), "test.pl".to_string());
+
+    let goto_label_pos = content.find("TARGET;").ok_or("Could not find goto label usage")?;
+    let links =
+        provider.find_declaration(goto_label_pos, 0).ok_or("Should resolve goto label target")?;
+    assert_eq!(links.len(), 1);
+
+    let label_decl_pos = content.find("TARGET:").ok_or("Could not find label declaration")?;
+    assert_eq!(links[0].target_selection_range.0, label_decl_pos);
+    assert_eq!(links[0].target_selection_range.1, label_decl_pos + "TARGET".len());
+    Ok(())
+}
+
 #[cfg(feature = "package-qualified")]
 #[test]
 fn test_tricky_names() -> TestResult {

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -338,6 +338,14 @@ impl<'a> DeclarationProvider<'a> {
                 self.find_method_declaration(node, method, object)
             }
             NodeKind::Identifier { name } => self.find_identifier_declaration(node, name),
+            NodeKind::Goto { target } => {
+                if let NodeKind::Identifier { name } = &target.kind {
+                    self.find_label_declaration(node, name)
+                        .or_else(|| self.find_subroutine_declaration(node, name))
+                } else {
+                    None
+                }
+            }
             // Handle string literals that are method names inside modifier calls:
             // `before 'save' => sub { }` — cursor on 'save' navigates to sub save { }
             NodeKind::String { value, .. } => self.find_modifier_target_declaration(node, value),
@@ -568,6 +576,14 @@ impl<'a> DeclarationProvider<'a> {
 
     /// Find declaration for an identifier
     fn find_identifier_declaration(&self, node: &Node, name: &str) -> Option<Vec<LocationLink>> {
+        // `goto LABEL` should resolve to the statement label before considering
+        // sub/package/constant declarations.
+        if self.identifier_is_goto_target(node)
+            && let Some(links) = self.find_label_declaration(node, name)
+        {
+            return Some(links);
+        }
+
         // Try to find as subroutine first
         if let Some(links) = self.find_subroutine_declaration(node, name) {
             return Some(links);
@@ -594,6 +610,80 @@ impl<'a> DeclarationProvider<'a> {
         }
 
         None
+    }
+
+    fn find_label_declaration(&self, origin: &Node, label_name: &str) -> Option<Vec<LocationLink>> {
+        let mut labels = Vec::new();
+        self.collect_label_declarations(&self.ast, label_name, &mut labels);
+        let labeled_stmt = labels.first().copied()?;
+
+        Some(vec![self.create_location_link(
+            origin,
+            labeled_stmt,
+            self.get_labeled_statement_label_range(labeled_stmt),
+        )])
+    }
+
+    fn collect_label_declarations<'b>(
+        &'b self,
+        node: &'b Node,
+        label_name: &str,
+        labels: &mut Vec<&'b Node>,
+    ) {
+        if let NodeKind::LabeledStatement { label, .. } = &node.kind
+            && label == label_name
+        {
+            labels.push(node);
+        }
+
+        for child in self.get_children(node) {
+            self.collect_label_declarations(child, label_name, labels);
+        }
+    }
+
+    fn get_labeled_statement_label_range(&self, node: &Node) -> (usize, usize) {
+        let NodeKind::LabeledStatement { label, .. } = &node.kind else {
+            return (node.location.start, node.location.end);
+        };
+
+        let start = node.location.start;
+        let end = node.location.end.min(self.content.len());
+        if start >= end {
+            return (node.location.start, node.location.end);
+        }
+
+        let text = &self.content[start..end];
+        let label_start = text.find(label).map_or(start, |idx| start + idx);
+        let label_end = label_start.saturating_add(label.len()).min(end);
+        (label_start, label_end)
+    }
+
+    fn identifier_is_goto_target(&self, node: &Node) -> bool {
+        let temp_parent_map;
+        let parent_map = if let Some(pm) = self.parent_map {
+            pm
+        } else {
+            temp_parent_map = {
+                let mut map = FxHashMap::default();
+                Self::build_parent_map(&self.ast, &mut map, None);
+                map
+            };
+            &temp_parent_map
+        };
+        let node_lookup = self.build_node_lookup_map();
+
+        let node_ptr = node as *const _;
+        let Some(parent_ptr) = parent_map.get(&node_ptr).copied() else {
+            return false;
+        };
+        let Some(parent) = node_lookup.get(&parent_ptr).copied() else {
+            return false;
+        };
+
+        match &parent.kind {
+            NodeKind::Goto { target } => std::ptr::eq(target.as_ref(), node),
+            _ => false,
+        }
     }
 
     /// Find the definition of the method that a modifier string argument targets.


### PR DESCRIPTION
### Motivation

- `goto LABEL` did not navigate to the corresponding statement label, causing go-to navigation to miss valid control-flow targets.

### Description

- Add explicit handling for `NodeKind::Goto` in `DeclarationProvider::find_declaration` to attempt label resolution first and fall back to subroutine lookup. 
- Implement label helpers: `find_label_declaration`, `collect_label_declarations`, and `get_labeled_statement_label_range` to locate `LabeledStatement` nodes and compute precise selection ranges. 
- Add `identifier_is_goto_target` to detect when an identifier node is the target of a surrounding `goto`. 
- Preserve existing behavior by retaining subroutine/package/constant fallbacks when label resolution does not apply. 
- Add a regression test `test_goto_label_resolves_to_labeled_statement` in `crates/perl-parser/tests/declaration_unit_tests.rs` to verify `goto TARGET;` resolves to `TARGET:`.

### Testing

- Ran `cargo test -p perl-parser --test declaration_unit_tests test_goto_label_resolves_to_labeled_statement`, which passed. 
- Ran `cargo check --all-targets -p perl-semantic-analyzer`, which passed. 
- Ran `cargo clippy -p perl-semantic-analyzer --all-targets -- -D warnings`, which passed. 
- Ran `cargo xtask fmt` to format changes. 
- `just pr-fast` was not available in this environment (command not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea917f9f1c8333ad6a1fc94b0bd379)