### PR TITLE
feat(module-resolution): analyze static require + manual import (#3476)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1865,6 +1865,99 @@ fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
         }
     }
 
+    fn require_module_name(node: &Node) -> Option<String> {
+        let args = match &node.kind {
+            NodeKind::FunctionCall { name, args } if name == "require" => args,
+            _ => return None,
+        };
+        let first = args.first()?;
+        match &first.kind {
+            NodeKind::Identifier { name } => Some(name.clone()),
+            NodeKind::String { value, .. } => {
+                let cleaned = value.trim_matches('\'').trim_matches('"').trim();
+                let module = cleaned.trim_end_matches(".pm").replace('/', "::");
+                if module.is_empty() { None } else { Some(module) }
+            }
+            _ => None,
+        }
+    }
+
+    fn inner_expr(node: &Node) -> &Node {
+        if let NodeKind::ExpressionStatement { expression } = &node.kind {
+            expression
+        } else {
+            node
+        }
+    }
+
+    fn import_receiver_name(node: &Node) -> Option<&str> {
+        let NodeKind::MethodCall { object, method, .. } = &node.kind else {
+            return None;
+        };
+        if method != "import" {
+            return None;
+        }
+        match &object.kind {
+            NodeKind::Identifier { name } => Some(name),
+            _ => None,
+        }
+    }
+
+    fn collect_manual_require_imports(
+        statements: &[Node],
+        imported: &mut std::collections::HashSet<String>,
+    ) {
+        let mut required_modules: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for statement in statements {
+            if let Some(module) = require_module_name(inner_expr(statement)) {
+                required_modules.insert(module);
+            }
+        }
+        if required_modules.is_empty() {
+            return;
+        }
+
+        for statement in statements {
+            let expr = inner_expr(statement);
+            let NodeKind::MethodCall { args, .. } = &expr.kind else {
+                continue;
+            };
+            let Some(receiver) = import_receiver_name(expr) else {
+                continue;
+            };
+            if !required_modules.contains(receiver) {
+                continue;
+            }
+
+            for arg in args {
+                match &arg.kind {
+                    NodeKind::String { value, .. } => push_symbol(imported, receiver, value),
+                    NodeKind::Identifier { name } => {
+                        if name.starts_with("qw") {
+                            let content = name
+                                .trim_start_matches("qw")
+                                .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                                .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                            for token in content.split_whitespace() {
+                                push_symbol(imported, receiver, token);
+                            }
+                        } else {
+                            push_symbol(imported, receiver, name);
+                        }
+                    }
+                    NodeKind::ArrayLiteral { elements } => {
+                        for element in elements {
+                            if let NodeKind::String { value, .. } = &element.kind {
+                                push_symbol(imported, receiver, value);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
     fn visit(node: &Node, imported: &mut std::collections::HashSet<String>) {
         if let NodeKind::Use { module, args, .. } = &node.kind {
             for arg in args {
@@ -1880,6 +1973,13 @@ fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
                     push_symbol(imported, module, arg);
                 }
             }
+        }
+
+        match &node.kind {
+            NodeKind::Program { statements } | NodeKind::Block { statements } => {
+                collect_manual_require_imports(statements, imported);
+            }
+            _ => {}
         }
 
         for child in node.children() {

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -149,3 +149,18 @@ load_data();
         "$loader->import() should resolve back to static use_module target, got: {pkg:?}"
     );
 }
+
+#[test]
+fn dynamic_require_target_does_not_resolve_import_source() {
+    let code = r#"my $module = 'My::Loader';
+require $module;
+My::Loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_ne!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "dynamic require target should stay unresolved for declaration lookup"
+    );
+}

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1914,6 +1914,67 @@ print WIFEXITED(0);
 }
 
 #[test]
+fn strict_subs_allows_static_require_manual_import_string() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+require My::Loader;
+My::Loader->import('load_data');
+print load_data;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "load_data"
+        }),
+        "strict 'subs' should treat static require + import('...') names as imported barewords"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_subs_allows_static_require_manual_import_qw() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+require My::Loader;
+My::Loader->import(qw(alpha beta));
+print alpha;
+print beta;
+"#;
+    let issues = scope_issues_strict(code);
+
+    for symbol in ["alpha", "beta"] {
+        assert!(
+            !issues.iter().any(|issue| {
+                matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == symbol
+            }),
+            "strict 'subs' should treat static require + import(qw(...)) symbol '{symbol}' as imported"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn strict_subs_dynamic_require_manual_import_is_not_assumed() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+my $module = 'My::Loader';
+require $module;
+My::Loader->import('load_data');
+print load_data;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "load_data"
+        }),
+        "dynamic require target should remain unresolved and continue to trigger strict bareword checks"
+    );
+    Ok(())
+}
+
+#[test]
 fn version_pragma_enables_strict_vars_and_subs() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use v5.40;

--- a/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
@@ -147,6 +147,29 @@ fn test_multi_file_cross_file_search() -> Result<(), Box<dyn std::error::Error>>
 }
 
 #[test]
+fn test_cross_file_static_require_manual_import_symbols_are_indexed() -> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let module_uri = file_url("/lib/Foo.pm")?;
+    let consumer_uri = file_url("/app/main.pl")?;
+
+    index.index_file(module_uri, "package Foo;\nsub bar { 1 }\n1;\n".to_string())?;
+    index.index_file(
+        consumer_uri,
+        "require Foo;\nFoo->import('bar');\nbar();\n".to_string(),
+    )?;
+
+    let definition = must_some(index.find_definition("Foo::bar"));
+    assert!(definition.uri.contains("Foo.pm"));
+
+    let references = index.find_references("bar");
+    assert!(
+        references.iter().any(|location| location.uri.contains("main.pl")),
+        "consumer file call-site should be indexed for imported symbol usage"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_remove_file() -> Result<(), Box<dyn std::error::Error>> {
     let index = WorkspaceIndex::new();
     let uri = file_url("/removeme.pl")?;


### PR DESCRIPTION
### Motivation

- Make the analyzer treat literal `require Module; Module->import(...)` forms as static imports so imported bareword names are visible to strict-subs, completion, and goto-definition without guessing dynamic runtime behavior.
- Be conservative: only handle statically-known module names and statically-known symbol lists (string literals and `qw(...)`), leaving dynamic/variable-driven cases unresolved.

### Description

- Added literal-only `require` + manual `->import(...)` detection into `collect_imported_barewords` by extracting `require` module names, locating `Module->import(...)` receivers, and collecting quoted/`qw`/array literal symbol tokens. (`crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs`)
- Utility helpers added: `require_module_name`, `inner_expr`, `import_receiver_name`, and `collect_manual_require_imports` to keep the logic local and conservative.
- Added unit tests validating the supported static forms and ensuring dynamic forms remain unresolved: updates to `require_import_resolution.rs` and `scope_and_symbol_tests.rs` in `perl-semantic-analyzer`.
- Added a cross-file workspace-index test that indexes a provider module and a consumer using `require Foo; Foo->import('bar');` and asserts definition visibility and consumer usage indexing (`crates/perl-workspace-index/tests/comprehensive_unit_tests.rs`).

### Testing

- Ran `cargo test -p perl-semantic-analyzer` and all tests passed (including the new require/import resolution cases).
- Ran `cargo test -p perl-workspace` (covers the workspace index crate tests) and the new cross-file index test passed.
- Ran `cargo check --workspace --all-targets` which failed due to a pre-existing unrelated syntax error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` (unterminated string); this is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead31fb2e8833380f29e1df4ffab17)