### PR TITLE
fix(ux-tests): resolve LSP binary path at runtime (#0000)

### DIFF
--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -621,9 +621,14 @@ impl FormatResult {
 ///
 /// Resolution order:
 /// 1. `PERL_LSP_BIN` env var (explicit override).
-/// 2. `CARGO_BIN_EXE_perl-lsp` compile-time constant (set by Cargo during tests).
-/// 3. `perl-lsp` in PATH.
-/// 4. `cargo run -p perl-lsp-rs` fallback (slow but always works).
+/// 2. Runtime walk from `current_exe()` — finds `target/debug/perl-lsp[.exe]` by
+///    traversing parent directories. Avoids the `option_env!` compile-time approach
+///    which strips backslashes on Windows CI (OS error 3 / path not found).
+/// 3. `CARGO_TARGET_DIR` env var — if set, probe its `debug/` and `release/` subdirs.
+/// 4. `CARGO_MANIFEST_DIR`-relative workspace root walk — same approach used by
+///    `perl-lsp-rs` integration tests.
+/// 5. `perl-lsp` / `perllsp` in PATH.
+/// 6. Error with actionable message.
 pub fn resolve_binary() -> Result<String> {
     // 1. Explicit override
     if let Ok(p) = std::env::var("PERL_LSP_BIN") {
@@ -632,12 +637,44 @@ pub fn resolve_binary() -> Result<String> {
         }
     }
 
-    // 2. Compile-time constant (only available when tests run via `cargo test`)
-    if let Some(p) = option_env!("CARGO_BIN_EXE_perl-lsp") {
-        return Ok(p.to_string());
+    // 2. Runtime walk from current_exe() — robust on all platforms including
+    //    Windows where option_env! bakes paths with backslashes stripped.
+    //
+    //    Test binaries live at:
+    //      <workspace>/target/debug/deps/<test-binary-name>[.exe]
+    //    The LSP server lives at:
+    //      <workspace>/target/debug/perl-lsp[.exe]
+    //      <workspace>/target/release/perl-lsp[.exe]
+    //
+    //    We walk up from current_exe() until we find a `target` directory
+    //    whose parent contains `Cargo.lock` (the workspace root).
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(binary) = find_binary_near_exe(&exe) {
+            return Ok(binary);
+        }
     }
 
-    // 3. PATH lookup
+    // 3. CARGO_TARGET_DIR — if set, look directly in its debug/release subdirs.
+    //    This covers custom target directories (e.g. agent worktrees using
+    //    CARGO_TARGET_DIR=/tmp/agent-...).
+    if let Ok(target_dir) = std::env::var("CARGO_TARGET_DIR") {
+        if let Some(binary) = find_binary_in_target(std::path::Path::new(&target_dir)) {
+            return Ok(binary);
+        }
+    }
+
+    // 4. CARGO_MANIFEST_DIR walk — find workspace root via Cargo.lock, then
+    //    check target/{debug,release}/perl-lsp[.exe].
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let crate_dir = std::path::Path::new(&manifest_dir);
+        let workspace_root =
+            crate_dir.ancestors().find(|p| p.join("Cargo.lock").exists()).unwrap_or(crate_dir);
+        if let Some(binary) = find_binary_in_target(workspace_root) {
+            return Ok(binary);
+        }
+    }
+
+    // 5. PATH lookup
     if let Ok(p) = which::which("perl-lsp") {
         return Ok(p.to_string_lossy().to_string());
     }
@@ -645,12 +682,51 @@ pub fn resolve_binary() -> Result<String> {
         return Ok(p.to_string_lossy().to_string());
     }
 
-    // 4. cargo run fallback — we return the cargo invocation as a string
-    // handled specially by UxClient::spawn.
+    // 6. No binary found — actionable error message.
     Err(anyhow!(
         "perl-lsp binary not found. \
         Set PERL_LSP_BIN=/path/to/perl-lsp or run: cargo build -p perl-lsp-rs"
     ))
+}
+
+/// Walk up from the test binary's path to locate `perl-lsp[.exe]` in the
+/// nearest `target/debug` or `target/release` directory.
+///
+/// Test binaries are placed in `<workspace>/target/<profile>/deps/`, so we
+/// ascend until we find a directory named `target` whose parent has a
+/// `Cargo.lock` file, then probe `<profile>/perl-lsp[.exe]`.
+fn find_binary_near_exe(exe: &std::path::Path) -> Option<String> {
+    // Walk up the ancestor chain looking for a `target` directory.
+    for ancestor in exe.ancestors() {
+        if ancestor.file_name().and_then(|n| n.to_str()) == Some("target") {
+            let workspace_root = ancestor.parent()?;
+            if workspace_root.join("Cargo.lock").exists() {
+                return find_binary_in_target(workspace_root);
+            }
+        }
+    }
+    None
+}
+
+/// Given a workspace root, probe `target/debug` and `target/release` for
+/// the `perl-lsp` binary (with `.exe` extension on Windows).
+fn find_binary_in_target(workspace_root: &std::path::Path) -> Option<String> {
+    let bin_name = if cfg!(windows) { "perl-lsp.exe" } else { "perl-lsp" };
+    let alt_bin_name = if cfg!(windows) { "perllsp.exe" } else { "perllsp" };
+
+    // Prefer debug (matches `cargo test` default profile) over release.
+    let profiles = ["debug", "release"];
+    for profile in profiles {
+        let candidate = workspace_root.join("target").join(profile).join(bin_name);
+        if candidate.exists() {
+            return Some(candidate.to_string_lossy().into_owned());
+        }
+        let alt_candidate = workspace_root.join("target").join(profile).join(alt_bin_name);
+        if alt_candidate.exists() {
+            return Some(alt_candidate.to_string_lossy().into_owned());
+        }
+    }
+    None
 }
 
 /// Utility: find `perl` on PATH, returning its path or `None`.


### PR DESCRIPTION
## Root Cause

`resolve_binary()` in `crates/perl-lsp-ux-tests/src/lib.rs` used `option_env!("CARGO_BIN_EXE_perl-lsp")` to locate the LSP server binary. This compile-time macro bakes the path into the binary at compile time. On Windows CI, the path is stored with backslashes stripped — returning `H:CodeRustperl-lsp...` instead of `H:\Code\Rust\perl-lsp\...`. When the test process tries to spawn the binary using this corrupt path, it fails with OS error 3 ("The system cannot find the path specified"), causing all UX scenario tests to report "Failed to spawn LSP server".

This blocked ALL cluster winners' UX Regression Gate (#5921, #5936, #5938, #5939, #5943, #5952, #5754) — 3/3 scenario_01 tests failing on Windows CI.

## Fix

Replace the compile-time `option_env!` approach with a 6-step runtime resolution strategy:

1. `PERL_LSP_BIN` env var (explicit override — unchanged)
2. `std::env::current_exe()` ancestor walk — traverse up from the test binary's path until we find a `target/` dir whose parent has `Cargo.lock`, then probe `target/{debug,release}/perl-lsp[.exe]`. Uses `std::path::Path::join` so separators are always correct on all platforms.
3. `CARGO_TARGET_DIR` env var probe — handles custom target directories (agent worktrees)
4. `CARGO_MANIFEST_DIR` workspace-root walk — fallback matching `perl-lsp-rs`'s own `binary_resolution.rs` pattern
5. PATH lookup (`which::which`)
6. Actionable error message

## Test Plan

- [x] `cargo check -p perl-lsp-ux-tests` — compiles clean
- [x] `cargo clippy -p perl-lsp-ux-tests` — no warnings
- [x] `cargo fmt -p perl-lsp-ux-tests -- --check` — no formatting issues
- [x] `cargo test -p perl-lsp-ux-tests --lib` — 2 tests pass
- [ ] CI Windows: UX Regression Gate should now find `target\debug\perl-lsp.exe` via the ancestor walk and spawn the server successfully

## Files Changed

- `crates/perl-lsp-ux-tests/src/lib.rs` — single function change (`resolve_binary`) + two private helpers (`find_binary_near_exe`, `find_binary_in_target`)