### PR TITLE
fix(lexer): harden Unicode, BOM, and multibyte span handling (#6597)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -176,6 +176,7 @@ const MAX_HEREDOC_BYTES: usize = 256 * 1024; // 256KB max for heredoc bodies
 const MAX_DELIM_NEST: usize = 128; // Max nesting depth for delimiters
 const MAX_HEREDOC_DEPTH: usize = 100; // Max nesting depth for heredocs
 const HEREDOC_TIMEOUT_MS: u64 = 5000; // 5 seconds timeout for heredoc parsing
+const UTF8_BOM_BYTES: [u8; 3] = [0xEF, 0xBB, 0xBF];
 
 /// Maximum scan iterations for a single regex literal.
 /// This is a lexer parse budget, not regex-engine backtracking detection.
@@ -332,9 +333,9 @@ impl<'a> PerlLexer<'a> {
     /// Normalize file start by skipping BOM if present
     fn normalize_file_start(&mut self) {
         // Skip UTF-8 BOM (EF BB BF) if at file start
-        if self.position == 0 && self.matches_bytes(&[0xEF, 0xBB, 0xBF]) {
-            self.position = 3;
-            self.line_start_offset = 3;
+        if self.position == 0 && self.matches_bytes(&UTF8_BOM_BYTES) {
+            self.position = UTF8_BOM_BYTES.len();
+            self.line_start_offset = UTF8_BOM_BYTES.len();
         }
     }
 
@@ -396,6 +397,8 @@ impl<'a> PerlLexer<'a> {
     /// Returns `None` only after an `EOF` token has already been emitted.
     /// The final meaningful call returns `Some(Token { token_type: TokenType::EOF, .. })`.
     pub fn next_token(&mut self) -> Option<Token> {
+        debug_assert!(self.input.is_char_boundary(self.position));
+
         // Normalize file start (BOM) once
         if self.position == 0 {
             self.normalize_file_start();

--- a/crates/perl-lexer/src/unicode.rs
+++ b/crates/perl-lexer/src/unicode.rs
@@ -12,6 +12,42 @@ use unicode_ident::{is_xid_continue, is_xid_start};
 static UNICODE_CHAR_CHECKS: AtomicU64 = AtomicU64::new(0);
 static UNICODE_EMOJI_HITS: AtomicU64 = AtomicU64::new(0);
 
+#[inline]
+fn is_emoji_identifier_start(ch: char) -> bool {
+    matches!(
+        ch as u32,
+        // Emoji and symbols
+        0x1F300..=0x1F6FF |  // Miscellaneous Symbols and Pictographs (includes 🚀)
+            0x1F900..=0x1F9FF |  // Supplemental Symbols and Pictographs
+            0x2600..=0x26FF |    // Miscellaneous Symbols (includes ♥)
+            0x2700..=0x27BF |    // Dingbats
+            0x1F000..=0x1F02F |  // Mahjong Tiles
+            0x1F0A0..=0x1F0FF |  // Playing Cards
+            0x1F100..=0x1F1FF |  // Enclosed Alphanumeric Supplement
+            0x1F200..=0x1F2FF |  // Enclosed Ideographic Supplement
+            0x1F700..=0x1F77F |  // Alchemical Symbols
+            0x1F780..=0x1F7FF |  // Geometric Shapes Extended
+            0x1F800..=0x1F8FF |  // Supplemental Arrows-C
+            0x1FA00..=0x1FA6F |  // Chess Symbols
+            0x1FA70..=0x1FAFF    // Symbols and Pictographs Extended-A
+    )
+}
+
+#[inline]
+fn is_emoji_identifier_continue(ch: char) -> bool {
+    matches!(
+        ch as u32,
+        // Unicode join controls used in emoji and script shaping.
+        0x200C | 0x200D |
+            // Standard variation selectors (e.g. U+FE0F) used to keep emoji presentation.
+            0xFE00..=0xFE0F |
+            // Supplementary variation selectors.
+            0xE0100..=0xE01EF |
+            // Fitzpatrick skin-tone modifiers.
+            0x1F3FB..=0x1F3FF
+    )
+}
+
 /// Get Unicode processing statistics for debugging
 #[allow(dead_code)]
 pub fn get_unicode_stats() -> (u64, u64) {
@@ -37,22 +73,7 @@ pub fn is_perl_identifier_start(ch: char) -> bool {
 
     // Check additional Unicode blocks that Perl allows
     // but aren't included in XID_Start (primarily emoji)
-    let is_emoji = matches!(ch as u32,
-        // Emoji and symbols
-        0x1F300..=0x1F6FF |  // Miscellaneous Symbols and Pictographs (includes 🚀)
-        0x1F900..=0x1F9FF |  // Supplemental Symbols and Pictographs
-        0x2600..=0x26FF |    // Miscellaneous Symbols (includes ♥)
-        0x2700..=0x27BF |    // Dingbats
-        0x1F000..=0x1F02F |  // Mahjong Tiles
-        0x1F0A0..=0x1F0FF |  // Playing Cards
-        0x1F100..=0x1F1FF |  // Enclosed Alphanumeric Supplement
-        0x1F200..=0x1F2FF |  // Enclosed Ideographic Supplement
-        0x1F700..=0x1F77F |  // Alchemical Symbols
-        0x1F780..=0x1F7FF |  // Geometric Shapes Extended
-        0x1F800..=0x1F8FF |  // Supplemental Arrows-C
-        0x1FA00..=0x1FA6F |  // Chess Symbols
-        0x1FA70..=0x1FAFF    // Symbols and Pictographs Extended-A
-    );
+    let is_emoji = is_emoji_identifier_start(ch);
 
     if is_emoji {
         UNICODE_EMOJI_HITS.fetch_add(1, Ordering::Relaxed);
@@ -69,15 +90,7 @@ pub fn is_perl_identifier_continue(ch: char) -> bool {
     is_perl_identifier_start(ch)
         || is_xid_continue(ch)
         || ch == '\''
-        || matches!(
-            ch as u32,
-            // Unicode join controls used in emoji and script shaping.
-            0x200C | 0x200D |
-            // Standard variation selectors (e.g. U+FE0F) used to keep emoji presentation.
-            0xFE00..=0xFE0F |
-            // Fitzpatrick skin-tone modifiers.
-            0x1F3FB..=0x1F3FF
-        )
+        || is_emoji_identifier_continue(ch)
 }
 
 /// Validate Unicode string complexity for performance monitoring
@@ -139,6 +152,7 @@ mod tests {
         assert!(is_perl_identifier_continue('\u{200C}'));
         assert!(is_perl_identifier_continue('\u{200D}'));
         assert!(is_perl_identifier_continue('\u{FE0F}'));
+        assert!(is_perl_identifier_continue('\u{E0100}'));
         assert!(is_perl_identifier_continue('\u{1F3FB}'));
         assert!(is_perl_identifier_continue('\u{1F3FD}'));
         assert!(!is_perl_identifier_continue(' '));

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -44,6 +44,18 @@ fn assert_terminates(input: &str) {
             input.len()
         );
         assert!(t.start <= t.end, "Token {:?} has start {} > end {}", t.token_type, t.start, t.end);
+        assert!(
+            input.is_char_boundary(t.start),
+            "Token {:?} start {} is not a char boundary",
+            t.token_type,
+            t.start
+        );
+        assert!(
+            input.is_char_boundary(t.end),
+            "Token {:?} end {} is not a char boundary",
+            t.token_type,
+            t.end
+        );
     }
     assert!(
         toks.iter().any(|t| matches!(t.token_type, TokenType::EOF)),

--- a/crates/perl-lexer/tests/unicode_fix_test.rs
+++ b/crates/perl-lexer/tests/unicode_fix_test.rs
@@ -1,10 +1,23 @@
-// Test to verify the Unicode fix works correctly
+//! Regression tests for Unicode, BOM, and span robustness.
 
-use perl_lexer::PerlLexer;
+use perl_lexer::{PerlLexer, Token, TokenType};
+
+fn collect_all_tokens(input: &str) -> Vec<Token> {
+    let mut lexer = PerlLexer::new(input);
+    let mut out = Vec::new();
+    while let Some(token) = lexer.next_token() {
+        let is_eof = token.token_type == TokenType::EOF;
+        out.push(token);
+        if is_eof {
+            break;
+        }
+    }
+    out
+}
 
 #[test]
 fn test_unicode_heredoc_fixes() {
-    let test_cases = vec![
+    let test_cases = [
         "¡<<'",        // The specific failing case - should not panic
         "<<'END'",     // Valid heredoc for comparison
         "¡test",       // Unicode identifier
@@ -12,21 +25,11 @@ fn test_unicode_heredoc_fixes() {
     ];
 
     for input in test_cases {
-        println!("Testing input: {:?}", input);
-        let mut lexer = PerlLexer::new(input);
-
-        // This should not panic - the main test
-        let mut token_count = 0;
-        while let Some(token) = lexer.next_token() {
-            println!("  Token: {:?} '{}'", token.token_type, token.text);
-            token_count += 1;
-
-            // Safety valve to prevent infinite loops in testing
-            if token_count > 10 {
-                break;
-            }
-        }
-        println!("  Success! Processed {} tokens without panic", token_count);
+        let tokens = collect_all_tokens(input);
+        assert!(
+            tokens.iter().any(|t| t.token_type == TokenType::EOF),
+            "Expected EOF token for input {input:?}"
+        );
     }
 }
 
@@ -41,4 +44,67 @@ fn test_unicode_regression_case() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| lexer.next_token()));
 
     assert!(result.is_ok(), "Lexer should not panic on Unicode input: {:?}", input);
+}
+
+#[test]
+fn test_bom_is_skipped_and_spans_stay_byte_exact() {
+    let input = "\u{FEFF}my $x = 1;";
+    let tokens = collect_all_tokens(input);
+
+    let first_non_ws = tokens
+        .iter()
+        .find(|t| {
+            !matches!(t.token_type, TokenType::Whitespace | TokenType::Newline | TokenType::EOF)
+        })
+        .expect("expected at least one non-whitespace token");
+
+    assert_eq!(first_non_ws.text.as_ref(), "my");
+    assert_eq!(first_non_ws.start, 3, "first token should start after UTF-8 BOM bytes");
+    assert_eq!(&input[first_non_ws.start..first_non_ws.end], first_non_ws.text.as_ref());
+}
+
+#[test]
+fn test_multibyte_spans_and_emoji_joiner_continuations() {
+    let input = "my $👨‍👩‍👧‍👦️ = 1;";
+    let tokens = collect_all_tokens(input);
+
+    for token in &tokens {
+        assert!(token.start <= token.end, "Invalid span ordering for {:?}", token.token_type);
+        assert!(token.end <= input.len(), "Token end out of bounds for {:?}", token.token_type);
+        assert!(
+            input.is_char_boundary(token.start),
+            "Token start is not char boundary for {:?}",
+            token.token_type
+        );
+        assert!(
+            input.is_char_boundary(token.end),
+            "Token end is not char boundary for {:?}",
+            token.token_type
+        );
+        assert_eq!(
+            &input[token.start..token.end],
+            token.text.as_ref(),
+            "Token text must match input slice for {:?}",
+            token.token_type
+        );
+    }
+
+    assert!(
+        tokens.iter().any(
+            |t| matches!(&t.token_type, TokenType::Identifier(name) if name.as_ref() == "$👨‍👩‍👧‍👦️")
+        ),
+        "Expected emoji ZWJ identifier token"
+    );
+}
+
+#[test]
+fn test_weird_unicode_prefixes_do_not_panic() {
+    let cases =
+        ["🙂<<'END'\nbody\nEND\n", "🙂q'abc'", "🙂m/abc/", "🙂tr/a/b/", "🙂<<\"EOF\"\nX\nEOF\n"];
+
+    for input in cases {
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| collect_all_tokens(input)));
+        assert!(result.is_ok(), "Lexer panicked for input {input:?}");
+    }
 }


### PR DESCRIPTION
### Motivation

- Fix lexer crashes and incorrect spans caused by Unicode prefixes and emoji grapheme sequences, and ensure BOM normalization at file start does not produce invalid byte offsets.

### Description

- Extracted emoji start/continue helpers (`is_emoji_identifier_start`, `is_emoji_identifier_continue`) and expanded continuation support to include supplementary variation selectors (`U+E0100..U+E01EF`) while reusing the existing profiling counters.\
- Added `UTF8_BOM_BYTES` constant and updated `normalize_file_start` to use it, and placed a `debug_assert!(self.input.is_char_boundary(self.position))` at the top of `next_token` to catch invalid byte offsets in debug builds.\
- Hardened identifier continuation checks by delegating to the new emoji helpers without changing the public token model (`is_perl_identifier_start` / `is_perl_identifier_continue`).\
- Strengthened tests: expanded `unicode_fix_test.rs` with BOM, multibyte span, emoji ZWJ continuations, and weird-Unicode-prefix no-panic cases; added char-boundary assertions to `edge_case_tests.rs` to ensure token `start`/`end` are UTF-8 boundaries.

### Testing

- Ran `cargo xtask fmt` successfully.\
- Ran `cargo test -p perl-lexer unicode` and the crate unit tests; all tests passed.\
- Ran `cargo test -p perl-lexer` for the package-wide test suite; all tests passed.\
- Ran `cargo check --workspace --all-targets`; the workspace checked successfully (only unrelated warnings in other crates).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c910edc8333844c601f2cc64fe5)