### PR TITLE
fix(perl-module): normalize Windows module paths to long-form canonical paths (#5593)

### DIFF
--- a/crates/perl-module/Cargo.toml
+++ b/crates/perl-module/Cargo.toml
@@ -12,6 +12,9 @@ url = { workspace = true }
 perl-parser-core = { workspace = true }
 perl-workspace = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59.0", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 proptest = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/perl-module/src/path/mod.rs
+++ b/crates/perl-module/src/path/mod.rs
@@ -4,6 +4,7 @@
 //! names (e.g., `Foo::Bar`) and module file paths (e.g., `Foo/Bar.pm`).
 
 use std::borrow::Cow;
+use std::path::{Path, PathBuf};
 
 /// Normalize legacy package separator `'` to canonical `::`.
 #[must_use]
@@ -49,6 +50,44 @@ pub fn file_path_to_module_name(file_path: &str) -> String {
         .filter(|segment| !segment.is_empty())
         .unwrap_or(without_ext)
         .to_string()
+}
+
+/// Normalize Windows 8.3 short paths into long-form paths.
+///
+/// On non-Windows platforms this returns `path` unchanged.
+#[must_use]
+pub fn canonicalize_path_long_form(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        use std::ffi::OsString;
+        use std::iter;
+        use std::os::windows::ffi::{OsStrExt, OsStringExt};
+        use windows_sys::Win32::Storage::FileSystem::GetLongPathNameW;
+
+        let wide_path = path.as_os_str().encode_wide().chain(iter::once(0)).collect::<Vec<u16>>();
+
+        // SAFETY: `wide_path` is NUL-terminated and lives for the duration of the call.
+        let required_len = unsafe { GetLongPathNameW(wide_path.as_ptr(), std::ptr::null_mut(), 0) };
+        if required_len == 0 {
+            return path.to_path_buf();
+        }
+
+        let mut long_path = vec![0_u16; required_len as usize + 1];
+        // SAFETY: input is NUL-terminated, output buffer is valid for `long_path.len()` UTF-16 code units.
+        let written_len = unsafe {
+            GetLongPathNameW(wide_path.as_ptr(), long_path.as_mut_ptr(), long_path.len() as u32)
+        };
+        if written_len == 0 {
+            return path.to_path_buf();
+        }
+
+        return PathBuf::from(OsString::from_wide(&long_path[..written_len as usize]));
+    }
+
+    #[cfg(not(windows))]
+    {
+        path.to_path_buf()
+    }
 }
 
 fn strip_to_lib_relative_path(path: &str) -> Option<&str> {

--- a/crates/perl-module/src/resolution/path.rs
+++ b/crates/perl-module/src/resolution/path.rs
@@ -5,7 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::path::module_name_to_path;
+use crate::path::{canonicalize_path_long_form, module_name_to_path};
 use perl_parser_core::path_security::validate_workspace_path;
 
 /// Resolve a Perl module name to a workspace-relative filesystem path candidate.
@@ -43,9 +43,9 @@ pub fn resolve_module_path(
         };
 
         if safe_candidate.exists() {
-            return Some(safe_candidate);
+            return Some(canonicalize_path_long_form(&safe_candidate));
         }
     }
 
-    Some(root.join("lib").join(relative_path))
+    Some(canonicalize_path_long_form(&root.join("lib").join(relative_path)))
 }

--- a/crates/perl-module/tests/module_resolution_path_integration.rs
+++ b/crates/perl-module/tests/module_resolution_path_integration.rs
@@ -24,3 +24,57 @@ fn returns_lib_fallback_when_no_include_path_matches() {
 
     assert_eq!(resolved, Some(workspace.join("lib").join("Missing/Module.pm")));
 }
+
+#[cfg(windows)]
+#[test]
+fn normalizes_short_paths_to_long_form_when_available() -> Result<(), Box<dyn std::error::Error>> {
+    use std::iter;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+    use windows_sys::Win32::Storage::FileSystem::GetShortPathNameW;
+
+    fn to_wide(path: &std::path::Path) -> Vec<u16> {
+        path.as_os_str().encode_wide().chain(iter::once(0)).collect::<Vec<u16>>()
+    }
+
+    fn get_short_path(path: &std::path::Path) -> Option<PathBuf> {
+        let input_wide = to_wide(path);
+        // SAFETY: input pointer is valid and NUL-terminated, and output pointer is null for probe call.
+        let required_len =
+            unsafe { GetShortPathNameW(input_wide.as_ptr(), std::ptr::null_mut(), 0) };
+        if required_len == 0 {
+            return None;
+        }
+
+        let mut short_wide = vec![0_u16; required_len as usize + 1];
+        // SAFETY: both pointers are valid for the provided lengths and input is NUL-terminated.
+        let written_len = unsafe {
+            GetShortPathNameW(input_wide.as_ptr(), short_wide.as_mut_ptr(), short_wide.len() as u32)
+        };
+        if written_len == 0 {
+            return None;
+        }
+
+        Some(PathBuf::from(std::ffi::OsString::from_wide(&short_wide[..written_len as usize])))
+    }
+
+    let temp = tempfile::tempdir()?;
+    let workspace_long = temp.path().join("workspace_with_long_segments");
+    let module_file_long = workspace_long.join("lib").join("Demo").join("Worker.pm");
+
+    std::fs::create_dir_all(module_file_long.parent().unwrap_or(&workspace_long))?;
+    std::fs::write(&module_file_long, "package Demo::Worker; 1;")?;
+
+    let Some(workspace_short) = get_short_path(&workspace_long) else {
+        return Ok(());
+    };
+    let Some(module_short) = get_short_path(&module_file_long) else {
+        return Ok(());
+    };
+    if workspace_short == workspace_long || module_short == module_file_long {
+        return Ok(());
+    }
+
+    let resolved = resolve_module_path(&workspace_short, "Demo::Worker", &["lib".to_string()]);
+    assert_eq!(resolved, Some(module_file_long));
+    Ok(())
+}

--- a/crates/perl-module/tests/path_comprehensive_unit_tests.rs
+++ b/crates/perl-module/tests/path_comprehensive_unit_tests.rs
@@ -7,8 +7,10 @@
 //! - `file_path_to_module_name`
 
 use perl_module::path::{
-    file_path_to_module_name, module_name_to_path, module_path_to_name, normalize_package_separator,
+    canonicalize_path_long_form, file_path_to_module_name, module_name_to_path,
+    module_path_to_name, normalize_package_separator,
 };
+use std::path::Path;
 
 // ── normalize_package_separator ─────────────────────────────────────
 
@@ -366,5 +368,24 @@ fn file_path_lib_segment_in_filename_not_directory() -> Result<(), Box<dyn std::
 fn file_path_empty_string() -> Result<(), Box<dyn std::error::Error>> {
     let result = file_path_to_module_name("");
     assert_eq!(result, "");
+    Ok(())
+}
+
+#[test]
+fn canonicalize_long_form_non_windows_noop() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(not(windows))]
+    {
+        let input = Path::new("lib/Foo/Bar.pm");
+        let normalized = canonicalize_path_long_form(input);
+        assert_eq!(normalized, input);
+    }
+    Ok(())
+}
+
+#[test]
+fn canonicalize_long_form_nonexistent_path_is_stable() -> Result<(), Box<dyn std::error::Error>> {
+    let input = Path::new("this/path/does/not/exist.pm");
+    let normalized = canonicalize_path_long_form(input);
+    assert_eq!(normalized, input);
     Ok(())
 }


### PR DESCRIPTION
### Motivation

- Windows 8.3 short-path vs long-path mismatches caused module-resolution comparisons to diverge and break guardrail checks.
- The intent is to normalize returned module filesystem paths to a stable long-form representation on Windows while leaving other platforms unchanged.

### Description

- Added a Windows-target helper `canonicalize_path_long_form(path: &Path) -> PathBuf` which calls `GetLongPathNameW` and falls back to the original path on failure or when not on Windows.
- Applied `canonicalize_path_long_form` at all return sites in `resolve_module_path` so both include-path matches and the `root/lib/...` fallback are consistently normalized.
- Added `windows-sys` as a `cfg(windows)` dependency with the `Win32_Storage_FileSystem` feature to provide `GetLongPathNameW` only on Windows.
- Added targeted tests: two unit tests that assert no-op/stable behavior on non-Windows and a Windows-only integration test that exercises short-path -> long-path normalization when available.

### Testing

- Ran `cargo test -p perl-module` and all tests in the crate passed.
- Ran `cargo check --workspace --all-targets` and it completed successfully.
- Ran `cargo check --all-targets -p perl-module` and it completed successfully.
- Ran `cargo clippy -p perl-module` which completed, and note that running clippy with `-D warnings` surfaced an unrelated collapsible-if lint in a test which is not part of this change; `just pr-fast` was not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb00715b688333a8a4c7298f948744)