### PR TITLE
fix(perl-module): support legacy ASCII separators in parent/base references (#0000)

### DIFF
--- a/crates/perl-module/src/reference/mod.rs
+++ b/crates/perl-module/src/reference/mod.rs
@@ -147,12 +147,13 @@ fn find_parent_base_module_in_line<'a>(
         }
 
         let token_start_in_args = i;
-        let token_end_in_args = scan_canonical_module_token(bytes, i);
+        let token_end_in_args = scan_module_token(bytes, i);
         let token_start_in_line = args_start_in_line + token_start_in_args;
         let token_end_in_line = args_start_in_line + token_end_in_args;
         let module_name = &args_area[token_start_in_args..token_end_in_args];
 
         let is_module_like = module_name.contains("::")
+            || module_name.contains('\'')
             || module_name.as_bytes().first().is_some_and(u8::is_ascii_uppercase);
 
         if is_module_like
@@ -173,7 +174,7 @@ fn find_parent_base_module_in_line<'a>(
     None
 }
 
-fn scan_canonical_module_token(bytes: &[u8], start: usize) -> usize {
+fn scan_module_token(bytes: &[u8], start: usize) -> usize {
     let mut i = start;
 
     loop {
@@ -188,9 +189,19 @@ fn scan_canonical_module_token(bytes: &[u8], start: usize) -> usize {
             && is_module_start_byte(bytes[i + 2])
         {
             i += 2;
-        } else {
-            break;
+            continue;
         }
+
+        if i < bytes.len()
+            && bytes[i] == b'\''
+            && i + 1 < bytes.len()
+            && is_module_start_byte(bytes[i + 1])
+        {
+            i += 1;
+            continue;
+        }
+
+        break;
     }
 
     i

--- a/crates/perl-module/tests/module_reference_integration.rs
+++ b/crates/perl-module/tests/module_reference_integration.rs
@@ -62,6 +62,19 @@ fn extended_extracts_parent_module_and_converts_to_path() {
 }
 
 #[test]
+fn extended_extracts_legacy_ascii_separator_module_from_parent_qw() {
+    let line = "use parent qw(Base'Class Other'Parent);";
+    let cursor = line.find("Other'Parent").unwrap_or(0);
+
+    let reference = find_module_reference_extended(line, cursor);
+    assert!(reference.is_some());
+    if let Some(reference) = reference {
+        let canonical = reference.canonical_module_name();
+        assert_eq!(canonical, "Other::Parent");
+        assert_eq!(module_name_to_path(&canonical), "Other/Parent.pm");
+    }
+}
+#[test]
 fn extended_extracts_base_module_and_converts_to_path() {
     let line = "use base 'Exporter';";
     let cursor = line.find("Exporter").unwrap_or(0);


### PR DESCRIPTION
### Motivation

- `find_module_reference_extended` only scanned canonical `::` separators in `use parent`/`use base` argument lists, so legacy ASCII tick separators (`'`) were not recognized as module references.
- This made cursor-based module extraction and subsequent canonicalization fail for legacy-style module names inside `parent`/`base` `qw(...)` lists.

### Description

- Replaced the canonical-only scanner with `scan_module_token` in `crates/perl-module/src/reference/mod.rs` to accept both `::` and legacy ASCII tick (`'`) separators when scanning argument lists.
- Treated tokens containing a `'` as module-like by updating the `is_module_like` check so legacy separators are recognized for extraction.
- Added an integration test `extended_extracts_legacy_ascii_separator_module_from_parent_qw` in `crates/perl-module/tests/module_reference_integration.rs` that verifies extraction and canonicalization of legacy `'`-separated modules inside `use parent qw(...)`.

### Testing

- `cargo test -p perl-module` completed successfully with all tests passing.
- `cargo test -p perl-module --test module_reference_integration` completed successfully and the new integration test passed.
- `cargo check --all-targets -p perl-module` completed successfully.
- `cargo clippy -p perl-module --all-targets` completed (reports only pre-existing warnings unrelated to this change) and `cargo xtask fmt` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa079b3e483339958abeb446b6c2a)