### PR TITLE
refactor(completion): plumb effective @INC paths into module completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -122,6 +122,7 @@ use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
 use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_workspace::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Maps module_name -> Set of explicitly imported symbol names.
@@ -170,6 +171,8 @@ pub struct CompletionProvider {
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
     import_map: ImportMap,
+    include_paths: Vec<PathBuf>,
+    system_inc_paths: Vec<PathBuf>,
 }
 
 impl CompletionProvider {
@@ -249,6 +252,26 @@ impl CompletionProvider {
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
     ) -> Self {
+        Self::new_with_index_and_source_and_inc(
+            ast,
+            source,
+            workspace_index,
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+
+    /// Create a completion provider with workspace index and effective @INC path plumbing.
+    ///
+    /// This constructor is used by the runtime layer to pass document-scoped include roots.
+    /// The paths are intentionally stored without scanning in this phase.
+    pub fn new_with_index_and_source_and_inc(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        include_paths: Vec<PathBuf>,
+        system_inc_paths: Vec<PathBuf>,
+    ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
         let type_engine = workspace_index.as_ref().map(|_| {
@@ -258,7 +281,15 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            import_map,
+            include_paths,
+            system_inc_paths,
+        }
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -774,6 +805,8 @@ impl CompletionProvider {
                 &mut completions,
                 &context,
                 &self.workspace_index,
+                &self.include_paths,
+                &self.system_inc_paths,
             );
         } else if self.is_has_type_value_context(source, position) {
             self.add_has_type_completions(&mut completions, &context);
@@ -2147,8 +2180,43 @@ mod tests {
     use perl_parser_core::Parser;
     use perl_tdd_support::{must, must_some};
     use perl_workspace::workspace_index::WorkspaceIndex;
+    use std::path::PathBuf;
     use std::sync::Arc;
     use url::Url;
+
+    #[test]
+    fn test_provider_stores_doc_specific_inc_paths() {
+        let code = "use strict;";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+
+        let include_paths =
+            vec![PathBuf::from("/workspace/project/lib"), PathBuf::from("local/lib/perl5")];
+        let system_inc_paths = vec![PathBuf::from("/usr/lib/perl5")];
+
+        let provider = CompletionProvider::new_with_index_and_source_and_inc(
+            &ast,
+            code,
+            None,
+            include_paths.clone(),
+            system_inc_paths.clone(),
+        );
+
+        assert_eq!(provider.include_paths, include_paths);
+        assert_eq!(provider.system_inc_paths, system_inc_paths);
+    }
+
+    #[test]
+    fn test_provider_defaults_to_empty_inc_paths() {
+        let code = "my $value = 1;";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+
+        let provider = CompletionProvider::new_with_index_and_source(&ast, code, None);
+
+        assert!(provider.include_paths.is_empty());
+        assert!(provider.system_inc_paths.is_empty());
+    }
 
     #[test]
     fn test_variable_completion() {

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -14,6 +14,7 @@ use perl_workspace::workspace_index::{
     SymbolKind as WsSymbolKind, VarKind, WorkspaceIndex, WorkspaceSymbol,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Add workspace symbol completions for functions and variables
@@ -240,7 +241,10 @@ pub fn add_use_module_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
+    include_paths: &[PathBuf],
+    system_inc_paths: &[PathBuf],
 ) {
+    let _ = (include_paths, system_inc_paths);
     let Some(index) = workspace_index else {
         return;
     };

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -319,6 +319,17 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let include_paths = self.include_paths_for_doc(uri);
+                let system_inc_paths = self
+                    .config_for_doc(uri)
+                    .map(|mut config| {
+                        if config.use_system_inc {
+                            config.get_system_inc().to_vec()
+                        } else {
+                            Vec::new()
+                        }
+                    })
+                    .unwrap_or_default();
 
                 // Get completions, with fallback for missing AST
                 #[cfg_attr(not(feature = "workspace"), allow(unused_mut))]
@@ -332,15 +343,22 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_and_source_and_inc(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
 
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_and_source_and_inc(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
 
                     let mut base_completions =
                         provider.get_completions_with_path(&doc.text, offset, Some(uri));
@@ -548,6 +566,17 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let include_paths = self.include_paths_for_doc(uri);
+                let system_inc_paths = self
+                    .config_for_doc(uri)
+                    .map(|mut config| {
+                        if config.use_system_inc {
+                            config.get_system_inc().to_vec()
+                        } else {
+                            Vec::new()
+                        }
+                    })
+                    .unwrap_or_default();
 
                 // Create optimized cancellation callback with reduced frequency
                 // Performance optimization: reduced overhead from 16.66% to <10%
@@ -574,14 +603,21 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_and_source_and_inc(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_and_source_and_inc(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
 
                     // Use cancellable provider method
                     provider.get_completions_with_path_cancellable(


### PR DESCRIPTION
### Motivation
- Provide document-specific include-path data and optional system @INC into module-name completion plumbing so future module-scanning/ranking can use accurate search roots.
- Only probe system `@INC` when the workspace config opt-in (`use_system_inc`) is enabled to avoid unnecessary probing/costs.

### Description
- Added `include_paths: Vec<PathBuf>` and `system_inc_paths: Vec<PathBuf>` fields to `CompletionProvider` and a new constructor `new_with_index_and_source_and_inc(...)` to accept plumbing vectors while keeping existing constructors defaulting to empty vectors.
- Runtime completion handlers now call `include_paths_for_doc(uri)` and `config_for_doc(uri)` and only call `get_system_inc()` when `use_system_inc` is true, then pass both vectors into the provider constructor for both cancellable and non-cancellable flows.
- Threaded the new path vectors into the module completion call site by extending `add_use_module_completions` to accept `include_paths` and `system_inc_paths` (currently unused inside; plumbing only in this phase).
- Added unit tests asserting the provider stores doc-specific include/system paths and that legacy constructors default to empty vectors, without changing existing completion behavior when vectors are empty.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Attempted `cargo test -p perl-lsp-completion` but the package name does not exist in this repo layout (no tests run for that package name).
- Ran unit tests: `cargo test -p perl-lsp-rs-core test_provider_stores_doc_specific_inc_paths` and `cargo test -p perl-lsp-rs-core test_provider_defaults_to_empty_inc_paths`, both passed.
- Ran `cargo test -p perl-lsp-rs-core` which exercised the crate test-suite; one unrelated existing test (`test_perl_lsp_cargo_toml_removed_g1b_imports`) failed due to an expected-missing path outside the scope of this change.
- Ran `cargo check --workspace --all-targets` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadc163d388333ac10208b13515224)