### PR TITLE
refactor(completion): plumb effective @INC paths into module completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -122,6 +122,7 @@ use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
 use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_workspace::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Maps module_name -> Set of explicitly imported symbol names.
@@ -169,6 +170,8 @@ pub struct CompletionProvider {
     class_models: Vec<ClassModel>,
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
+    include_paths: Vec<PathBuf>,
+    system_inc_paths: Vec<PathBuf>,
     import_map: ImportMap,
 }
 
@@ -200,7 +203,7 @@ impl CompletionProvider {
     /// ```
     /// Arguments: `ast`, `workspace_index`.
     pub fn new_with_index(ast: &Node, workspace_index: Option<Arc<WorkspaceIndex>>) -> Self {
-        Self::new_with_index_and_source(ast, "", workspace_index)
+        Self::new_with_index_and_source_and_inc(ast, "", workspace_index, Vec::new(), Vec::new())
     }
 
     /// Create a new completion provider from parsed AST and source with workspace integration
@@ -249,6 +252,23 @@ impl CompletionProvider {
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
     ) -> Self {
+        Self::new_with_index_and_source_and_inc(
+            ast,
+            source,
+            workspace_index,
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+
+    /// Create a new completion provider with explicit include path context for module completion.
+    pub fn new_with_index_and_source_and_inc(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        include_paths: Vec<PathBuf>,
+        system_inc_paths: Vec<PathBuf>,
+    ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
         let type_engine = workspace_index.as_ref().map(|_| {
@@ -258,7 +278,15 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            include_paths,
+            system_inc_paths,
+            import_map,
+        }
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -810,7 +838,13 @@ impl CompletionProvider {
                 &self.workspace_index,
             );
         } else if context.prefix.starts_with('$') && context.prefix.contains("::") {
-            packages::add_package_completions(&mut completions, &context, &self.workspace_index);
+            packages::add_package_completions(
+                &mut completions,
+                &context,
+                &self.workspace_index,
+                &self.include_paths,
+                &self.system_inc_paths,
+            );
             if !completions.is_empty() {
                 return completions;
             }
@@ -837,7 +871,13 @@ impl CompletionProvider {
             }
             variables::add_special_variables(&mut completions, &context, "$");
         } else if context.prefix.starts_with('@') && context.prefix.contains("::") {
-            packages::add_package_completions(&mut completions, &context, &self.workspace_index);
+            packages::add_package_completions(
+                &mut completions,
+                &context,
+                &self.workspace_index,
+                &self.include_paths,
+                &self.system_inc_paths,
+            );
             if !completions.is_empty() {
                 return completions;
             }
@@ -864,7 +904,13 @@ impl CompletionProvider {
             }
             variables::add_special_variables(&mut completions, &context, "@");
         } else if context.prefix.starts_with('%') && context.prefix.contains("::") {
-            packages::add_package_completions(&mut completions, &context, &self.workspace_index);
+            packages::add_package_completions(
+                &mut completions,
+                &context,
+                &self.workspace_index,
+                &self.include_paths,
+                &self.system_inc_paths,
+            );
             if !completions.is_empty() {
                 return completions;
             }
@@ -895,7 +941,13 @@ impl CompletionProvider {
             functions::add_function_completions(&mut completions, &context, &self.symbol_table);
         } else if context.trigger_character == Some(':') && context.prefix.ends_with("::") {
             // Package member completion
-            packages::add_package_completions(&mut completions, &context, &self.workspace_index);
+            packages::add_package_completions(
+                &mut completions,
+                &context,
+                &self.workspace_index,
+                &self.include_paths,
+                &self.system_inc_paths,
+            );
         } else if context.in_string {
             // String interpolation or file path
             let line_prefix = &source[..context.position];
@@ -2147,8 +2199,60 @@ mod tests {
     use perl_parser_core::Parser;
     use perl_tdd_support::{must, must_some};
     use perl_workspace::workspace_index::WorkspaceIndex;
+    use std::path::PathBuf;
     use std::sync::Arc;
     use url::Url;
+
+    #[test]
+    fn test_provider_stores_explicit_include_path_context() {
+        let code = "use Foo::Bar;";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+
+        let include_paths = vec![PathBuf::from("lib"), PathBuf::from("vendor/lib")];
+        let system_inc_paths = vec![PathBuf::from("/usr/lib/perl5")];
+
+        let provider = CompletionProvider::new_with_index_and_source_and_inc(
+            &ast,
+            code,
+            None,
+            include_paths.clone(),
+            system_inc_paths.clone(),
+        );
+
+        assert_eq!(provider.include_paths, include_paths);
+        assert_eq!(provider.system_inc_paths, system_inc_paths);
+    }
+
+    #[test]
+    fn test_explicit_empty_inc_context_keeps_completion_behavior() {
+        let code = "use ";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let position = code.len();
+
+        let baseline_provider = CompletionProvider::new_with_index_and_source(&ast, code, None);
+        let explicit_empty_provider = CompletionProvider::new_with_index_and_source_and_inc(
+            &ast,
+            code,
+            None,
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let baseline_labels: Vec<String> = baseline_provider
+            .get_completions(code, position)
+            .into_iter()
+            .map(|item| item.label)
+            .collect();
+        let explicit_labels: Vec<String> = explicit_empty_provider
+            .get_completions(code, position)
+            .into_iter()
+            .map(|item| item.label)
+            .collect();
+
+        assert_eq!(baseline_labels, explicit_labels);
+    }
 
     #[test]
     fn test_variable_completion() {

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/packages.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/packages.rs
@@ -10,6 +10,7 @@ use perl_workspace::workspace_index::{
     SymbolKind as WsSymbolKind, WorkspaceIndex, WorkspaceSymbol,
 };
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 fn known_core_module_members(package_name: &str) -> &'static [(&'static str, &'static str)] {
@@ -209,6 +210,8 @@ pub fn add_package_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
+    _include_paths: &[PathBuf],
+    _system_inc_paths: &[PathBuf],
 ) {
     // Split the prefix into package name and member prefix
     let (requested_sigil, prefix_body) = split_sigil(&context.prefix);

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -22,6 +22,7 @@ use perl_lexer::LSP_RUNTIME_COMPLETION_KEYWORDS;
 use perl_parser::type_inference::TypeInferenceEngine;
 use regex::Regex;
 use serde_json::{Value, json};
+use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 
@@ -56,6 +57,23 @@ fn commit_chars_for_kind(kind: CompletionItemKind) -> Option<&'static [&'static 
 }
 
 impl LspServer {
+    fn completion_inc_paths_for_doc(&self, uri: &str) -> (Vec<PathBuf>, Vec<PathBuf>) {
+        let mut config =
+            self.config_for_doc(uri).unwrap_or_else(|| self.workspace_config.lock().clone());
+        let perl5lib_paths = std::env::var("PERL5LIB")
+            .map(|v| perl_lsp_rs_core::config::WorkspaceConfig::parse_perl5lib(&v))
+            .unwrap_or_default();
+        let include_paths = config
+            .effective_include_paths(&perl5lib_paths)
+            .into_iter()
+            .map(PathBuf::from)
+            .collect();
+        let system_inc_paths =
+            if config.use_system_inc { config.get_system_inc().to_vec() } else { Vec::new() };
+
+        (include_paths, system_inc_paths)
+    }
+
     fn split_sigil(name: &str) -> (Option<char>, &str) {
         let mut chars = name.chars();
         match chars.next() {
@@ -323,6 +341,7 @@ impl LspServer {
                 // Get completions, with fallback for missing AST
                 #[cfg_attr(not(feature = "workspace"), allow(unused_mut))]
                 let mut completions = if let Some(ast) = &doc.ast {
+                    let (include_paths, system_inc_paths) = self.completion_inc_paths_for_doc(uri);
                     // Only provide workspace index when Full access is available
                     // This ensures we don't bypass routing policy
                     #[cfg(feature = "workspace")]
@@ -331,16 +350,16 @@ impl LspServer {
                         _ => None,
                     };
 
-                    #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    #[cfg(not(feature = "workspace"))]
+                    let workspace_idx = None;
+
+                    let provider = CompletionProvider::new_with_index_and_source_and_inc(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths,
+                        system_inc_paths,
                     );
-
-                    #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
 
                     let mut base_completions =
                         provider.get_completions_with_path(&doc.text, offset, Some(uri));
@@ -565,6 +584,7 @@ impl LspServer {
 
                 // Get completions with optimized cancellation support
                 let mut completions = if let Some(ast) = &doc.ast {
+                    let (include_paths, system_inc_paths) = self.completion_inc_paths_for_doc(uri);
                     // Only provide workspace index when Full access is available
                     // This ensures we don't bypass routing policy
                     #[cfg(feature = "workspace")]
@@ -573,15 +593,16 @@ impl LspServer {
                         _ => None,
                     };
 
-                    #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    #[cfg(not(feature = "workspace"))]
+                    let workspace_idx = None;
+
+                    let provider = CompletionProvider::new_with_index_and_source_and_inc(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths,
+                        system_inc_paths,
                     );
-                    #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
 
                     // Use cancellable provider method
                     provider.get_completions_with_path_cancellable(


### PR DESCRIPTION
### Motivation

- Module completion needs document-scoped include-path context and opt-in system `@INC` to implement phase 1 plumbing for #4314 without adding directory scanning yet.

### Description

- Add `include_paths: Vec<PathBuf>` and `system_inc_paths: Vec<PathBuf>` to `CompletionProvider` and introduce `new_with_index_and_source_and_inc(...)` while preserving existing constructors by defaulting to empty vectors.
- Compute per-document effective include paths (workspace config + `PERL5LIB`) and system `@INC` only when `use_system_inc` is enabled in the runtime completion handler and return them as `(include_paths, system_inc_paths)` tuples. 
- Thread those vectors into `CompletionProvider` construction for both normal and cancellable completion paths in the LSP runtime (`crates/perl-lsp-rs/src/runtime/language/completion.rs`).
- Extend package-member completion call sites to accept include/system paths and pass the provider-held vectors through to `packages::add_package_completions(...)` without implementing any filesystem scanning or resolution changes.

### Testing

- Ran `cargo test -p perl-lsp-rs-core test_provider_stores_explicit_include_path_context` and it passed.
- Ran `cargo test -p perl-lsp-rs-core test_explicit_empty_inc_context_keeps_completion_behavior` and it passed.
- Ran `cargo check --workspace --all-targets` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadc163d388333ac10208b13515224)