### PR TITLE
fix(perl-semantic-analyzer): resolve goto label definitions (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
@@ -1018,6 +1018,30 @@ my $documented = 42;
     }
 
     #[test]
+    fn test_analyzer_find_definition_goto_label() -> Result<(), Box<dyn std::error::Error>> {
+        let code = "START: while (1) {\n    goto START;\n}\n";
+        let mut parser = Parser::new(code);
+        let ast = parser.parse()?;
+
+        let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+        let ref_pos = code.find("START;\n").ok_or("could not find goto label")?;
+
+        let symbol = analyzer
+            .find_definition(ref_pos)
+            .ok_or("definition not found for goto label reference")?;
+
+        assert_eq!(symbol.name, "START");
+        assert_eq!(symbol.kind, SymbolKind::Label);
+        assert!(
+            symbol.location.start < ref_pos,
+            "Label definition {:?} should precede goto reference at byte {}",
+            symbol.location.start,
+            ref_pos
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_anonymous_subroutine_semantic_tokens() -> Result<(), Box<dyn std::error::Error>> {
         let code = r#"
 my $closure = sub {

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -964,8 +964,21 @@ impl SymbolExtractor {
                 }
             }
 
-            NodeKind::Untie { variable } | NodeKind::Goto { target: variable } => {
+            NodeKind::Untie { variable } => {
                 self.visit_node(variable);
+            }
+
+            NodeKind::Goto { target } => {
+                if let NodeKind::Identifier { name } = &target.kind {
+                    self.table.add_reference(SymbolReference {
+                        name: name.clone(),
+                        kind: SymbolKind::Label,
+                        location: target.location,
+                        scope_id: self.table.current_scope(),
+                        is_write: false,
+                    });
+                }
+                self.visit_node(target);
             }
 
             // Regex related nodes - we recurse into expression


### PR DESCRIPTION
### Motivation

- Go-to-definition on `goto LABEL` bareword targets did not resolve to in-file label definitions because `goto` identifier targets were not recorded as references.

### Description

- Record `NodeKind::Goto` identifier targets as `SymbolReference` entries with `SymbolKind::Label` in the symbol extractor so label references are discoverable.
- Add a regression test `test_analyzer_find_definition_goto_label` that verifies `find_definition` resolves a `goto START;` to the `START:` label symbol and that the label location precedes the reference.
- Keep traversal behavior unchanged except for the new `goto` handling and preserve existing `Untie` handling separately.

### Testing

- Ran `cargo test -p perl-semantic-analyzer test_analyzer_find_definition_goto_label`, which passed.
- Ran `cargo check --all-targets -p perl-semantic-analyzer`, which passed.
- Ran `cargo clippy -p perl-semantic-analyzer --all-targets -- -D warnings`, which passed.
- Ran `cargo xtask fmt` to format the workspace, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea917f9f1c8333ad6a1fc94b0bd379)