### PR TITLE
test(incremental): expand batch-edit and boundary regression coverage (#6615)

### DIFF
--- a/crates/perl-parser/tests/incremental_integration_test.rs
+++ b/crates/perl-parser/tests/incremental_integration_test.rs
@@ -3,11 +3,49 @@
 #[cfg(feature = "incremental")]
 mod incremental_tests {
     use perl_parser::incremental_integration::{
-        DocumentParser, IncrementalConfig, byte_to_lsp_pos, lsp_pos_to_byte,
+        byte_to_lsp_pos, lsp_pos_to_byte, DocumentParser, IncrementalConfig,
     };
     use ropey::Rope;
     use serde_json::json;
     use std::time::Instant;
+
+    use perl_parser::Parser;
+
+    fn assert_incremental_matches_full_parse(content: &str, doc: &DocumentParser) {
+        let mut full_parser = Parser::new(content);
+        let full_parse = full_parser.parse();
+
+        match full_parse {
+            Ok(full_ast) => {
+                let incremental_ast =
+                    doc.ast().expect("incremental AST should exist for valid parse");
+                assert_eq!(format!("{:?}", *incremental_ast), format!("{:?}", full_ast));
+            }
+            Err(_) => {
+                // For malformed scenarios, the key invariant is that incremental application does not panic.
+                assert!(doc.ast().is_some());
+            }
+        }
+    }
+
+    fn lsp_change_from_byte_range(
+        source: &str,
+        start_byte: usize,
+        end_byte: usize,
+        text: &str,
+    ) -> serde_json::Value {
+        let rope = Rope::from_str(source);
+        let (start_line, start_char) = byte_to_lsp_pos(&rope, start_byte);
+        let (end_line, end_char) = byte_to_lsp_pos(&rope, end_byte);
+
+        json!({
+            "range": {
+                "start": {"line": start_line, "character": start_char},
+                "end": {"line": end_line, "character": end_char}
+            },
+            "text": text
+        })
+    }
 
     #[test]
     #[serial_test::serial]
@@ -196,6 +234,210 @@ sub world {
 
         assert_eq!(doc.content(), "my $y = 99;");
         assert!(doc.ast().is_some());
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_incremental_large_deletion_matches_full_parse() -> Result<(), Box<dyn std::error::Error>>
+    {
+        unsafe { std::env::set_var("PERL_LSP_INCREMENTAL", "1") };
+        let config = IncrementalConfig::default();
+
+        let initial_code = "sub keep_one {
+    my $x = 1;
+}
+
+sub remove_me {
+    my $tmp = 100;
+    my $extra = 200;
+    print $tmp + $extra;
+}
+
+sub keep_two {
+    my $y = 2;
+}
+";
+
+        let mut doc = DocumentParser::new(initial_code.to_string(), &config)?;
+        let remove_start = initial_code.find("sub remove_me").ok_or("missing remove_me start")?;
+        let remove_end = initial_code.find("sub keep_two").ok_or("missing keep_two marker")?;
+        let changes = vec![lsp_change_from_byte_range(initial_code, remove_start, remove_end, "")];
+
+        doc.apply_changes(&changes, &config)?;
+
+        assert!(!doc.content().contains("remove_me"));
+        assert_incremental_matches_full_parse(doc.content(), &doc);
+
+        unsafe { std::env::remove_var("PERL_LSP_INCREMENTAL") };
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_incremental_insertion_invalidation_matches_full_parse(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        unsafe { std::env::set_var("PERL_LSP_INCREMENTAL", "1") };
+        let config = IncrementalConfig::default();
+
+        let initial_code = "my $base = 1;
+my $next = $base + 2;
+print $next;
+";
+        let mut doc = DocumentParser::new(initial_code.to_string(), &config)?;
+
+        let changes = vec![json!({
+            "range": {
+                "start": {"line": 0, "character": 0},
+                "end": {"line": 0, "character": 0}
+            },
+            "text": "my $inserted = 41;
+        "
+        })];
+
+        doc.apply_changes(&changes, &config)?;
+
+        assert!(doc.content().starts_with("my $inserted = 41;"));
+        assert_incremental_matches_full_parse(doc.content(), &doc);
+
+        unsafe { std::env::remove_var("PERL_LSP_INCREMENTAL") };
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_incremental_whitespace_only_edit_matches_full_parse(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        unsafe { std::env::set_var("PERL_LSP_INCREMENTAL", "1") };
+        let config = IncrementalConfig::default();
+
+        let initial_code = "my $x=1;
+my $y=2;
+print $x+$y;
+";
+        let mut doc = DocumentParser::new(initial_code.to_string(), &config)?;
+
+        let replacement = "my  $x = 1;
+	my $y = 2;
+print   $x + $y;
+";
+        let full_replace = vec![json!({
+            "range": {
+                "start": {"line": 0, "character": 0},
+                "end": {"line": 2, "character": 12}
+            },
+            "text": replacement
+        })];
+
+        doc.apply_changes(&full_replace, &config)?;
+
+        assert!(doc.content().starts_with(replacement));
+        assert_incremental_matches_full_parse(doc.content(), &doc);
+
+        unsafe { std::env::remove_var("PERL_LSP_INCREMENTAL") };
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_incremental_multibyte_boundary_edit_matches_full_parse(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        unsafe { std::env::set_var("PERL_LSP_INCREMENTAL", "1") };
+        let config = IncrementalConfig::default();
+
+        let initial_code = "my $emoji = \"😀\";\nprint $emoji;\n";
+        let mut doc = DocumentParser::new(initial_code.to_string(), &config)?;
+
+        let emoji_start = initial_code.find("😀").ok_or("emoji start not found")?;
+        let emoji_end = emoji_start + "😀".len();
+        let changes = vec![lsp_change_from_byte_range(initial_code, emoji_start, emoji_end, "😺")];
+
+        doc.apply_changes(&changes, &config)?;
+
+        assert!(doc.content().contains("😺"));
+        let mut full_parser = Parser::new(doc.content());
+        assert!(full_parser.parse().is_ok(), "full parse should still succeed for multibyte edit");
+
+        unsafe { std::env::remove_var("PERL_LSP_INCREMENTAL") };
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_incremental_batch_edits_with_independent_shifts_matches_full_parse(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        unsafe { std::env::set_var("PERL_LSP_INCREMENTAL", "1") };
+        let config = IncrementalConfig::default();
+
+        let initial_code = "my $a = 10;
+my $b = 20;
+my $c = $a + $b;
+print $c;
+";
+        let mut doc = DocumentParser::new(initial_code.to_string(), &config)?;
+
+        let changes = vec![
+            json!({
+                "range": {
+                    "start": {"line": 0, "character": 8},
+                    "end": {"line": 0, "character": 10}
+                },
+                "text": "100"
+            }),
+            json!({
+                "range": {
+                    "start": {"line": 2, "character": 14},
+                    "end": {"line": 2, "character": 16}
+                },
+                "text": "$a * $b"
+            }),
+        ];
+
+        doc.apply_changes(&changes, &config)?;
+
+        assert!(doc.content().contains("my $a = 100;"));
+        assert!(doc.content().contains("$a * $b"));
+        let mut full_parser = Parser::new(doc.content());
+        assert!(full_parser.parse().is_ok(), "full parse should succeed after batch edits");
+        assert!(doc.ast().is_some(), "incremental parse should produce an AST");
+
+        unsafe { std::env::remove_var("PERL_LSP_INCREMENTAL") };
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_incremental_unmappable_edit_fallback_no_panic() -> Result<(), Box<dyn std::error::Error>>
+    {
+        unsafe { std::env::set_var("PERL_LSP_INCREMENTAL", "1") };
+        let config = IncrementalConfig::default();
+
+        let initial_code = "my $x = 1;
+";
+        let mut doc = DocumentParser::new(initial_code.to_string(), &config)?;
+        let replacement = "my $fallback = 99;
+print $fallback;
+";
+
+        let malformed_change = vec![json!({
+            "range": {
+                "start": {"line": "bad", "character": 0},
+                "end": {"line": 0, "character": 0}
+            },
+            "text": replacement
+        })];
+
+        let apply_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            doc.apply_changes(&malformed_change, &config)
+        }));
+
+        assert!(apply_result.is_ok(), "malformed edit should not panic");
+        let parse_result = apply_result.expect("unwind result should be available");
+        assert!(parse_result.is_ok(), "malformed edit should gracefully fallback");
+        assert_eq!(doc.content(), replacement);
+        assert_incremental_matches_full_parse(doc.content(), &doc);
+
+        unsafe { std::env::remove_var("PERL_LSP_INCREMENTAL") };
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Improve incremental parsing regression coverage for known edit slices (large deletions, insertion invalidation, whitespace-only edits, multibyte-boundary edits, batch edits with independent shifts, and unmappable edit fallback) without changing production logic.

### Description

- Added two shared helpers to the incremental integration test: `assert_incremental_matches_full_parse` to compare incremental output with a fresh full parse and `lsp_change_from_byte_range` to build deterministic LSP ranges from byte offsets.
- Added six focused tests exercising the incremental slices listed above, using `serial_test::serial` where needed and explicit `catch_unwind` for malformed/unmappable edits.
- All changes are test-only and confined to `crates/perl-parser/tests/incremental_integration_test.rs` with no production code modifications.

### Testing

- Ran `cargo test -p perl-parser --features incremental --test incremental_integration_test` and the incremental integration test binary passed (all added tests passed).
- Ran `cargo check --all-targets -p perl-parser` which completed successfully.
- Ran `cargo test -p perl-parser` which exposes a pre-existing unrelated failure in `refactor::refactoring::tests::validation_tests::test_cleanup_respects_retention_count` (this failure is not caused by the test-only changes in this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eade0e09ac8333a5c832e309a1d02b)