### PR TITLE
fix(lexer): harden heredoc and data-section scanning under edge cases

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -173,6 +173,7 @@ struct HeredocSpec {
 // about truncation but won't crash or hang.
 const MAX_REGEX_BYTES: usize = 64 * 1024; // 64KB max for regex patterns
 const MAX_HEREDOC_BYTES: usize = 256 * 1024; // 256KB max for heredoc bodies
+const MAX_HEREDOC_LABEL_BYTES: usize = 4096; // Avoid runaway scans on malformed delimiters
 const MAX_DELIM_NEST: usize = 128; // Max nesting depth for delimiters
 const MAX_HEREDOC_DEPTH: usize = 100; // Max nesting depth for heredocs
 const HEREDOC_TIMEOUT_MS: u64 = 5000; // 5 seconds timeout for heredoc parsing
@@ -1130,66 +1131,30 @@ impl<'a> PerlLexer<'a> {
             match self.current_char() {
                 Some('"') if !backslashed => {
                     // Double-quoted delimiter
-                    text.push('"');
-                    self.advance();
-                    let mut delim = String::new();
-                    while self.position < self.input.len() {
-                        if let Some(ch) = self.current_char() {
-                            if ch == '"' {
-                                text.push('"');
-                                self.advance();
-                                break;
-                            }
-                            delim.push(ch);
-                            text.push(ch);
-                            self.advance();
-                        } else {
-                            break;
-                        }
+                    if let Some(delim) = self.parse_heredoc_quoted_label(&mut text, '"') {
+                        delim
+                    } else {
+                        self.position = start;
+                        return None;
                     }
-                    delim
                 }
                 Some('\'') if !backslashed => {
                     // Single-quoted delimiter
-                    text.push('\'');
-                    self.advance();
-                    let mut delim = String::new();
-                    while self.position < self.input.len() {
-                        if let Some(ch) = self.current_char() {
-                            if ch == '\'' {
-                                text.push('\'');
-                                self.advance();
-                                break;
-                            }
-                            delim.push(ch);
-                            text.push(ch);
-                            self.advance();
-                        } else {
-                            break;
-                        }
+                    if let Some(delim) = self.parse_heredoc_quoted_label(&mut text, '\'') {
+                        delim
+                    } else {
+                        self.position = start;
+                        return None;
                     }
-                    delim
                 }
                 Some('`') if !backslashed => {
                     // Backtick delimiter
-                    text.push('`');
-                    self.advance();
-                    let mut delim = String::new();
-                    while self.position < self.input.len() {
-                        if let Some(ch) = self.current_char() {
-                            if ch == '`' {
-                                text.push('`');
-                                self.advance();
-                                break;
-                            }
-                            delim.push(ch);
-                            text.push(ch);
-                            self.advance();
-                        } else {
-                            break;
-                        }
+                    if let Some(delim) = self.parse_heredoc_quoted_label(&mut text, '`') {
+                        delim
+                    } else {
+                        self.position = start;
+                        return None;
                     }
-                    delim
                 }
                 Some(c) if is_perl_identifier_start(c) => {
                     // Bare word delimiter
@@ -1197,6 +1162,9 @@ impl<'a> PerlLexer<'a> {
                     while self.position < self.input.len() {
                         if let Some(c) = self.current_char() {
                             if is_perl_identifier_continue(c) {
+                                if delim.len() >= MAX_HEREDOC_LABEL_BYTES {
+                                    break;
+                                }
                                 delim.push(c);
                                 text.push(c);
                                 self.advance();
@@ -1221,6 +1189,11 @@ impl<'a> PerlLexer<'a> {
             self.position = start;
             return None;
         };
+
+        if delimiter.is_empty() {
+            self.position = start;
+            return None;
+        }
 
         // For now, return a placeholder token
         // The actual heredoc body would be parsed later when we encounter it
@@ -1249,6 +1222,33 @@ impl<'a> PerlLexer<'a> {
             start,
             end: self.position,
         })
+    }
+
+    fn parse_heredoc_quoted_label(
+        &mut self,
+        token_text: &mut String,
+        quote: char,
+    ) -> Option<String> {
+        token_text.push(quote);
+        self.advance();
+
+        let mut delim = String::new();
+        while self.position < self.input.len() {
+            let ch = self.current_char()?;
+            if ch == quote {
+                token_text.push(quote);
+                self.advance();
+                return Some(delim);
+            }
+            // Quoted heredoc labels cannot cross lines.
+            if ch == '\n' || ch == '\r' || delim.len() >= MAX_HEREDOC_LABEL_BYTES {
+                return None;
+            }
+            delim.push(ch);
+            token_text.push(ch);
+            self.advance();
+        }
+        None
     }
 
     fn try_string(&mut self) -> Option<Token> {
@@ -2030,14 +2030,11 @@ impl<'a> PerlLexer<'a> {
                         // Consume the rest of the line (the marker line)
                         while self.position < self.input.len()
                             && self.input_bytes[self.position] != b'\n'
+                            && self.input_bytes[self.position] != b'\r'
                         {
                             self.advance();
                         }
-                        if self.position < self.input.len()
-                            && self.input_bytes[self.position] == b'\n'
-                        {
-                            self.advance();
-                        }
+                        self.consume_newline();
 
                         // Switch to data section mode
                         self.mode = LexerMode::InDataSection;

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -200,6 +200,34 @@ fn heredoc_with_trailing_whitespace_on_terminator() -> R {
     Ok(())
 }
 
+#[test]
+fn heredoc_quoted_and_unquoted_labels_are_distinct() -> R {
+    let quoted = significant("<<\"EOF\"\nbody\nEOF\n");
+    let bare = significant("<<EOF\nbody\nEOF\n");
+    let q = quoted.first().ok_or("no tokens for quoted heredoc")?;
+    let b = bare.first().ok_or("no tokens for bare heredoc")?;
+
+    assert!(matches!(q.token_type, TokenType::HeredocStart));
+    assert!(matches!(b.token_type, TokenType::HeredocStart));
+    assert_eq!(q.text.as_ref(), "<<\"EOF\"");
+    assert_eq!(b.text.as_ref(), "<<EOF");
+    Ok(())
+}
+
+#[test]
+fn heredoc_indented_backtick_label() -> R {
+    let input = "<<~`CMD`\n\t echo hello\n\t CMD\nmy $x = 1;\n";
+    assert_terminates(input);
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(matches!(first.token_type, TokenType::HeredocStart));
+    assert_eq!(first.text.as_ref(), "<<~`CMD`");
+    let has_my =
+        sig.iter().any(|t| matches!(&t.token_type, TokenType::Keyword(k) if k.as_ref() == "my"));
+    assert!(has_my, "expected lexer to resume after <<~ backtick heredoc");
+    Ok(())
+}
+
 // ===========================================================================
 // 2. Regex delimiters
 // ===========================================================================

--- a/crates/perl-lexer/tests/heredoc_regression_tests.rs
+++ b/crates/perl-lexer/tests/heredoc_regression_tests.rs
@@ -1,4 +1,4 @@
-use perl_lexer::PerlLexer;
+use perl_lexer::{PerlLexer, TokenType};
 
 #[test]
 fn lexer_terminates_on_backtick_heredoc_with_cr() {
@@ -83,5 +83,36 @@ fn lexer_handles_malformed_heredoc_gracefully() {
             break;
         }
         assert!(token_count < 20, "Too many tokens, possible infinite loop");
+    }
+}
+
+#[test]
+fn lexer_rejects_unclosed_backtick_heredoc_label() {
+    let input = "<<`CMD\rprint 1;\r";
+    let toks = PerlLexer::new(input).collect_tokens();
+    assert!(
+        toks.iter().all(|t| !matches!(t.token_type, TokenType::HeredocStart)),
+        "unterminated backtick heredoc label must not be accepted"
+    );
+    assert!(
+        toks.iter().any(|t| matches!(t.token_type, TokenType::EOF)),
+        "lexer should still terminate after malformed heredoc label"
+    );
+}
+
+#[test]
+fn data_marker_line_with_crlf_transitions_cleanly() {
+    let input = "my $x = 1;\r\n__DATA__\r\npayload\r\n";
+    let toks = PerlLexer::new(input).collect_tokens();
+    let marker = toks.iter().find(|t| matches!(t.token_type, TokenType::DataMarker(_)));
+    let body = toks.iter().find(|t| matches!(t.token_type, TokenType::DataBody(_)));
+
+    assert!(marker.is_some(), "expected __DATA__ marker token");
+    assert!(body.is_some(), "expected data body token");
+    if let Some(marker) = marker {
+        assert_eq!(marker.text.as_ref(), "__DATA__");
+    }
+    if let Some(body) = body {
+        assert_eq!(body.text.as_ref(), "payload\r\n");
     }
 }

--- a/crates/perl-lexer/tests/heredoc_security_tests.rs
+++ b/crates/perl-lexer/tests/heredoc_security_tests.rs
@@ -38,3 +38,26 @@ fn test_heredoc_timeout() {
 
     assert!(duration < Duration::from_secs(10), "Lexer should not hang for more than 10 seconds");
 }
+
+#[test]
+fn test_malformed_quoted_heredoc_label_is_bounded() {
+    let mut code = String::from("<<\"");
+    code.push_str(&"A".repeat(20_000));
+    code.push('\r');
+    code.push_str("my $x = 1;\r");
+
+    let start = Instant::now();
+    let mut lexer = PerlLexer::new(&code);
+    let tokens = lexer.collect_tokens();
+    let duration = start.elapsed();
+
+    assert!(duration < Duration::from_secs(2), "Malformed heredoc label path should stay bounded");
+    assert!(
+        tokens.iter().all(|t| !matches!(t.token_type, TokenType::HeredocStart)),
+        "unterminated quoted heredoc labels must not become HeredocStart"
+    );
+    assert!(
+        tokens.iter().any(|t| matches!(t.token_type, TokenType::EOF)),
+        "lexer should terminate cleanly"
+    );
+}


### PR DESCRIPTION
### Motivation

- Heredoc delimiter parsing could over-scan or misclassify tokens for malformed quoted/backtick labels and CR/CRLF line endings, risking hangs or incorrect token flows. 
- `__DATA__`/`__END__` marker consumption needed to be CR/CRLF-safe so mode transitions are correct on Windows/old-Mac line endings.

### Description

- Add a bounded label length `MAX_HEREDOC_LABEL_BYTES` and reject empty delimiters to avoid runaway scans on malformed heredoc labels. 
- Introduce `parse_heredoc_quoted_label` to require quoted/backtick heredoc labels to close on the same line and enforce the length cap. 
- Cap bare-word heredoc label scanning to the same label-size budget. 
- Make data-marker consumption CR/CRLF-aware by using `consume_newline()` so `__DATA__`/`__END__` lines transition cleanly to `InDataSection`. 
- Add targeted tests: `heredoc_regression_tests.rs`, `heredoc_security_tests.rs`, and `edge_case_tests.rs` to cover backtick/quoted-label failures, CRLF data-marker transitions, label-length bounding, and `<<~`/quoted vs unquoted label distinctions.

### Testing

- Ran `cargo test -p perl-lexer heredoc` and relevant heredoc tests passed. 
- Ran `cargo test -p perl-lexer` and the crate test-suite passed. 
- Ran `cargo check --workspace --all-targets` and it completed successfully. 
- Ran `cargo xtask fmt` to format changes and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c8d69fc8333938ddccc576defe7)