### PR TITLE
fix(perl-module): normalize @INC entries in URI resolution (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/uri.rs
+++ b/crates/perl-module/src/resolution/uri.rs
@@ -4,8 +4,9 @@
 
 use crate::path::module_name_to_path;
 use perl_parser_core::path_security::validate_workspace_path;
+use std::collections::HashSet;
 use perl_workspace::folder::workspace_folder_to_path;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, Instant};
 use url::Url;
 
@@ -65,8 +66,14 @@ pub fn resolve_module_uri(
     timeout: Duration,
 ) -> ModuleUriResolution {
     let mut effective_inc_roots = Vec::new();
-    for (idx, include_path) in include_paths.iter().enumerate() {
-        let path = PathBuf::from(include_path);
+    let mut seen_include_paths = HashSet::new();
+    for include_path in include_paths {
+        let Some(path) = normalize_include_path(include_path) else {
+            continue;
+        };
+        if !seen_include_paths.insert(path.clone()) {
+            continue;
+        }
         let kind = if path.is_absolute() {
             IncRootKind::ExternalAbsolute
         } else {
@@ -75,16 +82,23 @@ pub fn resolve_module_uri(
         effective_inc_roots.push(IncRoot {
             kind,
             path,
-            precedence: idx,
+            precedence: effective_inc_roots.len(),
             source: "includePaths".to_string(),
         });
     }
     if use_system_inc {
-        for (offset, path) in system_inc.iter().enumerate() {
+        let mut seen_system_paths = HashSet::new();
+        for path in system_inc {
+            let Some(path) = normalize_system_inc_path(path) else {
+                continue;
+            };
+            if !seen_system_paths.insert(path.clone()) {
+                continue;
+            }
             effective_inc_roots.push(IncRoot {
                 kind: IncRootKind::InterpreterStartup,
-                path: path.clone(),
-                precedence: include_paths.len() + offset,
+                path,
+                precedence: effective_inc_roots.len(),
                 source: "interpreter-startup-inc".to_string(),
             });
         }
@@ -96,6 +110,45 @@ pub fn resolve_module_uri(
         &effective_inc_roots,
         timeout,
     )
+}
+
+fn normalize_include_path(include_path: &str) -> Option<PathBuf> {
+    let trimmed = include_path.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    Some(normalize_logical_path(Path::new(trimmed)))
+}
+
+fn normalize_system_inc_path(path: &Path) -> Option<PathBuf> {
+    let trimmed = path.to_string_lossy().trim().to_string();
+    if trimmed.is_empty() || trimmed == "." {
+        return None;
+    }
+
+    let normalized = normalize_logical_path(Path::new(&trimmed));
+    if normalized == Path::new(".") {
+        return None;
+    }
+
+    Some(normalized)
+}
+
+fn normalize_logical_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        normalized
+    }
 }
 
 /// Resolve a module name to a `file://` URI using an ordered effective `@INC` model.

--- a/crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs
+++ b/crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs
@@ -179,6 +179,29 @@ fn workspace_folder_with_dot_include_path() -> Result<(), Box<dyn std::error::Er
 }
 
 #[test]
+fn whitespace_only_include_paths_are_ignored() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp, workspace_uri) = setup_workspace_with_module("lib/Trimmed/Path.pm")?;
+
+    let result = resolve_module_uri(
+        "Trimmed::Path",
+        &[],
+        &[workspace_uri],
+        &["   ".to_string(), "\t".to_string(), "lib".to_string()],
+        false,
+        &[],
+        Duration::from_millis(100),
+    );
+
+    match result {
+        ModuleUriResolution::Resolved(uri) => {
+            assert!(uri.ends_with("Trimmed/Path.pm"));
+        }
+        other => return Err(format!("expected Resolved, got {other:?}").into()),
+    }
+    Ok(())
+}
+
+#[test]
 fn workspace_folder_multiple_include_paths_first_match_wins()
 -> Result<(), Box<dyn std::error::Error>> {
     let temp = tempfile::tempdir()?;
@@ -359,6 +382,40 @@ fn system_inc_first_matching_path_wins() -> Result<(), Box<dyn std::error::Error
 }
 
 #[test]
+fn duplicate_system_inc_entries_do_not_change_resolution_order()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+
+    let inc1 = temp.path().join("inc1");
+    let file1 = inc1.join("Dedupe.pm");
+    std::fs::create_dir_all(&inc1)?;
+    std::fs::write(&file1, "1;")?;
+
+    let inc2 = temp.path().join("inc2");
+    let file2 = inc2.join("Dedupe.pm");
+    std::fs::create_dir_all(&inc2)?;
+    std::fs::write(&file2, "1;")?;
+
+    let result = resolve_module_uri(
+        "Dedupe",
+        &[],
+        &[],
+        &[],
+        true,
+        &[PathBuf::from(&inc1), PathBuf::from(&inc1), PathBuf::from(&inc2)],
+        Duration::from_millis(100),
+    );
+
+    match result {
+        ModuleUriResolution::Resolved(uri) => {
+            assert!(uri.contains("inc1"));
+        }
+        other => return Err(format!("expected Resolved, got {other:?}").into()),
+    }
+    Ok(())
+}
+
+#[test]
 fn system_inc_missing_file_returns_not_found() {
     let result = resolve_module_uri(
         "Nonexistent::Pkg",
@@ -426,6 +483,37 @@ fn workspace_beats_system_inc() -> Result<(), Box<dyn std::error::Error>> {
         ModuleUriResolution::Resolved(uri) => {
             // Workspace match should win; URI should reference the workspace path
             assert!(!uri.contains("inc"));
+        }
+        other => return Err(format!("expected Resolved, got {other:?}").into()),
+    }
+    Ok(())
+}
+
+#[test]
+fn normalized_entries_keep_workspace_before_system_precedence()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (_temp, workspace_uri) = setup_workspace_with_module("lib/Stable/Order.pm")?;
+
+    let temp2 = tempfile::tempdir()?;
+    let inc_dir = temp2.path().join("inc");
+    let inc_file = inc_dir.join("Stable").join("Order.pm");
+    std::fs::create_dir_all(must_some(inc_file.parent()))?;
+    std::fs::write(&inc_file, "1;")?;
+
+    let result = resolve_module_uri(
+        "Stable::Order",
+        &[],
+        &[workspace_uri],
+        &[" ./lib ".to_string(), "lib".to_string(), "   ".to_string()],
+        true,
+        &[PathBuf::from("."), PathBuf::from(&inc_dir), PathBuf::from(&inc_dir)],
+        Duration::from_millis(100),
+    );
+
+    match result {
+        ModuleUriResolution::Resolved(uri) => {
+            assert!(!uri.contains("inc"));
+            assert!(uri.ends_with("Stable/Order.pm"));
         }
         other => return Err(format!("expected Resolved, got {other:?}").into()),
     }


### PR DESCRIPTION
### Motivation
- Whitespace-only, duplicate, and `.` entries in `include_paths` and system `@INC` could be treated as distinct roots and distort precedence and search order during URI resolution.
- The resolver must preserve deterministic, first-seen precedence while ignoring no-op or equivalent roots so workspace vs system precedence remains monotonic after normalization.

### Description
- Add logical-path normalization helpers (`normalize_include_path`, `normalize_system_inc_path`, `normalize_logical_path`) and use them when building effective `IncRoot` entries in `resolve_module_uri` in `crates/perl-module/src/resolution/uri.rs`.
- Trim and drop empty/whitespace-only include paths, drop system `"."`, remove `.` path components, and dedupe entries with `HashSet` while preserving first-seen order by assigning precedence from `effective_inc_roots.len()`.
- Update tests in `crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs` with regression cases for ignoring whitespace-only `includePaths`, duplicate system `@INC` entries not affecting resolution order, and ensuring workspace-before-system precedence remains stable after normalization.

### Testing
- Ran `cargo test -p perl-module`, all tests passed (new and existing tests green).
- Ran `cargo check --all-targets -p perl-module`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadc125f748333ae412a2a52d801f8)