### PR TITLE
fix(lexer): harden quote-like operator and transliteration tokenization (#6656)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2072,17 +2072,10 @@ impl<'a> PerlLexer<'a> {
                 if let Some(next) = candidate {
                     // `s => 1` should remain a fat-arrow hash key, not quote op.
                     let is_fat_arrow = next == '=' && char_after_next == Some('>');
-                    let is_paired_delim = matches!(next, '{' | '[' | '(' | '<');
-                    let is_quote_char = matches!(next, '\'' | '"') && text != "s";
-                    let transliteration_allows_whitespace = text == "tr" || text == "y";
-                    let substitution_disallows_whitespace = text == "s" && has_whitespace;
-                    let is_valid_delim = Self::is_quote_delim(next)
-                        && !is_fat_arrow
-                        && !substitution_disallows_whitespace
-                        && (!has_whitespace
-                            || is_paired_delim
-                            || is_quote_char
-                            || transliteration_allows_whitespace);
+                    let allows_spaced =
+                        !has_whitespace || quote_handler::allows_spaced_delimiter(text, next);
+                    let is_valid_delim =
+                        Self::is_quote_delim(next) && !is_fat_arrow && allows_spaced;
 
                     if is_valid_delim {
                         match text {
@@ -2155,19 +2148,11 @@ impl<'a> PerlLexer<'a> {
                             // not a valid substitution delimiter. Treat as identifier.
                             let is_fat_arrow = next == '=' && char_after_next == Some('>');
 
-                            // When whitespace precedes the delimiter, only unambiguous
-                            // delimiters are accepted:
-                            //   - Paired delimiters ({, [, (, <) are always safe.
-                            //   - ' and " are safe for all operators EXCEPT `s` — `-s 'filename'`
-                            //     is a valid file-size filetest and must not be treated as a
-                            //     substitution start. All other operators (qw, q, qq, qr, qx, m,
-                            //     tr, y) have no corresponding file-test operator.
-                            //   - Non-paired, non-quote chars ($, @, ,, etc.) remain rejected.
-                            let is_paired_delim = matches!(next, '{' | '[' | '(' | '<');
-                            let is_quote_char = matches!(next, '\'' | '"') && op != "s";
+                            // Optional whitespace before delimiter is allowed per operator.
                             let is_valid_delim = Self::is_quote_delim(next)
                                 && !is_fat_arrow
-                                && (!has_whitespace || is_paired_delim || is_quote_char);
+                                && (!has_whitespace
+                                    || quote_handler::allows_spaced_delimiter(op, next));
 
                             if is_valid_delim {
                                 self.mode = LexerMode::ExpectDelimiter;
@@ -3314,8 +3299,9 @@ impl<'a> PerlLexer<'a> {
             }
         }
 
-        // Parse replacement list - same delimiter handling
-        if is_paired {
+        // Parse replacement list. Like substitution, paired search delimiters can
+        // be followed by a different replacement delimiter (e.g. tr{a-z}[A-Z]).
+        let (repl_delimiter, repl_closing, repl_is_paired) = if is_paired {
             // Skip whitespace between search and replace for paired delimiters
             while let Some(ch) = self.current_char() {
                 if ch.is_whitespace() {
@@ -3325,13 +3311,23 @@ impl<'a> PerlLexer<'a> {
                 }
             }
 
-            // Expect opening delimiter for replacement
-            if self.current_char() == Some(delimiter) {
-                self.advance();
-                depth = 1;
+            if let Some(repl_delim) = self.current_char() {
+                if matches!(repl_delim, '{' | '[' | '(' | '<') {
+                    let repl_close = Self::paired_closing(repl_delim);
+                    self.advance();
+                    (repl_delim, repl_close, true)
+                } else {
+                    self.advance();
+                    (repl_delim, repl_delim, false)
+                }
+            } else {
+                (delimiter, closing, is_paired)
             }
-        }
+        } else {
+            (delimiter, closing, false)
+        };
 
+        depth = 1;
         while let Some(ch) = self.current_char() {
             match ch {
                 '\\' => {
@@ -3340,13 +3336,13 @@ impl<'a> PerlLexer<'a> {
                         self.advance();
                     }
                 }
-                _ if ch == delimiter && is_paired => {
+                _ if ch == repl_delimiter && repl_is_paired => {
                     depth += 1;
                     self.advance();
                 }
-                _ if ch == closing => {
+                _ if ch == repl_closing => {
                     self.advance();
-                    if is_paired {
+                    if repl_is_paired {
                         depth = depth.saturating_sub(1);
                         if depth == 0 {
                             break;

--- a/crates/perl-lexer/src/quote_handler.rs
+++ b/crates/perl-lexer/src/quote_handler.rs
@@ -43,6 +43,25 @@ pub fn paired_close(open: char) -> Option<char> {
     }
 }
 
+/// Whether optional whitespace before the delimiter is accepted for this
+/// quote-like operator in lexer disambiguation.
+///
+/// Perl allows optional whitespace in many quote-like forms. We still keep a
+/// few conservative guardrails here to avoid over-eager misclassification in
+/// ambiguous bareword contexts.
+pub fn allows_spaced_delimiter(operator: &str, delimiter: char) -> bool {
+    let is_paired = paired_close(delimiter).is_some();
+    match operator {
+        // Keep `s` conservative in spaced form to avoid false positives in
+        // bareword contexts; paired delimiters are unambiguous.
+        "s" => is_paired,
+        // Other quote-like operators support optional whitespace before
+        // arbitrary delimiters.
+        "q" | "qq" | "qw" | "qx" | "m" | "qr" | "tr" | "y" => true,
+        _ => false,
+    }
+}
+
 /// Canonicalize modifier flags to a consistent order for stable comparisons
 ///
 /// Note: Currently unused as modifier validation moved to parser layer (MUT_005 fix).

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -318,6 +318,20 @@ fn substitution_with_modifiers_ge() -> R {
 }
 
 #[test]
+fn substitution_with_spaced_paired_delimiter() -> R {
+    let input = "s {old} {new}g";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Substitution),
+        "Expected Substitution for spaced paired delimiters, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "s {old} {new}g");
+    Ok(())
+}
+
+#[test]
 fn transliteration_pipe_delimiter() -> R {
     let input = "tr|a-z|A-Z|";
     let sig = significant(input);
@@ -356,6 +370,20 @@ fn transliteration_with_modifiers_cds() -> R {
         first.token_type
     );
     assert_eq!(first.text.as_ref(), "tr/a-z/A-Z/cds");
+    Ok(())
+}
+
+#[test]
+fn transliteration_with_mixed_paired_delimiters() -> R {
+    let input = "tr{a-z}[A-Z]cdr";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Transliteration),
+        "Expected Transliteration for tr{{...}}[...], got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "tr{a-z}[A-Z]cdr");
     Ok(())
 }
 
@@ -654,6 +682,16 @@ fn q_with_escaped_delimiter() -> R {
         first.token_type
     );
     assert_eq!(first.text.as_ref(), r"q|hello \| world|");
+    Ok(())
+}
+
+#[test]
+fn quote_like_malformed_construct_does_not_panic() -> R {
+    let input = "my $x = qr{foo; my $y = s{a}{b";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_qr = sig.iter().any(|t| matches!(t.token_type, TokenType::QuoteRegex));
+    assert!(has_qr, "expected lexer to produce a QuoteRegex token without panicking");
     Ok(())
 }
 

--- a/crates/perl-lexer/tests/regex_arbitrary_delimiters_issue_444.rs
+++ b/crates/perl-lexer/tests/regex_arbitrary_delimiters_issue_444.rs
@@ -256,3 +256,40 @@ fn test_m_vs_bareword_disambiguation() {
         tokens2[0].token_type
     );
 }
+
+#[test]
+fn test_spaced_nonpaired_delimiters_for_quote_like_ops() {
+    let cases = [
+        ("m /pattern/", TokenType::RegexMatch),
+        ("qr !pattern!ms", TokenType::QuoteRegex),
+        ("q |literal|", TokenType::QuoteSingle),
+        ("qq /double/", TokenType::QuoteDouble),
+        ("qw /foo bar/", TokenType::QuoteWords),
+        ("qx !echo hi!", TokenType::QuoteCommand),
+    ];
+
+    for (code, expected) in cases {
+        let mut lexer = PerlLexer::new(code);
+        let tokens = lexer.collect_tokens();
+        assert_eq!(tokens.len(), 2, "Expected 2 tokens for {code}");
+        assert_eq!(tokens[0].token_type, expected, "Wrong token type for {code}");
+        assert_eq!(tokens[0].text.as_ref(), code, "Text mismatch for {code}");
+    }
+}
+
+#[test]
+fn test_spaced_substitution_and_transliteration_paired_delimiters() {
+    let cases = [
+        ("s {foo} {bar}ge", TokenType::Substitution),
+        ("tr {a-z} [A-Z]cds", TokenType::Transliteration),
+        ("y {a-z} (A-Z)r", TokenType::Transliteration),
+    ];
+
+    for (code, expected) in cases {
+        let mut lexer = PerlLexer::new(code);
+        let tokens = lexer.collect_tokens();
+        assert_eq!(tokens.len(), 2, "Expected 2 tokens for {code}");
+        assert_eq!(tokens[0].token_type, expected, "Wrong token type for {code}");
+        assert_eq!(tokens[0].text.as_ref(), code, "Text mismatch for {code}");
+    }
+}


### PR DESCRIPTION
### Motivation

- The lexer misclassified some quote-like operators when optional whitespace preceded delimiters and mishandled transliteration replacement delimiters, producing incorrect tokens/spans and fragile behavior on malformed input.

### Description

- Added `allows_spaced_delimiter` in `crates/perl-lexer/src/quote_handler.rs` to centralize operator-specific rules for accepting optional whitespace before a delimiter.
- Applied the spaced-delimiter policy to both the `s|tr|y` fast-path and the general quote-operator disambiguation in `crates/perl-lexer/src/lib.rs` so lexer decision-making matches Perl's allowed forms while avoiding false positives for `s` in ambiguous contexts.
- Hardened transliteration parsing in `crates/perl-lexer/src/lib.rs` to detect and honor a different replacement delimiter after a paired search delimiter (e.g. `tr{a-z}[A-Z]...`) and to keep modifiers attached to the token text/span.
- Added/updated focused regression tests in `crates/perl-lexer/tests/regex_arbitrary_delimiters_issue_444.rs` and `crates/perl-lexer/tests/edge_case_tests.rs` covering spaced delimiters, mixed paired transliteration delimiters, and malformed quote-like constructs to ensure non-panicking behavior and correct token text/spans.

### Testing

- Ran formatting: `cargo xtask fmt` (completed successfully).
- Ran targeted unit tests: `cargo test -p perl-lexer --test regex_arbitrary_delimiters_issue_444` (17 passed) and `cargo test -p perl-lexer --test edge_case_tests` (93 passed).
- Ran crate tests: `cargo test -p perl-lexer` (all perl-lexer tests passed).
- Ran workspace static check: `cargo check --workspace --all-targets` (completed successfully).
- Note: `just pr-fast` is not available in this environment (tooling limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c8990008333814aefa29e725084)