### PR TITLE
feat(parser-status): cluster corpus failures and expose missing node-kind coverage (#6680)

### DIFF
--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard
@@ -24,7 +24,7 @@
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |
 <!-- END: PARSER_RELIABILITY_ROW -->
 <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->
-| **Strict-clean subset** | 10/10 (100%) | 10 pinned modules, zero-error gate | `.ci/common-corpus-manifest.txt` |
+| **Strict-clean subset** | 10 modules (unverified) | run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |
 <!-- END: PARSER_STRICT_CLEAN_ROW -->
 
 <!-- BEGIN: PARSER_METRICS_BULLETS -->
@@ -32,4 +32,14 @@
 - **Strict promise lists**: `just common-corpus-check` and the CPAN known-clean manifest inside `just cpan-corpus-check` pin subsets that must remain clean on top of the broader baseline receipts.
 - **Fixture bank**: `tree-sitter-perl/test/corpus` contributes ~611 focused syntax sections for targeted parser cases.
 - **CPAN install hygiene**: `cargo xtask cpan-corpus install` reuses `target/cpan-corpus/.cpanm`; pass `--reset` only for a cold rebuild.
+- **Parser failure clusters** (first-error buckets across Ubuntu + CPAN baselines):
+  | Category | File count | Top buckets | Representative files |
+  | --- | ---: | --- | --- |
+  | transliteration / quote parsing | 8 | invalid_substitution_modifier (6), Missing replacement in substitution (2) | `/usr/share/perl/5.38.2/ExtUtils/MM_VMS.pm`, `/usr/share/perl/5.38/ExtUtils/MM_VMS.pm` |
+  | declaration / package parsing | 4 | CHECK must be followed by a block (2), signature_param (2) | `target/cpan-corpus/lib/perl5/Mojo/Exception.pm`, `target/cpan-corpus/lib/perl5/Test/LectroTest/Property.pm` |
+  | heredoc / delimiter handling | 216 | unclosed_paren_identifier (63), unclosed_brace (51) | `/usr/lib/x86_64-linux-gnu/perl/5.38.2/Encode/Guess.pm`, `/usr/lib/x86_64-linux-gnu/perl/5.38.2/Unicode/Collate.pm` |
+  | recovery-only failures | 364 | unexpected_token_in_expr (67), unexpected_comma_expr (66) | `/usr/lib/x86_64-linux-gnu/perl/5.38.2/Data/Dumper.pm`, `/usr/lib/x86_64-linux-gnu/perl/5.38.2/File/Spec/Win32.pm` |
+  | encoding / multibyte failures | 0 | none | — |
+  | other | 0 | none | — |
+- **Never-seen node kinds** (4): `MissingBlock`, `MissingIdentifier`, `MissingStatement`, `UnknownRest`.
 <!-- END: PARSER_METRICS_BULLETS -->

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -82,6 +82,7 @@ pub struct StatusSummary {
     pub perl_corpus_files: usize,
     pub nodekind_covered: usize,
     pub nodekind_total: usize,
+    pub never_seen_nodekinds: Vec<String>,
     pub ga_covered: usize,
     pub ga_total: usize,
 }
@@ -131,6 +132,7 @@ pub fn compute_status_summary(corpus_path: &Path, timeout: Duration) -> Result<S
         perl_corpus_files,
         nodekind_covered: nodekind_stats.covered_count,
         nodekind_total: nodekind_stats.total_count,
+        never_seen_nodekinds: nodekind_stats.never_seen,
         ga_covered: ga_coverage.covered_count,
         ga_total: ga_coverage.total_count,
     })

--- a/xtask/src/tasks/corpus_audit/nodekind_analysis.rs
+++ b/xtask/src/tasks/corpus_audit/nodekind_analysis.rs
@@ -76,11 +76,12 @@ pub fn analyze_nodekind_coverage(
         if total_count > 0 { (covered_count as f64 / total_count as f64) * 100.0 } else { 0.0 };
 
     // Find never-seen NodeKinds
-    let never_seen: Vec<String> =
+    let mut never_seen: Vec<String> =
         all_nodekinds.iter().filter(|nk| !nodekind_counts.contains_key(*nk)).cloned().collect();
+    never_seen.sort();
 
     // Find at-risk NodeKinds (low coverage)
-    let at_risk: Vec<AtRiskNodeKind> = nodekind_counts
+    let mut at_risk: Vec<AtRiskNodeKind> = nodekind_counts
         .iter()
         .filter(|(_, count)| **count < 5)
         .map(|(name, count)| {
@@ -96,6 +97,7 @@ pub fn analyze_nodekind_coverage(
             AtRiskNodeKind { name: name.clone(), count, risk_level }
         })
         .collect();
+    at_risk.sort_by(|a, b| a.name.cmp(&b.name));
 
     NodeKindStats {
         total_count,

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use color_eyre::eyre::Result;
 use regex::Regex;
+use std::collections::{BTreeMap, BTreeSet};
 
 use super::replace_block;
 
@@ -24,6 +25,36 @@ pub(super) struct ParserMetrics {
     pub common_corpus_receipt: Option<super::super::parser_corpus_sweep::SweepReport>,
     /// Number of pinned modules in `.ci/common-corpus-manifest.txt`.
     pub common_corpus_pinned: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum FailureCategory {
+    TransliterationQuote,
+    DeclarationPackage,
+    HeredocDelimiter,
+    RecoveryOnly,
+    EncodingMultibyte,
+    Other,
+}
+
+impl FailureCategory {
+    fn label(self) -> &'static str {
+        match self {
+            FailureCategory::TransliterationQuote => "transliteration / quote parsing",
+            FailureCategory::DeclarationPackage => "declaration / package parsing",
+            FailureCategory::HeredocDelimiter => "heredoc / delimiter handling",
+            FailureCategory::RecoveryOnly => "recovery-only failures",
+            FailureCategory::EncodingMultibyte => "encoding / multibyte failures",
+            FailureCategory::Other => "other",
+        }
+    }
+}
+
+#[derive(Default)]
+struct FailureCategorySummary {
+    files: usize,
+    buckets: BTreeMap<String, usize>,
+    examples: BTreeSet<String>,
 }
 
 pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
@@ -87,6 +118,154 @@ fn format_clean_rate(clean_files: usize, total_files: usize) -> String {
 
 fn short_day(timestamp: &str) -> &str {
     timestamp.get(..10).unwrap_or(timestamp)
+}
+
+fn categorize_bucket(bucket: &str) -> FailureCategory {
+    let lower = bucket.to_ascii_lowercase();
+    if lower.contains("substitution")
+        || lower.contains("modifier")
+        || lower.contains("quote")
+        || lower.contains("transliteration")
+    {
+        return FailureCategory::TransliterationQuote;
+    }
+    if lower.contains("signature")
+        || lower.contains("module_name")
+        || lower.contains("package")
+        || lower.contains("check must be followed by a block")
+    {
+        return FailureCategory::DeclarationPackage;
+    }
+    if lower.starts_with("unclosed_") || lower.contains("delimiter") || lower.contains("heredoc") {
+        return FailureCategory::HeredocDelimiter;
+    }
+    if lower.contains("encoding")
+        || lower.contains("unicode")
+        || lower.contains("multibyte")
+        || lower.contains("utf")
+        || lower.contains("wide character")
+    {
+        return FailureCategory::EncodingMultibyte;
+    }
+    if lower.starts_with("expected_")
+        || lower.starts_with("unexpected_")
+        || lower.contains("incomplete arrow expression")
+    {
+        return FailureCategory::RecoveryOnly;
+    }
+    FailureCategory::Other
+}
+
+fn summarize_failure_categories(
+    reports: &[&super::super::parser_corpus_sweep::SweepReport],
+) -> Vec<(FailureCategory, FailureCategorySummary)> {
+    let mut by_category: BTreeMap<FailureCategory, FailureCategorySummary> = BTreeMap::new();
+
+    for report in reports {
+        for (bucket, count) in &report.first_error_buckets {
+            let category = categorize_bucket(bucket);
+            let category_entry = by_category.entry(category).or_default();
+            category_entry.files += *count;
+            *category_entry.buckets.entry(bucket.clone()).or_default() += *count;
+            if let Some(paths) = report.files_by_bucket.get(bucket) {
+                for path in paths {
+                    category_entry.examples.insert(path.clone());
+                }
+            }
+        }
+    }
+
+    let ordered = [
+        FailureCategory::TransliterationQuote,
+        FailureCategory::DeclarationPackage,
+        FailureCategory::HeredocDelimiter,
+        FailureCategory::RecoveryOnly,
+        FailureCategory::EncodingMultibyte,
+        FailureCategory::Other,
+    ];
+
+    ordered
+        .iter()
+        .map(|category| (*category, by_category.remove(category).unwrap_or_default()))
+        .collect()
+}
+
+fn format_failure_worklist(
+    metrics: &ParserMetrics,
+    nodekind_never_seen: Option<&[String]>,
+) -> String {
+    let mut report_refs = Vec::new();
+    if let Some(report) = metrics.system_receipt.as_ref() {
+        report_refs.push(report);
+    }
+    if let Some(report) = metrics.cpan_receipt.as_ref() {
+        report_refs.push(report);
+    }
+
+    if report_refs.is_empty() {
+        return "- **Parser failure clusters**: unavailable (sweep receipts missing).\n\
+                - **Never-seen node kinds**: unavailable (project corpus summary missing)."
+            .to_string();
+    }
+
+    let category_rows = summarize_failure_categories(&report_refs);
+    let mut lines = vec![
+        "- **Parser failure clusters** (first-error buckets across Ubuntu + CPAN baselines):"
+            .to_string(),
+        "  | Category | File count | Top buckets | Representative files |".to_string(),
+        "  | --- | ---: | --- | --- |".to_string(),
+    ];
+
+    for (category, summary) in category_rows {
+        let top_buckets = if summary.buckets.is_empty() {
+            "none".to_string()
+        } else {
+            let mut buckets: Vec<_> = summary.buckets.iter().collect();
+            buckets.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+            buckets
+                .into_iter()
+                .take(2)
+                .map(|(bucket, count)| format!("{bucket} ({count})"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let examples = if summary.examples.is_empty() {
+            "—".to_string()
+        } else {
+            summary
+                .examples
+                .iter()
+                .take(2)
+                .map(|path| format!("`{path}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        lines.push(format!(
+            "  | {} | {} | {} | {} |",
+            category.label(),
+            summary.files,
+            top_buckets,
+            examples
+        ));
+    }
+
+    let never_seen_line = if let Some(nodekinds) = nodekind_never_seen {
+        if nodekinds.is_empty() {
+            "- **Never-seen node kinds**: none.".to_string()
+        } else {
+            let preview = nodekinds
+                .iter()
+                .take(8)
+                .map(|kind| format!("`{kind}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("- **Never-seen node kinds** ({}): {preview}.", nodekinds.len(),)
+        }
+    } else {
+        "- **Never-seen node kinds**: unavailable (project corpus summary missing).".to_string()
+    };
+    lines.push(never_seen_line);
+    lines.join("\n")
 }
 
 // ---------------------------------------------------------------------------
@@ -203,12 +382,20 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
 
     let tracking_table = [system_row, cpan_row, project_row].join("\n");
 
+    let nodekind_never_seen = metrics
+        .project_corpus
+        .as_ref()
+        .map(|summary| summary.never_seen_nodekinds.as_slice());
+    let failure_worklist = format_failure_worklist(metrics, nodekind_never_seen);
+
     let parser_coverage_bullets = format!(
         "- **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.\n\
          - **Strict promise lists**: `just common-corpus-check` and the CPAN known-clean manifest inside `just cpan-corpus-check` pin subsets that must remain clean on top of the broader baseline receipts.\n\
          - **Fixture bank**: `tree-sitter-perl/test/corpus` contributes ~{} focused syntax sections for targeted parser cases.\n\
-         - **CPAN install hygiene**: `cargo xtask cpan-corpus install` reuses `target/cpan-corpus/.cpanm`; pass `--reset` only for a cold rebuild.",
+         - **CPAN install hygiene**: `cargo xtask cpan-corpus install` reuses `target/cpan-corpus/.cpanm`; pass `--reset` only for a cold rebuild.\n\
+         {}",
         metrics.syntax_sections,
+        failure_worklist,
     );
 
     let mut text = original.to_string();
@@ -292,6 +479,12 @@ mod tests {
             perl_corpus_files: 22,
             nodekind_covered: 65,
             nodekind_total: 69,
+            never_seen_nodekinds: vec![
+                "HereDoc".to_string(),
+                "MatchRegex".to_string(),
+                "Transliteration".to_string(),
+                "VersionLiteral".to_string(),
+            ],
             ga_covered: 12,
             ga_total: 12,
         };
@@ -317,6 +510,10 @@ mod tests {
             "strict-clean no-receipt row should say 'unverified'"
         );
         assert!(!result.contains("10/10"), "strict-clean no-receipt row must not show 10/10");
+        assert!(
+            result.contains("Never-seen node kinds (4): `HereDoc`, `MatchRegex`, `Transliteration`, `VersionLiteral`."),
+            "metrics bullets should include explicit missing node-kind set",
+        );
         Ok(())
     }
 
@@ -392,5 +589,55 @@ mod tests {
             "strict-clean row missing pinned modules note"
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_failure_cluster_worklist_renders_categories_and_examples() {
+        use std::collections::BTreeMap;
+        let report = super::super::super::parser_corpus_sweep::SweepReport {
+            schema_version: "1".to_string(),
+            commit: "abc".to_string(),
+            timestamp: "2026-04-11T00:00:00Z".to_string(),
+            corpus_profile: "system".to_string(),
+            corpus_roots: vec![],
+            resolved_roots_count: 0,
+            perl_version: "5.038".to_string(),
+            total_files: 4,
+            files_unreadable: 0,
+            clean_files: 0,
+            files_with_errors: 4,
+            total_error_nodes: 8,
+            first_error_buckets: BTreeMap::from([
+                ("invalid_substitution_modifier".to_string(), 2),
+                ("unclosed_brace".to_string(), 1),
+                ("unexpected_token_in_expr".to_string(), 1),
+            ]),
+            files_by_bucket: BTreeMap::from([
+                (
+                    "invalid_substitution_modifier".to_string(),
+                    vec!["lib/Foo.pm".to_string()],
+                ),
+                ("unclosed_brace".to_string(), vec!["lib/Bar.pm".to_string()]),
+            ]),
+            file_results: vec![],
+            elapsed_secs: 1.0,
+            phase_timings: None,
+            median_error_density_per_1k_loc: None,
+            slowest_files: vec![],
+        };
+        let metrics = ParserMetrics {
+            syntax_sections: 611,
+            system_receipt: Some(report),
+            cpan_receipt: None,
+            project_corpus: None,
+            common_corpus_receipt: None,
+            common_corpus_pinned: 10,
+        };
+        let rendered = format_failure_worklist(&metrics, None);
+        assert!(rendered.contains("transliteration / quote parsing"));
+        assert!(rendered.contains("heredoc / delimiter handling"));
+        assert!(rendered.contains("recovery-only failures"));
+        assert!(rendered.contains("`lib/Foo.pm`"));
+        assert!(rendered.contains("`lib/Bar.pm`"));
     }
 }


### PR DESCRIPTION
### Motivation

- Make the remaining parser failure tail actionable by grouping first-error buckets into a small set of high-signal categories and surfacing representative examples. 
- Explicitly expose the set of never-seen `NodeKind`s so the 65/69 coverage gap is visible and reproducible.

### Description

- Add a lightweight failure classifier and worklist formatter in `xtask/src/tasks/update_status/parser.rs` that maps `first_error_buckets` into categories (`transliteration / quote parsing`, `declaration / package parsing`, `heredoc / delimiter handling`, `recovery-only failures`, `encoding / multibyte failures`, `other`) and emits counts, top buckets, and representative file examples. 
- Wire `NodeKind` never-seen output through `corpus_audit::StatusSummary` by adding `never_seen_nodekinds` and including a preview in the parser status bullets. 
- Make node-kind analysis deterministic by sorting `never_seen` and `at_risk` lists in `xtask/src/tasks/corpus_audit/nodekind_analysis.rs`. 
- Regenerate `docs/project/status/parser.md` to include the new clustered failure worklist and explicit never-seen node-kind list. 
- Add unit tests for the new rendering paths and the failure-cluster worklist in `xtask` tests.

### Testing

- Ran `cargo xtask update-status --only parser --write` which updated `docs/project/status/parser.md` successfully. (passed)
- Ran the focused unit test `cargo test -p xtask test_failure_cluster_worklist_renders_categories_and_examples` which passed. (passed)
- Ran `cargo check --workspace --all-targets` to validate the workspace builds and types. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb00921e5c833397d58ce9da044859)