### PR TITLE
fix(perl-pragma): normalize Windows-1252 encoding aliases (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -370,6 +370,21 @@ fn normalized_pragma_token(arg: &str) -> &str {
     arg.trim().trim_matches('\'').trim_matches('"')
 }
 
+fn normalize_source_encoding(arg: &str) -> Option<String> {
+    let normalized = normalized_pragma_token(arg);
+    if normalized.is_empty() {
+        return None;
+    }
+
+    let lower = normalized.to_ascii_lowercase();
+    let canonical = match lower.as_str() {
+        "cp1252" | "cp-1252" | "windows1252" | "windows-1252" => "windows-1252",
+        _ => lower.as_str(),
+    };
+
+    Some(canonical.to_string())
+}
+
 fn is_tracked_pragma_module(module: &str) -> bool {
     matches!(module, "strict" | "warnings" | "utf8" | "encoding" | "locale" | "feature" | "builtin")
 }
@@ -523,7 +538,7 @@ impl PragmaTracker {
                         "encoding" => {
                             current_state.encoding = conditional_args
                                 .first()
-                                .map(|arg| normalized_pragma_token(arg).to_string());
+                                .and_then(|arg| normalize_source_encoding(arg));
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -615,9 +630,8 @@ impl PragmaTracker {
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }
                     "encoding" => {
-                        current_state.encoding = args
-                            .first()
-                            .map(|arg| arg.trim().trim_matches('\'').trim_matches('"').to_string());
+                        current_state.encoding =
+                            args.first().and_then(|arg| normalize_source_encoding(arg));
                         ranges
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -281,6 +281,16 @@ fn use_if_encoding_targets_encoding_not_argument() -> Result<(), Box<dyn std::er
 }
 
 #[test]
+fn use_if_encoding_normalizes_windows_1252_aliases() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("if", &["$cond", "encoding", "'cp1252'"], 0, 34)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+
+    assert_eq!(state.encoding.as_deref(), Some("windows-1252"));
+    Ok(())
+}
+
+#[test]
 fn no_strict_disables_all() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("strict", &[], 0, 12), no_node("strict", &[], 13, 23)]);
     let map = PragmaTracker::build(&ast);
@@ -455,6 +465,20 @@ fn use_encoding_tracks_active_source_encoding() -> Result<(), Box<dyn std::error
     assert_eq!(map.len(), 2);
     assert_eq!(map[0].1.encoding.as_deref(), Some("utf8"));
     assert!(map[1].1.encoding.is_none());
+    Ok(())
+}
+
+#[test]
+fn use_encoding_normalizes_windows_1252_aliases() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("encoding", &["'Windows1252'"], 0, 25),
+        use_node("encoding", &["'cp-1252'"], 26, 47),
+    ]);
+
+    let map = PragmaTracker::build(&ast);
+
+    assert_eq!(map[0].1.encoding.as_deref(), Some("windows-1252"));
+    assert_eq!(map[1].1.encoding.as_deref(), Some("windows-1252"));
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- Source encoding values from `use encoding` were recorded verbatim which caused equivalent Windows-1252 spellings (`cp1252`, `cp-1252`, `windows1252`, etc.) to be treated as different encodings.

### Description

- Add `normalize_source_encoding` to canonicalize `use encoding` argument tokens and map common Windows-1252 aliases to the canonical string `windows-1252`.
- Use the normalization helper for both conditional (`use if/unless ... encoding ...`) and direct (`use encoding ...`) pragma handling so the tracked `PragmaState.encoding` is consistent.
- Add unit tests `use_if_encoding_normalizes_windows_1252_aliases` and `use_encoding_normalizes_windows_1252_aliases` to cover alias normalization in conditional and direct forms.

### Testing

- Ran `cargo test -p perl-pragma` and all tests passed (`103` tests in `comprehensive_unit_tests` plus behavior tests succeeded).
- Ran `cargo check --all-targets -p perl-pragma` which completed successfully.
- Ran `cargo clippy -p perl-pragma --all-targets -- -D warnings` which completed with no warnings.
- Ran `cargo xtask fmt` which completed successfully in this environment, while `just pr-fast` could not be run because `just` is not installed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa09c51708333a9714059daa6e91b)