### PR TITLE
feat(module-resolution): support static Module::Runtime imports (#3415)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1564,13 +1564,12 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             let NodeKind::FunctionCall { name, args } = &call_node.kind else {
                 return None;
             };
-            if !matches!(
+            let is_qualified = matches!(
                 name.as_str(),
-                "use_module"
-                    | "require_module"
-                    | "Module::Runtime::use_module"
-                    | "Module::Runtime::require_module"
-            ) {
+                "Module::Runtime::use_module" | "Module::Runtime::require_module"
+            );
+            let is_bare = matches!(name.as_str(), "use_module" | "require_module");
+            if !is_qualified && !is_bare {
                 return None;
             }
             let first = args.first()?;
@@ -1582,6 +1581,31 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
                 return None;
             }
             Some((alias_name.to_string(), module.to_string()))
+        }
+
+        fn module_runtime_module_name(
+            expr: &Node,
+        ) -> Option<String> {
+            let NodeKind::FunctionCall { name, args } = &expr.kind else {
+                return None;
+            };
+            let is_qualified = matches!(
+                name.as_str(),
+                "Module::Runtime::use_module" | "Module::Runtime::require_module"
+            );
+            let is_bare = matches!(name.as_str(), "use_module" | "require_module");
+            if !is_qualified && !is_bare {
+                return None;
+            }
+            let first = args.first()?;
+            let NodeKind::String { value, .. } = &first.kind else {
+                return None;
+            };
+            let module = value.trim_matches('\'').trim_matches('"').trim();
+            if module.is_empty() {
+                return None;
+            }
+            Some(module.to_string())
         }
 
         /// Unwrap an ExpressionStatement to its inner expression, or return
@@ -1608,6 +1632,11 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             for stmt in stmts {
                 if let Some((alias, module)) = module_runtime_alias(inner_expr(stmt)) {
                     aliases.insert(alias, module.clone());
+                    if !required_modules.contains(&module) {
+                        required_modules.push(module);
+                    }
+                }
+                if let Some(module) = module_runtime_module_name(inner_expr(stmt)) {
                     if !required_modules.contains(&module) {
                         required_modules.push(module);
                     }

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -149,3 +149,49 @@ load_data();
         "$loader->import() should resolve back to static use_module target, got: {pkg:?}"
     );
 }
+
+#[test]
+fn module_runtime_imported_bare_calls_resolve_pkg() {
+    let code = r#"use Module::Runtime qw(use_module require_module);
+my $loader = use_module('My::Loader');
+$loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "literal use_module() should resolve when imported from Module::Runtime, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_require_module_literal_enables_manual_import_resolution() {
+    let code = r#"use Module::Runtime qw(require_module);
+require_module('My::Loader');
+My::Loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "literal require_module() should register require-like dependency, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_dynamic_name_stays_conservative() {
+    let code = r#"use Module::Runtime qw(use_module);
+my $name = 'My::Loader';
+my $loader = use_module($name);
+$loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_ne!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "dynamic module names should remain unresolved for Module::Runtime"
+    );
+}

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -2696,6 +2696,7 @@ struct IndexVisitor {
     uri: String,
     current_package: Option<String>,
     workspace_folder_uri: Option<String>,
+    imported_module_runtime_funcs: std::collections::HashSet<String>,
 }
 
 fn is_interpolated_var_start(byte: u8) -> bool {
@@ -2742,7 +2743,30 @@ impl IndexVisitor {
             uri,
             current_package: Some("main".to_string()),
             workspace_folder_uri,
+            imported_module_runtime_funcs: std::collections::HashSet::new(),
         }
+    }
+
+    fn module_runtime_call_target(&self, name: &str, args: &[Node]) -> Option<String> {
+        let is_qualified = matches!(
+            name,
+            "Module::Runtime::use_module" | "Module::Runtime::require_module"
+        );
+        let is_imported_bare = matches!(name, "use_module" | "require_module")
+            && self.imported_module_runtime_funcs.contains(name);
+        if !is_qualified && !is_imported_bare {
+            return None;
+        }
+
+        let first = args.first()?;
+        let NodeKind::String { value, .. } = &first.kind else {
+            return None;
+        };
+        let module = value.trim().trim_matches('\'').trim_matches('"');
+        if module.is_empty() {
+            return None;
+        }
+        Some(normalize_dependency_module_name(module))
     }
 
     fn visit(&mut self, node: &Node, file_index: &mut FileIndex) {
@@ -2987,6 +3011,9 @@ impl IndexVisitor {
                             .insert(normalize_dependency_module_name(&module_name));
                     }
                 }
+                if let Some(module_name) = self.module_runtime_call_target(name, args) {
+                    file_index.dependencies.insert(module_name);
+                }
 
                 // Visit arguments
                 for arg in args {
@@ -2997,6 +3024,14 @@ impl IndexVisitor {
             NodeKind::Use { module, args, .. } => {
                 let module_name = normalize_dependency_module_name(module);
                 file_index.dependencies.insert(module_name.clone());
+
+                if module == "Module::Runtime" {
+                    for import in extract_module_names_from_use_args(args) {
+                        if matches!(import.as_str(), "use_module" | "require_module") {
+                            self.imported_module_runtime_funcs.insert(import);
+                        }
+                    }
+                }
 
                 // Also track actual parent/base class names for dependency discovery.
                 // `use parent 'Foo::Bar'` stores module="parent" and args=["'Foo::Bar'"],
@@ -3991,6 +4026,39 @@ use Data::Dumper;
         assert!(deps.contains("strict"));
         assert!(deps.contains("warnings"));
         assert!(deps.contains("Data::Dumper"));
+    }
+
+    #[test]
+    fn test_dependencies_include_literal_module_runtime_targets() {
+        let index = WorkspaceIndex::new();
+        let uri = "file:///module_runtime_deps.pl";
+        let code = r#"
+use Module::Runtime qw(use_module require_module);
+my $m = use_module('Some::Module');
+require_module('Other::Module');
+"#;
+
+        must(index.index_file(must(url::Url::parse(uri)), code.to_string()));
+        let deps = index.file_dependencies(uri);
+        assert!(deps.contains("Module::Runtime"));
+        assert!(deps.contains("Some::Module"));
+        assert!(deps.contains("Other::Module"));
+    }
+
+    #[test]
+    fn test_dependencies_skip_dynamic_module_runtime_targets() {
+        let index = WorkspaceIndex::new();
+        let uri = "file:///module_runtime_dynamic.pl";
+        let code = r#"
+use Module::Runtime qw(use_module);
+my $name = 'Some::Module';
+my $m = use_module($name);
+"#;
+
+        must(index.index_file(must(url::Url::parse(uri)), code.to_string()));
+        let deps = index.file_dependencies(uri);
+        assert!(deps.contains("Module::Runtime"));
+        assert!(!deps.contains("Some::Module"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Recognize literal `Module::Runtime` call sites (`use_module` / `require_module`) so manual import resolution can resolve static module names and register dependencies without inventing a parallel resolution system.
- Preserve conservative behaviour for dynamic module-name cases and reuse existing `require`/`Module->import` resolution paths.

### Description
- Added literal `Module::Runtime` handling in the semantic analyzer by extracting module names from `use_module` / `require_module` call sites and feeding them into the existing `require` + `Module->import(...)` resolution path via `module_runtime_module_name` and updated scanning logic in `crates/perl-semantic-analyzer/src/analysis/declaration.rs`.
- Kept alias resolution working for assignments like `my $loader = use_module('Foo');` so `$loader->import(...)` still maps back to the static module name.
- Updated workspace indexing in `crates/perl-workspace-index/src/workspace/workspace_index.rs` to record literal Module::Runtime targets, added `module_runtime_call_target` to capture literal targets and tracked imported bare names from `use Module::Runtime qw(...)` so bare `use_module`/`require_module` resolve when explicitly imported.
- Added unit tests: semantic-analyzer tests in `tests/require_import_resolution.rs` for imported bare calls, literal `require_module`, and dynamic-name conservatism; workspace-index tests in `workspace_index.rs` to assert literal dependencies are recorded and dynamic cases are skipped.

### Testing
- Ran `cargo test -p perl-semantic-analyzer` and the full semantic-analyzer test suite (including the new tests), which passed.
- Ran `cargo test -p perl-workspace` and the workspace-index tests (including the new dependency tests), which passed.
- Ran `cargo check --workspace --all-targets`, which failed due to an unrelated pre-existing syntax error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` (unterminated string), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead323e32c8333a5bb56bcdad80e01)