### PR TITLE
fix(incremental): harden batch edit normalization and UTF-8 boundary fallback (#6704)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_document.rs
+++ b/crates/perl-parser/src/incremental/incremental_document.rs
@@ -128,32 +128,24 @@ impl IncrementalDocument {
         // Reset metrics for this batch of edits
         self.metrics = ParseMetrics::default();
 
-        // Sort edits by position (reverse order for correct application)
-        let mut sorted_edits = edits.edits.clone();
-        sorted_edits.sort_by(|a, b| b.start_byte.cmp(&a.start_byte));
+        let Some(sorted_edits) = edits.normalized_reverse() else {
+            debug!("Batch edit normalization failed; falling back to full reparse");
+            return self.fallback_full_reparse(start);
+        };
 
         // Apply all edits to source in-place.
         // Reverse ordering keeps byte offsets stable while avoiding repeated
         // full-string allocations for each edit.
-        let mut new_source = self.source.clone();
-        for edit in &sorted_edits {
-            self.apply_edit_in_place(&mut new_source, edit);
-        }
-
-        // Find all affected ranges
-        let affected_ranges: Vec<_> =
-            sorted_edits.iter().map(|e| (e.start_byte, e.old_end_byte)).collect();
-
-        // Collect reusable subtrees outside affected ranges
-        let reusable = self.find_reusable_for_ranges(&affected_ranges);
-
-        // Parse with reuse when possible
-        let new_root = if !reusable.is_empty() {
-            self.parse_with_reuse(&new_source, reusable)?
-        } else {
-            let mut parser = Parser::new(&new_source);
-            parser.parse()?
+        let Some(new_source) = self.try_apply_batch_to_source(&sorted_edits) else {
+            debug!("Batch contains unmappable edit(s); falling back to full reparse");
+            return self.fallback_full_reparse(start);
         };
+
+        // For batch updates, use a conservative full parse once mapping succeeds.
+        // This avoids optimistic reuse assumptions across multiple edits while
+        // keeping reverse-order byte semantics deterministic.
+        let mut parser = Parser::new(&new_source);
+        let new_root = parser.parse()?;
 
         // Update state
         self.source = new_source;
@@ -171,40 +163,68 @@ impl IncrementalDocument {
     }
 
     fn apply_edit_to_string(&self, source: &str, edit: &IncrementalEdit) -> String {
-        let mut result = String::with_capacity(source.len() + edit.new_text.len());
+        let mut result = source.to_string();
 
-        // Safely handle byte positions with bounds checking
-        let start = edit.start_byte.min(source.len());
-        let end = edit.old_end_byte.min(source.len());
-
-        // Ensure we're on UTF-8 boundaries
-        if source.is_char_boundary(start) && source.is_char_boundary(end) {
-            result.push_str(&source[..start]);
-            result.push_str(&edit.new_text);
-            result.push_str(&source[end..]);
+        if self.apply_edit_in_place(&mut result, edit) {
+            result
         } else {
-            // Fallback: if boundaries are invalid, use the original source
-            debug!("Invalid UTF-8 boundaries in edit: start={}, end={}", start, end);
-            result.push_str(source);
+            // Fallback: if mapping is invalid, use the original source
+            debug!(
+                "Invalid edit mapping in apply_edit_to_string: start={}, end={}",
+                edit.start_byte, edit.old_end_byte
+            );
+            source.to_string()
         }
-
-        result
     }
 
-    fn apply_edit_in_place(&self, source: &mut String, edit: &IncrementalEdit) {
-        let start = edit.start_byte.min(source.len());
-        let end = edit.old_end_byte.min(source.len());
+    fn apply_edit_in_place(&self, source: &mut String, edit: &IncrementalEdit) -> bool {
+        let start = edit.start_byte;
+        let end = edit.old_end_byte;
 
         if start > end {
             debug!("Skipping invalid edit range: start={}, end={}", start, end);
-            return;
+            return false;
+        }
+
+        if end > source.len() {
+            debug!(
+                "Skipping out-of-bounds edit range: start={}, end={}, len={}",
+                start,
+                end,
+                source.len()
+            );
+            return false;
         }
 
         if source.is_char_boundary(start) && source.is_char_boundary(end) {
             source.replace_range(start..end, &edit.new_text);
+            true
         } else {
             debug!("Invalid UTF-8 boundaries in edit: start={}, end={}", start, end);
+            false
         }
+    }
+
+    fn try_apply_batch_to_source(&self, edits: &[IncrementalEdit]) -> Option<String> {
+        let mut new_source = self.source.clone();
+        for edit in edits {
+            if !self.apply_edit_in_place(&mut new_source, edit) {
+                return None;
+            }
+        }
+
+        Some(new_source)
+    }
+
+    fn fallback_full_reparse(&mut self, start: Instant) -> ParseResult<()> {
+        let mut parser = Parser::new(&self.source);
+        let new_root = parser.parse()?;
+
+        self.root = Arc::new(new_root);
+        self.cache_subtrees();
+        self.metrics.last_parse_time_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+        Ok(())
     }
 
     /// Find subtrees that can be reused (outside the edited range)
@@ -230,28 +250,6 @@ impl IncrementalDocument {
                     self.metrics.cache_hits += 1;
                     self.metrics.nodes_reused += self.count_nodes(node);
                 }
-            } else {
-                self.metrics.cache_misses += 1;
-            }
-        }
-
-        reusable
-    }
-
-    /// Find reusable subtrees for multiple affected ranges
-    fn find_reusable_for_ranges(&mut self, ranges: &[(usize, usize)]) -> Vec<Arc<Node>> {
-        let mut reusable = Vec::new();
-
-        for ((start, end), node) in &self.subtree_cache.by_range {
-            let affected = ranges.iter().any(|(r_start, r_end)| {
-                // Check if this subtree overlaps with any affected range
-                *start < *r_end && *end > *r_start
-            });
-
-            if !affected {
-                reusable.push(node.clone());
-                self.metrics.cache_hits += 1;
-                self.metrics.nodes_reused += self.count_nodes(node);
             } else {
                 self.metrics.cache_misses += 1;
             }

--- a/crates/perl-parser/src/incremental/incremental_edit.rs
+++ b/crates/perl-parser/src/incremental/incremental_edit.rs
@@ -67,6 +67,11 @@ impl IncrementalEdit {
     pub fn is_after(&self, pos: usize) -> bool {
         self.start_byte >= pos
     }
+
+    /// Returns true when this edit range is ordered (not backwards).
+    pub fn has_ordered_range(&self) -> bool {
+        self.start_byte <= self.old_end_byte
+    }
 }
 
 /// Collection of incremental edits
@@ -96,6 +101,44 @@ impl IncrementalEditSet {
         self.edits.sort_by_key(|e| std::cmp::Reverse(e.start_byte));
     }
 
+    /// Returns normalized reverse-ordered edits for deterministic application.
+    ///
+    /// Returns `None` when any edit is malformed (backwards range) or when edits
+    /// overlap on the original source document.
+    pub fn normalized_reverse(&self) -> Option<Vec<IncrementalEdit>> {
+        if self.edits.is_empty() {
+            return Some(Vec::new());
+        }
+
+        let mut indexed: Vec<(usize, &IncrementalEdit)> = self.edits.iter().enumerate().collect();
+        indexed.sort_by_key(|(_, edit)| (edit.start_byte, edit.old_end_byte));
+
+        let mut previous_end: Option<usize> = None;
+        for (_, edit) in &indexed {
+            if !edit.has_ordered_range() {
+                return None;
+            }
+
+            if let Some(end) = previous_end
+                && edit.start_byte < end
+            {
+                return None;
+            }
+
+            previous_end = Some(edit.old_end_byte);
+        }
+
+        indexed.sort_by(|(left_idx, left), (right_idx, right)| {
+            right
+                .start_byte
+                .cmp(&left.start_byte)
+                .then_with(|| right.old_end_byte.cmp(&left.old_end_byte))
+                .then_with(|| right_idx.cmp(left_idx))
+        });
+
+        Some(indexed.into_iter().map(|(_, edit)| edit.clone()).collect())
+    }
+
     /// Check if the edit set is empty
     pub fn is_empty(&self) -> bool {
         self.edits.is_empty()
@@ -112,21 +155,21 @@ impl IncrementalEditSet {
             return source.to_string();
         }
 
-        // Sort edits in reverse order to apply from end to start
-        let mut sorted_edits = self.edits.clone();
-        sorted_edits.sort_by_key(|e| std::cmp::Reverse(e.start_byte));
+        let Some(sorted_edits) = self.normalized_reverse() else {
+            return source.to_string();
+        };
 
         let mut result = source.to_string();
         for edit in &sorted_edits {
-            let start = edit.start_byte.min(result.len());
-            let end = edit.old_end_byte.min(result.len());
+            let start = edit.start_byte;
+            let end = edit.old_end_byte;
 
-            if start > end {
-                continue;
+            if end > result.len() || start > end {
+                return source.to_string();
             }
 
             if !result.is_char_boundary(start) || !result.is_char_boundary(end) {
-                continue;
+                return source.to_string();
             }
 
             result.replace_range(start..end, &edit.new_text);
@@ -177,5 +220,31 @@ mod tests {
         let source = "hello world";
         let result = edits.apply_to_string(source);
         assert_eq!(result, "Hello Perl");
+    }
+
+    #[test]
+    fn test_normalized_reverse_rejects_overlap() {
+        let mut edits = IncrementalEditSet::new();
+        edits.add(IncrementalEdit::new(1, 4, "x".to_string()));
+        edits.add(IncrementalEdit::new(3, 5, "y".to_string()));
+
+        assert!(edits.normalized_reverse().is_none());
+    }
+
+    #[test]
+    fn test_normalized_reverse_preserves_zero_width_insertions() {
+        let mut edits = IncrementalEditSet::new();
+        edits.add(IncrementalEdit::new(2, 2, "A".to_string()));
+        edits.add(IncrementalEdit::new(2, 2, "B".to_string()));
+
+        let normalized = if let Some(normalized) = edits.normalized_reverse() {
+            normalized
+        } else {
+            assert!(false, "zero-width insertions should be valid");
+            return;
+        };
+        assert_eq!(normalized.len(), 2);
+        assert_eq!(normalized[0].new_text, "B");
+        assert_eq!(normalized[1].new_text, "A");
     }
 }

--- a/crates/perl-parser/tests/incremental_batch_boundary_regressions.rs
+++ b/crates/perl-parser/tests/incremental_batch_boundary_regressions.rs
@@ -1,0 +1,102 @@
+#![cfg(feature = "incremental")]
+
+use perl_parser::Parser;
+use perl_parser::incremental::incremental_document::IncrementalDocument;
+use perl_parser::incremental::incremental_edit::{IncrementalEdit, IncrementalEditSet};
+use std::error::Error;
+use std::io;
+
+fn find_index(haystack: &str, needle: &str) -> Result<usize, io::Error> {
+    haystack
+        .find(needle)
+        .ok_or_else(|| io::Error::other(format!("'{needle}' should exist in test source")))
+}
+
+#[test]
+fn overlapping_batch_edits_fallback_without_partial_application() -> Result<(), Box<dyn Error>> {
+    let source = "my $x = 12345;";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+
+    let mut edits = IncrementalEditSet::new();
+    let first = find_index(source, "123")?;
+    let second = find_index(source, "345")?;
+    edits.add(IncrementalEdit::new(first, first + 3, "ABC".to_string()));
+    edits.add(IncrementalEdit::new(second, second + 3, "XYZ".to_string()));
+
+    doc.apply_edits(&edits)?;
+
+    assert_eq!(doc.source, source);
+    Ok(())
+}
+
+#[test]
+fn backwards_range_batch_edits_fallback_without_mutation() -> Result<(), Box<dyn Error>> {
+    let source = "my $x = 10;";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(8, 6, "42".to_string()));
+
+    doc.apply_edits(&edits)?;
+
+    assert_eq!(doc.source, source);
+    Ok(())
+}
+
+#[test]
+fn mid_codepoint_single_edit_is_ignored_safely() -> Result<(), Box<dyn Error>> {
+    let source = "my $greeting = \"é\";";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+    let codepoint_start = find_index(source, "é")?;
+
+    // Target the middle byte of a 2-byte UTF-8 codepoint.
+    let invalid_mid_byte = codepoint_start + 1;
+    let edit = IncrementalEdit::new(invalid_mid_byte, invalid_mid_byte, "x".to_string());
+    doc.apply_edit(edit)?;
+
+    assert_eq!(doc.source, source);
+    Ok(())
+}
+
+#[test]
+fn one_bad_edit_forces_batch_fallback() -> Result<(), Box<dyn Error>> {
+    let source = "my $name = \"é\"; my $value = 1;";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+
+    let mut edits = IncrementalEditSet::new();
+    let value_pos = find_index(source, "1")?;
+    edits.add(IncrementalEdit::new(value_pos, value_pos + 1, "2".to_string()));
+
+    let multibyte_start = find_index(source, "é")?;
+    let invalid_mid_byte = multibyte_start + 1;
+    edits.add(IncrementalEdit::new(invalid_mid_byte, invalid_mid_byte, "!".to_string()));
+
+    doc.apply_edits(&edits)?;
+
+    // Entire batch should conservatively fall back without partially applying edits.
+    assert_eq!(doc.source, source);
+    Ok(())
+}
+
+#[test]
+fn supported_batch_edits_match_fresh_parse() -> Result<(), Box<dyn Error>> {
+    let source = "my $x = 1; my $y = 2;";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+
+    let mut edits = IncrementalEditSet::new();
+    let x_pos = find_index(source, "1")?;
+    let y_pos = find_index(source, "2")?;
+    edits.add(IncrementalEdit::new(x_pos, x_pos + 1, "10".to_string()));
+    edits.add(IncrementalEdit::new(y_pos, y_pos + 1, "20".to_string()));
+    edits.add(IncrementalEdit::new(source.len(), source.len(), " # trailing".to_string()));
+
+    doc.apply_edits(&edits)?;
+
+    let expected_source = "my $x = 10; my $y = 20; # trailing";
+    let mut parser = Parser::new(expected_source);
+    let fresh = parser.parse()?;
+
+    assert_eq!(doc.source, expected_source);
+    assert_eq!(&*doc.root, &fresh);
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Batch incremental edits assumed well-formed byte ranges and UTF-8 boundaries which could lead to optimistic/partial application for malformed edit sets.
- Make batch application deterministic and safe by validating ranges and falling back conservatively when any edit is unmappable.

### Description
- Add deterministic normalization and validation in `IncrementalEditSet::normalized_reverse()` to reject backwards ranges and overlapping edits while preserving valid zero-width insertions, and expose `has_ordered_range()` on `IncrementalEdit` (`crates/perl-parser/src/incremental/incremental_edit.rs`).
- Harden `IncrementalDocument` batch/single-edit application by adding strict bounds and UTF-8 boundary checks, `try_apply_batch_to_source()`, and `fallback_full_reparse()` so a malformed batch or unmappable edit triggers a conservative full reparse; preserve existing reverse-order semantics for valid batches (`crates/perl-parser/src/incremental/incremental_document.rs`).
- Replace optimistic multi-edit reuse with a conservative full parse after successful batch mapping to ensure incremental state equals a fresh parse for supported cases.
- Add targeted regression tests exercising overlapping batches, backwards ranges, mid-codepoint edits, one-bad-edit batch fallback, and successful batch parity with a fresh parse (`crates/perl-parser/tests/incremental_batch_boundary_regressions.rs`).

### Testing
- Ran `cargo test -p perl-parser --features incremental --test incremental_batch_boundary_regressions` and the new regression suite passed (5/5 tests).
- Ran `cargo check --all-targets -p perl-parser` which completed successfully.
- Ran the full `cargo test -p perl-parser`; the run failed due to an unrelated existing test in `refactor::refactoring::tests::validation_tests::test_cleanup_respects_retention_count`, not due to changes in incremental code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaff94025083338c5ee4779cd0492d)