### PR TITLE
feat(completion): include external @INC modules in use/require completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -122,6 +122,7 @@ use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
 use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_workspace::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Maps module_name -> Set of explicitly imported symbol names.
@@ -170,6 +171,8 @@ pub struct CompletionProvider {
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
     import_map: ImportMap,
+    include_roots: Vec<PathBuf>,
+    system_inc_paths: Vec<PathBuf>,
 }
 
 impl CompletionProvider {
@@ -249,6 +252,23 @@ impl CompletionProvider {
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
     ) -> Self {
+        Self::new_with_index_source_and_inc_paths(
+            ast,
+            source,
+            workspace_index,
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+
+    /// Create a new completion provider with workspace index and resolved @INC roots.
+    pub fn new_with_index_source_and_inc_paths(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        include_roots: Vec<PathBuf>,
+        system_inc_paths: Vec<PathBuf>,
+    ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
         let type_engine = workspace_index.as_ref().map(|_| {
@@ -258,7 +278,15 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            import_map,
+            include_roots,
+            system_inc_paths,
+        }
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -774,6 +802,8 @@ impl CompletionProvider {
                 &mut completions,
                 &context,
                 &self.workspace_index,
+                &self.include_roots,
+                &self.system_inc_paths,
             );
         } else if self.is_has_type_value_context(source, position) {
             self.add_has_type_completions(&mut completions, &context);
@@ -2147,7 +2177,9 @@ mod tests {
     use perl_parser_core::Parser;
     use perl_tdd_support::{must, must_some};
     use perl_workspace::workspace_index::WorkspaceIndex;
+    use std::fs;
     use std::sync::Arc;
+    use tempfile::tempdir;
     use url::Url;
 
     #[test]
@@ -3556,6 +3588,88 @@ sub helper { }
         assert_eq!(
             myapp_count, 1,
             "Duplicate package declarations should produce exactly one completion"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_use_module_completion_includes_configured_include_roots()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let include_root = tempdir()?;
+        let dbix_dir = include_root.path().join("DBIx");
+        fs::create_dir_all(&dbix_dir)?;
+        fs::write(dbix_dir.join("Class.pm"), "package DBIx::Class;\n1;\n")?;
+
+        let code = "use DB";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index_source_and_inc_paths(
+            &ast,
+            code,
+            None,
+            vec![include_root.path().to_path_buf()],
+            Vec::new(),
+        );
+        let completions = provider.get_completions(code, code.len());
+
+        assert!(
+            completions.iter().any(|c| c.label == "DBIx::Class"),
+            "expected include-root module completion for DBIx::Class; got: {:?}",
+            completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_use_module_completion_workspace_precedence_and_dedupe()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let index = Arc::new(WorkspaceIndex::new());
+        index.index_file(
+            Url::parse("file:///workspace/lib/Foo/Bar.pm")?,
+            "package Foo::Bar;\n1;\n".to_string(),
+        )?;
+
+        let include_root = tempdir()?;
+        fs::create_dir_all(include_root.path().join("Foo"))?;
+        fs::write(include_root.path().join("Foo").join("Bar.pm"), "package Foo::Bar;\n1;\n")?;
+        fs::create_dir_all(include_root.path().join("Extra"))?;
+        fs::write(include_root.path().join("Extra").join("One.pm"), "package Extra::One;\n1;\n")?;
+
+        let system_root = tempdir()?;
+        fs::create_dir_all(system_root.path().join("Foo"))?;
+        fs::write(system_root.path().join("Foo").join("Bar.pm"), "package Foo::Bar;\n1;\n")?;
+        fs::create_dir_all(system_root.path().join("Sys"))?;
+        fs::write(system_root.path().join("Sys").join("Mod.pm"), "package Sys::Mod;\n1;\n")?;
+
+        let code = "use ";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index_source_and_inc_paths(
+            &ast,
+            code,
+            Some(index),
+            vec![include_root.path().to_path_buf()],
+            vec![system_root.path().to_path_buf()],
+        );
+        let completions = provider.get_completions(code, code.len());
+
+        let foo_entries: Vec<&CompletionItem> =
+            completions.iter().filter(|item| item.label == "Foo::Bar").collect();
+        assert_eq!(foo_entries.len(), 1, "Foo::Bar should be deduped across all sources");
+        assert_eq!(
+            foo_entries.first().and_then(|item| item.detail.as_deref()),
+            Some("module"),
+            "workspace module should win precedence over include/system paths"
+        );
+        assert_eq!(
+            completions.iter().filter(|item| item.label == "Extra::One").count(),
+            1,
+            "module from include roots should appear once"
+        );
+        assert_eq!(
+            completions.iter().filter(|item| item.label == "Sys::Mod").count(),
+            1,
+            "module from system @INC should appear once"
         );
         Ok(())
     }

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -14,7 +14,9 @@ use perl_workspace::workspace_index::{
     SymbolKind as WsSymbolKind, VarKind, WorkspaceIndex, WorkspaceSymbol,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use walkdir::WalkDir;
 
 /// Add workspace symbol completions for functions and variables
 ///
@@ -240,55 +242,132 @@ pub fn add_use_module_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
+    include_roots: &[PathBuf],
+    system_inc_paths: &[PathBuf],
 ) {
-    let Some(index) = workspace_index else {
-        return;
-    };
-
-    if !index.has_symbols() {
-        return;
-    }
-
     let mut seen: HashSet<String> = HashSet::new();
 
-    // Search for package symbols matching the prefix
-    let all_symbols = if context.prefix.is_empty() {
-        index.all_symbols()
-    } else {
-        index.find_symbols(&context.prefix)
-    };
+    if let Some(index) = workspace_index
+        && index.has_symbols()
+    {
+        // Search for package symbols matching the prefix
+        let all_symbols = if context.prefix.is_empty() {
+            index.all_symbols()
+        } else {
+            index.find_symbols(&context.prefix)
+        };
 
-    for symbol in all_symbols {
-        if symbol.kind != WsSymbolKind::Package {
+        for symbol in all_symbols {
+            if symbol.kind != WsSymbolKind::Package {
+                continue;
+            }
+
+            // Match against the module name prefix
+            if !context.prefix.is_empty() && !symbol.name.starts_with(&context.prefix) {
+                continue;
+            }
+
+            if !seen.insert(symbol.name.clone()) {
+                continue;
+            }
+
+            let name = &symbol.name;
+            completions.push(CompletionItem {
+                label: name.clone(),
+                kind: CompletionItemKind::Module,
+                detail: Some("module".to_string()),
+                documentation: symbol
+                    .documentation
+                    .clone()
+                    .or_else(|| Some(format!("Package `{name}`"))),
+                insert_text: Some(name.clone()),
+                sort_text: Some(format!("1{}_{name}", module_sort_tier(name))),
+                filter_text: Some(name.clone()),
+                additional_edits: vec![],
+                text_edit_range: Some((context.prefix_start, context.position)),
+                commit_characters: None,
+            });
+        }
+    }
+
+    for name in scan_module_names_from_roots(include_roots) {
+        if !context.prefix.is_empty() && !name.starts_with(&context.prefix) {
             continue;
         }
-
-        // Match against the module name prefix
-        if !context.prefix.is_empty() && !symbol.name.starts_with(&context.prefix) {
+        if !seen.insert(name.clone()) {
             continue;
         }
-
-        if !seen.insert(symbol.name.clone()) {
-            continue;
-        }
-
-        let name = &symbol.name;
         completions.push(CompletionItem {
             label: name.clone(),
             kind: CompletionItemKind::Module,
-            detail: Some("module".to_string()),
-            documentation: symbol
-                .documentation
-                .clone()
-                .or_else(|| Some(format!("Package `{name}`"))),
+            detail: Some("include path module".to_string()),
+            documentation: Some(format!("Module `{name}` from configured include roots.")),
             insert_text: Some(name.clone()),
-            sort_text: Some(format!("1{}_{name}", module_sort_tier(name))),
+            sort_text: Some(format!("2{}_{name}", module_sort_tier(&name))),
             filter_text: Some(name.clone()),
             additional_edits: vec![],
             text_edit_range: Some((context.prefix_start, context.position)),
             commit_characters: None,
         });
     }
+
+    for name in scan_module_names_from_roots(system_inc_paths) {
+        if !context.prefix.is_empty() && !name.starts_with(&context.prefix) {
+            continue;
+        }
+        if !seen.insert(name.clone()) {
+            continue;
+        }
+        completions.push(CompletionItem {
+            label: name.clone(),
+            kind: CompletionItemKind::Module,
+            detail: Some("system @INC module".to_string()),
+            documentation: Some(format!("Module `{name}` from system @INC.")),
+            insert_text: Some(name.clone()),
+            sort_text: Some(format!("3{}_{name}", module_sort_tier(&name))),
+            filter_text: Some(name.clone()),
+            additional_edits: vec![],
+            text_edit_range: Some((context.prefix_start, context.position)),
+            commit_characters: None,
+        });
+    }
+}
+
+fn scan_module_names_from_roots(roots: &[PathBuf]) -> Vec<String> {
+    let mut names = Vec::new();
+    for root in roots {
+        for path in scan_pm_files(root) {
+            if let Some(module_name) = path_to_module_name(root, &path) {
+                names.push(module_name);
+            }
+        }
+    }
+    names
+}
+
+fn scan_pm_files(root: &Path) -> Vec<PathBuf> {
+    if !root.is_dir() {
+        return Vec::new();
+    }
+
+    WalkDir::new(root)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_file())
+        .filter(|entry| entry.path().extension().is_some_and(|ext| ext.eq_ignore_ascii_case("pm")))
+        .map(|entry| entry.into_path())
+        .collect()
+}
+
+fn path_to_module_name(root: &Path, module_path: &Path) -> Option<String> {
+    let relative = module_path.strip_prefix(root).ok()?;
+    let mut module = relative.to_string_lossy().replace(['/', '\\'], "::");
+    if !module.ends_with(".pm") {
+        return None;
+    }
+    let new_len = module.len().saturating_sub(3);
+    module.truncate(new_len);
+    if module.is_empty() { None } else { Some(module) }
 }
 
 /// Add import completions for symbols inside `use Module qw(...)`.


### PR DESCRIPTION
### Motivation

- `use`/`require` completions only surfaced modules indexed in the workspace, which missed modules present in configured include roots and optional system `@INC` paths.

### Description

- Add `include_roots: Vec<PathBuf>` and `system_inc_paths: Vec<PathBuf>` to `CompletionProvider` and a new constructor `new_with_index_source_and_inc_paths` to accept resolved include vectors while preserving existing constructors.
- Extend `add_use_module_completions` to merge workspace-index package results with modules discovered by scanning configured include roots and system `@INC`, deduping by module name and giving workspace-index entries precedence.
- Add filesystem helpers `scan_pm_files`, `path_to_module_name`, and `scan_module_names_from_roots` (using `walkdir`) to enumerate `.pm` files and convert paths to module names.
- Modified files: `crates/perl-lsp-rs-core/src/providers/completion/completion.rs`, `crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs`, and added focused unit tests for include-root scanning and merge/dedupe behavior.

### Testing

- Ran the crate tests for the new cases: `cargo test -p perl-lsp-rs-core` (targeted tests for the new behavior `test_use_module_completion_includes_configured_include_roots` and `test_use_module_completion_workspace_precedence_and_dedupe` passed); a separate unrelated test in the full suite failed in this environment due to a missing workspace file not touched by this change.
- Performed `cargo check --workspace --all-targets`, `cargo clippy -p perl-lsp-rs-core`, and `cargo xtask fmt`, all of which completed successfully in this environment.
- Note: `just pr-fast` was not available in the execution environment and was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb00674f348333a28751e83d8c9385)