### PR TITLE
feat(completion): include external @INC modules in use/require completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -122,6 +122,7 @@ use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
 use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_workspace::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Maps module_name -> Set of explicitly imported symbol names.
@@ -170,6 +171,8 @@ pub struct CompletionProvider {
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
     import_map: ImportMap,
+    module_include_paths: Vec<PathBuf>,
+    module_system_inc_paths: Vec<PathBuf>,
 }
 
 impl CompletionProvider {
@@ -258,7 +261,27 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            import_map,
+            module_include_paths: Vec::new(),
+            module_system_inc_paths: Vec::new(),
+        }
+    }
+
+    /// Configure external roots used for `use` / `require` module completion.
+    #[must_use]
+    pub fn with_module_search_paths(
+        mut self,
+        include_paths: Vec<PathBuf>,
+        system_inc_paths: Vec<PathBuf>,
+    ) -> Self {
+        self.module_include_paths = include_paths;
+        self.module_system_inc_paths = system_inc_paths;
+        self
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -774,6 +797,8 @@ impl CompletionProvider {
                 &mut completions,
                 &context,
                 &self.workspace_index,
+                &self.module_include_paths,
+                &self.module_system_inc_paths,
             );
         } else if self.is_has_type_value_context(source, position) {
             self.add_has_type_completions(&mut completions, &context);
@@ -2147,7 +2172,9 @@ mod tests {
     use perl_parser_core::Parser;
     use perl_tdd_support::{must, must_some};
     use perl_workspace::workspace_index::WorkspaceIndex;
+    use std::fs;
     use std::sync::Arc;
+    use tempfile::tempdir;
     use url::Url;
 
     #[test]
@@ -3557,6 +3584,53 @@ sub helper { }
             myapp_count, 1,
             "Duplicate package declarations should produce exactly one completion"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_use_module_workspace_precedes_external_scan() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let index = Arc::new(WorkspaceIndex::new());
+        index.index_file(Url::parse("file:///lib/DBI.pm")?, "package DBI;\n1;\n".to_string())?;
+
+        let temp = tempdir()?;
+        let include_root = temp.path().join("vendor_lib");
+        fs::create_dir_all(&include_root)?;
+        fs::write(include_root.join("DBI.pm"), "package DBI;\n1;\n")?;
+
+        let code = "use DB";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index(&ast, Some(index))
+            .with_module_search_paths(vec![include_root], Vec::new());
+        let completions = provider.get_completions(code, code.len());
+
+        let dbi: Vec<&CompletionItem> =
+            completions.iter().filter(|item| item.label == "DBI").collect();
+        assert_eq!(dbi.len(), 1, "DBI should be deduped across workspace and external roots");
+        assert_eq!(dbi[0].detail.as_deref(), Some("module"), "workspace completion must win");
+        Ok(())
+    }
+
+    #[test]
+    fn test_use_module_system_inc_opt_in() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempdir()?;
+        let system_root = temp.path().join("system_inc");
+        fs::create_dir_all(&system_root)?;
+        fs::write(system_root.join("DBIx.pm"), "package DBIx;\n1;\n")?;
+
+        let code = "use DB";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index_and_source(&ast, code, None)
+            .with_module_search_paths(Vec::new(), vec![system_root]);
+        let completions = provider.get_completions(code, code.len());
+
+        let dbix = completions
+            .iter()
+            .find(|item| item.label == "DBIx")
+            .ok_or("DBIx should be suggested from system @INC roots")?;
+        assert_eq!(dbix.detail.as_deref(), Some("module (system @INC)"));
         Ok(())
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -14,7 +14,9 @@ use perl_workspace::workspace_index::{
     SymbolKind as WsSymbolKind, VarKind, WorkspaceIndex, WorkspaceSymbol,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use walkdir::WalkDir;
 
 /// Add workspace symbol completions for functions and variables
 ///
@@ -230,6 +232,68 @@ fn module_sort_tier(name: &str) -> &'static str {
     }
 }
 
+const MODULE_SCAN_MAX_ENTRIES: usize = 4_096;
+const MODULE_SCAN_MAX_DEPTH: usize = 12;
+
+fn path_to_module_name(root: &Path, path: &Path) -> Option<String> {
+    let rel = path.strip_prefix(root).ok()?;
+    if rel.extension().and_then(|ext| ext.to_str()) != Some("pm") {
+        return None;
+    }
+
+    let mut components: Vec<String> = rel
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().into_owned())
+        .collect();
+
+    let last = components.pop()?;
+    let stem = last.strip_suffix(".pm")?;
+    if stem.is_empty() {
+        return None;
+    }
+    components.push(stem.to_string());
+
+    if components.iter().any(|part| part.is_empty()) {
+        return None;
+    }
+
+    Some(components.join("::"))
+}
+
+fn scan_directory_for_modules(root: &Path, prefix: &str) -> Vec<String> {
+    if !root.is_dir() {
+        return Vec::new();
+    }
+
+    // TODO(#4314): Add caching keyed by roots + mtimes to avoid repeated scans on each keystroke.
+    let mut modules = Vec::new();
+    let mut examined = 0usize;
+    for entry in WalkDir::new(root)
+        .follow_links(false)
+        .max_depth(MODULE_SCAN_MAX_DEPTH)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        if examined >= MODULE_SCAN_MAX_ENTRIES {
+            break;
+        }
+        examined += 1;
+
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let Some(module_name) = path_to_module_name(root, entry.path()) else {
+            continue;
+        };
+        if !prefix.is_empty() && !module_name.starts_with(prefix) {
+            continue;
+        }
+        modules.push(module_name);
+    }
+
+    modules
+}
+
 /// Add module name completions for `use` and `require` statements.
 ///
 /// When the cursor is after `use ` or `require `, suggests package names from the
@@ -240,54 +304,92 @@ pub fn add_use_module_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
+    include_paths: &[PathBuf],
+    system_inc_paths: &[PathBuf],
 ) {
-    let Some(index) = workspace_index else {
-        return;
-    };
-
-    if !index.has_symbols() {
-        return;
-    }
-
     let mut seen: HashSet<String> = HashSet::new();
 
-    // Search for package symbols matching the prefix
-    let all_symbols = if context.prefix.is_empty() {
-        index.all_symbols()
-    } else {
-        index.find_symbols(&context.prefix)
-    };
+    if let Some(index) = workspace_index
+        && index.has_symbols()
+    {
+        // Search for package symbols matching the prefix
+        let all_symbols = if context.prefix.is_empty() {
+            index.all_symbols()
+        } else {
+            index.find_symbols(&context.prefix)
+        };
 
-    for symbol in all_symbols {
-        if symbol.kind != WsSymbolKind::Package {
-            continue;
+        for symbol in all_symbols {
+            if symbol.kind != WsSymbolKind::Package {
+                continue;
+            }
+
+            // Match against the module name prefix
+            if !context.prefix.is_empty() && !symbol.name.starts_with(&context.prefix) {
+                continue;
+            }
+
+            if !seen.insert(symbol.name.clone()) {
+                continue;
+            }
+
+            let name = &symbol.name;
+            completions.push(CompletionItem {
+                label: name.clone(),
+                kind: CompletionItemKind::Module,
+                detail: Some("module".to_string()),
+                documentation: symbol
+                    .documentation
+                    .clone()
+                    .or_else(|| Some(format!("Package `{name}`"))),
+                insert_text: Some(name.clone()),
+                sort_text: Some(format!("1{}_{name}", module_sort_tier(name))),
+                filter_text: Some(name.clone()),
+                additional_edits: vec![],
+                text_edit_range: Some((context.prefix_start, context.position)),
+                commit_characters: None,
+            });
         }
+    }
 
-        // Match against the module name prefix
-        if !context.prefix.is_empty() && !symbol.name.starts_with(&context.prefix) {
-            continue;
+    for root in include_paths {
+        for name in scan_directory_for_modules(root, &context.prefix) {
+            if !seen.insert(name.clone()) {
+                continue;
+            }
+            completions.push(CompletionItem {
+                label: name.clone(),
+                kind: CompletionItemKind::Module,
+                detail: Some("module (external)".to_string()),
+                documentation: Some(format!("Module from include path: {}", root.display())),
+                insert_text: Some(name.clone()),
+                sort_text: Some(format!("2{}_{name}", module_sort_tier(&name))),
+                filter_text: Some(name),
+                additional_edits: vec![],
+                text_edit_range: Some((context.prefix_start, context.position)),
+                commit_characters: None,
+            });
         }
+    }
 
-        if !seen.insert(symbol.name.clone()) {
-            continue;
+    for root in system_inc_paths {
+        for name in scan_directory_for_modules(root, &context.prefix) {
+            if !seen.insert(name.clone()) {
+                continue;
+            }
+            completions.push(CompletionItem {
+                label: name.clone(),
+                kind: CompletionItemKind::Module,
+                detail: Some("module (system @INC)".to_string()),
+                documentation: Some(format!("Module from system @INC: {}", root.display())),
+                insert_text: Some(name.clone()),
+                sort_text: Some(format!("3{}_{name}", module_sort_tier(&name))),
+                filter_text: Some(name),
+                additional_edits: vec![],
+                text_edit_range: Some((context.prefix_start, context.position)),
+                commit_characters: None,
+            });
         }
-
-        let name = &symbol.name;
-        completions.push(CompletionItem {
-            label: name.clone(),
-            kind: CompletionItemKind::Module,
-            detail: Some("module".to_string()),
-            documentation: symbol
-                .documentation
-                .clone()
-                .or_else(|| Some(format!("Package `{name}`"))),
-            insert_text: Some(name.clone()),
-            sort_text: Some(format!("1{}_{name}", module_sort_tier(name))),
-            filter_text: Some(name.clone()),
-            additional_edits: vec![],
-            text_edit_range: Some((context.prefix_start, context.position)),
-            commit_characters: None,
-        });
     }
 }
 
@@ -653,4 +755,44 @@ fn find_assignment_eq(line: &str) -> Option<usize> {
         return Some(i);
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{path_to_module_name, scan_directory_for_modules};
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn path_to_module_name_maps_nested_pm_file() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempdir()?;
+        let root = temp.path().join("lib");
+        let module_path = root.join("File/Path/To/Module.pm");
+        fs::create_dir_all(module_path.parent().ok_or("missing parent")?)?;
+        fs::write(&module_path, "package File::Path::To::Module;\n1;\n")?;
+
+        let module = path_to_module_name(&root, &module_path).ok_or("missing module name")?;
+        assert_eq!(module, "File::Path::To::Module");
+        Ok(())
+    }
+
+    #[test]
+    fn scan_directory_for_modules_filters_by_prefix() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempdir()?;
+        let root = temp.path().join("external_lib");
+        fs::create_dir_all(root.join("HTTP"))?;
+        fs::write(root.join("DBI.pm"), "package DBI;\n1;\n")?;
+        fs::write(root.join("HTTP/Tiny.pm"), "package HTTP::Tiny;\n1;\n")?;
+
+        let scanned = scan_directory_for_modules(&root, "DB");
+        assert!(
+            scanned.iter().any(|name| name == "DBI"),
+            "expected DBI from include-path scan, got: {scanned:?}"
+        );
+        assert!(
+            !scanned.iter().any(|name| name == "HTTP::Tiny"),
+            "prefix DB must exclude HTTP::Tiny, got: {scanned:?}"
+        );
+        Ok(())
+    }
 }

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -19,9 +19,11 @@ use crate::{
     state::{completion_cap, completion_deadline},
 };
 use perl_lexer::LSP_RUNTIME_COMPLETION_KEYWORDS;
+use perl_lsp_rs_core::config::WorkspaceConfig;
 use perl_parser::type_inference::TypeInferenceEngine;
 use regex::Regex;
 use serde_json::{Value, json};
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 
@@ -56,6 +58,37 @@ fn commit_chars_for_kind(kind: CompletionItemKind) -> Option<&'static [&'static 
 }
 
 impl LspServer {
+    fn completion_module_roots_for_doc(&self, doc_uri: &str) -> (Vec<PathBuf>, Vec<PathBuf>) {
+        let Some(folder) = self.folder_for_doc_uri(doc_uri) else {
+            return (Vec::new(), Vec::new());
+        };
+
+        let root_path = folder.path.clone();
+        let mut config = folder.effective_workspace_config.clone();
+        let perl5lib_paths = std::env::var("PERL5LIB")
+            .map(|value| WorkspaceConfig::parse_perl5lib(&value))
+            .unwrap_or_default();
+
+        let mut include_paths = Vec::new();
+        for include_path in config.effective_include_paths(&perl5lib_paths) {
+            let resolved = if Path::new(&include_path).is_absolute() {
+                PathBuf::from(&include_path)
+            } else if let Some(root) = root_path.as_ref() {
+                root.join(&include_path)
+            } else {
+                PathBuf::from(&include_path)
+            };
+            if !include_paths.iter().any(|existing| existing == &resolved) {
+                include_paths.push(resolved);
+            }
+        }
+
+        let system_inc_paths =
+            if config.use_system_inc { config.get_system_inc().to_vec() } else { Vec::new() };
+
+        (include_paths, system_inc_paths)
+    }
+
     fn split_sigil(name: &str) -> (Option<char>, &str) {
         let mut chars = name.chars();
         match chars.next() {
@@ -323,6 +356,8 @@ impl LspServer {
                 // Get completions, with fallback for missing AST
                 #[cfg_attr(not(feature = "workspace"), allow(unused_mut))]
                 let mut completions = if let Some(ast) = &doc.ast {
+                    let (include_paths, system_inc_paths) =
+                        self.completion_module_roots_for_doc(uri);
                     // Only provide workspace index when Full access is available
                     // This ensures we don't bypass routing policy
                     #[cfg(feature = "workspace")]
@@ -336,11 +371,13 @@ impl LspServer {
                         ast,
                         &doc.text,
                         workspace_idx,
-                    );
+                    )
+                    .with_module_search_paths(include_paths, system_inc_paths);
 
                     #[cfg(not(feature = "workspace"))]
                     let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None)
+                            .with_module_search_paths(include_paths, system_inc_paths);
 
                     let mut base_completions =
                         provider.get_completions_with_path(&doc.text, offset, Some(uri));
@@ -565,6 +602,8 @@ impl LspServer {
 
                 // Get completions with optimized cancellation support
                 let mut completions = if let Some(ast) = &doc.ast {
+                    let (include_paths, system_inc_paths) =
+                        self.completion_module_roots_for_doc(uri);
                     // Only provide workspace index when Full access is available
                     // This ensures we don't bypass routing policy
                     #[cfg(feature = "workspace")]
@@ -578,10 +617,12 @@ impl LspServer {
                         ast,
                         &doc.text,
                         workspace_idx,
-                    );
+                    )
+                    .with_module_search_paths(include_paths, system_inc_paths);
                     #[cfg(not(feature = "workspace"))]
                     let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None)
+                            .with_module_search_paths(include_paths, system_inc_paths);
 
                     // Use cancellable provider method
                     provider.get_completions_with_path_cancellable(


### PR DESCRIPTION
### Motivation

- `use` / `require` completion only suggested workspace-indexed packages and missed modules present in configured `include_paths`, PERL5LIB-derived roots, and (optionally) system `@INC`.

### Description

- Add `path_to_module_name(...)` and `scan_directory_for_modules(...)` to map `.pm` files to module names and perform bounded directory scans (`MODULE_SCAN_MAX_ENTRIES`, `MODULE_SCAN_MAX_DEPTH`).
- Extend `add_use_module_completions(...)` to merge workspace-index results with modules discovered from `include_paths` and optional `system_inc_paths`, deduping by module name and preserving workspace-first precedence, and annotate external/system hits with distinct `detail` text.
- Add plumbing on `CompletionProvider` (`module_include_paths`, `module_system_inc_paths`, `with_module_search_paths`) and wire runtime completion to compute effective roots (workspace `include_paths` + `PERL5LIB` precedence + optional system `@INC`) via `completion_module_roots_for_doc` and pass them into the provider for both normal and cancellable flows.
- Add unit tests for `path_to_module_name`, `scan_directory_for_modules`, workspace-vs-external dedupe, and system-`@INC` opt-in behavior, and leave a `TODO(#4314)` for caching to avoid repeated scans.

### Testing

- Ran `cargo xtask fmt` successfully.
- Ran `cargo check --workspace --all-targets` successfully.
- Focused unit tests in `perl-lsp-rs-core` passed: `path_to_module_name_maps_nested_pm_file`, `scan_directory_for_modules_filters_by_prefix`, `test_use_module_workspace_precedes_external_scan`, and `test_use_module_system_inc_opt_in` all succeeded.
- `cargo test -p perl-lsp-completion` did not run because that package is not present in the workspace; `cargo test -p perl-lsp-rs-core` exercised the suite but one unrelated test failed in the environment (external to these changes) — targeted completion tests listed above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadc2203f08333afa73792c4459227)