### PR TITLE
test(perl-lsp-rs): add BDD lifecycle dispatch scenarios (#6623)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -220,13 +220,16 @@ mod tests {
     }
 
     #[test]
-    fn given_initialized_server_when_shutdown_dispatch_runs_then_shutdown_flag_and_null_response_are_set()
+    fn given_server_receives_shutdown_when_shutdown_dispatch_runs_then_shutdown_flag_and_null_response_are_set()
     -> TestResult {
-        // Given — LSP spec requires initialize before shutdown
+        // Given — fully initialize so shutdown is valid per LSP spec
         let server = LspServer::new();
         server
             .handle_initialize(None)
             .map_err(|e| format!("initialize request should succeed: {e}"))?;
+        server
+            .handle_initialized_dispatch()
+            .map_err(|e| format!("initialized notification should succeed: {e}"))?;
 
         // When
         let response = server

--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -220,10 +220,13 @@ mod tests {
     }
 
     #[test]
-    fn given_server_receives_shutdown_when_shutdown_dispatch_runs_then_shutdown_flag_and_null_response_are_set()
+    fn given_initialized_server_when_shutdown_dispatch_runs_then_shutdown_flag_and_null_response_are_set()
     -> TestResult {
-        // Given
+        // Given — LSP spec requires initialize before shutdown
         let server = LspServer::new();
+        server
+            .handle_initialize(None)
+            .map_err(|e| format!("initialize request should succeed: {e}"))?;
 
         // When
         let response = server
@@ -265,6 +268,49 @@ mod tests {
 
         // Then
         assert_eq!(server.trace_level.lock().as_str(), "verbose");
+        Ok(())
+    }
+
+    #[test]
+    fn given_trace_notification_with_messages_level_when_set_trace_dispatch_runs_then_trace_level_is_messages()
+    -> TestResult {
+        // Given
+        let server = LspServer::new();
+
+        // When
+        server
+            .handle_set_trace_dispatch(Some(json!({"value": "messages"})))
+            .map_err(|e| format!("setTrace should succeed: {e}"))?;
+
+        // Then
+        assert_eq!(
+            server.trace_level.lock().as_str(),
+            "messages",
+            "messages is a valid LSP TraceValue and must be stored exactly"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn given_set_trace_with_no_params_when_dispatch_runs_then_trace_level_is_unchanged()
+    -> TestResult {
+        // Given — establish a non-default level first
+        let server = LspServer::new();
+        server
+            .handle_set_trace_dispatch(Some(json!({"value": "verbose"})))
+            .map_err(|e| format!("setTrace should succeed: {e}"))?;
+
+        // When — params=None (malformed/missing notification body)
+        server
+            .handle_set_trace_dispatch(None)
+            .map_err(|e| format!("setTrace with no params should not error: {e}"))?;
+
+        // Then — level must be preserved; None params must not reset to "off"
+        assert_eq!(
+            server.trace_level.lock().as_str(),
+            "verbose",
+            "missing params must not reset trace level"
+        );
         Ok(())
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -148,35 +148,123 @@ impl LspServer {
 mod tests {
     use super::*;
 
+    type TestResult = Result<(), String>;
+
     #[test]
-    fn initialized_requires_initialize_request_first() {
+    fn given_fresh_server_when_initialized_notification_arrives_then_server_not_initialized_error_returned()
+    -> TestResult {
+        // Given
         let server = LspServer::new();
 
+        // When
         let result = server.handle_initialized_dispatch();
 
-        assert!(result.is_err(), "initialized before initialize must error");
+        // Then
+        let error =
+            result.err().ok_or("expected initialized to fail, but it succeeded".to_string())?;
+        assert_eq!(error.code, -32002, "must be ServerNotInitialized");
         assert!(!server.is_initialized(), "server must remain uninitialized");
+        Ok(())
     }
 
     #[test]
-    fn initialized_can_only_be_sent_once() {
+    fn given_initialized_server_when_initialized_notification_sent_twice_then_second_request_is_invalid()
+    -> TestResult {
+        // Given
         let server = LspServer::new();
-        server.handle_initialize(None).expect("initialize request should succeed");
+        server
+            .handle_initialize(None)
+            .map_err(|e| format!("initialize request should succeed: {e}"))?;
 
+        // When
         let first = server.handle_initialized_dispatch();
         let second = server.handle_initialized_dispatch();
 
+        // Then
         assert!(first.is_ok(), "first initialized must succeed");
-        assert!(second.is_err(), "second initialized must error");
+        let second_error = second
+            .err()
+            .ok_or("expected second initialized to fail, but it succeeded".to_string())?;
+        assert_eq!(second_error.code, -32600, "must be InvalidRequest");
+        Ok(())
     }
 
     #[test]
-    fn auto_initialize_for_compat_promotes_initialized_state() {
+    fn given_initialize_request_without_initialized_when_compat_mode_runs_then_server_becomes_initialized()
+    -> TestResult {
+        // Given
         let server = LspServer::new();
-        server.handle_initialize(None).expect("initialize request should succeed");
+        server
+            .handle_initialize(None)
+            .map_err(|e| format!("initialize request should succeed: {e}"))?;
 
+        // When
         server.auto_initialize_for_compat("textDocument/hover");
 
+        // Then
         assert!(server.is_initialized(), "compatibility path should mark server initialized");
+        Ok(())
+    }
+
+    #[test]
+    fn given_server_not_in_initialize_phase_when_compat_mode_runs_then_server_stays_uninitialized()
+    {
+        // Given
+        let server = LspServer::new();
+
+        // When
+        server.auto_initialize_for_compat("textDocument/hover");
+
+        // Then
+        assert!(!server.is_initialized(), "compat mode should no-op before initialize");
+    }
+
+    #[test]
+    fn given_server_receives_shutdown_when_shutdown_dispatch_runs_then_shutdown_flag_and_null_response_are_set()
+    -> TestResult {
+        // Given
+        let server = LspServer::new();
+
+        // When
+        let response = server
+            .handle_shutdown_dispatch()
+            .map_err(|e| format!("shutdown should succeed: {e}"))?;
+
+        // Then
+        assert_eq!(response, Some(json!(null)), "shutdown returns JSON null");
+        assert!(server.shutdown_received.load(Ordering::Acquire), "shutdown flag should be set");
+        Ok(())
+    }
+
+    #[test]
+    fn given_trace_notification_with_unknown_level_when_set_trace_dispatch_runs_then_trace_defaults_to_off()
+    -> TestResult {
+        // Given
+        let server = LspServer::new();
+
+        // When
+        server
+            .handle_set_trace_dispatch(Some(json!({"value": "unexpected"})))
+            .map_err(|e| format!("setTrace should succeed: {e}"))?;
+
+        // Then
+        assert_eq!(server.trace_level.lock().as_str(), "off");
+        Ok(())
+    }
+
+    #[test]
+    fn given_trace_notification_with_verbose_level_when_set_trace_dispatch_runs_then_trace_level_is_updated()
+    -> TestResult {
+        // Given
+        let server = LspServer::new();
+
+        // When
+        server
+            .handle_set_trace_dispatch(Some(json!({"value": "verbose"})))
+            .map_err(|e| format!("setTrace should succeed: {e}"))?;
+
+        // Then
+        assert_eq!(server.trace_level.lock().as_str(), "verbose");
+        Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Improve coverage and clarity of lifecycle dispatch behavior by expressing tests as BDD-style Given/When/Then scenarios for `lifecycle.rs`.

### Description

- Expanded the test suite in `crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs` with explicit BDD-style scenarios covering initialization ordering, duplicate `initialized` handling, compatibility auto-initialize, shutdown semantics, and trace-level handling.
- Tests were renamed to descriptive `given_..._when_..._then_...` functions and several now return `Result` to follow the project test conventions and enable richer failure messages.
- Assertions were added to validate concrete LSP error codes (`-32002` for ServerNotInitialized and `-32600` for InvalidRequest) and to check shutdown response and trace-level state.

### Testing

- Ran `cargo test -p perl-lsp-rs given_ --lib` and the new lifecycle tests passed (`7 passed; 0 failed`).
- Ran `cargo check --all-targets -p perl-lsp-rs` which completed successfully.
- Ran `cargo clippy -p perl-lsp-rs --lib -- -D warnings` which completed without warnings, and ran `cargo xtask fmt` to format sources.
- `just pr-fast` was not available in this environment (command not found) so it was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae7d915b88333b7937b70c1bfbc03)