### PR TITLE
fix(perl-parser): isolate backup retention test root (#6670)

### DIFF
--- a/crates/perl-parser/src/refactor/refactoring.rs
+++ b/crates/perl-parser/src/refactor/refactoring.rs
@@ -2824,10 +2824,12 @@ sub complex {
         fn test_cleanup_respects_retention_count() {
             use std::io::Write;
 
+            let temp_dir = must(tempfile::tempdir());
             let config = RefactoringConfig {
                 create_backups: true,
                 max_backup_retention: 2,
                 backup_max_age_seconds: 0, // Disable age-based retention
+                backup_root: Some(temp_dir.path().to_path_buf()),
                 ..RefactoringConfig::default()
             };
 


### PR DESCRIPTION
### Motivation

- The test `test_cleanup_respects_retention_count` relied on the global/default backup root and could be influenced by other backup state, making retention cleanup assertions flaky.

### Description

- Use a per-test temporary directory by creating `let temp_dir = must(tempfile::tempdir());` and setting `backup_root: Some(temp_dir.path().to_path_buf())` in `test_cleanup_respects_retention_count` in `crates/perl-parser/src/refactor/refactoring.rs` so the test operates on an isolated backup root.

### Testing

- Ran `cargo test -p perl-parser refactor::refactoring::tests::validation_tests::test_cleanup_respects_retention_count -- --exact` and the test passed.
- Ran `cargo check --all-targets -p perl-parser` and it completed successfully.
- Ran `cargo clippy -p perl-parser --all-targets -- -D warnings` and it completed successfully, and `just pr-fast` was not run because `just` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb12a179cc83339e6bf142db843dc0)