### PR TITLE
test(lexer-keywords): lock down keyword inventory invariants and drift checks (#6666)

### DIFF
--- a/crates/perl-lexer/src/keywords/mod.rs
+++ b/crates/perl-lexer/src/keywords/mod.rs
@@ -371,6 +371,19 @@ mod tests {
         }
     }
 
+    fn assert_proper_subset(name: &str, subset: &[&str], superset_name: &str, superset: &[&str]) {
+        assert!(
+            subset.len() < superset.len(),
+            "{name} must be a proper subset of {superset_name}"
+        );
+        for &item in subset {
+            assert!(
+                superset.binary_search(&item).is_ok(),
+                "{name} entry {item:?} missing from {superset_name}"
+            );
+        }
+    }
+
     #[test]
     fn keyword_lists_are_sorted_and_unique() {
         assert_sorted_unique("KEYWORDS", KEYWORDS);
@@ -380,6 +393,44 @@ mod tests {
         assert_sorted_unique("RENAME_KEYWORDS", RENAME_KEYWORDS);
         assert_sorted_unique("PARSER_LSP_KEYWORDS", PARSER_LSP_KEYWORDS);
         assert_sorted_unique("LEXER_KEYWORDS", LEXER_KEYWORDS);
+    }
+
+    #[test]
+    fn keyword_list_counts_are_stable() {
+        assert_eq!(127, KEYWORDS.len(), "KEYWORDS count changed; review inventory drift");
+        assert_eq!(68, LSP_COMPLETION_KEYWORDS.len(), "LSP completion inventory drifted");
+        assert_eq!(72, DAP_COMPLETION_KEYWORDS.len(), "DAP completion inventory drifted");
+        assert_eq!(
+            40,
+            LSP_RUNTIME_COMPLETION_KEYWORDS.len(),
+            "runtime completion inventory drifted"
+        );
+        assert_eq!(25, RENAME_KEYWORDS.len(), "rename inventory drifted");
+        assert_eq!(32, PARSER_LSP_KEYWORDS.len(), "parser LSP inventory drifted");
+        assert_eq!(67, LEXER_KEYWORDS.len(), "lexer inventory drifted");
+    }
+
+    #[test]
+    fn keyword_subset_relationships_are_explicit() {
+        assert_proper_subset("LSP_COMPLETION_KEYWORDS", LSP_COMPLETION_KEYWORDS, "KEYWORDS", KEYWORDS);
+        assert_proper_subset("DAP_COMPLETION_KEYWORDS", DAP_COMPLETION_KEYWORDS, "KEYWORDS", KEYWORDS);
+        assert_proper_subset(
+            "LSP_RUNTIME_COMPLETION_KEYWORDS",
+            LSP_RUNTIME_COMPLETION_KEYWORDS,
+            "KEYWORDS",
+            KEYWORDS,
+        );
+        assert_proper_subset("RENAME_KEYWORDS", RENAME_KEYWORDS, "KEYWORDS", KEYWORDS);
+        assert_proper_subset("PARSER_LSP_KEYWORDS", PARSER_LSP_KEYWORDS, "KEYWORDS", KEYWORDS);
+        assert_proper_subset("LEXER_KEYWORDS", LEXER_KEYWORDS, "KEYWORDS", KEYWORDS);
+
+        // Rename validation vocabulary is intentionally sourced from completion-safe keywords.
+        assert_proper_subset(
+            "RENAME_KEYWORDS",
+            RENAME_KEYWORDS,
+            "LSP_COMPLETION_KEYWORDS",
+            LSP_COMPLETION_KEYWORDS,
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Keyword inventories were validated by scattered tests which made sortedness, subset relationships, and accidental list-size drift harder to detect centrally.

### Description
- Added a reusable `assert_proper_subset` helper and explicit subset assertions to the unit-test module in `crates/perl-lexer/src/keywords/mod.rs` to verify containment and proper-subset semantics.
- Added `keyword_list_counts_are_stable` which asserts exact lengths for `KEYWORDS`, `LSP_COMPLETION_KEYWORDS`, `DAP_COMPLETION_KEYWORDS`, `LSP_RUNTIME_COMPLETION_KEYWORDS`, `RENAME_KEYWORDS`, `PARSER_LSP_KEYWORDS`, and `LEXER_KEYWORDS` to detect inventory drift.
- Added `keyword_subset_relationships_are_explicit` which checks each specialized list is a proper subset of `KEYWORDS` and that `RENAME_KEYWORDS` is a proper subset of `LSP_COMPLETION_KEYWORDS`.
- All changes are confined to the test module in `crates/perl-lexer/src/keywords/mod.rs` and use existing `binary_search` helpers for membership checks.

### Testing
- Ran `cargo test -p perl-lexer keywords` and the focused keyword tests passed.
- Ran `cargo test -p perl-lexer` and the full `perl-lexer` test suite passed.
- Ran `cargo check --workspace --all-targets` and the workspace check completed successfully (with unrelated warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c76d268833386d161b0bff3b80b)