### PR TITLE
refactor(ux-tests): consolidate canonical editor UX harness (#5306)

### DIFF
--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -51,11 +51,11 @@ pub mod workspace;
 
 pub use client::{LspEvent, UxClient};
 pub use env::{PathGuard, RestrictedPath};
-pub use scorecard::{EditorUxScorecard, ScenarioScore, aggregate_editor_ux_scorecard};
+pub use scorecard::{aggregate_editor_ux_scorecard, EditorUxScorecard, ScenarioScore};
 pub use workspace::FakeWorkspace;
 
-use anyhow::{Context, Result, anyhow};
-use serde_json::{Value, json};
+use anyhow::{anyhow, Context, Result};
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -157,6 +157,20 @@ pub struct UxHarness {
     document_versions: Mutex<HashMap<String, i32>>,
 }
 
+/// UTF-16 cursor position used by editor-facing scenario fixtures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CursorPosition {
+    pub line: u32,
+    pub character: u32,
+}
+
+impl CursorPosition {
+    #[must_use]
+    pub const fn new(line: u32, character: u32) -> Self {
+        Self { line, character }
+    }
+}
+
 impl UxHarness {
     /// Spawn a fresh LSP server and set up a clean workspace.
     pub fn new(config: ScenarioConfig) -> Result<Self> {
@@ -218,6 +232,44 @@ impl UxHarness {
         self.client.did_open_with_language_id(&uri, content, language_id)
     }
 
+    /// Parse a fixture containing a cursor marker, open it, and return the marker position.
+    ///
+    /// Marker defaults to `<|>` in tests, but any non-empty marker is accepted.
+    pub fn open_fixture_with_cursor(
+        &self,
+        relative_path: &str,
+        fixture_with_cursor: &str,
+        marker: &str,
+    ) -> Result<CursorPosition> {
+        let (content, cursor) = Self::extract_cursor(fixture_with_cursor, marker)?;
+        self.open_file(relative_path, &content)?;
+        Ok(cursor)
+    }
+
+    /// Extract and remove a marker from fixture content, returning clean text + cursor position.
+    pub fn extract_cursor(
+        fixture_with_cursor: &str,
+        marker: &str,
+    ) -> Result<(String, CursorPosition)> {
+        if marker.is_empty() {
+            return Err(anyhow!("cursor marker must be non-empty"));
+        }
+        let Some(offset) = fixture_with_cursor.find(marker) else {
+            return Err(anyhow!("cursor marker {marker:?} not found in fixture"));
+        };
+        let clean = fixture_with_cursor.replacen(marker, "", 1);
+        let prefix = &fixture_with_cursor[..offset];
+        let line = prefix.bytes().filter(|b| *b == b'\n').count() as u32;
+        let line_start = prefix.rfind('\n').map_or(0, |idx| idx + 1);
+        let character = prefix[line_start..].chars().count() as u32;
+        Ok((clean, CursorPosition::new(line, character)))
+    }
+
+    /// Request hover information at the given cursor.
+    pub fn hover_at(&self, relative_path: &str, cursor: CursorPosition) -> Result<Option<Value>> {
+        self.hover(relative_path, cursor.line, cursor.character)
+    }
+
     /// Request hover information at `(line, character)` (0-indexed UTF-16).
     ///
     /// Returns `None` if the server returned a null/empty result (degraded mode is OK).
@@ -260,6 +312,11 @@ impl UxHarness {
                 None => Ok(Vec::new()),
             },
         }
+    }
+
+    /// Request completion at the given cursor.
+    pub fn completion_at(&self, relative_path: &str, cursor: CursorPosition) -> Result<Vec<Value>> {
+        self.completion(relative_path, cursor.line, cursor.character)
     }
 
     /// Request document formatting.
@@ -338,6 +395,32 @@ impl UxHarness {
                 }
             }
         }
+    }
+
+    /// Request references (`textDocument/references`).
+    pub fn references(&self, relative_path: &str, line: u32, character: u32) -> Result<Vec<Value>> {
+        let uri = self.workspace.uri(relative_path);
+        let resp = self.client.request(
+            "textDocument/references",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character },
+                "context": { "includeDeclaration": true }
+            }),
+            self.config.timeout,
+        )?;
+        if resp.get("error").is_some() {
+            return Err(anyhow!("references returned error: {}", resp["error"]));
+        }
+        match resp["result"].as_array() {
+            Some(locs) => Ok(locs.clone()),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// Request references at the given cursor.
+    pub fn references_at(&self, relative_path: &str, cursor: CursorPosition) -> Result<Vec<Value>> {
+        self.references(relative_path, cursor.line, cursor.character)
     }
 
     /// Notify the server that workspace folders changed.
@@ -461,6 +544,11 @@ impl UxHarness {
         }
     }
 
+    /// Request go-to-definition at the given cursor.
+    pub fn definition_at(&self, relative_path: &str, cursor: CursorPosition) -> Result<Vec<Value>> {
+        self.definition(relative_path, cursor.line, cursor.character)
+    }
+
     /// Request go-to-declaration.
     pub fn declaration(
         &self,
@@ -491,6 +579,33 @@ impl UxHarness {
                 }
             }
         }
+    }
+
+    /// Apply a full-document edit and wait for refreshed diagnostics.
+    pub fn apply_edit_and_collect_diagnostics(
+        &self,
+        relative_path: &str,
+        updated_content: &str,
+        timeout: Duration,
+    ) -> Result<Vec<Value>> {
+        self.change_file_full(relative_path, updated_content)?;
+        Ok(self.wait_for_diagnostics(relative_path, timeout))
+    }
+
+    /// Normalize and compare two JSON responses for platform-stable assertions.
+    pub fn assert_normalized_eq(&self, actual: &Value, expected: &Value) {
+        let normalized_actual = self.normalize_response(actual);
+        let normalized_expected = self.normalize_response(expected);
+        assert_eq!(
+            normalized_actual, normalized_expected,
+            "normalized LSP response mismatch.\nactual={normalized_actual:#}\nexpected={normalized_expected:#}"
+        );
+    }
+
+    /// Normalize URI/range-heavy LSP payloads for cross-platform assertions.
+    #[must_use]
+    pub fn normalize_response(&self, value: &Value) -> Value {
+        normalize_value(value, self.root_uri())
     }
 
     /// Drain any pending server-initiated messages (window/showMessage, etc.)
@@ -587,6 +702,71 @@ impl UxHarness {
     }
 }
 
+const URI_KEYS: &[&str] = &["uri", "targetUri", "workspaceFolderUri"];
+const RANGE_KEYS: &[&str] = &["range", "targetRange", "selectionRange"];
+
+fn normalize_value(value: &Value, workspace_root_uri: &str) -> Value {
+    match value {
+        Value::Array(items) => Value::Array(
+            items.iter().map(|item| normalize_value(item, workspace_root_uri)).collect(),
+        ),
+        Value::Object(map) => {
+            let mut normalized = serde_json::Map::new();
+            for (key, val) in map {
+                let normalized_val = if URI_KEYS.contains(&key.as_str()) {
+                    val.as_str()
+                        .map(|uri| Value::String(normalize_uri(uri, workspace_root_uri)))
+                        .unwrap_or_else(|| normalize_value(val, workspace_root_uri))
+                } else if RANGE_KEYS.contains(&key.as_str()) {
+                    normalize_range(val, workspace_root_uri)
+                } else {
+                    normalize_value(val, workspace_root_uri)
+                };
+                normalized.insert(key.clone(), normalized_val);
+            }
+            Value::Object(normalized)
+        }
+        _ => value.clone(),
+    }
+}
+
+fn normalize_range(value: &Value, workspace_root_uri: &str) -> Value {
+    match value {
+        Value::Object(range) => {
+            let mut normalized = serde_json::Map::new();
+            for (key, val) in range {
+                if key == "start" || key == "end" {
+                    normalized.insert(key.clone(), normalize_position(val));
+                } else {
+                    normalized.insert(key.clone(), normalize_value(val, workspace_root_uri));
+                }
+            }
+            Value::Object(normalized)
+        }
+        _ => normalize_value(value, workspace_root_uri),
+    }
+}
+
+fn normalize_position(value: &Value) -> Value {
+    match value {
+        Value::Object(position) => {
+            let line = position.get("line").and_then(Value::as_i64).unwrap_or_default();
+            let character = position.get("character").and_then(Value::as_i64).unwrap_or_default();
+            json!({ "line": line, "character": character })
+        }
+        _ => value.clone(),
+    }
+}
+
+fn normalize_uri(uri: &str, workspace_root_uri: &str) -> String {
+    let workspace_prefix = workspace_root_uri.trim_end_matches('/');
+    if let Some(relative) = uri.strip_prefix(workspace_prefix) {
+        let relative = relative.trim_start_matches('/');
+        return format!("file://$WORKSPACE/{relative}").replace('\\', "/");
+    }
+    uri.replace('\\', "/")
+}
+
 /// Outcome of a formatting request.
 #[derive(Debug)]
 pub enum FormatResult {
@@ -606,7 +786,11 @@ impl FormatResult {
 
     /// Extract the error message string if this is an error.
     pub fn error_message(&self) -> Option<&str> {
-        if let Self::Error(v) = self { v["message"].as_str() } else { None }
+        if let Self::Error(v) = self {
+            v["message"].as_str()
+        } else {
+            None
+        }
     }
 
     /// True if there are text edits.

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
@@ -13,7 +13,7 @@
 //!   pointing back into that file.
 //! - No crash signatures after the request.
 
-use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::{CursorPosition, ScenarioConfig, UxHarness};
 use std::time::Duration;
 
 fn binary_available() -> bool {
@@ -34,6 +34,18 @@ sub greet {\n\
 greet('World');\n\
 ";
 
+const GOTO_SOURCE_WITH_CURSOR: &str = "\
+use strict;\n\
+use warnings;\n\
+\n\
+sub greet {\n\
+    my ($name) = @_;\n\
+    return \"Hello, $name!\";\n\
+}\n\
+\n\
+<|>greet('World');\n\
+";
+
 #[test]
 fn scenario_10_definition_request_does_not_error() {
     if !binary_available() {
@@ -47,13 +59,14 @@ fn scenario_10_definition_request_does_not_error() {
     )
     .expect("Failed to create UX harness");
 
-    harness.open_file("greet.pl", GOTO_SOURCE).expect("didOpen should succeed");
+    let cursor = harness
+        .open_fixture_with_cursor("greet.pl", GOTO_SOURCE_WITH_CURSOR, "<|>")
+        .expect("fixture should open with cursor marker");
 
     // Allow the server to index the file.
     std::thread::sleep(Duration::from_millis(500));
 
-    // Request definition on the call site `greet('World')` — line 8, char 0.
-    let result = harness.definition("greet.pl", 8, 0);
+    let result = harness.definition_at("greet.pl", cursor);
     assert!(
         result.is_ok(),
         "textDocument/definition must not return a JSON-RPC error — feature grid regression: {:?}",
@@ -76,11 +89,13 @@ fn scenario_10_definition_result_is_location_or_empty() {
     )
     .expect("Failed to create UX harness");
 
-    harness.open_file("greet.pl", GOTO_SOURCE).expect("didOpen should succeed");
+    let cursor = harness
+        .open_fixture_with_cursor("greet.pl", GOTO_SOURCE_WITH_CURSOR, "<|>")
+        .expect("fixture should open with cursor marker");
 
     std::thread::sleep(Duration::from_millis(500));
 
-    let defs = harness.definition("greet.pl", 8, 0).expect("definition must not error");
+    let defs = harness.definition_at("greet.pl", cursor).expect("definition must not error");
 
     // If results are returned they must be well-formed Location objects.
     for loc in &defs {
@@ -90,12 +105,15 @@ fn scenario_10_definition_result_is_location_or_empty() {
             loc
         );
         // The location must point to our file (not some unrelated URI).
-        let uri = loc["uri"].as_str().unwrap_or("");
-        assert!(
-            uri.ends_with("greet.pl"),
-            "Definition location should point to greet.pl, got uri={:?}",
-            uri
-        );
+        if loc["uri"].is_string() && loc["range"].is_object() {
+            harness.assert_normalized_eq(
+                loc,
+                &serde_json::json!({
+                    "uri": "file://$WORKSPACE/greet.pl",
+                    "range": loc["range"].clone(),
+                }),
+            );
+        }
     }
 
     harness.assert_no_crash();
@@ -116,7 +134,7 @@ fn scenario_10_definition_on_unknown_position_returns_empty() {
 
     // Position in middle of `strict` string literal — no definition expected.
     let defs = harness
-        .definition("simple.pl", 0, 5)
+        .definition_at("simple.pl", CursorPosition::new(0, 5))
         .expect("definition must not error on arbitrary position");
 
     // Empty is fine; what we are testing is that no crash or error occurs.

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_11_hover.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_11_hover.rs
@@ -34,6 +34,32 @@ my $result = calculate_sum(3, 7);\n\
 print $result;\n\
 ";
 
+const HOVER_SOURCE_WITH_RESULT_CURSOR: &str = "\
+use strict;\n\
+use warnings;\n\
+\n\
+sub calculate_sum {\n\
+    my ($a, $b) = @_;\n\
+    return $a + $b;\n\
+}\n\
+\n\
+my <|>$result = calculate_sum(3, 7);\n\
+print $result;\n\
+";
+
+const HOVER_SOURCE_WITH_SUB_CURSOR: &str = "\
+use strict;\n\
+use warnings;\n\
+\n\
+sub <|>calculate_sum {\n\
+    my ($a, $b) = @_;\n\
+    return $a + $b;\n\
+}\n\
+\n\
+my $result = calculate_sum(3, 7);\n\
+print $result;\n\
+";
+
 #[test]
 fn scenario_11_hover_on_variable_does_not_error() {
     if !binary_available() {
@@ -47,12 +73,13 @@ fn scenario_11_hover_on_variable_does_not_error() {
     )
     .expect("Failed to create UX harness");
 
-    harness.open_file("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
+    let cursor = harness
+        .open_fixture_with_cursor("calc.pl", HOVER_SOURCE_WITH_RESULT_CURSOR, "<|>")
+        .expect("fixture should open with cursor marker");
 
     std::thread::sleep(Duration::from_millis(300));
 
-    // Hover on `$result` — line 8, char 3 (inside `$result`).
-    let hover_result = harness.hover("calc.pl", 8, 3);
+    let hover_result = harness.hover_at("calc.pl", cursor);
     assert!(
         hover_result.is_ok(),
         "textDocument/hover must not return a JSON-RPC error — feature grid regression: {:?}",
@@ -75,11 +102,13 @@ fn scenario_11_hover_result_has_valid_shape_when_non_null() {
     )
     .expect("Failed to create UX harness");
 
-    harness.open_file("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
+    let cursor = harness
+        .open_fixture_with_cursor("calc.pl", HOVER_SOURCE_WITH_RESULT_CURSOR, "<|>")
+        .expect("fixture should open with cursor marker");
 
     std::thread::sleep(Duration::from_millis(300));
 
-    match harness.hover("calc.pl", 8, 3) {
+    match harness.hover_at("calc.pl", cursor) {
         Ok(Some(result)) => {
             // Must contain `contents` field.
             assert!(
@@ -123,12 +152,13 @@ fn scenario_11_hover_on_sub_name_does_not_crash() {
     )
     .expect("Failed to create UX harness");
 
-    harness.open_file("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
+    let cursor = harness
+        .open_fixture_with_cursor("calc.pl", HOVER_SOURCE_WITH_SUB_CURSOR, "<|>")
+        .expect("fixture should open with cursor marker");
 
     std::thread::sleep(Duration::from_millis(300));
 
-    // Hover on `calculate_sum` sub declaration — line 3, char 4.
-    let hover_result = harness.hover("calc.pl", 3, 4);
+    let hover_result = harness.hover_at("calc.pl", cursor);
     assert!(hover_result.is_ok(), "Hover on sub declaration must not error: {:?}", hover_result);
 
     harness.assert_no_crash();

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_diagnostics_after_edit.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_diagnostics_after_edit.rs
@@ -6,7 +6,7 @@
 //! Verifies that the UX harness can drive a real edit cycle and observe
 //! follow-up `textDocument/publishDiagnostics` updates for the edited file.
 
-use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::{Duration, Instant};
 
 fn binary_available() -> bool {
@@ -66,11 +66,9 @@ fn scenario_18_diagnostics_republish_after_full_document_edit() {
     // Drain so the next wait_for_diagnostics sees only the post-edit notification.
     harness.collect_notifications();
 
-    harness
-        .change_file_full("edit_diag.pl", FIXED_SOURCE)
+    let updated = harness
+        .apply_edit_and_collect_diagnostics("edit_diag.pl", FIXED_SOURCE, Duration::from_secs(5))
         .expect("didChange full document should succeed");
-
-    let updated = harness.wait_for_diagnostics("edit_diag.pl", Duration::from_secs(5));
     for diag in &updated {
         assert!(
             diag.get("range").is_some() && diag.get("message").is_some(),
@@ -81,14 +79,17 @@ fn scenario_18_diagnostics_republish_after_full_document_edit() {
 
     // After draining the open-event and sending didChange, wait for the server
     // to republish diagnostics.  We expect at least 1 new diagnostics event.
-    let uri = harness.workspace.uri("edit_diag.pl");
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut diagnostics_event_count = 0_usize;
     while Instant::now() < deadline {
         diagnostics_event_count = harness
             .peek_notifications()
             .iter()
-            .filter(|event| matches!(event, LspEvent::Diagnostics { uri: event_uri, .. } if event_uri == &uri))
+            .filter_map(|event| match event {
+                perl_lsp_ux_tests::LspEvent::Diagnostics { uri: event_uri, .. } => Some(event_uri),
+                _ => None,
+            })
+            .filter(|event_uri| event_uri.ends_with("/edit_diag.pl"))
             .count();
         if diagnostics_event_count >= 1 {
             break;

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs
@@ -26,8 +26,17 @@ my $result = inc($value);
 print "$result\n";
 "#;
 
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
 #[test]
 fn scenario_18_declaration_request_does_not_error() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_18 declaration: perl-lsp binary not found");
+        return Ok(());
+    }
+
     let harness =
         UxHarness::new(ScenarioConfig::default().with_file("declaration.pl", DECLARATION_FIXTURE))?;
 
@@ -46,6 +55,11 @@ fn scenario_18_declaration_request_does_not_error() -> Result<()> {
 
 #[test]
 fn scenario_18_declaration_result_is_location_or_empty() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_18 declaration: perl-lsp binary not found");
+        return Ok(());
+    }
+
     let harness =
         UxHarness::new(ScenarioConfig::default().with_file("declaration.pl", DECLARATION_FIXTURE))?;
 


### PR DESCRIPTION
### Motivation

- Reduce duplicated editor-facing test plumbing and platform-dependent URI/range assertions by providing one canonical UX harness API.
- Make scenario tests easier to write and more stable by centralizing cursor fixtures, request helpers, and normalization logic.

### Description

- Added cursor-oriented editor helpers to the harness: `CursorPosition`, `open_fixture_with_cursor`, and `extract_cursor` to open fixtures containing an inline cursor marker and return a UTF-16 cursor position. 
- Exposed cursor-based request wrappers and new requests: `hover_at`, `completion_at`, `definition_at`, `references`, and `references_at`, plus `apply_edit_and_collect_diagnostics` for edit+diagnostics workflows.
- Introduced centralized normalization and assertion utilities (`normalize_response`, `assert_normalized_eq`) and helper functions to normalize URIs, ranges, and positions for cross-platform stable expectations.
- Migrated representative tests to the shared API: Scenario 10 (go-to-definition) and Scenario 11 (hover) now use cursor fixtures and harness helpers, and Scenario 18 (diagnostics-after-edit) now uses `apply_edit_and_collect_diagnostics`; declaration tests now skip cleanly when the `perl-lsp` binary is unavailable.

### Testing

- Ran `cargo xtask fmt` to format the modified files and the task completed successfully.
- Built the LSP binary with `cargo build -p perl-lsp-rs` and ran the UX test suite with `PERL_LSP_BIN=/workspace/perl-lsp/target/debug/perl-lsp cargo test -p perl-lsp-ux-tests`, which completed successfully.
- Ran a focused test invocation `PERL_LSP_BIN=/workspace/perl-lsp/target/debug/perl-lsp cargo test -p perl-lsp-ux-tests --test ux_scenario_10_goto_definition --test ux_scenario_11_hover --test ux_scenario_18_diagnostics_after_edit --test ux_scenario_18_goto_declaration` and all selected tests passed.
- Ran `cargo check --workspace --all-targets` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae70420608333bffbf79557cf13ef)