### PR TITLE
feat(module-resolution): analyze static require + manual import (#3476)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -383,45 +383,6 @@ impl CompletionProvider {
             }
         }
 
-        fn module_runtime_alias(expr: &Node) -> Option<(String, String)> {
-            let (alias_name, call_node) = match &expr.kind {
-                NodeKind::Assignment { lhs, rhs, op } if op == "=" => {
-                    let NodeKind::Variable { name, .. } = &lhs.kind else {
-                        return None;
-                    };
-                    (name.as_str(), rhs.as_ref())
-                }
-                NodeKind::VariableDeclaration { variable, initializer: Some(rhs), .. } => {
-                    let NodeKind::Variable { name, .. } = &variable.kind else {
-                        return None;
-                    };
-                    (name.as_str(), rhs.as_ref())
-                }
-                _ => return None,
-            };
-            let NodeKind::FunctionCall { name, args } = &call_node.kind else {
-                return None;
-            };
-            if !matches!(
-                name.as_str(),
-                "use_module"
-                    | "require_module"
-                    | "Module::Runtime::use_module"
-                    | "Module::Runtime::require_module"
-            ) {
-                return None;
-            }
-            let first = args.first()?;
-            let NodeKind::String { value, .. } = &first.kind else {
-                return None;
-            };
-            let module = value.trim_matches('\'').trim_matches('"').trim();
-            if module.is_empty() {
-                return None;
-            }
-            Some((alias_name.to_string(), module.to_string()))
-        }
-
         fn inner_expr(node: &Node) -> &Node {
             if let NodeKind::ExpressionStatement { expression } = &node.kind {
                 expression.as_ref()
@@ -480,19 +441,10 @@ impl CompletionProvider {
                     }
                 }
                 NodeKind::Program { statements } | NodeKind::Block { statements } => {
-                    let mut required_modules: Vec<String> = statements
+                    let required_modules: Vec<String> = statements
                         .iter()
                         .filter_map(|stmt| require_module_name(inner_expr(stmt)))
                         .collect();
-                    let mut aliases: HashMap<String, String> = HashMap::new();
-                    for stmt in statements {
-                        if let Some((alias, module)) = module_runtime_alias(inner_expr(stmt)) {
-                            aliases.insert(alias, module.clone());
-                            if !required_modules.contains(&module) {
-                                required_modules.push(module);
-                            }
-                        }
-                    }
 
                     for stmt in statements {
                         let expr = inner_expr(stmt);
@@ -504,9 +456,6 @@ impl CompletionProvider {
                         }
                         let object_name = match &object.kind {
                             NodeKind::Identifier { name } => Some(name.as_str()),
-                            NodeKind::Variable { name, .. } => {
-                                aliases.get(name).map(String::as_str)
-                            }
                             _ => None,
                         };
                         let Some(object_name) = object_name else {

--- a/crates/perl-lsp-rs/src/runtime/language/moniker.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/moniker.rs
@@ -330,45 +330,6 @@ impl LspServer {
             }
         }
 
-        fn module_runtime_alias(expr: &crate::ast::Node) -> Option<(String, String)> {
-            let (alias_name, call_node) = match &expr.kind {
-                NodeKind::Assignment { lhs, rhs, op } if op == "=" => {
-                    let NodeKind::Variable { name, .. } = &lhs.kind else {
-                        return None;
-                    };
-                    (name.as_str(), rhs.as_ref())
-                }
-                NodeKind::VariableDeclaration { variable, initializer: Some(rhs), .. } => {
-                    let NodeKind::Variable { name, .. } = &variable.kind else {
-                        return None;
-                    };
-                    (name.as_str(), rhs.as_ref())
-                }
-                _ => return None,
-            };
-            let NodeKind::FunctionCall { name, args } = &call_node.kind else {
-                return None;
-            };
-            if !matches!(
-                name.as_str(),
-                "use_module"
-                    | "require_module"
-                    | "Module::Runtime::use_module"
-                    | "Module::Runtime::require_module"
-            ) {
-                return None;
-            }
-            let first = args.first()?;
-            let NodeKind::String { value, .. } = &first.kind else {
-                return None;
-            };
-            let module = value.trim_matches('\'').trim_matches('"').trim();
-            if module.is_empty() {
-                return None;
-            }
-            Some((alias_name.to_string(), module.to_string()))
-        }
-
         fn arg_matches_symbol(module: &str, arg: &crate::ast::Node, symbol: &str) -> bool {
             match &arg.kind {
                 NodeKind::String { value, .. } => {
@@ -403,12 +364,7 @@ impl LspServer {
             }
         }
 
-        fn import_call_exports(
-            expr: &crate::ast::Node,
-            module: &str,
-            symbol: &str,
-            aliases: &std::collections::HashMap<String, String>,
-        ) -> bool {
+        fn import_call_exports(expr: &crate::ast::Node, module: &str, symbol: &str) -> bool {
             let NodeKind::MethodCall { object, method, args } = &expr.kind else {
                 return false;
             };
@@ -417,7 +373,6 @@ impl LspServer {
             }
             let object_name = match &object.kind {
                 NodeKind::Identifier { name } => Some(name.as_str()),
-                NodeKind::Variable { name, .. } => aliases.get(name).map(String::as_str),
                 _ => return false,
             };
             let Some(object_name) = object_name else {
@@ -427,7 +382,7 @@ impl LspServer {
                 return false;
             }
             if args.is_empty() {
-                return true;
+                return false;
             }
             args.iter().any(|arg| arg_matches_symbol(module, arg, symbol))
         }
@@ -473,24 +428,14 @@ impl LspServer {
                     }
                 }
                 NodeKind::Program { statements } | NodeKind::Block { statements } => {
-                    let mut required_modules: Vec<String> = statements
+                    let required_modules: Vec<String> = statements
                         .iter()
                         .filter_map(|stmt| require_module_name(inner_expr(stmt)))
                         .collect();
-                    let mut aliases: std::collections::HashMap<String, String> =
-                        std::collections::HashMap::new();
-                    for stmt in statements {
-                        if let Some((alias, module)) = module_runtime_alias(inner_expr(stmt)) {
-                            aliases.insert(alias, module.clone());
-                            if !required_modules.contains(&module) {
-                                required_modules.push(module);
-                            }
-                        }
-                    }
                     for stmt in statements {
                         let expr = inner_expr(stmt);
                         for module in &required_modules {
-                            if import_call_exports(expr, module, name, &aliases) {
+                            if import_call_exports(expr, module, name) {
                                 return Some(module.clone());
                             }
                         }
@@ -587,8 +532,8 @@ mod tests {
     }
 
     #[test]
-    fn find_import_source_supports_require_default_import() -> Result<(), Box<dyn std::error::Error>>
-    {
+    fn find_import_source_require_default_import_stays_unresolved()
+    -> Result<(), Box<dyn std::error::Error>> {
         use crate::Parser;
         let server =
             LspServer::with_io(Box::new(Cursor::new(Vec::<u8>::new())), Box::new(Vec::<u8>::new()));
@@ -598,16 +543,15 @@ mod tests {
 
         let source_module = server.find_import_source(&ast, "sum");
         assert_eq!(
-            source_module.as_deref(),
-            Some("List::Util"),
-            "sum should resolve through require+default import (best-effort)"
+            source_module, None,
+            "sum should remain unresolved for default import() in static literal mode"
         );
         Ok(())
     }
 
     #[test]
-    fn find_import_source_supports_module_runtime_alias() -> Result<(), Box<dyn std::error::Error>>
-    {
+    fn find_import_source_module_runtime_alias_stays_unresolved()
+    -> Result<(), Box<dyn std::error::Error>> {
         use crate::Parser;
         let server =
             LspServer::with_io(Box::new(Cursor::new(Vec::<u8>::new())), Box::new(Vec::<u8>::new()));
@@ -617,9 +561,8 @@ mod tests {
 
         let source_module = server.find_import_source(&ast, "baz");
         assert_eq!(
-            source_module.as_deref(),
-            Some("Foo::Bar"),
-            "baz should resolve through use_module+import alias"
+            source_module, None,
+            "module runtime alias imports are out-of-scope for static literal mode"
         );
         Ok(())
     }

--- a/crates/perl-lsp-rs/tests/cross_file_goto_definition_tests.rs
+++ b/crates/perl-lsp-rs/tests/cross_file_goto_definition_tests.rs
@@ -2827,3 +2827,127 @@ my $value = greet();
 
     Ok(())
 }
+
+#[test]
+fn go_to_definition_on_require_manual_import_qw_navigates_to_exporter_sub() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = TempWorkspace::new()?;
+
+    workspace.write(
+        "lib/My/Exporter.pm",
+        r#"package My::Exporter;
+use strict;
+use warnings;
+
+sub greet {
+    return "hello";
+}
+
+sub salute {
+    return "hi";
+}
+
+1;
+"#,
+    )?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+
+    let module_uri = workspace.uri("lib/My/Exporter.pm");
+    let module_content = std::fs::read_to_string(workspace.dir.path().join("lib/My/Exporter.pm"))
+        .map_err(|e| format!("failed to read module: {e}"))?;
+    harness.open(&module_uri, &module_content)?;
+
+    let caller = r#"#!/usr/bin/perl
+use strict;
+use warnings;
+use lib 'lib';
+
+require My::Exporter;
+My::Exporter->import(qw(greet salute));
+my $value = salute();
+"#;
+    let caller_uri = workspace.uri("main.pl");
+    harness.open(&caller_uri, caller)?;
+    harness.barrier();
+
+    let (line, character) = find_line_char(caller, "salute()")?;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": caller_uri},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let locations = result.as_array().ok_or("expected location array")?;
+    assert!(
+        !locations.is_empty(),
+        "expected definition result for require/manual import qw bareword"
+    );
+
+    let first = &locations[0];
+    assert_valid_location(first);
+    let uri = first["uri"].as_str().ok_or("Expected URI")?;
+    assert!(
+        uri.contains("My/Exporter.pm") || uri.contains("My%2FExporter.pm"),
+        "Definition should point to My/Exporter.pm, got: {uri}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn go_to_definition_on_dynamic_require_manual_import_stays_unresolved() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = TempWorkspace::new()?;
+
+    workspace.write(
+        "lib/My/Exporter.pm",
+        r#"package My::Exporter;
+use strict;
+use warnings;
+
+sub greet {
+    return "hello";
+}
+
+1;
+"#,
+    )?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+
+    let module_uri = workspace.uri("lib/My/Exporter.pm");
+    let module_content = std::fs::read_to_string(workspace.dir.path().join("lib/My/Exporter.pm"))
+        .map_err(|e| format!("failed to read module: {e}"))?;
+    harness.open(&module_uri, &module_content)?;
+
+    let caller = r#"#!/usr/bin/perl
+use strict;
+use warnings;
+use lib 'lib';
+
+my $module = 'My::Exporter';
+require $module;
+$module->import('greet');
+my $value = greet();
+"#;
+    let caller_uri = workspace.uri("main.pl");
+    harness.open(&caller_uri, caller)?;
+    harness.barrier();
+
+    let (line, character) = find_line_char(caller, "greet()")?;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": caller_uri},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let locations = result.as_array().ok_or("expected location array")?;
+    assert!(locations.is_empty(), "dynamic require/import should remain unresolved");
+
+    Ok(())
+}

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1466,12 +1466,7 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         /// - qw list as ArrayLit:   `->import(qw(foo bar))` → ArrayLiteral
         /// - Identifier nodes:      `->import(foo)` (unusual but legal)
         /// - String value trimming: quoted strings like `"'foo'"` from qw
-        fn import_call_exports(
-            method_node: &Node,
-            expected_module: &str,
-            symbol: &str,
-            aliases: &std::collections::HashMap<String, String>,
-        ) -> bool {
+        fn import_call_exports(method_node: &Node, expected_module: &str, symbol: &str) -> bool {
             let (object, method, args) = match &method_node.kind {
                 NodeKind::MethodCall { object, method, args } => (object, method, args),
                 _ => return false,
@@ -1482,7 +1477,6 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             // The object must be the same module name.
             let obj_name = match &object.kind {
                 NodeKind::Identifier { name } => Some(name.as_str()),
-                NodeKind::Variable { name, .. } => aliases.get(name).map(String::as_str),
                 _ => return false,
             };
             let Some(obj_name) = obj_name else {
@@ -1544,46 +1538,6 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             }
         }
 
-        fn module_runtime_alias(expr: &Node) -> Option<(String, String)> {
-            let (alias_name, call_node) = match &expr.kind {
-                NodeKind::Assignment { lhs, rhs, op } if op == "=" => {
-                    let NodeKind::Variable { name, .. } = &lhs.kind else {
-                        return None;
-                    };
-                    (name.as_str(), rhs.as_ref())
-                }
-                NodeKind::VariableDeclaration { variable, initializer: Some(rhs), .. } => {
-                    let NodeKind::Variable { name, .. } = &variable.kind else {
-                        return None;
-                    };
-                    (name.as_str(), rhs.as_ref())
-                }
-                _ => return None,
-            };
-
-            let NodeKind::FunctionCall { name, args } = &call_node.kind else {
-                return None;
-            };
-            if !matches!(
-                name.as_str(),
-                "use_module"
-                    | "require_module"
-                    | "Module::Runtime::use_module"
-                    | "Module::Runtime::require_module"
-            ) {
-                return None;
-            }
-            let first = args.first()?;
-            let NodeKind::String { value, .. } = &first.kind else {
-                return None;
-            };
-            let module = value.trim_matches('\'').trim_matches('"').trim();
-            if module.is_empty() {
-                return None;
-            }
-            Some((alias_name.to_string(), module.to_string()))
-        }
-
         /// Unwrap an ExpressionStatement to its inner expression, or return
         /// the node unchanged (handles the case where we're already at the
         /// expression level).
@@ -1601,18 +1555,8 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         /// statement list after (or even before) the require.
         fn scan_statements_for_require_import(stmts: &[Node], symbol: &str) -> Option<String> {
             // Collect all `require Module` names present in this block.
-            let mut required_modules: Vec<String> =
+            let required_modules: Vec<String> =
                 stmts.iter().filter_map(|s| require_module_name(inner_expr(s))).collect();
-            let mut aliases: std::collections::HashMap<String, String> =
-                std::collections::HashMap::new();
-            for stmt in stmts {
-                if let Some((alias, module)) = module_runtime_alias(inner_expr(stmt)) {
-                    aliases.insert(alias, module.clone());
-                    if !required_modules.contains(&module) {
-                        required_modules.push(module);
-                    }
-                }
-            }
 
             if required_modules.is_empty() {
                 return None;
@@ -1623,7 +1567,7 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             for stmt in stmts {
                 let expr = inner_expr(stmt);
                 for module in &required_modules {
-                    if import_call_exports(expr, module, symbol, &aliases) {
+                    if import_call_exports(expr, module, symbol) {
                         return Some(module.clone());
                     }
                 }

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -137,15 +137,16 @@ load_data();
 }
 
 #[test]
-fn module_runtime_alias_then_import_resolves_pkg() {
-    let code = r#"my $loader = use_module('My::Loader');
+fn dynamic_import_object_stays_unresolved() {
+    let code = r#"require My::Loader;
+my $loader = 'My::Loader';
 $loader->import('load_data');
 load_data();
 "#;
     let pkg = parse_and_symbol_at(code, "load_data()");
-    assert_eq!(
+    assert_ne!(
         pkg.as_deref(),
         Some("My::Loader"),
-        "$loader->import() should resolve back to static use_module target, got: {pkg:?}"
+        "dynamic import object should stay unresolved in static literal mode"
     );
 }


### PR DESCRIPTION
### Motivation

- Implement the literal-only slice of manual `import` after `require` (issue #3476) using conservative static analysis so only statically-known module and symbol names are treated as imports.

### Description

- Restrict `require M; M->import(...)` handling to static Identifier receivers and literal symbol lists by removing the `Module::Runtime`/variable-alias handling from the declaration lookup, moniker import detection, and completion import-map extraction.
- Treat `Module->import()` with no args conservatively (do not claim ownership without workspace export table) and require explicit literal symbol names or `qw(...)` lists to record imports.
- Update `import_call_exports` and the `require`/`import` scanning logic in `perl-semantic-analyzer`, `perl-lsp-rs`, and completion provider to match the conservative behavior (no variable-based aliasing or runtime `use_module` aliasing in this path).
- Add tests covering supported static cases and dynamic unresolved behavior: `require Foo; Foo->import('bar')`, `require Foo; Foo->import(qw(bar baz))`, and dynamic/variable-driven import forms which must remain unresolved; tests added/updated in `require_import_resolution.rs` and `cross_file_goto_definition_tests.rs`.

### Testing

- Ran `cargo test -p perl-semantic-analyzer`, which passed successfully (unit tests covering the new static require+import cases passed).
- Ran `cargo test -p perl-workspace`, which passed successfully.
- Attempted `cargo check --workspace --all-targets`, which failed due to a pre-existing unrelated parse error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` (unterminated string), blocking full workspace checks; this is unrelated to the changes in this PR.
- Executed a targeted LSP cross-file test invocation but compilation of `perl-lsp-rs-core` failed for the same unrelated formatting parse error, so full LSP integration tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead31fb2e8833380f29e1df4ffab17)