### PR TITLE
feat(lsp): surface inherited methods in completion + navigation (#3482)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -9,11 +9,10 @@ use super::{
     context::CompletionContext,
     items::{CompletionItem, CompletionItemKind},
 };
+use crate::providers::inheritance::collect_accessible_package_members;
 use perl_semantic_analyzer::type_inference::{PerlType, TypeInferenceEngine};
-use perl_workspace::workspace_index::{
-    SymbolKind as WsSymbolKind, VarKind, WorkspaceIndex, WorkspaceSymbol,
-};
-use std::collections::{HashMap, HashSet, VecDeque};
+use perl_workspace::workspace_index::{SymbolKind as WsSymbolKind, VarKind, WorkspaceIndex};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 /// Add workspace symbol completions for functions and variables
@@ -485,7 +484,7 @@ pub fn add_workspace_method_completions(
     // Collect all methods from the receiver package AND its ancestor chain (parents + roles).
     // Child methods take priority: collect_all_package_members deduplicates by keeping the
     // first occurrence (closest to the receiver in the BFS order).
-    let members = collect_all_package_members(index, &package_name);
+    let members = collect_accessible_package_members(index, &package_name);
 
     // Build an auto-import edit once for all methods from this package.
     let auto_import_edit = auto_import::build_auto_import_edit(source, &package_name);
@@ -536,100 +535,6 @@ pub fn add_workspace_method_completions(
             commit_characters: None,
         });
     }
-}
-
-/// Collect all method symbols accessible from a package, following parent/role chains.
-///
-/// Performs BFS over the inheritance graph starting at `package_name`, collecting
-/// subroutine and method symbols from each package in the resolution order.
-/// Child-defined methods shadow parent methods — the first occurrence of each name wins.
-///
-/// Edge-case handling:
-/// - Diamond inheritance: BFS visited-set prevents duplicate traversal.
-/// - Circular `@ISA`: visited-set prevents infinite loops.
-/// - Package not indexed: `get_package_members` returns `Vec::new()` gracefully.
-/// - `use parent -norequire`: already handled by `ClassModelBuilder`; model.parents
-///   contains the parent names regardless.
-///
-/// NOTE: C3 MRO ordering is NOT honoured — this uses BFS (breadth-first), which
-/// approximates but does not exactly match C3 for complex diamond hierarchies.
-/// This is a pre-existing approximation shared with `navigation.rs`. A follow-up
-/// issue should address strict C3 ordering if it becomes important (see issue #3482).
-fn collect_all_package_members(index: &WorkspaceIndex, package_name: &str) -> Vec<WorkspaceSymbol> {
-    let mut seen_names: HashSet<String> = HashSet::new();
-    let mut result: Vec<WorkspaceSymbol> = Vec::new();
-
-    let mut visited: HashSet<String> = HashSet::new();
-    let mut queue: VecDeque<String> = VecDeque::new();
-
-    // Cache of package_name → list of parent/role package names, populated lazily.
-    let mut related_cache: HashMap<String, Vec<String>> = HashMap::new();
-
-    // Collect related packages (parents + roles) for a given package by parsing
-    // its source file from the workspace index or filesystem.
-    let collect_related = |pkg: &str, cache: &mut HashMap<String, Vec<String>>| -> Vec<String> {
-        cache
-            .entry(pkg.to_string())
-            .or_insert_with(|| {
-                let Some(pkg_location) = index.find_definition(pkg) else {
-                    return Vec::new();
-                };
-
-                let text = index.document_store().get_text(&pkg_location.uri).or_else(|| {
-                    perl_workspace::workspace_index::uri_to_fs_path(&pkg_location.uri)
-                        .and_then(|path| std::fs::read_to_string(path).ok())
-                });
-
-                let Some(text) = text else {
-                    return Vec::new();
-                };
-
-                let mut parser = perl_semantic_analyzer::Parser::new(&text);
-                let Ok(ast) = parser.parse() else {
-                    return Vec::new();
-                };
-
-                perl_semantic_analyzer::semantic::SemanticAnalyzer::analyze_with_source(&ast, &text)
-                    .class_models
-                    .into_iter()
-                    .find(|model| model.name == pkg)
-                    .map(|model| {
-                        model.parents.iter().chain(model.roles.iter()).cloned().collect::<Vec<_>>()
-                    })
-                    .unwrap_or_default()
-            })
-            .clone()
-    };
-
-    // Start with the receiver package itself
-    queue.push_back(package_name.to_string());
-    visited.insert(package_name.to_string());
-
-    while let Some(pkg) = queue.pop_front() {
-        // Collect direct members for this package
-        let members = index.get_package_members(&pkg);
-        for symbol in members {
-            // Only include subroutines and methods
-            match symbol.kind {
-                WsSymbolKind::Subroutine | WsSymbolKind::Method => {}
-                _ => continue,
-            }
-            // Child wins: skip if a closer ancestor already provided this name
-            if seen_names.insert(symbol.name.clone()) {
-                result.push(symbol);
-            }
-        }
-
-        // Enqueue ancestor packages
-        let related = collect_related(&pkg, &mut related_cache);
-        for ancestor in related {
-            if visited.insert(ancestor.clone()) {
-                queue.push_back(ancestor);
-            }
-        }
-    }
-
-    result
 }
 
 /// Find the position of a single assignment `=` in a line, skipping compound

--- a/crates/perl-lsp-rs-core/src/providers/inheritance.rs
+++ b/crates/perl-lsp-rs-core/src/providers/inheritance.rs
@@ -1,0 +1,104 @@
+//! Shared inheritance graph traversal helpers for LSP consumers.
+//!
+//! Centralizes parent/role walking used by completion and navigation so both
+//! providers resolve inherited methods consistently.
+
+use perl_workspace::workspace_index::{
+    Location, SymbolKind, WorkspaceIndex, WorkspaceSymbol, uri_to_fs_path,
+};
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// Collect method symbols accessible from `package_name`, including inherited
+/// parents and composed roles.
+pub fn collect_accessible_package_members(
+    index: &WorkspaceIndex,
+    package_name: &str,
+) -> Vec<WorkspaceSymbol> {
+    let mut seen_names: HashSet<String> = HashSet::new();
+    let mut result: Vec<WorkspaceSymbol> = Vec::new();
+
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+    let mut related_cache: HashMap<String, Vec<String>> = HashMap::new();
+
+    queue.push_back(package_name.to_string());
+    visited.insert(package_name.to_string());
+
+    while let Some(pkg) = queue.pop_front() {
+        for symbol in index.get_package_members(&pkg) {
+            match symbol.kind {
+                SymbolKind::Subroutine | SymbolKind::Method => {}
+                _ => continue,
+            }
+
+            if seen_names.insert(symbol.name.clone()) {
+                result.push(symbol);
+            }
+        }
+
+        for related in collect_related_packages(index, &pkg, &mut related_cache) {
+            if visited.insert(related.clone()) {
+                queue.push_back(related);
+            }
+        }
+    }
+
+    result
+}
+
+/// Resolve `method_name` on ancestors of `receiver_pkg`.
+pub fn find_inherited_method_definition(
+    index: &WorkspaceIndex,
+    receiver_pkg: &str,
+    method_name: &str,
+) -> Option<Location> {
+    collect_accessible_package_members(index, receiver_pkg)
+        .into_iter()
+        .find_map(|symbol| {
+            if symbol.name != method_name {
+                return None;
+            }
+            let defining_pkg = symbol.container_name.as_deref()?;
+            if defining_pkg == receiver_pkg {
+                return None;
+            }
+
+            index.find_definition(&format!("{defining_pkg}::{method_name}"))
+        })
+}
+
+fn collect_related_packages(
+    index: &WorkspaceIndex,
+    package_name: &str,
+    related_cache: &mut HashMap<String, Vec<String>>,
+) -> Vec<String> {
+    related_cache
+        .entry(package_name.to_string())
+        .or_insert_with(|| {
+            let Some(pkg_location) = index.find_definition(package_name) else {
+                return Vec::new();
+            };
+
+            let text = index.document_store().get_text(&pkg_location.uri).or_else(|| {
+                uri_to_fs_path(&pkg_location.uri).and_then(|path| std::fs::read_to_string(path).ok())
+            });
+            let Some(text) = text else {
+                return Vec::new();
+            };
+
+            let mut parser = perl_semantic_analyzer::Parser::new(&text);
+            let Ok(ast) = parser.parse() else {
+                return Vec::new();
+            };
+
+            perl_semantic_analyzer::semantic::SemanticAnalyzer::analyze_with_source(&ast, &text)
+                .class_models
+                .into_iter()
+                .find(|model| model.name == package_name)
+                .map(|model| {
+                    model.parents.iter().chain(model.roles.iter()).cloned().collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+        })
+        .clone()
+}

--- a/crates/perl-lsp-rs-core/src/providers/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/mod.rs
@@ -12,6 +12,7 @@
 
 // Group 1 -- helpers (no inter-provider dependencies)
 pub mod completion_item;
+pub mod inheritance;
 pub mod symbol_query;
 
 // Group 2 -- consumers of Group 1 helpers
@@ -56,6 +57,7 @@ pub use code_lens::*;
 pub use color::*;
 pub use completion::*;
 pub use completion_item::*;
+pub use inheritance::*;
 pub use diagnostics::*;
 pub use document_highlight::*;
 pub use document_links::*;

--- a/crates/perl-lsp-rs/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/navigation.rs
@@ -7,7 +7,7 @@ use super::super::*;
 use crate::cancellation::RequestCleanupGuard;
 use crate::protocol::{req_position, req_uri};
 use crate::util::token_under_cursor;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::HashMap;
 
 #[cfg(feature = "workspace")]
 use crate::runtime::routing::{IndexAccessMode, route_index_access};
@@ -477,17 +477,6 @@ fn find_plack_middleware_definition_location(
 }
 
 #[cfg(feature = "workspace")]
-pub(super) fn workspace_document_text(
-    workspace_index: &crate::workspace_index::WorkspaceIndex,
-    uri: &str,
-) -> Option<String> {
-    workspace_index.document_store().get_text(uri).or_else(|| {
-        crate::workspace_index::uri_to_fs_path(uri)
-            .and_then(|path| std::fs::read_to_string(path).ok())
-    })
-}
-
-#[cfg(feature = "workspace")]
 fn get_mojo_string_route_regex() -> Result<&'static regex::Regex, JsonRpcError> {
     MOJO_STRING_ROUTE_RE
         .get_or_init(|| {
@@ -662,79 +651,13 @@ fn inherited_method_definition_location(
     receiver_pkg: &str,
     method_name: &str,
 ) -> Option<crate::workspace_index::Location> {
-    let mut visited = HashSet::from([receiver_pkg.to_string()]);
-    let mut queue = VecDeque::new();
-    let mut related_package_cache: HashMap<String, Vec<String>> = HashMap::new();
-
-    let mut enqueue_related_packages =
-        |package_name: &str, queue: &mut VecDeque<String>, visited: &HashSet<String>| {
-            let related_packages = related_package_cache
-                .entry(package_name.to_string())
-                .or_insert_with(|| {
-                    let Some(package_location) = workspace_index.find_definition(package_name)
-                    else {
-                        return Vec::new();
-                    };
-                    let Some(text) =
-                        workspace_document_text(workspace_index, &package_location.uri)
-                    else {
-                        return Vec::new();
-                    };
-
-                    let mut parser = Parser::new(&text);
-                    let Ok(ast) = parser.parse() else {
-                        return Vec::new();
-                    };
-
-                    crate::semantic::SemanticAnalyzer::analyze_with_source(&ast, &text)
-                        .class_models
-                        .into_iter()
-                        .find(|model| model.name == package_name)
-                        .map(|model| {
-                            // Include both parent classes and composed roles in the BFS
-                            // so that `with 'Role'` methods are resolved alongside
-                            // `extends`/`use parent` methods.
-                            // NOTE: BFS visited-set (above) handles diamond and circular inheritance.
-                            // NOTE: C3 MRO ordering is a pre-existing approximation; BFS does not
-                            // honour strict C3 order. Filed as follow-up (see issue #3482).
-                            model
-                                .parents
-                                .iter()
-                                .chain(model.roles.iter())
-                                .cloned()
-                                .collect::<Vec<_>>()
-                        })
-                        .unwrap_or_default()
-                })
-                .clone();
-
-            for related_package in related_packages {
-                if !visited.contains(&related_package) {
-                    queue.push_back(related_package);
-                }
-            }
-        };
-
-    enqueue_related_packages(receiver_pkg, &mut queue, &visited);
-
-    while let Some(package_name) = queue.pop_front() {
-        if !visited.insert(package_name.clone()) {
-            continue;
-        }
-
-        if let Some(location) =
-            find_workspace_definition_location(workspace_index, &package_name, method_name)
-        {
-            tracing::debug!(
-                receiver_pkg,
-                package_name,
-                method_name,
-                "resolved inherited/role method definition"
-            );
-            return Some(location);
-        }
-
-        enqueue_related_packages(&package_name, &mut queue, &visited);
+    if let Some(location) = perl_lsp_rs_core::providers::find_inherited_method_definition(
+        workspace_index,
+        receiver_pkg,
+        method_name,
+    ) {
+        tracing::debug!(receiver_pkg, method_name, "resolved inherited/role method definition");
+        return Some(location);
     }
 
     None


### PR DESCRIPTION
### Motivation

- Make inherited methods visible to completion and navigation consumers by sharing hierarchy traversal, avoiding duplicate logic and improving consistency when resolving inherited/sub-methods.

### Description

- Add a shared inheritance helper module `providers::inheritance::collect_accessible_package_members` and `find_inherited_method_definition` in `crates/perl-lsp-rs-core` to centralize BFS traversal of parents/roles and shadowing semantics.
- Wire workspace `->` method completion to use the new helper so inherited methods appear in completion results with defining-package origin and tiered ranking preserved.
- Update LSP navigation inherited-method resolution to call the shared helper so go-to-definition for inherited methods returns parent definitions consistently.
- Export the new `inheritance` provider from the `perl-lsp-rs-core` providers facade so multiple consumers reuse the same logic.

### Testing

- Ran `cargo check -p perl-workspace` which succeeded. 
- Attempted `cargo test -p perl-lsp-navigation` and `cargo test -p perl-lsp-completion` but those package names do not exist in this workspace (they are absorbed into `perl-lsp-rs-core`).
- Ran `cargo test -p perl-lsp-rs` (targeting completion/inheritance tests) and `cargo check --workspace --all-targets`, both of which failed to complete due to a pre-existing unrelated syntax error (unterminated string) in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` rather than the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead353e04083339d1b5cc126ee7b86)