### PR TITLE
feat(module-resolution): support static Module::Runtime imports (#3415)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1544,7 +1544,74 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             }
         }
 
-        fn module_runtime_alias(expr: &Node) -> Option<(String, String)> {
+        fn extract_module_runtime_imports(stmts: &[Node]) -> std::collections::HashSet<String> {
+            let mut imported = std::collections::HashSet::new();
+
+            for stmt in stmts {
+                let NodeKind::Use { module, args, .. } = &inner_expr(stmt).kind else {
+                    continue;
+                };
+                if module != "Module::Runtime" {
+                    continue;
+                }
+
+                for arg in args {
+                    let trimmed = arg.trim().trim_matches('\'').trim_matches('"').trim();
+                    if trimmed == "use_module" || trimmed == "require_module" {
+                        imported.insert(trimmed.to_string());
+                        continue;
+                    }
+
+                    if trimmed.starts_with("qw") {
+                        let content = trimmed
+                            .trim_start_matches("qw")
+                            .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                            .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                        for token in content.split_whitespace() {
+                            if token == "use_module" || token == "require_module" {
+                                imported.insert(token.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+
+            imported
+        }
+
+        fn module_runtime_call_module(
+            expr: &Node,
+            imported_runtime_calls: &std::collections::HashSet<String>,
+        ) -> Option<String> {
+            let NodeKind::FunctionCall { name, args } = &expr.kind else {
+                return None;
+            };
+
+            let accepts_bare = matches!(name.as_str(), "use_module" | "require_module")
+                && imported_runtime_calls.contains(name);
+            let accepts_fully_qualified = matches!(
+                name.as_str(),
+                "Module::Runtime::use_module" | "Module::Runtime::require_module"
+            );
+            if !accepts_bare && !accepts_fully_qualified {
+                return None;
+            }
+
+            let first = args.first()?;
+            let NodeKind::String { value, .. } = &first.kind else {
+                return None;
+            };
+            let module = value.trim_matches('\'').trim_matches('"').trim();
+            if module.is_empty() {
+                return None;
+            }
+            Some(module.to_string())
+        }
+
+        fn module_runtime_alias(
+            expr: &Node,
+            imported_runtime_calls: &std::collections::HashSet<String>,
+        ) -> Option<(String, String)> {
             let (alias_name, call_node) = match &expr.kind {
                 NodeKind::Assignment { lhs, rhs, op } if op == "=" => {
                     let NodeKind::Variable { name, .. } = &lhs.kind else {
@@ -1560,28 +1627,8 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
                 }
                 _ => return None,
             };
-
-            let NodeKind::FunctionCall { name, args } = &call_node.kind else {
-                return None;
-            };
-            if !matches!(
-                name.as_str(),
-                "use_module"
-                    | "require_module"
-                    | "Module::Runtime::use_module"
-                    | "Module::Runtime::require_module"
-            ) {
-                return None;
-            }
-            let first = args.first()?;
-            let NodeKind::String { value, .. } = &first.kind else {
-                return None;
-            };
-            let module = value.trim_matches('\'').trim_matches('"').trim();
-            if module.is_empty() {
-                return None;
-            }
-            Some((alias_name.to_string(), module.to_string()))
+            let module = module_runtime_call_module(call_node, imported_runtime_calls)?;
+            Some((alias_name.to_string(), module))
         }
 
         /// Unwrap an ExpressionStatement to its inner expression, or return
@@ -1600,13 +1647,20 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         /// be adjacent — the import just needs to appear anywhere in the same
         /// statement list after (or even before) the require.
         fn scan_statements_for_require_import(stmts: &[Node], symbol: &str) -> Option<String> {
+            let imported_runtime_calls = extract_module_runtime_imports(stmts);
             // Collect all `require Module` names present in this block.
             let mut required_modules: Vec<String> =
                 stmts.iter().filter_map(|s| require_module_name(inner_expr(s))).collect();
             let mut aliases: std::collections::HashMap<String, String> =
                 std::collections::HashMap::new();
             for stmt in stmts {
-                if let Some((alias, module)) = module_runtime_alias(inner_expr(stmt)) {
+                let expr = inner_expr(stmt);
+                if let Some(module) = module_runtime_call_module(expr, &imported_runtime_calls) {
+                    if !required_modules.contains(&module) {
+                        required_modules.push(module);
+                    }
+                }
+                if let Some((alias, module)) = module_runtime_alias(expr, &imported_runtime_calls) {
                     aliases.insert(alias, module.clone());
                     if !required_modules.contains(&module) {
                         required_modules.push(module);

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -138,7 +138,8 @@ load_data();
 
 #[test]
 fn module_runtime_alias_then_import_resolves_pkg() {
-    let code = r#"my $loader = use_module('My::Loader');
+    let code = r#"use Module::Runtime qw(use_module);
+my $loader = use_module('My::Loader');
 $loader->import('load_data');
 load_data();
 "#;
@@ -147,5 +148,36 @@ load_data();
         pkg.as_deref(),
         Some("My::Loader"),
         "$loader->import() should resolve back to static use_module target, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_require_module_then_import_resolves_pkg() {
+    let code = r#"use Module::Runtime qw(require_module);
+require_module('My::Loader');
+My::Loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "require_module('My::Loader') should resolve to static import source, got: {pkg:?}"
+    );
+}
+
+#[test]
+fn module_runtime_dynamic_name_stays_unresolved() {
+    let code = r#"use Module::Runtime qw(use_module);
+my $module = 'My::Loader';
+my $loader = use_module($module);
+$loader->import('load_data');
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_ne!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "dynamic module names should remain conservative and unresolved"
     );
 }

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -2695,6 +2695,7 @@ struct IndexVisitor {
     document: Document,
     uri: String,
     current_package: Option<String>,
+    module_runtime_imports: HashSet<String>,
     workspace_folder_uri: Option<String>,
 }
 
@@ -2741,6 +2742,7 @@ impl IndexVisitor {
             document: document.clone(),
             uri,
             current_package: Some("main".to_string()),
+            module_runtime_imports: HashSet::new(),
             workspace_folder_uri,
         }
     }
@@ -2987,6 +2989,13 @@ impl IndexVisitor {
                             .insert(normalize_dependency_module_name(&module_name));
                     }
                 }
+                if let Some(module_name) = extract_module_runtime_literal_dependency(
+                    name,
+                    args,
+                    &self.module_runtime_imports,
+                ) {
+                    file_index.dependencies.insert(normalize_dependency_module_name(&module_name));
+                }
 
                 // Visit arguments
                 for arg in args {
@@ -2997,6 +3006,9 @@ impl IndexVisitor {
             NodeKind::Use { module, args, .. } => {
                 let module_name = normalize_dependency_module_name(module);
                 file_index.dependencies.insert(module_name.clone());
+                if module == "Module::Runtime" {
+                    self.module_runtime_imports.extend(extract_module_runtime_import_names(args));
+                }
 
                 // Also track actual parent/base class names for dependency discovery.
                 // `use parent 'Foo::Bar'` stores module="parent" and args=["'Foo::Bar'"],
@@ -3436,6 +3448,55 @@ fn extract_module_names_from_call_args(args: &[Node]) -> Vec<String> {
         collect_from_node(arg, &mut modules);
     }
     modules
+}
+
+fn extract_module_runtime_import_names(args: &[String]) -> HashSet<String> {
+    let mut imported = HashSet::new();
+    let joined = args.join(" ");
+    let (qw_words, remainder) = extract_qw_words(&joined);
+
+    for word in qw_words {
+        let token = word.trim_matches(|c: char| matches!(c, '\'' | '"' | ',' | ';')).trim();
+        if token == "use_module" || token == "require_module" {
+            imported.insert(token.to_string());
+        }
+    }
+
+    for token in remainder.split_whitespace() {
+        let token = token.trim_matches(|c: char| matches!(c, '\'' | '"' | ',' | ';')).trim();
+        if token == "use_module" || token == "require_module" {
+            imported.insert(token.to_string());
+        }
+    }
+
+    imported
+}
+
+fn extract_module_runtime_literal_dependency(
+    name: &str,
+    args: &[Node],
+    imported_runtime_calls: &HashSet<String>,
+) -> Option<String> {
+    let accepts_bare = matches!(name, "use_module" | "require_module")
+        && imported_runtime_calls.contains(name);
+    let accepts_fully_qualified =
+        matches!(name, "Module::Runtime::use_module" | "Module::Runtime::require_module");
+
+    if !accepts_bare && !accepts_fully_qualified {
+        return None;
+    }
+
+    let first = args.first()?;
+    let NodeKind::String { value, .. } = &first.kind else {
+        return None;
+    };
+
+    let module_name = value.trim_matches('\'').trim_matches('"').trim();
+    if module_name.is_empty() {
+        return None;
+    }
+
+    Some(module_name.to_string())
 }
 
 fn canonicalize_perl_module_name(name: &str) -> String {

--- a/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
@@ -2148,3 +2148,40 @@ fn test_find_dependents_via_use_parent_qw() -> Result<(), Box<dyn std::error::Er
     assert!(!other_deps.is_empty(), "Other::Base should be a registered dependency");
     Ok(())
 }
+
+#[test]
+fn test_find_dependents_via_module_runtime_literal_use_module() -> Result<(), Box<dyn std::error::Error>>
+{
+    let index = WorkspaceIndex::new();
+    let uri = file_url("/runtime_use_module.pl")?;
+    index.index_file(
+        uri,
+        "use Module::Runtime qw(use_module);\nmy $m = use_module('My::Runtime::Target');\n1;\n"
+            .to_string(),
+    )?;
+
+    let dependents = index.find_dependents("My::Runtime::Target");
+    assert!(
+        !dependents.is_empty(),
+        "literal use_module('My::Runtime::Target') should register a dependency"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_module_runtime_dynamic_name_stays_conservative() -> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let uri = file_url("/runtime_dynamic.pl")?;
+    index.index_file(
+        uri,
+        "use Module::Runtime qw(use_module);\nmy $name = 'My::Runtime::Dynamic';\nmy $m = use_module($name);\n1;\n"
+            .to_string(),
+    )?;
+
+    let dependents = index.find_dependents("My::Runtime::Dynamic");
+    assert!(
+        dependents.is_empty(),
+        "dynamic module names passed to use_module should not be indexed as static dependencies"
+    );
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Module::Runtime loader calls (`use_module` / `require_module`) used to be untracked or only partially handled, preventing literal static imports from participating in import-resolution and workspace dependency indexing.
- The goal is to recognize only literal module-name usages for `Module::Runtime` when the loader functions are explicitly imported (or fully-qualified) and keep variable-driven cases conservative.

### Description
- Reused the existing require/import resolution path in `crates/perl-semantic-analyzer/src/analysis/declaration.rs` by adding `extract_module_runtime_imports`, `module_runtime_call_module`, and wiring them into the existing `scan_statements_for_require_import` logic so literal `use_module`/`require_module` calls are treated like `require` + `->import` pairs.
- Added indexing support in `crates/perl-workspace-index/src/workspace/workspace_index.rs` by tracking `Module::Runtime` imports per file and exposing `extract_module_runtime_literal_dependency` / `extract_module_runtime_import_names` so literal runtime loader calls register dependencies via the normal path.
- Added tests: positive literal cases and a negative dynamic-name case in `crates/perl-semantic-analyzer/tests/require_import_resolution.rs`, and workspace-index dependency tests in `crates/perl-workspace-index/tests/comprehensive_unit_tests.rs` to assert literal resolution and conservative handling of dynamic names.
- Kept behavior conservative: variable-driven module names remain unresolved and no new parallel resolution system was introduced.

### Testing
- Ran `cargo test -p perl-semantic-analyzer` and all tests passed.
- Ran `cargo test -p perl-workspace` and all tests passed (workspace crate is `perl-workspace`).
- Ran `cargo check --all-targets -p perl-semantic-analyzer` and `cargo check --all-targets -p perl-workspace` and both succeeded.
- `cargo check --workspace --all-targets` / formatting runs are blocked by a pre-existing syntax error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` unrelated to these changes, so full workspace check/format could not complete in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead34d1a108333af72b6d8b44f0222)