### PR TITLE
fix(encoding): improve UTF-7 POD directive handling (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -290,6 +290,33 @@ pub struct PerlLexer<'a> {
 }
 
 impl<'a> PerlLexer<'a> {
+    #[inline]
+    fn is_pod_start_directive_at_line_start(remaining: &[u8]) -> bool {
+        const POD_STARTS: [&[u8]; 9] = [
+            b"=pod",
+            b"=head",
+            b"=over",
+            b"=item",
+            b"=back",
+            b"=begin",
+            b"=end",
+            b"=for",
+            b"=encoding",
+        ];
+
+        POD_STARTS.iter().any(|directive| {
+            remaining.len() >= directive.len()
+                && remaining[..directive.len()].eq_ignore_ascii_case(directive)
+        })
+    }
+
+    #[inline]
+    fn is_cut_directive_at_line_start(remaining: &[u8]) -> bool {
+        let directive = b"=cut";
+        remaining.len() >= directive.len()
+            && remaining[..directive.len()].eq_ignore_ascii_case(directive)
+    }
+
     /// Create a new lexer for the given input
     pub fn new(input: &'a str) -> Self {
         Self::with_config(input, LexerConfig::default())
@@ -1010,16 +1037,7 @@ impl<'a> PerlLexer<'a> {
                     // Check if this starts a POD section (=pod, =head, =over, etc.)
                     // Use byte-safe checks — avoid slicing &str at arbitrary byte positions
                     let remaining = &self.input_bytes[self.position..];
-                    if remaining.starts_with(b"=pod")
-                        || remaining.starts_with(b"=head")
-                        || remaining.starts_with(b"=over")
-                        || remaining.starts_with(b"=item")
-                        || remaining.starts_with(b"=back")
-                        || remaining.starts_with(b"=begin")
-                        || remaining.starts_with(b"=end")
-                        || remaining.starts_with(b"=for")
-                        || remaining.starts_with(b"=encoding")
-                    {
+                    if Self::is_pod_start_directive_at_line_start(remaining) {
                         // Scan forward for \n=cut (end of POD block)
                         let search_start = self.position;
                         let mut found_cut = false;
@@ -1028,7 +1046,7 @@ impl<'a> PerlLexer<'a> {
                         while i < bytes.len() {
                             // Look for =cut at the start of a line
                             if (i == 0 || matches!(bytes[i - 1], b'\n' | b'\r'))
-                                && bytes[i..].starts_with(b"=cut")
+                                && Self::is_cut_directive_at_line_start(&bytes[i..])
                             {
                                 i += 4; // Skip "=cut"
                                 // Skip rest of the =cut line

--- a/crates/perl-lexer/tests/pod_skipping_tests.rs
+++ b/crates/perl-lexer/tests/pod_skipping_tests.rs
@@ -198,3 +198,13 @@ fn pod_with_multibyte_utf8_content() -> R {
     assert_eq!(my_count, 2, "Should have two 'my' keywords: {texts:?}");
     Ok(())
 }
+
+#[test]
+fn uppercase_encoding_directive_with_utf7_is_skipped() -> R {
+    let code = "my $x = 1;\n=ENCODING UTF-7\n=head1 NAME\nDemo\n=CUT\nmy $y = 2;";
+    let toks = significant(code);
+    let texts: Vec<&str> = toks.iter().map(|t| t.text.as_ref()).collect();
+    let my_count = texts.iter().filter(|&&t| t == "my").count();
+    assert_eq!(my_count, 2, "Should have two 'my' keywords: {texts:?}");
+    Ok(())
+}

--- a/crates/perl-parser-core/src/tokens/trivia_parser.rs
+++ b/crates/perl-parser-core/src/tokens/trivia_parser.rs
@@ -40,6 +40,22 @@ struct PositionTracker {
     line_starts: Vec<usize>,
 }
 
+#[inline]
+fn is_pod_start_directive_at_line_start(remaining: &str) -> bool {
+    const POD_STARTS: [&str; 9] =
+        ["=pod", "=head", "=over", "=item", "=back", "=begin", "=end", "=for", "=encoding"];
+    POD_STARTS.iter().any(|directive| {
+        remaining.len() >= directive.len()
+            && remaining[..directive.len()].eq_ignore_ascii_case(directive)
+    })
+}
+
+#[inline]
+fn is_cut_directive_at_line_start(remaining: &str) -> bool {
+    const CUT: &str = "=cut";
+    remaining.len() >= CUT.len() && remaining[..CUT.len()].eq_ignore_ascii_case(CUT)
+}
+
 impl PositionTracker {
     fn new(source: &str) -> Self {
         let mut line_starts = vec![0];
@@ -211,16 +227,7 @@ impl TriviaParserContext {
                 b'=' if *position == 0 || (*position > 0 && bytes[*position - 1] == b'\n') => {
                     // Check if this starts a POD section
                     let remaining = &source[*position..];
-                    if remaining.starts_with("=pod")
-                        || remaining.starts_with("=head")
-                        || remaining.starts_with("=over")
-                        || remaining.starts_with("=item")
-                        || remaining.starts_with("=back")
-                        || remaining.starts_with("=begin")
-                        || remaining.starts_with("=end")
-                        || remaining.starts_with("=for")
-                        || remaining.starts_with("=encoding")
-                    {
+                    if is_pod_start_directive_at_line_start(remaining) {
                         let pod_start = *position;
 
                         // Edge case fix: Find =cut at start of line (including position 0 or after newline)
@@ -228,7 +235,7 @@ impl TriviaParserContext {
                         while *position < source.len() {
                             // Check for =cut at the start of a line
                             if (*position == 0 || (*position > 0 && bytes[*position - 1] == b'\n'))
-                                && source[*position..].starts_with("=cut")
+                                && is_cut_directive_at_line_start(&source[*position..])
                             {
                                 *position += 4; // Skip "=cut"
                                 // Skip to end of line

--- a/crates/perl-parser-core/tests/trivia_edge_cases.rs
+++ b/crates/perl-parser-core/tests/trivia_edge_cases.rs
@@ -203,6 +203,28 @@ my $x = 1;
 }
 
 #[test]
+fn test_uppercase_encoding_utf7_pod_commands() {
+    let source = r#"=ENCODING UTF-7
+
+=HEAD1 NAME
+
+Demo::UTF7
+
+=CUT
+
+my $x = 1;
+"#
+    .to_string();
+
+    let parser = TriviaPreservingParser::new(source);
+    let result = parser.parse();
+
+    let pod_count =
+        result.leading_trivia.iter().filter(|t| matches!(&t.trivia, Trivia::PodComment(_))).count();
+    assert!(pod_count >= 1, "Should detect uppercase POD directives for UTF-7 blocks");
+}
+
+#[test]
 fn test_hash_in_string_not_comment() {
     // Edge case: Hash character in string should not be treated as comment
     // This tests the parser's ability to distinguish context

--- a/crates/perl-pod/src/lib.rs
+++ b/crates/perl-pod/src/lib.rs
@@ -12,6 +12,23 @@ use std::collections::HashMap;
 use std::io;
 use std::path::Path;
 
+fn starts_with_pod_directive(line: &str, directive: &str) -> bool {
+    let line_bytes = line.as_bytes();
+    let directive_bytes = directive.as_bytes();
+    line_bytes.len() >= directive_bytes.len()
+        && line_bytes[..directive_bytes.len()].eq_ignore_ascii_case(directive_bytes)
+}
+
+fn is_pod_start(line: &str) -> bool {
+    starts_with_pod_directive(line, "=head")
+        || starts_with_pod_directive(line, "=pod")
+        || starts_with_pod_directive(line, "=over")
+        || starts_with_pod_directive(line, "=begin")
+        || starts_with_pod_directive(line, "=for")
+        || starts_with_pod_directive(line, "=encoding")
+        || starts_with_pod_directive(line, "=item")
+}
+
 /// Extracted POD documentation from a Perl module.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PodDoc {
@@ -57,14 +74,7 @@ pub fn extract_pod(source: &str) -> PodDoc {
 
     for line in source.lines() {
         // Detect POD start directives
-        if line.starts_with("=head")
-            || line.starts_with("=pod")
-            || line.starts_with("=over")
-            || line.starts_with("=begin")
-            || line.starts_with("=for")
-            || line.starts_with("=encoding")
-            || line.starts_with("=item")
-        {
+        if is_pod_start(line) {
             in_pod = true;
         }
 
@@ -73,7 +83,7 @@ pub fn extract_pod(source: &str) -> PodDoc {
         }
 
         // =cut ends POD
-        if line.starts_with("=cut") {
+        if starts_with_pod_directive(line, "=cut") {
             flush_section(&mut doc, &current_section, &body, in_over);
             current_section = None;
             body.clear();
@@ -83,17 +93,17 @@ pub fn extract_pod(source: &str) -> PodDoc {
         }
 
         // =over / =item / =back for lists
-        if line.starts_with("=over") {
+        if starts_with_pod_directive(line, "=over") {
             in_over = true;
             body.push('\n');
             continue;
         }
-        if line.starts_with("=back") {
+        if starts_with_pod_directive(line, "=back") {
             in_over = false;
             body.push('\n');
             continue;
         }
-        if line.starts_with("=item") {
+        if starts_with_pod_directive(line, "=item") {
             let item_text = line.strip_prefix("=item").map(str::trim).unwrap_or("");
             if !body.is_empty() {
                 body.push('\n');
@@ -105,7 +115,11 @@ pub fn extract_pod(source: &str) -> PodDoc {
         }
 
         // New head1 section
-        if let Some(heading) = line.strip_prefix("=head1") {
+        if let Some(heading) = line
+            .get(0..6)
+            .filter(|prefix| prefix.eq_ignore_ascii_case("=head1"))
+            .and_then(|_| line.get(6..))
+        {
             flush_section(&mut doc, &current_section, &body, false);
             body.clear();
             let heading = heading.trim();
@@ -119,7 +133,11 @@ pub fn extract_pod(source: &str) -> PodDoc {
         }
 
         // New head2 section — treated as method documentation
-        if let Some(heading) = line.strip_prefix("=head2") {
+        if let Some(heading) = line
+            .get(0..6)
+            .filter(|prefix| prefix.eq_ignore_ascii_case("=head2"))
+            .and_then(|_| line.get(6..))
+        {
             flush_section(&mut doc, &current_section, &body, false);
             body.clear();
             let heading = heading.trim().to_string();
@@ -128,11 +146,11 @@ pub fn extract_pod(source: &str) -> PodDoc {
         }
 
         // Skip other directives
-        if line.starts_with("=pod")
-            || line.starts_with("=encoding")
-            || line.starts_with("=begin")
-            || line.starts_with("=end")
-            || line.starts_with("=for")
+        if starts_with_pod_directive(line, "=pod")
+            || starts_with_pod_directive(line, "=encoding")
+            || starts_with_pod_directive(line, "=begin")
+            || starts_with_pod_directive(line, "=end")
+            || starts_with_pod_directive(line, "=for")
         {
             continue;
         }

--- a/crates/perl-pod/tests/pod_extraction_tests.rs
+++ b/crates/perl-pod/tests/pod_extraction_tests.rs
@@ -357,6 +357,21 @@ Encoded::Module - Uses UTF-8
 }
 
 #[test]
+fn uppercase_encoding_directive_with_utf7_starts_pod() {
+    let source = r#"
+=ENCODING UTF-7
+
+=HEAD1 NAME
+
+Encoded::Module - Uses UTF-7
+
+=CUT
+"#;
+    let doc = extract_pod(source);
+    assert_eq!(doc.name.as_deref(), Some("Encoded::Module - Uses UTF-7"));
+}
+
+#[test]
 fn f_format_code_for_filenames() {
     let doc = extract_pod("=head1 NAME\n\nSee F<config.yml>\n\n=cut\n");
     assert_eq!(doc.name.as_deref(), Some("See config.yml"));


### PR DESCRIPTION
### Motivation
- POD start/end detection was ASCII-case-sensitive, so uppercase directives like `=ENCODING UTF-7` / `=CUT` could be missed and POD blocks not skipped or extracted correctly.
- Support for UTF-7-encoded POD blocks (and other uppercase directive variants) is required for robust real-world parsing and LSP tooling.

### Description
- Added ASCII case-insensitive POD start detection helpers in the lexer: `PerlLexer::is_pod_start_directive_at_line_start` and `PerlLexer::is_cut_directive_at_line_start`, and used them when scanning for POD blocks in `crates/perl-lexer/src/lib.rs`.
- Added equivalent helpers in the trivia-preserving parser: `is_pod_start_directive_at_line_start` and `is_cut_directive_at_line_start` in `crates/perl-parser-core/src/tokens/trivia_parser.rs` and used them to collect POD trivia reliably.
- Updated POD extraction logic in `crates/perl-pod/src/lib.rs` to use `starts_with_pod_directive` / `is_pod_start` with bytewise case-insensitive checks and to handle `=head1`/`=head2` in an ASCII-case-insensitive manner.
- Added regression tests covering uppercase `=ENCODING UTF-7`/`=CUT` flows in `perl-pod`, `perl-lexer`, and `perl-parser-core` test suites, and ran formatting (`cargo xtask fmt`).

### Testing
- Ran `cargo test -p perl-pod` and all pod extraction tests passed (`37 passed`).
- Ran the targeted lexer test `uppercase_encoding_directive_with_utf7_is_skipped` with `cargo test -p perl-lexer` and it passed.
- Ran the targeted trivia parser test `test_uppercase_encoding_utf7_pod_commands` with `cargo test -p perl-parser-core` and it passed.
- Ran `cargo xtask fmt` to ensure formatting; it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa0a0572883339fd7424729c22ea0)