### PR TITLE
feat(completion): include external @INC modules in use/require completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -122,6 +122,7 @@ use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
 use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_workspace::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Maps module_name -> Set of explicitly imported symbol names.
@@ -169,6 +170,8 @@ pub struct CompletionProvider {
     class_models: Vec<ClassModel>,
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
+    include_paths: Vec<PathBuf>,
+    system_inc_paths: Vec<PathBuf>,
     import_map: ImportMap,
 }
 
@@ -200,7 +203,13 @@ impl CompletionProvider {
     /// ```
     /// Arguments: `ast`, `workspace_index`.
     pub fn new_with_index(ast: &Node, workspace_index: Option<Arc<WorkspaceIndex>>) -> Self {
-        Self::new_with_index_and_source(ast, "", workspace_index)
+        Self::new_with_index_and_source_and_module_paths(
+            ast,
+            "",
+            workspace_index,
+            Vec::new(),
+            Vec::new(),
+        )
     }
 
     /// Create a new completion provider from parsed AST and source with workspace integration
@@ -249,6 +258,26 @@ impl CompletionProvider {
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
     ) -> Self {
+        Self::new_with_index_and_source_and_module_paths(
+            ast,
+            source,
+            workspace_index,
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+
+    /// Create a completion provider with explicit external module roots for `use`/`require`.
+    ///
+    /// `include_paths` should contain configured/effective include roots (e.g. project include paths
+    /// and PERL5LIB-derived paths). `system_inc_paths` should contain optional system @INC roots.
+    pub fn new_with_index_and_source_and_module_paths(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        include_paths: Vec<PathBuf>,
+        system_inc_paths: Vec<PathBuf>,
+    ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
         let type_engine = workspace_index.as_ref().map(|_| {
@@ -258,7 +287,15 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            include_paths,
+            system_inc_paths,
+            import_map,
+        }
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -774,6 +811,8 @@ impl CompletionProvider {
                 &mut completions,
                 &context,
                 &self.workspace_index,
+                &self.include_paths,
+                &self.system_inc_paths,
             );
         } else if self.is_has_type_value_context(source, position) {
             self.add_has_type_completions(&mut completions, &context);
@@ -2147,6 +2186,8 @@ mod tests {
     use perl_parser_core::Parser;
     use perl_tdd_support::{must, must_some};
     use perl_workspace::workspace_index::WorkspaceIndex;
+    use std::fs;
+    use std::path::PathBuf;
     use std::sync::Arc;
     use url::Url;
 
@@ -3556,6 +3597,104 @@ sub helper { }
         assert_eq!(
             myapp_count, 1,
             "Duplicate package declarations should produce exactly one completion"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_use_statement_scans_include_paths() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let include_root = temp.path().join("external_lib");
+        fs::create_dir_all(include_root.join("DB"))?;
+        fs::write(include_root.join("DB").join("Driver.pm"), "package DB::Driver;\n1;\n")?;
+
+        let code = "use DB";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index_and_source_and_module_paths(
+            &ast,
+            code,
+            None,
+            vec![include_root],
+            Vec::new(),
+        );
+        let completions = provider.get_completions(code, code.len());
+        assert!(completions.iter().any(|c| c.label == "DB::Driver"));
+        assert!(
+            completions
+                .iter()
+                .any(|c| c.label == "DB::Driver" && c.detail.as_deref() == Some("external module"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_use_statement_workspace_precedence_over_external()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let include_root = temp.path().join("external_lib");
+        fs::create_dir_all(include_root.join("MyApp"))?;
+        fs::write(include_root.join("MyApp").join("Utils.pm"), "package MyApp::Utils;\n1;\n")?;
+
+        let index = Arc::new(WorkspaceIndex::new());
+        index.index_file(
+            Url::parse("file:///workspace/lib/MyApp/Utils.pm")?,
+            "package MyApp::Utils;\n1;\n".to_string(),
+        )?;
+
+        let code = "use MyApp::U";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index_and_source_and_module_paths(
+            &ast,
+            code,
+            Some(index),
+            vec![include_root],
+            Vec::new(),
+        );
+        let completions = provider.get_completions(code, code.len());
+        let matches: Vec<&CompletionItem> =
+            completions.iter().filter(|item| item.label == "MyApp::Utils").collect();
+        assert_eq!(matches.len(), 1, "workspace + external should be deduplicated");
+        assert_eq!(matches[0].detail.as_deref(), Some("module"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_use_statement_system_inc_opt_in() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let system_root = temp.path().join("system_inc");
+        fs::create_dir_all(system_root.join("DB"))?;
+        fs::write(system_root.join("DB").join("Sys.pm"), "package DB::Sys;\n1;\n")?;
+
+        let code = "use DB::S";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+
+        let provider_without_system =
+            CompletionProvider::new_with_index_and_source_and_module_paths(
+                &ast,
+                code,
+                None,
+                Vec::new(),
+                Vec::new(),
+            );
+        let without = provider_without_system.get_completions(code, code.len());
+        assert!(!without.iter().any(|item| item.label == "DB::Sys"));
+
+        let provider_with_system = CompletionProvider::new_with_index_and_source_and_module_paths(
+            &ast,
+            code,
+            None,
+            Vec::new(),
+            vec![PathBuf::from(system_root)],
+        );
+        let with_system = provider_with_system.get_completions(code, code.len());
+        assert!(
+            with_system
+                .iter()
+                .any(|item| item.label == "DB::Sys"
+                    && item.detail.as_deref() == Some("system module"))
         );
         Ok(())
     }

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -14,7 +14,9 @@ use perl_workspace::workspace_index::{
     SymbolKind as WsSymbolKind, VarKind, WorkspaceIndex, WorkspaceSymbol,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use walkdir::WalkDir;
 
 /// Add workspace symbol completions for functions and variables
 ///
@@ -240,54 +242,177 @@ pub fn add_use_module_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
+    include_paths: &[PathBuf],
+    system_inc_paths: &[PathBuf],
 ) {
-    let Some(index) = workspace_index else {
-        return;
-    };
-
-    if !index.has_symbols() {
-        return;
-    }
-
     let mut seen: HashSet<String> = HashSet::new();
 
-    // Search for package symbols matching the prefix
-    let all_symbols = if context.prefix.is_empty() {
-        index.all_symbols()
-    } else {
-        index.find_symbols(&context.prefix)
-    };
+    if let Some(index) = workspace_index
+        && index.has_symbols()
+    {
+        let all_symbols = if context.prefix.is_empty() {
+            index.all_symbols()
+        } else {
+            index.find_symbols(&context.prefix)
+        };
 
-    for symbol in all_symbols {
-        if symbol.kind != WsSymbolKind::Package {
+        for symbol in all_symbols {
+            if symbol.kind != WsSymbolKind::Package {
+                continue;
+            }
+            if !context.prefix.is_empty() && !symbol.name.starts_with(&context.prefix) {
+                continue;
+            }
+            if !seen.insert(symbol.name.clone()) {
+                continue;
+            }
+
+            let name = &symbol.name;
+            completions.push(CompletionItem {
+                label: name.clone(),
+                kind: CompletionItemKind::Module,
+                detail: Some("module".to_string()),
+                documentation: symbol
+                    .documentation
+                    .clone()
+                    .or_else(|| Some(format!("Package `{name}`"))),
+                insert_text: Some(name.clone()),
+                sort_text: Some(format!("1{}_{name}", module_sort_tier(name))),
+                filter_text: Some(name.clone()),
+                additional_edits: vec![],
+                text_edit_range: Some((context.prefix_start, context.position)),
+                commit_characters: None,
+            });
+        }
+    }
+
+    for module_name in scan_directory_for_modules(include_paths) {
+        if !context.prefix.is_empty() && !module_name.starts_with(&context.prefix) {
+            continue;
+        }
+        if !seen.insert(module_name.clone()) {
             continue;
         }
 
-        // Match against the module name prefix
-        if !context.prefix.is_empty() && !symbol.name.starts_with(&context.prefix) {
-            continue;
-        }
-
-        if !seen.insert(symbol.name.clone()) {
-            continue;
-        }
-
-        let name = &symbol.name;
         completions.push(CompletionItem {
-            label: name.clone(),
+            label: module_name.clone(),
             kind: CompletionItemKind::Module,
-            detail: Some("module".to_string()),
-            documentation: symbol
-                .documentation
-                .clone()
-                .or_else(|| Some(format!("Package `{name}`"))),
-            insert_text: Some(name.clone()),
-            sort_text: Some(format!("1{}_{name}", module_sort_tier(name))),
-            filter_text: Some(name.clone()),
+            detail: Some("external module".to_string()),
+            documentation: Some(format!("Discovered in include paths: `{module_name}`")),
+            insert_text: Some(module_name.clone()),
+            sort_text: Some(format!("2{}_{module_name}", module_sort_tier(&module_name))),
+            filter_text: Some(module_name),
             additional_edits: vec![],
             text_edit_range: Some((context.prefix_start, context.position)),
             commit_characters: None,
         });
+    }
+
+    for module_name in scan_directory_for_modules(system_inc_paths) {
+        if !context.prefix.is_empty() && !module_name.starts_with(&context.prefix) {
+            continue;
+        }
+        if !seen.insert(module_name.clone()) {
+            continue;
+        }
+
+        completions.push(CompletionItem {
+            label: module_name.clone(),
+            kind: CompletionItemKind::Module,
+            detail: Some("system module".to_string()),
+            documentation: Some(format!("Discovered in system @INC: `{module_name}`")),
+            insert_text: Some(module_name.clone()),
+            sort_text: Some(format!("3{}_{module_name}", module_sort_tier(&module_name))),
+            filter_text: Some(module_name),
+            additional_edits: vec![],
+            text_edit_range: Some((context.prefix_start, context.position)),
+            commit_characters: None,
+        });
+    }
+}
+
+const MODULE_SCAN_MAX_DEPTH: usize = 20;
+const MODULE_SCAN_MAX_FILES: usize = 20_000;
+
+fn scan_directory_for_modules(roots: &[PathBuf]) -> Vec<String> {
+    let mut modules: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut scanned_files = 0usize;
+
+    for root in roots {
+        if scanned_files >= MODULE_SCAN_MAX_FILES {
+            break;
+        }
+        if !root.is_dir() {
+            continue;
+        }
+
+        for entry in WalkDir::new(root)
+            .max_depth(MODULE_SCAN_MAX_DEPTH)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(Result::ok)
+        {
+            if scanned_files >= MODULE_SCAN_MAX_FILES {
+                break;
+            }
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            scanned_files += 1;
+            if let Some(module_name) = path_to_module_name(root, entry.path())
+                && seen.insert(module_name.clone())
+            {
+                modules.push(module_name);
+            }
+        }
+    }
+
+    modules
+}
+
+fn path_to_module_name(root: &Path, path: &Path) -> Option<String> {
+    if path.extension().and_then(std::ffi::OsStr::to_str) != Some("pm") {
+        return None;
+    }
+
+    let rel_path = path.strip_prefix(root).ok()?;
+    let mut module_name = rel_path.to_str()?.replace(['/', '\\'], "::");
+    module_name.truncate(module_name.len().saturating_sub(3));
+
+    if module_name.is_empty() || module_name.contains("..") {
+        return None;
+    }
+
+    Some(module_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{path_to_module_name, scan_directory_for_modules};
+    use std::fs;
+
+    #[test]
+    fn path_to_module_name_maps_pm_path() -> Result<(), Box<dyn std::error::Error>> {
+        let root = std::path::PathBuf::from("/tmp/lib");
+        let module = std::path::PathBuf::from("/tmp/lib/File/Path/To/Module.pm");
+        let mapped = path_to_module_name(&root, &module);
+        assert_eq!(mapped.as_deref(), Some("File::Path::To::Module"));
+        Ok(())
+    }
+
+    #[test]
+    fn scan_directory_for_modules_finds_pm_files() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().join("lib");
+        fs::create_dir_all(root.join("DB"))?;
+        fs::write(root.join("DB").join("Driver.pm"), "package DB::Driver;\n1;\n")?;
+        fs::write(root.join("README.txt"), "not a module\n")?;
+
+        let modules = scan_directory_for_modules(&[root]);
+        assert!(modules.iter().any(|module| module == "DB::Driver"));
+        assert!(!modules.iter().any(|module| module == "README"));
+        Ok(())
     }
 }
 

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -22,6 +22,7 @@ use perl_lexer::LSP_RUNTIME_COMPLETION_KEYWORDS;
 use perl_parser::type_inference::TypeInferenceEngine;
 use regex::Regex;
 use serde_json::{Value, json};
+use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 
@@ -295,6 +296,36 @@ impl LspServer {
         }
     }
 
+    fn module_completion_paths_for_doc(&self, doc_uri: &str) -> (Vec<PathBuf>, Vec<PathBuf>) {
+        let Some(folder) = self.folder_for_doc_uri(doc_uri) else {
+            return (Vec::new(), Vec::new());
+        };
+
+        let mut config = folder.effective_workspace_config.clone();
+        let perl5lib_paths = std::env::var("PERL5LIB")
+            .map(|value| perl_lsp_rs_core::config::WorkspaceConfig::parse_perl5lib(&value))
+            .unwrap_or_default();
+
+        let mut include_paths: Vec<PathBuf> = Vec::new();
+        for include_path in config.effective_include_paths(&perl5lib_paths) {
+            let path = PathBuf::from(include_path);
+            let resolved = if path.is_absolute() {
+                path
+            } else if let Some(root_path) = folder.path.as_ref() {
+                root_path.join(path)
+            } else {
+                path
+            };
+            if !include_paths.iter().any(|existing| existing == &resolved) {
+                include_paths.push(resolved);
+            }
+        }
+
+        let system_inc_paths =
+            if config.use_system_inc { config.get_system_inc().to_vec() } else { Vec::new() };
+        (include_paths, system_inc_paths)
+    }
+
     /// Handle completion request
     pub(crate) fn handle_completion(
         &self,
@@ -323,6 +354,8 @@ impl LspServer {
                 // Get completions, with fallback for missing AST
                 #[cfg_attr(not(feature = "workspace"), allow(unused_mut))]
                 let mut completions = if let Some(ast) = &doc.ast {
+                    let (include_paths, system_inc_paths) =
+                        self.module_completion_paths_for_doc(uri);
                     // Only provide workspace index when Full access is available
                     // This ensures we don't bypass routing policy
                     #[cfg(feature = "workspace")]
@@ -332,15 +365,22 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_and_source_and_module_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths,
+                        system_inc_paths,
                     );
 
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_and_source_and_module_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths,
+                        system_inc_paths,
+                    );
 
                     let mut base_completions =
                         provider.get_completions_with_path(&doc.text, offset, Some(uri));
@@ -565,6 +605,8 @@ impl LspServer {
 
                 // Get completions with optimized cancellation support
                 let mut completions = if let Some(ast) = &doc.ast {
+                    let (include_paths, system_inc_paths) =
+                        self.module_completion_paths_for_doc(uri);
                     // Only provide workspace index when Full access is available
                     // This ensures we don't bypass routing policy
                     #[cfg(feature = "workspace")]
@@ -574,14 +616,21 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_and_source_and_module_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths,
+                        system_inc_paths,
                     );
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_and_source_and_module_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths,
+                        system_inc_paths,
+                    );
 
                     // Use cancellable provider method
                     provider.get_completions_with_path_cancellable(


### PR DESCRIPTION
### Motivation

- `use`/`require` completion only surfaced packages indexed in the workspace, omitting modules available on configured include roots, PERL5LIB-derived roots, and optional system `@INC` paths.

### Description

- Plumb `include_paths` and `system_inc_paths` into `CompletionProvider` and add a new constructor `new_with_index_and_source_and_module_paths(...)` to carry module discovery roots.
- Extend `add_use_module_completions()` to merge workspace-index package completions with on-disk `.pm` discovery from configured include roots and optional system `@INC`, deduping by module name with workspace-first precedence and marking external/system modules in the `detail` field.
- Add bounded filesystem scanners `scan_directory_for_modules(...)` and `path_to_module_name(...)` (normalized mapping `lib/File/Path/To/Module.pm` → `File::Path::To::Module`) with conservative limits to avoid unbounded work per keystroke.
- Wire runtime to compute effective include roots (merge of workspace `include_paths` and `PERL5LIB`, resolve relative paths against workspace folder) and pass both include+system roots into the completion provider in normal and cancellable code paths.

### Testing

- Ran targeted unit tests: `cargo test -p perl-lsp-rs-core use_statement_scans_include_paths` — passed. 
- Additional unit verifications: `cargo test -p perl-lsp-rs-core use_statement_workspace_precedence_over_external`, `cargo test -p perl-lsp-rs-core system_inc_opt_in`, and `cargo test -p perl-lsp-rs-core path_to_module_name_maps_pm_path` — all passed. 
- Performed full workspace typecheck with `cargo check --workspace --all-targets` — passed. 
- Note: `just pr-fast` was unavailable in the environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadc2203f08333afa73792c4459227)