### PR TITLE
perf(lexer): optimize measured hot path in token classification/scanning (#6595)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1291,9 +1291,10 @@ impl<'a> PerlLexer<'a> {
                     self.position = pos;
                     let text = &self.input[start..self.position];
                     self.mode = LexerMode::ExpectOperator;
+                    let text_arc: Arc<str> = Arc::from(text);
                     return Some(Token {
-                        token_type: TokenType::Number(Arc::from(text)),
-                        text: Arc::from(text),
+                        token_type: TokenType::Number(text_arc.clone()),
+                        text: text_arc,
                         start,
                         end: self.position,
                     });
@@ -1314,9 +1315,10 @@ impl<'a> PerlLexer<'a> {
                     self.position = pos;
                     let text = &self.input[start..self.position];
                     self.mode = LexerMode::ExpectOperator;
+                    let text_arc: Arc<str> = Arc::from(text);
                     return Some(Token {
-                        token_type: TokenType::Number(Arc::from(text)),
-                        text: Arc::from(text),
+                        token_type: TokenType::Number(text_arc.clone()),
+                        text: text_arc,
                         start,
                         end: self.position,
                     });
@@ -1337,9 +1339,10 @@ impl<'a> PerlLexer<'a> {
                     self.position = pos;
                     let text = &self.input[start..self.position];
                     self.mode = LexerMode::ExpectOperator;
+                    let text_arc: Arc<str> = Arc::from(text);
                     return Some(Token {
-                        token_type: TokenType::Number(Arc::from(text)),
-                        text: Arc::from(text),
+                        token_type: TokenType::Number(text_arc.clone()),
+                        text: text_arc,
                         start,
                         end: self.position,
                     });
@@ -1442,10 +1445,11 @@ impl<'a> PerlLexer<'a> {
         // Avoid string slicing for common number cases - use Arc::from directly on slice
         let text = &self.input[start..self.position];
         self.mode = LexerMode::ExpectOperator;
+        let text_arc: Arc<str> = Arc::from(text);
 
         Some(Token {
-            token_type: TokenType::Number(Arc::from(text)),
-            text: Arc::from(text),
+            token_type: TokenType::Number(text_arc.clone()),
+            text: text_arc,
             start,
             end: self.position,
         })
@@ -1496,10 +1500,11 @@ impl<'a> PerlLexer<'a> {
 
         let text = &self.input[start..self.position];
         self.mode = LexerMode::ExpectOperator;
+        let text_arc: Arc<str> = Arc::from(text);
 
         Some(Token {
-            token_type: TokenType::Number(Arc::from(text)),
-            text: Arc::from(text),
+            token_type: TokenType::Number(text_arc.clone()),
+            text: text_arc,
             start,
             end: self.position,
         })
@@ -2239,7 +2244,8 @@ impl<'a> PerlLexer<'a> {
                     }
                     _ => {}
                 }
-                TokenType::Keyword(Arc::from(text))
+                let text_arc: Arc<str> = Arc::from(text);
+                TokenType::Keyword(text_arc)
             } else {
                 // Mirror parser bare-builtin handling so `/` after builtins like
                 // `join` or `print` is lexed as a regex term, not division.
@@ -2248,14 +2254,19 @@ impl<'a> PerlLexer<'a> {
                 } else {
                     self.mode = LexerMode::ExpectOperator;
                 }
-                TokenType::Identifier(Arc::from(text))
+                let text_arc: Arc<str> = Arc::from(text);
+                TokenType::Identifier(text_arc)
             };
 
             self.after_arrow = false;
             // A keyword/identifier is not a variable; `{` after it is a block opener.
             self.after_var_subscript = false;
             // hash_brace_depth is managed by { and } handlers, not cleared per-token
-            Some(Token { token_type, text: Arc::from(text), start, end: self.position })
+            let text_arc = match &token_type {
+                TokenType::Keyword(value) | TokenType::Identifier(value) => value.clone(),
+                _ => Arc::from(text),
+            };
+            Some(Token { token_type, text: text_arc, start, end: self.position })
         } else {
             None
         }
@@ -2558,9 +2569,10 @@ impl<'a> PerlLexer<'a> {
             self.mode = LexerMode::ExpectTerm;
         }
 
+        let text_arc: Arc<str> = Arc::from(text);
         Some(Token {
-            token_type: TokenType::Operator(Arc::from(text)),
-            text: Arc::from(text),
+            token_type: TokenType::Operator(text_arc.clone()),
+            text: text_arc,
             start,
             end: self.position,
         })


### PR DESCRIPTION
### Motivation

- Reduce allocation overhead in lexer hot paths where `TokenType` payloads and `Token.text` were each allocating separate `Arc<str>` instances, which inflated work in number/identifier/operator-heavy workloads.

### Description

- Reuse a single `Arc<str>` per token for both the `TokenType` payload and `Token.text` in hot scanner paths by creating `let text_arc: Arc<str> = Arc::from(text)` and cloning the `Arc` where the token enum also needs ownership.
- Applied the allocation reuse in `try_number`/`parse_decimal_number` (number scanning), `try_identifier_or_keyword` (identifier/keyword classification), and `try_operator` (operator scanning) to keep the change local and measurable.
- No semantic changes to token kinds or lexer behavior were introduced; tokens still carry identical text and kinds but reduce duplicate allocation work.

### Testing

- Ran `cargo bench -p perl-lexer --bench lexer_benchmarks -- --noplot` and observed statistically significant improvements post-change, for example: `keyword_heavy` improved from ~457.00–461.26 µs to ~383.41–391.32 µs (~17.8% faster), `number_parsing` improved from ~1.0718–1.0833 µs to ~895.90–936.60 ns (~18.3% faster), and `large_file` improved from ~2.6188–2.6989 ms to ~2.2802–2.3032 ms (~13.8% faster).
- Ran `cargo test -p perl-lexer` and all lexer tests passed.
- Ran `cargo check --workspace --all-targets` and the workspace type-check succeeded.
- Ran formatting (`cargo xtask fmt`) successfully; `just pr-fast` was not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c9503888333a841035ad331bba8)