### PR TITLE
refactor(ux-tests): consolidate canonical editor UX harness (#5306)

### DIFF
--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -57,6 +57,7 @@ pub use workspace::FakeWorkspace;
 use anyhow::{Context, Result, anyhow};
 use serde_json::{Value, json};
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -157,6 +158,22 @@ pub struct UxHarness {
     document_versions: Mutex<HashMap<String, i32>>,
 }
 
+/// 0-based UTF-16 cursor position used by LSP text document requests.
+#[derive(Debug, Clone, Copy)]
+pub struct CursorPosition {
+    /// Line number (0-based).
+    pub line: u32,
+    /// Character offset in UTF-16 code units (0-based).
+    pub character: u32,
+}
+
+impl CursorPosition {
+    /// Construct a cursor position.
+    pub fn new(line: u32, character: u32) -> Self {
+        Self { line, character }
+    }
+}
+
 impl UxHarness {
     /// Spawn a fresh LSP server and set up a clean workspace.
     pub fn new(config: ScenarioConfig) -> Result<Self> {
@@ -188,6 +205,11 @@ impl UxHarness {
         self.client.did_open(&uri, content)?;
         self.document_versions.lock().unwrap_or_else(|e| e.into_inner()).insert(uri, 1);
         Ok(())
+    }
+
+    /// Open a fixture file in the temporary workspace and send `didOpen`.
+    pub fn open_fixture(&self, relative_path: &str, content: &str) -> Result<()> {
+        self.open_file(relative_path, content)
     }
 
     /// Apply a full-document text replacement and send `textDocument/didChange`.
@@ -223,12 +245,17 @@ impl UxHarness {
     /// Returns `None` if the server returned a null/empty result (degraded mode is OK).
     /// Returns `Err` only if the server returned a JSON-RPC error or timed out.
     pub fn hover(&self, relative_path: &str, line: u32, character: u32) -> Result<Option<Value>> {
+        self.hover_at(relative_path, CursorPosition::new(line, character))
+    }
+
+    /// Request hover information at a cursor position.
+    pub fn hover_at(&self, relative_path: &str, cursor: CursorPosition) -> Result<Option<Value>> {
         let uri = self.workspace.uri(relative_path);
         let resp = self.client.request(
             "textDocument/hover",
             json!({
                 "textDocument": { "uri": uri },
-                "position": { "line": line, "character": character }
+                "position": { "line": cursor.line, "character": cursor.character }
             }),
             self.config.timeout,
         )?;
@@ -240,12 +267,17 @@ impl UxHarness {
 
     /// Request completion at `(line, character)`.
     pub fn completion(&self, relative_path: &str, line: u32, character: u32) -> Result<Vec<Value>> {
+        self.completion_at(relative_path, CursorPosition::new(line, character))
+    }
+
+    /// Request completion at a cursor position.
+    pub fn completion_at(&self, relative_path: &str, cursor: CursorPosition) -> Result<Vec<Value>> {
         let uri = self.workspace.uri(relative_path);
         let resp = self.client.request(
             "textDocument/completion",
             json!({
                 "textDocument": { "uri": uri },
-                "position": { "line": line, "character": character },
+                "position": { "line": cursor.line, "character": cursor.character },
                 "context": { "triggerKind": 1 }
             }),
             self.config.timeout,
@@ -436,12 +468,17 @@ impl UxHarness {
 
     /// Request go-to-definition.
     pub fn definition(&self, relative_path: &str, line: u32, character: u32) -> Result<Vec<Value>> {
+        self.definition_at(relative_path, CursorPosition::new(line, character))
+    }
+
+    /// Request go-to-definition at a cursor position.
+    pub fn definition_at(&self, relative_path: &str, cursor: CursorPosition) -> Result<Vec<Value>> {
         let uri = self.workspace.uri(relative_path);
         let resp = self.client.request(
             "textDocument/definition",
             json!({
                 "textDocument": { "uri": uri },
-                "position": { "line": line, "character": character }
+                "position": { "line": cursor.line, "character": cursor.character }
             }),
             self.config.timeout,
         )?;
@@ -468,12 +505,21 @@ impl UxHarness {
         line: u32,
         character: u32,
     ) -> Result<Vec<Value>> {
+        self.declaration_at(relative_path, CursorPosition::new(line, character))
+    }
+
+    /// Request go-to-declaration at a cursor position.
+    pub fn declaration_at(
+        &self,
+        relative_path: &str,
+        cursor: CursorPosition,
+    ) -> Result<Vec<Value>> {
         let uri = self.workspace.uri(relative_path);
         let resp = self.client.request(
             "textDocument/declaration",
             json!({
                 "textDocument": { "uri": uri },
-                "position": { "line": line, "character": character }
+                "position": { "line": cursor.line, "character": cursor.character }
             }),
             self.config.timeout,
         )?;
@@ -491,6 +537,55 @@ impl UxHarness {
                 }
             }
         }
+    }
+
+    /// Request references at a cursor position.
+    pub fn references_at(&self, relative_path: &str, cursor: CursorPosition) -> Result<Vec<Value>> {
+        let uri = self.workspace.uri(relative_path);
+        let resp = self.client.request(
+            "textDocument/references",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": cursor.line, "character": cursor.character },
+                "context": { "includeDeclaration": true }
+            }),
+            self.config.timeout,
+        )?;
+        if resp.get("error").is_some() {
+            return Err(anyhow!("references returned error: {}", resp["error"]));
+        }
+        match resp["result"].as_array() {
+            Some(locs) => Ok(locs.clone()),
+            None => {
+                if resp["result"].is_null() {
+                    Ok(Vec::new())
+                } else {
+                    Ok(vec![resp["result"].clone()])
+                }
+            }
+        }
+    }
+
+    /// Apply a full-document edit and collect the next diagnostics update.
+    pub fn apply_edit_and_collect_diagnostics(
+        &self,
+        relative_path: &str,
+        updated_content: &str,
+        timeout: Duration,
+    ) -> Result<Vec<Value>> {
+        self.collect_notifications();
+        self.change_file_full(relative_path, updated_content)?;
+        Ok(self.wait_for_diagnostics(relative_path, timeout))
+    }
+
+    /// Normalize URIs/ranges and compare the response to an expected JSON value.
+    pub fn assert_normalized_response_eq(&self, actual: &Value, expected: &Value) {
+        let normalized_actual = normalize_value(actual, self.workspace.dir.path());
+        let normalized_expected = normalize_value(expected, self.workspace.dir.path());
+        assert_eq!(
+            normalized_actual, normalized_expected,
+            "normalized response mismatch\nactual: {normalized_actual:#}\nexpected: {normalized_expected:#}"
+        );
     }
 
     /// Drain any pending server-initiated messages (window/showMessage, etc.)
@@ -666,4 +761,44 @@ pub fn find_perltidy() -> Option<String> {
 /// Utility: find `perlcritic` on PATH, returning its path or `None`.
 pub fn find_perlcritic() -> Option<String> {
     which::which("perlcritic").ok().map(|p| p.to_string_lossy().to_string())
+}
+
+fn normalize_value(value: &Value, workspace_root: &Path) -> Value {
+    match value {
+        Value::Array(items) => Value::Array(
+            items.iter()
+                .map(|item| normalize_value(item, workspace_root))
+                .collect(),
+        ),
+        Value::Object(map) => {
+            let mut normalized = serde_json::Map::new();
+            for (key, item) in map {
+                if key == "uri" || key.ends_with("Uri") {
+                    if let Some(uri) = item.as_str() {
+                        normalized.insert(key.clone(), Value::String(normalize_uri(uri, workspace_root)));
+                    } else {
+                        normalized.insert(key.clone(), normalize_value(item, workspace_root));
+                    }
+                } else {
+                    normalized.insert(key.clone(), normalize_value(item, workspace_root));
+                }
+            }
+            Value::Object(normalized)
+        }
+        _ => value.clone(),
+    }
+}
+
+fn normalize_uri(uri: &str, workspace_root: &Path) -> String {
+    if let Ok(url) = url::Url::parse(uri)
+        && url.scheme() == "file"
+        && let Ok(path) = url.to_file_path()
+    {
+        if let Ok(relative) = path.strip_prefix(workspace_root) {
+            let relative = relative.to_string_lossy().replace('\\', "/");
+            return format!("$WORKSPACE/{}", relative.trim_start_matches('/'));
+        }
+        return path.to_string_lossy().replace('\\', "/");
+    }
+    uri.replace('\\', "/")
 }

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
@@ -13,7 +13,8 @@
 //!   pointing back into that file.
 //! - No crash signatures after the request.
 
-use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::{CursorPosition, ScenarioConfig, UxHarness};
+use serde_json::json;
 use std::time::Duration;
 
 fn binary_available() -> bool {
@@ -80,21 +81,18 @@ fn scenario_10_definition_result_is_location_or_empty() {
 
     std::thread::sleep(Duration::from_millis(500));
 
-    let defs = harness.definition("greet.pl", 8, 0).expect("definition must not error");
+    let defs = harness
+        .definition_at("greet.pl", CursorPosition::new(8, 0))
+        .expect("definition must not error");
 
     // If results are returned they must be well-formed Location objects.
     for loc in &defs {
-        assert!(
-            loc.get("uri").is_some() && loc.get("range").is_some(),
-            "Definition result must have 'uri' and 'range' fields, got: {:?}",
-            loc
-        );
-        // The location must point to our file (not some unrelated URI).
-        let uri = loc["uri"].as_str().unwrap_or("");
-        assert!(
-            uri.ends_with("greet.pl"),
-            "Definition location should point to greet.pl, got uri={:?}",
-            uri
+        harness.assert_normalized_response_eq(
+            loc,
+            &json!({
+                "uri": "$WORKSPACE/greet.pl",
+                "range": loc["range"].clone(),
+            }),
         );
     }
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_11_hover.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_11_hover.rs
@@ -13,7 +13,7 @@
 //! - A null/empty result is acceptable (degraded mode).
 //! - No crash signatures after the request.
 
-use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::{CursorPosition, ScenarioConfig, UxHarness};
 use std::time::Duration;
 
 fn binary_available() -> bool {
@@ -47,12 +47,12 @@ fn scenario_11_hover_on_variable_does_not_error() {
     )
     .expect("Failed to create UX harness");
 
-    harness.open_file("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
+    harness.open_fixture("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
 
     std::thread::sleep(Duration::from_millis(300));
 
     // Hover on `$result` — line 8, char 3 (inside `$result`).
-    let hover_result = harness.hover("calc.pl", 8, 3);
+    let hover_result = harness.hover_at("calc.pl", CursorPosition::new(8, 3));
     assert!(
         hover_result.is_ok(),
         "textDocument/hover must not return a JSON-RPC error — feature grid regression: {:?}",
@@ -75,11 +75,11 @@ fn scenario_11_hover_result_has_valid_shape_when_non_null() {
     )
     .expect("Failed to create UX harness");
 
-    harness.open_file("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
+    harness.open_fixture("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
 
     std::thread::sleep(Duration::from_millis(300));
 
-    match harness.hover("calc.pl", 8, 3) {
+    match harness.hover_at("calc.pl", CursorPosition::new(8, 3)) {
         Ok(Some(result)) => {
             // Must contain `contents` field.
             assert!(
@@ -123,12 +123,12 @@ fn scenario_11_hover_on_sub_name_does_not_crash() {
     )
     .expect("Failed to create UX harness");
 
-    harness.open_file("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
+    harness.open_fixture("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
 
     std::thread::sleep(Duration::from_millis(300));
 
     // Hover on `calculate_sum` sub declaration — line 3, char 4.
-    let hover_result = harness.hover("calc.pl", 3, 4);
+    let hover_result = harness.hover_at("calc.pl", CursorPosition::new(3, 4));
     assert!(hover_result.is_ok(), "Hover on sub declaration must not error: {:?}", hover_result);
 
     harness.assert_no_crash();

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_diagnostics_after_edit.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_diagnostics_after_edit.rs
@@ -63,14 +63,9 @@ fn scenario_18_diagnostics_republish_after_full_document_edit() {
         "Expected at least one diagnostic for BROKEN_SOURCE (unterminated expression); \
          got none — check the fixture content"
     );
-    // Drain so the next wait_for_diagnostics sees only the post-edit notification.
-    harness.collect_notifications();
-
-    harness
-        .change_file_full("edit_diag.pl", FIXED_SOURCE)
+    let updated = harness
+        .apply_edit_and_collect_diagnostics("edit_diag.pl", FIXED_SOURCE, Duration::from_secs(5))
         .expect("didChange full document should succeed");
-
-    let updated = harness.wait_for_diagnostics("edit_diag.pl", Duration::from_secs(5));
     for diag in &updated {
         assert!(
             diag.get("range").is_some() && diag.get("message").is_some(),

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs
@@ -26,8 +26,17 @@ my $result = inc($value);
 print "$result\n";
 "#;
 
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
 #[test]
 fn scenario_18_declaration_request_does_not_error() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_18 declaration: perl-lsp binary not found");
+        return Ok(());
+    }
+
     let harness =
         UxHarness::new(ScenarioConfig::default().with_file("declaration.pl", DECLARATION_FIXTURE))?;
 
@@ -46,6 +55,11 @@ fn scenario_18_declaration_request_does_not_error() -> Result<()> {
 
 #[test]
 fn scenario_18_declaration_result_is_location_or_empty() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_18 declaration: perl-lsp binary not found");
+        return Ok(());
+    }
+
     let harness =
         UxHarness::new(ScenarioConfig::default().with_file("declaration.pl", DECLARATION_FIXTURE))?;
 


### PR DESCRIPTION
### Motivation

- Reduce duplicated editor-facing helpers across UX scenario tests by providing one canonical harness API with stable normalization for platform-independent expectations.

### Description

- Added `CursorPosition` and cursor-based request helpers (`hover_at`, `completion_at`, `definition_at`, `declaration_at`, `references_at`) plus `open_fixture` to `crates/perl-lsp-ux-tests/src/lib.rs` to centralize editor interactions.
- Introduced `apply_edit_and_collect_diagnostics` to perform an edit and await diagnostics, and `assert_normalized_response_eq` with `normalize_value`/`normalize_uri` to normalize URIs/range-containing responses to a `$WORKSPACE/...` form for stable assertions across platforms.
- Migrated representative scenarios to the harness API: Scenario 10 (go-to-definition) now uses cursor requests and normalized assertions, Scenario 11 (hover) uses `open_fixture` and cursor hover calls, and Scenario 18 (diagnostics after edit) uses the edit+collect helper.
- Made Scenario 18 go-to-declaration tests skip cleanly when the `perl-lsp` binary is not available to match existing patterns in the suite.

### Testing

- Ran `cargo test -p perl-lsp-ux-tests` which initially failed when the `perl-lsp` binary was not available in the environment (expected fallback behavior guarded by existing checks in tests).
- Built the server with `cargo build -p perl-lsp-rs` and ran `PERL_LSP_BIN=/workspace/perl-lsp/target/debug/perl-lsp cargo test -p perl-lsp-ux-tests`, which completed successfully (migrated scenarios exercised and passed).
- Ran `cargo check --workspace --all-targets`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae70420608333bffbf79557cf13ef)