### PR TITLE
fix(lexer): tighten slash disambiguation and mode-transition correctness (#6658)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2107,8 +2107,7 @@ impl<'a> PerlLexer<'a> {
             let token_type = if is_keyword_fast(text) {
                 // Check for special keywords that affect lexer mode
                 match text {
-                    "if" | "unless" | "while" | "until" | "for" | "foreach" | "grep" | "map"
-                    | "sort" | "split" => {
+                    kw if keyword_keeps_expect_term(kw) => {
                         self.mode = LexerMode::ExpectTerm;
                     }
                     "sub" => {
@@ -3633,9 +3632,19 @@ fn is_keyword_fast(word: &str) -> bool {
 }
 
 #[inline]
+fn keyword_keeps_expect_term(word: &str) -> bool {
+    EXPECT_TERM_KEYWORDS.binary_search(&word).is_ok()
+}
+
+#[inline]
 fn is_builtin_function(word: &str) -> bool {
     BARE_TERM_BUILTINS.binary_search(&word).is_ok()
 }
+
+const EXPECT_TERM_KEYWORDS: &[&str] = &[
+    "do", "else", "elsif", "eval", "for", "foreach", "given", "grep", "if", "map", "return",
+    "sort", "split", "unless", "until", "when", "while",
+];
 
 const BARE_TERM_BUILTINS: &[&str] = &[
     "abs", "chomp", "chop", "chr", "close", "defined", "delete", "each", "exists", "hex", "int",

--- a/crates/perl-lexer/src/mode.rs
+++ b/crates/perl-lexer/src/mode.rs
@@ -24,6 +24,8 @@
 //! | keyword                | ExpectTerm     | `if /pattern/`    |
 //! | operator               | ExpectTerm     | `=~ /test/`       |
 //! | opening paren/bracket  | ExpectTerm     | `( /regex/`       |
+//! | term-leading keyword   | ExpectTerm     | `return /re/`     |
+//! | bare-term builtin      | ExpectTerm     | `print /re/`      |
 //!
 //! ## Timeout Protection
 //!

--- a/crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs
+++ b/crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs
@@ -946,3 +946,33 @@ fn lexer_slash_division_after_number_literal() -> TestResult {
 
     Ok(())
 }
+
+#[test]
+fn lexer_slash_regex_after_return_keyword() -> TestResult {
+    let mut lexer = PerlLexer::new("return /pattern/");
+    let kw = lexer.next_token().ok_or("Expected return keyword")?;
+    assert!(matches!(kw.token_type, TokenType::Keyword(ref k) if k.as_ref() == "return"));
+
+    let slash = lexer.next_token().ok_or("Expected regex after return")?;
+    assert!(
+        matches!(slash.token_type, TokenType::RegexMatch),
+        "Expected regex after return keyword, got {:?}",
+        slash.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn lexer_slash_division_after_subscript_with_comment_gap() -> TestResult {
+    let mut lexer = PerlLexer::new("$hash{key} # keep operator mode\n / 2");
+    loop {
+        let tok = lexer.next_token().ok_or("Expected slash token")?;
+        if matches!(tok.token_type, TokenType::Division) {
+            return Ok(());
+        }
+        if matches!(tok.token_type, TokenType::EOF) {
+            break;
+        }
+    }
+    Err("Expected division token after subscript/comment boundary".into())
+}

--- a/crates/perl-lexer/tests/lexer_mode_issue_3030.rs
+++ b/crates/perl-lexer/tests/lexer_mode_issue_3030.rs
@@ -258,3 +258,33 @@ fn mode_transitions_after_keyword_to_expect_term() -> R {
     assert!(has_regex, "after 'if' keyword the slash must start a regex");
     Ok(())
 }
+
+#[test]
+fn mode_transitions_after_return_keyword_to_expect_term() -> R {
+    let mut lexer = PerlLexer::new("return /pattern/");
+    let tokens: Vec<_> = lexer
+        .collect_tokens()
+        .into_iter()
+        .filter(|t| {
+            !matches!(t.token_type, TokenType::Whitespace | TokenType::Newline | TokenType::EOF)
+        })
+        .collect();
+    let has_regex = tokens.iter().any(|t| matches!(t.token_type, TokenType::RegexMatch));
+    assert!(has_regex, "after 'return' keyword the slash must start a regex");
+    Ok(())
+}
+
+#[test]
+fn mode_transitions_after_builtin_identifier_to_expect_term() -> R {
+    let mut lexer = PerlLexer::new("print /pattern/");
+    let tokens: Vec<_> = lexer
+        .collect_tokens()
+        .into_iter()
+        .filter(|t| {
+            !matches!(t.token_type, TokenType::Whitespace | TokenType::Newline | TokenType::EOF)
+        })
+        .collect();
+    let has_regex = tokens.iter().any(|t| matches!(t.token_type, TokenType::RegexMatch));
+    assert!(has_regex, "after bare builtin 'print' the slash must start a regex");
+    Ok(())
+}

--- a/crates/perl-lexer/tests/lexer_slash_timeout_tests.rs
+++ b/crates/perl-lexer/tests/lexer_slash_timeout_tests.rs
@@ -284,3 +284,24 @@ fn test_budget_guard_prevents_infinite_loop() {
     // Should successfully parse or gracefully fail, not hang
     assert!(token.is_some());
 }
+
+#[test]
+fn test_defined_or_after_comment_boundary() -> TestResult {
+    let mut lexer = PerlLexer::new("$a # comment\n // $b");
+    lexer.next_token(); // $a
+    let token = lexer.next_token().ok_or("Expected // token")?;
+    assert!(
+        matches!(token.token_type, TokenType::Operator(ref op) if op.as_ref() == "//"),
+        "Expected defined-or operator after comment boundary, got {:?}",
+        token.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn test_empty_regex_at_expression_start_with_leading_whitespace() -> TestResult {
+    let mut lexer = PerlLexer::new("   //");
+    let token = lexer.next_token().ok_or("Expected regex token")?;
+    assert_eq!(token.token_type, TokenType::RegexMatch);
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Close gaps where term-leading keywords and certain builtin/whitespace/comment boundaries caused `/` to be mis-classified between division, `//`, and regex without changing the mode-driven, no-backtracking design.

### Description

- Replace the inline keyword match with a `keyword_keeps_expect_term()` helper and `EXPECT_TERM_KEYWORDS` table so term-leading keywords (e.g., `return`) consistently preserve `ExpectTerm` without backtracking (`crates/perl-lexer/src/lib.rs`).
- Document the expanded contexts that should retain `ExpectTerm` (term-leading keywords and bare-term builtins) in `crates/perl-lexer/src/mode.rs`.
- Add targeted regression tests covering `return /…/`, `print /…/`, defined-or `//` and empty-regex edge cases near comment/whitespace boundaries, and subscript+comment boundaries to ensure division vs regex is stable (`crates/perl-lexer/tests/*_slash_*.rs`).
- Preserve existing budget/timeout protections and the overall `LexerMode`-based slash strategy; no backtracking or speculative parsing was introduced.

### Testing

- Ran formatting: `cargo xtask fmt` (succeeded).
- Ran focused tests: `cargo test -p perl-lexer slash` (all slash-related tests passed).
- Ran full crate tests: `cargo test -p perl-lexer` (passed).
- Ran workspace check: `cargo check --workspace --all-targets` (passed; unrelated warnings remain in other crates).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c8698308333829130a5b343bd36)