### PR TITLE
feat(parser-metrics): publish parser performance scorecard from existing benches (#6699)

### DIFF
--- a/crates/perl-parser/benches/incremental_benchmark.rs
+++ b/crates/perl-parser/benches/incremental_benchmark.rs
@@ -4,8 +4,13 @@ use perl_parser::incremental_document::IncrementalDocument;
 use perl_parser::incremental_edit::{IncrementalEdit, IncrementalEditSet};
 use perl_tdd_support::{must, must_some};
 use std::hint::black_box;
+use std::sync::OnceLock;
+
+#[path = "support/performance_scorecard.rs"]
+mod performance_scorecard;
 
 fn bench_incremental_small_edit(c: &mut Criterion) {
+    emit_incremental_scorecard_once();
     let source = r#"
 use strict;
 use warnings;
@@ -54,6 +59,7 @@ process_data($items);
 }
 
 fn bench_full_reparse(c: &mut Criterion) {
+    emit_incremental_scorecard_once();
     let source = r#"
 use strict;
 use warnings;
@@ -105,6 +111,7 @@ process_data($items);
 ///   reused, single small edit applied via the checkpoint-driven incremental
 ///   lexing path.
 fn bench_warm_reparse(c: &mut Criterion) {
+    emit_incremental_scorecard_once();
     let source = r#"
 use strict;
 use warnings;
@@ -146,6 +153,7 @@ process_data($items);
 }
 
 fn bench_multiple_edits(c: &mut Criterion) {
+    emit_incremental_scorecard_once();
     let source = r#"
 my $x = 1;
 my $y = 2;
@@ -184,6 +192,7 @@ print "$x $y $z\n";
 }
 
 fn bench_incremental_document_single_edit(c: &mut Criterion) {
+    emit_incremental_scorecard_once();
     let source = "my $x = 42; my $y = 100; print $x + $y;";
     let start = must_some(source.find("42"));
     let end = start + 2;
@@ -202,6 +211,7 @@ fn bench_incremental_document_single_edit(c: &mut Criterion) {
 }
 
 fn bench_incremental_document_multiple_edits(c: &mut Criterion) {
+    emit_incremental_scorecard_once();
     let source = "sub calc { my $a = 10; my $b = 20; $a + $b }";
     let pos_a = must_some(source.find("10"));
     let pos_b = must_some(source.find("20"));
@@ -217,6 +227,110 @@ fn bench_incremental_document_multiple_edits(c: &mut Criterion) {
                 black_box(doc.metrics.nodes_reused);
             },
             BatchSize::SmallInput,
+        );
+    });
+}
+
+fn emit_incremental_scorecard_once() {
+    static EMITTED: OnceLock<()> = OnceLock::new();
+    EMITTED.get_or_init(|| {
+        let source = r#"
+use strict;
+use warnings;
+
+sub process_data {
+    my ($data) = @_;
+    for my $item (@$data) {
+        my $result = transform($item);
+        print "Result: $result\n";
+    }
+    return 1;
+}
+
+sub transform {
+    my ($value) = @_;
+    return $value * 2;
+}
+
+my $items = [1, 2, 3, 4, 5];
+process_data($items);
+"#
+        .to_string();
+
+        let rename_start = must_some(source.find("transform"));
+        let rename_end = rename_start + "transform".len();
+
+        let cold_parse = performance_scorecard::measure_scenario(
+            || {
+                let state = IncrementalState::new(source.clone());
+                black_box(&state.ast);
+            },
+            30,
+        );
+        let warm_reparse = performance_scorecard::measure_scenario(
+            || {
+                let mut state = IncrementalState::new(source.clone());
+                let _ = apply_edits(&mut state, &[]);
+                black_box(&state.ast);
+            },
+            30,
+        );
+        let incremental_small_edit = performance_scorecard::measure_scenario(
+            || {
+                let mut state = IncrementalState::new(source.clone());
+                let edit = Edit {
+                    start_byte: rename_start,
+                    old_end_byte: rename_end,
+                    new_end_byte: rename_start + "process".len(),
+                    new_text: "process".to_string(),
+                };
+                let _ = apply_edits(&mut state, &[edit]);
+                black_box(&state.ast);
+            },
+            30,
+        );
+
+        let multi_edit_source = r#"
+my $x = 1;
+my $y = 2;
+my $z = 3;
+print "$x $y $z\n";
+"#
+        .to_string();
+        let pos_1 = must_some(multi_edit_source.find("= 1")) + 2;
+        let pos_2 = must_some(multi_edit_source.find("= 2")) + 2;
+
+        let incremental_multiple_edits = performance_scorecard::measure_scenario(
+            || {
+                let mut state = IncrementalState::new(multi_edit_source.clone());
+                let edits = vec![
+                    Edit {
+                        start_byte: pos_1,
+                        old_end_byte: pos_1 + 1,
+                        new_end_byte: pos_1 + 2,
+                        new_text: "10".to_string(),
+                    },
+                    Edit {
+                        start_byte: pos_2,
+                        old_end_byte: pos_2 + 1,
+                        new_end_byte: pos_2 + 2,
+                        new_text: "20".to_string(),
+                    },
+                ];
+                let _ = apply_edits(&mut state, &edits);
+                black_box(&state.ast);
+            },
+            30,
+        );
+
+        performance_scorecard::write_scorecard(
+            "incremental_benchmark",
+            [
+                ("cold_parse", cold_parse),
+                ("warm_reparse", warm_reparse),
+                ("incremental_small_edit", incremental_small_edit),
+                ("incremental_multiple_edits", incremental_multiple_edits),
+            ],
         );
     });
 }

--- a/crates/perl-parser/benches/parser_benchmark.rs
+++ b/crates/perl-parser/benches/parser_benchmark.rs
@@ -7,6 +7,10 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use perl_parser::{Parser, ScopeAnalyzer};
 use std::hint::black_box;
+use std::sync::OnceLock;
+
+#[path = "support/performance_scorecard.rs"]
+mod performance_scorecard;
 
 const SIMPLE_SCRIPT: &str = r#"
 my $x = 42;
@@ -72,6 +76,7 @@ sub fibonacci {
 "#;
 
 fn benchmark_simple_parsing(c: &mut Criterion) {
+    emit_parser_scorecard_once();
     c.bench_function("parse_simple_script", |b| {
         b.iter(|| {
             let mut parser = Parser::new(black_box(SIMPLE_SCRIPT));
@@ -81,6 +86,7 @@ fn benchmark_simple_parsing(c: &mut Criterion) {
 }
 
 fn benchmark_complex_parsing(c: &mut Criterion) {
+    emit_parser_scorecard_once();
     c.bench_function("parse_complex_script", |b| {
         b.iter(|| {
             let mut parser = Parser::new(black_box(COMPLEX_SCRIPT));
@@ -90,6 +96,7 @@ fn benchmark_complex_parsing(c: &mut Criterion) {
 }
 
 fn benchmark_ast_generation(c: &mut Criterion) {
+    emit_parser_scorecard_once();
     let mut parser = Parser::new(COMPLEX_SCRIPT);
     let ast = parser.parse().expect("COMPLEX_SCRIPT must parse for benchmark");
 
@@ -101,6 +108,7 @@ fn benchmark_ast_generation(c: &mut Criterion) {
 }
 
 fn benchmark_isolated_components(c: &mut Criterion) {
+    emit_parser_scorecard_once();
     // Benchmark just the lexer phase
     c.bench_function("lexer_only", |b| {
         use perl_lexer::{PerlLexer, TokenType};
@@ -125,6 +133,7 @@ fn benchmark_isolated_components(c: &mut Criterion) {
 }
 
 fn benchmark_scope_analysis(c: &mut Criterion) {
+    emit_parser_scorecard_once();
     let mut parser = Parser::new(COMPLEX_SCRIPT);
     let ast = parser.parse().expect("COMPLEX_SCRIPT must parse for benchmark");
     let analyzer = ScopeAnalyzer::new();
@@ -134,6 +143,41 @@ fn benchmark_scope_analysis(c: &mut Criterion) {
         b.iter(|| {
             analyzer.analyze(black_box(&ast), black_box(COMPLEX_SCRIPT), black_box(&pragma_map));
         });
+    });
+}
+
+fn emit_parser_scorecard_once() {
+    static EMITTED: OnceLock<()> = OnceLock::new();
+    EMITTED.get_or_init(|| {
+        let lexer_only = performance_scorecard::measure_scenario(
+            || {
+                use perl_lexer::{PerlLexer, TokenType};
+                let mut lexer = PerlLexer::new(COMPLEX_SCRIPT);
+                loop {
+                    let Some(token) = lexer.next_token() else { break };
+                    if matches!(token.token_type, TokenType::EOF) {
+                        break;
+                    }
+                }
+            },
+            40,
+        );
+        let scope_analysis = performance_scorecard::measure_scenario(
+            || {
+                let mut parser = Parser::new(COMPLEX_SCRIPT);
+                if let Ok(ast) = parser.parse() {
+                    let analyzer = ScopeAnalyzer::new();
+                    let pragma_map = vec![];
+                    let _ = analyzer.analyze(&ast, COMPLEX_SCRIPT, &pragma_map);
+                }
+            },
+            25,
+        );
+
+        performance_scorecard::write_scorecard(
+            "parser_benchmark",
+            [("lexer_only", lexer_only), ("scope_analysis", scope_analysis)],
+        );
     });
 }
 

--- a/crates/perl-parser/benches/support/performance_scorecard.rs
+++ b/crates/perl-parser/benches/support/performance_scorecard.rs
@@ -1,0 +1,94 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+use std::time::Instant;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ScenarioScore {
+    pub sample_count: usize,
+    pub median_micros: f64,
+    pub p95_micros: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ParserPerformanceScorecard {
+    pub schema_version: u32,
+    pub benches: Vec<String>,
+    pub scenarios: BTreeMap<String, ScenarioScore>,
+}
+
+impl Default for ParserPerformanceScorecard {
+    fn default() -> Self {
+        Self { schema_version: 1, benches: Vec::new(), scenarios: BTreeMap::new() }
+    }
+}
+
+pub(crate) fn measure_scenario(mut op: impl FnMut(), samples: usize) -> ScenarioScore {
+    let sample_count = samples.max(5);
+    let mut durations = Vec::with_capacity(sample_count);
+    for _ in 0..sample_count {
+        let started = Instant::now();
+        op();
+        let elapsed = started.elapsed();
+        durations.push(elapsed.as_secs_f64() * 1_000_000.0);
+    }
+
+    durations.sort_by(|a, b| a.total_cmp(b));
+
+    let median = percentile(&durations, 0.50);
+    let p95 = percentile(&durations, 0.95);
+
+    ScenarioScore { sample_count, median_micros: median, p95_micros: p95 }
+}
+
+pub(crate) fn write_scorecard(
+    bench_name: &str,
+    scenarios: impl IntoIterator<Item = (&'static str, ScenarioScore)>,
+) {
+    let path = scorecard_path();
+    let parent = match path.parent() {
+        Some(parent) => parent,
+        None => return,
+    };
+
+    if fs::create_dir_all(parent).is_err() {
+        return;
+    }
+
+    let mut scorecard = fs::read_to_string(&path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<ParserPerformanceScorecard>(&raw).ok())
+        .unwrap_or_default();
+
+    for (name, score) in scenarios {
+        scorecard.scenarios.insert(name.to_string(), score);
+    }
+
+    if !scorecard.benches.iter().any(|item| item == bench_name) {
+        scorecard.benches.push(bench_name.to_string());
+        scorecard.benches.sort();
+    }
+
+    if let Ok(json) = serde_json::to_string_pretty(&scorecard) {
+        let _ = fs::write(path, json);
+    }
+}
+
+pub(crate) fn scorecard_path() -> PathBuf {
+    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    crate_dir.parent().and_then(|path| path.parent()).map_or_else(
+        || PathBuf::from("target/receipts/parser-performance-scorecard.json"),
+        |root| root.join("target/receipts/parser-performance-scorecard.json"),
+    )
+}
+
+fn percentile(sorted: &[f64], q: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+
+    let upper_index = sorted.len().saturating_sub(1);
+    let index = ((upper_index as f64) * q).round() as usize;
+    sorted[index.min(upper_index)]
+}

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard
@@ -24,12 +24,26 @@
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |
 <!-- END: PARSER_RELIABILITY_ROW -->
 <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->
-| **Strict-clean subset** | 10/10 (100%) | 10 pinned modules, zero-error gate | `.ci/common-corpus-manifest.txt` |
+| **Strict-clean subset** | 10 modules (unverified) | run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |
 <!-- END: PARSER_STRICT_CLEAN_ROW -->
+
+## Parser Performance Scorecard
+
+| Regime | Value | Notes | Source |
+| --- | --- | --- | --- |
+<!-- BEGIN: PARSER_PERF_SCORECARD -->
+| **Cold parse** | p50 `44.3`µs / p95 `73.8`µs | 30 samples (schema v1) | `target/receipts/parser-performance-scorecard.json` |
+| **Warm reparse** | p50 `114.8`µs / p95 `162.5`µs | 30 samples (schema v1) | `target/receipts/parser-performance-scorecard.json` |
+| **Incremental small edit** | p50 `60.4`µs / p95 `93.8`µs | 30 samples (schema v1) | `target/receipts/parser-performance-scorecard.json` |
+| **Incremental multiple edits** | p50 `36.4`µs / p95 `49.4`µs | 30 samples (schema v1) | `target/receipts/parser-performance-scorecard.json` |
+| **Lexer-only** | p50 `25.3`µs / p95 `46.7`µs | 40 samples (schema v1) | `target/receipts/parser-performance-scorecard.json` |
+| **Scope analysis** | p50 `94.9`µs / p95 `138.8`µs | 25 samples (schema v1) | `target/receipts/parser-performance-scorecard.json` |
+<!-- END: PARSER_PERF_SCORECARD -->
 
 <!-- BEGIN: PARSER_METRICS_BULLETS -->
 - **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.
 - **Strict promise lists**: `just common-corpus-check` and the CPAN known-clean manifest inside `just cpan-corpus-check` pin subsets that must remain clean on top of the broader baseline receipts.
 - **Fixture bank**: `tree-sitter-perl/test/corpus` contributes ~611 focused syntax sections for targeted parser cases.
 - **CPAN install hygiene**: `cargo xtask cpan-corpus install` reuses `target/cpan-corpus/.cpanm`; pass `--reset` only for a cold rebuild.
+- **Performance scorecard artifact**: parser benches write `target/receipts/parser-performance-scorecard.json` with p50/p95 for cold/warm/incremental parse regimes plus lexer/scope phase timings.
 <!-- END: PARSER_METRICS_BULLETS -->

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -24,6 +24,20 @@ pub(super) struct ParserMetrics {
     pub common_corpus_receipt: Option<super::super::parser_corpus_sweep::SweepReport>,
     /// Number of pinned modules in `.ci/common-corpus-manifest.txt`.
     pub common_corpus_pinned: usize,
+    pub performance_scorecard: Option<ParserPerformanceScorecard>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct ParserPerformanceScorecard {
+    pub schema_version: u32,
+    pub scenarios: std::collections::BTreeMap<String, ParserPerfScenario>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct ParserPerfScenario {
+    pub sample_count: usize,
+    pub median_micros: f64,
+    pub p95_micros: f64,
 }
 
 pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
@@ -41,6 +55,9 @@ pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
         .ok(),
         common_corpus_receipt,
         common_corpus_pinned,
+        performance_scorecard: read_parser_performance_scorecard(
+            &root.join("target/receipts/parser-performance-scorecard.json"),
+        ),
     }
 }
 
@@ -56,6 +73,11 @@ pub(super) fn count_common_corpus_pinned(root: &Path) -> usize {
 pub(super) fn read_sweep_report(
     path: &Path,
 ) -> Option<super::super::parser_corpus_sweep::SweepReport> {
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+pub(super) fn read_parser_performance_scorecard(path: &Path) -> Option<ParserPerformanceScorecard> {
     let raw = fs::read_to_string(path).ok()?;
     serde_json::from_str(&raw).ok()
 }
@@ -207,8 +229,45 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         "- **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.\n\
          - **Strict promise lists**: `just common-corpus-check` and the CPAN known-clean manifest inside `just cpan-corpus-check` pin subsets that must remain clean on top of the broader baseline receipts.\n\
          - **Fixture bank**: `tree-sitter-perl/test/corpus` contributes ~{} focused syntax sections for targeted parser cases.\n\
-         - **CPAN install hygiene**: `cargo xtask cpan-corpus install` reuses `target/cpan-corpus/.cpanm`; pass `--reset` only for a cold rebuild.",
+         - **CPAN install hygiene**: `cargo xtask cpan-corpus install` reuses `target/cpan-corpus/.cpanm`; pass `--reset` only for a cold rebuild.\n\
+         - **Performance scorecard artifact**: parser benches write `target/receipts/parser-performance-scorecard.json` with p50/p95 for cold/warm/incremental parse regimes plus lexer/scope phase timings.",
         metrics.syntax_sections,
+    );
+
+    let parser_perf_rows = metrics.performance_scorecard.as_ref().map_or_else(
+        || {
+            "| **Cold parse** | UNVERIFIED | run `cargo bench -p perl-parser --bench incremental_benchmark` | `target/receipts/parser-performance-scorecard.json` |\n\
+             | **Warm reparse** | UNVERIFIED | run `cargo bench -p perl-parser --bench incremental_benchmark` | `target/receipts/parser-performance-scorecard.json` |\n\
+             | **Incremental small edit** | UNVERIFIED | run `cargo bench -p perl-parser --bench incremental_benchmark` | `target/receipts/parser-performance-scorecard.json` |\n\
+             | **Incremental multiple edits** | UNVERIFIED | run `cargo bench -p perl-parser --bench incremental_benchmark` | `target/receipts/parser-performance-scorecard.json` |\n\
+             | **Lexer-only** | UNVERIFIED | run `cargo bench -p perl-parser --bench parser_benchmark` | `target/receipts/parser-performance-scorecard.json` |\n\
+             | **Scope analysis** | UNVERIFIED | run `cargo bench -p perl-parser --bench parser_benchmark` | `target/receipts/parser-performance-scorecard.json` |".to_string()
+        },
+        |scorecard| {
+            let keys = [
+                ("Cold parse", "cold_parse"),
+                ("Warm reparse", "warm_reparse"),
+                ("Incremental small edit", "incremental_small_edit"),
+                ("Incremental multiple edits", "incremental_multiple_edits"),
+                ("Lexer-only", "lexer_only"),
+                ("Scope analysis", "scope_analysis"),
+            ];
+            keys.iter()
+                .map(|(label, key)| match scorecard.scenarios.get(*key) {
+                    Some(scenario) => format!(
+                        "| **{label}** | p50 `{:.1}`µs / p95 `{:.1}`µs | {} samples (schema v{}) | `target/receipts/parser-performance-scorecard.json` |",
+                        scenario.median_micros,
+                        scenario.p95_micros,
+                        scenario.sample_count,
+                        scorecard.schema_version,
+                    ),
+                    None => format!(
+                        "| **{label}** | UNVERIFIED | missing `{key}` in scorecard artifact | `target/receipts/parser-performance-scorecard.json` |"
+                    ),
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        },
     );
 
     let mut text = original.to_string();
@@ -241,6 +300,12 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         "<!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->",
         "<!-- END: PARSER_STRICT_CLEAN_ROW -->",
         &strict_clean_row,
+    )?;
+    text = replace_block(
+        &text,
+        "<!-- BEGIN: PARSER_PERF_SCORECARD -->",
+        "<!-- END: PARSER_PERF_SCORECARD -->",
+        &parser_perf_rows,
     )?;
     Ok(text)
 }
@@ -302,11 +367,13 @@ mod tests {
             project_corpus: Some(summary),
             common_corpus_receipt: None,
             common_corpus_pinned: 10,
+            performance_scorecard: None,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_PERF_SCORECARD -->\nold\n<!-- END: PARSER_PERF_SCORECARD -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(result.contains("65/69"), "nodekind row missing 65/69");
@@ -329,11 +396,13 @@ mod tests {
             project_corpus: None,
             common_corpus_receipt: None,
             common_corpus_pinned: 10,
+            performance_scorecard: None,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_PERF_SCORECARD -->\nold\n<!-- END: PARSER_PERF_SCORECARD -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(
@@ -378,11 +447,13 @@ mod tests {
             project_corpus: None,
             common_corpus_receipt: Some(receipt),
             common_corpus_pinned: 10,
+            performance_scorecard: None,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_PERF_SCORECARD -->\nold\n<!-- END: PARSER_PERF_SCORECARD -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(result.contains("10/10"), "strict-clean row missing 10/10");

--- a/xtask/tests/post_merge_status_regen_tests.rs
+++ b/xtask/tests/post_merge_status_regen_tests.rs
@@ -254,6 +254,10 @@ fn test_subsystem_files_have_markers() -> Result<(), Box<dyn std::error::Error>>
         parser.contains("<!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->"),
         "parser.md missing PARSER_STRICT_CLEAN_ROW block"
     );
+    assert!(
+        parser.contains("<!-- BEGIN: PARSER_PERF_SCORECARD -->"),
+        "parser.md missing PARSER_PERF_SCORECARD block"
+    );
 
     let quality = fs::read_to_string(status_dir.join("quality.md"))?;
     assert!(


### PR DESCRIPTION
### Motivation
- Provide a single, repeatable, machine-readable parser performance artifact so maintainers can compare cold/warm/incremental/phase timings over time. 
- Surface those timings in the existing status generation flow so `docs/project/status/parser.md` shows the same measured regimes alongside other parser metrics.

### Description
- Added a shared bench helper `crates/perl-parser/benches/support/performance_scorecard.rs` that measures p50/p95 (microseconds), merges per-bench results, and writes `target/receipts/parser-performance-scorecard.json`.
- Extended `crates/perl-parser/benches/incremental_benchmark.rs` to emit cold parse, warm reparse, incremental small edit, and incremental multiple-edits samples into the scorecard (emitted once per bench run using `OnceLock`).
- Extended `crates/perl-parser/benches/parser_benchmark.rs` to emit `lexer-only` and `scope-analysis` timings into the same scorecard (also once per run).
- Updated the status generator `xtask/src/tasks/update_status/parser.rs` to load `target/receipts/parser-performance-scorecard.json` and render a new `<!-- BEGIN: PARSER_PERF_SCORECARD -->` block summarizing the six regimes (with UNVERIFIED fallbacks if the artifact or keys are missing).
- Added the `Parser Performance Scorecard` section to `docs/project/status/parser.md` and updated the post-merge status marker test in `xtask/tests/post_merge_status_regen_tests.rs` to require the new block.

### Testing
- Ran `cargo bench -p perl-parser --bench incremental_benchmark --features incremental` to produce cold/warm/incremental entries and it completed successfully.
- Ran `cargo bench -p perl-parser --bench parser_benchmark` to produce lexer/scope timings and it completed successfully.
- Updated status generation with `cargo run -p xtask -- update-status --write --only parser` and verified `docs/project/status/parser.md` was updated to include the rendered performance table.
- Ran `cargo test -p xtask --test post_merge_status_regen_tests` and all tests passed.
- Ran `cargo check --workspace --all-targets` and the workspace type-check completed successfully.

Notes: `incremental_benchmark` requires the `incremental` feature flag (use `--features incremental` when running that bench). The emitted artifact is `target/receipts/parser-performance-scorecard.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaff8d956883339b2288643c97713d)