### PR TITLE
feat(refactor): add safe-delete reference preflight (#3522)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -989,6 +989,19 @@ pub struct Location {
     pub range: Range,
 }
 
+/// Outcome for a symbol safe-delete preflight check.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum SafeDeletePreflight {
+    /// No external references were found; symbol can be safely deleted.
+    SafeToDelete,
+    /// External references were found and should block delete.
+    Blocked {
+        /// Cross-file reference locations that still point at the symbol.
+        external_references: Vec<Location>,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// A symbol in the workspace for Index/Navigate workflows.
 pub struct WorkspaceSymbol {
@@ -1974,6 +1987,46 @@ impl WorkspaceIndex {
         }
 
         seen.len()
+    }
+
+    /// Preflight a symbol delete by checking for cross-file references.
+    ///
+    /// Returns [`SafeDeletePreflight::Blocked`] when references exist in files
+    /// other than the symbol's defining file URI.
+    pub fn safe_delete_symbol_preflight(
+        &self,
+        symbol_name: &str,
+        definition_uri: &str,
+    ) -> SafeDeletePreflight {
+        let definition_uri_key = uri_key(definition_uri);
+        let mut external_references: Vec<Location> = self
+            .find_references(symbol_name)
+            .into_iter()
+            .filter(|loc| uri_key(&loc.uri) != definition_uri_key)
+            .collect();
+
+        external_references.sort_by(|left, right| {
+            (
+                left.uri.as_str(),
+                left.range.start.line,
+                left.range.start.column,
+                left.range.end.line,
+                left.range.end.column,
+            )
+                .cmp(&(
+                    right.uri.as_str(),
+                    right.range.start.line,
+                    right.range.start.column,
+                    right.range.end.line,
+                    right.range.end.column,
+                ))
+        });
+
+        if external_references.is_empty() {
+            SafeDeletePreflight::SafeToDelete
+        } else {
+            SafeDeletePreflight::Blocked { external_references }
+        }
     }
 
     fn is_qualified_variant_of(candidate: &str, bare_symbol: &str) -> bool {

--- a/crates/perl-workspace-index/tests/safe_delete_preflight_tests.rs
+++ b/crates/perl-workspace-index/tests/safe_delete_preflight_tests.rs
@@ -1,0 +1,77 @@
+use perl_workspace::workspace::workspace_index::{SafeDeletePreflight, WorkspaceIndex};
+use url::Url;
+
+#[test]
+fn safe_delete_preflight_blocks_symbol_with_external_references()
+-> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let symbol_uri = Url::parse("file:///workspace/lib/DeleteTarget.pm")?;
+    let caller_uri = Url::parse("file:///workspace/lib/Caller.pm")?;
+
+    index.index_file(
+        symbol_uri.clone(),
+        r#"
+package DeleteTarget;
+sub to_delete { return 1; }
+1;
+"#
+        .to_string(),
+    )?;
+    index.index_file(
+        caller_uri.clone(),
+        r#"
+package Caller;
+DeleteTarget::to_delete();
+1;
+"#
+        .to_string(),
+    )?;
+
+    let preflight =
+        index.safe_delete_symbol_preflight("DeleteTarget::to_delete", symbol_uri.as_str());
+    match preflight {
+        SafeDeletePreflight::Blocked { external_references } => {
+            assert!(
+                external_references.iter().any(|location| location.uri == caller_uri.as_str()),
+                "expected caller URI in blocking references, got: {external_references:?}"
+            );
+        }
+        SafeDeletePreflight::SafeToDelete => {
+            return Err("expected preflight to block external references".into());
+        }
+        _ => return Err("unexpected safe-delete preflight variant".into()),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn safe_delete_preflight_allows_symbol_with_no_external_references()
+-> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let symbol_uri = Url::parse("file:///workspace/lib/Solo.pm")?;
+
+    index.index_file(
+        symbol_uri.clone(),
+        r#"
+package Solo;
+sub internal_only { return 1; }
+internal_only();
+1;
+"#
+        .to_string(),
+    )?;
+
+    let preflight = index.safe_delete_symbol_preflight("Solo::internal_only", symbol_uri.as_str());
+    match preflight {
+        SafeDeletePreflight::SafeToDelete => {}
+        SafeDeletePreflight::Blocked { external_references } => {
+            return Err(
+                format!("expected safe delete, got blocked refs: {external_references:?}").into(),
+            );
+        }
+        _ => return Err("unexpected safe-delete preflight variant".into()),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Provide a deterministic, reference-based preflight for safe-delete flows so the workspace can block deletions when symbols are referenced elsewhere.

### Description

- Add `SafeDeletePreflight` enum to represent `SafeToDelete` or `Blocked { external_references }` in `crates/perl-workspace-index/src/workspace/workspace_index.rs`.
- Implement `WorkspaceIndex::safe_delete_symbol_preflight(symbol_name, definition_uri)` which uses existing `find_references`, filters out the defining file, sorts the results, and returns the appropriate `SafeDeletePreflight` outcome.
- Add focused tests in `crates/perl-workspace-index/tests/safe_delete_preflight_tests.rs` covering a blocked case (external references exist) and an allowed case (no external references).

### Testing

- Ran `cargo test -p perl-workspace`, and the crate tests (including the two new tests) passed.
- Ran `cargo check --all-targets -p perl-workspace`, which completed successfully.
- Ran `cargo check --workspace --all-targets` which failed due to an unrelated pre-existing compile error (unterminated string in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead36bde4c833398f0fe52fcbe10d1)