### PR TITLE
fix(navigation): resolve goto LABEL definitions (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/navigation.rs
@@ -40,6 +40,12 @@ static MOJO_KV_ROUTE_RE_ACTION_FIRST: OnceLock<Result<regex::Regex, regex::Error
     OnceLock::new();
 
 #[cfg(feature = "workspace")]
+static GOTO_LABEL_RE: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
+
+#[cfg(feature = "workspace")]
+static LABEL_DECLARATION_RE: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
+
+#[cfg(feature = "workspace")]
 fn get_fqn_regex() -> Result<&'static regex::Regex, JsonRpcError> {
     FQN_RE
         .get_or_init(|| regex::Regex::new(r"([A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*)"))
@@ -108,6 +114,42 @@ fn get_super_method_regex() -> Result<&'static regex::Regex, JsonRpcError> {
                 "Failed to initialize SUPER method-call regex: {err}"
             ))
         })
+}
+
+#[cfg(feature = "workspace")]
+fn get_goto_label_regex() -> Result<&'static regex::Regex, JsonRpcError> {
+    GOTO_LABEL_RE
+        .get_or_init(|| regex::Regex::new(r"\bgoto\s+([A-Za-z_][A-Za-z0-9_]*)"))
+        .as_ref()
+        .map_err(|err| {
+            crate::protocol::internal_error(&format!(
+                "Failed to initialize goto label regex: {err}"
+            ))
+        })
+}
+
+#[cfg(feature = "workspace")]
+fn get_label_declaration_regex() -> Result<&'static regex::Regex, JsonRpcError> {
+    LABEL_DECLARATION_RE
+        .get_or_init(|| regex::Regex::new(r"(?m)^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:"))
+        .as_ref()
+        .map_err(|err| {
+            crate::protocol::internal_error(&format!(
+                "Failed to initialize label declaration regex: {err}"
+            ))
+        })
+}
+
+#[cfg(feature = "workspace")]
+fn find_label_declaration_span(
+    text: &str,
+    label: &str,
+) -> Result<Option<(usize, usize)>, JsonRpcError> {
+    let label_re = get_label_declaration_regex()?;
+    Ok(label_re.captures_iter(text).find_map(|cap| {
+        let declared_label = cap.get(1)?;
+        (declared_label.as_str() == label).then_some((declared_label.start(), declared_label.end()))
+    }))
 }
 
 #[derive(Debug, Clone)]
@@ -1059,6 +1101,32 @@ impl LspServer {
                 let text_start = offset.saturating_sub(radius);
                 let text_around = self.get_text_around_offset(&doc.text, offset, radius);
                 let cursor_in_text = offset - text_start;
+
+                let goto_label_re = get_goto_label_regex()?;
+                for cap in goto_label_re.captures_iter(&text_around) {
+                    if let Some(label_match) = cap.get(1)
+                        && cursor_in_text >= label_match.start()
+                        && cursor_in_text <= label_match.end()
+                        && let Some((target_start, target_end)) =
+                            find_label_declaration_span(&doc.text, label_match.as_str())?
+                    {
+                        let (def_line, def_char) = self.offset_to_pos16(doc, target_start);
+                        let (def_end_line, def_end_char) = self.offset_to_pos16(doc, target_end);
+                        return Ok(Some(json!([{
+                            "uri": uri,
+                            "range": {
+                                "start": {
+                                    "line": def_line,
+                                    "character": def_char,
+                                },
+                                "end": {
+                                    "line": def_end_line,
+                                    "character": def_end_char,
+                                },
+                            },
+                        }])));
+                    }
+                }
 
                 if let Some(mason_location) = self.resolve_mason_definition(uri, &doc.text, offset)
                 {

--- a/crates/perl-lsp-rs/tests/lsp_definition_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_definition_tests.rs
@@ -251,6 +251,42 @@ my $greeting = "Hi $name";
     Ok(())
 }
 
+/// Validates that go-to-definition on a `goto LABEL` target resolves to the label declaration.
+#[test]
+fn test_go_to_label_definition_from_goto_statement() -> TestResult {
+    let doc = r#"
+sub run {
+    goto FINISH;
+    return 0;
+FINISH:
+    return 1;
+}
+"#;
+
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open_document("file:///goto_label.pl", doc)?;
+
+    let result = harness
+        .request(
+            "textDocument/definition",
+            json!({
+                "textDocument": {"uri": "file:///goto_label.pl"},
+                "position": {"line": 2, "character": 9} // Position on "FINISH" in `goto FINISH`
+            }),
+        )
+        .unwrap_or(json!(null));
+
+    let locations = result.as_array().ok_or("Expected array result")?;
+    assert!(!locations.is_empty(), "Expected goto label definition to resolve");
+    assert_valid_location(&locations[0]);
+
+    let def_line = locations[0].pointer("/range/start/line").and_then(|l| l.as_u64());
+    assert_eq!(def_line, Some(4), "Label FINISH should resolve to line 4");
+
+    Ok(())
+}
+
 /// Tests feature spec: navigation.rs#definition-empty-file
 ///
 /// Validates graceful handling of go-to-definition on an empty document.


### PR DESCRIPTION
### Motivation

- Go-to-definition on `goto LABEL` could resolve to unrelated symbols because control-flow labels were not handled explicitly.
- Provide precise same-file navigation for `goto` targets so editors jump to the correct label declaration.

### Description

- Added cached regex helpers and matchers for `goto LABEL` and label declarations in `crates/perl-lsp-rs/src/runtime/language/navigation.rs` to detect `goto` usages and label spans. 
- Implemented `find_label_declaration_span` and short-circuited the `textDocument/definition` flow to return the label location when the cursor is on a `goto` target. 
- Added an integration test `test_go_to_label_definition_from_goto_statement` in `crates/perl-lsp-rs/tests/lsp_definition_tests.rs` which verifies that `goto FINISH;` navigates to the `FINISH:` label. 

### Testing

- Ran the new integration test: `cargo test -p perl-lsp-rs --test lsp_definition_tests test_go_to_label_definition_from_goto_statement`, which passed. 
- Verified build and targets with `cargo check --all-targets -p perl-lsp-rs`, which passed. 
- Ran lints with `cargo clippy -p perl-lsp-rs -- -D warnings`, which passed. 
- Formatted code with `cargo xtask fmt`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea917f9f1c8333ad6a1fc94b0bd379)