### PR TITLE
feat(module-resolution): support static Module::Runtime imports (#3415)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1544,7 +1544,48 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             }
         }
 
-        fn module_runtime_alias(expr: &Node) -> Option<(String, String)> {
+        fn parse_qw_items(raw: &str) -> Vec<&str> {
+            if !raw.starts_with("qw") {
+                return Vec::new();
+            }
+            let content = raw
+                .trim_start_matches("qw")
+                .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+            content.split_whitespace().collect()
+        }
+
+        fn module_runtime_imports(stmts: &[Node]) -> std::collections::HashSet<String> {
+            let mut imported = std::collections::HashSet::new();
+            for stmt in stmts {
+                let expr = inner_expr(stmt);
+                let NodeKind::Use { module, args, .. } = &expr.kind else {
+                    continue;
+                };
+                if module != "Module::Runtime" {
+                    continue;
+                }
+                for arg in args {
+                    let bare =
+                        arg.trim().trim_matches(',').trim_matches('\'').trim_matches('"').trim();
+                    if bare == "use_module" || bare == "require_module" {
+                        imported.insert(bare.to_string());
+                        continue;
+                    }
+                    for item in parse_qw_items(bare) {
+                        if item == "use_module" || item == "require_module" {
+                            imported.insert(item.to_string());
+                        }
+                    }
+                }
+            }
+            imported
+        }
+
+        fn module_runtime_alias(
+            expr: &Node,
+            imported_runtime_calls: &std::collections::HashSet<String>,
+        ) -> Option<(String, String)> {
             let (alias_name, call_node) = match &expr.kind {
                 NodeKind::Assignment { lhs, rhs, op } if op == "=" => {
                     let NodeKind::Variable { name, .. } = &lhs.kind else {
@@ -1564,13 +1605,12 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             let NodeKind::FunctionCall { name, args } = &call_node.kind else {
                 return None;
             };
-            if !matches!(
-                name.as_str(),
-                "use_module"
-                    | "require_module"
-                    | "Module::Runtime::use_module"
-                    | "Module::Runtime::require_module"
-            ) {
+            let call_allowed = match name.as_str() {
+                "Module::Runtime::use_module" | "Module::Runtime::require_module" => true,
+                "use_module" | "require_module" => imported_runtime_calls.contains(name),
+                _ => false,
+            };
+            if !call_allowed {
                 return None;
             }
             let first = args.first()?;
@@ -1603,10 +1643,13 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             // Collect all `require Module` names present in this block.
             let mut required_modules: Vec<String> =
                 stmts.iter().filter_map(|s| require_module_name(inner_expr(s))).collect();
+            let imported_runtime_calls = module_runtime_imports(stmts);
             let mut aliases: std::collections::HashMap<String, String> =
                 std::collections::HashMap::new();
             for stmt in stmts {
-                if let Some((alias, module)) = module_runtime_alias(inner_expr(stmt)) {
+                if let Some((alias, module)) =
+                    module_runtime_alias(inner_expr(stmt), &imported_runtime_calls)
+                {
                     aliases.insert(alias, module.clone());
                     if !required_modules.contains(&module) {
                         required_modules.push(module);

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -138,7 +138,8 @@ load_data();
 
 #[test]
 fn module_runtime_alias_then_import_resolves_pkg() {
-    let code = r#"my $loader = use_module('My::Loader');
+    let code = r#"use Module::Runtime qw(use_module);
+my $loader = use_module('My::Loader');
 $loader->import('load_data');
 load_data();
 "#;
@@ -147,5 +148,36 @@ load_data();
         pkg.as_deref(),
         Some("My::Loader"),
         "$loader->import() should resolve back to static use_module target, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_require_module_alias_then_import_resolves_pkg() {
+    let code = r#"use Module::Runtime qw(require_module);
+my $loader = require_module('My::Loader');
+$loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "$loader->import() should resolve back to static require_module target, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_dynamic_name_remains_conservative() {
+    let code = r#"use Module::Runtime qw(use_module);
+my $name = 'My::Loader';
+my $loader = use_module($name);
+$loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_ne!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "dynamic module names should remain unresolved and conservative"
     );
 }

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -2696,6 +2696,7 @@ struct IndexVisitor {
     uri: String,
     current_package: Option<String>,
     workspace_folder_uri: Option<String>,
+    module_runtime_imports: HashSet<String>,
 }
 
 fn is_interpolated_var_start(byte: u8) -> bool {
@@ -2742,6 +2743,7 @@ impl IndexVisitor {
             uri,
             current_package: Some("main".to_string()),
             workspace_folder_uri,
+            module_runtime_imports: HashSet::new(),
         }
     }
 
@@ -2811,6 +2813,15 @@ impl IndexVisitor {
 
     fn visit_node(&mut self, node: &Node, file_index: &mut FileIndex) {
         match &node.kind {
+            NodeKind::Program { statements } => {
+                let prior_imports = self.module_runtime_imports.clone();
+                self.module_runtime_imports = collect_module_runtime_imports(statements);
+                for stmt in statements {
+                    self.visit_node(stmt, file_index);
+                }
+                self.module_runtime_imports = prior_imports;
+            }
+
             NodeKind::Package { name, .. } => {
                 let package_name = name.clone();
 
@@ -2986,6 +2997,11 @@ impl IndexVisitor {
                             .dependencies
                             .insert(normalize_dependency_module_name(&module_name));
                     }
+                }
+                if let Some(module_name) =
+                    module_runtime_literal_dependency(name, args, &self.module_runtime_imports)
+                {
+                    file_index.dependencies.insert(normalize_dependency_module_name(&module_name));
                 }
 
                 // Visit arguments
@@ -3436,6 +3452,66 @@ fn extract_module_names_from_call_args(args: &[Node]) -> Vec<String> {
         collect_from_node(arg, &mut modules);
     }
     modules
+}
+
+fn parse_qw_items(raw: &str) -> Vec<&str> {
+    if !raw.starts_with("qw") {
+        return Vec::new();
+    }
+    let content = raw
+        .trim_start_matches("qw")
+        .trim_start_matches(|c: char| "([{/<|!".contains(c))
+        .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+    content.split_whitespace().collect()
+}
+
+fn collect_module_runtime_imports(statements: &[Node]) -> HashSet<String> {
+    let mut imports = HashSet::new();
+    for stmt in statements {
+        let NodeKind::Use { module, args, .. } = &stmt.kind else {
+            continue;
+        };
+        if module != "Module::Runtime" {
+            continue;
+        }
+        for arg in args {
+            let bare = arg.trim().trim_matches(',').trim_matches('\'').trim_matches('"').trim();
+            if bare == "use_module" || bare == "require_module" {
+                imports.insert(bare.to_string());
+                continue;
+            }
+            for item in parse_qw_items(bare) {
+                if item == "use_module" || item == "require_module" {
+                    imports.insert(item.to_string());
+                }
+            }
+        }
+    }
+    imports
+}
+
+fn module_runtime_literal_dependency(
+    name: &str,
+    args: &[Node],
+    imported_runtime_calls: &HashSet<String>,
+) -> Option<String> {
+    let is_runtime_loader = match name {
+        "Module::Runtime::use_module" | "Module::Runtime::require_module" => true,
+        "use_module" | "require_module" => imported_runtime_calls.contains(name),
+        _ => false,
+    };
+    if !is_runtime_loader {
+        return None;
+    }
+    let first = args.first()?;
+    let NodeKind::String { value, .. } = &first.kind else {
+        return None;
+    };
+    let module_name = value.trim_matches('\'').trim_matches('"').trim();
+    if module_name.is_empty() {
+        return None;
+    }
+    Some(module_name.to_string())
 }
 
 fn canonicalize_perl_module_name(name: &str) -> String {
@@ -4997,6 +5073,44 @@ Utils::process_data();
 
         let deps = index.file_dependencies(consumer_url.as_str());
         assert!(deps.contains("My::App::Role"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_index_dependency_via_module_runtime_literal_loader()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let index = WorkspaceIndex::new();
+        let uri = must(url::Url::parse("file:///test/workspace/runtime-loader.pl"));
+        let src = r#"use Module::Runtime qw(use_module require_module);
+my $a = use_module('My::Runtime::One');
+my $b = require_module('My::Runtime::Two');
+1;
+"#;
+        must(index.index_file(uri.clone(), src.to_string()));
+
+        let deps = index.file_dependencies(uri.as_str());
+        assert!(deps.contains("My::Runtime::One"));
+        assert!(deps.contains("My::Runtime::Two"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_index_dependency_via_module_runtime_dynamic_loader_stays_conservative()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let index = WorkspaceIndex::new();
+        let uri = must(url::Url::parse("file:///test/workspace/runtime-loader-dynamic.pl"));
+        let src = r#"use Module::Runtime qw(use_module);
+my $name = 'My::Runtime::Dynamic';
+my $mod = use_module($name);
+1;
+"#;
+        must(index.index_file(uri.clone(), src.to_string()));
+
+        let deps = index.file_dependencies(uri.as_str());
+        assert!(
+            !deps.contains("My::Runtime::Dynamic"),
+            "dynamic loader argument should not be indexed as dependency, got {deps:?}"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation

- Add a literal-only Module::Runtime slice so calls like `use_module('Foo::Bar')` and `require_module('Foo::Bar')` imported from `use Module::Runtime ...` are analyzable without inventing a parallel resolver. 
- Preserve conservative behavior for dynamic module-name uses and reuse the existing manual `require`/`Module->import(...)` resolution path so import resolution and dependency indexing remain consistent.

### Description

- Update the semantic analyzer to detect `use Module::Runtime qw(...)` imports and treat unqualified `use_module`/`require_module` as analyzable only when actually imported, by adding `parse_qw_items` and `module_runtime_imports` helpers and updating `module_runtime_alias` in `crates/perl-semantic-analyzer/src/analysis/declaration.rs`.
- Extend the workspace index visitor to track Module::Runtime imports, recognize literal `use_module`/`require_module` call sites, and index the literal module names as dependencies via `module_runtime_literal_dependency` and `collect_module_runtime_imports` in `crates/perl-workspace-index/src/workspace/workspace_index.rs`.
- Add unit tests to verify literal-resolution and conservative dynamic behavior in `crates/perl-semantic-analyzer/tests/require_import_resolution.rs` and end-to-end indexing tests in `crates/perl-workspace-index/src/workspace/workspace_index.rs`.

### Testing

- Ran `cargo test -p perl-semantic-analyzer` and the crate's test suite passed.
- Ran `cargo test -p perl-semantic-analyzer --test require_import_resolution` and the new/modified import-resolution tests passed.
- Ran `cargo test -p perl-workspace` and the workspace-index tests including the new Module::Runtime dependency tests passed.
- Ran `cargo check --workspace --all-targets` which failed due to a pre-existing, unrelated compile error (unterminated string) in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs`, so global workspace check/formatting was blocked but the modified crates' tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead34d1a108333af72b6d8b44f0222)