### PR TITLE
feat(tree-sitter-perl-rs): add first semantic overlay queries (#0000)

### DIFF
--- a/crates/tree-sitter-perl-rs/Cargo.toml
+++ b/crates/tree-sitter-perl-rs/Cargo.toml
@@ -37,6 +37,9 @@ path = "src/bin/bench_facade.rs"
 [dependencies]
 perl-parser-core = { workspace = true }
 perl-ast = { workspace = true }
+perl-semantic-analyzer = { workspace = true }
+perl-pragma = { workspace = true }
+perl-module = { workspace = true }
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -52,8 +52,12 @@
     clippy::missing_panics_doc
 )]
 
-use perl_ast::Node as AstNode;
+use perl_ast::{Node as AstNode, NodeKind as AstNodeKind};
+use perl_module::import::resolve_known_export_tag;
 use perl_parser_core::Parser as CoreParser;
+use perl_pragma::{PragmaState, PragmaTracker};
+use perl_semantic_analyzer::semantic::SemanticModel;
+use perl_semantic_analyzer::symbol::SymbolKind;
 
 /// Re-export of Edit type for tree-sitter-compatible incremental parsing.
 ///
@@ -199,6 +203,42 @@ pub fn language() -> PerlLanguage {
 /// The [`PerlLanguage`] descriptor as a constant.
 pub static LANGUAGE: PerlLanguage = PerlLanguage { kind_names: perl_ast::NodeKind::ALL_KIND_NAMES };
 
+/// A provisional semantic definition result from [`Tree::definition_at_offset`].
+///
+/// This API is intentionally small and read-only while semantic overlay support
+/// is under active development.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SemanticDefinition {
+    /// Symbol name under the queried offset.
+    pub name: String,
+    /// Fully-qualified symbol name.
+    pub qualified_name: String,
+    /// Symbol classification.
+    pub kind: SymbolKind,
+    /// Start byte offset of the definition.
+    pub start_byte: usize,
+    /// End byte offset of the definition.
+    pub end_byte: usize,
+}
+
+/// A provisional visible import record from [`Tree::visible_imports_at_offset`].
+///
+/// The values are derived from lexical `use` statements that are in scope at
+/// the queried offset.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct VisibleImport {
+    /// Imported module name from `use <module>`.
+    pub module: String,
+    /// Import arguments normalized into bare symbols when possible.
+    pub symbols: Vec<String>,
+    /// Start byte offset for the import statement.
+    pub start_byte: usize,
+    /// End byte offset for the import statement.
+    pub end_byte: usize,
+}
+
 /// The result of a successful parse: an owned syntax tree and the source text.
 ///
 /// Use [`root_node`][Tree::root_node] to begin traversal.
@@ -240,6 +280,125 @@ impl Tree {
     pub fn walk(&self) -> TreeCursor<'_> {
         self.root_node().walk()
     }
+
+    /// Resolve a definition at a byte offset using the shared semantic model facade.
+    ///
+    /// This method is intentionally limited and read-only while the semantic
+    /// overlay API for this crate is still in development.
+    pub fn definition_at_offset(&self, offset: usize) -> Option<SemanticDefinition> {
+        let model = SemanticModel::build(&self.root, &self.source);
+        let symbol = model.definition_at(offset)?;
+        Some(SemanticDefinition {
+            name: symbol.name.clone(),
+            qualified_name: symbol.qualified_name.clone(),
+            kind: symbol.kind,
+            start_byte: symbol.location.start,
+            end_byte: symbol.location.end,
+        })
+    }
+
+    /// Resolve a definition for a byte span by querying at `start_byte`.
+    ///
+    /// This is a convenience wrapper around [`definition_at_offset`][Tree::definition_at_offset].
+    pub fn definition_at_span(
+        &self,
+        start_byte: usize,
+        _end_byte: usize,
+    ) -> Option<SemanticDefinition> {
+        self.definition_at_offset(start_byte)
+    }
+
+    /// Return lexical `use` imports visible at a byte offset.
+    ///
+    /// This first semantic-overlay query is intentionally scoped: it only reports
+    /// visible imports and does not attempt to model mutable editor overlays.
+    pub fn visible_imports_at_offset(&self, offset: usize) -> Vec<VisibleImport> {
+        let mut out = Vec::new();
+        collect_visible_imports(&self.root, offset, &mut out);
+        out
+    }
+
+    /// Return the effective pragma state at `offset`.
+    ///
+    /// This delegates to the shared pragma tracker facade and returns the
+    /// computed compile-time state (`strict`, `warnings`, `feature`, etc.).
+    pub fn effective_pragma_state_at_offset(&self, offset: usize) -> PragmaState {
+        let map = PragmaTracker::build(&self.root);
+        PragmaTracker::state_for_offset(&map, offset)
+    }
+}
+
+fn collect_visible_imports(node: &AstNode, offset: usize, out: &mut Vec<VisibleImport>) {
+    match &node.kind {
+        AstNodeKind::Program { statements } | AstNodeKind::Block { statements } => {
+            for statement in statements {
+                if statement.location.start > offset {
+                    break;
+                }
+                if let Some(import) = to_visible_import(statement) {
+                    out.push(import);
+                }
+                if offset >= statement.location.start && offset <= statement.location.end {
+                    collect_visible_imports(statement, offset, out);
+                }
+            }
+        }
+        AstNodeKind::Subroutine { body, .. } => {
+            if offset >= body.location.start && offset <= body.location.end {
+                collect_visible_imports(body, offset, out);
+            }
+        }
+        AstNodeKind::Package { block, .. } => {
+            if let Some(body) = block
+                && offset >= body.location.start
+                && offset <= body.location.end
+            {
+                collect_visible_imports(body, offset, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn to_visible_import(node: &AstNode) -> Option<VisibleImport> {
+    if let AstNodeKind::Use { module, args, .. } = &node.kind {
+        let mut symbols = Vec::new();
+        for arg in args {
+            if let Some(expanded) = resolve_known_export_tag(module, arg) {
+                symbols.extend(expanded.iter().map(|name| (*name).to_string()));
+            } else if let Some(items) = parse_qw_items(arg) {
+                symbols.extend(items);
+            } else {
+                let normalized = arg.trim_matches(|ch| ch == '\'' || ch == '"').to_string();
+                if !normalized.is_empty() {
+                    symbols.push(normalized);
+                }
+            }
+        }
+
+        return Some(VisibleImport {
+            module: module.clone(),
+            symbols,
+            start_byte: node.location.start,
+            end_byte: node.location.end,
+        });
+    }
+
+    None
+}
+
+fn parse_qw_items(arg: &str) -> Option<Vec<String>> {
+    let trimmed = arg.trim();
+    if !trimmed.starts_with("qw") {
+        return None;
+    }
+
+    let body = trimmed.trim_start_matches("qw").trim();
+    let content = body
+        .trim_start_matches(|ch: char| "([{/<|!".contains(ch))
+        .trim_end_matches(|ch: char| ")]}/>!|".contains(ch));
+
+    Some(content.split_whitespace().map(std::string::ToString::to_string).collect())
 }
 
 /// A borrowed reference to a node in the syntax tree.
@@ -968,7 +1127,10 @@ mod tests {
         // After last goto_next_sibling returns false, cursor should still be valid
         // and still have a node (the last sibling).
         let node = cursor.node();
-        assert!(!node.kind().is_empty(), "cursor should remain at valid node after exhausting siblings");
+        assert!(
+            !node.kind().is_empty(),
+            "cursor should remain at valid node after exhausting siblings"
+        );
     }
 
     #[test]
@@ -1009,11 +1171,7 @@ mod tests {
 
         // reset() should bring us back to root
         cursor.reset();
-        assert_eq!(
-            cursor.node().grammar_kind(),
-            "source_file",
-            "reset must return cursor to root"
-        );
+        assert_eq!(cursor.node().grammar_kind(), "source_file", "reset must return cursor to root");
     }
 
     #[test]
@@ -1073,10 +1231,7 @@ mod tests {
             sibling_count += 1;
         }
 
-        assert_eq!(
-            sibling_count, child_count,
-            "sibling count should match root.child_count()"
-        );
+        assert_eq!(sibling_count, child_count, "sibling count should match root.child_count()");
     }
 
     #[test]

--- a/crates/tree-sitter-perl-rs/tests/semantic_overlay_tests.rs
+++ b/crates/tree-sitter-perl-rs/tests/semantic_overlay_tests.rs
@@ -1,0 +1,44 @@
+//! Semantic overlay query smoke tests for the tree-sitter facade.
+
+use perl_tdd_support::must_some;
+use tree_sitter_perl_rs::Parser;
+
+fn parse(source: &str) -> tree_sitter_perl_rs::Tree {
+    let mut parser = Parser::new();
+    must_some(parser.parse(source))
+}
+
+#[test]
+fn definition_query_resolves_symbol_at_offset() {
+    let source = "my $value = 1;\n$value += 1;\n";
+    let tree = parse(source);
+    let offset = must_some(source.find("$value += 1"));
+    let definition = must_some(tree.definition_at_offset(offset));
+
+    assert_eq!(definition.name, "value");
+    assert!(definition.start_byte < definition.end_byte);
+}
+
+#[test]
+fn visible_imports_query_returns_in_scope_use_statements() {
+    let source = "use strict;\nuse List::Util qw(first);\nmy $x = first(@vals);\n";
+    let tree = parse(source);
+    let offset = must_some(source.find("first(@vals)"));
+    let imports = tree.visible_imports_at_offset(offset);
+
+    assert!(imports.iter().any(|entry| entry.module == "strict"));
+    assert!(imports.iter().any(|entry| {
+        entry.module == "List::Util" && entry.symbols.iter().any(|symbol| symbol == "first")
+    }));
+}
+
+#[test]
+fn pragma_state_query_reflects_effective_state() {
+    let source = "use strict;\nno strict 'subs';\nfoo;\n";
+    let tree = parse(source);
+    let offset = must_some(source.find("foo;"));
+    let state = tree.effective_pragma_state_at_offset(offset);
+
+    assert!(!state.strict_subs);
+    assert!(state.strict_refs);
+}


### PR DESCRIPTION
### Motivation
- Provide a thin, read-only semantic overlay surface on top of the existing tree-sitter-style facade so consumers can query basic semantic facts without pulling full analyzer internals into their code.
- Expose high-value, low-risk queries that are useful for LSP workflows: definition lookup at an offset/span, visible `use` imports at an offset, and effective pragma state at an offset.

### Description
- Added provisional API types `SemanticDefinition` and `VisibleImport` and three `Tree` methods: `definition_at_offset`, `definition_at_span`, and `visible_imports_at_offset`, plus `effective_pragma_state_at_offset` that delegates to the shared pragma tracker facade, all implemented in `crates/tree-sitter-perl-rs/src/lib.rs`.
- Implemented minimal traversal/helpers to collect lexical `use` statements in-scope and to normalize import args (including `qw(...)` expansion) without introducing new semantic engines or mutation paths.
- Added crate dependencies in `crates/tree-sitter-perl-rs/Cargo.toml` on `perl-semantic-analyzer`, `perl-pragma`, and `perl-module` to consume the shared facades.
- Added smoke tests in `crates/tree-sitter-perl-rs/tests/semantic_overlay_tests.rs` that exercise definition lookup, visible imports, and the pragma state query.

### Testing
- Ran `cargo fmt` and it completed successfully.
- Ran `cargo test -p tree-sitter-perl-rs` and the new test suite (including `semantic_overlay_tests`) passed.
- Ran `cargo check --workspace --all-targets` and the workspace type-check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb007dae4c83339d8ba93174e16efd)