### PR TITLE
feat(parser-metrics): publish parser performance scorecard from existing benches (#6701)

### DIFF
--- a/crates/perl-parser/benches/incremental_benchmark.rs
+++ b/crates/perl-parser/benches/incremental_benchmark.rs
@@ -3,7 +3,210 @@ use perl_parser::incremental::{Edit, IncrementalState, apply_edits};
 use perl_parser::incremental_document::IncrementalDocument;
 use perl_parser::incremental_edit::{IncrementalEdit, IncrementalEditSet};
 use perl_tdd_support::{must, must_some};
+use serde::{Deserialize, Serialize};
+use std::fs;
 use std::hint::black_box;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+const SCORECARD_FILENAME: &str = "parser_performance_scorecard.json";
+
+#[derive(Debug, Clone)]
+struct ScorecardSample {
+    scenario: &'static str,
+    unit: &'static str,
+    iterations: usize,
+    mean_ns: u64,
+    median_ns: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct ParserPerformanceScorecard {
+    schema_version: u32,
+    measured_at_unix_s: u64,
+    results: Vec<ScorecardEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ScorecardEntry {
+    scenario: String,
+    unit: String,
+    iterations: usize,
+    mean_ns: u64,
+    median_ns: u64,
+}
+
+fn run_scorecard_sample(iterations: usize, mut op: impl FnMut()) -> (u64, u64) {
+    let mut samples: Vec<u64> = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let started = Instant::now();
+        op();
+        let elapsed = started.elapsed().as_nanos();
+        let sample = u64::try_from(elapsed).unwrap_or(u64::MAX);
+        samples.push(sample);
+    }
+    samples.sort_unstable();
+    let total: u128 = samples.iter().map(|&v| u128::from(v)).sum();
+    let mean_ns = u64::try_from(total / iterations as u128).unwrap_or(u64::MAX);
+    let median_ns = samples[iterations / 2];
+    (mean_ns, median_ns)
+}
+
+fn emit_scorecard(samples: &[ScorecardSample]) {
+    let path = scorecard_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    let mut scorecard = fs::read_to_string(&path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<ParserPerformanceScorecard>(&raw).ok())
+        .unwrap_or_default();
+    scorecard.schema_version = 1;
+    scorecard.measured_at_unix_s =
+        SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |duration| duration.as_secs());
+
+    for sample in samples {
+        let entry = ScorecardEntry {
+            scenario: sample.scenario.to_string(),
+            unit: sample.unit.to_string(),
+            iterations: sample.iterations,
+            mean_ns: sample.mean_ns,
+            median_ns: sample.median_ns,
+        };
+        if let Some(existing) =
+            scorecard.results.iter_mut().find(|row| row.scenario == entry.scenario)
+        {
+            *existing = entry;
+        } else {
+            scorecard.results.push(entry);
+        }
+    }
+    scorecard.results.sort_by(|a, b| a.scenario.cmp(&b.scenario));
+
+    if let Ok(raw) = serde_json::to_string_pretty(&scorecard) {
+        let _ = fs::write(path, raw);
+    }
+}
+
+fn scorecard_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("target")
+        .join("metrics")
+        .join(SCORECARD_FILENAME)
+}
+
+fn sample_full_reparse() -> ScorecardSample {
+    let source = r#"
+use strict;
+use warnings;
+sub process_data { my ($data) = @_; for my $item (@$data) { my $result = transform($item); print "Result: $result\n"; } return 1; }
+sub transform { my ($value) = @_; return $value * 2; }
+my $items = [1, 2, 3, 4, 5];
+process_data($items);
+"#
+    .to_string();
+    let iterations = 25;
+    let (mean_ns, median_ns) = run_scorecard_sample(iterations, || {
+        let state = IncrementalState::new(source.clone());
+        black_box(&state.ast);
+    });
+    ScorecardSample { scenario: "cold_parse", unit: "ns", iterations, mean_ns, median_ns }
+}
+
+fn sample_warm_reparse() -> ScorecardSample {
+    let source = r#"
+use strict;
+use warnings;
+sub process_data { my ($data) = @_; for my $item (@$data) { my $result = transform($item); print "Result: $result\n"; } return 1; }
+sub transform { my ($value) = @_; return $value * 2; }
+my $items = [1, 2, 3, 4, 5];
+process_data($items);
+"#
+    .to_string();
+    let iterations = 25;
+    let (mean_ns, median_ns) = run_scorecard_sample(iterations, || {
+        let mut state = IncrementalState::new(source.clone());
+        must(apply_edits(&mut state, &[]));
+        black_box(&state.ast);
+    });
+    ScorecardSample { scenario: "warm_reparse", unit: "ns", iterations, mean_ns, median_ns }
+}
+
+fn sample_incremental_small_edit() -> ScorecardSample {
+    let source = r#"
+use strict;
+use warnings;
+sub process_data { my ($data) = @_; for my $item (@$data) { my $result = transform($item); print "Result: $result\n"; } return 1; }
+sub transform { my ($value) = @_; return $value * 2; }
+my $items = [1, 2, 3, 4, 5];
+process_data($items);
+"#
+    .to_string();
+    let start = must_some(source.find("transform"));
+    let old_end = start + "transform".len();
+    let iterations = 25;
+    let (mean_ns, median_ns) = run_scorecard_sample(iterations, || {
+        let mut state = IncrementalState::new(source.clone());
+        let edit = Edit {
+            start_byte: start,
+            old_end_byte: old_end,
+            new_end_byte: start + "process".len(),
+            new_text: "process".to_string(),
+        };
+        must(apply_edits(&mut state, &[edit]));
+        black_box(&state.ast);
+    });
+    ScorecardSample {
+        scenario: "incremental_small_edit",
+        unit: "ns",
+        iterations,
+        mean_ns,
+        median_ns,
+    }
+}
+
+fn sample_incremental_multiple_edits() -> ScorecardSample {
+    let source = r#"
+my $x = 1;
+my $y = 2;
+my $z = 3;
+print "$x $y $z\n";
+"#
+    .to_string();
+    let pos_1 = must_some(source.find("= 1")) + 2;
+    let pos_2 = must_some(source.find("= 2")) + 2;
+    let iterations = 25;
+    let (mean_ns, median_ns) = run_scorecard_sample(iterations, || {
+        let mut state = IncrementalState::new(source.clone());
+        let edits = vec![
+            Edit {
+                start_byte: pos_1,
+                old_end_byte: pos_1 + 1,
+                new_end_byte: pos_1 + 2,
+                new_text: "10".to_string(),
+            },
+            Edit {
+                start_byte: pos_2,
+                old_end_byte: pos_2 + 1,
+                new_end_byte: pos_2 + 2,
+                new_text: "20".to_string(),
+            },
+        ];
+        must(apply_edits(&mut state, &edits));
+        black_box(&state.ast);
+    });
+    ScorecardSample {
+        scenario: "incremental_multiple_edits",
+        unit: "ns",
+        iterations,
+        mean_ns,
+        median_ns,
+    }
+}
 
 fn bench_incremental_small_edit(c: &mut Criterion) {
     let source = r#"
@@ -221,6 +424,23 @@ fn bench_incremental_document_multiple_edits(c: &mut Criterion) {
     });
 }
 
+fn bench_emit_scorecard(_c: &mut Criterion) {
+    static SCORECARD_EMITTED: OnceLock<()> = OnceLock::new();
+    _c.bench_function("emit_parser_performance_scorecard_incremental", |b| {
+        b.iter(|| {
+            SCORECARD_EMITTED.get_or_init(|| {
+                let samples = vec![
+                    sample_full_reparse(),
+                    sample_warm_reparse(),
+                    sample_incremental_small_edit(),
+                    sample_incremental_multiple_edits(),
+                ];
+                emit_scorecard(&samples);
+            });
+        });
+    });
+}
+
 // Cold / warm / incremental regime group — the three parse regimes a
 // language server has to care about, instrumented together so their p50/p95
 // estimates land in sibling Criterion reports under the same group name.
@@ -239,5 +459,6 @@ criterion_group!(
     bench_multiple_edits,
     bench_incremental_document_single_edit,
     bench_incremental_document_multiple_edits,
+    bench_emit_scorecard,
 );
 criterion_main!(parse_regime, benches);

--- a/crates/perl-parser/benches/parser_benchmark.rs
+++ b/crates/perl-parser/benches/parser_benchmark.rs
@@ -6,7 +6,12 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use perl_parser::{Parser, ScopeAnalyzer};
+use serde::{Deserialize, Serialize};
+use std::fs;
 use std::hint::black_box;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 const SIMPLE_SCRIPT: &str = r#"
 my $x = 42;
@@ -70,6 +75,125 @@ sub fibonacci {
 
 1;
 "#;
+
+const SCORECARD_FILENAME: &str = "parser_performance_scorecard.json";
+
+#[derive(Debug, Clone)]
+struct ScorecardSample {
+    scenario: &'static str,
+    unit: &'static str,
+    iterations: usize,
+    mean_ns: u64,
+    median_ns: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct ParserPerformanceScorecard {
+    schema_version: u32,
+    measured_at_unix_s: u64,
+    results: Vec<ScorecardEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ScorecardEntry {
+    scenario: String,
+    unit: String,
+    iterations: usize,
+    mean_ns: u64,
+    median_ns: u64,
+}
+
+fn run_scorecard_sample(iterations: usize, mut op: impl FnMut()) -> (u64, u64) {
+    let mut samples: Vec<u64> = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let started = Instant::now();
+        op();
+        let elapsed = started.elapsed().as_nanos();
+        let sample = u64::try_from(elapsed).unwrap_or(u64::MAX);
+        samples.push(sample);
+    }
+
+    samples.sort_unstable();
+    let total: u128 = samples.iter().map(|&v| u128::from(v)).sum();
+    let mean_ns = u64::try_from(total / iterations as u128).unwrap_or(u64::MAX);
+    let median_ns = samples[iterations / 2];
+    (mean_ns, median_ns)
+}
+
+fn sample_lexer_only() -> ScorecardSample {
+    use perl_lexer::{PerlLexer, TokenType};
+    let iterations = 25;
+    let (mean_ns, median_ns) = run_scorecard_sample(iterations, || {
+        let mut lexer = PerlLexer::new(COMPLEX_SCRIPT);
+        loop {
+            let Some(token) = lexer.next_token() else {
+                break;
+            };
+            if matches!(token.token_type, TokenType::EOF) {
+                break;
+            }
+        }
+    });
+    ScorecardSample { scenario: "lexer_only", unit: "ns", iterations, mean_ns, median_ns }
+}
+
+fn sample_scope_analysis() -> ScorecardSample {
+    let mut parser = Parser::new(COMPLEX_SCRIPT);
+    let ast = parser.parse().expect("COMPLEX_SCRIPT must parse for scope sample");
+    let analyzer = ScopeAnalyzer::new();
+    let pragma_map = vec![];
+    let iterations = 25;
+    let (mean_ns, median_ns) = run_scorecard_sample(iterations, || {
+        analyzer.analyze(&ast, COMPLEX_SCRIPT, &pragma_map);
+    });
+    ScorecardSample { scenario: "scope_analysis", unit: "ns", iterations, mean_ns, median_ns }
+}
+
+fn emit_scorecard(samples: &[ScorecardSample]) {
+    let path = scorecard_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    let mut scorecard = fs::read_to_string(&path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<ParserPerformanceScorecard>(&raw).ok())
+        .unwrap_or_default();
+    scorecard.schema_version = 1;
+    scorecard.measured_at_unix_s =
+        SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |duration| duration.as_secs());
+
+    for sample in samples {
+        let entry = ScorecardEntry {
+            scenario: sample.scenario.to_string(),
+            unit: sample.unit.to_string(),
+            iterations: sample.iterations,
+            mean_ns: sample.mean_ns,
+            median_ns: sample.median_ns,
+        };
+        if let Some(existing) =
+            scorecard.results.iter_mut().find(|row| row.scenario == entry.scenario)
+        {
+            *existing = entry;
+        } else {
+            scorecard.results.push(entry);
+        }
+    }
+    scorecard.results.sort_by(|a, b| a.scenario.cmp(&b.scenario));
+
+    if let Ok(raw) = serde_json::to_string_pretty(&scorecard) {
+        let _ = fs::write(path, raw);
+    }
+}
+
+fn scorecard_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("target")
+        .join("metrics")
+        .join(SCORECARD_FILENAME)
+}
 
 fn benchmark_simple_parsing(c: &mut Criterion) {
     c.bench_function("parse_simple_script", |b| {
@@ -137,12 +261,25 @@ fn benchmark_scope_analysis(c: &mut Criterion) {
     });
 }
 
+fn benchmark_emit_scorecard(_c: &mut Criterion) {
+    static SCORECARD_EMITTED: OnceLock<()> = OnceLock::new();
+    _c.bench_function("emit_parser_performance_scorecard_parser", |b| {
+        b.iter(|| {
+            SCORECARD_EMITTED.get_or_init(|| {
+                let samples = vec![sample_lexer_only(), sample_scope_analysis()];
+                emit_scorecard(&samples);
+            });
+        });
+    });
+}
+
 criterion_group!(
     benches,
     benchmark_simple_parsing,
     benchmark_complex_parsing,
     benchmark_ast_generation,
     benchmark_isolated_components,
-    benchmark_scope_analysis
+    benchmark_scope_analysis,
+    benchmark_emit_scorecard
 );
 criterion_main!(benches);

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard
@@ -24,8 +24,11 @@
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |
 <!-- END: PARSER_RELIABILITY_ROW -->
 <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->
-| **Strict-clean subset** | 10/10 (100%) | 10 pinned modules, zero-error gate | `.ci/common-corpus-manifest.txt` |
+| **Strict-clean subset** | 10 modules (unverified) | run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |
 <!-- END: PARSER_STRICT_CLEAN_ROW -->
+<!-- BEGIN: PARSER_PERFORMANCE_ROW -->
+| **Parser performance scorecard** | cold=0.05 ms / warm=0.19 ms / inc-small=0.06 ms / inc-multi=0.04 ms / lexer=0.03 ms / scope=0.01 ms | snapshot at unix=1777011115 | `target/metrics/parser_performance_scorecard.json` |
+<!-- END: PARSER_PERFORMANCE_ROW -->
 
 <!-- BEGIN: PARSER_METRICS_BULLETS -->
 - **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -24,6 +24,20 @@ pub(super) struct ParserMetrics {
     pub common_corpus_receipt: Option<super::super::parser_corpus_sweep::SweepReport>,
     /// Number of pinned modules in `.ci/common-corpus-manifest.txt`.
     pub common_corpus_pinned: usize,
+    /// Parser benchmark scorecard emitted by parser bench binaries.
+    pub performance_scorecard: Option<ParserPerformanceScorecard>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub(super) struct ParserPerformanceScorecard {
+    pub measured_at_unix_s: u64,
+    pub results: Vec<ParserPerformanceRow>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub(super) struct ParserPerformanceRow {
+    pub scenario: String,
+    pub median_ns: u64,
 }
 
 pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
@@ -41,6 +55,9 @@ pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
         .ok(),
         common_corpus_receipt,
         common_corpus_pinned,
+        performance_scorecard: read_performance_scorecard(
+            &root.join("target/metrics/parser_performance_scorecard.json"),
+        ),
     }
 }
 
@@ -56,6 +73,11 @@ pub(super) fn count_common_corpus_pinned(root: &Path) -> usize {
 pub(super) fn read_sweep_report(
     path: &Path,
 ) -> Option<super::super::parser_corpus_sweep::SweepReport> {
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+pub(super) fn read_performance_scorecard(path: &Path) -> Option<ParserPerformanceScorecard> {
     let raw = fs::read_to_string(path).ok()?;
     serde_json::from_str(&raw).ok()
 }
@@ -200,6 +222,29 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
             )
         },
     );
+    let performance_row = metrics.performance_scorecard.as_ref().map_or_else(
+        || "| **Parser performance scorecard** | UNVERIFIED | Run parser benches to emit `target/metrics/parser_performance_scorecard.json` | `target/metrics/parser_performance_scorecard.json` |".to_string(),
+        |scorecard| {
+            let scenario_median = |name: &str| {
+                scorecard
+                    .results
+                    .iter()
+                    .find(|row| row.scenario == name)
+                    .map(|row| format!("{:.2} ms", row.median_ns as f64 / 1_000_000.0))
+                    .unwrap_or_else(|| "n/a".to_string())
+            };
+            format!(
+                "| **Parser performance scorecard** | cold={} / warm={} / inc-small={} / inc-multi={} / lexer={} / scope={} | snapshot at unix={} | `target/metrics/parser_performance_scorecard.json` |",
+                scenario_median("cold_parse"),
+                scenario_median("warm_reparse"),
+                scenario_median("incremental_small_edit"),
+                scenario_median("incremental_multiple_edits"),
+                scenario_median("lexer_only"),
+                scenario_median("scope_analysis"),
+                scorecard.measured_at_unix_s,
+            )
+        },
+    );
 
     let tracking_table = [system_row, cpan_row, project_row].join("\n");
 
@@ -241,6 +286,12 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         "<!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->",
         "<!-- END: PARSER_STRICT_CLEAN_ROW -->",
         &strict_clean_row,
+    )?;
+    text = replace_block(
+        &text,
+        "<!-- BEGIN: PARSER_PERFORMANCE_ROW -->",
+        "<!-- END: PARSER_PERFORMANCE_ROW -->",
+        &performance_row,
     )?;
     Ok(text)
 }
@@ -302,11 +353,13 @@ mod tests {
             project_corpus: Some(summary),
             common_corpus_receipt: None,
             common_corpus_pinned: 10,
+            performance_scorecard: None,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_PERFORMANCE_ROW -->\nold\n<!-- END: PARSER_PERFORMANCE_ROW -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(result.contains("65/69"), "nodekind row missing 65/69");
@@ -315,6 +368,10 @@ mod tests {
         assert!(
             result.contains("unverified"),
             "strict-clean no-receipt row should say 'unverified'"
+        );
+        assert!(
+            result.contains("Parser performance scorecard"),
+            "performance row should render in parser status"
         );
         assert!(!result.contains("10/10"), "strict-clean no-receipt row must not show 10/10");
         Ok(())
@@ -329,11 +386,13 @@ mod tests {
             project_corpus: None,
             common_corpus_receipt: None,
             common_corpus_pinned: 10,
+            performance_scorecard: None,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_PERFORMANCE_ROW -->\nold\n<!-- END: PARSER_PERFORMANCE_ROW -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(
@@ -378,11 +437,13 @@ mod tests {
             project_corpus: None,
             common_corpus_receipt: Some(receipt),
             common_corpus_pinned: 10,
+            performance_scorecard: None,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_PERFORMANCE_ROW -->\nold\n<!-- END: PARSER_PERFORMANCE_ROW -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(result.contains("10/10"), "strict-clean row missing 10/10");

--- a/xtask/tests/post_merge_status_regen_tests.rs
+++ b/xtask/tests/post_merge_status_regen_tests.rs
@@ -254,6 +254,10 @@ fn test_subsystem_files_have_markers() -> Result<(), Box<dyn std::error::Error>>
         parser.contains("<!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->"),
         "parser.md missing PARSER_STRICT_CLEAN_ROW block"
     );
+    assert!(
+        parser.contains("<!-- BEGIN: PARSER_PERFORMANCE_ROW -->"),
+        "parser.md missing PARSER_PERFORMANCE_ROW block"
+    );
 
     let quality = fs::read_to_string(status_dir.join("quality.md"))?;
     assert!(


### PR DESCRIPTION
### Motivation
- Consolidate existing parser and incremental benchmarks into a single, repeatable, machine-readable parser performance scorecard so maintainers can track cold/warm/incremental/lexer/scope cost over time.

### Description
- Emit a shared JSON scorecard from the existing bench binaries by adding lightweight sampling helpers and per-scenario samplers to `crates/perl-parser/benches/parser_benchmark.rs` and `crates/perl-parser/benches/incremental_benchmark.rs` that write `target/metrics/parser_performance_scorecard.json`.
- Implement `run_scorecard_sample`, `sample_*` functions and an `emit_scorecard` writer that records `mean_ns`/`median_ns` and a stable `measured_at_unix_s` timestamp, with a `OnceLock` guard to emit once per bench process.
- Wire the xtask status generator to consume the emitted artifact by adding `read_performance_scorecard` and a `PARSER_PERFORMANCE_ROW` into `xtask/src/tasks/update_status/parser.rs` and render a combined performance row in `docs/project/status/parser.md`.
- Add the new marker to `xtask/tests/post_merge_status_regen_tests.rs` so the status-generation contract is preserved.

### Testing
- Ran formatting: `cargo xtask fmt --package perl-parser --package xtask` succeeded. 
- Bench runs: `cargo bench -p perl-parser --features incremental --bench incremental_benchmark` succeeded and emitted the scorecard, and `cargo bench -p perl-parser --bench parser_benchmark` succeeded (both benches include the new emit entrypoints).
- Status update: `cargo xtask update-status --write --only parser` succeeded and patched `docs/project/status/parser.md` with the performance row. 
- Build checks: `cargo check --workspace --all-targets` succeeded. 
- Note: `just status-update --only parser` was not runnable in this environment because `just` is not installed, so `cargo xtask update-status` was used instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaff8d956883339b2288643c97713d)