### PR TITLE
perf(incremental-v2): improve safe shifted-node reuse across batch edits (#0000)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_advanced_reuse.rs
+++ b/crates/perl-parser/src/incremental/incremental_advanced_reuse.rs
@@ -158,7 +158,13 @@ impl AdvancedReuseAnalyzer {
         self.find_direct_structural_matches(&old_analysis, &new_analysis, &mut reuse_map, config);
 
         // Strategy 2: Position-shifted matching
-        self.find_position_shifted_matches(&old_analysis, &new_analysis, &mut reuse_map, config);
+        self.find_position_shifted_matches(
+            &old_analysis,
+            &new_analysis,
+            &mut reuse_map,
+            edits,
+            config,
+        );
 
         // Strategy 3: Content-updated matching
         if config.enable_content_reuse {
@@ -368,13 +374,22 @@ impl AdvancedReuseAnalyzer {
         old_analysis: &TreeAnalysis,
         new_analysis: &TreeAnalysis,
         reuse_map: &mut HashMap<usize, ReuseStrategy>,
+        edits: &EditSet,
         config: &ReuseConfig,
     ) {
         for (old_pos, old_info) in &old_analysis.node_info {
-            // Skip if already matched or is a leaf node
-            if reuse_map.contains_key(old_pos) || old_info.children_count == 0 {
+            // Skip if already matched
+            if reuse_map.contains_key(old_pos) {
                 continue;
             }
+
+            // Project old position into the new document using the exact edit sequence.
+            // This helps batch edits where unaffected nodes only need location shifts.
+            let expected_position = edits
+                .apply_to_position(Position::new(*old_pos, 0, 0))
+                .map(|position| position.byte);
+
+            let mut best_match: Option<ReuseStrategy> = None;
 
             // Look for content matches that may have shifted position
             for (new_pos, new_info) in &new_analysis.node_info {
@@ -382,23 +397,55 @@ impl AdvancedReuseAnalyzer {
                     && old_info.structural_hash == new_info.structural_hash
                 {
                     let position_shift = (*new_pos as isize - *old_pos as isize).unsigned_abs();
-                    if position_shift <= config.max_position_shift {
-                        let confidence = self.calculate_match_confidence(old_info, new_info) * 0.9; // Slight penalty for position shift
-                        if confidence >= config.min_confidence {
-                            reuse_map.insert(
-                                *old_pos,
-                                ReuseStrategy {
-                                    target_position: *new_pos,
-                                    reuse_type: ReuseType::PositionShift,
-                                    confidence_score: confidence,
-                                    position_adjustment: (*new_pos as isize) - (*old_pos as isize),
-                                },
-                            );
-                            self.analysis_stats.position_adjustments += 1;
-                            break;
-                        }
+                    if position_shift > config.max_position_shift {
+                        continue;
+                    }
+
+                    let projected_distance = expected_position
+                        .map(|expected| expected.abs_diff(*new_pos))
+                        .unwrap_or(position_shift);
+
+                    // Favor candidates that align with the projected shift from edits.
+                    let projection_bonus = if projected_distance == 0 {
+                        0.1
+                    } else if projected_distance <= 4 {
+                        0.06
+                    } else if projected_distance <= 16 {
+                        0.03
+                    } else {
+                        0.0
+                    };
+
+                    let confidence = (self.calculate_match_confidence(old_info, new_info) * 0.9
+                        + projection_bonus)
+                        .min(1.0);
+                    if confidence < config.min_confidence {
+                        continue;
+                    }
+
+                    let strategy = ReuseStrategy {
+                        target_position: *new_pos,
+                        reuse_type: ReuseType::PositionShift,
+                        confidence_score: confidence,
+                        position_adjustment: (*new_pos as isize) - (*old_pos as isize),
+                    };
+
+                    if best_match.as_ref().is_none_or(|current| {
+                        strategy.confidence_score > current.confidence_score
+                            || (strategy.confidence_score == current.confidence_score
+                                && projected_distance
+                                    < expected_position
+                                        .map(|expected| expected.abs_diff(current.target_position))
+                                        .unwrap_or(position_shift))
+                    }) {
+                        best_match = Some(strategy);
                     }
                 }
+            }
+
+            if let Some(strategy) = best_match {
+                reuse_map.insert(*old_pos, strategy);
+                self.analysis_stats.position_adjustments += 1;
             }
         }
     }
@@ -585,7 +632,11 @@ impl AdvancedReuseAnalyzer {
         match &node.kind {
             NodeKind::Program { statements } | NodeKind::Block { statements } => statements.len(),
             NodeKind::VariableDeclaration { initializer, .. } => {
-                if initializer.is_some() { 2 } else { 1 } // variable + optional initializer
+                if initializer.is_some() {
+                    2
+                } else {
+                    1
+                } // variable + optional initializer
             }
             NodeKind::Binary { .. } => 2, // left + right
             NodeKind::Unary { .. } => 1,  // operand
@@ -820,7 +871,7 @@ impl ReuseAnalysisResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use perl_parser_core::{SourceLocation, ast::Node};
+    use perl_parser_core::{ast::Node, SourceLocation};
 
     #[test]
     fn test_advanced_reuse_analyzer_creation() {

--- a/crates/perl-parser/src/incremental/incremental_v2.rs
+++ b/crates/perl-parser/src/incremental/incremental_v2.rs
@@ -361,9 +361,14 @@ impl IncrementalParserV2 {
         // Store analysis results for inspection
         self.last_reuse_analysis = Some(analysis_result);
 
-        // Check if reuse analysis meets our efficiency targets
+        // Use advanced analysis whenever it provides actionable reuse in
+        // batch-edit scenarios, while keeping single-edit quality gates.
         if let Some(ref analysis) = self.last_reuse_analysis {
-            if analysis.meets_efficiency_target(self.reuse_config.min_confidence * 100.0) {
+            let should_use_advanced = analysis
+                .meets_efficiency_target(self.reuse_config.min_confidence * 100.0)
+                || (self.pending_edits.len() > 1 && analysis.reused_nodes > 0);
+
+            if should_use_advanced {
                 // Update statistics based on analysis
                 self.reused_nodes = analysis.reused_nodes;
                 self.reparsed_nodes = analysis.total_new_nodes - analysis.reused_nodes;
@@ -1267,6 +1272,13 @@ mod tests {
         budget
     }
 
+    fn assert_matches_fresh_parse(source: &str, incremental_tree: &Node) -> ParseResult<()> {
+        let mut parser = Parser::new(source);
+        let full_tree = parser.parse()?;
+        assert_eq!(*incremental_tree, full_tree);
+        Ok(())
+    }
+
     #[test]
     fn test_basic_compilation() {
         let parser = IncrementalParserV2::new();
@@ -2122,6 +2134,94 @@ if ($condition) {
         let source2 = "my $x=  42;";
         parser.parse(source2)?;
         assert!(parser.reused_nodes > 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_batch_non_overlapping_whitespace_comment_edits_shift_reuse() -> ParseResult<()> {
+        let mut parser = IncrementalParserV2::new();
+        let source1 = "my $a = 1;\nmy $b = 2;\nmy $c = 3;\n";
+        parser.parse(source1)?;
+
+        // Edit 1: insert extra spacing before $b.
+        let first_insert =
+            source1.find("$b").ok_or(perl_parser_core::error::ParseError::UnexpectedEof)?;
+        parser.edit(Edit::new(
+            first_insert,
+            first_insert,
+            first_insert + 2,
+            Position::new(first_insert, 0, 0),
+            Position::new(first_insert, 0, 0),
+            Position::new(first_insert + 2, 0, 0),
+        ));
+
+        let source_after_first =
+            format!("{}  {}", &source1[..first_insert], &source1[first_insert..]);
+
+        // Edit 2: add comment on a separate line region.
+        let second_insert = source_after_first
+            .find("1;")
+            .map(|idx| idx + 2)
+            .ok_or(perl_parser_core::error::ParseError::UnexpectedEof)?;
+        let comment = " # keep-a";
+        parser.edit(Edit::new(
+            second_insert,
+            second_insert,
+            second_insert + comment.len(),
+            Position::new(second_insert, 0, 0),
+            Position::new(second_insert, 0, 0),
+            Position::new(second_insert + comment.len(), 0, 0),
+        ));
+
+        let source2 = "my $a = 1; # keep-a\nmy   $b = 2;\nmy $c = 3;\n";
+        let tree = parser.parse(source2)?;
+
+        assert!(parser.reused_nodes >= 6);
+        assert!(parser.used_advanced_reuse());
+        assert_matches_fresh_parse(source2, &tree)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_batch_identifier_and_value_edits_keep_shifted_reuse() -> ParseResult<()> {
+        let mut parser = IncrementalParserV2::new();
+        let source1 = "my $name = 10;\nmy $other = 20;\nmy $third = 30;\n";
+        parser.parse(source1)?;
+
+        // Edit 1: identifier expansion.
+        let id_start = source1
+            .find("$name")
+            .map(|idx| idx + 1)
+            .ok_or(perl_parser_core::error::ParseError::UnexpectedEof)?;
+        parser.edit(Edit::new(
+            id_start,
+            id_start + 4,
+            id_start + 8,
+            Position::new(id_start, 0, 0),
+            Position::new(id_start + 4, 0, 0),
+            Position::new(id_start + 8, 0, 0),
+        ));
+
+        // Edit 2: value expansion in a separate statement.
+        let source_after_first = source1.replacen("$name", "$name_new", 1);
+        let value_start = source_after_first
+            .rfind("30")
+            .ok_or(perl_parser_core::error::ParseError::UnexpectedEof)?;
+        parser.edit(Edit::new(
+            value_start,
+            value_start + 2,
+            value_start + 4,
+            Position::new(value_start, 0, 0),
+            Position::new(value_start + 2, 0, 0),
+            Position::new(value_start + 4, 0, 0),
+        ));
+
+        let source2 = "my $name_new = 10;\nmy $other = 20;\nmy $third = 3000;\n";
+        let tree = parser.parse(source2)?;
+
+        assert!(parser.reused_nodes >= 6);
+        assert!(parser.reparsed_nodes >= 1);
+        assert_matches_fresh_parse(source2, &tree)?;
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- Batch edits that only shift unaffected subtrees were not being matched reliably, so safe subtree reuse was undercounted for non-overlapping edits and separate whitespace/comment or identifier/value edits.
- The advanced reuse analyzer already computes edit- and position-aware information but its shifted-node matching wasn't projecting old positions through the exact edit sequence before scoring.

### Description
- Pass the `EditSet` into `find_position_shifted_matches` and use `edits.apply_to_position(...)` to project old node positions into the new document so shifted candidates are preferred when appropriate.
- Improve shifted-node scoring by adding a projection proximity bonus and selecting the best candidate per old node (confidence + projected-distance tie-breaker), while respecting `max_position_shift` and `min_confidence` limits.
- Relax the advanced-reuse acceptance in `incremental_v2` so multi-edit batches with actionable reuse (non-zero reused nodes) will use the analyzer even if the single-edit quality gate would not pass; single-edit quality checks remain unchanged.
- Add regression tests to `incremental_v2` that exercise (a) non-overlapping whitespace/comment edits and (b) separated identifier + value edits, and assert AST equivalence with a fresh full parse to ensure correctness.

### Testing
- Ran `cargo check --all-targets -p perl-parser`, which completed successfully.
- Ran the new incremental-v2 regression tests individually and they passed, including the fresh-parse equivalence assertions for the generated trees.
- Ran targeted existing tests in isolation (the refactor cleanup test that had been flaky) and they passed when run alone; the full `cargo test -p perl-parser` run encountered unrelated pre-existing failures in other test modules while the modified incremental code compiled and behaved as expected.
- Ran `cargo xtask fmt` to format changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaffad48548333b1fa7c7a5297e07f)