### PR TITLE
fix(parser): correct transliteration part extraction and expand regressions (#6705)

### DIFF
--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -301,83 +301,64 @@ pub fn extract_substitution_parts(text: &str) -> (String, String, String) {
 
 /// Extract search, replace, and modifiers from a transliteration token
 pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
-    // Skip 'tr' or 'y' prefix
-    let content = if let Some(stripped) = text.strip_prefix("tr") {
+    // Skip `tr` or `y` prefix, then allow optional whitespace before delimiter.
+    let after_op = if let Some(stripped) = text.strip_prefix("tr") {
         stripped
     } else if let Some(stripped) = text.strip_prefix('y') {
         stripped
     } else {
         text
     };
+    let content = after_op.trim_start();
 
     // Get delimiter - content must be non-empty to have a delimiter
     let delimiter = match content.chars().next() {
         Some(d) => d,
         None => return (String::new(), String::new(), String::new()),
     };
+    // Obvious malformed forms: delimiter must be punctuation-like, not whitespace/alnum.
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return (String::new(), String::new(), String::new());
+    }
+
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
     // Parse first body (search pattern)
-    let (search, rest1) = extract_delimited_content(content, delimiter, closing);
-
-    // For paired delimiters, skip whitespace and allow any paired opening delimiter for the
-    // replacement list. Perl accepts forms like tr[abc]{xyz} in addition to tr[abc][xyz].
-    let rest2_owned;
-    let rest2 = if is_paired {
-        rest1.trim_start()
-    } else {
-        rest2_owned = format!("{}{}", delimiter, rest1);
-        &rest2_owned
-    };
+    let (search, rest1, search_closed) =
+        extract_delimited_content_strict(content, delimiter, closing);
+    if !search_closed {
+        return (search, String::new(), String::new());
+    }
 
     // Parse second body (replacement pattern)
-    let (replacement, modifiers_str) = if !is_paired && !rest1.is_empty() {
-        // Manually parse the replacement for non-paired delimiters
-        let chars = rest1.char_indices();
-        let mut body = String::new();
-        let mut escaped = false;
-        let mut end_pos = rest1.len();
-
-        for (i, ch) in chars {
-            if escaped {
-                body.push(ch);
-                escaped = false;
-                continue;
-            }
-
-            match ch {
-                '\\' => {
-                    body.push(ch);
-                    escaped = true;
-                }
-                c if c == closing => {
-                    end_pos = i + ch.len_utf8();
-                    break;
-                }
-                _ => body.push(ch),
-            }
-        }
-
-        (body, &rest1[end_pos..])
-    } else if is_paired {
-        if let Some(repl_delimiter) = starts_with_paired_delimiter(rest2) {
-            let repl_closing = get_closing_delimiter(repl_delimiter);
-            extract_delimited_content(rest2, repl_delimiter, repl_closing)
+    let (replacement, modifiers_str, replacement_closed) = if !is_paired {
+        if rest1.is_empty() {
+            (String::new(), "", false)
         } else {
-            (String::new(), rest2)
+            extract_unpaired_body_skip_strings(rest1, closing)
         }
     } else {
-        (String::new(), rest1)
+        let trimmed = rest1.trim_start();
+        if let Some(repl_delimiter) = starts_with_paired_delimiter(trimmed) {
+            let repl_closing = get_closing_delimiter(repl_delimiter);
+            extract_delimited_content_strict(trimmed, repl_delimiter, repl_closing)
+        } else {
+            (String::new(), "", false)
+        }
     };
 
     // Extract and validate only valid transliteration modifiers
-    // Security fix: Apply consistent validation for all delimiter types
-    let modifiers = modifiers_str
-        .chars()
-        .take_while(|c| c.is_ascii_alphabetic())
-        .filter(|&c| matches!(c, 'c' | 'd' | 's' | 'r'))
-        .collect();
+    // Only consider modifiers when the replacement was properly closed.
+    let modifiers = if replacement_closed {
+        modifiers_str
+            .chars()
+            .take_while(|c| c.is_ascii_alphabetic())
+            .filter(|&c| matches!(c, 'c' | 'd' | 's' | 'r'))
+            .collect()
+    } else {
+        String::new()
+    };
 
     (search, replacement, modifiers)
 }
@@ -413,7 +394,8 @@ pub fn extract_transliteration_parts_strict(
     let is_paired = delimiter != closing;
 
     // Parse first body (search).
-    let (search, rest1, search_closed) = extract_delimited_content_strict(content, delimiter, closing);
+    let (search, rest1, search_closed) =
+        extract_delimited_content_strict(content, delimiter, closing);
     if !search_closed {
         return Err(TransliterationError::MissingClosingDelimiter);
     }
@@ -447,10 +429,7 @@ pub fn extract_transliteration_parts_strict(
 
     // Validate transliteration modifiers strictly.
     let mut modifiers = String::new();
-    for modifier in modifiers_str
-        .chars()
-        .take_while(|c: &char| c.is_ascii_alphanumeric())
-    {
+    for modifier in modifiers_str.chars().take_while(|c: &char| c.is_ascii_alphanumeric()) {
         if matches!(modifier, 'c' | 'd' | 's' | 'r') {
             modifiers.push(modifier);
         } else {

--- a/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
+++ b/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
@@ -1,18 +1,4 @@
-/// Minimal reproduction case for transliteration parsing bug discovered in fuzz testing
-///
-/// CRASH DETAILS:
-/// - Input: "tr/abc/xyz/"
-/// - Expected: ("abc", "xyz", "")
-/// - Actual: ("abc", "", "xyz")
-///
-/// This indicates a critical bug in extract_transliteration_parts where the replacement
-/// and modifiers are being swapped for non-paired delimiters.
-///
-/// IMPACT: This affects Perl transliteration operator parsing throughout the entire
-/// parser pipeline, potentially causing incorrect syntax highlighting, code analysis,
-/// and refactoring operations.
-///
-/// REPRODUCTION: Run with `cargo test -p perl-parser --test fuzz_transliteration_crash_repro`
+/// Regression bank for fuzz-discovered transliteration extraction failures.
 use perl_parser::quote_parser::extract_transliteration_parts;
 
 #[test]
@@ -20,37 +6,64 @@ fn minimal_transliteration_crash_repro() {
     let input = "tr/abc/xyz/";
     let (search, replace, modifiers) = extract_transliteration_parts(input);
 
-    println!("FUZZ BUG REPRODUCED: tr// parsing issue");
-    println!("Input: {}", input);
-    println!("Expected: ('abc', 'xyz', '')");
-    println!("Actual: ('{}', '{}', '{}')", search, replace, modifiers);
-
-    // Demonstrate the bug - these will fail due to the parsing issue
     assert_eq!(search.as_str(), "abc", "Search pattern incorrect");
     assert_eq!(replace.as_str(), "xyz", "Replace pattern incorrect");
     assert_eq!(modifiers.as_str(), "", "Modifiers incorrect");
 }
 
 #[test]
-fn fuzz_transliteration_regression_suite() {
-    // Test additional variants that likely have the same bug
-    let test_cases = vec![
+fn transliteration_non_paired_delimiters_regression_bank() {
+    let test_cases = [
+        ("tr/abc/xyz/", ("abc", "xyz", "")),
         ("y/abc/xyz/", ("abc", "xyz", "")),
         ("tr/a/b/d", ("a", "b", "d")),
-        ("y/x/y/g", ("x", "y", "")), // 'g' is not a valid transliteration modifier
-        ("tr{abc}{xyz}d", ("abc", "xyz", "d")), // This might work correctly with paired delimiters
+        ("y/x/y/g", ("x", "y", "")),
+        ("tr!a\\!!b\\!!cdr", ("a\\!", "b\\!", "cdr")),
+        ("tr /a/b/d", ("a", "b", "d")),
     ];
 
     for (input, expected) in test_cases {
         let (search, replace, modifiers) = extract_transliteration_parts(input);
         let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
+        assert_eq!(actual, expected, "input: {input}");
+    }
+}
 
-        println!("Testing: {} -> expected {:?}, got {:?}", input, expected, actual);
+#[test]
+fn transliteration_paired_delimiters_regression_bank() {
+    let test_cases = [
+        ("tr{abc}{xyz}d", ("abc", "xyz", "d")),
+        ("tr[abc][xyz]cdr", ("abc", "xyz", "cdr")),
+        ("tr<abc>{xyz}s", ("abc", "xyz", "s")),
+        ("y(a(b)c)(x(y)z)r", ("a(b)c", "x(y)z", "r")),
+    ];
 
-        if actual != expected {
-            println!("  BUG CONFIRMED in variant: {}", input);
-        } else {
-            println!("  PASSED: {}", input);
-        }
+    for (input, expected) in test_cases {
+        let (search, replace, modifiers) = extract_transliteration_parts(input);
+        let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
+        assert_eq!(actual, expected, "input: {input}");
+    }
+}
+
+#[test]
+fn transliteration_malformed_is_non_panicking_and_does_not_leak_modifiers() {
+    let malformed_cases = [
+        ("tr", ("", "", "")),
+        ("trabc", ("", "", "")),
+        ("tr/abc", ("abc", "", "")),
+        ("tr/abc/xyz", ("abc", "xyz", "")),
+        ("tr{abc}{xyz", ("abc", "xyz", "")),
+        ("tr{abc}xyzcdr", ("abc", "", "")),
+    ];
+
+    for (input, expected) in malformed_cases {
+        let result = std::panic::catch_unwind(|| extract_transliteration_parts(input));
+        assert!(result.is_ok(), "input panicked: {input}");
+        let (search, replace, modifiers) = match result {
+            Ok(parts) => parts,
+            Err(_) => unreachable!("asserted is_ok above"),
+        };
+        let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
+        assert_eq!(actual, expected, "input: {input}");
     }
 }


### PR DESCRIPTION
### Motivation
- The existing `extract_transliteration_parts` had edge-case parsing gaps that caused replacement/modifier mis-parsing for non-paired delimiters, and could behave inconsistently for paired delimiters and malformed inputs.
- The fuzz repro coverage was narrow and did not exercise paired/non-paired edge cases, escaped delimiters, or malformed-but-nonpanicking inputs.

### Description
- Tighten transliteration parsing in `crates/perl-parser-core/src/syntax/quote.rs` by accepting optional whitespace after `tr`/`y`, rejecting obvious malformed delimiters (alphanumeric/whitespace), and using strict delimiter-close tracking for both search and replacement sections.
- Ensure replacement parsing distinguishes paired vs non-paired delimiters correctly and uses `extract_unpaired_body_skip_strings` / strict paired extraction to avoid swapping replacement and modifiers.
- Only extract transliteration modifiers when the replacement section was properly closed to avoid leaking trailing text as modifiers.
- Expand the regression bank in `crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs` with focused tests for non-paired `tr///`/`y///`, paired delimiters (including mixed paired forms), escaped-delimiter and whitespace variants, and malformed-but-nonpanicking cases.

### Testing
- Ran `cargo test -p perl-parser --test fuzz_transliteration_crash_repro` and all tests in that binary passed.
- Ran `cargo check --all-targets -p perl-parser` and the crate type checks passed.
- Ran `cargo clippy -p perl-parser --all-targets -- -D warnings` and lints passed with no warnings.
- Ran `cargo xtask fmt` and formatting check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaffa3b31c8333ac509b6c5961125f)