### PR TITLE
fix(runtime): improve source path handling for raw absolute paths (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/mod.rs
@@ -121,9 +121,12 @@ use perl_position_tracking::{WireLocation, WirePosition, WireRange};
 use crate::fallback::text::extract_text_based_symbols;
 
 pub(super) fn source_path_from_uri(uri: &str) -> Option<PathBuf> {
-    Url::parse(uri)
-        .ok()
-        .and_then(|value| if value.scheme() == "file" { value.to_file_path().ok() } else { None })
+    if let Ok(value) = Url::parse(uri) {
+        return if value.scheme() == "file" { value.to_file_path().ok() } else { None };
+    }
+
+    let path = Path::new(uri);
+    if path.is_absolute() { Some(path.to_path_buf()) } else { None }
 }
 
 fn workspace_folder_path(folder: &WorkspaceFolderState) -> Option<PathBuf> {
@@ -862,6 +865,21 @@ mod tests {
             &folder,
             "vscode-remote://ssh-remote+dev/workspace-other/lib/Foo.pm"
         ));
+    }
+
+    #[test]
+    fn source_path_from_uri_accepts_absolute_filesystem_paths()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let path = std::env::current_dir()?.join("lib/Foo.pm");
+        let raw_path = path.to_string_lossy();
+
+        assert_eq!(source_path_from_uri(raw_path.as_ref()), Some(path));
+        Ok(())
+    }
+
+    #[test]
+    fn source_path_from_uri_rejects_relative_filesystem_paths() {
+        assert_eq!(source_path_from_uri("lib/Foo.pm"), None);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- `source_path_from_uri` only converted parseable `file://` URIs and ignored raw absolute filesystem paths, causing runtime flows that receive plain absolute paths to miss them.

### Description
- Update `source_path_from_uri` to attempt `Url::parse` first and then fall back to treating non-URI absolute inputs as filesystem paths using `Path::is_absolute()` and `Path::to_path_buf()`.
- Add unit tests `source_path_from_uri_accepts_absolute_filesystem_paths` and `source_path_from_uri_rejects_relative_filesystem_paths` to cover the new behavior.

### Testing
- Ran `cargo check -p perl-lsp-rs --lib`, which succeeded.
- Ran `cargo test -p perl-lsp-rs source_path_from_uri -- --nocapture`, which did not complete due to pre-existing, unrelated compilation errors in other tests; failures are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea97ef0e38833388c1436fed6bbf77)