### PR TITLE
refactor(semantic): introduce ImportSurface / VisibleImports record (#4246)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -6,6 +6,7 @@
 use crate::ast::{Node, NodeKind};
 use crate::symbol::is_universal_method;
 use crate::workspace_index::{SymKind, SymbolKey};
+use perl_module::import::resolve_known_export_tag;
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
@@ -1399,43 +1400,12 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
     }
 
-    fn export_tag_members(module: &str, tag: &str) -> &'static [&'static str] {
-        match (module, tag) {
-            // POSIX tag sets commonly used in system scripts.
-            ("POSIX", ":sys_wait_h") => {
-                &["WEXITSTATUS", "WIFEXITED", "WIFSIGNALED", "WIFSTOPPED", "WTERMSIG"]
-            }
-            ("POSIX", ":fcntl_h") => &["F_GETFD", "F_SETFD", "F_GETFL", "F_SETFL", "FD_CLOEXEC"],
-            ("POSIX", ":termios_h") => {
-                &["B9600", "B19200", "B38400", "TCSANOW", "TCSADRAIN", "TCSAFLUSH"]
-            }
-            // File::Find exports.
-            ("File::Find", ":find") => &["find", "finddepth"],
-            // Fcntl exports.
-            ("Fcntl", ":seek") => &["SEEK_SET", "SEEK_CUR", "SEEK_END"],
-            ("Fcntl", ":lock") => &["LOCK_SH", "LOCK_EX", "LOCK_NB", "LOCK_UN"],
-            // Encode exports.
-            ("Encode", ":fallback") => &[
-                "FB_DEFAULT",
-                "FB_CROAK",
-                "FB_QUIET",
-                "FB_WARN",
-                "FB_PERLQQ",
-                "FB_HTMLCREF",
-                "FB_XMLCREF",
-            ],
-            _ => &[],
-        }
-    }
-
-    fn tag_imports_symbol(module: &str, import_token: &str, symbol_name: &str) -> bool {
-        if !import_token.starts_with(':') {
-            return false;
-        }
-        export_tag_members(module, import_token).contains(&symbol_name)
-    }
-
     fn find_import_source(ast: &Node, symbol_name: &str) -> Option<String> {
+        let import_surface = crate::analysis::import_surface::ImportSurface::from_ast(ast);
+        if let Some(module) = import_surface.first_source_package_for(symbol_name) {
+            return Some(module.to_string());
+        }
+
         /// Extract the module name from a `require Module;` statement node.
         ///
         /// Matches both `require Foo::Bar` (Identifier arg) and
@@ -1517,7 +1487,10 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
                     // Strip surrounding single/double quotes that some code
                     // paths leave in the value (e.g. qw in quotes.rs).
                     let bare = value.trim_matches('\'').trim_matches('"');
-                    bare == symbol || tag_imports_symbol(module, bare, symbol)
+                    bare == symbol
+                        || (bare.starts_with(':')
+                            && resolve_known_export_tag(module, bare)
+                                .is_some_and(|names| names.contains(&symbol)))
                 }
                 NodeKind::Identifier { name } => {
                     if name == symbol {
@@ -1530,9 +1503,12 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
                             .trim_start_matches("qw")
                             .trim_start_matches(|c: char| "([{/<|!".contains(c))
                             .trim_end_matches(|c: char| ")]}/|!>".contains(c));
-                        return content
-                            .split_whitespace()
-                            .any(|tok| tok == symbol || tag_imports_symbol(module, tok, symbol));
+                        return content.split_whitespace().any(|tok| {
+                            tok == symbol
+                                || (tok.starts_with(':')
+                                    && resolve_known_export_tag(module, tok)
+                                        .is_some_and(|names| names.contains(&symbol)))
+                        });
                     }
                     false
                 }
@@ -1632,46 +1608,6 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         }
 
         fn find(node: &Node, name: &str) -> Option<String> {
-            if let NodeKind::Use { module, args, .. } = &node.kind {
-                // Skip `use constant` — constants are not import-list symbols
-                if module == "constant" {
-                    // Fall through to children
-                } else {
-                    for arg in args {
-                        if arg == name {
-                            return Some(module.clone());
-                        }
-                        if tag_imports_symbol(module, arg, name) {
-                            return Some(module.clone());
-                        }
-                        if arg.starts_with("qw") {
-                            let content = arg
-                                .trim_start_matches("qw")
-                                .trim_start_matches(|c: char| "([{/<|!".contains(c))
-                                .trim_end_matches(|c: char| ")]}/|!>".contains(c));
-                            for import_token in content.split_whitespace() {
-                                if import_token == name
-                                    || tag_imports_symbol(module, import_token, name)
-                                {
-                                    return Some(module.clone());
-                                }
-                            }
-                        } else {
-                            // Parenthesized import list: use Foo ('bar', 'baz')
-                            // The parser emits each token as a separate arg including commas
-                            // and string literals with their surrounding quotes.
-                            let bare = arg.trim().trim_matches('\'').trim_matches('"').trim();
-                            if bare == name {
-                                return Some(module.clone());
-                            }
-                            if tag_imports_symbol(module, bare, name) {
-                                return Some(module.clone());
-                            }
-                        }
-                    }
-                }
-            }
-
             // Scan block/program statement lists for `require M; M->import(sym)` patterns.
             let stmts = match &node.kind {
                 NodeKind::Program { statements } => Some(statements.as_slice()),

--- a/crates/perl-semantic-analyzer/src/analysis/import_surface.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/import_surface.rs
@@ -1,0 +1,361 @@
+//! Canonical per-file import visibility model.
+//!
+//! This module centralizes extraction of visible imported bare names so
+//! consumers (diagnostics, declaration lookup, completion) can share one
+//! consistent view.
+
+use perl_module::import::resolve_known_export_tag;
+
+use crate::{Node, NodeKind, SourceLocation};
+
+/// How a visible name became available in the current file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VisibleImportKind {
+    /// Explicit symbol list import, e.g. `use Module qw(foo)` or `use Module 'foo'`.
+    UseList,
+    /// Import via export tag expansion, e.g. `use POSIX qw(:sys_wait_h)`.
+    ExportTag,
+    /// Constant declaration via `use constant ...`.
+    UseConstant,
+}
+
+/// One visible bare-name import candidate in a file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VisibleImport {
+    /// Imported/visible bare symbol name.
+    pub bare_name: String,
+    /// Source module or package that provides the symbol.
+    pub source_package: String,
+    /// Import form used to make the symbol visible.
+    pub kind: VisibleImportKind,
+    /// Source span for the originating statement, when available.
+    pub origin_span: Option<SourceLocation>,
+    /// Whether symbol origin has been resolved with static certainty.
+    pub is_resolved: bool,
+}
+
+/// Per-file import visibility surface.
+#[derive(Debug, Clone, Default)]
+pub struct ImportSurface {
+    entries: Vec<VisibleImport>,
+}
+
+impl ImportSurface {
+    /// Build visible import entries from an AST.
+    #[must_use]
+    pub fn from_ast(ast: &Node) -> Self {
+        let mut surface = Self::default();
+        Self::collect(ast, "main", &mut surface);
+        surface
+    }
+
+    /// Returns all visible import entries.
+    #[must_use]
+    pub fn entries(&self) -> &[VisibleImport] {
+        &self.entries
+    }
+
+    /// Returns true if a visible bare-name import exists.
+    #[must_use]
+    pub fn has_visible_bare_name(&self, name: &str) -> bool {
+        self.entries.iter().any(|entry| entry.bare_name == name)
+    }
+
+    /// Return the first resolved source package for an imported bare name.
+    #[must_use]
+    pub fn first_source_package_for(&self, name: &str) -> Option<&str> {
+        self.entries
+            .iter()
+            .find(|entry| entry.bare_name == name && entry.is_resolved)
+            .map(|entry| entry.source_package.as_str())
+    }
+
+    fn collect(node: &Node, current_package: &str, surface: &mut Self) {
+        let mut pkg = current_package;
+        if let NodeKind::Package { name, .. } = &node.kind {
+            pkg = name.as_str();
+        }
+
+        if let NodeKind::Use { module, args, .. } = &node.kind {
+            if module == "constant" {
+                Self::collect_constant_use(node, args, pkg, surface);
+            } else {
+                Self::collect_regular_use(node, module, args, surface);
+            }
+        }
+
+        for child in node.children() {
+            Self::collect(child, pkg, surface);
+        }
+    }
+
+    fn collect_regular_use(node: &Node, module: &str, args: &[String], surface: &mut Self) {
+        for arg in args {
+            if arg.starts_with("qw") {
+                for token in Self::split_qw_tokens(arg) {
+                    Self::push_regular_token(node, module, token, surface);
+                }
+            } else {
+                Self::push_regular_token(node, module, arg, surface);
+            }
+        }
+    }
+
+    fn push_regular_token(node: &Node, module: &str, token: &str, surface: &mut Self) {
+        let symbol = Self::normalize_token(token);
+        if symbol.is_empty() {
+            return;
+        }
+
+        if symbol.starts_with(':') {
+            if let Some(expanded) = resolve_known_export_tag(module, symbol) {
+                for name in expanded {
+                    surface.entries.push(VisibleImport {
+                        bare_name: (*name).to_string(),
+                        source_package: module.to_string(),
+                        kind: VisibleImportKind::ExportTag,
+                        origin_span: Some(node.location),
+                        is_resolved: true,
+                    });
+                }
+            }
+            return;
+        }
+
+        if Self::is_bareword(symbol) {
+            surface.entries.push(VisibleImport {
+                bare_name: symbol.to_string(),
+                source_package: module.to_string(),
+                kind: VisibleImportKind::UseList,
+                origin_span: Some(node.location),
+                is_resolved: true,
+            });
+        }
+    }
+
+    fn collect_constant_use(node: &Node, args: &[String], package: &str, surface: &mut Self) {
+        let stripped = Self::strip_constant_options(args);
+        let args_text = stripped.join(" ");
+        if let Some(first) = stripped.first() {
+            let bare = Self::normalize_token(first);
+            if Self::is_bareword(bare) {
+                surface.entries.push(VisibleImport {
+                    bare_name: bare.to_string(),
+                    source_package: package.to_string(),
+                    kind: VisibleImportKind::UseConstant,
+                    origin_span: Some(node.location),
+                    is_resolved: true,
+                });
+            }
+        }
+
+        for arg in stripped {
+            if arg.starts_with("qw") {
+                for name in Self::split_qw_tokens(arg) {
+                    let bare = Self::normalize_token(name);
+                    if Self::is_bareword(bare) {
+                        surface.entries.push(VisibleImport {
+                            bare_name: bare.to_string(),
+                            source_package: package.to_string(),
+                            kind: VisibleImportKind::UseConstant,
+                            origin_span: Some(node.location),
+                            is_resolved: true,
+                        });
+                    }
+                }
+            }
+        }
+        for bare in Self::extract_qw_names(&args_text) {
+            surface.entries.push(VisibleImport {
+                bare_name: bare,
+                source_package: package.to_string(),
+                kind: VisibleImportKind::UseConstant,
+                origin_span: Some(node.location),
+                is_resolved: true,
+            });
+        }
+
+        for pair in stripped.windows(2) {
+            if pair[1] != "=>" {
+                continue;
+            }
+            let lhs = Self::normalize_token(&pair[0]);
+            if Self::is_bareword(lhs) {
+                surface.entries.push(VisibleImport {
+                    bare_name: lhs.to_string(),
+                    source_package: package.to_string(),
+                    kind: VisibleImportKind::UseConstant,
+                    origin_span: Some(node.location),
+                    is_resolved: true,
+                });
+            }
+        }
+        for lhs in Self::extract_arrow_lhs_names(&args_text) {
+            surface.entries.push(VisibleImport {
+                bare_name: lhs,
+                source_package: package.to_string(),
+                kind: VisibleImportKind::UseConstant,
+                origin_span: Some(node.location),
+                is_resolved: true,
+            });
+        }
+    }
+
+    fn split_qw_tokens(raw: &str) -> impl Iterator<Item = &str> {
+        raw.trim_start_matches("qw")
+            .trim_start_matches(|c: char| "([{/<|!".contains(c))
+            .trim_end_matches(|c: char| ")]}/|!>".contains(c))
+            .split_whitespace()
+    }
+
+    fn strip_constant_options(args: &[String]) -> &[String] {
+        let mut i = 0;
+        while i < args.len() && args[i].starts_with('-') {
+            i += 1;
+        }
+        if i < args.len() && args[i] == "," {
+            i += 1;
+        }
+        &args[i..]
+    }
+
+    fn normalize_token(token: &str) -> &str {
+        token
+            .trim()
+            .trim_matches(',')
+            .trim()
+            .trim_matches('\'')
+            .trim_matches('"')
+            .trim()
+            .trim_matches('{')
+            .trim_matches('}')
+            .trim_matches('(')
+            .trim_matches(')')
+            .trim()
+    }
+
+    fn is_bareword(symbol: &str) -> bool {
+        symbol.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+            && symbol
+                .as_bytes()
+                .first()
+                .is_some_and(|first| first.is_ascii_alphabetic() || *first == b'_')
+    }
+
+    fn extract_qw_names(text: &str) -> Vec<String> {
+        let mut names = Vec::new();
+        let bytes = text.as_bytes();
+        let mut i = 0usize;
+        while i + 2 <= bytes.len() {
+            if bytes[i..].starts_with(b"qw") {
+                let delim = bytes.get(i + 2).copied().unwrap_or_default() as char;
+                let close = match delim {
+                    '(' => ')',
+                    '[' => ']',
+                    '{' => '}',
+                    '<' => '>',
+                    c => c,
+                };
+                let start = i + 3;
+                if start > text.len() {
+                    break;
+                }
+                if let Some(end_rel) = text[start..].find(close) {
+                    let end = start + end_rel;
+                    for token in text[start..end].split_whitespace() {
+                        let bare = Self::normalize_token(token);
+                        if Self::is_bareword(bare) {
+                            names.push(bare.to_string());
+                        }
+                    }
+                    i = end + 1;
+                    continue;
+                }
+            }
+            i += 1;
+        }
+        names
+    }
+
+    fn extract_arrow_lhs_names(text: &str) -> Vec<String> {
+        let bytes = text.as_bytes();
+        let mut names = Vec::new();
+        let mut i = 0usize;
+        while i + 2 <= bytes.len() {
+            if bytes[i].is_ascii_alphabetic() || bytes[i] == b'_' {
+                let start = i;
+                i += 1;
+                while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                    i += 1;
+                }
+                let ident = &text[start..i];
+                let mut j = i;
+                while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+                if bytes.get(j) == Some(&b'=') && bytes.get(j + 1) == Some(&b'>') {
+                    names.push(ident.to_string());
+                }
+            } else {
+                i += 1;
+            }
+        }
+        names
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ImportSurface, VisibleImportKind};
+    use crate::Parser;
+
+    fn collect(code: &str) -> Result<ImportSurface, Box<dyn std::error::Error>> {
+        let mut parser = Parser::new(code);
+        let ast = parser.parse()?;
+        Ok(ImportSurface::from_ast(&ast))
+    }
+
+    #[test]
+    fn collects_qw_imports() -> Result<(), Box<dyn std::error::Error>> {
+        let surface = collect("use POSIX qw(WIFEXITED);")?;
+        assert!(surface.has_visible_bare_name("WIFEXITED"));
+        assert!(surface.entries().iter().any(|entry| {
+            entry.bare_name == "WIFEXITED" && entry.kind == VisibleImportKind::UseList
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn collects_parenthesized_and_single_quote_imports() -> Result<(), Box<dyn std::error::Error>> {
+        let surface = collect("use Carp ('croak'); use Carp 'confess';")?;
+        assert!(surface.has_visible_bare_name("croak"));
+        assert!(surface.has_visible_bare_name("confess"));
+        Ok(())
+    }
+
+    #[test]
+    fn expands_known_export_tags() -> Result<(), Box<dyn std::error::Error>> {
+        let surface = collect("use POSIX qw(:sys_wait_h);")?;
+        assert!(surface.has_visible_bare_name("WIFEXITED"));
+        assert!(surface.entries().iter().any(|entry| {
+            entry.bare_name == "WIFEXITED" && entry.kind == VisibleImportKind::ExportTag
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn collects_use_constant_forms() -> Result<(), Box<dyn std::error::Error>> {
+        let surface = collect(
+            "use constant PI => 3.14; use constant { MIN => 1, MAX => 2 }; use constant qw(FOO BAR);",
+        )?;
+        assert!(surface.has_visible_bare_name("PI"));
+        assert!(surface.has_visible_bare_name("MIN"));
+        assert!(surface.has_visible_bare_name("MAX"));
+        assert!(surface.has_visible_bare_name("FOO"));
+        assert!(surface.has_visible_bare_name("BAR"));
+        assert!(surface.entries().iter().any(|entry| {
+            entry.bare_name == "PI" && entry.kind == VisibleImportKind::UseConstant
+        }));
+        Ok(())
+    }
+}

--- a/crates/perl-semantic-analyzer/src/analysis/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/mod.rs
@@ -5,6 +5,8 @@ pub mod class_model;
 /// Go-to-declaration support and parent map construction.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod declaration;
+/// Per-file visible import surface extraction.
+pub mod import_surface;
 /// Lightweight workspace symbol index.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod index;

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -49,9 +49,9 @@
 //! # }
 //! ```
 
+use crate::analysis::import_surface::ImportSurface;
 use crate::ast::{Node, NodeKind};
 use crate::pragma_tracker::{PragmaState, PragmaTracker};
-use perl_module::import::resolve_known_export_tag;
 use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
 use std::ops::Range;
@@ -358,7 +358,7 @@ enum ExtractedName<'a> {
 struct AnalysisContext<'a> {
     code: &'a str,
     pragma_map: &'a [(Range<usize>, PragmaState)],
-    imported_barewords: std::collections::HashSet<String>,
+    import_surface: ImportSurface,
     line_starts: RefCell<Option<Vec<usize>>>,
     /// Current package name, updated as `package` statements are traversed.
     current_package: RefCell<String>,
@@ -369,14 +369,14 @@ impl<'a> AnalysisContext<'a> {
         Self {
             code,
             pragma_map,
-            imported_barewords: collect_imported_barewords(ast),
+            import_surface: ImportSurface::from_ast(ast),
             line_starts: RefCell::new(None),
             current_package: RefCell::new("main".to_string()),
         }
     }
 
     fn has_imported_bareword(&self, name: &str) -> bool {
-        self.imported_barewords.contains(name)
+        self.import_surface.has_visible_bare_name(name)
     }
 
     fn get_line(&self, offset: usize) -> usize {
@@ -1839,57 +1839,6 @@ impl ScopeAnalyzer {
             })
             .collect()
     }
-}
-
-fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
-    fn push_symbol(imported: &mut std::collections::HashSet<String>, module: &str, token: &str) {
-        let symbol = token.trim().trim_matches('\'').trim_matches('"').trim();
-        if symbol.is_empty() || symbol == "," {
-            return;
-        }
-
-        if symbol.starts_with(':') {
-            if let Some(expanded) = resolve_known_export_tag(module, symbol) {
-                imported.extend(expanded.iter().map(|name| (*name).to_string()));
-            }
-            return;
-        }
-
-        let is_bareword = symbol.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
-            && symbol
-                .as_bytes()
-                .first()
-                .is_some_and(|first| first.is_ascii_alphabetic() || *first == b'_');
-        if is_bareword {
-            imported.insert(symbol.to_string());
-        }
-    }
-
-    fn visit(node: &Node, imported: &mut std::collections::HashSet<String>) {
-        if let NodeKind::Use { module, args, .. } = &node.kind {
-            for arg in args {
-                if arg.starts_with("qw") {
-                    let content = arg
-                        .trim_start_matches("qw")
-                        .trim_start_matches(|c: char| "([{/<|!".contains(c))
-                        .trim_end_matches(|c: char| ")]}/|!>".contains(c));
-                    for token in content.split_whitespace() {
-                        push_symbol(imported, module, token);
-                    }
-                } else {
-                    push_symbol(imported, module, arg);
-                }
-            }
-        }
-
-        for child in node.children() {
-            visit(child, imported);
-        }
-    }
-
-    let mut imported = std::collections::HashSet::new();
-    visit(ast, &mut imported);
-    imported
 }
 
 /// Returns true if `name` (without sigil) is a numbered capture variable.

--- a/crates/perl-semantic-analyzer/src/lib.rs
+++ b/crates/perl-semantic-analyzer/src/lib.rs
@@ -68,6 +68,7 @@ pub mod analysis;
 pub use analysis::class_model;
 #[cfg(not(target_arch = "wasm32"))]
 pub use analysis::declaration;
+pub use analysis::import_surface;
 #[cfg(not(target_arch = "wasm32"))]
 pub use analysis::index;
 pub use analysis::scope_analyzer;


### PR DESCRIPTION
### Motivation
- Replace scattered ad-hoc tracking of visible imported bare names with a single per-file abstraction so consumers (diagnostics, completion, declaration lookup) share one consistent view.

### Description
- Add `crates/perl-semantic-analyzer/src/analysis/import_surface.rs` implementing `ImportSurface`, `VisibleImport`, and `VisibleImportKind` with origin span and resolved/candidate flags, and tests covering `qw`/parenthesized/single-quote/tag/`use constant` forms.
- Wire the new module into the public API by registering `analysis::import_surface` and re-exporting it from `perl-semantic-analyzer` crate root.
- Replace the ad-hoc `collect_imported_barewords` usage in scope analysis with `ImportSurface::from_ast(...)` and call sites now query `ImportSurface` (preserving previous semantics for visible names).
- Route declaration/`find_import_source` lookup to consult `ImportSurface` first for static `use`-based visibility while keeping the existing `require` + `Module->import(...)` scan and export-tag resolution to avoid regressions.

### Testing
- Ran `cargo test -p perl-semantic-analyzer` and the crate's unit tests (including the new `import_surface` tests) passed.
- Ran `cargo check --all-targets -p perl-semantic-analyzer` and it succeeded for the crate under change.
- Ran `cargo check --workspace --all-targets` and it surfaced an unrelated pre-existing compile error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` (unterminated string); this failure is not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead312e7d483339c7ab101ae3f71c6)