### PR TITLE
feat(refactor): add safe-delete reference preflight (#3522)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/mod.rs
+++ b/crates/perl-workspace-index/src/workspace/mod.rs
@@ -51,4 +51,4 @@ pub use state_machine::{
     BuildPhase, DegradationReason, IndexState, IndexStateKind, IndexStateMachine,
     InvalidationReason, ResourceKind, TransitionResult,
 };
-pub use workspace_index::{IndexResourceLimits, Location, WorkspaceIndex};
+pub use workspace_index::{IndexResourceLimits, Location, SafeDeletePreflight, WorkspaceIndex};

--- a/crates/perl-workspace-index/src/workspace/production_coordinator.rs
+++ b/crates/perl-workspace-index/src/workspace/production_coordinator.rs
@@ -439,6 +439,14 @@ impl ProductionIndexCoordinator {
         result
     }
 
+    /// Preflight safe-delete validation for a normalized symbol key.
+    pub fn preflight_safe_delete(
+        &self,
+        key: &super::workspace_index::SymbolKey,
+    ) -> super::workspace_index::SafeDeletePreflight {
+        self.index.preflight_safe_delete(key)
+    }
+
     /// Invalidate the index.
     ///
     /// # Arguments

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -989,6 +989,18 @@ pub struct Location {
     pub range: Range,
 }
 
+#[derive(Debug, Clone)]
+/// Preflight result for symbol-safe deletion planning.
+pub enum SafeDeletePreflight {
+    /// No external references were found, so deletion can proceed.
+    SafeToDelete,
+    /// References in other files were found, so deletion should be blocked.
+    Blocked {
+        /// Reference locations outside the defining file.
+        external_references: Vec<Location>,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// A symbol in the workspace for Index/Navigate workflows.
 pub struct WorkspaceSymbol {
@@ -2688,6 +2700,26 @@ impl WorkspaceIndex {
 
         all_refs
     }
+
+    /// Run safe-delete preflight by checking for external references.
+    ///
+    /// Returns [`SafeDeletePreflight::Blocked`] when references to the symbol
+    /// exist outside the defining file; otherwise returns
+    /// [`SafeDeletePreflight::SafeToDelete`].
+    pub fn preflight_safe_delete(&self, key: &SymbolKey) -> SafeDeletePreflight {
+        let refs = self.find_refs(key);
+        let external_references = if let Some(definition) = self.find_def(key) {
+            refs.into_iter().filter(|reference| reference.uri != definition.uri).collect()
+        } else {
+            refs
+        };
+
+        if external_references.is_empty() {
+            SafeDeletePreflight::SafeToDelete
+        } else {
+            SafeDeletePreflight::Blocked { external_references }
+        }
+    }
 }
 
 /// AST visitor for extracting symbols and references
@@ -3971,6 +4003,90 @@ UsageDemo::helper();
         assert!(
             bare_usage_count >= qualified_usage_count,
             "bare-name usage count should include qualified call sites"
+        );
+    }
+
+    #[test]
+    fn test_safe_delete_preflight_blocks_when_external_references_exist() {
+        let index = WorkspaceIndex::new();
+        must(
+            index.index_file(
+                must(url::Url::parse("file:///lib/DeleteDemo.pm")),
+                r#"
+package DeleteDemo;
+sub helper {
+    return 1;
+}
+1;
+"#
+                .to_string(),
+            ),
+        );
+        must(
+            index.index_file(
+                must(url::Url::parse("file:///lib/Caller.pm")),
+                r#"
+package Caller;
+DeleteDemo::helper();
+1;
+"#
+                .to_string(),
+            ),
+        );
+
+        let key = SymbolKey {
+            pkg: Arc::from("DeleteDemo"),
+            name: Arc::from("helper"),
+            sigil: None,
+            kind: SymKind::Sub,
+        };
+        let preflight = index.preflight_safe_delete(&key);
+
+        assert!(matches!(preflight, SafeDeletePreflight::Blocked { .. }));
+        if let SafeDeletePreflight::Blocked { external_references } = preflight {
+            assert_eq!(
+                external_references.len(),
+                1,
+                "expected one external reference in Caller.pm"
+            );
+            assert!(
+                external_references
+                    .iter()
+                    .any(|reference| reference.uri == "file:///lib/Caller.pm")
+            );
+        }
+    }
+
+    #[test]
+    fn test_safe_delete_preflight_allows_when_no_external_references_exist() {
+        let index = WorkspaceIndex::new();
+        must(
+            index.index_file(
+                must(url::Url::parse("file:///lib/DeleteLocal.pm")),
+                r#"
+package DeleteLocal;
+sub helper {
+    return 1;
+}
+
+helper();
+1;
+"#
+                .to_string(),
+            ),
+        );
+
+        let key = SymbolKey {
+            pkg: Arc::from("DeleteLocal"),
+            name: Arc::from("helper"),
+            sigil: None,
+            kind: SymKind::Sub,
+        };
+        let preflight = index.preflight_safe_delete(&key);
+
+        assert!(
+            matches!(preflight, SafeDeletePreflight::SafeToDelete),
+            "expected safe-delete preflight to allow deletion when only local references exist"
         );
     }
 


### PR DESCRIPTION
### Motivation
- Prevent accidental deletion of symbols that are still referenced elsewhere by adding a reference-based preflight check for delete operations.
- Provide internal plumbing so higher-level callers (e.g., coordinator/UI) can ask whether deletion is safe before performing file removal.

### Description
- Add `SafeDeletePreflight` enum to represent `SafeToDelete` or `Blocked { external_references: Vec<Location> }` in `workspace_index`.
- Implement `WorkspaceIndex::preflight_safe_delete(&SymbolKey) -> SafeDeletePreflight` that uses existing reference lookup to collect references outside the symbol definition file.
- Expose coordinator plumbing via `ProductionIndexCoordinator::preflight_safe_delete(...)` so callers can run the preflight via the coordinator API.
- Re-export `SafeDeletePreflight` from the workspace module surface for downstream consumers.
- Add unit tests covering blocked case (symbol referenced from another file) and allowed case (only local references exist).

### Testing
- Ran `cargo test -p perl-workspace` which completed successfully and included the new unit tests for the preflight logic (passed).
- Attempted `cargo test -p perl-workspace-index` failed because the crate name is `perl-workspace` (used `perl-workspace` instead and tests passed).
- Ran `cargo check --workspace --all-targets` which failed due to a pre-existing, unrelated parse error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` (unterminated string), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead36bde4c833398f0fe52fcbe10d1)