### PR TITLE
feat(parser-metrics): publish parser performance scorecard from existing benches (#6702)

### DIFF
--- a/crates/perl-parser/benches/common/scorecard.rs
+++ b/crates/perl-parser/benches/common/scorecard.rs
@@ -1,0 +1,98 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+const SCORECARD_PATH: &str = "docs/project/status/parser-performance-scorecard.json";
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub(crate) struct ParserPerformanceScorecard {
+    pub schema_version: u32,
+    pub measurements: BTreeMap<String, BenchmarkMeasurement>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct BenchmarkMeasurement {
+    pub regime: String,
+    pub benchmark: String,
+    pub iterations: u32,
+    pub median_ns: u64,
+    pub p95_ns: u64,
+}
+
+pub(crate) fn measure_and_record<F>(
+    key: &str,
+    regime: &str,
+    benchmark: &str,
+    iterations: u32,
+    mut workload: F,
+) where
+    F: FnMut(),
+{
+    let mut samples = Vec::with_capacity(iterations as usize);
+
+    for _ in 0..3 {
+        workload();
+    }
+
+    for _ in 0..iterations {
+        let start = Instant::now();
+        workload();
+        samples.push(start.elapsed().as_nanos() as u64);
+    }
+
+    samples.sort_unstable();
+    let median_ns = percentile(&samples, 0.5);
+    let p95_ns = percentile(&samples, 0.95);
+
+    let mut scorecard = read_existing_scorecard().unwrap_or_default();
+    if scorecard.schema_version == 0 {
+        scorecard.schema_version = SCHEMA_VERSION;
+    }
+
+    scorecard.measurements.insert(
+        key.to_string(),
+        BenchmarkMeasurement {
+            regime: regime.to_string(),
+            benchmark: benchmark.to_string(),
+            iterations,
+            median_ns,
+            p95_ns,
+        },
+    );
+
+    let _ = write_scorecard(&scorecard);
+}
+
+fn percentile(values: &[u64], p: f64) -> u64 {
+    if values.is_empty() {
+        return 0;
+    }
+    let last = values.len().saturating_sub(1);
+    let idx = (last as f64 * p).round() as usize;
+    values[idx.min(last)]
+}
+
+fn read_existing_scorecard() -> Option<ParserPerformanceScorecard> {
+    let path = scorecard_path();
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn write_scorecard(scorecard: &ParserPerformanceScorecard) -> Result<(), std::io::Error> {
+    let path = scorecard_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let serialized = serde_json::to_string_pretty(scorecard).map_err(std::io::Error::other)?;
+    fs::write(path, format!("{serialized}\n"))
+}
+
+fn scorecard_path() -> PathBuf {
+    // CARGO_MANIFEST_DIR points to crates/perl-parser for these benches.
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    crate_root.join("../..").join(SCORECARD_PATH)
+}

--- a/crates/perl-parser/benches/incremental_benchmark.rs
+++ b/crates/perl-parser/benches/incremental_benchmark.rs
@@ -5,6 +5,9 @@ use perl_parser::incremental_edit::{IncrementalEdit, IncrementalEditSet};
 use perl_tdd_support::{must, must_some};
 use std::hint::black_box;
 
+#[path = "common/scorecard.rs"]
+mod scorecard;
+
 fn bench_incremental_small_edit(c: &mut Criterion) {
     let source = r#"
 use strict;
@@ -34,6 +37,24 @@ process_data($items);
 
     let start = must_some(source.find("transform"));
     let old_end = start + "transform".len();
+
+    scorecard::measure_and_record(
+        "incremental_small_edit",
+        "incremental small edit",
+        "incremental small edit",
+        40,
+        || {
+            let mut state = IncrementalState::new(source.clone());
+            let edit = Edit {
+                start_byte: start,
+                old_end_byte: old_end,
+                new_end_byte: start + "process".len(),
+                new_text: "process".to_string(),
+            };
+            must(apply_edits(&mut state, &[edit]));
+            black_box(&state.ast);
+        },
+    );
 
     c.bench_function("incremental small edit", |b| {
         b.iter_batched(
@@ -79,6 +100,11 @@ my $items = [1, 2, 3, 4, 5];
 process_data($items);
 "#
     .to_string();
+
+    scorecard::measure_and_record("cold_parse", "cold parse", "full reparse", 40, || {
+        let state = IncrementalState::new(source.clone());
+        black_box(&state.ast);
+    });
 
     c.bench_function("full reparse", |b| {
         b.iter(|| {
@@ -131,6 +157,12 @@ process_data($items);
 "#
     .to_string();
 
+    scorecard::measure_and_record("warm_reparse", "warm reparse", "warm reparse", 40, || {
+        let mut state = IncrementalState::new(source.clone());
+        must(apply_edits(&mut state, &[]));
+        black_box(&state.ast);
+    });
+
     c.bench_function("warm reparse", |b| {
         b.iter_batched(
             || IncrementalState::new(source.clone()),
@@ -156,6 +188,32 @@ print "$x $y $z\n";
 
     let pos_1 = must_some(source.find("= 1")) + 2;
     let pos_2 = must_some(source.find("= 2")) + 2;
+
+    scorecard::measure_and_record(
+        "incremental_multiple_edits",
+        "incremental multiple edits",
+        "incremental multiple edits",
+        40,
+        || {
+            let mut state = IncrementalState::new(source.clone());
+            let edits = vec![
+                Edit {
+                    start_byte: pos_1,
+                    old_end_byte: pos_1 + 1,
+                    new_end_byte: pos_1 + 2,
+                    new_text: "10".to_string(),
+                },
+                Edit {
+                    start_byte: pos_2,
+                    old_end_byte: pos_2 + 1,
+                    new_end_byte: pos_2 + 2,
+                    new_text: "20".to_string(),
+                },
+            ];
+            must(apply_edits(&mut state, &edits));
+            black_box(&state.ast);
+        },
+    );
 
     c.bench_function("incremental multiple edits", |b| {
         b.iter_batched(

--- a/crates/perl-parser/benches/parser_benchmark.rs
+++ b/crates/perl-parser/benches/parser_benchmark.rs
@@ -8,6 +8,9 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use perl_parser::{Parser, ScopeAnalyzer};
 use std::hint::black_box;
 
+#[path = "common/scorecard.rs"]
+mod scorecard;
+
 const SIMPLE_SCRIPT: &str = r#"
 my $x = 42;
 my $y = "Hello, World!";
@@ -101,6 +104,22 @@ fn benchmark_ast_generation(c: &mut Criterion) {
 }
 
 fn benchmark_isolated_components(c: &mut Criterion) {
+    scorecard::measure_and_record("lexer_only", "lexer-only", "lexer_only", 40, || {
+        use perl_lexer::{PerlLexer, TokenType};
+
+        let mut lexer = PerlLexer::new(COMPLEX_SCRIPT);
+        let mut count = 0usize;
+
+        while let Some(token) = lexer.next_token() {
+            if matches!(token.token_type, TokenType::EOF) {
+                break;
+            }
+            count += 1;
+        }
+
+        black_box(count);
+    });
+
     // Benchmark just the lexer phase
     c.bench_function("lexer_only", |b| {
         use perl_lexer::{PerlLexer, TokenType};
@@ -129,6 +148,10 @@ fn benchmark_scope_analysis(c: &mut Criterion) {
     let ast = parser.parse().expect("COMPLEX_SCRIPT must parse for benchmark");
     let analyzer = ScopeAnalyzer::new();
     let pragma_map = vec![];
+
+    scorecard::measure_and_record("scope_analysis", "scope analysis", "scope_analysis", 40, || {
+        analyzer.analyze(black_box(&ast), black_box(COMPLEX_SCRIPT), black_box(&pragma_map));
+    });
 
     c.bench_function("scope_analysis", |b| {
         b.iter(|| {

--- a/docs/project/status/parser-performance-scorecard.json
+++ b/docs/project/status/parser-performance-scorecard.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "measurements": {
+    "cold_parse": {
+      "regime": "cold parse",
+      "benchmark": "full reparse",
+      "iterations": 40,
+      "median_ns": 44288,
+      "p95_ns": 60209
+    },
+    "incremental_multiple_edits": {
+      "regime": "incremental multiple edits",
+      "benchmark": "incremental multiple edits",
+      "iterations": 40,
+      "median_ns": 64390,
+      "p95_ns": 94923
+    },
+    "incremental_small_edit": {
+      "regime": "incremental small edit",
+      "benchmark": "incremental small edit",
+      "iterations": 40,
+      "median_ns": 61605,
+      "p95_ns": 92791
+    },
+    "lexer_only": {
+      "regime": "lexer-only",
+      "benchmark": "lexer_only",
+      "iterations": 40,
+      "median_ns": 24008,
+      "p95_ns": 43044
+    },
+    "scope_analysis": {
+      "regime": "scope analysis",
+      "benchmark": "scope_analysis",
+      "iterations": 40,
+      "median_ns": 9803,
+      "p95_ns": 10226
+    },
+    "warm_reparse": {
+      "regime": "warm reparse",
+      "benchmark": "warm reparse",
+      "iterations": 40,
+      "median_ns": 117155,
+      "p95_ns": 178780
+    }
+  }
+}

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard
@@ -24,8 +24,21 @@
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |
 <!-- END: PARSER_RELIABILITY_ROW -->
 <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->
-| **Strict-clean subset** | 10/10 (100%) | 10 pinned modules, zero-error gate | `.ci/common-corpus-manifest.txt` |
+| **Strict-clean subset** | 10 modules (unverified) | run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |
 <!-- END: PARSER_STRICT_CLEAN_ROW -->
+
+## Parser Performance Scorecard
+
+| Regime | Value | Notes | Source |
+| --- | --- | --- | --- |
+<!-- BEGIN: PARSER_PERFORMANCE_TABLE -->
+| **Cold parse** | median 44.29 µs / p95 60.21 µs | cold parse (`full reparse`), 40 samples | `docs/project/status/parser-performance-scorecard.json` |
+| **Warm reparse** | median 117.16 µs / p95 178.78 µs | warm reparse (`warm reparse`), 40 samples | `docs/project/status/parser-performance-scorecard.json` |
+| **Incremental small edit** | median 61.60 µs / p95 92.79 µs | incremental small edit (`incremental small edit`), 40 samples | `docs/project/status/parser-performance-scorecard.json` |
+| **Incremental multiple edits** | median 64.39 µs / p95 94.92 µs | incremental multiple edits (`incremental multiple edits`), 40 samples | `docs/project/status/parser-performance-scorecard.json` |
+| **Lexer-only** | median 24.01 µs / p95 43.04 µs | lexer-only (`lexer_only`), 40 samples | `docs/project/status/parser-performance-scorecard.json` |
+| **Scope analysis** | median 9.80 µs / p95 10.23 µs | scope analysis (`scope_analysis`), 40 samples | `docs/project/status/parser-performance-scorecard.json` |
+<!-- END: PARSER_PERFORMANCE_TABLE -->
 
 <!-- BEGIN: PARSER_METRICS_BULLETS -->
 - **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -2,18 +2,34 @@
 //!
 //! Owns corpus tracking, sweep report loading, and parser.md generation.
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 use std::time::Duration;
 
 use color_eyre::eyre::Result;
 use regex::Regex;
+use serde::Deserialize;
 
 use super::replace_block;
 
 // ---------------------------------------------------------------------------
 // Parser metrics struct
 // ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ParserPerformanceScorecard {
+    measurements: BTreeMap<String, ParserPerformanceMeasurement>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ParserPerformanceMeasurement {
+    regime: String,
+    benchmark: String,
+    iterations: u32,
+    median_ns: u64,
+    p95_ns: u64,
+}
 
 pub(super) struct ParserMetrics {
     pub syntax_sections: usize,
@@ -24,6 +40,7 @@ pub(super) struct ParserMetrics {
     pub common_corpus_receipt: Option<super::super::parser_corpus_sweep::SweepReport>,
     /// Number of pinned modules in `.ci/common-corpus-manifest.txt`.
     pub common_corpus_pinned: usize,
+    performance_scorecard: Option<ParserPerformanceScorecard>,
 }
 
 pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
@@ -41,6 +58,9 @@ pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
         .ok(),
         common_corpus_receipt,
         common_corpus_pinned,
+        performance_scorecard: read_parser_performance_scorecard(
+            &root.join("docs/project/status/parser-performance-scorecard.json"),
+        ),
     }
 }
 
@@ -56,6 +76,11 @@ pub(super) fn count_common_corpus_pinned(root: &Path) -> usize {
 pub(super) fn read_sweep_report(
     path: &Path,
 ) -> Option<super::super::parser_corpus_sweep::SweepReport> {
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn read_parser_performance_scorecard(path: &Path) -> Option<ParserPerformanceScorecard> {
     let raw = fs::read_to_string(path).ok()?;
     serde_json::from_str(&raw).ok()
 }
@@ -87,6 +112,30 @@ fn format_clean_rate(clean_files: usize, total_files: usize) -> String {
 
 fn short_day(timestamp: &str) -> &str {
     timestamp.get(..10).unwrap_or(timestamp)
+}
+
+fn format_perf_ns(ns: u64) -> String {
+    if ns >= 1_000_000 {
+        format!("{:.2} ms", ns as f64 / 1_000_000.0)
+    } else if ns >= 1_000 {
+        format!("{:.2} µs", ns as f64 / 1_000.0)
+    } else {
+        format!("{ns} ns")
+    }
+}
+
+fn perf_row(metrics: &ParserMetrics, key: &str, label: &str) -> String {
+    metrics.performance_scorecard.as_ref().and_then(|card| card.measurements.get(key)).map_or_else(
+        || format!("| **{label}** | UNVERIFIED | run parser benches to refresh scorecard | `docs/project/status/parser-performance-scorecard.json` |"),
+        |m| format!(
+            "| **{label}** | median {} / p95 {} | {} (`{}`), {} samples | `docs/project/status/parser-performance-scorecard.json` |",
+            format_perf_ns(m.median_ns),
+            format_perf_ns(m.p95_ns),
+            m.regime,
+            m.benchmark,
+            m.iterations,
+        ),
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -203,6 +252,16 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
 
     let tracking_table = [system_row, cpan_row, project_row].join("\n");
 
+    let perf_table = [
+        perf_row(metrics, "cold_parse", "Cold parse"),
+        perf_row(metrics, "warm_reparse", "Warm reparse"),
+        perf_row(metrics, "incremental_small_edit", "Incremental small edit"),
+        perf_row(metrics, "incremental_multiple_edits", "Incremental multiple edits"),
+        perf_row(metrics, "lexer_only", "Lexer-only"),
+        perf_row(metrics, "scope_analysis", "Scope analysis"),
+    ]
+    .join("\n");
+
     let parser_coverage_bullets = format!(
         "- **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.\n\
          - **Strict promise lists**: `just common-corpus-check` and the CPAN known-clean manifest inside `just cpan-corpus-check` pin subsets that must remain clean on top of the broader baseline receipts.\n\
@@ -223,6 +282,12 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         "<!-- BEGIN: PARSER_METRICS_BULLETS -->",
         "<!-- END: PARSER_METRICS_BULLETS -->",
         &parser_coverage_bullets,
+    )?;
+    text = replace_block(
+        &text,
+        "<!-- BEGIN: PARSER_PERFORMANCE_TABLE -->",
+        "<!-- END: PARSER_PERFORMANCE_TABLE -->",
+        &perf_table,
     )?;
     text = replace_block(
         &text,
@@ -302,12 +367,14 @@ mod tests {
             project_corpus: Some(summary),
             common_corpus_receipt: None,
             common_corpus_pinned: 10,
+            performance_scorecard: None,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
-                        <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
+                        <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n\
+                        <!-- BEGIN: PARSER_PERFORMANCE_TABLE -->\nold\n<!-- END: PARSER_PERFORMANCE_TABLE -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(result.contains("65/69"), "nodekind row missing 65/69");
         assert!(result.contains("94.2"), "nodekind row missing 94.2%");
@@ -329,12 +396,14 @@ mod tests {
             project_corpus: None,
             common_corpus_receipt: None,
             common_corpus_pinned: 10,
+            performance_scorecard: None,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
-                        <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
+                        <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n\
+                        <!-- BEGIN: PARSER_PERFORMANCE_TABLE -->\nold\n<!-- END: PARSER_PERFORMANCE_TABLE -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(
             result.contains("10 modules (unverified)"),
@@ -378,12 +447,14 @@ mod tests {
             project_corpus: None,
             common_corpus_receipt: Some(receipt),
             common_corpus_pinned: 10,
+            performance_scorecard: None,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
-                        <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
+                        <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n\
+                        <!-- BEGIN: PARSER_PERFORMANCE_TABLE -->\nold\n<!-- END: PARSER_PERFORMANCE_TABLE -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(result.contains("10/10"), "strict-clean row missing 10/10");
         assert!(result.contains("100%"), "strict-clean row missing 100%");

--- a/xtask/tests/post_merge_status_regen_tests.rs
+++ b/xtask/tests/post_merge_status_regen_tests.rs
@@ -254,6 +254,10 @@ fn test_subsystem_files_have_markers() -> Result<(), Box<dyn std::error::Error>>
         parser.contains("<!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->"),
         "parser.md missing PARSER_STRICT_CLEAN_ROW block"
     );
+    assert!(
+        parser.contains("<!-- BEGIN: PARSER_PERFORMANCE_TABLE -->"),
+        "parser.md missing PARSER_PERFORMANCE_TABLE block"
+    );
 
     let quality = fs::read_to_string(status_dir.join("quality.md"))?;
     assert!(


### PR DESCRIPTION
### Motivation

- Provide a single, repeatable performance scorecard so parser cold/warm/incremental regimes can be compared over time. 
- Surface bench results in the existing status flow so maintainers can see parser performance alongside coverage and reliability metrics.

### Description

- Add a shared bench helper `crates/perl-parser/benches/common/scorecard.rs` that measures median/p95 over a fixed sample set and writes a machine-readable scorecard to `docs/project/status/parser-performance-scorecard.json`.
- Wire the existing benches to emit measurements: `crates/perl-parser/benches/incremental_benchmark.rs` records cold parse, warm reparse, incremental small edit, and incremental multiple edits; `crates/perl-parser/benches/parser_benchmark.rs` records lexer-only and scope analysis.
- Update the status generator `xtask/src/tasks/update_status/parser.rs` to read the JSON scorecard and render a `PARSER_PERFORMANCE_TABLE` block into `docs/project/status/parser.md` with UNVERIFIED fallbacks when the artifact is absent.
- Update `xtask/tests/post_merge_status_regen_tests.rs` to require the new `PARSER_PERFORMANCE_TABLE` marker and include the generated `docs/project/status/parser-performance-scorecard.json` in the change set.

### Testing

- Ran `cargo fmt --all` successfully.
- Ran `cargo bench -p perl-parser --bench incremental_benchmark --features incremental` and the bench completed and produced the scorecard measurements (merged into `docs/project/status/parser-performance-scorecard.json`).
- Ran `cargo bench -p perl-parser --bench parser_benchmark` and the bench completed normally and contributed lexer/scope measurements to the scorecard.
- Ran `cargo check --workspace --all-targets` and `cargo run -p xtask -- update-status --write --only parser`, which updated `docs/project/status/parser.md` and validated the new performance table insertion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaff8d956883339b2288643c97713d)