### PR TITLE
fix(perl-module): normalize Windows module paths to long-form canonical paths (#5593)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,6 +1724,7 @@ dependencies = [
  "proptest",
  "tempfile",
  "url",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/perl-module/Cargo.toml
+++ b/crates/perl-module/Cargo.toml
@@ -12,6 +12,9 @@ url = { workspace = true }
 perl-parser-core = { workspace = true }
 perl-workspace = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 proptest = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/perl-module/src/path/mod.rs
+++ b/crates/perl-module/src/path/mod.rs
@@ -4,6 +4,57 @@
 //! names (e.g., `Foo::Bar`) and module file paths (e.g., `Foo/Bar.pm`).
 
 use std::borrow::Cow;
+use std::path::{Path, PathBuf};
+
+/// Normalize module paths to long-form filesystem paths on Windows.
+///
+/// On non-Windows platforms this is a no-op and returns `path` as-is.
+#[must_use]
+pub fn canonicalize_path_long_form(path: &Path) -> PathBuf {
+    canonicalize_path_long_form_impl(path)
+}
+
+#[cfg(not(windows))]
+fn canonicalize_path_long_form_impl(path: &Path) -> PathBuf {
+    path.to_path_buf()
+}
+
+#[cfg(windows)]
+fn canonicalize_path_long_form_impl(path: &Path) -> PathBuf {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+    use windows_sys::Win32::Storage::FileSystem::GetLongPathNameW;
+
+    if path.as_os_str().is_empty() {
+        return path.to_path_buf();
+    }
+
+    let input_wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    let mut capacity: usize = 260;
+
+    loop {
+        let mut output_wide = vec![0_u16; capacity];
+
+        let written = unsafe {
+            GetLongPathNameW(
+                input_wide.as_ptr(),
+                output_wide.as_mut_ptr(),
+                output_wide.len() as u32,
+            )
+        };
+
+        if written == 0 {
+            return path.to_path_buf();
+        }
+
+        let written_len = written as usize;
+        if written_len < output_wide.len() {
+            return OsString::from_wide(&output_wide[..written_len]).into();
+        }
+
+        capacity = written_len.saturating_add(1);
+    }
+}
 
 /// Normalize legacy package separator `'` to canonical `::`.
 #[must_use]

--- a/crates/perl-module/src/resolution/path.rs
+++ b/crates/perl-module/src/resolution/path.rs
@@ -5,7 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::path::module_name_to_path;
+use crate::path::{canonicalize_path_long_form, module_name_to_path};
 use perl_parser_core::path_security::validate_workspace_path;
 
 /// Resolve a Perl module name to a workspace-relative filesystem path candidate.
@@ -43,9 +43,9 @@ pub fn resolve_module_path(
         };
 
         if safe_candidate.exists() {
-            return Some(safe_candidate);
+            return Some(canonicalize_path_long_form(&safe_candidate));
         }
     }
 
-    Some(root.join("lib").join(relative_path))
+    Some(canonicalize_path_long_form(&root.join("lib").join(relative_path)))
 }

--- a/crates/perl-module/tests/module_resolution_path_bdd.rs
+++ b/crates/perl-module/tests/module_resolution_path_bdd.rs
@@ -1,3 +1,4 @@
+use perl_module::path::canonicalize_path_long_form;
 use perl_module::resolution::path::resolve_module_path;
 use std::path::PathBuf;
 use tempfile::tempdir;
@@ -12,7 +13,7 @@ fn given_current_directory_include_path_when_resolving_then_result_is_root_relat
 
     let resolved = resolve_module_path(&root, "Foo::Bar", &[".".to_string()]);
 
-    assert_eq!(resolved, Some(root.join("Foo/Bar.pm")));
+    assert_eq!(resolved, Some(canonicalize_path_long_form(&root.join("Foo/Bar.pm"))));
     Ok(())
 }
 
@@ -25,5 +26,5 @@ fn given_traversal_include_path_when_resolving_then_fallback_remains_inside_work
     let resolved = resolved.unwrap_or_default();
 
     assert!(resolved.starts_with(&root));
-    assert_eq!(resolved, root.join("lib").join("Foo/Bar.pm"));
+    assert_eq!(resolved, canonicalize_path_long_form(&root.join("lib").join("Foo/Bar.pm")));
 }

--- a/crates/perl-module/tests/path_comprehensive_unit_tests.rs
+++ b/crates/perl-module/tests/path_comprehensive_unit_tests.rs
@@ -7,8 +7,10 @@
 //! - `file_path_to_module_name`
 
 use perl_module::path::{
-    file_path_to_module_name, module_name_to_path, module_path_to_name, normalize_package_separator,
+    canonicalize_path_long_form, file_path_to_module_name, module_name_to_path,
+    module_path_to_name, normalize_package_separator,
 };
+use std::path::PathBuf;
 
 // ── normalize_package_separator ─────────────────────────────────────
 
@@ -258,6 +260,15 @@ fn file_path_deeply_nested_lib() -> Result<(), Box<dyn std::error::Error>> {
         file_path_to_module_name("/opt/perl/local/lib/App/Service/Worker/Queue.pm"),
         "App::Service::Worker::Queue"
     );
+    Ok(())
+}
+
+#[cfg(not(windows))]
+#[test]
+fn canonicalize_long_form_is_noop_on_non_windows() -> Result<(), Box<dyn std::error::Error>> {
+    let input = PathBuf::from("/workspace/lib/Foo/Bar.pm");
+    let canonicalized = canonicalize_path_long_form(&input);
+    assert_eq!(canonicalized, input);
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- Prevent mismatches between 8.3 short-path and long-path Windows names that broke module-resolution guardrails by normalizing returned module filesystem paths.

### Description

- Added `canonicalize_path_long_form(path: &Path) -> PathBuf` in `crates/perl-module/src/path/mod.rs` which is a no-op on non-Windows and uses `GetLongPathNameW` on Windows to return long-form paths.
- Updated resolver return sites in `crates/perl-module/src/resolution/path.rs` to call `canonicalize_path_long_form` for both found include-path candidates and the `root/lib/<module>.pm` fallback so all returned paths are normalized.
- Added a Windows-only dependency under `cfg(windows)` on `windows-sys` (feature `Win32_Storage_FileSystem`) in `crates/perl-module/Cargo.toml` and captured the lockfile change.
- Added/adjusted targeted tests in `crates/perl-module/tests/` to assert the resolver returns the canonicalized path and to verify the helper is a no-op on non-Windows via an added test using `canonicalize_path_long_form`.

### Testing

- Ran `cargo test -p perl-module` and all tests passed.
- Ran `cargo check --workspace --all-targets` and it completed successfully.
- Ran `cargo clippy -p perl-module` and it completed without errors.
- Ran formatting via `cargo xtask fmt` locally; `just pr-fast` was not available in this environment so it was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb00715b688333a8a4c7298f948744)