### PR TITLE
fix(incremental-reuse): tune AdvancedReuseAnalyzer shifted-node heuristics (#0000)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_advanced_reuse.rs
+++ b/crates/perl-parser/src/incremental/incremental_advanced_reuse.rs
@@ -340,6 +340,10 @@ impl AdvancedReuseAnalyzer {
 
             // Look for exact structural matches in new tree
             for (new_pos, new_info) in &new_analysis.node_info {
+                if old_pos != new_pos {
+                    continue;
+                }
+
                 if old_info.structural_hash == new_info.structural_hash
                     && old_info.children_count == new_info.children_count
                 {
@@ -371,34 +375,54 @@ impl AdvancedReuseAnalyzer {
         config: &ReuseConfig,
     ) {
         for (old_pos, old_info) in &old_analysis.node_info {
-            // Skip if already matched or is a leaf node
-            if reuse_map.contains_key(old_pos) || old_info.children_count == 0 {
+            // Skip if already matched
+            if reuse_map.contains_key(old_pos) {
                 continue;
             }
+
+            let allow_shift_reuse =
+                old_info.children_count > 0 || self.is_shift_safe_terminal(&old_info.node);
+            if !allow_shift_reuse {
+                continue;
+            }
+
+            let mut best_match: Option<(usize, f64)> = None;
 
             // Look for content matches that may have shifted position
             for (new_pos, new_info) in &new_analysis.node_info {
                 if old_info.content_hash == new_info.content_hash
                     && old_info.structural_hash == new_info.structural_hash
+                    && self.is_position_unclaimed(reuse_map, *new_pos)
                 {
                     let position_shift = (*new_pos as isize - *old_pos as isize).unsigned_abs();
                     if position_shift <= config.max_position_shift {
-                        let confidence = self.calculate_match_confidence(old_info, new_info) * 0.9; // Slight penalty for position shift
-                        if confidence >= config.min_confidence {
-                            reuse_map.insert(
-                                *old_pos,
-                                ReuseStrategy {
-                                    target_position: *new_pos,
-                                    reuse_type: ReuseType::PositionShift,
-                                    confidence_score: confidence,
-                                    position_adjustment: (*new_pos as isize) - (*old_pos as isize),
-                                },
-                            );
-                            self.analysis_stats.position_adjustments += 1;
-                            break;
+                        let base_confidence = self.calculate_match_confidence(old_info, new_info);
+                        let confidence = self.calculate_shift_confidence(
+                            &old_info.node,
+                            base_confidence,
+                            position_shift,
+                            config,
+                        );
+                        if confidence >= config.min_confidence
+                            && best_match.as_ref().is_none_or(|(_, best)| confidence > *best)
+                        {
+                            best_match = Some((*new_pos, confidence));
                         }
                     }
                 }
+            }
+
+            if let Some((best_pos, confidence)) = best_match {
+                reuse_map.insert(
+                    *old_pos,
+                    ReuseStrategy {
+                        target_position: best_pos,
+                        reuse_type: ReuseType::PositionShift,
+                        confidence_score: confidence,
+                        position_adjustment: (best_pos as isize) - (*old_pos as isize),
+                    },
+                );
+                self.analysis_stats.position_adjustments += 1;
             }
         }
     }
@@ -421,6 +445,7 @@ impl AdvancedReuseAnalyzer {
                 for (new_pos, new_info) in &new_analysis.node_info {
                     if old_info.structural_hash == new_info.structural_hash
                         && old_info.content_hash != new_info.content_hash
+                        && self.is_position_unclaimed(reuse_map, *new_pos)
                         && self.are_compatible_for_content_update(&old_info.node, &new_info.node)
                     {
                         let confidence = 0.8; // Content updates get medium confidence
@@ -458,13 +483,28 @@ impl AdvancedReuseAnalyzer {
                 continue;
             }
 
+            if old_info.children_count == 0 || !self.is_container_node(&old_info.node) {
+                continue;
+            }
+
             let mut best_match: Option<(usize, f64)> = None;
 
             for (new_pos, new_info) in &new_analysis.node_info {
+                if !self.is_container_node(&new_info.node)
+                    || !self.is_position_unclaimed(reuse_map, *new_pos)
+                {
+                    continue;
+                }
+
+                let position_shift = (*new_pos as isize - *old_pos as isize).unsigned_abs();
+                if position_shift > config.max_position_shift / 2 {
+                    continue;
+                }
+
                 // Compare structural similarity
                 let similarity =
                     self.calculate_structural_similarity(&old_info.node, &new_info.node);
-                if similarity >= config.min_confidence * 0.8 {
+                if similarity >= config.min_confidence * 0.85 {
                     // Slightly lower threshold for aggressive matching
                     if best_match.as_ref().is_none_or(|&(_, s)| similarity > s) {
                         best_match = Some((*new_pos, similarity));
@@ -585,7 +625,11 @@ impl AdvancedReuseAnalyzer {
         match &node.kind {
             NodeKind::Program { statements } | NodeKind::Block { statements } => statements.len(),
             NodeKind::VariableDeclaration { initializer, .. } => {
-                if initializer.is_some() { 2 } else { 1 } // variable + optional initializer
+                if initializer.is_some() {
+                    2
+                } else {
+                    1
+                } // variable + optional initializer
             }
             NodeKind::Binary { .. } => 2, // left + right
             NodeKind::Unary { .. } => 1,  // operand
@@ -688,6 +732,54 @@ impl AdvancedReuseAnalyzer {
             (NodeKind::Identifier { .. }, NodeKind::Identifier { .. }) => true,
             _ => false,
         }
+    }
+
+    fn is_position_unclaimed(
+        &self,
+        reuse_map: &HashMap<usize, ReuseStrategy>,
+        new_pos: usize,
+    ) -> bool {
+        !reuse_map.values().any(|strategy| strategy.target_position == new_pos)
+    }
+
+    fn is_shift_safe_terminal(&self, node: &Node) -> bool {
+        matches!(
+            node.kind,
+            NodeKind::Number { .. }
+                | NodeKind::String { .. }
+                | NodeKind::Variable { .. }
+                | NodeKind::Identifier { .. }
+        )
+    }
+
+    fn is_container_node(&self, node: &Node) -> bool {
+        matches!(
+            node.kind,
+            NodeKind::Program { .. }
+                | NodeKind::Block { .. }
+                | NodeKind::If { .. }
+                | NodeKind::FunctionCall { .. }
+                | NodeKind::VariableDeclaration { .. }
+                | NodeKind::Binary { .. }
+                | NodeKind::Unary { .. }
+        )
+    }
+
+    fn calculate_shift_confidence(
+        &self,
+        node: &Node,
+        base_confidence: f64,
+        position_shift: usize,
+        config: &ReuseConfig,
+    ) -> f64 {
+        if config.max_position_shift == 0 {
+            return 0.0;
+        }
+
+        let shift_ratio = position_shift as f64 / config.max_position_shift as f64;
+        let penalty_weight = if self.is_shift_safe_terminal(node) { 0.08 } else { 0.2 };
+        let distance_penalty = (shift_ratio * penalty_weight).min(penalty_weight);
+        (base_confidence - distance_penalty).clamp(0.0, 1.0)
     }
 
     /// Validate a reuse strategy for correctness
@@ -820,7 +912,7 @@ impl ReuseAnalysisResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use perl_parser_core::{SourceLocation, ast::Node};
+    use perl_parser_core::{ast::Node, SourceLocation};
 
     #[test]
     fn test_advanced_reuse_analyzer_creation() {

--- a/crates/perl-parser/tests/advanced_reuse_analyzer_heuristics_test.rs
+++ b/crates/perl-parser/tests/advanced_reuse_analyzer_heuristics_test.rs
@@ -1,0 +1,100 @@
+#![cfg(feature = "incremental")]
+
+use perl_parser::incremental_advanced_reuse::{AdvancedReuseAnalyzer, ReuseConfig, ReuseType};
+use perl_parser_core::{
+    ast::{Node, NodeKind},
+    edit::EditSet,
+    SourceLocation,
+};
+
+#[test]
+fn shifted_identifier_reuse_prefers_safe_shifted_candidate() {
+    let mut analyzer = AdvancedReuseAnalyzer::new();
+    let old_tree = Node::new(
+        NodeKind::Identifier { name: "same".to_string() },
+        SourceLocation { start: 100, end: 104 },
+    );
+    let new_tree = Node::new(
+        NodeKind::Identifier { name: "same".to_string() },
+        SourceLocation { start: 112, end: 116 },
+    );
+    let edits = EditSet::new();
+    let config = ReuseConfig { max_position_shift: 200, ..ReuseConfig::default() };
+
+    let result = analyzer.analyze_reuse_opportunities(&old_tree, &new_tree, &edits, &config);
+
+    let reuse = result.reuse_map.get(&100);
+    assert!(reuse.is_some());
+    if let Some(reuse) = reuse {
+        assert_eq!(reuse.reuse_type, ReuseType::PositionShift);
+        assert_eq!(reuse.target_position, 112);
+        assert!(reuse.confidence_score >= config.min_confidence);
+    }
+}
+
+#[test]
+fn unsafe_leaf_structural_edit_does_not_reuse_when_content_changes() {
+    let mut analyzer = AdvancedReuseAnalyzer::new();
+    let old_tree = Node::new(
+        NodeKind::Number { value: "1".to_string() },
+        SourceLocation { start: 10, end: 11 },
+    );
+    let new_tree = Node::new(
+        NodeKind::Number { value: "2".to_string() },
+        SourceLocation { start: 10, end: 11 },
+    );
+    let edits = EditSet::new();
+    let config = ReuseConfig {
+        enable_content_reuse: false,
+        aggressive_structural_matching: true,
+        min_confidence: 0.75,
+        ..ReuseConfig::default()
+    };
+
+    let result = analyzer.analyze_reuse_opportunities(&old_tree, &new_tree, &edits, &config);
+
+    assert!(result.reuse_map.is_empty());
+}
+
+#[test]
+fn container_reuse_rejects_large_shift_for_structural_equivalent_matches() {
+    let mut analyzer = AdvancedReuseAnalyzer::new();
+    let old_tree = Node::new(
+        NodeKind::Binary {
+            op: "+".to_string(),
+            left: Box::new(Node::new(
+                NodeKind::Identifier { name: "a".to_string() },
+                SourceLocation { start: 1, end: 2 },
+            )),
+            right: Box::new(Node::new(
+                NodeKind::Identifier { name: "b".to_string() },
+                SourceLocation { start: 5, end: 6 },
+            )),
+        },
+        SourceLocation { start: 0, end: 6 },
+    );
+    let new_tree = Node::new(
+        NodeKind::Binary {
+            op: "+".to_string(),
+            left: Box::new(Node::new(
+                NodeKind::Identifier { name: "x".to_string() },
+                SourceLocation { start: 401, end: 402 },
+            )),
+            right: Box::new(Node::new(
+                NodeKind::Identifier { name: "y".to_string() },
+                SourceLocation { start: 405, end: 406 },
+            )),
+        },
+        SourceLocation { start: 400, end: 406 },
+    );
+    let edits = EditSet::new();
+    let config = ReuseConfig {
+        max_position_shift: 100,
+        enable_content_reuse: false,
+        ..ReuseConfig::default()
+    };
+
+    let result = analyzer.analyze_reuse_opportunities(&old_tree, &new_tree, &edits, &config);
+
+    assert!(result.reuse_map.is_empty());
+}


### PR DESCRIPTION
### Motivation
- Reduce unsafe reuse from overly-permissive matching while enabling clearly safe shifted reuse for terminal nodes.

### Description
- Require identical positions for `Direct` reuse to avoid misclassifying shifted nodes as direct matches.
- Improve position-shifted matching by allowing safe terminals (identifiers, literals, variables), selecting the best candidate by confidence, preventing multiple old nodes claiming the same new position, and applying a shift-distance penalty that is lighter for safe terminals.
- Tighten aggressive structural matching to only consider container nodes, require unclaimed targets, and reject large shifts for structural-equivalent matches.
- Add helper heuristics (`is_position_unclaimed`, `is_shift_safe_terminal`, `is_container_node`, `calculate_shift_confidence`) and a new feature-gated test file `crates/perl-parser/tests/advanced_reuse_analyzer_heuristics_test.rs` exercising shifted, unsafe leaf, and container reuse cases.

### Testing
- `cargo test -p perl-parser --features incremental --test advanced_reuse_analyzer_heuristics_test` passed (3 tests).
- `cargo check --all-targets -p perl-parser` passed.
- `cargo test -p perl-parser` was attempted but failed due to an existing unrelated test (`refactor::refactoring::tests::validation_tests::test_cleanup_respects_retention_count`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaddf8eb108333bfdc642ca6857674)