### PR TITLE
refactor(completion): plumb effective @INC paths into module completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -122,6 +122,7 @@ use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
 use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_workspace::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Maps module_name -> Set of explicitly imported symbol names.
@@ -170,6 +171,8 @@ pub struct CompletionProvider {
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
     import_map: ImportMap,
+    include_paths: Vec<PathBuf>,
+    system_inc_paths: Vec<PathBuf>,
 }
 
 impl CompletionProvider {
@@ -200,7 +203,7 @@ impl CompletionProvider {
     /// ```
     /// Arguments: `ast`, `workspace_index`.
     pub fn new_with_index(ast: &Node, workspace_index: Option<Arc<WorkspaceIndex>>) -> Self {
-        Self::new_with_index_and_source(ast, "", workspace_index)
+        Self::new_with_index_and_source_and_paths(ast, "", workspace_index, Vec::new(), Vec::new())
     }
 
     /// Create a new completion provider from parsed AST and source with workspace integration
@@ -249,6 +252,23 @@ impl CompletionProvider {
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
     ) -> Self {
+        Self::new_with_index_and_source_and_paths(
+            ast,
+            source,
+            workspace_index,
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+
+    /// Create a new completion provider from parsed AST and source with effective include paths.
+    pub fn new_with_index_and_source_and_paths(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        include_paths: Vec<PathBuf>,
+        system_inc_paths: Vec<PathBuf>,
+    ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
         let type_engine = workspace_index.as_ref().map(|_| {
@@ -258,7 +278,15 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            import_map,
+            include_paths,
+            system_inc_paths,
+        }
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -774,6 +802,8 @@ impl CompletionProvider {
                 &mut completions,
                 &context,
                 &self.workspace_index,
+                &self.include_paths,
+                &self.system_inc_paths,
             );
         } else if self.is_has_type_value_context(source, position) {
             self.add_has_type_completions(&mut completions, &context);
@@ -2147,6 +2177,7 @@ mod tests {
     use perl_parser_core::Parser;
     use perl_tdd_support::{must, must_some};
     use perl_workspace::workspace_index::WorkspaceIndex;
+    use std::path::PathBuf;
     use std::sync::Arc;
     use url::Url;
 
@@ -3375,6 +3406,55 @@ sub helper { }
             !completions.iter().any(|c| c.label == "OtherLib"),
             "use MyA should not suggest OtherLib"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_provider_stores_doc_specific_include_paths() {
+        let code = "use MyApp;";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let include_paths =
+            vec![PathBuf::from("/workspace/current/lib"), PathBuf::from("/workspace/shared/lib")];
+        let system_inc_paths = vec![PathBuf::from("/usr/lib/perl5")];
+
+        let provider = CompletionProvider::new_with_index_and_source_and_paths(
+            &ast,
+            code,
+            None,
+            include_paths.clone(),
+            system_inc_paths.clone(),
+        );
+
+        assert_eq!(provider.include_paths, include_paths);
+        assert_eq!(provider.system_inc_paths, system_inc_paths);
+    }
+
+    #[test]
+    fn test_use_completion_unchanged_with_empty_include_vectors()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let index = Arc::new(WorkspaceIndex::new());
+        index
+            .index_file(Url::parse("file:///lib/MyApp.pm")?, "package MyApp;\n1;\n".to_string())?;
+        let code = "use MyA";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let legacy_provider = CompletionProvider::new_with_index(&ast, Some(Arc::clone(&index)));
+        let legacy = legacy_provider.get_completions(code, code.len());
+
+        let new_provider = CompletionProvider::new_with_index_and_source_and_paths(
+            &ast,
+            code,
+            Some(index),
+            Vec::new(),
+            Vec::new(),
+        );
+        let with_empty_paths = new_provider.get_completions(code, code.len());
+
+        let legacy_labels: Vec<&str> = legacy.iter().map(|item| item.label.as_str()).collect();
+        let new_labels: Vec<&str> =
+            with_empty_paths.iter().map(|item| item.label.as_str()).collect();
+        assert_eq!(legacy_labels, new_labels);
         Ok(())
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -14,6 +14,7 @@ use perl_workspace::workspace_index::{
     SymbolKind as WsSymbolKind, VarKind, WorkspaceIndex, WorkspaceSymbol,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Add workspace symbol completions for functions and variables
@@ -240,6 +241,8 @@ pub fn add_use_module_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
+    _include_paths: &[PathBuf],
+    _system_inc_paths: &[PathBuf],
 ) {
     let Some(index) = workspace_index else {
         return;

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -22,6 +22,7 @@ use perl_lexer::LSP_RUNTIME_COMPLETION_KEYWORDS;
 use perl_parser::type_inference::TypeInferenceEngine;
 use regex::Regex;
 use serde_json::{Value, json};
+use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 
@@ -56,6 +57,18 @@ fn commit_chars_for_kind(kind: CompletionItemKind) -> Option<&'static [&'static 
 }
 
 impl LspServer {
+    fn completion_paths_for_doc(&self, doc_uri: &str) -> (Vec<PathBuf>, Vec<PathBuf>) {
+        let include_paths = self.include_paths_for_doc(doc_uri);
+        let mut doc_config = self.config_for_doc(doc_uri).unwrap_or_default();
+        let system_inc_paths = if doc_config.use_system_inc {
+            doc_config.get_system_inc().to_vec()
+        } else {
+            Vec::new()
+        };
+
+        (include_paths, system_inc_paths)
+    }
+
     fn split_sigil(name: &str) -> (Option<char>, &str) {
         let mut chars = name.chars();
         match chars.next() {
@@ -319,6 +332,7 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let (include_paths, system_inc_paths) = self.completion_paths_for_doc(uri);
 
                 // Get completions, with fallback for missing AST
                 #[cfg_attr(not(feature = "workspace"), allow(unused_mut))]
@@ -331,16 +345,23 @@ impl LspServer {
                         _ => None,
                     };
 
+                    #[cfg(not(feature = "workspace"))]
+                    let provider = CompletionProvider::new_with_index_and_source_and_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
+
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_and_source_and_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
-
-                    #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
 
                     let mut base_completions =
                         provider.get_completions_with_path(&doc.text, offset, Some(uri));
@@ -548,6 +569,7 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let (include_paths, system_inc_paths) = self.completion_paths_for_doc(uri);
 
                 // Create optimized cancellation callback with reduced frequency
                 // Performance optimization: reduced overhead from 16.66% to <10%
@@ -574,14 +596,21 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_and_source_and_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_and_source_and_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
 
                     // Use cancellable provider method
                     provider.get_completions_with_path_cancellable(


### PR DESCRIPTION
### Motivation
- Module-name completion lacked document-scoped include-path context and optional system `@INC` data, blocking later work to scan include paths for `.pm` files.
- Provide a minimal, safe plumbing layer to expose effective per-document include paths and opt-in system `@INC` to the completion provider without changing completion ranking or scanning behavior.

### Description
- Added `include_paths: Vec<PathBuf>` and `system_inc_paths: Vec<PathBuf>` fields to `CompletionProvider` and a new constructor `new_with_index_and_source_and_paths(...)` that accepts them while preserving existing constructors (which default to empty vectors).
- Runtime completion handlers now compute document-specific include paths and only probe system `@INC` when `use_system_inc` is enabled via `completion_paths_for_doc(...)`, and pass those vectors into the provider constructors in both normal and cancellable completion flows (`crates/perl-lsp-rs/src/runtime/language/completion.rs`).
- Threaded the new fields through the `use`/`require` module completion path by extending the `add_use_module_completions` signature (currently accepted but not yet used for filesystem scanning) in `workspace.rs`.
- Added targeted unit tests that verify a provider can be constructed with doc-specific include/system paths and that behavior is unchanged when empty vectors are provided (`crates/perl-lsp-rs-core/src/providers/completion/completion.rs`).

### Testing
- Ran `cargo xtask fmt` which completed successfully.
- Attempted `cargo test -p perl-lsp-completion` which failed because that package name does not exist in the workspace (expected workspace package is `perl-lsp-rs-core`).
- Ran `cargo test -p perl-lsp-rs-core completion`, which succeeded (completion-related unit tests passed).
- Ran `cargo check --workspace --all-targets`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae60d84c08333a48253285caa90a4)