### PR TITLE
fix(parser): correct transliteration part extraction and expand regressions (#6706)

### DIFF
--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -302,82 +302,62 @@ pub fn extract_substitution_parts(text: &str) -> (String, String, String) {
 /// Extract search, replace, and modifiers from a transliteration token
 pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
     // Skip 'tr' or 'y' prefix
-    let content = if let Some(stripped) = text.strip_prefix("tr") {
+    let after_op = if let Some(stripped) = text.strip_prefix("tr") {
         stripped
     } else if let Some(stripped) = text.strip_prefix('y') {
         stripped
     } else {
         text
     };
+    // Perl allows optional whitespace between operator and delimiter.
+    let content = after_op.trim_start();
 
     // Get delimiter - content must be non-empty to have a delimiter
     let delimiter = match content.chars().next() {
         Some(d) => d,
         None => return (String::new(), String::new(), String::new()),
     };
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return (String::new(), String::new(), String::new());
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
     // Parse first body (search pattern)
-    let (search, rest1) = extract_delimited_content(content, delimiter, closing);
-
-    // For paired delimiters, skip whitespace and allow any paired opening delimiter for the
-    // replacement list. Perl accepts forms like tr[abc]{xyz} in addition to tr[abc][xyz].
-    let rest2_owned;
-    let rest2 = if is_paired {
-        rest1.trim_start()
-    } else {
-        rest2_owned = format!("{}{}", delimiter, rest1);
-        &rest2_owned
-    };
+    let (search, rest1, search_closed) =
+        extract_delimited_content_strict(content, delimiter, closing);
+    if !search_closed {
+        return (search, String::new(), String::new());
+    }
 
     // Parse second body (replacement pattern)
-    let (replacement, modifiers_str) = if !is_paired && !rest1.is_empty() {
-        // Manually parse the replacement for non-paired delimiters
-        let chars = rest1.char_indices();
-        let mut body = String::new();
-        let mut escaped = false;
-        let mut end_pos = rest1.len();
-
-        for (i, ch) in chars {
-            if escaped {
-                body.push(ch);
-                escaped = false;
-                continue;
-            }
-
-            match ch {
-                '\\' => {
-                    body.push(ch);
-                    escaped = true;
-                }
-                c if c == closing => {
-                    end_pos = i + ch.len_utf8();
-                    break;
-                }
-                _ => body.push(ch),
-            }
-        }
-
-        (body, &rest1[end_pos..])
+    let (replacement, modifiers_str, replacement_closed) = if !is_paired && !rest1.is_empty() {
+        // Parse replacement for non-paired delimiters and track delimiter closure explicitly.
+        extract_unpaired_body_skip_strings(rest1, closing)
     } else if is_paired {
+        // For paired delimiters, skip whitespace and allow any paired opening delimiter for
+        // replacement. Perl accepts forms like tr[abc]{xyz}.
+        let rest2 = rest1.trim_start();
         if let Some(repl_delimiter) = starts_with_paired_delimiter(rest2) {
             let repl_closing = get_closing_delimiter(repl_delimiter);
-            extract_delimited_content(rest2, repl_delimiter, repl_closing)
+            extract_delimited_content_strict(rest2, repl_delimiter, repl_closing)
         } else {
-            (String::new(), rest2)
+            (String::new(), rest2, false)
         }
     } else {
-        (String::new(), rest1)
+        (String::new(), rest1, false)
     };
 
-    // Extract and validate only valid transliteration modifiers
-    // Security fix: Apply consistent validation for all delimiter types
-    let modifiers = modifiers_str
-        .chars()
-        .take_while(|c| c.is_ascii_alphabetic())
-        .filter(|&c| matches!(c, 'c' | 'd' | 's' | 'r'))
-        .collect();
+    // Extract and validate transliteration modifiers only when replacement parsing completed.
+    let modifiers = if replacement_closed {
+        modifiers_str
+            .chars()
+            .take_while(|c| c.is_ascii_alphabetic())
+            .filter(|&c| matches!(c, 'c' | 'd' | 's' | 'r'))
+            .collect()
+    } else {
+        String::new()
+    };
 
     (search, replacement, modifiers)
 }
@@ -413,7 +393,8 @@ pub fn extract_transliteration_parts_strict(
     let is_paired = delimiter != closing;
 
     // Parse first body (search).
-    let (search, rest1, search_closed) = extract_delimited_content_strict(content, delimiter, closing);
+    let (search, rest1, search_closed) =
+        extract_delimited_content_strict(content, delimiter, closing);
     if !search_closed {
         return Err(TransliterationError::MissingClosingDelimiter);
     }
@@ -447,10 +428,7 @@ pub fn extract_transliteration_parts_strict(
 
     // Validate transliteration modifiers strictly.
     let mut modifiers = String::new();
-    for modifier in modifiers_str
-        .chars()
-        .take_while(|c: &char| c.is_ascii_alphanumeric())
-    {
+    for modifier in modifiers_str.chars().take_while(|c: &char| c.is_ascii_alphanumeric()) {
         if matches!(modifier, 'c' | 'd' | 's' | 'r') {
             modifiers.push(modifier);
         } else {

--- a/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
+++ b/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
@@ -1,18 +1,3 @@
-/// Minimal reproduction case for transliteration parsing bug discovered in fuzz testing
-///
-/// CRASH DETAILS:
-/// - Input: "tr/abc/xyz/"
-/// - Expected: ("abc", "xyz", "")
-/// - Actual: ("abc", "", "xyz")
-///
-/// This indicates a critical bug in extract_transliteration_parts where the replacement
-/// and modifiers are being swapped for non-paired delimiters.
-///
-/// IMPACT: This affects Perl transliteration operator parsing throughout the entire
-/// parser pipeline, potentially causing incorrect syntax highlighting, code analysis,
-/// and refactoring operations.
-///
-/// REPRODUCTION: Run with `cargo test -p perl-parser --test fuzz_transliteration_crash_repro`
 use perl_parser::quote_parser::extract_transliteration_parts;
 
 #[test]
@@ -20,37 +5,38 @@ fn minimal_transliteration_crash_repro() {
     let input = "tr/abc/xyz/";
     let (search, replace, modifiers) = extract_transliteration_parts(input);
 
-    println!("FUZZ BUG REPRODUCED: tr// parsing issue");
-    println!("Input: {}", input);
-    println!("Expected: ('abc', 'xyz', '')");
-    println!("Actual: ('{}', '{}', '{}')", search, replace, modifiers);
-
-    // Demonstrate the bug - these will fail due to the parsing issue
     assert_eq!(search.as_str(), "abc", "Search pattern incorrect");
     assert_eq!(replace.as_str(), "xyz", "Replace pattern incorrect");
     assert_eq!(modifiers.as_str(), "", "Modifiers incorrect");
 }
 
 #[test]
-fn fuzz_transliteration_regression_suite() {
-    // Test additional variants that likely have the same bug
-    let test_cases = vec![
-        ("y/abc/xyz/", ("abc", "xyz", "")),
-        ("tr/a/b/d", ("a", "b", "d")),
-        ("y/x/y/g", ("x", "y", "")), // 'g' is not a valid transliteration modifier
-        ("tr{abc}{xyz}d", ("abc", "xyz", "d")), // This might work correctly with paired delimiters
+fn transliteration_regression_bank() {
+    let test_cases = [
+        // Non-paired delimiters: tr/// and y///
+        ("tr/a/b/", ("a", "b", "")),
+        ("tr/a/b/cds", ("a", "b", "cds")),
+        ("y/abc/xyz/r", ("abc", "xyz", "r")),
+        ("y/x/y/g", ("x", "y", "")), // invalid transliteration modifier is filtered out
+        // Paired delimiters, including mixed replacement delimiter
+        ("tr{abc}{xyz}d", ("abc", "xyz", "d")),
+        ("tr[abc]{xyz}rs", ("abc", "xyz", "rs")),
+        ("y(a[b]c){x[y]z}c", ("a[b]c", "x[y]z", "c")),
+        // Delimiter edge cases
+        ("tr!a!b!r", ("a", "b", "r")),
+        ("tr<ab><xy>z", ("ab", "xy", "")), // invalid modifier z filtered out
+        ("tr /a/b/d", ("a", "b", "d")),
+        // Malformed-but-nonpanicking cases
+        ("tr{abc}", ("abc", "", "")),
+        ("tr{abc}d", ("abc", "", "")), // no replacement delimiter => no modifiers
+        ("tr/abc", ("abc", "", "")),
+        ("trabc", ("", "", "")), // invalid delimiter after operator
+        ("y", ("", "", "")),
     ];
 
     for (input, expected) in test_cases {
         let (search, replace, modifiers) = extract_transliteration_parts(input);
         let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
-
-        println!("Testing: {} -> expected {:?}, got {:?}", input, expected, actual);
-
-        if actual != expected {
-            println!("  BUG CONFIRMED in variant: {}", input);
-        } else {
-            println!("  PASSED: {}", input);
-        }
+        assert_eq!(actual, expected, "mismatch for input {input}");
     }
 }


### PR DESCRIPTION
### Motivation

- Fix correctness gaps in transliteration parsing (both `tr///` and `y///`) that caused replacement/modifier mis-attribution and brittle behavior for various delimiters.
- Handle both non-paired and paired delimiter forms, proper modifier separation, and obvious malformed-but-nonpanicking inputs. 
- Expand the regression coverage so the original fuzz-discovered repro is asserted and similar edge cases are prevented from regressing.

### Description

- Tighten `extract_transliteration_parts` in `crates/perl-parser-core/src/syntax/quote.rs` to allow optional whitespace after the operator, reject invalid delimiters (alphanumeric/whitespace), and determine paired vs non-paired delimiter semantics up-front. 
- Use strict extraction helpers (`extract_delimited_content_strict`, `extract_unpaired_body_skip_strings`, `extract_delimited_content_strict`) to track whether the search and replacement sections were properly closed and to avoid leaking characters into the modifier string. 
- Only parse and validate transliteration modifiers after the replacement section is confirmed closed; otherwise return empty modifiers to avoid misclassification. 
- Replace the print-based repro test with a focused regression bank in `crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs` (renamed test `transliteration_regression_bank`) that asserts a matrix of non-paired, paired, mixed, edge-delimiter, and malformed-but-nonpanicking inputs.

### Testing

- Ran `cargo test -p perl-parser --test fuzz_transliteration_crash_repro`, which executed the minimal repro and the regression bank and reported all tests passed. 
- Ran `cargo check --all-targets -p perl-parser`, which completed successfully. 
- Ran formatting via `cargo xtask fmt` as part of the verification step and completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaffa3b31c8333ac509b6c5961125f)