### PR TITLE
feat(workspace-index): add cross-file reference query foundation (#3522)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/mod.rs
+++ b/crates/perl-workspace-index/src/workspace/mod.rs
@@ -51,4 +51,6 @@ pub use state_machine::{
     BuildPhase, DegradationReason, IndexState, IndexStateKind, IndexStateMachine,
     InvalidationReason, ResourceKind, TransitionResult,
 };
-pub use workspace_index::{IndexResourceLimits, Location, WorkspaceIndex};
+pub use workspace_index::{
+    CrossFileReferenceQuery, IndexResourceLimits, Location, SymbolIdentity, WorkspaceIndex,
+};

--- a/crates/perl-workspace-index/src/workspace/production_coordinator.rs
+++ b/crates/perl-workspace-index/src/workspace/production_coordinator.rs
@@ -439,6 +439,21 @@ impl ProductionIndexCoordinator {
         result
     }
 
+    /// Query definition + references with a stable symbol identity.
+    pub fn query_cross_file_references(
+        &self,
+        symbol_name: &str,
+    ) -> Option<super::workspace_index::CrossFileReferenceQuery> {
+        let start = self.slo_tracker.start_operation(OperationType::FindReferences);
+        let result = self.index.query_cross_file_references(symbol_name);
+        self.slo_tracker.record_operation_type(
+            OperationType::FindReferences,
+            start,
+            OperationResult::Success,
+        );
+        result
+    }
+
     /// Invalidate the index.
     ///
     /// # Arguments

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -989,6 +989,30 @@ pub struct Location {
     pub range: Range,
 }
 
+/// Stable symbol identity for cross-file reference queries.
+#[derive(Debug, Clone)]
+pub struct SymbolIdentity {
+    /// Canonical symbol key used for cross-file lookups.
+    ///
+    /// Prefer a fully-qualified name (`Package::name`) when available.
+    pub stable_key: String,
+    /// Bare symbol name without package qualification.
+    pub bare_name: String,
+    /// Fully-qualified symbol name when available.
+    pub qualified_name: Option<String>,
+}
+
+/// Result for workspace-wide definition + references lookup.
+#[derive(Debug, Clone)]
+pub struct CrossFileReferenceQuery {
+    /// Stable identity of the queried symbol.
+    pub symbol: SymbolIdentity,
+    /// Definition location for the symbol.
+    pub definition: Location,
+    /// Reference locations (definition excluded), sorted deterministically.
+    pub references: Vec<Location>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// A symbol in the workspace for Index/Navigate workflows.
 pub struct WorkspaceSymbol {
@@ -1129,6 +1153,62 @@ pub struct WorkspaceIndex {
 }
 
 impl WorkspaceIndex {
+    fn location_key(location: &Location) -> (&str, u32, u32, u32, u32) {
+        (
+            &location.uri,
+            location.range.start.line,
+            location.range.start.column,
+            location.range.end.line,
+            location.range.end.column,
+        )
+    }
+
+    fn sort_dedup_locations(mut locations: Vec<Location>) -> Vec<Location> {
+        locations.sort_by(|left, right| Self::location_key(left).cmp(&Self::location_key(right)));
+        locations.dedup_by(|left, right| Self::location_key(left) == Self::location_key(right));
+        locations
+    }
+
+    fn resolve_symbol_identity(&self, definition: &Location) -> Option<SymbolIdentity> {
+        let files = self.files.read();
+        let file_index = files.values().find(|fi| fi.source_uri == definition.uri)?;
+        let definition_symbol =
+            file_index.symbols.iter().find(|symbol| symbol.range == definition.range)?;
+
+        let qualified_name = definition_symbol.qualified_name.clone();
+        let stable_key = qualified_name.clone().unwrap_or_else(|| definition_symbol.name.clone());
+        Some(SymbolIdentity {
+            stable_key,
+            bare_name: definition_symbol.name.clone(),
+            qualified_name,
+        })
+    }
+
+    fn collect_exact_references(
+        &self,
+        keys: &[String],
+        definition: &Location,
+        include_definition: bool,
+    ) -> Vec<Location> {
+        let global_refs = self.global_references.read();
+        let mut references: Vec<Location> = Vec::new();
+        for key in keys {
+            if let Some(locations) = global_refs.get(key) {
+                for location in locations {
+                    let candidate = Location { uri: location.uri.clone(), range: location.range };
+                    if !include_definition
+                        && Self::location_key(&candidate) == Self::location_key(definition)
+                    {
+                        continue;
+                    }
+                    references.push(candidate);
+                }
+            }
+        }
+
+        Self::sort_dedup_locations(references)
+    }
+
     fn rebuild_symbol_cache(
         files: &HashMap<String, FileIndex>,
         symbols: &mut HashMap<String, String>,
@@ -2022,6 +2102,37 @@ impl WorkspaceIndex {
         }
 
         None
+    }
+
+    /// Query definition + references for statically-resolved cross-file symbol lookups.
+    ///
+    /// This foundation API intentionally prefers exact symbol keys to avoid
+    /// false positives from ambiguous bare-name matching. It is designed for
+    /// workspace rename/safe-delete planning, where conservative accuracy is
+    /// preferred over speculative matches.
+    pub fn query_cross_file_references(
+        &self,
+        symbol_name: &str,
+    ) -> Option<CrossFileReferenceQuery> {
+        let definition = self.find_definition(symbol_name)?;
+        let symbol = self.resolve_symbol_identity(&definition).unwrap_or_else(|| {
+            let bare_name = symbol_name
+                .rsplit_once("::")
+                .map_or(symbol_name.to_string(), |(_, bare)| bare.to_string());
+            SymbolIdentity {
+                stable_key: symbol_name.to_string(),
+                bare_name,
+                qualified_name: symbol_name.contains("::").then(|| symbol_name.to_string()),
+            }
+        });
+
+        let mut lookup_keys = vec![symbol.stable_key.clone()];
+        if symbol_name != symbol.stable_key {
+            lookup_keys.push(symbol_name.to_string());
+        }
+
+        let references = self.collect_exact_references(&lookup_keys, &definition, false);
+        Some(CrossFileReferenceQuery { symbol, definition, references })
     }
 
     /// Get all symbols in the workspace

--- a/crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs
+++ b/crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs
@@ -1,0 +1,61 @@
+use perl_workspace::workspace::workspace_index::WorkspaceIndex;
+use url::Url;
+
+fn file_url(path: &str) -> Result<Url, Box<dyn std::error::Error>> {
+    Ok(Url::parse(&format!("file://{path}"))?)
+}
+
+#[test]
+fn query_cross_file_references_returns_definition_and_cross_file_usages()
+-> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let def_uri = file_url("/workspace/lib/Utils.pm")?;
+    let caller_a_uri = file_url("/workspace/app/main.pl")?;
+    let caller_b_uri = file_url("/workspace/app/worker.pl")?;
+
+    index
+        .index_file(def_uri.clone(), "package Utils;\nsub process_data { 1 }\n1;\n".to_string())?;
+    index.index_file(caller_a_uri, "package App::Main;\nUtils::process_data();\n".to_string())?;
+    index.index_file(caller_b_uri, "package App::Worker;\nUtils::process_data();\n".to_string())?;
+
+    let result =
+        index.query_cross_file_references("Utils::process_data").ok_or("symbol not found")?;
+
+    assert_eq!(result.symbol.stable_key, "Utils::process_data");
+    assert_eq!(result.symbol.qualified_name.as_deref(), Some("Utils::process_data"));
+    assert!(result.definition.uri.ends_with("/workspace/lib/Utils.pm"));
+    assert_eq!(result.references.len(), 2);
+    assert!(
+        result.references[0].uri <= result.references[1].uri,
+        "references should be deterministically ordered"
+    );
+    assert!(
+        result.references.iter().all(|location| location.uri != def_uri.to_string()),
+        "definition should not be returned as a usage reference"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn query_cross_file_references_avoids_bare_name_false_positives_and_handles_not_found()
+-> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let alpha_uri = file_url("/workspace/lib/Alpha.pm")?;
+    let beta_uri = file_url("/workspace/lib/Beta.pm")?;
+    let caller_uri = file_url("/workspace/app/caller.pl")?;
+
+    index.index_file(alpha_uri, "package Alpha;\nsub helper { 1 }\n1;\n".to_string())?;
+    index.index_file(beta_uri, "package Beta;\nsub helper { 1 }\n1;\n".to_string())?;
+    index.index_file(caller_uri, "package Caller;\nAlpha::helper();\n".to_string())?;
+
+    let result = index.query_cross_file_references("Alpha::helper").ok_or("symbol not found")?;
+
+    assert_eq!(result.symbol.stable_key, "Alpha::helper");
+    assert_eq!(result.references.len(), 1);
+    assert!(result.references[0].uri.ends_with("/workspace/app/caller.pl"));
+
+    assert!(index.query_cross_file_references("Does::Not::Exist").is_none());
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Provide a stable, read-only cross-file query useful for workspace-wide rename and safe-delete planning that returns a stable symbol identity plus definition and deterministic reference locations. 
- Avoid ambiguous bare-name false-positives by preferring exact / fully-qualified keys for conservative, safe refactoring decisions. 

### Description
- Added `SymbolIdentity` and `CrossFileReferenceQuery` types to model a stable symbol key, bare/qualified names, definition location, and deterministic list of references. 
- Implemented `WorkspaceIndex::query_cross_file_references()` with helpers (`location_key`, `sort_dedup_locations`, `resolve_symbol_identity`, `collect_exact_references`) that prefer exact symbol keys, exclude the definition from usage results, and return deduplicated, deterministically ordered locations. 
- Exposed the new query through production coordinator glue (`ProductionIndexCoordinator::query_cross_file_references`) and re-exported the new types from the workspace module for ergonomic imports. 
- Added cross-file tests (`crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs`) that validate definition+references across files, deterministic ordering, exclusion of definition from usages, false-positive avoidance, and not-found behavior. 

### Testing
- Ran `cargo test -p perl-workspace` which executed the workspace-index unit test suite (including the new cross-file tests) and completed successfully. 
- Ran `cargo check --workspace --all-targets` which completed successfully. 
- Ran formatting via `cargo xtask fmt` as part of verification and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae70415a48333b75ead59ecf473a1)