### PR TITLE
fix(perl-module): normalize Windows module paths to long-form canonical paths (#5593)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,6 +1724,7 @@ dependencies = [
  "proptest",
  "tempfile",
  "url",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -321,6 +321,7 @@ clap = { version = "4.5.60", features = ["derive"] }
 tokio = { version = "1.51.1", features = ["net", "rt-multi-thread", "macros", "io-util", "sync", "time"] }
 proptest = "1.11.0"
 criterion = "0.8.1"
+windows-sys = "0.61.2"
 
 # Profile for development - slightly optimized for better performance
 [profile.dev]

--- a/crates/perl-module/Cargo.toml
+++ b/crates/perl-module/Cargo.toml
@@ -16,3 +16,6 @@ perl-workspace = { workspace = true }
 proptest = { workspace = true }
 tempfile = { workspace = true }
 perl-tdd-support = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }

--- a/crates/perl-module/src/path/mod.rs
+++ b/crates/perl-module/src/path/mod.rs
@@ -4,6 +4,7 @@
 //! names (e.g., `Foo::Bar`) and module file paths (e.g., `Foo/Bar.pm`).
 
 use std::borrow::Cow;
+use std::path::{Path, PathBuf};
 
 /// Normalize legacy package separator `'` to canonical `::`.
 #[must_use]
@@ -16,6 +17,22 @@ pub fn normalize_package_separator(module_name: &str) -> Cow<'_, str> {
 pub fn module_name_to_path(module_name: &str) -> String {
     let normalized = normalize_package_separator(module_name);
     format!("{}.pm", normalized.replace("::", "/"))
+}
+
+/// Normalize Windows paths to their long-form representation.
+///
+/// On non-Windows platforms this is a no-op and returns `path.to_path_buf()`.
+#[must_use]
+pub fn canonicalize_path_long_form(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        windows_long_path(path).unwrap_or_else(|| path.to_path_buf())
+    }
+
+    #[cfg(not(windows))]
+    {
+        path.to_path_buf()
+    }
 }
 
 /// Convert a module path/key into a module name.
@@ -57,6 +74,31 @@ fn strip_to_lib_relative_path(path: &str) -> Option<&str> {
     }
 
     path.rfind("/lib/").map(|lib_idx| &path[lib_idx + "/lib/".len()..])
+}
+
+#[cfg(windows)]
+fn windows_long_path(path: &Path) -> Option<PathBuf> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+    use windows_sys::Win32::Storage::FileSystem::GetLongPathNameW;
+
+    let path_wide: Vec<u16> = path.as_os_str().encode_wide().chain(std::iter::once(0)).collect();
+    // SAFETY: `path_wide` is NUL-terminated and pointers are valid for this call.
+    let required_len = unsafe { GetLongPathNameW(path_wide.as_ptr(), std::ptr::null_mut(), 0) };
+    if required_len == 0 {
+        return None;
+    }
+
+    let mut output = vec![0_u16; required_len as usize];
+    // SAFETY: input is NUL-terminated and `output` is allocated with `required_len` UTF-16 units.
+    let written_len =
+        unsafe { GetLongPathNameW(path_wide.as_ptr(), output.as_mut_ptr(), required_len) };
+    if written_len == 0 {
+        return None;
+    }
+
+    Some(PathBuf::from(OsString::from_wide(&output[..written_len as usize])))
 }
 
 fn strip_perl_extension(path: &str) -> &str {

--- a/crates/perl-module/src/resolution/path.rs
+++ b/crates/perl-module/src/resolution/path.rs
@@ -5,7 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::path::module_name_to_path;
+use crate::path::{canonicalize_path_long_form, module_name_to_path};
 use perl_parser_core::path_security::validate_workspace_path;
 
 /// Resolve a Perl module name to a workspace-relative filesystem path candidate.
@@ -43,9 +43,9 @@ pub fn resolve_module_path(
         };
 
         if safe_candidate.exists() {
-            return Some(safe_candidate);
+            return Some(canonicalize_path_long_form(&safe_candidate));
         }
     }
 
-    Some(root.join("lib").join(relative_path))
+    Some(canonicalize_path_long_form(&root.join("lib").join(relative_path)))
 }

--- a/crates/perl-module/tests/module_resolution_path_integration.rs
+++ b/crates/perl-module/tests/module_resolution_path_integration.rs
@@ -1,3 +1,4 @@
+use perl_module::path::canonicalize_path_long_form;
 use perl_module::resolution::path::resolve_module_path;
 use std::path::PathBuf;
 
@@ -12,7 +13,7 @@ fn resolves_existing_module_under_include_path() -> Result<(), Box<dyn std::erro
 
     let resolved = resolve_module_path(&workspace, "Demo::Worker", &["lib".to_string()]);
 
-    assert_eq!(resolved, Some(module_file));
+    assert_eq!(resolved, Some(canonicalize_path_long_form(&module_file)));
     Ok(())
 }
 
@@ -22,5 +23,8 @@ fn returns_lib_fallback_when_no_include_path_matches() {
     let resolved =
         resolve_module_path(&workspace, "Missing::Module", &["nonexistent/include".to_string()]);
 
-    assert_eq!(resolved, Some(workspace.join("lib").join("Missing/Module.pm")));
+    assert_eq!(
+        resolved,
+        Some(canonicalize_path_long_form(&workspace.join("lib").join("Missing/Module.pm"),))
+    );
 }

--- a/crates/perl-module/tests/module_resolution_windows_long_path.rs
+++ b/crates/perl-module/tests/module_resolution_windows_long_path.rs
@@ -1,0 +1,45 @@
+#![cfg(windows)]
+
+use perl_module::path::canonicalize_path_long_form;
+
+use std::ffi::OsString;
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
+use std::path::{Path, PathBuf};
+
+use windows_sys::Win32::Storage::FileSystem::GetShortPathNameW;
+
+#[test]
+fn canonicalize_long_form_expands_short_path() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let long_dir = temp.path().join("Long Module Directory");
+    let module_file = long_dir.join("Long Module Name.pm");
+
+    std::fs::create_dir_all(&long_dir)?;
+    std::fs::write(&module_file, "package Long::Module::Name; 1;")?;
+
+    let short_path = short_path_for(&module_file)?;
+    let normalized = canonicalize_path_long_form(&short_path);
+
+    assert_eq!(normalized, module_file);
+    Ok(())
+}
+
+fn short_path_for(path: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let wide_path: Vec<u16> = path.as_os_str().encode_wide().chain(std::iter::once(0)).collect();
+
+    // SAFETY: Input is a valid NUL-terminated UTF-16 buffer and output pointer is null for size query.
+    let required_len = unsafe { GetShortPathNameW(wide_path.as_ptr(), std::ptr::null_mut(), 0) };
+    if required_len == 0 {
+        return Err("GetShortPathNameW length query failed".into());
+    }
+
+    let mut output = vec![0_u16; required_len as usize];
+    // SAFETY: Input is valid and `output` has space for `required_len` UTF-16 units.
+    let written_len =
+        unsafe { GetShortPathNameW(wide_path.as_ptr(), output.as_mut_ptr(), required_len) };
+    if written_len == 0 {
+        return Err("GetShortPathNameW write failed".into());
+    }
+
+    Ok(PathBuf::from(OsString::from_wide(&output[..written_len as usize])))
+}


### PR DESCRIPTION
### Motivation

- Windows 8.3 short-path vs long-path mismatches caused inconsistent filesystem paths from module resolution and broke guardrail checks, so resolved module paths must be normalized to a consistent long form.

### Description

- Add `canonicalize_path_long_form(path: &Path) -> PathBuf` in `crates/perl-module/src/path/mod.rs` that is a no-op on non-Windows and calls `GetLongPathNameW` on Windows.
- Use `canonicalize_path_long_form` at all return sites in `resolve_module_path` so resolved candidates and the `root/lib/...` fallback are consistently normalized (`crates/perl-module/src/resolution/path.rs`).
- Wire `windows-sys` as a `cfg(windows)` dependency for `perl-module` and add a workspace-level `windows-sys` entry to the top-level `Cargo.toml` so the Win32 API is available only on Windows (`crates/perl-module/Cargo.toml`, `Cargo.toml`).
- Update existing integration assertions to compare against normalized paths and add a Windows-only test `module_resolution_windows_long_path.rs` that creates a file, obtains its 8.3 short form via `GetShortPathNameW`, and verifies `canonicalize_path_long_form` expands it back.

### Testing

- Ran `cargo test -p perl-module`, which passed (module crate tests all OK).
- Ran `cargo check --workspace --all-targets`, which completed successfully.
- Ran `cargo xtask fmt` and formatting completed.
- Ran `cargo clippy -p perl-module --all-targets -- -D warnings`, which failed due to an existing clippy warning (a `collapsible-if`) in an unrelated test file; the failure is pre-existing and unrelated to the Windows helper changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb00715b688333a8a4c7298f948744)