### PR TITLE
feat(refactor): add module-move import rewrites (#3522)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -1006,29 +1006,36 @@ impl LspServer {
                             }
                         }
 
-                        // Find all files that reference the old module
-                        // Note: Query operation - use coordinator.index() for consistency
+                        // Find all files that reference the old module.
+                        // This starts with dependency edges and then expands to open/indexed
+                        // documents that contain obvious static references (for qualified calls
+                        // without imports, package declarations, and similar safe rewrites).
+                        // Note: Query operation - use coordinator.index() for consistency.
                         #[cfg(feature = "workspace")]
-                        let dependents = if let Some(coordinator) = self.coordinator() {
-                            coordinator.index().find_dependents(&old_module)
+                        let candidates = if let Some(coordinator) = self.coordinator() {
+                            collect_module_move_candidate_uris(
+                                coordinator.index().as_ref(),
+                                old_uri,
+                                &old_module,
+                            )
                         } else {
-                            Vec::new()
+                            std::collections::BTreeSet::new()
                         };
 
                         #[cfg(not(feature = "workspace"))]
-                        let dependents = Vec::<String>::new();
+                        let candidates = std::collections::BTreeSet::<String>::new();
 
-                        for dependent_uri in dependents {
-                            if !planned_workspace_texts.contains_key(&dependent_uri) {
-                                let Some(text) = self.read_workspace_text(&dependent_uri) else {
+                        for candidate_uri in candidates {
+                            if !planned_workspace_texts.contains_key(&candidate_uri) {
+                                let Some(text) = self.read_workspace_text(&candidate_uri) else {
                                     continue;
                                 };
                                 planned_workspace_texts
-                                    .insert(dependent_uri.clone(), (text.clone(), text));
+                                    .insert(candidate_uri.clone(), (text.clone(), text));
                             }
 
                             if let Some((_, current_text)) =
-                                planned_workspace_texts.get_mut(&dependent_uri)
+                                planned_workspace_texts.get_mut(&candidate_uri)
                             {
                                 let planned = plan_module_rename_edits(
                                     current_text,
@@ -1934,6 +1941,36 @@ fn collect_delete_target_module_names(
     }
 
     module_names
+}
+
+#[cfg(feature = "workspace")]
+fn collect_module_move_candidate_uris(
+    index: &perl_parser::workspace_index::WorkspaceIndex,
+    old_uri: &str,
+    old_module: &str,
+) -> std::collections::BTreeSet<String> {
+    let normalized_old_uri = perl_parser::workspace_index::uri_key(old_uri);
+    let mut candidates = std::collections::BTreeSet::new();
+    candidates.insert(normalized_old_uri.clone());
+
+    for dependent_uri in index.find_dependents(old_module) {
+        candidates.insert(dependent_uri);
+    }
+
+    let legacy_old_module = old_module.replace("::", "'");
+    for doc in index.document_store().all_documents() {
+        let normalized_doc_uri = perl_parser::workspace_index::uri_key(&doc.uri);
+        if normalized_doc_uri == normalized_old_uri {
+            continue;
+        }
+        if module_name_appears_in_text(&doc.text, old_module)
+            || module_name_appears_in_text(&doc.text, &legacy_old_module)
+        {
+            candidates.insert(normalized_doc_uri);
+        }
+    }
+
+    candidates
 }
 
 #[cfg(feature = "workspace")]

--- a/crates/perl-lsp-rs/tests/lsp_workspace_file_ops_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_workspace_file_ops_tests.rs
@@ -1404,3 +1404,128 @@ fn test_will_rename_files_updates_package_declaration_in_renamed_file()
     );
     Ok(())
 }
+
+/// Module-move slice: update imports + statically safe qualified references across workspace.
+///
+/// Covers:
+/// - import rewrite in two consumer files
+/// - fully-qualified call rewrite where statically safe
+/// - no rewrite for ambiguous string/comment content
+#[test]
+fn test_will_rename_files_module_move_updates_two_consumers_and_leaves_ambiguous_sites()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_test_server();
+
+    let init_params = json!({
+        "processId": 1234,
+        "rootUri": "file:///test/workspace",
+        "capabilities": {}
+    });
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
+
+    let producer_open = json!({
+        "textDocument": {
+            "uri": "file:///test/workspace/lib/Old/Name.pm",
+            "languageId": "perl",
+            "version": 1,
+            "text": "package Old::Name;\nsub run { return 1 }\n1;\n"
+        }
+    });
+    let _ = make_request(&server, "textDocument/didOpen", Some(producer_open));
+
+    let consumer_one_open = json!({
+        "textDocument": {
+            "uri": "file:///test/workspace/consumer_one.pl",
+            "languageId": "perl",
+            "version": 1,
+            "text": "use Old::Name;\nmy $v = Old::Name::run();\n1;\n"
+        }
+    });
+    let _ = make_request(&server, "textDocument/didOpen", Some(consumer_one_open));
+
+    let consumer_two_open = json!({
+        "textDocument": {
+            "uri": "file:///test/workspace/consumer_two.pl",
+            "languageId": "perl",
+            "version": 1,
+            "text": "use Old::Name;\nmy $s = 'Old::Name::run';\n# Old::Name::run in comment\n1;\n"
+        }
+    });
+    let _ = make_request(&server, "textDocument/didOpen", Some(consumer_two_open));
+
+    let consumer_three_open = json!({
+        "textDocument": {
+            "uri": "file:///test/workspace/consumer_three.pl",
+            "languageId": "perl",
+            "version": 1,
+            "text": "my $v = Old::Name::run();\n1;\n"
+        }
+    });
+    let _ = make_request(&server, "textDocument/didOpen", Some(consumer_three_open));
+
+    let params = json!({
+        "files": [{
+            "oldUri": "file:///test/workspace/lib/Old/Name.pm",
+            "newUri": "file:///test/workspace/lib/New/Name.pm"
+        }]
+    });
+
+    let edit = make_request(&server, "workspace/willRenameFiles", Some(params))?
+        .ok_or("expected workspace edit response")?;
+    let changes =
+        edit.get("changes").and_then(Value::as_object).ok_or("expected changes object")?;
+
+    let first_edits = changes
+        .get("file:///test/workspace/consumer_one.pl")
+        .and_then(Value::as_array)
+        .ok_or("expected edits for consumer_one.pl")?;
+    let first_new_texts: Vec<&str> = first_edits
+        .iter()
+        .filter_map(|entry| entry.get("newText").and_then(Value::as_str))
+        .collect();
+    assert!(
+        first_new_texts.contains(&"use New::Name;"),
+        "consumer_one import should be rewritten: {first_new_texts:?}"
+    );
+    assert!(
+        first_new_texts.contains(&"my $v = New::Name::run();"),
+        "consumer_one qualified call should be rewritten: {first_new_texts:?}"
+    );
+
+    let second_edits = changes
+        .get("file:///test/workspace/consumer_two.pl")
+        .and_then(Value::as_array)
+        .ok_or("expected edits for consumer_two.pl")?;
+    let second_new_texts: Vec<&str> = second_edits
+        .iter()
+        .filter_map(|entry| entry.get("newText").and_then(Value::as_str))
+        .collect();
+    assert!(
+        second_new_texts.contains(&"use New::Name;"),
+        "consumer_two import should be rewritten: {second_new_texts:?}"
+    );
+    assert!(
+        !second_new_texts.iter().any(|text| text.contains("'New::Name::run'")),
+        "string literal references must remain untouched: {second_new_texts:?}"
+    );
+    assert!(
+        !second_new_texts.iter().any(|text| text.contains("# New::Name::run")),
+        "comment references must remain untouched: {second_new_texts:?}"
+    );
+
+    let third_edits = changes
+        .get("file:///test/workspace/consumer_three.pl")
+        .and_then(Value::as_array)
+        .ok_or("expected edits for consumer_three.pl")?;
+    let third_new_texts: Vec<&str> = third_edits
+        .iter()
+        .filter_map(|entry| entry.get("newText").and_then(Value::as_str))
+        .collect();
+    assert!(
+        third_new_texts.contains(&"my $v = New::Name::run();"),
+        "qualified call-only consumer should be rewritten: {third_new_texts:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Module rename planning only walked dependency edges and missed statically obvious qualified references in files that did not record an import dependency.

### Description
- Expand candidate discovery for `workspace/willRenameFiles` to include indexed/open documents that contain the old module token (modern `::` and legacy `'` forms) and union those with dependency edges. 
- Apply the existing conservative line-based planner (`plan_module_rename_edits` / `apply_module_rename_edits`) to the expanded candidate set so imports and safe qualified references are rewritten.
- Add a regression test `test_will_rename_files_module_move_updates_two_consumers_and_leaves_ambiguous_sites` validating two import consumers are updated, a qualified-call-only consumer is updated, and string/comment occurrences are left unchanged.

### Testing
- Ran `cargo test -p perl-workspace`, which completed successfully.
- Attempted to run the new workspace rename test via `cargo test -p perl-lsp-rs test_will_rename_files_module_move_updates_two_consumers_and_leaves_ambiguous_sites`, but the build was blocked by a pre-existing parse error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` and could not complete.
- `cargo fmt` and `cargo check --workspace --all-targets` were also blocked by the same pre-existing parse error; unrelated failing crate prevented full workspace verification.
- Notes: some package-name invocations from the original acceptance list (e.g., `perl-workspace-index`, `perl-lsp-code-actions`) do not map directly to current workspace package IDs and were not applicable in this checkout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead367d0d48333a329da76aac2455d)