### PR TITLE
fix(fmt): restore master formatting (#0000)

### DIFF
--- a/crates/perl-lexer/src/keywords/mod.rs
+++ b/crates/perl-lexer/src/keywords/mod.rs
@@ -212,11 +212,11 @@ pub const LSP_COMPLETION_KEYWORDS: &[&str] = &[
 pub const DAP_COMPLETION_KEYWORDS: &[&str] = &[
     "abs", "bless", "chomp", "chop", "chr", "close", "defined", "delete", "die", "do", "each",
     "else", "elsif", "eval", "exists", "for", "foreach", "grep", "hex", "if", "index", "int",
-    "isa", "join", "keys", "last", "lc", "lcfirst", "length", "local", "map", "my", "next",
-    "oct", "open", "ord", "our", "pack", "package", "pop", "print", "printf", "push", "qw",
-    "redo", "ref", "require", "return", "reverse", "rindex", "say", "scalar", "shift", "sort",
-    "splice", "split", "sprintf", "sqrt", "sub", "substr", "tie", "uc", "ucfirst", "unless",
-    "unpack", "unshift", "untie", "until", "use", "values", "warn", "while",
+    "isa", "join", "keys", "last", "lc", "lcfirst", "length", "local", "map", "my", "next", "oct",
+    "open", "ord", "our", "pack", "package", "pop", "print", "printf", "push", "qw", "redo", "ref",
+    "require", "return", "reverse", "rindex", "say", "scalar", "shift", "sort", "splice", "split",
+    "sprintf", "sqrt", "sub", "substr", "tie", "uc", "ucfirst", "unless", "unpack", "unshift",
+    "untie", "until", "use", "values", "warn", "while",
 ];
 
 /// Keywords used by runtime fallback completion in `perl-lsp`.

--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2055,8 +2055,7 @@ impl<'a> PerlLexer<'a> {
             // Check for substitution/transliteration operators
             // Skip if after '->'  -- these are method names, not operators.
             #[allow(clippy::collapsible_if)]
-            if !self.after_arrow && self.hash_brace_depth == 0 && matches!(text, "s" | "tr" | "y")
-            {
+            if !self.after_arrow && self.hash_brace_depth == 0 && matches!(text, "s" | "tr" | "y") {
                 let immediate = self.current_char();
                 let (candidate, char_after_next, has_whitespace) =
                     if immediate.is_some_and(|c| c.is_whitespace()) {

--- a/crates/perl-lexer/tests/keywords_classification.rs
+++ b/crates/perl-lexer/tests/keywords_classification.rs
@@ -358,7 +358,8 @@ fn comparison_operators_are_disjoint_from_control_flow() {
 
 #[test]
 fn uppercase_keywords_are_phase_blocks_or_dunders() {
-    let uppercase_reserved = ["ADJUST", "AUTOLOAD", "BEGIN", "CHECK", "DESTROY", "END", "INIT", "UNITCHECK"];
+    let uppercase_reserved =
+        ["ADJUST", "AUTOLOAD", "BEGIN", "CHECK", "DESTROY", "END", "INIT", "UNITCHECK"];
     for &kw in KEYWORDS {
         if kw.starts_with("__") {
             continue; // dunder tokens handled separately

--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -256,8 +256,9 @@ impl PerlTidyFormatter {
         end_line: u32,
     ) -> Result<String, String> {
         if start_line > end_line {
-            return Err("Invalid line range: start line must be less than or equal to end line"
-                .to_string());
+            return Err(
+                "Invalid line range: start line must be less than or equal to end line".to_string()
+            );
         }
 
         let lines: Vec<&str> = code.lines().collect();
@@ -374,8 +375,7 @@ impl BuiltInFormatter {
             // We already decremented by leading_closers before printing, so add them
             // back to avoid double-counting: the net change for the *next* line is
             // delta + leading_closers (leading closers cancel in the net formula).
-            indent_level =
-                (indent_level + net_delimiter_delta(trimmed) + leading_closers).max(0);
+            indent_level = (indent_level + net_delimiter_delta(trimmed) + leading_closers).max(0);
         }
 
         result

--- a/crates/perl-lsp-perltidy/tests/config_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/config_tests.rs
@@ -246,7 +246,8 @@ fn builtin_formatter_indents_multiline_function_arguments() {
 #[test]
 fn builtin_formatter_ignores_delimiters_inside_strings_and_comments() {
     let formatter = BuiltInFormatter::new(PerlTidyConfig::default());
-    let formatted = formatter.format("if ($ok) {\nprint \"literal ) ] }\"; # comment )\nprint \"done\";\n}\n");
+    let formatted =
+        formatter.format("if ($ok) {\nprint \"literal ) ] }\"; # comment )\nprint \"done\";\n}\n");
 
     let lines: Vec<&str> = formatted.lines().collect();
     assert_eq!(lines[0], "if ($ok) {");
@@ -292,8 +293,8 @@ fn builtin_formatter_multi_closer_line_does_not_over_decrement() {
     assert_eq!(lines[0], "if ($a) {");
     assert_eq!(lines[1], "    if ($b) {");
     assert_eq!(lines[2], "        print 1;");
-    assert_eq!(lines[3], "    }");           // one closer — back to level 1
-    assert_eq!(lines[4], "    print 2;");   // still at level 1
-    assert_eq!(lines[5], "}");              // one closer — back to level 0
-    assert_eq!(lines[6], "print 3;");      // at level 0, not negative
+    assert_eq!(lines[3], "    }"); // one closer — back to level 1
+    assert_eq!(lines[4], "    print 2;"); // still at level 1
+    assert_eq!(lines[5], "}"); // one closer — back to level 0
+    assert_eq!(lines[6], "print 3;"); // at level 0, not negative
 }

--- a/crates/perl-lsp-rs-core/src/config/mod.rs
+++ b/crates/perl-lsp-rs-core/src/config/mod.rs
@@ -501,11 +501,7 @@ impl WorkspaceConfig {
     /// returned list contains only `self.include_paths` entries (trimmed and deduplicated).
     pub fn effective_include_paths(&self, perl5lib_paths: &[String]) -> Vec<String> {
         if !self.use_perl5lib || perl5lib_paths.is_empty() {
-            return dedupe_preserve_order(
-                self.include_paths
-                    .iter()
-                    .map(String::as_str),
-            );
+            return dedupe_preserve_order(self.include_paths.iter().map(String::as_str));
         }
         match self.perl5lib_precedence {
             Perl5LibPrecedence::Prepend => dedupe_preserve_order(

--- a/crates/perl-lsp-rs-core/src/critic_parser/mod.rs
+++ b/crates/perl-lsp-rs-core/src/critic_parser/mod.rs
@@ -139,8 +139,8 @@ mod tests {
     fn parse_perlcritic_line_accepts_severity_boundaries() {
         for sev in 1u8..=5 {
             let line = format!("lib/Foo.pm:1:1:{sev}:TestingAndDebugging::RequireUseStrict:msg");
-            let parsed = parse_perlcritic_line(&line)
-                .unwrap_or_else(|| panic!("severity {sev} must parse"));
+            let parsed =
+                parse_perlcritic_line(&line).unwrap_or_else(|| panic!("severity {sev} must parse"));
             assert_eq!(parsed.severity, sev);
         }
     }
@@ -174,8 +174,7 @@ mod tests {
     fn parse_perlcritic_output_handles_crlf_separated_input() {
         // Whole output in CRLF — str::lines() already splits, but each line still
         // carries a trailing `\r` that must be trimmed.
-        let output =
-            "lib/Foo.pm:1:1:5:TestingAndDebugging::RequireUseStrict:msg1\r\n\
+        let output = "lib/Foo.pm:1:1:5:TestingAndDebugging::RequireUseStrict:msg1\r\n\
              lib/Bar.pm:2:2:3:TestingAndDebugging::RequireUseWarnings:msg2\r\n";
         let parsed = parse_perlcritic_output(output);
         assert_eq!(parsed.len(), 2);
@@ -239,9 +238,15 @@ mod tests {
     fn parse_perlcritic_line_rejects_truncated_line() {
         // Missing message and/or policy.
         assert!(parse_perlcritic_line("lib/Foo.pm:1:1:3").is_none());
-        assert!(parse_perlcritic_line("lib/Foo.pm:1:1:3:TestingAndDebugging::RequireUseStrict").is_none());
+        assert!(
+            parse_perlcritic_line("lib/Foo.pm:1:1:3:TestingAndDebugging::RequireUseStrict")
+                .is_none()
+        );
         // Empty message.
-        assert!(parse_perlcritic_line("lib/Foo.pm:1:1:3:TestingAndDebugging::RequireUseStrict:").is_none());
+        assert!(
+            parse_perlcritic_line("lib/Foo.pm:1:1:3:TestingAndDebugging::RequireUseStrict:")
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/common_mistakes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/common_mistakes.rs
@@ -89,11 +89,7 @@ fn check_bareword_filehandle(
     }
 
     let open_args: &[Node] = if args.len() == 1 {
-        if let NodeKind::ArrayLiteral { elements } = &args[0].kind {
-            elements
-        } else {
-            args
-        }
+        if let NodeKind::ArrayLiteral { elements } = &args[0].kind { elements } else { args }
     } else {
         args
     };
@@ -106,10 +102,7 @@ fn check_bareword_filehandle(
         return;
     };
 
-    if matches!(
-        name.as_str(),
-        "STDIN" | "STDOUT" | "STDERR" | "ARGV" | "ARGVOUT" | "DATA"
-    ) {
+    if matches!(name.as_str(), "STDIN" | "STDOUT" | "STDERR" | "ARGV" | "ARGVOUT" | "DATA") {
         return;
     }
 
@@ -120,8 +113,9 @@ fn check_bareword_filehandle(
         message: "Use lexical filehandles instead of bareword filehandles".to_string(),
         related_information: vec![RelatedInformation {
             location: (node.location.start, node.location.end),
-            message: "Bareword filehandles are global and can lead to accidental reuse across scopes"
-                .to_string(),
+            message:
+                "Bareword filehandles are global and can lead to accidental reuse across scopes"
+                    .to_string(),
         }],
         tags: Vec::new(),
         suggestion: Some("Use lexical filehandle: open(my $fh, ... )".to_string()),

--- a/crates/perl-lsp-rs-core/src/providers/file_completion/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/file_completion/mod.rs
@@ -146,10 +146,8 @@ fn file_completion_metadata(entry: &walkdir::DirEntry) -> (String, Option<String
     let file_type = entry.file_type();
     if file_type.is_dir() {
         let directory_name = entry.file_name().to_string_lossy();
-        if matches!(
-            directory_name.to_ascii_lowercase().as_str(),
-            "docs" | "doc" | "documentation"
-        ) {
+        if matches!(directory_name.to_ascii_lowercase().as_str(), "docs" | "doc" | "documentation")
+        {
             ("documentation directory".to_string(), Some("Documentation directory".to_string()))
         } else {
             ("directory".to_string(), Some("Directory".to_string()))
@@ -169,10 +167,7 @@ fn file_completion_metadata(entry: &walkdir::DirEntry) -> (String, Option<String
             "toml" => "TOML file",
             _ if matches!(
                 file_name.to_ascii_lowercase().as_str(),
-                "readme"
-                    | "changelog"
-                    | "contributing"
-                    | "license"
+                "readme" | "changelog" | "contributing" | "license"
             ) =>
             {
                 "Project documentation file"

--- a/crates/perl-lsp-rs-core/src/runtime/input_validation/mod.rs
+++ b/crates/perl-lsp-rs-core/src/runtime/input_validation/mod.rs
@@ -17,8 +17,7 @@ const MAX_PATH_LENGTH: usize = 4096;
 /// Allowed file extensions for Perl files.
 const ALLOWED_EXTENSIONS: &[&str] = &["pl", "pm", "t", "pod"];
 /// Allowed URI schemes for text document synchronization.
-const ALLOWED_TEXT_DOCUMENT_URI_SCHEMES: &[&str] =
-    &["file://", "untitled:", "opencode:"];
+const ALLOWED_TEXT_DOCUMENT_URI_SCHEMES: &[&str] = &["file://", "untitled:", "opencode:"];
 
 /// Validates and sanitizes a file path to prevent path traversal attacks.
 pub fn validate_file_path<P: AsRef<Path>>(path: P, workspace_root: &Path) -> Result<PathBuf> {
@@ -123,10 +122,7 @@ fn validate_text_document_params(params: &serde_json::Value) -> Result<()> {
         .and_then(|text_document| text_document.get("uri"))
         .and_then(serde_json::Value::as_str)
     {
-        if !ALLOWED_TEXT_DOCUMENT_URI_SCHEMES
-            .iter()
-            .any(|scheme| uri.starts_with(scheme))
-        {
+        if !ALLOWED_TEXT_DOCUMENT_URI_SCHEMES.iter().any(|scheme| uri.starts_with(scheme)) {
             return Err(anyhow!("Invalid URI scheme: {}", uri));
         }
 
@@ -374,7 +370,7 @@ mod tests {
         assert!(result.is_ok(), "file:// URI must be accepted after scheme allowlist refactor");
     }
 
-        #[test]
+    #[test]
     fn test_file_size_limit_sourced_from_lsp_limits() {
         // The file size limit must come from perl-lsp-limits, not a local constant.
         // This test documents the expected single source of truth.

--- a/crates/perl-lsp-rs-core/src/runtime/launcher/mod.rs
+++ b/crates/perl-lsp-rs-core/src/runtime/launcher/mod.rs
@@ -915,18 +915,12 @@ mod tests {
 
         // Fish uses `-l mcp` (long-option form without double-dashes);
         // other shells embed `--mcp` literally. Pick the right token per shell.
-        for (shell, needle) in [
-            ("bash", "--mcp"),
-            ("zsh", "--mcp"),
-            ("fish", "-l mcp"),
-            ("powershell", "--mcp"),
-        ] {
+        for (shell, needle) in
+            [("bash", "--mcp"), ("zsh", "--mcp"), ("fish", "-l mcp"), ("powershell", "--mcp")]
+        {
             let script = super::shell_completion(shell)
                 .unwrap_or_else(|| panic!("missing completion for {shell}"));
-            assert!(
-                script.contains(needle),
-                "{shell} completion is missing {needle}: {script}"
-            );
+            assert!(script.contains(needle), "{shell} completion is missing {needle}: {script}");
         }
 
         // Parser side: --mcp must still resolve to stdio (alias semantics).
@@ -1241,7 +1235,10 @@ mod tests {
     fn ansi_force_color_enables_ansi_without_terminal() {
         let _guard_nc = EnvGuard::remove("NO_COLOR");
         let _guard = EnvGuard::set("FORCE_COLOR", "1");
-        assert!(super::should_use_ansi(false), "FORCE_COLOR=1 must enable ANSI even without a terminal");
+        assert!(
+            super::should_use_ansi(false),
+            "FORCE_COLOR=1 must enable ANSI even without a terminal"
+        );
     }
 
     /// Guard: is_warp_terminal() must be true when TERM_PROGRAM=WarpTerminal.

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs
@@ -1,6 +1,6 @@
-use super::{built_in_quick_fix, insertion_range, QuickFix, Severity, Violation};
-use perl_parser_core::position::{Position, Range};
+use super::{QuickFix, Severity, Violation, built_in_quick_fix, insertion_range};
 use perl_parser_core::Node;
+use perl_parser_core::position::{Position, Range};
 
 /// Built-in policy analyzer that works without external perlcritic
 pub struct BuiltInAnalyzer {

--- a/crates/perl-lsp-rs/src/execute_command/tests.rs
+++ b/crates/perl-lsp-rs/src/execute_command/tests.rs
@@ -628,13 +628,8 @@ fn test_normalize_file_path_uri_handling() {
         assert_eq!(normalized, "/tmp/test.pl", "Should leave regular paths unchanged");
 
         // Test file URI decoding
-        let normalized =
-            provider.normalize_file_path("file:///tmp/path%20with%20spaces/test.pl");
-        assert_eq!(
-            normalized,
-            "/tmp/path with spaces/test.pl",
-            "Should decode file URI path"
-        );
+        let normalized = provider.normalize_file_path("file:///tmp/path%20with%20spaces/test.pl");
+        assert_eq!(normalized, "/tmp/path with spaces/test.pl", "Should decode file URI path");
 
         // Test localhost authority in file URI
         let normalized = provider.normalize_file_path("file://localhost/tmp/test.pl");

--- a/crates/perl-lsp-rs/src/features/workspace_rename.rs
+++ b/crates/perl-lsp-rs/src/features/workspace_rename.rs
@@ -161,10 +161,8 @@ fn is_non_target_package_declaration(
     // Try to read the original source span to detect a qualified name like "Bar::process_data".
     // When the index returns an inverted range (end < start, a known indexer edge case), we fall
     // through to the package-context check below rather than conservatively returning false.
-    let maybe_original = doc
-        .line_index
-        .position_to_offset(start_line, start_char)
-        .and_then(|start_off| {
+    let maybe_original =
+        doc.line_index.position_to_offset(start_line, start_char).and_then(|start_off| {
             doc.line_index
                 .position_to_offset(end_line, end_char)
                 .and_then(|end_off| doc.text.get(start_off..end_off))

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -88,11 +88,7 @@ impl PullDiagnosticsOrchestrator {
         // Get config values
         let (perlcritic_enabled, perlcritic_severity, perlcritic_profile) = {
             let cfg = server.config.lock();
-            (
-                cfg.perlcritic_enabled,
-                cfg.perlcritic_severity,
-                cfg.perlcritic_profile.clone(),
-            )
+            (cfg.perlcritic_enabled, cfg.perlcritic_severity, cfg.perlcritic_profile.clone())
         };
 
         let profile =

--- a/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
@@ -56,7 +56,7 @@ pub(crate) use cancellation::enhanced_cancelled_response;
 
 use super::*;
 use crate::cancellation::{
-    PerlLspCancellationToken, ProviderCleanupContext, GLOBAL_CANCELLATION_REGISTRY,
+    GLOBAL_CANCELLATION_REGISTRY, PerlLspCancellationToken, ProviderCleanupContext,
 };
 use std::time::Instant;
 
@@ -424,9 +424,7 @@ mod tests {
 
         let initialize = server.handle_request(request(2, "initialize", Some(json!({}))));
         assert!(
-            initialize
-                .as_ref()
-                .is_some_and(|response| response.error.is_none()),
+            initialize.as_ref().is_some_and(|response| response.error.is_none()),
             "initialize request should succeed"
         );
 

--- a/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
@@ -4,7 +4,7 @@
 
 use super::super::*;
 use perl_workspace::folder::{extract_workspace_folder_uris, root_path_to_file_uri};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 impl LspServer {
     /// Handle initialize request
@@ -428,8 +428,8 @@ pub(crate) fn apply_disabled_feature_id(
 #[cfg(test)]
 mod tests {
     use super::apply_disabled_feature_id;
-    use crate::protocol::capabilities::BuildFlags;
     use crate::LspServer;
+    use crate::protocol::capabilities::BuildFlags;
     use serde_json::json;
 
     #[test]

--- a/crates/perl-lsp-rs/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/module_resolution.rs
@@ -1232,7 +1232,9 @@ use Overlay::Live;
             .map(|o| o.status.success())
             .unwrap_or(false);
         if !perl_available {
-            eprintln!("SKIP: test_resolve_module_path_with_uri_honors_system_inc_opt_in — perl not found on PATH");
+            eprintln!(
+                "SKIP: test_resolve_module_path_with_uri_honors_system_inc_opt_in — perl not found on PATH"
+            );
             return Ok(());
         }
 

--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -2136,10 +2136,7 @@ mod tests {
 
         let docs = server.documents.lock();
         let doc = docs.get(uri).ok_or("template document not stored after didOpen")?;
-        assert!(
-            doc.ast.is_some(),
-            "template with mojolicious languageId should be parsed as Perl"
-        );
+        assert!(doc.ast.is_some(), "template with mojolicious languageId should be parsed as Perl");
         Ok(())
     }
 

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -238,7 +238,8 @@ impl LspServer {
         // even if client responses are slow or missing.
         if pending.len() >= 10 {
             let to_remove = pending.len() - 9;
-            let mut entries: Vec<_> = pending.iter().map(|(id, req)| (*id, req.created_at)).collect();
+            let mut entries: Vec<_> =
+                pending.iter().map(|(id, req)| (*id, req.created_at)).collect();
             entries.sort_by_key(|(_, created_at)| *created_at);
             for (id, _) in entries.iter().take(to_remove) {
                 tracing::debug!(

--- a/crates/perl-lsp-rs/tests/cross_file_goto_definition_tests.rs
+++ b/crates/perl-lsp-rs/tests/cross_file_goto_definition_tests.rs
@@ -2641,9 +2641,7 @@ $store->component_method();
     )?;
 
     let locations = result.as_array().ok_or_else(|| {
-        format!(
-            "Expected array for deep mixed-inheritance CPAN-style goto-def, got: {result:?}"
-        )
+        format!("Expected array for deep mixed-inheritance CPAN-style goto-def, got: {result:?}")
     })?;
     assert!(
         !locations.is_empty(),

--- a/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
+++ b/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
@@ -62,10 +62,8 @@ fn editor_ux_fixture_matrix_covers_all_scenarios() -> Result<()> {
     let allowed_metrics =
         top_line_metrics.union(&component_metrics).cloned().collect::<BTreeSet<_>>();
     let mut confidence_signals_exercised = BTreeSet::new();
-    let baseline_metrics = BTreeSet::from([
-        "workflow_pass_rate".to_string(),
-        "workflow_stability_rate".to_string(),
-    ]);
+    let baseline_metrics =
+        BTreeSet::from(["workflow_pass_rate".to_string(), "workflow_stability_rate".to_string()]);
     let mut metric_usage_counts: HashMap<String, usize> =
         allowed_metrics.iter().cloned().map(|metric| (metric, 0_usize)).collect();
     let mut workflows_with_extended_metrics = 0_usize;

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs
@@ -10,7 +10,7 @@
 
 use anyhow::{Context, Result};
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::time::Duration;
 
 fn binary_available() -> bool {

--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -413,7 +413,8 @@ pub fn extract_transliteration_parts_strict(
     let is_paired = delimiter != closing;
 
     // Parse first body (search).
-    let (search, rest1, search_closed) = extract_delimited_content_strict(content, delimiter, closing);
+    let (search, rest1, search_closed) =
+        extract_delimited_content_strict(content, delimiter, closing);
     if !search_closed {
         return Err(TransliterationError::MissingClosingDelimiter);
     }
@@ -447,10 +448,7 @@ pub fn extract_transliteration_parts_strict(
 
     // Validate transliteration modifiers strictly.
     let mut modifiers = String::new();
-    for modifier in modifiers_str
-        .chars()
-        .take_while(|c: &char| c.is_ascii_alphanumeric())
-    {
+    for modifier in modifiers_str.chars().take_while(|c: &char| c.is_ascii_alphanumeric()) {
         if matches!(modifier, 'c' | 'd' | 's' | 'r') {
             modifiers.push(modifier);
         } else {

--- a/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
+++ b/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
@@ -17,4 +17,3 @@ fn transliteration_rejects_invalid_modifiers() {
     assert_has_error(r#"$x =~ tr/a-z/A-Z/z;"#, "invalid transliteration modifier");
     assert_has_error(r#"$x =~ y/a-z/A-Z/1;"#, "invalid transliteration modifier");
 }
-

--- a/crates/perl-parser/src/incremental/mod.rs
+++ b/crates/perl-parser/src/incremental/mod.rs
@@ -649,12 +649,7 @@ mod tests {
         // Delete almost the entire document; this should use full-reparse fallback
         // to keep incremental behavior predictable for large edits.
         let old_end_byte = state.source.len().saturating_sub(1);
-        let edit = Edit {
-            start_byte: 0,
-            old_end_byte,
-            new_end_byte: 0,
-            new_text: String::new(),
-        };
+        let edit = Edit { start_byte: 0, old_end_byte, new_end_byte: 0, new_text: String::new() };
 
         let result = apply_edits(&mut state, &[edit])?;
 

--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -42,8 +42,7 @@ pub fn uri_key(uri: &str) -> String {
 /// Check if a URI uses the `file://` scheme.
 #[must_use]
 pub fn is_file_uri(uri: &str) -> bool {
-    uri.get(..7)
-        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("file://"))
+    uri.get(..7).is_some_and(|prefix| prefix.eq_ignore_ascii_case("file://"))
 }
 
 /// Check if a URI uses a special scheme (not `file://`).

--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -968,7 +968,10 @@ mod tests {
         // After last goto_next_sibling returns false, cursor should still be valid
         // and still have a node (the last sibling).
         let node = cursor.node();
-        assert!(!node.kind().is_empty(), "cursor should remain at valid node after exhausting siblings");
+        assert!(
+            !node.kind().is_empty(),
+            "cursor should remain at valid node after exhausting siblings"
+        );
     }
 
     #[test]
@@ -1009,11 +1012,7 @@ mod tests {
 
         // reset() should bring us back to root
         cursor.reset();
-        assert_eq!(
-            cursor.node().grammar_kind(),
-            "source_file",
-            "reset must return cursor to root"
-        );
+        assert_eq!(cursor.node().grammar_kind(), "source_file", "reset must return cursor to root");
     }
 
     #[test]
@@ -1073,10 +1072,7 @@ mod tests {
             sibling_count += 1;
         }
 
-        assert_eq!(
-            sibling_count, child_count,
-            "sibling count should match root.child_count()"
-        );
+        assert_eq!(sibling_count, child_count, "sibling count should match root.child_count()");
     }
 
     #[test]

--- a/xtask/src/tasks/benchmarks.rs
+++ b/xtask/src/tasks/benchmarks.rs
@@ -659,11 +659,8 @@ mod tests {
     #[test]
     fn parse_criterion_identity_handles_plain_layout_without_new_subdir() {
         // Older Criterion versions write estimates.json directly under bench_name/
-        let parts = vec![
-            "parser".to_string(),
-            "large_file".to_string(),
-            "estimates.json".to_string(),
-        ];
+        let parts =
+            vec!["parser".to_string(), "large_file".to_string(), "estimates.json".to_string()];
         let result = parse_criterion_identity(&parts);
         assert_eq!(result, Some(("parser".to_string(), "large_file".to_string())));
     }

--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -1699,7 +1699,8 @@ mod tests {
         // EnvironmentInfo, AgentReceipt, …) by hand.  compare_receipts only
         // reads receipt.gates and receipt.metadata.timestamp, so the rest can
         // be placeholder values.
-        let mut receipt: Receipt = serde_json::from_str(r#"{
+        let mut receipt: Receipt = serde_json::from_str(
+            r#"{
             "schema_version": "1",
             "metadata": {
                 "timestamp": "2026-04-23T00:00:00Z",
@@ -1734,7 +1735,9 @@ mod tests {
                 "baselines": [],
                 "next_actions": []
             }
-        }"#).expect("minimal receipt JSON is valid");
+        }"#,
+        )
+        .expect("minimal receipt JSON is valid");
         receipt.gates.push(GateResult {
             gate_name: "tests".to_string(),
             tier: "pr_fast".to_string(),


### PR DESCRIPTION
## Summary

One-shot mechanical unblock for the `cargo xtask fmt --check` CI failure on master HEAD (3fc0cd0f2), which is blocking PR Smoke on ~20+ open editor-support PRs.

**Root cause:** Pre-existing formatting drift accumulated across multiple PRs. Not introduced by any single PR.

## Files touched (30 files, all pure rustfmt output — zero semantic changes)

- `crates/perl-lexer/src/keywords/mod.rs`
- `crates/perl-lexer/src/lib.rs`
- `crates/perl-lexer/tests/keywords_classification.rs`
- `crates/perl-lsp-perltidy/src/lib.rs`
- `crates/perl-lsp-perltidy/tests/config_tests.rs`
- `crates/perl-lsp-rs-core/src/config/mod.rs`
- `crates/perl-lsp-rs-core/src/critic_parser/mod.rs`
- `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/common_mistakes.rs`
- `crates/perl-lsp-rs-core/src/providers/file_completion/mod.rs`
- `crates/perl-lsp-rs-core/src/runtime/input_validation/mod.rs`
- `crates/perl-lsp-rs-core/src/runtime/launcher/mod.rs`
- `crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs`
- `crates/perl-lsp-rs/src/execute_command/tests.rs`
- `crates/perl-lsp-rs/src/features/workspace_rename.rs`
- `crates/perl-lsp-rs/src/runtime/diagnostics.rs`
- `crates/perl-lsp-rs/src/runtime/dispatch/mod.rs`
- `crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs`
- `crates/perl-lsp-rs/src/runtime/lifecycle/module_resolution.rs`
- `crates/perl-lsp-rs/src/runtime/text_sync.rs`
- `crates/perl-lsp-rs/src/runtime/workspace.rs`
- `crates/perl-lsp-rs/tests/cross_file_goto_definition_tests.rs`
- `crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs`
- `crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs`
- `crates/perl-parser-core/src/syntax/quote.rs`
- `crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs`
- `crates/perl-parser/src/incremental/mod.rs`
- `crates/perl-uri/src/classify.rs`
- `crates/tree-sitter-perl-rs/src/lib.rs`
- `xtask/src/tasks/benchmarks.rs`
- `xtask/src/tasks/gates.rs`

## Verification

- `cargo xtask fmt --check` exits 0 after this commit
- `cargo check --workspace` passes (252 crates, no errors)
- Diff is 100% mechanical rustfmt output: line wrapping, trailing newlines, whitespace — no logic changes

## Context

The two files originally identified by CI log analysis (`crates/perl-parser-core/src/syntax/quote.rs` and `crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs`) were the crates that failed first, causing xtask fmt to abort early. The formatter touched 28 additional files with equivalent drift when allowed to run to completion.