### PR TITLE
feat(module-resolution): resolve inherited bareword methods via parent chain (#3482)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -50,10 +50,12 @@
 //! ```
 
 use crate::ast::{Node, NodeKind};
+use crate::analysis::class_model::ClassModelBuilder;
 use crate::pragma_tracker::{PragmaState, PragmaTracker};
 use perl_module::import::resolve_known_export_tag;
 use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::rc::Rc;
 
@@ -358,7 +360,8 @@ enum ExtractedName<'a> {
 struct AnalysisContext<'a> {
     code: &'a str,
     pragma_map: &'a [(Range<usize>, PragmaState)],
-    imported_barewords: std::collections::HashSet<String>,
+    imported_barewords: HashSet<String>,
+    inherited_barewords_by_package: HashMap<String, HashSet<String>>,
     line_starts: RefCell<Option<Vec<usize>>>,
     /// Current package name, updated as `package` statements are traversed.
     current_package: RefCell<String>,
@@ -370,6 +373,7 @@ impl<'a> AnalysisContext<'a> {
             code,
             pragma_map,
             imported_barewords: collect_imported_barewords(ast),
+            inherited_barewords_by_package: collect_inherited_barewords_by_package(ast),
             line_starts: RefCell::new(None),
             current_package: RefCell::new("main".to_string()),
         }
@@ -377,6 +381,13 @@ impl<'a> AnalysisContext<'a> {
 
     fn has_imported_bareword(&self, name: &str) -> bool {
         self.imported_barewords.contains(name)
+    }
+
+    fn has_inherited_bareword(&self, name: &str) -> bool {
+        let current_package = self.current_package.borrow();
+        self.inherited_barewords_by_package
+            .get(current_package.as_str())
+            .is_some_and(|symbols| symbols.contains(name))
     }
 
     fn get_line(&self, offset: usize) -> usize {
@@ -986,6 +997,7 @@ impl ScopeAnalyzer {
                     && !is_known_function(name)
                     && !pragma_state.has_builtin_import(name)
                     && !context.has_imported_bareword(name)
+                    && !context.has_inherited_bareword(name)
                     && !self.is_in_hash_key_context(node, ancestors, 10)
                 {
                     issues.push(ScopeIssue {
@@ -1890,6 +1902,82 @@ fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
     let mut imported = std::collections::HashSet::new();
     visit(ast, &mut imported);
     imported
+}
+
+fn collect_inherited_barewords_by_package(ast: &Node) -> HashMap<String, HashSet<String>> {
+    let models = ClassModelBuilder::new().build(ast);
+    let mut models_by_name: HashMap<String, _> = HashMap::new();
+    let mut methods_by_name: HashMap<String, HashSet<String>> = HashMap::new();
+
+    for model in &models {
+        models_by_name.insert(model.name.clone(), model);
+        methods_by_name.insert(
+            model.name.clone(),
+            model.methods.iter().map(|method| method.name.clone()).collect(),
+        );
+    }
+
+    fn visit_parent_methods(
+        package_name: &str,
+        models_by_name: &HashMap<String, &crate::analysis::class_model::ClassModel>,
+        methods_by_name: &HashMap<String, HashSet<String>>,
+        seen_packages: &mut HashSet<String>,
+        inherited_methods: &mut HashMap<String, String>,
+    ) {
+        let Some(model) = models_by_name.get(package_name) else {
+            return;
+        };
+
+        for parent_name in &model.parents {
+            if !seen_packages.insert(parent_name.clone()) {
+                continue;
+            }
+
+            if let Some(parent_methods) = methods_by_name.get(parent_name) {
+                for method_name in parent_methods {
+                    inherited_methods
+                        .entry(method_name.clone())
+                        .or_insert_with(|| parent_name.clone());
+                }
+            }
+
+            visit_parent_methods(
+                parent_name,
+                models_by_name,
+                methods_by_name,
+                seen_packages,
+                inherited_methods,
+            );
+        }
+    }
+
+    let mut inherited_by_package: HashMap<String, HashSet<String>> = HashMap::new();
+
+    for model in &models {
+        let local_methods = methods_by_name.get(&model.name).cloned().unwrap_or_default();
+        let mut inherited_methods_with_origin: HashMap<String, String> = HashMap::new();
+        let mut seen_packages: HashSet<String> = HashSet::new();
+        seen_packages.insert(model.name.clone());
+
+        visit_parent_methods(
+            &model.name,
+            &models_by_name,
+            &methods_by_name,
+            &mut seen_packages,
+            &mut inherited_methods_with_origin,
+        );
+
+        let inherited_methods = inherited_methods_with_origin
+            .into_iter()
+            .filter_map(|(method_name, _origin)| {
+                if local_methods.contains(&method_name) { None } else { Some(method_name) }
+            })
+            .collect::<HashSet<_>>();
+
+        inherited_by_package.insert(model.name.clone(), inherited_methods);
+    }
+
+    inherited_by_package
 }
 
 /// Returns true if `name` (without sigil) is a numbered capture variable.

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1914,6 +1914,119 @@ print WIFEXITED(0);
 }
 
 #[test]
+fn strict_subs_allows_inherited_bareword_method_single_parent()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+package Base;
+sub inherited_method { 1 }
+
+package Child;
+use parent 'Base';
+inherited_method();
+"#;
+
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "inherited_method"
+        }),
+        "inherited bareword method should not be flagged for a single-parent hierarchy"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_subs_allows_inherited_bareword_method_grandparent_chain()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+package Grandparent;
+sub inherited_method { 1 }
+
+package Parent;
+use parent 'Grandparent';
+
+package Child;
+use parent 'Parent';
+inherited_method();
+"#;
+
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "inherited_method"
+        }),
+        "grandparent inherited method should not be flagged as bareword"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_subs_multiple_inheritance_prefers_earlier_parent_order()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+package ParentA;
+sub from_a { 1 }
+
+package ParentB;
+sub from_b { 1 }
+
+package Child;
+use parent qw(ParentA ParentB);
+from_a();
+from_b();
+"#;
+
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "from_a"
+        }),
+        "method inherited from first parent should be accepted"
+    );
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "from_b"
+        }),
+        "method inherited from second parent should be accepted"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_subs_child_override_shadows_parent_method()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+package Base;
+sub inherited_method { 1 }
+
+package Child;
+use parent 'Base';
+sub inherited_method { 2 }
+inherited_method();
+"#;
+
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "inherited_method"
+        }),
+        "child-local override should shadow parent method and remain a valid bareword call"
+    );
+    Ok(())
+}
+
+#[test]
 fn version_pragma_enables_strict_vars_and_subs() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use v5.40;


### PR DESCRIPTION
### Motivation

- `use strict 'subs'` reported bareword diagnostics for bareword method calls that are inherited via `use parent`/`use base` or `@ISA` chains, producing false positives during scope analysis.

### Description

- Reused the existing class-model builder by invoking `ClassModelBuilder::new().build(ast)` and constructed a per-package inherited-method set via `collect_inherited_barewords_by_package` that walks parent chains recursively while guarding against cycles.
- Extended `AnalysisContext` with `inherited_barewords_by_package` and added `has_inherited_bareword` which is consulted during bareword checks in `NodeKind::Identifier` to suppress `UnquotedBareword` when the name is an inherited method that is not shadowed by a child-local method.
- Implemented parent-chain traversal that collects ancestor methods, respects child-local overrides (child methods shadow parents), and deduplicates inherited names for package-level lookup.
- Added tests in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` covering single parent, grandparent chain, multiple inheritance, and child override shadowing scenarios to validate inherited bareword acceptance.

### Testing

- Ran `cargo test -p perl-semantic-analyzer`, which passed successfully.
- Ran `cargo check --all-targets -p perl-semantic-analyzer`, which passed successfully.
- Ran `cargo clippy -p perl-semantic-analyzer --all-targets -- -D warnings`, which passed without warnings.
- `cargo check --workspace --all-targets` failed due to a pre-existing unrelated compile error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` (unterminated string), so full workspace verification is blocked by that unrelated issue.
- Attempted `cargo test -p perl-lsp-type-hierarchy` but the package name is not present in this workspace (test invocation is not applicable here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead3504b148333900b4a2c26c1196a)