### PR TITLE
feat(module-resolution): support static require + manual import visibility (#3476)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1842,6 +1842,28 @@ impl ScopeAnalyzer {
 }
 
 fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
+    fn require_module_name(node: &Node) -> Option<String> {
+        let (name, args) = match &node.kind {
+            NodeKind::FunctionCall { name, args } => (name, args),
+            _ => return None,
+        };
+        if name != "require" {
+            return None;
+        }
+        let first = args.first()?;
+        match &first.kind {
+            NodeKind::Identifier { name } => Some(name.clone()),
+            NodeKind::String { value, .. } => {
+                let cleaned = value.trim_matches('\'').trim_matches('"').trim();
+                if cleaned.is_empty() {
+                    return None;
+                }
+                Some(cleaned.trim_end_matches(".pm").replace('/', "::"))
+            }
+            _ => None,
+        }
+    }
+
     fn push_symbol(imported: &mut std::collections::HashSet<String>, module: &str, token: &str) {
         let symbol = token.trim().trim_matches('\'').trim_matches('"').trim();
         if symbol.is_empty() || symbol == "," {
@@ -1865,6 +1887,76 @@ fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
         }
     }
 
+    fn arg_node_tokens(arg: &Node, out: &mut Vec<String>) {
+        match &arg.kind {
+            NodeKind::String { value, .. } => out.push(value.clone()),
+            NodeKind::Identifier { name } => {
+                if name.starts_with("qw") {
+                    let content = name
+                        .trim_start_matches("qw")
+                        .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                        .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                    out.extend(content.split_whitespace().map(str::to_string));
+                } else {
+                    out.push(name.clone());
+                }
+            }
+            NodeKind::ArrayLiteral { elements } => {
+                for element in elements {
+                    arg_node_tokens(element, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn inner_expr(node: &Node) -> &Node {
+        if let NodeKind::ExpressionStatement { expression } = &node.kind {
+            expression.as_ref()
+        } else {
+            node
+        }
+    }
+
+    fn collect_manual_imports_in_statements(
+        stmts: &[Node],
+        imported: &mut std::collections::HashSet<String>,
+    ) {
+        let mut required_modules: Vec<String> =
+            stmts.iter().filter_map(|stmt| require_module_name(inner_expr(stmt))).collect();
+        required_modules.sort();
+        required_modules.dedup();
+
+        if required_modules.is_empty() {
+            return;
+        }
+
+        for stmt in stmts {
+            let expr = inner_expr(stmt);
+            let (object, method, args) = match &expr.kind {
+                NodeKind::MethodCall { object, method, args } => (object, method, args),
+                _ => continue,
+            };
+            if method != "import" || args.is_empty() {
+                continue;
+            }
+            let NodeKind::Identifier { name: object_name } = &object.kind else {
+                continue;
+            };
+            if !required_modules.iter().any(|module| module == object_name) {
+                continue;
+            }
+
+            for arg in args {
+                let mut tokens = Vec::new();
+                arg_node_tokens(arg, &mut tokens);
+                for token in tokens {
+                    push_symbol(imported, object_name, &token);
+                }
+            }
+        }
+    }
+
     fn visit(node: &Node, imported: &mut std::collections::HashSet<String>) {
         if let NodeKind::Use { module, args, .. } = &node.kind {
             for arg in args {
@@ -1880,6 +1972,10 @@ fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
                     push_symbol(imported, module, arg);
                 }
             }
+        }
+
+        if let NodeKind::Program { statements } | NodeKind::Block { statements } = &node.kind {
+            collect_manual_imports_in_statements(statements, imported);
         }
 
         for child in node.children() {

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -42,6 +42,27 @@ my $v = helper_func();
 }
 
 #[test]
+fn require_import_qw_multi_symbol_resolves_pkg() {
+    let code = r#"require My::Tools;
+My::Tools->import(qw(helper_one helper_two));
+helper_one();
+helper_two();
+"#;
+    let pkg_one = parse_and_symbol_at(code, "helper_one()");
+    let pkg_two = parse_and_symbol_at(code, "helper_two()");
+    assert_eq!(
+        pkg_one.as_deref(),
+        Some("My::Tools"),
+        "helper_one() should resolve to My::Tools via require+qw import, got: {pkg_one:?}"
+    );
+    assert_eq!(
+        pkg_two.as_deref(),
+        Some("My::Tools"),
+        "helper_two() should resolve to My::Tools via require+qw import, got: {pkg_two:?}"
+    );
+}
+
+#[test]
 fn use_import_still_resolves_correctly() {
     let code = r#"use Carp qw(croak);
 croak("error");

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1914,6 +1914,53 @@ print WIFEXITED(0);
 }
 
 #[test]
+fn strict_subs_allows_require_manual_import_barewords() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+require My::Tools;
+My::Tools->import('helper_one', 'helper_two');
+print helper_one();
+print helper_two();
+"#;
+    let issues = scope_issues_strict(code);
+
+    for symbol in ["helper_one", "helper_two"] {
+        assert!(
+            !issues.iter().any(|issue| {
+                matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == symbol
+            }),
+            "strict 'subs' should not flag statically manual-imported symbol {symbol}"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn strict_subs_allows_require_manual_import_qw_barewords() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = r#"
+use strict 'subs';
+require My::Tools;
+My::Tools->import(qw(helper_three helper_four));
+print helper_three();
+print helper_four();
+"#;
+    let issues = scope_issues_strict(code);
+
+    for symbol in ["helper_three", "helper_four"] {
+        assert!(
+            !issues.iter().any(|issue| {
+                matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == symbol
+            }),
+            "strict 'subs' should not flag qw manual-imported symbol {symbol}"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
 fn version_pragma_enables_strict_vars_and_subs() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use v5.40;

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -2987,6 +2987,19 @@ impl IndexVisitor {
                             .insert(normalize_dependency_module_name(&module_name));
                     }
                 }
+                if name == "require" {
+                    if let Some(module_name) = extract_static_require_module_name(args.first()) {
+                        let normalized = normalize_dependency_module_name(&module_name);
+                        file_index.dependencies.insert(normalized.clone());
+                        file_index.references.entry(normalized).or_default().push(
+                            SymbolReference {
+                                uri: self.uri.clone(),
+                                range: self.node_to_range(node),
+                                kind: ReferenceKind::Import,
+                            },
+                        );
+                    }
+                }
 
                 // Visit arguments
                 for arg in args {
@@ -3158,6 +3171,20 @@ impl IndexVisitor {
                         kind: ReferenceKind::Usage,
                     },
                 );
+
+                if method == "import" && !args.is_empty() {
+                    if let NodeKind::Identifier { name: module_name } = &object.kind {
+                        let normalized = normalize_dependency_module_name(module_name);
+                        file_index.dependencies.insert(normalized.clone());
+                        file_index.references.entry(normalized).or_default().push(
+                            SymbolReference {
+                                uri: self.uri.clone(),
+                                range: self.node_to_range(node),
+                                kind: ReferenceKind::Import,
+                            },
+                        );
+                    }
+                }
 
                 // Visit arguments
                 for arg in args {
@@ -3436,6 +3463,22 @@ fn extract_module_names_from_call_args(args: &[Node]) -> Vec<String> {
         collect_from_node(arg, &mut modules);
     }
     modules
+}
+
+fn extract_static_require_module_name(arg: Option<&Node>) -> Option<String> {
+    let node = arg?;
+    match &node.kind {
+        NodeKind::Identifier { name } => Some(name.clone()),
+        NodeKind::String { value, .. } => {
+            let cleaned = value.trim_matches('\'').trim_matches('"').trim();
+            if cleaned.is_empty() {
+                return None;
+            }
+            let module = cleaned.trim_end_matches(".pm").replace('/', "::");
+            if module.is_empty() { None } else { Some(module) }
+        }
+        _ => None,
+    }
 }
 
 fn canonicalize_perl_module_name(name: &str) -> String {
@@ -4955,6 +4998,38 @@ Utils::process_data();
         let deps = index.file_dependencies(uri.as_str());
         assert!(deps.contains("My::Base"));
         assert!(!deps.contains("My'Base"));
+    }
+
+    #[test]
+    fn test_file_dependencies_include_static_require_module() {
+        let index = WorkspaceIndex::new();
+        let uri = must(url::Url::parse("file:///test/workspace/require-static.pl"));
+        let src = "package Consumer;\nrequire My::Loader;\nMy::Loader->import('load_data');\n1;\n";
+        must(index.index_file(uri.clone(), src.to_string()));
+
+        let deps = index.file_dependencies(uri.as_str());
+        assert!(
+            deps.contains("My::Loader"),
+            "require/import static form should register dependency, got: {deps:?}"
+        );
+    }
+
+    #[test]
+    fn test_find_dependents_include_static_require_manual_import() {
+        let index = WorkspaceIndex::new();
+        let exporter_url = must(url::Url::parse("file:///test/workspace/lib/My/Loader.pm"));
+        let exporter_src = "package My::Loader;\nsub load_data { 1 }\n1;\n";
+        must(index.index_file(exporter_url, exporter_src.to_string()));
+
+        let consumer_url = must(url::Url::parse("file:///test/workspace/consumer-require.pl"));
+        let consumer_src = "package Consumer;\nrequire My::Loader;\nMy::Loader->import(qw(load_data));\nload_data();\n1;\n";
+        must(index.index_file(consumer_url, consumer_src.to_string()));
+
+        let dependents = index.find_dependents("My::Loader");
+        assert!(
+            dependents.contains(&"file:///test/workspace/consumer-require.pl".to_string()),
+            "consumer-require.pl should be in dependents for static require/manual import, got: {dependents:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Static manual-import forms like `require Foo; Foo->import('sym')` and `require 'Foo/Bar.pm'; Foo->import(qw(...))` were not being accounted for in import visibility, causing strict-subs diagnostics, cross-file go-to-definition, and workspace dependency consumers to miss these imported symbols.

### Description
- Extend the semantic layer to collect statically-manual-imported barewords by adding `require` + `Module->import(...)` scanning into `collect_imported_barewords` so imported names are treated like `use` imports for strict-subs suppression and visibility (`crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs`).
- Add an `arg_node_tokens`/`collect_manual_imports_in_statements` helper to handle string, `qw(...)`, and array literal import argument forms and reuse tag expansion via `resolve_known_export_tag`.
- Wire static `require` and static `Module->import(...)` into workspace indexing by recording normalized module dependencies and `ReferenceKind::Import` occurrences and add `extract_static_require_module_name` helper to normalize `require 'Foo/Bar.pm'` -> `Foo::Bar` (`crates/perl-workspace-index/src/workspace/workspace_index.rs`).
- Add focused tests: manual-import visibility and strict-subs suppression tests in `require_import_resolution.rs` and `scope_and_symbol_tests.rs`, and workspace dependency tests for `require`/manual-import cases in `workspace_index.rs`.

### Testing
- Ran `cargo test -p perl-semantic-analyzer` and the test suite passed (`121` unit tests + many integration tests; all relevant new tests passed).
- Ran `cargo test -p perl-workspace` and workspace index tests passed (added dependency/find_dependents tests succeeded).
- Ran `cargo check --workspace --all-targets` and it completed successfully.

Problem: static manual-import forms (`require Foo; Foo->import(...)`) were not fully fed into import visibility/dependency tracking used by strict-subs diagnostics, symbol visibility, and workspace dependency consumers.
Fix: Added static require/manual-import extraction in semantic bareword import collection and workspace dependency indexing (including `require 'Foo/Bar.pm'` normalization), with focused tests for string/qw manual-import cases and dependent discovery.
Verification: `cargo test -p perl-semantic-analyzer` passes; `cargo test -p perl-workspace` passes; `cargo check --workspace --all-targets` passes

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb003b2d888333928e63a22508b59f)