### PR TITLE
perf(lexer): optimize measured hot path in token classification/scanning (#6596)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1906,6 +1906,8 @@ impl<'a> PerlLexer<'a> {
     fn try_identifier_or_keyword(&mut self) -> Option<Token> {
         let start = self.position;
         let ch = self.current_char()?;
+        let bytes = self.input_bytes;
+        let len = bytes.len();
 
         if is_perl_identifier_start(ch) {
             // Special case: substitution/transliteration with single-quote delimiter
@@ -1936,44 +1938,63 @@ impl<'a> PerlLexer<'a> {
                 return self.parse_transliteration(start);
             }
 
-            while let Some(ch) = self.current_char() {
-                // Single quote is usually allowed inside Perl identifiers (legacy package separator),
-                // but it can also be the delimiter for quote-like operators (q'..', qq'..', qr'..', m'..').
-                // If we've already read one of those operator words, stop before consuming the quote
-                // so the quote-operator path can handle it.
-                if ch == '\''
-                    && matches!(
-                        &self.input[start..self.position],
-                        "m" | "q" | "qq" | "qw" | "qx" | "qr"
-                    )
-                {
+            // Fast ASCII path for identifier continuation.
+            while self.position < len {
+                let byte = bytes[self.position];
+                if byte == b'\'' && is_quote_op_word_prefix(&bytes[start..self.position]) {
+                    // Keep apostrophe for quote-operator parsing in cases like q'...'.
                     break;
                 }
 
-                if is_perl_identifier_continue(ch) {
-                    self.advance();
-                } else {
+                if byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'\'' {
+                    self.position += 1;
+                    continue;
+                }
+
+                if byte < 128 {
                     break;
                 }
+
+                if let Some(ch) = self.current_char()
+                    && is_perl_identifier_continue(ch)
+                {
+                    self.advance();
+                    continue;
+                }
+                break;
             }
-            // Handle package-qualified identifiers like Foo::bar
-            while self.current_char() == Some(':') && self.peek_char(1) == Some(':') {
-                // consume '::'
-                self.advance();
-                self.advance();
+            // Handle package-qualified identifiers like Foo::bar.
+            while self.config.max_lookahead >= 1
+                && self.position + 1 < len
+                && bytes[self.position] == b':'
+                && bytes[self.position + 1] == b':'
+            {
+                self.position += 2; // consume '::'
 
                 // consume following identifier segment if present
-                if let Some(ch) = self.current_char()
-                    && is_perl_identifier_start(ch)
-                {
-                    self.advance();
-                    while let Some(ch) = self.current_char() {
-                        if is_perl_identifier_continue(ch) {
-                            self.advance();
-                        } else {
-                            break;
-                        }
+                let Some(ch) = self.current_char() else {
+                    break;
+                };
+                if !is_perl_identifier_start(ch) {
+                    break;
+                }
+                self.advance();
+                while self.position < len {
+                    let byte = bytes[self.position];
+                    if byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'\'' {
+                        self.position += 1;
+                        continue;
                     }
+                    if byte < 128 {
+                        break;
+                    }
+                    if let Some(ch) = self.current_char()
+                        && is_perl_identifier_continue(ch)
+                    {
+                        self.advance();
+                        continue;
+                    }
+                    break;
                 }
             }
 
@@ -3370,6 +3391,11 @@ fn is_keyword_fast(word: &str) -> bool {
 #[inline]
 fn is_builtin_function(word: &str) -> bool {
     BARE_TERM_BUILTINS.binary_search(&word).is_ok()
+}
+
+#[inline(always)]
+fn is_quote_op_word_prefix(word: &[u8]) -> bool {
+    matches!(word, b"m" | b"q" | b"qq" | b"qw" | b"qx" | b"qr")
 }
 
 const BARE_TERM_BUILTINS: &[&str] = &[


### PR DESCRIPTION
### Motivation
- Benchmarks showed identifier-heavy tokenization as a hot path; repeated char-level continuation checks in `try_identifier_or_keyword` were creating measurable overhead that could be optimized locally.

### Description
- Add an ASCII byte-scan fast path inside `try_identifier_or_keyword` to advance through common ASCII identifier characters without repeated `char` decoding, falling back to the existing Unicode `is_perl_identifier_continue` checks when needed.
- Preserve quote-operator semantics by adding a small helper `is_quote_op_word_prefix` and by stopping the fast-path before an apostrophe when the leading bytes match `m`, `q`, `qq`, `qw`, `qx`, or `qr`.
- Restore lookahead-sensitive behavior for `::` package separators by gating multi-byte `::` scanning with `config.max_lookahead` to avoid changing semantics for small-lookahead configurations.
- Keep Unicode behavior, error handling, and public API unchanged; changes are local to `crates/perl-lexer/src/lib.rs` in the identifier scanning hot path.

### Testing
- Ran `cargo bench -p perl-lexer --bench lexer_benchmarks -- --noplot` and observed measurable improvements (baseline -> optimized): `simple_tokens` ~1.82 µs -> ~1.72 µs (~6.5% faster median), `string_interpolation` ~4.50 µs -> ~4.02 µs (~11.5% faster median), `whitespace_heavy` ~2.10 µs -> ~1.98 µs (~7% faster median), and `keyword_heavy` ~580 µs -> ~500 µs (~13.5% faster median).
- Ran `cargo test -p perl-lexer` which initially exposed a failure (`with_config_small_lookahead_limits_namespace_parsing`) that was fixed by restoring the lookahead-sensitive `::` behavior, after which `cargo test -p perl-lexer` completed successfully (all tests passed).
- Ran `cargo check --workspace --all-targets` and `cargo check --all-targets -p perl-lexer` successfully.
- Ran `cargo clippy -p perl-lexer --all-targets -- -D warnings` and addressed lints so the check completed cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c9503888333a841035ad331bba8)