### PR TITLE
fix(fmt): apply rustfmt to perl-parser incremental_v2.rs (#0000)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_v2.rs
+++ b/crates/perl-parser/src/incremental/incremental_v2.rs
@@ -450,7 +450,13 @@ impl IncrementalParserV2 {
             // - old source text being replaced
             // - new source text inserted by the edit
             // If either side introduces structural tokens, fall back.
-            if !self.is_edit_non_structural(tree, source, edit.start_byte, edit.old_end_byte, edit.new_end_byte) {
+            if !self.is_edit_non_structural(
+                tree,
+                source,
+                edit.start_byte,
+                edit.old_end_byte,
+                edit.new_end_byte,
+            ) {
                 return false;
             }
         }
@@ -1897,10 +1903,7 @@ if ($condition) {
         parser.parse(source2)?;
 
         assert!(parser.reused_nodes > 0, "Whitespace insertion should reuse prior tree");
-        assert!(
-            parser.reparsed_nodes <= 1,
-            "Whitespace insertion should avoid broad reparsing"
-        );
+        assert!(parser.reparsed_nodes <= 1, "Whitespace insertion should avoid broad reparsing");
         Ok(())
     }
 
@@ -1994,7 +1997,14 @@ if ($condition) {
         let mut parser = IncrementalParserV2::new();
         let source1 = "my $x = 42;";
         parser.parse(source1)?;
-        parser.edit(Edit::new(6, 6, 9, Position::new(6, 1, 7), Position::new(6, 1, 7), Position::new(9, 1, 10)));
+        parser.edit(Edit::new(
+            6,
+            6,
+            9,
+            Position::new(6, 1, 7),
+            Position::new(6, 1, 7),
+            Position::new(9, 1, 10),
+        ));
         let source2 = "my $x   = 42;";
         parser.parse(source2)?;
         assert!(parser.reused_nodes > 0);
@@ -2006,7 +2016,14 @@ if ($condition) {
         let mut parser = IncrementalParserV2::new();
         let source1 = "my $x = 42;";
         parser.parse(source1)?;
-        parser.edit(Edit::new(10, 11, 24, Position::new(10, 1, 11), Position::new(11, 1, 12), Position::new(24, 1, 25)));
+        parser.edit(Edit::new(
+            10,
+            11,
+            24,
+            Position::new(10, 1, 11),
+            Position::new(11, 1, 12),
+            Position::new(24, 1, 25),
+        ));
         let source2 = "my $x = 42; # comment";
         parser.parse(source2)?;
         assert!(parser.reused_nodes > 0);
@@ -2018,7 +2035,14 @@ if ($condition) {
         let mut parser = IncrementalParserV2::new();
         let source1 = "my $x = 42;";
         parser.parse(source1)?;
-        parser.edit(Edit::new(11, 11, 16, Position::new(11, 1, 12), Position::new(11, 1, 12), Position::new(16, 1, 17)));
+        parser.edit(Edit::new(
+            11,
+            11,
+            16,
+            Position::new(11, 1, 12),
+            Position::new(11, 1, 12),
+            Position::new(16, 1, 17),
+        ));
         let source2 = "my $x = 42;     ";
         parser.parse(source2)?;
         assert!(parser.reused_nodes > 0);
@@ -2030,7 +2054,14 @@ if ($condition) {
         let mut parser = IncrementalParserV2::new();
         let source1 = "my $x = 42;";
         parser.parse(source1)?;
-        parser.edit(Edit::new(11, 11, 12, Position::new(11, 1, 12), Position::new(11, 1, 12), Position::new(12, 2, 1)));
+        parser.edit(Edit::new(
+            11,
+            11,
+            12,
+            Position::new(11, 1, 12),
+            Position::new(11, 1, 12),
+            Position::new(12, 2, 1),
+        ));
         let source2 = "my $x = 42;\n";
         parser.parse(source2)?;
         assert!(parser.reused_nodes > 0);
@@ -2042,7 +2073,14 @@ if ($condition) {
         let mut parser = IncrementalParserV2::new();
         let source1 = "my  $x  =  42;";
         parser.parse(source1)?;
-        parser.edit(Edit::new(3, 5, 4, Position::new(3, 1, 4), Position::new(5, 1, 6), Position::new(4, 1, 5)));
+        parser.edit(Edit::new(
+            3,
+            5,
+            4,
+            Position::new(3, 1, 4),
+            Position::new(5, 1, 6),
+            Position::new(4, 1, 5),
+        ));
         let source2 = "my $x  =  42;";
         parser.parse(source2)?;
         assert!(parser.reused_nodes > 0);
@@ -2054,7 +2092,14 @@ if ($condition) {
         let mut parser = IncrementalParserV2::new();
         let source1 = "print 'hello';my $x = 42;";
         parser.parse(source1)?;
-        parser.edit(Edit::new(14, 14, 15, Position::new(14, 1, 15), Position::new(14, 1, 15), Position::new(15, 1, 16)));
+        parser.edit(Edit::new(
+            14,
+            14,
+            15,
+            Position::new(14, 1, 15),
+            Position::new(14, 1, 15),
+            Position::new(15, 1, 16),
+        ));
         let source2 = "print 'hello'; my $x = 42;";
         parser.parse(source2)?;
         assert!(parser.reused_nodes > 0);
@@ -2066,7 +2111,14 @@ if ($condition) {
         let mut parser = IncrementalParserV2::new();
         let source1 = "my $x = 42;";
         parser.parse(source1)?;
-        parser.edit(Edit::new(6, 7, 8, Position::new(6, 1, 7), Position::new(7, 1, 8), Position::new(8, 1, 9)));
+        parser.edit(Edit::new(
+            6,
+            7,
+            8,
+            Position::new(6, 1, 7),
+            Position::new(7, 1, 8),
+            Position::new(8, 1, 9),
+        ));
         let source2 = "my $x=  42;";
         parser.parse(source2)?;
         assert!(parser.reused_nodes > 0);


### PR DESCRIPTION
## Summary

Apply rustfmt to resolve pre-existing formatting drift in `crates/perl-parser/src/incremental/incremental_v2.rs` introduced by merged PR #5467. Unblocks CI fmt checks on master for the perl-parser crate.

## Changes

- Wrap multi-argument `is_edit_non_structural` call onto separate lines
- Wrap multi-argument `Edit::new` / `parser.edit` test call-sites
- Collapse short `assert!` macros onto single lines where they fit

## Verification

- `cargo fmt -p perl-parser -- --check` — clean after fix
- `cargo check -p perl-parser` — compiles cleanly

## Test plan
- [ ] CI fmt check passes
- [ ] CI build check passes
- [ ] `cargo fmt -p perl-parser -- --check` clean