### PR TITLE
fix(lexer): tighten slash disambiguation and mode-transition correctness (#6660)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2107,8 +2107,7 @@ impl<'a> PerlLexer<'a> {
             let token_type = if is_keyword_fast(text) {
                 // Check for special keywords that affect lexer mode
                 match text {
-                    "if" | "unless" | "while" | "until" | "for" | "foreach" | "grep" | "map"
-                    | "sort" | "split" => {
+                    kw if keyword_expects_term(kw) => {
                         self.mode = LexerMode::ExpectTerm;
                     }
                     "sub" => {
@@ -2242,7 +2241,7 @@ impl<'a> PerlLexer<'a> {
                 TokenType::Keyword(Arc::from(text))
             } else {
                 // Mirror parser bare-builtin handling so `/` after builtins like
-                // `join` or `print` is lexed as a regex term, not division.
+                // `join`, `print`, or `printf` is lexed as a regex term, not division.
                 if is_builtin_function(text) {
                     self.mode = LexerMode::ExpectTerm;
                 } else {
@@ -3637,11 +3636,33 @@ fn is_builtin_function(word: &str) -> bool {
     BARE_TERM_BUILTINS.binary_search(&word).is_ok()
 }
 
+#[inline]
+fn keyword_expects_term(word: &str) -> bool {
+    matches!(
+        word,
+        "if" | "unless"
+            | "while"
+            | "until"
+            | "for"
+            | "foreach"
+            | "grep"
+            | "map"
+            | "sort"
+            | "split"
+            | "do"
+            | "return"
+            | "and"
+            | "or"
+            | "xor"
+            | "not"
+    )
+}
+
 const BARE_TERM_BUILTINS: &[&str] = &[
     "abs", "chomp", "chop", "chr", "close", "defined", "delete", "each", "exists", "hex", "int",
-    "join", "keys", "lc", "lcfirst", "length", "oct", "open", "ord", "pack", "print", "push",
-    "read", "ref", "reverse", "rindex", "say", "scalar", "splice", "sprintf", "sqrt", "substr",
-    "tie", "uc", "ucfirst", "unpack", "unshift", "untie", "values", "write",
+    "join", "keys", "lc", "lcfirst", "length", "oct", "open", "ord", "pack", "print", "printf",
+    "push", "read", "ref", "reverse", "rindex", "say", "scalar", "splice", "sprintf", "sqrt",
+    "substr", "tie", "uc", "ucfirst", "unpack", "unshift", "untie", "values", "write",
 ];
 
 /// Fast lookup table for compound operator second characters

--- a/crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs
+++ b/crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs
@@ -299,6 +299,20 @@ fn lexer_slash_ambiguity_regex_whitespace_variations() -> TestResult {
     Ok(())
 }
 
+/// Test slash after keyword with an intervening comment/newline
+#[test]
+fn lexer_slash_ambiguity_regex_after_keyword_comment_gap() -> TestResult {
+    let mut lexer = PerlLexer::new("if # comment keeps ExpectTerm\n/pattern/");
+    let _ = lexer.next_token(); // if
+    let tok = lexer.next_token().ok_or("Expected regex token")?;
+    assert!(
+        matches!(tok.token_type, TokenType::RegexMatch),
+        "Expected regex after keyword+comment gap, got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
 /// Test slash after string literal
 ///
 /// Tests feature spec: ROADMAP.md#slash-ambiguity

--- a/crates/perl-lexer/tests/lexer_mode_issue_3030.rs
+++ b/crates/perl-lexer/tests/lexer_mode_issue_3030.rs
@@ -258,3 +258,30 @@ fn mode_transitions_after_keyword_to_expect_term() -> R {
     assert!(has_regex, "after 'if' keyword the slash must start a regex");
     Ok(())
 }
+
+#[test]
+fn mode_transitions_after_return_keyword_to_expect_term() -> R {
+    let mut lexer = PerlLexer::new("return /pattern/");
+    let _ = lexer.next_token().ok_or("expected return token")?;
+    let slash = lexer.next_token().ok_or("expected slash token")?;
+    assert!(
+        matches!(slash.token_type, TokenType::RegexMatch),
+        "after 'return' keyword the slash must start regex, got {:?}",
+        slash.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn mode_transitions_after_word_logical_operator_to_expect_term() -> R {
+    let mut lexer = PerlLexer::new("$x and /pattern/");
+    let _ = lexer.next_token().ok_or("expected variable token")?;
+    let _ = lexer.next_token().ok_or("expected and keyword")?;
+    let slash = lexer.next_token().ok_or("expected slash token")?;
+    assert!(
+        matches!(slash.token_type, TokenType::RegexMatch),
+        "after 'and' keyword the slash must start regex, got {:?}",
+        slash.token_type
+    );
+    Ok(())
+}

--- a/crates/perl-lexer/tests/lexer_slash_timeout_tests.rs
+++ b/crates/perl-lexer/tests/lexer_slash_timeout_tests.rs
@@ -66,6 +66,26 @@ fn test_slash_after_keyword_is_regex() -> TestResult {
 }
 
 #[test]
+fn test_slash_after_logical_keyword_is_regex() -> TestResult {
+    // Word logical operators should keep us in ExpectTerm.
+    let mut lexer = PerlLexer::new("$x and /pattern/");
+    lexer.next_token(); // $x
+    lexer.next_token(); // and
+    let token = lexer.next_token().ok_or("Expected regex token")?;
+    assert_eq!(token.token_type, TokenType::RegexMatch);
+    Ok(())
+}
+
+#[test]
+fn test_slash_after_printf_builtin_is_regex() -> TestResult {
+    let mut lexer = PerlLexer::new("printf /%s/, $x");
+    lexer.next_token(); // printf
+    let token = lexer.next_token().ok_or("Expected regex token")?;
+    assert_eq!(token.token_type, TokenType::RegexMatch);
+    Ok(())
+}
+
+#[test]
 fn test_slash_after_opening_paren_is_regex() -> TestResult {
     // After opening paren → likely regex
     let mut lexer = PerlLexer::new("if (/pattern/)");
@@ -138,6 +158,19 @@ fn test_defined_or_vs_empty_regex() -> TestResult {
 
     // After $a (identifier), // should be defined-or operator
     assert!(matches!(token.token_type, TokenType::Operator(_)));
+    Ok(())
+}
+
+#[test]
+fn test_defined_or_after_comment_stays_operator() -> TestResult {
+    let mut lexer = PerlLexer::new("$a # keep mode\n// $b");
+    lexer.next_token(); // $a
+    let token = lexer.next_token().ok_or("Expected defined-or token")?;
+    assert!(
+        matches!(token.token_type, TokenType::Operator(ref op) if op.as_ref() == "//"),
+        "Expected defined-or operator, got {:?}",
+        token.token_type
+    );
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Harden slash disambiguation so `/` is interpreted correctly in division, regex, and defined-or contexts without changing the mode-driven, no-backtracking design.
- Close gaps where keyword/builtin transitions (including logical words and `return`) or comment/newline adjacency could leave the lexer in the wrong `LexerMode` before a `/`.

### Description
- Centralized keyword-to-`ExpectTerm` logic by adding `keyword_expects_term` and using it when classifying keywords so slash-sensitive words (`if`, `unless`, `while`, `until`, `for`, `foreach`, `grep`, `map`, `sort`, `split`, `do`, `return`, `and`, `or`, `xor`, `not`) consistently set `LexerMode::ExpectTerm` (change in `crates/perl-lexer/src/lib.rs`).
- Expanded the bare-term builtin set to include `printf` so `printf /.../` is lexed as a regex-start context (change in `crates/perl-lexer/src/lib.rs`).
- Added targeted regression tests covering logical-word transitions, `return`, comment/newline gaps before `/` or `//`, and `printf`-related regex contexts (updates in `crates/perl-lexer/tests/lexer_slash_timeout_tests.rs`, `crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs`, and `crates/perl-lexer/tests/lexer_mode_issue_3030.rs`).
- No redesign of quote-like operators, no mode backtracking introduced, and `LexerMode` enum remains unchanged.

### Testing
- Ran `cargo test -p perl-lexer slash` and all slash-focused tests passed.
- Ran `cargo test -p perl-lexer` and the full `perl-lexer` test suite passed.
- Ran `cargo check --workspace --all-targets` and it completed successfully.
- Ran `cargo xtask fmt` to ensure formatting, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c8698308333829130a5b343bd36)