### PR TITLE
fix(lifecycle): remove forbidden test expect and justify allow (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -101,6 +101,7 @@ impl LspServer {
     ///
     /// Only sends if trace level is "messages" or "verbose".
     /// The verbose field is only included when trace level is "verbose".
+    // Kept for feature-gated trace instrumentation paths that may not be compiled in every target.
     #[allow(dead_code)]
     pub(crate) fn send_log_trace(&self, message: &str, verbose: Option<&str>) {
         let current_level = self.trace_level.lock().clone();
@@ -161,7 +162,11 @@ mod tests {
     #[test]
     fn initialized_can_only_be_sent_once() {
         let server = LspServer::new();
-        server.handle_initialize(None).expect("initialize request should succeed");
+        let initialize_result = server.handle_initialize(None);
+        assert!(
+            initialize_result.is_ok(),
+            "initialize request should succeed: {initialize_result:?}"
+        );
 
         let first = server.handle_initialized_dispatch();
         let second = server.handle_initialized_dispatch();
@@ -173,7 +178,11 @@ mod tests {
     #[test]
     fn auto_initialize_for_compat_promotes_initialized_state() {
         let server = LspServer::new();
-        server.handle_initialize(None).expect("initialize request should succeed");
+        let initialize_result = server.handle_initialize(None);
+        assert!(
+            initialize_result.is_ok(),
+            "initialize request should succeed: {initialize_result:?}"
+        );
 
         server.auto_initialize_for_compat("textDocument/hover");
 


### PR DESCRIPTION
### Motivation

- Tests in `lifecycle.rs` used `expect(...)`, which is banned by the project test quality bar, and the `#[allow(dead_code)]` on `send_log_trace` lacked an inline justification comment.

### Description

- Added an inline justification comment for the `#[allow(dead_code)]` on `send_log_trace` to document why the allow is necessary for feature-gated trace instrumentation paths.
- Replaced `expect(...)` calls in tests with an explicit `let initialize_result = server.handle_initialize(None); assert!(initialize_result.is_ok(), "initialize request should succeed: {initialize_result:?}");` pattern to preserve diagnostics while avoiding forbidden `expect` usage.
- Committed as a single focused change to `crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs`.

### Testing

- Ran `cargo test -p perl-lsp-rs --lib lifecycle` and the lifecycle test suite passed (`53 passed; 0 failed`).
- Ran `cargo check --all-targets -p perl-lsp-rs`, `cargo clippy -p perl-lsp-rs`, and `cargo xtask fmt`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae7c83ac483338f794a6e8a0cbb2f)