### PR TITLE
refactor(diagnostics): consume shared PragmaState in strict-related checks (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -99,6 +99,33 @@ impl PragmaState {
         self.warnings && !self.disabled_warning_categories.iter().any(|c| c == category)
     }
 
+    /// Returns `true` if `strict 'vars'` is effectively active in this scope.
+    ///
+    /// This includes explicit `use strict 'vars'` and feature-driven strictness
+    /// such as `use feature 'signatures'`.
+    #[must_use]
+    pub fn is_strict_vars_active(&self) -> bool {
+        self.strict_vars || self.signatures_strict
+    }
+
+    /// Returns `true` if `strict 'subs'` is effectively active in this scope.
+    ///
+    /// This includes explicit `use strict 'subs'` and feature-driven strictness
+    /// such as `use feature 'signatures'`.
+    #[must_use]
+    pub fn is_strict_subs_active(&self) -> bool {
+        self.strict_subs || self.signatures_strict
+    }
+
+    /// Returns `true` if `strict 'refs'` is effectively active in this scope.
+    ///
+    /// This includes explicit `use strict 'refs'` and feature-driven strictness
+    /// such as `use feature 'signatures'`.
+    #[must_use]
+    pub fn is_strict_refs_active(&self) -> bool {
+        self.strict_refs || self.signatures_strict
+    }
+
     /// Returns `true` if the given feature name is currently enabled.
     #[must_use]
     pub fn has_feature(&self, feature: &str) -> bool {

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -1587,3 +1587,16 @@ fn package_block_pragma_inside_is_visible_at_inner_offset() -> Result<(), Box<dy
     assert!(inside.strict_vars, "strict_vars declared inside package block must be visible");
     Ok(())
 }
+
+#[test]
+fn strict_query_api_treats_signatures_as_effective_strict() -> Result<(), Box<dyn std::error::Error>>
+{
+    let ast = program(vec![use_node("feature", &["'signatures'"], 0, 25)]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 12);
+    assert!(state.is_strict_vars_active());
+    assert!(state.is_strict_subs_active());
+    assert!(state.is_strict_refs_active());
+    Ok(())
+}

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -585,8 +585,8 @@ impl ScopeAnalyzer {
     ) {
         // Get effective pragma state at this node's location
         let pragma_state = PragmaTracker::state_for_offset(context.pragma_map, node.location.start);
-        let strict_vars_mode = pragma_state.strict_vars || pragma_state.signatures_strict;
-        let strict_subs_mode = pragma_state.strict_subs || pragma_state.signatures_strict;
+        let strict_vars_mode = pragma_state.is_strict_vars_active();
+        let strict_subs_mode = pragma_state.is_strict_subs_active();
         match &node.kind {
             NodeKind::VariableDeclaration { declarator, variable, initializer, .. } => {
                 let extracted = self.extract_variable_name(variable);

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -3762,6 +3762,64 @@ try {
     Ok(())
 }
 
+#[test]
+fn strict_vars_remains_active_after_eval_block() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'vars';
+eval {
+    my $inside_eval = 1;
+    print $inside_eval;
+};
+$outside_eval = 2;
+"#;
+
+    let issues = scope_issues_strict(code);
+    let undeclared_issues: Vec<_> =
+        issues.iter().filter(|issue| issue.kind == IssueKind::UndeclaredVariable).collect();
+
+    assert_eq!(
+        undeclared_issues.len(),
+        1,
+        "strict vars should remain active after eval block; issues: {:?}",
+        issues
+    );
+    assert!(
+        undeclared_issues.first().is_some_and(|issue| issue.variable_name.contains("outside_eval")),
+        "only post-eval undeclared variable should be flagged; issues: {:?}",
+        issues
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_vars_in_nested_block_restores_after_block() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'vars';
+{
+    no strict 'vars';
+    $inner_only = 1;
+}
+$outer_after_block = 2;
+"#;
+
+    let issues = scope_issues_strict(code);
+    let undeclared: Vec<_> =
+        issues.iter().filter(|issue| issue.kind == IssueKind::UndeclaredVariable).collect();
+
+    assert_eq!(
+        undeclared.len(),
+        1,
+        "strict vars should not leak disabled state out of nested block; issues: {:?}",
+        issues
+    );
+    assert!(
+        undeclared.first().is_some_and(|issue| issue.variable_name.contains("outer_after_block")),
+        "only post-block variable use should be undeclared; issues: {:?}",
+        issues
+    );
+    Ok(())
+}
+
 /// The catch variable range must point into the source at the catch parameter,
 /// not at an arbitrary offset, so that LSP diagnostics display correctly.
 #[test]


### PR DESCRIPTION
### Motivation

- Consumers were re-deriving effective strictness (`strict_* || signatures_strict`) locally which risks subtle mismatches at scope edges (eval/package/phase blocks). The change centralizes the query logic.

### Description

- Added explicit query helpers on `PragmaState`: `is_strict_vars_active`, `is_strict_subs_active`, and `is_strict_refs_active` in `crate::perl-pragma` so callers can ask the canonical question about effective strictness at a position.
- Replaced local `pragma_state.strict_* || pragma_state.signatures_strict` logic in `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs` with calls to `PragmaState` helpers so diagnostics consume the shared API.
- Added regression tests in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` covering eval/post-eval and nested-block no/restore behavior, and a `perl-pragma` test ensuring `use feature 'signatures'` counts as effective strictness.

### Testing

- Ran `cargo test -p perl-pragma` and all `perl-pragma` tests passed.
- Ran `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests` and the modified semantic analyzer tests passed (including new regressions).
- Ran `cargo check --workspace --all-targets` and it failed due to a pre-existing syntax error (unterminated string) in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs`, which is unrelated to these changes and blocks a full workspace check.
- Note: `cargo fmt --all` was also blocked by the same pre-existing parse error in `crates/perl-lsp-rs-core`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead35e4d6c8333889444b1fefbae8f)