### PR TITLE
test(parser-core): add hash-slice comma regression coverage (#6625)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -147,36 +147,138 @@ impl LspServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     #[test]
-    fn initialized_requires_initialize_request_first() {
+    fn initialized_requires_initialize_request_first() -> Result<(), JsonRpcError> {
         let server = LspServer::new();
 
         let result = server.handle_initialized_dispatch();
 
         assert!(result.is_err(), "initialized before initialize must error");
         assert!(!server.is_initialized(), "server must remain uninitialized");
+        Ok(())
     }
 
     #[test]
-    fn initialized_can_only_be_sent_once() {
+    fn initialized_can_only_be_sent_once() -> Result<(), JsonRpcError> {
         let server = LspServer::new();
-        server.handle_initialize(None).expect("initialize request should succeed");
+        server.handle_initialize(None)?;
 
         let first = server.handle_initialized_dispatch();
         let second = server.handle_initialized_dispatch();
 
         assert!(first.is_ok(), "first initialized must succeed");
         assert!(second.is_err(), "second initialized must error");
+        Ok(())
     }
 
     #[test]
-    fn auto_initialize_for_compat_promotes_initialized_state() {
+    fn auto_initialize_for_compat_promotes_initialized_state() -> Result<(), JsonRpcError> {
         let server = LspServer::new();
-        server.handle_initialize(None).expect("initialize request should succeed");
+        server.handle_initialize(None)?;
 
         server.auto_initialize_for_compat("textDocument/hover");
 
         assert!(server.is_initialized(), "compatibility path should mark server initialized");
+        Ok(())
+    }
+
+    #[derive(Clone, Debug)]
+    enum LifecycleAction {
+        InitializeNull,
+        InitializeEmptyObject,
+        Initialized,
+        AutoInitializeCompat,
+        Shutdown,
+        SetTraceOff,
+        SetTraceMessages,
+        SetTraceVerbose,
+        SetTraceInvalid,
+        SetTraceMissingValue,
+    }
+
+    fn lifecycle_action_strategy() -> impl Strategy<Value = LifecycleAction> {
+        prop_oneof![
+            Just(LifecycleAction::InitializeNull),
+            Just(LifecycleAction::InitializeEmptyObject),
+            Just(LifecycleAction::Initialized),
+            Just(LifecycleAction::AutoInitializeCompat),
+            Just(LifecycleAction::Shutdown),
+            Just(LifecycleAction::SetTraceOff),
+            Just(LifecycleAction::SetTraceMessages),
+            Just(LifecycleAction::SetTraceVerbose),
+            Just(LifecycleAction::SetTraceInvalid),
+            Just(LifecycleAction::SetTraceMissingValue),
+        ]
+    }
+
+    proptest! {
+        #[test]
+        fn lifecycle_dispatch_fuzz_does_not_violate_core_invariants(
+            actions in prop::collection::vec(lifecycle_action_strategy(), 0..128)
+        ) {
+            let server = LspServer::new();
+
+            for action in actions {
+                match action {
+                    LifecycleAction::InitializeNull => {
+                        let _ = server.handle_initialize_dispatch(None);
+                    }
+                    LifecycleAction::InitializeEmptyObject => {
+                        let _ = server.handle_initialize_dispatch(Some(json!({})));
+                    }
+                    LifecycleAction::Initialized => {
+                        let initialized_result = server.handle_initialized_dispatch();
+                        if !server.initialize_requested.load(Ordering::Acquire) {
+                            prop_assert!(
+                                matches!(
+                                    initialized_result,
+                                    Err(JsonRpcError {
+                                        code: -32002,
+                                        ..
+                                    })
+                                ),
+                                "initialized before initialize request must return ServerNotInitialized"
+                            );
+                        }
+                    }
+                    LifecycleAction::AutoInitializeCompat => {
+                        server.auto_initialize_for_compat("textDocument/hover");
+                    }
+                    LifecycleAction::Shutdown => {
+                        let _ = server.handle_shutdown_dispatch();
+                    }
+                    LifecycleAction::SetTraceOff => {
+                        let _ = server.handle_set_trace_dispatch(Some(json!({ "value": "off" })));
+                    }
+                    LifecycleAction::SetTraceMessages => {
+                        let _ = server.handle_set_trace_dispatch(Some(json!({ "value": "messages" })));
+                    }
+                    LifecycleAction::SetTraceVerbose => {
+                        let _ = server.handle_set_trace_dispatch(Some(json!({ "value": "verbose" })));
+                    }
+                    LifecycleAction::SetTraceInvalid => {
+                        let _ = server.handle_set_trace_dispatch(Some(json!({ "value": "unexpected" })));
+                    }
+                    LifecycleAction::SetTraceMissingValue => {
+                        let _ = server.handle_set_trace_dispatch(Some(json!({ "not_value": true })));
+                    }
+                }
+
+                if server.is_initialized() {
+                    prop_assert!(
+                        server.initialize_requested.load(Ordering::Acquire),
+                        "initialized state requires initialize request"
+                    );
+                }
+
+                let trace_level = server.trace_level.lock().clone();
+                prop_assert!(
+                    matches!(trace_level.as_str(), "off" | "messages" | "verbose"),
+                    "trace level must always remain in the allowed set"
+                );
+            }
+        }
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -149,52 +149,158 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
+    type TestResult = Result<(), String>;
+
     #[test]
-    fn initialized_requires_initialize_request_first() -> Result<(), JsonRpcError> {
+    fn given_fresh_server_when_initialized_notification_arrives_then_server_not_initialized_error_returned()
+    -> TestResult {
+        // Given
         let server = LspServer::new();
 
+        // When
         let result = server.handle_initialized_dispatch();
 
-        assert!(result.is_err(), "initialized before initialize must error");
+        // Then
+        let error =
+            result.err().ok_or("expected initialized to fail, but it succeeded".to_string())?;
+        assert_eq!(error.code, -32002, "must be ServerNotInitialized");
         assert!(!server.is_initialized(), "server must remain uninitialized");
         Ok(())
     }
 
     #[test]
-    fn initialized_can_only_be_sent_once() -> Result<(), JsonRpcError> {
+    fn given_initialized_server_when_initialized_notification_sent_twice_then_second_request_is_invalid()
+    -> TestResult {
+        // Given
         let server = LspServer::new();
-        server.handle_initialize(None)?;
+        server
+            .handle_initialize(None)
+            .map_err(|e| format!("initialize request should succeed: {e}"))?;
 
+        // When
         let first = server.handle_initialized_dispatch();
         let second = server.handle_initialized_dispatch();
 
+        // Then
         assert!(first.is_ok(), "first initialized must succeed");
-        assert!(second.is_err(), "second initialized must error");
+        let second_error = second
+            .err()
+            .ok_or("expected second initialized to fail, but it succeeded".to_string())?;
+        assert_eq!(second_error.code, -32600, "must be InvalidRequest");
         Ok(())
     }
 
     #[test]
-    fn auto_initialize_for_compat_promotes_initialized_state() -> Result<(), JsonRpcError> {
+    fn given_initialize_request_without_initialized_when_compat_mode_runs_then_server_becomes_initialized()
+    -> TestResult {
+        // Given
         let server = LspServer::new();
-        server.handle_initialize(None)?;
+        server
+            .handle_initialize(None)
+            .map_err(|e| format!("initialize request should succeed: {e}"))?;
 
+        // When
         server.auto_initialize_for_compat("textDocument/hover");
 
+        // Then
         assert!(server.is_initialized(), "compatibility path should mark server initialized");
         Ok(())
     }
+
+    #[test]
+    fn given_server_not_in_initialize_phase_when_compat_mode_runs_then_server_stays_uninitialized()
+    {
+        // Given
+        let server = LspServer::new();
+
+        // When
+        server.auto_initialize_for_compat("textDocument/hover");
+
+        // Then
+        assert!(!server.is_initialized(), "compat mode should no-op before initialize");
+    }
+
+    #[test]
+    fn given_server_receives_shutdown_when_shutdown_dispatch_runs_then_shutdown_flag_and_null_response_are_set()
+    -> TestResult {
+        // Given
+        let server = LspServer::new();
+        server
+            .handle_initialize(None)
+            .map_err(|e| format!("initialize request should succeed: {e}"))?;
+        server
+            .handle_initialized_dispatch()
+            .map_err(|e| format!("initialized notification should succeed: {e}"))?;
+
+        // When
+        let response = server
+            .handle_shutdown_dispatch()
+            .map_err(|e| format!("shutdown should succeed: {e}"))?;
+
+        // Then
+        assert_eq!(response, Some(json!(null)), "shutdown returns JSON null");
+        assert!(server.shutdown_received.load(Ordering::Acquire), "shutdown flag should be set");
+        Ok(())
+    }
+
+    #[test]
+    fn given_trace_notification_with_unknown_level_when_set_trace_dispatch_runs_then_trace_defaults_to_off()
+    -> TestResult {
+        // Given
+        let server = LspServer::new();
+
+        // When
+        server
+            .handle_set_trace_dispatch(Some(json!({"value": "unexpected"})))
+            .map_err(|e| format!("setTrace should succeed: {e}"))?;
+
+        // Then
+        assert_eq!(server.trace_level.lock().as_str(), "off");
+        Ok(())
+    }
+
+    #[test]
+    fn given_trace_notification_with_verbose_level_when_set_trace_dispatch_runs_then_trace_level_is_updated()
+    -> TestResult {
+        // Given
+        let server = LspServer::new();
+
+        // When
+        server
+            .handle_set_trace_dispatch(Some(json!({"value": "verbose"})))
+            .map_err(|e| format!("setTrace should succeed: {e}"))?;
+
+        // Then
+        assert_eq!(server.trace_level.lock().as_str(), "verbose");
+        Ok(())
+    }
+
+    // --- Property-based sequence fuzzing ---
+    //
+    // Drives arbitrary orderings of lifecycle calls and asserts structural
+    // invariants that must hold regardless of sequencing.
+    //
+    // This is *constrained* proptest, not malformed-input fuzzing: each action
+    // is a fixed valid call. The value under test is the ordering invariants,
+    // not input parsing robustness (that is tested via dedicated fuzz targets
+    // in the fuzz/ workspace member).
 
     #[derive(Clone, Debug)]
     enum LifecycleAction {
         InitializeNull,
         InitializeEmptyObject,
+        /// Sends `initialized` notification (valid or premature)
         Initialized,
         AutoInitializeCompat,
         Shutdown,
+        /// Sends `initialize` again after shutdown — tests double-init guard
+        InitializeAfterShutdown,
         SetTraceOff,
         SetTraceMessages,
         SetTraceVerbose,
+        /// Invalid trace value — must normalise to "off", never corrupt state
         SetTraceInvalid,
+        /// Missing `value` key — must be a no-op, trace stays unchanged
         SetTraceMissingValue,
     }
 
@@ -205,6 +311,7 @@ mod tests {
             Just(LifecycleAction::Initialized),
             Just(LifecycleAction::AutoInitializeCompat),
             Just(LifecycleAction::Shutdown),
+            Just(LifecycleAction::InitializeAfterShutdown),
             Just(LifecycleAction::SetTraceOff),
             Just(LifecycleAction::SetTraceMessages),
             Just(LifecycleAction::SetTraceVerbose),
@@ -215,12 +322,20 @@ mod tests {
 
     proptest! {
         #[test]
-        fn lifecycle_dispatch_fuzz_does_not_violate_core_invariants(
+        fn lifecycle_dispatch_sequence_invariants(
             actions in prop::collection::vec(lifecycle_action_strategy(), 0..128)
         ) {
             let server = LspServer::new();
 
             for action in actions {
+                // Snapshot state BEFORE the call so post-call assertions are
+                // meaningful and can distinguish "this call changed state" from
+                // "state was already like that."
+                let was_initialized_before = server.is_initialized();
+                let was_initialize_requested_before =
+                    server.initialize_requested.load(Ordering::Acquire);
+                let trace_before = server.trace_level.lock().clone();
+
                 match action {
                     LifecycleAction::InitializeNull => {
                         let _ = server.handle_initialize_dispatch(None);
@@ -229,17 +344,36 @@ mod tests {
                         let _ = server.handle_initialize_dispatch(Some(json!({})));
                     }
                     LifecycleAction::Initialized => {
-                        let initialized_result = server.handle_initialized_dispatch();
-                        if !server.initialize_requested.load(Ordering::Acquire) {
+                        let result = server.handle_initialized_dispatch();
+                        if !was_initialize_requested_before {
+                            // LSP spec: initialized before initialize MUST be
+                            // ServerNotInitialized (-32002). This assertion is
+                            // non-vacuous: it fires on sequences that omit
+                            // InitializeNull/InitializeEmptyObject first.
                             prop_assert!(
                                 matches!(
-                                    initialized_result,
-                                    Err(JsonRpcError {
-                                        code: -32002,
-                                        ..
-                                    })
+                                    result,
+                                    Err(JsonRpcError { code: -32002, .. })
                                 ),
-                                "initialized before initialize request must return ServerNotInitialized"
+                                "initialized before initialize request must return \
+                                 ServerNotInitialized (-32002); got: {:?}",
+                                result
+                            );
+                            // Server must stay un-initialized
+                            prop_assert!(
+                                !server.is_initialized(),
+                                "premature initialized must not promote server state"
+                            );
+                        } else if was_initialized_before {
+                            // LSP spec: second initialized MUST be InvalidRequest (-32600)
+                            prop_assert!(
+                                matches!(
+                                    result,
+                                    Err(JsonRpcError { code: -32600, .. })
+                                ),
+                                "duplicate initialized must return InvalidRequest (-32600); \
+                                 got: {:?}",
+                                result
                             );
                         }
                     }
@@ -247,36 +381,91 @@ mod tests {
                         server.auto_initialize_for_compat("textDocument/hover");
                     }
                     LifecycleAction::Shutdown => {
-                        let _ = server.handle_shutdown_dispatch();
+                        let result = server.handle_shutdown_dispatch();
+                        // shutdown_dispatch MUST succeed and return json!(null)
+                        prop_assert!(
+                            result.is_ok(),
+                            "shutdown must always return Ok; got: {:?}",
+                            result
+                        );
+                        prop_assert_eq!(
+                            result.unwrap(),
+                            Some(json!(null)),
+                            "shutdown must return JSON null"
+                        );
+                        // After any shutdown call the flag MUST be set
+                        prop_assert!(
+                            server.shutdown_received.load(Ordering::Acquire),
+                            "shutdown_received flag must be set after handle_shutdown_dispatch"
+                        );
+                    }
+                    LifecycleAction::InitializeAfterShutdown => {
+                        // Re-initialize after shutdown — the result is
+                        // implementation-defined (may succeed or error), but
+                        // the server must not panic and state must remain
+                        // consistent with the invariants checked below.
+                        let _ = server.handle_initialize_dispatch(None);
                     }
                     LifecycleAction::SetTraceOff => {
                         let _ = server.handle_set_trace_dispatch(Some(json!({ "value": "off" })));
                     }
                     LifecycleAction::SetTraceMessages => {
-                        let _ = server.handle_set_trace_dispatch(Some(json!({ "value": "messages" })));
+                        let _ = server.handle_set_trace_dispatch(
+                            Some(json!({ "value": "messages" })),
+                        );
                     }
                     LifecycleAction::SetTraceVerbose => {
-                        let _ = server.handle_set_trace_dispatch(Some(json!({ "value": "verbose" })));
+                        let _ = server.handle_set_trace_dispatch(
+                            Some(json!({ "value": "verbose" })),
+                        );
                     }
                     LifecycleAction::SetTraceInvalid => {
-                        let _ = server.handle_set_trace_dispatch(Some(json!({ "value": "unexpected" })));
+                        let result = server.handle_set_trace_dispatch(
+                            Some(json!({ "value": "unexpected" })),
+                        );
+                        prop_assert!(result.is_ok(), "setTrace must not error on invalid value");
+                        // Invalid value MUST normalise to "off" — non-vacuous
+                        // because trace_before may have been "messages" or "verbose".
+                        let trace_after_invalid = server.trace_level.lock().clone();
+                        prop_assert_eq!(
+                            trace_after_invalid.as_str(),
+                            "off",
+                            "invalid trace value must normalise to 'off' (was '{}')",
+                            trace_before
+                        );
                     }
                     LifecycleAction::SetTraceMissingValue => {
-                        let _ = server.handle_set_trace_dispatch(Some(json!({ "not_value": true })));
+                        let _ = server
+                            .handle_set_trace_dispatch(Some(json!({ "not_value": true })));
+                        // Missing `value` key is a no-op — trace must be unchanged
+                        prop_assert_eq!(
+                            server.trace_level.lock().clone(),
+                            trace_before,
+                            "missing 'value' key must leave trace_level unchanged"
+                        );
                     }
                 }
 
+                // --- Post-action global invariants ---
+
+                // Invariant 1 (non-vacuous when InitializeAfterShutdown or
+                // AutoInitializeCompat fires without a prior Initialize):
+                // is_initialized() == true implies initialize_requested == true.
                 if server.is_initialized() {
                     prop_assert!(
                         server.initialize_requested.load(Ordering::Acquire),
-                        "initialized state requires initialize request"
+                        "initialized state requires initialize_requested to be set"
                     );
                 }
 
+                // Invariant 2: trace_level must always be in the allowed set.
+                // Non-vacuous because SetTraceInvalid tests the normalisation
+                // path and SetTraceMissingValue tests the no-op path.
                 let trace_level = server.trace_level.lock().clone();
                 prop_assert!(
                     matches!(trace_level.as_str(), "off" | "messages" | "verbose"),
-                    "trace level must always remain in the allowed set"
+                    "trace_level '{}' is outside the allowed set {{off, messages, verbose}}",
+                    trace_level
                 );
             }
         }


### PR DESCRIPTION
### Motivation

- Improve coverage for lifecycle request/notification ordering and trace-level handling by adding property-based fuzzing over sequences of lifecycle calls.
- Align touched unit tests with project testing rules by returning `Result` and avoiding `expect`/panic-based assertions.

### Description

- Added a proptest-driven fuzz test `lifecycle_dispatch_fuzz_does_not_violate_core_invariants` that generates sequences of lifecycle actions and asserts core invariants (initialization ordering and allowed trace levels) in `crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs`.
- Introduced a `LifecycleAction` enum and `lifecycle_action_strategy` to model randomized lifecycle events for the fuzzer.
- Converted existing lifecycle unit tests to return `Result<(), JsonRpcError>` and replaced `expect` calls with `?` to comply with test rules.

### Testing

- Ran `cargo test -p perl-lsp-rs --lib lifecycle_dispatch_fuzz_does_not_violate_core_invariants` and the test passed.
- Ran `cargo check -p perl-lsp-rs --lib` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae7ec965c8333b2ef91171cf59c19)