### PR TITLE
fix(position-tracking): clamp UTF-8 mid-codepoint offsets (#0000)

### DIFF
--- a/crates/perl-position-tracking/src/line_index.rs
+++ b/crates/perl-position-tracking/src/line_index.rs
@@ -1,6 +1,12 @@
 //! Line index for efficient UTF-16 position calculations.
 use ropey::Rope;
 
+/// Returns true if `b` is a UTF-8 continuation byte (0b10xxxxxx).
+#[inline]
+fn is_utf8_continuation(b: u8) -> bool {
+    (b & 0b1100_0000) == 0b1000_0000
+}
+
 /// Caches byte offsets for line starts to speed up coordinate conversion.
 #[derive(Debug, Clone)]
 pub struct LineStartsCache {
@@ -89,13 +95,30 @@ impl LineStartsCache {
 
     /// Converts a byte offset in `rope` to `(line, column_utf16)`.
     pub fn offset_to_position_rope(&self, rope: &Rope, offset: usize) -> (u32, u32) {
-        let offset = offset.min(rope.len_bytes());
+        let offset = Self::normalize_rope_offset(rope, offset);
         let line = self.line_starts.binary_search(&offset).unwrap_or_else(|i| i.saturating_sub(1));
         let ls = self.line_starts[line];
         (
             line as u32,
             rope.byte_slice(ls..offset).chars().map(|c| c.len_utf16()).sum::<usize>() as u32,
         )
+    }
+
+    /// Clamp `offset` into `rope` and snap it back to a UTF-8 char boundary.
+    ///
+    /// `Rope::byte_slice` panics if the offset splits a multi-byte codepoint, so
+    /// the clamp here mirrors [`Self::normalize_text_offset`]. Ropey 1.x does
+    /// not expose `is_char_boundary` directly, so we inspect the byte at the
+    /// candidate offset: UTF-8 continuation bytes always satisfy `b & 0xC0 ==
+    /// 0x80` (top two bits are `10`), and every other byte is a codepoint
+    /// start.
+    fn normalize_rope_offset(rope: &Rope, offset: usize) -> usize {
+        let len = rope.len_bytes();
+        let mut normalized = offset.min(len);
+        while normalized > 0 && normalized < len && is_utf8_continuation(rope.byte(normalized)) {
+            normalized -= 1;
+        }
+        normalized
     }
 
     /// Converts `(line, column_utf16)` into a byte offset in `rope`.

--- a/crates/perl-position-tracking/src/line_index.rs
+++ b/crates/perl-position-tracking/src/line_index.rs
@@ -7,6 +7,15 @@ pub struct LineStartsCache {
     line_starts: Vec<usize>,
 }
 impl LineStartsCache {
+    /// Clamp `offset` into `text` and ensure it is on a UTF-8 char boundary.
+    fn normalize_text_offset(text: &str, offset: usize) -> usize {
+        let mut normalized = offset.min(text.len());
+        while normalized > 0 && !text.is_char_boundary(normalized) {
+            normalized -= 1;
+        }
+        normalized
+    }
+
     /// Builds a cache from UTF-8 source text.
     pub fn new(text: &str) -> Self {
         let mut ls = vec![0];
@@ -41,7 +50,7 @@ impl LineStartsCache {
 
     /// Converts a byte offset in `text` to `(line, column_utf16)`.
     pub fn offset_to_position(&self, text: &str, offset: usize) -> (u32, u32) {
-        let offset = offset.min(text.len());
+        let offset = Self::normalize_text_offset(text, offset);
         let line = self.line_starts.binary_search(&offset).unwrap_or_else(|i| i.saturating_sub(1));
         let ls = self.line_starts[line];
         (line as u32, text[ls..offset].chars().map(|c| c.len_utf16()).sum::<usize>() as u32)

--- a/crates/perl-position-tracking/tests/extended_unit_tests.rs
+++ b/crates/perl-position-tracking/tests/extended_unit_tests.rs
@@ -605,6 +605,66 @@ fn line_starts_cache_offset_mid_utf8_char_clamps_to_boundary() {
     assert_eq!(col, 1);
 }
 
+#[test]
+fn line_starts_cache_offset_at_every_mid_byte_of_4byte_char_clamps_down() {
+    // 😀 (U+1F600) occupies bytes 1..5. Any in-the-middle offset (2, 3, 4)
+    // must clamp back to byte 1 (the start of the codepoint), not forward
+    // to byte 5 — clamping forward would bill the caller for 2 UTF-16 units
+    // for a character they never asked about.
+    let src = "a😀b";
+    let cache = LineStartsCache::new(src);
+    for mid_byte in [2usize, 3, 4] {
+        let (line, col) = cache.offset_to_position(src, mid_byte);
+        assert_eq!(line, 0, "offset={mid_byte} line");
+        assert_eq!(col, 1, "offset={mid_byte} should clamp back to start of 😀 (col=1)");
+    }
+
+    // Byte 5 is the start of 'b' and must give col=3 (a=1 + 😀=2).
+    let (line, col) = cache.offset_to_position(src, 5);
+    assert_eq!((line, col), (0, 3));
+}
+
+#[test]
+fn line_starts_cache_offset_mid_utf8_across_newline() {
+    // A multi-byte codepoint immediately after a newline: clamping must
+    // land on the start of the codepoint on the *new* line, not drift
+    // back across the newline into the previous line.
+    let src = "x\n😀y"; // newline at byte 1 → line 1 starts at byte 2
+    let cache = LineStartsCache::new(src);
+
+    // Byte 3 is one byte into 😀 (which begins at byte 2). Must clamp
+    // back to 2 and stay on line 1 (col 0), not leak to line 0.
+    let (line, col) = cache.offset_to_position(src, 3);
+    assert_eq!(line, 1, "must not drift back across newline");
+    assert_eq!(col, 0);
+}
+
+#[test]
+fn line_starts_cache_offset_mid_utf8_bom() {
+    // A BOM (U+FEFF, encoded as 0xEF 0xBB 0xBF — 3 bytes) at the very start
+    // is sometimes produced by editors. Any in-the-middle offset must clamp
+    // back to 0, not forward to 3.
+    let src = "\u{feff}fn";
+    let cache = LineStartsCache::new(src);
+    for mid_byte in [1usize, 2] {
+        let (line, col) = cache.offset_to_position(src, mid_byte);
+        assert_eq!(line, 0);
+        assert_eq!(col, 0, "mid-BOM offset {mid_byte} must clamp back to col 0");
+    }
+}
+
+#[test]
+fn line_starts_cache_offset_empty_text_any_offset() {
+    // Empty text: any offset (including beyond the text) must produce
+    // (0, 0), not panic on array indexing.
+    let src = "";
+    let cache = LineStartsCache::new(src);
+    for offset in [0usize, 1, 100, usize::MAX] {
+        let (line, col) = cache.offset_to_position(src, offset);
+        assert_eq!((line, col), (0, 0), "offset={offset}");
+    }
+}
+
 // ─── LineStartsCache: position_to_offset ─────────────────────────────────────
 
 #[test]
@@ -686,6 +746,34 @@ fn line_starts_cache_rope_beyond_end() {
     let cache = LineStartsCache::new_rope(&rope);
     let off = cache.position_to_offset_rope(&rope, 99, 0);
     assert_eq!(off, rope.len_bytes());
+}
+
+#[test]
+fn line_starts_cache_rope_offset_mid_utf8_char_clamps_to_boundary() {
+    // Rope byte_slice panics on mid-codepoint offsets; verify the rope
+    // variant snaps back to a char boundary just like the &str variant.
+    let src = "a😀b";
+    let rope = ropey::Rope::from_str(src);
+    let cache = LineStartsCache::new_rope(&rope);
+    for mid_byte in [2usize, 3, 4] {
+        let (line, col) = cache.offset_to_position_rope(&rope, mid_byte);
+        assert_eq!(line, 0, "offset={mid_byte}");
+        assert_eq!(col, 1, "mid-byte offset {mid_byte} must clamp back to col 1");
+    }
+    // Byte 5 is the start of 'b' — (line=0, col=3).
+    let (line, col) = cache.offset_to_position_rope(&rope, 5);
+    assert_eq!((line, col), (0, 3));
+}
+
+#[test]
+fn line_starts_cache_rope_offset_empty_rope_any_offset() {
+    // Empty rope: clamping must not panic for offsets at or beyond zero.
+    let rope = ropey::Rope::from_str("");
+    let cache = LineStartsCache::new_rope(&rope);
+    for offset in [0usize, 1, 100, usize::MAX] {
+        let (line, col) = cache.offset_to_position_rope(&rope, offset);
+        assert_eq!((line, col), (0, 0), "offset={offset}");
+    }
 }
 
 // ─── LineIndex ───────────────────────────────────────────────────────────────

--- a/crates/perl-position-tracking/tests/extended_unit_tests.rs
+++ b/crates/perl-position-tracking/tests/extended_unit_tests.rs
@@ -594,6 +594,17 @@ fn line_starts_cache_offset_clamped() {
     assert_eq!(col, 3);
 }
 
+#[test]
+fn line_starts_cache_offset_mid_utf8_char_clamps_to_boundary() {
+    let src = "a😀b";
+    let cache = LineStartsCache::new(src);
+
+    // Byte offset 2 is in the middle of 😀 (starts at 1, ends before 5).
+    let (line, col) = cache.offset_to_position(src, 2);
+    assert_eq!(line, 0);
+    assert_eq!(col, 1);
+}
+
 // ─── LineStartsCache: position_to_offset ─────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
### Motivation
- Prevent panics when callers pass a byte offset that falls inside a multi-byte UTF-8 codepoint by ensuring offsets are on UTF-8 char boundaries before slicing. 
- Improve robustness of UTF-16/UTF-8 position conversion code used by LSP position mapping. 

### Description
- Add `normalize_text_offset(text: &str, offset: usize)` to `LineStartsCache` to clamp the offset into `text` and move it back to the previous UTF-8 codepoint boundary. 
- Use `normalize_text_offset` in `LineStartsCache::offset_to_position` before indexing/slicing the input `&str` to avoid slicing at non-boundaries. 
- Add a regression test `line_starts_cache_offset_mid_utf8_char_clamps_to_boundary` in `extended_unit_tests.rs` that verifies a mid-emoji byte offset is safely clamped and yields the expected UTF-16 column. 

### Testing
- Ran `cargo test -p perl-position-tracking`, and all tests passed. 
- Ran `cargo check --all-targets -p perl-position-tracking`, `cargo xtask fmt`, and `cargo clippy -p perl-position-tracking`, and they completed successfully. 
- `just pr-fast` could not be executed in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea97d6cba48333a58903a0e4d9309b)