### PR TITLE
refactor(incremental): centralize edit-batch normalization in IncrementalEditSet (#0000)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_edit.rs
+++ b/crates/perl-parser/src/incremental/incremental_edit.rs
@@ -75,6 +75,15 @@ pub struct IncrementalEditSet {
     pub edits: Vec<IncrementalEdit>,
 }
 
+/// Validation failures for incremental edit batches.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IncrementalEditSetValidationError {
+    /// An edit had a backward range (`start_byte > old_end_byte`).
+    BackwardRange { edit_index: usize, start_byte: usize, old_end_byte: usize },
+    /// Two edits overlap after normalization.
+    OverlappingEdits { first_edit_index: usize, second_edit_index: usize },
+}
+
 impl IncrementalEditSet {
     /// Create a new empty edit set
     pub fn new() -> Self {
@@ -93,7 +102,7 @@ impl IncrementalEditSet {
 
     /// Sort edits in reverse order (for applying from end to start)
     pub fn sort_reverse(&mut self) {
-        self.edits.sort_by_key(|e| std::cmp::Reverse(e.start_byte));
+        self.edits.sort_by(Self::reverse_application_order);
     }
 
     /// Check if the edit set is empty
@@ -106,6 +115,64 @@ impl IncrementalEditSet {
         self.edits.iter().map(|e| e.byte_shift()).sum()
     }
 
+    /// Build a deterministically ordered copy for reverse application (end to start).
+    pub fn normalized_for_reverse_application(&self) -> Self {
+        let mut edits = self.edits.clone();
+        edits.sort_by(Self::reverse_application_order);
+        Self { edits }
+    }
+
+    /// Normalize and validate a batch of edits.
+    ///
+    /// The returned set is sorted for reverse application order.
+    ///
+    /// If `allow_overlapping` is `false`, overlapping edits are rejected.
+    /// If `filter_no_ops` is `true`, strictly obvious no-ops are removed.
+    pub fn normalize_and_validate(
+        &self,
+        allow_overlapping: bool,
+        filter_no_ops: bool,
+    ) -> Result<Self, IncrementalEditSetValidationError> {
+        let mut indexed_edits = Vec::with_capacity(self.edits.len());
+
+        for (edit_index, edit) in self.edits.iter().enumerate() {
+            if edit.start_byte > edit.old_end_byte {
+                return Err(IncrementalEditSetValidationError::BackwardRange {
+                    edit_index,
+                    start_byte: edit.start_byte,
+                    old_end_byte: edit.old_end_byte,
+                });
+            }
+
+            let should_keep = !(filter_no_ops
+                && edit.start_byte == edit.old_end_byte
+                && edit.new_text.is_empty());
+            if should_keep {
+                indexed_edits.push((edit_index, edit.clone()));
+            }
+        }
+
+        if !allow_overlapping {
+            let mut forward_order = indexed_edits.clone();
+            forward_order.sort_by(Self::forward_validation_order);
+
+            for pair in forward_order.windows(2) {
+                if let [previous, current] = pair
+                    && previous.1.old_end_byte > current.1.start_byte
+                {
+                    return Err(IncrementalEditSetValidationError::OverlappingEdits {
+                        first_edit_index: previous.0,
+                        second_edit_index: current.0,
+                    });
+                }
+            }
+        }
+
+        indexed_edits.sort_by(Self::indexed_reverse_application_order);
+        let edits = indexed_edits.into_iter().map(|(_, edit)| edit).collect();
+        Ok(Self { edits })
+    }
+
     /// Apply edits to a string
     pub fn apply_to_string(&self, source: &str) -> String {
         if self.edits.is_empty() {
@@ -113,8 +180,7 @@ impl IncrementalEditSet {
         }
 
         // Sort edits in reverse order to apply from end to start
-        let mut sorted_edits = self.edits.clone();
-        sorted_edits.sort_by_key(|e| std::cmp::Reverse(e.start_byte));
+        let sorted_edits = self.normalized_for_reverse_application().edits;
 
         let mut result = source.to_string();
         for edit in &sorted_edits {
@@ -133,6 +199,42 @@ impl IncrementalEditSet {
         }
 
         result
+    }
+
+    fn reverse_application_order(
+        left: &IncrementalEdit,
+        right: &IncrementalEdit,
+    ) -> std::cmp::Ordering {
+        right
+            .start_byte
+            .cmp(&left.start_byte)
+            .then_with(|| right.old_end_byte.cmp(&left.old_end_byte))
+            .then_with(|| right.new_text.len().cmp(&left.new_text.len()))
+            .then_with(|| right.new_text.cmp(&left.new_text))
+            .then_with(|| right.start_position.byte.cmp(&left.start_position.byte))
+            .then_with(|| right.start_position.line.cmp(&left.start_position.line))
+            .then_with(|| right.start_position.column.cmp(&left.start_position.column))
+            .then_with(|| right.old_end_position.byte.cmp(&left.old_end_position.byte))
+            .then_with(|| right.old_end_position.line.cmp(&left.old_end_position.line))
+            .then_with(|| right.old_end_position.column.cmp(&left.old_end_position.column))
+    }
+
+    fn indexed_reverse_application_order(
+        left: &(usize, IncrementalEdit),
+        right: &(usize, IncrementalEdit),
+    ) -> std::cmp::Ordering {
+        Self::reverse_application_order(&left.1, &right.1).then_with(|| left.0.cmp(&right.0))
+    }
+
+    fn forward_validation_order(
+        left: &(usize, IncrementalEdit),
+        right: &(usize, IncrementalEdit),
+    ) -> std::cmp::Ordering {
+        left.1
+            .start_byte
+            .cmp(&right.1.start_byte)
+            .then_with(|| left.1.old_end_byte.cmp(&right.1.old_end_byte))
+            .then_with(|| left.0.cmp(&right.0))
     }
 }
 

--- a/crates/perl-parser/tests/incremental_edit_set_normalization_test.rs
+++ b/crates/perl-parser/tests/incremental_edit_set_normalization_test.rs
@@ -1,0 +1,82 @@
+#![cfg(feature = "incremental")]
+
+use perl_parser::incremental_edit::{
+    IncrementalEdit, IncrementalEditSet, IncrementalEditSetValidationError,
+};
+
+#[test]
+fn unsorted_batch_normalizes_to_reverse_application_order()
+-> Result<(), IncrementalEditSetValidationError> {
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(5, 5, "x".to_string()));
+    edits.add(IncrementalEdit::new(1, 1, "y".to_string()));
+    edits.add(IncrementalEdit::new(9, 10, "zz".to_string()));
+
+    let normalized = edits.normalize_and_validate(false, false)?;
+
+    let start_bytes: Vec<usize> = normalized.edits.iter().map(|edit| edit.start_byte).collect();
+    assert_eq!(start_bytes, vec![9, 5, 1]);
+    Ok(())
+}
+
+#[test]
+fn overlapping_edits_are_rejected_cleanly() {
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(3, 8, "abc".to_string()));
+    edits.add(IncrementalEdit::new(6, 9, "def".to_string()));
+
+    let result = edits.normalize_and_validate(false, false);
+
+    assert_eq!(
+        result.err(),
+        Some(IncrementalEditSetValidationError::OverlappingEdits {
+            first_edit_index: 0,
+            second_edit_index: 1,
+        })
+    );
+}
+
+#[test]
+fn backward_range_is_rejected_cleanly() {
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(5, 4, "bad".to_string()));
+
+    let result = edits.normalize_and_validate(false, false);
+
+    assert_eq!(
+        result.err(),
+        Some(IncrementalEditSetValidationError::BackwardRange {
+            edit_index: 0,
+            start_byte: 5,
+            old_end_byte: 4,
+        })
+    );
+}
+
+#[test]
+fn zero_width_insertion_is_accepted() -> Result<(), IncrementalEditSetValidationError> {
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(4, 4, "insert".to_string()));
+
+    let normalized = edits.normalize_and_validate(false, false)?;
+
+    assert_eq!(normalized.edits.len(), 1);
+    assert_eq!(normalized.edits[0].start_byte, 4);
+    assert_eq!(normalized.edits[0].old_end_byte, 4);
+    Ok(())
+}
+
+#[test]
+fn total_byte_shift_remains_correct_after_normalization()
+-> Result<(), IncrementalEditSetValidationError> {
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(10, 10, "abc".to_string())); // +3
+    edits.add(IncrementalEdit::new(0, 4, "z".to_string())); // -3
+    edits.add(IncrementalEdit::new(7, 9, "".to_string())); // -2
+
+    let normalized = edits.normalize_and_validate(false, false)?;
+
+    assert_eq!(edits.total_byte_shift(), -2);
+    assert_eq!(normalized.total_byte_shift(), -2);
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Centralize batch-shape logic for incremental edits so normalization and validation are owned by `IncrementalEditSet` rather than scattered across callers.
- Provide deterministic reverse-application ordering and clear validation rules so callers (e.g. incremental document code) can rely on a single canonical behavior.
- Preserve valid zero-width insertions, optionally filter obvious no-ops, and reject malformed batches (backward ranges / overlapping edits) with explicit errors.

### Description

- Added `IncrementalEditSetValidationError` enum to represent `BackwardRange` and `OverlappingEdits` failures.
- Implemented `normalize_and_validate(&self, allow_overlapping: bool, filter_no_ops: bool) -> Result<Self, _>` to produce a deterministically ordered edit set (sorted for reverse application) and perform validation.
- Added `normalized_for_reverse_application`, deterministic ordering helpers (`reverse_application_order`, `indexed_reverse_application_order`, `forward_validation_order`), and switched `apply_to_string` to use the normalized reverse-application order.
- Added focused tests in `crates/perl-parser/tests/incremental_edit_set_normalization_test.rs` covering unsorted normalization, overlap rejection, backward-range rejection, zero-width insertion acceptance, and total byte-shift invariants.

### Testing

- Ran the focused test suite: `cargo test -p perl-parser --features incremental --test incremental_edit_set_normalization_test`, resulting in `5 passed` for the new tests.
- Performed a type/target check with `cargo check --all-targets -p perl-parser`, which completed successfully.
- Note: a full `cargo test -p perl-parser` run failed due to a pre-existing unrelated test (`refactor::refactoring::tests::validation_tests::test_cleanup_respects_retention_count`), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadde4a72c8333a6a9bc1479a473fe)