### PR TITLE
test(perl-lsp-rs): harden lifecycle mutation coverage (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -155,28 +155,75 @@ mod tests {
         let result = server.handle_initialized_dispatch();
 
         assert!(result.is_err(), "initialized before initialize must error");
+        let Err(error) = result else {
+            return;
+        };
+        assert_eq!(
+            error.code, -32002,
+            "initialized before initialize must return ServerNotInitialized",
+        );
+        assert_eq!(error.message, "Server not initialized");
         assert!(!server.is_initialized(), "server must remain uninitialized");
     }
 
     #[test]
-    fn initialized_can_only_be_sent_once() {
+    fn initialized_can_only_be_sent_once() -> Result<(), JsonRpcError> {
         let server = LspServer::new();
-        server.handle_initialize(None).expect("initialize request should succeed");
+        server.handle_initialize(None)?;
 
-        let first = server.handle_initialized_dispatch();
+        let first = server.handle_initialized_dispatch()?;
         let second = server.handle_initialized_dispatch();
 
-        assert!(first.is_ok(), "first initialized must succeed");
+        assert!(first.is_none(), "initialized notification should not return a payload");
         assert!(second.is_err(), "second initialized must error");
+        let Err(error) = second else {
+            return Ok(());
+        };
+        assert_eq!(error.code, -32600, "second initialized must be InvalidRequest");
+        assert_eq!(
+            error.message, "initialized notification may only be sent once",
+            "second initialized message must explain one-time semantics",
+        );
+        Ok(())
     }
 
     #[test]
-    fn auto_initialize_for_compat_promotes_initialized_state() {
+    fn auto_initialize_for_compat_promotes_initialized_state() -> Result<(), JsonRpcError> {
         let server = LspServer::new();
-        server.handle_initialize(None).expect("initialize request should succeed");
+        server.handle_initialize(None)?;
 
         server.auto_initialize_for_compat("textDocument/hover");
 
         assert!(server.is_initialized(), "compatibility path should mark server initialized");
+        Ok(())
+    }
+
+    #[test]
+    fn auto_initialize_for_compat_requires_initialize_request() {
+        let server = LspServer::new();
+
+        server.auto_initialize_for_compat("textDocument/hover");
+
+        assert!(
+            !server.is_initialized(),
+            "compatibility path must not initialize server without initialize request",
+        );
+    }
+
+    #[test]
+    fn shutdown_dispatch_clears_cancellation_state() -> Result<(), JsonRpcError> {
+        let server = LspServer::new();
+        let cancelled_id = json!(9);
+        server.cancel_mark(&cancelled_id);
+        assert!(server.is_cancelled(&cancelled_id), "sanity check: cancel marker must be set");
+
+        let response = server.handle_shutdown_dispatch()?;
+
+        assert_eq!(response, Some(json!(null)), "shutdown should reply with null");
+        assert!(
+            !server.is_cancelled(&cancelled_id),
+            "shutdown must clear pending cancellation markers",
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Strengthen unit tests for LSP lifecycle handlers to prevent mutation survivors that change error codes/messages, guard semantics, or shutdown cleanup behavior.

### Description

- Tightened tests in `crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs` to assert exact `JsonRpcError` codes and messages for `initialized` contract violations.
- Converted some lifecycle tests to return `Result<(), JsonRpcError>` and use `?` to avoid new `expect()` usage while improving failure diagnostics.
- Added tests asserting that `auto_initialize_for_compat` does not initialize the server unless an `initialize` request was first observed.
- Added a shutdown test that verifies `handle_shutdown_dispatch` returns `null` and clears pending cancellation markers.

### Testing

- Ran `cargo test -p perl-lsp-rs lifecycle::tests --lib` and all lifecycle tests passed.
- Ran `cargo check --all-targets -p perl-lsp-rs -q` and it completed successfully.
- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo clippy -p perl-lsp-rs --all-targets -- -D warnings` which failed on pre-existing clippy-denied issues unrelated to this change (not introduced here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae7efd2588333bb97f4ee7abb67d4)