### PR TITLE
fix(perl-module): restore Windows include-path normalization (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/path.rs
+++ b/crates/perl-module/src/resolution/path.rs
@@ -33,17 +33,16 @@ pub fn resolve_module_path(
             root.join(base).join(&relative_path)
         };
 
-        let safe_candidate = if base_path.is_absolute() {
-            candidate
-        } else {
-            match validate_workspace_path(&candidate, root) {
-                Ok(path) => path,
-                Err(_) => continue,
-            }
-        };
+        // For relative paths, validate safety (traversal prevention) but keep
+        // the original candidate so the returned path stays relative to `root`
+        // without canonicalization (canonicalize expands 8.3 short names on
+        // Windows, making the result inconsistent with the caller-supplied root).
+        if !base_path.is_absolute() && validate_workspace_path(&candidate, root).is_err() {
+            continue;
+        }
 
-        if safe_candidate.exists() {
-            return Some(safe_candidate);
+        if candidate.exists() {
+            return Some(candidate);
         }
     }
 


### PR DESCRIPTION
## Root Cause

`resolve_module_path` in `crates/perl-module/src/resolution/path.rs` called `validate_workspace_path`, which internally calls `std::fs::canonicalize` on existing paths. On the GitHub Actions Windows runner, `tempfile::tempdir().path()` returns paths using 8.3 short names (e.g. `C:\Users\RUNNER~1\AppData\...`), while `canonicalize` expands them to long names (`C:\Users\runneradmin\AppData\...`). The returned path used a different form than the caller-supplied `root`, causing 18 `assert_eq!` failures in the Windows Guardrails CI lane.

## Fix

In `resolve_module_path`, use `validate_workspace_path` only for its security purpose (traversal prevention): if it returns `Err`, skip the candidate. Return the original `candidate` path — built from the caller-supplied `root` — rather than the canonicalized form from `validate_workspace_path`. The security guarantee is fully preserved.

**Diff: 1 file, -10/+9 lines.**

## Tests Restored (18 in `module_resolution_use_require`)

- `use_lib_effect::use_lib_prepends_to_include_paths`
- `use_lib_effect::multiple_use_lib_stacking_last_prepend_wins`
- `use_lib_effect::use_lib_nonexistent_path_falls_through`
- `inc_search_order::include_paths_searched_in_array_order`
- `relative_vs_absolute_paths::relative_include_path_joined_to_root`
- `relative_vs_absolute_paths::nested_relative_include_path`
- `relative_vs_absolute_paths::dot_path_resolves_from_workspace_root`
- `relative_vs_absolute_paths::mixed_relative_and_dot_include_paths`
- `require_module_resolution::require_module_name_resolves_via_path`
- `require_file_path_resolution::file_path_require_resolves_same_as_module_name`
- `require_file_path_resolution::file_path_require_single_segment`
- `require_file_path_resolution::file_path_require_deep_nesting`
- `module_name_to_path_mapping::two_segment_module_maps_colons_to_slashes`
- `module_name_to_path_mapping::three_segment_module_creates_nested_dirs`
- `module_name_to_path_mapping::single_segment_module_maps_to_flat_file`
- `module_name_to_path_mapping::five_segment_module_maps_to_deep_path`
- `legacy_separator_resolution::legacy_separator_resolves_via_path_after_normalization`
- `combined_edge_cases::many_include_paths_some_nonexistent`

## Verification

- `cargo test --locked -p perl-module --test path_comprehensive_unit_tests --test module_resolution_use_require`: **86 passed** (matches exact CI command)
- `cargo test -p perl-module`: **921 passed** (all tests)
- `cargo clippy -p perl-module`: no issues
- `cargo fmt -p perl-module -- --check`: no issues
- Traversal security tests (`traversal_path_rejected`, `double_traversal_rejected`) still pass — security guarantee intact