### PR TITLE
refactor(completion): plumb effective @INC paths into module completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -122,6 +122,7 @@ use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
 use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_workspace::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Maps module_name -> Set of explicitly imported symbol names.
@@ -170,6 +171,8 @@ pub struct CompletionProvider {
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
     import_map: ImportMap,
+    include_paths: Vec<PathBuf>,
+    system_inc_paths: Vec<PathBuf>,
 }
 
 impl CompletionProvider {
@@ -200,7 +203,7 @@ impl CompletionProvider {
     /// ```
     /// Arguments: `ast`, `workspace_index`.
     pub fn new_with_index(ast: &Node, workspace_index: Option<Arc<WorkspaceIndex>>) -> Self {
-        Self::new_with_index_and_source(ast, "", workspace_index)
+        Self::new_with_index_source_and_paths(ast, "", workspace_index, Vec::new(), Vec::new())
     }
 
     /// Create a new completion provider from parsed AST and source with workspace integration
@@ -249,6 +252,20 @@ impl CompletionProvider {
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
     ) -> Self {
+        Self::new_with_index_source_and_paths(ast, source, workspace_index, Vec::new(), Vec::new())
+    }
+
+    /// Create a completion provider with explicit include paths and system `@INC` paths.
+    ///
+    /// This constructor is used by runtime handlers that resolve document-scoped workspace
+    /// configuration and need to pass effective include data into module completion plumbing.
+    pub fn new_with_index_source_and_paths(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        include_paths: Vec<PathBuf>,
+        system_inc_paths: Vec<PathBuf>,
+    ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
         let type_engine = workspace_index.as_ref().map(|_| {
@@ -258,7 +275,15 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            import_map,
+            include_paths,
+            system_inc_paths,
+        }
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -770,6 +795,7 @@ impl CompletionProvider {
             );
         } else if context.in_use_statement && !context.prefix.starts_with('$') {
             // Module name completion after `use` or `require`
+            let _module_search_paths = (&self.include_paths, &self.system_inc_paths);
             workspace::add_use_module_completions(
                 &mut completions,
                 &context,
@@ -3375,6 +3401,65 @@ sub helper { }
             !completions.iter().any(|c| c.label == "OtherLib"),
             "use MyA should not suggest OtherLib"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_provider_carries_document_specific_inc_paths() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let code = "use MyA";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let include_paths = vec![PathBuf::from("/workspace/project/lib")];
+        let system_inc_paths = vec![PathBuf::from("/usr/lib/perl5")];
+
+        let provider = CompletionProvider::new_with_index_source_and_paths(
+            &ast,
+            code,
+            None,
+            include_paths.clone(),
+            system_inc_paths.clone(),
+        );
+
+        assert_eq!(provider.include_paths, include_paths);
+        assert_eq!(provider.system_inc_paths, system_inc_paths);
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_inc_paths_preserve_module_completion_behavior()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let index = Arc::new(WorkspaceIndex::new());
+        index.index_file(Url::parse("file:///lib/MyApp.pm")?, "package MyApp;\n1;\n".to_string())?;
+        index.index_file(
+            Url::parse("file:///lib/OtherLib.pm")?,
+            "package OtherLib;\n1;\n".to_string(),
+        )?;
+        let code = "use MyA";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+
+        let baseline_provider = CompletionProvider::new_with_index_and_source(
+            &ast,
+            code,
+            Some(Arc::clone(&index)),
+        );
+        let baseline = baseline_provider.get_completions(code, code.len());
+
+        let explicit_empty_provider = CompletionProvider::new_with_index_source_and_paths(
+            &ast,
+            code,
+            Some(index),
+            Vec::new(),
+            Vec::new(),
+        );
+        let with_empty_paths = explicit_empty_provider.get_completions(code, code.len());
+
+        let baseline_labels: Vec<(String, CompletionItemKind)> =
+            baseline.into_iter().map(|item| (item.label, item.kind)).collect();
+        let with_empty_labels: Vec<(String, CompletionItemKind)> =
+            with_empty_paths.into_iter().map(|item| (item.label, item.kind)).collect();
+        assert_eq!(baseline_labels, with_empty_labels);
         Ok(())
     }
 

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -315,6 +315,17 @@ impl LspServer {
 
             // Use routing to determine workspace index access mode
             let workspace_mode = route_index_access(self.coordinator());
+            let include_paths = self.include_paths_for_doc(uri);
+            let system_inc_paths = self
+                .config_for_doc(uri)
+                .map(|mut config| {
+                    if config.use_system_inc {
+                        config.get_system_inc().to_vec()
+                    } else {
+                        Vec::new()
+                    }
+                })
+                .unwrap_or_default();
 
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
@@ -332,15 +343,22 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
 
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
 
                     let mut base_completions =
                         provider.get_completions_with_path(&doc.text, offset, Some(uri));
@@ -544,6 +562,17 @@ impl LspServer {
 
             // Use routing to determine workspace index access mode
             let workspace_mode = route_index_access(self.coordinator());
+            let include_paths = self.include_paths_for_doc(uri);
+            let system_inc_paths = self
+                .config_for_doc(uri)
+                .map(|mut config| {
+                    if config.use_system_inc {
+                        config.get_system_inc().to_vec()
+                    } else {
+                        Vec::new()
+                    }
+                })
+                .unwrap_or_default();
 
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
@@ -574,14 +603,21 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
 
                     // Use cancellable provider method
                     provider.get_completions_with_path_cancellable(


### PR DESCRIPTION
### Motivation

- Module completion needs document-scoped include-path data and opt-in system `@INC` paths so future module lookup/scanning can use the effective search roots without changing global state.

### Description

- Extended `CompletionProvider` to carry `include_paths: Vec<PathBuf>` and `system_inc_paths: Vec<PathBuf>` and added a new constructor `new_with_index_source_and_paths(...)` that accepts those vectors while keeping existing constructors backward-compatible by defaulting to empty vectors.
- In runtime completion handlers (`handle_completion` and cancellable variant`) resolved per-document data using `include_paths_for_doc()` and `config_for_doc()` and only materialized system `@INC` via `get_system_inc()` when `use_system_inc` is enabled, then passed both vectors into the new provider constructor.
- Threaded the path fields through the module-completion call sites (plumbing only) and left scanning/dedupe/ranking logic out of scope.
- Added unit tests to validate the provider can be constructed with document-specific include/system paths and that behavior is unchanged when both vectors are empty.

### Testing

- Ran targeted unit tests: `cargo test -p perl-lsp-rs-core test_provider_carries_document_specific_inc_paths` succeeded and `cargo test -p perl-lsp-rs-core test_empty_inc_paths_preserve_module_completion_behavior` succeeded.
- Ran `cargo test -p perl-lsp-rs-core` where the newly added tests pass but one unrelated existing test (`test_perl_lsp_cargo_toml_removed_g1b_imports`) failed due to a pre-existing workspace path expectation; this failure is unrelated to the change.
- Ran `cargo check --workspace --all-targets` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadc163d388333ac10208b13515224)