### PR TITLE
fix(incremental): harden batch edit normalization and UTF-8 boundary fallback (#6698)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_document.rs
+++ b/crates/perl-parser/src/incremental/incremental_document.rs
@@ -128,40 +128,56 @@ impl IncrementalDocument {
         // Reset metrics for this batch of edits
         self.metrics = ParseMetrics::default();
 
-        // Sort edits by position (reverse order for correct application)
-        let mut sorted_edits = edits.edits.clone();
-        sorted_edits.sort_by(|a, b| b.start_byte.cmp(&a.start_byte));
+        let mut normalized_edits = match edits.normalize_for_batch() {
+            Some(normalized) => normalized,
+            None => {
+                debug!(
+                    "Batch normalization failed (overlap/backwards); using conservative fallback"
+                );
+                return self.reparse_from_source(edits.apply_to_string(&self.source), start);
+            }
+        };
 
         // Apply all edits to source in-place.
         // Reverse ordering keeps byte offsets stable while avoiding repeated
         // full-string allocations for each edit.
         let mut new_source = self.source.clone();
-        for edit in &sorted_edits {
-            self.apply_edit_in_place(&mut new_source, edit);
+        normalized_edits.reverse();
+
+        for edit in &normalized_edits {
+            if !self.apply_edit_in_place(&mut new_source, edit) {
+                debug!("Unmappable edit in batch; using conservative fallback parse");
+                return self.reparse_from_source(edits.apply_to_string(&self.source), start);
+            }
         }
 
         // Find all affected ranges
         let affected_ranges: Vec<_> =
-            sorted_edits.iter().map(|e| (e.start_byte, e.old_end_byte)).collect();
+            normalized_edits.iter().map(|e| (e.start_byte, e.old_end_byte)).collect();
 
         // Collect reusable subtrees outside affected ranges
         let reusable = self.find_reusable_for_ranges(&affected_ranges);
 
         // Parse with reuse when possible
-        let new_root = if !reusable.is_empty() {
+        let incremental_root = if !reusable.is_empty() {
             self.parse_with_reuse(&new_source, reusable)?
         } else {
             let mut parser = Parser::new(&new_source);
             parser.parse()?
         };
 
-        // Update state
-        self.source = new_source;
-        self.root = Arc::new(new_root);
-        self.cache_subtrees();
+        // Safety check: if reuse yields a different structure than a fresh parse,
+        // conservatively fall back to the fresh parse result.
+        let mut fresh_parser = Parser::new(&new_source);
+        let fresh_root = fresh_parser.parse()?;
+        let new_root = if incremental_root.to_sexp() == fresh_root.to_sexp() {
+            incremental_root
+        } else {
+            debug!("Batch incremental parse diverged from fresh parse; using fresh parse result");
+            fresh_root
+        };
 
-        self.metrics.last_parse_time_ms = start.elapsed().as_secs_f64() * 1000.0;
-
+        self.finish_reparse(new_source, new_root, start);
         Ok(())
     }
 
@@ -171,11 +187,27 @@ impl IncrementalDocument {
     }
 
     fn apply_edit_to_string(&self, source: &str, edit: &IncrementalEdit) -> String {
+        if edit.start_byte > edit.old_end_byte {
+            debug!(
+                "Rejecting backwards edit range: start={}, end={}",
+                edit.start_byte, edit.old_end_byte
+            );
+            return source.to_string();
+        }
+        if edit.start_byte > source.len() || edit.old_end_byte > source.len() {
+            debug!(
+                "Rejecting out-of-bounds edit range: start={}, end={}, len={}",
+                edit.start_byte,
+                edit.old_end_byte,
+                source.len()
+            );
+            return source.to_string();
+        }
+
         let mut result = String::with_capacity(source.len() + edit.new_text.len());
 
-        // Safely handle byte positions with bounds checking
-        let start = edit.start_byte.min(source.len());
-        let end = edit.old_end_byte.min(source.len());
+        let start = edit.start_byte;
+        let end = edit.old_end_byte;
 
         // Ensure we're on UTF-8 boundaries
         if source.is_char_boundary(start) && source.is_char_boundary(end) {
@@ -191,20 +223,53 @@ impl IncrementalDocument {
         result
     }
 
-    fn apply_edit_in_place(&self, source: &mut String, edit: &IncrementalEdit) {
-        let start = edit.start_byte.min(source.len());
-        let end = edit.old_end_byte.min(source.len());
+    fn apply_edit_in_place(&self, source: &mut String, edit: &IncrementalEdit) -> bool {
+        if edit.start_byte > edit.old_end_byte {
+            debug!(
+                "Skipping backwards edit range: start={}, end={}",
+                edit.start_byte, edit.old_end_byte
+            );
+            return false;
+        }
+        if edit.start_byte > source.len() || edit.old_end_byte > source.len() {
+            debug!(
+                "Skipping out-of-bounds edit range: start={}, end={}, len={}",
+                edit.start_byte,
+                edit.old_end_byte,
+                source.len()
+            );
+            return false;
+        }
+
+        let start = edit.start_byte;
+        let end = edit.old_end_byte;
 
         if start > end {
             debug!("Skipping invalid edit range: start={}, end={}", start, end);
-            return;
+            return false;
         }
 
         if source.is_char_boundary(start) && source.is_char_boundary(end) {
             source.replace_range(start..end, &edit.new_text);
+            true
         } else {
             debug!("Invalid UTF-8 boundaries in edit: start={}, end={}", start, end);
+            false
         }
+    }
+
+    fn finish_reparse(&mut self, new_source: String, new_root: Node, start: Instant) {
+        self.source = new_source;
+        self.root = Arc::new(new_root);
+        self.cache_subtrees();
+        self.metrics.last_parse_time_ms = start.elapsed().as_secs_f64() * 1000.0;
+    }
+
+    fn reparse_from_source(&mut self, new_source: String, start: Instant) -> ParseResult<()> {
+        let mut parser = Parser::new(&new_source);
+        let new_root = parser.parse()?;
+        self.finish_reparse(new_source, new_root, start);
+        Ok(())
     }
 
     /// Find subtrees that can be reused (outside the edited range)
@@ -308,7 +373,11 @@ impl IncrementalDocument {
         let mut new_root = (*self.root).clone();
 
         // Find and update the affected token
-        if self.update_token_in_tree(&mut new_root, source, edit) { Some(new_root) } else { None }
+        if self.update_token_in_tree(&mut new_root, source, edit) {
+            Some(new_root)
+        } else {
+            None
+        }
     }
 
     /// Update a single token in the tree

--- a/crates/perl-parser/src/incremental/incremental_edit.rs
+++ b/crates/perl-parser/src/incremental/incremental_edit.rs
@@ -96,6 +96,32 @@ impl IncrementalEditSet {
         self.edits.sort_by_key(|e| std::cmp::Reverse(e.start_byte));
     }
 
+    /// Normalize and validate edits for deterministic batch processing.
+    ///
+    /// Returns edits sorted by ascending source order when all edits are valid.
+    /// Returns `None` when a range is backwards or if two edits overlap.
+    /// Zero-width insertions are preserved and considered non-overlapping.
+    pub fn normalize_for_batch(&self) -> Option<Vec<IncrementalEdit>> {
+        let mut normalized = self.edits.clone();
+        normalized.sort_by_key(|edit| (edit.start_byte, edit.old_end_byte));
+
+        for edit in &normalized {
+            if edit.start_byte > edit.old_end_byte {
+                return None;
+            }
+        }
+
+        for pair in normalized.windows(2) {
+            let current = &pair[0];
+            let next = &pair[1];
+            if current.old_end_byte > next.start_byte {
+                return None;
+            }
+        }
+
+        Some(normalized)
+    }
+
     /// Check if the edit set is empty
     pub fn is_empty(&self) -> bool {
         self.edits.is_empty()
@@ -177,5 +203,31 @@ mod tests {
         let source = "hello world";
         let result = edits.apply_to_string(source);
         assert_eq!(result, "Hello Perl");
+    }
+
+    #[test]
+    fn test_normalize_for_batch_rejects_backwards_range() {
+        let mut edits = IncrementalEditSet::new();
+        edits.add(IncrementalEdit::new(3, 1, "x".to_string()));
+        assert!(edits.normalize_for_batch().is_none());
+    }
+
+    #[test]
+    fn test_normalize_for_batch_rejects_overlap() {
+        let mut edits = IncrementalEditSet::new();
+        edits.add(IncrementalEdit::new(1, 3, "x".to_string()));
+        edits.add(IncrementalEdit::new(2, 4, "y".to_string()));
+        assert!(edits.normalize_for_batch().is_none());
+    }
+
+    #[test]
+    fn test_normalize_for_batch_keeps_zero_width_insertions() -> Result<(), String> {
+        let mut edits = IncrementalEditSet::new();
+        edits.add(IncrementalEdit::new(1, 1, "x".to_string()));
+        edits.add(IncrementalEdit::new(1, 1, "y".to_string()));
+        let normalized = edits.normalize_for_batch();
+        let normalized = normalized.ok_or("zero-width insertions should be preserved")?;
+        assert_eq!(normalized.len(), 2);
+        Ok(())
     }
 }

--- a/crates/perl-parser/tests/incremental_batch_boundary_regressions.rs
+++ b/crates/perl-parser/tests/incremental_batch_boundary_regressions.rs
@@ -1,0 +1,93 @@
+#![cfg(feature = "incremental")]
+
+use perl_parser::incremental_document::IncrementalDocument;
+use perl_parser::incremental_edit::{IncrementalEdit, IncrementalEditSet};
+use perl_parser::Parser;
+
+#[test]
+fn overlapping_batch_edits_fallback_safely() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "my $x = 10;";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(4, 8, "$value".to_string()));
+    edits.add(IncrementalEdit::new(6, 10, "99".to_string()));
+
+    doc.apply_edits(&edits)?;
+
+    let expected_source = edits.apply_to_string(source);
+    assert_eq!(doc.source, expected_source);
+    Ok(())
+}
+
+#[test]
+fn backwards_range_fallback_safely() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "my $x = 10;";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(8, 6, "11".to_string()));
+
+    doc.apply_edits(&edits)?;
+
+    let expected_source = edits.apply_to_string(source);
+    assert_eq!(doc.source, expected_source);
+    Ok(())
+}
+
+#[test]
+fn mid_codepoint_edit_attempt_falls_back_without_corruption(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let source = "my $emoji = \"😀\";";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+
+    let emoji_start = source.find('😀').ok_or("emoji must exist")?;
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(emoji_start + 1, emoji_start + 2, "x".to_string()));
+
+    doc.apply_edits(&edits)?;
+
+    let expected_source = edits.apply_to_string(source);
+    assert_eq!(doc.source, expected_source);
+    Ok(())
+}
+
+#[test]
+fn one_bad_edit_in_batch_forces_batch_fallback() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "my $emoji = \"😀\"; my $x = 1;";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+
+    let replacement_start = source.find("1;").ok_or("value must exist")?;
+    let emoji_start = source.find('😀').ok_or("emoji must exist")?;
+
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(replacement_start, replacement_start + 1, "2".to_string()));
+    edits.add(IncrementalEdit::new(emoji_start + 1, emoji_start + 2, "x".to_string()));
+
+    doc.apply_edits(&edits)?;
+
+    let expected_source = edits.apply_to_string(source);
+    assert_eq!(doc.source, expected_source);
+    Ok(())
+}
+
+#[test]
+fn supported_batch_edits_match_fresh_parse() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "my $x = 10; my $y = 20;";
+    let mut doc = IncrementalDocument::new(source.to_string())?;
+
+    let mut edits = IncrementalEditSet::new();
+    let x_pos = source.find("10").ok_or("10 must exist")?;
+    let y_pos = source.find("20").ok_or("20 must exist")?;
+
+    edits.add(IncrementalEdit::new(x_pos, x_pos + 2, "11".to_string()));
+    edits.add(IncrementalEdit::new(y_pos, y_pos + 2, "21".to_string()));
+
+    doc.apply_edits(&edits)?;
+
+    let mut parser = Parser::new(&doc.source);
+    let fresh = parser.parse()?;
+
+    assert_eq!(doc.root.to_sexp(), fresh.to_sexp());
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Batch edits could be applied with overlapping or backwards ranges or at non-UTF-8 byte boundaries which risks producing corrupted source or inconsistent incremental trees. 
- The incremental code relied on optimistic in-place application and optimistic fast-path reuse, so a single malformed edit could subtly break byte/char invariants or incremental parity with a fresh parse. 
- Make the batch path conservative and deterministic so malformed batches degrade safely to a full parse rather than corrupting state.

### Description

- Added `IncrementalEditSet::normalize_for_batch` to validate and deterministically sort edits, rejecting backwards ranges and overlapping edits while preserving zero-width insertions. (file: `crates/perl-parser/src/incremental/incremental_edit.rs`) 
- Updated `IncrementalDocument::apply_edits` to use normalization, preserve reverse-order application semantics for valid batches, and fall back to a conservative full-parse when normalization fails or any in-place edit is unmappable. (file: `crates/perl-parser/src/incremental/incremental_document.rs`) 
- Strengthened bounds and UTF-8 char-boundary checks in `apply_edit_to_string` and `apply_edit_in_place`, and made in-place application return a boolean success so the batch can detect unmappable edits. (file: `crates/perl-parser/src/incremental/incremental_document.rs`) 
- Added a safety parity check that compares the incremental/with-reuse parse result against a fresh parse and uses the fresh parse when they diverge, and added a focused regression test file covering overlapping edits, backwards ranges, mid-codepoint edits, one-bad-edit batch fallback, and incremental == fresh parse parity. (tests: `crates/perl-parser/tests/incremental_batch_boundary_regressions.rs`) 

### Testing

- Ran `cargo test -p perl-parser --test incremental_batch_boundary_regressions --features incremental` and the new regression suite passed (`5 passed`).
- Ran `cargo check --all-targets -p perl-parser` which completed successfully.
- Ran full `cargo test -p perl-parser` which uncovered a pre-existing unrelated test failure in refactor retention tests (`test_cleanup_respects_retention_count`), so the incremental-focused tests and checks introduced by this change are green while a separate unrelated test remains failing in the wider suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaff94025083338c5ee4779cd0492d)