### PR TITLE
test(runtime): add bdd lifecycle dispatch coverage (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -147,9 +147,11 @@ impl LspServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
-    fn initialized_requires_initialize_request_first() {
+    fn given_initialized_notification_without_initialize_when_dispatched_then_server_not_initialized_error()
+     {
         let server = LspServer::new();
 
         let result = server.handle_initialized_dispatch();
@@ -159,9 +161,11 @@ mod tests {
     }
 
     #[test]
-    fn initialized_can_only_be_sent_once() {
+    fn given_initialized_notification_after_initialize_when_dispatched_twice_then_second_is_invalid_request()
+     {
         let server = LspServer::new();
-        server.handle_initialize(None).expect("initialize request should succeed");
+        let initialize_result = server.handle_initialize(None);
+        assert!(initialize_result.is_ok(), "initialize request should succeed");
 
         let first = server.handle_initialized_dispatch();
         let second = server.handle_initialized_dispatch();
@@ -171,12 +175,50 @@ mod tests {
     }
 
     #[test]
-    fn auto_initialize_for_compat_promotes_initialized_state() {
+    fn given_compat_request_after_initialize_when_initialized_notification_missing_then_server_auto_initializes()
+     {
         let server = LspServer::new();
-        server.handle_initialize(None).expect("initialize request should succeed");
+        let initialize_result = server.handle_initialize(None);
+        assert!(initialize_result.is_ok(), "initialize request should succeed");
 
         server.auto_initialize_for_compat("textDocument/hover");
 
         assert!(server.is_initialized(), "compatibility path should mark server initialized");
+    }
+
+    #[test]
+    fn given_shutdown_request_when_dispatched_then_shutdown_flag_is_set_and_null_response_returned()
+    {
+        let server = LspServer::new();
+
+        let result = server.handle_shutdown_dispatch();
+
+        assert!(result.is_ok(), "shutdown dispatch should succeed");
+        assert!(
+            server.shutdown_received.load(Ordering::Acquire),
+            "shutdown flag should be set after dispatch"
+        );
+        assert_eq!(result.ok(), Some(Some(json!(null))));
+    }
+
+    #[test]
+    fn given_set_trace_notification_with_invalid_level_when_dispatched_then_trace_level_defaults_to_off()
+     {
+        let server = LspServer::new();
+
+        let result = server.handle_set_trace_dispatch(Some(json!({ "value": "trace-everything" })));
+
+        assert!(result.is_ok(), "setTrace dispatch should succeed");
+        assert_eq!(&*server.trace_level.lock(), "off");
+    }
+
+    #[test]
+    fn given_set_trace_notification_with_verbose_level_when_dispatched_then_trace_level_updates() {
+        let server = LspServer::new();
+
+        let result = server.handle_set_trace_dispatch(Some(json!({ "value": "verbose" })));
+
+        assert!(result.is_ok(), "setTrace dispatch should succeed");
+        assert_eq!(&*server.trace_level.lock(), "verbose");
     }
 }


### PR DESCRIPTION
### Motivation

- Lifecycle dispatch unit coverage was minimal and used terse test names that hid intent.
- The shutdown and `$\/setTrace` dispatch behaviors lacked focused unit tests.
- Tests should follow BDD-style Given/When/Then naming and avoid `expect()` to meet test hygiene rules.

### Description

- Renamed existing lifecycle tests to descriptive BDD-style names and added `use serde_json::json` for test helpers.
- Added tests for `handle_shutdown_dispatch` to assert the shutdown flag is set and a null response is returned.
- Added tests for `handle_set_trace_dispatch` to cover invalid trace values defaulting to `off` and the `verbose` level being applied.
- Replaced direct `expect()` usage in touched tests with explicit `is_ok()` assertions to align with test guidelines.

### Testing

- Ran `cargo test -p perl-lsp-rs --lib lifecycle::tests` and the lifecycle test suite passed (6 passed, 0 failed). 
- Ran `cargo check --all-targets -p perl-lsp-rs` and it completed successfully. 
- Ran `cargo xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae7d915b88333b7937b70c1bfbc03)