### PR TITLE
feat(textdoc): add UTF-32 position encoding support (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/textdoc.rs
+++ b/crates/perl-lsp-rs/src/textdoc.rs
@@ -29,7 +29,7 @@ pub struct Doc {
 
 /// Position encoding format for LSP compatibility
 ///
-/// LSP uses UTF-16 code units for positions, while Rust strings are UTF-8.
+/// LSP uses UTF-16 code units for positions by default, while Rust strings are UTF-8.
 /// This enum determines how position conversions are performed.
 #[derive(Clone, Copy)]
 pub enum PosEnc {
@@ -37,6 +37,8 @@ pub enum PosEnc {
     Utf16,
     /// UTF-8 encoding (Rust native) - counts UTF-8 bytes
     Utf8,
+    /// UTF-32 encoding - counts Unicode scalar values (Rust `char`s)
+    Utf32,
 }
 
 /// Convert LSP position to char index with UTF-16/UTF-8 encoding support
@@ -91,6 +93,12 @@ pub fn lsp_pos_to_char(rope: &Rope, pos: Position, enc: PosEnc) -> usize {
                 char_idx += 1;
             }
             char_idx
+        }
+        PosEnc::Utf32 => {
+            // UTF-32: pos.character is scalar value offset
+            // Rope indices are scalar-value-based chars, so this is direct clamping.
+            let line_chars = line_slice.chars().count();
+            (pos.character as usize).min(line_chars)
         }
     };
 
@@ -149,6 +157,10 @@ pub fn byte_to_lsp_pos(rope: &Rope, byte: usize, enc: PosEnc) -> Position {
             // UTF-16: return UTF-16 code unit count from start of line
             let line_slice = rope.line(line);
             line_slice.chars().take(col_chars).map(|c| c.len_utf16() as u32).sum()
+        }
+        PosEnc::Utf32 => {
+            // UTF-32: return scalar value count from start of line
+            col_chars as u32
         }
     };
 

--- a/crates/perl-lsp-rs/tests/utf32_position_validation.rs
+++ b/crates/perl-lsp-rs/tests/utf32_position_validation.rs
@@ -1,0 +1,26 @@
+use lsp_types::Position;
+use perl_lsp::textdoc::{PosEnc, byte_to_lsp_pos, lsp_pos_to_byte};
+use ropey::Rope;
+
+#[test]
+fn utf32_position_counts_scalars_for_non_bmp_chars() {
+    let rope = Rope::from_str("hi \u{1F600}x");
+
+    // UTF-32 counts scalar values, so 'x' is at scalar column 4.
+    let pos = Position { line: 0, character: 4 };
+    let byte = lsp_pos_to_byte(&rope, pos, PosEnc::Utf32);
+
+    assert_eq!(byte, 7);
+}
+
+#[test]
+fn utf32_roundtrip_byte_to_position_to_byte() {
+    let rope = Rope::from_str("a\u{1F600}b");
+    let byte = 5; // 'b'
+
+    let pos = byte_to_lsp_pos(&rope, byte, PosEnc::Utf32);
+    assert_eq!(pos.character, 2);
+
+    let back = lsp_pos_to_byte(&rope, pos, PosEnc::Utf32);
+    assert_eq!(back, byte);
+}


### PR DESCRIPTION
### Motivation
- Position conversion utilities only supported UTF-8 and UTF-16 semantics, leaving editors or tools that want UTF-32 (Unicode scalar) column semantics unsupported.

### Description
- Added `PosEnc::Utf32` variant to the `PosEnc` enum to represent UTF-32 / Unicode scalar-value column semantics.
- Implemented UTF-32 handling in `lsp_pos_to_char` so LSP positions interpreted as scalar indices map correctly to rope char indices.
- Implemented UTF-32 handling in `byte_to_lsp_pos` so byte→LSP position conversions can return scalar-value column counts.
- Added focused integration tests in `crates/perl-lsp-rs/tests/utf32_position_validation.rs` that validate scalar counting for non-BMP characters and a byte→pos→byte roundtrip under UTF-32 semantics.

### Testing
- Ran `cargo fmt --all` and formatting completed successfully.
- Ran `cargo check -p perl-lsp-rs --lib` and `cargo clippy -p perl-lsp-rs --lib -- -D warnings` which completed successfully for the modified crate.
- Ran `cargo test -p perl-lsp-rs --test utf32_position_validation --test utf16_position_validation` and all tests passed (UTF-32 tests passed and existing UTF-16 tests remained green).
- Ran `cargo check --all-targets -p perl-lsp-rs` which failed due to pre-existing unrelated test-signature errors in other test modules, not related to the UTF-32 changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa074b3d08333b6c8679588736564)