### PR TITLE
feat(module-resolution): support static Module::Runtime imports (#3415)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1441,9 +1441,60 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         /// Matches both `require Foo::Bar` (Identifier arg) and
         /// `require "Foo/Bar.pm"` forms, returning the module name as a
         /// `::` -separated string suitable for workspace lookup.
-        fn require_module_name(node: &Node) -> Option<String> {
+        fn module_runtime_helper_imports(stmts: &[Node]) -> std::collections::HashSet<String> {
+            fn imported_symbols(args: &[String]) -> std::collections::HashSet<String> {
+                let mut imported = std::collections::HashSet::new();
+                for arg in args {
+                    let bare = arg.trim().trim_matches('\'').trim_matches('"').trim();
+                    if matches!(bare, "use_module" | "require_module") {
+                        imported.insert(bare.to_string());
+                    }
+                    if arg.starts_with("qw") {
+                        let content = arg
+                            .trim_start_matches("qw")
+                            .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                            .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                        for token in content.split_whitespace() {
+                            if matches!(token, "use_module" | "require_module") {
+                                imported.insert(token.to_string());
+                            }
+                        }
+                    }
+                }
+                imported
+            }
+
+            stmts
+                .iter()
+                .filter_map(|stmt| {
+                    let expr = inner_expr(stmt);
+                    let NodeKind::Use { module, args, .. } = &expr.kind else {
+                        return None;
+                    };
+                    if module != "Module::Runtime" {
+                        return None;
+                    }
+                    Some(imported_symbols(args))
+                })
+                .flatten()
+                .collect()
+        }
+
+        fn require_module_name(
+            node: &Node,
+            module_runtime_helpers: &std::collections::HashSet<String>,
+        ) -> Option<String> {
             let args = match &node.kind {
                 NodeKind::FunctionCall { name, args } if name == "require" => args,
+                NodeKind::FunctionCall { name, args }
+                    if matches!(name.as_str(), "Module::Runtime::require_module")
+                        || (name == "require_module"
+                            && module_runtime_helpers.contains("require_module"))
+                        || (name == "use_module"
+                            && module_runtime_helpers.contains("use_module")) =>
+                {
+                    args
+                }
                 _ => return None,
             };
             let arg = args.first()?;
@@ -1544,7 +1595,10 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             }
         }
 
-        fn module_runtime_alias(expr: &Node) -> Option<(String, String)> {
+        fn module_runtime_alias(
+            expr: &Node,
+            module_runtime_helpers: &std::collections::HashSet<String>,
+        ) -> Option<(String, String)> {
             let (alias_name, call_node) = match &expr.kind {
                 NodeKind::Assignment { lhs, rhs, op } if op == "=" => {
                     let NodeKind::Variable { name, .. } = &lhs.kind else {
@@ -1566,11 +1620,12 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             };
             if !matches!(
                 name.as_str(),
-                "use_module"
-                    | "require_module"
-                    | "Module::Runtime::use_module"
+                "Module::Runtime::use_module"
                     | "Module::Runtime::require_module"
-            ) {
+            ) && !(name == "use_module" && module_runtime_helpers.contains("use_module"))
+                && !(name == "require_module"
+                    && module_runtime_helpers.contains("require_module"))
+            {
                 return None;
             }
             let first = args.first()?;
@@ -1600,13 +1655,18 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         /// be adjacent — the import just needs to appear anywhere in the same
         /// statement list after (or even before) the require.
         fn scan_statements_for_require_import(stmts: &[Node], symbol: &str) -> Option<String> {
+            let module_runtime_helpers = module_runtime_helper_imports(stmts);
             // Collect all `require Module` names present in this block.
-            let mut required_modules: Vec<String> =
-                stmts.iter().filter_map(|s| require_module_name(inner_expr(s))).collect();
+            let mut required_modules: Vec<String> = stmts
+                .iter()
+                .filter_map(|s| require_module_name(inner_expr(s), &module_runtime_helpers))
+                .collect();
             let mut aliases: std::collections::HashMap<String, String> =
                 std::collections::HashMap::new();
             for stmt in stmts {
-                if let Some((alias, module)) = module_runtime_alias(inner_expr(stmt)) {
+                if let Some((alias, module)) =
+                    module_runtime_alias(inner_expr(stmt), &module_runtime_helpers)
+                {
                     aliases.insert(alias, module.clone());
                     if !required_modules.contains(&module) {
                         required_modules.push(module);

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -138,7 +138,8 @@ load_data();
 
 #[test]
 fn module_runtime_alias_then_import_resolves_pkg() {
-    let code = r#"my $loader = use_module('My::Loader');
+    let code = r#"use Module::Runtime qw(use_module);
+my $loader = use_module('My::Loader');
 $loader->import('load_data');
 load_data();
 "#;
@@ -147,5 +148,36 @@ load_data();
         pkg.as_deref(),
         Some("My::Loader"),
         "$loader->import() should resolve back to static use_module target, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_require_then_import_resolves_pkg() {
+    let code = r#"use Module::Runtime qw(require_module);
+require_module('My::Loader');
+My::Loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "require_module()+import() should resolve back to static target, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_dynamic_name_stays_unresolved() {
+    let code = r#"use Module::Runtime qw(require_module);
+my $name = 'My::Loader';
+require_module($name);
+My::Loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_ne!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "dynamic require_module target should remain unresolved"
     );
 }

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -2695,6 +2695,7 @@ struct IndexVisitor {
     document: Document,
     uri: String,
     current_package: Option<String>,
+    module_runtime_helpers: std::collections::HashSet<String>,
     workspace_folder_uri: Option<String>,
 }
 
@@ -2741,8 +2742,37 @@ impl IndexVisitor {
             document: document.clone(),
             uri,
             current_package: Some("main".to_string()),
+            module_runtime_helpers: std::collections::HashSet::new(),
             workspace_folder_uri,
         }
+    }
+
+    fn record_module_runtime_use_imports(&mut self, module: &str, args: &[String]) {
+        if module != "Module::Runtime" {
+            return;
+        }
+        for symbol in extract_module_runtime_helper_names(args) {
+            self.module_runtime_helpers.insert(symbol);
+        }
+    }
+
+    fn module_runtime_call_target(&self, name: &str, args: &[Node]) -> Option<String> {
+        let is_runtime_helper = matches!(
+            name,
+            "Module::Runtime::use_module" | "Module::Runtime::require_module"
+        ) || (name == "use_module" && self.module_runtime_helpers.contains("use_module"))
+            || (name == "require_module" && self.module_runtime_helpers.contains("require_module"));
+        if !is_runtime_helper {
+            return None;
+        }
+        let NodeKind::String { value, .. } = &args.first()?.kind else {
+            return None;
+        };
+        let module = value.trim_matches('\'').trim_matches('"').trim();
+        if module.is_empty() {
+            return None;
+        }
+        Some(normalize_dependency_module_name(module))
     }
 
     fn visit(&mut self, node: &Node, file_index: &mut FileIndex) {
@@ -2980,6 +3010,10 @@ impl IndexVisitor {
                     kind: ReferenceKind::Usage,
                 });
 
+                if let Some(module_name) = self.module_runtime_call_target(name, args) {
+                    file_index.dependencies.insert(module_name);
+                }
+
                 if name == "extends" || name == "with" {
                     for module_name in extract_module_names_from_call_args(args) {
                         file_index
@@ -2995,6 +3029,7 @@ impl IndexVisitor {
             }
 
             NodeKind::Use { module, args, .. } => {
+                self.record_module_runtime_use_imports(module, args);
                 let module_name = normalize_dependency_module_name(module);
                 file_index.dependencies.insert(module_name.clone());
 
@@ -3436,6 +3471,28 @@ fn extract_module_names_from_call_args(args: &[Node]) -> Vec<String> {
         collect_from_node(arg, &mut modules);
     }
     modules
+}
+
+fn extract_module_runtime_helper_names(args: &[String]) -> Vec<String> {
+    let mut helpers = std::collections::HashSet::new();
+    for arg in args {
+        let bare = arg.trim().trim_matches('\'').trim_matches('"').trim();
+        if matches!(bare, "use_module" | "require_module") {
+            helpers.insert(bare.to_string());
+        }
+        if arg.starts_with("qw") {
+            let content = arg
+                .trim_start_matches("qw")
+                .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+            for token in content.split_whitespace() {
+                if matches!(token, "use_module" | "require_module") {
+                    helpers.insert(token.to_string());
+                }
+            }
+        }
+    }
+    helpers.into_iter().collect()
 }
 
 fn canonicalize_perl_module_name(name: &str) -> String {

--- a/crates/perl-workspace-index/tests/dual_indexing_tests.rs
+++ b/crates/perl-workspace-index/tests/dual_indexing_tests.rs
@@ -340,6 +340,53 @@ exported();
     Ok(())
 }
 
+#[test]
+fn module_runtime_literal_calls_track_dependencies() -> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let uri = file_url("/scripts/runtime_loader.pl")?;
+    let code = "\
+use Module::Runtime qw(use_module require_module);
+my $m = use_module('My::Loader');
+require_module('My::Other');
+";
+    let uri_str = uri.to_string();
+    index.index_file(uri, code.to_string())?;
+
+    let deps = index.file_dependencies(&uri_str);
+    assert!(
+        deps.contains("My::Loader"),
+        "literal use_module should add dependency, deps: {:?}",
+        deps
+    );
+    assert!(
+        deps.contains("My::Other"),
+        "literal require_module should add dependency, deps: {:?}",
+        deps
+    );
+    Ok(())
+}
+
+#[test]
+fn module_runtime_dynamic_calls_stay_conservative() -> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let uri = file_url("/scripts/runtime_loader_dynamic.pl")?;
+    let code = "\
+use Module::Runtime qw(require_module);
+my $name = 'My::Loader';
+require_module($name);
+";
+    let uri_str = uri.to_string();
+    index.index_file(uri, code.to_string())?;
+
+    let deps = index.file_dependencies(&uri_str);
+    assert!(
+        !deps.contains("My::Loader"),
+        "dynamic require_module argument should remain unresolved, deps: {:?}",
+        deps
+    );
+    Ok(())
+}
+
 // =========================================================================
 // 5. Real-world pattern: Moose method modifiers
 // =========================================================================


### PR DESCRIPTION
### Motivation
- Allow literal `use_module`/`require_module` calls (including when brought in via `use Module::Runtime qw(...)`) to be analyzed as static dependencies and participate in existing `require`+`->import(...)` resolution paths.
- Reuse existing import/module-resolution logic and avoid introducing a parallel resolver while remaining conservative for dynamic names.

### Description
- Added detection of `Module::Runtime` manual imports and a small literal-only slice to the declaration resolution flow so `use_module('X')` / `require_module('X')` are treated like `require X` when the helper is imported or fully-qualified (file: `crates/perl-semantic-analyzer/src/analysis/declaration.rs`).
- Extended `module_runtime_alias` / `require_module_name` and `scan_statements_for_require_import` to consult the set of imported runtime-helper names and require literal-string first args before resolving (file: `crates/perl-semantic-analyzer/src/analysis/declaration.rs`).
- Updated the workspace index visitor to record `Module::Runtime` manual imports and to index literal `use_module`/`require_module` call targets as dependencies via `module_runtime_call_target`, and added `extract_module_runtime_helper_names` helper (file: `crates/perl-workspace-index/src/workspace/workspace_index.rs`).
- Added unit tests covering the static-literal cases and the conservative dynamic case in both analyzer and workspace-index tests (files: `crates/perl-semantic-analyzer/tests/require_import_resolution.rs` and `crates/perl-workspace-index/tests/dual_indexing_tests.rs`).

### Testing
- Ran `cargo test -p perl-semantic-analyzer` and the crate's test suite passed.
- Ran `cargo test -p perl-workspace` and the crate's test suite passed.
- Ran `cargo check --workspace --all-targets` which failed due to a pre-existing unrelated syntax error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` and not because of these changes.
- Ran `cargo xtask fmt` but formatting/build was blocked by the same unrelated compile error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead323e32c8333a5bb56bcdad80e01)