### PR TITLE
refactor(semantic): introduce ImportSurface / VisibleImports record (#4246)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -3,6 +3,7 @@
 //! Provides go-to-declaration functionality for finding where symbols are declared.
 //! Supports LocationLink for enhanced client experience.
 
+use crate::analysis::import_surface::ImportSurface;
 use crate::ast::{Node, NodeKind};
 use crate::symbol::is_universal_method;
 use crate::workspace_index::{SymKind, SymbolKey};
@@ -1435,7 +1436,11 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         export_tag_members(module, import_token).contains(&symbol_name)
     }
 
-    fn find_import_source(ast: &Node, symbol_name: &str) -> Option<String> {
+    fn find_import_source(
+        ast: &Node,
+        surface: &ImportSurface,
+        symbol_name: &str,
+    ) -> Option<String> {
         /// Extract the module name from a `require Module;` statement node.
         ///
         /// Matches both `require Foo::Bar` (Identifier arg) and
@@ -1693,6 +1698,10 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             None
         }
 
+        if let Some(module) = surface.first_resolved_symbol_source(symbol_name) {
+            return Some(module.to_string());
+        }
+
         find(ast, symbol_name)
     }
 
@@ -1843,6 +1852,7 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
     }
 
     let (path, node) = find_symbol_node_at_offset(ast, offset)?;
+    let import_surface = ImportSurface::from_ast(ast);
 
     if let Some(symbol_key) = plack_builder_middleware_symbol(&path, offset) {
         return Some(symbol_key);
@@ -1864,7 +1874,8 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
                 (name[..idx].to_string(), name[idx + 2..].to_string())
             } else {
                 (
-                    find_import_source(ast, name).unwrap_or_else(|| current_pkg.to_string()),
+                    find_import_source(ast, &import_surface, name)
+                        .unwrap_or_else(|| current_pkg.to_string()),
                     name.clone(),
                 )
             };

--- a/crates/perl-semantic-analyzer/src/analysis/import_surface.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/import_surface.rs
@@ -1,0 +1,304 @@
+//! Canonical per-file visible import collection.
+
+use std::collections::{HashMap, HashSet};
+
+use perl_module::import::resolve_known_export_tag;
+
+use crate::{Node, NodeKind, SourceLocation};
+
+/// Kind of import visibility entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VisibleImportKind {
+    /// Explicit symbol imported from a `use Module ...` list.
+    UseList,
+    /// Symbol materialized from an export-tag expansion (for example `:sys_wait_h`).
+    ExportTag,
+    /// Constant introduced by `use constant ...` forms.
+    UseConstant,
+}
+
+/// A visible bare-name import in one file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VisibleImport {
+    /// Bare symbol name visible in the current file.
+    pub bare_name: String,
+    /// Source module or package associated with the visibility.
+    pub source: String,
+    /// Import record kind.
+    pub kind: VisibleImportKind,
+    /// Location of the originating statement when available.
+    pub origin: Option<SourceLocation>,
+    /// Whether the entry is fully resolved (`true`) or a candidate (`false`).
+    pub is_resolved: bool,
+}
+
+/// Canonical set of visible imported bare names for a file.
+#[derive(Debug, Clone, Default)]
+pub struct ImportSurface {
+    entries: Vec<VisibleImport>,
+    by_name: HashMap<String, Vec<usize>>,
+}
+
+impl ImportSurface {
+    /// Build a visible import surface by scanning a file AST.
+    pub fn from_ast(ast: &Node) -> Self {
+        let mut collector = Collector {
+            entries: Vec::new(),
+            seen: HashSet::new(),
+            current_package: "main".to_string(),
+        };
+        collector.visit(ast);
+        Self::from_entries(collector.entries)
+    }
+
+    fn from_entries(entries: Vec<VisibleImport>) -> Self {
+        let mut by_name: HashMap<String, Vec<usize>> = HashMap::new();
+        for (idx, entry) in entries.iter().enumerate() {
+            by_name.entry(entry.bare_name.clone()).or_default().push(idx);
+        }
+        Self { entries, by_name }
+    }
+
+    /// Returns all visible import entries.
+    pub fn entries(&self) -> &[VisibleImport] {
+        &self.entries
+    }
+
+    /// Returns true if `name` is a visible imported bare name.
+    pub fn has_visible_name(&self, name: &str) -> bool {
+        self.by_name.contains_key(name)
+    }
+
+    /// Returns the first resolved non-constant source module for `name`.
+    pub fn first_resolved_symbol_source(&self, name: &str) -> Option<&str> {
+        let indexes = self.by_name.get(name)?;
+        indexes
+            .iter()
+            .filter_map(|idx| self.entries.get(*idx))
+            .find(|entry| {
+                entry.is_resolved && !matches!(entry.kind, VisibleImportKind::UseConstant)
+            })
+            .map(|entry| entry.source.as_str())
+    }
+}
+
+struct Collector {
+    entries: Vec<VisibleImport>,
+    seen: HashSet<(String, String, VisibleImportKind)>,
+    current_package: String,
+}
+
+impl Collector {
+    fn visit(&mut self, node: &Node) {
+        if let NodeKind::Package { name, .. } = &node.kind {
+            self.current_package = name.clone();
+        }
+
+        if let NodeKind::Use { module, args, .. } = &node.kind {
+            if module == "constant" {
+                for constant_name in parse_constant_names(args) {
+                    self.push_entry(VisibleImport {
+                        bare_name: constant_name,
+                        source: self.current_package.clone(),
+                        kind: VisibleImportKind::UseConstant,
+                        origin: Some(node.location),
+                        is_resolved: true,
+                    });
+                }
+            } else {
+                for arg in args {
+                    if arg.starts_with("qw") {
+                        for token in parse_qw_tokens(arg) {
+                            self.push_use_token(module, token, node.location);
+                        }
+                    } else {
+                        self.push_use_token(module, arg, node.location);
+                    }
+                }
+            }
+        }
+
+        for child in node.children() {
+            self.visit(child);
+        }
+    }
+
+    fn push_entry(&mut self, entry: VisibleImport) {
+        let key = (entry.bare_name.clone(), entry.source.clone(), entry.kind);
+        if self.seen.insert(key) {
+            self.entries.push(entry);
+        }
+    }
+
+    fn push_use_token(&mut self, module: &str, token: &str, origin: SourceLocation) {
+        let symbol = normalize_symbol(token);
+        if symbol.is_empty() || symbol == "," {
+            return;
+        }
+
+        if symbol.starts_with(':') {
+            if let Some(expanded) = resolve_known_export_tag(module, symbol) {
+                for name in expanded {
+                    self.push_entry(VisibleImport {
+                        bare_name: (*name).to_string(),
+                        source: module.to_string(),
+                        kind: VisibleImportKind::ExportTag,
+                        origin: Some(origin),
+                        is_resolved: true,
+                    });
+                }
+            }
+            return;
+        }
+
+        if is_bareword(symbol) {
+            self.push_entry(VisibleImport {
+                bare_name: symbol.to_string(),
+                source: module.to_string(),
+                kind: VisibleImportKind::UseList,
+                origin: Some(origin),
+                is_resolved: true,
+            });
+        }
+    }
+}
+
+fn normalize_symbol(token: &str) -> &str {
+    token.trim().trim_matches('\'').trim_matches('"').trim()
+}
+
+fn is_bareword(symbol: &str) -> bool {
+    symbol.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+        && symbol
+            .as_bytes()
+            .first()
+            .is_some_and(|first| first.is_ascii_alphabetic() || *first == b'_')
+}
+
+fn parse_qw_tokens(arg: &str) -> impl Iterator<Item = &str> {
+    arg.trim_start_matches("qw")
+        .trim_start_matches(|c: char| "([{/<|!".contains(c))
+        .trim_end_matches(|c: char| ")]}/|!>".contains(c))
+        .split_whitespace()
+}
+
+fn parse_constant_names(args: &[String]) -> Vec<String> {
+    fn push_unique(names: &mut Vec<String>, seen: &mut HashSet<String>, token: &str) {
+        if is_bareword(token) && seen.insert(token.to_string()) {
+            names.push(token.to_string());
+        }
+    }
+
+    let mut names = Vec::new();
+    let mut seen = HashSet::new();
+
+    let tokens: Vec<&str> = args.iter().map(String::as_str).collect();
+    let mut start = 0usize;
+    while matches!(tokens.get(start), Some(token) if token.starts_with('-') || *token == ",") {
+        start += 1;
+    }
+
+    if let Some(first) = tokens.get(start) {
+        if first.starts_with("qw") {
+            for token in parse_qw_tokens(first) {
+                let normalized = normalize_symbol(token);
+                push_unique(&mut names, &mut seen, normalized);
+            }
+            return names;
+        }
+    }
+
+    let mut i = start;
+    while i < tokens.len() {
+        let token = normalize_symbol(tokens[i]);
+        if token.is_empty() {
+            i += 1;
+            continue;
+        }
+
+        if token == "{" || token == "+{" || token == "+" || token == "}" {
+            i += 1;
+            continue;
+        }
+
+        if is_bareword(token) {
+            push_unique(&mut names, &mut seen, token);
+            if i + 1 < tokens.len() && tokens[i + 1].trim() == "=>" {
+                i += 2;
+                continue;
+            }
+        }
+
+        i += 1;
+    }
+
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Parser;
+
+    use super::{ImportSurface, VisibleImportKind};
+
+    fn import_surface(code: &str) -> Result<ImportSurface, Box<dyn std::error::Error>> {
+        let mut parser = Parser::new(code);
+        let ast = parser.parse()?;
+        Ok(ImportSurface::from_ast(&ast))
+    }
+
+    #[test]
+    fn collects_qw_parens_and_single_quote_imports() -> Result<(), Box<dyn std::error::Error>> {
+        let code = r#"
+use List::Util qw(sum);
+use Carp ('croak');
+use Cwd 'getcwd';
+"#;
+        let surface = import_surface(code)?;
+
+        assert!(surface.has_visible_name("sum"));
+        assert_eq!(surface.first_resolved_symbol_source("sum"), Some("List::Util"));
+        assert_eq!(surface.first_resolved_symbol_source("croak"), Some("Carp"));
+        assert_eq!(surface.first_resolved_symbol_source("getcwd"), Some("Cwd"));
+        Ok(())
+    }
+
+    #[test]
+    fn expands_known_export_tags() -> Result<(), Box<dyn std::error::Error>> {
+        let code = "use POSIX qw(:sys_wait_h);";
+        let surface = import_surface(code)?;
+
+        assert!(surface.has_visible_name("WIFEXITED"));
+        let tag_entry = surface
+            .entries()
+            .iter()
+            .find(|entry| entry.bare_name == "WIFEXITED")
+            .ok_or("WIFEXITED should be visible via :sys_wait_h")?;
+        assert_eq!(tag_entry.kind, VisibleImportKind::ExportTag);
+        assert!(tag_entry.is_resolved);
+        Ok(())
+    }
+
+    #[test]
+    fn collects_supported_use_constant_forms() -> Result<(), Box<dyn std::error::Error>> {
+        let code = r#"
+use constant PI => 3.14;
+use constant ('TAU', 6.28);
+use constant qw(FOO BAR);
+use constant { MIN => 1, MAX => 2 };
+"#;
+        let surface = import_surface(code)?;
+
+        for constant in ["PI", "TAU", "FOO", "BAR", "MIN", "MAX"] {
+            let entry = surface
+                .entries()
+                .iter()
+                .find(|entry| entry.bare_name == constant)
+                .ok_or("constant should be visible")?;
+            assert_eq!(entry.kind, VisibleImportKind::UseConstant);
+            assert!(entry.is_resolved);
+            assert_eq!(entry.source, "main");
+        }
+        Ok(())
+    }
+}

--- a/crates/perl-semantic-analyzer/src/analysis/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/mod.rs
@@ -5,6 +5,8 @@ pub mod class_model;
 /// Go-to-declaration support and parent map construction.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod declaration;
+/// Canonical visible import surface for a file.
+pub mod import_surface;
 /// Lightweight workspace symbol index.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod index;

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -49,9 +49,9 @@
 //! # }
 //! ```
 
+use crate::analysis::import_surface::ImportSurface;
 use crate::ast::{Node, NodeKind};
 use crate::pragma_tracker::{PragmaState, PragmaTracker};
-use perl_module::import::resolve_known_export_tag;
 use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
 use std::ops::Range;
@@ -358,7 +358,7 @@ enum ExtractedName<'a> {
 struct AnalysisContext<'a> {
     code: &'a str,
     pragma_map: &'a [(Range<usize>, PragmaState)],
-    imported_barewords: std::collections::HashSet<String>,
+    import_surface: ImportSurface,
     line_starts: RefCell<Option<Vec<usize>>>,
     /// Current package name, updated as `package` statements are traversed.
     current_package: RefCell<String>,
@@ -369,14 +369,14 @@ impl<'a> AnalysisContext<'a> {
         Self {
             code,
             pragma_map,
-            imported_barewords: collect_imported_barewords(ast),
+            import_surface: ImportSurface::from_ast(ast),
             line_starts: RefCell::new(None),
             current_package: RefCell::new("main".to_string()),
         }
     }
 
     fn has_imported_bareword(&self, name: &str) -> bool {
-        self.imported_barewords.contains(name)
+        self.import_surface.has_visible_name(name)
     }
 
     fn get_line(&self, offset: usize) -> usize {
@@ -1839,57 +1839,6 @@ impl ScopeAnalyzer {
             })
             .collect()
     }
-}
-
-fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
-    fn push_symbol(imported: &mut std::collections::HashSet<String>, module: &str, token: &str) {
-        let symbol = token.trim().trim_matches('\'').trim_matches('"').trim();
-        if symbol.is_empty() || symbol == "," {
-            return;
-        }
-
-        if symbol.starts_with(':') {
-            if let Some(expanded) = resolve_known_export_tag(module, symbol) {
-                imported.extend(expanded.iter().map(|name| (*name).to_string()));
-            }
-            return;
-        }
-
-        let is_bareword = symbol.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
-            && symbol
-                .as_bytes()
-                .first()
-                .is_some_and(|first| first.is_ascii_alphabetic() || *first == b'_');
-        if is_bareword {
-            imported.insert(symbol.to_string());
-        }
-    }
-
-    fn visit(node: &Node, imported: &mut std::collections::HashSet<String>) {
-        if let NodeKind::Use { module, args, .. } = &node.kind {
-            for arg in args {
-                if arg.starts_with("qw") {
-                    let content = arg
-                        .trim_start_matches("qw")
-                        .trim_start_matches(|c: char| "([{/<|!".contains(c))
-                        .trim_end_matches(|c: char| ")]}/|!>".contains(c));
-                    for token in content.split_whitespace() {
-                        push_symbol(imported, module, token);
-                    }
-                } else {
-                    push_symbol(imported, module, arg);
-                }
-            }
-        }
-
-        for child in node.children() {
-            visit(child, imported);
-        }
-    }
-
-    let mut imported = std::collections::HashSet::new();
-    visit(ast, &mut imported);
-    imported
 }
 
 /// Returns true if `name` (without sigil) is a numbered capture variable.

--- a/crates/perl-semantic-analyzer/src/lib.rs
+++ b/crates/perl-semantic-analyzer/src/lib.rs
@@ -68,6 +68,7 @@ pub mod analysis;
 pub use analysis::class_model;
 #[cfg(not(target_arch = "wasm32"))]
 pub use analysis::declaration;
+pub use analysis::import_surface;
 #[cfg(not(target_arch = "wasm32"))]
 pub use analysis::index;
 pub use analysis::scope_analyzer;

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -55,6 +55,59 @@ croak("error");
 }
 
 #[test]
+fn use_parenthesized_import_resolves_pkg() {
+    let code = r#"use Carp ('croak');
+croak("error");
+"#;
+    let pkg = parse_and_symbol_at(code, "croak(");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("Carp"),
+        "croak() should resolve to Carp via parenthesized import, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn use_single_quote_import_resolves_pkg() {
+    let code = r#"use Cwd 'getcwd';
+my $cwd = getcwd();
+"#;
+    let pkg = parse_and_symbol_at(code, "getcwd()");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("Cwd"),
+        "getcwd() should resolve to Cwd via single-quote import, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn use_known_tag_import_resolves_pkg() {
+    let code = r#"use POSIX qw(:sys_wait_h);
+my $ok = WIFEXITED($status);
+"#;
+    let pkg = parse_and_symbol_at(code, "WIFEXITED(");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("POSIX"),
+        "WIFEXITED() should resolve to POSIX via known export tag, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn use_constant_does_not_resolve_to_constant_module() {
+    let code = r#"package Demo;
+use constant PI => 3.14;
+my $x = PI();
+"#;
+    let pkg = parse_and_symbol_at(code, "PI()");
+    assert_ne!(
+        pkg.as_deref(),
+        Some("constant"),
+        "PI() should not resolve to the constant pragma module, got: {pkg:?}"
+    );
+}
+
+#[test]
 fn require_import_multiple_symbols_both_resolve() {
     let code = r#"require My::Utils;
 My::Utils->import('alpha', 'beta');


### PR DESCRIPTION
### Motivation

- Imported bareword visibility and import-origin logic were scattered across ad-hoc checks in scope and declaration code, making reasoning and future extension harder.

### Description

- Add a new `ImportSurface` abstraction and `VisibleImport` / `VisibleImportKind` types in `crates/perl-semantic-analyzer/src/analysis/import_surface.rs` to represent per-file visible imported bare names and their origin (bare name, source module/package, kind, origin span, resolved flag).
- Populate `ImportSurface` from static `use` forms already supported: `qw(...)`, parenthesized import lists, single-quoted imports, known export tag expansions, and `use constant` variants (including hash/`qw`/pair forms).
- Thread `ImportSurface` into existing consumers: replace the ad-hoc imported-barewords set in `scope_analyzer` with `ImportSurface::from_ast(...)` and use `has_visible_name`, and consult `ImportSurface` from `declaration::find_import_source` to prefer file-local visible imports before falling back to the existing `require ...; Module->import(...)` logic.
- Re-export the new module via `analysis/mod.rs` and `lib.rs` so other crates can reference `import_surface`.
- Add unit tests exercising `qw`/parenthesized/single-quote/tag/`use constant` forms and extend declaration tests to cover parenthesized/single-quote/tag imports and that `use constant` entries do not incorrectly resolve to the `constant` pragma module.

### Testing

- Ran formatting: `cargo xtask fmt` / `cargo fmt -p perl-semantic-analyzer` (completed).
- Ran unit tests for the changed crate: `cargo test -p perl-semantic-analyzer` — all tests passed.
- Ran checks for the changed crate: `cargo check --all-targets -p perl-semantic-analyzer` — succeeded.
- Full workspace check: `cargo check --workspace --all-targets` surfaced an unrelated pre-existing syntax issue in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` (not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead312e7d483339c7ab101ae3f71c6)