### PR TITLE
refactor(ux-tests): consolidate canonical editor UX harness (#5306)

### DIFF
--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -57,6 +57,7 @@ pub use workspace::FakeWorkspace;
 use anyhow::{Context, Result, anyhow};
 use serde_json::{Value, json};
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -157,6 +158,14 @@ pub struct UxHarness {
     document_versions: Mutex<HashMap<String, i32>>,
 }
 
+/// Cursor location in a workspace document.
+#[derive(Debug, Clone)]
+pub struct CursorPosition {
+    pub relative_path: String,
+    pub line: u32,
+    pub character: u32,
+}
+
 impl UxHarness {
     /// Spawn a fresh LSP server and set up a clean workspace.
     pub fn new(config: ScenarioConfig) -> Result<Self> {
@@ -188,6 +197,16 @@ impl UxHarness {
         self.client.did_open(&uri, content)?;
         self.document_versions.lock().unwrap_or_else(|e| e.into_inner()).insert(uri, 1);
         Ok(())
+    }
+
+    /// Open fixture content in the workspace and send `didOpen`.
+    pub fn open_fixture(&self, relative_path: &str, content: &str) -> Result<()> {
+        self.open_file(relative_path, content)
+    }
+
+    /// Create a reusable cursor position for editor-facing requests.
+    pub fn cursor(&self, relative_path: &str, line: u32, character: u32) -> CursorPosition {
+        CursorPosition { relative_path: relative_path.to_string(), line, character }
     }
 
     /// Apply a full-document text replacement and send `textDocument/didChange`.
@@ -238,6 +257,11 @@ impl UxHarness {
         Ok(Some(resp["result"].clone()))
     }
 
+    /// Request hover information at a previously built cursor position.
+    pub fn hover_at(&self, position: &CursorPosition) -> Result<Option<Value>> {
+        self.hover(&position.relative_path, position.line, position.character)
+    }
+
     /// Request completion at `(line, character)`.
     pub fn completion(&self, relative_path: &str, line: u32, character: u32) -> Result<Vec<Value>> {
         let uri = self.workspace.uri(relative_path);
@@ -260,6 +284,11 @@ impl UxHarness {
                 None => Ok(Vec::new()),
             },
         }
+    }
+
+    /// Request completion at a previously built cursor position.
+    pub fn completion_at(&self, position: &CursorPosition) -> Result<Vec<Value>> {
+        self.completion(&position.relative_path, position.line, position.character)
     }
 
     /// Request document formatting.
@@ -461,6 +490,70 @@ impl UxHarness {
         }
     }
 
+    /// Request go-to-definition at a previously built cursor position.
+    pub fn definition_at(&self, position: &CursorPosition) -> Result<Vec<Value>> {
+        self.definition(&position.relative_path, position.line, position.character)
+    }
+
+    /// Request references at a previously built cursor position.
+    pub fn references_at(&self, position: &CursorPosition) -> Result<Vec<Value>> {
+        self.references(&position.relative_path, position.line, position.character)
+    }
+
+    /// Request references.
+    pub fn references(&self, relative_path: &str, line: u32, character: u32) -> Result<Vec<Value>> {
+        let uri = self.workspace.uri(relative_path);
+        let resp = self.client.request(
+            "textDocument/references",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character },
+                "context": { "includeDeclaration": true }
+            }),
+            self.config.timeout,
+        )?;
+        if resp.get("error").is_some() {
+            return Err(anyhow!("references returned error: {}", resp["error"]));
+        }
+        match resp["result"].as_array() {
+            Some(locs) => Ok(locs.clone()),
+            None => {
+                if resp["result"].is_null() {
+                    Ok(Vec::new())
+                } else {
+                    Ok(vec![resp["result"].clone()])
+                }
+            }
+        }
+    }
+
+    /// Apply an edit and wait for diagnostics update for that file.
+    pub fn apply_edit_and_collect_diagnostics(
+        &self,
+        relative_path: &str,
+        updated_content: &str,
+        timeout: Duration,
+    ) -> Result<Vec<Value>> {
+        self.change_file_full(relative_path, updated_content)?;
+        Ok(self.wait_for_diagnostics(relative_path, timeout))
+    }
+
+    /// Normalize an LSP response payload for platform-stable comparisons.
+    pub fn normalize_response(&self, value: &Value) -> Value {
+        normalize_value(value, &self.workspace.root_uri)
+    }
+
+    /// Compare normalized response payload to normalized expectation.
+    pub fn assert_normalized_response(&self, actual: &Value, expected: &Value) {
+        let normalized_actual = self.normalize_response(actual);
+        let normalized_expected = self.normalize_response(expected);
+        assert_eq!(
+            normalized_actual, normalized_expected,
+            "Normalized response mismatch.\nactual={:?}\nexpected={:?}",
+            normalized_actual, normalized_expected
+        );
+    }
+
     /// Request go-to-declaration.
     pub fn declaration(
         &self,
@@ -584,6 +677,66 @@ impl UxHarness {
     /// Returns the root URI of the workspace (useful for the `rootUri` initialize param).
     pub fn root_uri(&self) -> &str {
         &self.workspace.root_uri
+    }
+}
+
+fn normalize_value(value: &Value, root_uri: &str) -> Value {
+    match value {
+        Value::Array(items) => {
+            let mut normalized =
+                items.iter().map(|item| normalize_value(item, root_uri)).collect::<Vec<Value>>();
+            normalized.sort_by_key(|entry| entry.to_string());
+            Value::Array(normalized)
+        }
+        Value::Object(map) => {
+            let mut normalized = serde_json::Map::new();
+            for (key, val) in map {
+                let normalized_value =
+                    if matches!(key.as_str(), "uri" | "targetUri" | "workspaceFolderUri") {
+                        normalize_uri_like_value(val, root_uri)
+                    } else {
+                        normalize_value(val, root_uri)
+                    };
+                normalized.insert(key.clone(), normalized_value);
+            }
+            Value::Object(normalized)
+        }
+        Value::String(text) => {
+            if text.starts_with("file://") {
+                normalize_uri_like_value(value, root_uri)
+            } else {
+                Value::String(text.replace("\\", "/"))
+            }
+        }
+        _ => value.clone(),
+    }
+}
+
+fn normalize_uri_like_value(value: &Value, root_uri: &str) -> Value {
+    match value {
+        Value::String(uri) => {
+            let slash_uri = uri.replace('\\', "/");
+            let slash_root = root_uri.replace('\\', "/");
+            let mut replaced_root = slash_uri.replace(&slash_root, "$WORKSPACE");
+            if let Some(rest) = replaced_root.strip_prefix("$WORKSPACE")
+                && !rest.is_empty()
+                && !rest.starts_with('/')
+            {
+                replaced_root = format!("$WORKSPACE/{rest}");
+            }
+            if replaced_root.starts_with("$WORKSPACE") {
+                Value::String(replaced_root.trim_end_matches('/').to_string())
+            } else if let Some(stripped) = replaced_root.strip_prefix("file://") {
+                let filename = Path::new(stripped)
+                    .file_name()
+                    .map(|name| name.to_string_lossy().to_string())
+                    .unwrap_or_else(|| stripped.to_string());
+                Value::String(filename)
+            } else {
+                Value::String(replaced_root)
+            }
+        }
+        _ => normalize_value(value, root_uri),
     }
 }
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
@@ -48,12 +48,13 @@ fn scenario_10_definition_request_does_not_error() {
     .expect("Failed to create UX harness");
 
     harness.open_file("greet.pl", GOTO_SOURCE).expect("didOpen should succeed");
+    let call_site = harness.cursor("greet.pl", 8, 0);
 
     // Allow the server to index the file.
     std::thread::sleep(Duration::from_millis(500));
 
     // Request definition on the call site `greet('World')` — line 8, char 0.
-    let result = harness.definition("greet.pl", 8, 0);
+    let result = harness.definition_at(&call_site);
     assert!(
         result.is_ok(),
         "textDocument/definition must not return a JSON-RPC error — feature grid regression: {:?}",
@@ -76,11 +77,12 @@ fn scenario_10_definition_result_is_location_or_empty() {
     )
     .expect("Failed to create UX harness");
 
-    harness.open_file("greet.pl", GOTO_SOURCE).expect("didOpen should succeed");
+    harness.open_fixture("greet.pl", GOTO_SOURCE).expect("didOpen should succeed");
+    let call_site = harness.cursor("greet.pl", 8, 0);
 
     std::thread::sleep(Duration::from_millis(500));
 
-    let defs = harness.definition("greet.pl", 8, 0).expect("definition must not error");
+    let defs = harness.definition_at(&call_site).expect("definition must not error");
 
     // If results are returned they must be well-formed Location objects.
     for loc in &defs {
@@ -90,11 +92,9 @@ fn scenario_10_definition_result_is_location_or_empty() {
             loc
         );
         // The location must point to our file (not some unrelated URI).
-        let uri = loc["uri"].as_str().unwrap_or("");
-        assert!(
-            uri.ends_with("greet.pl"),
-            "Definition location should point to greet.pl, got uri={:?}",
-            uri
+        harness.assert_normalized_response(
+            &serde_json::json!({ "uri": loc["uri"].clone() }),
+            &serde_json::json!({ "uri": "$WORKSPACE/greet.pl" }),
         );
     }
 
@@ -113,10 +113,11 @@ fn scenario_10_definition_on_unknown_position_returns_empty() {
         .expect("Failed to create UX harness");
 
     harness.open_file("simple.pl", source).expect("didOpen should succeed");
+    let unknown_position = harness.cursor("simple.pl", 0, 5);
 
     // Position in middle of `strict` string literal — no definition expected.
     let defs = harness
-        .definition("simple.pl", 0, 5)
+        .definition_at(&unknown_position)
         .expect("definition must not error on arbitrary position");
 
     // Empty is fine; what we are testing is that no crash or error occurs.

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_13_document_symbols.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_13_document_symbols.rs
@@ -57,7 +57,7 @@ fn scenario_13_document_symbol_does_not_error() {
     )
     .expect("Failed to create UX harness");
 
-    harness.open_file("Greeter.pm", SYMBOLS_SOURCE).expect("didOpen should succeed");
+    harness.open_fixture("Greeter.pm", SYMBOLS_SOURCE).expect("didOpen should succeed");
 
     std::thread::sleep(Duration::from_millis(300));
 
@@ -85,7 +85,7 @@ fn scenario_13_returned_symbols_have_valid_shape() {
     )
     .expect("Failed to create UX harness");
 
-    harness.open_file("Greeter.pm", SYMBOLS_SOURCE).expect("didOpen should succeed");
+    harness.open_fixture("Greeter.pm", SYMBOLS_SOURCE).expect("didOpen should succeed");
 
     std::thread::sleep(Duration::from_millis(300));
 
@@ -108,6 +108,12 @@ fn scenario_13_returned_symbols_have_valid_shape() {
              (SymbolInformation), got: {:?}",
             sym
         );
+        if let Some(location_uri) = sym.pointer("/location/uri") {
+            harness.assert_normalized_response(
+                &serde_json::json!({ "uri": location_uri.clone() }),
+                &serde_json::json!({ "uri": "$WORKSPACE/Greeter.pm" }),
+            );
+        }
     }
 
     harness.assert_no_crash();
@@ -126,7 +132,7 @@ fn scenario_13_rich_file_returns_known_sub_names() {
     )
     .expect("Failed to create UX harness");
 
-    harness.open_file("Greeter.pm", SYMBOLS_SOURCE).expect("didOpen should succeed");
+    harness.open_fixture("Greeter.pm", SYMBOLS_SOURCE).expect("didOpen should succeed");
 
     std::thread::sleep(Duration::from_millis(300));
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_15_workspace_symbols.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_15_workspace_symbols.rs
@@ -112,5 +112,19 @@ fn scenario_15_workspace_symbol_multi_root_disambiguation() {
         folder_uris
     );
 
+    let normalized_folder_uris = run_symbols
+        .iter()
+        .filter_map(|symbol| symbol.get("workspaceFolderUri"))
+        .map(|uri| harness.normalize_response(uri))
+        .filter_map(|uri| uri.as_str().map(ToOwned::to_owned))
+        .collect::<BTreeSet<String>>();
+    let expected_folder_uris =
+        BTreeSet::from(["$WORKSPACE/svc-a".to_string(), "$WORKSPACE/svc-b".to_string()]);
+    assert!(
+        expected_folder_uris.is_subset(&normalized_folder_uris),
+        "Expected normalized workspace folder URIs to include svc-a and svc-b, got {:?}",
+        normalized_folder_uris
+    );
+
     harness.assert_no_crash();
 }


### PR DESCRIPTION
### Motivation
- Tests duplicated editor-facing helpers and platform-sensitive URI/range normalization across multiple scenario files, making expectations noisy and brittle.
- Provide a single, small API surface for common editor interactions (open fixture, cursor, hover/completion/definition/references, edits+diagnostics) and centralized normalization for platform-stable assertions.

### Description
- Added a canonical harness API to `crates/perl-lsp-ux-tests/src/lib.rs`: `CursorPosition`, `open_fixture`, `cursor`, `hover_at`, `completion_at`, `definition_at`, `references_at`, `references`, and `apply_edit_and_collect_diagnostics` for common editor flows.
- Implemented centralized normalization helpers `normalize_value` and `normalize_uri_like_value` plus `normalize_response` and `assert_normalized_response` to make URI and path comparisons platform-stable (`$WORKSPACE` substitution, slash normalization, trimming).
- Migrated representative scenarios to use the harness and normalization: updated scenarios 10 (`ux_scenario_10_goto_definition.rs`), 13 (`ux_scenario_13_document_symbols.rs`), and 15 (`ux_scenario_15_workspace_symbols.rs`) to use the new API and assertions.
- Kept behavior conservative: new helpers wrap existing `UxClient` requests and preserve previous error/empty-result semantics.

### Testing
- Built the LSP binary with `cargo build -p perl-lsp-rs` and used it as `PERL_LSP_BIN` for tests, which succeeded.
- Ran `PERL_LSP_BIN=/workspace/perl-lsp/target/debug/perl-lsp cargo test -p perl-lsp-ux-tests --quiet` and all ux-tests passed.
- Ran `cargo check --workspace --all-targets` which completed successfully.
- Ran formatting via `cargo xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae70420608333bffbf79557cf13ef)