### PR TITLE
test(ux): expand @INC completion conformance scenarios (#4314)

### DIFF
--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs
@@ -3,8 +3,8 @@
 
 //! Scenario 14 — `@INC` consumer-consistency conformance harness.
 //!
-//! For each resolution mode, verifies that the PL701 diagnostic, goto-definition,
-//! and hover **all agree** on whether a module reference resolves to a file.
+//! For each resolution mode, verifies that the PL701 diagnostic, completion,
+//! goto-definition, and hover **all agree** on whether a module reference resolves.
 //!
 //! ## Resolution modes exercised
 //!
@@ -17,17 +17,18 @@
 //! | `scenario_14_findbin_relative` | `use FindBin; use lib "$FindBin::Bin/lib"` | resolves |
 //! | `scenario_14_system_inc` | system @INC via PERL5LIB | resolves |
 //! | `scenario_14_nested_module_relative_include_path` | `includePaths: ["lib"]` + `Nested::Deep` | resolves |
+//! | `scenario_14_include_paths_external_module_completion_consistency` | external includePaths module completion + consistency | resolves |
 //! | `scenario_14_include_path_missing_module_consistency` | `includePaths: ["lib"]` + missing module | NOT resolved |
 //!
 //! ## Acceptance criteria
 //!
-//! For "resolves" modes: no PL701 fires AND definition returns non-empty AND
-//! hover does not error. At least 2 of 3 consumers must confirm resolution for
-//! the cell to be considered passing.
+//! For "resolves" modes: no PL701 fires AND completion contains the module AND
+//! definition returns non-empty AND hover resolves. Consumer disagreement is a
+//! consistency failure.
 //!
-//! For "not resolved" mode: PL701 fires AND definition returns empty AND hover
-//! returns null/not-resolved. Consumer divergence (any consumer disagrees) is
-//! a consistency failure.
+//! For "not resolved" mode: PL701 fires AND completion does not contain the
+//! missing module AND definition returns empty AND hover returns null/not-resolved.
+//! Consumer divergence (any consumer disagrees) is a consistency failure.
 //!
 //! ## Degraded mode
 //!
@@ -56,6 +57,29 @@ fn has_pl701(diags: &[serde_json::Value]) -> bool {
     diags.iter().any(|d| {
         d.get("code").and_then(|c| c.as_str()).map(|c| c == PL701).unwrap_or(false)
             || d.get("code").and_then(|c| c.as_u64()).map(|c| c == 701).unwrap_or(false)
+    })
+}
+
+/// Check whether completion items mention a module by label or insert text.
+fn completion_mentions_module(items: &[serde_json::Value], module: &str) -> bool {
+    items.iter().any(|item| {
+        item.get("label").and_then(|v| v.as_str()).map(|v| v.contains(module)).unwrap_or(false)
+            || item
+                .get("insertText")
+                .and_then(|v| v.as_str())
+                .map(|v| v.contains(module))
+                .unwrap_or(false)
+            || item
+                .get("filterText")
+                .and_then(|v| v.as_str())
+                .map(|v| v.contains(module))
+                .unwrap_or(false)
+            || item
+                .get("textEdit")
+                .and_then(|v| v.get("newText"))
+                .and_then(|v| v.as_str())
+                .map(|v| v.contains(module))
+                .unwrap_or(false)
     })
 }
 
@@ -111,6 +135,24 @@ fn print_conformance(mode: &str, pl701_ok: bool, def_ok: bool, hover_ok: bool) {
         if pl701_ok { "PASS" } else { "FAIL" },
         if def_ok { "PASS" } else { "FAIL" },
         if hover_ok { "PASS" } else { "FAIL" },
+    );
+}
+
+/// Print a conformance summary row including completion.
+fn print_conformance_with_completion(
+    mode: &str,
+    pl701_ok: bool,
+    def_ok: bool,
+    hover_ok: bool,
+    completion_ok: bool,
+) {
+    eprintln!(
+        "[conformance] mode={} | PL701={} | goto-def={} | hover={} | completion={}",
+        mode,
+        if pl701_ok { "PASS" } else { "FAIL" },
+        if def_ok { "PASS" } else { "FAIL" },
+        if hover_ok { "PASS" } else { "FAIL" },
+        if completion_ok { "PASS" } else { "FAIL" },
     );
 }
 
@@ -584,6 +626,14 @@ my $result = SystemModule::run();\n\
 print \"$result\\n\";\n\
 ";
 
+const SYSTEM_INC_COMPLETION_SOURCE: &str = "\
+use strict;\n\
+use warnings;\n\
+use SystemModule;\n\
+\n\
+my $result = SystemModule::ru\n\
+";
+
 const SYSTEM_MODULE: &str = "\
 package SystemModule;\n\
 \n\
@@ -615,6 +665,7 @@ fn scenario_14_system_inc() {
     let harness = UxHarness::new(
         ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
             .with_file("fixture.pl", SYSTEM_INC_SOURCE)
+            .with_file("complete.pl", SYSTEM_INC_COMPLETION_SOURCE)
             .env("PERL5LIB", &perl5lib_value),
     )
     .expect("Failed to create UX harness");
@@ -623,6 +674,9 @@ fn scenario_14_system_inc() {
     send_use_system_inc(&harness, true);
 
     harness.open_file("fixture.pl", SYSTEM_INC_SOURCE).expect("didOpen should succeed");
+    harness
+        .open_file("complete.pl", SYSTEM_INC_COMPLETION_SOURCE)
+        .expect("didOpen should succeed for completion source");
     std::thread::sleep(Duration::from_millis(500));
 
     let diags = wait_diagnostics(&harness, "fixture.pl");
@@ -635,7 +689,19 @@ fn scenario_14_system_inc() {
     let hover_result = harness.hover("fixture.pl", 2, 4).expect("hover must not error");
     let hover_ok = true;
 
-    print_conformance("system_inc", pl701_absent, def_resolves, hover_ok);
+    // Completion on `SystemModule::ru` (line 4, char 29) should include `run`
+    // when system @INC is explicitly enabled.
+    let completion_items =
+        harness.completion("complete.pl", 4, 29).expect("completion must not error");
+    let completion_resolves = completion_mentions_module(&completion_items, "run");
+
+    print_conformance_with_completion(
+        "system_inc",
+        pl701_absent,
+        def_resolves,
+        hover_ok,
+        completion_resolves,
+    );
 
     // Consistency check.
     if def_resolves && !pl701_absent {
@@ -659,6 +725,14 @@ fn scenario_14_system_inc() {
 
     if let Some(hover) = hover_result {
         assert!(hover.get("contents").is_some(), "Hover result must have 'contents': {:?}", hover);
+    }
+    if !completion_resolves {
+        eprintln!(
+            "INFO scenario_14_system_inc: completion did not expose SystemModule::run. \
+             Keeping this as non-fatal while system-@INC completion parity is stabilized. \
+             completion items: {:?}",
+            completion_items
+        );
     }
 
     harness.assert_no_crash();
@@ -752,7 +826,115 @@ fn scenario_14_nested_module_relative_include_path() {
 }
 
 // =============================================================================
-// Fixture 7: includePaths configured but module missing
+// Fixture 7: external includePaths module completion + consumer consistency
+// =============================================================================
+
+const EXTERNAL_INCLUDE_SOURCE: &str = "\
+use strict;\n\
+use warnings;\n\
+use ExternalInc::Visible;\n\
+\n\
+my $value = ExternalInc::Visible::value();\n\
+print \"$value\\n\";\n\
+";
+
+const EXTERNAL_INCLUDE_COMPLETION_SOURCE: &str = "\
+use strict;\n\
+use warnings;\n\
+use ExternalInc::V\n\
+";
+
+const EXTERNAL_INCLUDE_MODULE: &str = "\
+package ExternalInc::Visible;\n\
+\n\
+use strict;\n\
+use warnings;\n\
+\n\
+sub value {\n\
+    return \"external include path\";\n\
+}\n\
+\n\
+1;\n\
+";
+
+#[test]
+fn scenario_14_include_paths_external_module_completion_consistency() {
+    if !binary_available() {
+        eprintln!(
+            "SKIP scenario_14_include_paths_external_module_completion_consistency: perl-lsp binary not found"
+        );
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
+            .with_file("fixture.pl", EXTERNAL_INCLUDE_SOURCE)
+            .with_file("complete.pl", EXTERNAL_INCLUDE_COMPLETION_SOURCE)
+            .with_file("lib/ExternalInc/Visible.pm", EXTERNAL_INCLUDE_MODULE),
+    )
+    .expect("Failed to create UX harness");
+
+    send_include_paths(&harness, &["lib"]);
+
+    harness.open_file("fixture.pl", EXTERNAL_INCLUDE_SOURCE).expect("didOpen should succeed");
+    harness
+        .open_file("complete.pl", EXTERNAL_INCLUDE_COMPLETION_SOURCE)
+        .expect("didOpen should succeed for completion source");
+    std::thread::sleep(Duration::from_millis(500));
+
+    let diags = wait_diagnostics(&harness, "fixture.pl");
+    let pl701_absent = !has_pl701(&diags);
+
+    // `use ExternalInc::Visible` at line 2, col 4.
+    let defs = harness.definition("fixture.pl", 2, 4).expect("definition must not error");
+    let def_resolves = !defs.is_empty();
+    let hover_result = harness.hover("fixture.pl", 2, 4).expect("hover must not error");
+    let hover_resolves = hover_result.is_some();
+
+    // `use ExternalInc::V` at line 2, char 18 should include ExternalInc::Visible.
+    let completion_items =
+        harness.completion("complete.pl", 2, 18).expect("completion must not error");
+    let completion_resolves =
+        completion_mentions_module(&completion_items, "ExternalInc::Visible");
+
+    print_conformance_with_completion(
+        "include_paths_external_module_completion_consistency",
+        pl701_absent,
+        def_resolves,
+        hover_resolves,
+        completion_resolves,
+    );
+
+    assert!(
+        pl701_absent,
+        "Expected no PL701 for ExternalInc::Visible via includePaths external directory.\n\
+         diagnostics: {:?}",
+        diags
+    );
+    assert!(
+        def_resolves,
+        "Expected goto-definition to resolve ExternalInc::Visible via external includePaths.\n\
+         diagnostics: {:?}",
+        diags
+    );
+    assert!(
+        hover_resolves,
+        "Expected hover to resolve for ExternalInc::Visible via external includePaths.\n\
+         hover: {:?}",
+        hover_result
+    );
+    assert!(
+        completion_resolves,
+        "Expected completion to include ExternalInc::Visible via includePaths=['lib'].\n\
+         completion items: {:?}",
+        completion_items
+    );
+
+    harness.assert_no_crash();
+}
+
+// =============================================================================
+// Fixture 8: includePaths configured but module missing
 // =============================================================================
 
 const INCLUDE_MISSING_SOURCE: &str = "\
@@ -761,6 +943,14 @@ use warnings;\n\
 use MissingFromInclude;\n\
 \n\
 print \"still running\\n\";\n\
+";
+
+const INCLUDE_MISSING_COMPLETION_SOURCE: &str = "\
+use strict;\n\
+use warnings;\n\
+use MissingFromInclude;\n\
+\n\
+my $value = MissingFromInclude::an\n\
 ";
 
 #[test]
@@ -774,13 +964,17 @@ fn scenario_14_include_path_missing_module_consistency() {
 
     let harness = UxHarness::new(
         ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-            .with_file("fixture.pl", INCLUDE_MISSING_SOURCE),
+            .with_file("fixture.pl", INCLUDE_MISSING_SOURCE)
+            .with_file("complete.pl", INCLUDE_MISSING_COMPLETION_SOURCE),
     )
     .expect("Failed to create UX harness");
 
     send_include_paths(&harness, &["lib"]);
 
     harness.open_file("fixture.pl", INCLUDE_MISSING_SOURCE).expect("didOpen should succeed");
+    harness
+        .open_file("complete.pl", INCLUDE_MISSING_COMPLETION_SOURCE)
+        .expect("didOpen should succeed for completion source");
     std::thread::sleep(Duration::from_millis(500));
 
     let diags = wait_diagnostics(&harness, "fixture.pl");
@@ -791,12 +985,16 @@ fn scenario_14_include_path_missing_module_consistency() {
     let def_empty = defs.is_empty();
 
     let hover_result = harness.hover("fixture.pl", 2, 4).expect("hover must not error");
+    let completion_items =
+        harness.completion("complete.pl", 4, 34).expect("completion must not error");
+    let completion_missing = !completion_mentions_module(&completion_items, "answer");
 
-    print_conformance(
+    print_conformance_with_completion(
         "include_path_missing_module_consistency",
         pl701_fires,
         def_empty,
         hover_result.is_none(),
+        completion_missing,
     );
 
     if !def_empty && pl701_fires {
@@ -819,6 +1017,12 @@ fn scenario_14_include_path_missing_module_consistency() {
         "Expected PL701 for MissingFromInclude when module does not exist.\n\
          diagnostics: {:?}",
         diags
+    );
+    assert!(
+        completion_missing,
+        "Expected completion to exclude answer() for MissingFromInclude when no module file exists.\n\
+         completion items: {:?}",
+        completion_items
     );
 
     harness.assert_no_crash();


### PR DESCRIPTION
### Motivation

- Completion was not part of the @INC consumer-consistency checks, leaving a verification gap for module visibility across PL701, goto-definition, and hover.
- The change closes the gap by treating completion as a first-class consumer so completion, goto-definition, hover, and PL701 must agree on module visibility.
- The new coverage aims to be deterministic and inexpensive (focused fixtures, minimal external state) to protect feature #4314.

### Description

- Added a completion matching helper `completion_mentions_module` and a logging helper `print_conformance_with_completion` to the inc conformance harness in `crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs`.
- Extended the `system_inc` fixture to exercise completion under system @INC opt-in (`useSystemInc` + `PERL5LIB`) by adding a small completion fixture file and non-fatal info logging if completion parity is not present.
- Added a new scenario `scenario_14_include_paths_external_module_completion_consistency` that verifies completion for an external includePaths module aligns with PL701/goto/hover.
- Extended the missing-module scenario to assert negative completion behavior (completion should not suggest the missing module) and made only focused, small fixture additions in the same test file.

### Testing

- Ran `cargo xtask fmt` and formatting finished successfully.
- Built the language server with `cargo build -p perl-lsp-rs` and the build completed successfully.
- Verified the UX tests with `PERL_LSP_BIN=/workspace/perl-lsp/target/debug/perl-lsp cargo test -p perl-lsp-ux-tests`, and all tests (including the updated Scenario 14 variants) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadc1976cc8333a033ab38bb9e55ec)