### PR TITLE
refactor(diagnostics): consume shared PragmaState in strict-related checks (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
@@ -65,10 +65,7 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
     // This avoids the false-negative from .any() which sees eval-interior ranges.
     // signatures_strict is included to honour `use feature 'signatures'` (#4038).
     let top_level_state = PragmaTracker::state_for_offset(&pragma_map, usize::MAX);
-    let mut has_strict = top_level_state.strict_vars
-        || top_level_state.strict_subs
-        || top_level_state.strict_refs
-        || top_level_state.signatures_strict;
+    let mut has_strict = top_level_state.is_any_strict_active();
     let mut has_warnings = top_level_state.warnings;
 
     // OO frameworks that implicitly provide strict+warnings

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -99,6 +99,24 @@ impl PragmaState {
         self.warnings && !self.disabled_warning_categories.iter().any(|c| c == category)
     }
 
+    /// Returns `true` if strict-vars checks should be enforced at this point.
+    #[must_use]
+    pub fn is_strict_vars_active(&self) -> bool {
+        self.strict_vars || self.signatures_strict
+    }
+
+    /// Returns `true` if strict-subs checks should be enforced at this point.
+    #[must_use]
+    pub fn is_strict_subs_active(&self) -> bool {
+        self.strict_subs || self.signatures_strict
+    }
+
+    /// Returns `true` if any strict category is active at this point.
+    #[must_use]
+    pub fn is_any_strict_active(&self) -> bool {
+        self.is_strict_vars_active() || self.is_strict_subs_active() || self.strict_refs
+    }
+
     /// Returns `true` if the given feature name is currently enabled.
     #[must_use]
     pub fn has_feature(&self, feature: &str) -> bool {

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -585,8 +585,8 @@ impl ScopeAnalyzer {
     ) {
         // Get effective pragma state at this node's location
         let pragma_state = PragmaTracker::state_for_offset(context.pragma_map, node.location.start);
-        let strict_vars_mode = pragma_state.strict_vars || pragma_state.signatures_strict;
-        let strict_subs_mode = pragma_state.strict_subs || pragma_state.signatures_strict;
+        let strict_vars_mode = pragma_state.is_strict_vars_active();
+        let strict_subs_mode = pragma_state.is_strict_subs_active();
         match &node.kind {
             NodeKind::VariableDeclaration { declarator, variable, initializer, .. } => {
                 let extracted = self.extract_variable_name(variable);

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1878,6 +1878,49 @@ print PL_sv_undef;
 }
 
 #[test]
+fn strict_subs_restored_after_eval_scope() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+eval { no strict 'subs'; print FOO; };
+print BAR;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        issues
+            .iter()
+            .any(|i| { matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "BAR" }),
+        "strict subs should be restored after eval scope exits"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_vars_restored_after_nested_block_scope() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'vars';
+{
+    {
+        no strict 'vars';
+        print $inner;
+    }
+}
+print $outer;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "inner"),
+        "nested no strict 'vars' should suppress undeclared variable diagnostics only in that scope"
+    );
+    assert!(
+        has_issue(&issues, IssueKind::UndeclaredVariable, "outer"),
+        "strict vars should be restored after nested blocks"
+    );
+    Ok(())
+}
+
+#[test]
 fn strict_subs_allows_qw_imported_barewords() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';


### PR DESCRIPTION
### Motivation
- Avoid duplicated local logic for deciding effective strictness and eliminate subtle lexical-scoping mismatches by using a single authoritative API on `PragmaState`.
- Ensure consumers (diagnostics and semantic checks) consistently honour `signatures`-driven strictness and scope restores (eval/blocks).

### Description
- Added explicit `PragmaState` query helpers: `is_strict_vars_active`, `is_strict_subs_active`, and `is_any_strict_active` to centralize effective strictness logic in `crates/perl-pragma/src/lib.rs`.
- Replaced ad-hoc strict derivation in the strict/warnings lints to use `PragmaTracker::state_for_offset(...).is_any_strict_active()` in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs`.
- Updated semantic analyzer strict checks to call `is_strict_vars_active()` / `is_strict_subs_active()` where node-local strict decisions are made in `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs`.
- Added regression tests that exercise restoration semantics across `eval` and nested block scopes in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` to guard against leakage.

### Testing
- Ran `cargo test -p perl-pragma`, which completed successfully.
- Ran `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests`, which completed successfully (new tests pass).
- Ran `cargo check --all-targets -p perl-semantic-analyzer`, which completed successfully.
- `cargo xtask fmt` and `cargo check --workspace --all-targets` are blocked by a pre-existing syntax error (unterminated string) in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead35e4d6c8333889444b1fefbae8f)