### PR TITLE
feat(module-resolution): support static Module::Runtime imports (#3415)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1544,7 +1544,63 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             }
         }
 
-        fn module_runtime_alias(expr: &Node) -> Option<(String, String)> {
+        fn parse_module_runtime_import_token(token: &str, target: &str) -> bool {
+            if token == target {
+                return true;
+            }
+
+            if token.starts_with("qw") {
+                let content = token
+                    .trim_start_matches("qw")
+                    .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                    .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                return content.split_whitespace().any(|part| part == target);
+            }
+
+            token.trim().trim_matches('\'').trim_matches('"').trim() == target
+        }
+
+        fn has_module_runtime_manual_import(stmts: &[Node]) -> bool {
+            stmts.iter().any(|stmt| {
+                let NodeKind::Use { module, args, .. } = &inner_expr(stmt).kind else {
+                    return false;
+                };
+                if module != "Module::Runtime" {
+                    return false;
+                }
+                args.iter().any(|arg| {
+                    parse_module_runtime_import_token(arg, "use_module")
+                        || parse_module_runtime_import_token(arg, "require_module")
+                })
+            })
+        }
+
+        fn module_runtime_call_module(call_node: &Node, allow_bare_runtime_calls: bool) -> Option<String> {
+            let NodeKind::FunctionCall { name, args } = &call_node.kind else {
+                return None;
+            };
+            let is_runtime_loader = matches!(
+                name.as_str(),
+                "Module::Runtime::use_module" | "Module::Runtime::require_module"
+            ) || (allow_bare_runtime_calls && matches!(name.as_str(), "use_module" | "require_module"));
+            if !is_runtime_loader {
+                return None;
+            }
+            let first = args.first()?;
+            let NodeKind::String { value, .. } = &first.kind else {
+                return None;
+            };
+            let module = value.trim_matches('\'').trim_matches('"').trim();
+            if module.is_empty() {
+                return None;
+            }
+            Some(module.to_string())
+        }
+
+        fn module_runtime_alias(
+            expr: &Node,
+            allow_bare_runtime_calls: bool,
+        ) -> Option<(String, String)> {
             let (alias_name, call_node) = match &expr.kind {
                 NodeKind::Assignment { lhs, rhs, op } if op == "=" => {
                     let NodeKind::Variable { name, .. } = &lhs.kind else {
@@ -1561,27 +1617,8 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
                 _ => return None,
             };
 
-            let NodeKind::FunctionCall { name, args } = &call_node.kind else {
-                return None;
-            };
-            if !matches!(
-                name.as_str(),
-                "use_module"
-                    | "require_module"
-                    | "Module::Runtime::use_module"
-                    | "Module::Runtime::require_module"
-            ) {
-                return None;
-            }
-            let first = args.first()?;
-            let NodeKind::String { value, .. } = &first.kind else {
-                return None;
-            };
-            let module = value.trim_matches('\'').trim_matches('"').trim();
-            if module.is_empty() {
-                return None;
-            }
-            Some((alias_name.to_string(), module.to_string()))
+            let module = module_runtime_call_module(call_node, allow_bare_runtime_calls)?;
+            Some((alias_name.to_string(), module))
         }
 
         /// Unwrap an ExpressionStatement to its inner expression, or return
@@ -1600,13 +1637,23 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         /// be adjacent — the import just needs to appear anywhere in the same
         /// statement list after (or even before) the require.
         fn scan_statements_for_require_import(stmts: &[Node], symbol: &str) -> Option<String> {
+            let allow_bare_runtime_calls = has_module_runtime_manual_import(stmts);
             // Collect all `require Module` names present in this block.
             let mut required_modules: Vec<String> =
                 stmts.iter().filter_map(|s| require_module_name(inner_expr(s))).collect();
             let mut aliases: std::collections::HashMap<String, String> =
                 std::collections::HashMap::new();
             for stmt in stmts {
-                if let Some((alias, module)) = module_runtime_alias(inner_expr(stmt)) {
+                if let Some(module) =
+                    module_runtime_call_module(inner_expr(stmt), allow_bare_runtime_calls)
+                {
+                    if !required_modules.contains(&module) {
+                        required_modules.push(module);
+                    }
+                }
+                if let Some((alias, module)) =
+                    module_runtime_alias(inner_expr(stmt), allow_bare_runtime_calls)
+                {
                     aliases.insert(alias, module.clone());
                     if !required_modules.contains(&module) {
                         required_modules.push(module);

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -138,7 +138,8 @@ load_data();
 
 #[test]
 fn module_runtime_alias_then_import_resolves_pkg() {
-    let code = r#"my $loader = use_module('My::Loader');
+    let code = r#"use Module::Runtime qw(use_module);
+my $loader = use_module('My::Loader');
 $loader->import('load_data');
 load_data();
 "#;
@@ -147,5 +148,36 @@ load_data();
         pkg.as_deref(),
         Some("My::Loader"),
         "$loader->import() should resolve back to static use_module target, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_require_module_then_import_resolves_pkg() {
+    let code = r#"use Module::Runtime qw(require_module);
+require_module('My::Loader');
+My::Loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "load_data() should resolve via require_module()+import(), got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_dynamic_name_stays_unresolved() {
+    let code = r#"use Module::Runtime qw(use_module);
+my $name = 'My::Loader';
+my $loader = use_module($name);
+$loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_ne!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "dynamic module names should remain conservative and unresolved"
     );
 }

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -2696,6 +2696,7 @@ struct IndexVisitor {
     uri: String,
     current_package: Option<String>,
     workspace_folder_uri: Option<String>,
+    has_module_runtime_manual_import: bool,
 }
 
 fn is_interpolated_var_start(byte: u8) -> bool {
@@ -2742,6 +2743,7 @@ impl IndexVisitor {
             uri,
             current_package: Some("main".to_string()),
             workspace_folder_uri,
+            has_module_runtime_manual_import: false,
         }
     }
 
@@ -2988,6 +2990,30 @@ impl IndexVisitor {
                     }
                 }
 
+                let module_runtime_call = match name.as_str() {
+                    "Module::Runtime::use_module" | "Module::Runtime::require_module" => true,
+                    "use_module" | "require_module" => self.has_module_runtime_manual_import,
+                    _ => false,
+                };
+                if module_runtime_call {
+                    file_index
+                        .dependencies
+                        .insert(normalize_dependency_module_name("Module::Runtime"));
+                    if let Some(Node {
+                        kind: NodeKind::String { value, .. },
+                        ..
+                    }) = args.first()
+                    {
+                        for module_name in
+                            extract_module_names_from_use_args(std::slice::from_ref(value))
+                        {
+                            file_index
+                                .dependencies
+                                .insert(normalize_dependency_module_name(&module_name));
+                        }
+                    }
+                }
+
                 // Visit arguments
                 for arg in args {
                     self.visit_node(arg, file_index);
@@ -2997,6 +3023,9 @@ impl IndexVisitor {
             NodeKind::Use { module, args, .. } => {
                 let module_name = normalize_dependency_module_name(module);
                 file_index.dependencies.insert(module_name.clone());
+                if module == "Module::Runtime" && has_module_runtime_loader_import(args) {
+                    self.has_module_runtime_manual_import = true;
+                }
 
                 // Also track actual parent/base class names for dependency discovery.
                 // `use parent 'Foo::Bar'` stores module="parent" and args=["'Foo::Bar'"],
@@ -3436,6 +3465,19 @@ fn extract_module_names_from_call_args(args: &[Node]) -> Vec<String> {
         collect_from_node(arg, &mut modules);
     }
     modules
+}
+
+fn has_module_runtime_loader_import(args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        let (qw_words, remainder) = extract_qw_words(arg);
+        qw_words
+            .iter()
+            .any(|word| matches!(word.as_str(), "use_module" | "require_module"))
+            || remainder.split(|c: char| c.is_whitespace() || c == ',').any(|token| {
+                let trimmed = token.trim_matches('\'').trim_matches('"').trim();
+                matches!(trimmed, "use_module" | "require_module")
+            })
+    })
 }
 
 fn canonicalize_perl_module_name(name: &str) -> String {

--- a/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
@@ -1373,6 +1373,41 @@ fn test_find_dependents() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn test_module_runtime_literal_loader_creates_dependency() -> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let uri = file_url("/runtime_dep.pl")?;
+    let uri_str = uri.to_string();
+    index.index_file(
+        uri,
+        "use Module::Runtime qw(use_module require_module);\nmy $m = use_module('Foo::Bar');\nrequire_module('Other::Base');"
+            .to_string(),
+    )?;
+
+    let deps = index.file_dependencies(&uri_str);
+    assert!(deps.contains("Module::Runtime"));
+    assert!(deps.contains("Foo::Bar"));
+    assert!(deps.contains("Other::Base"));
+    Ok(())
+}
+
+#[test]
+fn test_module_runtime_dynamic_loader_stays_conservative() -> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let uri = file_url("/runtime_dynamic.pl")?;
+    let uri_str = uri.to_string();
+    index.index_file(
+        uri,
+        "use Module::Runtime qw(use_module);\nmy $name = 'Foo::Bar';\nmy $m = use_module($name);"
+            .to_string(),
+    )?;
+
+    let deps = index.file_dependencies(&uri_str);
+    assert!(deps.contains("Module::Runtime"));
+    assert!(!deps.contains("Foo::Bar"));
+    Ok(())
+}
+
 // =========================================================================
 // WorkspaceIndex – clear_file / clear_file_url
 // =========================================================================


### PR DESCRIPTION
### Motivation
- Recognize literal `Module::Runtime` loader calls (`use_module`, `require_module`) so static cases like `use_module('Foo::Bar')` / `require_module('Foo::Bar')` are tracked by existing manual-import resolution and dependency machinery.
- Keep behavior conservative for dynamic-name calls and only enable bare `use_module`/`require_module` recognition when the file explicitly imports those symbols from `Module::Runtime`.

### Description
- Added parsing helpers and logic to the semantic analyzer to extract literal module names from `Module::Runtime::use_module` / `Module::Runtime::require_module` and to feed them into the existing `require M; M->import(...)` resolution path, including `parse_module_runtime_import_token`, `has_module_runtime_manual_import`, `module_runtime_call_module`, and updated `module_runtime_alias` usages (in `crates/perl-semantic-analyzer/src/analysis/declaration.rs`).
- Updated `scan_statements_for_require_import` to include literal Module::Runtime loader calls and to gate bare `use_module`/`require_module` recognition on an explicit `use Module::Runtime qw(...)` import.
- Extended the workspace index visitor to record `Module::Runtime` as a dependency and to add literal loader targets as dependencies when safe, tracked by a file-level `has_module_runtime_manual_import` flag and helper `has_module_runtime_loader_import` (in `crates/perl-workspace-index/src/workspace/workspace_index.rs`).
- Added focused unit tests: semantic analyzer tests for static `use_module`/`require_module` flows and a dynamic-name unresolved case (in `crates/perl-semantic-analyzer/tests/require_import_resolution.rs`), and workspace-index tests for literal loader dependency capture and conservative dynamic behavior (in `crates/perl-workspace-index/tests/comprehensive_unit_tests.rs`).

### Testing
- Ran `cargo test -p perl-semantic-analyzer` and the crate's test suite completed successfully (`121` unit tests passed in this run). 
- Ran `cargo test -p perl-workspace` and the workspace-index tests completed successfully. 
- Attempted `cargo test -p perl-workspace-index` but the package id does not match the workspace crate name (used `perl-workspace` instead and it passed). 
- Ran `cargo xtask fmt` and `cargo check --workspace --all-targets` which both surfaced a pre-existing unrelated compile error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` (unterminated string), causing those full-workspace checks to fail; the failures are unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead323e32c8333a5bb56bcdad80e01)