### PR TITLE
fix(lexer): tighten slash disambiguation and mode-transition correctness (#6659)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2106,11 +2106,10 @@ impl<'a> PerlLexer<'a> {
 
             let token_type = if is_keyword_fast(text) {
                 // Check for special keywords that affect lexer mode
+                if LexerMode::keyword_keeps_expect_term(text) {
+                    self.mode = LexerMode::ExpectTerm;
+                }
                 match text {
-                    "if" | "unless" | "while" | "until" | "for" | "foreach" | "grep" | "map"
-                    | "sort" | "split" => {
-                        self.mode = LexerMode::ExpectTerm;
-                    }
                     "sub" => {
                         self.after_sub = true;
                     }

--- a/crates/perl-lexer/src/mode.rs
+++ b/crates/perl-lexer/src/mode.rs
@@ -69,4 +69,47 @@ impl LexerMode {
     pub fn is_expect_operator(&self) -> bool {
         matches!(self, LexerMode::ExpectOperator)
     }
+
+    /// Keywords that should keep the lexer in `ExpectTerm` mode.
+    ///
+    /// These are prefix/control-flow keywords where the next token starts a
+    /// term-like expression (including regex literals), not an infix operator.
+    #[must_use]
+    pub fn keyword_keeps_expect_term(keyword: &str) -> bool {
+        matches!(
+            keyword,
+            "if"
+                | "unless"
+                | "while"
+                | "until"
+                | "for"
+                | "foreach"
+                | "grep"
+                | "map"
+                | "sort"
+                | "split"
+                | "and"
+                | "or"
+                | "xor"
+                | "not"
+                | "return"
+                | "next"
+                | "last"
+                | "redo"
+                | "goto"
+                | "do"
+                | "elsif"
+                | "else"
+                | "given"
+                | "when"
+                | "continue"
+                | "use"
+                | "require"
+                | "no"
+                | "my"
+                | "our"
+                | "state"
+                | "local"
+        )
+    }
 }

--- a/crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs
+++ b/crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs
@@ -946,3 +946,49 @@ fn lexer_slash_division_after_number_literal() -> TestResult {
 
     Ok(())
 }
+
+#[test]
+fn lexer_slash_ambiguity_defined_or_after_closing_delimiter() -> TestResult {
+    let mut lexer = PerlLexer::new("($x) // $fallback");
+    let mut saw_right_paren = false;
+
+    while let Some(tok) = lexer.next_token() {
+        if matches!(tok.token_type, TokenType::RightParen) {
+            saw_right_paren = true;
+            continue;
+        }
+        if saw_right_paren {
+            assert!(
+                matches!(tok.token_type, TokenType::Operator(ref op) if op.as_ref() == "//"),
+                "expected // operator after right paren, got {:?}",
+                tok.token_type
+            );
+            return Ok(());
+        }
+    }
+
+    Err("expected // after right paren".into())
+}
+
+#[test]
+fn lexer_slash_ambiguity_division_after_subscript_with_comment_gap() -> TestResult {
+    let mut lexer = PerlLexer::new("$h{key} # comment\n / 2");
+
+    let mut saw_right_brace = false;
+    while let Some(tok) = lexer.next_token() {
+        if matches!(tok.token_type, TokenType::RightBrace) {
+            saw_right_brace = true;
+            continue;
+        }
+        if saw_right_brace {
+            assert!(
+                matches!(tok.token_type, TokenType::Division),
+                "expected division after subscript + comment/newline, got {:?}",
+                tok.token_type
+            );
+            return Ok(());
+        }
+    }
+
+    Err("expected division after subscript/comment gap".into())
+}

--- a/crates/perl-lexer/tests/lexer_mode_issue_3030.rs
+++ b/crates/perl-lexer/tests/lexer_mode_issue_3030.rs
@@ -258,3 +258,27 @@ fn mode_transitions_after_keyword_to_expect_term() -> R {
     assert!(has_regex, "after 'if' keyword the slash must start a regex");
     Ok(())
 }
+
+#[test]
+fn keyword_helper_marks_logical_keywords_as_expect_term() {
+    assert!(LexerMode::keyword_keeps_expect_term("and"));
+    assert!(LexerMode::keyword_keeps_expect_term("or"));
+    assert!(LexerMode::keyword_keeps_expect_term("not"));
+}
+
+#[test]
+fn mode_transitions_after_logical_keyword_to_expect_term() -> R {
+    // After keyword-form logical operators, slash should still start regex.
+    let mut lexer = PerlLexer::new("$flag and /pattern/");
+    let tokens: Vec<_> = lexer
+        .collect_tokens()
+        .into_iter()
+        .filter(|t| {
+            !matches!(t.token_type, TokenType::Whitespace | TokenType::Newline | TokenType::EOF)
+        })
+        .collect();
+
+    let has_regex = tokens.iter().any(|t| matches!(t.token_type, TokenType::RegexMatch));
+    assert!(has_regex, "after 'and' keyword the slash must start a regex");
+    Ok(())
+}

--- a/crates/perl-lexer/tests/lexer_slash_timeout_tests.rs
+++ b/crates/perl-lexer/tests/lexer_slash_timeout_tests.rs
@@ -272,6 +272,28 @@ fn test_slash_after_hash_subscript() -> TestResult {
 }
 
 #[test]
+fn test_slash_after_logical_keyword_is_regex() -> TestResult {
+    // `and` is keyword-form logical operator, so it should keep ExpectTerm.
+    let mut lexer = PerlLexer::new("$ok and /pattern/");
+    lexer.next_token(); // $ok
+    lexer.next_token(); // and
+    let token = lexer.next_token().ok_or("Expected regex token")?;
+    assert_eq!(token.token_type, TokenType::RegexMatch);
+    Ok(())
+}
+
+#[test]
+fn test_slash_after_builtin_with_comment_is_regex() -> TestResult {
+    // Builtins like print expect a following term; comment/newline should not
+    // change slash disambiguation.
+    let mut lexer = PerlLexer::new("print # comment\n /pattern/");
+    lexer.next_token(); // print
+    let token = lexer.next_token().ok_or("Expected regex token")?;
+    assert_eq!(token.token_type, TokenType::RegexMatch);
+    Ok(())
+}
+
+#[test]
 fn test_budget_guard_prevents_infinite_loop() {
     // Test that budget guard prevents infinite loops
     // Create a regex that approaches but doesn't exceed the limit


### PR DESCRIPTION
### Motivation

- Harden slash `/` handling so division, regex, and defined-or (`//`) are classified correctly across closing delimiters, subscripts, comment/whitespace gaps, and keyword/builtin contexts while preserving the mode-driven, no-backtracking design.

### Description

- Add `LexerMode::keyword_keeps_expect_term(keyword: &str)` to centralize keywords that should keep the lexer in `ExpectTerm` instead of scattering the logic; this covers control-flow and logical-word forms (e.g., `if`, `and`, `or`, `not`, `split`, `sort`, etc.).
- Apply the helper in the keyword handling path so the lexer sets `self.mode = LexerMode::ExpectTerm` for those keywords before existing special-case logic (no speculative/backtracking changes to the algorithm).
- Add focused regression tests to cover edge cases: `//` defined-or after closing delimiter, division after subscript separated by comment/newline, slash-after-logical-keyword regex behavior, and builtin-with-intervening-comment regex behavior.

### Testing

- Ran `cargo test -p perl-lexer slash` and the slash-focused suite passed.
- Ran `cargo test -p perl-lexer` and the crate test-suite passed.
- Ran `cargo check --workspace --all-targets` and the workspace check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c8698308333829130a5b343bd36)