### PR TITLE
refactor(completion): plumb effective @INC paths into module completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -122,6 +122,7 @@ use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
 use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_workspace::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Maps module_name -> Set of explicitly imported symbol names.
@@ -170,6 +171,8 @@ pub struct CompletionProvider {
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
     import_map: ImportMap,
+    include_paths: Vec<PathBuf>,
+    system_inc_paths: Vec<PathBuf>,
 }
 
 impl CompletionProvider {
@@ -249,6 +252,17 @@ impl CompletionProvider {
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
     ) -> Self {
+        Self::new_with_index_source_paths(ast, source, workspace_index, Vec::new(), Vec::new())
+    }
+
+    /// Create a completion provider with explicit include-path inputs.
+    pub fn new_with_index_source_paths(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        include_paths: Vec<PathBuf>,
+        system_inc_paths: Vec<PathBuf>,
+    ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
         let type_engine = workspace_index.as_ref().map(|_| {
@@ -258,7 +272,15 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            import_map,
+            include_paths,
+            system_inc_paths,
+        }
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -774,6 +796,8 @@ impl CompletionProvider {
                 &mut completions,
                 &context,
                 &self.workspace_index,
+                &self.include_paths,
+                &self.system_inc_paths,
             );
         } else if self.is_has_type_value_context(source, position) {
             self.add_has_type_completions(&mut completions, &context);
@@ -3332,6 +3356,52 @@ sub helper { }
     // -------------------------------------------------------------------------
     // Tests for is_use_statement_context and add_use_module_completions
     // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_provider_can_be_constructed_with_include_and_system_inc_paths() {
+        let code = "use ";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+
+        let include_paths = vec![PathBuf::from("/workspace/lib"), PathBuf::from("./local/lib")];
+        let system_inc_paths = vec![PathBuf::from("/usr/lib/perl5")];
+        let provider = CompletionProvider::new_with_index_source_paths(
+            &ast,
+            code,
+            None,
+            include_paths.clone(),
+            system_inc_paths.clone(),
+        );
+
+        assert_eq!(provider.include_paths, include_paths);
+        assert_eq!(provider.system_inc_paths, system_inc_paths);
+    }
+
+    #[test]
+    fn test_use_completion_unchanged_with_empty_include_vectors()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let index = Arc::new(WorkspaceIndex::new());
+        index
+            .index_file(Url::parse("file:///lib/MyApp.pm")?, "package MyApp;\n1;\n".to_string())?;
+
+        let code = "use MyA";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index_source_paths(
+            &ast,
+            code,
+            Some(index),
+            Vec::new(),
+            Vec::new(),
+        );
+        let completions = provider.get_completions(code, code.len());
+
+        assert!(
+            completions.iter().any(|c| c.label == "MyApp" && c.kind == CompletionItemKind::Module),
+            "empty include/system paths should preserve existing module completion behavior"
+        );
+        Ok(())
+    }
 
     #[test]
     fn test_use_statement_context_after_use_keyword() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -240,6 +240,8 @@ pub fn add_use_module_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
+    _include_paths: &[std::path::PathBuf],
+    _system_inc_paths: &[std::path::PathBuf],
 ) {
     let Some(index) = workspace_index else {
         return;

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -319,6 +319,12 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let mut doc_config = self.config_for_doc(uri);
+                let include_paths = self.include_paths_for_doc(uri);
+                let system_inc_paths = doc_config
+                    .as_mut()
+                    .filter(|config| config.use_system_inc)
+                    .map_or_else(Vec::new, |config| config.get_system_inc().to_vec());
 
                 // Get completions, with fallback for missing AST
                 #[cfg_attr(not(feature = "workspace"), allow(unused_mut))]
@@ -332,15 +338,22 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_source_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
 
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_source_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
 
                     let mut base_completions =
                         provider.get_completions_with_path(&doc.text, offset, Some(uri));
@@ -548,6 +561,12 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let mut doc_config = self.config_for_doc(uri);
+                let include_paths = self.include_paths_for_doc(uri);
+                let system_inc_paths = doc_config
+                    .as_mut()
+                    .filter(|config| config.use_system_inc)
+                    .map_or_else(Vec::new, |config| config.get_system_inc().to_vec());
 
                 // Create optimized cancellation callback with reduced frequency
                 // Performance optimization: reduced overhead from 16.66% to <10%
@@ -574,14 +593,21 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_source_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_source_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
 
                     // Use cancellable provider method
                     provider.get_completions_with_path_cancellable(


### PR DESCRIPTION
### Motivation
- Module-name completion needed document-specific include-path context and opted-in system `@INC` visibility to enable future include-path-aware suggestions without implementing filesystem scanning yet.

### Description
- Thread document-scoped config and effective include paths into completion entrypoints by calling `config_for_doc(uri)`, `include_paths_for_doc(uri)`, and collecting system `@INC` only when `use_system_inc` is enabled. 
- Extend `CompletionProvider` with `include_paths: Vec<PathBuf>` and `system_inc_paths: Vec<PathBuf>` and add `new_with_index_source_paths(...)` that accepts those vectors while preserving the old `new_with_index_and_source(...)` behavior via empty-vector defaults. 
- Pass the new include/system vectors into the `use`/`require` module completion path by adjusting the call site and plumbing `add_use_module_completions(...)` signature; no scanning, ranking, or dedupe behavior was changed. 
- Add targeted tests verifying provider construction with provided include/system vectors and that existing `use` completion behavior is preserved when include/system vectors are empty.

### Testing
- Ran `cargo xtask fmt` which completed successfully. 
- Ran `cargo test -p perl-lsp-rs-core completion::` which passed (`148` tests in that suite ran and succeeded). 
- Ran `cargo check --workspace --all-targets` which completed successfully. 
- Ran `cargo test -p perl-lsp-completion` which failed because the package name does not exist in this workspace (command returned an error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae60d84c08333a48253285caa90a4)