### PR TITLE
fix(perl-pragma): improve GB18030 pragma parsing (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -370,6 +370,13 @@ fn normalized_pragma_token(arg: &str) -> &str {
     arg.trim().trim_matches('\'').trim_matches('"')
 }
 
+fn first_pragma_arg_item(arg: &str) -> Option<String> {
+    pragma_arg_items(arg)
+        .into_iter()
+        .map(|item| normalized_pragma_token(&item).to_string())
+        .find(|item| !item.is_empty())
+}
+
 fn is_tracked_pragma_module(module: &str) -> bool {
     matches!(module, "strict" | "warnings" | "utf8" | "encoding" | "locale" | "feature" | "builtin")
 }
@@ -389,9 +396,9 @@ fn conditional_target_tail_is_valid(module: &str, tail: &[String]) -> bool {
         "strict" => tail.is_empty() || valid_strict_args(tail),
         "warnings" => true,
         "utf8" => tail.is_empty(),
-        "encoding" => tail.len() == 1 && !normalized_pragma_token(&tail[0]).is_empty(),
+        "encoding" => tail.len() == 1 && first_pragma_arg_item(&tail[0]).is_some(),
         "locale" => {
-            tail.is_empty() || (tail.len() == 1 && !normalized_pragma_token(&tail[0]).is_empty())
+            tail.is_empty() || (tail.len() == 1 && first_pragma_arg_item(&tail[0]).is_some())
         }
         "feature" => !tail.is_empty(),
         "builtin" => tail.iter().any(|arg| !builtin_import_names(arg).is_empty()),
@@ -521,9 +528,8 @@ impl PragmaTracker {
                             return;
                         }
                         "encoding" => {
-                            current_state.encoding = conditional_args
-                                .first()
-                                .map(|arg| normalized_pragma_token(arg).to_string());
+                            current_state.encoding =
+                                conditional_args.first().and_then(|arg| first_pragma_arg_item(arg));
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -532,9 +538,8 @@ impl PragmaTracker {
                         }
                         "locale" => {
                             current_state.locale = true;
-                            current_state.locale_scope = conditional_args
-                                .first()
-                                .map(|arg| normalized_pragma_token(arg).to_string());
+                            current_state.locale_scope =
+                                conditional_args.first().and_then(|arg| first_pragma_arg_item(arg));
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -615,17 +620,15 @@ impl PragmaTracker {
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }
                     "encoding" => {
-                        current_state.encoding = args
-                            .first()
-                            .map(|arg| arg.trim().trim_matches('\'').trim_matches('"').to_string());
+                        current_state.encoding =
+                            args.first().and_then(|arg| first_pragma_arg_item(arg));
                         ranges
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }
                     "locale" => {
                         current_state.locale = true;
-                        current_state.locale_scope = args
-                            .first()
-                            .map(|arg| arg.trim().trim_matches('\'').trim_matches('"').to_string());
+                        current_state.locale_scope =
+                            args.first().and_then(|arg| first_pragma_arg_item(arg));
                         ranges
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -459,6 +459,24 @@ fn use_encoding_tracks_active_source_encoding() -> Result<(), Box<dyn std::error
 }
 
 #[test]
+fn use_encoding_supports_gb18030_identifier() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("encoding", &["'GB18030'"], 0, 21)]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 1);
+    assert_eq!(map[0].1.encoding.as_deref(), Some("GB18030"));
+    Ok(())
+}
+
+#[test]
+fn use_encoding_qw_argument_tracks_charset_name() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("encoding", &["qw(GB18030)"], 0, 23)]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 1);
+    assert_eq!(map[0].1.encoding.as_deref(), Some("GB18030"));
+    Ok(())
+}
+
+#[test]
 fn use_locale_tracks_scope_and_clears_on_no_locale() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![
         use_node("locale", &["':not_characters'"], 0, 28),


### PR DESCRIPTION
### Motivation
- Pragmas like `use encoding 'GB18030'` and wrapped forms such as `use encoding qw(GB18030)` were not normalized consistently, causing charset names to be captured incorrectly.
- Ensure `encoding` and `locale` pragma handling recognizes common argument forms (quoted or `qw(...)`) so charset and locale names are recorded reliably.

### Description
- Added `first_pragma_arg_item(arg: &str) -> Option<String>` to normalize pragma arguments and extract the first meaningful item, handling `qw(...)` and trimming quotes.
- Replaced ad-hoc quote trimming for `encoding` and `locale` in both regular `use` and conditional `use if/unless` paths to call `first_pragma_arg_item`, unifying behavior across entry points.
- Updated tests in `crates/perl-pragma/tests/comprehensive_unit_tests.rs` to cover `use encoding 'GB18030'` and `use encoding qw(GB18030)` cases.
- Kept change surface minimal and localized to `crates/perl-pragma/src/lib.rs` and associated tests.

### Testing
- Ran `cargo test -p perl-pragma`, which passed (`121` tests across suites for the crate passed in this run). 
- Ran `cargo check --all-targets -p perl-pragma`, which completed successfully. 
- Ran `cargo clippy -p perl-pragma --all-targets -- -D warnings`, which completed with no warnings. 
- Ran `cargo xtask fmt`, which completed successfully in this environment, and noted that `just pr-fast` could not be run because `just` is not installed (`/bin/bash: line 1: just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa08cdc8c83338c6757da99d839f6)