### PR TITLE
fix(incremental): harden batch edit normalization and UTF-8 boundary fallback (#0000)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_boundary_regressions.rs
+++ b/crates/perl-parser/src/incremental/incremental_boundary_regressions.rs
@@ -1,0 +1,104 @@
+#![cfg(test)]
+
+use super::incremental_document::IncrementalDocument;
+use super::incremental_edit::{IncrementalEdit, IncrementalEditSet};
+use anyhow::{anyhow, Result};
+use perl_parser_core::parser::Parser;
+
+fn parse_to_sexp(source: &str) -> Result<String> {
+    let mut parser = Parser::new(source);
+    let node = parser.parse()?;
+    Ok(node.to_sexp())
+}
+
+#[test]
+fn overlapping_batch_edits_fallback_to_safe_application() -> Result<()> {
+    let source = "my $x = 1;\n".to_string();
+    let mut document = IncrementalDocument::new(source.clone())?;
+
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(4, 8, "$value".to_string()));
+    edits.add(IncrementalEdit::new(6, 9, "$oops".to_string()));
+
+    let apply_result = document.apply_edits(&edits);
+    assert!(apply_result.is_ok());
+
+    // Overlapping ranges are rejected by normalization, so source is derived by
+    // conservative per-edit application that skips invalid overlaps.
+    let expected_source = edits.apply_to_string(&source);
+    assert_eq!(document.source, expected_source);
+    assert_eq!(document.root.to_sexp(), parse_to_sexp(&expected_source)?);
+    Ok(())
+}
+
+#[test]
+fn backwards_range_is_rejected_and_source_is_unchanged() -> Result<()> {
+    let source = "my $x = 1;\n".to_string();
+    let mut document = IncrementalDocument::new(source.clone())?;
+
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(8, 3, "2".to_string()));
+
+    let apply_result = document.apply_edits(&edits);
+    assert!(apply_result.is_ok());
+    assert_eq!(document.source, source);
+    assert_eq!(document.root.to_sexp(), parse_to_sexp(&document.source)?);
+    Ok(())
+}
+
+#[test]
+fn mid_codepoint_edit_is_skipped_without_panicking() -> Result<()> {
+    let source = "my $x = \"é\";\n".to_string();
+    let mut document = IncrementalDocument::new(source.clone())?;
+    let e_start = source.find('é').ok_or_else(|| anyhow!("test setup missing UTF-8 codepoint"))?;
+
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(e_start + 1, e_start + 1, "x".to_string()));
+
+    let apply_result = document.apply_edits(&edits);
+    assert!(apply_result.is_ok());
+    assert_eq!(document.source, source);
+    assert_eq!(document.root.to_sexp(), parse_to_sexp(&source)?);
+    Ok(())
+}
+
+#[test]
+fn one_bad_edit_in_batch_falls_back_and_preserves_good_edit() -> Result<()> {
+    let source = "my $x = \"é\";\n".to_string();
+    let mut document = IncrementalDocument::new(source.clone())?;
+    let e_start = source.find('é').ok_or_else(|| anyhow!("test setup missing UTF-8 codepoint"))?;
+    let x_pos = source
+        .find("$x")
+        .map(|idx| idx + 1) // Replace identifier name only.
+        .ok_or_else(|| anyhow!("test setup missing variable"))?;
+
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(e_start + 1, e_start + 1, "x".to_string())); // invalid boundary
+    edits.add(IncrementalEdit::new(x_pos, x_pos + 1, "name".to_string())); // valid
+
+    let apply_result = document.apply_edits(&edits);
+    assert!(apply_result.is_ok());
+
+    let expected_source = edits.apply_to_string(&source);
+    assert_eq!(document.source, expected_source);
+    assert!(document.source.contains("$name"));
+    assert_eq!(document.root.to_sexp(), parse_to_sexp(&expected_source)?);
+    Ok(())
+}
+
+#[test]
+fn supported_batch_edits_match_fresh_parse() -> Result<()> {
+    let source = "my $value = 1;\n$value = $value + 1;\n".to_string();
+    let mut document = IncrementalDocument::new(source.clone())?;
+
+    let mut edits = IncrementalEditSet::new();
+    edits.add(IncrementalEdit::new(4, 9, "$total".to_string()));
+    edits.add(IncrementalEdit::new(22, 27, "$total".to_string()));
+
+    let apply_result = document.apply_edits(&edits);
+    assert!(apply_result.is_ok());
+
+    let fresh = parse_to_sexp(&document.source)?;
+    assert_eq!(document.root.to_sexp(), fresh);
+    Ok(())
+}

--- a/crates/perl-parser/src/incremental/incremental_document.rs
+++ b/crates/perl-parser/src/incremental/incremental_document.rs
@@ -128,16 +128,26 @@ impl IncrementalDocument {
         // Reset metrics for this batch of edits
         self.metrics = ParseMetrics::default();
 
-        // Sort edits by position (reverse order for correct application)
-        let mut sorted_edits = edits.edits.clone();
-        sorted_edits.sort_by(|a, b| b.start_byte.cmp(&a.start_byte));
+        let Some(sorted_edits) = edits.normalized_for_batch() else {
+            debug!("Batch edits rejected by normalization; falling back to full parse");
+            return self.reparse_fallback_batch(start, edits);
+        };
 
         // Apply all edits to source in-place.
         // Reverse ordering keeps byte offsets stable while avoiding repeated
         // full-string allocations for each edit.
         let mut new_source = self.source.clone();
+        let mut unmappable_edit = false;
         for edit in &sorted_edits {
-            self.apply_edit_in_place(&mut new_source, edit);
+            if !self.apply_edit_in_place(&mut new_source, edit) {
+                unmappable_edit = true;
+                break;
+            }
+        }
+
+        if unmappable_edit {
+            debug!("Batch contains unmappable edit; falling back to full parse");
+            return self.reparse_fallback_batch(start, edits);
         }
 
         // Find all affected ranges
@@ -165,45 +175,92 @@ impl IncrementalDocument {
         Ok(())
     }
 
+    fn reparse_fallback_batch(
+        &mut self,
+        start: Instant,
+        edits: &IncrementalEditSet,
+    ) -> ParseResult<()> {
+        let fallback_source = edits.apply_to_string(&self.source);
+        let mut parser = Parser::new(&fallback_source);
+        let new_root = parser.parse()?;
+        self.source = fallback_source;
+        self.root = Arc::new(new_root);
+        self.cache_subtrees();
+        self.metrics.last_parse_time_ms = start.elapsed().as_secs_f64() * 1000.0;
+        Ok(())
+    }
+
     /// Apply edit to source string
     fn apply_edit_to_source(&self, edit: &IncrementalEdit) -> String {
         self.apply_edit_to_string(&self.source, edit)
     }
 
     fn apply_edit_to_string(&self, source: &str, edit: &IncrementalEdit) -> String {
+        if edit.start_byte > edit.old_end_byte {
+            debug!(
+                "Invalid backwards edit range: start={}, end={}",
+                edit.start_byte, edit.old_end_byte
+            );
+            return source.to_string();
+        }
+
+        if edit.start_byte > source.len() || edit.old_end_byte > source.len() {
+            debug!(
+                "Edit out of bounds for source len {}: start={}, end={}",
+                source.len(),
+                edit.start_byte,
+                edit.old_end_byte
+            );
+            return source.to_string();
+        }
+
         let mut result = String::with_capacity(source.len() + edit.new_text.len());
 
-        // Safely handle byte positions with bounds checking
-        let start = edit.start_byte.min(source.len());
-        let end = edit.old_end_byte.min(source.len());
-
         // Ensure we're on UTF-8 boundaries
-        if source.is_char_boundary(start) && source.is_char_boundary(end) {
-            result.push_str(&source[..start]);
+        if source.is_char_boundary(edit.start_byte) && source.is_char_boundary(edit.old_end_byte) {
+            result.push_str(&source[..edit.start_byte]);
             result.push_str(&edit.new_text);
-            result.push_str(&source[end..]);
+            result.push_str(&source[edit.old_end_byte..]);
         } else {
             // Fallback: if boundaries are invalid, use the original source
-            debug!("Invalid UTF-8 boundaries in edit: start={}, end={}", start, end);
+            debug!(
+                "Invalid UTF-8 boundaries in edit: start={}, end={}",
+                edit.start_byte, edit.old_end_byte
+            );
             result.push_str(source);
         }
 
         result
     }
 
-    fn apply_edit_in_place(&self, source: &mut String, edit: &IncrementalEdit) {
-        let start = edit.start_byte.min(source.len());
-        let end = edit.old_end_byte.min(source.len());
-
-        if start > end {
-            debug!("Skipping invalid edit range: start={}, end={}", start, end);
-            return;
+    fn apply_edit_in_place(&self, source: &mut String, edit: &IncrementalEdit) -> bool {
+        if edit.start_byte > edit.old_end_byte {
+            debug!(
+                "Skipping invalid backwards edit range: start={}, end={}",
+                edit.start_byte, edit.old_end_byte
+            );
+            return false;
         }
 
-        if source.is_char_boundary(start) && source.is_char_boundary(end) {
-            source.replace_range(start..end, &edit.new_text);
+        if edit.start_byte > source.len() || edit.old_end_byte > source.len() {
+            debug!(
+                "Edit out of bounds for source len {}: start={}, end={}",
+                source.len(),
+                edit.start_byte,
+                edit.old_end_byte
+            );
+            return false;
+        }
+
+        if source.is_char_boundary(edit.start_byte) && source.is_char_boundary(edit.old_end_byte) {
+            source.replace_range(edit.start_byte..edit.old_end_byte, &edit.new_text);
+            true
         } else {
-            debug!("Invalid UTF-8 boundaries in edit: start={}, end={}", start, end);
+            debug!(
+                "Invalid UTF-8 boundaries in edit: start={}, end={}",
+                edit.start_byte, edit.old_end_byte
+            );
+            false
         }
     }
 
@@ -308,7 +365,11 @@ impl IncrementalDocument {
         let mut new_root = (*self.root).clone();
 
         // Find and update the affected token
-        if self.update_token_in_tree(&mut new_root, source, edit) { Some(new_root) } else { None }
+        if self.update_token_in_tree(&mut new_root, source, edit) {
+            Some(new_root)
+        } else {
+            None
+        }
     }
 
     /// Update a single token in the tree

--- a/crates/perl-parser/src/incremental/incremental_edit.rs
+++ b/crates/perl-parser/src/incremental/incremental_edit.rs
@@ -21,6 +21,11 @@ pub struct IncrementalEdit {
 }
 
 impl IncrementalEdit {
+    /// Returns true when the edit range is well-formed (`start <= end`).
+    pub fn has_valid_range(&self) -> bool {
+        self.start_byte <= self.old_end_byte
+    }
+
     /// Create a new incremental edit
     pub fn new(start_byte: usize, old_end_byte: usize, new_text: String) -> Self {
         IncrementalEdit {
@@ -106,6 +111,37 @@ impl IncrementalEditSet {
         self.edits.iter().map(|e| e.byte_shift()).sum()
     }
 
+    /// Validate and normalize edits for deterministic reverse-order application.
+    ///
+    /// Returns `None` when ranges are malformed or overlap in the original
+    /// source. Adjacent edits and zero-width insertions are preserved.
+    pub fn normalized_for_batch(&self) -> Option<Vec<IncrementalEdit>> {
+        if self.edits.is_empty() {
+            return Some(Vec::new());
+        }
+
+        let mut by_start = self.edits.clone();
+        by_start.sort_by_key(|e| (e.start_byte, e.old_end_byte));
+
+        let mut previous_end = 0usize;
+        let mut is_first = true;
+        for edit in &by_start {
+            if !edit.has_valid_range() {
+                return None;
+            }
+
+            if !is_first && edit.start_byte < previous_end {
+                return None;
+            }
+
+            previous_end = edit.old_end_byte;
+            is_first = false;
+        }
+
+        by_start.sort_by_key(|e| std::cmp::Reverse(e.start_byte));
+        Some(by_start)
+    }
+
     /// Apply edits to a string
     pub fn apply_to_string(&self, source: &str) -> String {
         if self.edits.is_empty() {
@@ -177,5 +213,37 @@ mod tests {
         let source = "hello world";
         let result = edits.apply_to_string(source);
         assert_eq!(result, "Hello Perl");
+    }
+
+    #[test]
+    fn test_normalized_for_batch_rejects_overlapping_ranges() {
+        let mut edits = IncrementalEditSet::new();
+        edits.add(IncrementalEdit::new(1, 4, "abc".to_string()));
+        edits.add(IncrementalEdit::new(3, 6, "xyz".to_string()));
+
+        assert!(edits.normalized_for_batch().is_none());
+    }
+
+    #[test]
+    fn test_normalized_for_batch_rejects_backwards_range() {
+        let mut edits = IncrementalEditSet::new();
+        edits.add(IncrementalEdit::new(5, 2, "x".to_string()));
+
+        assert!(edits.normalized_for_batch().is_none());
+    }
+
+    #[test]
+    fn test_normalized_for_batch_preserves_zero_width_insertions() {
+        let mut edits = IncrementalEditSet::new();
+        edits.add(IncrementalEdit::new(2, 2, "a".to_string()));
+        edits.add(IncrementalEdit::new(6, 6, "b".to_string()));
+
+        let normalized = edits.normalized_for_batch();
+        assert!(normalized.is_some());
+        if let Some(normalized_edits) = normalized {
+            assert_eq!(normalized_edits.len(), 2);
+            assert_eq!(normalized_edits[0].start_byte, 6);
+            assert_eq!(normalized_edits[1].start_byte, 2);
+        }
     }
 }

--- a/crates/perl-parser/src/incremental/mod.rs
+++ b/crates/perl-parser/src/incremental/mod.rs
@@ -12,6 +12,8 @@ use perl_parser_core::ast::{Node, NodeKind, SourceLocation};
 use perl_parser_core::parser::Parser;
 
 pub mod incremental_advanced_reuse;
+#[cfg(test)]
+mod incremental_boundary_regressions;
 pub mod incremental_checkpoint;
 pub mod incremental_document;
 pub mod incremental_edit;


### PR DESCRIPTION
### Motivation

- Batch incremental edits previously assumed well-formed, non-overlapping byte ranges and valid UTF-8 boundaries which made malformed batches unsafe. 
- The goal is to make batch edit application deterministic and to degrade conservatively (fallback to full reparse) when anything is unmappable or malformed.

### Description

- Added `IncrementalEdit::has_valid_range` and `IncrementalEditSet::normalized_for_batch` to validate and produce a deterministic reverse-order edit list while rejecting overlapping or backwards ranges and preserving zero-width insertions (`crates/perl-parser/src/incremental/incremental_edit.rs`).
- Hardened `IncrementalDocument::apply_edits` to use normalization, detect unmappable edits (out-of-bounds or mid-codepoint), and fall back to a conservative full reparse via a new `reparse_fallback_batch` helper when normalization or mapping fails, while keeping reverse-order application semantics (`crates/perl-parser/src/incremental/incremental_document.rs`).
- Strengthened single-edit application guards to explicitly reject backwards ranges, out-of-bounds indices, and invalid UTF-8 boundaries, and made in-place edit application return a boolean to drive fallbacks (`crates/perl-parser/src/incremental/incremental_document.rs`).
- Added dedicated regression tests covering overlapping batches, backwards ranges, mid-codepoint edits, one-bad-edit batch fallback, and parity with fresh parse for supported batches, and wired the test module into incremental tests (`crates/perl-parser/src/incremental/incremental_boundary_regressions.rs` and `crates/perl-parser/src/incremental/mod.rs`).

### Testing

- Ran `cargo test -p perl-parser --features incremental incremental_boundary_regressions` and the new boundary regression tests passed.
- Ran `cargo check --all-targets -p perl-parser` which completed successfully.
- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo test -p perl-parser` which exposed a pre-existing unrelated failing test (`refactor::refactoring::tests::validation_tests::test_cleanup_respects_retention_count`); the incremental-specific tests added here still pass under the incremental feature.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb008d92588333b0ab698c070e4791)