### PR TITLE
refactor(completion): plumb effective include roots into module completion (#4314)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -170,6 +170,8 @@ pub struct CompletionProvider {
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
     import_map: ImportMap,
+    include_paths: Vec<String>,
+    system_inc_paths: Vec<String>,
 }
 
 impl CompletionProvider {
@@ -200,7 +202,7 @@ impl CompletionProvider {
     /// ```
     /// Arguments: `ast`, `workspace_index`.
     pub fn new_with_index(ast: &Node, workspace_index: Option<Arc<WorkspaceIndex>>) -> Self {
-        Self::new_with_index_and_source(ast, "", workspace_index)
+        Self::new_with_index_source_and_paths(ast, "", workspace_index, Vec::new(), Vec::new())
     }
 
     /// Create a new completion provider from parsed AST and source with workspace integration
@@ -249,6 +251,21 @@ impl CompletionProvider {
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
     ) -> Self {
+        Self::new_with_index_source_and_paths(ast, source, workspace_index, Vec::new(), Vec::new())
+    }
+
+    /// Create a new completion provider with explicit include path vectors.
+    ///
+    /// `include_paths` and `system_inc_paths` are currently threaded through
+    /// module completion plumbing and reserved for future filesystem-backed
+    /// module completion expansion.
+    pub fn new_with_index_source_and_paths(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        include_paths: Vec<String>,
+        system_inc_paths: Vec<String>,
+    ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
         let type_engine = workspace_index.as_ref().map(|_| {
@@ -258,7 +275,15 @@ impl CompletionProvider {
         });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
+        CompletionProvider {
+            symbol_table,
+            class_models,
+            type_engine,
+            workspace_index,
+            import_map,
+            include_paths,
+            system_inc_paths,
+        }
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -774,6 +799,8 @@ impl CompletionProvider {
                 &mut completions,
                 &context,
                 &self.workspace_index,
+                &self.include_paths,
+                &self.system_inc_paths,
             );
         } else if self.is_has_type_value_context(source, position) {
             self.add_has_type_completions(&mut completions, &context);
@@ -3348,6 +3375,37 @@ sub helper { }
             completions.iter().any(|c| c.label == "MyApp" && c.kind == CompletionItemKind::Module),
             "use <cursor> should suggest workspace module names; got: {:?}",
             completions.iter().map(|c| (&c.label, &c.kind)).collect::<Vec<_>>()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_use_module_completion_with_explicit_include_vectors()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let index = Arc::new(WorkspaceIndex::new());
+        index.index_file(
+            Url::parse("file:///lib/MyFeature.pm")?,
+            "package MyFeature;\n1;\n".to_string(),
+        )?;
+
+        let code = "use MyF";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+
+        let provider = CompletionProvider::new_with_index_source_and_paths(
+            &ast,
+            code,
+            Some(index),
+            vec!["lib".to_string()],
+            vec!["/usr/lib/perl5".to_string()],
+        );
+        let completions = provider.get_completions(code, code.len());
+
+        assert!(
+            completions
+                .iter()
+                .any(|c| c.label == "MyFeature" && c.kind == CompletionItemKind::Module),
+            "module completion should still work when include/system vectors are provided"
         );
         Ok(())
     }

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -240,6 +240,8 @@ pub fn add_use_module_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
+    _include_paths: &[String],
+    _system_inc_paths: &[String],
 ) {
     let Some(index) = workspace_index else {
         return;

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -319,6 +319,22 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let mut workspace_config = self
+                    .config_for_doc(uri)
+                    .unwrap_or_else(|| self.workspace_config.lock().clone());
+                let perl5lib_paths = std::env::var("PERL5LIB")
+                    .map(|v| perl_lsp_rs_core::config::WorkspaceConfig::parse_perl5lib(&v))
+                    .unwrap_or_default();
+                let include_paths = workspace_config.effective_include_paths(&perl5lib_paths);
+                let system_inc_paths: Vec<String> = if workspace_config.use_system_inc {
+                    workspace_config
+                        .get_system_inc()
+                        .iter()
+                        .map(|path| path.to_string_lossy().to_string())
+                        .collect()
+                } else {
+                    Vec::new()
+                };
 
                 // Get completions, with fallback for missing AST
                 #[cfg_attr(not(feature = "workspace"), allow(unused_mut))]
@@ -331,16 +347,23 @@ impl LspServer {
                         _ => None,
                     };
 
+                    #[cfg(not(feature = "workspace"))]
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
+
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
-
-                    #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
 
                     let mut base_completions =
                         provider.get_completions_with_path(&doc.text, offset, Some(uri));
@@ -548,6 +571,22 @@ impl LspServer {
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
+                let mut workspace_config = self
+                    .config_for_doc(uri)
+                    .unwrap_or_else(|| self.workspace_config.lock().clone());
+                let perl5lib_paths = std::env::var("PERL5LIB")
+                    .map(|v| perl_lsp_rs_core::config::WorkspaceConfig::parse_perl5lib(&v))
+                    .unwrap_or_default();
+                let include_paths = workspace_config.effective_include_paths(&perl5lib_paths);
+                let system_inc_paths: Vec<String> = if workspace_config.use_system_inc {
+                    workspace_config
+                        .get_system_inc()
+                        .iter()
+                        .map(|path| path.to_string_lossy().to_string())
+                        .collect()
+                } else {
+                    Vec::new()
+                };
 
                 // Create optimized cancellation callback with reduced frequency
                 // Performance optimization: reduced overhead from 16.66% to <10%
@@ -574,14 +613,21 @@ impl LspServer {
                     };
 
                     #[cfg(feature = "workspace")]
-                    let provider = CompletionProvider::new_with_index_and_source(
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
                         ast,
                         &doc.text,
                         workspace_idx,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
                     );
                     #[cfg(not(feature = "workspace"))]
-                    let provider =
-                        CompletionProvider::new_with_index_and_source(ast, &doc.text, None);
+                    let provider = CompletionProvider::new_with_index_source_and_paths(
+                        ast,
+                        &doc.text,
+                        None,
+                        include_paths.clone(),
+                        system_inc_paths.clone(),
+                    );
 
                     // Use cancellable provider method
                     provider.get_completions_with_path_cancellable(


### PR DESCRIPTION
### Motivation

- Ensure module-name completion has access to the document-scoped include roots and optional system `@INC` so future module-resolution and filesystem-backed completions can use accurate search scopes.

### Description

- In the LSP completion handler, load the document's effective `WorkspaceConfig`, compute `include_paths` (merging `PERL5LIB`) and collect `system_inc_paths` only when `use_system_inc` is enabled, then pass those vectors into provider creation for both normal and cancellable completion paths.
- Extend `CompletionProvider` with `include_paths` and `system_inc_paths` fields and add `new_with_index_source_and_paths` constructor while keeping existing constructors backward-compatible (empty vectors by default).
- Thread the include/system vectors into the module-name completion path by adding parameters to `add_use_module_completions` and passing the provider-held vectors into that call site (no filesystem scanning or resolution logic added yet).
- Add a focused unit test that constructs a `CompletionProvider` with explicit include and system vectors and verifies module completions still work (plumbing validation for phase 1).

### Testing

- Ran `cargo check --workspace --all-targets` which passed.
- Ran `cargo test -p perl-lsp-rs-core` which could not fully pass in this environment due to a pre-existing test expectation around a missing `crates/perl-lsp/Cargo.toml` (unrelated to this change); the new unit test added for include vectors passed in local test runs that exercised the provider constructor.
- Ran `cargo test -p perl-lsp-rs` which failed in this environment due to linker/disk exhaustion during test builds (environmental), not due to logic changes.
- Performed `cargo clean` to recover disk space so checks could complete after cleanup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb003617988333afec4189fc3d127f)