### PR TITLE
refactor(diagnostics): consume shared PragmaState in strict-related checks (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
@@ -63,12 +63,8 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
     // Using usize::MAX ensures we get the last entry, which reflects the
     // restored top-level state after any eval/sub/block scopes have closed.
     // This avoids the false-negative from .any() which sees eval-interior ranges.
-    // signatures_strict is included to honour `use feature 'signatures'` (#4038).
     let top_level_state = PragmaTracker::state_for_offset(&pragma_map, usize::MAX);
-    let mut has_strict = top_level_state.strict_vars
-        || top_level_state.strict_subs
-        || top_level_state.strict_refs
-        || top_level_state.signatures_strict;
+    let mut has_strict = top_level_state.is_any_strict_active();
     let mut has_warnings = top_level_state.warnings;
 
     // OO frameworks that implicitly provide strict+warnings
@@ -619,6 +615,28 @@ mod tests {
         assert!(
             diags.iter().any(|d| d.code.as_deref() == Some("PL101")),
             "eval-scoped Moose should not suppress missing-warnings (PL101)"
+        );
+    }
+
+    #[test]
+    fn eval_scoped_signatures_does_not_suppress_missing_strict() {
+        let diags = strict_warnings_diags(
+            "eval { use feature 'signatures'; sub inner ($x) { $x } };\nmy $x = 1;\n",
+        );
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL100")),
+            "eval-scoped signatures strictness must not suppress missing-strict (PL100)"
+        );
+    }
+
+    #[test]
+    fn top_level_signatures_after_eval_suppresses_missing_strict() {
+        let diags = strict_warnings_diags(
+            "eval { my $tmp = 1; };\nuse feature 'signatures';\nsub inner ($x) { $x }\n",
+        );
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL100")),
+            "top-level feature signatures after eval should suppress missing-strict"
         );
     }
 

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -99,6 +99,39 @@ impl PragmaState {
         self.warnings && !self.disabled_warning_categories.iter().any(|c| c == category)
     }
 
+    /// Returns `true` if strict `vars` semantics are active in this scope.
+    ///
+    /// This includes both explicit `use strict 'vars'` and implicit strictness
+    /// driven by `use feature 'signatures'`.
+    #[must_use]
+    pub fn is_strict_vars_active(&self) -> bool {
+        self.strict_vars || self.signatures_strict
+    }
+
+    /// Returns `true` if strict `subs` semantics are active in this scope.
+    ///
+    /// This includes both explicit `use strict 'subs'` and implicit strictness
+    /// driven by `use feature 'signatures'`.
+    #[must_use]
+    pub fn is_strict_subs_active(&self) -> bool {
+        self.strict_subs || self.signatures_strict
+    }
+
+    /// Returns `true` if strict `refs` semantics are active in this scope.
+    ///
+    /// This includes both explicit `use strict 'refs'` and implicit strictness
+    /// driven by `use feature 'signatures'`.
+    #[must_use]
+    pub fn is_strict_refs_active(&self) -> bool {
+        self.strict_refs || self.signatures_strict
+    }
+
+    /// Returns `true` when any strict category is active in this scope.
+    #[must_use]
+    pub fn is_any_strict_active(&self) -> bool {
+        self.is_strict_vars_active() || self.is_strict_subs_active() || self.is_strict_refs_active()
+    }
+
     /// Returns `true` if the given feature name is currently enabled.
     #[must_use]
     pub fn has_feature(&self, feature: &str) -> bool {

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -585,8 +585,8 @@ impl ScopeAnalyzer {
     ) {
         // Get effective pragma state at this node's location
         let pragma_state = PragmaTracker::state_for_offset(context.pragma_map, node.location.start);
-        let strict_vars_mode = pragma_state.strict_vars || pragma_state.signatures_strict;
-        let strict_subs_mode = pragma_state.strict_subs || pragma_state.signatures_strict;
+        let strict_vars_mode = pragma_state.is_strict_vars_active();
+        let strict_subs_mode = pragma_state.is_strict_subs_active();
         match &node.kind {
             NodeKind::VariableDeclaration { declarator, variable, initializer, .. } => {
                 let extracted = self.extract_variable_name(variable);

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -2043,6 +2043,51 @@ sub foo ($x) { $z = 1; }
 }
 
 #[test]
+fn eval_scoped_signatures_does_not_enable_top_level_strict_vars()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+eval { use feature 'signatures'; sub inner ($x) { $x } };
+print $undeclared;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "undeclared"),
+        "eval-scoped signatures must not leak strict vars to top-level"
+    );
+    Ok(())
+}
+
+#[test]
+fn nested_no_strict_subs_does_not_leak_outside_block() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+{
+    no strict 'subs';
+    print BAREWORD_INNER_OK;
+}
+print BAREWORD_OUTER_MUST_FAIL;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "BAREWORD_OUTER_MUST_FAIL"
+        }),
+        "no strict 'subs' in nested block must not disable strict subs outside that block"
+    );
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "BAREWORD_INNER_OK"
+        }),
+        "bareword inside nested no strict 'subs' block should remain allowed"
+    );
+    Ok(())
+}
+
+#[test]
 fn signature_parameters_are_registered_as_symbols() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 sub add ($x, $y = 1, @rest) {


### PR DESCRIPTION
### Motivation

- Consumers were re-deriving effective strict semantics (including `signatures`-implied strictness) locally which risks subtle lexical-scope mismatches and duplicated logic.

### Description

- Added explicit query helpers on `PragmaState`: `is_strict_vars_active`, `is_strict_subs_active`, `is_strict_refs_active`, and `is_any_strict_active` in `crates/perl-pragma/src/lib.rs` so callers use a single authoritative API.
- Replaced local derivation in the semantic scope analyzer with calls to `PragmaState::is_strict_vars_active()` and `PragmaState::is_strict_subs_active()` in `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs`.
- Switched strict/warnings diagnostic logic to use `PragmaState::is_any_strict_active()` for top-level strict detection in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs`.
- Added regression tests to cover eval- and nested-scope behavior for `use feature 'signatures'` and `no strict 'subs'` leakage in `crates/perl-lsp-rs-core` tests and `crates/perl-semantic-analyzer` tests.

### Testing

- Ran `cargo test -p perl-pragma`, which passed.
- Ran `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests`, which passed and includes the new regression tests for eval/nested-scope strictness.
- Attempted `cargo test -p perl-lsp-rs-core strict_warnings -- --nocapture`, which did not complete due to a pre-existing syntax error (unterminated string literal) in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` unrelated to these changes.
- `cargo check --workspace --all-targets` also failed for the same pre-existing parse error in `crates/perl-lsp-rs-core` and is not caused by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead35e4d6c8333889444b1fefbae8f)