### PR TITLE
refactor(completion): plumb effective include roots into module completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -122,6 +122,7 @@ use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
 use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_workspace::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Maps module_name -> Set of explicitly imported symbol names.
@@ -170,6 +171,8 @@ pub struct CompletionProvider {
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
     import_map: ImportMap,
+    effective_include_paths: Vec<PathBuf>,
+    system_include_paths: Vec<PathBuf>,
 }
 
 impl CompletionProvider {
@@ -200,7 +203,7 @@ impl CompletionProvider {
     /// ```
     /// Arguments: `ast`, `workspace_index`.
     pub fn new_with_index(ast: &Node, workspace_index: Option<Arc<WorkspaceIndex>>) -> Self {
-        Self::new_with_index_and_source(ast, "", workspace_index)
+        Self::new_with_index_source_and_paths(ast, "", workspace_index, Vec::new(), Vec::new())
     }
 
     /// Create a new completion provider from parsed AST and source with workspace integration
@@ -249,6 +252,17 @@ impl CompletionProvider {
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
     ) -> Self {
+        Self::new_with_index_source_and_paths(ast, source, workspace_index, Vec::new(), Vec::new())
+    }
+
+    /// Create a new completion provider with precomputed include-path context.
+    pub fn new_with_index_source_and_paths(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        effective_include_paths: Vec<PathBuf>,
+        system_include_paths: Vec<PathBuf>,
+    ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
         let type_engine = workspace_index.as_ref().map(|_| {
@@ -258,7 +272,15 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            import_map,
+            effective_include_paths,
+            system_include_paths,
+        }
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -774,6 +796,8 @@ impl CompletionProvider {
                 &mut completions,
                 &context,
                 &self.workspace_index,
+                &self.effective_include_paths,
+                &self.system_include_paths,
             );
         } else if self.is_has_type_value_context(source, position) {
             self.add_has_type_completions(&mut completions, &context);

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -14,6 +14,7 @@ use perl_workspace::workspace_index::{
     SymbolKind as WsSymbolKind, VarKind, WorkspaceIndex, WorkspaceSymbol,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Add workspace symbol completions for functions and variables
@@ -240,7 +241,11 @@ pub fn add_use_module_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
+    effective_include_paths: &[PathBuf],
+    system_include_paths: &[PathBuf],
 ) {
+    let _ = (effective_include_paths, system_include_paths);
+
     let Some(index) = workspace_index else {
         return;
     };

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -22,6 +22,7 @@ use perl_lexer::LSP_RUNTIME_COMPLETION_KEYWORDS;
 use perl_parser::type_inference::TypeInferenceEngine;
 use regex::Regex;
 use serde_json::{Value, json};
+use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 
@@ -56,6 +57,29 @@ fn commit_chars_for_kind(kind: CompletionItemKind) -> Option<&'static [&'static 
 }
 
 impl LspServer {
+    fn completion_include_path_context(&self, doc_uri: &str) -> (Vec<PathBuf>, Vec<PathBuf>) {
+        let mut workspace_config =
+            self.config_for_doc(doc_uri).unwrap_or_else(|| self.workspace_config.lock().clone());
+
+        let perl5lib_paths = std::env::var("PERL5LIB")
+            .map(|value| perl_lsp_rs_core::config::WorkspaceConfig::parse_perl5lib(&value))
+            .unwrap_or_default();
+
+        let effective_include_paths = workspace_config
+            .effective_include_paths(&perl5lib_paths)
+            .into_iter()
+            .map(PathBuf::from)
+            .collect();
+
+        let system_include_paths = if workspace_config.use_system_inc {
+            workspace_config.get_system_inc().to_vec()
+        } else {
+            Vec::new()
+        };
+
+        (effective_include_paths, system_include_paths)
+    }
+
     fn split_sigil(name: &str) -> (Option<char>, &str) {
         let mut chars = name.chars();
         match chars.next() {
@@ -319,6 +343,8 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let (effective_include_paths, system_include_paths) =
+                    self.completion_include_path_context(uri);
 
                 // Get completions, with fallback for missing AST
                 #[cfg_attr(not(feature = "workspace"), allow(unused_mut))]
@@ -332,15 +358,22 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        effective_include_paths,
+                        system_include_paths,
                     );
 
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        effective_include_paths,
+                        system_include_paths,
+                    );
 
                     let mut base_completions =
                         provider.get_completions_with_path(&doc.text, offset, Some(uri));
@@ -548,6 +581,8 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let (effective_include_paths, system_include_paths) =
+                    self.completion_include_path_context(uri);
 
                 // Create optimized cancellation callback with reduced frequency
                 // Performance optimization: reduced overhead from 16.66% to <10%
@@ -574,14 +609,21 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        effective_include_paths,
+                        system_include_paths,
                     );
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        effective_include_paths,
+                        system_include_paths,
+                    );
 
                     // Use cancellable provider method
                     provider.get_completions_with_path_cancellable(


### PR DESCRIPTION
### Motivation

- Module completion needs document-scoped include-path context (workspace include paths, `PERL5LIB` policy, and opt-in system `@INC`) so later phases can use those roots for module resolution and completion without yet performing filesystem scanning.

### Description

- Added `effective_include_paths: Vec<PathBuf>` and `system_include_paths: Vec<PathBuf>` fields to `CompletionProvider` and a new constructor `new_with_index_source_and_paths` that accepts those vectors, while existing constructors default to empty vectors to preserve prior behaviour.
- Added `LspServer::completion_include_path_context` to gather doc-specific `WorkspaceConfig`, compute `effective_include_paths` (honouring `PERL5LIB` and precedence), and fetch system `@INC` only when `use_system_inc` is true.
- Threaded the include/system vectors into completion provider construction in both the normal and cancellable completion flows and extended `workspace::add_use_module_completions` to accept the paths; the values are currently only used on the `use`/`require` module completion path and are no-ops when empty.
- No filesystem scanning, dedupe/ranking, caching, or module-resolution logic was added in this change; this is plumbing only.

### Testing

- Ran `cargo test -p perl-lsp-rs-core`; unit test suite executed and largely passed, with one pre-existing failing test (`green_tdd_wave_g1b_regression_hardening::test_perl_lsp_cargo_toml_removed_g1b_imports`) that fails in this workspace snapshot due to a missing `crates/perl-lsp/Cargo.toml` (existing repo state), not this change.
- Attempted `cargo test -p perl-lsp-rs` and `cargo check --workspace --all-targets`, but they failed in this environment due to linker/disk exhaustion (`No space left on device`) unrelated to the code changes; `cargo clean` was run to recover space during execution.
- Verified new constructors accept include/system path vectors and that behaviour is unchanged when empty by defaulting legacy constructors to empty vectors in the wiring.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb003617988333afec4189fc3d127f)