### PR TITLE
fix(perl-parser): decode GB18030 source files (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1741,7 @@ version = "0.12.4"
 dependencies = [
  "anyhow",
  "criterion",
+ "encoding_rs",
  "insta",
  "lsp-types",
  "perl-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,6 +318,7 @@ once_cell = "1.21.3"
 tracing = "0.1.44"
 walkdir = "2.5.0"
 clap = { version = "4.5.60", features = ["derive"] }
+encoding_rs = "0.8.35"
 tokio = { version = "1.51.1", features = ["net", "rt-multi-thread", "macros", "io-util", "sync", "time"] }
 proptest = "1.11.0"
 criterion = "0.8.1"

--- a/crates/perl-parser/Cargo.toml
+++ b/crates/perl-parser/Cargo.toml
@@ -42,6 +42,7 @@ serde_json.workspace = true
 regex.workspace = true
 lsp-types = { workspace = true, optional = true }
 url.workspace = true
+encoding_rs.workspace = true
 rustc-hash = "2.1.2"
 # Core dependencies for position mapping (unconditional, all targets)
 ropey = "1.6.1"

--- a/crates/perl-parser/src/bin/perl-parse.rs
+++ b/crates/perl-parser/src/bin/perl-parse.rs
@@ -3,6 +3,7 @@ use std::io::{self, Read, Write};
 use std::path::PathBuf;
 use std::time::Instant;
 
+use encoding_rs::{Encoding, GB18030};
 use perl_parser::{Node, ParseError, Parser};
 
 #[derive(Default)]
@@ -304,6 +305,12 @@ fn read_source_bytes(bytes: Vec<u8>) -> io::Result<String> {
         Ok(source) => Ok(source),
         Err(err) => {
             let raw = err.into_bytes();
+            if let Some(encoding) = detect_declared_source_encoding(&raw) {
+                let (decoded, _, had_errors) = encoding.decode(&raw);
+                if !had_errors {
+                    return Ok(decoded.into_owned());
+                }
+            }
             let mut decoded = String::with_capacity(raw.len());
             for byte in raw {
                 decoded.push(char::from(byte));
@@ -311,6 +318,48 @@ fn read_source_bytes(bytes: Vec<u8>) -> io::Result<String> {
             Ok(decoded)
         }
     }
+}
+
+fn detect_declared_source_encoding(bytes: &[u8]) -> Option<&'static Encoding> {
+    let probe_len = bytes.len().min(4096);
+    let probe = String::from_utf8_lossy(&bytes[..probe_len]);
+
+    for line in probe.lines() {
+        if let Some(encoding_name) = parse_encoding_pragma(line.trim())
+            && is_gb18030_alias(encoding_name)
+        {
+            return Some(GB18030);
+        }
+    }
+
+    None
+}
+
+fn parse_encoding_pragma(line: &str) -> Option<&str> {
+    let without_use = line.strip_prefix("use ")?;
+    let without_encoding = without_use.trim_start().strip_prefix("encoding")?;
+    let mut token = without_encoding.trim_start().trim_end_matches(';').trim();
+
+    if token.is_empty() {
+        return None;
+    }
+
+    if let Some(stripped) = token.strip_prefix('\'') {
+        token = stripped;
+        token = token.strip_suffix('\'')?;
+    } else if let Some(stripped) = token.strip_prefix('"') {
+        token = stripped;
+        token = token.strip_suffix('"')?;
+    } else {
+        token = token.split(|ch: char| ch.is_whitespace() || ch == ';').next().unwrap_or("");
+    }
+
+    if token.is_empty() { None } else { Some(token) }
+}
+
+fn is_gb18030_alias(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    matches!(lower.as_str(), "gb18030" | "gb-18030")
 }
 
 fn ast_to_json(ast: &Node) -> serde_json::Value {
@@ -432,7 +481,7 @@ fn print_error_context(source: &str, position: usize, stderr: &mut io::Stderr) {
 
 #[cfg(test)]
 mod tests {
-    use super::read_source_bytes;
+    use super::{detect_declared_source_encoding, read_source_bytes};
 
     #[test]
     fn read_source_bytes_preserves_utf8() -> Result<(), Box<dyn std::error::Error>> {
@@ -447,5 +496,21 @@ mod tests {
         let decoded = read_source_bytes(vec![0x53, 0xE5, 0x72, 0x0A])?;
         assert_eq!(decoded, "Sår\n");
         Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_decodes_declared_gb18030() -> Result<(), Box<dyn std::error::Error>> {
+        let mut source = b"use encoding 'gb18030';\n".to_vec();
+        source.extend_from_slice(&[0xD6, 0xD0, 0xCE, 0xC4, 0x0A]); // 中文\n in GB18030
+
+        let decoded = read_source_bytes(source)?;
+        assert!(decoded.contains("中文"));
+        Ok(())
+    }
+
+    #[test]
+    fn detect_declared_source_encoding_accepts_dash_alias() {
+        let encoding = detect_declared_source_encoding(b"use encoding 'GB-18030';\n");
+        assert!(encoding.is_some());
     }
 }


### PR DESCRIPTION
### Motivation

- `perl-parse` previously only attempted UTF-8 and otherwise fell back to byte-preserving Latin-1 semantics, so Perl files declaring `use encoding 'gb18030'` were mis-decoded.

### Description

- Add the `encoding_rs` workspace dependency and enable it for the `perl-parser` crate by updating `Cargo.toml` and the lockfile.
- Inspect the first ~4KB of a source buffer for a `use encoding '...'` pragma and, for `gb18030` / `gb-18030` aliases, decode the full buffer with `encoding_rs::GB18030` before falling back to byte-preserving decoding via `read_source_bytes`.
- Implement helper functions `detect_declared_source_encoding`, `parse_encoding_pragma`, and `is_gb18030_alias`, and wire the detection into `read_source_bytes` in `crates/perl-parser/src/bin/perl-parse.rs`.
- Add unit tests covering declared GB18030 decoding and alias recognition in the `perl-parse` binary tests.

### Testing

- Ran `cargo test -p perl-parser --features cli --bin perl-parse` and the added tests passed.
- Ran `cargo check --all-targets -p perl-parser --features cli` and it completed successfully.
- Ran `cargo clippy -p perl-parser --features cli --bin perl-parse -- -D warnings` with no warnings.
- Ran `cargo xtask fmt` to format changes; `just pr-fast` was not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa08cdc8c83338c6757da99d839f6)