### PR TITLE
feat(module-resolution): support static require + manual import visibility (#3476)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1865,6 +1865,100 @@ fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
         }
     }
 
+    fn module_name_from_require_expr(node: &Node) -> Option<String> {
+        let NodeKind::FunctionCall { name, args } = &node.kind else {
+            return None;
+        };
+        if name != "require" {
+            return None;
+        }
+        let first = args.first()?;
+        match &first.kind {
+            NodeKind::Identifier { name } => Some(name.clone()),
+            NodeKind::String { value, .. } => {
+                let cleaned = value.trim_matches('\'').trim_matches('"').trim();
+                if cleaned.is_empty() {
+                    return None;
+                }
+                Some(cleaned.trim_end_matches(".pm").replace('/', "::"))
+            }
+            _ => None,
+        }
+    }
+
+    fn collect_import_args(
+        imported: &mut std::collections::HashSet<String>,
+        module: &str,
+        arg: &Node,
+    ) {
+        match &arg.kind {
+            NodeKind::String { value, .. } => push_symbol(imported, module, value),
+            NodeKind::Identifier { name } => {
+                if name.starts_with("qw") {
+                    let content = name
+                        .trim_start_matches("qw")
+                        .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                        .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                    for token in content.split_whitespace() {
+                        push_symbol(imported, module, token);
+                    }
+                } else {
+                    push_symbol(imported, module, name);
+                }
+            }
+            NodeKind::ArrayLiteral { elements } => {
+                for element in elements {
+                    collect_import_args(imported, module, element);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn collect_static_manual_imports(
+        stmts: &[Node],
+        imported: &mut std::collections::HashSet<String>,
+    ) {
+        let mut required_modules = std::collections::HashSet::new();
+        for stmt in stmts {
+            let expr = if let NodeKind::ExpressionStatement { expression } = &stmt.kind {
+                expression.as_ref()
+            } else {
+                stmt
+            };
+            if let Some(module) = module_name_from_require_expr(expr) {
+                required_modules.insert(module);
+            }
+        }
+
+        if required_modules.is_empty() {
+            return;
+        }
+
+        for stmt in stmts {
+            let expr = if let NodeKind::ExpressionStatement { expression } = &stmt.kind {
+                expression.as_ref()
+            } else {
+                stmt
+            };
+            let NodeKind::MethodCall { object, method, args } = &expr.kind else {
+                continue;
+            };
+            if method != "import" {
+                continue;
+            }
+            let NodeKind::Identifier { name: module } = &object.kind else {
+                continue;
+            };
+            if !required_modules.contains(module) {
+                continue;
+            }
+            for arg in args {
+                collect_import_args(imported, module, arg);
+            }
+        }
+    }
+
     fn visit(node: &Node, imported: &mut std::collections::HashSet<String>) {
         if let NodeKind::Use { module, args, .. } = &node.kind {
             for arg in args {
@@ -1880,6 +1974,10 @@ fn collect_imported_barewords(ast: &Node) -> std::collections::HashSet<String> {
                     push_symbol(imported, module, arg);
                 }
             }
+        }
+
+        if let NodeKind::Program { statements } | NodeKind::Block { statements } = &node.kind {
+            collect_static_manual_imports(statements, imported);
         }
 
         for child in node.children() {

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1914,6 +1914,47 @@ print WIFEXITED(0);
 }
 
 #[test]
+fn strict_subs_allows_manual_require_imported_barewords() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = r#"
+use strict 'subs';
+require My::Loader;
+My::Loader->import('load_data');
+print load_data();
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "load_data"
+        }),
+        "strict 'subs' should not flag manually imported bareword function names"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_subs_allows_manual_require_qw_imported_barewords()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+require My::Tools;
+My::Tools->import(qw(helper_func another_helper));
+print helper_func();
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && (issue.variable_name == "helper_func" || issue.variable_name == "another_helper")
+        }),
+        "strict 'subs' should not flag manually qw-imported bareword function names"
+    );
+    Ok(())
+}
+
+#[test]
 fn version_pragma_enables_strict_vars_and_subs() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use v5.40;

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -2987,6 +2987,27 @@ impl IndexVisitor {
                             .insert(normalize_dependency_module_name(&module_name));
                     }
                 }
+                if name == "require" {
+                    if let Some(first) = args.first() {
+                        let maybe_module = match &first.kind {
+                            NodeKind::Identifier { name } => Some(name.clone()),
+                            NodeKind::String { value, .. } => {
+                                let cleaned = value.trim_matches('\'').trim_matches('"').trim();
+                                if cleaned.is_empty() {
+                                    None
+                                } else {
+                                    Some(cleaned.trim_end_matches(".pm").replace('/', "::"))
+                                }
+                            }
+                            _ => None,
+                        };
+                        if let Some(module_name) = maybe_module {
+                            file_index
+                                .dependencies
+                                .insert(normalize_dependency_module_name(&module_name));
+                        }
+                    }
+                }
 
                 // Visit arguments
                 for arg in args {
@@ -3158,6 +3179,14 @@ impl IndexVisitor {
                         kind: ReferenceKind::Usage,
                     },
                 );
+
+                if method == "import" {
+                    if let NodeKind::Identifier { name: module_name } = &object.kind {
+                        file_index
+                            .dependencies
+                            .insert(normalize_dependency_module_name(module_name));
+                    }
+                }
 
                 // Visit arguments
                 for arg in args {
@@ -3991,6 +4020,44 @@ use Data::Dumper;
         assert!(deps.contains("strict"));
         assert!(deps.contains("warnings"));
         assert!(deps.contains("Data::Dumper"));
+    }
+
+    #[test]
+    fn test_dependencies_include_static_require_and_manual_import() {
+        let index = WorkspaceIndex::new();
+        let uri = "file:///manual-import.pl";
+        let code = r#"
+require My::Loader;
+My::Loader->import('load_data');
+load_data();
+"#;
+
+        must(index.index_file(must(url::Url::parse(uri)), code.to_string()));
+
+        let deps = index.file_dependencies(uri);
+        assert!(
+            deps.contains("My::Loader"),
+            "static require + manual import should register My::Loader dependency, got: {deps:?}"
+        );
+    }
+
+    #[test]
+    fn test_dependencies_include_static_require_path_and_qw_manual_import() {
+        let index = WorkspaceIndex::new();
+        let uri = "file:///manual-import-qw.pl";
+        let code = r#"
+require 'My/Tools.pm';
+My::Tools->import(qw(helper another));
+helper();
+"#;
+
+        must(index.index_file(must(url::Url::parse(uri)), code.to_string()));
+
+        let deps = index.file_dependencies(uri);
+        assert!(
+            deps.contains("My::Tools"),
+            "file-path require + qw manual import should register My::Tools dependency, got: {deps:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Static manual-import forms like `require Foo; Foo->import('sym')` (including `qw(...)` and file-path `require`) were not contributing imported bareword visibility or file dependency tracking, causing strict bareword checks and workspace consumers to be conservative.

### Description

- Extend `collect_imported_barewords` to scan Program/Block statement lists for static `require Module` + `Module->import(...)` pairs and extract string, `Identifier`/`qw(...)`, and `ArrayLiteral` import arguments into the imported-barewords set.
- Add helpers to normalize `require 'Foo/Bar.pm'` into `Foo::Bar` and to parse `qw(...)` encoded in identifiers, preserving the existing tag-expansion path for known export tags.
- Index static `require` targets and static `Module->import(...)` objects as file dependencies in the workspace index so cross-file consumers (completion, find-dependents) see the module relationship.
- Add focused tests: two semantic analyzer tests to ensure strict 'subs' does not flag manually imported barewords, and two workspace-index tests to ensure static `require` + manual import registers dependencies for both identifier and file-path `require` / `qw` import forms.

### Testing

- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo test -p perl-semantic-analyzer` and all tests passed.
- Ran `cargo test -p perl-workspace` and all workspace-index tests passed, including the new dependency tests.
- Ran `cargo check --workspace --all-targets` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb003b2d888333928e63a22508b59f)