### PR TITLE
fix(fmt): apply rustfmt to perl-parser incremental/mod.rs (#0000)

### DIFF
--- a/crates/perl-parser/src/incremental/mod.rs
+++ b/crates/perl-parser/src/incremental/mod.rs
@@ -649,12 +649,7 @@ mod tests {
         // Delete almost the entire document; this should use full-reparse fallback
         // to keep incremental behavior predictable for large edits.
         let old_end_byte = state.source.len().saturating_sub(1);
-        let edit = Edit {
-            start_byte: 0,
-            old_end_byte,
-            new_end_byte: 0,
-            new_text: String::new(),
-        };
+        let edit = Edit { start_byte: 0, old_end_byte, new_end_byte: 0, new_text: String::new() };
 
         let result = apply_edits(&mut state, &[edit])?;
 


### PR DESCRIPTION
## Summary

Pre-existing fmt drift in `crates/perl-parser/src/incremental/mod.rs` — a 7-line `Edit { .. }` struct literal introduced by merged #5465 needs rustfmt collapse onto a single line. Blocks the `cargo fmt --check` gate on master.

## What changed

- Ran `cargo fmt -p perl-parser` — only `incremental/mod.rs` needed changes after excluding `incremental_v2.rs` (already covered by #5751).
- Diff: `1 insertion(+), 6 deletions(-)` — rustfmt collapses the `Edit { start_byte, old_end_byte, new_end_byte, new_text }` literal to one line.

## Scope boundary

- This PR: `incremental/mod.rs` only.
- `incremental_v2.rs` is handled separately by #5751.

## Verification

- `cargo fmt -p perl-parser` — no further changes.
- `cargo check -p perl-parser` — passes.

## Test plan

- [x] `cargo fmt -p perl-parser` idempotent
- [x] `cargo check -p perl-parser` green
- [ ] CI `cargo fmt --check` green on this branch