### PR TITLE
fix(lexer-checkpoint): harden checkpoint edit application and cache invariants (#6668)

### DIFF
--- a/crates/perl-lexer/src/checkpoint.rs
+++ b/crates/perl-lexer/src/checkpoint.rs
@@ -53,6 +53,8 @@ pub enum CheckpointContext {
 }
 
 impl LexerCheckpoint {
+    const INVALID_LINE_COLUMN: u32 = 0;
+
     /// Create a new checkpoint with default values
     pub fn new() -> Self {
         Self {
@@ -100,28 +102,51 @@ impl LexerCheckpoint {
 
     /// Apply an edit to this checkpoint
     pub fn apply_edit(&mut self, start: usize, old_len: usize, new_len: usize) {
-        if self.position > start {
-            if self.position >= start + old_len {
-                // Checkpoint is after the edit
-                self.position = self.position - old_len + new_len;
-            } else {
-                // Checkpoint is inside the edit - invalidate
-                self.position = start;
-                self.mode = LexerMode::ExpectTerm;
-                self.delimiter_stack.clear();
-                self.in_prototype = false;
-                self.prototype_depth = 0;
-                self.after_sub = false;
-                self.after_arrow = false;
-                self.hash_brace_depth = 0;
-                self.after_var_subscript = false;
-                self.paren_depth = 0;
-                self.context = CheckpointContext::Normal;
-            }
+        let edit_end = start.saturating_add(old_len);
+        let edit_spans_checkpoint = if old_len == 0 {
+            self.position == start
+        } else {
+            self.position >= start && self.position < edit_end
+        };
+
+        if edit_spans_checkpoint {
+            self.reset_to(start);
+            return;
         }
 
-        // Update position tracking
-        // In a real implementation, we'd update line/column based on the edit
+        if self.position > start && self.position >= edit_end {
+            // Checkpoint is after the edit.
+            let position_delta = new_len as isize - old_len as isize;
+            self.position = shift_usize(self.position, position_delta);
+            self.current_pos.byte = shift_usize(self.current_pos.byte, position_delta);
+
+            // We only know exact line/column tracking when byte offset is unchanged.
+            // For edits with net byte movement before the checkpoint, conservatively mark
+            // line/column unknown and let the next lexing pass recompute precise values.
+            if position_delta != 0 {
+                self.current_pos.line = Self::INVALID_LINE_COLUMN;
+                self.current_pos.column = Self::INVALID_LINE_COLUMN;
+            }
+        }
+    }
+
+    fn reset_to(&mut self, position: usize) {
+        self.position = position;
+        self.mode = LexerMode::ExpectTerm;
+        self.delimiter_stack.clear();
+        self.in_prototype = false;
+        self.prototype_depth = 0;
+        self.after_sub = false;
+        self.after_arrow = false;
+        self.hash_brace_depth = 0;
+        self.after_var_subscript = false;
+        self.paren_depth = 0;
+        self.context = CheckpointContext::Normal;
+        self.current_pos = Position {
+            byte: position,
+            line: Self::INVALID_LINE_COLUMN,
+            column: Self::INVALID_LINE_COLUMN,
+        };
     }
 
     /// Validate that this checkpoint is valid for the given input
@@ -307,9 +332,24 @@ impl CheckpointCache {
             *pos = checkpoint.position;
         }
 
-        // Remove invalid checkpoints
-        self.checkpoints
-            .retain(|(_, cp)| !matches!(cp.context, CheckpointContext::Normal) || cp.position > 0);
+        // Restore cache invariants after edits:
+        // 1) sort by position for binary-search lookups,
+        // 2) collapse duplicates caused by edits,
+        // 3) enforce max size.
+        self.checkpoints.sort_by_key(|(pos, _)| *pos);
+        self.checkpoints.dedup_by_key(|(pos, _)| *pos);
+
+        if self.checkpoints.len() > self.max_checkpoints {
+            self.checkpoints.truncate(self.max_checkpoints);
+        }
+    }
+}
+
+fn shift_usize(value: usize, delta: isize) -> usize {
+    if delta >= 0 {
+        value.saturating_add(delta as usize)
+    } else {
+        value.saturating_sub((-delta) as usize)
     }
 }
 

--- a/crates/perl-lexer/tests/checkpoint_regression_tests.rs
+++ b/crates/perl-lexer/tests/checkpoint_regression_tests.rs
@@ -1,0 +1,103 @@
+use perl_lexer::{CheckpointCache, LexerCheckpoint, LexerMode, Position};
+
+type R = std::result::Result<(), Box<dyn std::error::Error>>;
+
+#[test]
+fn edit_before_checkpoint_updates_position_and_invalidates_line_column() {
+    let mut cp = LexerCheckpoint::at_position(20);
+    cp.current_pos = Position::new(20, 3, 9);
+
+    cp.apply_edit(5, 2, 7);
+
+    assert_eq!(cp.position, 25);
+    assert_eq!(cp.current_pos.byte, 25);
+    assert_eq!(cp.current_pos.line, 0);
+    assert_eq!(cp.current_pos.column, 0);
+}
+
+#[test]
+fn edit_spanning_checkpoint_resets_state_conservatively() {
+    let mut cp = LexerCheckpoint::at_position(30);
+    cp.mode = LexerMode::ExpectOperator;
+    cp.delimiter_stack.push('{');
+    cp.current_pos = Position::new(30, 5, 8);
+
+    cp.apply_edit(25, 10, 4);
+
+    assert_eq!(cp.position, 25);
+    assert_eq!(cp.mode, LexerMode::ExpectTerm);
+    assert!(cp.delimiter_stack.is_empty());
+    assert_eq!(cp.current_pos.byte, 25);
+    assert_eq!(cp.current_pos.line, 0);
+    assert_eq!(cp.current_pos.column, 0);
+}
+
+#[test]
+fn insertion_at_checkpoint_boundary_is_invalidated() {
+    let mut cp = LexerCheckpoint::at_position(30);
+    cp.mode = LexerMode::ExpectOperator;
+    cp.current_pos = Position::new(30, 3, 4);
+
+    cp.apply_edit(30, 0, 4);
+
+    assert_eq!(cp.position, 30);
+    assert_eq!(cp.mode, LexerMode::ExpectTerm);
+    assert_eq!(cp.current_pos.line, 0);
+    assert_eq!(cp.current_pos.column, 0);
+}
+
+#[test]
+fn newline_edit_before_checkpoint_marks_line_column_unknown() {
+    let mut cp = LexerCheckpoint::at_position(12);
+    cp.current_pos = Position::new(12, 1, 13);
+
+    // Inserting a newline before the checkpoint changes line/column, which cannot
+    // be derived safely from byte lengths alone.
+    cp.apply_edit(4, 0, 1);
+
+    assert_eq!(cp.position, 13);
+    assert_eq!(cp.current_pos.byte, 13);
+    assert_eq!(cp.current_pos.line, 0);
+    assert_eq!(cp.current_pos.column, 0);
+}
+
+#[test]
+fn checkpoint_cache_apply_edit_preserves_sorted_unique_invariants() -> R {
+    let mut cache = CheckpointCache::new(10);
+    cache.add(LexerCheckpoint::at_position(10));
+    cache.add(LexerCheckpoint::at_position(20));
+    cache.add(LexerCheckpoint::at_position(30));
+
+    // Deleting bytes before 20 and 30 moves them to 15 and 25, preserving order.
+    cache.apply_edit(15, 5, 0);
+
+    let before_100 = cache.find_before(100).ok_or("expected checkpoint")?;
+    assert_eq!(before_100.position, 25);
+
+    // Deleting [5, 30) maps both shifted checkpoints to 5; cache should deduplicate.
+    cache.apply_edit(5, 25, 0);
+
+    let before_6 = cache.find_before(6).ok_or("expected checkpoint at 5")?;
+    assert_eq!(before_6.position, 5);
+
+    let after_5 = cache.find_after(5).ok_or("expected checkpoint at 5")?;
+    assert_eq!(after_5.position, 5);
+
+    let after_6 = cache.find_after(6);
+    assert!(after_6.is_none(), "duplicate positions should be collapsed");
+    Ok(())
+}
+
+#[test]
+fn malformed_large_edit_lengths_do_not_panic() {
+    let mut cp = LexerCheckpoint::at_position(10);
+    cp.apply_edit(usize::MAX - 2, 100, usize::MAX);
+    assert!(cp.position <= usize::MAX);
+
+    let mut cache = CheckpointCache::new(4);
+    cache.add(LexerCheckpoint::at_position(0));
+    cache.add(LexerCheckpoint::at_position(1));
+    cache.apply_edit(usize::MAX - 1, usize::MAX, usize::MAX);
+
+    assert!(cache.find_before(usize::MAX).is_some());
+}


### PR DESCRIPTION
### Motivation
- Incremental lexer checkpoints were shifted by byte-length arithmetic only and could become incorrect or violate cache invariants after edits, especially around edits that span or touch checkpoint boundaries and newline-sensitive edits.
- The change aims to keep correctness-first behavior (reset when state cannot be safely preserved) while providing conservative line/column handling and preventing panics on malformed/large edit inputs.

### Description
- Hardened `LexerCheckpoint::apply_edit` to compute edit end with saturating math and treat edits that span or insert at a checkpoint boundary as conservative invalidations via a new `reset_to` helper, preserving the previous reset behavior for unsafe cases.
- When a checkpoint is shifted (edit before it), update byte offsets using a safe `shift_usize` helper and conservatively mark `current_pos.line`/`column` as unknown (`0`) when net byte movement makes line/column uncertain.
- Tightened `CheckpointCache::apply_edit` to re-sort, deduplicate by position, and enforce `max_checkpoints` after applying edits so binary-search lookup invariants remain valid even when edits collapse or move checkpoints.
- Added focused regression tests in `crates/perl-lexer/tests/checkpoint_regression_tests.rs` covering edits before checkpoints, edits spanning checkpoints, newline-sensitive line/column invalidation, insertion-at-boundary invalidation, cache ordering/dedup behavior, and malformed large-edit inputs.

### Testing
- Ran `cargo test -p perl-lexer` which passed (including the new `checkpoint_regression_tests` tests).
- Ran `cargo check --workspace --all-targets` which completed successfully with no errors.
- Ran `cargo xtask fmt` to ensure formatting; it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c72c6948333bda77b89506e810b)