### PR TITLE
fix(position-tracking): clamp mid-codepoint UTF-16 offsets (#0000)

### DIFF
--- a/crates/perl-position-tracking/src/convert.rs
+++ b/crates/perl-position-tracking/src/convert.rs
@@ -36,7 +36,9 @@ pub fn offset_to_utf16_line_col(text: &str, offset: usize) -> (u32, u32) {
             while cs > 0 && !line.is_char_boundary(cs) {
                 cs -= 1;
             }
-            return (line_idx as u32, line[..cs].encode_utf16().count() as u32 + 1);
+            // Clamp to the previous Unicode scalar boundary.
+            // Returning a half-surrogate UTF-16 column would violate LSP invariants.
+            return (line_idx as u32, line[..cs].encode_utf16().count() as u32);
         }
         acc = next;
     }
@@ -79,6 +81,17 @@ pub fn utf16_line_col_to_offset(text: &str, line: u32, col: u32) -> usize {
 #[cfg(test)]
 mod tests {
     use super::{offset_to_utf16_line_col, utf16_line_col_to_offset};
+
+    #[test]
+    fn offset_to_utf16_clamps_mid_codepoint_offsets_to_previous_boundary() {
+        let text = "💖z";
+
+        // Byte offset 1 sits inside the first UTF-8 codepoint (the emoji).
+        // The reported UTF-16 column must stay on a valid boundary (0 or 2).
+        assert_eq!(offset_to_utf16_line_col(text, 1), (0, 0));
+        assert_eq!(offset_to_utf16_line_col(text, 2), (0, 0));
+        assert_eq!(offset_to_utf16_line_col(text, 3), (0, 0));
+    }
 
     #[test]
     fn offset_to_utf16_handles_multibyte_and_surrogate_pairs() {


### PR DESCRIPTION
### Motivation
- Prevent `offset_to_utf16_line_col` from returning a half-surrogate / invalid UTF-16 column when a byte offset falls inside a multibyte UTF-8 codepoint, which would violate LSP position invariants.

### Description
- Modify `crates/perl-position-tracking/src/convert.rs` to clamp non-char-boundary offsets to the previous Unicode scalar boundary (remove the previous `+ 1` behavior) so the returned UTF-16 column is always on a valid boundary and add a regression test `offset_to_utf16_clamps_mid_codepoint_offsets_to_previous_boundary` that verifies mid-codepoint byte offsets map to a valid UTF-16 boundary.

### Testing
- Ran `cargo test -p perl-position-tracking`, `cargo check --all-targets -p perl-position-tracking`, and `cargo clippy -p perl-position-tracking --all-targets -- -D warnings`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa05fa954833385161e44b178c4f3)