### PR TITLE
refactor(semantic): introduce ImportSurface / VisibleImports record (#4246)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -4,6 +4,7 @@
 //! Supports LocationLink for enhanced client experience.
 
 use crate::ast::{Node, NodeKind};
+use crate::analysis::import_surface::ImportSurface;
 use crate::symbol::is_universal_method;
 use crate::workspace_index::{SymKind, SymbolKey};
 use rustc_hash::FxHashMap;
@@ -1436,6 +1437,11 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
     }
 
     fn find_import_source(ast: &Node, symbol_name: &str) -> Option<String> {
+        let import_surface = ImportSurface::from_ast(ast);
+        if let Some(module) = import_surface.source_for_name(symbol_name) {
+            return Some(module.to_string());
+        }
+
         /// Extract the module name from a `require Module;` statement node.
         ///
         /// Matches both `require Foo::Bar` (Identifier arg) and
@@ -1632,46 +1638,6 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         }
 
         fn find(node: &Node, name: &str) -> Option<String> {
-            if let NodeKind::Use { module, args, .. } = &node.kind {
-                // Skip `use constant` — constants are not import-list symbols
-                if module == "constant" {
-                    // Fall through to children
-                } else {
-                    for arg in args {
-                        if arg == name {
-                            return Some(module.clone());
-                        }
-                        if tag_imports_symbol(module, arg, name) {
-                            return Some(module.clone());
-                        }
-                        if arg.starts_with("qw") {
-                            let content = arg
-                                .trim_start_matches("qw")
-                                .trim_start_matches(|c: char| "([{/<|!".contains(c))
-                                .trim_end_matches(|c: char| ")]}/|!>".contains(c));
-                            for import_token in content.split_whitespace() {
-                                if import_token == name
-                                    || tag_imports_symbol(module, import_token, name)
-                                {
-                                    return Some(module.clone());
-                                }
-                            }
-                        } else {
-                            // Parenthesized import list: use Foo ('bar', 'baz')
-                            // The parser emits each token as a separate arg including commas
-                            // and string literals with their surrounding quotes.
-                            let bare = arg.trim().trim_matches('\'').trim_matches('"').trim();
-                            if bare == name {
-                                return Some(module.clone());
-                            }
-                            if tag_imports_symbol(module, bare, name) {
-                                return Some(module.clone());
-                            }
-                        }
-                    }
-                }
-            }
-
             // Scan block/program statement lists for `require M; M->import(sym)` patterns.
             let stmts = match &node.kind {
                 NodeKind::Program { statements } => Some(statements.as_slice()),

--- a/crates/perl-semantic-analyzer/src/analysis/import_surface.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/import_surface.rs
@@ -1,0 +1,302 @@
+//! Canonical per-file import visibility surface.
+
+use crate::ast::{Node, NodeKind, SourceLocation};
+use perl_module::import::resolve_known_export_tag;
+use std::collections::HashSet;
+
+/// Classifies how a visible import candidate was introduced.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ImportKind {
+    /// `use Module qw(foo bar)` and related list forms.
+    UseList,
+    /// `use Module ':tag'` expanded via known export-tag metadata.
+    ExportTag {
+        /// Export tag token (for example `:sys_wait_h`).
+        tag: String,
+    },
+    /// `use constant NAME => ...` forms.
+    UseConstant,
+}
+
+/// One visible bare-name entry in a file's import surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VisibleImport {
+    /// Imported or otherwise visible bare symbol name.
+    pub bare_name: String,
+    /// Source package/module that provides the visible name.
+    pub source_package: String,
+    /// Classification of the import mechanism.
+    pub kind: ImportKind,
+    /// Source span for the origin import statement, if available.
+    pub origin: Option<SourceLocation>,
+    /// Whether this entry is fully resolved (`true`) or only a candidate (`false`).
+    pub is_resolved: bool,
+}
+
+/// Per-file canonical record of visible imported bare names.
+#[derive(Debug, Clone, Default)]
+pub struct ImportSurface {
+    entries: Vec<VisibleImport>,
+}
+
+impl ImportSurface {
+    /// Build an import surface from the AST using currently supported static cases.
+    pub fn from_ast(ast: &Node) -> Self {
+        fn normalize_symbol(token: &str) -> Option<&str> {
+            let symbol = token.trim().trim_matches('\'').trim_matches('"').trim();
+            if symbol.is_empty() || symbol == "," { None } else { Some(symbol) }
+        }
+
+        fn is_bareword(symbol: &str) -> bool {
+            symbol.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+                && symbol
+                    .as_bytes()
+                    .first()
+                    .is_some_and(|first| first.is_ascii_alphabetic() || *first == b'_')
+        }
+
+        fn parse_qw_words(token: &str) -> Option<Vec<String>> {
+            if !token.trim_start().starts_with("qw") {
+                return None;
+            }
+            let content = token
+                .trim_start()
+                .trim_start_matches("qw")
+                .trim_start_matches(|c: char| c.is_whitespace())
+                .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+            Some(content.split_whitespace().map(ToString::to_string).collect())
+        }
+
+        fn extract_constant_names(args: &[String]) -> Vec<String> {
+            fn normalize_constant_name(token: &str) -> Option<&str> {
+                let stripped = token.trim_matches(|c: char| {
+                    matches!(c, '\'' | '"' | '(' | ')' | '[' | ']' | '{' | '}' | ',' | ';')
+                });
+                if stripped.is_empty() || stripped.starts_with('-') {
+                    return None;
+                }
+                stripped.chars().all(|c| c.is_alphanumeric() || c == '_').then_some(stripped)
+            }
+
+            let mut names = Vec::new();
+            let mut seen = HashSet::new();
+
+            let Some(first) = args.first().map(String::as_str) else {
+                return names;
+            };
+
+            if let Some(words) = parse_qw_words(first) {
+                for word in words {
+                    if let Some(candidate) = normalize_constant_name(&word)
+                        && seen.insert(candidate.to_string())
+                    {
+                        names.push(candidate.to_string());
+                    }
+                }
+                return names;
+            }
+
+            let starts_hash_form = first == "{"
+                || first == "+{"
+                || (first == "+" && args.get(1).map(String::as_str) == Some("{"));
+            if starts_hash_form {
+                let mut skipped_leading_plus = false;
+                let mut iter = args.iter().peekable();
+                while let Some(arg) = iter.next() {
+                    if arg == "+{" {
+                        skipped_leading_plus = true;
+                        continue;
+                    }
+                    if arg == "+" && !skipped_leading_plus {
+                        skipped_leading_plus = true;
+                        continue;
+                    }
+                    if arg == "{" || arg == "}" || arg == "," || arg == "=>" {
+                        continue;
+                    }
+                    if let Some(candidate) = normalize_constant_name(arg)
+                        && iter.peek().map(|s| s.as_str()) == Some("=>")
+                        && seen.insert(candidate.to_string())
+                    {
+                        names.push(candidate.to_string());
+                    }
+                }
+                return names;
+            }
+
+            if let Some(candidate) = normalize_constant_name(first)
+                && seen.insert(candidate.to_string())
+            {
+                names.push(candidate.to_string());
+            }
+
+            names
+        }
+
+        fn insert_entry(
+            entries: &mut Vec<VisibleImport>,
+            dedupe: &mut HashSet<(String, String, ImportKind)>,
+            bare_name: &str,
+            source_package: &str,
+            kind: ImportKind,
+            origin: Option<SourceLocation>,
+            is_resolved: bool,
+        ) {
+            let key = (bare_name.to_string(), source_package.to_string(), kind.clone());
+            if dedupe.insert(key) {
+                entries.push(VisibleImport {
+                    bare_name: bare_name.to_string(),
+                    source_package: source_package.to_string(),
+                    kind,
+                    origin,
+                    is_resolved,
+                });
+            }
+        }
+
+        fn visit(
+            node: &Node,
+            current_package: &mut String,
+            entries: &mut Vec<VisibleImport>,
+            dedupe: &mut HashSet<(String, String, ImportKind)>,
+        ) {
+            match &node.kind {
+                NodeKind::Package { name, .. } => {
+                    *current_package = name.clone();
+                }
+                NodeKind::Use { module, args, .. } => {
+                    if module == "constant" {
+                        for constant_name in extract_constant_names(args) {
+                            insert_entry(
+                                entries,
+                                dedupe,
+                                &constant_name,
+                                current_package,
+                                ImportKind::UseConstant,
+                                Some(node.location),
+                                true,
+                            );
+                        }
+                    } else {
+                        for arg in args {
+                            if let Some(words) = parse_qw_words(arg) {
+                                for token in words {
+                                    if let Some(symbol) = normalize_symbol(&token) {
+                                        if symbol.starts_with(':') {
+                                            if let Some(expanded) =
+                                                resolve_known_export_tag(module, symbol)
+                                            {
+                                                for expanded_symbol in expanded {
+                                                    insert_entry(
+                                                        entries,
+                                                        dedupe,
+                                                        expanded_symbol,
+                                                        module,
+                                                        ImportKind::ExportTag {
+                                                            tag: symbol.to_string(),
+                                                        },
+                                                        Some(node.location),
+                                                        true,
+                                                    );
+                                                }
+                                            }
+                                        } else if is_bareword(symbol) {
+                                            insert_entry(
+                                                entries,
+                                                dedupe,
+                                                symbol,
+                                                module,
+                                                ImportKind::UseList,
+                                                Some(node.location),
+                                                true,
+                                            );
+                                        }
+                                    }
+                                }
+                                continue;
+                            }
+
+                            let Some(symbol) = normalize_symbol(arg) else {
+                                continue;
+                            };
+                            if symbol.starts_with(':') {
+                                if let Some(expanded) = resolve_known_export_tag(module, symbol) {
+                                    for expanded_symbol in expanded {
+                                        insert_entry(
+                                            entries,
+                                            dedupe,
+                                            expanded_symbol,
+                                            module,
+                                            ImportKind::ExportTag { tag: symbol.to_string() },
+                                            Some(node.location),
+                                            true,
+                                        );
+                                    }
+                                }
+                            } else if is_bareword(symbol) {
+                                insert_entry(
+                                    entries,
+                                    dedupe,
+                                    symbol,
+                                    module,
+                                    ImportKind::UseList,
+                                    Some(node.location),
+                                    true,
+                                );
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            for child in node.children() {
+                visit(child, current_package, entries, dedupe);
+            }
+        }
+
+        let mut entries = Vec::new();
+        let mut dedupe = HashSet::new();
+        let mut current_package = "main".to_string();
+        visit(ast, &mut current_package, &mut entries, &mut dedupe);
+
+        Self { entries }
+    }
+
+    /// All visible import entries.
+    pub fn entries(&self) -> &[VisibleImport] {
+        &self.entries
+    }
+
+    /// Returns whether `name` is visible as a bare import.
+    pub fn contains_name(&self, name: &str) -> bool {
+        self.entries.iter().any(|entry| entry.bare_name == name)
+    }
+
+    /// Returns the source package for the first resolved matching entry.
+    pub fn source_for_name(&self, name: &str) -> Option<&str> {
+        self.entries
+            .iter()
+            .find(|entry| entry.bare_name == name && entry.is_resolved)
+            .map(|entry| entry.source_package.as_str())
+            .or_else(|| {
+                self.entries
+                    .iter()
+                    .find(|entry| entry.bare_name == name)
+                    .map(|entry| entry.source_package.as_str())
+            })
+    }
+
+    /// Unique visible bare names, useful for completion-style candidate gathering.
+    pub fn visible_names(&self) -> Vec<&str> {
+        let mut names = Vec::new();
+        let mut seen = HashSet::new();
+        for entry in &self.entries {
+            if seen.insert(entry.bare_name.as_str()) {
+                names.push(entry.bare_name.as_str());
+            }
+        }
+        names
+    }
+}

--- a/crates/perl-semantic-analyzer/src/analysis/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/mod.rs
@@ -8,6 +8,8 @@ pub mod declaration;
 /// Lightweight workspace symbol index.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod index;
+/// Canonical visible-import collection for per-file semantic consumers.
+pub mod import_surface;
 /// Scope analysis for variable and subroutine resolution.
 #[allow(missing_docs)]
 pub mod scope_analyzer;

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -51,7 +51,7 @@
 
 use crate::ast::{Node, NodeKind};
 use crate::pragma_tracker::{PragmaState, PragmaTracker};
-use perl_module::import::resolve_known_export_tag;
+use crate::analysis::import_surface::ImportSurface;
 use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
 use std::ops::Range;
@@ -358,7 +358,7 @@ enum ExtractedName<'a> {
 struct AnalysisContext<'a> {
     code: &'a str,
     pragma_map: &'a [(Range<usize>, PragmaState)],
-    imported_barewords: std::collections::HashSet<String>,
+    import_surface: ImportSurface,
     line_starts: RefCell<Option<Vec<usize>>>,
     /// Current package name, updated as `package` statements are traversed.
     current_package: RefCell<String>,
@@ -369,14 +369,14 @@ impl<'a> AnalysisContext<'a> {
         Self {
             code,
             pragma_map,
-            imported_barewords: collect_imported_barewords(ast),
+            import_surface: ImportSurface::from_ast(ast),
             line_starts: RefCell::new(None),
             current_package: RefCell::new("main".to_string()),
         }
     }
 
     fn has_imported_bareword(&self, name: &str) -> bool {
-        self.imported_barewords.contains(name)
+        self.import_surface.contains_name(name)
     }
 
     fn get_line(&self, offset: usize) -> usize {
@@ -1839,57 +1839,6 @@ impl ScopeAnalyzer {
             })
             .collect()
     }
-}
-
-fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
-    fn push_symbol(imported: &mut std::collections::HashSet<String>, module: &str, token: &str) {
-        let symbol = token.trim().trim_matches('\'').trim_matches('"').trim();
-        if symbol.is_empty() || symbol == "," {
-            return;
-        }
-
-        if symbol.starts_with(':') {
-            if let Some(expanded) = resolve_known_export_tag(module, symbol) {
-                imported.extend(expanded.iter().map(|name| (*name).to_string()));
-            }
-            return;
-        }
-
-        let is_bareword = symbol.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
-            && symbol
-                .as_bytes()
-                .first()
-                .is_some_and(|first| first.is_ascii_alphabetic() || *first == b'_');
-        if is_bareword {
-            imported.insert(symbol.to_string());
-        }
-    }
-
-    fn visit(node: &Node, imported: &mut std::collections::HashSet<String>) {
-        if let NodeKind::Use { module, args, .. } = &node.kind {
-            for arg in args {
-                if arg.starts_with("qw") {
-                    let content = arg
-                        .trim_start_matches("qw")
-                        .trim_start_matches(|c: char| "([{/<|!".contains(c))
-                        .trim_end_matches(|c: char| ")]}/|!>".contains(c));
-                    for token in content.split_whitespace() {
-                        push_symbol(imported, module, token);
-                    }
-                } else {
-                    push_symbol(imported, module, arg);
-                }
-            }
-        }
-
-        for child in node.children() {
-            visit(child, imported);
-        }
-    }
-
-    let mut imported = std::collections::HashSet::new();
-    visit(ast, &mut imported);
-    imported
 }
 
 /// Returns true if `name` (without sigil) is a numbered capture variable.

--- a/crates/perl-semantic-analyzer/tests/import_surface_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/import_surface_tests.rs
@@ -1,0 +1,68 @@
+use perl_semantic_analyzer::Parser;
+use perl_semantic_analyzer::analysis::import_surface::{ImportKind, ImportSurface};
+
+fn build_surface(code: &str) -> Result<ImportSurface, Box<dyn std::error::Error>> {
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    Ok(ImportSurface::from_ast(&ast))
+}
+
+#[test]
+fn import_surface_collects_qw_use_list() -> Result<(), Box<dyn std::error::Error>> {
+    let surface = build_surface("use List::Util qw(sum min);\nsum();\n")?;
+    let sum = surface
+        .entries()
+        .iter()
+        .find(|entry| entry.bare_name == "sum")
+        .ok_or("sum should be collected")?;
+    assert_eq!(sum.source_package, "List::Util");
+    assert!(matches!(sum.kind, ImportKind::UseList));
+    assert!(sum.is_resolved);
+    Ok(())
+}
+
+#[test]
+fn import_surface_collects_parenthesized_and_single_quoted_use_list(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let surface = build_surface("use Foo ('bar');\nuse Baz 'quux';\n")?;
+    assert!(surface.contains_name("bar"), "bar should be visible from paren list");
+    assert!(surface.contains_name("quux"), "quux should be visible from single-quoted form");
+    Ok(())
+}
+
+#[test]
+fn import_surface_expands_known_export_tags() -> Result<(), Box<dyn std::error::Error>> {
+    let surface = build_surface("use POSIX ':sys_wait_h';\nWIFEXITED($status);\n")?;
+    let wifexited = surface
+        .entries()
+        .iter()
+        .find(|entry| entry.bare_name == "WIFEXITED")
+        .ok_or("WIFEXITED should be expanded from :sys_wait_h")?;
+    assert_eq!(wifexited.source_package, "POSIX");
+    assert!(matches!(wifexited.kind, ImportKind::ExportTag { .. }));
+    assert!(wifexited.is_resolved);
+    Ok(())
+}
+
+#[test]
+fn import_surface_collects_use_constant_forms() -> Result<(), Box<dyn std::error::Error>> {
+    let surface = build_surface(
+        "use constant PI => 3.14;\nuse constant { MIN => 1, MAX => 9 };\npackage App;\nuse constant APP_NAME => 'x';\n",
+    )?;
+    let pi = surface
+        .entries()
+        .iter()
+        .find(|entry| entry.bare_name == "PI")
+        .ok_or("PI should be collected")?;
+    assert_eq!(pi.source_package, "main");
+    assert!(matches!(pi.kind, ImportKind::UseConstant));
+    assert!(surface.contains_name("MIN"));
+    assert!(surface.contains_name("MAX"));
+    let app_name = surface
+        .entries()
+        .iter()
+        .find(|entry| entry.bare_name == "APP_NAME")
+        .ok_or("APP_NAME should be collected")?;
+    assert_eq!(app_name.source_package, "App");
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Import visibility for bare names was implemented with scattered ad-hoc logic across declaration and scope analysis, making it hard to reason about and extend.  
- Introduce a single per-file canonical representation to centralize import visibility and make downstream consumers simpler and more consistent.

### Description

- Add `analysis::import_surface` with `ImportSurface`, `VisibleImport`, and `ImportKind` (variants: `UseList`, `ExportTag`, `UseConstant`) that record `bare_name`, `source_package`, `kind`, `origin` span, and `is_resolved` status.  
- Populate `ImportSurface::from_ast` from static `use` and `use constant` forms, including `qw(...)`, parenthesized/single-quoted args, export-tag expansion via `resolve_known_export_tag`, and constant forms.  
- Thread the abstraction into existing consumers by checking `ImportSurface::source_for_name` in `declaration::find_import_source` and replacing the local imported-bareword collector in `scope_analyzer` with `ImportSurface::from_ast`.  
- Export the new module in `analysis::mod` and add unit tests in `crates/perl-semantic-analyzer/tests/import_surface_tests.rs` covering `qw/parens/single-quote/tag/constant` forms.

### Testing

- `cargo test -p perl-semantic-analyzer` ran the crate test suite and succeeded (new tests included).  
- `cargo check --all-targets -p perl-semantic-analyzer` and `cargo clippy -p perl-semantic-analyzer` completed successfully.  
- `cargo check --workspace --all-targets` failed due to a pre-existing, unrelated syntax error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` that prevents a full workspace build in this environment.  
- `just pr-fast` was not executed in this environment because `just` is not available (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead312e7d483339c7ab101ae3f71c6)