### PR TITLE
feat(refactor): add safe-delete cross-file preflight (#3522)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/mod.rs
+++ b/crates/perl-workspace-index/src/workspace/mod.rs
@@ -51,4 +51,7 @@ pub use state_machine::{
     BuildPhase, DegradationReason, IndexState, IndexStateKind, IndexStateMachine,
     InvalidationReason, ResourceKind, TransitionResult,
 };
-pub use workspace_index::{IndexResourceLimits, Location, WorkspaceIndex};
+pub use workspace_index::{
+    IndexResourceLimits, Location, SafeDeletePreflightResult, SafeDeletePreflightStatus,
+    WorkspaceIndex,
+};

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -937,6 +937,28 @@ pub struct SymbolKey {
     pub kind: SymKind,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// Outcome state for safe-delete preflight checks.
+pub enum SafeDeletePreflightStatus {
+    /// Deletion can proceed because no external references were found.
+    Safe,
+    /// Deletion is blocked by references in other files.
+    BlockedByExternalReferences,
+}
+
+#[derive(Clone, Debug)]
+/// Structured result for safe-delete preflight checks.
+pub struct SafeDeletePreflightResult {
+    /// Symbol key used for the preflight query.
+    pub key: SymbolKey,
+    /// Definition location, if resolvable in the current index state.
+    pub definition: Option<Location>,
+    /// References found in files other than the definition file.
+    pub external_references: Vec<Location>,
+    /// Final preflight status.
+    pub status: SafeDeletePreflightStatus,
+}
+
 /// Normalize a Perl variable name for Index/Analyze workflows.
 ///
 /// Extracts an optional sigil and bare name for consistent symbol indexing.
@@ -2687,6 +2709,37 @@ impl WorkspaceIndex {
         });
 
         all_refs
+    }
+
+    /// Run safe-delete preflight for a symbol key using cross-file references.
+    ///
+    /// This plumbing-first API only enforces one blocking rule:
+    /// references in files other than the definition file.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - Normalized symbol key to evaluate for deletion safety.
+    ///
+    /// # Returns
+    ///
+    /// Structured preflight result suitable for later code-action/UI wiring.
+    pub fn safe_delete_preflight(&self, key: &SymbolKey) -> SafeDeletePreflightResult {
+        let definition = self.find_def(key);
+        let all_refs = self.find_refs(key);
+
+        let external_references = if let Some(def) = &definition {
+            all_refs.into_iter().filter(|reference| reference.uri != def.uri).collect()
+        } else {
+            all_refs
+        };
+
+        let status = if external_references.is_empty() {
+            SafeDeletePreflightStatus::Safe
+        } else {
+            SafeDeletePreflightStatus::BlockedByExternalReferences
+        };
+
+        SafeDeletePreflightResult { key: key.clone(), definition, external_references, status }
     }
 }
 

--- a/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
@@ -17,7 +17,8 @@ use perl_workspace::workspace::state_machine::{
     InvalidationReason, ResourceKind, TransitionResult,
 };
 use perl_workspace::workspace::workspace_index::{
-    IndexCoordinator, IndexResourceLimits, SymKind, SymbolKey, WorkspaceIndex,
+    IndexCoordinator, IndexResourceLimits, SafeDeletePreflightStatus, SymKind, SymbolKey,
+    WorkspaceIndex,
 };
 use std::sync::Arc;
 use url::Url;
@@ -324,6 +325,50 @@ fn test_find_refs_with_symbol_key() -> Result<(), Box<dyn std::error::Error>> {
     };
     // find_refs excludes the definition site
     let _refs = index.find_refs(&key);
+    Ok(())
+}
+
+#[test]
+fn test_safe_delete_preflight_blocked_by_external_refs() -> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let def_uri = file_url("/safe_delete_def.pm")?;
+    let caller_uri = file_url("/safe_delete_caller.pm")?;
+    index.index_file(def_uri, "package SafeDelete;\nsub victim { 1 }\nvictim();".to_string())?;
+    index.index_file(caller_uri, "package Caller;\nSafeDelete::victim();".to_string())?;
+
+    let key = SymbolKey {
+        pkg: Arc::from("SafeDelete"),
+        name: Arc::from("victim"),
+        sigil: None,
+        kind: SymKind::Sub,
+    };
+    let result = index.safe_delete_preflight(&key);
+
+    assert_eq!(result.status, SafeDeletePreflightStatus::BlockedByExternalReferences);
+    assert_eq!(result.external_references.len(), 1);
+    assert!(result.external_references[0].uri.contains("safe_delete_caller.pm"));
+
+    Ok(())
+}
+
+#[test]
+fn test_safe_delete_preflight_safe_when_no_external_refs() -> Result<(), Box<dyn std::error::Error>>
+{
+    let index = WorkspaceIndex::new();
+    let def_uri = file_url("/safe_delete_only.pm")?;
+    index.index_file(def_uri, "package SafeDelete;\nsub victim { 1 }\nvictim();".to_string())?;
+
+    let key = SymbolKey {
+        pkg: Arc::from("SafeDelete"),
+        name: Arc::from("victim"),
+        sigil: None,
+        kind: SymKind::Sub,
+    };
+    let result = index.safe_delete_preflight(&key);
+
+    assert_eq!(result.status, SafeDeletePreflightStatus::Safe);
+    assert!(result.external_references.is_empty());
+
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Problem: safe-delete needs a cross-file preflight that blocks deletion when a symbol is referenced from other files. 
- The first slice should be plumbing-first and return structured data usable later by code-actions or UI wiring.

### Description
- Added `SafeDeletePreflightStatus` and `SafeDeletePreflightResult` types to represent preflight outcome and structured details. 
- Implemented `WorkspaceIndex::safe_delete_preflight(&SymbolKey)` which uses `find_def` + `find_refs` and treats any references outside the definition file as blocking. 
- Re-exported the new types from `workspace::mod` and added unit tests covering both "external refs => blocked" and "no refs => safe" scenarios.

### Testing
- Ran `cargo test -p perl-workspace` and the crate test suite passed. 
- `cargo test -p perl-workspace-index` did not match a package name in this workspace (the package is `perl-workspace`), so the canonical test invocation is `cargo test -p perl-workspace`. 
- Ran `cargo check --workspace --all-targets` which completed successfully. 
- Ran `cargo xtask fmt` as part of verification which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb00514cd483339c126853d049c22f)