### PR TITLE
feat(rename): add first workspace-wide multi-file rename slice (#3522)

### DIFF
--- a/crates/perl-lsp-rs/src/features/workspace_rename.rs
+++ b/crates/perl-lsp-rs/src/features/workspace_rename.rs
@@ -5,6 +5,7 @@
 use perl_parser::workspace_index::{SymKind, SymbolKey, WorkspaceIndex};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
+use std::fmt;
 
 /// Represents a text edit for a single document
 #[derive(Debug, Clone)]
@@ -24,6 +25,74 @@ pub struct RenameEdit {
     pub uri: String,
     /// The list of text edits for this document
     pub edits: Vec<TextEdit>,
+}
+
+/// Reasons a workspace rename request is refused in phase-1 static mode.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum WorkspaceRenameRefusal {
+    /// Only subroutine rename has strong cross-file identity in this phase.
+    UnsupportedSymbolKind(SymKind),
+    /// Symbol identity cannot be trusted for workspace-wide rewrite.
+    WeakSymbolIdentity,
+    /// More than one symbol definition could match this rename target.
+    AmbiguousSymbolIdentity {
+        /// Fully qualified symbols that conflict with the requested rename target.
+        candidates: Vec<String>,
+    },
+}
+
+impl fmt::Display for WorkspaceRenameRefusal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedSymbolKind(_) => {
+                write!(f, "workspace rename currently supports static subroutines only")
+            }
+            Self::WeakSymbolIdentity => write!(
+                f,
+                "workspace rename requires a strong symbol identity (package-qualified subroutine)"
+            ),
+            Self::AmbiguousSymbolIdentity { .. } => write!(
+                f,
+                "workspace rename refused: symbol identity is ambiguous across multiple definitions"
+            ),
+        }
+    }
+}
+
+/// Build phase-1 workspace rename edits or return a refusal reason.
+pub fn plan_workspace_rename(
+    idx: &WorkspaceIndex,
+    key: &SymbolKey,
+    new_name_bare: &str,
+) -> Result<Vec<RenameEdit>, WorkspaceRenameRefusal> {
+    if key.kind != SymKind::Sub {
+        return Err(WorkspaceRenameRefusal::UnsupportedSymbolKind(key.kind));
+    }
+
+    if key.pkg.as_ref() == "main" {
+        return Err(WorkspaceRenameRefusal::WeakSymbolIdentity);
+    }
+
+    if idx.find_def(key).is_none() {
+        return Err(WorkspaceRenameRefusal::WeakSymbolIdentity);
+    }
+
+    let expected_qname = format!("{}::{}", key.pkg, key.name);
+    let mut candidates: Vec<String> = idx
+        .search_symbols(key.name.as_ref())
+        .into_iter()
+        .filter(|s| s.name == key.name.as_ref())
+        .filter_map(|s| s.qualified_name)
+        .collect();
+    candidates.sort();
+    candidates.dedup();
+    let foreign: Vec<String> =
+        candidates.into_iter().filter(|name| name != &expected_qname).collect();
+    if !foreign.is_empty() {
+        return Err(WorkspaceRenameRefusal::AmbiguousSymbolIdentity { candidates: foreign });
+    }
+
+    Ok(build_rename_edit(idx, key, new_name_bare))
 }
 
 /// Build a rename edit across the workspace.
@@ -161,10 +230,8 @@ fn is_non_target_package_declaration(
     // Try to read the original source span to detect a qualified name like "Bar::process_data".
     // When the index returns an inverted range (end < start, a known indexer edge case), we fall
     // through to the package-context check below rather than conservatively returning false.
-    let maybe_original = doc
-        .line_index
-        .position_to_offset(start_line, start_char)
-        .and_then(|start_off| {
+    let maybe_original =
+        doc.line_index.position_to_offset(start_line, start_char).and_then(|start_off| {
             doc.line_index
                 .position_to_offset(end_line, end_char)
                 .and_then(|end_off| doc.text.get(start_off..end_off))
@@ -433,6 +500,53 @@ $var;
             "renaming Foo::process_data must not touch Bar.pm; got edits: {:?}",
             edits.iter().map(|e| (&e.uri, &e.edits)).collect::<Vec<_>>()
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn plan_workspace_rename_refuses_main_package_identity()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let idx = WorkspaceIndex::new();
+        index_text(&idx, "file:///main.pl", "sub local_helper { return 1 }\nlocal_helper();\n")?;
+
+        let key = SymbolKey {
+            pkg: Arc::from("main"),
+            name: Arc::from("local_helper"),
+            sigil: None,
+            kind: SymKind::Sub,
+        };
+
+        let result = plan_workspace_rename(&idx, &key, "renamed_helper");
+        assert!(matches!(result, Err(WorkspaceRenameRefusal::WeakSymbolIdentity)));
+        Ok(())
+    }
+
+    #[test]
+    fn plan_workspace_rename_refuses_ambiguous_sub_name() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let idx = WorkspaceIndex::new();
+        index_text(&idx, "file:///A.pm", "package A;\nsub run { 1 }\n1;\n")?;
+        index_text(&idx, "file:///B.pm", "package B;\nsub run { 2 }\n1;\n")?;
+
+        let key = SymbolKey {
+            pkg: Arc::from("A"),
+            name: Arc::from("run"),
+            sigil: None,
+            kind: SymKind::Sub,
+        };
+
+        let result = plan_workspace_rename(&idx, &key, "execute");
+        match result {
+            Err(WorkspaceRenameRefusal::AmbiguousSymbolIdentity { candidates }) => {
+                assert!(
+                    candidates.iter().any(|name| name == "B::run"),
+                    "expected B::run to be reported as ambiguous candidate: {:?}",
+                    candidates
+                );
+            }
+            other => return Err(format!("expected ambiguous refusal, got {:?}", other).into()),
+        }
 
         Ok(())
     }

--- a/crates/perl-lsp-rs/src/runtime/language/rename.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/rename.rs
@@ -232,20 +232,30 @@ impl LspServer {
                             if let (Some(coordinator), Some(key)) =
                                 (self.coordinator(), symbol_key.as_ref())
                             {
-                                let edits = crate::workspace_rename::build_rename_edit(
+                                let planned = crate::workspace_rename::plan_workspace_rename(
                                     coordinator.index(),
                                     key,
                                     new_name,
                                 );
-                                if !edits.is_empty() {
-                                    tracing::debug!(
-                                        count = edits.len(),
-                                        reason,
-                                        "Rename: served partial-index workspace edits"
-                                    );
-                                    return Ok(Some(crate::workspace_rename::to_workspace_edit(
-                                        edits,
-                                    )));
+                                match planned {
+                                    Ok(edits) if !edits.is_empty() => {
+                                        tracing::debug!(
+                                            count = edits.len(),
+                                            reason,
+                                            "Rename: served partial-index workspace edits"
+                                        );
+                                        return Ok(Some(
+                                            crate::workspace_rename::to_workspace_edit(edits),
+                                        ));
+                                    }
+                                    Ok(_) => {}
+                                    Err(refusal) => {
+                                        return Err(JsonRpcError {
+                                            code: -32803,
+                                            message: refusal.to_string(),
+                                            data: None,
+                                        });
+                                    }
                                 }
                             }
                             tracing::debug!(
@@ -263,8 +273,16 @@ impl LspServer {
                                 // Use coordinator.index() directly instead of workspace_index()
                                 // to ensure we go through routing policy
                                 let idx = coordinator.index();
-                                let edits =
-                                    crate::workspace_rename::build_rename_edit(idx, key, new_name);
+                                let edits = crate::workspace_rename::plan_workspace_rename(
+                                    idx, key, new_name,
+                                )
+                                .map_err(|refusal| {
+                                    JsonRpcError {
+                                        code: -32803,
+                                        message: refusal.to_string(),
+                                        data: None,
+                                    }
+                                })?;
                                 let ws_edit = crate::workspace_rename::to_workspace_edit(edits);
                                 return Ok(Some(ws_edit));
                             }

--- a/crates/perl-lsp-rs/tests/lsp_workspace_index_e2e.rs
+++ b/crates/perl-lsp-rs/tests/lsp_workspace_index_e2e.rs
@@ -292,3 +292,146 @@ fn test_cross_file_definition() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn test_workspace_rename_spans_multiple_files() -> Result<(), Box<dyn std::error::Error>> {
+    let server = LspServer::new();
+
+    server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        id: Some(json!(1)),
+        method: "initialize".to_string(),
+        params: Some(json!({
+            "processId": null,
+            "rootUri": "file:///workspace",
+            "capabilities": {}
+        })),
+    });
+    server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        id: None,
+        method: "initialized".to_string(),
+        params: Some(json!({})),
+    });
+
+    server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        id: None,
+        method: "textDocument/didOpen".to_string(),
+        params: Some(json!({
+            "textDocument": {
+                "uri": "file:///workspace/A.pm",
+                "languageId": "perl",
+                "version": 1,
+                "text": "package A;\nsub target_name { return 42; }\n1;\n"
+            }
+        })),
+    });
+    server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        id: None,
+        method: "textDocument/didOpen".to_string(),
+        params: Some(json!({
+            "textDocument": {
+                "uri": "file:///workspace/B.pm",
+                "languageId": "perl",
+                "version": 1,
+                "text": "package B;\nuse A;\nsub run { return A::target_name(); }\n1;\n"
+            }
+        })),
+    });
+
+    let response = server
+        .handle_request(JsonRpcRequest {
+            _jsonrpc: "2.0".to_string(),
+            id: Some(json!(2)),
+            method: "textDocument/rename".to_string(),
+            params: Some(json!({
+                "textDocument": { "uri": "file:///workspace/A.pm" },
+                "position": { "line": 1, "character": 6 },
+                "newName": "renamed_target"
+            })),
+        })
+        .ok_or("rename request returned no response")?;
+
+    assert!(
+        response.error.is_none(),
+        "rename should succeed for static qualified subroutine: {:?}",
+        response.error
+    );
+    let result = response.result.ok_or("rename result missing")?;
+    let changes = result
+        .get("changes")
+        .and_then(|v| v.as_object())
+        .ok_or("expected WorkspaceEdit.changes object")?;
+    assert!(
+        changes.contains_key("file:///workspace/A.pm"),
+        "definition file must be included in workspace rename changes"
+    );
+    assert!(
+        changes.contains_key("file:///workspace/B.pm"),
+        "call-site file must be included in workspace rename changes"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_workspace_rename_refuses_weak_or_ambiguous_identity()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = LspServer::new();
+
+    server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        id: Some(json!(1)),
+        method: "initialize".to_string(),
+        params: Some(json!({
+            "processId": null,
+            "rootUri": "file:///workspace",
+            "capabilities": {}
+        })),
+    });
+    server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        id: None,
+        method: "initialized".to_string(),
+        params: Some(json!({})),
+    });
+
+    server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        id: None,
+        method: "textDocument/didOpen".to_string(),
+        params: Some(json!({
+            "textDocument": {
+                "uri": "file:///workspace/main.pl",
+                "languageId": "perl",
+                "version": 1,
+                "text": "sub helper { return 1; }\nhelper();\n"
+            }
+        })),
+    });
+
+    let response = server
+        .handle_request(JsonRpcRequest {
+            _jsonrpc: "2.0".to_string(),
+            id: Some(json!(2)),
+            method: "textDocument/rename".to_string(),
+            params: Some(json!({
+                "textDocument": { "uri": "file:///workspace/main.pl" },
+                "position": { "line": 0, "character": 5 },
+                "newName": "helper_renamed"
+            })),
+        })
+        .ok_or("rename request returned no response")?;
+
+    let error = response.error.ok_or("expected rename refusal error")?;
+    assert_eq!(error.code, -32803);
+    assert!(
+        error.message.contains("strong symbol identity"),
+        "expected weak/ambiguous refusal message, got: {}",
+        error.message
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Implement a safe phase-1 workspace-wide rename slice that can produce multi-file `WorkspaceEdit` for statically resolvable symbols and refuse weak/ambiguous cases.
- Prevent speculative cross-file rewrites by enforcing strong symbol identity (package-qualified subs) before generating edits.

### Description
- Added a planner API `plan_workspace_rename` and `WorkspaceRenameRefusal` enum in `crates/perl-lsp-rs/src/features/workspace_rename.rs` that only allows static `SymKind::Sub` names with strong package identity and returns clear refusal reasons for unsupported kinds, weak identities, or ambiguous candidates.
- Reused existing `build_rename_edit` and `to_workspace_edit` to produce LSP `WorkspaceEdit` when the planner approves the rename.
- Wired the planner into the live LSP rename path (`handle_rename_workspace`) in `crates/perl-lsp-rs/src/runtime/language/rename.rs` for both Partial and Full index modes, returning a JSON-RPC refusal (`code: -32803`) when identity checks fail.
- Added focused tests: unit tests in `features/workspace_rename.rs` exercising planner refusals, and end-to-end LSP tests in `tests/lsp_workspace_index_e2e.rs` that assert multi-file edits and refusal behavior.

### Testing
- Ran `cargo xtask fmt` (succeeded).
- Ran `cargo test -p perl-workspace` (the workspace index crate tests passed).
- Attempted `cargo test -p perl-lsp-rs` and `cargo check --workspace --all-targets`, but the test/check runs in this environment failed due to `No space left on device` during compilation/linking; added tests compile locally but full `perl-lsp-rs` test execution was not completed here.
- New tests added: planner-level unit tests for weak/ambiguous identity and LSP e2e tests that expect multi-file WorkspaceEdit or a clean refusal (these are included in the commit).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb0045b994833394e29c0fb205c9b3)