### PR TITLE
feat(semantic): add narrow flow-sensitive refinement

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -2399,6 +2399,35 @@ $"#;
     }
 
     #[test]
+    fn test_variable_completion_ranks_declaration_before_cursor_ahead_of_later_declaration() {
+        let code = concat!(
+            "sub process {\n",
+            "    my $alpha_before = 1;\n",
+            "    $alp\n",
+            "    my $alpha_after = 2;\n",
+            "}\n"
+        );
+
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index_and_source(&ast, code, None);
+        let cursor = must_some(code.find("$alp")) + "$alp".len();
+        let completions = provider.get_completions(code, cursor);
+
+        let before_item =
+            must_some(completions.iter().find(|completion| completion.label == "$alpha_before"));
+        let after_item =
+            must_some(completions.iter().find(|completion| completion.label == "$alpha_after"));
+
+        assert!(
+            before_item.sort_text < after_item.sort_text,
+            "expected variable declared before cursor to outrank later declaration, got before={:?} after={:?}",
+            before_item.sort_text,
+            after_item.sort_text
+        );
+    }
+
+    #[test]
     fn test_package_member_completion() {
         // Create workspace index with a module exporting a function
         let index = Arc::new(WorkspaceIndex::new());

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/variables.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/variables.rs
@@ -8,6 +8,14 @@ use super::scope_distance::compute_scope_distance;
 use super::{context::CompletionContext, items::CompletionItem};
 use perl_semantic_analyzer::symbol::{SymbolKind, SymbolTable};
 
+fn flow_order_key(declaration_start: usize, cursor_position: usize) -> char {
+    if declaration_start <= cursor_position {
+        'a'
+    } else {
+        'b'
+    }
+}
+
 /// Add variable completions with scope-distance ranking.
 ///
 /// Variables from the immediate scope rank highest, then parent scopes,
@@ -29,6 +37,7 @@ pub fn add_variable_completions(
 
                 let distance =
                     compute_scope_distance(symbol_table, context.cursor_scope_id, symbol.scope_id);
+                let flow_key = flow_order_key(symbol.location.start, context.position);
 
                 completions.push(CompletionItem {
                     label: insert_text.clone(),
@@ -45,7 +54,7 @@ pub fn add_variable_completions(
                     ),
                     documentation: symbol.documentation.clone(),
                     insert_text: Some(insert_text),
-                    sort_text: Some(format!("1{}_{}", distance.sort_key(), name)),
+                    sort_text: Some(format!("1{}{}_{name}", distance.sort_key(), flow_key)),
                     filter_text: Some(name.clone()),
                     additional_edits: vec![],
                     text_edit_range: Some((context.prefix_start, context.position)),
@@ -138,6 +147,7 @@ pub fn add_all_variables(
                         context.cursor_scope_id,
                         symbol.scope_id,
                     );
+                    let flow_key = flow_order_key(symbol.location.start, context.position);
                     completions.push(CompletionItem {
                         label: format!("{}{}", sigil, name),
                         kind: super::items::CompletionItemKind::Variable,
@@ -147,7 +157,7 @@ pub fn add_all_variables(
                         )),
                         documentation: symbol.documentation.clone(),
                         insert_text: Some(format!("{}{}", sigil, name)),
-                        sort_text: Some(format!("5{}_{}", distance.sort_key(), name)),
+                        sort_text: Some(format!("5{}{}_{name}", distance.sort_key(), flow_key)),
                         filter_text: Some(name.clone()),
                         additional_edits: vec![],
                         text_edit_range: Some((context.prefix_start, context.position)),


### PR DESCRIPTION
### Motivation
- Prefer local variables declared at-or-before the completion cursor over later same-scope declarations so completion ranking is more flow-sensitive while preserving existing scope-distance tiers.

### Description
- Add a narrow flow-order tie-breaker (`flow_order_key`) into variable completion sort keys in `crates/perl-lsp-rs-core/src/providers/completion/completion/variables.rs` so `sort_text` embeds a flow key in both sigil-prefixed and interpolation-style variable completions.
- Update variable `sort_text` to `format!("<tier><flow>_{name}")` so closer scope items still win but declarations before the cursor outrank identical-prefix declarations that occur later in the file.
- Add a regression test `test_variable_completion_ranks_declaration_before_cursor_ahead_of_later_declaration` to `crates/perl-lsp-rs-core/src/providers/completion/completion.rs` that verifies a variable declared before the cursor sorts ahead of a later declaration with the same prefix.
- Changes committed as a single focused commit and prepared as PR titled `feat(semantic): add narrow flow-sensitive refinement`.

### Testing
- Ran `cargo test -p perl-lsp-rs-core`; the run started but the build failed due to a pre-existing unrelated syntax error (unterminated string) in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs`, so the test suite could not complete.
- Ran `cargo check --workspace --all-targets`; this also failed on the same pre-existing parse error in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs` preventing a full workspace check.
- Ran `cargo xtask fmt`; formatting step also could not complete due to the same compile blocker while building workspace tooling.
- Note: a focused, deterministic regression test was added and will validate the new flow-sensitive ordering once the unrelated parse error in `formatting.rs` is resolved and the workspace rebuilds successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead3797154833389f4bb0fdfb5d72b)