### PR TITLE
fix(perl-parser): stabilize backup retention cleanup test (#6672)

### DIFF
--- a/crates/perl-parser/src/refactor/refactoring.rs
+++ b/crates/perl-parser/src/refactor/refactoring.rs
@@ -2824,10 +2824,12 @@ sub complex {
         fn test_cleanup_respects_retention_count() {
             use std::io::Write;
 
+            let temp_dir = must(tempfile::tempdir());
             let config = RefactoringConfig {
                 create_backups: true,
                 max_backup_retention: 2,
                 backup_max_age_seconds: 0, // Disable age-based retention
+                backup_root: Some(temp_dir.path().to_path_buf()),
                 ..RefactoringConfig::default()
             };
 
@@ -2853,7 +2855,7 @@ sub complex {
             let result = must(engine.clear_history());
 
             // Should have removed excess directories (4 created - 2 retained = 2 removed)
-            assert!(result.directories_removed >= 2);
+            assert_eq!(result.directories_removed, 2);
         }
 
         #[test]


### PR DESCRIPTION
### Motivation
- The test `test_cleanup_respects_retention_count` was flaky because it used the shared default backup root, allowing cross-test interference and non-deterministic removal counts.

### Description
- In `crates/perl-parser/src/refactor/refactoring.rs` the test `test_cleanup_respects_retention_count` now creates an isolated `tempfile::tempdir()` and sets `backup_root` to it, and the assertion was tightened to `assert_eq!(result.directories_removed, 2)` for deterministic behavior.

### Testing
- Ran `cargo test -p perl-parser --lib refactor::refactoring::tests::validation_tests::test_cleanup_respects_retention_count -- --exact`, which passed.
- Ran full crate tests with `cargo test -p perl-parser`, which completed successfully (`133 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb12a179cc83339e6bf142db843dc0)