### PR TITLE
refactor(completion): plumb effective include roots into module completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -170,6 +170,8 @@ pub struct CompletionProvider {
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
     import_map: ImportMap,
+    include_paths: Vec<String>,
+    system_inc_paths: Vec<String>,
 }
 
 impl CompletionProvider {
@@ -200,7 +202,7 @@ impl CompletionProvider {
     /// ```
     /// Arguments: `ast`, `workspace_index`.
     pub fn new_with_index(ast: &Node, workspace_index: Option<Arc<WorkspaceIndex>>) -> Self {
-        Self::new_with_index_and_source(ast, "", workspace_index)
+        Self::new_with_index_source_and_inc_paths(ast, "", workspace_index, Vec::new(), Vec::new())
     }
 
     /// Create a new completion provider from parsed AST and source with workspace integration
@@ -249,6 +251,26 @@ impl CompletionProvider {
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
     ) -> Self {
+        Self::new_with_index_source_and_inc_paths(
+            ast,
+            source,
+            workspace_index,
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+
+    /// Create a new completion provider with module-resolution include roots.
+    ///
+    /// `include_paths` and `system_inc_paths` are threaded through module
+    /// completion plumbing only; filesystem scanning is handled elsewhere.
+    pub fn new_with_index_source_and_inc_paths(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        include_paths: Vec<String>,
+        system_inc_paths: Vec<String>,
+    ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
         let type_engine = workspace_index.as_ref().map(|_| {
@@ -258,7 +280,15 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            import_map,
+            include_paths,
+            system_inc_paths,
+        }
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -774,6 +804,8 @@ impl CompletionProvider {
                 &mut completions,
                 &context,
                 &self.workspace_index,
+                &self.include_paths,
+                &self.system_inc_paths,
             );
         } else if self.is_has_type_value_context(source, position) {
             self.add_has_type_completions(&mut completions, &context);
@@ -2149,6 +2181,24 @@ mod tests {
     use perl_workspace::workspace_index::WorkspaceIndex;
     use std::sync::Arc;
     use url::Url;
+
+    #[test]
+    fn test_provider_accepts_include_and_system_inc_paths() {
+        let code = "use strict;\n";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+
+        let provider = CompletionProvider::new_with_index_source_and_inc_paths(
+            &ast,
+            code,
+            None,
+            vec!["lib".to_string(), "local/lib/perl5".to_string()],
+            vec!["/usr/lib/perl5".to_string()],
+        );
+
+        assert_eq!(provider.include_paths, vec!["lib".to_string(), "local/lib/perl5".to_string()]);
+        assert_eq!(provider.system_inc_paths, vec!["/usr/lib/perl5".to_string()]);
+    }
 
     #[test]
     fn test_variable_completion() {

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -240,6 +240,8 @@ pub fn add_use_module_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
+    _include_paths: &[String],
+    _system_inc_paths: &[String],
 ) {
     let Some(index) = workspace_index else {
         return;

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -19,6 +19,7 @@ use crate::{
     state::{completion_cap, completion_deadline},
 };
 use perl_lexer::LSP_RUNTIME_COMPLETION_KEYWORDS;
+use perl_lsp_rs_core::config::WorkspaceConfig;
 use perl_parser::type_inference::TypeInferenceEngine;
 use regex::Regex;
 use serde_json::{Value, json};
@@ -319,6 +320,22 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let mut doc_workspace_config = self
+                    .config_for_doc(uri)
+                    .unwrap_or_else(|| self.workspace_config.lock().clone());
+                let perl5lib_paths = std::env::var("PERL5LIB")
+                    .map(|value| WorkspaceConfig::parse_perl5lib(&value))
+                    .unwrap_or_default();
+                let include_paths = doc_workspace_config.effective_include_paths(&perl5lib_paths);
+                let system_inc_paths: Vec<String> = if doc_workspace_config.use_system_inc {
+                    doc_workspace_config
+                        .get_system_inc()
+                        .iter()
+                        .map(|path| path.to_string_lossy().into_owned())
+                        .collect()
+                } else {
+                    Vec::new()
+                };
 
                 // Get completions, with fallback for missing AST
                 #[cfg_attr(not(feature = "workspace"), allow(unused_mut))]
@@ -332,15 +349,22 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_source_and_inc_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
 
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_source_and_inc_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
 
                     let mut base_completions =
                         provider.get_completions_with_path(&doc.text, offset, Some(uri));
@@ -548,6 +572,22 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let mut doc_workspace_config = self
+                    .config_for_doc(uri)
+                    .unwrap_or_else(|| self.workspace_config.lock().clone());
+                let perl5lib_paths = std::env::var("PERL5LIB")
+                    .map(|value| WorkspaceConfig::parse_perl5lib(&value))
+                    .unwrap_or_default();
+                let include_paths = doc_workspace_config.effective_include_paths(&perl5lib_paths);
+                let system_inc_paths: Vec<String> = if doc_workspace_config.use_system_inc {
+                    doc_workspace_config
+                        .get_system_inc()
+                        .iter()
+                        .map(|path| path.to_string_lossy().into_owned())
+                        .collect()
+                } else {
+                    Vec::new()
+                };
 
                 // Create optimized cancellation callback with reduced frequency
                 // Performance optimization: reduced overhead from 16.66% to <10%
@@ -574,14 +614,21 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_source_and_inc_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_source_and_inc_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
 
                     // Use cancellable provider method
                     provider.get_completions_with_path_cancellable(


### PR DESCRIPTION
### Motivation

- Ensure module-name completion has access to document-scoped include roots and optional system `@INC` so future module-resolution work (scanning/ranking) can use correct search roots.

### Description

- Fetch the doc-specific workspace config in completion handlers and compute effective include paths via `WorkspaceConfig::effective_include_paths` and `PERL5LIB` merging, and obtain system `@INC` only when `use_system_inc` is enabled in the workspace config.
- Extend `CompletionProvider` with `include_paths: Vec<String>` and `system_inc_paths: Vec<String>` and add `new_with_index_source_and_inc_paths(...)` to construct providers with those vectors while keeping existing constructors behaviour unchanged (empty vectors by default).
- Thread the include/system path vectors from the LSP completion handlers (both normal and cancellable paths) into provider construction and pass them into the `use`/`require` module completion plumbing (`add_use_module_completions`) as plumbing-only arguments for now.
- Add a focused unit test that verifies a `CompletionProvider` can be constructed with include and system `@INC` vectors.

### Testing

- Ran `cargo check --workspace --all-targets`, which completed successfully.
- Ran `cargo test -p perl-lsp-rs-core`, which exercised unit tests but failed one pre-existing regression test (`test_perl_lsp_cargo_toml_removed_g1b_imports`) that expects a removed path, unrelated to this change.
- Ran `cargo test -p perl-lsp-rs`, which started but failed in this environment due to disk-space exhaustion during the large integration test build (OS error: `No space left on device`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb003617988333afec4189fc3d127f)