### PR TITLE
fix(perl-symbol): improve UTF-16 surrogate offset mapping (#0000)

### DIFF
--- a/crates/perl-symbol/src/cursor/mod.rs
+++ b/crates/perl-symbol/src/cursor/mod.rs
@@ -102,10 +102,14 @@ pub fn is_modchar(byte: u8) -> bool {
 pub fn byte_offset_utf16(line_text: &str, col_utf16: usize) -> usize {
     let mut units = 0;
     for (i, ch) in line_text.char_indices() {
-        if units == col_utf16 {
+        if units >= col_utf16 {
             return i;
         }
-        units += if ch as u32 >= 0x10000 { 2 } else { 1 };
+        let ch_units = if ch as u32 >= 0x10000 { 2 } else { 1 };
+        units += ch_units;
+        if units > col_utf16 {
+            return i;
+        }
     }
     line_text.len()
 }
@@ -172,6 +176,7 @@ mod tests {
         let line = "A😀B";
         assert_eq!(byte_offset_utf16(line, 0), 0);
         assert_eq!(byte_offset_utf16(line, 1), 1);
+        assert_eq!(byte_offset_utf16(line, 2), 1);
         assert_eq!(byte_offset_utf16(line, 3), 5);
         assert_eq!(byte_offset_utf16(line, 4), 6);
     }


### PR DESCRIPTION
### Motivation
- Prevent UTF-16 cursor columns that fall inside a surrogate pair from mapping to end-of-line by clamping such mid-surrogate columns to the character start.

### Description
- Adjusted `byte_offset_utf16` in `crates/perl-symbol/src/cursor/mod.rs` to return the byte index for the current character when a UTF-16 column lands inside a surrogate pair and added a regression assertion for `byte_offset_utf16("A😀B", 2) == 1`.

### Testing
- Ran `cargo test -p perl-symbol`, `cargo check --all-targets -p perl-symbol`, `cargo clippy -p perl-symbol --all-targets -- -D warnings`, and `cargo xtask fmt`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa05fa954833385161e44b178c4f3)