### PR TITLE
fix(parser): improve mojibake decoding fallback (#0000)

### DIFF
--- a/crates/perl-parser/src/bin/perl-parse.rs
+++ b/crates/perl-parser/src/bin/perl-parse.rs
@@ -300,16 +300,81 @@ fn read_input(input: &Input) -> io::Result<String> {
 }
 
 fn read_source_bytes(bytes: Vec<u8>) -> io::Result<String> {
+    if let Some(decoded) = decode_utf16_with_bom(&bytes) {
+        return Ok(decoded);
+    }
+
     match String::from_utf8(bytes) {
         Ok(source) => Ok(source),
         Err(err) => {
             let raw = err.into_bytes();
             let mut decoded = String::with_capacity(raw.len());
             for byte in raw {
-                decoded.push(char::from(byte));
+                decoded.push(decode_byte_as_windows_1252(byte));
             }
             Ok(decoded)
         }
+    }
+}
+
+fn decode_utf16_with_bom(bytes: &[u8]) -> Option<String> {
+    if bytes.len() < 2 {
+        return None;
+    }
+
+    let little_endian = if bytes.starts_with(&[0xFF, 0xFE]) {
+        true
+    } else if bytes.starts_with(&[0xFE, 0xFF]) {
+        false
+    } else {
+        return None;
+    };
+
+    let mut words = Vec::with_capacity((bytes.len().saturating_sub(2)) / 2);
+    let mut index = 2usize;
+    while index + 1 < bytes.len() {
+        let word = if little_endian {
+            u16::from_le_bytes([bytes[index], bytes[index + 1]])
+        } else {
+            u16::from_be_bytes([bytes[index], bytes[index + 1]])
+        };
+        words.push(word);
+        index += 2;
+    }
+
+    Some(String::from_utf16_lossy(&words))
+}
+
+fn decode_byte_as_windows_1252(byte: u8) -> char {
+    match byte {
+        0x80 => '\u{20AC}', // €
+        0x82 => '\u{201A}', // ‚
+        0x83 => '\u{0192}', // ƒ
+        0x84 => '\u{201E}', // „
+        0x85 => '\u{2026}', // …
+        0x86 => '\u{2020}', // †
+        0x87 => '\u{2021}', // ‡
+        0x88 => '\u{02C6}', // ˆ
+        0x89 => '\u{2030}', // ‰
+        0x8A => '\u{0160}', // Š
+        0x8B => '\u{2039}', // ‹
+        0x8C => '\u{0152}', // Œ
+        0x8E => '\u{017D}', // Ž
+        0x91 => '\u{2018}', // ‘
+        0x92 => '\u{2019}', // ’
+        0x93 => '\u{201C}', // “
+        0x94 => '\u{201D}', // ”
+        0x95 => '\u{2022}', // •
+        0x96 => '\u{2013}', // –
+        0x97 => '\u{2014}', // —
+        0x98 => '\u{02DC}', // ˜
+        0x99 => '\u{2122}', // ™
+        0x9A => '\u{0161}', // š
+        0x9B => '\u{203A}', // ›
+        0x9C => '\u{0153}', // œ
+        0x9E => '\u{017E}', // ž
+        0x9F => '\u{0178}', // Ÿ
+        _ => char::from(byte),
     }
 }
 
@@ -446,6 +511,27 @@ mod tests {
         // "Sår" in ISO-8859-1 bytes
         let decoded = read_source_bytes(vec![0x53, 0xE5, 0x72, 0x0A])?;
         assert_eq!(decoded, "Sår\n");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_decodes_windows_1252_punctuation() -> Result<(), Box<dyn std::error::Error>>
+    {
+        // “quote” in Windows-1252 bytes
+        let decoded = read_source_bytes(vec![0x93, b'q', b'u', b'o', b't', b'e', 0x94, b'\n'])?;
+        assert_eq!(decoded, "“quote”\n");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_decodes_utf16_le_bom() -> Result<(), Box<dyn std::error::Error>> {
+        let bytes = vec![
+            0xFF, 0xFE, // UTF-16LE BOM
+            b'u', 0x00, b's', 0x00, b'e', 0x00, b' ', 0x00, b'8', 0x00, b';', 0x00, b'\n',
+            0x00,
+        ];
+        let decoded = read_source_bytes(bytes)?;
+        assert_eq!(decoded, "use 8;\n");
         Ok(())
     }
 }

--- a/crates/perl-parser/src/bin/perl-parse.rs
+++ b/crates/perl-parser/src/bin/perl-parse.rs
@@ -527,11 +527,161 @@ mod tests {
     fn read_source_bytes_decodes_utf16_le_bom() -> Result<(), Box<dyn std::error::Error>> {
         let bytes = vec![
             0xFF, 0xFE, // UTF-16LE BOM
-            b'u', 0x00, b's', 0x00, b'e', 0x00, b' ', 0x00, b'8', 0x00, b';', 0x00, b'\n',
-            0x00,
+            b'u', 0x00, b's', 0x00, b'e', 0x00, b' ', 0x00, b'8', 0x00, b';', 0x00, b'\n', 0x00,
         ];
         let decoded = read_source_bytes(bytes)?;
         assert_eq!(decoded, "use 8;\n");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_decodes_utf16_be_bom() -> Result<(), Box<dyn std::error::Error>> {
+        // UTF-16BE BOM followed by "use 8;\n" in big-endian encoding.
+        let bytes = vec![
+            0xFE, 0xFF, // UTF-16BE BOM
+            0x00, b'u', 0x00, b's', 0x00, b'e', 0x00, b' ', 0x00, b'8', 0x00, b';', 0x00, b'\n',
+        ];
+        let decoded = read_source_bytes(bytes)?;
+        assert_eq!(decoded, "use 8;\n");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_decodes_utf16_surrogate_pair() -> Result<(), Box<dyn std::error::Error>> {
+        // UTF-16LE BOM + U+1F600 (grinning face), encoded as surrogate pair
+        // high=0xD83D, low=0xDE00 → LE bytes: 3D D8 00 DE.
+        let bytes = vec![
+            0xFF, 0xFE, // UTF-16LE BOM
+            0x3D, 0xD8, 0x00, 0xDE, // surrogate pair for U+1F600
+        ];
+        let decoded = read_source_bytes(bytes)?;
+        assert_eq!(decoded, "\u{1F600}");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_handles_unpaired_high_surrogate() -> Result<(), Box<dyn std::error::Error>>
+    {
+        // UTF-16LE BOM + lone high surrogate (0xD83D) followed by a valid BMP char 'A' (0x0041).
+        // from_utf16_lossy replaces the unpaired surrogate with U+FFFD.
+        let bytes = vec![
+            0xFF, 0xFE, // UTF-16LE BOM
+            0x3D, 0xD8, // unpaired high surrogate (no low surrogate follows)
+            0x41, 0x00, // 'A'
+        ];
+        let decoded = read_source_bytes(bytes)?;
+        assert_eq!(decoded, "\u{FFFD}A");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_handles_unpaired_low_surrogate() -> Result<(), Box<dyn std::error::Error>>
+    {
+        // UTF-16LE BOM + lone low surrogate (0xDE00) without a preceding high surrogate.
+        let bytes = vec![
+            0xFF, 0xFE, // UTF-16LE BOM
+            0x00, 0xDE, // unpaired low surrogate
+        ];
+        let decoded = read_source_bytes(bytes)?;
+        assert_eq!(decoded, "\u{FFFD}");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_handles_utf16_odd_byte_length() -> Result<(), Box<dyn std::error::Error>> {
+        // UTF-16LE BOM + 'A' (0x41 0x00) + trailing lone byte 0x42.
+        // The loop condition `index + 1 < bytes.len()` drops the trailing byte.
+        let bytes = vec![
+            0xFF, 0xFE, // UTF-16LE BOM
+            0x41, 0x00, // 'A'
+            0x42, // orphan trailing byte — must not panic
+        ];
+        let decoded = read_source_bytes(bytes)?;
+        assert_eq!(decoded, "A");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_handles_utf16_bom_only() -> Result<(), Box<dyn std::error::Error>> {
+        // Just the BOM with no payload — empty string expected, no panic.
+        let decoded = read_source_bytes(vec![0xFF, 0xFE])?;
+        assert_eq!(decoded, "");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_handles_empty_input() -> Result<(), Box<dyn std::error::Error>> {
+        let decoded = read_source_bytes(Vec::new())?;
+        assert_eq!(decoded, "");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_handles_truncated_utf8_multibyte() -> Result<(), Box<dyn std::error::Error>>
+    {
+        // Valid UTF-8 "ab" followed by a truncated 2-byte sequence (0xC3 without continuation).
+        // from_utf8 fails → Windows-1252 fallback kicks in. 0xC3 is undefined in the mapping
+        // table so it falls through to char::from(byte) = U+00C3 ('Ã').
+        let bytes = vec![b'a', b'b', 0xC3];
+        let decoded = read_source_bytes(bytes)?;
+        assert_eq!(decoded, "ab\u{00C3}");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_handles_lone_utf8_continuation_byte()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // 0x80 is a UTF-8 continuation byte with no leader — invalid UTF-8.
+        // Falls through to Windows-1252 which maps 0x80 → U+20AC ('€').
+        let bytes = vec![b'x', 0x80, b'y'];
+        let decoded = read_source_bytes(bytes)?;
+        assert_eq!(decoded, "x\u{20AC}y");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_preserves_null_bytes_in_utf8() -> Result<(), Box<dyn std::error::Error>> {
+        // NUL (0x00) is valid UTF-8 and valid in Rust strings.
+        let bytes = vec![b'a', 0x00, b'b'];
+        let decoded = read_source_bytes(bytes)?;
+        assert_eq!(decoded, "a\u{0000}b");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_maps_undefined_windows_1252_bytes_as_latin1()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Windows-1252 has five undefined slots: 0x81, 0x8D, 0x8F, 0x90, 0x9D.
+        // The fallback's `_` arm maps them via `char::from(byte)` which is Latin-1 (U+00xx).
+        // Combined with a truncated UTF-8 prefix byte to force the fallback path.
+        let bytes = vec![0xC3, 0x81, 0x8D, 0x8F, 0x90, 0x9D];
+        let decoded = read_source_bytes(bytes)?;
+        assert_eq!(decoded, "\u{00C3}\u{0081}\u{008D}\u{008F}\u{0090}\u{009D}");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_handles_utf16_with_embedded_null_code_unit()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // UTF-16LE BOM + 'A' + U+0000 (NUL, as a 16-bit code unit) + 'B'.
+        let bytes = vec![
+            0xFF, 0xFE, // UTF-16LE BOM
+            0x41, 0x00, // 'A'
+            0x00, 0x00, // NUL
+            0x42, 0x00, // 'B'
+        ];
+        let decoded = read_source_bytes(bytes)?;
+        assert_eq!(decoded, "A\u{0000}B");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_rejects_partial_bom_as_not_utf16() -> Result<(), Box<dyn std::error::Error>>
+    {
+        // A single 0xFF byte is neither a full BOM nor valid UTF-8; Windows-1252 fallback
+        // maps 0xFF through the `_` arm to U+00FF ('ÿ').
+        let decoded = read_source_bytes(vec![0xFF])?;
+        assert_eq!(decoded, "\u{00FF}");
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- `read_source_bytes` previously fell back to byte-for-byte single-byte decoding which produced mojibake for common Windows-1252 punctuation and did not handle UTF-16 BOM-encoded inputs.

### Description
- Add UTF-16 BOM detection and decoding via `decode_utf16_with_bom` and try it before UTF-8 decoding in `read_source_bytes`.
- Replace the previous raw-byte fallback with `decode_byte_as_windows_1252` to map the 0x80–0x9F range to correct typographic characters while preserving single-byte behavior for other bytes.
- Update `read_source_bytes` to: try UTF-16 BOM, then `String::from_utf8`, then Windows-1252 fallback.
- Add focused unit tests (UTF-8 preservation, Latin-1 lossless, Windows-1252 punctuation, UTF-16LE BOM) in `crates/perl-parser/src/bin/perl-parse.rs`.

### Testing
- Ran `cargo test -p perl-parser --features cli --bin perl-parse read_source_bytes`, which passed (4 tests).
- Ran `cargo check --all-targets -p perl-parser --features cli`, which passed.
- Ran `cargo clippy -p perl-parser --features cli -- -D warnings`, which passed.
- `just pr-fast` was not run because `just` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea97de19408333bfc087f1b4773ad0)