### PR TITLE
fix(parser): correct transliteration part extraction and expand regressions (#6683)

### DIFF
--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -301,71 +301,55 @@ pub fn extract_substitution_parts(text: &str) -> (String, String, String) {
 
 /// Extract search, replace, and modifiers from a transliteration token
 pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
-    // Skip 'tr' or 'y' prefix
-    let content = if let Some(stripped) = text.strip_prefix("tr") {
+    // Skip 'tr' or 'y' prefix, then allow optional whitespace before delimiter.
+    let after_op = if let Some(stripped) = text.strip_prefix("tr") {
         stripped
     } else if let Some(stripped) = text.strip_prefix('y') {
         stripped
     } else {
         text
     };
+    let content = after_op.trim_start();
 
     // Get delimiter - content must be non-empty to have a delimiter
     let delimiter = match content.chars().next() {
         Some(d) => d,
         None => return (String::new(), String::new(), String::new()),
     };
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return (String::new(), String::new(), String::new());
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
     // Parse first body (search pattern)
-    let (search, rest1) = extract_delimited_content(content, delimiter, closing);
-
-    // For paired delimiters, skip whitespace and allow any paired opening delimiter for the
-    // replacement list. Perl accepts forms like tr[abc]{xyz} in addition to tr[abc][xyz].
-    let rest2_owned;
-    let rest2 = if is_paired {
-        rest1.trim_start()
-    } else {
-        rest2_owned = format!("{}{}", delimiter, rest1);
-        &rest2_owned
-    };
+    let (search, rest1, search_closed) = extract_delimited_content_strict(content, delimiter, closing);
+    if !search_closed {
+        return (search, String::new(), String::new());
+    }
 
     // Parse second body (replacement pattern)
-    let (replacement, modifiers_str) = if !is_paired && !rest1.is_empty() {
-        // Manually parse the replacement for non-paired delimiters
-        let chars = rest1.char_indices();
-        let mut body = String::new();
-        let mut escaped = false;
-        let mut end_pos = rest1.len();
-
-        for (i, ch) in chars {
-            if escaped {
-                body.push(ch);
-                escaped = false;
-                continue;
-            }
-
-            match ch {
-                '\\' => {
-                    body.push(ch);
-                    escaped = true;
-                }
-                c if c == closing => {
-                    end_pos = i + ch.len_utf8();
-                    break;
-                }
-                _ => body.push(ch),
-            }
+    let (replacement, modifiers_str) = if !is_paired {
+        if rest1.is_empty() {
+            return (search, String::new(), String::new());
         }
-
-        (body, &rest1[end_pos..])
+        let (body, rest, found_closing) = extract_unpaired_body_skip_strings(rest1, closing);
+        if !found_closing {
+            return (search, String::new(), String::new());
+        }
+        (body, rest)
     } else if is_paired {
-        if let Some(repl_delimiter) = starts_with_paired_delimiter(rest2) {
+        let trimmed = rest1.trim_start();
+        if let Some(repl_delimiter) = starts_with_paired_delimiter(trimmed) {
             let repl_closing = get_closing_delimiter(repl_delimiter);
-            extract_delimited_content(rest2, repl_delimiter, repl_closing)
+            let (body, rest, replacement_closed) =
+                extract_delimited_content_strict(trimmed, repl_delimiter, repl_closing);
+            if !replacement_closed {
+                return (search, String::new(), String::new());
+            }
+            (body, rest)
         } else {
-            (String::new(), rest2)
+            (String::new(), trimmed)
         }
     } else {
         (String::new(), rest1)

--- a/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
+++ b/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
@@ -1,56 +1,103 @@
-/// Minimal reproduction case for transliteration parsing bug discovered in fuzz testing
-///
-/// CRASH DETAILS:
-/// - Input: "tr/abc/xyz/"
-/// - Expected: ("abc", "xyz", "")
-/// - Actual: ("abc", "", "xyz")
-///
-/// This indicates a critical bug in extract_transliteration_parts where the replacement
-/// and modifiers are being swapped for non-paired delimiters.
-///
-/// IMPACT: This affects Perl transliteration operator parsing throughout the entire
-/// parser pipeline, potentially causing incorrect syntax highlighting, code analysis,
-/// and refactoring operations.
-///
-/// REPRODUCTION: Run with `cargo test -p perl-parser --test fuzz_transliteration_crash_repro`
 use perl_parser::quote_parser::extract_transliteration_parts;
 
 #[test]
-fn minimal_transliteration_crash_repro() {
-    let input = "tr/abc/xyz/";
-    let (search, replace, modifiers) = extract_transliteration_parts(input);
-
-    println!("FUZZ BUG REPRODUCED: tr// parsing issue");
-    println!("Input: {}", input);
-    println!("Expected: ('abc', 'xyz', '')");
-    println!("Actual: ('{}', '{}', '{}')", search, replace, modifiers);
-
-    // Demonstrate the bug - these will fail due to the parsing issue
-    assert_eq!(search.as_str(), "abc", "Search pattern incorrect");
-    assert_eq!(replace.as_str(), "xyz", "Replace pattern incorrect");
-    assert_eq!(modifiers.as_str(), "", "Modifiers incorrect");
-}
-
-#[test]
-fn fuzz_transliteration_regression_suite() {
-    // Test additional variants that likely have the same bug
-    let test_cases = vec![
+fn transliteration_non_paired_regressions() {
+    let cases = [
+        ("tr/abc/xyz/", ("abc", "xyz", "")),
         ("y/abc/xyz/", ("abc", "xyz", "")),
         ("tr/a/b/d", ("a", "b", "d")),
         ("y/x/y/g", ("x", "y", "")), // 'g' is not a valid transliteration modifier
-        ("tr{abc}{xyz}d", ("abc", "xyz", "d")), // This might work correctly with paired delimiters
+        ("tr /abc/xyz/cdr", ("abc", "xyz", "cdr")),
     ];
 
-    for (input, expected) in test_cases {
+    for (input, expected) in cases {
         let (search, replace, modifiers) = extract_transliteration_parts(input);
         let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
+        assert_eq!(actual, expected, "failed for input {input:?}");
+    }
+}
 
-        println!("Testing: {} -> expected {:?}, got {:?}", input, expected, actual);
+#[test]
+fn transliteration_paired_delimiter_regressions() {
+    let cases = [
+        ("tr{abc}{xyz}d", ("abc", "xyz", "d")),
+        ("y[abc][xyz]s", ("abc", "xyz", "s")),
+        ("tr(abc)(xyz)r", ("abc", "xyz", "r")),
+        ("tr<abc>{xyz}cd", ("abc", "xyz", "cd")),
+        ("tr [a[b]c] {x{y}z} r", ("a[b]c", "x{y}z", "")),
+    ];
 
-        if actual != expected {
-            println!("  BUG CONFIRMED in variant: {}", input);
-        } else {
-            println!("  PASSED: {}", input);
-        }
+    for (input, expected) in cases {
+        let (search, replace, modifiers) = extract_transliteration_parts(input);
+        let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
+        assert_eq!(actual, expected, "failed for input {input:?}");
+    }
+}
+
+#[test]
+fn transliteration_malformed_non_panicking_regressions() {
+    let malformed_inputs = [
+        "tr",                // missing delimiter
+        "tr ",               // missing delimiter after whitespace
+        "trabc",             // invalid delimiter
+        "tr/abc",            // missing replacement section
+        "tr/abc/xyz",        // missing closing delimiter
+        "tr{abc",            // missing closing delimiter for search section
+        "tr{abc}{xyz",       // missing closing delimiter for replacement section
+        "tr{abc} xyz",       // paired search with no replacement delimiter
+        "y/a/b/q",           // invalid modifier should be dropped
+        "y/a/b/rq",          // valid + invalid modifier, keep valid prefix
+        "tr#a#b#cd!",        // stop modifiers at first non-alnum
+    ];
+
+    for input in malformed_inputs {
+        let result = std::panic::catch_unwind(|| extract_transliteration_parts(input));
+        assert!(result.is_ok(), "should never panic for malformed input {input:?}");
+    }
+
+    assert_eq!(
+        extract_transliteration_parts("tr/abc"),
+        ("abc".to_string(), String::new(), String::new())
+    );
+    assert_eq!(
+        extract_transliteration_parts("tr/abc/xyz"),
+        ("abc".to_string(), String::new(), String::new())
+    );
+    assert_eq!(
+        extract_transliteration_parts("tr{abc}{xyz"),
+        ("abc".to_string(), String::new(), String::new())
+    );
+    assert_eq!(
+        extract_transliteration_parts("tr{abc} xyz"),
+        ("abc".to_string(), String::new(), String::new())
+    );
+    assert_eq!(
+        extract_transliteration_parts("trabc"),
+        (String::new(), String::new(), String::new())
+    );
+    assert_eq!(
+        extract_transliteration_parts("y/a/b/rq"),
+        ("a".to_string(), "b".to_string(), "r".to_string())
+    );
+    assert_eq!(
+        extract_transliteration_parts("tr#a#b#cd!"),
+        ("a".to_string(), "b".to_string(), "cd".to_string())
+    );
+}
+
+#[test]
+fn transliteration_delimiter_edge_cases() {
+    let cases = [
+        ("tr||", ("", "", "")),
+        ("tr///", ("", "", "")),
+        ("tr#\\##\\##", ("\\#", "\\#", "")),
+        ("tr@@@", ("", "", "")),
+        ("y/🦀/🐪/r", ("🦀", "🐪", "r")),
+    ];
+
+    for (input, expected) in cases {
+        let (search, replace, modifiers) = extract_transliteration_parts(input);
+        let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
+        assert_eq!(actual, expected, "failed for input {input:?}");
     }
 }


### PR DESCRIPTION
### Motivation
- A fuzz run produced a concrete regression where `extract_transliteration_parts` misclassified replacement and modifier text for non-paired delimiters and could panic or return incorrect parts on malformed transliteration forms.
- The goal is to make transliteration parsing robust across non-paired and paired delimiters, ensure modifiers are separated correctly, and add focused regression coverage for the discovered failure shapes.

### Description
- Harden `extract_transliteration_parts` in `crates/perl-parser-core/src/syntax/quote.rs` by trimming whitespace after `tr`/`y`, rejecting obviously invalid delimiters (alphanumeric/whitespace), and using the strict delimited-content helpers to require properly-closed search and replacement sections.
- For non-paired delimiters the function now uses `extract_unpaired_body_skip_strings` and verifies a closing delimiter was found before accepting replacement text, returning safe partial results (search + empty replacement/mods) on malformed inputs.
- For paired delimiters the function now trims and detects the replacement opening, then uses `extract_delimited_content_strict` and rejects or returns empty replacement/modifiers when the replacement is not properly closed.
- Expanded `crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs` into a small regression bank with targeted tests for non-paired forms, paired-delimiter forms (including mixed paired delimiters), malformed-but-nonpanicking inputs, and delimiter edge cases.

### Testing
- Ran `cargo test -p perl-parser --test fuzz_transliteration_crash_repro` and the test binary completed with all tests passing (regressions for non-paired, paired, malformed, and edge cases).
- Ran `cargo check --all-targets -p perl-parser` and it completed successfully without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb009a9f788333a1b9362972a3774c)