### PR TITLE
refactor(completion): plumb effective @INC paths into module completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -122,6 +122,7 @@ use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
 use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_workspace::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Maps module_name -> Set of explicitly imported symbol names.
@@ -170,6 +171,8 @@ pub struct CompletionProvider {
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
     import_map: ImportMap,
+    include_paths: Vec<PathBuf>,
+    system_inc_paths: Vec<PathBuf>,
 }
 
 impl CompletionProvider {
@@ -249,6 +252,26 @@ impl CompletionProvider {
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
     ) -> Self {
+        Self::new_with_index_and_source_and_paths(
+            ast,
+            source,
+            workspace_index,
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+
+    /// Create a completion provider with explicit document include-path context.
+    ///
+    /// This is used by runtime call-sites that have already resolved effective
+    /// include paths and optional system `@INC` paths for a specific document.
+    pub fn new_with_index_and_source_and_paths(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        include_paths: Vec<PathBuf>,
+        system_inc_paths: Vec<PathBuf>,
+    ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
         let type_engine = workspace_index.as_ref().map(|_| {
@@ -258,7 +281,15 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            import_map,
+            include_paths,
+            system_inc_paths,
+        }
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -774,6 +805,8 @@ impl CompletionProvider {
                 &mut completions,
                 &context,
                 &self.workspace_index,
+                &self.include_paths,
+                &self.system_inc_paths,
             );
         } else if self.is_has_type_value_context(source, position) {
             self.add_has_type_completions(&mut completions, &context);
@@ -3605,6 +3638,63 @@ sub helper { }
             "cursor after `use Module;` should not trigger module-name completions; got: {:?}",
             completions.iter().map(|c| (&c.label, &c.kind)).collect::<Vec<_>>()
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_provider_accepts_doc_specific_include_and_system_paths()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let code = "use ";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let include_paths = vec![PathBuf::from("/workspace/lib"), PathBuf::from("/workspace/ext")];
+        let system_inc_paths = vec![PathBuf::from("/usr/lib/perl5")];
+
+        let provider = CompletionProvider::new_with_index_and_source_and_paths(
+            &ast,
+            code,
+            None,
+            include_paths.clone(),
+            system_inc_paths.clone(),
+        );
+
+        assert_eq!(provider.include_paths, include_paths);
+        assert_eq!(provider.system_inc_paths, system_inc_paths);
+        Ok(())
+    }
+
+    #[test]
+    fn test_use_completion_unchanged_with_empty_inc_vectors()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let index = Arc::new(WorkspaceIndex::new());
+        index
+            .index_file(Url::parse("file:///lib/MyApp.pm")?, "package MyApp;\n1;\n".to_string())?;
+        let code = "use My";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+
+        let base_provider =
+            CompletionProvider::new_with_index_and_source(&ast, code, Some(Arc::clone(&index)));
+        let empty_paths_provider = CompletionProvider::new_with_index_and_source_and_paths(
+            &ast,
+            code,
+            Some(index),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let base_labels: Vec<String> = base_provider
+            .get_completions(code, code.len())
+            .into_iter()
+            .map(|item| item.label)
+            .collect();
+        let empty_labels: Vec<String> = empty_paths_provider
+            .get_completions(code, code.len())
+            .into_iter()
+            .map(|item| item.label)
+            .collect();
+
+        assert_eq!(base_labels, empty_labels);
         Ok(())
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -14,6 +14,7 @@ use perl_workspace::workspace_index::{
     SymbolKind as WsSymbolKind, VarKind, WorkspaceIndex, WorkspaceSymbol,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Add workspace symbol completions for functions and variables
@@ -240,6 +241,8 @@ pub fn add_use_module_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
+    _include_paths: &[PathBuf],
+    _system_inc_paths: &[PathBuf],
 ) {
     let Some(index) = workspace_index else {
         return;

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -319,6 +319,17 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let doc_config = self.config_for_doc(uri);
+                let include_paths = self.include_paths_for_doc(uri);
+                let system_inc_paths = if let Some(mut config) = doc_config {
+                    if config.use_system_inc {
+                        config.get_system_inc().to_vec()
+                    } else {
+                        Vec::new()
+                    }
+                } else {
+                    Vec::new()
+                };
 
                 // Get completions, with fallback for missing AST
                 #[cfg_attr(not(feature = "workspace"), allow(unused_mut))]
@@ -332,15 +343,22 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_and_source_and_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
 
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_and_source_and_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
 
                     let mut base_completions =
                         provider.get_completions_with_path(&doc.text, offset, Some(uri));
@@ -548,6 +566,17 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let doc_config = self.config_for_doc(uri);
+                let include_paths = self.include_paths_for_doc(uri);
+                let system_inc_paths = if let Some(mut config) = doc_config {
+                    if config.use_system_inc {
+                        config.get_system_inc().to_vec()
+                    } else {
+                        Vec::new()
+                    }
+                } else {
+                    Vec::new()
+                };
 
                 // Create optimized cancellation callback with reduced frequency
                 // Performance optimization: reduced overhead from 16.66% to <10%
@@ -574,14 +603,21 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_and_source_and_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_and_source_and_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
 
                     // Use cancellable provider method
                     provider.get_completions_with_path_cancellable(


### PR DESCRIPTION
### Motivation
- Provide document-scoped module search-path context to module-name completion (phase 1 of #4314) so the completion provider can be constructed with effective include paths and optional system `@INC` without yet implementing filesystem scanning.

### Description
- Fetch document config and effective include paths at runtime via `config_for_doc` and `include_paths_for_doc` and compute `system_inc_paths` only when `use_system_inc` is enabled, then pass both vectors into completion construction in `handle_completion` and `handle_completion_cancellable`.
- Extend `CompletionProvider` with `include_paths: Vec<PathBuf>` and `system_inc_paths: Vec<PathBuf>`, and add a new constructor `new_with_index_and_source_and_paths(...)` while keeping existing constructors defaulting to empty vectors.
- Thread the new fields through the `use`/`require` module completion path by updating the `add_use_module_completions` signature to accept `_include_paths` and `_system_inc_paths` (plumbing only; no scanning/ranking changes in this PR).
- Add targeted tests that verify a provider can be constructed with document-specific include/system vectors and that behavior is unchanged when those vectors are empty.

### Testing
- Ran `cargo test -p perl-lsp-rs-core doc_specific_include_and_system_paths` and the new provider-construction test passed.
- Ran `cargo test -p perl-lsp-rs-core test_use_completion_unchanged_with_empty_inc_vectors` (and the grouped test run covering it) and it passed, confirming unchanged behavior with empty vectors.
- Ran `cargo check --workspace --all-targets` and the workspace compiled successfully (warnings only), indicating the changes type-check across targets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae60d84c08333a48253285caa90a4)