### PR TITLE
fix(parser): correct transliteration part extraction and expand regressions (#6685)

### DIFF
--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -301,79 +301,61 @@ pub fn extract_substitution_parts(text: &str) -> (String, String, String) {
 
 /// Extract search, replace, and modifiers from a transliteration token
 pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
-    // Skip 'tr' or 'y' prefix
-    let content = if let Some(stripped) = text.strip_prefix("tr") {
+    // Skip `tr` or `y` prefix, then allow optional whitespace before delimiter.
+    let after_op = if let Some(stripped) = text.strip_prefix("tr") {
         stripped
     } else if let Some(stripped) = text.strip_prefix('y') {
         stripped
     } else {
         text
     };
+    let content = after_op.trim_start();
 
-    // Get delimiter - content must be non-empty to have a delimiter
+    // Get delimiter.
     let delimiter = match content.chars().next() {
         Some(d) => d,
         None => return (String::new(), String::new(), String::new()),
     };
+
+    // Obvious malformed forms like `trabc` or `tr a b` have no delimiter.
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return (String::new(), String::new(), String::new());
+    }
+
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
-    // Parse first body (search pattern)
-    let (search, rest1) = extract_delimited_content(content, delimiter, closing);
+    // Parse first body (search).
+    let (search, rest1, search_closed) = extract_delimited_content_strict(content, delimiter, closing);
 
-    // For paired delimiters, skip whitespace and allow any paired opening delimiter for the
-    // replacement list. Perl accepts forms like tr[abc]{xyz} in addition to tr[abc][xyz].
-    let rest2_owned;
-    let rest2 = if is_paired {
-        rest1.trim_start()
-    } else {
-        rest2_owned = format!("{}{}", delimiter, rest1);
-        &rest2_owned
-    };
-
-    // Parse second body (replacement pattern)
-    let (replacement, modifiers_str) = if !is_paired && !rest1.is_empty() {
-        // Manually parse the replacement for non-paired delimiters
-        let chars = rest1.char_indices();
-        let mut body = String::new();
-        let mut escaped = false;
-        let mut end_pos = rest1.len();
-
-        for (i, ch) in chars {
-            if escaped {
-                body.push(ch);
-                escaped = false;
-                continue;
-            }
-
-            match ch {
-                '\\' => {
-                    body.push(ch);
-                    escaped = true;
-                }
-                c if c == closing => {
-                    end_pos = i + ch.len_utf8();
-                    break;
-                }
-                _ => body.push(ch),
-            }
+    // Parse second body (replacement).
+    let (replacement, modifiers_str) = if !is_paired {
+        if rest1.is_empty() {
+            (String::new(), "")
+        } else {
+            let (body, rest, _replacement_closed) = extract_unpaired_body_skip_strings(rest1, closing);
+            (body, rest)
         }
-
-        (body, &rest1[end_pos..])
     } else if is_paired {
+        let rest2 = rest1.trim_start();
         if let Some(repl_delimiter) = starts_with_paired_delimiter(rest2) {
             let repl_closing = get_closing_delimiter(repl_delimiter);
-            extract_delimited_content(rest2, repl_delimiter, repl_closing)
+            let (body, rest, _replacement_closed) =
+                extract_delimited_content_strict(rest2, repl_delimiter, repl_closing);
+            (body, rest)
         } else {
-            (String::new(), rest2)
+            (String::new(), "")
         }
     } else {
         (String::new(), rest1)
     };
 
-    // Extract and validate only valid transliteration modifiers
-    // Security fix: Apply consistent validation for all delimiter types
-    let modifiers = modifiers_str
+    // If the first body wasn't closed, keep malformed input non-panicking and avoid
+    // treating trailing body text as modifiers.
+    let modifiers_input = if search_closed { modifiers_str } else { "" };
+
+    // Extract and validate only valid transliteration modifiers.
+    let modifiers = modifiers_input
         .chars()
         .take_while(|c| c.is_ascii_alphabetic())
         .filter(|&c| matches!(c, 'c' | 'd' | 's' | 'r'))

--- a/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
+++ b/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
@@ -1,56 +1,55 @@
-/// Minimal reproduction case for transliteration parsing bug discovered in fuzz testing
-///
-/// CRASH DETAILS:
-/// - Input: "tr/abc/xyz/"
-/// - Expected: ("abc", "xyz", "")
-/// - Actual: ("abc", "", "xyz")
-///
-/// This indicates a critical bug in extract_transliteration_parts where the replacement
-/// and modifiers are being swapped for non-paired delimiters.
-///
-/// IMPACT: This affects Perl transliteration operator parsing throughout the entire
-/// parser pipeline, potentially causing incorrect syntax highlighting, code analysis,
-/// and refactoring operations.
-///
-/// REPRODUCTION: Run with `cargo test -p perl-parser --test fuzz_transliteration_crash_repro`
 use perl_parser::quote_parser::extract_transliteration_parts;
 
 #[test]
 fn minimal_transliteration_crash_repro() {
-    let input = "tr/abc/xyz/";
-    let (search, replace, modifiers) = extract_transliteration_parts(input);
-
-    println!("FUZZ BUG REPRODUCED: tr// parsing issue");
-    println!("Input: {}", input);
-    println!("Expected: ('abc', 'xyz', '')");
-    println!("Actual: ('{}', '{}', '{}')", search, replace, modifiers);
-
-    // Demonstrate the bug - these will fail due to the parsing issue
-    assert_eq!(search.as_str(), "abc", "Search pattern incorrect");
-    assert_eq!(replace.as_str(), "xyz", "Replace pattern incorrect");
-    assert_eq!(modifiers.as_str(), "", "Modifiers incorrect");
+    assert_eq!(
+        extract_transliteration_parts("tr/abc/xyz/"),
+        ("abc".to_string(), "xyz".to_string(), "".to_string())
+    );
 }
 
 #[test]
 fn fuzz_transliteration_regression_suite() {
-    // Test additional variants that likely have the same bug
-    let test_cases = vec![
+    let test_cases = [
+        // tr/// and y///
+        ("tr/abc/xyz/", ("abc", "xyz", "")),
         ("y/abc/xyz/", ("abc", "xyz", "")),
-        ("tr/a/b/d", ("a", "b", "d")),
-        ("y/x/y/g", ("x", "y", "")), // 'g' is not a valid transliteration modifier
-        ("tr{abc}{xyz}d", ("abc", "xyz", "d")), // This might work correctly with paired delimiters
+        ("tr/a/b/ds", ("a", "b", "ds")),
+        ("y/x/y/g", ("x", "y", "")), // invalid modifier is filtered out
+        // paired delimiter forms
+        ("tr{abc}{xyz}d", ("abc", "xyz", "d")),
+        ("tr[abc]{xyz}cr", ("abc", "xyz", "cr")),
+        ("y(foo)(bar)s", ("foo", "bar", "s")),
+        // delimiter edge cases
+        ("tr#abc#xyz#cdr", ("abc", "xyz", "cdr")),
+        ("tr /abc/xyz/r", ("abc", "xyz", "r")),
+        ("tr/a\\/b/c\\/d/", ("a\\/b", "c\\/d", "")),
     ];
 
     for (input, expected) in test_cases {
         let (search, replace, modifiers) = extract_transliteration_parts(input);
         let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
+        assert_eq!(actual, expected, "failed transliteration case: {input}");
+    }
+}
 
-        println!("Testing: {} -> expected {:?}, got {:?}", input, expected, actual);
+#[test]
+fn malformed_transliteration_is_nonpanicking() {
+    let malformed_cases = [
+        "tr",
+        "trabc",
+        "tr/abc",
+        "tr/abc/",
+        "tr/abc/xyz",
+        "tr{abc}",
+        "tr{abc}{",
+        "tr{abc}xyz",
+        "y",
+        "y ",
+    ];
 
-        if actual != expected {
-            println!("  BUG CONFIRMED in variant: {}", input);
-        } else {
-            println!("  PASSED: {}", input);
-        }
+    for input in malformed_cases {
+        let result = std::panic::catch_unwind(|| extract_transliteration_parts(input));
+        assert!(result.is_ok(), "panicked for malformed transliteration: {input}");
     }
 }


### PR DESCRIPTION
### Motivation
- The transliteration extractor was fragile for `tr`/`y` forms and could swap replacement and modifiers or panic on malformed inputs.
- Add focused regression coverage to lock in the real fuzz-discovered failure modes for paired and non-paired delimiters and modifier handling.

### Description
- Harden `extract_transliteration_parts` to allow optional whitespace after the operator, reject obvious malformed delimiter starts, and determine paired vs non-paired delimiters correctly. 
- Parse the first body using `extract_delimited_content_strict` and parse replacements with `extract_unpaired_body_skip_strings` for non-paired and `extract_delimited_content_strict` for paired delimiters so replacement/modifier boundaries are correct. 
- Prevent trailing/ malformed first bodies from being interpreted as modifiers by gating modifier extraction on whether the first body closed successfully. 
- Files changed: `crates/perl-parser-core/src/syntax/quote.rs` and `crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs` (expanded regression bank and added non-panicking malformed cases).

### Testing
- Ran `cargo test -p perl-parser --test fuzz_transliteration_crash_repro` which executed the focused suite (3 tests) and all tests passed. 
- Ran `cargo check --all-targets -p perl-parser` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb009a9f788333a1b9362972a3774c)