### PR TITLE
fix(perl-module): normalize @INC entries in URI resolution (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/uri.rs
+++ b/crates/perl-module/src/resolution/uri.rs
@@ -5,6 +5,7 @@
 use crate::path::module_name_to_path;
 use perl_parser_core::path_security::validate_workspace_path;
 use perl_workspace::folder::workspace_folder_to_path;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use url::Url;
@@ -65,8 +66,18 @@ pub fn resolve_module_uri(
     timeout: Duration,
 ) -> ModuleUriResolution {
     let mut effective_inc_roots = Vec::new();
-    for (idx, include_path) in include_paths.iter().enumerate() {
-        let path = PathBuf::from(include_path);
+    let mut include_seen = HashSet::new();
+    for include_path in include_paths {
+        let trimmed = include_path.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let path = normalize_for_dedupe(Path::new(trimmed));
+        if !include_seen.insert(path.clone()) {
+            continue;
+        }
+
         let kind = if path.is_absolute() {
             IncRootKind::ExternalAbsolute
         } else {
@@ -75,16 +86,27 @@ pub fn resolve_module_uri(
         effective_inc_roots.push(IncRoot {
             kind,
             path,
-            precedence: idx,
+            precedence: effective_inc_roots.len(),
             source: "includePaths".to_string(),
         });
     }
+
     if use_system_inc {
-        for (offset, path) in system_inc.iter().enumerate() {
+        let mut system_seen = HashSet::new();
+        for raw_path in system_inc {
+            let trimmed = raw_path.to_string_lossy().trim().to_string();
+            if trimmed.is_empty() || trimmed == "." {
+                continue;
+            }
+            let path = normalize_for_dedupe(Path::new(&trimmed));
+            if !system_seen.insert(path.clone()) {
+                continue;
+            }
+
             effective_inc_roots.push(IncRoot {
                 kind: IncRootKind::InterpreterStartup,
-                path: path.clone(),
-                precedence: include_paths.len() + offset,
+                path,
+                precedence: effective_inc_roots.len(),
                 source: "interpreter-startup-inc".to_string(),
             });
         }
@@ -193,4 +215,21 @@ fn full_path_for_root(
         | IncRootKind::InterpreterStartup
         | IncRootKind::RuntimeDerived => Some(inc_root.path.join(relative_path)),
     }
+}
+
+fn normalize_for_dedupe(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.push(component.as_os_str());
+            }
+            std::path::Component::RootDir
+            | std::path::Component::Prefix(_)
+            | std::path::Component::Normal(_) => normalized.push(component.as_os_str()),
+        }
+    }
+
+    if normalized.as_os_str().is_empty() { PathBuf::from(".") } else { normalized }
 }

--- a/crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs
+++ b/crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs
@@ -236,6 +236,29 @@ fn workspace_folder_module_not_on_disk_returns_not_found() -> Result<(), Box<dyn
 }
 
 #[test]
+fn whitespace_only_include_paths_are_ignored() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp, workspace_uri) = setup_workspace_with_module("lib/Norm/Whitespace.pm")?;
+
+    let result = resolve_module_uri(
+        "Norm::Whitespace",
+        &[],
+        &[workspace_uri],
+        &["   ".to_string(), "\t".to_string(), "lib".to_string()],
+        false,
+        &[],
+        Duration::from_millis(100),
+    );
+
+    match result {
+        ModuleUriResolution::Resolved(uri) => {
+            assert!(uri.ends_with("Norm/Whitespace.pm"));
+        }
+        other => return Err(format!("expected Resolved, got {other:?}").into()),
+    }
+    Ok(())
+}
+
+#[test]
 fn multiple_workspace_folders_searches_in_order() -> Result<(), Box<dyn std::error::Error>> {
     let temp = tempfile::tempdir()?;
 
@@ -373,6 +396,43 @@ fn system_inc_missing_file_returns_not_found() {
     assert_eq!(result, ModuleUriResolution::NotFound);
 }
 
+#[test]
+fn duplicate_system_inc_entries_preserve_first_match_order()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+
+    let inc1 = temp.path().join("sys1");
+    std::fs::create_dir_all(&inc1)?;
+    std::fs::write(inc1.join("Dedup.pm"), "1;")?;
+
+    let inc2 = temp.path().join("sys2");
+    std::fs::create_dir_all(&inc2)?;
+    std::fs::write(inc2.join("Dedup.pm"), "1;")?;
+
+    let result = resolve_module_uri(
+        "Dedup",
+        &[],
+        &[],
+        &[],
+        true,
+        &[
+            PathBuf::from(format!("{}  ", inc1.display())),
+            PathBuf::from(inc1.clone()),
+            PathBuf::from("."),
+            PathBuf::from(inc2),
+        ],
+        Duration::from_millis(100),
+    );
+
+    match result {
+        ModuleUriResolution::Resolved(uri) => {
+            assert!(uri.contains("sys1"));
+        }
+        other => return Err(format!("expected Resolved, got {other:?}").into()),
+    }
+    Ok(())
+}
+
 // ===========================================================================
 // Search precedence: open docs > workspace > system @INC
 // ===========================================================================
@@ -426,6 +486,49 @@ fn workspace_beats_system_inc() -> Result<(), Box<dyn std::error::Error>> {
         ModuleUriResolution::Resolved(uri) => {
             // Workspace match should win; URI should reference the workspace path
             assert!(!uri.contains("inc"));
+        }
+        other => return Err(format!("expected Resolved, got {other:?}").into()),
+    }
+    Ok(())
+}
+
+#[test]
+fn normalization_keeps_precedence_monotonic_across_sources()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+
+    let workspace = temp.path().join("workspace");
+    let ws_module = workspace.join("lib").join("Priority").join("Stable.pm");
+    std::fs::create_dir_all(must_some(ws_module.parent()))?;
+    std::fs::write(&ws_module, "1;")?;
+    let workspace_uri = url::Url::from_file_path(&workspace).map_err(|()| "workspace uri")?;
+
+    let inc1 = temp.path().join("sys_a");
+    std::fs::create_dir_all(inc1.join("Priority"))?;
+    std::fs::write(inc1.join("Priority").join("Stable.pm"), "1;")?;
+    let inc2 = temp.path().join("sys_b");
+    std::fs::create_dir_all(inc2.join("Priority"))?;
+    std::fs::write(inc2.join("Priority").join("Stable.pm"), "1;")?;
+
+    let result = resolve_module_uri(
+        "Priority::Stable",
+        &[],
+        &[workspace_uri.to_string()],
+        &["   ".to_string(), "./lib".to_string(), "lib".to_string(), "lib/".to_string()],
+        true,
+        &[
+            PathBuf::from(" . "),
+            PathBuf::from(format!("{}/", inc1.display())),
+            PathBuf::from(inc1.clone()),
+            PathBuf::from(inc2),
+        ],
+        Duration::from_millis(100),
+    );
+
+    match result {
+        ModuleUriResolution::Resolved(uri) => {
+            assert!(uri.contains("/workspace/"));
+            assert!(uri.ends_with("Priority/Stable.pm"));
         }
         other => return Err(format!("expected Resolved, got {other:?}").into()),
     }


### PR DESCRIPTION
### Motivation
- URI resolution accepted unnormalized `include_paths` and system `@INC` entries so whitespace-only, duplicate, and `.` inputs could distort effective search order and precedence.

### Description
- Trim and drop empty/whitespace-only `include_paths`, lexically normalize them for dedupe, and deduplicate while preserving first-seen precedence when building `IncRoot` entries.
- Trim system `@INC` entries, drop empty entries and `.` entries, lexically normalize for dedupe, and deduplicate while preserving deterministic order.
- Assign `precedence` based on the post-normalization effective list to keep search precedence monotonic across include paths and system roots, and add `normalize_for_dedupe` helper used for comparisons.
- Add regression tests in `crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs` for whitespace-only includePaths, duplicate system `@INC` entries, and precedence stability after normalization.

### Testing
- Ran `cargo test -p perl-module` and all tests passed successfully.
- Ran `cargo check --all-targets -p perl-module` and the check passed successfully.
- Ran formatting via `cargo xtask fmt` to ensure style consistency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadc125f748333ae412a2a52d801f8)