### PR TITLE
fix(parser): correct transliteration part extraction and expand regressions (#6684)

### DIFF
--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -315,6 +315,9 @@ pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
         Some(d) => d,
         None => return (String::new(), String::new(), String::new()),
     };
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return (String::new(), String::new(), String::new());
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
@@ -332,12 +335,13 @@ pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
     };
 
     // Parse second body (replacement pattern)
-    let (replacement, modifiers_str) = if !is_paired && !rest1.is_empty() {
+    let (replacement, modifiers_str, replacement_closed) = if !is_paired && !rest1.is_empty() {
         // Manually parse the replacement for non-paired delimiters
         let chars = rest1.char_indices();
         let mut body = String::new();
         let mut escaped = false;
         let mut end_pos = rest1.len();
+        let mut found_closing = false;
 
         for (i, ch) in chars {
             if escaped {
@@ -353,31 +357,38 @@ pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
                 }
                 c if c == closing => {
                     end_pos = i + ch.len_utf8();
+                    found_closing = true;
                     break;
                 }
                 _ => body.push(ch),
             }
         }
 
-        (body, &rest1[end_pos..])
+        (body, &rest1[end_pos..], found_closing)
     } else if is_paired {
         if let Some(repl_delimiter) = starts_with_paired_delimiter(rest2) {
             let repl_closing = get_closing_delimiter(repl_delimiter);
-            extract_delimited_content(rest2, repl_delimiter, repl_closing)
+            let (body, rest, found_closing) =
+                extract_delimited_content_strict(rest2, repl_delimiter, repl_closing);
+            (body, rest, found_closing)
         } else {
-            (String::new(), rest2)
+            (String::new(), "", false)
         }
     } else {
-        (String::new(), rest1)
+        (String::new(), "", false)
     };
 
-    // Extract and validate only valid transliteration modifiers
-    // Security fix: Apply consistent validation for all delimiter types
-    let modifiers = modifiers_str
-        .chars()
-        .take_while(|c| c.is_ascii_alphabetic())
-        .filter(|&c| matches!(c, 'c' | 'd' | 's' | 'r'))
-        .collect();
+    // Extract and validate only valid transliteration modifiers. Only consume
+    // modifiers after a complete replacement section is parsed.
+    let modifiers = if replacement_closed {
+        modifiers_str
+            .chars()
+            .take_while(|c| c.is_ascii_alphabetic())
+            .filter(|&c| matches!(c, 'c' | 'd' | 's' | 'r'))
+            .collect()
+    } else {
+        String::new()
+    };
 
     (search, replacement, modifiers)
 }

--- a/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
+++ b/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
@@ -20,12 +20,6 @@ fn minimal_transliteration_crash_repro() {
     let input = "tr/abc/xyz/";
     let (search, replace, modifiers) = extract_transliteration_parts(input);
 
-    println!("FUZZ BUG REPRODUCED: tr// parsing issue");
-    println!("Input: {}", input);
-    println!("Expected: ('abc', 'xyz', '')");
-    println!("Actual: ('{}', '{}', '{}')", search, replace, modifiers);
-
-    // Demonstrate the bug - these will fail due to the parsing issue
     assert_eq!(search.as_str(), "abc", "Search pattern incorrect");
     assert_eq!(replace.as_str(), "xyz", "Replace pattern incorrect");
     assert_eq!(modifiers.as_str(), "", "Modifiers incorrect");
@@ -33,24 +27,27 @@ fn minimal_transliteration_crash_repro() {
 
 #[test]
 fn fuzz_transliteration_regression_suite() {
-    // Test additional variants that likely have the same bug
-    let test_cases = vec![
+    let test_cases = [
+        // tr/// and y///
         ("y/abc/xyz/", ("abc", "xyz", "")),
         ("tr/a/b/d", ("a", "b", "d")),
-        ("y/x/y/g", ("x", "y", "")), // 'g' is not a valid transliteration modifier
-        ("tr{abc}{xyz}d", ("abc", "xyz", "d")), // This might work correctly with paired delimiters
+        ("y/x/y/g", ("x", "y", "")), // invalid transliteration modifier filtered out
+        // paired delimiters
+        ("tr{abc}{xyz}d", ("abc", "xyz", "d")),
+        ("tr[abc]{xyz}sr", ("abc", "xyz", "sr")),
+        // delimiter edge cases
+        (r"tr|a\|b|x\|y|d", (r"a\|b", r"x\|y", "d")),
+        ("tr<ab<cd>><xy>r", ("ab<cd>", "xy", "r")),
+        // malformed-but-nonpanicking
+        ("tr/abc", ("abc", "", "")),
+        ("tr{abc}xyz", ("abc", "", "")),
+        ("tr abc xyz", ("", "", "")),
+        ("tr", ("", "", "")),
     ];
 
     for (input, expected) in test_cases {
         let (search, replace, modifiers) = extract_transliteration_parts(input);
         let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
-
-        println!("Testing: {} -> expected {:?}, got {:?}", input, expected, actual);
-
-        if actual != expected {
-            println!("  BUG CONFIRMED in variant: {}", input);
-        } else {
-            println!("  PASSED: {}", input);
-        }
+        assert_eq!(actual, expected, "failed transliteration parse for `{input}`");
     }
 }


### PR DESCRIPTION
### Motivation
- The transliteration extractor could mis-handle non-paired and paired delimiters and mix replacement text with modifiers, causing incorrect parse results for `tr///` and `y///` forms.
- Fuzzing produced a concrete repro (`tr/abc/xyz/`) demonstrating swapped replacement/modifier output which must be fixed to avoid downstream analysis errors.
- The goal is to make `extract_transliteration_parts` robust on malformed inputs and to broaden regression coverage around the real failure mode.

### Description
- Tightened `extract_transliteration_parts` to reject alphanumeric/whitespace delimiters early and to detect whether the replacement section is actually closed before consuming modifiers. (`crates/perl-parser-core/src/syntax/quote.rs`).
- For non-paired delimiters the code now tracks a `replacement_closed` flag when scanning the replacement, and for paired replacements uses `extract_delimited_content_strict` to determine closure and rest content. (`extract_delimited_content_strict`, `extract_transliteration_parts`).
- Expanded the focused regression suite in `crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs` to cover `tr///`, `y///`, paired-delimiter forms, escaped-delimiter edge cases, and malformed-but-nonpanicking inputs with direct assertions.

### Testing
- Ran `cargo test -p perl-parser --test fuzz_transliteration_crash_repro` and the two tests in that target passed successfully. 
- Ran `cargo check --all-targets -p perl-parser` and the crate type checks completed without errors. 
- Ran formatting via `cargo xtask fmt` as part of verification and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb009a9f788333a1b9362972a3774c)