### PR TITLE
fix(execute-command): improve file URI path normalization (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/execute_command/provider.rs
+++ b/crates/perl-lsp-rs/src/execute_command/provider.rs
@@ -1,5 +1,6 @@
 use crate::perl_critic::{BuiltInAnalyzer, CriticAnalyzer, CriticConfig};
 use serde_json::{Value, json};
+use std::borrow::Cow;
 #[cfg(windows)]
 use std::ffi::OsString;
 #[cfg(windows)]
@@ -8,6 +9,7 @@ use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::path::{Component, Prefix};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use url::Url;
 
 /// Strip the Windows extended-length path prefix (`\\?\`) before passing a path
 /// to an external command such as `perl`, `prove`, or `yath`.
@@ -336,12 +338,13 @@ impl ExecuteCommandProvider {
     #[allow(deprecated)]
     pub(crate) fn run_critic(&self, file_path: &str) -> Result<Value, String> {
         let normalized_path = self.normalize_file_path(file_path);
-        let path = Path::new(normalized_path);
+        let path = Path::new(normalized_path.as_ref());
 
         if !path.exists() {
-            return Ok(
-                self.format_critic_error(format!("File not found: {}", normalized_path), "none")
-            );
+            return Ok(self.format_critic_error(
+                format!("File not found: {}", normalized_path.as_ref()),
+                "none",
+            ));
         }
 
         if command_exists("perlcritic") {
@@ -843,8 +846,18 @@ impl ExecuteCommandProvider {
 
     #[deprecated(since = "0.8.9", note = "Use resolve_path_from_args for secure path resolution")]
     #[allow(dead_code)]
-    pub(crate) fn normalize_file_path<'a>(&self, file_path: &'a str) -> &'a str {
-        file_path.strip_prefix("file://").unwrap_or(file_path)
+    pub(crate) fn normalize_file_path<'a>(&self, file_path: &'a str) -> Cow<'a, str> {
+        if !file_path.starts_with("file://") {
+            return Cow::Borrowed(file_path);
+        }
+
+        if let Ok(url) = Url::parse(file_path)
+            && let Ok(path) = url.to_file_path()
+        {
+            return Cow::Owned(path.to_string_lossy().into_owned());
+        }
+
+        Cow::Borrowed(file_path.strip_prefix("file://").unwrap_or(file_path))
     }
 
     pub(crate) fn format_violation(

--- a/crates/perl-lsp-rs/src/execute_command/tests.rs
+++ b/crates/perl-lsp-rs/src/execute_command/tests.rs
@@ -608,25 +608,38 @@ fn test_parameter_validation_missing_subroutine_name() -> Result<(), Box<dyn std
 fn test_normalize_file_path_uri_handling() {
     let provider = ExecuteCommandProvider::new();
 
-    // Test file:// URI scheme stripping
-    let normalized = provider.normalize_file_path("file:///tmp/test.pl");
-    assert_eq!(normalized, "/tmp/test.pl", "Should strip file:// prefix");
-
-    // Test regular path (no URI scheme)
-    let normalized = provider.normalize_file_path("/tmp/test.pl");
-    assert_eq!(normalized, "/tmp/test.pl", "Should leave regular paths unchanged");
-
     // Test empty string
     let normalized = provider.normalize_file_path("");
     assert_eq!(normalized, "", "Should handle empty strings");
 
-    // Test file URI decoding
-    let normalized = provider.normalize_file_path("file:///tmp/path%20with%20spaces/test.pl");
-    assert_eq!(normalized, "/tmp/path with spaces/test.pl", "Should decode file URI path");
+    // Test regular path without URI scheme (platform-neutral: just passes through)
+    let normalized = provider.normalize_file_path("some/relative/path.pl");
+    assert_eq!(normalized, "some/relative/path.pl", "Should leave non-URI paths unchanged");
 
-    // Test localhost authority in file URI
-    let normalized = provider.normalize_file_path("file://localhost/tmp/test.pl");
-    assert_eq!(normalized, "/tmp/test.pl", "Should support localhost file URI");
+    // Unix-specific assertions: file:// URI decoding produces Unix-style paths
+    #[cfg(unix)]
+    {
+        // Test file:// URI scheme stripping
+        let normalized = provider.normalize_file_path("file:///tmp/test.pl");
+        assert_eq!(normalized, "/tmp/test.pl", "Should strip file:// prefix");
+
+        // Test regular absolute path (no URI scheme)
+        let normalized = provider.normalize_file_path("/tmp/test.pl");
+        assert_eq!(normalized, "/tmp/test.pl", "Should leave regular paths unchanged");
+
+        // Test file URI decoding
+        let normalized =
+            provider.normalize_file_path("file:///tmp/path%20with%20spaces/test.pl");
+        assert_eq!(
+            normalized,
+            "/tmp/path with spaces/test.pl",
+            "Should decode file URI path"
+        );
+
+        // Test localhost authority in file URI
+        let normalized = provider.normalize_file_path("file://localhost/tmp/test.pl");
+        assert_eq!(normalized, "/tmp/test.pl", "Should support localhost file URI");
+    }
 }
 
 #[test]
@@ -1057,22 +1070,30 @@ fn test_format_functions_not_default() -> Result<(), Box<dyn std::error::Error>>
 fn test_normalize_file_path_not_hardcoded() {
     let provider = ExecuteCommandProvider::new();
 
-    // Test that normalize_file_path returns actual processed values, not hardcoded ones
-    let file_uri = "file:///home/user/test.pl";
-    let result = provider.normalize_file_path(file_uri);
-    assert_eq!(result, "/home/user/test.pl", "Should properly strip file:// prefix");
+    // Non-URI passthrough: a plain path without file:// scheme is returned unchanged.
+    let plain = "not-a-uri.pl";
+    let result = provider.normalize_file_path(plain);
+    assert_eq!(result, plain, "Should return input unchanged for non-URI paths");
     assert_ne!(result, "", "Should not return empty string");
     assert_ne!(result, "xyzzy", "Should not return hardcoded value");
 
-    let regular_path = "/home/user/test.pl";
-    let result = provider.normalize_file_path(regular_path);
-    assert_eq!(result, regular_path, "Should return input unchanged");
-    assert_ne!(result, "", "Should not return empty string");
-    assert_ne!(result, "xyzzy", "Should not return hardcoded value");
+    // Unix-specific: to_file_path() returns Unix-style paths only on Unix.
+    #[cfg(unix)]
+    {
+        let file_uri = "file:///home/user/test.pl";
+        let result = provider.normalize_file_path(file_uri);
+        assert_eq!(result, "/home/user/test.pl", "Should properly strip file:// prefix");
+        assert_ne!(result, "", "Should not return empty string");
+        assert_ne!(result, "xyzzy", "Should not return hardcoded value");
 
-    let encoded_file_uri = "file:///home/user/my%20test.pl";
-    let result = provider.normalize_file_path(encoded_file_uri);
-    assert_eq!(result, "/home/user/my test.pl", "Should decode URI escaped characters");
+        let regular_path = "/home/user/test.pl";
+        let result = provider.normalize_file_path(regular_path);
+        assert_eq!(result, regular_path, "Should return input unchanged");
+
+        let encoded_file_uri = "file:///home/user/my%20test.pl";
+        let result = provider.normalize_file_path(encoded_file_uri);
+        assert_eq!(result, "/home/user/my test.pl", "Should decode URI escaped characters");
+    }
 }
 
 #[test]

--- a/crates/perl-lsp-rs/src/execute_command/tests.rs
+++ b/crates/perl-lsp-rs/src/execute_command/tests.rs
@@ -619,6 +619,14 @@ fn test_normalize_file_path_uri_handling() {
     // Test empty string
     let normalized = provider.normalize_file_path("");
     assert_eq!(normalized, "", "Should handle empty strings");
+
+    // Test file URI decoding
+    let normalized = provider.normalize_file_path("file:///tmp/path%20with%20spaces/test.pl");
+    assert_eq!(normalized, "/tmp/path with spaces/test.pl", "Should decode file URI path");
+
+    // Test localhost authority in file URI
+    let normalized = provider.normalize_file_path("file://localhost/tmp/test.pl");
+    assert_eq!(normalized, "/tmp/test.pl", "Should support localhost file URI");
 }
 
 #[test]
@@ -1061,6 +1069,10 @@ fn test_normalize_file_path_not_hardcoded() {
     assert_eq!(result, regular_path, "Should return input unchanged");
     assert_ne!(result, "", "Should not return empty string");
     assert_ne!(result, "xyzzy", "Should not return hardcoded value");
+
+    let encoded_file_uri = "file:///home/user/my%20test.pl";
+    let result = provider.normalize_file_path(encoded_file_uri);
+    assert_eq!(result, "/home/user/my test.pl", "Should decode URI escaped characters");
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- `normalize_file_path` previously only stripped a literal `file://` prefix, which did not decode percent-encoded segments or correctly handle authority-form URIs such as `file://localhost/...`.

### Description
- Change `normalize_file_path` to return `Cow<'a, str>` and parse `file://` inputs with `url::Url` using `to_file_path` so filesystem paths are decoded and returned when possible.
- Update `run_critic` to use `normalized_path.as_ref()` when constructing a `Path` and when formatting error messages to work with the new `Cow` return type.
- Add unit tests in `crates/perl-lsp-rs/src/execute_command/tests.rs` to verify URI-decoding, `file://localhost` handling, and percent-encoded characters.
- Add imports for `std::borrow::Cow` and `url::Url` and keep a safe fallback of simple prefix-stripping when URL conversion fails.

### Testing
- Ran `cargo fmt -p perl-lsp-rs`, which passed.
- Ran `cargo check -p perl-lsp-rs --lib`, which passed.
- Attempted `cargo check --all-targets -p perl-lsp-rs` and `cargo test -p perl-lsp-rs normalize_file_path -- --nocapture`, which failed to complete due to pre-existing unrelated generic `Result` signature errors in `crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea97ef0e38833388c1436fed6bbf77)