### PR TITLE
refactor(pragma): expose explicit PragmaState query API (#0000)

### DIFF
--- a/crates/perl-pragma/README.md
+++ b/crates/perl-pragma/README.md
@@ -12,10 +12,14 @@ in the source.
 ## Public API
 
 - **`PragmaState`** -- tracks `strict_vars`, `strict_subs`, `strict_refs`,
-  and `warnings` booleans. Provides `all_strict()` and `Default`.
+  `warnings`, and tracked feature/builtin state. Provides helper query methods.
+- **`PragmaEnvironment`** -- immutable compile-time environment with
+  `query(PragmaQuery)` / `snapshot_at(offset)` APIs for position-based state
+  lookup.
+- **`PragmaSnapshot`** -- immutable per-position snapshot exposing strict,
+  warnings, and feature checks for downstream diagnostics/semantic consumers.
 - **`PragmaTracker`** -- walks an AST via `build()` to produce a sorted
-  `Vec<(Range<usize>, PragmaState)>`, and offers `state_for_offset()` to
-  query it.
+  `Vec<(Range<usize>, PragmaState)>` for compatibility with existing callers.
 
 ## Workspace Role
 

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -65,6 +65,118 @@ pub struct PragmaState {
     pub builtin_imports: Vec<String>,
 }
 
+/// Query object for asking which pragma state applies at a file position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PragmaQuery {
+    /// Byte offset in the source file.
+    pub offset: usize,
+}
+
+impl PragmaQuery {
+    /// Build a pragma query at the given source offset.
+    #[must_use]
+    pub const fn at_offset(offset: usize) -> Self {
+        Self { offset }
+    }
+}
+
+/// Immutable snapshot of effective pragma state at a query point.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PragmaSnapshot {
+    state: PragmaState,
+}
+
+impl PragmaSnapshot {
+    fn from_state(state: PragmaState) -> Self {
+        Self { state }
+    }
+
+    /// Returns the effective strict state (`vars`, `subs`, `refs`).
+    #[must_use]
+    pub fn strict(&self) -> (bool, bool, bool) {
+        (self.state.strict_vars, self.state.strict_subs, self.state.strict_refs)
+    }
+
+    /// Returns `true` when warnings are globally enabled.
+    #[must_use]
+    pub fn warnings(&self) -> bool {
+        self.state.warnings
+    }
+
+    /// Returns `true` when the given feature is currently enabled.
+    #[must_use]
+    pub fn has_feature(&self, feature: &str) -> bool {
+        self.state.has_feature(feature)
+    }
+
+    /// Borrow the underlying complete pragma state.
+    #[must_use]
+    pub fn state(&self) -> &PragmaState {
+        &self.state
+    }
+
+    /// Consume the snapshot and return the underlying pragma state value.
+    #[must_use]
+    pub fn into_state(self) -> PragmaState {
+        self.state
+    }
+}
+
+/// Immutable compile-time pragma environment built from a Perl AST.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct PragmaEnvironment {
+    ranges: Vec<(Range<usize>, PragmaState)>,
+}
+
+impl PragmaEnvironment {
+    /// Build a range-indexed pragma environment from an AST.
+    #[must_use]
+    pub fn build(ast: &Node) -> Self {
+        let mut ranges = Vec::new();
+        let mut current_state = PragmaState::default();
+
+        PragmaTracker::build_ranges(ast, &mut current_state, &mut ranges);
+        ranges.sort_by_key(|(range, _)| range.start);
+
+        Self { ranges }
+    }
+
+    /// Query the effective pragma state for a source position.
+    #[must_use]
+    pub fn query(&self, query: PragmaQuery) -> PragmaSnapshot {
+        let idx = self.ranges.partition_point(|(range, _)| range.start <= query.offset);
+
+        let mut state =
+            if idx > 0 { self.ranges[idx - 1].1.clone() } else { PragmaState::default() };
+
+        if state.signatures_strict {
+            state.strict_vars = true;
+            state.strict_subs = true;
+            state.strict_refs = true;
+        }
+
+        PragmaSnapshot::from_state(state)
+    }
+
+    /// Convenience for directly querying by byte offset.
+    #[must_use]
+    pub fn snapshot_at(&self, offset: usize) -> PragmaSnapshot {
+        self.query(PragmaQuery::at_offset(offset))
+    }
+
+    /// Borrow the internal range transitions used by the query engine.
+    #[must_use]
+    pub fn ranges(&self) -> &[(Range<usize>, PragmaState)] {
+        &self.ranges
+    }
+
+    /// Consume the environment and return underlying range transitions.
+    #[must_use]
+    pub fn into_ranges(self) -> Vec<(Range<usize>, PragmaState)> {
+        self.ranges
+    }
+}
+
 impl PragmaState {
     /// Create a new pragma state with all strict modes enabled
     pub fn all_strict() -> Self {
@@ -419,16 +531,7 @@ pub struct PragmaTracker;
 impl PragmaTracker {
     /// Build a range-indexed pragma map from an AST
     pub fn build(ast: &Node) -> Vec<(Range<usize>, PragmaState)> {
-        let mut ranges = Vec::new();
-        let mut current_state = PragmaState::default();
-
-        // Build the pragma map by walking the AST
-        Self::build_ranges(ast, &mut current_state, &mut ranges);
-
-        // Sort by start offset
-        ranges.sort_by_key(|(range, _)| range.start);
-
-        ranges
+        PragmaEnvironment::build(ast).into_ranges()
     }
 
     /// Get the pragma state at a specific byte offset
@@ -436,22 +539,7 @@ impl PragmaTracker {
         pragma_map: &[(Range<usize>, PragmaState)],
         offset: usize,
     ) -> PragmaState {
-        // Find the last pragma state that starts before this offset.
-        // pragma_map is sorted by start offset (guaranteed by build()).
-        // We use partition_point to find the first element where start > offset,
-        // then take the element before it.
-        let idx = pragma_map.partition_point(|(range, _)| range.start <= offset);
-
-        let mut state =
-            if idx > 0 { pragma_map[idx - 1].1.clone() } else { PragmaState::default() };
-
-        if state.signatures_strict {
-            state.strict_vars = true;
-            state.strict_subs = true;
-            state.strict_refs = true;
-        }
-
-        state
+        PragmaEnvironment { ranges: pragma_map.to_vec() }.snapshot_at(offset).into_state()
     }
 
     /// Process a lexically scoped body and then restore the caller state.

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -5,7 +5,10 @@
 
 use perl_ast::SourceLocation;
 use perl_ast::ast::{Node, NodeKind};
-use perl_pragma::{PerlVersion, PragmaState, PragmaTracker, features_enabled_by_version};
+use perl_pragma::{
+    PerlVersion, PragmaEnvironment, PragmaQuery, PragmaState, PragmaTracker,
+    features_enabled_by_version,
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1453,6 +1456,56 @@ fn eval_string_is_conservative_and_does_not_enable_pragmas()
     assert!(!state.strict_subs, "eval STRING must not assume strict is enabled");
     assert!(!state.strict_refs, "eval STRING must not assume strict is enabled");
     assert!(!state.warnings, "eval STRING must not assume warnings are enabled");
+    Ok(())
+}
+
+#[test]
+fn environment_query_inner_no_strict_does_not_leak() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        block(vec![no_node("strict", &["refs"], 20, 36)], 18, 40),
+        dummy_node(41, 48),
+    ]);
+    let env = PragmaEnvironment::build(&ast);
+
+    let inside = env.query(PragmaQuery::at_offset(28));
+    assert_eq!(inside.strict(), (true, true, false));
+
+    let outside = env.snapshot_at(44);
+    assert_eq!(outside.strict(), (true, true, true));
+    Ok(())
+}
+
+#[test]
+fn environment_query_eval_block_restores_outer_state() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("warnings", &[], 0, 14),
+        eval_node(block(vec![no_node("warnings", &[], 22, 35)], 20, 37), 18, 39),
+        dummy_node(40, 47),
+    ]);
+    let env = PragmaEnvironment::build(&ast);
+
+    let inside_eval = env.snapshot_at(30);
+    assert!(!inside_eval.warnings());
+
+    let after_eval = env.snapshot_at(45);
+    assert!(after_eval.warnings());
+    Ok(())
+}
+
+#[test]
+fn environment_query_string_eval_does_not_change_outer_static_state()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        eval_node(string_node("use warnings; no strict 'refs';", false, 13, 43), 13, 43),
+        dummy_node(44, 50),
+    ]);
+    let env = PragmaEnvironment::build(&ast);
+
+    let after_eval_string = env.snapshot_at(48);
+    assert_eq!(after_eval_string.strict(), (true, true, true));
+    assert!(!after_eval_string.warnings());
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Provide a small, explicit, immutable API for asking “what pragma/feature state is in effect at this file position?” so downstream diagnostics and semantic consumers can query compile-time pragma environment cleanly.

### Description
- Added `PragmaEnvironment`, `PragmaQuery`, and `PragmaSnapshot` to represent an immutable compile-time pragma environment, a position query object, and per-position snapshots respectively in `crates/perl-pragma/src/lib.rs`.
- Implemented `PragmaEnvironment::build(ast)` to produce the same range-indexed transitions previously returned by `PragmaTracker::build` and added `query` / `snapshot_at` convenience accessors.
- Preserved backward compatibility by routing `PragmaTracker::build` and `PragmaTracker::state_for_offset` through the new `PragmaEnvironment`/`PragmaSnapshot` layer.
- Added tests that exercise the new query surface to verify inner `no strict` does not leak, `eval { ... }` restores outer state, and string `eval` does not mutate outer static pragma state, and updated README to document the new API surface.

### Testing
- Ran `cargo test -p perl-pragma` and the crate tests passed (behavior and comprehensive unit tests ran and succeeded).
- Ran `cargo check --all-targets -p perl-pragma` and it completed successfully for the crate.
- Ran `cargo check --workspace --all-targets` which fails on unrelated existing code in `crates/perl-lsp-rs-core` (`formatting.rs` has an unterminated string literal); this is unrelated to the changes in `perl-pragma`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead35a5b3883339078b9b2a0a697e1)