### PR TITLE
fix(lexer): harden heredoc and data-section scanning under edge cases

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -382,13 +382,30 @@ impl<'a> PerlLexer<'a> {
         while end < bytes.len() && bytes[end] != b'\n' && bytes[end] != b'\r' {
             end += 1;
         }
-        // Visible end strips trailing \r if followed by \n
-        let visible_end = if end > start && end > 0 && bytes[end.saturating_sub(1)] == b'\r' {
-            end - 1
-        } else {
-            end
-        };
-        (end, visible_end)
+        (end, end)
+    }
+
+    #[inline]
+    fn parse_quoted_heredoc_label(&mut self, text: &mut String, quote: char) -> Option<Arc<str>> {
+        text.push(quote);
+        self.advance();
+        let mut delim = String::new();
+        while self.position < self.input.len() {
+            let ch = self.current_char()?;
+            if ch == quote {
+                text.push(quote);
+                self.advance();
+                return Some(Arc::from(delim));
+            }
+            // Heredoc label delimiters must close on the same line.
+            if matches!(ch, '\n' | '\r') {
+                return None;
+            }
+            delim.push(ch);
+            text.push(ch);
+            self.advance();
+        }
+        None
     }
 
     /// Advance the lexer and return the next token.
@@ -1129,67 +1146,28 @@ impl<'a> PerlLexer<'a> {
         let delimiter = if self.position < self.input.len() {
             match self.current_char() {
                 Some('"') if !backslashed => {
-                    // Double-quoted delimiter
-                    text.push('"');
-                    self.advance();
-                    let mut delim = String::new();
-                    while self.position < self.input.len() {
-                        if let Some(ch) = self.current_char() {
-                            if ch == '"' {
-                                text.push('"');
-                                self.advance();
-                                break;
-                            }
-                            delim.push(ch);
-                            text.push(ch);
-                            self.advance();
-                        } else {
-                            break;
-                        }
+                    if let Some(delim) = self.parse_quoted_heredoc_label(&mut text, '"') {
+                        delim
+                    } else {
+                        self.position = start;
+                        return None;
                     }
-                    delim
                 }
                 Some('\'') if !backslashed => {
-                    // Single-quoted delimiter
-                    text.push('\'');
-                    self.advance();
-                    let mut delim = String::new();
-                    while self.position < self.input.len() {
-                        if let Some(ch) = self.current_char() {
-                            if ch == '\'' {
-                                text.push('\'');
-                                self.advance();
-                                break;
-                            }
-                            delim.push(ch);
-                            text.push(ch);
-                            self.advance();
-                        } else {
-                            break;
-                        }
+                    if let Some(delim) = self.parse_quoted_heredoc_label(&mut text, '\'') {
+                        delim
+                    } else {
+                        self.position = start;
+                        return None;
                     }
-                    delim
                 }
                 Some('`') if !backslashed => {
-                    // Backtick delimiter
-                    text.push('`');
-                    self.advance();
-                    let mut delim = String::new();
-                    while self.position < self.input.len() {
-                        if let Some(ch) = self.current_char() {
-                            if ch == '`' {
-                                text.push('`');
-                                self.advance();
-                                break;
-                            }
-                            delim.push(ch);
-                            text.push(ch);
-                            self.advance();
-                        } else {
-                            break;
-                        }
+                    if let Some(delim) = self.parse_quoted_heredoc_label(&mut text, '`') {
+                        delim
+                    } else {
+                        self.position = start;
+                        return None;
                     }
-                    delim
                 }
                 Some(c) if is_perl_identifier_start(c) => {
                     // Bare word delimiter
@@ -1207,7 +1185,7 @@ impl<'a> PerlLexer<'a> {
                             break;
                         }
                     }
-                    delim
+                    Arc::from(delim)
                 }
                 _ => {
                     // Not a valid heredoc delimiter - reset position and return None
@@ -1238,7 +1216,7 @@ impl<'a> PerlLexer<'a> {
 
         // Queue the heredoc spec with its label
         self.pending_heredocs.push(HeredocSpec {
-            label: Arc::from(delimiter.as_str()),
+            label: delimiter,
             body_start: 0, // Will be set when we see the newline after this line
             allow_indent,
         });
@@ -2027,17 +2005,10 @@ impl<'a> PerlLexer<'a> {
                     // Check if rest of line is only whitespace
                     // Only treat as data marker if line has no trailing junk
                     if Self::trailing_ws_only(self.input_bytes, self.position) {
-                        // Consume the rest of the line (the marker line)
-                        while self.position < self.input.len()
-                            && self.input_bytes[self.position] != b'\n'
-                        {
-                            self.advance();
-                        }
-                        if self.position < self.input.len()
-                            && self.input_bytes[self.position] == b'\n'
-                        {
-                            self.advance();
-                        }
+                        // Consume marker line including CR/LF variants.
+                        let (line_end, _) = Self::find_line_end(self.input_bytes, self.position);
+                        self.position = line_end;
+                        self.consume_newline();
 
                         // Switch to data section mode
                         self.mode = LexerMode::InDataSection;

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -200,6 +200,26 @@ fn heredoc_with_trailing_whitespace_on_terminator() -> R {
     Ok(())
 }
 
+#[test]
+fn heredoc_unquoted_label_disallows_leading_indent_on_terminator() -> R {
+    let input = "<<EOF\nbody\n  EOF\nprint 1;\n";
+    let sig = significant(input);
+    let has_unknown_rest = sig.iter().any(|t| matches!(t.token_type, TokenType::UnknownRest));
+    assert!(has_unknown_rest, "indented terminator must not close non-<<~ heredoc");
+    Ok(())
+}
+
+#[test]
+fn heredoc_indented_allows_crlf_terminator() -> R {
+    let input = "<<~EOF\r\nline\r\n\tEOF\r\nmy $x = 1;\r\n";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_my =
+        sig.iter().any(|t| matches!(&t.token_type, TokenType::Keyword(k) if k.as_ref() == "my"));
+    assert!(has_my, "expected lexer to resume normal lexing after <<~ terminator");
+    Ok(())
+}
+
 // ===========================================================================
 // 2. Regex delimiters
 // ===========================================================================

--- a/crates/perl-lexer/tests/heredoc_regression_tests.rs
+++ b/crates/perl-lexer/tests/heredoc_regression_tests.rs
@@ -1,4 +1,4 @@
-use perl_lexer::PerlLexer;
+use perl_lexer::{PerlLexer, TokenType};
 
 #[test]
 fn lexer_terminates_on_backtick_heredoc_with_cr() {
@@ -84,4 +84,20 @@ fn lexer_handles_malformed_heredoc_gracefully() {
         }
         assert!(token_count < 20, "Too many tokens, possible infinite loop");
     }
+}
+
+#[test]
+fn lexer_does_not_treat_unterminated_quoted_labels_as_heredoc() {
+    let mut lx = PerlLexer::new("my $x = <<\"EOF\r\nprint 1;\r\n");
+    let toks = lx.collect_tokens();
+    let has_heredoc = toks.iter().any(|t| matches!(t.token_type, TokenType::HeredocStart));
+    assert!(!has_heredoc, "unterminated quoted label must not queue heredoc");
+}
+
+#[test]
+fn lexer_does_not_treat_unterminated_backtick_label_as_heredoc() {
+    let mut lx = PerlLexer::new("my $x = <<`CMD\rprint 1;\r");
+    let toks = lx.collect_tokens();
+    let has_heredoc = toks.iter().any(|t| matches!(t.token_type, TokenType::HeredocStart));
+    assert!(!has_heredoc, "unterminated backtick label must not queue heredoc");
 }

--- a/crates/perl-lexer/tests/heredoc_security_tests.rs
+++ b/crates/perl-lexer/tests/heredoc_security_tests.rs
@@ -38,3 +38,22 @@ fn test_heredoc_timeout() {
 
     assert!(duration < Duration::from_secs(10), "Lexer should not hang for more than 10 seconds");
 }
+
+#[test]
+fn test_cr_data_marker_transition_does_not_runaway() {
+    let src = "my $x = 1;\r__DATA__\rpayload\rmore";
+    let start = Instant::now();
+    let mut lexer = PerlLexer::new(src);
+    let tokens = lexer.collect_tokens();
+    let duration = start.elapsed();
+
+    assert!(duration < Duration::from_secs(2), "CR marker transition should stay bounded");
+    assert!(
+        tokens.iter().any(|t| matches!(t.token_type, TokenType::DataMarker(_))),
+        "expected DataMarker token"
+    );
+    assert!(
+        tokens.iter().any(|t| matches!(t.token_type, TokenType::DataBody(_))),
+        "expected DataBody token"
+    );
+}


### PR DESCRIPTION
### Motivation

- Improve heredoc correctness for CR / CRLF edge cases, backtick heredocs, `<<~` indentation, quoted vs unquoted labels, and to keep slow-paths bounded for pathological inputs.
- Ensure `__DATA__`/`__END__` transitions are robust across CR-only lines and do not cause runaway scanning while preserving existing time/depth budgets.

### Description

- Add `parse_quoted_heredoc_label` helper to strictly parse quoted/backtick heredoc labels and require the closing quote to appear on the same line, returning `None` for unterminated labels so they fallback to non-heredoc parsing.
- Replace inline quoted-label scanning with the new helper for `"..."`, `'...'`, and `` `...` ``, and store quoted labels as `Arc<str>` in `pending_heredocs` for consistent ownership.
- Simplify `find_line_end` return semantics and make `__DATA__/__END__` marker consumption use the CR/LF-aware `find_line_end` + `consume_newline` path to correctly handle CR, CRLF and LF variants.
- Add targeted tests for unterminated quoted/backtick labels, indented-terminator rules for unquoted heredocs, `<<~` + CRLF terminator behavior, and a bounded CR `__DATA__` transition test.

### Testing

- Ran `cargo test -p perl-lexer heredoc` and `cargo test -p perl-lexer`, both completed successfully with all tests passing.
- Ran `cargo check --workspace --all-targets`, which completed successfully with the workspace checking cleanly.
- Ran formatting via `cargo xtask fmt` successfully; `just pr-fast` was not available in the environment so it was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c8d69fc8333938ddccc576defe7)