### PR TITLE
refactor(incremental-v2): improve shifted-node reuse across batch edits (#0000)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_advanced_reuse.rs
+++ b/crates/perl-parser/src/incremental/incremental_advanced_reuse.rs
@@ -158,7 +158,13 @@ impl AdvancedReuseAnalyzer {
         self.find_direct_structural_matches(&old_analysis, &new_analysis, &mut reuse_map, config);
 
         // Strategy 2: Position-shifted matching
-        self.find_position_shifted_matches(&old_analysis, &new_analysis, &mut reuse_map, config);
+        self.find_position_shifted_matches(
+            &old_analysis,
+            &new_analysis,
+            edits,
+            &mut reuse_map,
+            config,
+        );
 
         // Strategy 3: Content-updated matching
         if config.enable_content_reuse {
@@ -367,40 +373,79 @@ impl AdvancedReuseAnalyzer {
         &mut self,
         old_analysis: &TreeAnalysis,
         new_analysis: &TreeAnalysis,
+        edits: &EditSet,
         reuse_map: &mut HashMap<usize, ReuseStrategy>,
         config: &ReuseConfig,
     ) {
         for (old_pos, old_info) in &old_analysis.node_info {
-            // Skip if already matched or is a leaf node
-            if reuse_map.contains_key(old_pos) || old_info.children_count == 0 {
+            // Skip if already matched or touched by an edit.
+            if reuse_map.contains_key(old_pos) || self.affected_nodes.contains(old_pos) {
                 continue;
             }
 
-            // Look for content matches that may have shifted position
+            // Estimate where this old node should land after applying all edits.
+            let expected_new_pos = *old_pos as isize + self.estimated_shift_at(*old_pos, edits);
+            let mut best_match: Option<(usize, f64)> = None;
+
+            // Look for structurally equivalent nodes that may have shifted position.
             for (new_pos, new_info) in &new_analysis.node_info {
-                if old_info.content_hash == new_info.content_hash
-                    && old_info.structural_hash == new_info.structural_hash
+                if old_info.structural_hash != new_info.structural_hash
+                    || old_info.content_hash != new_info.content_hash
                 {
-                    let position_shift = (*new_pos as isize - *old_pos as isize).unsigned_abs();
-                    if position_shift <= config.max_position_shift {
-                        let confidence = self.calculate_match_confidence(old_info, new_info) * 0.9; // Slight penalty for position shift
-                        if confidence >= config.min_confidence {
-                            reuse_map.insert(
-                                *old_pos,
-                                ReuseStrategy {
-                                    target_position: *new_pos,
-                                    reuse_type: ReuseType::PositionShift,
-                                    confidence_score: confidence,
-                                    position_adjustment: (*new_pos as isize) - (*old_pos as isize),
-                                },
-                            );
-                            self.analysis_stats.position_adjustments += 1;
-                            break;
-                        }
-                    }
+                    continue;
+                }
+
+                let expected_delta = (*new_pos as isize - expected_new_pos).unsigned_abs();
+                if expected_delta > config.max_position_shift {
+                    continue;
+                }
+
+                // Confidence is based on structural quality and a penalty for distance from
+                // expected shifted position.
+                let base_confidence = self.calculate_match_confidence(old_info, new_info);
+                let distance_penalty =
+                    1.0 - (expected_delta as f64 / config.max_position_shift as f64);
+                let confidence = (base_confidence * 0.95) * distance_penalty.max(0.1);
+
+                if confidence >= config.min_confidence
+                    && best_match
+                        .as_ref()
+                        .is_none_or(|(_, best_confidence)| confidence > *best_confidence)
+                {
+                    best_match = Some((*new_pos, confidence));
                 }
             }
+
+            if let Some((target_position, confidence_score)) = best_match {
+                reuse_map.insert(
+                    *old_pos,
+                    ReuseStrategy {
+                        target_position,
+                        reuse_type: ReuseType::PositionShift,
+                        confidence_score,
+                        position_adjustment: (target_position as isize) - (*old_pos as isize),
+                    },
+                );
+                self.analysis_stats.position_adjustments += 1;
+            }
         }
+    }
+
+    /// Estimate the cumulative byte shift at a given original source position.
+    ///
+    /// This mirrors how incremental edits are applied sequentially, allowing us
+    /// to find expected target positions for unchanged nodes after multi-edit updates.
+    fn estimated_shift_at(&self, position: usize, edits: &EditSet) -> isize {
+        let mut shift = 0isize;
+        for edit in edits.edits() {
+            let original_old_end = (edit.old_end_byte as isize - shift) as usize;
+            if original_old_end <= position {
+                shift += edit.byte_shift();
+            } else {
+                break;
+            }
+        }
+        shift
     }
 
     /// Find content-updated matches (structure same, values changed)
@@ -585,7 +630,11 @@ impl AdvancedReuseAnalyzer {
         match &node.kind {
             NodeKind::Program { statements } | NodeKind::Block { statements } => statements.len(),
             NodeKind::VariableDeclaration { initializer, .. } => {
-                if initializer.is_some() { 2 } else { 1 } // variable + optional initializer
+                if initializer.is_some() {
+                    2
+                } else {
+                    1
+                } // variable + optional initializer
             }
             NodeKind::Binary { .. } => 2, // left + right
             NodeKind::Unary { .. } => 1,  // operand
@@ -820,7 +869,7 @@ impl ReuseAnalysisResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use perl_parser_core::{SourceLocation, ast::Node};
+    use perl_parser_core::{ast::Node, SourceLocation};
 
     #[test]
     fn test_advanced_reuse_analyzer_creation() {

--- a/crates/perl-parser/src/incremental/incremental_v2.rs
+++ b/crates/perl-parser/src/incremental/incremental_v2.rs
@@ -1242,7 +1242,7 @@ impl Default for IncrementalParserV2 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use perl_parser_core::position::Position;
+    use perl_parser_core::{error::ParseError, position::Position};
     use std::time::Instant;
 
     fn adaptive_perf_budget_micros(base_budget_micros: u128) -> u128 {
@@ -1265,6 +1265,18 @@ mod tests {
         }
 
         budget
+    }
+
+    fn apply_single_edit(
+        source: &str,
+        old: &str,
+        new: &str,
+    ) -> ParseResult<(String, usize, usize)> {
+        let start = source.find(old).ok_or(ParseError::UnexpectedEof)?;
+        let old_end = start + old.len();
+        let updated = source.replacen(old, new, 1);
+        let new_end = start + new.len();
+        Ok((updated, old_end, new_end))
     }
 
     #[test]
@@ -2122,6 +2134,109 @@ if ($condition) {
         let source2 = "my $x=  42;";
         parser.parse(source2)?;
         assert!(parser.reused_nodes > 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_batch_non_overlapping_identifier_and_value_edits_reuse_shifted_nodes() -> ParseResult<()>
+    {
+        let mut parser = IncrementalParserV2::new();
+        let source1 = "my $alpha = 10;\nmy $beta = 20;\nmy $delta = 30;\n";
+        parser.parse(source1)?;
+
+        let first_start = source1.find("10").ok_or(ParseError::UnexpectedEof)?;
+        let first_old_end = first_start + 2;
+        let first_new_end = first_start + 3;
+        parser.edit(Edit::new(
+            first_start,
+            first_old_end,
+            first_new_end,
+            Position::new(first_start, 1, 1),
+            Position::new(first_old_end, 1, 1),
+            Position::new(first_new_end, 1, 1),
+        ));
+
+        let second_original_start = source1.find("$delta").ok_or(ParseError::UnexpectedEof)?;
+        let second_start = second_original_start + 1; // account for first edit shift (+1)
+        let second_old_end = second_start + "$delta".len();
+        let second_new_end = second_start + "$omega".len();
+        parser.edit(Edit::new(
+            second_start,
+            second_old_end,
+            second_new_end,
+            Position::new(second_start, 1, 1),
+            Position::new(second_old_end, 1, 1),
+            Position::new(second_new_end, 1, 1),
+        ));
+
+        let source2 = "my $alpha = 100;\nmy $beta = 20;\nmy $omega = 30;\n";
+        let incremental_tree = parser.parse(source2)?;
+
+        let mut fresh_parser = Parser::new(source2);
+        let fresh_tree = fresh_parser.parse()?;
+
+        assert_eq!(incremental_tree, fresh_tree, "Incremental AST must match fresh parse AST");
+        assert!(
+            parser.reused_nodes >= 6,
+            "Expected substantial reuse for non-overlapping batch edits"
+        );
+        assert!(
+            parser.last_reuse_analysis.is_some(),
+            "Expected advanced reuse analysis for batch edits"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_multi_region_whitespace_and_comment_edits_keep_high_reuse() -> ParseResult<()> {
+        let mut parser = IncrementalParserV2::new();
+        let source1 = "my $x = 42;\nmy $y = 7;\nmy $z = 9;\n";
+        parser.parse(source1)?;
+
+        let (after_comment, first_old_end, first_new_end) =
+            apply_single_edit(source1, ";\nmy $y", "; # local comment\nmy $y")?;
+        let first_start = source1.find(";\nmy $y").ok_or(ParseError::UnexpectedEof)?;
+        parser.edit(Edit::new(
+            first_start,
+            first_old_end,
+            first_new_end,
+            Position::new(first_start, 1, 1),
+            Position::new(first_old_end, 1, 1),
+            Position::new(first_new_end, 1, 1),
+        ));
+
+        let second_old_start_in_new =
+            after_comment.find("$z = 9").ok_or(ParseError::UnexpectedEof)? + "$z".len();
+        let second_old_end = second_old_start_in_new + 1;
+        let second_new_end = second_old_start_in_new + 3;
+        parser.edit(Edit::new(
+            second_old_start_in_new,
+            second_old_end,
+            second_new_end,
+            Position::new(second_old_start_in_new, 1, 1),
+            Position::new(second_old_end, 1, 1),
+            Position::new(second_new_end, 1, 1),
+        ));
+
+        let source2 = "my $x = 42; # local comment\nmy $y = 7;\nmy $z   = 9;\n";
+        let incremental_tree = parser.parse(source2)?;
+
+        let mut fresh_parser = Parser::new(source2);
+        let fresh_tree = fresh_parser.parse()?;
+
+        assert_eq!(incremental_tree, fresh_tree, "Incremental AST must match fresh parse AST");
+        let total = parser.reused_nodes + parser.reparsed_nodes;
+        let reuse_ratio = if total == 0 { 0.0 } else { parser.reused_nodes as f64 / total as f64 };
+        assert!(
+            reuse_ratio >= 0.6,
+            "Expected at least 60% reuse for separated non-structural edits"
+        );
+        assert!(
+            parser.last_reuse_analysis.is_some(),
+            "Expected advanced reuse analysis in multi-region non-structural edits"
+        );
+
         Ok(())
     }
 }

--- a/crates/perl-parser/tests/incremental_v2_reuse_regression.rs
+++ b/crates/perl-parser/tests/incremental_v2_reuse_regression.rs
@@ -1,0 +1,94 @@
+#![cfg(feature = "incremental")]
+
+use perl_parser::{
+    edit::Edit, error::ParseError, incremental_v2::IncrementalParserV2, position::Position, Parser,
+};
+
+fn edit(source: &str, old: &str, new: &str) -> Result<(usize, usize, usize), ParseError> {
+    let start = source.find(old).ok_or(ParseError::UnexpectedEof)?;
+    let old_end = start + old.len();
+    let new_end = start + new.len();
+    Ok((start, old_end, new_end))
+}
+
+#[test]
+fn batch_non_overlapping_edits_preserve_ast_and_improve_shifted_reuse() -> Result<(), ParseError> {
+    let mut parser = IncrementalParserV2::new();
+    let source1 = "my $alpha = 10;\nmy $beta = 20;\nmy $delta = 30;\n";
+    parser.parse(source1)?;
+
+    let (start1, old_end1, new_end1) = edit(source1, "10", "100")?;
+    parser.edit(Edit::new(
+        start1,
+        old_end1,
+        new_end1,
+        Position::new(start1, 0, 0),
+        Position::new(old_end1, 0, 0),
+        Position::new(new_end1, 0, 0),
+    ));
+
+    let source_after_first = source1.replacen("10", "100", 1);
+    let (start2, old_end2, new_end2) = edit(&source_after_first, "$delta", "$omega")?;
+    parser.edit(Edit::new(
+        start2,
+        old_end2,
+        new_end2,
+        Position::new(start2, 0, 0),
+        Position::new(old_end2, 0, 0),
+        Position::new(new_end2, 0, 0),
+    ));
+
+    let source2 = "my $alpha = 100;\nmy $beta = 20;\nmy $omega = 30;\n";
+    let incremental_tree = parser.parse(source2)?;
+    let mut fresh_parser = Parser::new(source2);
+    let fresh_tree = fresh_parser.parse()?;
+
+    assert_eq!(incremental_tree, fresh_tree);
+    assert!(parser.reused_nodes >= 6);
+    assert!(parser.last_reuse_analysis.is_some());
+
+    Ok(())
+}
+
+#[test]
+fn multi_region_comment_and_whitespace_edits_keep_equivalence_and_reuse() -> Result<(), ParseError>
+{
+    let mut parser = IncrementalParserV2::new();
+    let source1 = "my $x = 42;\nmy $y = 7;\nmy $z = 9;\n";
+    parser.parse(source1)?;
+
+    let (start1, old_end1, new_end1) = edit(source1, ";\nmy $y", "; # local comment\nmy $y")?;
+    parser.edit(Edit::new(
+        start1,
+        old_end1,
+        new_end1,
+        Position::new(start1, 0, 0),
+        Position::new(old_end1, 0, 0),
+        Position::new(new_end1, 0, 0),
+    ));
+
+    let source_after_first = source1.replacen(";\nmy $y", "; # local comment\nmy $y", 1);
+    let (start2, old_end2, new_end2) = edit(&source_after_first, "$z = 9", "$z   = 9")?;
+    parser.edit(Edit::new(
+        start2,
+        old_end2,
+        new_end2,
+        Position::new(start2, 0, 0),
+        Position::new(old_end2, 0, 0),
+        Position::new(new_end2, 0, 0),
+    ));
+
+    let source2 = "my $x = 42; # local comment\nmy $y = 7;\nmy $z   = 9;\n";
+    let incremental_tree = parser.parse(source2)?;
+    let mut fresh_parser = Parser::new(source2);
+    let fresh_tree = fresh_parser.parse()?;
+
+    assert_eq!(incremental_tree, fresh_tree);
+    let total_nodes = parser.reused_nodes + parser.reparsed_nodes;
+    let reuse_ratio =
+        if total_nodes > 0 { parser.reused_nodes as f64 / total_nodes as f64 } else { 0.0 };
+    assert!(reuse_ratio >= 0.6);
+    assert!(parser.last_reuse_analysis.is_some());
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Incremental v2 under-counted safe shifted-node reuse for multi-edit batches, hurting reuse for non-overlapping edits and separated whitespace/comment edits.
- Improve reuse for simple identifier/value edits where only node positions shift while keeping AST equivalence with a fresh full parse as the correctness constraint.

### Description

- Make position-shifted matching edit-aware by passing the incoming `EditSet` into `find_position_shifted_matches` and skipping nodes marked as affected by edits.
- Add `estimated_shift_at` to compute expected post-edit positions and prefer position-shift matches close to the expected shifted location, applying a distance-based confidence penalty.
- Score candidates by combined structural/content confidence and distance-from-expected-position, inserting chosen `PositionShift` strategies into the reuse map and incrementing `analysis_stats.position_adjustments`.
- Add focused regression tests (feature-gated `incremental`) that assert fresh-parse AST equivalence and improved reuse for: non-overlapping identifier/value edits and multi-region whitespace/comment edits, plus small helpers in the in-module tests.

### Testing

- Ran `cargo test -p perl-parser --features incremental --test incremental_v2_reuse_regression` and the new regression tests passed.
- Ran `cargo check --all-targets -p perl-parser` and `cargo check --all-targets -p perl-parser --features incremental` and both succeeded.
- Ran broader `cargo test -p perl-parser` during development and observed an intermittent, unrelated failure in an external refactor test when run as part of the full suite; that failing test passes when run in isolation and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb009eed908333badab3c2a8950ad1)