### PR TITLE
feat(workspace-index): add cross-file reference query foundation (#3522)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -937,6 +937,26 @@ pub struct SymbolKey {
     pub kind: SymKind,
 }
 
+impl SymbolKey {
+    /// Build a stable identity string that can be used as a cache/refactor key.
+    ///
+    /// The output format is intentionally explicit and deterministic:
+    ///
+    /// - `sub:<pkg>::<name>`
+    /// - `pack:<pkg>`
+    /// - `var:<pkg>::<sigil><name>`
+    pub fn stable_id(&self) -> String {
+        match self.kind {
+            SymKind::Sub => format!("sub:{}::{}", self.pkg, self.name),
+            SymKind::Pack => format!("pack:{}", self.pkg),
+            SymKind::Var => {
+                let sigil = self.sigil.unwrap_or('$');
+                format!("var:{}::{}{}", self.pkg, sigil, self.name)
+            }
+        }
+    }
+}
+
 /// Normalize a Perl variable name for Index/Analyze workflows.
 ///
 /// Extracts an optional sigil and bare name for consistent symbol indexing.
@@ -1245,7 +1265,13 @@ impl WorkspaceIndex {
         symbol_name: &str,
         uri_filter: Option<&str>,
     ) -> Option<(Location, String)> {
-        for file_index in files.values() {
+        let mut file_keys: Vec<&String> = files.keys().collect();
+        file_keys.sort_unstable();
+
+        for file_key in file_keys {
+            let Some(file_index) = files.get(file_key) else {
+                continue;
+            };
             if let Some(filter) = uri_filter
                 && file_index.symbols.first().is_some_and(|symbol| symbol.uri != filter)
             {
@@ -1265,6 +1291,17 @@ impl WorkspaceIndex {
         }
 
         None
+    }
+
+    fn sort_locations_deterministically(locations: &mut [Location]) {
+        locations.sort_by(|left, right| {
+            left.uri
+                .cmp(&right.uri)
+                .then_with(|| left.range.start.line.cmp(&right.range.start.line))
+                .then_with(|| left.range.start.column.cmp(&right.range.start.column))
+                .then_with(|| left.range.end.line.cmp(&right.range.end.line))
+                .then_with(|| left.range.end.column.cmp(&right.range.end.column))
+        });
     }
 
     /// Create a new empty index
@@ -1916,6 +1953,7 @@ impl WorkspaceIndex {
             }
         }
 
+        Self::sort_locations_deterministically(&mut locations);
         locations
     }
 
@@ -2686,6 +2724,7 @@ impl WorkspaceIndex {
             ))
         });
 
+        Self::sort_locations_deterministically(&mut all_refs);
         all_refs
     }
 }

--- a/crates/perl-workspace-index/tests/reference_query_foundation_tests.rs
+++ b/crates/perl-workspace-index/tests/reference_query_foundation_tests.rs
@@ -1,0 +1,59 @@
+use perl_workspace::workspace::workspace_index::{SymKind, SymbolKey, WorkspaceIndex};
+use std::sync::Arc;
+use url::Url;
+
+fn file_url(path: &str) -> Result<Url, Box<dyn std::error::Error>> {
+    Ok(Url::parse(&format!("file://{}", path))?)
+}
+
+#[test]
+fn symbol_key_queries_resolve_cross_file_definition_and_references()
+-> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+
+    index.index_file(
+        file_url("/workspace/lib/My/App.pm")?,
+        "package My::App;\nsub run { return 1; }\n".to_string(),
+    )?;
+
+    index.index_file(file_url("/workspace/bin/tool.pl")?, "My::App::run();\n".to_string())?;
+
+    index.index_file(file_url("/workspace/t/run.t")?, "run();\n".to_string())?;
+
+    let key = SymbolKey {
+        pkg: Arc::from("My::App"),
+        name: Arc::from("run"),
+        sigil: None,
+        kind: SymKind::Sub,
+    };
+
+    let definition = index.find_def(&key);
+    assert!(definition.is_some(), "expected definition for My::App::run");
+
+    let refs = index.find_refs(&key);
+    assert_eq!(refs.len(), 2, "expected two cross-file callsite references");
+
+    let files: Vec<&str> = refs.iter().map(|location| location.uri.as_str()).collect();
+    assert_eq!(
+        files,
+        vec!["file:///workspace/bin/tool.pl", "file:///workspace/t/run.t"],
+        "reference ordering should be deterministic by URI",
+    );
+
+    assert_eq!(key.stable_id(), "sub:My::App::run");
+    Ok(())
+}
+
+#[test]
+fn symbol_key_queries_return_clean_not_found_results() {
+    let index = WorkspaceIndex::new();
+    let key = SymbolKey {
+        pkg: Arc::from("Missing::Pkg"),
+        name: Arc::from("missing_sub"),
+        sigil: None,
+        kind: SymKind::Sub,
+    };
+
+    assert!(index.find_def(&key).is_none(), "missing symbol should have no definition");
+    assert!(index.find_refs(&key).is_empty(), "missing symbol should have no references");
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, stable cross-file query surface (definition lookup, cross-file references, stable symbol identity) as a foundation for later workspace refactors and WorkspaceEdit flows.
- Build on the existing `WorkspaceIndex` and avoid introducing a separate index while keeping ordering deterministic for reproducible UX and tests.

### Description
- Added `SymbolKey::stable_id()` to produce a deterministic identity string for symbols (formats: `sub:<pkg>::<name>`, `pack:<pkg>`, `var:<pkg>::<sigil><name>`).
- Made definition resolution deterministic by sorting file keys before scanning in `find_definition_in_files`.
- Normalized reference result ordering by adding `sort_locations_deterministically` and calling it from `find_references` and `find_refs` to ensure results are stable by URI and range.
- Added focused integration tests in `crates/perl-workspace-index/tests/reference_query_foundation_tests.rs` that verify cross-file definition + references, deterministic ordering, and clean not-found behavior.

### Testing
- Ran `cargo test -p perl-workspace` and all workspace-index tests (including the new `reference_query_foundation_tests`) passed.
- Ran `cargo check --workspace --all-targets` and it completed successfully.
- Ran `cargo xtask fmt` and formatting completed successfully.
- `cargo clippy -p perl-workspace --all-targets` surfaced pre-existing, unrelated `expect()` usages in tests and failed; the clippy failures are not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb00303aa4833382137c8a270de758)