### PR TITLE
perf(lexer): optimize measured hot path in token classification/scanning (#6593)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1290,10 +1290,11 @@ impl<'a> PerlLexer<'a> {
                 if pos > digit_start && saw_digit {
                     self.position = pos;
                     let text = &self.input[start..self.position];
+                    let text_arc: Arc<str> = Arc::from(text);
                     self.mode = LexerMode::ExpectOperator;
                     return Some(Token {
-                        token_type: TokenType::Number(Arc::from(text)),
-                        text: Arc::from(text),
+                        token_type: TokenType::Number(text_arc.clone()),
+                        text: text_arc,
                         start,
                         end: self.position,
                     });
@@ -1313,10 +1314,11 @@ impl<'a> PerlLexer<'a> {
                 if pos > digit_start && saw_digit {
                     self.position = pos;
                     let text = &self.input[start..self.position];
+                    let text_arc: Arc<str> = Arc::from(text);
                     self.mode = LexerMode::ExpectOperator;
                     return Some(Token {
-                        token_type: TokenType::Number(Arc::from(text)),
-                        text: Arc::from(text),
+                        token_type: TokenType::Number(text_arc.clone()),
+                        text: text_arc,
                         start,
                         end: self.position,
                     });
@@ -1336,10 +1338,11 @@ impl<'a> PerlLexer<'a> {
                 if pos > digit_start && saw_digit {
                     self.position = pos;
                     let text = &self.input[start..self.position];
+                    let text_arc: Arc<str> = Arc::from(text);
                     self.mode = LexerMode::ExpectOperator;
                     return Some(Token {
-                        token_type: TokenType::Number(Arc::from(text)),
-                        text: Arc::from(text),
+                        token_type: TokenType::Number(text_arc.clone()),
+                        text: text_arc,
                         start,
                         end: self.position,
                     });
@@ -1441,11 +1444,12 @@ impl<'a> PerlLexer<'a> {
 
         // Avoid string slicing for common number cases - use Arc::from directly on slice
         let text = &self.input[start..self.position];
+        let text_arc: Arc<str> = Arc::from(text);
         self.mode = LexerMode::ExpectOperator;
 
         Some(Token {
-            token_type: TokenType::Number(Arc::from(text)),
-            text: Arc::from(text),
+            token_type: TokenType::Number(text_arc.clone()),
+            text: text_arc,
             start,
             end: self.position,
         })
@@ -2239,7 +2243,8 @@ impl<'a> PerlLexer<'a> {
                     }
                     _ => {}
                 }
-                TokenType::Keyword(Arc::from(text))
+                let text_arc: Arc<str> = Arc::from(text);
+                TokenType::Keyword(text_arc)
             } else {
                 // Mirror parser bare-builtin handling so `/` after builtins like
                 // `join` or `print` is lexed as a regex term, not division.
@@ -2248,14 +2253,19 @@ impl<'a> PerlLexer<'a> {
                 } else {
                     self.mode = LexerMode::ExpectOperator;
                 }
-                TokenType::Identifier(Arc::from(text))
+                let text_arc: Arc<str> = Arc::from(text);
+                TokenType::Identifier(text_arc)
             };
 
             self.after_arrow = false;
             // A keyword/identifier is not a variable; `{` after it is a block opener.
             self.after_var_subscript = false;
             // hash_brace_depth is managed by { and } handlers, not cleared per-token
-            Some(Token { token_type, text: Arc::from(text), start, end: self.position })
+            let text_arc = match &token_type {
+                TokenType::Keyword(inner) | TokenType::Identifier(inner) => inner.clone(),
+                _ => Arc::from(text),
+            };
+            Some(Token { token_type, text: text_arc, start, end: self.position })
         } else {
             None
         }
@@ -2543,6 +2553,7 @@ impl<'a> PerlLexer<'a> {
         }
 
         let text = &self.input[start..self.position];
+        let text_arc: Arc<str> = Arc::from(text);
         // Operator ends prototype window (e.g. `:` for attributes)
         self.after_sub = false;
         // Track whether this operator is '->' for method name disambiguation
@@ -2559,8 +2570,8 @@ impl<'a> PerlLexer<'a> {
         }
 
         Some(Token {
-            token_type: TokenType::Operator(Arc::from(text)),
-            text: Arc::from(text),
+            token_type: TokenType::Operator(text_arc.clone()),
+            text: text_arc,
             start,
             end: self.position,
         })


### PR DESCRIPTION
### Motivation
- Benchmarks showed the lexer hot path was allocating duplicate `Arc<str>` values when constructing `TokenType` and `Token.text`, adding measurable allocation cost in token classification/scanning.
- The change aims to eliminate that redundant allocation on the hottest paths (numbers, identifiers/keywords, operators) with a small local refactor.

### Description
- Reuse a single `Arc<str>` per lexeme in hot-path token creation by computing `text_arc: Arc<str> = Arc::from(text)` once and sharing it between `TokenType` and `Token.text` in `try_number`, the identifier/keyword path, and operator emission in `crates/perl-lexer/src/lib.rs`.
- Adjusted `TokenType` constructors to accept the cloned `Arc` where appropriate so both token fields point at the same allocation.
- Change is local to `crates/perl-lexer/src/lib.rs` and preserves lexer semantics and token text content.
- Single focused commit: `perf(lexer): optimize hot-path token Arc reuse (#0000)`.

### Testing
- Ran `cargo test -p perl-lexer` and all unit/integration/doctests passed (50+ suites reported as OK).
- Ran `cargo bench -p perl-lexer --bench lexer_benchmarks` and observed measurable improvements (criterion):
  - `simple_tokens`: ~1.44 µs -> ~1.35 µs (~5% faster).
  - `slash_disambiguation`: ~4.46 µs -> ~3.89 µs (~14% faster).
  - `operator_heavy`: ~3.93–4.02 µs -> ~3.54–3.68 µs (~11% faster).
  - `number_parsing`: ~1.19–1.21 µs -> ~0.85–0.86 µs (~30% faster).
  - `keyword_heavy`: ~465–478 µs -> ~383–394 µs (~17% faster).
  - `large_file` showed no significant change (within noise).
- Ran `cargo check --workspace --all-targets`, `cargo xtask fmt`, and `cargo clippy -p perl-lexer --all-targets` with no blocking failures.
- Note: `just pr-fast` was not available in the execution environment and could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c9503888333a841035ad331bba8)