### PR TITLE
fix(runtime): decode Latin-1 workspace files (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/navigation.rs
@@ -6,6 +6,8 @@
 use super::super::*;
 use crate::cancellation::RequestCleanupGuard;
 use crate::protocol::{req_position, req_uri};
+#[cfg(feature = "workspace")]
+use crate::runtime::source_decoding::read_source_file;
 use crate::util::token_under_cursor;
 use std::collections::{HashMap, HashSet, VecDeque};
 
@@ -300,7 +302,7 @@ fn xs_bootstrap_location(path: &Path, module_name: &str) -> Value {
     let uri = Url::from_file_path(path).map(|url| url.to_string()).unwrap_or_default();
     let boot_symbol = xs_boot_symbol_name(module_name);
 
-    if let Ok(text) = std::fs::read_to_string(path)
+    if let Ok(text) = read_source_file(path)
         && let Some(offset) = text.find(&boot_symbol)
     {
         let (start_line, start_char) = byte_to_line_col(&text, offset);
@@ -440,8 +442,7 @@ pub(super) fn workspace_document_text(
     uri: &str,
 ) -> Option<String> {
     workspace_index.document_store().get_text(uri).or_else(|| {
-        crate::workspace_index::uri_to_fs_path(uri)
-            .and_then(|path| std::fs::read_to_string(path).ok())
+        crate::workspace_index::uri_to_fs_path(uri).and_then(|path| read_source_file(&path).ok())
     })
 }
 

--- a/crates/perl-lsp-rs/src/runtime/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/mod.rs
@@ -25,6 +25,7 @@ mod refresh;
 pub mod routing;
 pub(crate) mod scheduler;
 mod serving;
+mod source_decoding;
 pub(crate) mod stream_session;
 mod symbol_extraction;
 mod test_api;

--- a/crates/perl-lsp-rs/src/runtime/source_decoding.rs
+++ b/crates/perl-lsp-rs/src/runtime/source_decoding.rs
@@ -1,0 +1,42 @@
+//! Helpers for decoding on-disk source files.
+//!
+//! Perl codebases still contain legacy Latin-1 encoded sources.
+//! We decode UTF-8 first and then fall back to byte-preserving Latin-1
+//! so indexing/features remain available for those files.
+
+use std::path::Path;
+
+pub(crate) fn decode_source_bytes(bytes: Vec<u8>) -> String {
+    match String::from_utf8(bytes) {
+        Ok(source) => source,
+        Err(err) => {
+            let raw = err.into_bytes();
+            let mut decoded = String::with_capacity(raw.len());
+            for byte in raw {
+                decoded.push(char::from(byte));
+            }
+            decoded
+        }
+    }
+}
+
+pub(crate) fn read_source_file(path: &Path) -> std::io::Result<String> {
+    std::fs::read(path).map(decode_source_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_source_bytes;
+
+    #[test]
+    fn decode_source_bytes_preserves_utf8() {
+        let decoded = decode_source_bytes(b"use strict;\n".to_vec());
+        assert_eq!(decoded, "use strict;\n");
+    }
+
+    #[test]
+    fn decode_source_bytes_decodes_latin1_losslessly() {
+        let decoded = decode_source_bytes(vec![0x53, 0xE5, 0x72, 0x0A]);
+        assert_eq!(decoded, "Sår\n");
+    }
+}

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -11,6 +11,8 @@
 use super::*;
 #[cfg(feature = "workspace")]
 use crate::runtime::routing::{IndexAccessMode, route_index_access};
+#[cfg(feature = "workspace")]
+use crate::runtime::source_decoding::read_source_file;
 use crate::state::workspace_symbol_cap;
 use perl_module::path::file_path_to_module_name;
 use perl_module::rename::{apply_module_rename_edits, plan_module_rename_edits};
@@ -897,7 +899,7 @@ impl LspServer {
             let workspace_index = coordinator.index();
             if is_perl_source_uri(uri) {
                 if let Some(path) = uri_to_fs_path(uri) {
-                    match std::fs::read_to_string(&path) {
+                    match read_source_file(&path) {
                         Ok(content) => {
                             if let Ok(url) = url::Url::parse(uri) {
                                 // Clear old index data before re-indexing
@@ -928,7 +930,7 @@ impl LspServer {
             let mut documents = self.documents.lock();
             if let Some(doc) = self.get_document_mut(&mut documents, uri) {
                 if let Some(path) = uri_to_fs_path(uri) {
-                    match std::fs::read_to_string(&path) {
+                    match read_source_file(&path) {
                         Ok(content) => {
                             doc.text = content;
                             doc.version += 1;
@@ -1046,7 +1048,7 @@ impl LspServer {
                         let workspace_index = coordinator.index();
                         workspace_index.remove_file(old_uri);
                         if let Some(path) = uri_to_fs_path(new_uri) {
-                            if let Ok(content) = std::fs::read_to_string(&path) {
+                            if let Ok(content) = read_source_file(&path) {
                                 if let Ok(url) = url::Url::parse(new_uri) {
                                     if let Err(e) = workspace_index.index_file(url, content.clone())
                                     {
@@ -1297,7 +1299,7 @@ impl LspServer {
                     if let Some(coordinator) = self.coordinator() {
                         if is_perl_source_uri(uri) {
                             if let Some(path) = uri_to_fs_path(uri) {
-                                match std::fs::read_to_string(&path) {
+                                match read_source_file(&path) {
                                     Ok(content) => {
                                         coordinator.notify_change(uri);
                                         if let Ok(url) = url::Url::parse(uri) {
@@ -1370,7 +1372,7 @@ impl LspServer {
                         // Index new file if it's a Perl file
                         if is_perl_source_uri(new_uri) {
                             if let Some(path) = uri_to_fs_path(new_uri) {
-                                match std::fs::read_to_string(&path) {
+                                match read_source_file(&path) {
                                     Ok(content) => {
                                         if let Ok(url) = url::Url::parse(new_uri) {
                                             match coordinator.index().index_file(url, content) {
@@ -1620,7 +1622,7 @@ impl LspServer {
                     break;
                 }
 
-                let content = match std::fs::read_to_string(&path) {
+                let content = match read_source_file(&path) {
                     Ok(c) => c,
                     Err(e) => {
                         if is_permission_denied_error(&e) {
@@ -1863,7 +1865,7 @@ impl LspServer {
             }
         }
 
-        uri_to_fs_path(uri).and_then(|path| std::fs::read_to_string(path).ok())
+        uri_to_fs_path(uri).and_then(|path| read_source_file(&path).ok())
     }
 }
 


### PR DESCRIPTION
### Motivation
- Workspace indexing and navigation used UTF-8-only file reads which caused legacy Latin-1 Perl sources to be mis-decoded or skipped, reducing feature coverage for those files.

### Description
- Add `crates/perl-lsp-rs/src/runtime/source_decoding.rs` providing `decode_source_bytes` and `read_source_file` which attempt UTF-8 decoding and fall back to a byte-preserving Latin-1 mapping.
- Wire the new `source_decoding` module into the runtime and replace UTF-8-only filesystem reads with `read_source_file` in `workspace.rs` and `navigation.rs` so indexing, re-indexing, rename handling, and navigation fallbacks work for Latin-1 files.
- Add unit tests in `source_decoding.rs` that verify UTF-8 is preserved and Latin-1 bytes decode losslessly.

### Testing
- `cargo fmt --all` ran and succeeded.
- `cargo check -p perl-lsp-rs --lib` ran and succeeded.
- `cargo clippy -p perl-lsp-rs --lib -- -D warnings` ran and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa094b3c88333a4e44e2d48d60cdd)