### PR TITLE
feat(parser-status): cluster corpus failures and expose missing node-kind coverage (#6678)

### DIFF
--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard
@@ -24,8 +24,25 @@
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |
 <!-- END: PARSER_RELIABILITY_ROW -->
 <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->
-| **Strict-clean subset** | 10/10 (100%) | 10 pinned modules, zero-error gate | `.ci/common-corpus-manifest.txt` |
+| **Strict-clean subset** | 10 modules (unverified) | run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |
 <!-- END: PARSER_STRICT_CLEAN_ROW -->
+
+## Corpus Failure Worklist
+
+<!-- BEGIN: PARSER_FAILURE_WORKLIST -->
+| Cluster | Files | Representative examples |
+| --- | ---: | --- |
+| recovery-only failures | 566 | `expected_colon` → `/usr/share/perl5/IO/Socket/SSL/Intercept.pm`<br>`expected_colon` → `/usr/share/perl5/Mail/Address.pm`<br>`expected_colon` → `target/cpan-corpus/lib/perl5/IO/Socket/SSL/Intercept.pm` |
+| declaration / package parsing | 12 | `expected_identifier` → `target/cpan-corpus/lib/perl5/auto/share/dist/Dancer2/skel/default/lib/AppFile.pm`<br>`expected_identifier` → `target/cpan-corpus/lib/perl5/auto/share/dist/Dancer2/skel/tutorial/lib/AppFile/Schema/Result/Entry.pm`<br>`signature_param` → `target/cpan-corpus/lib/perl5/Test/LectroTest/Property.pm` |
+| transliteration / quote parsing | 8 | `Missing replacement in substitution` → `target/cpan-corpus/lib/perl5/Module/Build/Platform/Unix.pm`<br>`invalid_substitution_modifier` → `/usr/share/perl/5.38.2/ExtUtils/MM_VMS.pm`<br>`invalid_substitution_modifier` → `/usr/share/perl/5.38/ExtUtils/MM_VMS.pm` |
+| other | 6 | `CHECK must be followed by a block` → `target/cpan-corpus/lib/perl5/Mojo/Exception.pm`<br>`Incomplete arrow expression` → `target/cpan-corpus/lib/perl5/IO/Async/Function.pm`<br>`Incomplete arrow expression` → `target/cpan-corpus/lib/perl5/IO/Async/Resolver.pm` |
+<!-- END: PARSER_FAILURE_WORKLIST -->
+
+## Never-Seen Node Kinds
+
+<!-- BEGIN: PARSER_NEVER_SEEN_NODEKINDS -->
+- Missing NodeKinds (4): `MissingBlock`, `MissingIdentifier`, `MissingStatement`, `UnknownRest`
+<!-- END: PARSER_NEVER_SEEN_NODEKINDS -->
 
 <!-- BEGIN: PARSER_METRICS_BULLETS -->
 - **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -82,6 +82,7 @@ pub struct StatusSummary {
     pub perl_corpus_files: usize,
     pub nodekind_covered: usize,
     pub nodekind_total: usize,
+    pub nodekind_never_seen: Vec<String>,
     pub ga_covered: usize,
     pub ga_total: usize,
 }
@@ -131,6 +132,11 @@ pub fn compute_status_summary(corpus_path: &Path, timeout: Duration) -> Result<S
         perl_corpus_files,
         nodekind_covered: nodekind_stats.covered_count,
         nodekind_total: nodekind_stats.total_count,
+        nodekind_never_seen: {
+            let mut never_seen = nodekind_stats.never_seen;
+            never_seen.sort();
+            never_seen
+        },
         ga_covered: ga_coverage.covered_count,
         ga_total: ga_coverage.total_count,
     })

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -5,6 +5,7 @@
 use std::fs;
 use std::path::Path;
 use std::time::Duration;
+use std::{cmp::Reverse, collections::BTreeMap};
 
 use color_eyre::eyre::Result;
 use regex::Regex;
@@ -24,6 +25,35 @@ pub(super) struct ParserMetrics {
     pub common_corpus_receipt: Option<super::super::parser_corpus_sweep::SweepReport>,
     /// Number of pinned modules in `.ci/common-corpus-manifest.txt`.
     pub common_corpus_pinned: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum FailureCluster {
+    TransliterationQuote,
+    DeclarationPackage,
+    HeredocDelimiter,
+    RecoveryOnly,
+    EncodingMultibyte,
+    Other,
+}
+
+impl FailureCluster {
+    fn label(self) -> &'static str {
+        match self {
+            Self::TransliterationQuote => "transliteration / quote parsing",
+            Self::DeclarationPackage => "declaration / package parsing",
+            Self::HeredocDelimiter => "heredoc / delimiter handling",
+            Self::RecoveryOnly => "recovery-only failures",
+            Self::EncodingMultibyte => "encoding / multibyte failures",
+            Self::Other => "other",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ClusterStats {
+    count: usize,
+    examples: Vec<(String, String)>,
 }
 
 pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
@@ -87,6 +117,125 @@ fn format_clean_rate(clean_files: usize, total_files: usize) -> String {
 
 fn short_day(timestamp: &str) -> &str {
     timestamp.get(..10).unwrap_or(timestamp)
+}
+
+fn classify_bucket(bucket: &str) -> FailureCluster {
+    let name = bucket.to_ascii_lowercase();
+    if name.contains("encoding")
+        || name.contains("unicode")
+        || name.contains("utf")
+        || name.contains("multibyte")
+        || name.contains("wide_char")
+    {
+        return FailureCluster::EncodingMultibyte;
+    }
+    if name.contains("heredoc")
+        || name.contains("delimiter")
+        || name.contains("unclosed_substitution")
+    {
+        return FailureCluster::HeredocDelimiter;
+    }
+    if name.contains("translit")
+        || name.contains("transliteration")
+        || name.contains("quote")
+        || name.contains("substitution")
+    {
+        return FailureCluster::TransliterationQuote;
+    }
+    if name.contains("package")
+        || name.contains("signature")
+        || name.contains("module")
+        || name.contains("subroutine")
+        || name.contains("expected_identifier")
+    {
+        return FailureCluster::DeclarationPackage;
+    }
+    if name.starts_with("expected_")
+        || name.starts_with("unexpected_")
+        || name.starts_with("unclosed_")
+        || name == "catastrophic_parse_failure"
+    {
+        return FailureCluster::RecoveryOnly;
+    }
+    FailureCluster::Other
+}
+
+fn collect_failure_clusters(metrics: &ParserMetrics) -> BTreeMap<FailureCluster, ClusterStats> {
+    let mut by_cluster: BTreeMap<FailureCluster, ClusterStats> = BTreeMap::new();
+
+    for report in [&metrics.system_receipt, &metrics.cpan_receipt].into_iter().flatten() {
+        for (bucket, count) in &report.first_error_buckets {
+            let cluster = classify_bucket(bucket);
+            let stats = by_cluster
+                .entry(cluster)
+                .or_insert_with(|| ClusterStats { count: 0, examples: Vec::new() });
+            stats.count += count;
+
+            if let Some(paths) = report.files_by_bucket.get(bucket) {
+                for path in paths.iter().take(3) {
+                    stats.examples.push((bucket.clone(), path.clone()));
+                }
+            }
+        }
+    }
+
+    for stats in by_cluster.values_mut() {
+        stats.examples.sort();
+        stats.examples.dedup();
+        if stats.examples.len() > 3 {
+            stats.examples.truncate(3);
+        }
+    }
+
+    by_cluster
+}
+
+fn render_failure_worklist(metrics: &ParserMetrics) -> String {
+    let clusters = collect_failure_clusters(metrics);
+    if clusters.is_empty() {
+        return "- No parser corpus failures were available from baseline receipts.".to_string();
+    }
+
+    let mut lines = vec![
+        "| Cluster | Files | Representative examples |".to_string(),
+        "| --- | ---: | --- |".to_string(),
+    ];
+
+    let mut rows: Vec<(FailureCluster, ClusterStats)> = clusters.into_iter().collect();
+    rows.sort_by_key(|(cluster, stats)| (Reverse(stats.count), *cluster));
+
+    for (cluster, stats) in rows {
+        let examples = if stats.examples.is_empty() {
+            "n/a".to_string()
+        } else {
+            stats
+                .examples
+                .iter()
+                .map(|(bucket, path)| format!("`{bucket}` → `{path}`"))
+                .collect::<Vec<_>>()
+                .join("<br>")
+        };
+        lines.push(format!("| {} | {} | {} |", cluster.label(), stats.count, examples));
+    }
+
+    lines.join("\n")
+}
+
+fn render_never_seen_nodekinds(metrics: &ParserMetrics) -> String {
+    let Some(summary) = metrics.project_corpus.as_ref() else {
+        return "- UNVERIFIED: live repo scan unavailable.".to_string();
+    };
+    if summary.nodekind_never_seen.is_empty() {
+        return "- None: all declared NodeKinds are represented in the project corpus.".to_string();
+    }
+
+    let list = summary
+        .nodekind_never_seen
+        .iter()
+        .map(|name| format!("`{name}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("- Missing NodeKinds ({}): {list}", summary.nodekind_never_seen.len())
 }
 
 // ---------------------------------------------------------------------------
@@ -242,6 +391,18 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         "<!-- END: PARSER_STRICT_CLEAN_ROW -->",
         &strict_clean_row,
     )?;
+    text = replace_block(
+        &text,
+        "<!-- BEGIN: PARSER_FAILURE_WORKLIST -->",
+        "<!-- END: PARSER_FAILURE_WORKLIST -->",
+        &render_failure_worklist(metrics),
+    )?;
+    text = replace_block(
+        &text,
+        "<!-- BEGIN: PARSER_NEVER_SEEN_NODEKINDS -->",
+        "<!-- END: PARSER_NEVER_SEEN_NODEKINDS -->",
+        &render_never_seen_nodekinds(metrics),
+    )?;
     Ok(text)
 }
 
@@ -292,6 +453,12 @@ mod tests {
             perl_corpus_files: 22,
             nodekind_covered: 65,
             nodekind_total: 69,
+            nodekind_never_seen: vec![
+                "DereferenceExpression".to_string(),
+                "FormatStatement".to_string(),
+                "GivenStatement".to_string(),
+                "WhenStatement".to_string(),
+            ],
             ga_covered: 12,
             ga_total: 12,
         };
@@ -307,6 +474,8 @@ mod tests {
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_FAILURE_WORKLIST -->\nold\n<!-- END: PARSER_FAILURE_WORKLIST -->\n\
+                        <!-- BEGIN: PARSER_NEVER_SEEN_NODEKINDS -->\nold\n<!-- END: PARSER_NEVER_SEEN_NODEKINDS -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(result.contains("65/69"), "nodekind row missing 65/69");
@@ -334,6 +503,8 @@ mod tests {
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_FAILURE_WORKLIST -->\nold\n<!-- END: PARSER_FAILURE_WORKLIST -->\n\
+                        <!-- BEGIN: PARSER_NEVER_SEEN_NODEKINDS -->\nold\n<!-- END: PARSER_NEVER_SEEN_NODEKINDS -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(
@@ -383,6 +554,8 @@ mod tests {
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_FAILURE_WORKLIST -->\nold\n<!-- END: PARSER_FAILURE_WORKLIST -->\n\
+                        <!-- BEGIN: PARSER_NEVER_SEEN_NODEKINDS -->\nold\n<!-- END: PARSER_NEVER_SEEN_NODEKINDS -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(result.contains("10/10"), "strict-clean row missing 10/10");
@@ -391,6 +564,80 @@ mod tests {
             result.contains("10 pinned modules"),
             "strict-clean row missing pinned modules note"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_failure_worklist_and_never_seen_section() -> Result<()> {
+        use std::collections::BTreeMap;
+
+        let summary = super::super::super::corpus_audit::StatusSummary {
+            total_files: 91,
+            ok_files: 90,
+            error_files: 1,
+            timeout_files: 0,
+            panic_files: 0,
+            test_corpus_files: 69,
+            perl_corpus_files: 22,
+            nodekind_covered: 65,
+            nodekind_total: 69,
+            nodekind_never_seen: vec!["GivenStatement".to_string(), "WhenStatement".to_string()],
+            ga_covered: 12,
+            ga_total: 12,
+        };
+        let receipt = super::super::super::parser_corpus_sweep::SweepReport {
+            schema_version: "1".to_string(),
+            commit: "abc".to_string(),
+            timestamp: "2026-04-11T00:00:00Z".to_string(),
+            corpus_profile: "cpan".to_string(),
+            corpus_roots: vec![],
+            resolved_roots_count: 0,
+            perl_version: "5.038".to_string(),
+            total_files: 10,
+            files_unreadable: 0,
+            clean_files: 8,
+            files_with_errors: 2,
+            total_error_nodes: 2,
+            first_error_buckets: BTreeMap::from([
+                ("unexpected_token_package".to_string(), 1),
+                ("unclosed_substitution_delimiter".to_string(), 1),
+            ]),
+            files_by_bucket: BTreeMap::from([
+                (
+                    "unexpected_token_package".to_string(),
+                    vec!["target/cpan-corpus/lib/perl5/Foo/Bar.pm".to_string()],
+                ),
+                (
+                    "unclosed_substitution_delimiter".to_string(),
+                    vec!["target/cpan-corpus/lib/perl5/Baz.pm".to_string()],
+                ),
+            ]),
+            file_results: vec![],
+            elapsed_secs: 1.0,
+            phase_timings: None,
+            median_error_density_per_1k_loc: None,
+            slowest_files: vec![],
+        };
+        let metrics = ParserMetrics {
+            syntax_sections: 611,
+            system_receipt: None,
+            cpan_receipt: Some(receipt),
+            project_corpus: Some(summary),
+            common_corpus_receipt: None,
+            common_corpus_pinned: 10,
+        };
+        let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
+                        <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
+                        <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
+                        <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_FAILURE_WORKLIST -->\nold\n<!-- END: PARSER_FAILURE_WORKLIST -->\n\
+                        <!-- BEGIN: PARSER_NEVER_SEEN_NODEKINDS -->\nold\n<!-- END: PARSER_NEVER_SEEN_NODEKINDS -->\n\
+                        <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
+        let result = generate_parser_status(&metrics, template)?;
+        assert!(result.contains("declaration / package parsing"));
+        assert!(result.contains("heredoc / delimiter handling"));
+        assert!(result.contains("GivenStatement"));
+        assert!(result.contains("WhenStatement"));
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Make parser-status output actionable by clustering remaining parse failures into targeted worklist buckets (quote/transliteration, declaration/package, heredoc/delimiter, recovery-only, encoding/multibyte, other). 
- Surface the exact set of never-seen NodeKinds (the 65/69 gap) so coverage gaps are explicit and reproducible.

### Description

- Extend `StatusSummary` so it carries a deterministic, sorted `nodekind_never_seen: Vec<String>` produced by `compute_status_summary` in `xtask/src/tasks/corpus_audit.rs`.
- Add a lightweight failure classifier and clustering pipeline in `xtask/src/tasks/update_status/parser.rs` (`FailureCluster`, `classify_bucket`, `collect_failure_clusters`) that aggregates `first_error_buckets` from baseline receipts and captures representative examples.
- Add rendering helpers `render_failure_worklist` and `render_never_seen_nodekinds`, and patch `generate_parser_status` to replace two new doc blocks: `PARSER_FAILURE_WORKLIST` and `PARSER_NEVER_SEEN_NODEKINDS`.
- Update `docs/project/status/parser.md` to include the new "Corpus Failure Worklist" table and "Never-Seen Node Kinds" section, and add unit tests in `xtask` to validate rendering and deterministic output.

### Testing

- Ran `cargo xtask update-status --write --only parser` to regenerate `docs/project/status/parser.md`, and the file was updated successfully.
- Ran `cargo check --workspace --all-targets` and the workspace checked successfully with no errors.
- Ran `cargo test -p xtask test_failure_worklist_and_never_seen_section` and the new test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb00921e5c833397d58ce9da044859)