### PR TITLE
refactor(diagnostics): consume shared PragmaState in strict-related checks (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
@@ -63,12 +63,8 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
     // Using usize::MAX ensures we get the last entry, which reflects the
     // restored top-level state after any eval/sub/block scopes have closed.
     // This avoids the false-negative from .any() which sees eval-interior ranges.
-    // signatures_strict is included to honour `use feature 'signatures'` (#4038).
     let top_level_state = PragmaTracker::state_for_offset(&pragma_map, usize::MAX);
-    let mut has_strict = top_level_state.strict_vars
-        || top_level_state.strict_subs
-        || top_level_state.strict_refs
-        || top_level_state.signatures_strict;
+    let mut has_strict = top_level_state.is_any_strict_active();
     let mut has_warnings = top_level_state.warnings;
 
     // OO frameworks that implicitly provide strict+warnings

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -99,6 +99,39 @@ impl PragmaState {
         self.warnings && !self.disabled_warning_categories.iter().any(|c| c == category)
     }
 
+    /// Returns `true` when strict variable checks are effectively active.
+    ///
+    /// This includes `use strict 'vars'` as well as strictness implied through
+    /// `use feature 'signatures'`.
+    #[must_use]
+    pub const fn is_strict_vars_active(&self) -> bool {
+        self.strict_vars || self.signatures_strict
+    }
+
+    /// Returns `true` when strict bareword/subroutine checks are effectively active.
+    ///
+    /// This includes `use strict 'subs'` as well as strictness implied through
+    /// `use feature 'signatures'`.
+    #[must_use]
+    pub const fn is_strict_subs_active(&self) -> bool {
+        self.strict_subs || self.signatures_strict
+    }
+
+    /// Returns `true` when strict symbolic-reference checks are effectively active.
+    ///
+    /// This includes `use strict 'refs'` as well as strictness implied through
+    /// `use feature 'signatures'`.
+    #[must_use]
+    pub const fn is_strict_refs_active(&self) -> bool {
+        self.strict_refs || self.signatures_strict
+    }
+
+    /// Returns `true` when any strict mode is effectively active.
+    #[must_use]
+    pub const fn is_any_strict_active(&self) -> bool {
+        self.is_strict_vars_active() || self.is_strict_subs_active() || self.is_strict_refs_active()
+    }
+
     /// Returns `true` if the given feature name is currently enabled.
     #[must_use]
     pub fn has_feature(&self, feature: &str) -> bool {

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -585,8 +585,8 @@ impl ScopeAnalyzer {
     ) {
         // Get effective pragma state at this node's location
         let pragma_state = PragmaTracker::state_for_offset(context.pragma_map, node.location.start);
-        let strict_vars_mode = pragma_state.strict_vars || pragma_state.signatures_strict;
-        let strict_subs_mode = pragma_state.strict_subs || pragma_state.signatures_strict;
+        let strict_vars_mode = pragma_state.is_strict_vars_active();
+        let strict_subs_mode = pragma_state.is_strict_subs_active();
         match &node.kind {
             NodeKind::VariableDeclaration { declarator, variable, initializer, .. } => {
                 let extracted = self.extract_variable_name(variable);

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1878,6 +1878,47 @@ print PL_sv_undef;
 }
 
 #[test]
+fn eval_scoped_strict_subs_does_not_leak_to_outer_scope() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = r#"
+eval {
+    use strict;
+    my $inner = 1;
+};
+print $outer;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "outer"),
+        "strict inside eval must not leak to outer scope where strict is otherwise disabled"
+    );
+    Ok(())
+}
+
+#[test]
+fn nested_eval_no_strict_vars_does_not_disable_outer_strict()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+eval {
+    eval {
+        no strict 'vars';
+        my $inner = 1;
+    };
+};
+$outer = 1;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        has_issue(&issues, IssueKind::UndeclaredVariable, "outer"),
+        "strict vars should be restored after nested eval exits"
+    );
+    Ok(())
+}
+
+#[test]
 fn strict_subs_allows_qw_imported_barewords() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';


### PR DESCRIPTION
### Motivation

- Consumers were re-deriving effective strictness from raw `PragmaState` fields which duplicated logic and risked divergence from the shared pragma semantics.
- Real consumers (diagnostics and scope analysis) need a single authoritative query API to ensure consistent behavior across nested/eval scopes.

### Description

- Added explicit `PragmaState` query helpers: `is_strict_vars_active`, `is_strict_subs_active`, `is_strict_refs_active`, and `is_any_strict_active` in `crates/perl-pragma/src/lib.rs` to encapsulate effective strict semantics.
- Updated strict-related diagnostics to use `PragmaTracker::state_for_offset(...).is_any_strict_active()` in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs`.
- Switched scope analysis strict-mode checks to `is_strict_vars_active()` / `is_strict_subs_active()` in `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs` to avoid local recomputation.
- Added regression tests for eval and nested-eval scope correctness in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` to assert no leakage/restoration of pragma state.

### Testing

- Ran `cargo test -p perl-pragma` which succeeded.
- Ran `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests` which succeeded and includes the new eval/nested-scope regression tests validating no leakage of strict state.
- Ran `cargo clippy -p perl-semantic-analyzer --all-targets` which passed with no warnings.
- Ran `cargo check --workspace --all-targets` which failed due to an unrelated pre-existing syntax error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` (unterminated string), so full workspace check is blocked by that unrelated file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead35e4d6c8333889444b1fefbae8f)