### PR TITLE
fix(perl-uri): improve mojibake file URI decoding (#0000)

### DIFF
--- a/crates/perl-uri/src/lib.rs
+++ b/crates/perl-uri/src/lib.rs
@@ -78,7 +78,8 @@ pub fn uri_to_fs_path(uri: &str) -> Option<std::path::PathBuf> {
     // Convert to filesystem path using the url crate's built-in method.
     // On Windows, accept rooted file URIs like file:///tmp/test.pl as \tmp\test.pl
     // so cross-platform tests and internal helpers stay permissive.
-    url.to_file_path().ok().or_else(|| windows_rooted_file_uri_to_path(&url))
+    let path = url.to_file_path().ok().or_else(|| windows_rooted_file_uri_to_path(&url))?;
+    Some(repair_path_mojibake(path))
 }
 
 /// Convert a filesystem path to a `file://` URI.
@@ -180,6 +181,52 @@ fn windows_rooted_file_uri_to_path(url: &Url) -> Option<std::path::PathBuf> {
 #[cfg(all(not(target_arch = "wasm32"), not(windows)))]
 fn windows_rooted_file_uri_to_path(_url: &Url) -> Option<std::path::PathBuf> {
     None
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn repair_path_mojibake(path: std::path::PathBuf) -> std::path::PathBuf {
+    let Some(path_text) = path.to_str() else {
+        return path;
+    };
+
+    let repaired = repair_mojibake_text(path_text);
+    if repaired == path_text { path } else { std::path::PathBuf::from(repaired) }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn repair_mojibake_text(text: &str) -> String {
+    if !looks_like_mojibake(text) {
+        return text.to_string();
+    }
+
+    let mut bytes = Vec::with_capacity(text.len());
+    for ch in text.chars() {
+        let code = u32::from(ch);
+        let Ok(byte) = u8::try_from(code) else {
+            return text.to_string();
+        };
+        bytes.push(byte);
+    }
+
+    let Ok(candidate) = String::from_utf8(bytes) else {
+        return text.to_string();
+    };
+
+    if mojibake_marker_count(&candidate) < mojibake_marker_count(text) {
+        candidate
+    } else {
+        text.to_string()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn looks_like_mojibake(text: &str) -> bool {
+    mojibake_marker_count(text) > 0
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn mojibake_marker_count(text: &str) -> usize {
+    text.chars().filter(|ch| matches!(ch, 'Ã' | 'Â' | 'â' | 'ð' | '�')).count()
 }
 
 /// Normalize a URI to a consistent form.
@@ -330,6 +377,13 @@ mod tests {
             let path = must_some(path);
             let path_str = path.to_string_lossy();
             assert!(path_str.contains("path with spaces"));
+        }
+
+        #[test]
+        fn test_uri_to_fs_path_repairs_common_mojibake() {
+            let path = must_some(uri_to_fs_path("file:///tmp/caf%C3%83%C2%A9.pl"));
+            let path_str = path.to_string_lossy();
+            assert!(path_str.contains("café.pl"), "expected repaired UTF-8 path, got {path_str}");
         }
 
         #[test]


### PR DESCRIPTION
### Motivation
- Some percent-encoded `file://` URIs can decode into mojibake (double-encoded UTF-8) which produces garbled filesystem paths and causes lookup mismatches for non-ASCII filenames. 
- Repair should be conservative and only applied when it plausibly reduces mojibake noise rather than unconditionally mutating paths.

### Description
- Pass successful `Url::to_file_path()` results through a new `repair_path_mojibake` step in `uri_to_fs_path` to attempt recovery of common mojibake cases. 
- Add helper utilities `looks_like_mojibake`, `mojibake_marker_count`, `repair_mojibake_text`, and `repair_path_mojibake` that reinterpret single-byte codepoints as bytes and accept the candidate only when marker count is reduced. 
- Add a focused regression test verifying a common double-encoded example (`file:///tmp/caf%C3%83%C2%A9.pl`) is repaired to a path containing `café.pl`.

### Testing
- Ran `cargo test -p perl-uri` and all unit and doc tests passed. 
- Ran `cargo check --all-targets -p perl-uri` and it completed successfully. 
- Ran `cargo clippy -p perl-uri --all-targets -- -D warnings` and no warnings were reported. 
- Ran `cargo xtask fmt` to format the workspace and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea97de19408333bfc087f1b4773ad0)