### PR TITLE
feat(module-resolution): support static Module::Runtime imports (#3415)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1544,7 +1544,71 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             }
         }
 
-        fn module_runtime_alias(expr: &Node) -> Option<(String, String)> {
+        fn module_runtime_imports(stmts: &[Node]) -> std::collections::HashSet<String> {
+            let mut imported = std::collections::HashSet::new();
+            for stmt in stmts {
+                let NodeKind::Use { module, args, .. } = &inner_expr(stmt).kind else {
+                    continue;
+                };
+                if module != "Module::Runtime" {
+                    continue;
+                }
+                for arg in args {
+                    if matches!(arg.as_str(), "use_module" | "require_module") {
+                        imported.insert(arg.clone());
+                        continue;
+                    }
+                    if arg.starts_with("qw") {
+                        let content = arg
+                            .trim_start_matches("qw")
+                            .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                            .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                        for token in content.split_whitespace() {
+                            if matches!(token, "use_module" | "require_module") {
+                                imported.insert(token.to_string());
+                            }
+                        }
+                        continue;
+                    }
+                    let bare = arg.trim().trim_matches('\'').trim_matches('"').trim();
+                    if matches!(bare, "use_module" | "require_module") {
+                        imported.insert(bare.to_string());
+                    }
+                }
+            }
+            imported
+        }
+
+        fn module_runtime_literal_module(
+            call_node: &Node,
+            module_runtime_imports: &std::collections::HashSet<String>,
+        ) -> Option<String> {
+            let NodeKind::FunctionCall { name, args } = &call_node.kind else {
+                return None;
+            };
+            let is_supported_runtime_call = matches!(
+                name.as_str(),
+                "Module::Runtime::use_module" | "Module::Runtime::require_module"
+            ) || (matches!(name.as_str(), "use_module" | "require_module")
+                && module_runtime_imports.contains(name));
+            if !is_supported_runtime_call {
+                return None;
+            }
+            let first = args.first()?;
+            let NodeKind::String { value, .. } = &first.kind else {
+                return None;
+            };
+            let module = value.trim_matches('\'').trim_matches('"').trim();
+            if module.is_empty() {
+                return None;
+            }
+            Some(module.to_string())
+        }
+
+        fn module_runtime_alias(
+            expr: &Node,
+            module_runtime_imports: &std::collections::HashSet<String>,
+        ) -> Option<(String, String)> {
             let (alias_name, call_node) = match &expr.kind {
                 NodeKind::Assignment { lhs, rhs, op } if op == "=" => {
                     let NodeKind::Variable { name, .. } = &lhs.kind else {
@@ -1561,27 +1625,8 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
                 _ => return None,
             };
 
-            let NodeKind::FunctionCall { name, args } = &call_node.kind else {
-                return None;
-            };
-            if !matches!(
-                name.as_str(),
-                "use_module"
-                    | "require_module"
-                    | "Module::Runtime::use_module"
-                    | "Module::Runtime::require_module"
-            ) {
-                return None;
-            }
-            let first = args.first()?;
-            let NodeKind::String { value, .. } = &first.kind else {
-                return None;
-            };
-            let module = value.trim_matches('\'').trim_matches('"').trim();
-            if module.is_empty() {
-                return None;
-            }
-            Some((alias_name.to_string(), module.to_string()))
+            let module = module_runtime_literal_module(call_node, module_runtime_imports)?;
+            Some((alias_name.to_string(), module))
         }
 
         /// Unwrap an ExpressionStatement to its inner expression, or return
@@ -1603,10 +1648,17 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             // Collect all `require Module` names present in this block.
             let mut required_modules: Vec<String> =
                 stmts.iter().filter_map(|s| require_module_name(inner_expr(s))).collect();
+            let runtime_imports = module_runtime_imports(stmts);
             let mut aliases: std::collections::HashMap<String, String> =
                 std::collections::HashMap::new();
             for stmt in stmts {
-                if let Some((alias, module)) = module_runtime_alias(inner_expr(stmt)) {
+                let expr = inner_expr(stmt);
+                if let Some(module) = module_runtime_literal_module(expr, &runtime_imports)
+                    && !required_modules.contains(&module)
+                {
+                    required_modules.push(module);
+                }
+                if let Some((alias, module)) = module_runtime_alias(expr, &runtime_imports) {
                     aliases.insert(alias, module.clone());
                     if !required_modules.contains(&module) {
                         required_modules.push(module);

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -138,7 +138,8 @@ load_data();
 
 #[test]
 fn module_runtime_alias_then_import_resolves_pkg() {
-    let code = r#"my $loader = use_module('My::Loader');
+    let code = r#"use Module::Runtime qw(use_module);
+my $loader = use_module('My::Loader');
 $loader->import('load_data');
 load_data();
 "#;
@@ -147,5 +148,64 @@ load_data();
         pkg.as_deref(),
         Some("My::Loader"),
         "$loader->import() should resolve back to static use_module target, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_qualified_use_module_resolves_pkg() {
+    let code = r#"my $loader = Module::Runtime::use_module('My::Loader');
+$loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "qualified Module::Runtime::use_module should resolve static target, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_require_module_literal_resolves_pkg() {
+    let code = r#"use Module::Runtime qw(require_module);
+require_module('My::Loader');
+My::Loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "require_module literal should behave like require for import resolution, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_dynamic_name_remains_unresolved() {
+    let code = r#"use Module::Runtime qw(use_module);
+my $name = 'My::Loader';
+my $loader = use_module($name);
+$loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_ne!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "dynamic Module::Runtime target should remain unresolved, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_unqualified_without_import_remains_unresolved() {
+    let code = r#"my $loader = use_module('My::Loader');
+$loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_ne!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "unqualified use_module without Module::Runtime import should stay conservative, got: {pkg:?}"
     );
 }


### PR DESCRIPTION
### Motivation

- Module::Runtime's `use_module`/`require_module` calls were not recognized through the existing manual-import resolution path, preventing literal static calls from resolving to their target modules.

### Description

- Teach the existing require+import scan to read `use Module::Runtime ...` import lists and collect `use_module`/`require_module` as imported names. 
- Accept unqualified `use_module(...)` / `require_module(...)` only when those names were actually imported and always accept fully-qualified `Module::Runtime::use_module` / `Module::Runtime::require_module` calls. 
- Resolve only literal string module-name arguments and fold literal runtime calls into the same `required_modules`/`aliases` scan instead of adding a parallel resolution path. 
- Add unit tests covering literal `use_module`/`require_module` cases, the qualified `Module::Runtime::use_module` form, the dynamic-name conservative path, and the unqualified-without-import conservative path.

### Testing

- Ran `cargo test -p perl-semantic-analyzer` which passed (all tests OK). 
- Ran `cargo test -p perl-workspace` which passed (all tests OK). 
- Ran `cargo check --workspace --all-targets` which failed due to a pre-existing unrelated compile error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` (E0765: unterminated string) and not due to these changes. 
- Ran `cargo xtask fmt` which could not complete because of the same pre-existing unrelated compile error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead34d1a108333af72b6d8b44f0222)