### PR TITLE
feat(module-resolution): support static require + manual import visibility (#3476)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1865,6 +1865,99 @@ fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
         }
     }
 
+    fn require_module_name(node: &Node) -> Option<String> {
+        let args = match &node.kind {
+            NodeKind::FunctionCall { name, args } if name == "require" => args,
+            _ => return None,
+        };
+        let first = args.first()?;
+        match &first.kind {
+            NodeKind::Identifier { name } => Some(name.clone()),
+            NodeKind::String { value, .. } => {
+                let cleaned = value.trim_matches('\'').trim_matches('"').trim();
+                if cleaned.is_empty() {
+                    return None;
+                }
+                Some(cleaned.trim_end_matches(".pm").replace('/', "::"))
+            }
+            _ => None,
+        }
+    }
+
+    fn import_arg_matches(
+        imported: &mut std::collections::HashSet<String>,
+        module: &str,
+        arg: &Node,
+    ) {
+        match &arg.kind {
+            NodeKind::String { value, .. } => push_symbol(imported, module, value),
+            NodeKind::Identifier { name } => {
+                if name.starts_with("qw") {
+                    let content = name
+                        .trim_start_matches("qw")
+                        .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                        .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                    for token in content.split_whitespace() {
+                        push_symbol(imported, module, token);
+                    }
+                } else {
+                    push_symbol(imported, module, name);
+                }
+            }
+            NodeKind::ArrayLiteral { elements } => {
+                for element in elements {
+                    import_arg_matches(imported, module, element);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn collect_require_manual_imports(
+        stmts: &[Node],
+        imported: &mut std::collections::HashSet<String>,
+    ) {
+        let mut required_modules: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        for stmt in stmts {
+            let expr = if let NodeKind::ExpressionStatement { expression } = &stmt.kind {
+                expression.as_ref()
+            } else {
+                stmt
+            };
+            if let Some(module) = require_module_name(expr) {
+                required_modules.insert(module);
+            }
+        }
+
+        if required_modules.is_empty() {
+            return;
+        }
+
+        for stmt in stmts {
+            let expr = if let NodeKind::ExpressionStatement { expression } = &stmt.kind {
+                expression.as_ref()
+            } else {
+                stmt
+            };
+            let NodeKind::MethodCall { object, method, args } = &expr.kind else {
+                continue;
+            };
+            if method != "import" || args.is_empty() {
+                continue;
+            }
+            let NodeKind::Identifier { name: module } = &object.kind else {
+                continue;
+            };
+            if !required_modules.contains(module) {
+                continue;
+            }
+            for arg in args {
+                import_arg_matches(imported, module, arg);
+            }
+        }
+    }
+
     fn visit(node: &Node, imported: &mut std::collections::HashSet<String>) {
         if let NodeKind::Use { module, args, .. } = &node.kind {
             for arg in args {
@@ -1880,6 +1973,10 @@ fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
                     push_symbol(imported, module, arg);
                 }
             }
+        }
+
+        if let NodeKind::Program { statements } | NodeKind::Block { statements } = &node.kind {
+            collect_require_manual_imports(statements, imported);
         }
 
         for child in node.children() {

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1914,6 +1914,45 @@ print WIFEXITED(0);
 }
 
 #[test]
+fn strict_subs_allows_require_manual_imported_barewords() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = r#"
+use strict 'subs';
+require My::Loader;
+My::Loader->import('load_data');
+print load_data;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "load_data"
+        }),
+        "strict 'subs' should not flag static require + manual imported symbols"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_subs_require_without_import_stays_conservative() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = r#"
+use strict 'subs';
+require My::Loader;
+print load_data;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "load_data"
+        }),
+        "strict 'subs' should still flag symbols without explicit manual import"
+    );
+    Ok(())
+}
+
+#[test]
 fn version_pragma_enables_strict_vars_and_subs() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use v5.40;

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -2980,6 +2980,28 @@ impl IndexVisitor {
                     kind: ReferenceKind::Usage,
                 });
 
+                if name == "require" {
+                    if let Some(first_arg) = args.first() {
+                        match &first_arg.kind {
+                            NodeKind::Identifier { name } => {
+                                file_index
+                                    .dependencies
+                                    .insert(normalize_dependency_module_name(name));
+                            }
+                            NodeKind::String { value, .. } => {
+                                let cleaned = value.trim_matches('\'').trim_matches('"').trim();
+                                if !cleaned.is_empty() {
+                                    let module = cleaned.trim_end_matches(".pm").replace('/', "::");
+                                    file_index
+                                        .dependencies
+                                        .insert(normalize_dependency_module_name(&module));
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+
                 if name == "extends" || name == "with" {
                     for module_name in extract_module_names_from_call_args(args) {
                         file_index
@@ -3158,6 +3180,12 @@ impl IndexVisitor {
                         kind: ReferenceKind::Usage,
                     },
                 );
+
+                if method == "import" {
+                    if let NodeKind::Identifier { name } = &object.kind {
+                        file_index.dependencies.insert(normalize_dependency_module_name(name));
+                    }
+                }
 
                 // Visit arguments
                 for arg in args {
@@ -3991,6 +4019,25 @@ use Data::Dumper;
         assert!(deps.contains("strict"));
         assert!(deps.contains("warnings"));
         assert!(deps.contains("Data::Dumper"));
+    }
+
+    #[test]
+    fn test_dependencies_include_static_require_and_manual_import() {
+        let index = WorkspaceIndex::new();
+        let uri = "file:///require_import.pl";
+
+        let code = r#"
+require Foo::Bar;
+Foo::Bar->import('baz');
+require 'Baz/Qux.pm';
+Baz::Qux->import(qw(alpha beta));
+"#;
+
+        must(index.index_file(must(url::Url::parse(uri)), code.to_string()));
+
+        let deps = index.file_dependencies(uri);
+        assert!(deps.contains("Foo::Bar"));
+        assert!(deps.contains("Baz::Qux"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Static manual-import patterns like `require Foo; Foo->import('bar')` were not contributing imported barewords into the visibility layer, leaving bareword goto/strict-subs and dependency discovery incomplete.
- The goal is to finish the literal/static manual-import slice so static `require` + explicit `->import(...)` cases are treated like `use` imports where appropriate.

### Description

- Added `require` + `Module->import(...)` collection to the semantic analyzer so `collect_imported_barewords` now recognizes identifier and string `require` forms, `->import` calls, `qw(...)` lists and array-literal forms, and export-tag expansions (file: `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs`).
- Implemented conservative handling for `Module->import()` with no args so default export sets are not claimed without workspace export data (same conservative behavior as prior design).
- Updated workspace index `IndexVisitor` to record dependencies from static `require` calls and from static `Module->import(...)` method calls so cross-file consumers can see these dependencies (file: `crates/perl-workspace-index/src/workspace/workspace_index.rs`).
- Added focused cross-file and scope tests: new strict-subs regression tests for manual imports and a workspace-index test validating `file_dependencies` includes `require` + manual `import` cases (file: `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs`, `crates/perl-workspace-index/src/workspace/workspace_index.rs`).

### Testing

- Ran `cargo test -p perl-semantic-analyzer` and all semantic analyzer tests passed (including the new `require->import` and strict-subs tests).
- Ran `cargo test -p perl-workspace` and the workspace index tests passed, including the new dependency test for static `require` + manual `import`.
- Ran `cargo check --workspace --all-targets` and the workspace type-check completed successfully.
- Ran `cargo xtask fmt` to format the workspace with no outstanding issues.

Problem: Static `require Foo; Foo->import(...)` patterns were not wired into import visibility, causing missing bareword visibility and dependency indexing.
Fix: Detect and collect literal `require` + `Module->import(...)` imports into `collect_imported_barewords` and index `require`/`->import` dependencies in the workspace index so existing consumers (goto-definition, undefined-symbol suppression, completion visibility) can use the information.
Verification: `cargo test -p perl-semantic-analyzer` passes, `cargo test -p perl-workspace` passes, and `cargo check --workspace --all-targets` passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb003b2d888333928e63a22508b59f)