### PR TITLE
feat(workspace-index): add cross-file reference query foundation (#3522)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -989,6 +989,26 @@ pub struct Location {
     pub range: Range,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+/// Stable symbol identity payload returned by cross-file reference queries.
+pub struct QuerySymbolIdentity {
+    /// Canonical symbol key used by semantic consumers.
+    pub key: SymbolKey,
+    /// Stable string key that can be persisted in downstream rename flows.
+    pub stable_key: String,
+}
+
+#[derive(Debug, Clone)]
+/// Cross-file symbol query result with definition and reference locations.
+pub struct SymbolReferenceQuery {
+    /// Queried symbol identity.
+    pub symbol: QuerySymbolIdentity,
+    /// Definition location (if indexed and resolvable).
+    pub definition: Option<Location>,
+    /// Non-definition reference locations in deterministic order.
+    pub references: Vec<Location>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// A symbol in the workspace for Index/Navigate workflows.
 pub struct WorkspaceSymbol {
@@ -1129,6 +1149,27 @@ pub struct WorkspaceIndex {
 }
 
 impl WorkspaceIndex {
+    fn stable_key_for_symbol(key: &SymbolKey) -> String {
+        if let Some(sigil) = key.sigil {
+            format!("{sigil}{}::{}", key.pkg, key.name)
+        } else if key.kind == SymKind::Pack {
+            key.pkg.to_string()
+        } else {
+            format!("{}::{}", key.pkg, key.name)
+        }
+    }
+
+    fn sort_locations_stably(locations: &mut [Location]) {
+        locations.sort_by(|left, right| {
+            left.uri
+                .cmp(&right.uri)
+                .then(left.range.start.line.cmp(&right.range.start.line))
+                .then(left.range.start.column.cmp(&right.range.start.column))
+                .then(left.range.end.line.cmp(&right.range.end.line))
+                .then(left.range.end.column.cmp(&right.range.end.column))
+        });
+    }
+
     fn rebuild_symbol_cache(
         files: &HashMap<String, FileIndex>,
         symbols: &mut HashMap<String, String>,
@@ -2687,6 +2728,26 @@ impl WorkspaceIndex {
         });
 
         all_refs
+    }
+
+    /// Query a symbol across the workspace with stable identity, definition, and references.
+    ///
+    /// This API is designed as a deterministic foundation for workspace-wide rename and safe
+    /// delete operations. Returned references always exclude the definition site and are sorted
+    /// by URI then source range.
+    pub fn query_symbol_references(&self, key: &SymbolKey) -> SymbolReferenceQuery {
+        let definition = self.find_def(key);
+        let mut references = self.find_refs(key);
+        Self::sort_locations_stably(&mut references);
+
+        SymbolReferenceQuery {
+            symbol: QuerySymbolIdentity {
+                key: key.clone(),
+                stable_key: Self::stable_key_for_symbol(key),
+            },
+            definition,
+            references,
+        }
     }
 }
 

--- a/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
@@ -327,6 +327,42 @@ fn test_find_refs_with_symbol_key() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn test_query_symbol_references_cross_file_returns_definition_and_refs(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let uri_def = file_url("/lib/Math.pm")?;
+    let uri_use_a = file_url("/app_a.pl")?;
+    let uri_use_b = file_url("/app_b.pl")?;
+
+    index.index_file(uri_def, "package Math;\nsub add { 1 }\n".to_string())?;
+    index.index_file(uri_use_a, "Math::add(1, 2);\n".to_string())?;
+    index.index_file(uri_use_b, "Math::add(3, 4);\n".to_string())?;
+
+    let key = SymbolKey {
+        pkg: Arc::from("Math"),
+        name: Arc::from("add"),
+        sigil: None,
+        kind: SymKind::Sub,
+    };
+
+    let query = index.query_symbol_references(&key);
+    let definition = must_some(query.definition);
+
+    assert!(definition.uri.ends_with("/lib/Math.pm"));
+    assert_eq!(query.symbol.stable_key, "Math::add");
+    assert_eq!(query.references.len(), 2, "expected exactly two call sites");
+    assert!(
+        query.references[0].uri.ends_with("/app_a.pl"),
+        "references should be deterministically sorted by uri"
+    );
+    assert!(
+        query.references[1].uri.ends_with("/app_b.pl"),
+        "references should be deterministically sorted by uri"
+    );
+    Ok(())
+}
+
 // =========================================================================
 // Content-hash early exit (re-indexing same content is a no-op)
 // =========================================================================


### PR DESCRIPTION
### Motivation

- Provide a small, stable, deterministic cross-file query payload that bundles symbol identity, definition, and references as a foundation for workspace-wide rename and safe-delete flows.

### Description

- Added `QuerySymbolIdentity` and `SymbolReferenceQuery` types to represent stable symbol identity and a query result that includes definition and references.
- Implemented `WorkspaceIndex::query_symbol_references(&SymbolKey)` which returns the `SymbolReferenceQuery` for a `SymbolKey` and excludes the definition from the returned references.
- Added helpers `stable_key_for_symbol` to produce a persistent stable string key and `sort_locations_stably` to enforce deterministic ordering of reference `Location`s by URI then range.
- Added the cross-file unit test `test_query_symbol_references_cross_file_returns_definition_and_refs` which indexes a definition and two call sites in separate files and asserts definition + deterministic references.

### Testing

- Ran `cargo test -p perl-workspace` and all relevant workspace-index unit tests passed, including the new cross-file test `test_query_symbol_references_cross_file_returns_definition_and_refs`.
- Ran `cargo check --all-targets -p perl-workspace` which succeeded for the modified crate.
- `cargo check --workspace --all-targets` failed due to a pre-existing, unrelated syntax error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs`; this error is outside the scope of the workspace-index changes and blocks a full workspace check but does not affect the new API or its tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead361471c8333a20d1fdb4edb0ec0)