### PR TITLE
fix(parser): correct transliteration part extraction and expand regressions (#6682)

### DIFF
--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -302,82 +302,67 @@ pub fn extract_substitution_parts(text: &str) -> (String, String, String) {
 /// Extract search, replace, and modifiers from a transliteration token
 pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
     // Skip 'tr' or 'y' prefix
-    let content = if let Some(stripped) = text.strip_prefix("tr") {
+    let after_op = if let Some(stripped) = text.strip_prefix("tr") {
         stripped
     } else if let Some(stripped) = text.strip_prefix('y') {
         stripped
     } else {
         text
     };
+    // Perl allows optional whitespace between the operator and delimiter.
+    let content = after_op.trim_start();
 
     // Get delimiter - content must be non-empty to have a delimiter
     let delimiter = match content.chars().next() {
         Some(d) => d,
         None => return (String::new(), String::new(), String::new()),
     };
+    // Alphanumeric and whitespace delimiters are malformed for quote-like operators.
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return (String::new(), String::new(), String::new());
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
     // Parse first body (search pattern)
-    let (search, rest1) = extract_delimited_content(content, delimiter, closing);
+    let (search, rest1, search_closed) =
+        extract_delimited_content_strict(content, delimiter, closing);
+    if !search_closed {
+        return (search, String::new(), String::new());
+    }
 
     // For paired delimiters, skip whitespace and allow any paired opening delimiter for the
     // replacement list. Perl accepts forms like tr[abc]{xyz} in addition to tr[abc][xyz].
-    let rest2_owned;
-    let rest2 = if is_paired {
-        rest1.trim_start()
-    } else {
-        rest2_owned = format!("{}{}", delimiter, rest1);
-        &rest2_owned
-    };
-
     // Parse second body (replacement pattern)
-    let (replacement, modifiers_str) = if !is_paired && !rest1.is_empty() {
-        // Manually parse the replacement for non-paired delimiters
-        let chars = rest1.char_indices();
-        let mut body = String::new();
-        let mut escaped = false;
-        let mut end_pos = rest1.len();
-
-        for (i, ch) in chars {
-            if escaped {
-                body.push(ch);
-                escaped = false;
-                continue;
-            }
-
-            match ch {
-                '\\' => {
-                    body.push(ch);
-                    escaped = true;
-                }
-                c if c == closing => {
-                    end_pos = i + ch.len_utf8();
-                    break;
-                }
-                _ => body.push(ch),
-            }
-        }
-
-        (body, &rest1[end_pos..])
+    let (replacement, modifiers_str, replacement_closed) = if !is_paired && !rest1.is_empty() {
+        // For non-paired delimiters, parse replacement from the remainder until the next
+        // closing delimiter and keep trailing text as the modifier candidate section.
+        extract_unpaired_body_skip_strings(rest1, closing)
     } else if is_paired {
+        let rest2 = rest1.trim_start();
         if let Some(repl_delimiter) = starts_with_paired_delimiter(rest2) {
             let repl_closing = get_closing_delimiter(repl_delimiter);
-            extract_delimited_content(rest2, repl_delimiter, repl_closing)
+            let (replacement, modifiers, found_closing) =
+                extract_delimited_content_strict(rest2, repl_delimiter, repl_closing);
+            (replacement, modifiers, found_closing)
         } else {
-            (String::new(), rest2)
+            (String::new(), rest2, false)
         }
     } else {
-        (String::new(), rest1)
+        (String::new(), rest1, false)
     };
 
     // Extract and validate only valid transliteration modifiers
-    // Security fix: Apply consistent validation for all delimiter types
-    let modifiers = modifiers_str
-        .chars()
-        .take_while(|c| c.is_ascii_alphabetic())
-        .filter(|&c| matches!(c, 'c' | 'd' | 's' | 'r'))
-        .collect();
+    // Only parse modifiers when replacement is properly delimited.
+    let modifiers = if replacement_closed {
+        modifiers_str
+            .chars()
+            .take_while(|c| c.is_ascii_alphabetic())
+            .filter(|&c| matches!(c, 'c' | 'd' | 's' | 'r'))
+            .collect()
+    } else {
+        String::new()
+    };
 
     (search, replacement, modifiers)
 }
@@ -413,7 +398,8 @@ pub fn extract_transliteration_parts_strict(
     let is_paired = delimiter != closing;
 
     // Parse first body (search).
-    let (search, rest1, search_closed) = extract_delimited_content_strict(content, delimiter, closing);
+    let (search, rest1, search_closed) =
+        extract_delimited_content_strict(content, delimiter, closing);
     if !search_closed {
         return Err(TransliterationError::MissingClosingDelimiter);
     }
@@ -447,10 +433,7 @@ pub fn extract_transliteration_parts_strict(
 
     // Validate transliteration modifiers strictly.
     let mut modifiers = String::new();
-    for modifier in modifiers_str
-        .chars()
-        .take_while(|c: &char| c.is_ascii_alphanumeric())
-    {
+    for modifier in modifiers_str.chars().take_while(|c: &char| c.is_ascii_alphanumeric()) {
         if matches!(modifier, 'c' | 'd' | 's' | 'r') {
             modifiers.push(modifier);
         } else {

--- a/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
+++ b/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
@@ -1,18 +1,5 @@
-/// Minimal reproduction case for transliteration parsing bug discovered in fuzz testing
-///
-/// CRASH DETAILS:
-/// - Input: "tr/abc/xyz/"
-/// - Expected: ("abc", "xyz", "")
-/// - Actual: ("abc", "", "xyz")
-///
-/// This indicates a critical bug in extract_transliteration_parts where the replacement
-/// and modifiers are being swapped for non-paired delimiters.
-///
-/// IMPACT: This affects Perl transliteration operator parsing throughout the entire
-/// parser pipeline, potentially causing incorrect syntax highlighting, code analysis,
-/// and refactoring operations.
-///
-/// REPRODUCTION: Run with `cargo test -p perl-parser --test fuzz_transliteration_crash_repro`
+//! Regression bank for fuzz-discovered transliteration parsing failures.
+
 use perl_parser::quote_parser::extract_transliteration_parts;
 
 #[test]
@@ -20,37 +7,70 @@ fn minimal_transliteration_crash_repro() {
     let input = "tr/abc/xyz/";
     let (search, replace, modifiers) = extract_transliteration_parts(input);
 
-    println!("FUZZ BUG REPRODUCED: tr// parsing issue");
-    println!("Input: {}", input);
-    println!("Expected: ('abc', 'xyz', '')");
-    println!("Actual: ('{}', '{}', '{}')", search, replace, modifiers);
-
-    // Demonstrate the bug - these will fail due to the parsing issue
-    assert_eq!(search.as_str(), "abc", "Search pattern incorrect");
-    assert_eq!(replace.as_str(), "xyz", "Replace pattern incorrect");
-    assert_eq!(modifiers.as_str(), "", "Modifiers incorrect");
+    assert_eq!(search, "abc", "search should be extracted from the first body");
+    assert_eq!(replace, "xyz", "replacement should be extracted from the second body");
+    assert_eq!(modifiers, "", "no modifiers are present in the minimal reproducer");
 }
 
 #[test]
-fn fuzz_transliteration_regression_suite() {
-    // Test additional variants that likely have the same bug
-    let test_cases = vec![
-        ("y/abc/xyz/", ("abc", "xyz", "")),
+fn transliteration_regression_bank_non_paired_tr_and_y() {
+    let cases = [
+        ("tr/a-z/A-Z/", ("a-z", "A-Z", "")),
+        ("y/a-z/A-Z/", ("a-z", "A-Z", "")),
         ("tr/a/b/d", ("a", "b", "d")),
-        ("y/x/y/g", ("x", "y", "")), // 'g' is not a valid transliteration modifier
-        ("tr{abc}{xyz}d", ("abc", "xyz", "d")), // This might work correctly with paired delimiters
+        ("y/x/y/g", ("x", "y", "")), // `g` is invalid for transliteration and is filtered
+        ("tr /left/right/c", ("left", "right", "c")), // optional whitespace after op
     ];
 
-    for (input, expected) in test_cases {
+    for (input, expected) in cases {
         let (search, replace, modifiers) = extract_transliteration_parts(input);
         let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
-
-        println!("Testing: {} -> expected {:?}, got {:?}", input, expected, actual);
-
-        if actual != expected {
-            println!("  BUG CONFIRMED in variant: {}", input);
-        } else {
-            println!("  PASSED: {}", input);
-        }
+        assert_eq!(actual, expected, "failed non-paired transliteration case: {input}");
     }
+}
+
+#[test]
+fn transliteration_regression_bank_paired_and_delimiter_edges() {
+    let cases = [
+        ("tr{abc}{xyz}d", ("abc", "xyz", "d")),
+        ("y(abc)(xyz)r", ("abc", "xyz", "r")),
+        ("tr[abc]{xyz}", ("abc", "xyz", "")), // different paired delimiter for replacement
+        ("tr<ab\\>c><xy\\>z>cd", ("ab\\>c", "xy\\>z", "cd")),
+        ("tr##", ("", "", "")),
+    ];
+
+    for (input, expected) in cases {
+        let (search, replace, modifiers) = extract_transliteration_parts(input);
+        let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
+        assert_eq!(actual, expected, "failed paired/delimiter transliteration case: {input}");
+    }
+}
+
+#[test]
+fn transliteration_regression_bank_malformed_nonpanicking_cases() {
+    let malformed_cases = [
+        "tr",
+        "trabc",
+        "tr{abc}incomplete",
+        "tr/abc",
+        "tr/abc/def",
+        "y{a}{b", // missing closing delimiter for replacement
+        "y /a/b", // missing closing delimiter for replacement with whitespace after op
+    ];
+
+    for input in malformed_cases {
+        let result = std::panic::catch_unwind(|| extract_transliteration_parts(input));
+        assert!(result.is_ok(), "parser panicked for malformed case: {input}");
+    }
+
+    assert_eq!(
+        extract_transliteration_parts("tr{abc}incomplete"),
+        ("abc".to_string(), String::new(), String::new()),
+        "missing replacement delimiter should preserve parsed search and clear replacement/modifiers"
+    );
+    assert_eq!(
+        extract_transliteration_parts("tr/abc/def"),
+        ("abc".to_string(), "def".to_string(), String::new()),
+        "unterminated non-paired replacement should not treat replacement bytes as modifiers"
+    );
 }


### PR DESCRIPTION
### Motivation

- Fix fragile transliteration parsing where replacement/modifier separation could be incorrect and malformed inputs could panic or produce swapped fields.
- Add a focused, assertion-based regression bank to cover `tr///`/`y///` variants, paired vs non-paired delimiters, delimiter edge cases, and malformed-but-nonpanicking inputs.

### Description

- Normalize operator suffix handling by allowing optional whitespace after `tr`/`y` and rejecting obviously malformed alphanumeric/whitespace delimiters in `extract_transliteration_parts`.
- Use strict delimited-content helpers (`extract_delimited_content_strict` / `extract_unpaired_body_skip_strings`) to ensure the search and replacement bodies are correctly located and that closure is tracked before accepting modifiers.
- For paired-delimiter replacements, detect and parse the replacement with `extract_delimited_content_strict`, and only accept modifier characters when the replacement was properly delimited.
- Replace the prior print-based repro with an expanded `crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs` regression bank covering non-paired `tr`/`y`, paired forms, mixed paired delimiters, delimiter edge cases, and malformed non-panicking cases.

### Testing

- Ran `cargo test -p perl-parser --test fuzz_transliteration_crash_repro` and all tests in that test file passed (4 passed; 0 failed).
- Ran `cargo check --all-targets -p perl-parser` and the crate type checks completed successfully.
- Ran `cargo fmt --all` to format changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb009a9f788333a1b9362972a3774c)