### PR TITLE
refactor(completion): plumb effective @INC paths into module completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -122,6 +122,7 @@ use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
 use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_workspace::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Maps module_name -> Set of explicitly imported symbol names.
@@ -170,6 +171,8 @@ pub struct CompletionProvider {
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
     import_map: ImportMap,
+    include_paths: Vec<PathBuf>,
+    system_inc_paths: Vec<PathBuf>,
 }
 
 impl CompletionProvider {
@@ -249,6 +252,17 @@ impl CompletionProvider {
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
     ) -> Self {
+        Self::new_with_index_source_and_paths(ast, source, workspace_index, Vec::new(), Vec::new())
+    }
+
+    /// Create a completion provider with explicit include paths for module completion plumbing.
+    pub fn new_with_index_source_and_paths(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        include_paths: Vec<PathBuf>,
+        system_inc_paths: Vec<PathBuf>,
+    ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
         let type_engine = workspace_index.as_ref().map(|_| {
@@ -258,7 +272,27 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            import_map,
+            include_paths,
+            system_inc_paths,
+        }
+    }
+
+    /// Include paths effective for the current document.
+    #[must_use]
+    pub fn include_paths(&self) -> &[PathBuf] {
+        &self.include_paths
+    }
+
+    /// System @INC paths attached to this provider.
+    #[must_use]
+    pub fn system_inc_paths(&self) -> &[PathBuf] {
+        &self.system_inc_paths
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -4038,5 +4072,54 @@ sub run {
             "keys from %%other must not leak into %%config completions; got: {:?}",
             completions.iter().map(|c| (&c.label, &c.kind)).collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn test_completion_provider_carries_include_and_system_paths() {
+        let code = "use My::Module;\n";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let include_paths = vec![std::path::PathBuf::from("/workspace/lib")];
+        let system_inc_paths = vec![std::path::PathBuf::from("/usr/lib/perl5")];
+
+        let provider = CompletionProvider::new_with_index_source_and_paths(
+            &ast,
+            code,
+            None,
+            include_paths.clone(),
+            system_inc_paths.clone(),
+        );
+
+        assert_eq!(provider.include_paths(), include_paths);
+        assert_eq!(provider.system_inc_paths(), system_inc_paths);
+    }
+
+    #[test]
+    fn test_completion_behavior_unchanged_with_empty_inc_vectors() {
+        let code = "use ";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let index = Arc::new(WorkspaceIndex::new());
+        must(index.index_file(
+            must(Url::parse("file:///lib/MyApp.pm")),
+            "package MyApp;\n1;\n".to_string(),
+        ));
+
+        let baseline =
+            CompletionProvider::new_with_index_and_source(&ast, code, Some(index.clone()));
+        let plumbed = CompletionProvider::new_with_index_source_and_paths(
+            &ast,
+            code,
+            Some(index),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let baseline_labels: std::collections::BTreeSet<String> =
+            baseline.get_completions(code, code.len()).into_iter().map(|item| item.label).collect();
+        let plumbed_labels: std::collections::BTreeSet<String> =
+            plumbed.get_completions(code, code.len()).into_iter().map(|item| item.label).collect();
+
+        assert_eq!(baseline_labels, plumbed_labels);
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -319,6 +319,12 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let mut doc_config = self.config_for_doc(uri);
+                let include_paths = self.include_paths_for_doc(uri);
+                let system_inc_paths = doc_config
+                    .as_mut()
+                    .filter(|config| config.use_system_inc)
+                    .map_or_else(Vec::new, |config| config.get_system_inc().to_vec());
 
                 // Get completions, with fallback for missing AST
                 #[cfg_attr(not(feature = "workspace"), allow(unused_mut))]
@@ -332,15 +338,22 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
 
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
 
                     let mut base_completions =
                         provider.get_completions_with_path(&doc.text, offset, Some(uri));
@@ -548,6 +561,12 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let mut doc_config = self.config_for_doc(uri);
+                let include_paths = self.include_paths_for_doc(uri);
+                let system_inc_paths = doc_config
+                    .as_mut()
+                    .filter(|config| config.use_system_inc)
+                    .map_or_else(Vec::new, |config| config.get_system_inc().to_vec());
 
                 // Create optimized cancellation callback with reduced frequency
                 // Performance optimization: reduced overhead from 16.66% to <10%
@@ -574,14 +593,21 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
 
                     // Use cancellable provider method
                     provider.get_completions_with_path_cancellable(


### PR DESCRIPTION
### Motivation
- Module completion needed document-scoped include path and opt-in system `@INC` plumbing to enable follow-on module-scanning work for issue `#4314` (phase 1). 

### Description
- Thread document workspace config and effective include paths into the runtime completion handlers and only fetch system `@INC` when `use_system_inc` is enabled in the workspace config (`crates/perl-lsp-rs/src/runtime/language/completion.rs`).
- Extend `CompletionProvider` to carry `include_paths: Vec<PathBuf>` and `system_inc_paths: Vec<PathBuf>` and add `new_with_index_source_and_paths` while keeping `new_with_index_and_source` backward-compatible (`crates/perl-lsp-rs-core/src/providers/completion/completion.rs`).
- Pass the collected include/system path vectors into the provider on both normal and cancellable completion paths and expose accessors `include_paths()` and `system_inc_paths()` for tests/consumers.
- Add focused tests proving the provider can be constructed with document-specific include/system paths and that behavior is unchanged when those vectors are empty (`CompletionProvider` unit tests in `crates/perl-lsp-rs-core`).

### Testing
- Ran `cargo xtask fmt` (format) — succeeded.
- Ran `cargo test -p perl-lsp-rs-core test_completion_provider_carries_include_and_system_paths` — passed.
- Ran `cargo test -p perl-lsp-rs-core test_completion_behavior_unchanged_with_empty_inc_vectors` — passed.
- Ran `cargo test -p perl-lsp-completion` — failed because the package name is not present in this workspace (no change to behavior expected).
- Ran `cargo check --workspace --all-targets` — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadc163d388333ac10208b13515224)