### PR TITLE
fix(lexer): harden quote-like operator and transliteration tokenization (#6653)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -3379,26 +3379,25 @@ impl<'a> PerlLexer<'a> {
         })
     }
 
-    /// Read content between delimiters
-    fn read_delimited_body(&mut self, delim: char) -> String {
+    /// Read content between delimiters, starting after the opening delimiter.
+    ///
+    /// Returns `true` if a closing delimiter was found, `false` if EOF was reached first.
+    fn read_delimited_body(&mut self, delim: char) -> bool {
         let paired = quote_handler::paired_close(delim);
         let close = paired.unwrap_or(delim);
-        let mut body = String::new();
-        let mut depth = i32::from(paired.is_some());
+        let mut depth = usize::from(paired.is_some());
+        let mut closed = false;
 
         while let Some(ch) = self.current_char() {
             if ch == '\\' {
-                body.push(ch);
                 self.advance();
-                if let Some(next) = self.current_char() {
-                    body.push(next);
+                if self.current_char().is_some() {
                     self.advance();
                 }
                 continue;
             }
 
             if paired.is_some() && ch == delim {
-                body.push(ch);
                 self.advance();
                 depth += 1;
                 continue;
@@ -3409,22 +3408,50 @@ impl<'a> PerlLexer<'a> {
                     depth -= 1;
                     if depth == 0 {
                         self.advance();
+                        closed = true;
                         break;
                     }
-                    body.push(ch);
                     self.advance();
                 } else {
                     self.advance();
+                    closed = true;
                     break;
                 }
                 continue;
             }
 
-            body.push(ch);
             self.advance();
         }
 
-        body
+        closed
+    }
+
+    /// For paired first delimiters in `s///` and `tr///`, Perl allows optional whitespace
+    /// before the second delimiter.
+    fn skip_quote_op_between_parts_whitespace(&mut self) {
+        while let Some(ch) = self.current_char() {
+            if ch.is_whitespace() {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Determine replacement/list delimiter for second part in `s` or `tr`/`y`.
+    fn second_part_delimiter(&mut self, first_delimiter: char) -> Option<char> {
+        if quote_handler::paired_close(first_delimiter).is_some() {
+            self.skip_quote_op_between_parts_whitespace();
+            let second_delim = self.current_char()?;
+            if Self::is_quote_delim(second_delim) {
+                self.advance();
+                Some(second_delim)
+            } else {
+                None
+            }
+        } else {
+            Some(first_delimiter)
+        }
     }
 
     /// Parse a quote operator after we've seen the delimiter
@@ -3437,63 +3464,35 @@ impl<'a> PerlLexer<'a> {
         match operator.as_str() {
             "s" => {
                 // Substitution: two bodies
-                let _pattern = self.read_delimited_body(delimiter);
-
-                // For paired delimiters, skip whitespace between bodies
-                if quote_handler::paired_close(delimiter).is_some() {
-                    while let Some(ch) = self.current_char() {
-                        if ch.is_whitespace() {
-                            self.advance();
-                        } else {
-                            break;
-                        }
-                    }
-                    // Expect same delimiter for replacement
-                    if self.current_char() == Some(delimiter) {
-                        self.advance();
-                    }
+                let _pattern_closed = self.read_delimited_body(delimiter);
+                if let Some(replacement_delim) = self.second_part_delimiter(delimiter) {
+                    let _replacement_closed = self.read_delimited_body(replacement_delim);
                 }
-
-                let _replacement = self.read_delimited_body(delimiter);
 
                 // Parse modifiers
                 self.parse_regex_modifiers(&quote_handler::S_SPEC);
             }
             "tr" | "y" => {
                 // Transliteration: two bodies
-                let _from = self.read_delimited_body(delimiter);
-
-                // For paired delimiters, skip whitespace between bodies
-                if quote_handler::paired_close(delimiter).is_some() {
-                    while let Some(ch) = self.current_char() {
-                        if ch.is_whitespace() {
-                            self.advance();
-                        } else {
-                            break;
-                        }
-                    }
-                    // Expect same delimiter for replacement
-                    if self.current_char() == Some(delimiter) {
-                        self.advance();
-                    }
+                let _from_closed = self.read_delimited_body(delimiter);
+                if let Some(to_delim) = self.second_part_delimiter(delimiter) {
+                    let _to_closed = self.read_delimited_body(to_delim);
                 }
-
-                let _to = self.read_delimited_body(delimiter);
 
                 // Parse modifiers
                 self.parse_regex_modifiers(&quote_handler::TR_SPEC);
             }
             "qr" => {
-                let _pattern = self.read_delimited_body(delimiter);
+                let _pattern_closed = self.read_delimited_body(delimiter);
                 self.parse_regex_modifiers(&quote_handler::QR_SPEC);
             }
             "m" => {
-                let _pattern = self.read_delimited_body(delimiter);
+                let _pattern_closed = self.read_delimited_body(delimiter);
                 self.parse_regex_modifiers(&quote_handler::M_SPEC);
             }
             _ => {
                 // q, qq, qw, qx - no modifiers
-                let _body = self.read_delimited_body(delimiter);
+                let _body_closed = self.read_delimited_body(delimiter);
             }
         }
 

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -644,6 +644,20 @@ fn qq_with_nested_parens() -> R {
 }
 
 #[test]
+fn qq_with_optional_whitespace_before_paired_delimiter() -> R {
+    let input = "qq {hello {nested}}";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteDouble),
+        "Expected QuoteDouble, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "qq {hello {nested}}");
+    Ok(())
+}
+
+#[test]
 fn q_with_escaped_delimiter() -> R {
     let input = r"q|hello \| world|";
     let sig = significant(input);
@@ -654,6 +668,20 @@ fn q_with_escaped_delimiter() -> R {
         first.token_type
     );
     assert_eq!(first.text.as_ref(), r"q|hello \| world|");
+    Ok(())
+}
+
+#[test]
+fn qr_with_escaped_delimiter_and_modifiers() -> R {
+    let input = r#"qr!foo\!bar!ims"#;
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteRegex),
+        "Expected QuoteRegex, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), r#"qr!foo\!bar!ims"#);
     Ok(())
 }
 
@@ -1171,6 +1199,20 @@ fn substitution_with_escaped_delimiters() -> R {
         first.token_type
     );
     assert_eq!(first.text.as_ref(), r"s/foo\/bar/baz\/qux/");
+    Ok(())
+}
+
+#[test]
+fn substitution_with_mixed_paired_delimiters_and_whitespace() -> R {
+    let input = "s{old}   [new]ge";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Substitution),
+        "Expected Substitution, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "s{old}   [new]ge");
     Ok(())
 }
 

--- a/crates/perl-lexer/tests/regex_arbitrary_delimiters_issue_444.rs
+++ b/crates/perl-lexer/tests/regex_arbitrary_delimiters_issue_444.rs
@@ -94,6 +94,21 @@ fn test_s_operator_brace_delimiter() {
 }
 
 #[test]
+fn test_s_operator_mixed_paired_delimiters() {
+    let code = r#"s{old}[new]g"#;
+    let mut lexer = PerlLexer::new(code);
+    let tokens = lexer.collect_tokens();
+
+    assert_eq!(tokens.len(), 2, "Expected 2 tokens");
+    assert!(
+        matches!(tokens[0].token_type, TokenType::Substitution),
+        "Expected Substitution token, got: {:?}",
+        tokens[0].token_type
+    );
+    assert_eq!(tokens[0].text.as_ref(), "s{old}[new]g");
+}
+
+#[test]
 fn test_s_operator_pipe_delimiter() {
     let code = r#"s|old|new|"#;
     let mut lexer = PerlLexer::new(code);
@@ -136,6 +151,51 @@ fn test_tr_operator_exclamation_delimiter() {
         tokens[0].token_type
     );
     assert_eq!(tokens[0].text.as_ref(), "tr!abc!xyz!");
+}
+
+#[test]
+fn test_tr_operator_mixed_paired_delimiters() {
+    let code = r#"tr{abc}[xyz]cds"#;
+    let mut lexer = PerlLexer::new(code);
+    let tokens = lexer.collect_tokens();
+
+    assert_eq!(tokens.len(), 2, "Expected 2 tokens");
+    assert!(
+        matches!(tokens[0].token_type, TokenType::Transliteration),
+        "Expected Transliteration token, got: {:?}",
+        tokens[0].token_type
+    );
+    assert_eq!(tokens[0].text.as_ref(), "tr{abc}[xyz]cds");
+}
+
+#[test]
+fn test_q_operator_optional_whitespace_before_paired_delimiter() {
+    let code = "q {hello}";
+    let mut lexer = PerlLexer::new(code);
+    let tokens = lexer.collect_tokens();
+
+    assert_eq!(tokens.len(), 2, "Expected 2 tokens");
+    assert!(
+        matches!(tokens[0].token_type, TokenType::QuoteSingle),
+        "Expected QuoteSingle token, got: {:?}",
+        tokens[0].token_type
+    );
+    assert_eq!(tokens[0].text.as_ref(), "q {hello}");
+}
+
+#[test]
+fn test_malformed_q_operator_does_not_panic() {
+    let code = "q{unterminated";
+    let mut lexer = PerlLexer::new(code);
+    let tokens = lexer.collect_tokens();
+
+    assert!(
+        matches!(tokens[0].token_type, TokenType::QuoteSingle),
+        "Expected QuoteSingle token, got: {:?}",
+        tokens[0].token_type
+    );
+    assert_eq!(tokens[0].text.as_ref(), "q{unterminated");
+    assert!(matches!(tokens.last().map(|t| &t.token_type), Some(TokenType::EOF)));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- The lexer had edge cases around quote-like operators (`q`, `qq`, `qw`, `qr`, `qx`, `m`, `s`, `tr`, `y`) involving arbitrary delimiters, optional whitespace before paired delimiters, mixed paired delimiters for second parts, nested balanced delimiters, escaped delimiters, and unterminated inputs.
- The goal is for the lexer to reliably tokenize these forms and attach modifier text to the same token span while leaving modifier validation to the parser.

### Description

- Reworked delimiter-body scanning by changing `read_delimited_body` to be EOF-safe and handle escapes and nested paired delimiters without panicking, returning whether a closing delimiter was seen instead of building an intermediate string.
- Added `skip_quote_op_between_parts_whitespace` and `second_part_delimiter` helpers to support optional whitespace and mixed second delimiters for `s` and `tr`/`y` operator forms, and updated `parse_quote_operator` to use them so the second part delimiter is detected correctly.
- Updated `parse_quote_operator` to use the new body-scanning model for `s`, `tr`/`y`, `m`, `qr` and the `q*` family so modifier text remains attached to the token span even on mixed or missing delimiters.
- Added focused regression tests and extended edge-case tests to cover mixed paired delimiters, optional whitespace before paired delimiters, escaped delimiters with modifiers, nested delimiters, and malformed/unterminated operators (tests in `crates/perl-lexer/tests/regex_arbitrary_delimiters_issue_444.rs` and `crates/perl-lexer/tests/edge_case_tests.rs`).

### Testing

- Ran formatting: `cargo xtask fmt` (succeeded).
- Ran targeted test suite: `cargo test -p perl-lexer --test regex_arbitrary_delimiters_issue_444` (all tests passed).
- Ran broader edge tests: `cargo test -p perl-lexer --test edge_case_tests` (all tests passed).
- Ran full crate tests and workspace check: `cargo test -p perl-lexer` and `cargo check --workspace --all-targets` (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c8990008333814aefa29e725084)