### PR TITLE
test(lsp): add proptest for lifecycle trace normalization (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -147,6 +147,7 @@ impl LspServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     #[test]
     fn initialized_requires_initialize_request_first() {
@@ -178,5 +179,21 @@ mod tests {
         server.auto_initialize_for_compat("textDocument/hover");
 
         assert!(server.is_initialized(), "compatibility path should mark server initialized");
+    }
+
+    proptest! {
+        #[test]
+        fn set_trace_dispatch_normalizes_unknown_levels_to_off(input in ".*") {
+            let server = LspServer::new();
+
+            let _ = server.handle_set_trace_dispatch(Some(json!({ "value": input })));
+
+            let expected = match input.as_str() {
+                "off" | "messages" | "verbose" => input,
+                _ => "off".to_string(),
+            };
+
+            prop_assert_eq!(server.trace_level.lock().clone(), expected);
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Add property-based coverage for lifecycle trace-level handling so only the allowed values ("off", "messages", "verbose") are preserved and arbitrary client-provided values normalize to "off".

### Description
- Add a `proptest!` in `crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs` that generates arbitrary strings and asserts `handle_set_trace_dispatch` preserves the three allowed trace levels and normalizes all other inputs to `"off"`.

### Testing
- Ran `rustfmt crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs` (passes) and iterated with targeted `cargo test` to resolve a compile error introduced by the initial assertion; a full `cargo check --all-targets -p perl-lsp-rs` / broader test run could not complete in this environment due to `No space left on device`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae7e9844c8333830cda7846071dbd)