### PR TITLE
fix(perl-module): normalize Windows module paths to long-form canonical paths (#5593)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,6 +1724,7 @@ dependencies = [
  "proptest",
  "tempfile",
  "url",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/perl-module/Cargo.toml
+++ b/crates/perl-module/Cargo.toml
@@ -12,6 +12,9 @@ url = { workspace = true }
 perl-parser-core = { workspace = true }
 perl-workspace = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 proptest = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/perl-module/src/path/mod.rs
+++ b/crates/perl-module/src/path/mod.rs
@@ -4,6 +4,7 @@
 //! names (e.g., `Foo::Bar`) and module file paths (e.g., `Foo/Bar.pm`).
 
 use std::borrow::Cow;
+use std::path::{Path, PathBuf};
 
 /// Normalize legacy package separator `'` to canonical `::`.
 #[must_use]
@@ -49,6 +50,52 @@ pub fn file_path_to_module_name(file_path: &str) -> String {
         .filter(|segment| !segment.is_empty())
         .unwrap_or(without_ext)
         .to_string()
+}
+
+/// Normalize filesystem paths to long-form on Windows.
+///
+/// On non-Windows platforms this is a no-op.
+#[must_use]
+pub fn canonicalize_path_long_form(path: &Path) -> PathBuf {
+    canonicalize_path_long_form_impl(path)
+}
+
+#[cfg(windows)]
+fn canonicalize_path_long_form_impl(path: &Path) -> PathBuf {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+    use windows_sys::Win32::Storage::FileSystem::GetLongPathNameW;
+
+    let mut input_utf16: Vec<u16> = path.as_os_str().encode_wide().collect();
+    input_utf16.push(0);
+
+    let required_len = unsafe {
+        // SAFETY: `input_utf16` is NUL-terminated and lives for the duration of the call.
+        // Passing a null output pointer with size 0 requests the required buffer length.
+        GetLongPathNameW(input_utf16.as_ptr(), std::ptr::null_mut(), 0)
+    };
+    if required_len == 0 {
+        return path.to_path_buf();
+    }
+
+    let mut output_utf16 = vec![0; required_len as usize + 1];
+    let written_len = unsafe {
+        // SAFETY: `input_utf16` is a valid NUL-terminated wide string and `output_utf16`
+        // points to writable memory sized according to the previously requested length.
+        GetLongPathNameW(input_utf16.as_ptr(), output_utf16.as_mut_ptr(), output_utf16.len() as u32)
+    };
+    if written_len == 0 {
+        return path.to_path_buf();
+    }
+
+    output_utf16.truncate(written_len as usize);
+    PathBuf::from(OsString::from_wide(&output_utf16))
+}
+
+#[cfg(not(windows))]
+fn canonicalize_path_long_form_impl(path: &Path) -> PathBuf {
+    path.to_path_buf()
 }
 
 fn strip_to_lib_relative_path(path: &str) -> Option<&str> {

--- a/crates/perl-module/src/resolution/path.rs
+++ b/crates/perl-module/src/resolution/path.rs
@@ -5,7 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::path::module_name_to_path;
+use crate::path::{canonicalize_path_long_form, module_name_to_path};
 use perl_parser_core::path_security::validate_workspace_path;
 
 /// Resolve a Perl module name to a workspace-relative filesystem path candidate.
@@ -43,9 +43,9 @@ pub fn resolve_module_path(
         };
 
         if safe_candidate.exists() {
-            return Some(safe_candidate);
+            return Some(canonicalize_path_long_form(&safe_candidate));
         }
     }
 
-    Some(root.join("lib").join(relative_path))
+    Some(canonicalize_path_long_form(&root.join("lib").join(relative_path)))
 }

--- a/crates/perl-module/tests/module_resolution_path_integration.rs
+++ b/crates/perl-module/tests/module_resolution_path_integration.rs
@@ -1,3 +1,4 @@
+use perl_module::path::canonicalize_path_long_form;
 use perl_module::resolution::path::resolve_module_path;
 use std::path::PathBuf;
 
@@ -12,7 +13,7 @@ fn resolves_existing_module_under_include_path() -> Result<(), Box<dyn std::erro
 
     let resolved = resolve_module_path(&workspace, "Demo::Worker", &["lib".to_string()]);
 
-    assert_eq!(resolved, Some(module_file));
+    assert_eq!(resolved, Some(canonicalize_path_long_form(&module_file)));
     Ok(())
 }
 
@@ -22,5 +23,6 @@ fn returns_lib_fallback_when_no_include_path_matches() {
     let resolved =
         resolve_module_path(&workspace, "Missing::Module", &["nonexistent/include".to_string()]);
 
-    assert_eq!(resolved, Some(workspace.join("lib").join("Missing/Module.pm")));
+    let expected = workspace.join("lib").join("Missing/Module.pm");
+    assert_eq!(resolved, Some(canonicalize_path_long_form(&expected)));
 }

--- a/crates/perl-module/tests/path_comprehensive_unit_tests.rs
+++ b/crates/perl-module/tests/path_comprehensive_unit_tests.rs
@@ -7,8 +7,10 @@
 //! - `file_path_to_module_name`
 
 use perl_module::path::{
-    file_path_to_module_name, module_name_to_path, module_path_to_name, normalize_package_separator,
+    canonicalize_path_long_form, file_path_to_module_name, module_name_to_path,
+    module_path_to_name, normalize_package_separator,
 };
+use std::path::PathBuf;
 
 // ── normalize_package_separator ─────────────────────────────────────
 
@@ -366,5 +368,13 @@ fn file_path_lib_segment_in_filename_not_directory() -> Result<(), Box<dyn std::
 fn file_path_empty_string() -> Result<(), Box<dyn std::error::Error>> {
     let result = file_path_to_module_name("");
     assert_eq!(result, "");
+    Ok(())
+}
+
+#[test]
+fn canonicalize_long_form_leaves_nonexistent_path_unchanged(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from("definitely_nonexistent_perl_module_path_test.pm");
+    assert_eq!(canonicalize_path_long_form(&path), path);
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Module resolution could return Windows 8.3 (short) paths in some cases and long-form paths in others, causing path mismatches in guardrail checks and downstream consumers.

### Description
- Added `canonicalize_path_long_form(path: &Path) -> PathBuf` to `crates/perl-module/src/path/mod.rs` with a Windows implementation that calls `GetLongPathNameW` and a non-Windows no-op that returns the input path unchanged.
- Normalized all return sites in `resolve_module_path` so both matched include-path results and the `root/lib/...` fallback are returned via `canonicalize_path_long_form` for consistent path form on Windows.
- Added a Windows-target dependency on `windows-sys` with the `Win32_Storage_FileSystem` feature in `crates/perl-module/Cargo.toml`.
- Updated integration/unit tests to compare against canonicalized expected paths and added a small test ensuring nonexistent paths are left unchanged by the helper.

### Testing
- Ran `cargo test -p perl-module`, which completed successfully (all tests passed).
- Ran `cargo check --workspace --all-targets`, which completed successfully.
- Ran formatting via `cargo xtask fmt` / `cargo fmt`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb00715b688333a8a4c7298f948744)