### PR TITLE
feat(completion): include external @INC modules in use/require completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -122,6 +122,7 @@ use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
 use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_workspace::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Maps module_name -> Set of explicitly imported symbol names.
@@ -170,6 +171,8 @@ pub struct CompletionProvider {
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
     import_map: ImportMap,
+    include_roots: Vec<PathBuf>,
+    system_inc_roots: Vec<PathBuf>,
 }
 
 impl CompletionProvider {
@@ -249,6 +252,26 @@ impl CompletionProvider {
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
     ) -> Self {
+        Self::new_with_index_source_and_inc_roots(
+            ast,
+            source,
+            workspace_index,
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+
+    /// Create a completion provider with workspace index and explicit include roots.
+    ///
+    /// `include_roots` and `system_inc_roots` are used for module-name completion in
+    /// `use` / `require` contexts and are scanned for `.pm` files.
+    pub fn new_with_index_source_and_inc_roots(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        include_roots: Vec<PathBuf>,
+        system_inc_roots: Vec<PathBuf>,
+    ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
         let type_engine = workspace_index.as_ref().map(|_| {
@@ -258,7 +281,15 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            import_map,
+            include_roots,
+            system_inc_roots,
+        }
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -774,6 +805,8 @@ impl CompletionProvider {
                 &mut completions,
                 &context,
                 &self.workspace_index,
+                &self.include_roots,
+                &self.system_inc_roots,
             );
         } else if self.is_has_type_value_context(source, position) {
             self.add_has_type_completions(&mut completions, &context);
@@ -2147,8 +2180,22 @@ mod tests {
     use perl_parser_core::Parser;
     use perl_tdd_support::{must, must_some};
     use perl_workspace::workspace_index::WorkspaceIndex;
+    use std::fs;
+    use std::path::PathBuf;
     use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
     use url::Url;
+
+    fn make_temp_test_dir(prefix: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
+        let stamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "perl_lsp_rs_core_{prefix}_{}_{}",
+            std::process::id(),
+            stamp
+        ));
+        fs::create_dir_all(&dir)?;
+        Ok(dir)
+    }
 
     #[test]
     fn test_variable_completion() {
@@ -3581,6 +3628,81 @@ sub helper { }
             !completions.iter().any(|c| c.sort_text.as_deref() == Some("1_MyApp")),
             "Module-priority sort_text should only appear in use context"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_use_module_completion_scans_include_roots() -> Result<(), Box<dyn std::error::Error>> {
+        let include_root = make_temp_test_dir("include_scan")?;
+        let nested = include_root.join("DBD");
+        fs::create_dir_all(&nested)?;
+        fs::write(nested.join("SQLite.pm"), "package DBD::SQLite;\n1;\n")?;
+
+        let code = "use DBD::SQ";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index_source_and_inc_roots(
+            &ast,
+            code,
+            None,
+            vec![include_root.clone()],
+            Vec::new(),
+        );
+        let completions = provider.get_completions(code, code.len());
+
+        assert!(
+            completions
+                .iter()
+                .any(|c| c.label == "DBD::SQLite" && c.kind == CompletionItemKind::Module),
+            "include roots should contribute module completions for use/require context; got: {:?}",
+            completions.iter().map(|c| (&c.label, &c.kind)).collect::<Vec<_>>()
+        );
+
+        fs::remove_dir_all(include_root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_use_module_workspace_precedence_and_dedupe_with_include_roots()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let index = Arc::new(WorkspaceIndex::new());
+        index.index_file(
+            Url::parse("file:///workspace/lib/DBI.pm")?,
+            "package DBI;\n1;\n".to_string(),
+        )?;
+
+        let include_root_1 = make_temp_test_dir("include_precedence_a")?;
+        let include_root_2 = make_temp_test_dir("include_precedence_b")?;
+        fs::write(include_root_1.join("DBI.pm"), "package DBI;\n1;\n")?;
+        fs::write(include_root_2.join("DBI.pm"), "package DBI;\n1;\n")?;
+
+        let code = "use DB";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index_source_and_inc_roots(
+            &ast,
+            code,
+            Some(index),
+            vec![include_root_1.clone()],
+            vec![include_root_2.clone()],
+        );
+        let completions = provider.get_completions(code, code.len());
+
+        let dbi_items: Vec<&CompletionItem> =
+            completions.iter().filter(|item| item.label == "DBI").collect();
+        assert_eq!(
+            dbi_items.len(),
+            1,
+            "DBI should be deduplicated across workspace/include/system roots"
+        );
+        assert_eq!(
+            dbi_items[0].detail.as_deref(),
+            Some("module"),
+            "workspace result should win precedence"
+        );
+
+        fs::remove_dir_all(include_root_1)?;
+        fs::remove_dir_all(include_root_2)?;
         Ok(())
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -14,6 +14,8 @@ use perl_workspace::workspace_index::{
     SymbolKind as WsSymbolKind, VarKind, WorkspaceIndex, WorkspaceSymbol,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 /// Add workspace symbol completions for functions and variables
@@ -240,55 +242,130 @@ pub fn add_use_module_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
+    include_roots: &[PathBuf],
+    system_inc_roots: &[PathBuf],
 ) {
-    let Some(index) = workspace_index else {
-        return;
-    };
-
-    if !index.has_symbols() {
-        return;
-    }
-
     let mut seen: HashSet<String> = HashSet::new();
 
-    // Search for package symbols matching the prefix
-    let all_symbols = if context.prefix.is_empty() {
-        index.all_symbols()
-    } else {
-        index.find_symbols(&context.prefix)
-    };
+    if let Some(index) = workspace_index
+        && index.has_symbols()
+    {
+        // Search for package symbols matching the prefix
+        let all_symbols = if context.prefix.is_empty() {
+            index.all_symbols()
+        } else {
+            index.find_symbols(&context.prefix)
+        };
 
-    for symbol in all_symbols {
-        if symbol.kind != WsSymbolKind::Package {
+        for symbol in all_symbols {
+            if symbol.kind != WsSymbolKind::Package {
+                continue;
+            }
+
+            // Match against the module name prefix
+            if !context.prefix.is_empty() && !symbol.name.starts_with(&context.prefix) {
+                continue;
+            }
+
+            if !seen.insert(symbol.name.clone()) {
+                continue;
+            }
+
+            let name = &symbol.name;
+            completions.push(CompletionItem {
+                label: name.clone(),
+                kind: CompletionItemKind::Module,
+                detail: Some("module".to_string()),
+                documentation: symbol
+                    .documentation
+                    .clone()
+                    .or_else(|| Some(format!("Package `{name}`"))),
+                insert_text: Some(name.clone()),
+                sort_text: Some(format!("1{}_{name}", module_sort_tier(name))),
+                filter_text: Some(name.clone()),
+                additional_edits: vec![],
+                text_edit_range: Some((context.prefix_start, context.position)),
+                commit_characters: None,
+            });
+        }
+    }
+
+    // Include roots and system @INC are appended after workspace symbols.
+    // Dedup by module name keeps workspace-first precedence.
+    for (root_kind, module_name) in scan_modules_from_roots(include_roots)
+        .into_iter()
+        .map(|module| ("include root", module))
+        .chain(
+            scan_modules_from_roots(system_inc_roots)
+                .into_iter()
+                .map(|module| ("system @INC", module)),
+        )
+    {
+        if !context.prefix.is_empty() && !module_name.starts_with(&context.prefix) {
+            continue;
+        }
+        if !seen.insert(module_name.clone()) {
             continue;
         }
 
-        // Match against the module name prefix
-        if !context.prefix.is_empty() && !symbol.name.starts_with(&context.prefix) {
-            continue;
-        }
-
-        if !seen.insert(symbol.name.clone()) {
-            continue;
-        }
-
-        let name = &symbol.name;
         completions.push(CompletionItem {
-            label: name.clone(),
+            label: module_name.clone(),
             kind: CompletionItemKind::Module,
-            detail: Some("module".to_string()),
-            documentation: symbol
-                .documentation
-                .clone()
-                .or_else(|| Some(format!("Package `{name}`"))),
-            insert_text: Some(name.clone()),
-            sort_text: Some(format!("1{}_{name}", module_sort_tier(name))),
-            filter_text: Some(name.clone()),
+            detail: Some(format!("module ({root_kind})")),
+            documentation: Some(format!("Module `{module_name}` from {root_kind}.")),
+            insert_text: Some(module_name.clone()),
+            sort_text: Some(format!("1{}_{module_name}", module_sort_tier(&module_name))),
+            filter_text: Some(module_name),
             additional_edits: vec![],
             text_edit_range: Some((context.prefix_start, context.position)),
             commit_characters: None,
         });
     }
+}
+
+fn scan_modules_from_roots(roots: &[PathBuf]) -> Vec<String> {
+    let mut modules: Vec<String> = Vec::new();
+    for root in roots {
+        let mut stack = vec![root.clone()];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().is_some_and(|ext| ext == "pm")
+                    && let Ok(relative) = path.strip_prefix(root)
+                    && let Some(module_name) = path_to_module_name(relative)
+                {
+                    modules.push(module_name);
+                }
+            }
+        }
+    }
+    modules
+}
+
+fn path_to_module_name(relative_path: &Path) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    for component in relative_path.components() {
+        let segment = component.as_os_str().to_string_lossy();
+        if segment.is_empty() {
+            continue;
+        }
+        parts.push(segment.to_string());
+    }
+
+    let file_name = parts.pop()?;
+    let module_stem = file_name.strip_suffix(".pm")?;
+    if module_stem.is_empty() {
+        return None;
+    }
+    parts.push(module_stem.to_string());
+    Some(parts.join("::"))
 }
 
 /// Add import completions for symbols inside `use Module qw(...)`.


### PR DESCRIPTION
### Motivation

- Module-name completion for `use`/`require` currently only surfaced workspace-indexed packages and missed modules available via configured include roots and optional system `@INC` paths.
- The goal is to augment completions with external `.pm` modules while preserving workspace-first precedence and avoiding duplicate entries.

### Description

- Added `include_roots: Vec<PathBuf>` and `system_inc_roots: Vec<PathBuf>` to `CompletionProvider` and a new constructor `new_with_index_source_and_inc_roots(...)` to accept explicit include/system roots.
- Extended `add_use_module_completions` to merge workspace-index results with modules discovered by scanning include roots and system `@INC`, deduping by module name and keeping workspace entries first.
- Implemented helper functions `scan_modules_from_roots(...)` and `path_to_module_name(...)` in `workspace.rs` to find `.pm` files and convert filesystem paths (e.g. `DBD/SQLite.pm`) into Perl module names (`DBD::SQLite`).
- Added focused tests exercising include-root scanning and workspace-precedence/dedup behavior and wired the new roots through the completion dispatch path.

### Testing

- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo check --workspace --all-targets` which completed successfully.
- Ran `cargo test -p perl-lsp-rs-core` and observed the repository-wide suite mostly passing but one unrelated existing test failed due to a missing fixture path (`/workspace/perl-lsp/crates/perl-lsp/Cargo.toml`) outside the scope of these changes.
- Ran the focused tests `cargo test -p perl-lsp-rs-core test_use_module_completion_scans_include_roots` and `cargo test -p perl-lsp-rs-core test_use_module_workspace_precedence_and_dedupe_with_include_roots` and both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb00674f348333a28751e83d8c9385)