### PR TITLE
fix(workspace): decode Latin-1 files during indexing (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -1620,8 +1620,8 @@ impl LspServer {
                     break;
                 }
 
-                let content = match std::fs::read_to_string(&path) {
-                    Ok(c) => c,
+                let content = match std::fs::read(&path) {
+                    Ok(bytes) => decode_workspace_source(bytes),
                     Err(e) => {
                         if is_permission_denied_error(&e) {
                             // ONE-TIME window/showMessage (AtomicBool guard)
@@ -1863,7 +1863,7 @@ impl LspServer {
             }
         }
 
-        uri_to_fs_path(uri).and_then(|path| std::fs::read_to_string(path).ok())
+        uri_to_fs_path(uri).and_then(|path| std::fs::read(path).ok()).map(decode_workspace_source)
     }
 }
 
@@ -2020,6 +2020,20 @@ fn short_uri(uri: &str) -> String {
         .unwrap_or_else(|| uri.to_string())
 }
 
+fn decode_workspace_source(bytes: Vec<u8>) -> String {
+    match String::from_utf8(bytes) {
+        Ok(source) => source,
+        Err(err) => {
+            let raw = err.into_bytes();
+            let mut decoded = String::with_capacity(raw.len());
+            for byte in raw {
+                decoded.push(char::from(byte));
+            }
+            decoded
+        }
+    }
+}
+
 /// Return `true` if `module_name` appears in `text` as a whole-identifier token.
 ///
 /// This prevents false-positive rename warnings when a short module name (e.g. `"Base"`)
@@ -2078,7 +2092,7 @@ pub(super) fn path_to_module_name(uri: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{LspServer, module_name_appears_in_text};
+    use super::{LspServer, decode_workspace_source, module_name_appears_in_text};
     use serde_json::json;
 
     #[test]
@@ -2156,5 +2170,11 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(server.pending_workspace_configuration_requests.lock().is_empty());
+    }
+
+    #[test]
+    fn decode_workspace_source_falls_back_to_latin1() {
+        let decoded = decode_workspace_source(vec![0x53, 0xE5, 0x72, 0x0A]);
+        assert_eq!(decoded, "Sår\n");
     }
 }


### PR DESCRIPTION
### Motivation
- Workspace indexing and on-disk reads previously relied on UTF-8-only APIs which caused Perl source files containing Latin-1 bytes to be decoded incorrectly or skipped during indexing.

### Description
- Change workspace file reads to use byte reads (`std::fs::read`) and added `decode_workspace_source` which tries `String::from_utf8` and falls back to a byte-preserving Latin-1 mapping when UTF-8 decoding fails.
- Apply the same byte-read + decode fallback to `read_workspace_text` so on-disk document lookup uses the same behavior.
- Add a regression unit test `decode_workspace_source_falls_back_to_latin1` that verifies `0xE5` decodes to `å` under the fallback.
- All changes are localized to `crates/perl-lsp-rs/src/runtime/workspace.rs` and touch only the workspace read path.

### Testing
- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo check -p perl-lsp-rs` which completed successfully and `cargo clippy -p perl-lsp-rs` which also passed.
- Attempted `cargo test -p perl-lsp-rs decode_workspace_source_falls_back_to_latin1` but test execution failed due to pre-existing, unrelated compile errors in `runtime/dispatch/lifecycle.rs` (generic `Result` signature issues) preventing the test binary from building.
- `cargo check --all-targets -p perl-lsp-rs` also fails for the same unrelated compile errors, and `just pr-fast` was unavailable in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa094b3c88333a4e44e2d48d60cdd)