### PR TITLE
feat(completion): include external @INC modules in use/require completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -122,6 +122,7 @@ use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
 use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_workspace::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Maps module_name -> Set of explicitly imported symbol names.
@@ -169,6 +170,8 @@ pub struct CompletionProvider {
     class_models: Vec<ClassModel>,
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
+    include_roots: Vec<PathBuf>,
+    system_inc_roots: Vec<PathBuf>,
     import_map: ImportMap,
 }
 
@@ -249,6 +252,23 @@ impl CompletionProvider {
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
     ) -> Self {
+        Self::new_with_index_and_source_and_paths(
+            ast,
+            source,
+            workspace_index,
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+
+    /// Create a new completion provider with workspace and external module roots.
+    pub fn new_with_index_and_source_and_paths(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        include_roots: Vec<PathBuf>,
+        system_inc_roots: Vec<PathBuf>,
+    ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
         let type_engine = workspace_index.as_ref().map(|_| {
@@ -258,7 +278,15 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            include_roots,
+            system_inc_roots,
+            import_map,
+        }
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -774,6 +802,8 @@ impl CompletionProvider {
                 &mut completions,
                 &context,
                 &self.workspace_index,
+                &self.include_roots,
+                &self.system_inc_roots,
             );
         } else if self.is_has_type_value_context(source, position) {
             self.add_has_type_completions(&mut completions, &context);
@@ -2147,7 +2177,9 @@ mod tests {
     use perl_parser_core::Parser;
     use perl_tdd_support::{must, must_some};
     use perl_workspace::workspace_index::WorkspaceIndex;
+    use std::fs;
     use std::sync::Arc;
+    use tempfile::TempDir;
     use url::Url;
 
     #[test]
@@ -3556,6 +3588,76 @@ sub helper { }
         assert_eq!(
             myapp_count, 1,
             "Duplicate package declarations should produce exactly one completion"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_use_module_completion_includes_configured_include_roots()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let include_dir = TempDir::new()?;
+        fs::create_dir_all(include_dir.path().join("DB"))?;
+        fs::write(include_dir.path().join("DB").join("Schema.pm"), "package DB::Schema;\n1;\n")?;
+
+        let code = "use DB";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+
+        let provider = CompletionProvider::new_with_index_and_source_and_paths(
+            &ast,
+            code,
+            None,
+            vec![include_dir.path().to_path_buf()],
+            Vec::new(),
+        );
+        let completions = provider.get_completions(code, code.len());
+
+        assert!(
+            completions
+                .iter()
+                .any(|c| c.label == "DB::Schema" && c.kind == CompletionItemKind::Module),
+            "use DB should surface DB::Schema from configured include roots; got: {:?}",
+            completions.iter().map(|c| (&c.label, &c.kind, &c.detail)).collect::<Vec<_>>()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_use_module_workspace_precedence_and_external_dedupe()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let include_dir = TempDir::new()?;
+        fs::create_dir_all(include_dir.path().join("My"))?;
+        fs::write(include_dir.path().join("My").join("App.pm"), "package My::App;\n1;\n")?;
+
+        let system_dir = TempDir::new()?;
+        fs::create_dir_all(system_dir.path().join("My"))?;
+        fs::write(system_dir.path().join("My").join("App.pm"), "package My::App;\n1;\n")?;
+
+        let index = Arc::new(WorkspaceIndex::new());
+        index.index_file(
+            Url::parse("file:///workspace/lib/My/App.pm")?,
+            "package My::App;\n1;\n".to_string(),
+        )?;
+
+        let code = "use My::A";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+
+        let provider = CompletionProvider::new_with_index_and_source_and_paths(
+            &ast,
+            code,
+            Some(index),
+            vec![include_dir.path().to_path_buf()],
+            vec![system_dir.path().to_path_buf()],
+        );
+        let completions = provider.get_completions(code, code.len());
+
+        let matching: Vec<_> = completions.iter().filter(|c| c.label == "My::App").collect();
+        assert_eq!(matching.len(), 1, "My::App should be deduplicated across all module sources");
+        assert_eq!(
+            matching.first().and_then(|item| item.detail.as_deref()),
+            Some("module"),
+            "workspace module should win precedence over include/system roots"
         );
         Ok(())
     }

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -14,6 +14,7 @@ use perl_workspace::workspace_index::{
     SymbolKind as WsSymbolKind, VarKind, WorkspaceIndex, WorkspaceSymbol,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 /// Add workspace symbol completions for functions and variables
@@ -240,55 +241,192 @@ pub fn add_use_module_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
+    include_roots: &[PathBuf],
+    system_inc_roots: &[PathBuf],
 ) {
-    let Some(index) = workspace_index else {
-        return;
-    };
-
-    if !index.has_symbols() {
-        return;
-    }
-
     let mut seen: HashSet<String> = HashSet::new();
 
-    // Search for package symbols matching the prefix
-    let all_symbols = if context.prefix.is_empty() {
-        index.all_symbols()
-    } else {
-        index.find_symbols(&context.prefix)
-    };
+    if let Some(index) = workspace_index
+        && index.has_symbols()
+    {
+        // Search for package symbols matching the prefix
+        let all_symbols = if context.prefix.is_empty() {
+            index.all_symbols()
+        } else {
+            index.find_symbols(&context.prefix)
+        };
 
-    for symbol in all_symbols {
-        if symbol.kind != WsSymbolKind::Package {
+        for symbol in all_symbols {
+            if symbol.kind != WsSymbolKind::Package {
+                continue;
+            }
+
+            // Match against the module name prefix
+            if !context.prefix.is_empty() && !symbol.name.starts_with(&context.prefix) {
+                continue;
+            }
+
+            if !seen.insert(symbol.name.clone()) {
+                continue;
+            }
+
+            let name = &symbol.name;
+            completions.push(CompletionItem {
+                label: name.clone(),
+                kind: CompletionItemKind::Module,
+                detail: Some("module".to_string()),
+                documentation: symbol
+                    .documentation
+                    .clone()
+                    .or_else(|| Some(format!("Package `{name}`"))),
+                insert_text: Some(name.clone()),
+                sort_text: Some(format!("1{}_{name}", module_sort_tier(name))),
+                filter_text: Some(name.clone()),
+                additional_edits: vec![],
+                text_edit_range: Some((context.prefix_start, context.position)),
+                commit_characters: None,
+            });
+        }
+    }
+
+    append_module_completions_from_roots(
+        completions,
+        context,
+        include_roots,
+        "module (include path)",
+        &mut seen,
+    );
+    append_module_completions_from_roots(
+        completions,
+        context,
+        system_inc_roots,
+        "module (system @INC)",
+        &mut seen,
+    );
+}
+
+fn append_module_completions_from_roots(
+    completions: &mut Vec<CompletionItem>,
+    context: &CompletionContext,
+    roots: &[PathBuf],
+    detail: &str,
+    seen: &mut HashSet<String>,
+) {
+    for module_name in scan_module_names_from_roots(roots, &context.prefix) {
+        if !seen.insert(module_name.clone()) {
             continue;
         }
 
-        // Match against the module name prefix
-        if !context.prefix.is_empty() && !symbol.name.starts_with(&context.prefix) {
-            continue;
-        }
-
-        if !seen.insert(symbol.name.clone()) {
-            continue;
-        }
-
-        let name = &symbol.name;
         completions.push(CompletionItem {
-            label: name.clone(),
+            label: module_name.clone(),
             kind: CompletionItemKind::Module,
-            detail: Some("module".to_string()),
-            documentation: symbol
-                .documentation
-                .clone()
-                .or_else(|| Some(format!("Package `{name}`"))),
-            insert_text: Some(name.clone()),
-            sort_text: Some(format!("1{}_{name}", module_sort_tier(name))),
-            filter_text: Some(name.clone()),
+            detail: Some(detail.to_string()),
+            documentation: None,
+            insert_text: Some(module_name.clone()),
+            sort_text: Some(format!("1{}_{module_name}", module_sort_tier(&module_name))),
+            filter_text: Some(module_name),
             additional_edits: vec![],
             text_edit_range: Some((context.prefix_start, context.position)),
             commit_characters: None,
         });
     }
+}
+
+fn scan_module_names_from_roots(roots: &[PathBuf], prefix: &str) -> Vec<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut modules = Vec::new();
+
+    for root in roots {
+        modules.extend(scan_module_names_from_root(root, prefix, &mut seen));
+    }
+
+    modules
+}
+
+fn scan_module_names_from_root(
+    root: &Path,
+    prefix: &str,
+    seen: &mut HashSet<String>,
+) -> Vec<String> {
+    if !root.is_dir() {
+        return Vec::new();
+    }
+
+    let mut modules = Vec::new();
+    let mut dirs: VecDeque<PathBuf> = VecDeque::from([root.to_path_buf()]);
+
+    while let Some(dir) = dirs.pop_front() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                dirs.push_back(path);
+                continue;
+            }
+
+            let is_pm = path.extension().and_then(|ext| ext.to_str()) == Some("pm");
+            if !is_pm {
+                continue;
+            }
+
+            let Some(module_name) = module_name_from_pm_path(root, &path) else {
+                continue;
+            };
+
+            if !prefix.is_empty() && !module_name.starts_with(prefix) {
+                continue;
+            }
+
+            if seen.insert(module_name.clone()) {
+                modules.push(module_name);
+            }
+        }
+    }
+
+    modules
+}
+
+fn module_name_from_pm_path(root: &Path, file_path: &Path) -> Option<String> {
+    let relative = file_path.strip_prefix(root).ok()?;
+    let mut components = relative.components().peekable();
+    let mut segments = Vec::new();
+
+    while let Some(component) = components.next() {
+        let segment = component.as_os_str().to_str()?;
+        if components.peek().is_none() {
+            let module_stem = segment.strip_suffix(".pm")?;
+            if !is_valid_module_segment(module_stem) {
+                return None;
+            }
+            segments.push(module_stem.to_string());
+        } else if is_valid_module_segment(segment) {
+            segments.push(segment.to_string());
+        } else {
+            return None;
+        }
+    }
+
+    if segments.is_empty() {
+        return None;
+    }
+
+    Some(segments.join("::"))
+}
+
+fn is_valid_module_segment(segment: &str) -> bool {
+    let mut chars = segment.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    if !first.is_ascii_alphabetic() && first != '_' {
+        return false;
+    }
+
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
 /// Add import completions for symbols inside `use Module qw(...)`.


### PR DESCRIPTION
### Motivation
- `use`/`require` completion only surfaced workspace-index packages and missed modules present in configured include roots or system @INC, making external modules hard to discover in the editor. 
- The goal is to merge filesystem-discovered `.pm` modules with workspace results, keep workspace modules winning precedence, and avoid duplicate names from multiple roots.

### Description
- Extended `add_use_module_completions` to accept `include_roots` and `system_inc_roots` and merge workspace-index package completions with modules discovered on disk.
- Added filesystem helpers: `scan_module_names_from_roots`, `scan_module_names_from_root`, `module_name_from_pm_path`, and `is_valid_module_segment` to locate `.pm` files and convert paths like `Foo/Bar.pm` → `Foo::Bar` safely.
- Added `append_module_completions_from_roots` to append include/system-derived completions and dedupe by module name using a workspace-first `seen` set.
- Extended `CompletionProvider` to carry `include_roots` and `system_inc_roots` and added `new_with_index_and_source_and_paths` while preserving existing constructor behavior.
- Added focused unit tests: `test_use_module_completion_includes_configured_include_roots` and `test_use_module_workspace_precedence_and_external_dedupe` to verify scanning, merge, precedence, and dedupe behavior.

### Testing
- Ran targeted unit tests: `cargo test -p perl-lsp-rs-core use_module_completion_includes_configured_include_roots` — passed. 
- Ran targeted unit tests: `cargo test -p perl-lsp-rs-core use_module_workspace_precedence_and_external_dedupe` — passed. 
- Performed workspace check: `cargo check --workspace --all-targets` — passed. 
- Ran full crate tests `cargo test -p perl-lsp-rs-core` where the two new focused tests passed but the full test run failed due to a pre-existing, unrelated test (`green_tdd_wave_g1b_regression_hardening::test_perl_lsp_cargo_toml_removed_g1b_imports`) external to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb00674f348333a28751e83d8c9385)