### PR TITLE
fix(perl-pragma): normalize UTF-7 encoding pragma names (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -370,6 +370,10 @@ fn normalized_pragma_token(arg: &str) -> &str {
     arg.trim().trim_matches('\'').trim_matches('"')
 }
 
+fn normalized_encoding_name(arg: &str) -> String {
+    normalized_pragma_token(arg).to_ascii_lowercase()
+}
+
 fn is_tracked_pragma_module(module: &str) -> bool {
     matches!(module, "strict" | "warnings" | "utf8" | "encoding" | "locale" | "feature" | "builtin")
 }
@@ -521,9 +525,8 @@ impl PragmaTracker {
                             return;
                         }
                         "encoding" => {
-                            current_state.encoding = conditional_args
-                                .first()
-                                .map(|arg| normalized_pragma_token(arg).to_string());
+                            current_state.encoding =
+                                conditional_args.first().map(|arg| normalized_encoding_name(arg));
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -615,9 +618,8 @@ impl PragmaTracker {
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }
                     "encoding" => {
-                        current_state.encoding = args
-                            .first()
-                            .map(|arg| arg.trim().trim_matches('\'').trim_matches('"').to_string());
+                        current_state.encoding =
+                            args.first().map(|arg| normalized_encoding_name(arg));
                         ranges
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -459,6 +459,24 @@ fn use_encoding_tracks_active_source_encoding() -> Result<(), Box<dyn std::error
 }
 
 #[test]
+fn use_encoding_utf7_is_normalized() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("encoding", &["'UTF-7'"], 0, 19)]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 1);
+    assert_eq!(map[0].1.encoding.as_deref(), Some("utf-7"));
+    Ok(())
+}
+
+#[test]
+fn use_if_encoding_utf7_is_normalized() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("if", &["$cond", "encoding", "'UTF-7'"], 0, 34)]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 1);
+    assert_eq!(map[0].1.encoding.as_deref(), Some("utf-7"));
+    Ok(())
+}
+
+#[test]
 fn use_locale_tracks_scope_and_clears_on_no_locale() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![
         use_node("locale", &["':not_characters'"], 0, 28),


### PR DESCRIPTION
### Motivation

- `use encoding 'UTF-7'` and the conditional `use if ..., encoding, 'UTF-7'` paths preserved mixed-case encoding names, producing inconsistent stored pragma state for encodings like UTF-7.

### Description

- Add `normalized_encoding_name` which trims quotes and lowercases encoding names before storage.
- Use `normalized_encoding_name` in both direct `use encoding` and conditional `use if ..., encoding, ...` branches so captured encoding names are normalized consistently.
- Add two unit tests `use_encoding_utf7_is_normalized` and `use_if_encoding_utf7_is_normalized` to assert `"UTF-7"` is normalized to `"utf-7"`.

### Testing

- Ran `cargo test -p perl-pragma` and all tests passed.
- Ran `cargo check --all-targets -p perl-pragma` and it completed successfully.
- Ran `cargo clippy -p perl-pragma` and it completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa0a0572883339fd7424729c22ea0)