### PR TITLE
feat(parser-metrics): publish parser performance scorecard from existing benches (#6700)

### DIFF
--- a/crates/perl-parser/benches/incremental_benchmark.rs
+++ b/crates/perl-parser/benches/incremental_benchmark.rs
@@ -4,8 +4,111 @@ use perl_parser::incremental_document::IncrementalDocument;
 use perl_parser::incremental_edit::{IncrementalEdit, IncrementalEditSet};
 use perl_tdd_support::{must, must_some};
 use std::hint::black_box;
+use std::sync::Once;
+
+#[path = "support/scorecard.rs"]
+mod scorecard;
+
+static SCORECARD_ONCE: Once = Once::new();
+
+fn emit_incremental_scorecard() {
+    SCORECARD_ONCE.call_once(|| {
+        let source = r#"
+use strict;
+use warnings;
+
+sub process_data {
+    my ($data) = @_;
+
+    # Process each item
+    for my $item (@$data) {
+        my $result = transform($item);
+        print "Result: $result\n";
+    }
+
+    return 1;
+}
+
+sub transform {
+    my ($value) = @_;
+    return $value * 2;
+}
+
+my $items = [1, 2, 3, 4, 5];
+process_data($items);
+"#
+        .to_string();
+
+        let transform_start = must_some(source.find("transform"));
+        let transform_end = transform_start + "transform".len();
+        let path = scorecard::scorecard_path();
+
+        let cold_parse = scorecard::measure_samples_us(|| {
+            let state = IncrementalState::new(source.clone());
+            black_box(&state.ast);
+        });
+        let _ = scorecard::upsert_metric(&path, "cold_parse", "incremental_benchmark", cold_parse);
+
+        let warm_reparse = scorecard::measure_samples_us(|| {
+            let mut state = IncrementalState::new(source.clone());
+            must(apply_edits(&mut state, &[]));
+            black_box(&state.ast);
+        });
+        let _ =
+            scorecard::upsert_metric(&path, "warm_reparse", "incremental_benchmark", warm_reparse);
+
+        let small_edit = scorecard::measure_samples_us(|| {
+            let mut state = IncrementalState::new(source.clone());
+            let edit = Edit {
+                start_byte: transform_start,
+                old_end_byte: transform_end,
+                new_end_byte: transform_start + "process".len(),
+                new_text: "process".to_string(),
+            };
+            must(apply_edits(&mut state, &[edit]));
+            black_box(&state.ast);
+        });
+        let _ = scorecard::upsert_metric(
+            &path,
+            "incremental_small_edit",
+            "incremental_benchmark",
+            small_edit,
+        );
+
+        let tiny = "my $x = 1;\nmy $y = 2;\nmy $z = 3;\nprint \"$x $y $z\\n\";\n".to_string();
+        let pos_1 = must_some(tiny.find("= 1")) + 2;
+        let pos_2 = must_some(tiny.find("= 2")) + 2;
+        let multiple_edits = scorecard::measure_samples_us(|| {
+            let mut state = IncrementalState::new(tiny.clone());
+            let edits = vec![
+                Edit {
+                    start_byte: pos_1,
+                    old_end_byte: pos_1 + 1,
+                    new_end_byte: pos_1 + 2,
+                    new_text: "10".to_string(),
+                },
+                Edit {
+                    start_byte: pos_2,
+                    old_end_byte: pos_2 + 1,
+                    new_end_byte: pos_2 + 2,
+                    new_text: "20".to_string(),
+                },
+            ];
+            must(apply_edits(&mut state, &edits));
+            black_box(&state.ast);
+        });
+        let _ = scorecard::upsert_metric(
+            &path,
+            "incremental_multiple_edits",
+            "incremental_benchmark",
+            multiple_edits,
+        );
+    });
+}
 
 fn bench_incremental_small_edit(c: &mut Criterion) {
+    emit_incremental_scorecard();
+
     let source = r#"
 use strict;
 use warnings;
@@ -54,6 +157,8 @@ process_data($items);
 }
 
 fn bench_full_reparse(c: &mut Criterion) {
+    emit_incremental_scorecard();
+
     let source = r#"
 use strict;
 use warnings;
@@ -105,6 +210,8 @@ process_data($items);
 ///   reused, single small edit applied via the checkpoint-driven incremental
 ///   lexing path.
 fn bench_warm_reparse(c: &mut Criterion) {
+    emit_incremental_scorecard();
+
     let source = r#"
 use strict;
 use warnings;
@@ -146,6 +253,8 @@ process_data($items);
 }
 
 fn bench_multiple_edits(c: &mut Criterion) {
+    emit_incremental_scorecard();
+
     let source = r#"
 my $x = 1;
 my $y = 2;

--- a/crates/perl-parser/benches/parser_benchmark.rs
+++ b/crates/perl-parser/benches/parser_benchmark.rs
@@ -7,6 +7,12 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use perl_parser::{Parser, ScopeAnalyzer};
 use std::hint::black_box;
+use std::sync::Once;
+
+#[path = "support/scorecard.rs"]
+mod scorecard;
+
+static SCORECARD_ONCE: Once = Once::new();
 
 const SIMPLE_SCRIPT: &str = r#"
 my $x = 42;
@@ -71,7 +77,46 @@ sub fibonacci {
 1;
 "#;
 
+fn emit_parser_scorecard() {
+    SCORECARD_ONCE.call_once(|| {
+        use perl_lexer::{PerlLexer, TokenType};
+
+        let scorecard_path = scorecard::scorecard_path();
+
+        let lexer_only = scorecard::measure_samples_us(|| {
+            let mut lexer = PerlLexer::new(COMPLEX_SCRIPT);
+            let mut count = 0;
+
+            while let Some(token) = lexer.next_token() {
+                if matches!(token.token_type, TokenType::EOF) {
+                    break;
+                }
+                count += 1;
+            }
+
+            black_box(count);
+        });
+        let _ =
+            scorecard::upsert_metric(&scorecard_path, "lexer_only", "parser_benchmark", lexer_only);
+
+        let scope_analysis = scorecard::measure_samples_us(|| {
+            let mut parser = Parser::new(COMPLEX_SCRIPT);
+            let ast = parser.parse().expect("COMPLEX_SCRIPT must parse for benchmark");
+            let analyzer = ScopeAnalyzer::new();
+            let pragma_map = vec![];
+            analyzer.analyze(&ast, COMPLEX_SCRIPT, &pragma_map);
+        });
+        let _ = scorecard::upsert_metric(
+            &scorecard_path,
+            "scope_analysis",
+            "parser_benchmark",
+            scope_analysis,
+        );
+    });
+}
+
 fn benchmark_simple_parsing(c: &mut Criterion) {
+    emit_parser_scorecard();
     c.bench_function("parse_simple_script", |b| {
         b.iter(|| {
             let mut parser = Parser::new(black_box(SIMPLE_SCRIPT));
@@ -81,6 +126,7 @@ fn benchmark_simple_parsing(c: &mut Criterion) {
 }
 
 fn benchmark_complex_parsing(c: &mut Criterion) {
+    emit_parser_scorecard();
     c.bench_function("parse_complex_script", |b| {
         b.iter(|| {
             let mut parser = Parser::new(black_box(COMPLEX_SCRIPT));
@@ -90,6 +136,7 @@ fn benchmark_complex_parsing(c: &mut Criterion) {
 }
 
 fn benchmark_ast_generation(c: &mut Criterion) {
+    emit_parser_scorecard();
     let mut parser = Parser::new(COMPLEX_SCRIPT);
     let ast = parser.parse().expect("COMPLEX_SCRIPT must parse for benchmark");
 
@@ -101,6 +148,7 @@ fn benchmark_ast_generation(c: &mut Criterion) {
 }
 
 fn benchmark_isolated_components(c: &mut Criterion) {
+    emit_parser_scorecard();
     // Benchmark just the lexer phase
     c.bench_function("lexer_only", |b| {
         use perl_lexer::{PerlLexer, TokenType};
@@ -125,6 +173,7 @@ fn benchmark_isolated_components(c: &mut Criterion) {
 }
 
 fn benchmark_scope_analysis(c: &mut Criterion) {
+    emit_parser_scorecard();
     let mut parser = Parser::new(COMPLEX_SCRIPT);
     let ast = parser.parse().expect("COMPLEX_SCRIPT must parse for benchmark");
     let analyzer = ScopeAnalyzer::new();

--- a/crates/perl-parser/benches/support/scorecard.rs
+++ b/crates/perl-parser/benches/support/scorecard.rs
@@ -1,0 +1,99 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+const DEFAULT_SAMPLES: usize = 25;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ScorecardMetric {
+    pub(crate) median_us: f64,
+    pub(crate) p95_us: f64,
+    pub(crate) samples: usize,
+    pub(crate) unit: String,
+    pub(crate) source_bench: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ParserPerformanceScorecard {
+    pub(crate) schema_version: u32,
+    pub(crate) metrics: BTreeMap<String, ScorecardMetric>,
+}
+
+impl Default for ParserPerformanceScorecard {
+    fn default() -> Self {
+        Self { schema_version: 1, metrics: BTreeMap::new() }
+    }
+}
+
+pub(crate) fn load_or_default(path: &Path) -> ParserPerformanceScorecard {
+    let Ok(raw) = fs::read_to_string(path) else {
+        return ParserPerformanceScorecard::default();
+    };
+    serde_json::from_str(&raw).unwrap_or_default()
+}
+
+pub(crate) fn scorecard_path() -> PathBuf {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| manifest_dir.to_path_buf());
+    workspace_root.join("target/receipts/parser-performance-scorecard.json")
+}
+
+pub(crate) fn upsert_metric(
+    path: &Path,
+    metric_name: &str,
+    source_bench: &str,
+    sample_micros: Vec<f64>,
+) -> std::io::Result<()> {
+    if sample_micros.is_empty() {
+        return Ok(());
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut scorecard = load_or_default(path);
+    scorecard.metrics.insert(metric_name.to_string(), summarize(sample_micros, source_bench));
+
+    let json = serde_json::to_string_pretty(&scorecard)?;
+    fs::write(path, json)
+}
+
+fn summarize(mut sample_micros: Vec<f64>, source_bench: &str) -> ScorecardMetric {
+    sample_micros.sort_by(|a, b| a.total_cmp(b));
+
+    let len = sample_micros.len();
+    let median_idx = len / 2;
+    let p95_idx = ((len as f64 * 0.95).ceil() as usize).saturating_sub(1).min(len - 1);
+
+    ScorecardMetric {
+        median_us: sample_micros[median_idx],
+        p95_us: sample_micros[p95_idx],
+        samples: len,
+        unit: "us".to_string(),
+        source_bench: source_bench.to_string(),
+    }
+}
+
+pub(crate) fn measure_samples_us(mut f: impl FnMut()) -> Vec<f64> {
+    let mut sample_micros = Vec::with_capacity(DEFAULT_SAMPLES);
+
+    for _ in 0..DEFAULT_SAMPLES {
+        let start = Instant::now();
+        f();
+        let elapsed = start.elapsed();
+        sample_micros.push(duration_to_micros(elapsed));
+    }
+
+    sample_micros
+}
+
+fn duration_to_micros(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000_000.0
+}

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard
@@ -24,8 +24,11 @@
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |
 <!-- END: PARSER_RELIABILITY_ROW -->
 <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->
-| **Strict-clean subset** | 10/10 (100%) | 10 pinned modules, zero-error gate | `.ci/common-corpus-manifest.txt` |
+| **Strict-clean subset** | 10 modules (unverified) | run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |
 <!-- END: PARSER_STRICT_CLEAN_ROW -->
+<!-- BEGIN: PARSER_PERF_ROW -->
+| **Parser performance scorecard** | 6/6 regimes captured | cold 44.6µs p50, warm 110.9µs p50, incremental 57.5µs p50 | `docs/project/status/parser_performance_scorecard.json` |
+<!-- END: PARSER_PERF_ROW -->
 
 <!-- BEGIN: PARSER_METRICS_BULLETS -->
 - **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.

--- a/docs/project/status/parser_performance_scorecard.json
+++ b/docs/project/status/parser_performance_scorecard.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "metrics": {
+    "cold_parse": {
+      "median_us": 44.573,
+      "p95_us": 67.291,
+      "samples": 25,
+      "unit": "us",
+      "source_bench": "incremental_benchmark"
+    },
+    "incremental_multiple_edits": {
+      "median_us": 34.049,
+      "p95_us": 54.265,
+      "samples": 25,
+      "unit": "us",
+      "source_bench": "incremental_benchmark"
+    },
+    "incremental_small_edit": {
+      "median_us": 57.513000000000005,
+      "p95_us": 92.53,
+      "samples": 25,
+      "unit": "us",
+      "source_bench": "incremental_benchmark"
+    },
+    "lexer_only": {
+      "median_us": 24.253,
+      "p95_us": 38.559000000000005,
+      "samples": 25,
+      "unit": "us",
+      "source_bench": "parser_benchmark"
+    },
+    "scope_analysis": {
+      "median_us": 159.109,
+      "p95_us": 222.062,
+      "samples": 25,
+      "unit": "us",
+      "source_bench": "parser_benchmark"
+    },
+    "warm_reparse": {
+      "median_us": 110.931,
+      "p95_us": 157.195,
+      "samples": 25,
+      "unit": "us",
+      "source_bench": "incremental_benchmark"
+    }
+  }
+}

--- a/xtask/src/tasks/update_status/mod.rs
+++ b/xtask/src/tasks/update_status/mod.rs
@@ -206,6 +206,17 @@ pub fn run(write: bool, check: bool, only: Option<StatusSubsystem>) -> Result<()
         if updated_parser != original_parser {
             files_to_update.push(("docs/project/status/parser.md", parser_path, updated_parser));
         }
+
+        let perf_path = root.join("docs/project/status/parser_performance_scorecard.json");
+        let original_perf = fs::read_to_string(&perf_path).unwrap_or_default();
+        let updated_perf = parser::render_performance_scorecard_json(&parser_metrics)?;
+        if updated_perf != original_perf {
+            files_to_update.push((
+                "docs/project/status/parser_performance_scorecard.json",
+                perf_path,
+                updated_perf,
+            ));
+        }
     }
 
     // --- Quality subsystem ---
@@ -317,6 +328,7 @@ mod mod_tests {
             "editor_ux.schema.json",
             "dap.md",
             "workspace.md",
+            "parser_performance_scorecard.json",
         ] {
             let path = status_dir.join(name);
             assert!(path.exists(), "subsystem file missing: {}", path.display());

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use color_eyre::eyre::Result;
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 
 use super::replace_block;
 
@@ -24,6 +25,23 @@ pub(super) struct ParserMetrics {
     pub common_corpus_receipt: Option<super::super::parser_corpus_sweep::SweepReport>,
     /// Number of pinned modules in `.ci/common-corpus-manifest.txt`.
     pub common_corpus_pinned: usize,
+    pub performance_scorecard: ParserPerformanceScorecard,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub(super) struct ParserPerformanceScorecard {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub metrics: std::collections::BTreeMap<String, ParserPerformanceMetric>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub(super) struct ParserPerformanceMetric {
+    pub median_us: f64,
+    pub p95_us: f64,
+    pub samples: usize,
+    pub unit: String,
+    pub source_bench: String,
 }
 
 pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
@@ -41,7 +59,24 @@ pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
         .ok(),
         common_corpus_receipt,
         common_corpus_pinned,
+        performance_scorecard: read_performance_scorecard(
+            &root.join("target/receipts/parser-performance-scorecard.json"),
+        ),
     }
+}
+
+fn read_performance_scorecard(path: &Path) -> ParserPerformanceScorecard {
+    let Ok(raw) = fs::read_to_string(path) else {
+        return ParserPerformanceScorecard {
+            schema_version: 1,
+            ..ParserPerformanceScorecard::default()
+        };
+    };
+
+    serde_json::from_str(&raw).unwrap_or(ParserPerformanceScorecard {
+        schema_version: 1,
+        ..ParserPerformanceScorecard::default()
+    })
 }
 
 /// Count the non-comment, non-blank lines in `.ci/common-corpus-manifest.txt`.
@@ -201,6 +236,8 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         },
     );
 
+    let performance_row = render_performance_row(metrics);
+
     let tracking_table = [system_row, cpan_row, project_row].join("\n");
 
     let parser_coverage_bullets = format!(
@@ -242,7 +279,60 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         "<!-- END: PARSER_STRICT_CLEAN_ROW -->",
         &strict_clean_row,
     )?;
+    text = replace_block(
+        &text,
+        "<!-- BEGIN: PARSER_PERF_ROW -->",
+        "<!-- END: PARSER_PERF_ROW -->",
+        &performance_row,
+    )?;
     Ok(text)
+}
+
+pub(super) fn render_performance_scorecard_json(metrics: &ParserMetrics) -> Result<String> {
+    let mut scorecard = metrics.performance_scorecard.clone();
+    if scorecard.schema_version == 0 {
+        scorecard.schema_version = 1;
+    }
+    Ok(format!("{}\n", serde_json::to_string_pretty(&scorecard)?))
+}
+
+fn render_performance_row(metrics: &ParserMetrics) -> String {
+    let required = [
+        "cold_parse",
+        "warm_reparse",
+        "incremental_small_edit",
+        "incremental_multiple_edits",
+        "lexer_only",
+        "scope_analysis",
+    ];
+    let available = required
+        .iter()
+        .filter(|name| metrics.performance_scorecard.metrics.contains_key(**name))
+        .count();
+
+    if available == 0 {
+        return "| **Parser performance scorecard** | UNVERIFIED | run parser benches to emit `target/receipts/parser-performance-scorecard.json` | `docs/project/status/parser_performance_scorecard.json` |".to_string();
+    }
+
+    let cold = metrics
+        .performance_scorecard
+        .metrics
+        .get("cold_parse")
+        .map_or_else(|| "n/a".to_string(), |m| format!("{:.1}µs p50", m.median_us));
+    let warm = metrics
+        .performance_scorecard
+        .metrics
+        .get("warm_reparse")
+        .map_or_else(|| "n/a".to_string(), |m| format!("{:.1}µs p50", m.median_us));
+    let incremental = metrics
+        .performance_scorecard
+        .metrics
+        .get("incremental_small_edit")
+        .map_or_else(|| "n/a".to_string(), |m| format!("{:.1}µs p50", m.median_us));
+
+    format!(
+        "| **Parser performance scorecard** | {available}/6 regimes captured | cold {cold}, warm {warm}, incremental {incremental} | `docs/project/status/parser_performance_scorecard.json` |"
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -302,11 +392,13 @@ mod tests {
             project_corpus: Some(summary),
             common_corpus_receipt: None,
             common_corpus_pinned: 10,
+            performance_scorecard: ParserPerformanceScorecard::default(),
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_PERF_ROW -->\nold\n<!-- END: PARSER_PERF_ROW -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(result.contains("65/69"), "nodekind row missing 65/69");
@@ -329,11 +421,13 @@ mod tests {
             project_corpus: None,
             common_corpus_receipt: None,
             common_corpus_pinned: 10,
+            performance_scorecard: ParserPerformanceScorecard::default(),
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_PERF_ROW -->\nold\n<!-- END: PARSER_PERF_ROW -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(
@@ -378,11 +472,13 @@ mod tests {
             project_corpus: None,
             common_corpus_receipt: Some(receipt),
             common_corpus_pinned: 10,
+            performance_scorecard: ParserPerformanceScorecard::default(),
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_PERF_ROW -->\nold\n<!-- END: PARSER_PERF_ROW -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(result.contains("10/10"), "strict-clean row missing 10/10");

--- a/xtask/tests/post_merge_status_regen_tests.rs
+++ b/xtask/tests/post_merge_status_regen_tests.rs
@@ -254,6 +254,10 @@ fn test_subsystem_files_have_markers() -> Result<(), Box<dyn std::error::Error>>
         parser.contains("<!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->"),
         "parser.md missing PARSER_STRICT_CLEAN_ROW block"
     );
+    assert!(
+        parser.contains("<!-- BEGIN: PARSER_PERF_ROW -->"),
+        "parser.md missing PARSER_PERF_ROW block"
+    );
 
     let quality = fs::read_to_string(status_dir.join("quality.md"))?;
     assert!(


### PR DESCRIPTION
### Motivation
- Provide a single, repeatable machine-readable parser performance artifact so maintainers can compare cold/warm/incremental/lexer/scope regimes over time.

### Description
- Add a small scorecard helper at `crates/perl-parser/benches/support/scorecard.rs` that samples 25 iterations, summarizes p50/p95, and upserts metrics to `target/receipts/parser-performance-scorecard.json`.
- Extend `crates/perl-parser/benches/incremental_benchmark.rs` to emit `cold_parse`, `warm_reparse`, `incremental_small_edit`, and `incremental_multiple_edits` once per run.
- Extend `crates/perl-parser/benches/parser_benchmark.rs` to emit `lexer_only` and `scope_analysis` into the same scorecard so both bench binaries contribute a coherent surface.
- Wire `xtask update-status` to read the receipt and publish `docs/project/status/parser_performance_scorecard.json` and render a `PARSER_PERF_ROW` in `docs/project/status/parser.md`; add marker validation for the new block.

### Testing
- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo bench -p perl-parser --features incremental --bench incremental_benchmark` which completed and produced scorecard entries for incremental regimes.
- Ran `cargo bench -p perl-parser --bench parser_benchmark` which completed and produced lexer/scope entries.
- Ran `cargo check --workspace --all-targets` which completed successfully and `cargo xtask update-status --write --Only parser` (via `cargo xtask update-status --write --only parser`) updated `docs/project/status/parser.md` and `docs/project/status/parser_performance_scorecard.json` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaff8d956883339b2288643c97713d)