### PR TITLE
feat(module-resolution): support static Module::Runtime imports (#3415)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1441,9 +1441,60 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         /// Matches both `require Foo::Bar` (Identifier arg) and
         /// `require "Foo/Bar.pm"` forms, returning the module name as a
         /// `::` -separated string suitable for workspace lookup.
-        fn require_module_name(node: &Node) -> Option<String> {
+        fn module_runtime_imports(stmts: &[Node]) -> (bool, bool) {
+            let mut imports_use_module = false;
+            let mut imports_require_module = false;
+            for stmt in stmts {
+                let expr = inner_expr(stmt);
+                let NodeKind::Use { module, args, .. } = &expr.kind else {
+                    continue;
+                };
+                if module != "Module::Runtime" {
+                    continue;
+                }
+                for arg in args {
+                    if arg == "use_module" {
+                        imports_use_module = true;
+                        continue;
+                    }
+                    if arg == "require_module" {
+                        imports_require_module = true;
+                        continue;
+                    }
+                    if !arg.starts_with("qw") {
+                        continue;
+                    }
+                    let content = arg
+                        .trim_start_matches("qw")
+                        .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                        .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                    for token in content.split_whitespace() {
+                        if token == "use_module" {
+                            imports_use_module = true;
+                        } else if token == "require_module" {
+                            imports_require_module = true;
+                        }
+                    }
+                }
+            }
+            (imports_use_module, imports_require_module)
+        }
+
+        fn require_module_name(
+            node: &Node,
+            imports_use_module: bool,
+            imports_require_module: bool,
+        ) -> Option<String> {
             let args = match &node.kind {
                 NodeKind::FunctionCall { name, args } if name == "require" => args,
+                NodeKind::FunctionCall { name, args }
+                    if name == "Module::Runtime::use_module"
+                        || name == "Module::Runtime::require_module"
+                        || (imports_use_module && name == "use_module")
+                        || (imports_require_module && name == "require_module") =>
+                {
+                    args
+                }
                 _ => return None,
             };
             let arg = args.first()?;
@@ -1600,9 +1651,14 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         /// be adjacent — the import just needs to appear anywhere in the same
         /// statement list after (or even before) the require.
         fn scan_statements_for_require_import(stmts: &[Node], symbol: &str) -> Option<String> {
+            let (imports_use_module, imports_require_module) = module_runtime_imports(stmts);
             // Collect all `require Module` names present in this block.
-            let mut required_modules: Vec<String> =
-                stmts.iter().filter_map(|s| require_module_name(inner_expr(s))).collect();
+            let mut required_modules: Vec<String> = stmts
+                .iter()
+                .filter_map(|s| {
+                    require_module_name(inner_expr(s), imports_use_module, imports_require_module)
+                })
+                .collect();
             let mut aliases: std::collections::HashMap<String, String> =
                 std::collections::HashMap::new();
             for stmt in stmts {

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -149,3 +149,34 @@ load_data();
         "$loader->import() should resolve back to static use_module target, got: {pkg:?}"
     );
 }
+
+#[test]
+fn module_runtime_require_module_then_import_resolves_pkg() {
+    let code = r#"use Module::Runtime qw(require_module);
+require_module('My::Loader');
+My::Loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "require_module('My::Loader') should participate in require+import resolution, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_dynamic_name_remains_unresolved() {
+    let code = r#"use Module::Runtime qw(require_module);
+my $target = 'My::Loader';
+require_module($target);
+My::Loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_ne!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "dynamic require_module target should stay conservative and unresolved"
+    );
+}

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -2696,6 +2696,8 @@ struct IndexVisitor {
     uri: String,
     current_package: Option<String>,
     workspace_folder_uri: Option<String>,
+    imports_module_runtime_use_module: bool,
+    imports_module_runtime_require_module: bool,
 }
 
 fn is_interpolated_var_start(byte: u8) -> bool {
@@ -2742,6 +2744,8 @@ impl IndexVisitor {
             uri,
             current_package: Some("main".to_string()),
             workspace_folder_uri,
+            imports_module_runtime_use_module: false,
+            imports_module_runtime_require_module: false,
         }
     }
 
@@ -2988,6 +2992,17 @@ impl IndexVisitor {
                     }
                 }
 
+                if module_runtime_function_call_is_dependency(
+                    name,
+                    self.imports_module_runtime_use_module,
+                    self.imports_module_runtime_require_module,
+                ) && let Some(module_name) = literal_module_name_from_runtime_call_arg(args.first())
+                {
+                    file_index
+                        .dependencies
+                        .insert(normalize_dependency_module_name(&module_name));
+                }
+
                 // Visit arguments
                 for arg in args {
                     self.visit_node(arg, file_index);
@@ -2997,6 +3012,13 @@ impl IndexVisitor {
             NodeKind::Use { module, args, .. } => {
                 let module_name = normalize_dependency_module_name(module);
                 file_index.dependencies.insert(module_name.clone());
+
+                if module == "Module::Runtime" {
+                    let (imports_use_module, imports_require_module) =
+                        module_runtime_import_kinds(args);
+                    self.imports_module_runtime_use_module |= imports_use_module;
+                    self.imports_module_runtime_require_module |= imports_require_module;
+                }
 
                 // Also track actual parent/base class names for dependency discovery.
                 // `use parent 'Foo::Bar'` stores module="parent" and args=["'Foo::Bar'"],
@@ -3452,6 +3474,57 @@ fn legacy_perl_module_name(name: &str) -> String {
 /// Converts legacy `'` separators to `::` so stored keys are canonical.
 fn normalize_dependency_module_name(module_name: &str) -> String {
     canonicalize_perl_module_name(module_name)
+}
+
+fn module_runtime_import_kinds(args: &[String]) -> (bool, bool) {
+    let mut imports_use_module = false;
+    let mut imports_require_module = false;
+    for arg in args {
+        if arg == "use_module" {
+            imports_use_module = true;
+            continue;
+        }
+        if arg == "require_module" {
+            imports_require_module = true;
+            continue;
+        }
+        if !arg.starts_with("qw") {
+            continue;
+        }
+        let content = arg
+            .trim_start_matches("qw")
+            .trim_start_matches(|c: char| "([{/<|!".contains(c))
+            .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+        for token in content.split_whitespace() {
+            if token == "use_module" {
+                imports_use_module = true;
+            } else if token == "require_module" {
+                imports_require_module = true;
+            }
+        }
+    }
+    (imports_use_module, imports_require_module)
+}
+
+fn module_runtime_function_call_is_dependency(
+    name: &str,
+    imports_use_module: bool,
+    imports_require_module: bool,
+) -> bool {
+    matches!(name, "Module::Runtime::use_module" | "Module::Runtime::require_module")
+        || (imports_use_module && name == "use_module")
+        || (imports_require_module && name == "require_module")
+}
+
+fn literal_module_name_from_runtime_call_arg(arg: Option<&Node>) -> Option<String> {
+    let NodeKind::String { value, .. } = &arg?.kind else {
+        return None;
+    };
+    let module = value.trim_matches('\'').trim_matches('"').trim();
+    if module.is_empty() {
+        return None;
+    }
+    Some(module.to_string())
 }
 
 fn extract_qw_words(input: &str) -> (Vec<String>, String) {
@@ -4998,6 +5071,28 @@ Utils::process_data();
         let deps = index.file_dependencies(consumer_url.as_str());
         assert!(deps.contains("My::App::Role"));
         Ok(())
+    }
+
+    #[test]
+    fn test_index_dependency_via_module_runtime_require_module_literal() {
+        let index = WorkspaceIndex::new();
+        let uri = must(url::Url::parse("file:///test/workspace/runtime-require.pl"));
+        let src = "package Consumer;\nuse Module::Runtime qw(require_module);\nrequire_module('My::Loader');\n1;\n";
+        must(index.index_file(uri.clone(), src.to_string()));
+
+        let deps = index.file_dependencies(uri.as_str());
+        assert!(deps.contains("My::Loader"));
+    }
+
+    #[test]
+    fn test_index_dependency_via_module_runtime_require_module_dynamic_is_conservative() {
+        let index = WorkspaceIndex::new();
+        let uri = must(url::Url::parse("file:///test/workspace/runtime-require-dynamic.pl"));
+        let src = "package Consumer;\nuse Module::Runtime qw(require_module);\nmy $mod = 'My::Loader';\nrequire_module($mod);\n1;\n";
+        must(index.index_file(uri.clone(), src.to_string()));
+
+        let deps = index.file_dependencies(uri.as_str());
+        assert!(!deps.contains("My::Loader"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The analyzer and workspace index did not recognize literal `Module::Runtime` loader helpers (`use_module`/`require_module`) imported via `use Module::Runtime qw(...)`, so static literal calls were missed for dependency tracking and require+import resolution.
- The goal is to resolve only literal module names and remain conservative for dynamic targets while reusing the existing `require`/`Module->import` resolution path.

### Description
- Extended the semantic analyzer in `crates/perl-semantic-analyzer/src/analysis/declaration.rs` to detect `use Module::Runtime qw(...)` and treat literal `Module::Runtime::use_module` / `Module::Runtime::require_module` (and imported unqualified `use_module` / `require_module`) as `require`-style loaders for the existing `require + Module->import(...)` resolution flow by adding `module_runtime_imports` and updating `require_module_name` and scan logic.
- Updated the workspace index in `crates/perl-workspace-index/src/workspace/workspace_index.rs` to record dependencies for literal `use_module('X')` / `require_module('X')` calls when the helper is imported (or fully-qualified), via new helpers `module_runtime_import_kinds`, `module_runtime_function_call_is_dependency`, and `literal_module_name_from_runtime_call_arg`.
- Added unit tests exercising the static literal cases and the conservative dynamic case in `crates/perl-semantic-analyzer/tests/require_import_resolution.rs` and new workspace-index tests in `crates/perl-workspace-index/src/workspace/workspace_index.rs` to assert literal resolution and conservative behavior for dynamic names.

### Testing
- Ran `cargo test -p perl-semantic-analyzer`, which passed (`121 passed; 0 failed` for that crate's test run). 
- Ran workspace-index tests via `cargo test -p perl-workspace -- --nocapture`, which passed (the crate package name is `perl-workspace`).
- Ran `cargo xtask fmt` and `cargo check --workspace --all-targets`, both of which failed due to a pre-existing compile error (an unterminated string) in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead323e32c8333a5bb56bcdad80e01)