### PR TITLE
feat(workspace-index): add cross-file reference query foundation (#3522)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -937,6 +937,30 @@ pub struct SymbolKey {
     pub kind: SymKind,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+/// Stable symbol identity anchored to its definition location.
+pub struct StableSymbolIdentity {
+    /// Normalized symbol key used by cross-file query APIs.
+    pub key: SymbolKey,
+    /// Definition file URI for deterministic symbol identity.
+    pub definition_uri: Arc<str>,
+    /// Definition start line (0-based).
+    pub definition_line: u32,
+    /// Definition start character (0-based, UTF-16 code units).
+    pub definition_column: u32,
+}
+
+#[derive(Debug, Clone)]
+/// Deterministic cross-file symbol query result.
+pub struct CrossFileSymbolQuery {
+    /// Stable identity for downstream refactoring operations.
+    pub identity: StableSymbolIdentity,
+    /// Symbol definition location.
+    pub definition: Location,
+    /// Symbol reference locations across files (definition excluded).
+    pub references: Vec<Location>,
+}
+
 /// Normalize a Perl variable name for Index/Analyze workflows.
 ///
 /// Extracts an optional sigil and bare name for consistent symbol indexing.
@@ -2687,6 +2711,99 @@ impl WorkspaceIndex {
         });
 
         all_refs
+    }
+
+    fn sort_locations_deterministic(locations: &mut [Location]) {
+        locations.sort_by(|left, right| {
+            left.uri
+                .cmp(&right.uri)
+                .then_with(|| left.range.start.line.cmp(&right.range.start.line))
+                .then_with(|| left.range.start.column.cmp(&right.range.start.column))
+                .then_with(|| left.range.end.line.cmp(&right.range.end.line))
+                .then_with(|| left.range.end.column.cmp(&right.range.end.column))
+        });
+    }
+
+    fn symbol_key_from_workspace_symbol(symbol: &WorkspaceSymbol) -> SymbolKey {
+        match symbol.kind {
+            SymbolKind::Variable(_) => {
+                let (sigil, bare_name) = normalize_var(&symbol.name);
+                let package = symbol.container_name.as_deref().unwrap_or("main");
+                SymbolKey {
+                    pkg: Arc::from(package),
+                    name: Arc::from(bare_name),
+                    sigil,
+                    kind: SymKind::Var,
+                }
+            }
+            SymbolKind::Package | SymbolKind::Class | SymbolKind::Role => {
+                let package_name = symbol.qualified_name.as_deref().unwrap_or(symbol.name.as_str());
+                SymbolKey {
+                    pkg: Arc::from(package_name),
+                    name: Arc::from(symbol.name.as_str()),
+                    sigil: None,
+                    kind: SymKind::Pack,
+                }
+            }
+            _ => {
+                let qualified_name =
+                    symbol.qualified_name.as_deref().unwrap_or(symbol.name.as_str());
+                let (package, bare_name) =
+                    qualified_name.rsplit_once("::").unwrap_or(("main", symbol.name.as_str()));
+                SymbolKey {
+                    pkg: Arc::from(package),
+                    name: Arc::from(bare_name),
+                    sigil: None,
+                    kind: SymKind::Sub,
+                }
+            }
+        }
+    }
+
+    /// Resolve a stable symbol key for a symbol name from indexed workspace symbols.
+    ///
+    /// Returns `None` when the symbol does not exist in the current workspace index.
+    pub fn symbol_key_for(&self, symbol_name: &str) -> Option<SymbolKey> {
+        let definition = self.find_definition(symbol_name)?;
+        let files = self.files.read();
+        files.values().find_map(|file_index| {
+            file_index
+                .symbols
+                .iter()
+                .find(|symbol| {
+                    symbol.uri == definition.uri
+                        && symbol.range == definition.range
+                        && (symbol.name == symbol_name
+                            || symbol.qualified_name.as_deref() == Some(symbol_name))
+                })
+                .map(Self::symbol_key_from_workspace_symbol)
+        })
+    }
+
+    /// Query definition + cross-file references with deterministic ordering.
+    ///
+    /// Returns `None` when the requested symbol is not indexed.
+    pub fn query_symbol_across_files(&self, symbol_name: &str) -> Option<CrossFileSymbolQuery> {
+        let definition = self.find_definition(symbol_name)?;
+        let key = self.symbol_key_for(symbol_name)?;
+        let mut references = self.find_refs(&key);
+        Self::sort_locations_deterministic(&mut references);
+        references.dedup_by(|left, right| {
+            left.uri == right.uri
+                && left.range.start == right.range.start
+                && left.range.end == right.range.end
+        });
+
+        Some(CrossFileSymbolQuery {
+            identity: StableSymbolIdentity {
+                key,
+                definition_uri: Arc::from(definition.uri.as_str()),
+                definition_line: definition.range.start.line,
+                definition_column: definition.range.start.column,
+            },
+            definition,
+            references,
+        })
     }
 }
 

--- a/crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs
+++ b/crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs
@@ -1,0 +1,45 @@
+use perl_workspace::workspace::workspace_index::WorkspaceIndex;
+use url::Url;
+
+fn file_url(path: &str) -> Result<Url, Box<dyn std::error::Error>> {
+    Ok(Url::parse(&format!("file://{}", path))?)
+}
+
+#[test]
+fn query_symbol_across_files_returns_definition_identity_and_references()
+-> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let def_uri = file_url("/lib/Utils.pm")?;
+    let caller_a = file_url("/app/a.pl")?;
+    let caller_b = file_url("/app/b.pl")?;
+
+    index.index_file(def_uri, "package Utils;\nsub process_data { return 1; }".to_string())?;
+    index.index_file(caller_a, "use Utils;\nprocess_data();\n".to_string())?;
+    index.index_file(caller_b, "use Utils;\nUtils::process_data();\n".to_string())?;
+
+    let result = index
+        .query_symbol_across_files("Utils::process_data")
+        .ok_or("expected query to resolve symbol")?;
+
+    assert_eq!(result.identity.key.pkg.as_ref(), "Utils");
+    assert_eq!(result.identity.key.name.as_ref(), "process_data");
+    assert_eq!(result.definition.uri, "file:///lib/Utils.pm");
+    assert_eq!(result.identity.definition_uri.as_ref(), result.definition.uri);
+
+    let uris: Vec<&str> = result.references.iter().map(|loc| loc.uri.as_str()).collect();
+    assert_eq!(uris, vec!["file:///app/a.pl", "file:///app/b.pl"]);
+
+    Ok(())
+}
+
+#[test]
+fn query_symbol_across_files_not_found_is_none() -> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let uri = file_url("/lib/Only.pm")?;
+    index.index_file(uri, "package Only;\nsub present { return 1; }".to_string())?;
+
+    assert!(index.query_symbol_across_files("Only::missing").is_none());
+    assert!(index.symbol_key_for("Only::missing").is_none());
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Provide a single, stable cross-file query surface that returns a symbol's definition, cross-file references, and a durable identity for downstream refactors.
- Build the API on top of the existing workspace index data (no new global index) and ensure deterministic ordering for consumer predictability.

### Description

- Added `StableSymbolIdentity` and `CrossFileSymbolQuery` structs to carry a durable identity anchored to the definition and a query result containing the definition and its cross-file references.
- Implemented `symbol_key_for(&self, symbol_name: &str) -> Option<SymbolKey>` to derive a normalized `SymbolKey` from existing indexed `WorkspaceSymbol`s and a clean `None` when not found.
- Implemented `query_symbol_across_files(&self, symbol_name: &str) -> Option<CrossFileSymbolQuery>` which returns the definition, stable identity, and deduplicated references with deterministic ordering via `sort_locations_deterministic`.
- Added `symbol_key_from_workspace_symbol` helper to derive `SymbolKey` from `WorkspaceSymbol` variants and a focused integration test file `tests/cross_file_reference_query_tests.rs` proving multi-file resolution and not-found behavior.

### Testing

- `cargo test -p perl-workspace` ran and passed (existing crate name in repo is `perl-workspace`).
- `cargo test -p perl-workspace --test cross_file_reference_query_tests` ran the new focused tests and passed.
- `cargo check --workspace --all-targets` ran and completed successfully.
- `cargo test -p perl-workspace-index` was attempted but failed due to a package name mismatch in this repository (use `perl-workspace` as the package name).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb00303aa4833382137c8a270de758)