### PR TITLE
feat(tree-sitter-perl-rs): add first semantic overlay queries (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,8 +3155,11 @@ version = "0.12.4"
 dependencies = [
  "insta",
  "perl-ast",
+ "perl-module",
  "perl-parser-core",
  "perl-position-tracking",
+ "perl-pragma",
+ "perl-semantic-analyzer",
  "perl-tdd-support",
 ]
 

--- a/crates/tree-sitter-perl-rs/Cargo.toml
+++ b/crates/tree-sitter-perl-rs/Cargo.toml
@@ -37,6 +37,9 @@ path = "src/bin/bench_facade.rs"
 [dependencies]
 perl-parser-core = { workspace = true }
 perl-ast = { workspace = true }
+perl-module = { workspace = true }
+perl-pragma = { workspace = true }
+perl-semantic-analyzer = { workspace = true }
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -53,7 +53,11 @@
 )]
 
 use perl_ast::Node as AstNode;
+use perl_module::import::{ModuleImportKind, parse_module_import_head};
 use perl_parser_core::Parser as CoreParser;
+use perl_pragma::{PragmaState, PragmaTracker};
+use perl_semantic_analyzer::semantic::SemanticModel;
+use perl_semantic_analyzer::symbol::Symbol as SemanticSymbol;
 
 /// Re-export of Edit type for tree-sitter-compatible incremental parsing.
 ///
@@ -210,6 +214,31 @@ pub struct Tree {
     pending_edits: Vec<InputEdit>,
 }
 
+/// Read-only semantic overlay queries over a parsed [`Tree`].
+///
+/// This API is intentionally narrow and considered in development. It exposes a
+/// small set of high-value semantic queries while the broader overlay surface is
+/// still being designed.
+pub struct SemanticOverlay {
+    source: String,
+    semantic_model: SemanticModel,
+    pragma_map: Vec<(std::ops::Range<usize>, PragmaState)>,
+}
+
+/// A visible import at a specific source location.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct VisibleImport {
+    /// Parsed import kind (for example `use`, `require`, `use parent`).
+    pub kind: ModuleImportKind,
+    /// Parsed import token/module name.
+    pub token: String,
+    /// Start byte offset of `token` in the source.
+    pub start_byte: usize,
+    /// End byte offset of `token` in the source.
+    pub end_byte: usize,
+}
+
 impl Tree {
     /// Returns the root node of the syntax tree.
     pub fn root_node(&self) -> Node<'_> {
@@ -239,6 +268,70 @@ impl Tree {
     /// `tree.root_node().walk()`.
     pub fn walk(&self) -> TreeCursor<'_> {
         self.root_node().walk()
+    }
+
+    /// Build a read-only semantic overlay facade for this tree.
+    pub fn semantic_overlay(&self) -> SemanticOverlay {
+        let semantic_model = SemanticModel::build(&self.root, &self.source);
+        let pragma_map = PragmaTracker::build(&self.root);
+        SemanticOverlay { source: self.source.clone(), semantic_model, pragma_map }
+    }
+}
+
+impl SemanticOverlay {
+    /// Find the definition symbol for the syntax node under a given byte offset.
+    pub fn definition_at_offset(&self, offset: usize) -> Option<SemanticSymbol> {
+        self.semantic_model.definition_at(offset).cloned()
+    }
+
+    /// Find the definition symbol associated with the provided byte span.
+    pub fn definition_for_span(
+        &self,
+        start_byte: usize,
+        end_byte: usize,
+    ) -> Option<SemanticSymbol> {
+        let clamped_start = start_byte.min(self.source.len());
+        let clamped_end = end_byte.min(self.source.len());
+        self.definition_at_offset(clamped_start).or_else(|| {
+            if clamped_start < clamped_end {
+                self.definition_at_offset(clamped_end - 1)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Find the definition symbol associated with a syntax [`Node`].
+    pub fn definition_for_node(&self, node: &Node<'_>) -> Option<SemanticSymbol> {
+        self.definition_for_span(node.start_byte(), node.end_byte())
+    }
+
+    /// Return parsed imports visible up to the provided byte offset.
+    pub fn visible_imports_at(&self, offset: usize) -> Vec<VisibleImport> {
+        let mut imports = Vec::new();
+        let clamped = offset.min(self.source.len());
+        let Some(prefix) = self.source.get(..clamped) else {
+            return imports;
+        };
+
+        let mut line_start = 0usize;
+        for line in prefix.lines() {
+            if let Some(import) = parse_module_import_head(line) {
+                imports.push(VisibleImport {
+                    kind: import.kind,
+                    token: import.token.to_string(),
+                    start_byte: line_start + import.token_start,
+                    end_byte: line_start + import.token_end,
+                });
+            }
+            line_start += line.len() + 1;
+        }
+        imports
+    }
+
+    /// Return the effective pragma state at a given byte offset.
+    pub fn effective_pragma_state_at(&self, offset: usize) -> PragmaState {
+        PragmaTracker::state_for_offset(&self.pragma_map, offset)
     }
 }
 
@@ -968,7 +1061,10 @@ mod tests {
         // After last goto_next_sibling returns false, cursor should still be valid
         // and still have a node (the last sibling).
         let node = cursor.node();
-        assert!(!node.kind().is_empty(), "cursor should remain at valid node after exhausting siblings");
+        assert!(
+            !node.kind().is_empty(),
+            "cursor should remain at valid node after exhausting siblings"
+        );
     }
 
     #[test]
@@ -1009,11 +1105,7 @@ mod tests {
 
         // reset() should bring us back to root
         cursor.reset();
-        assert_eq!(
-            cursor.node().grammar_kind(),
-            "source_file",
-            "reset must return cursor to root"
-        );
+        assert_eq!(cursor.node().grammar_kind(), "source_file", "reset must return cursor to root");
     }
 
     #[test]
@@ -1073,10 +1165,7 @@ mod tests {
             sibling_count += 1;
         }
 
-        assert_eq!(
-            sibling_count, child_count,
-            "sibling count should match root.child_count()"
-        );
+        assert_eq!(sibling_count, child_count, "sibling count should match root.child_count()");
     }
 
     #[test]

--- a/crates/tree-sitter-perl-rs/tests/semantic_overlay_tests.rs
+++ b/crates/tree-sitter-perl-rs/tests/semantic_overlay_tests.rs
@@ -1,0 +1,50 @@
+use std::error::Error;
+
+use tree_sitter_perl_rs::Parser;
+
+#[test]
+fn semantic_overlay_definition_lookup_for_reference() -> Result<(), Box<dyn Error>> {
+    let source = "my $value = 41;\nmy $copy = $value;\n";
+    let mut parser = Parser::new();
+    let tree = parser.parse(source).ok_or("expected parse tree")?;
+    let overlay = tree.semantic_overlay();
+
+    let reference_offset = source.rfind("$value").ok_or("reference not found")?;
+    let definition =
+        overlay.definition_at_offset(reference_offset).ok_or("definition not found")?;
+
+    assert_eq!(definition.name, "value");
+    assert_eq!(definition.location.start, 3);
+    Ok(())
+}
+
+#[test]
+fn semantic_overlay_visible_imports_at_offset() -> Result<(), Box<dyn Error>> {
+    let source = "use strict;\nuse warnings;\nmy $x = 1;\n";
+    let mut parser = Parser::new();
+    let tree = parser.parse(source).ok_or("expected parse tree")?;
+    let overlay = tree.semantic_overlay();
+
+    let offset = source.find("my $x").ok_or("offset marker not found")?;
+    let imports = overlay.visible_imports_at(offset);
+
+    assert_eq!(imports.len(), 2);
+    assert_eq!(imports[0].token, "strict");
+    assert_eq!(imports[1].token, "warnings");
+    Ok(())
+}
+
+#[test]
+fn semantic_overlay_effective_pragma_state_at_offset() -> Result<(), Box<dyn Error>> {
+    let source = "use strict;\nno strict 'refs';\nmy $x = 1;\n";
+    let mut parser = Parser::new();
+    let tree = parser.parse(source).ok_or("expected parse tree")?;
+    let overlay = tree.semantic_overlay();
+
+    let offset = source.find("my $x").ok_or("offset marker not found")?;
+    let pragma_state = overlay.effective_pragma_state_at(offset);
+
+    assert!(!pragma_state.strict_refs);
+    assert!(pragma_state.strict_vars);
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Provide a thin, ergonomic facade for a few high-value read-only semantic queries over a parsed `Tree` so downstream consumers can access definition lookup, visible imports, and pragma state without depending on larger analyzer internals.

### Description

- Added a `SemanticOverlay` facade produced by `Tree::semantic_overlay()` that builds a `SemanticModel` and `PragmaTracker` for read-only queries.
- Implemented `definition_at_offset`, `definition_for_span`, and `definition_for_node` which reuse `perl-semantic-analyzer` resolution logic and return cloned symbol metadata.
- Implemented `visible_imports_at` which parses leading `use`/`require` heads via `perl-module` utilities and returns a lightweight `VisibleImport` result type, and `effective_pragma_state_at` which returns the `PragmaState` at an offset via `perl-pragma`.
- Wired crate dependencies (`perl-module`, `perl-pragma`, `perl-semantic-analyzer`) into `crates/tree-sitter-perl-rs/Cargo.toml` and added focused tests in `crates/tree-sitter-perl-rs/tests/semantic_overlay_tests.rs` demonstrating the new methods.

### Testing

- Ran `cargo test -p tree-sitter-perl-rs` and all tests (including the new `semantic_overlay` tests) passed.
- Ran `cargo check --workspace --all-targets` which completed successfully.
- Ran formatting via `cargo xtask fmt` as part of verification and re-ran tests to ensure no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb007dae4c83339d8ba93174e16efd)