### PR TITLE
feat(workspace-index): add cross-file reference query foundation (#3522)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/mod.rs
+++ b/crates/perl-workspace-index/src/workspace/mod.rs
@@ -51,4 +51,6 @@ pub use state_machine::{
     BuildPhase, DegradationReason, IndexState, IndexStateKind, IndexStateMachine,
     InvalidationReason, ResourceKind, TransitionResult,
 };
-pub use workspace_index::{IndexResourceLimits, Location, WorkspaceIndex};
+pub use workspace_index::{
+    CrossFileReferenceQueryResult, IndexResourceLimits, Location, SymbolIdentity, WorkspaceIndex,
+};

--- a/crates/perl-workspace-index/src/workspace/production_coordinator.rs
+++ b/crates/perl-workspace-index/src/workspace/production_coordinator.rs
@@ -440,11 +440,21 @@ impl ProductionIndexCoordinator {
     }
 
     /// Resolve symbol identity + definition + references for cross-file planning.
+    ///
+    /// Returns `None` when no definition can be resolved for `symbol_name`.
+    /// SLO-tracked under `FindReferences` (same budget as find_references, same latency class).
     pub fn query_symbol_references(
         &self,
         symbol_name: &str,
     ) -> Option<super::workspace_index::CrossFileReferenceQueryResult> {
-        self.index.query_symbol_references(symbol_name)
+        let start = self.slo_tracker.start_operation(OperationType::FindReferences);
+        let result = self.index.query_symbol_references(symbol_name);
+        self.slo_tracker.record_operation_type(
+            OperationType::FindReferences,
+            start,
+            OperationResult::Success,
+        );
+        result
     }
 
     /// Invalidate the index.

--- a/crates/perl-workspace-index/src/workspace/production_coordinator.rs
+++ b/crates/perl-workspace-index/src/workspace/production_coordinator.rs
@@ -44,8 +44,8 @@ use super::slo::{OperationResult, OperationType, SloConfig, SloTracker};
 use super::state_machine::{IndexState, IndexStateMachine, InvalidationReason, TransitionResult};
 use super::workspace_index::{IndexResourceLimits, WorkspaceIndex};
 use crate::position::{Position, Range};
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use url::Url;
@@ -632,8 +632,8 @@ mod tests {
     }
 
     #[test]
-    fn test_coordinator_reuses_identical_file_contents_without_dropping_symbols(
-    ) -> Result<(), String> {
+    fn test_coordinator_reuses_identical_file_contents_without_dropping_symbols()
+    -> Result<(), String> {
         let coordinator = ProductionIndexCoordinator::new();
         coordinator.initialize()?;
 

--- a/crates/perl-workspace-index/src/workspace/production_coordinator.rs
+++ b/crates/perl-workspace-index/src/workspace/production_coordinator.rs
@@ -44,8 +44,8 @@ use super::slo::{OperationResult, OperationType, SloConfig, SloTracker};
 use super::state_machine::{IndexState, IndexStateMachine, InvalidationReason, TransitionResult};
 use super::workspace_index::{IndexResourceLimits, WorkspaceIndex};
 use crate::position::{Position, Range};
-use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use url::Url;
@@ -439,6 +439,14 @@ impl ProductionIndexCoordinator {
         result
     }
 
+    /// Resolve symbol identity + definition + references for cross-file planning.
+    pub fn query_symbol_references(
+        &self,
+        symbol_name: &str,
+    ) -> Option<super::workspace_index::CrossFileReferenceQueryResult> {
+        self.index.query_symbol_references(symbol_name)
+    }
+
     /// Invalidate the index.
     ///
     /// # Arguments
@@ -614,8 +622,8 @@ mod tests {
     }
 
     #[test]
-    fn test_coordinator_reuses_identical_file_contents_without_dropping_symbols()
-    -> Result<(), String> {
+    fn test_coordinator_reuses_identical_file_contents_without_dropping_symbols(
+    ) -> Result<(), String> {
         let coordinator = ProductionIndexCoordinator::new();
         coordinator.initialize()?;
 

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -980,13 +980,37 @@ pub fn normalize_var(name: &str) -> (Option<char>, &str) {
 
 // Using lsp_types for Position and Range
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// Internal location type used during Navigate/Analyze workflows.
 pub struct Location {
     /// File URI where the symbol is located
     pub uri: String,
     /// Line and character range within the file
     pub range: Range,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Stable symbol identity returned by cross-file reference queries.
+pub struct SymbolIdentity {
+    /// Canonical stable key for the symbol (qualified when available).
+    pub stable_key: String,
+    /// Bare symbol name.
+    pub name: String,
+    /// Fully qualified symbol name when available.
+    pub qualified_name: Option<String>,
+    /// Symbol kind (subroutine, package, variable, ...).
+    pub kind: SymbolKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Read-only cross-file query result used by rename/safe-delete planners.
+pub struct CrossFileReferenceQueryResult {
+    /// Identity for the resolved symbol.
+    pub symbol: SymbolIdentity,
+    /// Definition site for the resolved symbol.
+    pub definition: Location,
+    /// All reference locations (including definition) in deterministic order.
+    pub references: Vec<Location>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1129,6 +1153,22 @@ pub struct WorkspaceIndex {
 }
 
 impl WorkspaceIndex {
+    fn location_sort_key(location: &Location) -> (&str, u32, u32, u32, u32) {
+        (
+            location.uri.as_str(),
+            location.range.start.line,
+            location.range.start.column,
+            location.range.end.line,
+            location.range.end.column,
+        )
+    }
+
+    fn sort_locations_deterministically(locations: &mut [Location]) {
+        locations.sort_by(|left, right| {
+            Self::location_sort_key(left).cmp(&Self::location_sort_key(right))
+        });
+    }
+
     fn rebuild_symbol_cache(
         files: &HashMap<String, FileIndex>,
         symbols: &mut HashMap<String, String>,
@@ -1245,6 +1285,7 @@ impl WorkspaceIndex {
         symbol_name: &str,
         uri_filter: Option<&str>,
     ) -> Option<(Location, String)> {
+        let mut candidates: Vec<(Location, String)> = Vec::new();
         for file_index in files.values() {
             if let Some(filter) = uri_filter
                 && file_index.symbols.first().is_some_and(|symbol| symbol.uri != filter)
@@ -1256,7 +1297,7 @@ impl WorkspaceIndex {
                 if symbol.name == symbol_name
                     || symbol.qualified_name.as_deref() == Some(symbol_name)
                 {
-                    return Some((
+                    candidates.push((
                         Location { uri: symbol.uri.clone(), range: symbol.range },
                         symbol.uri.clone(),
                     ));
@@ -1264,7 +1305,88 @@ impl WorkspaceIndex {
             }
         }
 
-        None
+        candidates.sort_by(|left, right| {
+            Self::location_sort_key(&left.0).cmp(&Self::location_sort_key(&right.0))
+        });
+        candidates.into_iter().next()
+    }
+
+    fn find_symbol_by_definition(
+        &self,
+        definition: &Location,
+        symbol_name: &str,
+    ) -> Option<WorkspaceSymbol> {
+        let files = self.files.read();
+        files
+            .values()
+            .flat_map(|file_index| file_index.symbols.iter())
+            .filter(|symbol| {
+                symbol.uri == definition.uri
+                    && symbol.range == definition.range
+                    && (symbol.name == symbol_name
+                        || symbol.qualified_name.as_deref() == Some(symbol_name))
+            })
+            .min_by(|left, right| {
+                (
+                    left.qualified_name.as_deref().unwrap_or_default(),
+                    left.name.as_str(),
+                    left.kind.to_lsp_kind(),
+                )
+                    .cmp(&(
+                        right.qualified_name.as_deref().unwrap_or_default(),
+                        right.name.as_str(),
+                        right.kind.to_lsp_kind(),
+                    ))
+            })
+            .cloned()
+    }
+
+    fn has_unique_symbol_name_and_kind(&self, target: &WorkspaceSymbol) -> bool {
+        let files = self.files.read();
+        files
+            .values()
+            .flat_map(|file_index| file_index.symbols.iter())
+            .filter(|symbol| symbol.name == target.name && symbol.kind == target.kind)
+            .take(2)
+            .count()
+            == 1
+    }
+
+    fn collect_symbol_references(&self, symbol: &WorkspaceSymbol) -> Vec<Location> {
+        let mut names_to_query: Vec<&str> = Vec::new();
+        if let Some(qualified_name) = symbol.qualified_name.as_deref() {
+            names_to_query.push(qualified_name);
+            if self.has_unique_symbol_name_and_kind(symbol) {
+                names_to_query.push(symbol.name.as_str());
+            }
+        } else {
+            names_to_query.push(symbol.name.as_str());
+        }
+
+        let global_refs = self.global_references.read();
+        let mut seen: HashSet<(String, u32, u32, u32, u32)> = HashSet::new();
+        let mut locations = Vec::new();
+
+        for symbol_name in names_to_query {
+            if let Some(refs) = global_refs.get(symbol_name) {
+                for location in refs {
+                    let key = (
+                        location.uri.clone(),
+                        location.range.start.line,
+                        location.range.start.column,
+                        location.range.end.line,
+                        location.range.end.column,
+                    );
+                    if seen.insert(key) {
+                        locations.push(location.clone());
+                    }
+                }
+            }
+        }
+        drop(global_refs);
+
+        Self::sort_locations_deterministically(&mut locations);
+        locations
     }
 
     /// Create a new empty index
@@ -1916,7 +2038,42 @@ impl WorkspaceIndex {
             }
         }
 
+        Self::sort_locations_deterministically(&mut locations);
         locations
+    }
+
+    /// Resolve a symbol and return its definition/reference set for cross-file planning.
+    ///
+    /// Returns `None` when no definition can be resolved for `symbol_name`.
+    pub fn query_symbol_references(
+        &self,
+        symbol_name: &str,
+    ) -> Option<CrossFileReferenceQueryResult> {
+        let definition = self.find_definition(symbol_name)?;
+        let symbol = self.find_symbol_by_definition(&definition, symbol_name)?;
+
+        let stable_key = symbol.qualified_name.clone().unwrap_or_else(|| {
+            format!(
+                "{}@{}:{}:{}",
+                symbol.name, symbol.uri, symbol.range.start.line, symbol.range.start.column
+            )
+        });
+        let mut references = self.collect_symbol_references(&symbol);
+        if !references.iter().any(|location| location == &definition) {
+            references.push(definition.clone());
+            Self::sort_locations_deterministically(&mut references);
+        }
+
+        Some(CrossFileReferenceQueryResult {
+            symbol: SymbolIdentity {
+                stable_key,
+                name: symbol.name,
+                qualified_name: symbol.qualified_name,
+                kind: symbol.kind,
+            },
+            definition,
+            references,
+        })
     }
 
     /// Count non-definition references (usages) of a symbol.

--- a/crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs
+++ b/crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs
@@ -5,6 +5,70 @@ fn file_url(path: &str) -> Result<Url, Box<dyn std::error::Error>> {
     Ok(Url::parse(&format!("file://{}", path))?)
 }
 
+// --- edge cases added by deep-review ---
+
+#[test]
+fn query_symbol_references_returns_none_on_empty_index() {
+    let index = WorkspaceIndex::new();
+    assert!(index.query_symbol_references("anything").is_none());
+    assert!(index.query_symbol_references("A::B::C").is_none());
+    assert!(index.query_symbol_references("").is_none());
+}
+
+#[test]
+fn query_symbol_references_definition_always_in_references(
+) -> Result<(), Box<dyn std::error::Error>> {
+    // The spec says references includes the definition site even when there are no callers.
+    let index = WorkspaceIndex::new();
+    index.index_file(
+        file_url("/workspace/lib/Standalone.pm")?,
+        "package Standalone;\nsub lone_wolf { 1 }\n".to_string(),
+    )?;
+
+    let query = index
+        .query_symbol_references("Standalone::lone_wolf")
+        .ok_or("query should resolve")?;
+
+    assert!(
+        query.references.iter().any(|loc| loc.uri == query.definition.uri),
+        "definition site must be present in references vec"
+    );
+    assert_eq!(query.definition.uri, "file:///workspace/lib/Standalone.pm");
+    Ok(())
+}
+
+#[test]
+fn query_symbol_references_is_stable_after_reindex() -> Result<(), Box<dyn std::error::Error>> {
+    // Idempotency: re-indexing a file with identical content must not change results.
+    let index = WorkspaceIndex::new();
+    let def_uri = file_url("/workspace/lib/Svc.pm")?;
+    let caller_uri = file_url("/workspace/lib/Cli.pm")?;
+    let src = "package Svc;\nsub run { 1 }\n".to_string();
+
+    index.index_file(def_uri.clone(), src.clone())?;
+    index.index_file(caller_uri, "package Cli;\nSvc::run();\n".to_string())?;
+
+    let first = index.query_symbol_references("Svc::run").ok_or("first query must resolve")?;
+
+    // Re-index the definition file with identical content — must be idempotent.
+    index.index_file(def_uri, src)?;
+
+    let second = index.query_symbol_references("Svc::run").ok_or("second query must resolve")?;
+
+    assert_eq!(
+        first.symbol.stable_key, second.symbol.stable_key,
+        "stable_key must not change on reindex with same content"
+    );
+    assert_eq!(
+        first.references.len(),
+        second.references.len(),
+        "reference count must be stable after reindex with same content"
+    );
+    Ok(())
+}
+
+// --- original builder tests ---
+
 #[test]
 fn query_symbol_references_returns_cross_file_definition_and_references(
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs
+++ b/crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs
@@ -16,8 +16,8 @@ fn query_symbol_references_returns_none_on_empty_index() {
 }
 
 #[test]
-fn query_symbol_references_definition_always_in_references(
-) -> Result<(), Box<dyn std::error::Error>> {
+fn query_symbol_references_definition_always_in_references()
+-> Result<(), Box<dyn std::error::Error>> {
     // The spec says references includes the definition site even when there are no callers.
     let index = WorkspaceIndex::new();
     index.index_file(
@@ -25,9 +25,8 @@ fn query_symbol_references_definition_always_in_references(
         "package Standalone;\nsub lone_wolf { 1 }\n".to_string(),
     )?;
 
-    let query = index
-        .query_symbol_references("Standalone::lone_wolf")
-        .ok_or("query should resolve")?;
+    let query =
+        index.query_symbol_references("Standalone::lone_wolf").ok_or("query should resolve")?;
 
     assert!(
         query.references.iter().any(|loc| loc.uri == query.definition.uri),
@@ -70,8 +69,8 @@ fn query_symbol_references_is_stable_after_reindex() -> Result<(), Box<dyn std::
 // --- original builder tests ---
 
 #[test]
-fn query_symbol_references_returns_cross_file_definition_and_references(
-) -> Result<(), Box<dyn std::error::Error>> {
+fn query_symbol_references_returns_cross_file_definition_and_references()
+-> Result<(), Box<dyn std::error::Error>> {
     let index = WorkspaceIndex::new();
 
     let def_uri = file_url("/workspace/lib/Service.pm")?;
@@ -117,8 +116,8 @@ fn query_symbol_references_returns_none_for_not_found() -> Result<(), Box<dyn st
 }
 
 #[test]
-fn query_symbol_references_avoids_false_positives_for_ambiguous_bare_symbols(
-) -> Result<(), Box<dyn std::error::Error>> {
+fn query_symbol_references_avoids_false_positives_for_ambiguous_bare_symbols()
+-> Result<(), Box<dyn std::error::Error>> {
     let index = WorkspaceIndex::new();
 
     index.index_file(

--- a/crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs
+++ b/crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs
@@ -1,0 +1,80 @@
+use perl_workspace::workspace::workspace_index::WorkspaceIndex;
+use url::Url;
+
+fn file_url(path: &str) -> Result<Url, Box<dyn std::error::Error>> {
+    Ok(Url::parse(&format!("file://{}", path))?)
+}
+
+#[test]
+fn query_symbol_references_returns_cross_file_definition_and_references(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+
+    let def_uri = file_url("/workspace/lib/Service.pm")?;
+    let call_a_uri = file_url("/workspace/lib/CallerA.pm")?;
+    let call_b_uri = file_url("/workspace/bin/run.pl")?;
+
+    index.index_file(def_uri, "package Service;\nsub process_payload { 1 }\n".to_string())?;
+    index.index_file(call_a_uri, "package CallerA;\nService::process_payload();\n".to_string())?;
+    index.index_file(call_b_uri, "package main;\nprocess_payload();\n".to_string())?;
+
+    let query =
+        index.query_symbol_references("Service::process_payload").ok_or("query should resolve")?;
+
+    assert_eq!(query.symbol.stable_key, "Service::process_payload");
+    assert_eq!(query.symbol.qualified_name.as_deref(), Some("Service::process_payload"));
+
+    let references: Vec<&str> =
+        query.references.iter().map(|location| location.uri.as_str()).collect();
+    assert_eq!(
+        references,
+        vec![
+            "file:///workspace/bin/run.pl",
+            "file:///workspace/lib/CallerA.pm",
+            "file:///workspace/lib/Service.pm",
+        ]
+    );
+
+    assert_eq!(query.definition.uri, "file:///workspace/lib/Service.pm");
+
+    Ok(())
+}
+
+#[test]
+fn query_symbol_references_returns_none_for_not_found() -> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let uri = file_url("/workspace/lib/Only.pm")?;
+    index.index_file(uri, "package Only;\nsub existing { 1 }\n".to_string())?;
+
+    assert!(index.query_symbol_references("Only::missing").is_none());
+    assert!(index.query_symbol_references("missing").is_none());
+
+    Ok(())
+}
+
+#[test]
+fn query_symbol_references_avoids_false_positives_for_ambiguous_bare_symbols(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+
+    index.index_file(
+        file_url("/workspace/lib/A.pm")?,
+        "package A;\nsub collide { 1 }\n".to_string(),
+    )?;
+    index.index_file(
+        file_url("/workspace/lib/B.pm")?,
+        "package B;\nsub collide { 1 }\n".to_string(),
+    )?;
+    index.index_file(
+        file_url("/workspace/lib/Caller.pm")?,
+        "package Caller;\ncollide();\n".to_string(),
+    )?;
+
+    let query = index.query_symbol_references("A::collide").ok_or("query should resolve")?;
+
+    let reference_uris: Vec<&str> =
+        query.references.iter().map(|location| location.uri.as_str()).collect();
+    assert_eq!(reference_uris, vec!["file:///workspace/lib/A.pm"]);
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Provide a stable, read-only cross-file query API required by workspace-wide rename and safe-delete planners that returns a stable symbol identity, the canonical definition site, and all references across files.
- Ensure deterministic ordering for returned locations to make tests and downstream planning deterministic and avoid false positives for ambiguous bare-name symbols.

### Description

- Added new read-only types `SymbolIdentity` and `CrossFileReferenceQueryResult` to model stable identity + definition + references returned by cross-file queries.
- Implemented `WorkspaceIndex::query_symbol_references(symbol_name)` which resolves the definition, selects the matching `WorkspaceSymbol`, and collects deterministic, de-duplicated `Location` results (including the definition).
- Added deterministic helpers `location_sort_key` and `sort_locations_deterministically`, improved `find_definition_in_files` to deterministically prefer a primary candidate, and implemented `find_symbol_by_definition`, `has_unique_symbol_name_and_kind`, and `collect_symbol_references` to support ambiguity-aware queries.
- Exposed a coordinator wrapper `ProductionIndexCoordinator::query_symbol_references(...)` and re-exported `SymbolIdentity` and `CrossFileReferenceQueryResult` from the `workspace` module for ergonomic downstream use.
- Added focused tests in `crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs` covering successful multi-file queries, not-found behavior, and protection against false positives when bare symbol names collide across packages.

### Testing

- Ran `cargo test -p perl-workspace --test cross_file_reference_query_tests` and the new cross-file tests passed (3 tests: success / not-found / ambiguity protection).
- Ran `cargo test -p perl-workspace` and the workspace index unit tests passed (existing suite + new tests ran successfully).
- Ran `cargo check --workspace --all-targets` which completed successfully.
- Note: `cargo test -p perl-workspace-index` initially failed because that package name is not present in the workspace (the crate/package used here is `perl-workspace`), so the canonical verification commands used were `cargo test -p perl-workspace` and `cargo check --workspace --all-targets`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae70415a48333b75ead59ecf473a1)