### PR TITLE
feat(rename): add first workspace-wide multi-file rename slice (#3522)

### DIFF
--- a/crates/perl-lsp-rs/src/features/workspace_rename.rs
+++ b/crates/perl-lsp-rs/src/features/workspace_rename.rs
@@ -5,6 +5,7 @@
 use perl_parser::workspace_index::{SymKind, SymbolKey, WorkspaceIndex};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
+use std::fmt;
 
 /// Represents a text edit for a single document
 #[derive(Debug, Clone)]
@@ -26,6 +27,33 @@ pub struct RenameEdit {
     pub edits: Vec<TextEdit>,
 }
 
+/// Why a workspace-wide rename cannot be planned safely.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RenameRefusal {
+    /// Symbol identity exists but is too weak for safe cross-file edits.
+    WeakIdentity(&'static str),
+    /// Multiple plausible targets were found; refusing avoids unsafe edits.
+    AmbiguousIdentity(&'static str),
+}
+
+impl fmt::Display for RenameRefusal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RenameRefusal::WeakIdentity(reason) => write!(f, "{reason}"),
+            RenameRefusal::AmbiguousIdentity(reason) => write!(f, "{reason}"),
+        }
+    }
+}
+
+impl std::error::Error for RenameRefusal {}
+
+impl RenameRefusal {
+    /// True when the caller can fall back to same-file rename safely.
+    pub fn can_fallback_same_file(&self) -> bool {
+        matches!(self, Self::WeakIdentity(_))
+    }
+}
+
 /// Build a rename edit across the workspace.
 ///
 /// Finds all references to the given symbol and builds text edits to rename them.
@@ -33,7 +61,9 @@ pub fn build_rename_edit(
     idx: &WorkspaceIndex,
     key: &SymbolKey,
     new_name_bare: &str,
-) -> Vec<RenameEdit> {
+) -> Result<Vec<RenameEdit>, RenameRefusal> {
+    ensure_workspace_identity_is_safe(idx, key)?;
+
     // 1) Get all references across the workspace
     let mut locs = idx.find_refs(key);
 
@@ -100,7 +130,28 @@ pub fn build_rename_edit(
     }
 
     // Convert to RenameEdit structs
-    grouped.into_iter().map(|(uri, edits)| RenameEdit { uri, edits }).collect()
+    Ok(grouped.into_iter().map(|(uri, edits)| RenameEdit { uri, edits }).collect())
+}
+
+fn ensure_workspace_identity_is_safe(
+    idx: &WorkspaceIndex,
+    key: &SymbolKey,
+) -> Result<(), RenameRefusal> {
+    if idx.find_def(key).is_none() {
+        return Err(RenameRefusal::WeakIdentity(
+            "workspace rename refused: symbol definition could not be resolved",
+        ));
+    }
+
+    match key.kind {
+        SymKind::Var => Err(RenameRefusal::WeakIdentity(
+            "workspace rename refused: variable identity is file-local or lexical",
+        )),
+        SymKind::Sub if key.pkg.as_ref() == "main" => Err(RenameRefusal::AmbiguousIdentity(
+            "workspace rename refused: main package subroutine identity is ambiguous",
+        )),
+        SymKind::Sub | SymKind::Pack => Ok(()),
+    }
 }
 
 fn package_name_for_line(text: &str, target_line: u32) -> &str {
@@ -161,10 +212,8 @@ fn is_non_target_package_declaration(
     // Try to read the original source span to detect a qualified name like "Bar::process_data".
     // When the index returns an inverted range (end < start, a known indexer edge case), we fall
     // through to the package-context check below rather than conservatively returning false.
-    let maybe_original = doc
-        .line_index
-        .position_to_offset(start_line, start_char)
-        .and_then(|start_off| {
+    let maybe_original =
+        doc.line_index.position_to_offset(start_line, start_char).and_then(|start_off| {
             doc.line_index
                 .position_to_offset(end_line, end_char)
                 .and_then(|end_off| doc.text.get(start_off..end_off))
@@ -275,7 +324,7 @@ $var;
             kind: SymKind::Sub,
         };
 
-        let edits = build_rename_edit(&idx, &key, "new_name");
+        let edits = build_rename_edit(&idx, &key, "new_name")?;
         assert_eq!(edits.len(), 1);
 
         let texts: Vec<String> = edits[0].edits.iter().map(|e| e.new_text.clone()).collect();
@@ -336,7 +385,7 @@ $var;
             kind: SymKind::Sub,
         };
 
-        let edits = build_rename_edit(&idx, &key, "renamed_target");
+        let edits = build_rename_edit(&idx, &key, "renamed_target")?;
 
         // The rename must produce at least one edit (for the definition in A.pm)
         assert!(
@@ -424,7 +473,7 @@ $var;
             kind: SymKind::Sub,
         };
 
-        let edits = build_rename_edit(&idx, &key, "process_records");
+        let edits = build_rename_edit(&idx, &key, "process_records")?;
 
         // Bar.pm must not appear in the edit list
         let bar_edit = edits.iter().find(|e| e.uri.contains("Bar.pm"));
@@ -434,6 +483,25 @@ $var;
             edits.iter().map(|e| (&e.uri, &e.edits)).collect::<Vec<_>>()
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn rename_main_sub_is_refused_as_ambiguous() -> Result<(), Box<dyn std::error::Error>> {
+        let idx = WorkspaceIndex::new();
+        index_text(&idx, "file:///a.pl", "sub helper { 1 }\nhelper();\n")?;
+        index_text(&idx, "file:///b.pl", "sub helper { 2 }\nhelper();\n")?;
+
+        let key = SymbolKey {
+            pkg: Arc::from("main"),
+            name: Arc::from("helper"),
+            sigil: None,
+            kind: SymKind::Sub,
+        };
+
+        let refusal = build_rename_edit(&idx, &key, "helper_renamed")
+            .expect_err("main package sub rename should be refused");
+        assert!(matches!(refusal, RenameRefusal::AmbiguousIdentity(_)));
         Ok(())
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/language/rename.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/rename.rs
@@ -237,15 +237,32 @@ impl LspServer {
                                     key,
                                     new_name,
                                 );
-                                if !edits.is_empty() {
-                                    tracing::debug!(
-                                        count = edits.len(),
-                                        reason,
-                                        "Rename: served partial-index workspace edits"
-                                    );
-                                    return Ok(Some(crate::workspace_rename::to_workspace_edit(
-                                        edits,
-                                    )));
+                                match edits {
+                                    Ok(edits) if !edits.is_empty() => {
+                                        tracing::debug!(
+                                            count = edits.len(),
+                                            reason,
+                                            "Rename: served partial-index workspace edits"
+                                        );
+                                        return Ok(Some(
+                                            crate::workspace_rename::to_workspace_edit(edits),
+                                        ));
+                                    }
+                                    Ok(_) => {}
+                                    Err(refusal) => {
+                                        if !refusal.can_fallback_same_file() {
+                                            return Err(JsonRpcError {
+                                                code: -32803,
+                                                message: refusal.to_string(),
+                                                data: None,
+                                            });
+                                        }
+                                        tracing::debug!(
+                                            reason,
+                                            refusal = %refusal,
+                                            "Rename: workspace rename refused, using same-file only"
+                                        );
+                                    }
                                 }
                             }
                             tracing::debug!(
@@ -263,10 +280,27 @@ impl LspServer {
                                 // Use coordinator.index() directly instead of workspace_index()
                                 // to ensure we go through routing policy
                                 let idx = coordinator.index();
-                                let edits =
-                                    crate::workspace_rename::build_rename_edit(idx, key, new_name);
-                                let ws_edit = crate::workspace_rename::to_workspace_edit(edits);
-                                return Ok(Some(ws_edit));
+                                match crate::workspace_rename::build_rename_edit(idx, key, new_name)
+                                {
+                                    Ok(edits) => {
+                                        let ws_edit =
+                                            crate::workspace_rename::to_workspace_edit(edits);
+                                        return Ok(Some(ws_edit));
+                                    }
+                                    Err(refusal) => {
+                                        if !refusal.can_fallback_same_file() {
+                                            return Err(JsonRpcError {
+                                                code: -32803,
+                                                message: refusal.to_string(),
+                                                data: None,
+                                            });
+                                        }
+                                        tracing::debug!(
+                                            refusal = %refusal,
+                                            "Rename: workspace rename refused, using same-file only"
+                                        );
+                                    }
+                                }
                             }
                         }
                     }

--- a/crates/perl-lsp-rs/tests/lsp_rename_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_rename_tests.rs
@@ -302,3 +302,28 @@ fn test_rename_out_of_bounds() -> TestResult {
 
     Ok(())
 }
+
+#[test]
+fn test_workspace_rename_refuses_ambiguous_main_package_sub() -> TestResult {
+    let mut harness = LspHarness::new();
+    let _init = harness.initialize(None)?;
+
+    let a_uri = "file:///workspace/a.pl";
+    let b_uri = "file:///workspace/b.pl";
+    harness.open(a_uri, "sub helper { 1 }\nhelper();\n")?;
+    harness.open(b_uri, "sub helper { 2 }\nhelper();\n")?;
+
+    let rename = harness.request(
+        "textDocument/rename",
+        json!({
+            "textDocument": { "uri": a_uri },
+            "position": { "line": 0, "character": 4 },
+            "newName": "helper_new"
+        }),
+    );
+
+    let err = rename.expect_err("ambiguous main-package rename should be refused");
+    assert!(err.contains("ambiguous"), "rename refusal should explain ambiguity, got: {err}");
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Provide a guarded workspace-wide rename planner that can assemble multi-file `WorkspaceEdit`s for statically resolved symbols while refusing unsafe or ambiguous cases.
- Ensure the live LSP rename path uses the planner and cleanly falls back to same-file behavior when workspace renames are unsafe.

### Description

- Added `RenameRefusal` (with `WeakIdentity` and `AmbiguousIdentity`) and `ensure_workspace_identity_is_safe` to validate symbol identity before producing cross-file edits. (`crates/perl-lsp-rs/src/features/workspace_rename.rs`).
- Changed `build_rename_edit` to return `Result<Vec<RenameEdit>, RenameRefusal>` and preserved previous edit-generation logic when identity is safe. (`crates/perl-lsp-rs/src/features/workspace_rename.rs`).
- Wired refusal semantics into the running LSP rename handler so workspace edits are returned when safe, weak-identity refusals allow same-file fallback, and ambiguous refusals surface a JSON-RPC error (`-32803`). (`crates/perl-lsp-rs/src/runtime/language/rename.rs`).
- Added tests: unit tests exercising planner behavior (cross-root rename and ambiguous `main` sub refusal) and an LSP-level test asserting an ambiguous rename request is refused cleanly. (`crates/perl-lsp-rs/src/features/workspace_rename.rs` tests and `crates/perl-lsp-rs/tests/lsp_rename_tests.rs`).
- Ran formatting on the modified files (`cargo fmt` invoked for the changed files).

### Testing

- Ran `cargo test -p perl-workspace` and the crate test suite completed successfully.
- Ran targeted `perl-lsp-rs` tests and they passed: `cargo test -p perl-lsp-rs workspace_rename::tests::rename_main_sub_is_refused_as_ambiguous --lib` passed and the LSP integration `test_workspace_rename_refuses_ambiguous_main_package_sub` also passed.
- Full `cargo test -p perl-lsp-rs` and `cargo check --workspace --all-targets` could not complete in this environment due to transient disk exhaustion (`No space left on device`); workspace cleanup was performed and targeted tests were re-run successfully.
- Note: an earlier command attempted `cargo test -p perl-workspace-index` but the crate name in this workspace is `perl-workspace` (tests were executed against the correct package name).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb0045b994833394e29c0fb205c9b3)