### PR TITLE
refactor(incremental): centralize edit-batch normalization in IncrementalEditSet (#0000)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_edit.rs
+++ b/crates/perl-parser/src/incremental/incremental_edit.rs
@@ -4,6 +4,7 @@
 //! being inserted, enabling efficient incremental parsing with subtree reuse.
 
 use perl_parser_core::position::Position;
+use std::fmt;
 
 /// Enhanced edit with text content for incremental parsing
 #[derive(Debug, Clone, PartialEq)]
@@ -69,6 +70,64 @@ impl IncrementalEdit {
     }
 }
 
+/// Options that influence edit-batch normalization behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct IncrementalEditNormalizationOptions {
+    /// Allow edits with overlapping byte ranges.
+    pub allow_overlaps: bool,
+    /// Drop obvious no-op edits (zero-width insertion of empty text).
+    pub filter_obvious_noops: bool,
+}
+
+/// Outcome details for normalization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct IncrementalEditNormalizationResult {
+    /// Number of edits removed while filtering obvious no-ops.
+    pub removed_noop_edits: usize,
+}
+
+/// Validation failures for malformed edit batches.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IncrementalEditBatchError {
+    /// One edit has a backward range where `start_byte > old_end_byte`.
+    BackwardRange { index: usize, start_byte: usize, old_end_byte: usize },
+    /// Two edits in a normalized batch overlap.
+    OverlappingEdits {
+        first_index: usize,
+        first_start_byte: usize,
+        first_old_end_byte: usize,
+        second_index: usize,
+        second_start_byte: usize,
+        second_old_end_byte: usize,
+    },
+}
+
+impl fmt::Display for IncrementalEditBatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IncrementalEditBatchError::BackwardRange { index, start_byte, old_end_byte } => {
+                write!(
+                    f,
+                    "edit at index {index} has backward range: start_byte ({start_byte}) > old_end_byte ({old_end_byte})"
+                )
+            }
+            IncrementalEditBatchError::OverlappingEdits {
+                first_index,
+                first_start_byte,
+                first_old_end_byte,
+                second_index,
+                second_start_byte,
+                second_old_end_byte,
+            } => write!(
+                f,
+                "overlapping edits in normalized batch: #{first_index} [{first_start_byte}, {first_old_end_byte}) overlaps #{second_index} [{second_start_byte}, {second_old_end_byte})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for IncrementalEditBatchError {}
+
 /// Collection of incremental edits
 #[derive(Debug, Clone, Default)]
 pub struct IncrementalEditSet {
@@ -94,6 +153,69 @@ impl IncrementalEditSet {
     /// Sort edits in reverse order (for applying from end to start)
     pub fn sort_reverse(&mut self) {
         self.edits.sort_by_key(|e| std::cmp::Reverse(e.start_byte));
+    }
+
+    /// Normalize and validate edits for deterministic reverse-application order.
+    pub fn normalize_and_validate(
+        &mut self,
+        options: IncrementalEditNormalizationOptions,
+    ) -> Result<IncrementalEditNormalizationResult, IncrementalEditBatchError> {
+        let mut indexed_edits: Vec<(usize, IncrementalEdit)> =
+            self.edits.drain(..).enumerate().collect();
+
+        let mut removed_noop_edits = 0;
+        if options.filter_obvious_noops {
+            indexed_edits.retain(|(_, edit)| {
+                let keep = !(edit.start_byte == edit.old_end_byte && edit.new_text.is_empty());
+                if !keep {
+                    removed_noop_edits += 1;
+                }
+                keep
+            });
+        }
+
+        for (index, edit) in &indexed_edits {
+            if edit.start_byte > edit.old_end_byte {
+                return Err(IncrementalEditBatchError::BackwardRange {
+                    index: *index,
+                    start_byte: edit.start_byte,
+                    old_end_byte: edit.old_end_byte,
+                });
+            }
+        }
+
+        if !options.allow_overlaps {
+            let mut ranges: Vec<(usize, &IncrementalEdit)> =
+                indexed_edits.iter().map(|(index, edit)| (*index, edit)).collect();
+            ranges.sort_by_key(|(index, edit)| (edit.start_byte, edit.old_end_byte, *index));
+
+            for pair in ranges.windows(2) {
+                if let [first, second] = pair {
+                    if first.1.overlaps(second.1.start_byte, second.1.old_end_byte) {
+                        return Err(IncrementalEditBatchError::OverlappingEdits {
+                            first_index: first.0,
+                            first_start_byte: first.1.start_byte,
+                            first_old_end_byte: first.1.old_end_byte,
+                            second_index: second.0,
+                            second_start_byte: second.1.start_byte,
+                            second_old_end_byte: second.1.old_end_byte,
+                        });
+                    }
+                }
+            }
+        }
+
+        indexed_edits.sort_by(|(left_index, left), (right_index, right)| {
+            right
+                .start_byte
+                .cmp(&left.start_byte)
+                .then_with(|| right.old_end_byte.cmp(&left.old_end_byte))
+                .then_with(|| left_index.cmp(right_index))
+        });
+
+        self.edits = indexed_edits.into_iter().map(|(_, edit)| edit).collect();
+
+        Ok(IncrementalEditNormalizationResult { removed_noop_edits })
     }
 
     /// Check if the edit set is empty

--- a/crates/perl-parser/tests/incremental_edit_set_normalization_tests.rs
+++ b/crates/perl-parser/tests/incremental_edit_set_normalization_tests.rs
@@ -1,0 +1,90 @@
+#![cfg(feature = "incremental")]
+
+use perl_parser::incremental::incremental_edit::{
+    IncrementalEdit, IncrementalEditBatchError, IncrementalEditNormalizationOptions,
+    IncrementalEditSet,
+};
+
+#[test]
+fn normalize_unsorted_batch_for_reverse_application() -> Result<(), Box<dyn std::error::Error>> {
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(2, 2, "A".to_string()));
+    edits.add(IncrementalEdit::new(8, 10, "xy".to_string()));
+    edits.add(IncrementalEdit::new(5, 6, "".to_string()));
+
+    let total_shift_before = edits.total_byte_shift();
+
+    edits.normalize_and_validate(IncrementalEditNormalizationOptions::default())?;
+
+    let ordered_starts: Vec<usize> = edits.edits.iter().map(|edit| edit.start_byte).collect();
+    assert_eq!(ordered_starts, vec![8, 5, 2]);
+    assert_eq!(edits.total_byte_shift(), total_shift_before);
+
+    Ok(())
+}
+
+#[test]
+fn normalize_rejects_overlapping_edits() {
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(5, 9, "foo".to_string()));
+    edits.add(IncrementalEdit::new(7, 12, "bar".to_string()));
+
+    let result = edits.normalize_and_validate(IncrementalEditNormalizationOptions::default());
+
+    assert_eq!(
+        result,
+        Err(IncrementalEditBatchError::OverlappingEdits {
+            first_index: 0,
+            first_start_byte: 5,
+            first_old_end_byte: 9,
+            second_index: 1,
+            second_start_byte: 7,
+            second_old_end_byte: 12,
+        })
+    );
+}
+
+#[test]
+fn normalize_rejects_backward_range() {
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(10, 8, "oops".to_string()));
+
+    let result = edits.normalize_and_validate(IncrementalEditNormalizationOptions::default());
+
+    assert_eq!(
+        result,
+        Err(IncrementalEditBatchError::BackwardRange { index: 0, start_byte: 10, old_end_byte: 8 })
+    );
+}
+
+#[test]
+fn normalize_accepts_zero_width_insertions() -> Result<(), Box<dyn std::error::Error>> {
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(3, 3, "A".to_string()));
+    edits.add(IncrementalEdit::new(3, 3, "B".to_string()));
+
+    edits.normalize_and_validate(IncrementalEditNormalizationOptions::default())?;
+
+    assert_eq!(edits.edits.len(), 2);
+    assert!(edits.edits.iter().all(|edit| edit.start_byte == edit.old_end_byte));
+
+    Ok(())
+}
+
+#[test]
+fn normalize_can_filter_obvious_noops() -> Result<(), Box<dyn std::error::Error>> {
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(0, 0, "".to_string()));
+    edits.add(IncrementalEdit::new(4, 4, "X".to_string()));
+
+    let result = edits.normalize_and_validate(IncrementalEditNormalizationOptions {
+        allow_overlaps: false,
+        filter_obvious_noops: true,
+    })?;
+
+    assert_eq!(result.removed_noop_edits, 1);
+    assert_eq!(edits.edits.len(), 1);
+    assert_eq!(edits.edits[0].start_byte, 4);
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Centralize edit-batch validation and normalization in `IncrementalEditSet` so batch-shape logic is deterministic, reusable, and not scattered across parser implementations.

### Description

- Added `IncrementalEditNormalizationOptions`, `IncrementalEditNormalizationResult`, and `IncrementalEditBatchError` types and implemented `Display` + `Error` for the error enum to allow ergonomic propagation of validation failures.
- Added `IncrementalEditSet::normalize_and_validate` which performs deterministic normalization for reverse-application order, rejects backward ranges, rejects overlapping edits by default, preserves zero-width insertions, and optionally filters obvious no-ops.
- Kept existing helpers (`byte_shift`, `overlaps`, `sort`, `sort_reverse`, `total_byte_shift`, `apply_to_string`) and integrated normalization to produce a stable reverse-application ordering.
- Added focused tests in `crates/perl-parser/tests/incremental_edit_set_normalization_tests.rs` covering unsorted normalization, overlap rejection, backward-range rejection, zero-width insertion acceptance, no-op filtering, and byte-shift stability.

### Testing

- Ran `cargo check --all-targets -p perl-parser` and it completed successfully.
- Ran `cargo test -p perl-parser --features incremental --test incremental_edit_set_normalization_tests` and the new incremental normalization tests passed (`5 passed`).
- Ran `cargo test -p perl-parser` and observed a pre-existing unrelated test failure (`refactor::refactoring::tests::validation_tests::test_cleanup_respects_retention_count`), which is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadde4a72c8333a6a9bc1479a473fe)