### PR TITLE
test(parser-core): add hash-slice comma regression coverage (#6626)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -254,4 +254,22 @@ mod tests {
             "invalid trace level must be coerced to off"
         );
     }
+
+    #[test]
+    fn set_trace_explicit_off_stores_off() {
+        let server = LspServer::new();
+        // First set to a non-default level so we can verify the write.
+        let r = server.handle_set_trace_dispatch(Some(json!({ "value": "verbose" })));
+        assert!(r.is_ok(), "setTrace(verbose) should succeed");
+        assert_eq!(server.trace_level.lock().as_str(), "verbose", "precondition");
+
+        // Explicit "off" must store "off", not be treated as an invalid value.
+        let r = server.handle_set_trace_dispatch(Some(json!({ "value": "off" })));
+        assert!(r.is_ok(), "setTrace(off) should succeed");
+        assert_eq!(
+            server.trace_level.lock().as_str(),
+            "off",
+            "explicit off level must be stored as off"
+        );
+    }
 }

--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -155,28 +155,103 @@ mod tests {
         let result = server.handle_initialized_dispatch();
 
         assert!(result.is_err(), "initialized before initialize must error");
+        if let Err(err) = result {
+            assert_eq!(err.code, -32002, "must report ServerNotInitialized");
+        }
         assert!(!server.is_initialized(), "server must remain uninitialized");
     }
 
     #[test]
     fn initialized_can_only_be_sent_once() {
         let server = LspServer::new();
-        server.handle_initialize(None).expect("initialize request should succeed");
+        let init = server.handle_initialize(None);
+        assert!(init.is_ok(), "initialize request should succeed");
 
         let first = server.handle_initialized_dispatch();
         let second = server.handle_initialized_dispatch();
 
         assert!(first.is_ok(), "first initialized must succeed");
         assert!(second.is_err(), "second initialized must error");
+        if let Err(err) = second {
+            assert_eq!(err.code, -32600, "must report InvalidRequest for duplicate initialized");
+        }
     }
 
     #[test]
     fn auto_initialize_for_compat_promotes_initialized_state() {
         let server = LspServer::new();
-        server.handle_initialize(None).expect("initialize request should succeed");
+        let init = server.handle_initialize(None);
+        assert!(init.is_ok(), "initialize request should succeed");
 
         server.auto_initialize_for_compat("textDocument/hover");
 
         assert!(server.is_initialized(), "compatibility path should mark server initialized");
+    }
+
+    #[test]
+    fn auto_initialize_for_compat_requires_initialize_request() {
+        let server = LspServer::new();
+
+        server.auto_initialize_for_compat("textDocument/hover");
+
+        assert!(
+            !server.is_initialized(),
+            "compatibility path must not initialize server before initialize request"
+        );
+    }
+
+    #[test]
+    fn auto_initialize_for_compat_noop_when_already_initialized() {
+        let server = LspServer::new();
+        let init = server.handle_initialize(None);
+        assert!(init.is_ok(), "initialize request should succeed");
+        let first_initialized = server.handle_initialized_dispatch();
+        assert!(first_initialized.is_ok(), "first initialized notification should succeed");
+
+        server.auto_initialize_for_compat("textDocument/hover");
+
+        assert!(server.is_initialized(), "server should remain initialized");
+    }
+
+    #[test]
+    fn set_trace_accepts_known_values() {
+        let server = LspServer::new();
+
+        let result_messages =
+            server.handle_set_trace_dispatch(Some(json!({ "value": "messages" })));
+        assert!(result_messages.is_ok(), "setTrace(messages) should succeed");
+        assert_eq!(
+            server.trace_level.lock().as_str(),
+            "messages",
+            "setTrace(messages) should store messages level"
+        );
+
+        let result_verbose = server.handle_set_trace_dispatch(Some(json!({ "value": "verbose" })));
+        assert!(result_verbose.is_ok(), "setTrace(verbose) should succeed");
+        assert_eq!(
+            server.trace_level.lock().as_str(),
+            "verbose",
+            "setTrace(verbose) should store verbose level"
+        );
+    }
+
+    #[test]
+    fn set_trace_invalid_value_defaults_to_off() {
+        let server = LspServer::new();
+        let set_messages = server.handle_set_trace_dispatch(Some(json!({ "value": "messages" })));
+        assert!(set_messages.is_ok(), "setTrace(messages) should succeed");
+        assert_eq!(
+            server.trace_level.lock().as_str(),
+            "messages",
+            "precondition: messages level should be set"
+        );
+
+        let invalid = server.handle_set_trace_dispatch(Some(json!({ "value": "invalid" })));
+        assert!(invalid.is_ok(), "setTrace(invalid) should still be accepted as notification");
+        assert_eq!(
+            server.trace_level.lock().as_str(),
+            "off",
+            "invalid trace level must be coerced to off"
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Improve mutation-hardening around LSP lifecycle dispatch logic where mutation candidates could survive due to weak assertions around initialization sequencing and trace handling.

### Description
- Added focused unit tests in `crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs` that assert exact error codes for `initialized` sequencing errors (`-32002` before `initialize`, `-32600` for duplicate notifications).
- Added tests that validate `auto_initialize_for_compat` only promotes the server after a prior `initialize` request and is a no-op when already initialized.
- Added tests for `$\/setTrace` behavior that verify accepted levels (`messages`, `verbose`) and that invalid values are coerced to `off`.

### Testing
- Ran `cargo test -p perl-lsp-rs --lib lifecycle::tests` and all added tests passed (7 passed, 0 failed).
- Ran `cargo check --all-targets -p perl-lsp-rs` which completed successfully.
- Ran `cargo clippy -p perl-lsp-rs -- -D warnings` which completed successfully.
- Launched `cargo mutants --no-config -p perl-lsp-rs -f 'crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs'` which discovered 22 mutants but the full mutation run was not completed in-session due to runtime duration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae7efd2588333bb97f4ee7abb67d4)