### PR TITLE
feat(rename): add workspace-wide rename for static cross-file references (#3522)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/rename.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/rename.rs
@@ -229,45 +229,61 @@ impl LspServer {
 
                     match access_mode {
                         IndexAccessMode::Partial(reason) => {
-                            if let (Some(coordinator), Some(key)) =
-                                (self.coordinator(), symbol_key.as_ref())
-                            {
-                                let edits = crate::workspace_rename::build_rename_edit(
-                                    coordinator.index(),
-                                    key,
-                                    new_name,
-                                );
-                                if !edits.is_empty() {
-                                    tracing::debug!(
-                                        count = edits.len(),
-                                        reason,
-                                        "Rename: served partial-index workspace edits"
-                                    );
-                                    return Ok(Some(crate::workspace_rename::to_workspace_edit(
-                                        edits,
-                                    )));
-                                }
-                            }
                             tracing::debug!(
                                 reason,
-                                "Rename: workspace rename unavailable, using same-file only"
+                                "Rename: refusing partial-index workspace rename"
                             );
-                            // Fall through to same-file rename
+                            return Err(JsonRpcError {
+                                code: -32602,
+                                message: format!(
+                                    "Workspace rename requires a fully ready index; current state: {}",
+                                    reason
+                                ),
+                                data: None,
+                            });
                         }
                         IndexAccessMode::None => {
                             tracing::debug!("Rename: no workspace feature, using same-file only");
                             // Fall through to same-file rename
                         }
                         IndexAccessMode::Full(coordinator) => {
-                            if let Some(key) = symbol_key.as_ref() {
-                                // Use coordinator.index() directly instead of workspace_index()
-                                // to ensure we go through routing policy
-                                let idx = coordinator.index();
-                                let edits =
-                                    crate::workspace_rename::build_rename_edit(idx, key, new_name);
-                                let ws_edit = crate::workspace_rename::to_workspace_edit(edits);
-                                return Ok(Some(ws_edit));
+                            let key = symbol_key.as_ref().ok_or_else(|| JsonRpcError {
+                                code: -32602,
+                                message: "Rename requires an unambiguous symbol at cursor"
+                                    .to_string(),
+                                data: None,
+                            })?;
+
+                            // Use coordinator.index() directly instead of workspace_index()
+                            // to ensure we go through routing policy.
+                            let idx = coordinator.index();
+
+                            if idx.find_def(key).is_none() {
+                                return Err(JsonRpcError {
+                                    code: -32602,
+                                    message: format!(
+                                        "Rename requires a statically resolved definition for {}::{}",
+                                        key.pkg, key.name
+                                    ),
+                                    data: None,
+                                });
                             }
+
+                            let edits =
+                                crate::workspace_rename::build_rename_edit(idx, key, new_name);
+                            if edits.is_empty() {
+                                return Err(JsonRpcError {
+                                    code: -32602,
+                                    message: format!(
+                                        "Rename could not produce a stable workspace edit for {}::{}",
+                                        key.pkg, key.name
+                                    ),
+                                    data: None,
+                                });
+                            }
+
+                            let ws_edit = crate::workspace_rename::to_workspace_edit(edits);
+                            return Ok(Some(ws_edit));
                         }
                     }
                 }

--- a/crates/perl-lsp-rs/tests/lsp_rename_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_rename_tests.rs
@@ -302,3 +302,77 @@ fn test_rename_out_of_bounds() -> TestResult {
 
     Ok(())
 }
+
+/// Test workspace-wide rename across two files using static cross-file references.
+#[test]
+fn test_workspace_rename_subroutine_across_two_files() -> TestResult {
+    let files = [
+        ("lib/A.pm", "package A;\n\nsub target_name {\n    return 42;\n}\n\n1;\n"),
+        ("lib/B.pm", "package B;\n\nuse A;\n\nsub run {\n    return A::target_name();\n}\n\n1;\n"),
+    ];
+    let (mut harness, workspace) =
+        LspHarness::with_workspace(&files).map_err(std::io::Error::other)?;
+
+    let a_uri = workspace.uri("lib/A.pm");
+    harness.open(&a_uri, "package A;\n\nsub target_name {\n    return 42;\n}\n\n1;\n")?;
+
+    let response = harness.request(
+        "textDocument/rename",
+        json!({
+            "textDocument": { "uri": a_uri },
+            "position": { "line": 2, "character": 6 },
+            "newName": "renamed_target"
+        }),
+    )?;
+
+    let changes = response
+        .get("changes")
+        .and_then(|v| v.as_object())
+        .ok_or("expected WorkspaceEdit.changes object")?;
+    assert_eq!(changes.len(), 2, "workspace rename should produce edits for exactly two files");
+
+    let b_uri = workspace.uri("lib/B.pm");
+    for uri in [a_uri, b_uri] {
+        let edits = changes
+            .get(&uri)
+            .and_then(|v| v.as_array())
+            .ok_or("expected edits array for renamed file")?;
+        assert!(!edits.is_empty(), "rename should include at least one edit for {}", uri);
+        for edit in edits {
+            let new_text = edit["newText"].as_str().ok_or("newText should be a string")?;
+            assert_eq!(new_text, "renamed_target");
+        }
+    }
+
+    Ok(())
+}
+
+/// Test that workspace rename refuses ambiguous/unresolved symbol identity.
+#[test]
+fn test_workspace_rename_refuses_unresolved_symbol_identity() -> TestResult {
+    let (mut harness, workspace) =
+        LspHarness::with_workspace(&[("main.pl", "my $x = 1;\nprint $x;\n")])
+            .map_err(std::io::Error::other)?;
+
+    let uri = workspace.uri("main.pl");
+    harness.open(&uri, "my $x = 1;\nprint $x;\n")?;
+
+    // Cursor on whitespace: no stable symbol identity should be available.
+    let err = harness
+        .request(
+            "textDocument/rename",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": 0, "character": 2 },
+                "newName": "renamed"
+            }),
+        )
+        .expect_err("rename should refuse unresolved symbol identity");
+
+    assert!(
+        err.contains("unambiguous symbol"),
+        "error should explain unresolved identity, got: {}",
+        err
+    );
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Workspace renames could produce partial or unstable edits when the index or symbol identity was not strong enough, leading to unsafe cross-file changes.
- Implement a conservative, atomic workspace rename slice that only runs for statically-resolved, unambiguous symbols so edits are reliable.

### Description

- Tighten `textDocument/rename` workspace path to refuse partial-index access and return a clear `InvalidParams` error instead of serving partial edits when the coordinator is not fully ready.
- Require an unambiguous symbol at the cursor and a statically-resolved definition (via `idx.find_def`) before building a workspace-wide edit, and refuse the request if these invariants are not met.
- Build the workspace edit via the existing `crate::workspace_rename::build_rename_edit` and convert it to an LSP `WorkspaceEdit` only when the produced edit set is non-empty.
- Add integration tests `test_workspace_rename_subroutine_across_two_files` and `test_workspace_rename_refuses_unresolved_symbol_identity` in `crates/perl-lsp-rs/tests/lsp_rename_tests.rs` to validate cross-file edits and a clean refusal on unresolved identity.

### Testing

- Ran `cargo xtask fmt` (formatting); run compiled many crates but failed due to a pre-existing syntax error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` which prevented completion of the fmt step.
- Ran `cargo test -p perl-lsp-rs --test lsp_rename_tests`; the test build was attempted but aborted by the same unrelated compile error in `perl-lsp-rs-core` before the new tests could run.
- Ran `cargo check --workspace --all-targets`; this also failed due to the unrelated syntax/compile error in `perl-lsp-rs-core` blocking workspace-wide verification.
- Attempted the requested package-scoped commands `cargo test -p perl-lsp-rename` and `cargo test -p perl-workspace-index` but those package names do not match current workspace layout (the functionality is inside `perl-lsp-rs` and `perl-workspace-index`/`perl-workspace` naming changed), so they were not applicable in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead3645c9c83339b29afc1eca144eb)