### PR TITLE
feat(module-resolution): resolve inherited bareword methods via parent chain (#3482)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -49,11 +49,13 @@
 //! # }
 //! ```
 
+use crate::analysis::class_model::{ClassModel, ClassModelBuilder, MethodResolutionOrder};
 use crate::ast::{Node, NodeKind};
 use crate::pragma_tracker::{PragmaState, PragmaTracker};
 use perl_module::import::resolve_known_export_tag;
 use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::rc::Rc;
 
@@ -359,6 +361,7 @@ struct AnalysisContext<'a> {
     code: &'a str,
     pragma_map: &'a [(Range<usize>, PragmaState)],
     imported_barewords: std::collections::HashSet<String>,
+    inherited_barewords: HashMap<String, HashMap<String, String>>,
     line_starts: RefCell<Option<Vec<usize>>>,
     /// Current package name, updated as `package` statements are traversed.
     current_package: RefCell<String>,
@@ -370,6 +373,7 @@ impl<'a> AnalysisContext<'a> {
             code,
             pragma_map,
             imported_barewords: collect_imported_barewords(ast),
+            inherited_barewords: collect_inherited_barewords(ast),
             line_starts: RefCell::new(None),
             current_package: RefCell::new("main".to_string()),
         }
@@ -377,6 +381,13 @@ impl<'a> AnalysisContext<'a> {
 
     fn has_imported_bareword(&self, name: &str) -> bool {
         self.imported_barewords.contains(name)
+    }
+
+    fn has_inherited_bareword(&self, name: &str) -> bool {
+        let current_package = self.current_package.borrow();
+        self.inherited_barewords
+            .get(current_package.as_str())
+            .is_some_and(|methods| methods.contains_key(name))
     }
 
     fn get_line(&self, offset: usize) -> usize {
@@ -986,6 +997,7 @@ impl ScopeAnalyzer {
                     && !is_known_function(name)
                     && !pragma_state.has_builtin_import(name)
                     && !context.has_imported_bareword(name)
+                    && !context.has_inherited_bareword(name)
                     && !self.is_in_hash_key_context(node, ancestors, 10)
                 {
                     issues.push(ScopeIssue {
@@ -1890,6 +1902,134 @@ fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
     let mut imported = std::collections::HashSet::new();
     visit(ast, &mut imported);
     imported
+}
+
+fn collect_inherited_barewords(ast: &Node) -> HashMap<String, HashMap<String, String>> {
+    let models = ClassModelBuilder::new().build(ast);
+    let models_by_name: HashMap<&str, &ClassModel> =
+        models.iter().map(|model| (model.name.as_str(), model)).collect();
+    let mut inherited = HashMap::new();
+
+    for model in &models {
+        let local_methods: HashSet<&str> =
+            model.methods.iter().map(|method| method.name.as_str()).collect();
+        let ancestor_order = match model.mro {
+            MethodResolutionOrder::Dfs => dfs_ancestor_order(model.name.as_str(), &models_by_name),
+            MethodResolutionOrder::C3 => c3_ancestor_order(model.name.as_str(), &models_by_name),
+        };
+
+        let mut inherited_for_package = HashMap::new();
+        for ancestor in ancestor_order {
+            if let Some(ancestor_model) = models_by_name.get(ancestor.as_str()).copied() {
+                for method in &ancestor_model.methods {
+                    if !local_methods.contains(method.name.as_str()) {
+                        inherited_for_package
+                            .entry(method.name.clone())
+                            .or_insert_with(|| ancestor.clone());
+                    }
+                }
+            }
+        }
+
+        inherited.insert(model.name.clone(), inherited_for_package);
+    }
+
+    inherited
+}
+
+fn dfs_ancestor_order(package: &str, models_by_name: &HashMap<&str, &ClassModel>) -> Vec<String> {
+    fn walk(
+        package: &str,
+        models_by_name: &HashMap<&str, &ClassModel>,
+        seen: &mut HashSet<String>,
+        out: &mut Vec<String>,
+    ) {
+        let Some(model) = models_by_name.get(package).copied() else {
+            return;
+        };
+
+        for parent in &model.parents {
+            if seen.insert(parent.clone()) {
+                out.push(parent.clone());
+                walk(parent, models_by_name, seen, out);
+            }
+        }
+    }
+
+    let mut seen = HashSet::from([package.to_string()]);
+    let mut out = Vec::new();
+    walk(package, models_by_name, &mut seen, &mut out);
+    out
+}
+
+fn c3_ancestor_order(package: &str, models_by_name: &HashMap<&str, &ClassModel>) -> Vec<String> {
+    fn linearize(
+        package: &str,
+        models_by_name: &HashMap<&str, &ClassModel>,
+        visited: &mut HashSet<String>,
+    ) -> Vec<String> {
+        if !visited.insert(package.to_string()) {
+            return vec![];
+        }
+
+        let Some(model) = models_by_name.get(package).copied() else {
+            return vec![package.to_string()];
+        };
+
+        let parents = model.parents.clone();
+        if parents.is_empty() {
+            return vec![package.to_string()];
+        }
+
+        let mut parent_mros: Vec<Vec<String>> = parents
+            .iter()
+            .map(|parent| linearize(parent, models_by_name, &mut visited.clone()))
+            .collect();
+        parent_mros.push(parents.clone());
+
+        let mut result = vec![package.to_string()];
+        loop {
+            parent_mros.retain(|list| !list.is_empty());
+            if parent_mros.is_empty() {
+                break;
+            }
+
+            let chosen = parent_mros.iter().find_map(|list| {
+                let candidate = list.first()?;
+                let in_tail = parent_mros
+                    .iter()
+                    .any(|other| other.iter().skip(1).any(|name| name == candidate));
+                if in_tail { None } else { Some(candidate.clone()) }
+            });
+
+            match chosen {
+                Some(name) => {
+                    if !result.contains(&name) {
+                        result.push(name.clone());
+                    }
+                    for list in &mut parent_mros {
+                        if list.first().is_some_and(|head| head == &name) {
+                            list.remove(0);
+                        }
+                    }
+                }
+                None => {
+                    for list in parent_mros {
+                        if let Some(head) = list.first()
+                            && !result.contains(head)
+                        {
+                            result.push(head.clone());
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        result
+    }
+
+    linearize(package, models_by_name, &mut HashSet::new()).into_iter().skip(1).collect()
 }
 
 /// Returns true if `name` (without sigil) is a numbered capture variable.

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1914,6 +1914,107 @@ print WIFEXITED(0);
 }
 
 #[test]
+fn strict_subs_allows_inherited_method_from_single_parent() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = r#"
+use strict 'subs';
+package Base;
+sub inherited_method { 1 }
+package Child;
+use parent 'Base';
+inherited_method();
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "inherited_method"
+        }),
+        "strict 'subs' should allow methods inherited through a single parent"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_subs_allows_inherited_method_from_grandparent() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = r#"
+use strict 'subs';
+package Grandparent;
+sub root_method { 1 }
+package Parent;
+use parent 'Grandparent';
+package Child;
+use parent 'Parent';
+root_method();
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "root_method"
+        }),
+        "strict 'subs' should allow methods inherited through parent/grandparent chains"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_subs_allows_inherited_methods_across_multiple_parents()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+package LeftParent;
+sub left_only { 1 }
+package RightParent;
+sub right_only { 1 }
+package Child;
+use parent qw(LeftParent RightParent);
+left_only();
+right_only();
+"#;
+    let issues = scope_issues_strict(code);
+
+    for method_name in ["left_only", "right_only"] {
+        assert!(
+            !issues.iter().any(|issue| {
+                matches!(issue.kind, IssueKind::UnquotedBareword)
+                    && issue.variable_name == method_name
+            }),
+            "strict 'subs' should allow inherited bareword method `{method_name}` across multiple parents"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn strict_subs_child_method_shadowing_parent_remains_allowed()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+package Parent;
+sub method_name { 1 }
+package Child;
+use parent 'Parent';
+sub method_name { 2 }
+method_name();
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "method_name"
+        }),
+        "child-local methods should shadow parent methods without triggering strict bareword diagnostics"
+    );
+    Ok(())
+}
+
+#[test]
 fn version_pragma_enables_strict_vars_and_subs() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use v5.40;


### PR DESCRIPTION
### Motivation

- `use parent` / `use base` parent relationships were collected but inherited methods were not exposed to scope analysis, causing `use strict 'subs'` to flag valid inherited bareword method calls as unquoted barewords.

### Description

- Reuse the existing `ClassModelBuilder` to build per-package inherited-method maps and expose them in `AnalysisContext` via `collect_inherited_barewords` and `has_inherited_bareword`.
- Add DFS/C3 ancestor-order helpers (`dfs_ancestor_order`, `c3_ancestor_order`) to walk parent chains and determine inherited methods while preserving child-local shadowing.
- Integrate the inherited-method visibility check into the strict-subs bareword logic so inherited methods are treated like imported barewords during `NodeKind::Identifier` analysis.
- Add tests covering single parent, grandparent chain, multiple inheritance ordering, and child override shadowing to ensure strict diagnostics no longer fire for supported inherited calls.

### Testing

- Ran `cargo test -p perl-semantic-analyzer` and the crate's full test suite: succeeded (all tests passed in that crate).
- Ran `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests`: succeeded (scope-related tests including new inheritance tests passed).
- Attempted `cargo test -p perl-lsp-type-hierarchy`: failed because package `perl-lsp-type-hierarchy` is not present in this workspace (the type-hierarchy provider is now inside `perl-lsp-rs-core`).
- Ran `cargo check --workspace --all-targets`: failed due to a pre-existing parse error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs`, which is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead3504b148333900b4a2c26c1196a)