### PR TITLE
fix(master): combined unblock for lifecycle.rs compile + parser_tests fmt (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -149,37 +149,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn initialized_requires_initialize_request_first() -> Result<()> {
+    fn initialized_requires_initialize_request_first() {
         let server = LspServer::new();
 
         let result = server.handle_initialized_dispatch();
 
         assert!(result.is_err(), "initialized before initialize must error");
         assert!(!server.is_initialized(), "server must remain uninitialized");
-        Ok(())
     }
 
     #[test]
-    fn initialized_can_only_be_sent_once() -> Result<()> {
+    fn initialized_can_only_be_sent_once() {
         let server = LspServer::new();
-        server.handle_initialize(None)?;
+        server.handle_initialize(None).expect("initialize request should succeed");
 
         let first = server.handle_initialized_dispatch();
         let second = server.handle_initialized_dispatch();
 
         assert!(first.is_ok(), "first initialized must succeed");
         assert!(second.is_err(), "second initialized must error");
-        Ok(())
     }
 
     #[test]
-    fn auto_initialize_for_compat_promotes_initialized_state() -> Result<()> {
+    fn auto_initialize_for_compat_promotes_initialized_state() {
         let server = LspServer::new();
-        server.handle_initialize(None)?;
+        server.handle_initialize(None).expect("initialize request should succeed");
 
         server.auto_initialize_for_compat("textDocument/hover");
 
         assert!(server.is_initialized(), "compatibility path should mark server initialized");
-        Ok(())
     }
 }

--- a/crates/perl-parser-core/tests/parser_tests.rs
+++ b/crates/perl-parser-core/tests/parser_tests.rs
@@ -160,7 +160,8 @@ fn parse_package_declaration_with_trailing_separator() -> Result<(), Box<dyn std
 }
 
 #[test]
-fn parse_package_declaration_with_trailing_separator_and_block() -> Result<(), Box<dyn std::error::Error>> {
+fn parse_package_declaration_with_trailing_separator_and_block()
+-> Result<(), Box<dyn std::error::Error>> {
     let mut parser = Parser::new("package My::App:: { my $x = 1; }");
     let ast = must(parser.parse());
 

--- a/crates/perl-parser-core/tests/parser_tests.rs
+++ b/crates/perl-parser-core/tests/parser_tests.rs
@@ -160,8 +160,8 @@ fn parse_package_declaration_with_trailing_separator() -> Result<(), Box<dyn std
 }
 
 #[test]
-fn parse_package_declaration_with_trailing_separator_and_block()
--> Result<(), Box<dyn std::error::Error>> {
+fn parse_package_declaration_with_trailing_separator_and_block(
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut parser = Parser::new("package My::App:: { my $x = 1; }");
     let ast = must(parser.parse());
 

--- a/crates/perl-parser-core/tests/parser_tests.rs
+++ b/crates/perl-parser-core/tests/parser_tests.rs
@@ -160,8 +160,8 @@ fn parse_package_declaration_with_trailing_separator() -> Result<(), Box<dyn std
 }
 
 #[test]
-fn parse_package_declaration_with_trailing_separator_and_block(
-) -> Result<(), Box<dyn std::error::Error>> {
+fn parse_package_declaration_with_trailing_separator_and_block()
+-> Result<(), Box<dyn std::error::Error>> {
     let mut parser = Parser::new("package My::App:: { my $x = 1; }");
     let ast = must(parser.parse());
 


### PR DESCRIPTION
Split `parse_package_declaration_with_trailing_separator_and_block()` signature across 2 lines (100+ char width). Unblocks PR Smoke fmt check on master.

This is a master-level fmt cascade from #5395 landing without the split.