### PR TITLE
fix(incremental): harden batch edit normalization and UTF-8 boundary fallback (#6703)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_boundary_regressions.rs
+++ b/crates/perl-parser/src/incremental/incremental_boundary_regressions.rs
@@ -1,0 +1,101 @@
+#[cfg(test)]
+mod tests {
+    use crate::incremental::incremental_document::IncrementalDocument;
+    use crate::incremental::incremental_edit::{IncrementalEdit, IncrementalEditSet};
+    use perl_parser_core::{
+        error::{ParseError, ParseResult},
+        parser::Parser,
+    };
+
+    fn missing_fragment(fragment: &str) -> ParseError {
+        ParseError::SyntaxError {
+            message: format!("test source should contain `{fragment}`"),
+            location: 0,
+        }
+    }
+
+    fn fresh_parse_debug(source: &str) -> ParseResult<String> {
+        let mut parser = Parser::new(source);
+        let root = parser.parse()?;
+        Ok(format!("{root:?}"))
+    }
+
+    #[test]
+    fn overlapping_batch_edits_fall_back_conservatively() -> ParseResult<()> {
+        let mut doc = IncrementalDocument::new("abcdef".to_string())?;
+        let mut edits = IncrementalEditSet::new();
+        edits.add(IncrementalEdit::new(0, 3, "X".to_string()));
+        edits.add(IncrementalEdit::new(2, 5, "Y".to_string()));
+
+        doc.apply_edits(&edits)?;
+
+        // Overlap causes fallback; conservative application keeps deterministic
+        // reverse-order behavior by applying the later-starting edit.
+        assert_eq!(doc.source, "abYf");
+        Ok(())
+    }
+
+    #[test]
+    fn backwards_ranges_are_rejected() -> ParseResult<()> {
+        let original = "my $x = 10;";
+        let mut doc = IncrementalDocument::new(original.to_string())?;
+        let mut edits = IncrementalEditSet::new();
+        edits.add(IncrementalEdit::new(7, 3, "oops".to_string()));
+
+        doc.apply_edits(&edits)?;
+
+        assert_eq!(doc.source, original);
+        Ok(())
+    }
+
+    #[test]
+    fn mid_codepoint_batch_edit_is_ignored() -> ParseResult<()> {
+        let original = "my $s = \"é\";";
+        let mut doc = IncrementalDocument::new(original.to_string())?;
+        let mut edits = IncrementalEditSet::new();
+        let char_start = original.find("é").ok_or_else(|| missing_fragment("é"))?;
+        // Edit starts inside UTF-8 codepoint for "é"
+        edits.add(IncrementalEdit::new(char_start + 1, char_start + 2, "x".to_string()));
+
+        doc.apply_edits(&edits)?;
+
+        assert_eq!(doc.source, original);
+        Ok(())
+    }
+
+    #[test]
+    fn batch_fallback_when_one_edit_is_unmappable() -> ParseResult<()> {
+        let original = "my $s = \"é\";\nmy $x = 1;\n";
+        let mut doc = IncrementalDocument::new(original.to_string())?;
+        let mut edits = IncrementalEditSet::new();
+        let valid_start = original.find("1;").ok_or_else(|| missing_fragment("1;"))?;
+        // Valid replacement for "1" -> "2"
+        edits.add(IncrementalEdit::new(valid_start, valid_start + 1, "2".to_string()));
+        let invalid_start = original.find("é").ok_or_else(|| missing_fragment("é"))?;
+        // Invalid UTF-8 boundary edit (inside "é")
+        edits.add(IncrementalEdit::new(
+            invalid_start + 1,
+            invalid_start + 2,
+            "x".to_string(),
+        ));
+
+        doc.apply_edits(&edits)?;
+
+        assert_eq!(doc.source, "my $s = \"é\";\nmy $x = 2;\n");
+        Ok(())
+    }
+
+    #[test]
+    fn incremental_matches_fresh_parse_for_supported_edit() -> ParseResult<()> {
+        let original = "my $x = 1;\nmy $y = 2;\n";
+        let mut doc = IncrementalDocument::new(original.to_string())?;
+        let line_break = original.find('\n').ok_or_else(|| missing_fragment("\\n"))?;
+        let edit = IncrementalEdit::new(line_break, line_break, "\n".to_string());
+
+        doc.apply_edit(edit)?;
+
+        let fresh = fresh_parse_debug(&doc.source)?;
+        assert_eq!(format!("{:?}", doc.root), fresh);
+        Ok(())
+    }
+}

--- a/crates/perl-parser/src/incremental/incremental_document.rs
+++ b/crates/perl-parser/src/incremental/incremental_document.rs
@@ -128,13 +128,20 @@ impl IncrementalDocument {
         // Reset metrics for this batch of edits
         self.metrics = ParseMetrics::default();
 
-        // Sort edits by position (reverse order for correct application)
-        let mut sorted_edits = edits.edits.clone();
-        sorted_edits.sort_by(|a, b| b.start_byte.cmp(&a.start_byte));
+        let Some(sorted_edits) = self.normalized_mappable_batch(edits) else {
+            debug!("Falling back to conservative batch application for unmappable edit set");
+            let new_source = edits.apply_to_string(&self.source);
+            let mut parser = Parser::new(&new_source);
+            let new_root = parser.parse()?;
 
-        // Apply all edits to source in-place.
-        // Reverse ordering keeps byte offsets stable while avoiding repeated
-        // full-string allocations for each edit.
+            self.source = new_source;
+            self.root = Arc::new(new_root);
+            self.cache_subtrees();
+            self.metrics.last_parse_time_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+            return Ok(());
+        };
+
         let mut new_source = self.source.clone();
         for edit in &sorted_edits {
             self.apply_edit_in_place(&mut new_source, edit);
@@ -165,6 +172,22 @@ impl IncrementalDocument {
         Ok(())
     }
 
+    fn normalized_mappable_batch(
+        &self,
+        edits: &IncrementalEditSet,
+    ) -> Option<Vec<IncrementalEdit>> {
+        let sorted = edits.normalized_reverse_non_overlapping(self.source.len())?;
+
+        if sorted.iter().any(|edit| {
+            !self.source.is_char_boundary(edit.start_byte)
+                || !self.source.is_char_boundary(edit.old_end_byte)
+        }) {
+            return None;
+        }
+
+        Some(sorted)
+    }
+
     /// Apply edit to source string
     fn apply_edit_to_source(&self, edit: &IncrementalEdit) -> String {
         self.apply_edit_to_string(&self.source, edit)
@@ -173,9 +196,25 @@ impl IncrementalDocument {
     fn apply_edit_to_string(&self, source: &str, edit: &IncrementalEdit) -> String {
         let mut result = String::with_capacity(source.len() + edit.new_text.len());
 
-        // Safely handle byte positions with bounds checking
-        let start = edit.start_byte.min(source.len());
-        let end = edit.old_end_byte.min(source.len());
+        if edit.start_byte > edit.old_end_byte {
+            debug!(
+                "Invalid edit range (backwards): start={}, end={}",
+                edit.start_byte, edit.old_end_byte
+            );
+            return source.to_string();
+        }
+        if edit.old_end_byte > source.len() {
+            debug!(
+                "Invalid edit range (out of bounds): start={}, end={}, source_len={}",
+                edit.start_byte,
+                edit.old_end_byte,
+                source.len()
+            );
+            return source.to_string();
+        }
+
+        let start = edit.start_byte;
+        let end = edit.old_end_byte;
 
         // Ensure we're on UTF-8 boundaries
         if source.is_char_boundary(start) && source.is_char_boundary(end) {
@@ -192,8 +231,25 @@ impl IncrementalDocument {
     }
 
     fn apply_edit_in_place(&self, source: &mut String, edit: &IncrementalEdit) {
-        let start = edit.start_byte.min(source.len());
-        let end = edit.old_end_byte.min(source.len());
+        if edit.start_byte > edit.old_end_byte {
+            debug!(
+                "Skipping invalid edit range (backwards): start={}, end={}",
+                edit.start_byte, edit.old_end_byte
+            );
+            return;
+        }
+        if edit.old_end_byte > source.len() {
+            debug!(
+                "Skipping invalid edit range (out of bounds): start={}, end={}, source_len={}",
+                edit.start_byte,
+                edit.old_end_byte,
+                source.len()
+            );
+            return;
+        }
+
+        let start = edit.start_byte;
+        let end = edit.old_end_byte;
 
         if start > end {
             debug!("Skipping invalid edit range: start={}, end={}", start, end);

--- a/crates/perl-parser/src/incremental/incremental_edit.rs
+++ b/crates/perl-parser/src/incremental/incremental_edit.rs
@@ -106,20 +106,64 @@ impl IncrementalEditSet {
         self.edits.iter().map(|e| e.byte_shift()).sum()
     }
 
+    /// Normalize edits for strict batch application.
+    ///
+    /// Returns edits in reverse byte order (end-to-start), or `None` when the
+    /// batch contains backwards ranges, out-of-bounds ranges, or overlaps.
+    pub fn normalized_reverse_non_overlapping(
+        &self,
+        source_len: usize,
+    ) -> Option<Vec<IncrementalEdit>> {
+        let mut ascending = self.edits.clone();
+        ascending.sort_by_key(|edit| (edit.start_byte, edit.old_end_byte));
+
+        for edit in &ascending {
+            if edit.start_byte > edit.old_end_byte {
+                return None;
+            }
+            if edit.old_end_byte > source_len {
+                return None;
+            }
+        }
+
+        for pair in ascending.windows(2) {
+            let first = &pair[0];
+            let second = &pair[1];
+            if first.old_end_byte > second.start_byte {
+                return None;
+            }
+        }
+
+        let mut reverse = ascending;
+        reverse.sort_by_key(|edit| std::cmp::Reverse(edit.start_byte));
+        Some(reverse)
+    }
+
     /// Apply edits to a string
     pub fn apply_to_string(&self, source: &str) -> String {
         if self.edits.is_empty() {
             return source.to_string();
         }
 
-        // Sort edits in reverse order to apply from end to start
+        // Sort edits in reverse order to apply from end to start.
         let mut sorted_edits = self.edits.clone();
         sorted_edits.sort_by_key(|e| std::cmp::Reverse(e.start_byte));
 
         let mut result = source.to_string();
+        let mut next_disjoint_start = usize::MAX;
         for edit in &sorted_edits {
-            let start = edit.start_byte.min(result.len());
-            let end = edit.old_end_byte.min(result.len());
+            if edit.start_byte > edit.old_end_byte {
+                continue;
+            }
+            if edit.old_end_byte > result.len() {
+                continue;
+            }
+            if edit.old_end_byte > next_disjoint_start {
+                continue;
+            }
+
+            let start = edit.start_byte;
+            let end = edit.old_end_byte;
 
             if start > end {
                 continue;
@@ -130,6 +174,7 @@ impl IncrementalEditSet {
             }
 
             result.replace_range(start..end, &edit.new_text);
+            next_disjoint_start = start;
         }
 
         result

--- a/crates/perl-parser/src/incremental/mod.rs
+++ b/crates/perl-parser/src/incremental/mod.rs
@@ -12,6 +12,8 @@ use perl_parser_core::ast::{Node, NodeKind, SourceLocation};
 use perl_parser_core::parser::Parser;
 
 pub mod incremental_advanced_reuse;
+#[cfg(test)]
+mod incremental_boundary_regressions;
 pub mod incremental_checkpoint;
 pub mod incremental_document;
 pub mod incremental_edit;
@@ -649,12 +651,7 @@ mod tests {
         // Delete almost the entire document; this should use full-reparse fallback
         // to keep incremental behavior predictable for large edits.
         let old_end_byte = state.source.len().saturating_sub(1);
-        let edit = Edit {
-            start_byte: 0,
-            old_end_byte,
-            new_end_byte: 0,
-            new_text: String::new(),
-        };
+        let edit = Edit { start_byte: 0, old_end_byte, new_end_byte: 0, new_text: String::new() };
 
         let result = apply_edits(&mut state, &[edit])?;
 


### PR DESCRIPTION
### Motivation
- Batch incremental edits relied on optimistic byte-range and UTF-8 assumptions which could produce nondeterministic or unsafe outcomes for overlapping, backwards, out-of-bounds, or mid-codepoint edits.

### Description
- Added `IncrementalEditSet::normalized_reverse_non_overlapping` to validate and normalize batches, rejecting backwards ranges, out-of-bounds ranges, and overlapping edits before fast-path application (`crates/perl-parser/src/incremental/incremental_edit.rs`).
- Implemented a mappable-batch gate in `IncrementalDocument::apply_edits` to require normalized, non-overlapping, and UTF-8-aligned edits; unmappable batches now fall back to conservative full-text application plus a full reparse (`crates/perl-parser/src/incremental/incremental_document.rs`).
- Hardened single-edit and in-place application with explicit backwards/out-of-bounds checks and UTF-8 char-boundary checks to avoid corrupting `source` on malformed ranges (`crates/perl-parser/src/incremental/incremental_document.rs`).
- Added targeted regression tests for boundary conditions covering overlapping edits, backwards ranges, mid-codepoint edits, one-bad-edit batch fallback, and an incremental-vs-fresh-parse parity case (`crates/perl-parser/src/incremental/incremental_boundary_regressions.rs`) and wired the test module into the incremental tree (`crates/perl-parser/src/incremental/mod.rs`).

### Testing
- Ran `cargo xtask fmt` to format changes successfully.
- Ran `cargo check --all-targets -p perl-parser` and `cargo check --all-targets -p perl-parser --features incremental`, both succeeded.
- Ran targeted tests with `cargo test -p perl-parser --features incremental --lib incremental::incremental_boundary_regressions::tests` and the new boundary regression suite passed (5/5 tests).
- Note: a pre-existing unrelated test (`refactor::refactoring::tests::validation_tests::test_cleanup_respects_retention_count`) fails in the full `cargo test -p perl-parser`; this failure predates and is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaff94025083338c5ee4779cd0492d)