### PR TITLE
fix(perl-lsp-config): block workspace perlPath/perlArgs for @INC probe (#3729)

### DIFF
--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -366,21 +366,6 @@ impl WorkspaceConfig {
                 }
                 self.use_system_inc = use_inc;
             }
-            if let Some(perl_path) = workspace.get("perlPath").and_then(|v| v.as_str()) {
-                let next = Some(perl_path.to_string());
-                if next != self.perl_path {
-                    self.system_inc_cache = None;
-                }
-                self.perl_path = next;
-            }
-            if let Some(perl_args) = workspace.get("perlArgs").and_then(|v| v.as_array()) {
-                let next: Vec<String> =
-                    perl_args.iter().filter_map(|v| v.as_str().map(str::to_string)).collect();
-                if next != self.perl_args {
-                    self.system_inc_cache = None;
-                }
-                self.perl_args = next;
-            }
             if let Some(timeout) = workspace.get("resolutionTimeout").and_then(|v| v.as_u64()) {
                 self.resolution_timeout_ms = timeout;
             }
@@ -783,7 +768,7 @@ mod tests {
     }
 
     #[test]
-    fn workspace_config_updates_perl_probe_settings() {
+    fn workspace_config_ignores_untrusted_perl_probe_settings() {
         let mut config = WorkspaceConfig::default();
         config.update_from_value(&json!({
             "workspace": {
@@ -791,8 +776,8 @@ mod tests {
                 "perlArgs": ["-I", "/tmp/custom/lib"]
             }
         }));
-        assert_eq!(config.perl_path.as_deref(), Some("/opt/custom/perl"));
-        assert_eq!(config.perl_args, vec!["-I", "/tmp/custom/lib"]);
+        assert!(config.perl_path.is_none());
+        assert!(config.perl_args.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- A workspace/client-controlled `perlPath`/`perlArgs` could override the executable and arguments used for the startup `@INC` probe and lead to arbitrary code execution when `useSystemInc` is enabled.
- Workspace settings are untrusted by default and must not be allowed to control process execution surfaces invoked by the server during normal initialization.

### Description
- Removed handling of `workspace.perlPath` and `workspace.perlArgs` from `WorkspaceConfig::update_from_value` in `crates/perl-lsp-config/src/lib.rs` to prevent untrusted configuration from altering the probe command.
- Kept `get_system_inc` / `fetch_perl_inc` unchanged so local, trusted code paths still resolve `@INC` from the toolchain or default `perl` on `PATH`.
- Added/updated unit test `workspace_config_ignores_untrusted_perl_probe_settings()` to assert `perl_path` remains `None` and `perl_args` remain empty after applying workspace settings that attempt to set them.

### Testing
- Ran formatting with `cargo fmt --all` and it completed successfully.
- Ran `cargo test -p perl-lsp-config` and all tests passed (unit and behavioral tests for the crate succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8cc4c96bc8333a2eccd39ba13f374)