### PR TITLE
fix(fmt): escape quotes in comment in formatting.rs (#5665)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
+++ b/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
@@ -313,9 +313,7 @@ mod tests {
     }
     #[test]
     fn apply_lsp_whitespace_options_trim_final_newlines_removes_all_trailing_newlines() {
-        // Regression: previous implementation used ends_with("
-
-") which left
+        // Regression: previous implementation used `ends_with("\n\n")` which left
         // one trailing newline. LSP trimFinalNewlines must remove ALL trailing newlines.
         let options = FormattingOptions {
             tab_size: 4,
@@ -324,17 +322,11 @@ mod tests {
             insert_final_newline: None,
             trim_final_newlines: Some(true),
         };
-        let r = apply_lsp_whitespace_options("content
-", &options);
+        let r = apply_lsp_whitespace_options("content\n", &options);
         assert_eq!(r, "content");
-        let r = apply_lsp_whitespace_options("content
-
-", &options);
+        let r = apply_lsp_whitespace_options("content\n\n", &options);
         assert_eq!(r, "content");
-        let r = apply_lsp_whitespace_options("content
-
-
-", &options);
+        let r = apply_lsp_whitespace_options("content\n\n\n", &options);
         assert_eq!(r, "content");
     }
-}}
+}


### PR DESCRIPTION
## Summary

Master is currently unbuildable due to a malformed regression test in
`crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs`. This PR restores
`cargo check --workspace` to green.

The file contained three related breakages, all introduced by #5665:

- **Broken comment** (lines 316-318): A `//` comment spanning
  `ends_with("\n\n") which left` was written with a literal newline in the middle
  and an unescaped `"`. After the intervening blank line, the tokenizer
  interpreted the `"` on line 318 as the *start* of a string literal, consuming
  the next several lines including the "comment" on line 319 and swallowing the
  first argument to `apply_lsp_whitespace_options` on line 327.
- **String literals with literal newlines** (lines 327-337): the
  `apply_lsp_whitespace_options("content\n", ...)` calls were authored with real
  newlines inside the string literals, which together with the broken comment
  prevented the module from parsing.
- **Extraneous closing brace** (line 340): `}}` where only `}` was needed to
  close `mod tests`.

Rewrote the regression comment using backticks and explicit `\n\n` escapes
(`// Regression: previous implementation used \`ends_with("\n\n")\` which left`),
converted the literal newlines to `\n` escapes, and dropped the extra `}`.

Minimal 5/13 line diff in a single file. No other changes.

## Verification

- `cargo check --workspace --lib` — passes
- `cargo check -p perl-lsp-rs-core --tests` — passes
- `cargo test -p perl-lsp-rs-core --lib apply_lsp_whitespace_options_trim_final_newlines_removes_all_trailing_newlines` — 1 passed
- `rustfmt --check` on the edited file — clean

## Test plan

- [ ] CI `cargo check --workspace` turns green
- [ ] Existing regression test still passes (it was passing locally — just unreadable before)
- [ ] No other crates in the workspace see new failures

Blocks all work on master until merged.