### PR TITLE
feat(rename): add workspace-wide rename for static cross-file references (#3522)

### DIFF
--- a/crates/perl-lsp-rs/src/features/workspace_rename.rs
+++ b/crates/perl-lsp-rs/src/features/workspace_rename.rs
@@ -4,7 +4,7 @@
 
 use perl_parser::workspace_index::{SymKind, SymbolKey, WorkspaceIndex};
 use serde_json::{Value, json};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Represents a text edit for a single document
 #[derive(Debug, Clone)]
@@ -42,8 +42,10 @@ pub fn build_rename_edit(
         locs.push(def);
     }
 
-    // 3) Group edits by URI and compute replacement text
+    // 3) Group edits by URI and compute replacement text.
+    //    Deduplicate ranges for stable, atomic WorkspaceEdit generation.
     let mut grouped: BTreeMap<String, Vec<TextEdit>> = BTreeMap::new();
+    let mut seen: BTreeSet<(String, u32, u32, u32, u32, String)> = BTreeSet::new();
 
     for loc in locs {
         let start_line = loc.range.start.line;
@@ -91,6 +93,17 @@ pub fn build_rename_edit(
                 new_name_bare.to_string()
             }
         };
+
+        if !seen.insert((
+            loc.uri.clone(),
+            start_line,
+            start_char,
+            end_line,
+            end_char,
+            replacement.clone(),
+        )) {
+            continue;
+        }
 
         grouped.entry(loc.uri.clone()).or_default().push(TextEdit {
             start: (start_line, start_char),

--- a/crates/perl-lsp-rs/src/runtime/language/rename.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/rename.rs
@@ -229,45 +229,50 @@ impl LspServer {
 
                     match access_mode {
                         IndexAccessMode::Partial(reason) => {
-                            if let (Some(coordinator), Some(key)) =
-                                (self.coordinator(), symbol_key.as_ref())
-                            {
-                                let edits = crate::workspace_rename::build_rename_edit(
-                                    coordinator.index(),
-                                    key,
-                                    new_name,
-                                );
-                                if !edits.is_empty() {
-                                    tracing::debug!(
-                                        count = edits.len(),
-                                        reason,
-                                        "Rename: served partial-index workspace edits"
-                                    );
-                                    return Ok(Some(crate::workspace_rename::to_workspace_edit(
-                                        edits,
-                                    )));
-                                }
-                            }
                             tracing::debug!(
                                 reason,
-                                "Rename: workspace rename unavailable, using same-file only"
+                                "Rename refused: workspace index is partial; atomic workspace \
+                                 edit unavailable"
                             );
-                            // Fall through to same-file rename
+                            return Err(JsonRpcError {
+                                code: -32803,
+                                message: "Rename requires a fully built workspace index".to_string(),
+                                data: None,
+                            });
                         }
                         IndexAccessMode::None => {
                             tracing::debug!("Rename: no workspace feature, using same-file only");
                             // Fall through to same-file rename
                         }
                         IndexAccessMode::Full(coordinator) => {
-                            if let Some(key) = symbol_key.as_ref() {
-                                // Use coordinator.index() directly instead of workspace_index()
-                                // to ensure we go through routing policy
-                                let idx = coordinator.index();
-                                let edits =
-                                    crate::workspace_rename::build_rename_edit(idx, key, new_name);
-                                let ws_edit = crate::workspace_rename::to_workspace_edit(edits);
-                                return Ok(Some(ws_edit));
+                            let key = match symbol_key.as_ref() {
+                                Some(key) => key,
+                                None => {
+                                    return Err(JsonRpcError {
+                                        code: -32803,
+                                        message:
+                                            "Rename requires an unambiguous symbol at cursor"
+                                                .to_string(),
+                                        data: None,
+                                    });
+                                }
+                            };
+
+                            // Use coordinator.index() directly instead of workspace_index()
+                            // to ensure we go through routing policy.
+                            let idx = coordinator.index();
+                            let edits = crate::workspace_rename::build_rename_edit(idx, key, new_name);
+                            if edits.is_empty() {
+                                return Err(JsonRpcError {
+                                    code: -32803,
+                                    message:
+                                        "Rename could not find stable workspace references for symbol"
+                                            .to_string(),
+                                    data: None,
+                                });
                             }
+                            let ws_edit = crate::workspace_rename::to_workspace_edit(edits);
+                            return Ok(Some(ws_edit));
                         }
                     }
                 }

--- a/crates/perl-lsp-rs/tests/multi_root_workspace_tests.rs
+++ b/crates/perl-lsp-rs/tests/multi_root_workspace_tests.rs
@@ -1315,19 +1315,7 @@ fn test_cross_folder_rename_spans_both_roots() -> TestResult {
         request_timeout(),
     );
 
-    // If rename is not supported at this position, skip gracefully
-    let response = match rename_result {
-        Ok(r) => r,
-        Err(_) => {
-            // Rename request failed or timed out — treat as no-op for now
-            return Ok(());
-        }
-    };
-
-    if response.is_null() {
-        // Server returned null — rename not available at this position; skip
-        return Ok(());
-    }
+    let response = rename_result.map_err(|e| format!("rename request failed: {e}"))?;
 
     // Verify structure: response must be a WorkspaceEdit
     assert!(
@@ -1336,28 +1324,18 @@ fn test_cross_folder_rename_spans_both_roots() -> TestResult {
         response
     );
 
-    let changes = match response.get("changes") {
-        Some(c) => c,
-        None => {
-            // documentChanges is also valid; accept either form
-            if response.get("documentChanges").is_some() {
-                return Ok(());
-            }
-            // Empty edit is acceptable if rename produced no results yet
-            return Ok(());
-        }
-    };
+    let changes = response
+        .get("changes")
+        .ok_or("WorkspaceEdit must use `changes` for textDocument/rename")?;
 
-    // If the server returned non-empty changes, assert cross-file coverage
-    let change_map = match changes.as_object() {
-        Some(m) => m,
-        None => return Ok(()),
-    };
+    let change_map = changes
+        .as_object()
+        .ok_or("WorkspaceEdit `changes` must be a URI -> TextEdit[] map")?;
 
-    if change_map.is_empty() {
-        // Index not ready or symbol not found — no hard failure
-        return Ok(());
-    }
+    assert!(
+        !change_map.is_empty(),
+        "WorkspaceEdit must not be empty for cross-folder rename"
+    );
 
     // At minimum, the definition file (A.pm) must appear in the edit
     let a_pm_key = change_map.keys().find(|k| k.contains("A.pm") || *k == &a_pm_uri);
@@ -1368,18 +1346,31 @@ fn test_cross_folder_rename_spans_both_roots() -> TestResult {
         change_map.keys().collect::<Vec<_>>()
     );
 
-    // If B.pm is also present in the edit, verify the new name appears there
+    // B.pm call sites must also be included in this workspace-wide rename slice.
     let b_pm_key = change_map.keys().find(|k| k.contains("B.pm") || *k == &b_pm_uri);
-    if let Some(b_key) = b_pm_key {
-        if let Some(edits) = change_map[b_key].as_array() {
-            for edit in edits {
-                let new_text = edit["newText"].as_str().unwrap_or("");
-                assert!(
-                    new_text.contains("renamed_target"),
-                    "B.pm edit must use the new name 'renamed_target', got: {:?}",
-                    edit
-                );
-            }
+    assert!(
+        b_pm_key.is_some(),
+        "WorkspaceEdit must include an edit for B.pm (call sites). \
+         Got changes for: {:?}",
+        change_map.keys().collect::<Vec<_>>()
+    );
+
+    // Every edit in both A.pm and B.pm must apply the target replacement.
+    let a_key = a_pm_key.ok_or("A.pm key missing after assertion")?;
+    let b_key = b_pm_key.ok_or("B.pm key missing after assertion")?;
+    for key in [a_key, b_key] {
+        let edits = change_map[key]
+            .as_array()
+            .ok_or("WorkspaceEdit entry must be an array of TextEdit objects")?;
+        assert!(!edits.is_empty(), "WorkspaceEdit entry for {key} must not be empty");
+        for edit in edits {
+            let new_text = edit["newText"].as_str().unwrap_or_default();
+            assert_eq!(
+                new_text, "renamed_target",
+                "Cross-file rename edits must be stable and use exactly the requested new name. \
+                 got edit: {:?}",
+                edit
+            );
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent generation of partial/unstable workspace renames when the index is partial or the symbol identity is weak, and make workspace rename edits deterministic and atomic.

### Description
- Gate workspace rename: refuse rename with a clear JSON-RPC `RequestFailed` error when the workspace index is partial, when the symbol at cursor is ambiguous, or when no stable workspace references are found.
- Deduplicate cross-file text edits in `workspace_rename::build_rename_edit` using a `BTreeSet` so emitted `WorkspaceEdit` `changes` are stable and atomic.
- Tighten the multi-root cross-folder rename test to require non-empty `changes`, presence of edits for both definition and call-site files, and exact replacement text equality for all edits.

### Testing
- Ran `cargo test -p perl-workspace`; it completed successfully (unit tests passed).
- Attempted `cargo test -p perl-lsp-rs test_cross_folder_rename_spans_both_roots -- --nocapture`; build was blocked by a pre-existing compile error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` (unterminated string), so the full LSP rename test could not complete.
- Ran `cargo check --workspace --all-targets`; it failed due to the same unrelated compile error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs`.
- Note: `perl-lsp-rename` and `perl-workspace-index` package names referenced in the issue do not exist in this workspace; verified `perl-workspace` is the correct package name used in tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead3645c9c83339b29afc1eca144eb)