### PR TITLE
refactor(ux-tests): consolidate canonical editor UX harness (#5306)

### DIFF
--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -57,8 +57,28 @@ pub use workspace::FakeWorkspace;
 use anyhow::{Context, Result, anyhow};
 use serde_json::{Value, json};
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Mutex;
 use std::time::Duration;
+use url::Url;
+
+/// Canonical cursor position for editor-facing UX requests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CursorPosition {
+    /// Relative file path in the temp workspace.
+    pub relative_path: String,
+    /// 0-based line offset.
+    pub line: u32,
+    /// 0-based UTF-16 code-unit offset.
+    pub character: u32,
+}
+
+impl CursorPosition {
+    /// Create a cursor position at `(line, character)` inside `relative_path`.
+    pub fn new(relative_path: impl Into<String>, line: u32, character: u32) -> Self {
+        Self { relative_path: relative_path.into(), line, character }
+    }
+}
 
 /// Configuration for a UX scenario.
 ///
@@ -190,6 +210,23 @@ impl UxHarness {
         Ok(())
     }
 
+    /// Open a fixture file pre-seeded in `ScenarioConfig.workspace_files`.
+    pub fn open_fixture(&self, relative_path: &str) -> Result<()> {
+        let content = std::fs::read_to_string(self.workspace.path(relative_path))
+            .with_context(|| format!("Fixture file {:?} was not pre-seeded", relative_path))?;
+        self.open_file(relative_path, &content)
+    }
+
+    /// Build a canonical cursor position for subsequent UX requests.
+    pub fn position_cursor(
+        &self,
+        relative_path: impl Into<String>,
+        line: u32,
+        character: u32,
+    ) -> CursorPosition {
+        CursorPosition::new(relative_path, line, character)
+    }
+
     /// Apply a full-document text replacement and send `textDocument/didChange`.
     pub fn change_file_full(&self, relative_path: &str, updated_content: &str) -> Result<()> {
         self.workspace.write(relative_path, updated_content)?;
@@ -260,6 +297,11 @@ impl UxHarness {
                 None => Ok(Vec::new()),
             },
         }
+    }
+
+    /// Request completion at a canonical cursor position.
+    pub fn completion_at(&self, cursor: &CursorPosition) -> Result<Vec<Value>> {
+        self.completion(&cursor.relative_path, cursor.line, cursor.character)
     }
 
     /// Request document formatting.
@@ -461,6 +503,48 @@ impl UxHarness {
         }
     }
 
+    /// Request go-to-definition at a canonical cursor position.
+    pub fn definition_at(&self, cursor: &CursorPosition) -> Result<Vec<Value>> {
+        self.definition(&cursor.relative_path, cursor.line, cursor.character)
+    }
+
+    /// Request references (`textDocument/references`) at a cursor position.
+    pub fn references(
+        &self,
+        relative_path: &str,
+        line: u32,
+        character: u32,
+        include_declaration: bool,
+    ) -> Result<Vec<Value>> {
+        let uri = self.workspace.uri(relative_path);
+        let resp = self.client.request(
+            "textDocument/references",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character },
+                "context": { "includeDeclaration": include_declaration }
+            }),
+            self.config.timeout,
+        )?;
+        if resp.get("error").is_some() {
+            return Err(anyhow!("references returned error: {}", resp["error"]));
+        }
+        match resp["result"].as_array() {
+            Some(locs) => Ok(locs.clone()),
+            None if resp["result"].is_null() => Ok(Vec::new()),
+            None => Ok(vec![resp["result"].clone()]),
+        }
+    }
+
+    /// Request references at a canonical cursor position.
+    pub fn references_at(
+        &self,
+        cursor: &CursorPosition,
+        include_declaration: bool,
+    ) -> Result<Vec<Value>> {
+        self.references(&cursor.relative_path, cursor.line, cursor.character, include_declaration)
+    }
+
     /// Request go-to-declaration.
     pub fn declaration(
         &self,
@@ -585,6 +669,83 @@ impl UxHarness {
     pub fn root_uri(&self) -> &str {
         &self.workspace.root_uri
     }
+
+    /// Apply a full-document edit and wait for diagnostics from that file.
+    pub fn apply_edit_and_collect_diagnostics(
+        &self,
+        relative_path: &str,
+        updated_content: &str,
+        timeout: Duration,
+    ) -> Result<Vec<Value>> {
+        self.change_file_full(relative_path, updated_content)?;
+        Ok(self.wait_for_diagnostics(relative_path, timeout))
+    }
+
+    /// Normalize LSP payloads for platform-stable expectations.
+    ///
+    /// - Workspace file URIs are rewritten as `file://$WORKSPACE/<relative-path>`.
+    /// - Directory separators in normalized URIs are always `/`.
+    pub fn normalize_response(&self, payload: &Value) -> Value {
+        normalize_lsp_payload(payload, self.workspace.dir.path())
+    }
+
+    /// Assert that two LSP payloads match after canonical normalization.
+    pub fn assert_normalized_eq(&self, actual: &Value, expected: &Value) {
+        let normalized_actual = self.normalize_response(actual);
+        let normalized_expected = self.normalize_response(expected);
+        assert_eq!(
+            normalized_actual, normalized_expected,
+            "normalized payload mismatch\nactual={:#}\nexpected={:#}",
+            normalized_actual, normalized_expected
+        );
+    }
+}
+
+/// Normalize editor-facing LSP payloads so fixture assertions are OS-stable.
+pub fn normalize_lsp_payload(payload: &Value, workspace_root: &Path) -> Value {
+    match payload {
+        Value::Array(values) => Value::Array(
+            values.iter().map(|entry| normalize_lsp_payload(entry, workspace_root)).collect(),
+        ),
+        Value::Object(map) => {
+            let mut normalized = serde_json::Map::with_capacity(map.len());
+            for (key, value) in map {
+                if matches!(key.as_str(), "uri" | "targetUri" | "workspaceFolderUri") {
+                    if let Some(uri) = value.as_str() {
+                        normalized.insert(
+                            key.clone(),
+                            Value::String(normalize_uri_for_expectations(uri, workspace_root)),
+                        );
+                        continue;
+                    }
+                }
+                normalized.insert(key.clone(), normalize_lsp_payload(value, workspace_root));
+            }
+            Value::Object(normalized)
+        }
+        _ => payload.clone(),
+    }
+}
+
+fn normalize_uri_for_expectations(uri: &str, workspace_root: &Path) -> String {
+    let Ok(parsed) = Url::parse(uri) else {
+        return uri.replace('\\', "/");
+    };
+
+    if parsed.scheme() != "file" {
+        return uri.to_string();
+    }
+
+    let Ok(path) = parsed.to_file_path() else {
+        return uri.replace('\\', "/");
+    };
+
+    if let Ok(relative) = path.strip_prefix(workspace_root) {
+        let relative = relative.to_string_lossy().replace('\\', "/");
+        return format!("file://$WORKSPACE/{}", relative.trim_start_matches('/'));
+    }
+
+    format!("file://{}", path.to_string_lossy().replace('\\', "/"))
 }
 
 /// Outcome of a formatting request.

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -753,7 +753,9 @@ fn normalize_uri_for_expectations(uri: &str, workspace_root: &Path) -> String {
         return format!("file://$WORKSPACE/{}", relative.trim_start_matches('/'));
     }
 
-    format!("file://{}", path.to_string_lossy().replace('\\', "/"))
+    // Non-workspace file URI: return the url crate's canonical form, which already
+    // handles Windows drive letters correctly (file:///C:/...) without reconstruction.
+    parsed.to_string()
 }
 
 /// Outcome of a formatting request.

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -728,6 +728,14 @@ pub fn normalize_lsp_payload(payload: &Value, workspace_root: &Path) -> Value {
 }
 
 fn normalize_uri_for_expectations(uri: &str, workspace_root: &Path) -> String {
+    // Short-circuit: sentinel tokens already contain "$WORKSPACE" and must be returned
+    // verbatim.  On Windows the url crate interprets "$WORKSPACE" as a UNC host and
+    // Url::to_file_path() succeeds, producing a mangled path like `\\$workspace\foo`.
+    // Checking up-front is both correct and cheaper than parsing.
+    if uri.contains("$WORKSPACE") {
+        return uri.to_string();
+    }
+
     let Ok(parsed) = Url::parse(uri) else {
         return uri.replace('\\', "/");
     };
@@ -827,4 +835,175 @@ pub fn find_perltidy() -> Option<String> {
 /// Utility: find `perlcritic` on PATH, returning its path or `None`.
 pub fn find_perlcritic() -> Option<String> {
     which::which("perlcritic").ok().map(|p| p.to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod normalize_tests {
+    use super::{normalize_lsp_payload, normalize_uri_for_expectations};
+    use serde_json::{Value, json};
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    // ── normalize_uri_for_expectations ────────────────────────────────────────
+
+    #[test]
+    fn non_file_uri_passes_through_unchanged() {
+        let root = Path::new("/tmp/workspace");
+        let result = normalize_uri_for_expectations("untitled:foo.pl", root);
+        assert_eq!(result, "untitled:foo.pl");
+    }
+
+    #[test]
+    fn malformed_uri_has_backslashes_replaced() {
+        let root = Path::new("/tmp/workspace");
+        // Not a valid URI — Url::parse will fail, so backslash-replace branch runs.
+        let result = normalize_uri_for_expectations("not a uri \\path", root);
+        assert_eq!(result, "not a uri /path");
+    }
+
+    #[test]
+    fn workspace_file_uri_becomes_dollar_workspace_token() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let file_uri = url::Url::from_file_path(root.join("lib/Foo.pm")).unwrap().to_string();
+        let result = normalize_uri_for_expectations(&file_uri, root);
+        assert_eq!(result, "file://$WORKSPACE/lib/Foo.pm");
+    }
+
+    #[test]
+    fn workspace_root_uri_itself_becomes_dollar_workspace_slash() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let root_uri = url::Url::from_file_path(root).unwrap().to_string();
+        let result = normalize_uri_for_expectations(&root_uri, root);
+        // strip_prefix of root against itself gives "" -> "file://$WORKSPACE/"
+        assert_eq!(result, "file://$WORKSPACE/");
+    }
+
+    #[test]
+    fn non_workspace_file_uri_preserved_with_forward_slashes() {
+        let root = Path::new("/tmp/workspace");
+        // A system path outside the workspace should not be rewritten as $WORKSPACE.
+        let result = normalize_uri_for_expectations("file:///usr/share/perl5/strict.pm", root);
+        assert_eq!(result, "file:///usr/share/perl5/strict.pm");
+    }
+
+    #[test]
+    fn directory_uri_with_trailing_slash_normalizes_correctly() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        // Url::from_directory_path produces a trailing slash.
+        // to_file_path() strips it, so strip_prefix sees "svc-a" (no slash).
+        // The result must NOT have a trailing slash in the sentinel form.
+        let dir_uri = url::Url::from_directory_path(root.join("svc-a")).unwrap().to_string();
+        assert!(dir_uri.ends_with('/'), "directory URI should end with /");
+        let result = normalize_uri_for_expectations(&dir_uri, root);
+        assert_eq!(result, "file://$WORKSPACE/svc-a");
+    }
+
+    // ── normalize_lsp_payload ─────────────────────────────────────────────────
+
+    #[test]
+    fn null_value_passes_through() {
+        let dir = TempDir::new().unwrap();
+        let result = normalize_lsp_payload(&Value::Null, dir.path());
+        assert_eq!(result, Value::Null);
+    }
+
+    #[test]
+    fn scalar_values_pass_through() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(normalize_lsp_payload(&json!(42), dir.path()), json!(42));
+        assert_eq!(normalize_lsp_payload(&json!(true), dir.path()), json!(true));
+        assert_eq!(normalize_lsp_payload(&json!("hello"), dir.path()), json!("hello"));
+    }
+
+    #[test]
+    fn uri_key_in_object_is_normalized() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let file_uri = url::Url::from_file_path(root.join("foo.pl")).unwrap().to_string();
+        let payload =
+            json!({ "uri": file_uri, "range": { "start": { "line": 0, "character": 0 } } });
+        let result = normalize_lsp_payload(&payload, root);
+        assert_eq!(result["uri"], "file://$WORKSPACE/foo.pl");
+        // Range should be preserved unchanged.
+        assert_eq!(result["range"]["start"]["line"], 0);
+    }
+
+    #[test]
+    fn target_uri_key_in_object_is_normalized() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let file_uri = url::Url::from_file_path(root.join("bar.pm")).unwrap().to_string();
+        let payload = json!({ "targetUri": file_uri });
+        let result = normalize_lsp_payload(&payload, root);
+        assert_eq!(result["targetUri"], "file://$WORKSPACE/bar.pm");
+    }
+
+    #[test]
+    fn workspace_folder_uri_key_is_normalized() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let folder_uri = url::Url::from_directory_path(root.join("svc-a")).unwrap().to_string();
+        let payload = json!({ "workspaceFolderUri": folder_uri });
+        let result = normalize_lsp_payload(&payload, root);
+        // The value should start with file://$WORKSPACE/svc-a regardless of trailing slash.
+        let normalized = result["workspaceFolderUri"].as_str().unwrap();
+        assert!(
+            normalized.starts_with("file://$WORKSPACE/svc-a"),
+            "Expected svc-a token, got: {normalized}"
+        );
+    }
+
+    #[test]
+    fn non_uri_key_string_value_is_not_rewritten() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let file_uri = url::Url::from_file_path(root.join("foo.pl")).unwrap().to_string();
+        // A key named "someOtherField" holding a file URI should NOT be normalized.
+        let payload = json!({ "someOtherField": file_uri });
+        let result = normalize_lsp_payload(&payload, root);
+        assert_eq!(result["someOtherField"].as_str().unwrap(), file_uri.as_str());
+    }
+
+    #[test]
+    fn array_of_locations_normalizes_each_entry() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let uri_a = url::Url::from_file_path(root.join("a.pl")).unwrap().to_string();
+        let uri_b = url::Url::from_file_path(root.join("b.pm")).unwrap().to_string();
+        let payload = json!([
+            { "uri": uri_a },
+            { "uri": uri_b },
+        ]);
+        let result = normalize_lsp_payload(&payload, root);
+        assert_eq!(result[0]["uri"], "file://$WORKSPACE/a.pl");
+        assert_eq!(result[1]["uri"], "file://$WORKSPACE/b.pm");
+    }
+
+    #[test]
+    fn nested_uri_in_object_is_normalized_recursively() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let file_uri = url::Url::from_file_path(root.join("deep.pl")).unwrap().to_string();
+        // URI nested inside a non-uri-keyed wrapper should still be normalized.
+        let payload = json!({ "location": { "uri": file_uri } });
+        let result = normalize_lsp_payload(&payload, root);
+        assert_eq!(result["location"]["uri"], "file://$WORKSPACE/deep.pl");
+    }
+
+    #[test]
+    fn dollar_workspace_token_in_expected_passes_through_unchanged() {
+        // assert_normalized_eq normalizes BOTH sides. A literal "$WORKSPACE" token
+        // in the expected side must survive the round-trip unchanged, so it can
+        // match the normalized actual side.
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let expected_payload = json!({ "uri": "file://$WORKSPACE/foo.pl" });
+        let result = normalize_lsp_payload(&expected_payload, root);
+        // Url::parse("file://$WORKSPACE/foo.pl") treats $WORKSPACE as host and
+        // to_file_path() fails -> backslash-replace branch returns string unchanged.
+        assert_eq!(result["uri"], "file://$WORKSPACE/foo.pl");
+    }
 }

--- a/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
+++ b/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
@@ -62,10 +62,8 @@ fn editor_ux_fixture_matrix_covers_all_scenarios() -> Result<()> {
     let allowed_metrics =
         top_line_metrics.union(&component_metrics).cloned().collect::<BTreeSet<_>>();
     let mut confidence_signals_exercised = BTreeSet::new();
-    let baseline_metrics = BTreeSet::from([
-        "workflow_pass_rate".to_string(),
-        "workflow_stability_rate".to_string(),
-    ]);
+    let baseline_metrics =
+        BTreeSet::from(["workflow_pass_rate".to_string(), "workflow_stability_rate".to_string()]);
     let mut metric_usage_counts: HashMap<String, usize> =
         allowed_metrics.iter().cloned().map(|metric| (metric, 0_usize)).collect();
     let mut workflows_with_extended_metrics = 0_usize;

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
@@ -14,6 +14,7 @@
 //! - No crash signatures after the request.
 
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::json;
 use std::time::Duration;
 
 fn binary_available() -> bool {
@@ -53,7 +54,8 @@ fn scenario_10_definition_request_does_not_error() {
     std::thread::sleep(Duration::from_millis(500));
 
     // Request definition on the call site `greet('World')` — line 8, char 0.
-    let result = harness.definition("greet.pl", 8, 0);
+    let cursor = harness.position_cursor("greet.pl", 8, 0);
+    let result = harness.definition_at(&cursor);
     assert!(
         result.is_ok(),
         "textDocument/definition must not return a JSON-RPC error — feature grid regression: {:?}",
@@ -80,7 +82,8 @@ fn scenario_10_definition_result_is_location_or_empty() {
 
     std::thread::sleep(Duration::from_millis(500));
 
-    let defs = harness.definition("greet.pl", 8, 0).expect("definition must not error");
+    let cursor = harness.position_cursor("greet.pl", 8, 0);
+    let defs = harness.definition_at(&cursor).expect("definition must not error");
 
     // If results are returned they must be well-formed Location objects.
     for loc in &defs {
@@ -89,12 +92,12 @@ fn scenario_10_definition_result_is_location_or_empty() {
             "Definition result must have 'uri' and 'range' fields, got: {:?}",
             loc
         );
-        // The location must point to our file (not some unrelated URI).
-        let uri = loc["uri"].as_str().unwrap_or("");
-        assert!(
-            uri.ends_with("greet.pl"),
-            "Definition location should point to greet.pl, got uri={:?}",
-            uri
+        harness.assert_normalized_eq(
+            loc,
+            &json!({
+                "uri": "file://$WORKSPACE/greet.pl",
+                "range": loc["range"].clone(),
+            }),
         );
     }
 
@@ -115,9 +118,9 @@ fn scenario_10_definition_on_unknown_position_returns_empty() {
     harness.open_file("simple.pl", source).expect("didOpen should succeed");
 
     // Position in middle of `strict` string literal — no definition expected.
-    let defs = harness
-        .definition("simple.pl", 0, 5)
-        .expect("definition must not error on arbitrary position");
+    let cursor = harness.position_cursor("simple.pl", 0, 5);
+    let defs =
+        harness.definition_at(&cursor).expect("definition must not error on arbitrary position");
 
     // Empty is fine; what we are testing is that no crash or error occurs.
     let _ = defs;

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_15_workspace_symbols.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_15_workspace_symbols.rs
@@ -8,7 +8,7 @@
 //! disambiguatable via `workspaceFolderUri`.
 
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::collections::BTreeSet;
 use std::time::{Duration, Instant};
 
@@ -36,8 +36,19 @@ sub run {\n\
 1;\n\
 ";
 
-fn matching_run_symbols(symbols: &[Value]) -> Vec<&Value> {
-    symbols.iter().filter(|symbol| symbol["name"].as_str() == Some("run")).collect()
+fn matching_run_symbols(symbols: &[Value]) -> Vec<Value> {
+    symbols.iter().filter(|symbol| symbol["name"].as_str() == Some("run")).cloned().collect()
+}
+
+fn normalized_folder_uris(harness: &UxHarness, symbols: &[Value]) -> BTreeSet<String> {
+    symbols
+        .iter()
+        .filter_map(|symbol| symbol.get("workspaceFolderUri"))
+        .map(|uri| harness.normalize_response(&json!({ "workspaceFolderUri": uri })))
+        .filter_map(|normalized| {
+            normalized.get("workspaceFolderUri").and_then(|uri| uri.as_str()).map(ToOwned::to_owned)
+        })
+        .collect()
 }
 
 #[test]
@@ -66,15 +77,12 @@ fn scenario_15_workspace_symbol_multi_root_disambiguation() {
             .expect("workspace/symbol must not return an error in multi-root mode");
 
         let run_symbols = matching_run_symbols(&latest_symbols);
-        let folder_uris: BTreeSet<&str> = run_symbols
-            .iter()
-            .filter_map(|symbol| symbol.get("workspaceFolderUri").and_then(|uri| uri.as_str()))
-            .collect();
+        let folder_uris = normalized_folder_uris(&harness, &run_symbols);
 
         if run_symbols.len() >= 2
             && folder_uris.len() >= 2
-            && folder_uris.iter().any(|uri| uri.contains("/svc-a/"))
-            && folder_uris.iter().any(|uri| uri.contains("/svc-b/"))
+            && folder_uris.contains("file://$WORKSPACE/svc-a")
+            && folder_uris.contains("file://$WORKSPACE/svc-b")
         {
             break;
         }
@@ -90,10 +98,7 @@ fn scenario_15_workspace_symbol_multi_root_disambiguation() {
         latest_symbols
     );
 
-    let folder_uris: BTreeSet<&str> = run_symbols
-        .iter()
-        .filter_map(|symbol| symbol.get("workspaceFolderUri").and_then(|uri| uri.as_str()))
-        .collect();
+    let folder_uris = normalized_folder_uris(&harness, &run_symbols);
 
     assert!(
         folder_uris.len() >= 2,
@@ -102,12 +107,12 @@ fn scenario_15_workspace_symbol_multi_root_disambiguation() {
         latest_symbols
     );
     assert!(
-        folder_uris.iter().any(|uri| uri.contains("/svc-a/")),
+        folder_uris.contains("file://$WORKSPACE/svc-a"),
         "Expected one workspace symbol to point at svc-a, got: {:?}",
         folder_uris
     );
     assert!(
-        folder_uris.iter().any(|uri| uri.contains("/svc-b/")),
+        folder_uris.contains("file://$WORKSPACE/svc-b"),
         "Expected one workspace symbol to point at svc-b, got: {:?}",
         folder_uris
     );

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_17_deleted_file_churn.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_17_deleted_file_churn.rs
@@ -8,6 +8,7 @@
 
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::Value;
+use serde_json::json;
 use std::time::{Duration, Instant};
 
 fn binary_available() -> bool {
@@ -55,6 +56,7 @@ fn scenario_17_deleted_module_evicted_from_symbols_and_definition() {
 
     harness.open_file("main.pl", SCRIPT_SOURCE).expect("didOpen should succeed");
 
+    let cursor = harness.position_cursor("main.pl", 5, 25);
     let before_deadline = Instant::now() + Duration::from_secs(10);
     let mut symbols_before = Vec::new();
     let mut defs_before = Vec::new();
@@ -63,7 +65,7 @@ fn scenario_17_deleted_module_evicted_from_symbols_and_definition() {
             .workspace_symbols("gone_value_4068")
             .expect("workspace/symbol must not error before delete");
         defs_before =
-            harness.definition("main.pl", 5, 25).expect("definition must not error before delete");
+            harness.definition_at(&cursor).expect("definition must not error before delete");
 
         if !symbols_before.is_empty() && !defs_before.is_empty() {
             break;
@@ -81,6 +83,13 @@ fn scenario_17_deleted_module_evicted_from_symbols_and_definition() {
         "Expected definition to resolve before delete, got {:?}",
         defs_before
     );
+    harness.assert_normalized_eq(
+        &defs_before[0],
+        &json!({
+            "uri": "file://$WORKSPACE/lib/ModuleGone.pm",
+            "range": defs_before[0]["range"].clone(),
+        }),
+    );
 
     harness.workspace.delete("lib/ModuleGone.pm").expect("module delete should succeed");
     harness
@@ -95,7 +104,7 @@ fn scenario_17_deleted_module_evicted_from_symbols_and_definition() {
             .workspace_symbols("gone_value_4068")
             .expect("workspace/symbol must not error after delete");
         defs_after =
-            harness.definition("main.pl", 5, 25).expect("definition must not error after delete");
+            harness.definition_at(&cursor).expect("definition must not error after delete");
 
         if symbols_after.is_empty() && defs_after.is_empty() {
             break;

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_diagnostics_after_edit.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_diagnostics_after_edit.rs
@@ -66,11 +66,9 @@ fn scenario_18_diagnostics_republish_after_full_document_edit() {
     // Drain so the next wait_for_diagnostics sees only the post-edit notification.
     harness.collect_notifications();
 
-    harness
-        .change_file_full("edit_diag.pl", FIXED_SOURCE)
+    let updated = harness
+        .apply_edit_and_collect_diagnostics("edit_diag.pl", FIXED_SOURCE, Duration::from_secs(5))
         .expect("didChange full document should succeed");
-
-    let updated = harness.wait_for_diagnostics("edit_diag.pl", Duration::from_secs(5));
     for diag in &updated {
         assert!(
             diag.get("range").is_some() && diag.get("message").is_some(),


### PR DESCRIPTION
### Motivation

- Tests duplicated cursor/request wiring and ad-hoc URI/range normalization, causing brittle, platform-dependent expectations.
- Provide a single, canonical editor-facing harness so scenario authors can express interactions consistently.
- Centralize normalization so assertions in fixtures are OS-stable (workspace-relative URIs use `file://$WORKSPACE/...`).

### Description

- Added a canonical cursor type and editor APIs to the UX harness in `crates/perl-lsp-ux-tests/src/lib.rs`, including `CursorPosition`, `open_fixture`, `position_cursor`, `completion_at`, `definition_at`, `references`/`references_at`, and `apply_edit_and_collect_diagnostics`.
- Centralized LSP payload normalization via `normalize_lsp_payload` / `normalize_uri_for_expectations` and exposed `normalize_response` and `assert_normalized_eq` for platform-stable expectations.
- Migrated representative scenarios to the shared harness APIs and normalization: `tests/ux_scenario_10_goto_definition.rs`, `tests/ux_scenario_15_workspace_symbols.rs`, `tests/ux_scenario_17_deleted_file_churn.rs`, and `tests/ux_scenario_18_diagnostics_after_edit.rs`.
- Kept the change scoped to the UX test crate and test files only, avoiding unrelated refactors.

### Testing

- Ran `PERL_LSP_BIN=/workspace/perl-lsp/target/debug/perl-lsp cargo test -p perl-lsp-ux-tests` and all UX-tests completed successfully (test suite passed).
- Ran targeted test subset for migrated scenarios (`ux_scenario_10`, `ux_scenario_15`, `ux_scenario_17`, `ux_scenario_18`) with `PERL_LSP_BIN=... cargo test -p perl-lsp-ux-tests --test ...` and they passed.
- Ran `cargo check --workspace --all-targets` which completed successfully.
- Ran `cargo xtask fmt` to ensure formatting, which completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae70420608333bffbf79557cf13ef)