### PR TITLE
refactor(incremental): make perl-parser source of truth for incremental parsing (#0000)

### DIFF
--- a/crates/perl-incremental-parsing/Cargo.toml
+++ b/crates/perl-incremental-parsing/Cargo.toml
@@ -24,14 +24,7 @@ include = [
 doctest = false
 
 [dependencies]
-perl-parser-core = { workspace = true }
-perl-lexer = { workspace = true }
-perl-line-index = { workspace = true }
-anyhow.workspace = true
-lsp-types.workspace = true
-ropey = "1.6.1"
-serde_json.workspace = true
-tracing.workspace = true
+perl-parser = { workspace = true, features = ["incremental"] }
 
 [features]
 default = []
@@ -39,7 +32,14 @@ default = []
 [dev-dependencies]
 perl-tdd-support = { workspace = true }
 criterion.workspace = true
-perl-parser = { workspace = true }
+perl-parser-core = { workspace = true }
+perl-lexer = { workspace = true }
+perl-line-index = { workspace = true }
+anyhow.workspace = true
+lsp-types.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+ropey = "1.6.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/perl-incremental-parsing/src/lib.rs
+++ b/crates/perl-incremental-parsing/src/lib.rs
@@ -1,34 +1,11 @@
-//! Incremental parsing support for Perl.
+//! Incremental parsing compatibility shim.
 //!
-//! This crate provides efficient incremental parsing capabilities for Perl code,
-//! enabling Language Server Protocol features to respond quickly to document edits
-//! by reusing portions of the previous parse tree.
-//!
-//! # Overview
-//!
-//! The incremental parser minimizes re-parsing overhead when documents change by:
-//! - Identifying which portions of the AST are affected by an edit
-//! - Reusing unaffected subtrees from the previous parse
-//! - Only re-parsing the modified regions and their dependent nodes
-//!
-//! # Usage
-//!
-//! ```no_run
-//! use perl_incremental_parsing::incremental;
-//! use perl_parser_core::Parser;
-//!
-//! // Initial parse
-//! let source = "sub foo { return 42; }";
-//! let mut parser = Parser::new(source);
-//! let ast = parser.parse();
-//!
-//! // After edit, incrementally reparse only affected portions
-//! // (specific APIs depend on incremental module implementation)
-//! ```
+//! `perl-parser` is the canonical owner of incremental parsing logic.
+//! This crate re-exports `perl_parser::incremental` to preserve compatibility
+//! for existing imports while avoiding code drift between two implementations.
 
 #![deny(unsafe_code)]
 #![deny(unreachable_pub)]
-#![cfg_attr(test, allow(clippy::panic, clippy::unwrap_used, clippy::expect_used))]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
 #![warn(clippy::all)]
@@ -67,10 +44,13 @@
     clippy::uninlined_format_args
 )]
 
-pub use perl_parser_core::edit;
-pub use perl_parser_core::{Node, NodeKind, SourceLocation};
-pub use perl_parser_core::{Parser, ast, error, parser, position};
+#[deprecated(
+    since = "0.12.4",
+    note = "Use perl-parser's incremental module directly: perl_parser::incremental"
+)]
+pub use perl_parser::incremental;
 
-/// Incremental parsing implementation and helpers.
-pub mod incremental;
-pub use incremental::*;
+pub use perl_parser::edit;
+pub use perl_parser::incremental::*;
+pub use perl_parser::{Node, NodeKind, SourceLocation};
+pub use perl_parser::{Parser, ast, error, parser, position};


### PR DESCRIPTION
### Motivation

- Reduce split-brain risk by making a single crate the canonical owner of incremental parsing logic.
- Preserve downstream compatibility while preventing future drift between duplicate implementations.

### Description

- Made `perl-parser` the explicit owner of incremental parsing and reworked `crates/perl-incremental-parsing` into a thin compatibility shim that re-exports `perl_parser::incremental`.
- Added a deprecation annotation and note on the shim export to steer users to `perl_parser::incremental` (preserves public API while discouraging new usage of the shim).
- Replaced the shim crate's fine-grained dependencies with a single dependency on `perl-parser` (feature `incremental`) and moved the former runtime requirements into `dev-dependencies` so benches/tests still build.
- Kept wildcard `incremental` exports and compatibility exports (`edit`, `Node`, `NodeKind`, `SourceLocation`, `Parser`, etc.) so external behavior remains unchanged.

### Testing

- Ran `cargo fmt --all` to normalize formatting and it completed successfully.
- Ran `cargo check --workspace --all-targets` and it completed successfully.
- Ran targeted parser incremental tests with `cargo test -p perl-parser --features incremental --lib incremental::incremental_checkpoint::tests::test_checkpoint_incremental_parsing -- --exact` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb00bbb8048333a1336263d56d8345)