### PR TITLE
fix(workspace): add Windows-1252 text fallback (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -10,7 +10,7 @@
 
 use super::*;
 #[cfg(feature = "workspace")]
-use crate::runtime::routing::{IndexAccessMode, route_index_access};
+use crate::runtime::routing::{route_index_access, IndexAccessMode};
 use crate::state::workspace_symbol_cap;
 use perl_module::path::file_path_to_module_name;
 use perl_module::rename::{apply_module_rename_edits, plan_module_rename_edits};
@@ -31,6 +31,38 @@ use std::time::Instant;
 use url::Url;
 
 const WORKSPACE_CONFIGURATION_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[cfg(feature = "workspace")]
+fn decode_windows_1252(bytes: &[u8]) -> String {
+    const WINDOWS_1252_EXTENDED: [char; 32] = [
+        '€', '\u{0081}', '‚', 'ƒ', '„', '…', '†', '‡', 'ˆ', '‰', 'Š', '‹', 'Œ', '\u{008d}', 'Ž',
+        '\u{008f}', '\u{0090}', '‘', '’', '“', '”', '•', '–', '—', '˜', '™', 'š', '›', 'œ',
+        '\u{009d}', 'ž', 'Ÿ',
+    ];
+
+    bytes
+        .iter()
+        .map(|&byte| {
+            if (0x80..=0x9F).contains(&byte) {
+                WINDOWS_1252_EXTENDED[(byte - 0x80) as usize]
+            } else {
+                char::from(byte)
+            }
+        })
+        .collect()
+}
+
+#[cfg(feature = "workspace")]
+fn read_text_with_encoding_fallback(path: &std::path::Path) -> std::io::Result<String> {
+    let bytes = std::fs::read(path)?;
+    match String::from_utf8(bytes) {
+        Ok(text) => Ok(text),
+        Err(err) => {
+            let bytes = err.into_bytes();
+            Ok(decode_windows_1252(&bytes))
+        }
+    }
+}
 // Note: WalkDir logic has been extracted to super::file_discovery.
 // These helper functions are retained for potential future use by
 // other workspace operations (e.g., file watcher filtering).
@@ -897,7 +929,7 @@ impl LspServer {
             let workspace_index = coordinator.index();
             if is_perl_source_uri(uri) {
                 if let Some(path) = uri_to_fs_path(uri) {
-                    match std::fs::read_to_string(&path) {
+                    match read_text_with_encoding_fallback(&path) {
                         Ok(content) => {
                             if let Ok(url) = url::Url::parse(uri) {
                                 // Clear old index data before re-indexing
@@ -928,7 +960,7 @@ impl LspServer {
             let mut documents = self.documents.lock();
             if let Some(doc) = self.get_document_mut(&mut documents, uri) {
                 if let Some(path) = uri_to_fs_path(uri) {
-                    match std::fs::read_to_string(&path) {
+                    match read_text_with_encoding_fallback(&path) {
                         Ok(content) => {
                             doc.text = content;
                             doc.version += 1;
@@ -1046,7 +1078,7 @@ impl LspServer {
                         let workspace_index = coordinator.index();
                         workspace_index.remove_file(old_uri);
                         if let Some(path) = uri_to_fs_path(new_uri) {
-                            if let Ok(content) = std::fs::read_to_string(&path) {
+                            if let Ok(content) = read_text_with_encoding_fallback(&path) {
                                 if let Ok(url) = url::Url::parse(new_uri) {
                                     if let Err(e) = workspace_index.index_file(url, content.clone())
                                     {
@@ -1297,7 +1329,7 @@ impl LspServer {
                     if let Some(coordinator) = self.coordinator() {
                         if is_perl_source_uri(uri) {
                             if let Some(path) = uri_to_fs_path(uri) {
-                                match std::fs::read_to_string(&path) {
+                                match read_text_with_encoding_fallback(&path) {
                                     Ok(content) => {
                                         coordinator.notify_change(uri);
                                         if let Ok(url) = url::Url::parse(uri) {
@@ -1370,7 +1402,7 @@ impl LspServer {
                         // Index new file if it's a Perl file
                         if is_perl_source_uri(new_uri) {
                             if let Some(path) = uri_to_fs_path(new_uri) {
-                                match std::fs::read_to_string(&path) {
+                                match read_text_with_encoding_fallback(&path) {
                                     Ok(content) => {
                                         if let Ok(url) = url::Url::parse(new_uri) {
                                             match coordinator.index().index_file(url, content) {
@@ -1620,7 +1652,7 @@ impl LspServer {
                     break;
                 }
 
-                let content = match std::fs::read_to_string(&path) {
+                let content = match read_text_with_encoding_fallback(&path) {
                     Ok(c) => c,
                     Err(e) => {
                         if is_permission_denied_error(&e) {
@@ -1863,7 +1895,7 @@ impl LspServer {
             }
         }
 
-        uri_to_fs_path(uri).and_then(|path| std::fs::read_to_string(path).ok())
+        uri_to_fs_path(uri).and_then(|path| read_text_with_encoding_fallback(&path).ok())
     }
 }
 
@@ -2078,7 +2110,7 @@ pub(super) fn path_to_module_name(uri: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{LspServer, module_name_appears_in_text};
+    use super::{module_name_appears_in_text, LspServer};
     use serde_json::json;
 
     #[test]
@@ -2156,5 +2188,19 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(server.pending_workspace_configuration_requests.lock().is_empty());
+    }
+
+    #[cfg(feature = "workspace")]
+    #[test]
+    fn decode_windows_1252_maps_smart_quotes_and_euro() {
+        let decoded = super::decode_windows_1252(&[0x93, b'H', b'i', 0x94, b' ', 0x80]);
+        assert_eq!(decoded, "“Hi” €");
+    }
+
+    #[cfg(feature = "workspace")]
+    #[test]
+    fn decode_windows_1252_preserves_latin1_bytes() {
+        let decoded = super::decode_windows_1252(&[0xE9, 0xF1, 0xFC]);
+        assert_eq!(decoded, "éñü");
     }
 }


### PR DESCRIPTION
### Motivation

- Workspace file reads currently assume UTF-8 and treat CP1252/Windows-1252 files as unreadable, preventing indexing and document updates for files saved with that encoding. 

### Description

- Added a UTF-8-first file reader with a Windows-1252 fallback implemented as `decode_windows_1252(bytes: &[u8])` and `read_text_with_encoding_fallback(path: &Path) -> Result<String, io::Error>` in `crates/perl-lsp-rs/src/runtime/workspace.rs`. 
- Wired the fallback reader into all workspace file-read paths including watcher reindex (`process_file_watcher_uri_immediate`), open-document refresh, rename/create flows, initial workspace scan, and `read_workspace_text`. 
- Added focused unit tests for the decoder in the same module covering smart quotes + euro and Latin-1-range bytes. 
- Kept scope minimal to only the workspace read/fallback logic and tests in `crates/perl-lsp-rs/src/runtime/workspace.rs`. 

### Testing

- Ran `cargo xtask fmt` which completed successfully. 
- `cargo check -p perl-lsp-rs --lib` completed successfully in this environment. 
- `cargo check --all-targets -p perl-lsp-rs` failed due to pre-existing test-target compile errors in unrelated `runtime/dispatch/lifecycle.rs`. 
- `cargo clippy -p perl-lsp-rs --all-targets` reported failures caused by existing clippy denies and unrelated test `panic!` usage; these are pre-existing and not introduced by this change. 
- Running `cargo test -p perl-lsp-rs --test decode_windows_1252` could not complete because the workspace has unrelated compile errors in other test targets; the new decoder unit tests are small and local to the modified module. 

Problem: Workspace file reads currently require UTF-8 and silently fail to index/update Perl files saved as Windows-1252.
Fix: Added a UTF-8-first file reader with Windows-1252 fallback and wired it into workspace read paths, plus focused decode tests.
Verification: `cargo check -p perl-lsp-rs --lib` passes; full-target checks and clippy currently surface pre-existing unrelated failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa09c51708333a9714059daa6e91b)