### PR TITLE
fix(perl-module): normalize @INC entries in URI resolution (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/uri.rs
+++ b/crates/perl-module/src/resolution/uri.rs
@@ -5,6 +5,7 @@
 use crate::path::module_name_to_path;
 use perl_parser_core::path_security::validate_workspace_path;
 use perl_workspace::folder::workspace_folder_to_path;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use url::Url;
@@ -65,8 +66,15 @@ pub fn resolve_module_uri(
     timeout: Duration,
 ) -> ModuleUriResolution {
     let mut effective_inc_roots = Vec::new();
-    for (idx, include_path) in include_paths.iter().enumerate() {
-        let path = PathBuf::from(include_path);
+    let mut seen_include_paths = HashSet::new();
+    for include_path in include_paths {
+        let Some(path) = normalize_include_path_entry(include_path) else {
+            continue;
+        };
+        if !seen_include_paths.insert(path.clone()) {
+            continue;
+        }
+
         let kind = if path.is_absolute() {
             IncRootKind::ExternalAbsolute
         } else {
@@ -75,16 +83,25 @@ pub fn resolve_module_uri(
         effective_inc_roots.push(IncRoot {
             kind,
             path,
-            precedence: idx,
+            precedence: effective_inc_roots.len(),
             source: "includePaths".to_string(),
         });
     }
+
     if use_system_inc {
-        for (offset, path) in system_inc.iter().enumerate() {
+        let mut seen_system_inc = HashSet::new();
+        for path in system_inc {
+            let Some(path) = normalize_system_inc_entry(path) else {
+                continue;
+            };
+            if !seen_system_inc.insert(path.clone()) {
+                continue;
+            }
+
             effective_inc_roots.push(IncRoot {
                 kind: IncRootKind::InterpreterStartup,
-                path: path.clone(),
-                precedence: include_paths.len() + offset,
+                path,
+                precedence: effective_inc_roots.len(),
                 source: "interpreter-startup-inc".to_string(),
             });
         }
@@ -170,6 +187,37 @@ pub fn resolve_module_uri_with_effective_inc(
     }
 
     ModuleUriResolution::NotFound
+}
+
+fn normalize_include_path_entry(entry: &str) -> Option<PathBuf> {
+    let trimmed = entry.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    Some(normalize_path_string(trimmed))
+}
+
+fn normalize_system_inc_entry(entry: &Path) -> Option<PathBuf> {
+    let trimmed = entry.to_string_lossy();
+    let trimmed = trimmed.trim();
+    if trimmed.is_empty() || trimmed == "." {
+        return None;
+    }
+
+    Some(normalize_path_string(trimmed))
+}
+
+fn normalize_path_string(path: &str) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in Path::new(path).components() {
+        match component {
+            std::path::Component::CurDir => {}
+            _ => normalized.push(component),
+        }
+    }
+
+    if normalized.as_os_str().is_empty() { PathBuf::from(".") } else { normalized }
 }
 
 fn full_path_for_root(

--- a/crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs
+++ b/crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs
@@ -179,6 +179,29 @@ fn workspace_folder_with_dot_include_path() -> Result<(), Box<dyn std::error::Er
 }
 
 #[test]
+fn workspace_whitespace_only_include_paths_are_ignored() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp, workspace_uri) = setup_workspace_with_module("lib/Trimmed/Path.pm")?;
+
+    let result = resolve_module_uri(
+        "Trimmed::Path",
+        &[],
+        &[workspace_uri],
+        &["   ".to_string(), "\n\t".to_string(), " lib ".to_string()],
+        false,
+        &[],
+        Duration::from_millis(100),
+    );
+
+    match result {
+        ModuleUriResolution::Resolved(uri) => {
+            assert!(uri.ends_with("Trimmed/Path.pm"));
+        }
+        other => return Err(format!("expected Resolved, got {other:?}").into()),
+    }
+    Ok(())
+}
+
+#[test]
 fn workspace_folder_multiple_include_paths_first_match_wins()
 -> Result<(), Box<dyn std::error::Error>> {
     let temp = tempfile::tempdir()?;
@@ -373,6 +396,44 @@ fn system_inc_missing_file_returns_not_found() {
     assert_eq!(result, ModuleUriResolution::NotFound);
 }
 
+#[test]
+fn duplicate_system_inc_entries_do_not_change_resolution_order()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+
+    let inc1 = temp.path().join("inc1");
+    let file1 = inc1.join("Stable.pm");
+    std::fs::create_dir_all(&inc1)?;
+    std::fs::write(&file1, "1;")?;
+
+    let inc2 = temp.path().join("inc2");
+    let file2 = inc2.join("Stable.pm");
+    std::fs::create_dir_all(&inc2)?;
+    std::fs::write(&file2, "1;")?;
+
+    let result = resolve_module_uri(
+        "Stable",
+        &[],
+        &[],
+        &[],
+        true,
+        &[
+            PathBuf::from(" . "),
+            PathBuf::from(" "),
+            PathBuf::from(&inc1),
+            PathBuf::from(&inc1),
+            PathBuf::from(&inc2),
+        ],
+        Duration::from_millis(100),
+    );
+
+    match result {
+        ModuleUriResolution::Resolved(uri) => assert!(uri.contains("inc1")),
+        other => return Err(format!("expected Resolved, got {other:?}").into()),
+    }
+    Ok(())
+}
+
 // ===========================================================================
 // Search precedence: open docs > workspace > system @INC
 // ===========================================================================
@@ -426,6 +487,38 @@ fn workspace_beats_system_inc() -> Result<(), Box<dyn std::error::Error>> {
         ModuleUriResolution::Resolved(uri) => {
             // Workspace match should win; URI should reference the workspace path
             assert!(!uri.contains("inc"));
+        }
+        other => return Err(format!("expected Resolved, got {other:?}").into()),
+    }
+    Ok(())
+}
+
+#[test]
+fn precedence_is_stable_after_include_path_normalization() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (_temp, workspace_uri) = setup_workspace_with_module("lib/Stable/Order.pm")?;
+
+    let temp2 = tempfile::tempdir()?;
+    let system_root = temp2.path().join("sys");
+    let system_module = system_root.join("Stable").join("Order.pm");
+    std::fs::create_dir_all(must_some(system_module.parent()))?;
+    std::fs::write(&system_module, "1;")?;
+
+    let result = resolve_module_uri(
+        "Stable::Order",
+        &[],
+        &[workspace_uri],
+        &["  ".to_string(), "./".to_string(), "lib/".to_string(), " lib ".to_string()],
+        true,
+        &[PathBuf::from(""), PathBuf::from(" . "), PathBuf::from(&system_root)],
+        Duration::from_millis(100),
+    );
+
+    match result {
+        ModuleUriResolution::Resolved(uri) => {
+            assert!(uri.contains("workspace"));
+            assert!(uri.ends_with("Stable/Order.pm"));
+            assert!(!uri.contains("/sys/"));
         }
         other => return Err(format!("expected Resolved, got {other:?}").into()),
     }


### PR DESCRIPTION
### Motivation
- Raw `include_paths` and system `@INC` strings (whitespace-only, duplicate, and `.` entries) could distort effective root ordering and change resolution precedence.
- Normalize and dedupe inputs early so resolution order remains deterministic and monotonic across combined include and system roots.

### Description
- Normalize and filter `include_paths` by trimming, dropping empty/whitespace-only entries, normalizing `.` components, and deduping with a `HashSet` while preserving first-seen precedence via `effective_inc_roots.len()` for `precedence` assignment.
- Normalize and filter system `@INC` entries by trimming, dropping empty entries and explicit `.` entries, normalizing path components, and deduping while preserving deterministic order.
- Added helpers `normalize_include_path_entry`, `normalize_system_inc_entry`, and `normalize_path_string` to encapsulate the normalization logic, and updated precedence assignment to be monotonic after filtering.
- Modified tests in `crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs` to add regression cases for whitespace-only include paths being ignored, duplicate system `@INC` not altering resolution order, and stable precedence after normalization; changes are in `crates/perl-module/src/resolution/uri.rs` and the tests file.

### Testing
- Ran `cargo fmt -p perl-module` and formatting completed successfully.
- Ran `cargo check --all-targets -p perl-module` and it completed successfully.
- Ran `cargo test -p perl-module` and all tests passed (including the new regression tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadc125f748333ae412a2a52d801f8)