### PR TITLE
fix(perl-module): improve multiline @INC pragma parsing (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/use_lib.rs
+++ b/crates/perl-module/src/resolution/use_lib.rs
@@ -38,8 +38,8 @@ pub enum UseLibAction {
 pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
     let mut paths = Vec::new();
 
-    for line in source.lines() {
-        let trimmed = line.trim();
+    for statement in split_perl_statements(source) {
+        let trimmed = statement.trim();
         if let Some(rest) = strip_use_lib_prefix(trimmed) {
             extract_paths_from_args(rest, &mut paths);
         }
@@ -53,8 +53,8 @@ pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
 pub fn extract_use_lib_operations(source: &str) -> Vec<UseLibAction> {
     let mut ops = Vec::new();
 
-    for line in source.lines() {
-        let trimmed = line.trim();
+    for statement in split_perl_statements(source) {
+        let trimmed = statement.trim();
         if let Some(rest) = strip_use_lib_prefix(trimmed) {
             let mut paths = Vec::new();
             extract_paths_from_args(rest, &mut paths);
@@ -74,6 +74,48 @@ pub fn extract_use_lib_operations(source: &str) -> Vec<UseLibAction> {
     }
 
     ops
+}
+
+fn split_perl_statements(source: &str) -> Vec<&str> {
+    let mut statements = Vec::new();
+    let mut start = 0;
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+
+    for (idx, ch) in source.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+
+        if let Some(active_quote) = quote {
+            if ch == active_quote {
+                quote = None;
+            }
+            continue;
+        }
+
+        if ch == '\'' || ch == '"' {
+            quote = Some(ch);
+            continue;
+        }
+
+        if ch == ';' {
+            statements.push(&source[start..idx]);
+            start = idx + ch.len_utf8();
+        }
+    }
+
+    if start < source.len() {
+        statements.push(&source[start..]);
+    }
+
+    statements
 }
 
 /// Resolve `use lib` paths against a workspace root and optional file directory.

--- a/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
+++ b/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
@@ -148,3 +148,59 @@ fn braced_short_findbin_exports_are_treated_as_findbin_paths() {
         }]),]
     );
 }
+
+#[test]
+fn multiline_use_lib_is_extracted() {
+    let source = "\
+use lib (
+    'alpha',
+    'beta'
+);
+";
+
+    let ops = extract_use_lib_operations(source);
+
+    assert_eq!(
+        ops,
+        vec![UseLibAction::Add(vec![
+            UseLibPath { path: "alpha".to_string(), from_findbin: false },
+            UseLibPath { path: "beta".to_string(), from_findbin: false },
+        ])]
+    );
+}
+
+#[test]
+fn multiline_use_and_no_lib_are_ordered() {
+    let source = "\
+use lib (
+    'alpha'
+);
+no lib (
+    'alpha'
+);
+use lib 'beta';
+";
+
+    let include_paths =
+        resolve_use_lib_paths_from_source_at_offset(source, source.len(), Path::new("/workspace"), None);
+
+    assert_eq!(include_paths, vec!["beta".to_string()]);
+}
+
+#[test]
+fn quoted_semicolon_does_not_split_statement() {
+    let source = "use lib 'semi;colon'; use lib 'second';";
+
+    let ops = extract_use_lib_operations(source);
+
+    assert_eq!(
+        ops,
+        vec![
+            UseLibAction::Add(vec![UseLibPath {
+                path: "semi;colon".to_string(),
+                from_findbin: false,
+            }]),
+            UseLibAction::Add(vec![UseLibPath { path: "second".to_string(), from_findbin: false }]),
+        ]
+    );
+}


### PR DESCRIPTION
### Motivation
- The extractor previously scanned source line-by-line which missed multiline/parenthesized `use lib` and `no lib` statements and produced incorrect lexical ordering and cancellation semantics.
- The goal is to recognize whole Perl statements (without full parsing) and avoid splitting on semicolons inside quoted strings so common multiline forms are handled correctly.

### Description
- Added a small quote-aware statement splitter `split_perl_statements` that splits on semicolons while ignoring semicolons inside single- and double-quoted strings and respecting escaped characters.
- Switched `extract_use_lib_paths` and `extract_use_lib_operations` to operate over statements produced by `split_perl_statements` instead of raw lines.
- Preserved existing argument parsing logic; unchanged behavior for simple single-line `use lib` forms is retained.
- Modified files: `crates/perl-module/src/resolution/use_lib.rs` and `crates/perl-module/tests/use_lib_resolution_unit_tests.rs`, and added focused regression tests for multiline forms and quoted-semicolon handling.

### Testing
- Ran `cargo test -p perl-module --test use_lib_resolution_unit_tests` and all tests passed.
- Ran `cargo check --all-targets -p perl-module` and the check passed.
- Ran `cargo clippy -p perl-module -- -D warnings` and no lints were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead9eed5788333a6f4d9da3c5377c4)