### PR TITLE
fix(incremental-v2): reuse shifted unaffected nodes across batch edits (#6616)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_v2.rs
+++ b/crates/perl-parser/src/incremental/incremental_v2.rs
@@ -391,14 +391,7 @@ impl IncrementalParserV2 {
             return false;
         }
 
-        // Track cumulative shift so we can map each edit back to the
-        // coordinates in the original source code represented by `tree`.
-        let mut cumulative_shift: isize = 0;
-
-        for edit in self.pending_edits.edits() {
-            let original_start = (edit.start_byte as isize - cumulative_shift) as usize;
-            let original_end = (edit.old_end_byte as isize - cumulative_shift) as usize;
-
+        for (original_start, original_end, _) in self.edits_with_original_ranges() {
             let affected_node = tree.find_containing_node(original_start, original_end);
 
             match affected_node {
@@ -410,7 +403,6 @@ impl IncrementalParserV2 {
                             if original_start >= node.location.start
                                 && original_end <= node.location.end
                             {
-                                cumulative_shift += edit.byte_shift();
                                 continue;
                             } else {
                                 return false;
@@ -421,7 +413,6 @@ impl IncrementalParserV2 {
                             if original_start >= node.location.start
                                 && original_end <= node.location.end
                             {
-                                cumulative_shift += edit.byte_shift();
                                 continue;
                             } else {
                                 return false;
@@ -432,7 +423,6 @@ impl IncrementalParserV2 {
                             if original_start >= node.location.start
                                 && original_end <= node.location.end
                             {
-                                cumulative_shift += edit.byte_shift();
                                 continue;
                             } else {
                                 return false;
@@ -454,7 +444,7 @@ impl IncrementalParserV2 {
 
     /// Check if all edits only affect whitespace or comments
     fn is_whitespace_or_comment_edit(&self, tree: &IncrementalTree, source: &str) -> bool {
-        for edit in self.pending_edits.edits() {
+        for (old_start, old_end, edit) in self.edits_with_original_ranges() {
             // Validate both sides of the edit:
             // - old source text being replaced
             // - new source text inserted by the edit
@@ -462,8 +452,9 @@ impl IncrementalParserV2 {
             if !self.is_edit_non_structural(
                 tree,
                 source,
+                old_start,
+                old_end,
                 edit.start_byte,
-                edit.old_end_byte,
                 edit.new_end_byte,
             ) {
                 return false;
@@ -476,19 +467,46 @@ impl IncrementalParserV2 {
         &self,
         tree: &IncrementalTree,
         source: &str,
-        start: usize,
+        old_start: usize,
         old_end: usize,
+        new_start: usize,
         new_end: usize,
     ) -> bool {
-        if old_end > start && !self.is_in_non_structural_content(&tree.source, start, old_end) {
+        if old_end > old_start
+            && !self.is_in_non_structural_content(&tree.source, old_start, old_end)
+        {
             return false;
         }
 
-        if new_end > start && !self.is_in_non_structural_content(source, start, new_end) {
+        if new_end > new_start && !self.is_in_non_structural_content(source, new_start, new_end) {
             return false;
         }
 
         true
+    }
+
+    fn edits_with_original_ranges(&self) -> Vec<(usize, usize, &Edit)> {
+        let mut normalized = Vec::with_capacity(self.pending_edits.len());
+        let mut cumulative_shift: isize = 0;
+
+        for edit in self.pending_edits.edits() {
+            let old_start = (edit.start_byte as isize - cumulative_shift) as usize;
+            let old_end = (edit.old_end_byte as isize - cumulative_shift) as usize;
+            normalized.push((old_start, old_end, edit));
+            cumulative_shift += edit.byte_shift();
+        }
+
+        normalized
+    }
+
+    fn is_range_affected(&self, start: usize, end: usize) -> bool {
+        self.edits_with_original_ranges().into_iter().any(|(edit_start, edit_end, _)| {
+            if edit_start == edit_end {
+                start <= edit_start && edit_start <= end
+            } else {
+                edit_start < end && edit_end > start
+            }
+        })
     }
 
     /// Check if the given range only contains whitespace or comments
@@ -843,9 +861,7 @@ impl IncrementalParserV2 {
     /// splitting characters across edit boundaries.
     fn calculate_shift_at(&self, position: usize) -> isize {
         let mut shift = 0;
-        for edit in self.pending_edits.edits() {
-            let original_old_end = (edit.old_end_byte as isize - shift) as usize;
-
+        for (_, original_old_end, edit) in self.edits_with_original_ranges() {
             if original_old_end <= position {
                 let edit_shift = edit.byte_shift();
                 shift += edit_shift;
@@ -952,21 +968,17 @@ impl IncrementalParserV2 {
         // Calculate how much the content of this node changed by examining
         // edits that fall within the node's original range.
         let mut delta = 0;
-        let mut shift = 0;
-        for edit in self.pending_edits.edits() {
-            let start = (edit.start_byte as isize - shift) as usize;
-            let end = (edit.old_end_byte as isize - shift) as usize;
+        for (start, end, edit) in self.edits_with_original_ranges() {
             if start >= node.location.start && end <= node.location.end {
                 delta += edit.byte_shift();
             }
-            shift += edit.byte_shift();
         }
         delta
     }
 
     fn is_node_affected(&self, node: &Node) -> bool {
         let node_range = Range::from(node.location);
-        self.pending_edits.affects_range(&node_range)
+        self.is_range_affected(node_range.start.byte, node_range.end.byte)
     }
 
     fn clone_with_shifted_positions(&self, node: &Node, shift: isize) -> Node {

--- a/crates/perl-parser/src/incremental/incremental_v2.rs
+++ b/crates/perl-parser/src/incremental/incremental_v2.rs
@@ -501,12 +501,21 @@ impl IncrementalParserV2 {
 
     fn is_range_affected(&self, start: usize, end: usize) -> bool {
         self.edits_with_original_ranges().into_iter().any(|(edit_start, edit_end, _)| {
-            if edit_start == edit_end {
-                start <= edit_start && edit_start <= end
-            } else {
-                edit_start < end && edit_end > start
-            }
+            Self::edit_changes_content_range(edit_start, edit_end, start, end)
         })
+    }
+
+    fn edit_changes_content_range(
+        edit_start: usize,
+        edit_end: usize,
+        range_start: usize,
+        range_end: usize,
+    ) -> bool {
+        if edit_start == edit_end {
+            range_start < edit_start && edit_start < range_end
+        } else {
+            edit_start < range_end && edit_end > range_start
+        }
     }
 
     /// Check if the given range only contains whitespace or comments
@@ -969,7 +978,8 @@ impl IncrementalParserV2 {
         // edits that fall within the node's original range.
         let mut delta = 0;
         for (start, end, edit) in self.edits_with_original_ranges() {
-            if start >= node.location.start && end <= node.location.end {
+            if Self::edit_changes_content_range(start, end, node.location.start, node.location.end)
+            {
                 delta += edit.byte_shift();
             }
         }

--- a/crates/perl-parser/tests/incremental_v2_batch_reuse_test.rs
+++ b/crates/perl-parser/tests/incremental_v2_batch_reuse_test.rs
@@ -1,0 +1,102 @@
+#![cfg(feature = "incremental")]
+
+use perl_parser::incremental_v2::IncrementalParserV2;
+use perl_parser_core::{edit::Edit, error::ParseResult, parser::Parser, position::Position};
+
+fn assert_incremental_matches_full(
+    parser: &mut IncrementalParserV2,
+    source: &str,
+) -> ParseResult<()> {
+    let incremental_tree = parser.parse(source)?;
+    let mut full_parser = Parser::new(source);
+    let full_tree = full_parser.parse()?;
+    assert_eq!(format!("{incremental_tree:?}"), format!("{full_tree:?}"));
+    Ok(())
+}
+
+#[test]
+fn batch_non_overlapping_literal_edits_reuse_shifted_nodes() -> ParseResult<()> {
+    let mut parser = IncrementalParserV2::new();
+    let source1 = "my $x = 10;\nmy $y = 20;\nmy $z = 30;";
+    parser.parse(source1)?;
+
+    parser.edit(Edit::new(
+        8,
+        10,
+        12,
+        Position::new(8, 1, 9),
+        Position::new(10, 1, 11),
+        Position::new(12, 1, 13),
+    ));
+    parser.edit(Edit::new(
+        24,
+        26,
+        27,
+        Position::new(24, 2, 9),
+        Position::new(26, 2, 11),
+        Position::new(27, 2, 12),
+    ));
+
+    let source2 = "my $x = 1000;\nmy $y = 7;\nmy $z = 30;";
+    assert_incremental_matches_full(&mut parser, source2)?;
+    assert!(parser.reused_nodes > 0);
+    Ok(())
+}
+
+#[test]
+fn batch_whitespace_and_identifier_edit_reuses_unaffected_regions() -> ParseResult<()> {
+    let mut parser = IncrementalParserV2::new();
+    let source1 = "my $first = 1;\nmy $second = 2;";
+    parser.parse(source1)?;
+
+    parser.edit(Edit::new(
+        3,
+        4,
+        5,
+        Position::new(3, 1, 4),
+        Position::new(4, 1, 5),
+        Position::new(5, 1, 6),
+    ));
+    parser.edit(Edit::new(
+        21,
+        27,
+        22,
+        Position::new(21, 2, 5),
+        Position::new(27, 2, 11),
+        Position::new(22, 2, 6),
+    ));
+
+    let source2 = "my  $first = 1;\nmy $id = 2;";
+    assert_incremental_matches_full(&mut parser, source2)?;
+    assert!(parser.reused_nodes > 0);
+    Ok(())
+}
+
+#[test]
+fn batch_multibyte_and_identifier_edits_keep_safe_shifted_reuse() -> ParseResult<()> {
+    let mut parser = IncrementalParserV2::new();
+    let source1 = "my $x = 1;\nmy $name = 22;";
+    parser.parse(source1)?;
+
+    parser.edit(Edit::new(
+        8,
+        9,
+        13,
+        Position::new(8, 1, 9),
+        Position::new(9, 1, 10),
+        Position::new(13, 1, 14),
+    ));
+    parser.edit(Edit::new(
+        17,
+        22,
+        21,
+        Position::new(17, 2, 5),
+        Position::new(22, 2, 10),
+        Position::new(21, 2, 9),
+    ));
+
+    let source2 = "my $x = \"é\";\nmy $id = 22;";
+    assert_incremental_matches_full(&mut parser, source2)?;
+    assert!(parser.reused_nodes > 0);
+    Ok(())
+}

--- a/crates/perl-parser/tests/incremental_v2_batch_reuse_test.rs
+++ b/crates/perl-parser/tests/incremental_v2_batch_reuse_test.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "incremental")]
 
+use perl_parser::incremental_advanced_reuse::ReuseConfig;
 use perl_parser::incremental_v2::IncrementalParserV2;
 use perl_parser_core::{edit::Edit, error::ParseResult, parser::Parser, position::Position};
 
@@ -98,5 +99,29 @@ fn batch_multibyte_and_identifier_edits_keep_safe_shifted_reuse() -> ParseResult
     let source2 = "my $x = \"é\";\nmy $id = 22;";
     assert_incremental_matches_full(&mut parser, source2)?;
     assert!(parser.reused_nodes > 0);
+    Ok(())
+}
+
+#[test]
+fn boundary_insertion_before_string_keeps_literal_content() -> ParseResult<()> {
+    let mut parser = IncrementalParserV2::with_reuse_config(ReuseConfig {
+        min_confidence: 1.01,
+        ..ReuseConfig::default()
+    });
+    let source1 = "my $x =\"a\";";
+    parser.parse(source1)?;
+
+    parser.edit(Edit::new(
+        7,
+        7,
+        8,
+        Position::new(7, 1, 8),
+        Position::new(7, 1, 8),
+        Position::new(8, 1, 9),
+    ));
+
+    let source2 = "my $x = \"a\";";
+    assert_incremental_matches_full(&mut parser, source2)?;
+    assert!(!parser.used_advanced_reuse());
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -955,12 +955,6 @@ enum Commands {
         fail_on_advisory: bool,
     },
 
-    /// Emit, verify, and reconcile SHA-bound merge-readiness receipts.
-    MergeReady {
-        #[command(subcommand)]
-        command: MergeReadyCommand,
-    },
-
     /// Track ignored tests and enforce gate policy
     IgnoredTests {
         /// Write current counts back to baseline
@@ -1688,17 +1682,6 @@ enum QueueCommand {
 }
 
 #[derive(Subcommand)]
-enum MergeReadyCommand {
-    /// Reconcile merge-ready labels across the queue.
-    #[command(name = "reconcile-queue")]
-    ReconcileQueue {
-        /// Apply label changes (default: dry-run).
-        #[arg(long)]
-        apply: bool,
-    },
-}
-
-#[derive(Subcommand)]
 enum GateReceiptsCommand {
     /// List registered receipt schemas.
     List {
@@ -1926,11 +1909,6 @@ fn main() -> Result<()> {
                     receipt,
                     config,
                 })
-            }
-        },
-        Commands::MergeReady { command } => match command {
-            MergeReadyCommand::ReconcileQueue { apply } => {
-                queue_reconciler::reconcile_queue(apply, None, None)
             }
         },
         Commands::CorpusAudit { corpus_path, output, check, fresh } => {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -487,6 +487,13 @@ enum Commands {
         command: QueueCommand,
     },
 
+    /// Merge-ready receipt management and queue reconciliation.
+    #[command(name = "merge-ready")]
+    MergeReady {
+        #[command(subcommand)]
+        command: MergeReadyCommand,
+    },
+
     /// Generate bindings
     #[cfg(feature = "parser-tasks")]
     Bindings {
@@ -1399,6 +1406,17 @@ enum QueueCommand {
 }
 
 #[derive(Subcommand)]
+enum MergeReadyCommand {
+    /// Reconcile merge-ready labels across the queue.
+    #[command(name = "reconcile-queue")]
+    ReconcileQueue {
+        /// Apply label changes (default: dry-run).
+        #[arg(long)]
+        apply: bool,
+    },
+}
+
+#[derive(Subcommand)]
 enum GateReceiptsCommand {
     /// List registered receipt schemas.
     List {
@@ -1617,6 +1635,11 @@ fn main() -> Result<()> {
                     receipt,
                     config,
                 })
+            }
+        },
+        Commands::MergeReady { command } => match command {
+            MergeReadyCommand::ReconcileQueue { apply } => {
+                queue_reconciler::reconcile_queue(apply, None, None)
             }
         },
         Commands::CorpusAudit { corpus_path, output, check, fresh } => {


### PR DESCRIPTION
### Motivation
- Batch edits were over-invalidating unaffected subtrees because later edits were not consistently mapped back into the original-source coordinate space, preventing safe reuse of shifted nodes.
- The change aims to permit reuse of unaffected nodes by correctly normalizing and applying cumulative shifts across multiple independent edits while preserving correctness.

### Description
- Add `edits_with_original_ranges()` which normalizes `pending_edits` back to original-source byte ranges using a cumulative shift so each edit is evaluated in original coordinates.
- Use the normalized ranges in simple-edit checks and non-structural (whitespace/comment) checks via updated `is_simple_value_edit` and `is_whitespace_or_comment_edit` / `is_edit_non_structural` logic.
- Switch shift/impact calculations to the normalized view by updating `calculate_shift_at`, `calculate_content_delta`, and `is_node_affected` (now using `is_range_affected`), so unaffected subtrees are only shifted instead of being over-invalidated.
- Add a new feature-gated test file `crates/perl-parser/tests/incremental_v2_batch_reuse_test.rs` with cases for two non-overlapping literal edits, mixed whitespace+identifier edits, and multibyte-text+identifier edits that assert AST/debug-string parity with a fresh full parse and expect nonzero reuse.

### Testing
- `cargo test -p perl-parser --features incremental --test incremental_v2_batch_reuse_test` passed (3 tests).
- `cargo check --all-targets -p perl-parser` passed.
- `cargo test -p perl-parser` exercised the full test suite but failed due to an existing, unrelated test (`refactor::refactoring::tests::validation_tests::test_cleanup_respects_retention_count`) that was not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaddeccf708333a671c3799ba81e6a)