### PR TITLE
fix(perl-pragma): normalize GB18030 encoding aliases (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -370,6 +370,15 @@ fn normalized_pragma_token(arg: &str) -> &str {
     arg.trim().trim_matches('\'').trim_matches('"')
 }
 
+fn normalized_encoding_name(arg: &str) -> Option<String> {
+    let encoding = normalized_pragma_token(arg);
+    if encoding.is_empty() {
+        return None;
+    }
+
+    Some(encoding.to_ascii_lowercase().chars().filter(|ch| *ch != '-' && *ch != '_').collect())
+}
+
 fn is_tracked_pragma_module(module: &str) -> bool {
     matches!(module, "strict" | "warnings" | "utf8" | "encoding" | "locale" | "feature" | "builtin")
 }
@@ -523,7 +532,7 @@ impl PragmaTracker {
                         "encoding" => {
                             current_state.encoding = conditional_args
                                 .first()
-                                .map(|arg| normalized_pragma_token(arg).to_string());
+                                .and_then(|arg| normalized_encoding_name(arg));
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -615,9 +624,8 @@ impl PragmaTracker {
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }
                     "encoding" => {
-                        current_state.encoding = args
-                            .first()
-                            .map(|arg| arg.trim().trim_matches('\'').trim_matches('"').to_string());
+                        current_state.encoding =
+                            args.first().and_then(|arg| normalized_encoding_name(arg));
                         ranges
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -459,6 +459,24 @@ fn use_encoding_tracks_active_source_encoding() -> Result<(), Box<dyn std::error
 }
 
 #[test]
+fn use_encoding_normalizes_gb18030_aliases() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("encoding", &["'GB-18030'"], 0, 23)]);
+    let map = PragmaTracker::build(&ast);
+
+    assert_eq!(map[0].1.encoding.as_deref(), Some("gb18030"));
+    Ok(())
+}
+
+#[test]
+fn use_if_encoding_normalizes_gb18030_aliases() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("if", &["$cond", "encoding", "'GB_18030'"], 0, 38)]);
+    let map = PragmaTracker::build(&ast);
+
+    assert_eq!(map[0].1.encoding.as_deref(), Some("gb18030"));
+    Ok(())
+}
+
+#[test]
 fn use_locale_tracks_scope_and_clears_on_no_locale() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![
         use_node("locale", &["':not_characters'"], 0, 28),


### PR DESCRIPTION
### Motivation
- Canonicalize values passed to `use encoding` so common aliases like `GB-18030` and `GB_18030` are recorded consistently and downstream logic can rely on a normalized encoding name.

### Description
- Add `normalized_encoding_name` to canonicalize encoding names by lowercasing and stripping `-`/`_` separators and return `Option<String>` when the token is empty.
- Use `normalized_encoding_name` in both conditional (`use if ..., encoding, ...`) and direct (`use encoding ...`) pragma handling paths so the recorded `PragmaState.encoding` is normalized.
- Add unit tests `use_encoding_normalizes_gb18030_aliases` and `use_if_encoding_normalizes_gb18030_aliases` to verify normalization for GB18030 aliases.

### Testing
- Ran `cargo test -p perl-pragma` and all tests passed.
- Ran `cargo check --all-targets -p perl-pragma` which completed successfully.
- Ran `cargo xtask fmt` and `cargo clippy -p perl-pragma --all-targets -- -D warnings` which completed without failures, and noted `just pr-fast` was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa08cdc8c83338c6757da99d839f6)