### PR TITLE
fix(perl-parser): decode Windows-1252 source bytes (#0000)

### DIFF
--- a/crates/perl-parser/src/bin/perl-parse.rs
+++ b/crates/perl-parser/src/bin/perl-parse.rs
@@ -306,10 +306,43 @@ fn read_source_bytes(bytes: Vec<u8>) -> io::Result<String> {
             let raw = err.into_bytes();
             let mut decoded = String::with_capacity(raw.len());
             for byte in raw {
-                decoded.push(char::from(byte));
+                decoded.push(decode_windows_1252_byte(byte));
             }
             Ok(decoded)
         }
+    }
+}
+
+fn decode_windows_1252_byte(byte: u8) -> char {
+    match byte {
+        0x80 => '\u{20AC}', // €
+        0x82 => '\u{201A}', // ‚
+        0x83 => '\u{0192}', // ƒ
+        0x84 => '\u{201E}', // „
+        0x85 => '\u{2026}', // …
+        0x86 => '\u{2020}', // †
+        0x87 => '\u{2021}', // ‡
+        0x88 => '\u{02C6}', // ˆ
+        0x89 => '\u{2030}', // ‰
+        0x8A => '\u{0160}', // Š
+        0x8B => '\u{2039}', // ‹
+        0x8C => '\u{0152}', // Œ
+        0x8E => '\u{017D}', // Ž
+        0x91 => '\u{2018}', // ‘
+        0x92 => '\u{2019}', // ’
+        0x93 => '\u{201C}', // “
+        0x94 => '\u{201D}', // ”
+        0x95 => '\u{2022}', // •
+        0x96 => '\u{2013}', // –
+        0x97 => '\u{2014}', // —
+        0x98 => '\u{02DC}', // ˜
+        0x99 => '\u{2122}', // ™
+        0x9A => '\u{0161}', // š
+        0x9B => '\u{203A}', // ›
+        0x9C => '\u{0153}', // œ
+        0x9E => '\u{017E}', // ž
+        0x9F => '\u{0178}', // Ÿ
+        _ => char::from(byte),
     }
 }
 
@@ -446,6 +479,15 @@ mod tests {
         // "Sår" in ISO-8859-1 bytes
         let decoded = read_source_bytes(vec![0x53, 0xE5, 0x72, 0x0A])?;
         assert_eq!(decoded, "Sår\n");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_decodes_windows_1252_punctuation() -> Result<(), Box<dyn std::error::Error>>
+    {
+        // “Hi”—€ encoded with Windows-1252 bytes.
+        let decoded = read_source_bytes(vec![0x93, 0x48, 0x69, 0x94, 0x97, 0x80])?;
+        assert_eq!(decoded, "“Hi”—€");
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- Non-UTF-8 source fallback previously mapped bytes with `char::from(byte)` (ISO-8859-1), which misinterprets Windows-1252 specific punctuation such as smart quotes, em dash, and the euro sign.

### Description
- Replace the byte-to-char fallback in `read_source_bytes` with an explicit `decode_windows_1252_byte` mapping for CP1252 control range bytes while preserving Latin-1 behavior for other bytes.
- Add a focused unit test `read_source_bytes_decodes_windows_1252_punctuation` that verifies decoding of `“Hi”—€` via the same code path.
- Modified file: `crates/perl-parser/src/bin/perl-parse.rs`.

### Testing
- Ran `cargo test -p perl-parser --features cli --bin perl-parse read_source_bytes` and the targeted tests passed (`3 passed`).
- Ran `cargo check --all-targets -p perl-parser --features cli` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa09c51708333a9714059daa6e91b)