### PR TITLE
fix(perl-pragma): normalize UTF-7 encoding aliases (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -370,6 +370,15 @@ fn normalized_pragma_token(arg: &str) -> &str {
     arg.trim().trim_matches('\'').trim_matches('"')
 }
 
+fn normalize_encoding_name(arg: &str) -> String {
+    let normalized = normalized_pragma_token(arg);
+    let folded = normalized.to_ascii_lowercase();
+    match folded.as_str() {
+        "utf7" | "utf_7" | "utf-7" => "utf-7".to_string(),
+        _ => normalized.to_string(),
+    }
+}
+
 fn is_tracked_pragma_module(module: &str) -> bool {
     matches!(module, "strict" | "warnings" | "utf8" | "encoding" | "locale" | "feature" | "builtin")
 }
@@ -521,9 +530,8 @@ impl PragmaTracker {
                             return;
                         }
                         "encoding" => {
-                            current_state.encoding = conditional_args
-                                .first()
-                                .map(|arg| normalized_pragma_token(arg).to_string());
+                            current_state.encoding =
+                                conditional_args.first().map(|arg| normalize_encoding_name(arg));
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -615,9 +623,8 @@ impl PragmaTracker {
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }
                     "encoding" => {
-                        current_state.encoding = args
-                            .first()
-                            .map(|arg| arg.trim().trim_matches('\'').trim_matches('"').to_string());
+                        current_state.encoding =
+                            args.first().map(|arg| normalize_encoding_name(arg));
                         ranges
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -459,6 +459,24 @@ fn use_encoding_tracks_active_source_encoding() -> Result<(), Box<dyn std::error
 }
 
 #[test]
+fn use_encoding_normalizes_utf7_aliases() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("encoding", &["'UTF7'"], 0, 18)]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 1);
+    assert_eq!(map[0].1.encoding.as_deref(), Some("utf-7"));
+    Ok(())
+}
+
+#[test]
+fn use_if_encoding_normalizes_utf7_aliases() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("if", &["$cond", "encoding", "'UTF_7'"], 0, 34)]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 1);
+    assert_eq!(map[0].1.encoding.as_deref(), Some("utf-7"));
+    Ok(())
+}
+
+#[test]
 fn use_locale_tracks_scope_and_clears_on_no_locale() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![
         use_node("locale", &["':not_characters'"], 0, 28),


### PR DESCRIPTION
### Motivation

- Make `use encoding` handling more robust by canonicalizing common UTF-7 aliases so pragma state is consistent across variants like `UTF7`, `UTF_7`, and `utf-7`.

### Description

- Added `normalize_encoding_name(arg: &str) -> String` which trims/normalizes the token and canonicalizes `utf7`, `utf_7`, and `utf-7` to `utf-7` while leaving other encodings unchanged.
- Use `normalize_encoding_name` in both direct `use encoding ...` and conditional `use if/unless ..., encoding, ...` code paths so both forms produce the canonical value.
- Added two unit tests `use_encoding_normalizes_utf7_aliases` and `use_if_encoding_normalizes_utf7_aliases` to cover the new normalization behavior.

### Testing

- Ran `cargo test -p perl-pragma` and all unit tests passed successfully.
- Ran `cargo check --all-targets -p perl-pragma` and it completed without errors.
- Ran `cargo clippy -p perl-pragma -- -D warnings` and the lint pass succeeded.
- Ran `cargo xtask fmt` to format changes and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa0a0572883339fd7424729c22ea0)