### PR TITLE
refactor(semantic): introduce ImportSurface / VisibleImports record (#4246)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -3,6 +3,7 @@
 //! Provides go-to-declaration functionality for finding where symbols are declared.
 //! Supports LocationLink for enhanced client experience.
 
+use super::import_surface::{ImportSurface, resolve_known_export_tag};
 use crate::ast::{Node, NodeKind};
 use crate::symbol::is_universal_method;
 use crate::workspace_index::{SymKind, SymbolKey};
@@ -1399,43 +1400,19 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
     }
 
-    fn export_tag_members(module: &str, tag: &str) -> &'static [&'static str] {
-        match (module, tag) {
-            // POSIX tag sets commonly used in system scripts.
-            ("POSIX", ":sys_wait_h") => {
-                &["WEXITSTATUS", "WIFEXITED", "WIFSIGNALED", "WIFSTOPPED", "WTERMSIG"]
-            }
-            ("POSIX", ":fcntl_h") => &["F_GETFD", "F_SETFD", "F_GETFL", "F_SETFL", "FD_CLOEXEC"],
-            ("POSIX", ":termios_h") => {
-                &["B9600", "B19200", "B38400", "TCSANOW", "TCSADRAIN", "TCSAFLUSH"]
-            }
-            // File::Find exports.
-            ("File::Find", ":find") => &["find", "finddepth"],
-            // Fcntl exports.
-            ("Fcntl", ":seek") => &["SEEK_SET", "SEEK_CUR", "SEEK_END"],
-            ("Fcntl", ":lock") => &["LOCK_SH", "LOCK_EX", "LOCK_NB", "LOCK_UN"],
-            // Encode exports.
-            ("Encode", ":fallback") => &[
-                "FB_DEFAULT",
-                "FB_CROAK",
-                "FB_QUIET",
-                "FB_WARN",
-                "FB_PERLQQ",
-                "FB_HTMLCREF",
-                "FB_XMLCREF",
-            ],
-            _ => &[],
-        }
-    }
-
     fn tag_imports_symbol(module: &str, import_token: &str, symbol_name: &str) -> bool {
         if !import_token.starts_with(':') {
             return false;
         }
-        export_tag_members(module, import_token).contains(&symbol_name)
+        resolve_known_export_tag(module, import_token)
+            .is_some_and(|members| members.contains(&symbol_name))
     }
 
     fn find_import_source(ast: &Node, symbol_name: &str) -> Option<String> {
+        if let Some(source) = ImportSurface::from_ast(ast).resolved_source_for(symbol_name) {
+            return Some(source.to_string());
+        }
+
         /// Extract the module name from a `require Module;` statement node.
         ///
         /// Matches both `require Foo::Bar` (Identifier arg) and

--- a/crates/perl-semantic-analyzer/src/analysis/import_surface.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/import_surface.rs
@@ -1,0 +1,317 @@
+//! Visible import surface extraction for a single Perl file.
+//!
+//! Consolidates import visibility into a single canonical record so downstream
+//! consumers (bareword resolution, diagnostics, completion seeding) can use one
+//! source of truth.
+
+use crate::ast::{Node, NodeKind, SourceLocation};
+use rustc_hash::FxHashMap;
+
+/// Canonical import origin kind for visible bare names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportKind {
+    /// `use Module qw(foo bar)` / `use Module 'foo'` / `use Module ('foo')`
+    UseList,
+    /// `use Module qw(:tag)` expanded through known tag tables.
+    ExportTag {
+        /// Original export-tag token (for example `:sys_wait_h`).
+        tag: String,
+    },
+    /// `use constant NAME => ...` or `use constant { NAME => ... }`.
+    UseConstant,
+}
+
+/// One visible bare name introduced by imports/constants in a file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VisibleImport {
+    /// Bare symbol name visible in the file.
+    pub bare_name: String,
+    /// Source module/package that contributes the name.
+    pub source_package: String,
+    /// Import form that introduced the visible name.
+    pub kind: ImportKind,
+    /// Source location of the originating statement, if available.
+    pub origin: Option<SourceLocation>,
+    /// Whether this entry is fully resolved (`true`) versus a candidate (`false`).
+    pub is_resolved: bool,
+}
+
+/// Per-file visible import record.
+#[derive(Debug, Clone, Default)]
+pub struct ImportSurface {
+    entries: Vec<VisibleImport>,
+    by_name: FxHashMap<String, Vec<usize>>,
+}
+
+impl ImportSurface {
+    /// Build the visible import surface for a parsed file AST.
+    pub fn from_ast(ast: &Node) -> Self {
+        fn visit(node: &Node, current_package: &str, surface: &mut ImportSurface) {
+            let mut package_for_children = current_package.to_string();
+
+            match &node.kind {
+                NodeKind::Package { name, .. } => {
+                    package_for_children = name.clone();
+                }
+                NodeKind::Use { module, args, .. } => {
+                    if module == "constant" {
+                        for name in extract_constant_names_from_use_args(args) {
+                            surface.push(VisibleImport {
+                                bare_name: name,
+                                source_package: current_package.to_string(),
+                                kind: ImportKind::UseConstant,
+                                origin: Some(node.location),
+                                is_resolved: true,
+                            });
+                        }
+                    } else {
+                        for arg in args {
+                            let normalized_arg = normalize_symbol_name(arg);
+                            if normalized_arg.is_empty() {
+                                continue;
+                            }
+
+                            if normalized_arg.starts_with("qw") {
+                                for token in qw_tokens(&normalized_arg) {
+                                    surface.push_use_token(module, token, node.location);
+                                }
+                                continue;
+                            }
+
+                            surface.push_use_token(module, &normalized_arg, node.location);
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            for child in node.children() {
+                visit(child, &package_for_children, surface);
+            }
+        }
+
+        let mut surface = Self::default();
+        visit(ast, "main", &mut surface);
+        surface
+    }
+
+    /// Immutable entries in insertion order.
+    pub fn entries(&self) -> &[VisibleImport] {
+        &self.entries
+    }
+
+    /// Returns true if the bare name is visible through any import entry.
+    pub fn contains_bare_name(&self, name: &str) -> bool {
+        self.by_name.contains_key(name)
+    }
+
+    /// Returns visible entries for a given bare symbol name.
+    pub fn visible_entries_for(&self, name: &str) -> impl Iterator<Item = &VisibleImport> {
+        self.by_name
+            .get(name)
+            .into_iter()
+            .flat_map(|indices| indices.iter().filter_map(|index| self.entries.get(*index)))
+    }
+
+    /// Find first resolved source package for a bare symbol, if present.
+    pub fn resolved_source_for(&self, name: &str) -> Option<&str> {
+        self.visible_entries_for(name)
+            .find(|entry| entry.is_resolved)
+            .map(|entry| entry.source_package.as_str())
+    }
+
+    fn push_use_token(&mut self, module: &str, token: &str, origin: SourceLocation) {
+        if token.starts_with(':') {
+            if let Some(expanded) = resolve_known_export_tag(module, token) {
+                for symbol in expanded {
+                    self.push(VisibleImport {
+                        bare_name: symbol.to_string(),
+                        source_package: module.to_string(),
+                        kind: ImportKind::ExportTag { tag: token.to_string() },
+                        origin: Some(origin),
+                        is_resolved: true,
+                    });
+                }
+            }
+            return;
+        }
+
+        if is_bareword(token) {
+            self.push(VisibleImport {
+                bare_name: token.to_string(),
+                source_package: module.to_string(),
+                kind: ImportKind::UseList,
+                origin: Some(origin),
+                is_resolved: true,
+            });
+        }
+    }
+
+    fn push(&mut self, entry: VisibleImport) {
+        let index = self.entries.len();
+        self.by_name.entry(entry.bare_name.clone()).or_default().push(index);
+        self.entries.push(entry);
+    }
+}
+
+/// Resolve known export-tag members for core/common modules.
+pub fn resolve_known_export_tag(module: &str, tag: &str) -> Option<&'static [&'static str]> {
+    match (module, tag) {
+        ("POSIX", ":sys_wait_h") => {
+            Some(&["WEXITSTATUS", "WIFEXITED", "WIFSIGNALED", "WIFSTOPPED", "WTERMSIG"])
+        }
+        ("POSIX", ":fcntl_h") => Some(&["F_GETFD", "F_SETFD", "F_GETFL", "F_SETFL", "FD_CLOEXEC"]),
+        ("POSIX", ":termios_h") => {
+            Some(&["B9600", "B19200", "B38400", "TCSANOW", "TCSADRAIN", "TCSAFLUSH"])
+        }
+        ("File::Find", ":find") => Some(&["find", "finddepth"]),
+        ("Fcntl", ":seek") => Some(&["SEEK_SET", "SEEK_CUR", "SEEK_END"]),
+        ("Fcntl", ":lock") => Some(&["LOCK_SH", "LOCK_EX", "LOCK_NB", "LOCK_UN"]),
+        ("Encode", ":fallback") => Some(&[
+            "FB_DEFAULT",
+            "FB_CROAK",
+            "FB_QUIET",
+            "FB_WARN",
+            "FB_PERLQQ",
+            "FB_HTMLCREF",
+            "FB_XMLCREF",
+        ]),
+        _ => None,
+    }
+}
+
+fn qw_tokens(arg: &str) -> impl Iterator<Item = &str> {
+    arg.trim_start_matches("qw")
+        .trim_start_matches(|c: char| "([{/<|!".contains(c))
+        .trim_end_matches(|c: char| ")]}/|!>".contains(c))
+        .split_whitespace()
+}
+
+fn normalize_symbol_name(raw: &str) -> String {
+    raw.trim().trim_matches('\'').trim_matches('"').trim().to_string()
+}
+
+fn is_bareword(symbol: &str) -> bool {
+    symbol.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+        && symbol
+            .as_bytes()
+            .first()
+            .is_some_and(|first| first.is_ascii_alphabetic() || *first == b'_')
+}
+
+fn extract_constant_names_from_use_args(args: &[String]) -> Vec<String> {
+    fn normalize_constant_name(token: &str) -> Option<&str> {
+        let trimmed = token.trim().trim_matches('\'').trim_matches('"').trim();
+        let candidate = trimmed
+            .trim_start_matches(|c: char| c == '{' || c == '(')
+            .trim_end_matches(|c: char| c == '}' || c == ')' || c == ',');
+
+        if candidate.is_empty() || candidate == "=>" {
+            return None;
+        }
+        if !candidate.chars().all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == ':') {
+            return None;
+        }
+        candidate.chars().next().filter(|ch| ch.is_ascii_alphabetic() || *ch == '_')?;
+        Some(candidate)
+    }
+
+    fn push_unique(
+        names: &mut Vec<String>,
+        seen: &mut std::collections::HashSet<String>,
+        candidate: &str,
+    ) {
+        if seen.insert(candidate.to_string()) {
+            names.push(candidate.to_string());
+        }
+    }
+
+    let mut names = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for arg in args {
+        if arg.starts_with('{') {
+            let mut expect_key = true;
+            for word in
+                arg.split(|ch: char| ch.is_whitespace() || [',', '{', '}', '(', ')'].contains(&ch))
+            {
+                if word.is_empty() {
+                    continue;
+                }
+                if word == "=>" {
+                    expect_key = true;
+                    continue;
+                }
+                if expect_key {
+                    if let Some(candidate) = normalize_constant_name(word) {
+                        push_unique(&mut names, &mut seen, candidate);
+                    }
+                    expect_key = false;
+                }
+            }
+            continue;
+        }
+
+        if arg.starts_with("qw") {
+            for word in qw_tokens(arg) {
+                if let Some(candidate) = normalize_constant_name(word) {
+                    push_unique(&mut names, &mut seen, candidate);
+                }
+            }
+            continue;
+        }
+
+        if let Some(candidate) = normalize_constant_name(arg)
+            && candidate != "constant"
+            && !candidate.contains("::")
+            && !candidate.chars().all(char::is_numeric)
+        {
+            push_unique(&mut names, &mut seen, candidate);
+            continue;
+        }
+    }
+
+    if names.is_empty() {
+        let Some(first) = args.first() else {
+            return names;
+        };
+        if let Some(candidate) = normalize_constant_name(first) {
+            push_unique(&mut names, &mut seen, candidate);
+        }
+    }
+
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ImportKind, ImportSurface};
+    use crate::Parser;
+
+    #[test]
+    fn collects_use_forms_tags_and_constants() -> Result<(), Box<dyn std::error::Error>> {
+        let code = r#"
+use List::Util qw(sum);
+use POSIX ('WIFEXITED');
+use POSIX 'WTERMSIG';
+use POSIX qw(:sys_wait_h);
+use constant PI => 3.14;
+"#;
+        let mut parser = Parser::new(code);
+        let ast = parser.parse()?;
+
+        let surface = ImportSurface::from_ast(&ast);
+
+        assert!(surface.contains_bare_name("sum"));
+        assert!(surface.contains_bare_name("WIFEXITED"));
+        assert!(surface.contains_bare_name("WTERMSIG"));
+        assert!(surface.contains_bare_name("WEXITSTATUS"));
+        assert!(surface.contains_bare_name("PI"));
+
+        let pi = surface.visible_entries_for("PI").next().ok_or("PI should be collected")?;
+        assert_eq!(pi.source_package, "main");
+        assert!(matches!(pi.kind, ImportKind::UseConstant));
+        assert!(pi.is_resolved);
+        Ok(())
+    }
+}

--- a/crates/perl-semantic-analyzer/src/analysis/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/mod.rs
@@ -5,6 +5,8 @@ pub mod class_model;
 /// Go-to-declaration support and parent map construction.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod declaration;
+/// Canonical per-file visible import surface.
+pub mod import_surface;
 /// Lightweight workspace symbol index.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod index;

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -49,9 +49,9 @@
 //! # }
 //! ```
 
+use super::import_surface::ImportSurface;
 use crate::ast::{Node, NodeKind};
 use crate::pragma_tracker::{PragmaState, PragmaTracker};
-use perl_module::import::resolve_known_export_tag;
 use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
 use std::ops::Range;
@@ -358,7 +358,7 @@ enum ExtractedName<'a> {
 struct AnalysisContext<'a> {
     code: &'a str,
     pragma_map: &'a [(Range<usize>, PragmaState)],
-    imported_barewords: std::collections::HashSet<String>,
+    import_surface: ImportSurface,
     line_starts: RefCell<Option<Vec<usize>>>,
     /// Current package name, updated as `package` statements are traversed.
     current_package: RefCell<String>,
@@ -369,14 +369,14 @@ impl<'a> AnalysisContext<'a> {
         Self {
             code,
             pragma_map,
-            imported_barewords: collect_imported_barewords(ast),
+            import_surface: ImportSurface::from_ast(ast),
             line_starts: RefCell::new(None),
             current_package: RefCell::new("main".to_string()),
         }
     }
 
     fn has_imported_bareword(&self, name: &str) -> bool {
-        self.imported_barewords.contains(name)
+        self.import_surface.contains_bare_name(name)
     }
 
     fn get_line(&self, offset: usize) -> usize {
@@ -1839,57 +1839,6 @@ impl ScopeAnalyzer {
             })
             .collect()
     }
-}
-
-fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
-    fn push_symbol(imported: &mut std::collections::HashSet<String>, module: &str, token: &str) {
-        let symbol = token.trim().trim_matches('\'').trim_matches('"').trim();
-        if symbol.is_empty() || symbol == "," {
-            return;
-        }
-
-        if symbol.starts_with(':') {
-            if let Some(expanded) = resolve_known_export_tag(module, symbol) {
-                imported.extend(expanded.iter().map(|name| (*name).to_string()));
-            }
-            return;
-        }
-
-        let is_bareword = symbol.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
-            && symbol
-                .as_bytes()
-                .first()
-                .is_some_and(|first| first.is_ascii_alphabetic() || *first == b'_');
-        if is_bareword {
-            imported.insert(symbol.to_string());
-        }
-    }
-
-    fn visit(node: &Node, imported: &mut std::collections::HashSet<String>) {
-        if let NodeKind::Use { module, args, .. } = &node.kind {
-            for arg in args {
-                if arg.starts_with("qw") {
-                    let content = arg
-                        .trim_start_matches("qw")
-                        .trim_start_matches(|c: char| "([{/<|!".contains(c))
-                        .trim_end_matches(|c: char| ")]}/|!>".contains(c));
-                    for token in content.split_whitespace() {
-                        push_symbol(imported, module, token);
-                    }
-                } else {
-                    push_symbol(imported, module, arg);
-                }
-            }
-        }
-
-        for child in node.children() {
-            visit(child, imported);
-        }
-    }
-
-    let mut imported = std::collections::HashSet::new();
-    visit(ast, &mut imported);
-    imported
 }
 
 /// Returns true if `name` (without sigil) is a numbered capture variable.

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1896,6 +1896,42 @@ print sum(1, 2, 3);
 }
 
 #[test]
+fn strict_subs_allows_paren_list_imported_barewords() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+use POSIX ('WIFEXITED');
+print WIFEXITED(0);
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "WIFEXITED"
+        }),
+        "strict 'subs' should not flag paren-list imported bareword function names"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_subs_allows_single_quoted_imported_barewords() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+use List::Util 'sum';
+print sum(1, 2, 3);
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "sum"
+        }),
+        "strict 'subs' should not flag single-quoted imported bareword function names"
+    );
+    Ok(())
+}
+
+#[test]
 fn strict_subs_allows_tag_imported_barewords() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
@@ -1909,6 +1945,24 @@ print WIFEXITED(0);
             matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "WIFEXITED"
         }),
         "strict 'subs' should not flag symbols imported through known export tags"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_subs_allows_use_constant_barewords() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+use constant PI => 3.14159;
+print PI;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "PI"
+        }),
+        "strict 'subs' should not flag barewords introduced by use constant"
     );
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Import visibility for bare names was implemented ad hoc in multiple places, complicating strict-subs suppression, go-to-definition import resolution, and future extensions.
- Provide a single per-file canonical record so downstream consumers can rely on one source of truth without changing behavior.

### Description
- Add `ImportSurface`, `VisibleImport`, and `ImportKind` in `crates/perl-semantic-analyzer/src/analysis/import_surface.rs` to represent per-file visible imports with bare name, source package, kind, origin location, and resolved/candidate state.
- Populate the surface from static `use` forms (qw/list/paren/single-quoted), known export-tag expansions, and `use constant` forms already supported by the code base.
- Wire `ScopeAnalyzer` to consume `ImportSurface::from_ast(ast)` instead of the previous ad hoc `HashSet` for bareword suppression (scope analysis). 
- Thread `declaration::find_import_source` to consult `ImportSurface` first for resolved import sources and centralize export-tag membership checks through the new helper.
- Register the new module in `analysis/mod.rs` and add unit tests exercising `qw`, paren-list, single-quoted, export-tag, and `use constant` cases.

### Testing
- Ran `cargo test -p perl-semantic-analyzer` and all tests passed (122 unit tests across the crate reported OK).
- Ran `cargo check --all-targets -p perl-semantic-analyzer` and it passed for the modified crate.
- Ran targeted tests `cargo test -p perl-semantic-analyzer strict_subs_allows_...` and the new/related tests passed.
- `cargo check --workspace --all-targets` and formatting (`cargo xtask fmt` / `cargo fmt --all`) are blocked by an unrelated pre-existing parse error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` (unterminated string literal), which prevented full workspace checks; this failure is outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead312e7d483339c7ab101ae3f71c6)