### PR TITLE
test(lifecycle): fuzz lifecycle dispatch paths (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -147,6 +147,7 @@ impl LspServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     #[test]
     fn initialized_requires_initialize_request_first() {
@@ -178,5 +179,45 @@ mod tests {
         server.auto_initialize_for_compat("textDocument/hover");
 
         assert!(server.is_initialized(), "compatibility path should mark server initialized");
+    }
+
+    proptest! {
+        #[test]
+        fn fuzz_set_trace_dispatch_never_rejects_input(raw in proptest::option::of(".*")) {
+            let server = LspServer::new();
+
+            let params = raw.as_ref().map(|value| json!({ "value": value }));
+            let result = server.handle_set_trace_dispatch(params);
+
+            prop_assert!(result.is_ok());
+            let level = server.trace_level.lock().clone();
+            prop_assert!(matches!(level.as_str(), "off" | "messages" | "verbose"));
+        }
+
+        #[test]
+        fn fuzz_initialize_lifecycle_transitions(actions in prop::collection::vec(0u8..=2, 0..64)) {
+            let server = LspServer::new();
+
+            for action in actions {
+                match action {
+                    0 => {
+                        let _ = server.handle_initialize(None);
+                    }
+                    1 => {
+                        let _ = server.handle_initialized_dispatch();
+                    }
+                    _ => {
+                        server.auto_initialize_for_compat("textDocument/hover");
+                    }
+                }
+
+                if !server.initialize_requested.load(Ordering::Acquire) {
+                    prop_assert!(
+                        !server.is_initialized(),
+                        "server cannot be initialized before initialize request"
+                    );
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Add property-based fuzz coverage to lifecycle dispatch handlers to validate robustness against arbitrary inputs and interleavings.

### Description
- Import `proptest` into the lifecycle test module and add two property tests in `crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs`.
- `fuzz_set_trace_dispatch_never_rejects_input` feeds randomized optional strings into `handle_set_trace_dispatch` and asserts the call never errors and the `trace_level` is one of `off|messages|verbose`.
- `fuzz_initialize_lifecycle_transitions` executes randomized sequences of `handle_initialize`, `handle_initialized_dispatch`, and `auto_initialize_for_compat`, asserting the server cannot become initialized before an `initialize` request is observed.

### Testing
- Ran `cargo test -p perl-lsp-rs --lib lifecycle::tests` and the added tests passed.
- Ran `cargo check --all-targets -p perl-lsp-rs` and it completed successfully.
- Ran `cargo clippy -p perl-lsp-rs --lib --tests -D warnings` which failed on pre-existing `expect`/`panic` lints in unrelated files and was not introduced by this change.
- `just pr-fast` was not run because `just` is not installed in this environment (command not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae7ec965c8333b2ef91171cf59c19)