### PR TITLE
feat(parser-metrics): publish parser performance scorecard from existing benches (#6676)

### DIFF
--- a/crates/perl-parser/benches/incremental_benchmark.rs
+++ b/crates/perl-parser/benches/incremental_benchmark.rs
@@ -4,8 +4,105 @@ use perl_parser::incremental_document::IncrementalDocument;
 use perl_parser::incremental_edit::{IncrementalEdit, IncrementalEditSet};
 use perl_tdd_support::{must, must_some};
 use std::hint::black_box;
+use std::sync::OnceLock;
+
+mod scorecard;
+
+fn emit_incremental_scorecard_once() {
+    static EMITTED: OnceLock<()> = OnceLock::new();
+    EMITTED.get_or_init(|| {
+        let source = r#"
+use strict;
+use warnings;
+
+sub process_data {
+    my ($data) = @_;
+
+    # Process each item
+    for my $item (@$data) {
+        my $result = transform($item);
+        print "Result: $result\n";
+    }
+
+    return 1;
+}
+
+sub transform {
+    my ($value) = @_;
+    return $value * 2;
+}
+
+my $items = [1, 2, 3, 4, 5];
+process_data($items);
+"#
+        .to_string();
+
+        let start = must_some(source.find("transform"));
+        let old_end = start + "transform".len();
+
+        let cold = scorecard::measure_iterations(60, || {
+            let state = IncrementalState::new(source.clone());
+            black_box(&state.ast);
+        });
+
+        let warm = scorecard::measure_iterations(60, || {
+            let mut state = IncrementalState::new(source.clone());
+            must(apply_edits(&mut state, &[]));
+            black_box(&state.ast);
+        });
+
+        let small = scorecard::measure_iterations(60, || {
+            let mut state = IncrementalState::new(source.clone());
+            let edit = Edit {
+                start_byte: start,
+                old_end_byte: old_end,
+                new_end_byte: start + "process".len(),
+                new_text: "process".to_string(),
+            };
+            must(apply_edits(&mut state, &[edit]));
+            black_box(&state.ast);
+        });
+
+        let small_multi_source = r#"
+my $x = 1;
+my $y = 2;
+my $z = 3;
+print "$x $y $z\n";
+"#
+        .to_string();
+        let pos_1 = must_some(small_multi_source.find("= 1")) + 2;
+        let pos_2 = must_some(small_multi_source.find("= 2")) + 2;
+        let multi = scorecard::measure_iterations(60, || {
+            let mut state = IncrementalState::new(small_multi_source.clone());
+            let edits = vec![
+                Edit {
+                    start_byte: pos_1,
+                    old_end_byte: pos_1 + 1,
+                    new_end_byte: pos_1 + 2,
+                    new_text: "10".to_string(),
+                },
+                Edit {
+                    start_byte: pos_2,
+                    old_end_byte: pos_2 + 1,
+                    new_end_byte: pos_2 + 2,
+                    new_text: "20".to_string(),
+                },
+            ];
+            must(apply_edits(&mut state, &edits));
+            black_box(&state.ast);
+        });
+
+        scorecard::write_scorecard(vec![
+            ("cold_parse", cold),
+            ("warm_reparse", warm),
+            ("incremental_small_edit", small),
+            ("incremental_multiple_edits", multi),
+        ]);
+    });
+}
 
 fn bench_incremental_small_edit(c: &mut Criterion) {
+    emit_incremental_scorecard_once();
     let source = r#"
 use strict;
 use warnings;

--- a/crates/perl-parser/benches/parser_benchmark.rs
+++ b/crates/perl-parser/benches/parser_benchmark.rs
@@ -7,6 +7,9 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use perl_parser::{Parser, ScopeAnalyzer};
 use std::hint::black_box;
+use std::sync::OnceLock;
+
+mod scorecard;
 
 const SIMPLE_SCRIPT: &str = r#"
 my $x = 42;
@@ -71,7 +74,42 @@ sub fibonacci {
 1;
 "#;
 
+fn emit_parser_component_scorecard_once() {
+    static EMITTED: OnceLock<()> = OnceLock::new();
+    EMITTED.get_or_init(|| {
+        let lexer_only = scorecard::measure_iterations(80, || {
+            use perl_lexer::{PerlLexer, TokenType};
+            let mut lexer = PerlLexer::new(COMPLEX_SCRIPT);
+            let mut count = 0usize;
+            while let Some(token) = lexer.next_token() {
+                if matches!(token.token_type, TokenType::EOF) {
+                    break;
+                }
+                count += 1;
+            }
+            black_box(count);
+        });
+
+        let mut parser = Parser::new(COMPLEX_SCRIPT);
+        let ast = match parser.parse() {
+            Ok(ast) => ast,
+            Err(_) => return,
+        };
+        let analyzer = ScopeAnalyzer::new();
+        let pragma_map = vec![];
+        let scope_analysis = scorecard::measure_iterations(80, || {
+            analyzer.analyze(&ast, COMPLEX_SCRIPT, &pragma_map);
+        });
+
+        scorecard::write_scorecard(vec![
+            ("lexer_only", lexer_only),
+            ("scope_analysis", scope_analysis),
+        ]);
+    });
+}
+
 fn benchmark_simple_parsing(c: &mut Criterion) {
+    emit_parser_component_scorecard_once();
     c.bench_function("parse_simple_script", |b| {
         b.iter(|| {
             let mut parser = Parser::new(black_box(SIMPLE_SCRIPT));

--- a/crates/perl-parser/benches/scorecard.rs
+++ b/crates/perl-parser/benches/scorecard.rs
@@ -1,0 +1,94 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerfMeasurement {
+    pub iterations: u32,
+    pub median_us: f64,
+    pub p95_us: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ParserPerformanceScorecard {
+    schema_version: u32,
+    measured_at_unix_secs: u64,
+    metrics: BTreeMap<String, PerfMeasurement>,
+}
+
+pub fn measure_iterations<F>(iterations: u32, mut f: F) -> PerfMeasurement
+where
+    F: FnMut(),
+{
+    let mut samples: Vec<f64> = Vec::with_capacity(iterations as usize);
+    for _ in 0..iterations {
+        let started = Instant::now();
+        f();
+        samples.push(started.elapsed().as_secs_f64() * 1_000_000.0);
+    }
+
+    samples.sort_by(f64::total_cmp);
+
+    let len = samples.len();
+    let median_idx = len / 2;
+    let p95_idx = ((len.saturating_sub(1) as f64) * 0.95).round() as usize;
+
+    PerfMeasurement {
+        iterations,
+        median_us: samples.get(median_idx).copied().unwrap_or(0.0),
+        p95_us: samples.get(p95_idx).copied().unwrap_or(0.0),
+    }
+}
+
+pub fn write_scorecard(entries: Vec<(&'static str, PerfMeasurement)>) {
+    if entries.is_empty() {
+        return;
+    }
+
+    if let Err(err) = try_write_scorecard(entries) {
+        eprintln!("parser scorecard emission failed: {err}");
+    }
+}
+
+fn try_write_scorecard(entries: Vec<(&'static str, PerfMeasurement)>) -> Result<(), String> {
+    let root = project_root()?;
+    let out_path = root.join("target/metrics/parser-performance-scorecard.json");
+
+    if let Some(parent) = out_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("create_dir_all({}): {e}", parent.display()))?;
+    }
+
+    let mut current = fs::read_to_string(&out_path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<ParserPerformanceScorecard>(&raw).ok())
+        .unwrap_or_else(|| ParserPerformanceScorecard {
+            schema_version: 1,
+            measured_at_unix_secs: 0,
+            metrics: BTreeMap::new(),
+        });
+
+    for (name, measurement) in entries {
+        current.metrics.insert(name.to_string(), measurement);
+    }
+
+    current.schema_version = 1;
+    current.measured_at_unix_secs =
+        SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+
+    let payload = serde_json::to_string_pretty(&current)
+        .map_err(|e| format!("serialize scorecard JSON: {e}"))?;
+    fs::write(&out_path, payload).map_err(|e| format!("write {}: {e}", out_path.display()))?;
+    Ok(())
+}
+
+fn project_root() -> Result<PathBuf, String> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| "failed to resolve workspace root from CARGO_MANIFEST_DIR".to_string())
+}

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard
@@ -24,8 +24,12 @@
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |
 <!-- END: PARSER_RELIABILITY_ROW -->
 <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->
-| **Strict-clean subset** | 10/10 (100%) | 10 pinned modules, zero-error gate | `.ci/common-corpus-manifest.txt` |
+| **Strict-clean subset** | 10 modules (unverified) | run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |
 <!-- END: PARSER_STRICT_CLEAN_ROW -->
+
+<!-- BEGIN: PARSER_PERFORMANCE_ROW -->
+| **Performance scorecard** | schema v1 | measured at unix `1777010308`; cold_parse: 53.6/79.0µs (p50/p95, n=60); warm_reparse: 117.6/169.7µs (p50/p95, n=60); incremental_small_edit: 60.4/91.7µs (p50/p95, n=60); incremental_multiple_edits: 36.0/56.8µs (p50/p95, n=60); lexer_only: 24.2/26.3µs (p50/p95, n=80); scope_analysis: 9.0/14.9µs (p50/p95, n=80) | `target/metrics/parser-performance-scorecard.json` |
+<!-- END: PARSER_PERFORMANCE_ROW -->
 
 <!-- BEGIN: PARSER_METRICS_BULLETS -->
 - **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -24,6 +24,22 @@ pub(super) struct ParserMetrics {
     pub common_corpus_receipt: Option<super::super::parser_corpus_sweep::SweepReport>,
     /// Number of pinned modules in `.ci/common-corpus-manifest.txt`.
     pub common_corpus_pinned: usize,
+    /// Parser performance scorecard emitted by parser bench runs.
+    pub performance_scorecard: Option<ParserPerformanceScorecard>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct ParserPerformanceScorecard {
+    pub schema_version: u32,
+    pub measured_at_unix_secs: u64,
+    pub metrics: std::collections::BTreeMap<String, ParserPerfMeasurement>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct ParserPerfMeasurement {
+    pub iterations: u32,
+    pub median_us: f64,
+    pub p95_us: f64,
 }
 
 pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
@@ -41,6 +57,9 @@ pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
         .ok(),
         common_corpus_receipt,
         common_corpus_pinned,
+        performance_scorecard: read_performance_scorecard(
+            &root.join("target/metrics/parser-performance-scorecard.json"),
+        ),
     }
 }
 
@@ -56,6 +75,11 @@ pub(super) fn count_common_corpus_pinned(root: &Path) -> usize {
 pub(super) fn read_sweep_report(
     path: &Path,
 ) -> Option<super::super::parser_corpus_sweep::SweepReport> {
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+pub(super) fn read_performance_scorecard(path: &Path) -> Option<ParserPerformanceScorecard> {
     let raw = fs::read_to_string(path).ok()?;
     serde_json::from_str(&raw).ok()
 }
@@ -201,6 +225,39 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         },
     );
 
+    let performance_row = metrics.performance_scorecard.as_ref().map_or_else(
+        || {
+            "| **Performance scorecard** | UNVERIFIED | run parser benches to emit `target/metrics/parser-performance-scorecard.json` | `target/metrics/parser-performance-scorecard.json` |".to_string()
+        },
+        |scorecard| {
+            let expected = [
+                "cold_parse",
+                "warm_reparse",
+                "incremental_small_edit",
+                "incremental_multiple_edits",
+                "lexer_only",
+                "scope_analysis",
+            ];
+            let mut parts: Vec<String> = Vec::new();
+            for key in expected {
+                if let Some(m) = scorecard.metrics.get(key) {
+                    parts.push(format!(
+                        "{key}: {:.1}/{:.1}µs (p50/p95, n={})",
+                        m.median_us, m.p95_us, m.iterations
+                    ));
+                } else {
+                    parts.push(format!("{key}: missing"));
+                }
+            }
+            format!(
+                "| **Performance scorecard** | schema v{} | measured at unix `{}`; {} | `target/metrics/parser-performance-scorecard.json` |",
+                scorecard.schema_version,
+                scorecard.measured_at_unix_secs,
+                parts.join("; "),
+            )
+        },
+    );
+
     let tracking_table = [system_row, cpan_row, project_row].join("\n");
 
     let parser_coverage_bullets = format!(
@@ -241,6 +298,12 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         "<!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->",
         "<!-- END: PARSER_STRICT_CLEAN_ROW -->",
         &strict_clean_row,
+    )?;
+    text = replace_block(
+        &text,
+        "<!-- BEGIN: PARSER_PERFORMANCE_ROW -->",
+        "<!-- END: PARSER_PERFORMANCE_ROW -->",
+        &performance_row,
     )?;
     Ok(text)
 }
@@ -302,11 +365,13 @@ mod tests {
             project_corpus: Some(summary),
             common_corpus_receipt: None,
             common_corpus_pinned: 10,
+            performance_scorecard: None,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_PERFORMANCE_ROW -->\nold\n<!-- END: PARSER_PERFORMANCE_ROW -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(result.contains("65/69"), "nodekind row missing 65/69");
@@ -329,11 +394,13 @@ mod tests {
             project_corpus: None,
             common_corpus_receipt: None,
             common_corpus_pinned: 10,
+            performance_scorecard: None,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_PERFORMANCE_ROW -->\nold\n<!-- END: PARSER_PERFORMANCE_ROW -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(
@@ -378,11 +445,13 @@ mod tests {
             project_corpus: None,
             common_corpus_receipt: Some(receipt),
             common_corpus_pinned: 10,
+            performance_scorecard: None,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_PERFORMANCE_ROW -->\nold\n<!-- END: PARSER_PERFORMANCE_ROW -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(result.contains("10/10"), "strict-clean row missing 10/10");


### PR DESCRIPTION
### Motivation
- Provide a single, repeatable, machine-readable parser performance artifact that brings cold/warm/incremental/lexer/scope timings together for longitudinal status and ratchet workflows.
- Surface bench-derived cost numbers in the existing parser status generation so maintainers can compare runtimes over time.

### Description
- Added a small bench helper `crates/perl-parser/benches/scorecard.rs` that measures p50/p95 (µs) over fixed iteration counts and writes/merges a JSON scorecard at `target/metrics/parser-performance-scorecard.json`.
- Extended `crates/perl-parser/benches/incremental_benchmark.rs` to emit scorecard entries for `cold_parse`, `warm_reparse`, `incremental_small_edit`, and `incremental_multiple_edits` while keeping the Criterion benches intact.
- Extended `crates/perl-parser/benches/parser_benchmark.rs` to emit `lexer_only` and `scope_analysis` entries so all six regimes appear together in the single artifact.
- Wired `xtask` status generation (`xtask/src/tasks/update_status/parser.rs`) to read the produced scorecard and render a `PARSER_PERFORMANCE_ROW` in `docs/project/status/parser.md`, adding the `<!-- BEGIN: PARSER_PERFORMANCE_ROW -->` marker for status updates.

### Testing
- Ran `cargo bench -p perl-parser --features incremental --bench incremental_benchmark` which executed and produced bench output and scorecard entries (success).
- Ran `cargo bench -p perl-parser --bench parser_benchmark` which executed and produced scorecard entries (success).
- Ran `cargo check --workspace --all-targets` which completed successfully (success).
- Updated docs via the xtask helper with `cargo xtask update-status --write --only parser`, which updated `docs/project/status/parser.md` to include the new performance row (success).
- Formatted the changed crates with `cargo xtask fmt` and `cargo fmt` as part of verification (success).

Problem: Parser performance benchmarks existed in separate bench binaries and did not emit one stable artifact that status reporting could surface together.
Fix: Added shared scorecard emission across existing parser and incremental benches to write `target/metrics/parser-performance-scorecard.json`, then wired parser status generation to render a unified performance row from that artifact.
Verification: `cargo bench -p perl-parser --features incremental --bench incremental_benchmark` passes / `cargo bench -p perl-parser --bench parser_benchmark` passes / `cargo check --workspace --all-targets` passes / `cargo xtask update-status --write --only parser` updates status output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb0085b4708333953526468272327e)