### PR TITLE
fix(incremental-document): harden batch edits for bounds and UTF-8 boundaries (#0000)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_document.rs
+++ b/crates/perl-parser/src/incremental/incremental_document.rs
@@ -135,25 +135,43 @@ impl IncrementalDocument {
         // Apply all edits to source in-place.
         // Reverse ordering keeps byte offsets stable while avoiding repeated
         // full-string allocations for each edit.
+        //
+        // If any edit cannot be mapped safely (out-of-bounds range, invalid
+        // range ordering, or non-UTF-8 boundary), take the conservative
+        // fallback path: keep the current source and perform a full parse.
+        // This avoids partial source mutations and prevents silent corruption.
         let mut new_source = self.source.clone();
+        let mut all_edits_mappable = true;
         for edit in &sorted_edits {
-            self.apply_edit_in_place(&mut new_source, edit);
+            if !self.apply_edit_in_place(&mut new_source, edit) {
+                all_edits_mappable = false;
+                break;
+            }
+        }
+
+        if !all_edits_mappable {
+            debug!("Batch contains unmappable edit(s); using conservative full-parse fallback");
+            let mut parser = Parser::new(&self.source);
+            let new_root = parser.parse()?;
+
+            self.root = Arc::new(new_root);
+            self.cache_subtrees();
+            self.metrics.last_parse_time_ms = start.elapsed().as_secs_f64() * 1000.0;
+            return Ok(());
         }
 
         // Find all affected ranges
         let affected_ranges: Vec<_> =
             sorted_edits.iter().map(|e| (e.start_byte, e.old_end_byte)).collect();
 
-        // Collect reusable subtrees outside affected ranges
-        let reusable = self.find_reusable_for_ranges(&affected_ranges);
+        // Collect reusable subtrees outside affected ranges for metrics. For
+        // batch edits we intentionally use a conservative full parse after all
+        // edits are safely applied, because aggressive subtree splicing can
+        // reintroduce stale nodes when multiple ranges are involved.
+        let _reusable = self.find_reusable_for_ranges(&affected_ranges);
 
-        // Parse with reuse when possible
-        let new_root = if !reusable.is_empty() {
-            self.parse_with_reuse(&new_source, reusable)?
-        } else {
-            let mut parser = Parser::new(&new_source);
-            parser.parse()?
-        };
+        let mut parser = Parser::new(&new_source);
+        let new_root = parser.parse()?;
 
         // Update state
         self.source = new_source;
@@ -191,20 +209,31 @@ impl IncrementalDocument {
         result
     }
 
-    fn apply_edit_in_place(&self, source: &mut String, edit: &IncrementalEdit) {
-        let start = edit.start_byte.min(source.len());
-        let end = edit.old_end_byte.min(source.len());
+    fn apply_edit_in_place(&self, source: &mut String, edit: &IncrementalEdit) -> bool {
+        let source_len = source.len();
+        if edit.start_byte > source_len || edit.old_end_byte > source_len {
+            debug!(
+                "Invalid edit range beyond source len: start={}, end={}, len={}",
+                edit.start_byte, edit.old_end_byte, source_len
+            );
+            return false;
+        }
+
+        let start = edit.start_byte.min(source_len);
+        let end = edit.old_end_byte.min(source_len);
 
         if start > end {
-            debug!("Skipping invalid edit range: start={}, end={}", start, end);
-            return;
+            debug!("Invalid edit range ordering: start={}, end={}", start, end);
+            return false;
         }
 
-        if source.is_char_boundary(start) && source.is_char_boundary(end) {
-            source.replace_range(start..end, &edit.new_text);
-        } else {
+        if !source.is_char_boundary(start) || !source.is_char_boundary(end) {
             debug!("Invalid UTF-8 boundaries in edit: start={}, end={}", start, end);
+            return false;
         }
+
+        source.replace_range(start..end, &edit.new_text);
+        true
     }
 
     /// Find subtrees that can be reused (outside the edited range)

--- a/crates/perl-parser/tests/incremental_document_batch_hardening.rs
+++ b/crates/perl-parser/tests/incremental_document_batch_hardening.rs
@@ -1,0 +1,96 @@
+#![cfg(feature = "incremental")]
+
+use perl_parser::incremental::incremental_document::IncrementalDocument;
+use perl_parser::incremental::incremental_edit::{IncrementalEdit, IncrementalEditSet};
+use perl_parser_core::error::{ParseError, ParseResult};
+use perl_parser_core::parser::Parser;
+
+fn find_or_err(haystack: &str, needle: &str) -> ParseResult<usize> {
+    haystack.find(needle).ok_or_else(|| ParseError::SyntaxError {
+        message: format!("expected test source to contain '{needle}'"),
+        location: 0,
+    })
+}
+
+#[test]
+fn start_end_beyond_source_len_falls_back_safely() -> ParseResult<()> {
+    let source = "my $x = 42;\n";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(source.len() + 1, source.len() + 2, "100".to_string()));
+
+    doc.apply_edits(&edits)?;
+
+    assert_eq!(doc.source, source);
+    Ok(())
+}
+
+#[test]
+fn start_greater_than_end_after_normalization_falls_back_safely() -> ParseResult<()> {
+    let source = "my $x = 42;\n";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(source.len() + 10, 3, "100".to_string()));
+
+    doc.apply_edits(&edits)?;
+
+    assert_eq!(doc.source, source);
+    Ok(())
+}
+
+#[test]
+fn mid_codepoint_insert_or_delete_falls_back_safely() -> ParseResult<()> {
+    let source = "my $x = \"é\";\n";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+
+    let codepoint_start = find_or_err(source, "é")?;
+    let mid_codepoint = codepoint_start + 1;
+
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(mid_codepoint, mid_codepoint + 1, "e".to_string()));
+
+    doc.apply_edits(&edits)?;
+
+    assert_eq!(doc.source, source);
+    Ok(())
+}
+
+#[test]
+fn batch_with_one_unmappable_edit_uses_safe_fallback() -> ParseResult<()> {
+    let source = "my $x = 42;\nmy $y = 10;\n";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+
+    let pos_42 = find_or_err(source, "42")?;
+
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(pos_42, pos_42 + 2, "43".to_string()));
+    edits.add(IncrementalEdit::new(source.len() + 100, source.len() + 101, "oops".to_string()));
+
+    doc.apply_edits(&edits)?;
+
+    assert_eq!(doc.source, source);
+    Ok(())
+}
+
+#[test]
+fn incremental_result_matches_fresh_full_parse_on_supported_batch() -> ParseResult<()> {
+    let source = "my $x = 42;\nmy $y = 10;\n";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+
+    let pos_42 = find_or_err(source, "42")?;
+    let pos_10 = find_or_err(source, "10")?;
+
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(pos_42, pos_42 + 2, "43".to_string()));
+    edits.add(IncrementalEdit::new(pos_10, pos_10 + 2, "11".to_string()));
+
+    doc.apply_edits(&edits)?;
+
+    let mut parser = Parser::new(&doc.source);
+    let fresh = parser.parse()?;
+    assert_eq!(*doc.root, fresh);
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Batch application of incremental edits could perform out-of-bounds slices or split UTF-8 codepoints, risking panics or silent corruption.  
- When one edit in a batch is unmappable, partial in-place mutation plus optimistic subtree splicing is unsafe.  
- Prefer a conservative fallback (full parse) over partial/incorrect mutations to preserve AST invariants.

### Description
- Validate every edit in `apply_edits`: attempt all edits on a cloned buffer and abort to a conservative full-parse fallback if any edit is unmappable (out-of-bounds, invalid ordering, or non-char-boundary).  
- Change `apply_edit_in_place` to return `bool` and perform explicit checks for source length, `start <= end`, and UTF-8 char boundaries before calling `replace_range`.  
- For multi-edit batches keep collecting reusable ranges for metrics but use a full parse of the resulting source (conservative behavior) to avoid stale subtree splicing across multiple ranges.  
- Add a focused, feature-gated test file `crates/perl-parser/tests/incremental_document_batch_hardening.rs` covering out-of-bounds ranges, start> end normalization cases, mid-codepoint edits, mixed valid+unmappable batch fallback, and parity with a fresh full parse for supported batches.

### Testing
- Ran `cargo test -p perl-parser --features incremental --test incremental_document_batch_hardening` and all new regression tests passed (5 passed).  
- Ran `cargo check --all-targets -p perl-parser` and it completed successfully.  
- Ran `cargo fmt --all`.  
- Note: a full `cargo test -p perl-parser` run shows a pre-existing, unrelated flaky failure in `refactor::refactoring::tests::validation_tests::test_cleanup_respects_retention_count`; this failure is not caused by the changes in this PR and the incremental-batch tests introduced by this change pass under the `incremental` feature.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadde20d288333b61dcbd07e72df84)