### PR TITLE
feat(module-resolution): support static Module::Runtime imports (#3415)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1544,7 +1544,67 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             }
         }
 
-        fn module_runtime_alias(expr: &Node) -> Option<(String, String)> {
+        #[derive(Default)]
+        struct ModuleRuntimeImports {
+            use_module: bool,
+            require_module: bool,
+        }
+
+        impl ModuleRuntimeImports {
+            fn tracks(&self, call_name: &str) -> bool {
+                matches!(
+                    (call_name, self.use_module, self.require_module),
+                    ("use_module", true, _) | ("require_module", _, true)
+                )
+            }
+        }
+
+        fn module_runtime_imports(stmts: &[Node]) -> ModuleRuntimeImports {
+            fn import_name(name: &str) -> &str {
+                name.trim().trim_matches('\'').trim_matches('"').trim()
+            }
+
+            let mut imports = ModuleRuntimeImports::default();
+            for stmt in stmts {
+                let expr = inner_expr(stmt);
+                let NodeKind::Use { module, args, .. } = &expr.kind else {
+                    continue;
+                };
+                if module != "Module::Runtime" {
+                    continue;
+                }
+
+                for arg in args {
+                    let bare = import_name(arg);
+                    if bare == "use_module" {
+                        imports.use_module = true;
+                    }
+                    if bare == "require_module" {
+                        imports.require_module = true;
+                    }
+                    if bare.starts_with("qw") {
+                        let content = bare
+                            .trim_start_matches("qw")
+                            .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                            .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                        for token in content.split_whitespace() {
+                            if token == "use_module" {
+                                imports.use_module = true;
+                            }
+                            if token == "require_module" {
+                                imports.require_module = true;
+                            }
+                        }
+                    }
+                }
+            }
+            imports
+        }
+
+        fn module_runtime_alias(
+            expr: &Node,
+            module_runtime_imports: &ModuleRuntimeImports,
+        ) -> Option<(String, String)> {
             let (alias_name, call_node) = match &expr.kind {
                 NodeKind::Assignment { lhs, rhs, op } if op == "=" => {
                     let NodeKind::Variable { name, .. } = &lhs.kind else {
@@ -1564,13 +1624,12 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             let NodeKind::FunctionCall { name, args } = &call_node.kind else {
                 return None;
             };
-            if !matches!(
-                name.as_str(),
-                "use_module"
-                    | "require_module"
-                    | "Module::Runtime::use_module"
-                    | "Module::Runtime::require_module"
-            ) {
+            let allowed_call = match name.as_str() {
+                "Module::Runtime::use_module" | "Module::Runtime::require_module" => true,
+                "use_module" | "require_module" => module_runtime_imports.tracks(name),
+                _ => false,
+            };
+            if !allowed_call {
                 return None;
             }
             let first = args.first()?;
@@ -1605,8 +1664,11 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
                 stmts.iter().filter_map(|s| require_module_name(inner_expr(s))).collect();
             let mut aliases: std::collections::HashMap<String, String> =
                 std::collections::HashMap::new();
+            let module_runtime_imports = module_runtime_imports(stmts);
             for stmt in stmts {
-                if let Some((alias, module)) = module_runtime_alias(inner_expr(stmt)) {
+                if let Some((alias, module)) =
+                    module_runtime_alias(inner_expr(stmt), &module_runtime_imports)
+                {
                     aliases.insert(alias, module.clone());
                     if !required_modules.contains(&module) {
                         required_modules.push(module);

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -138,7 +138,8 @@ load_data();
 
 #[test]
 fn module_runtime_alias_then_import_resolves_pkg() {
-    let code = r#"my $loader = use_module('My::Loader');
+    let code = r#"use Module::Runtime qw(use_module);
+my $loader = use_module('My::Loader');
 $loader->import('load_data');
 load_data();
 "#;
@@ -147,5 +148,50 @@ load_data();
         pkg.as_deref(),
         Some("My::Loader"),
         "$loader->import() should resolve back to static use_module target, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_require_module_alias_then_import_resolves_pkg() {
+    let code = r#"use Module::Runtime qw(require_module);
+my $loader = require_module('My::Loader');
+$loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "$loader->import() should resolve back to static require_module target, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_without_manual_import_stays_conservative() {
+    let code = r#"my $loader = use_module('My::Loader');
+$loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_ne!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "unqualified use_module() without Module::Runtime import should stay unresolved"
+    );
+}
+
+#[test]
+fn module_runtime_dynamic_name_stays_conservative() {
+    let code = r#"use Module::Runtime qw(use_module);
+my $name = 'My::Loader';
+my $loader = use_module($name);
+$loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_ne!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "dynamic module names should remain unresolved for use_module()"
     );
 }


### PR DESCRIPTION
### Motivation
- Enable resolving literal `use_module`/`require_module` calls when `Module::Runtime` explicitly imports those helpers while remaining conservative for dynamic or unimported cases.
- Fix incorrect alias detection that treated unqualified helper calls as module-runtime aliases even when `Module::Runtime` wasn't imported.

### Description
- Add `ModuleRuntimeImports` and `module_runtime_imports(stmts: &[Node])` to detect `use Module::Runtime qw(...)` helper imports in a statement list.
- Gate unqualified `use_module`/`require_module` alias detection on the presence of an explicit `Module::Runtime` import while still accepting fully-qualified `Module::Runtime::use_module`/`require_module` calls by updating `module_runtime_alias`.
- Thread the detected `module_runtime_imports` into `scan_statements_for_require_import` so the existing `require`+`->import(...)` resolution path is reused and remains literal-only for module names.
- Add tests in `tests/require_import_resolution.rs` covering static `use_module` and `require_module` with manual `Module::Runtime` import, the conservative behavior when the helper is not imported, and the conservative behavior for dynamic module-name arguments.

### Testing
- Ran `cargo test -p perl-semantic-analyzer` and all tests passed (121 + crate test suites ran; modified tests included and passed).
- Ran `cargo test -p perl-workspace` and the workspace-index tests passed.
- Attempted `cargo check --workspace --all-targets` which failed due to a pre-existing unrelated compile error (`E0765` unterminated string) in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` and not caused by these changes.
- The change was committed with message `feat(module-resolution): support static Module::Runtime imports (#3415)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead34d1a108333af72b6d8b44f0222)