### PR TITLE
perf(incremental-v2): improve safe shifted-node reuse across batch edits (#0000)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_advanced_reuse.rs
+++ b/crates/perl-parser/src/incremental/incremental_advanced_reuse.rs
@@ -158,7 +158,13 @@ impl AdvancedReuseAnalyzer {
         self.find_direct_structural_matches(&old_analysis, &new_analysis, &mut reuse_map, config);
 
         // Strategy 2: Position-shifted matching
-        self.find_position_shifted_matches(&old_analysis, &new_analysis, &mut reuse_map, config);
+        self.find_position_shifted_matches(
+            &old_analysis,
+            &new_analysis,
+            edits,
+            &mut reuse_map,
+            config,
+        );
 
         // Strategy 3: Content-updated matching
         if config.enable_content_reuse {
@@ -367,40 +373,91 @@ impl AdvancedReuseAnalyzer {
         &mut self,
         old_analysis: &TreeAnalysis,
         new_analysis: &TreeAnalysis,
+        edits: &EditSet,
         reuse_map: &mut HashMap<usize, ReuseStrategy>,
         config: &ReuseConfig,
     ) {
+        let mut used_targets: HashSet<usize> =
+            reuse_map.values().map(|strategy| strategy.target_position).collect();
+
         for (old_pos, old_info) in &old_analysis.node_info {
-            // Skip if already matched or is a leaf node
-            if reuse_map.contains_key(old_pos) || old_info.children_count == 0 {
+            // Skip if already matched
+            if reuse_map.contains_key(old_pos) {
                 continue;
             }
 
-            // Look for content matches that may have shifted position
-            for (new_pos, new_info) in &new_analysis.node_info {
+            let Some(expected_position) = self.project_position_through_edits(*old_pos, edits)
+            else {
+                continue;
+            };
+
+            let mut best_match: Option<(usize, f64)> = None;
+
+            // Prefer exact expected position to maximize safe shifted reuse.
+            if let Some(new_info) = new_analysis.node_info.get(&expected_position) {
                 if old_info.content_hash == new_info.content_hash
                     && old_info.structural_hash == new_info.structural_hash
+                    && !used_targets.contains(&expected_position)
                 {
+                    let confidence =
+                        self.calculate_match_confidence(old_info, new_info).min(1.0) * 0.95;
+                    best_match = Some((expected_position, confidence));
+                }
+            }
+
+            // Fall back to nearest structurally equivalent position when exact mapping is absent.
+            if best_match.is_none() {
+                for (new_pos, new_info) in &new_analysis.node_info {
+                    if old_info.content_hash != new_info.content_hash
+                        || old_info.structural_hash != new_info.structural_hash
+                        || used_targets.contains(new_pos)
+                    {
+                        continue;
+                    }
+
                     let position_shift = (*new_pos as isize - *old_pos as isize).unsigned_abs();
-                    if position_shift <= config.max_position_shift {
-                        let confidence = self.calculate_match_confidence(old_info, new_info) * 0.9; // Slight penalty for position shift
-                        if confidence >= config.min_confidence {
-                            reuse_map.insert(
-                                *old_pos,
-                                ReuseStrategy {
-                                    target_position: *new_pos,
-                                    reuse_type: ReuseType::PositionShift,
-                                    confidence_score: confidence,
-                                    position_adjustment: (*new_pos as isize) - (*old_pos as isize),
-                                },
-                            );
-                            self.analysis_stats.position_adjustments += 1;
-                            break;
-                        }
+                    if position_shift > config.max_position_shift {
+                        continue;
+                    }
+
+                    let expected_distance =
+                        (*new_pos as isize - expected_position as isize).unsigned_abs() as f64;
+                    let distance_penalty =
+                        (expected_distance / config.max_position_shift.max(1) as f64).min(1.0);
+                    let confidence = self.calculate_match_confidence(old_info, new_info)
+                        * 0.9
+                        * (1.0 - distance_penalty * 0.5);
+
+                    if best_match.as_ref().is_none_or(|(_, best_conf)| confidence > *best_conf) {
+                        best_match = Some((*new_pos, confidence));
                     }
                 }
             }
+
+            if let Some((new_pos, confidence)) = best_match {
+                if confidence >= config.min_confidence {
+                    reuse_map.insert(
+                        *old_pos,
+                        ReuseStrategy {
+                            target_position: new_pos,
+                            reuse_type: ReuseType::PositionShift,
+                            confidence_score: confidence,
+                            position_adjustment: (new_pos as isize) - (*old_pos as isize),
+                        },
+                    );
+                    used_targets.insert(new_pos);
+                    self.analysis_stats.position_adjustments += 1;
+                }
+            }
         }
+    }
+
+    fn project_position_through_edits(
+        &self,
+        old_position: usize,
+        edits: &EditSet,
+    ) -> Option<usize> {
+        edits.apply_to_position(Position::new(old_position, 0, 0)).map(|position| position.byte)
     }
 
     /// Find content-updated matches (structure same, values changed)

--- a/crates/perl-parser/src/incremental/incremental_v2.rs
+++ b/crates/perl-parser/src/incremental/incremental_v2.rs
@@ -1267,6 +1267,11 @@ mod tests {
         budget
     }
 
+    fn parse_fresh(source: &str) -> ParseResult<Node> {
+        let mut parser = Parser::new(source);
+        parser.parse()
+    }
+
     #[test]
     fn test_basic_compilation() {
         let parser = IncrementalParserV2::new();
@@ -2122,6 +2127,97 @@ if ($condition) {
         let source2 = "my $x=  42;";
         parser.parse(source2)?;
         assert!(parser.reused_nodes > 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_batch_non_overlapping_value_edits_improve_shifted_reuse() -> ParseResult<()> {
+        let mut parser = IncrementalParserV2::new();
+        let source1 = "my $a = 10;\nmy $b = 20;\nmy $c = 30;\n";
+        parser.parse(source1)?;
+
+        let first_start =
+            source1.find("10").ok_or(perl_parser_core::error::ParseError::UnexpectedEof)?;
+        parser.edit(Edit::new(
+            first_start,
+            first_start + 2,
+            first_start + 4,
+            Position::new(first_start, 1, 1),
+            Position::new(first_start + 2, 1, 3),
+            Position::new(first_start + 4, 1, 5),
+        ));
+
+        let third_start =
+            source1.rfind("30").ok_or(perl_parser_core::error::ParseError::UnexpectedEof)? + 2;
+        parser.edit(Edit::new(
+            third_start,
+            third_start + 2,
+            third_start + 3,
+            Position::new(third_start, 1, 1),
+            Position::new(third_start + 2, 1, 3),
+            Position::new(third_start + 3, 1, 4),
+        ));
+
+        let source2 = "my $a = 1000;\nmy $b = 20;\nmy $c = 300;\n";
+        let incremental_tree = parser.parse(source2)?;
+        let full_tree = parse_fresh(source2)?;
+
+        assert_eq!(incremental_tree, full_tree);
+        assert!(parser.reused_nodes >= 6, "expected strong subtree reuse for shifted nodes");
+        assert!(
+            parser
+                .last_reuse_analysis
+                .as_ref()
+                .is_some_and(|analysis| { analysis.analysis_stats.position_adjustments > 0 }),
+            "expected shifted-node matching to contribute position adjustments",
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_batch_whitespace_and_comment_edits_reuse_with_equivalence() -> ParseResult<()> {
+        let mut parser = IncrementalParserV2::new();
+        let source1 = "my $x = 1;\n# keep this\nmy $y = 2;\n";
+        parser.parse(source1)?;
+
+        let whitespace_insertion =
+            source1.find("= 1").ok_or(perl_parser_core::error::ParseError::UnexpectedEof)? + 1;
+        parser.edit(Edit::new(
+            whitespace_insertion,
+            whitespace_insertion,
+            whitespace_insertion + 2,
+            Position::new(whitespace_insertion, 1, 1),
+            Position::new(whitespace_insertion, 1, 1),
+            Position::new(whitespace_insertion + 2, 1, 3),
+        ));
+
+        let comment_text_start =
+            source1.find("keep this").ok_or(perl_parser_core::error::ParseError::UnexpectedEof)?
+                + 2;
+        parser.edit(Edit::new(
+            comment_text_start,
+            comment_text_start + 8,
+            comment_text_start + 12,
+            Position::new(comment_text_start, 2, 1),
+            Position::new(comment_text_start + 8, 2, 9),
+            Position::new(comment_text_start + 12, 2, 13),
+        ));
+
+        let source2 = "my $x  = 1;\n# keep this note\nmy $y = 2;\n";
+        let incremental_tree = parser.parse(source2)?;
+        let full_tree = parse_fresh(source2)?;
+
+        assert_eq!(incremental_tree, full_tree);
+        assert!(parser.reused_nodes > parser.reparsed_nodes);
+        assert!(
+            parser
+                .last_reuse_analysis
+                .as_ref()
+                .is_some_and(|analysis| { analysis.reuse_percentage >= 60.0 }),
+            "expected meaningful reuse for separated non-structural edits",
+        );
+
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Batch non-overlapping and separated non-structural edits were not taking full advantage of safe shifted-node reuse because position-shift matching did not anchor old nodes to edit-projected targets.

### Description

- Reworked the advanced position-shift matching in `crates/perl-parser/src/incremental/incremental_advanced_reuse.rs` to accept the `EditSet`, project old node positions through edits, prefer exact projected targets, and fall back to nearest structural/content-equivalent candidates with a bounded confidence penalty.
- Added target de-duplication (`used_targets`) so multiple old nodes do not claim the same new position during shifted reuse and introduced `project_position_through_edits` to map positions through `EditSet`.
- Added regression tests in `crates/perl-parser/src/incremental/incremental_v2.rs` that assert AST equivalence with a fresh parse and verify improved reuse for (a) batch non-overlapping value edits and (b) separated whitespace/comment edits.

### Testing

- Ran `cargo xtask fmt` (success).
- Ran `cargo check --all-targets -p perl-parser` (success).
- Ran targeted tests: `cargo test -p perl-parser --features incremental batch_non_overlapping_value_edits_improve_shifted_reuse -- --nocapture` and `cargo test -p perl-parser --features incremental batch_whitespace_and_comment_edits_reuse_with_equivalence -- --nocapture` (both passed).
- Ran full `cargo test -p perl-parser`, which failed due to a pre-existing, unrelated test (`refactor::refactoring::tests::validation_tests::test_cleanup_respects_retention_count`); the failures are unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb009eed908333badab3c2a8950ad1)