### PR TITLE
fix(lexer): harden quote-like operator and transliteration tokenization (#6655)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2072,16 +2072,15 @@ impl<'a> PerlLexer<'a> {
                 if let Some(next) = candidate {
                     // `s => 1` should remain a fat-arrow hash key, not quote op.
                     let is_fat_arrow = next == '=' && char_after_next == Some('>');
-                    let substitution_disallows_whitespace = text == "s" && has_whitespace;
 
-                    // Perl allows optional whitespace before quote-like delimiters for
-                    // quote-like operators, including arbitrary non-alnum delimiters.
-                    // Keep `s` strict to avoid mis-tokenizing `-s 'file'` file-test usage.
-                    let whitespace_allowed = !has_whitespace || text != "s";
+                    // For `s`, whitespace is allowed ONLY before paired delimiters like { [ ( <
+                    // For other operators (tr, y), whitespace is always allowed.
+                    let is_paired_delim = matches!(next, '{' | '[' | '(' | '<');
+                    let whitespace_allowed = !has_whitespace || text != "s" || is_paired_delim;
+
                     let is_valid_delim = Self::is_quote_delim(next)
                         && !is_fat_arrow
-                        && whitespace_allowed
-                        && !substitution_disallows_whitespace;
+                        && whitespace_allowed;
 
                     if is_valid_delim {
                         match text {
@@ -2145,11 +2144,11 @@ impl<'a> PerlLexer<'a> {
                             // not a valid substitution delimiter. Treat as identifier.
                             let is_fat_arrow = next == '=' && char_after_next == Some('>');
 
-                            // Perl allows optional whitespace before quote-like delimiters,
-                            // including arbitrary non-alnum delimiters.
-                            // Keep `s` strict to avoid mis-tokenizing `-s 'filename'` as
-                            // substitution rather than file-test.
-                            let whitespace_allowed = !has_whitespace || op != "s";
+                            // Perl allows optional whitespace before quote-like delimiters.
+                            // For `s`, whitespace is allowed ONLY before paired delimiters like { [ ( <
+                            // to avoid mis-tokenizing `-s 'filename'` as substitution rather than file-test.
+                            let is_paired_delim = matches!(next, '{' | '[' | '(' | '<');
+                            let whitespace_allowed = !has_whitespace || op != "s" || is_paired_delim;
                             let is_valid_delim =
                                 Self::is_quote_delim(next) && !is_fat_arrow && whitespace_allowed;
 

--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2072,17 +2072,16 @@ impl<'a> PerlLexer<'a> {
                 if let Some(next) = candidate {
                     // `s => 1` should remain a fat-arrow hash key, not quote op.
                     let is_fat_arrow = next == '=' && char_after_next == Some('>');
-                    let is_paired_delim = matches!(next, '{' | '[' | '(' | '<');
-                    let is_quote_char = matches!(next, '\'' | '"') && text != "s";
-                    let transliteration_allows_whitespace = text == "tr" || text == "y";
                     let substitution_disallows_whitespace = text == "s" && has_whitespace;
+
+                    // Perl allows optional whitespace before quote-like delimiters for
+                    // quote-like operators, including arbitrary non-alnum delimiters.
+                    // Keep `s` strict to avoid mis-tokenizing `-s 'file'` file-test usage.
+                    let whitespace_allowed = !has_whitespace || text != "s";
                     let is_valid_delim = Self::is_quote_delim(next)
                         && !is_fat_arrow
-                        && !substitution_disallows_whitespace
-                        && (!has_whitespace
-                            || is_paired_delim
-                            || is_quote_char
-                            || transliteration_allows_whitespace);
+                        && whitespace_allowed
+                        && !substitution_disallows_whitespace;
 
                     if is_valid_delim {
                         match text {
@@ -2123,18 +2122,9 @@ impl<'a> PerlLexer<'a> {
                         && self.hash_brace_depth == 0
                         && quote_handler::is_quote_operator(op) =>
                     {
-                        // Perl allows whitespace between a quote-like operator and its delimiter,
-                        // but ONLY for paired delimiters (s { ... } { ... }g).
-                        // For non-paired delimiters (s/foo/bar/, s,foo,bar,), the delimiter
-                        // must be immediately adjacent — otherwise `s $foo` would wrongly
-                        // treat `$` as a delimiter instead of being a bareword `s` followed
-                        // by a scalar variable.
-                        //
-                        // Strategy:
-                        //   1. Check the immediately-adjacent char first (no whitespace skip).
-                        //      If it is a valid delimiter → any non-alnum, non-whitespace char.
-                        //   2. If the adjacent char is whitespace, peek past it.
-                        //      Only accept PAIRED delimiters ({, [, (, <) in that case.
+                        // Perl allows optional whitespace before quote-like delimiters
+                        // for quote-like operators. We still keep `s` strict so `-s 'file'`
+                        // remains a file-test, not a substitution.
                         let immediate = self.current_char();
                         let (candidate, char_after_next, has_whitespace) =
                             if immediate.is_some_and(|c| c.is_whitespace()) {
@@ -2155,19 +2145,13 @@ impl<'a> PerlLexer<'a> {
                             // not a valid substitution delimiter. Treat as identifier.
                             let is_fat_arrow = next == '=' && char_after_next == Some('>');
 
-                            // When whitespace precedes the delimiter, only unambiguous
-                            // delimiters are accepted:
-                            //   - Paired delimiters ({, [, (, <) are always safe.
-                            //   - ' and " are safe for all operators EXCEPT `s` — `-s 'filename'`
-                            //     is a valid file-size filetest and must not be treated as a
-                            //     substitution start. All other operators (qw, q, qq, qr, qx, m,
-                            //     tr, y) have no corresponding file-test operator.
-                            //   - Non-paired, non-quote chars ($, @, ,, etc.) remain rejected.
-                            let is_paired_delim = matches!(next, '{' | '[' | '(' | '<');
-                            let is_quote_char = matches!(next, '\'' | '"') && op != "s";
-                            let is_valid_delim = Self::is_quote_delim(next)
-                                && !is_fat_arrow
-                                && (!has_whitespace || is_paired_delim || is_quote_char);
+                            // Perl allows optional whitespace before quote-like delimiters,
+                            // including arbitrary non-alnum delimiters.
+                            // Keep `s` strict to avoid mis-tokenizing `-s 'filename'` as
+                            // substitution rather than file-test.
+                            let whitespace_allowed = !has_whitespace || op != "s";
+                            let is_valid_delim =
+                                Self::is_quote_delim(next) && !is_fat_arrow && whitespace_allowed;
 
                             if is_valid_delim {
                                 self.mode = LexerMode::ExpectDelimiter;

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -1314,3 +1314,22 @@ fn sub_forward_declaration_does_not_leak() -> R {
     );
     Ok(())
 }
+
+/// Regression test: `s { old } { new }g` with whitespace before `{` should tokenize as Substitution.
+/// This tests the fix for the whitespace_allowed condition that was rejecting paired delimiters.
+#[test]
+fn substitution_with_block_form_and_whitespace() -> R {
+    let input = "s { old } { new }g";
+    let sig = significant(input);
+
+    let sub_tokens: Vec<_> = sig
+        .iter()
+        .filter(|t| matches!(t.token_type, TokenType::Substitution))
+        .collect();
+    assert!(
+        !sub_tokens.is_empty(),
+        "Expected Substitution token for block-form s with whitespace before {{, got tokens: {:?}",
+        sig.iter().map(|t| (&t.token_type, t.text.as_ref())).collect::<Vec<_>>()
+    );
+    Ok(())
+}

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -657,6 +657,32 @@ fn q_with_escaped_delimiter() -> R {
     Ok(())
 }
 
+#[test]
+fn q_with_whitespace_before_nonpaired_delimiter() -> R {
+    let input = "q |hello world|";
+    let first = first_significant(input).ok_or("no token")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteSingle),
+        "Expected QuoteSingle for q |...|, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "q |hello world|");
+    Ok(())
+}
+
+#[test]
+fn qq_with_whitespace_before_nonpaired_delimiter() -> R {
+    let input = "qq !hello $world!";
+    let first = first_significant(input).ok_or("no token")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteDouble),
+        "Expected QuoteDouble for qq !...!, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "qq !hello $world!");
+    Ok(())
+}
+
 // ===========================================================================
 // 4. Special variables
 // ===========================================================================

--- a/crates/perl-lexer/tests/regex_arbitrary_delimiters_issue_444.rs
+++ b/crates/perl-lexer/tests/regex_arbitrary_delimiters_issue_444.rs
@@ -256,3 +256,33 @@ fn test_m_vs_bareword_disambiguation() {
         tokens2[0].token_type
     );
 }
+
+#[test]
+fn test_m_operator_whitespace_before_arbitrary_delimiter() {
+    let code = "m !pattern!";
+    let mut lexer = PerlLexer::new(code);
+    let tokens = lexer.collect_tokens();
+
+    assert_eq!(tokens.len(), 2, "Expected 2 tokens (regex + EOF)");
+    assert!(
+        matches!(tokens[0].token_type, TokenType::RegexMatch),
+        "Expected RegexMatch token, got: {:?}",
+        tokens[0].token_type
+    );
+    assert_eq!(tokens[0].text.as_ref(), "m !pattern!");
+}
+
+#[test]
+fn test_qr_operator_whitespace_before_arbitrary_delimiter() {
+    let code = "qr #pattern#ms";
+    let mut lexer = PerlLexer::new(code);
+    let tokens = lexer.collect_tokens();
+
+    assert_eq!(tokens.len(), 2, "Expected 2 tokens (quote regex + EOF)");
+    assert!(
+        matches!(tokens[0].token_type, TokenType::QuoteRegex),
+        "Expected QuoteRegex token, got: {:?}",
+        tokens[0].token_type
+    );
+    assert_eq!(tokens[0].text.as_ref(), "qr #pattern#ms");
+}


### PR DESCRIPTION
### Motivation

- Quote-like operators were not consistently recognized when optional whitespace appeared before arbitrary non-alphanumeric delimiters, causing mis-tokenization for `m`, `qr`, `q*`, and `qq*` families while risking `-s 'file'` file-test misclassification.

### Description

- Relax delimiter acceptance in `crates/perl-lexer/src/lib.rs` to allow optional whitespace before arbitrary non-alphanumeric delimiters for quote-like operators while keeping `s` whitespace-strict to avoid file-test misclassification.
- Apply the change in both the substitution/transliteration detection path and the general quote-operator keyword branch, using a `whitespace_allowed` guard and `Self::is_quote_delim` for clarity.
- Add regression tests exercising whitespace-before-delimiter behavior for `m` and `qr` in `crates/perl-lexer/tests/regex_arbitrary_delimiters_issue_444.rs` and for `q`/`qq` in `crates/perl-lexer/tests/edge_case_tests.rs` to preserve token text/spans and token kinds.
- Keep modifier validation in the parser (no semantic validation moved into lexer) and ensure token text/spans are preserved for downstream parsing.

### Testing

- Ran `cargo test -p perl-lexer --test regex_arbitrary_delimiters_issue_444`, and all tests passed (17 passed).
- Ran `cargo test -p perl-lexer --test edge_case_tests`, and all tests passed (92 passed).
- Ran `cargo test -p perl-lexer`, and the crate test-suite completed successfully.
- Ran `cargo check --workspace --all-targets` and `cargo xtask fmt`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c8990008333814aefa29e725084)