### PR TITLE
fix(perl-module): improve multiline @INC pragma parsing (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/use_lib.rs
+++ b/crates/perl-module/src/resolution/use_lib.rs
@@ -38,8 +38,8 @@ pub enum UseLibAction {
 pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
     let mut paths = Vec::new();
 
-    for line in source.lines() {
-        let trimmed = line.trim();
+    for statement in split_perl_statements(source) {
+        let trimmed = statement.trim();
         if let Some(rest) = strip_use_lib_prefix(trimmed) {
             extract_paths_from_args(rest, &mut paths);
         }
@@ -53,8 +53,8 @@ pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
 pub fn extract_use_lib_operations(source: &str) -> Vec<UseLibAction> {
     let mut ops = Vec::new();
 
-    for line in source.lines() {
-        let trimmed = line.trim();
+    for statement in split_perl_statements(source) {
+        let trimmed = statement.trim();
         if let Some(rest) = strip_use_lib_prefix(trimmed) {
             let mut paths = Vec::new();
             extract_paths_from_args(rest, &mut paths);
@@ -74,6 +74,76 @@ pub fn extract_use_lib_operations(source: &str) -> Vec<UseLibAction> {
     }
 
     ops
+}
+
+fn split_perl_statements(source: &str) -> Vec<&str> {
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    enum QuoteState {
+        Single,
+        Double,
+    }
+
+    let mut statements = Vec::new();
+    let mut start = 0;
+    let mut quote_state = None;
+    let mut escaped = false;
+
+    for (index, ch) in source.char_indices() {
+        match quote_state {
+            Some(QuoteState::Single) => {
+                if escaped {
+                    escaped = false;
+                    continue;
+                }
+                if ch == '\\' {
+                    escaped = true;
+                    continue;
+                }
+                if ch == '\'' {
+                    quote_state = None;
+                }
+            }
+            Some(QuoteState::Double) => {
+                if escaped {
+                    escaped = false;
+                    continue;
+                }
+                if ch == '\\' {
+                    escaped = true;
+                    continue;
+                }
+                if ch == '"' {
+                    quote_state = None;
+                }
+            }
+            None => {
+                if ch == '\'' {
+                    quote_state = Some(QuoteState::Single);
+                    escaped = false;
+                    continue;
+                }
+                if ch == '"' {
+                    quote_state = Some(QuoteState::Double);
+                    escaped = false;
+                    continue;
+                }
+                if ch == ';' {
+                    let statement = source[start..index].trim();
+                    if !statement.is_empty() {
+                        statements.push(statement);
+                    }
+                    start = index + ch.len_utf8();
+                }
+            }
+        }
+    }
+
+    let trailing = source[start..].trim();
+    if !trailing.is_empty() {
+        statements.push(trailing);
+    }
+
+    statements
 }
 
 /// Resolve `use lib` paths against a workspace root and optional file directory.

--- a/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
+++ b/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
@@ -148,3 +148,60 @@ fn braced_short_findbin_exports_are_treated_as_findbin_paths() {
         }]),]
     );
 }
+
+#[test]
+fn multiline_use_lib_is_extracted() {
+    let source = "\
+use lib (
+    'alpha',
+    'beta'
+);
+";
+
+    let ops = extract_use_lib_operations(source);
+
+    assert_eq!(
+        ops,
+        vec![UseLibAction::Add(vec![
+            UseLibPath { path: "alpha".to_string(), from_findbin: false },
+            UseLibPath { path: "beta".to_string(), from_findbin: false },
+        ])]
+    );
+}
+
+#[test]
+fn multiline_use_and_no_lib_are_ordered() {
+    let source = "\
+use lib (
+    'first',
+    'second'
+);
+no lib (
+    'first'
+);
+";
+
+    let include_paths = resolve_use_lib_paths_from_source_at_offset(
+        source,
+        source.len(),
+        Path::new("/workspace"),
+        None,
+    );
+
+    assert_eq!(include_paths, vec!["second".to_string()]);
+}
+
+#[test]
+fn quoted_semicolon_does_not_split_statement() {
+    let source = "use lib 'path;still_path';\n";
+
+    let ops = extract_use_lib_operations(source);
+
+    assert_eq!(
+        ops,
+        vec![UseLibAction::Add(vec![UseLibPath {
+            path: "path;still_path".to_string(),
+            from_findbin: false,
+        }])]
+    );
+}


### PR DESCRIPTION
### Motivation

- The lexical @INC extraction scanned source line-by-line which failed to recognize multiline or parenthesized `use lib` / `no lib` statements. 
- The change aims to extract operations in true lexical order across statement boundaries while preserving existing single-line behavior.

### Description

- Switched `extract_use_lib_paths` and `extract_use_lib_operations` to iterate over whole statements produced by a new `split_perl_statements` helper instead of iterating over raw lines (files changed: `crates/perl-module/src/resolution/use_lib.rs`, `crates/perl-module/tests/use_lib_resolution_unit_tests.rs`).
- Added `split_perl_statements` which splits on semicolons but does not split inside single- or double-quoted strings and honors escaped quotes, enabling multiline and parenthesized `use lib (...)` and `no lib (...)` forms.
- Kept the existing argument-parsing logic (`extract_paths_from_args`, `extract_qw_paths`, `extract_quoted_list`, etc.) so simple single-line forms remain unchanged.
- Added focused unit tests `multiline_use_lib_is_extracted`, `multiline_use_and_no_lib_are_ordered`, and `quoted_semicolon_does_not_split_statement` to cover multiline extraction, add/remove ordering, and quoted-semicolon handling.

### Testing

- Ran `cargo test -p perl-module --test use_lib_resolution_unit_tests` and all tests passed, including the three new tests and existing coverage.
- Ran `cargo check --all-targets -p perl-module` which completed successfully.
- Ran `cargo clippy -p perl-module -- -D warnings` which passed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead9eed5788333a6f4d9da3c5377c4)