### PR TITLE
fix(perl-module): improve multiline @INC pragma parsing (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/use_lib.rs
+++ b/crates/perl-module/src/resolution/use_lib.rs
@@ -38,9 +38,8 @@ pub enum UseLibAction {
 pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
     let mut paths = Vec::new();
 
-    for line in source.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = strip_use_lib_prefix(trimmed) {
+    for statement in split_perl_statements(source) {
+        if let Some(rest) = strip_use_lib_prefix(statement) {
             extract_paths_from_args(rest, &mut paths);
         }
     }
@@ -53,9 +52,8 @@ pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
 pub fn extract_use_lib_operations(source: &str) -> Vec<UseLibAction> {
     let mut ops = Vec::new();
 
-    for line in source.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = strip_use_lib_prefix(trimmed) {
+    for statement in split_perl_statements(source) {
+        if let Some(rest) = strip_use_lib_prefix(statement) {
             let mut paths = Vec::new();
             extract_paths_from_args(rest, &mut paths);
             if !paths.is_empty() {
@@ -64,7 +62,7 @@ pub fn extract_use_lib_operations(source: &str) -> Vec<UseLibAction> {
             continue;
         }
 
-        if let Some(rest) = strip_no_lib_prefix(trimmed) {
+        if let Some(rest) = strip_no_lib_prefix(statement) {
             let mut paths = Vec::new();
             extract_paths_from_args(rest, &mut paths);
             if !paths.is_empty() {
@@ -161,6 +159,49 @@ pub fn resolve_use_lib_paths_from_source_at_offset(
         }
     }
     resolved
+}
+
+
+fn split_perl_statements(source: &str) -> Vec<&str> {
+    let mut statements = Vec::new();
+    let mut start = 0;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    for (index, ch) in source.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' if in_single || in_double => {
+                escaped = true;
+            }
+            '\'' if !in_double => {
+                in_single = !in_single;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+            }
+            ';' if !in_single && !in_double => {
+                let statement = source[start..index].trim();
+                if !statement.is_empty() {
+                    statements.push(statement);
+                }
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+
+    let trailing = source[start..].trim();
+    if !trailing.is_empty() {
+        statements.push(trailing);
+    }
+
+    statements
 }
 
 fn strip_use_lib_prefix(trimmed: &str) -> Option<&str> {

--- a/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
+++ b/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
 use perl_module::resolution::use_lib::{
-    UseLibAction, UseLibPath, extract_use_lib_operations, resolve_use_lib_paths,
-    resolve_use_lib_paths_from_source_at_offset,
+    extract_use_lib_operations, extract_use_lib_paths, resolve_use_lib_paths,
+    resolve_use_lib_paths_from_source_at_offset, UseLibAction, UseLibPath,
 };
 
 #[test]
@@ -146,5 +146,74 @@ fn braced_short_findbin_exports_are_treated_as_findbin_paths() {
             path: "../lib".to_string(),
             from_findbin: true,
         }]),]
+    );
+}
+
+#[test]
+fn multiline_use_lib_is_extracted() {
+    let source = "\
+use lib (\n\
+  'first',\n\
+  'second'\n\
+);\n\
+";
+
+    let paths = extract_use_lib_paths(source);
+
+    assert_eq!(
+        paths,
+        vec![
+            UseLibPath { path: "first".to_string(), from_findbin: false },
+            UseLibPath { path: "second".to_string(), from_findbin: false },
+        ]
+    );
+}
+
+#[test]
+fn multiline_use_and_no_lib_are_ordered() {
+    let source = "\
+use lib (\n\
+  'first',\n\
+  'second'\n\
+);\n\
+no lib (\n\
+  'first'\n\
+);\n\
+use lib 'third';\n\
+";
+
+    let ops = extract_use_lib_operations(source);
+
+    assert_eq!(
+        ops,
+        vec![
+            UseLibAction::Add(vec![
+                UseLibPath { path: "first".to_string(), from_findbin: false },
+                UseLibPath { path: "second".to_string(), from_findbin: false },
+            ]),
+            UseLibAction::Remove(vec![UseLibPath {
+                path: "first".to_string(),
+                from_findbin: false,
+            }]),
+            UseLibAction::Add(vec![UseLibPath { path: "third".to_string(), from_findbin: false }]),
+        ]
+    );
+}
+
+#[test]
+fn quoted_semicolon_does_not_split_statement() {
+    let source = "use lib \"path;with:semicolon\";\nuse lib 'second';\n";
+
+    let ops = extract_use_lib_operations(source);
+
+    assert_eq!(
+        ops,
+        vec![
+            UseLibAction::Add(vec![UseLibPath {
+                path: "path;with:semicolon".to_string(),
+                from_findbin: false,
+            }]),
+            UseLibAction::Add(vec![UseLibPath { path: "second".to_string(), from_findbin: false }]),
+        ]
     );
 }


### PR DESCRIPTION
### Motivation
- The extractor scanned source line-by-line which missed multiline or parenthesized `use lib` / `no lib` forms and mis-ordered lexical operations.
- The change scopes a small, robust statement splitter to treat whole Perl statements (semicolon-delimited) as the unit of extraction without implementing full Perl parsing.

### Description
- Switch `extract_use_lib_paths` and `extract_use_lib_operations` to iterate over semicolon-delimited statements via a new `split_perl_statements` helper instead of raw lines.
- Add `split_perl_statements` which splits on `;` but ignores semicolons inside single- and double-quoted strings with basic escape handling so quoted-semicolon cases are preserved.
- Update parsing to preserve ordering and cancellation semantics across multiple statements and retain existing single-line behavior.
- Modified files: `crates/perl-module/src/resolution/use_lib.rs` and tests added/updated in `crates/perl-module/tests/use_lib_resolution_unit_tests.rs` (added tests for multiline extraction, ordering with `no lib`, and quoted-semicolon behavior).

### Testing
- Ran `cargo test -p perl-module --test use_lib_resolution_unit_tests` and the unit test suite passed (all new and existing tests OK).
- Ran `cargo check --all-targets -p perl-module` which completed successfully for the `perl-module` crate.
- Ran `cargo clippy -p perl-module -- -D warnings` and lints for `perl-module` passed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead9eed5788333a6f4d9da3c5377c4)