### PR TITLE
fix(lexer): harden Unicode, BOM, and multibyte span handling (#6598)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -331,10 +331,12 @@ impl<'a> PerlLexer<'a> {
 
     /// Normalize file start by skipping BOM if present
     fn normalize_file_start(&mut self) {
-        // Skip UTF-8 BOM (EF BB BF) if at file start
-        if self.position == 0 && self.matches_bytes(&[0xEF, 0xBB, 0xBF]) {
-            self.position = 3;
-            self.line_start_offset = 3;
+        // Skip UTF-8 BOM (EF BB BF) / U+FEFF at file start.
+        if self.position == 0
+            && (self.matches_bytes(&[0xEF, 0xBB, 0xBF]) || self.current_char() == Some('\u{FEFF}'))
+        {
+            self.advance();
+            self.line_start_offset = self.position;
         }
     }
 

--- a/crates/perl-lexer/src/unicode.rs
+++ b/crates/perl-lexer/src/unicode.rs
@@ -37,22 +37,7 @@ pub fn is_perl_identifier_start(ch: char) -> bool {
 
     // Check additional Unicode blocks that Perl allows
     // but aren't included in XID_Start (primarily emoji)
-    let is_emoji = matches!(ch as u32,
-        // Emoji and symbols
-        0x1F300..=0x1F6FF |  // Miscellaneous Symbols and Pictographs (includes 🚀)
-        0x1F900..=0x1F9FF |  // Supplemental Symbols and Pictographs
-        0x2600..=0x26FF |    // Miscellaneous Symbols (includes ♥)
-        0x2700..=0x27BF |    // Dingbats
-        0x1F000..=0x1F02F |  // Mahjong Tiles
-        0x1F0A0..=0x1F0FF |  // Playing Cards
-        0x1F100..=0x1F1FF |  // Enclosed Alphanumeric Supplement
-        0x1F200..=0x1F2FF |  // Enclosed Ideographic Supplement
-        0x1F700..=0x1F77F |  // Alchemical Symbols
-        0x1F780..=0x1F7FF |  // Geometric Shapes Extended
-        0x1F800..=0x1F8FF |  // Supplemental Arrows-C
-        0x1FA00..=0x1FA6F |  // Chess Symbols
-        0x1FA70..=0x1FAFF    // Symbols and Pictographs Extended-A
-    );
+    let is_emoji = is_emoji_identifier_start(ch);
 
     if is_emoji {
         UNICODE_EMOJI_HITS.fetch_add(1, Ordering::Relaxed);
@@ -69,15 +54,45 @@ pub fn is_perl_identifier_continue(ch: char) -> bool {
     is_perl_identifier_start(ch)
         || is_xid_continue(ch)
         || ch == '\''
-        || matches!(
-            ch as u32,
-            // Unicode join controls used in emoji and script shaping.
-            0x200C | 0x200D |
-            // Standard variation selectors (e.g. U+FE0F) used to keep emoji presentation.
-            0xFE00..=0xFE0F |
-            // Fitzpatrick skin-tone modifiers.
-            0x1F3FB..=0x1F3FF
-        )
+        || is_perl_identifier_continuation_extension(ch)
+}
+
+#[inline]
+fn is_emoji_identifier_start(ch: char) -> bool {
+    matches!(
+        ch as u32,
+        // Emoji and symbols
+        0x1F300..=0x1F6FF | // Miscellaneous Symbols and Pictographs (includes 🚀)
+        0x1F900..=0x1F9FF | // Supplemental Symbols and Pictographs
+        0x2600..=0x26FF | // Miscellaneous Symbols (includes ♥)
+        0x2700..=0x27BF | // Dingbats
+        0x1F000..=0x1F02F | // Mahjong Tiles
+        0x1F0A0..=0x1F0FF | // Playing Cards
+        0x1F100..=0x1F1FF | // Enclosed Alphanumeric Supplement
+        0x1F200..=0x1F2FF | // Enclosed Ideographic Supplement
+        0x1F700..=0x1F77F | // Alchemical Symbols
+        0x1F780..=0x1F7FF | // Geometric Shapes Extended
+        0x1F800..=0x1F8FF | // Supplemental Arrows-C
+        0x1FA00..=0x1FA6F | // Chess Symbols
+        0x1FA70..=0x1FAFF // Symbols and Pictographs Extended-A
+    )
+}
+
+#[inline]
+fn is_perl_identifier_continuation_extension(ch: char) -> bool {
+    matches!(
+        ch as u32,
+        // Unicode join controls used in emoji and script shaping.
+        0x200C | 0x200D |
+        // Standard variation selectors (e.g. U+FE0F) used to keep emoji presentation.
+        0xFE00..=0xFE0F |
+        // Supplemental variation selectors used by some emoji/text shaping sequences.
+        0xE0100..=0xE01EF |
+        // Fitzpatrick skin-tone modifiers.
+        0x1F3FB..=0x1F3FF |
+        // Emoji tag sequences (used by some flags and family variants).
+        0xE0020..=0xE007F
+    )
 }
 
 /// Validate Unicode string complexity for performance monitoring
@@ -139,8 +154,10 @@ mod tests {
         assert!(is_perl_identifier_continue('\u{200C}'));
         assert!(is_perl_identifier_continue('\u{200D}'));
         assert!(is_perl_identifier_continue('\u{FE0F}'));
+        assert!(is_perl_identifier_continue('\u{E0100}'));
         assert!(is_perl_identifier_continue('\u{1F3FB}'));
         assert!(is_perl_identifier_continue('\u{1F3FD}'));
+        assert!(is_perl_identifier_continue('\u{E0067}'));
         assert!(!is_perl_identifier_continue(' '));
         assert!(!is_perl_identifier_continue('-'));
     }

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -44,6 +44,21 @@ fn assert_terminates(input: &str) {
             input.len()
         );
         assert!(t.start <= t.end, "Token {:?} has start {} > end {}", t.token_type, t.start, t.end);
+        assert!(
+            input.is_char_boundary(t.start) && input.is_char_boundary(t.end),
+            "Token {:?} has non-boundary UTF-8 span {}..{}",
+            t.token_type,
+            t.start,
+            t.end
+        );
+        assert_eq!(
+            t.text.as_ref(),
+            &input[t.start..t.end],
+            "Token {:?} text mismatch for span {}..{}",
+            t.token_type,
+            t.start,
+            t.end
+        );
     }
     assert!(
         toks.iter().any(|t| matches!(t.token_type, TokenType::EOF)),

--- a/crates/perl-lexer/tests/unicode_fix_test.rs
+++ b/crates/perl-lexer/tests/unicode_fix_test.rs
@@ -1,44 +1,73 @@
-// Test to verify the Unicode fix works correctly
+//! Unicode regression tests for tokenizer safety and span correctness.
 
-use perl_lexer::PerlLexer;
+use perl_lexer::{PerlLexer, TokenType};
 
-#[test]
-fn test_unicode_heredoc_fixes() {
-    let test_cases = vec![
-        "¡<<'",        // The specific failing case - should not panic
-        "<<'END'",     // Valid heredoc for comparison
-        "¡test",       // Unicode identifier
-        "¡ << 'test'", // Unicode with spacing
-    ];
+type R = Result<(), Box<dyn std::error::Error>>;
 
-    for input in test_cases {
-        println!("Testing input: {:?}", input);
-        let mut lexer = PerlLexer::new(input);
+fn assert_token_spans_within_input(input: &str) {
+    let tokens = PerlLexer::new(input).collect_tokens();
 
-        // This should not panic - the main test
-        let mut token_count = 0;
-        while let Some(token) = lexer.next_token() {
-            println!("  Token: {:?} '{}'", token.token_type, token.text);
-            token_count += 1;
-
-            // Safety valve to prevent infinite loops in testing
-            if token_count > 10 {
-                break;
-            }
-        }
-        println!("  Success! Processed {} tokens without panic", token_count);
+    for token in tokens {
+        assert!(token.start <= token.end, "invalid token span ordering for {:?}", token.token_type);
+        assert!(
+            token.end <= input.len(),
+            "token span out of bounds for {:?}: {}..{} > {}",
+            token.token_type,
+            token.start,
+            token.end,
+            input.len()
+        );
+        assert!(
+            input.is_char_boundary(token.start) && input.is_char_boundary(token.end),
+            "token span not on UTF-8 boundary for {:?}: {}..{}",
+            token.token_type,
+            token.start,
+            token.end
+        );
+        assert_eq!(token.text.as_ref(), &input[token.start..token.end]);
     }
 }
 
 #[test]
-fn test_unicode_regression_case() {
-    // The specific failing case from the proptest regression
-    let input = "¡<<'";
+fn unicode_prefixes_resembling_heredoc_do_not_panic() -> R {
+    for input in ["¡<<'", "𝑥<<'END'", "👩\u{200D}💻<<'EOF'", "¡ << 'test'"] {
+        let tokens = PerlLexer::new(input).collect_tokens();
+        let has_eof = tokens.iter().any(|token| matches!(token.token_type, TokenType::EOF));
+        assert!(has_eof, "lexer must always terminate with EOF for {input:?}");
+        assert_token_spans_within_input(input);
+    }
 
-    let mut lexer = PerlLexer::new(input);
+    Ok(())
+}
 
-    // This should not panic anymore
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| lexer.next_token()));
+#[test]
+fn utf8_bom_is_skipped_only_at_file_start() -> R {
+    let input = "\u{FEFF}my $x = 1;";
+    let tokens = PerlLexer::new(input).collect_tokens();
+    let first = tokens
+        .iter()
+        .find(|token| !matches!(token.token_type, TokenType::Whitespace | TokenType::Newline))
+        .ok_or("expected non-whitespace token")?;
 
-    assert!(result.is_ok(), "Lexer should not panic on Unicode input: {:?}", input);
+    assert!(matches!(first.token_type, TokenType::Keyword(ref kw) if kw.as_ref() == "my"));
+    assert_eq!(first.start, "\u{FEFF}".len());
+    assert_token_spans_within_input(input);
+    Ok(())
+}
+
+#[test]
+fn emoji_joiner_variation_selector_identifier_has_valid_multibyte_spans() -> R {
+    let input = "👩\u{200D}💻\u{FE0F}\u{E0100}\u{E0067}";
+    let tokens = PerlLexer::new(input).collect_tokens();
+
+    let ident = tokens
+        .iter()
+        .find(|token| matches!(token.token_type, TokenType::Identifier(_)))
+        .ok_or("identifier token should exist")?;
+
+    assert_eq!(ident.start, 0);
+    assert_eq!(ident.end, input.len());
+    assert_eq!(ident.text.as_ref(), input);
+    assert_token_spans_within_input(input);
+    Ok(())
 }


### PR DESCRIPTION
### Motivation

- Fix lexer panics and incorrect spans when inputs start with Unicode prefixes that resemble heredoc/quote starts or include multibyte emoji/variation-selector sequences. 
- Ensure BOM normalization is UTF‑8 safe and that token spans always align to UTF‑8 code‑point boundaries without changing public token model.

### Description

- Expanded Unicode classification by factoring out `is_emoji_identifier_start` and adding `is_perl_identifier_continuation_extension` to accept supplemental variation selectors (`U+E0100..U+E01EF`), emoji tag-range (`U+E0020..U+E007F`), and kept ZWJ/FE0F/skin-tone ranges; preserved the existing `UNICODE_*` counters. (modified `crates/perl-lexer/src/unicode.rs`)
- Made BOM/file-start normalization UTF‑8-safe by advancing with `advance()` when at position 0 and either a UTF‑8 BOM (`EF BB BF`) or `U+FEFF` is present, and updated `line_start_offset` accordingly. (modified `crates/perl-lexer/src/lib.rs`)
- Strengthened tests to assert no-panic termination, that every token `start..end` is within input bounds, aligned on UTF‑8 char boundaries, and that `token.text == input[start..end]`; added targeted regression cases for heredoc-like Unicode prefixes and emoji+joiner+variation-selector identifiers. (modified `crates/perl-lexer/tests/unicode_fix_test.rs` and `crates/perl-lexer/tests/edge_case_tests.rs`)

### Testing

- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran `cargo test -p perl-lexer unicode` and all unicode-focused tests passed.
- Ran `cargo test -p perl-lexer` and the full `perl-lexer` test suite passed.
- Ran `cargo check --workspace --all-targets` and type-check succeeded across the workspace.
- Note: `just pr-fast` is not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c910edc8333844c601f2cc64fe5)