### PR TITLE
fix(perl-module): support ASCII legacy separators in parent/base scan (#0000)

### DIFF
--- a/crates/perl-module/src/reference/mod.rs
+++ b/crates/perl-module/src/reference/mod.rs
@@ -188,9 +188,19 @@ fn scan_canonical_module_token(bytes: &[u8], start: usize) -> usize {
             && is_module_start_byte(bytes[i + 2])
         {
             i += 2;
-        } else {
-            break;
+            continue;
         }
+
+        if i < bytes.len()
+            && bytes[i] == b'\''
+            && i + 1 < bytes.len()
+            && is_module_start_byte(bytes[i + 1])
+        {
+            i += 1;
+            continue;
+        }
+
+        break;
     }
 
     i

--- a/crates/perl-module/tests/module_reference_integration.rs
+++ b/crates/perl-module/tests/module_reference_integration.rs
@@ -109,6 +109,14 @@ fn extended_selects_correct_module_from_qw_list() {
 }
 
 #[test]
+fn extended_supports_legacy_ascii_separator_in_parent_qw_list() {
+    let line = "use parent qw(First'Base Second'Base);";
+    let cursor = line.find("Second'Base").unwrap_or(0);
+
+    assert_eq!(extract_module_reference_extended(line, cursor), Some("Second::Base".to_string()));
+}
+
+#[test]
 fn extended_falls_back_to_direct_use_when_not_parent() {
     let line = "use File::Basename;";
     let cursor = line.find("File::Basename").unwrap_or(0);


### PR DESCRIPTION
### Motivation
- `use parent`/`use base` argument scanning did not treat the legacy ASCII apostrophe (`'`) as a package separator, so legacy-form tokens like `First'Base` inside `qw(...)` lists were not scanned/canonicalized correctly.

### Description
- Teach `scan_canonical_module_token` in `crates/perl-module/src/reference/mod.rs` to continue across ASCII apostrophe separators in addition to `::` so legacy separators are recognized during parent/base scanning.
- Add an integration test `extended_supports_legacy_ascii_separator_in_parent_qw_list` to `crates/perl-module/tests/module_reference_integration.rs` that verifies `use parent qw(First'Base Second'Base);` canonicalizes to `Second::Base` when the cursor is inside the legacy token.

### Testing
- Ran `cargo test -p perl-module` and all tests passed.
- Ran `cargo check --all-targets -p perl-module` and it passed.
- Ran `cargo clippy -p perl-module` and it passed.
- Ran `cargo xtask fmt` and it completed successfully.
- Ran `cargo test -p perl-module --test module_reference_integration` and the new integration test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa079b3e483339958abeb446b6c2a)