### PR TITLE
fix(lexer): harden heredoc and data-section scanning under edge cases (#6600)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -391,6 +391,54 @@ impl<'a> PerlLexer<'a> {
         (end, visible_end)
     }
 
+    /// Parse a quoted heredoc label, bounded to the current logical line.
+    ///
+    /// Returns `Some(label)` only when a matching closing quote is found before
+    /// any newline (`\n`, `\r`, or `\r\n`). Returns `None` for unterminated or
+    /// malformed quoted labels so callers can fall back to non-heredoc parsing.
+    #[inline]
+    fn parse_quoted_heredoc_label(&mut self, quote: char, text: &mut String) -> Option<String> {
+        text.push(quote);
+        self.advance(); // consume opening quote
+
+        let mut delim = String::new();
+        while self.position < self.input.len() {
+            let ch = self.current_char()?;
+
+            // Heredoc labels must terminate on the same line as the `<<` marker.
+            if matches!(ch, '\n' | '\r') {
+                return None;
+            }
+
+            if ch == '\\' {
+                // Keep escaped quote/backslash sequences intact in the raw label.
+                text.push(ch);
+                self.advance();
+
+                if self.position < self.input.len()
+                    && let Some(escaped) = self.current_char()
+                {
+                    delim.push(escaped);
+                    text.push(escaped);
+                    self.advance();
+                }
+                continue;
+            }
+
+            if ch == quote {
+                text.push(quote);
+                self.advance(); // consume closing quote
+                return Some(delim);
+            }
+
+            delim.push(ch);
+            text.push(ch);
+            self.advance();
+        }
+
+        None
+    }
+
     /// Advance the lexer and return the next token.
     ///
     /// Returns `None` only after an `EOF` token has already been emitted.
@@ -1129,66 +1177,27 @@ impl<'a> PerlLexer<'a> {
         let delimiter = if self.position < self.input.len() {
             match self.current_char() {
                 Some('"') if !backslashed => {
-                    // Double-quoted delimiter
-                    text.push('"');
-                    self.advance();
-                    let mut delim = String::new();
-                    while self.position < self.input.len() {
-                        if let Some(ch) = self.current_char() {
-                            if ch == '"' {
-                                text.push('"');
-                                self.advance();
-                                break;
-                            }
-                            delim.push(ch);
-                            text.push(ch);
-                            self.advance();
-                        } else {
-                            break;
-                        }
-                    }
+                    // Double-quoted delimiter (must close on this line)
+                    let Some(delim) = self.parse_quoted_heredoc_label('"', &mut text) else {
+                        self.position = start;
+                        return None;
+                    };
                     delim
                 }
                 Some('\'') if !backslashed => {
-                    // Single-quoted delimiter
-                    text.push('\'');
-                    self.advance();
-                    let mut delim = String::new();
-                    while self.position < self.input.len() {
-                        if let Some(ch) = self.current_char() {
-                            if ch == '\'' {
-                                text.push('\'');
-                                self.advance();
-                                break;
-                            }
-                            delim.push(ch);
-                            text.push(ch);
-                            self.advance();
-                        } else {
-                            break;
-                        }
-                    }
+                    // Single-quoted delimiter (must close on this line)
+                    let Some(delim) = self.parse_quoted_heredoc_label('\'', &mut text) else {
+                        self.position = start;
+                        return None;
+                    };
                     delim
                 }
                 Some('`') if !backslashed => {
-                    // Backtick delimiter
-                    text.push('`');
-                    self.advance();
-                    let mut delim = String::new();
-                    while self.position < self.input.len() {
-                        if let Some(ch) = self.current_char() {
-                            if ch == '`' {
-                                text.push('`');
-                                self.advance();
-                                break;
-                            }
-                            delim.push(ch);
-                            text.push(ch);
-                            self.advance();
-                        } else {
-                            break;
-                        }
-                    }
+                    // Backtick delimiter (must close on this line)
+                    let Some(delim) = self.parse_quoted_heredoc_label('`', &mut text) else {
+                        self.position = start;
+                        return None;
+                    };
                     delim
                 }
                 Some(c) if is_perl_identifier_start(c) => {
@@ -2027,17 +2036,10 @@ impl<'a> PerlLexer<'a> {
                     // Check if rest of line is only whitespace
                     // Only treat as data marker if line has no trailing junk
                     if Self::trailing_ws_only(self.input_bytes, self.position) {
-                        // Consume the rest of the line (the marker line)
-                        while self.position < self.input.len()
-                            && self.input_bytes[self.position] != b'\n'
-                        {
-                            self.advance();
-                        }
-                        if self.position < self.input.len()
-                            && self.input_bytes[self.position] == b'\n'
-                        {
-                            self.advance();
-                        }
+                        // Consume exactly the marker line, supporting LF/CRLF/CR.
+                        let (line_end, _) = Self::find_line_end(self.input_bytes, self.position);
+                        self.position = line_end;
+                        self.consume_newline();
 
                         // Switch to data section mode
                         self.mode = LexerMode::InDataSection;

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -200,6 +200,32 @@ fn heredoc_with_trailing_whitespace_on_terminator() -> R {
     Ok(())
 }
 
+#[test]
+fn heredoc_indented_with_tab_terminator() -> R {
+    let input = "<<~END\n\tline\n\tEND\nmy $x = 1;\n";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_heredoc = sig.iter().any(|t| matches!(t.token_type, TokenType::HeredocStart));
+    let has_my =
+        sig.iter().any(|t| matches!(&t.token_type, TokenType::Keyword(k) if k.as_ref() == "my"));
+    assert!(has_heredoc, "expected HeredocStart");
+    assert!(has_my, "expected tokenization to continue after <<~ terminator");
+    Ok(())
+}
+
+#[test]
+fn data_marker_with_cr_line_end_switches_cleanly() -> R {
+    let input = "print 1;\r__DATA__\rpayload\r";
+    let sig = significant(input);
+
+    let has_marker = sig.iter().any(|t| matches!(t.token_type, TokenType::DataMarker(_)));
+    let has_body = sig.iter().any(|t| matches!(t.token_type, TokenType::DataBody(_)));
+
+    assert!(has_marker, "expected __DATA__ marker to be detected with CR line endings");
+    assert!(has_body, "expected data body token after marker");
+    Ok(())
+}
+
 // ===========================================================================
 // 2. Regex delimiters
 // ===========================================================================

--- a/crates/perl-lexer/tests/heredoc_regression_tests.rs
+++ b/crates/perl-lexer/tests/heredoc_regression_tests.rs
@@ -85,3 +85,21 @@ fn lexer_handles_malformed_heredoc_gracefully() {
         assert!(token_count < 20, "Too many tokens, possible infinite loop");
     }
 }
+
+#[test]
+fn lexer_handles_unterminated_quoted_heredoc_labels_without_runaway_scan() {
+    // Unterminated quoted labels should not consume arbitrary following lines.
+    let samples = ["<<\"EOF\nprint 1;\n", "<<'EOF\rprint 1;\r", "<<`CMD\r\nprint 1;\r\n"];
+
+    for input in samples {
+        let mut lx = PerlLexer::new(input);
+        let mut token_count = 0;
+        while let Some(token) = lx.next_token() {
+            token_count += 1;
+            if matches!(token.token_type, perl_lexer::TokenType::EOF) {
+                break;
+            }
+            assert!(token_count < 40, "Too many tokens, possible infinite loop for {input:?}");
+        }
+    }
+}

--- a/crates/perl-lexer/tests/heredoc_security_tests.rs
+++ b/crates/perl-lexer/tests/heredoc_security_tests.rs
@@ -38,3 +38,21 @@ fn test_heredoc_timeout() {
 
     assert!(duration < Duration::from_secs(10), "Lexer should not hang for more than 10 seconds");
 }
+
+#[test]
+fn test_unterminated_quoted_heredoc_label_stays_bounded() {
+    let mut code = String::from("my $x = <<\"EOF\n");
+    for _ in 0..50_000 {
+        code.push_str("line with content\r\n");
+    }
+
+    let start = Instant::now();
+    let mut lexer = PerlLexer::new(&code);
+    let _tokens = lexer.collect_tokens();
+    let duration = start.elapsed();
+
+    assert!(
+        duration < Duration::from_secs(10),
+        "Lexer should keep malformed quoted heredoc handling bounded"
+    );
+}


### PR DESCRIPTION
### Motivation

- Fix heredoc label parsing edge cases that could over-consume input when quoted/backtick delimiters are unterminated or when CR/CRLF line endings occur.
- Keep slow-paths and malformed-input handling bounded (time/bytes/depth) while preserving graceful degradation and existing budget behavior.
- Ensure `__DATA__/__END__` detection and transition to data mode behave correctly across CR, CRLF, and LF line endings.

### Description

- Added a new helper `parse_quoted_heredoc_label` that parses quoted/backtick heredoc labels but is explicitly bounded to the current logical line and returns `None` on unterminated or malformed labels so the lexer falls back cleanly.
- Updated heredoc start handling to use the bounded quoted-label parser and to reset `self.position` and return `None` when a quoted delimiter does not terminate on the same line, preventing runaway scans for malformed quoted labels.
- Changed data-marker consumption to use `find_line_end` + `consume_newline` so marker lines are consumed in a CR/LF-aware way rather than naively scanning to `
`, avoiding incorrect transitions on CR-only or CRLF inputs.
- Added targeted tests covering unterminated quoted/backtick heredoc labels, bounded handling on large malformed inputs, `<<~` tab-indented terminators, and CR-only `__DATA__` transitions (`crates/perl-lexer/src/lib.rs`, updated tests in `crates/perl-lexer/tests/*`).

### Testing

- Ran `cargo test -p perl-lexer heredoc` and the heredoc-focused test suite passed.
- Ran full crate tests with `cargo test -p perl-lexer` and all `perl-lexer` tests passed.
- Ran a workspace-level check with `cargo check --workspace --all-targets` and it completed successfully.
- Formatting via `cargo xtask fmt` was executed as part of verification.

All automated tests mentioned above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c8d69fc8333938ddccc576defe7)