### PR TITLE
refactor(pragma): expose explicit PragmaState query API (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -110,6 +110,100 @@ impl PragmaState {
     pub fn has_builtin_import(&self, name: &str) -> bool {
         self.builtin_imports.iter().any(|import| import == name)
     }
+
+    /// Creates an immutable snapshot of this compile-time pragma state.
+    #[must_use]
+    pub fn snapshot(&self) -> PragmaSnapshot {
+        PragmaSnapshot { state: self.clone() }
+    }
+}
+
+/// Immutable saved pragma state for explicit save/restore operations.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PragmaSnapshot {
+    state: PragmaState,
+}
+
+impl PragmaSnapshot {
+    /// Returns the captured pragma state.
+    #[must_use]
+    pub fn state(&self) -> &PragmaState {
+        &self.state
+    }
+
+    /// Restores the captured state into a mutable target.
+    pub fn restore_into(self, target: &mut PragmaState) {
+        *target = self.state;
+    }
+}
+
+/// Query result for compile-time pragma state at a specific file offset.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PragmaStateQuery {
+    /// Byte offset used for the query.
+    pub offset: usize,
+    state: PragmaState,
+}
+
+impl PragmaStateQuery {
+    /// Returns the full pragma state in effect at this query offset.
+    #[must_use]
+    pub fn state(&self) -> &PragmaState {
+        &self.state
+    }
+
+    /// Returns `true` if all strict categories are active at this query offset.
+    #[must_use]
+    pub fn strict_enabled(&self) -> bool {
+        self.state.strict_vars && self.state.strict_subs && self.state.strict_refs
+    }
+
+    /// Returns `true` if warnings are globally active at this query offset.
+    #[must_use]
+    pub fn warnings_enabled(&self) -> bool {
+        self.state.warnings
+    }
+
+    /// Returns `true` if a feature is active at this query offset.
+    #[must_use]
+    pub fn has_feature(&self, feature: &str) -> bool {
+        self.state.has_feature(feature)
+    }
+}
+
+/// Compile-time lexical pragma environment for a file.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct CompileTimeEnvironment {
+    pragma_map: Vec<(Range<usize>, PragmaState)>,
+}
+
+impl CompileTimeEnvironment {
+    /// Builds a compile-time environment from an AST.
+    #[must_use]
+    pub fn from_ast(ast: &Node) -> Self {
+        Self { pragma_map: PragmaTracker::build(ast) }
+    }
+
+    /// Returns an immutable query object for state active at `offset`.
+    #[must_use]
+    pub fn query(&self, offset: usize) -> PragmaStateQuery {
+        PragmaStateQuery {
+            offset,
+            state: PragmaTracker::state_for_offset(&self.pragma_map, offset),
+        }
+    }
+
+    /// Returns the full state in effect at `offset`.
+    #[must_use]
+    pub fn state_at(&self, offset: usize) -> PragmaState {
+        self.query(offset).state
+    }
+
+    /// Returns the recorded internal range transitions.
+    #[must_use]
+    pub fn ranges(&self) -> &[(Range<usize>, PragmaState)] {
+        &self.pragma_map
+    }
 }
 
 /// Parse a Perl version string into a major/minor pair.
@@ -464,9 +558,9 @@ impl PragmaTracker {
         current_state: &mut PragmaState,
         ranges: &mut Vec<(Range<usize>, PragmaState)>,
     ) {
-        let saved_state = current_state.clone();
+        let saved_state = current_state.snapshot();
         Self::build_ranges(body, current_state, ranges);
-        *current_state = saved_state;
+        saved_state.restore_into(current_state);
         ranges.push((body.location.end..body.location.end, current_state.clone()));
     }
 
@@ -740,7 +834,7 @@ impl PragmaTracker {
             }
             NodeKind::Block { statements } => {
                 // Save current state
-                let saved_state = current_state.clone();
+                let saved_state = current_state.snapshot();
 
                 // Process statements in the block
                 for stmt in statements {
@@ -748,7 +842,7 @@ impl PragmaTracker {
                 }
 
                 // Restore state after block
-                *current_state = saved_state;
+                saved_state.restore_into(current_state);
                 ranges.push((node.location.end..node.location.end, current_state.clone()));
             }
             NodeKind::Program { statements } => {

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -5,7 +5,7 @@
 
 use perl_ast::SourceLocation;
 use perl_ast::ast::{Node, NodeKind};
-use perl_pragma::{PragmaState, PragmaTracker};
+use perl_pragma::{CompileTimeEnvironment, PragmaState, PragmaTracker};
 
 fn loc(start: usize, end: usize) -> SourceLocation {
     SourceLocation { start, end }
@@ -64,6 +64,24 @@ fn program(stmts: Vec<Node>) -> Node {
     Node { kind: NodeKind::Program { statements: stmts }, location: loc(0, end) }
 }
 
+fn eval_node(body_node: Node, start: usize, end: usize) -> Node {
+    Node { kind: NodeKind::Eval { block: Box::new(body_node) }, location: loc(start, end) }
+}
+
+fn function_call(name: &str, args: Vec<Node>, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::FunctionCall { name: name.to_string(), args },
+        location: loc(start, end),
+    }
+}
+
+fn string_node(value: &str, interpolated: bool, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::String { value: value.to_string(), interpolated },
+        location: loc(start, end),
+    }
+}
+
 #[test]
 fn given_fresh_file_when_no_pragmas_then_default_state_applies() {
     let ast = program(vec![]);
@@ -101,6 +119,58 @@ fn given_use_strict_when_no_strict_refs_in_inner_block_then_refs_is_restored_out
     assert!(outside.strict_subs);
     assert!(outside.strict_refs);
     assert!(outside.warnings);
+}
+
+#[test]
+fn compile_time_environment_query_does_not_leak_inner_no_strict() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        block(vec![no_node("strict", &["refs"], 15, 31)], 13, 33),
+        use_node("warnings", &[], 34, 49),
+    ]);
+    let env = CompileTimeEnvironment::from_ast(&ast);
+
+    let inside_query = env.query(25);
+    assert!(!inside_query.state().strict_refs);
+
+    let outside_query = env.query(40);
+    assert!(outside_query.strict_enabled());
+    assert!(outside_query.warnings_enabled());
+}
+
+#[test]
+fn compile_time_environment_query_restores_state_after_eval_block() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        eval_node(block(vec![no_node("strict", &["refs"], 20, 36)], 18, 38), 16, 40),
+        use_node("warnings", &[], 41, 56),
+    ]);
+    let env = CompileTimeEnvironment::from_ast(&ast);
+
+    let eval_query = env.query(30);
+    assert!(!eval_query.state().strict_refs);
+
+    let after_eval_query = env.query(50);
+    assert!(after_eval_query.strict_enabled());
+    assert!(after_eval_query.warnings_enabled());
+}
+
+#[test]
+fn compile_time_environment_query_keeps_string_eval_conservative() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        function_call(
+            "eval",
+            vec![string_node("use warnings; no strict 'refs';", true, 20, 53)],
+            15,
+            54,
+        ),
+    ]);
+    let env = CompileTimeEnvironment::from_ast(&ast);
+
+    let query = env.query(60);
+    assert!(query.strict_enabled());
+    assert!(!query.warnings_enabled());
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Provide an explicit, queryable compile-time pragma environment so downstream consumers can ask “what pragma/feature state is in effect at this file position?” and to make save/restore semantics explicit for lexical scopes.

### Description
- Added `CompileTimeEnvironment` with `from_ast`, `query`, `state_at`, and `ranges` to expose pragma state by file offset.
- Introduced `PragmaStateQuery` (with `strict_enabled`, `warnings_enabled`, `has_feature`) and `PragmaSnapshot` plus `PragmaState::snapshot()` / `PragmaSnapshot::restore_into()` to make save/restore operations explicit and immutable.
- Updated `PragmaTracker` to use the new snapshot/restore API when entering and leaving lexical scopes (`build_scoped_body` and `Block` handling).
- Added behavior-spec tests that exercise the new API and acceptance scenarios: inner `no strict` does not leak, `eval { ... }` restores outer state, and `eval` with a string argument is treated conservatively.

### Testing
- Ran `cargo test -p perl-pragma` and the crate tests passed (all new and existing tests succeeded).
- Ran `cargo check --workspace --all-targets` which failed due to a pre-existing, unrelated syntax error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` (unterminated string); this failure is not caused by this change.
- Ran per-crate formatting (`cargo fmt -p perl-pragma`) successfully; the workspace `cargo xtask fmt` / full-format step was impeded by the same unrelated parse error.

Problem: Compile-time pragma tracking was only exposed as ad hoc range lookups instead of an explicit queryable environment API.
Fix: Added `CompileTimeEnvironment` + `PragmaStateQuery` API and explicit `PragmaSnapshot` save/restore semantics, and updated tracker usage and tests.
Verification: `cargo test -p perl-pragma` passes; `cargo check --workspace --all-targets` currently fails due to an unrelated pre-existing syntax error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead35a5b3883339078b9b2a0a697e1)