### PR TITLE
fix(parser): correct transliteration part extraction and expand regressions (#6707)

### DIFF
--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -302,70 +302,51 @@ pub fn extract_substitution_parts(text: &str) -> (String, String, String) {
 /// Extract search, replace, and modifiers from a transliteration token
 pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
     // Skip 'tr' or 'y' prefix
-    let content = if let Some(stripped) = text.strip_prefix("tr") {
+    let after_op = if let Some(stripped) = text.strip_prefix("tr") {
         stripped
     } else if let Some(stripped) = text.strip_prefix('y') {
         stripped
     } else {
         text
     };
+    let content = after_op.trim_start();
 
     // Get delimiter - content must be non-empty to have a delimiter
     let delimiter = match content.chars().next() {
         Some(d) => d,
         None => return (String::new(), String::new(), String::new()),
     };
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return (String::new(), String::new(), String::new());
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
     // Parse first body (search pattern)
-    let (search, rest1) = extract_delimited_content(content, delimiter, closing);
-
-    // For paired delimiters, skip whitespace and allow any paired opening delimiter for the
-    // replacement list. Perl accepts forms like tr[abc]{xyz} in addition to tr[abc][xyz].
-    let rest2_owned;
-    let rest2 = if is_paired {
-        rest1.trim_start()
-    } else {
-        rest2_owned = format!("{}{}", delimiter, rest1);
-        &rest2_owned
-    };
+    let (search, rest1, search_closed) =
+        extract_delimited_content_strict(content, delimiter, closing);
+    if !search_closed {
+        return (search, String::new(), String::new());
+    }
 
     // Parse second body (replacement pattern)
-    let (replacement, modifiers_str) = if !is_paired && !rest1.is_empty() {
-        // Manually parse the replacement for non-paired delimiters
-        let chars = rest1.char_indices();
-        let mut body = String::new();
-        let mut escaped = false;
-        let mut end_pos = rest1.len();
-
-        for (i, ch) in chars {
-            if escaped {
-                body.push(ch);
-                escaped = false;
-                continue;
-            }
-
-            match ch {
-                '\\' => {
-                    body.push(ch);
-                    escaped = true;
-                }
-                c if c == closing => {
-                    end_pos = i + ch.len_utf8();
-                    break;
-                }
-                _ => body.push(ch),
-            }
-        }
-
-        (body, &rest1[end_pos..])
-    } else if is_paired {
-        if let Some(repl_delimiter) = starts_with_paired_delimiter(rest2) {
-            let repl_closing = get_closing_delimiter(repl_delimiter);
-            extract_delimited_content(rest2, repl_delimiter, repl_closing)
+    let (replacement, modifiers_str) = if !is_paired {
+        if rest1.is_empty() {
+            (String::new(), "")
         } else {
-            (String::new(), rest2)
+            let (body, rest, replacement_closed) =
+                extract_unpaired_body_skip_strings(rest1, closing);
+            if replacement_closed { (body, rest) } else { (body, "") }
+        }
+    } else if is_paired {
+        let trimmed = rest1.trim_start();
+        if let Some(repl_delimiter) = starts_with_paired_delimiter(trimmed) {
+            let repl_closing = get_closing_delimiter(repl_delimiter);
+            let (body, rest, replacement_closed) =
+                extract_delimited_content_strict(trimmed, repl_delimiter, repl_closing);
+            if replacement_closed { (body, rest) } else { (body, "") }
+        } else {
+            (String::new(), "")
         }
     } else {
         (String::new(), rest1)
@@ -413,7 +394,8 @@ pub fn extract_transliteration_parts_strict(
     let is_paired = delimiter != closing;
 
     // Parse first body (search).
-    let (search, rest1, search_closed) = extract_delimited_content_strict(content, delimiter, closing);
+    let (search, rest1, search_closed) =
+        extract_delimited_content_strict(content, delimiter, closing);
     if !search_closed {
         return Err(TransliterationError::MissingClosingDelimiter);
     }
@@ -447,10 +429,7 @@ pub fn extract_transliteration_parts_strict(
 
     // Validate transliteration modifiers strictly.
     let mut modifiers = String::new();
-    for modifier in modifiers_str
-        .chars()
-        .take_while(|c: &char| c.is_ascii_alphanumeric())
-    {
+    for modifier in modifiers_str.chars().take_while(|c: &char| c.is_ascii_alphanumeric()) {
         if matches!(modifier, 'c' | 'd' | 's' | 'r') {
             modifiers.push(modifier);
         } else {

--- a/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
+++ b/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
@@ -1,56 +1,72 @@
-/// Minimal reproduction case for transliteration parsing bug discovered in fuzz testing
-///
-/// CRASH DETAILS:
-/// - Input: "tr/abc/xyz/"
-/// - Expected: ("abc", "xyz", "")
-/// - Actual: ("abc", "", "xyz")
-///
-/// This indicates a critical bug in extract_transliteration_parts where the replacement
-/// and modifiers are being swapped for non-paired delimiters.
-///
-/// IMPACT: This affects Perl transliteration operator parsing throughout the entire
-/// parser pipeline, potentially causing incorrect syntax highlighting, code analysis,
-/// and refactoring operations.
-///
-/// REPRODUCTION: Run with `cargo test -p perl-parser --test fuzz_transliteration_crash_repro`
 use perl_parser::quote_parser::extract_transliteration_parts;
 
 #[test]
-fn minimal_transliteration_crash_repro() {
-    let input = "tr/abc/xyz/";
-    let (search, replace, modifiers) = extract_transliteration_parts(input);
-
-    println!("FUZZ BUG REPRODUCED: tr// parsing issue");
-    println!("Input: {}", input);
-    println!("Expected: ('abc', 'xyz', '')");
-    println!("Actual: ('{}', '{}', '{}')", search, replace, modifiers);
-
-    // Demonstrate the bug - these will fail due to the parsing issue
-    assert_eq!(search.as_str(), "abc", "Search pattern incorrect");
-    assert_eq!(replace.as_str(), "xyz", "Replace pattern incorrect");
-    assert_eq!(modifiers.as_str(), "", "Modifiers incorrect");
+fn minimal_transliteration_crash_repro() -> Result<(), Box<dyn std::error::Error>> {
+    let (search, replace, modifiers) = extract_transliteration_parts("tr/abc/xyz/");
+    assert_eq!((search.as_str(), replace.as_str(), modifiers.as_str()), ("abc", "xyz", ""));
+    Ok(())
 }
 
 #[test]
-fn fuzz_transliteration_regression_suite() {
-    // Test additional variants that likely have the same bug
-    let test_cases = vec![
+fn transliteration_regression_bank() -> Result<(), Box<dyn std::error::Error>> {
+    // tr/// and y/// coverage
+    let slash_cases = [
+        ("tr/abc/xyz/", ("abc", "xyz", "")),
         ("y/abc/xyz/", ("abc", "xyz", "")),
         ("tr/a/b/d", ("a", "b", "d")),
-        ("y/x/y/g", ("x", "y", "")), // 'g' is not a valid transliteration modifier
-        ("tr{abc}{xyz}d", ("abc", "xyz", "d")), // This might work correctly with paired delimiters
+        ("y/x/y/g", ("x", "y", "")),
+        ("tr /left/right/c", ("left", "right", "c")),
     ];
 
-    for (input, expected) in test_cases {
+    for (input, expected) in slash_cases {
         let (search, replace, modifiers) = extract_transliteration_parts(input);
-        let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
-
-        println!("Testing: {} -> expected {:?}, got {:?}", input, expected, actual);
-
-        if actual != expected {
-            println!("  BUG CONFIRMED in variant: {}", input);
-        } else {
-            println!("  PASSED: {}", input);
-        }
+        assert_eq!(
+            (search.as_str(), replace.as_str(), modifiers.as_str()),
+            expected,
+            "slash-delimited transliteration parse mismatch for `{input}`"
+        );
     }
+
+    // Paired delimiter forms, including mixed paired delimiters.
+    let paired_cases = [
+        ("tr{abc}{xyz}d", ("abc", "xyz", "d")),
+        ("tr[abc][xyz]s", ("abc", "xyz", "s")),
+        ("tr(abc)<xyz>r", ("abc", "xyz", "r")),
+        ("y<a-z>{A-Z}cd", ("a-z", "A-Z", "cd")),
+    ];
+
+    for (input, expected) in paired_cases {
+        let (search, replace, modifiers) = extract_transliteration_parts(input);
+        assert_eq!(
+            (search.as_str(), replace.as_str(), modifiers.as_str()),
+            expected,
+            "paired transliteration parse mismatch for `{input}`"
+        );
+    }
+
+    // Delimiter edge cases and malformed-but-nonpanicking cases.
+    let malformed_cases = [
+        ("tr/abc/xyz", ("abc", "xyz", "")),
+        ("tr{abc}{xyz", ("abc", "xyz", "")),
+        ("tr{abc}xyz", ("abc", "", "")),
+        ("trabc", ("", "", "")),
+        ("tr /abc/xyz/qd", ("abc", "xyz", "d")),
+        ("y", ("", "", "")),
+    ];
+
+    for (input, expected) in malformed_cases {
+        let result = std::panic::catch_unwind(|| extract_transliteration_parts(input));
+        assert!(result.is_ok(), "parser panicked for malformed input `{input}`");
+        let (search, replace, modifiers) = match result {
+            Ok(parts) => parts,
+            Err(_) => return Err("unexpected transliteration panic".into()),
+        };
+        assert_eq!(
+            (search.as_str(), replace.as_str(), modifiers.as_str()),
+            expected,
+            "malformed transliteration parse mismatch for `{input}`"
+        );
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
### Motivation
- Fix incorrect parsing of Perl transliteration operators where replacement and modifier parts could be misclassified or cause panics for malformed inputs.
- Ensure both non-paired and paired delimiter forms (and common edge cases) are handled robustly and consistently.

### Description
- Normalize input by allowing optional whitespace after the `tr`/`y` operator and reject obviously invalid delimiters (alphanumeric or whitespace) early.
- Parse the search list with `extract_delimited_content_strict` and bail if the search section is not properly closed to avoid mis-parsing downstream.
- Parse the replacement using `extract_unpaired_body_skip_strings` for non-paired delimiters and `extract_delimited_content_strict` for paired delimiters, only accepting modifiers after a successfully-closed replacement section.
- Expand the fuzz repro into a focused regression bank (`crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs`) covering `tr///`, `y///`, paired/mixed delimiters, delimiter edge cases, and malformed-but-nonpanicking inputs, and make the tests return `Result` for better integration with the test harness.

### Testing
- Ran `cargo test -p perl-parser --test fuzz_transliteration_crash_repro` and the test binary passed (all regression cases included in the new bank succeeded).
- Ran `cargo check --all-targets -p perl-parser` which completed without errors.
- Ran `cargo xtask fmt` to apply formatting which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaffa3b31c8333ac509b6c5961125f)