### PR TITLE
feat(tree-sitter-perl-rs): add first semantic overlay queries (#6674)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,6 +3157,7 @@ dependencies = [
  "perl-ast",
  "perl-parser-core",
  "perl-position-tracking",
+ "perl-semantic-analyzer",
  "perl-tdd-support",
 ]
 

--- a/crates/tree-sitter-perl-rs/Cargo.toml
+++ b/crates/tree-sitter-perl-rs/Cargo.toml
@@ -37,6 +37,7 @@ path = "src/bin/bench_facade.rs"
 [dependencies]
 perl-parser-core = { workspace = true }
 perl-ast = { workspace = true }
+perl-semantic-analyzer = { workspace = true }
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/tree-sitter-perl-rs/README.md
+++ b/crates/tree-sitter-perl-rs/README.md
@@ -47,6 +47,7 @@ if let Some(tree) = parser.parse("my $x = 42;") {
 | `Parser::parse(&mut self, source: &str) -> Option<Tree>` | Parse Perl source; `None` only on complete failure |
 | `Tree::root_node() -> Node<'_>` | Get the root of the syntax tree |
 | `Tree::source() -> &str` | Source text this tree was built from |
+| `Tree::semantic_overlay() -> SemanticOverlay<'_>` | Opt-in, in-development semantic queries |
 | `Node::kind() -> &'static str` | Node type name (e.g. `"Program"`, `"Subroutine"`) |
 | `Node::to_sexp() -> String` | Tree-sitter-compatible S-expression for this subtree |
 | `Node::child_count() -> usize` | Number of direct children |
@@ -58,6 +59,11 @@ if let Some(tree) = parser.parse("my $x = 42;") {
 | `Node::is_leaf() -> bool` | `true` if the node has no children |
 | `Node::inner() -> &perl_ast::Node` | Escape hatch to the v3 AST |
 | `PerlNodeKind` | Re-export of `perl_ast::NodeKind` for pattern matching |
+
+`SemanticOverlay` currently exposes a small, read-only query set:
+- `definition_at_offset` / `definition_for_node` / `definition_for_span`
+- `visible_imports_at_offset`
+- `effective_pragma_state_at_offset`
 
 ## Error tolerance
 
@@ -72,6 +78,7 @@ This means you can pipe any Perl source through this parser and rely on getting 
 - `Node::children()` allocates a `Vec` internally on each call. Prefer iterating once over calling repeatedly.
 - `RecursionLimit` / `NestingTooDeep` parse errors produce `None` rather than a partial tree.
 - `Node::kind()` returns v3 internal names (e.g. `"Program"`) rather than tree-sitter grammar names (e.g. `"source_file"`). Use `Node::to_sexp()` for grammar-canonical output.
+- `SemanticOverlay` is intentionally limited while semantic facade support is in development.
 
 ## Backlog roadmap
 

--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -53,7 +53,11 @@
 )]
 
 use perl_ast::Node as AstNode;
+use perl_ast::NodeKind as AstNodeKind;
 use perl_parser_core::Parser as CoreParser;
+use perl_parser_core::pragma_tracker::{PragmaState, PragmaTracker};
+use perl_semantic_analyzer::semantic::SemanticModel;
+use perl_semantic_analyzer::{SourceLocation, symbol::SymbolKind};
 
 /// Re-export of Edit type for tree-sitter-compatible incremental parsing.
 ///
@@ -210,6 +214,40 @@ pub struct Tree {
     pending_edits: Vec<InputEdit>,
 }
 
+/// Explicitly opt-in semantic query facade over a parsed [`Tree`].
+///
+/// This API is intentionally small and read-only while semantic overlay support
+/// in `tree-sitter-perl-rs` is still in development.
+pub struct SemanticOverlay<'tree> {
+    tree: &'tree Tree,
+    model: SemanticModel,
+    pragma_map: Vec<(std::ops::Range<usize>, PragmaState)>,
+}
+
+/// Summary of a resolved definition at a source position.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DefinitionMatch {
+    /// Symbol name (without sigil normalization changes).
+    pub name: String,
+    /// Fully qualified symbol name, when known.
+    pub qualified_name: String,
+    /// Symbol kind classification from semantic analysis.
+    pub kind: SymbolKind,
+    /// Byte range of the definition site.
+    pub location: SourceLocation,
+}
+
+/// Import visible in source order up to a requested offset.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct VisibleImport {
+    /// Imported module or pragma token from `use ...`.
+    pub module: String,
+    /// Byte range of the import statement.
+    pub location: SourceLocation,
+}
+
 impl Tree {
     /// Returns the root node of the syntax tree.
     pub fn root_node(&self) -> Node<'_> {
@@ -239,6 +277,61 @@ impl Tree {
     /// `tree.root_node().walk()`.
     pub fn walk(&self) -> TreeCursor<'_> {
         self.root_node().walk()
+    }
+
+    /// Build an explicit semantic overlay for query-style semantic reads.
+    ///
+    /// This is intentionally limited in scope and currently provides:
+    /// - definition lookup at a node/span offset,
+    /// - visible `use` imports at an offset,
+    /// - effective pragma state at an offset.
+    pub fn semantic_overlay(&self) -> SemanticOverlay<'_> {
+        SemanticOverlay {
+            tree: self,
+            model: SemanticModel::build(&self.root, &self.source),
+            pragma_map: PragmaTracker::build(&self.root),
+        }
+    }
+}
+
+impl SemanticOverlay<'_> {
+    /// Resolve the definition visible at the provided byte offset.
+    pub fn definition_at_offset(&self, offset: usize) -> Option<DefinitionMatch> {
+        self.model.definition_at(offset).map(|symbol| DefinitionMatch {
+            name: symbol.name.clone(),
+            qualified_name: symbol.qualified_name.clone(),
+            kind: symbol.kind,
+            location: symbol.location,
+        })
+    }
+
+    /// Resolve the definition for a tree node's start byte.
+    pub fn definition_for_node(&self, node: Node<'_>) -> Option<DefinitionMatch> {
+        self.definition_at_offset(node.start_byte())
+    }
+
+    /// Resolve the definition for the start of a byte span.
+    pub fn definition_for_span(
+        &self,
+        start_byte: usize,
+        _end_byte: usize,
+    ) -> Option<DefinitionMatch> {
+        self.definition_at_offset(start_byte)
+    }
+
+    /// List `use` imports visible up to the provided offset.
+    ///
+    /// This returns lexical imports encountered in source order where the
+    /// import statement starts at or before `offset`.
+    pub fn visible_imports_at_offset(&self, offset: usize) -> Vec<VisibleImport> {
+        let mut imports = Vec::new();
+        collect_visible_imports(&self.tree.root, offset, &mut imports);
+        imports
+    }
+
+    /// Return effective pragma state at the provided offset.
+    pub fn effective_pragma_state_at_offset(&self, offset: usize) -> PragmaState {
+        PragmaTracker::state_for_offset(&self.pragma_map, offset)
     }
 }
 
@@ -512,6 +605,21 @@ fn ast_child_at(node: &AstNode, index: usize) -> Option<&AstNode> {
         idx += 1;
     });
     found
+}
+
+fn collect_visible_imports(node: &AstNode, offset: usize, out: &mut Vec<VisibleImport>) {
+    if node.location.start > offset {
+        return;
+    }
+
+    if let AstNodeKind::Use { module, .. } = &node.kind {
+        out.push(VisibleImport {
+            module: module.clone(),
+            location: SourceLocation { start: node.location.start, end: node.location.end },
+        });
+    }
+
+    node.for_each_child(|child| collect_visible_imports(child, offset, out));
 }
 
 // Invariant: TreeCursor path is constructed by the traversal that just yielded this
@@ -965,10 +1073,14 @@ mod tests {
         while cursor.goto_next_sibling() {
             count += 1;
         }
+        assert!(count >= 1, "cursor should visit at least one sibling");
         // After last goto_next_sibling returns false, cursor should still be valid
         // and still have a node (the last sibling).
         let node = cursor.node();
-        assert!(!node.kind().is_empty(), "cursor should remain at valid node after exhausting siblings");
+        assert!(
+            !node.kind().is_empty(),
+            "cursor should remain at valid node after exhausting siblings"
+        );
     }
 
     #[test]
@@ -1009,11 +1121,7 @@ mod tests {
 
         // reset() should bring us back to root
         cursor.reset();
-        assert_eq!(
-            cursor.node().grammar_kind(),
-            "source_file",
-            "reset must return cursor to root"
-        );
+        assert_eq!(cursor.node().grammar_kind(), "source_file", "reset must return cursor to root");
     }
 
     #[test]
@@ -1073,10 +1181,7 @@ mod tests {
             sibling_count += 1;
         }
 
-        assert_eq!(
-            sibling_count, child_count,
-            "sibling count should match root.child_count()"
-        );
+        assert_eq!(sibling_count, child_count, "sibling count should match root.child_count()");
     }
 
     #[test]
@@ -1213,5 +1318,49 @@ mod tests {
         // Should be back at root
         assert_eq!(cursor.node().grammar_kind(), "source_file");
         assert_eq!(depth, 0, "should have gone back up to root (depth 0)");
+    }
+
+    #[test]
+    fn test_semantic_overlay_definition_queries() {
+        let source = "my $x = 1;\n$x + 2;\n";
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse(source));
+        let overlay = tree.semantic_overlay();
+
+        let usage_offset = must_some(source.rfind("$x"));
+        let by_offset = must_some(overlay.definition_at_offset(usage_offset));
+        assert_eq!(by_offset.name, "x");
+
+        let usage_stmt = must_some(tree.root_node().child(1));
+        let by_node = must_some(overlay.definition_for_node(usage_stmt));
+        assert_eq!(by_node.name, "x");
+
+        let by_span = must_some(overlay.definition_for_span(usage_offset, usage_offset + 2));
+        assert_eq!(by_span.qualified_name, by_offset.qualified_name);
+    }
+
+    #[test]
+    fn test_semantic_overlay_visible_imports() {
+        let source = "use strict;\nuse warnings;\nmy $x = 1;";
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse(source));
+        let overlay = tree.semantic_overlay();
+
+        let imports = overlay.visible_imports_at_offset(source.len());
+        let modules: Vec<_> = imports.into_iter().map(|import| import.module).collect();
+        assert!(modules.contains(&"strict".to_string()));
+        assert!(modules.contains(&"warnings".to_string()));
+    }
+
+    #[test]
+    fn test_semantic_overlay_effective_pragma_state_at_offset() {
+        let source = "use strict;\nno strict 'refs';\nmy $x = 1;";
+        let mut parser = Parser::new();
+        let tree = must_some(parser.parse(source));
+        let overlay = tree.semantic_overlay();
+
+        let strict_state = overlay.effective_pragma_state_at_offset(source.len());
+        assert!(strict_state.strict_vars);
+        assert!(!strict_state.strict_refs);
     }
 }


### PR DESCRIPTION
### Motivation
- Expose lightweight, read-only semantic queries from the native parser facade so callers can ask for common IDE-style information without depending on the full LSP server stack.
- Provide a thin ergonomic wrapper that reuses existing semantic/pragma infrastructure rather than reimplementing semantic logic.
- Keep the surface explicitly limited and marked as in-development to avoid prematurely committing to a large public API.

### Description
- Added an opt-in `SemanticOverlay<'_>` facade on `Tree` with `Tree::semantic_overlay()` that builds a `SemanticModel` and `PragmaTracker` for query reads.
- Implemented read-only queries: `definition_at_offset`, `definition_for_node`, `definition_for_span`, `visible_imports_at_offset`, and `effective_pragma_state_at_offset`, plus return types `DefinitionMatch` and `VisibleImport` (all marked limited/non-exhaustive). 
- Introduced `collect_visible_imports` helper to gather `use` imports in source order and wired `perl-semantic-analyzer` / `pragma_tracker` into the crate (added dependency in `Cargo.toml`).
- Added unit tests covering definition lookup, visible imports, and pragma-state queries, and updated `README.md` to document the new opt-in overlay surface.

### Testing
- Ran `cargo test -p tree-sitter-perl-rs`, which completed successfully (`49` unit tests + doctests and snapshot tests passed).
- Ran `cargo check --workspace --all-targets`, which completed successfully.
- Ran `cargo clippy -p tree-sitter-perl-rs --all-targets -- -D warnings`, which completed successfully after a small test assertion adjustment.
- Ran `cargo xtask fmt` to apply workspace formatting, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb007dae4c83339d8ba93174e16efd)