### PR TITLE
feat(lexer-metrics): publish lexer performance scorecard from existing benches (#6588)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,7 @@ dependencies = [
  "perl-token",
  "phf",
  "proptest",
+ "serde_json",
  "thiserror",
  "tracing",
  "unicode-ident",

--- a/crates/perl-lexer/Cargo.toml
+++ b/crates/perl-lexer/Cargo.toml
@@ -27,6 +27,7 @@ perl-position-tracking = { workspace = true }
 
 [dev-dependencies]
 criterion.workspace = true
+serde_json.workspace = true
 proptest.workspace = true
 perl-parser-core = { workspace = true }
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lexer/benches/lexer_benchmarks.rs
+++ b/crates/perl-lexer/benches/lexer_benchmarks.rs
@@ -1,9 +1,200 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use perl_lexer::{PerlLexer, Token};
+use serde_json::{Map, json};
+use std::fs;
 use std::hint::black_box;
+use std::path::PathBuf;
+use std::time::Instant;
+
+const SCORECARD_SCHEMA_VERSION: u32 = 1;
+const SCORECARD_SAMPLE_COUNT: usize = 200;
+const SCORECARD_WARMUP_RUNS: usize = 20;
+
+struct BenchScenario {
+    name: &'static str,
+    input: String,
+}
 
 fn collect_all_tokens(mut lexer: PerlLexer) -> Vec<Token> {
     lexer.collect_tokens()
+}
+
+fn scorecard_path() -> PathBuf {
+    if let Ok(path) = std::env::var("PERL_LEXER_SCORECARD_PATH") {
+        return PathBuf::from(path);
+    }
+
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("target")
+        .join("criterion")
+        .join("lexer_scorecard.json")
+}
+
+fn bench_scenarios() -> Vec<BenchScenario> {
+    let mut large_file = String::new();
+    for i in 0..1000 {
+        large_file.push_str(&format!("my $var{} = {};\n", i, i));
+        large_file.push_str(&format!("print \"Value: $var{}\\n\";\n", i));
+        if i % 10 == 0 {
+            large_file.push_str(&format!("if ($var{} =~ /\\d+/) {{\n", i));
+            large_file.push_str(&format!("    $var{} = $var{} / 2;\n", i, i));
+            large_file.push_str("}\n");
+        }
+    }
+
+    let keyword_heavy =
+        "if else while until for foreach return last next redo package require default continue"
+            .repeat(100);
+
+    vec![
+        BenchScenario { name: "simple_tokens", input: "my $x = 42; print $x;".to_string() },
+        BenchScenario {
+            name: "slash_disambiguation",
+            input: r#"
+                my $x = 10 / 2;
+                if ($str =~ /pattern/) {
+                    $str =~ s/foo/bar/g;
+                }
+                print 1/ /abc/;
+            "#
+            .to_string(),
+        },
+        BenchScenario {
+            name: "string_interpolation",
+            input: r#"
+                my $name = "World";
+                print "Hello, $name!\n";
+                print "The answer is ${count + 1}\n";
+                print "Array: @items\n";
+            "#
+            .to_string(),
+        },
+        BenchScenario { name: "large_file", input: large_file },
+        BenchScenario {
+            name: "whitespace_heavy",
+            input: r#"
+            # This is a comment
+            my   $x   =   42  ;  # Another comment
+
+            print    $x    ;
+
+            # More comments
+            "#
+            .to_string(),
+        },
+        BenchScenario {
+            name: "operator_heavy",
+            input: "$a += $b -= $c *= $d /= $e %= $f **= $g &&= $h ||= $i //= $j".to_string(),
+        },
+        BenchScenario {
+            name: "number_parsing",
+            input: "123 456.789 1_234_567 1.23e45 0xFF 0377 0b1010".to_string(),
+        },
+        BenchScenario { name: "keyword_heavy", input: keyword_heavy },
+    ]
+}
+
+fn emit_scorecard() {
+    let mut families = Map::new();
+    let scenarios = bench_scenarios();
+
+    for scenario in &scenarios {
+        for _ in 0..SCORECARD_WARMUP_RUNS {
+            let _ = collect_all_tokens(PerlLexer::new(&scenario.input));
+        }
+
+        let mut sample_time_ns = Vec::with_capacity(SCORECARD_SAMPLE_COUNT);
+        let mut sample_tokens = Vec::with_capacity(SCORECARD_SAMPLE_COUNT);
+        for _ in 0..SCORECARD_SAMPLE_COUNT {
+            let start = Instant::now();
+            let tokens = collect_all_tokens(PerlLexer::new(&scenario.input));
+            sample_time_ns.push(start.elapsed().as_nanos() as f64);
+            sample_tokens.push(tokens.len() as f64);
+        }
+
+        let total_time_ns: f64 = sample_time_ns.iter().sum();
+        let total_tokens: f64 = sample_tokens.iter().sum();
+        let mean_time_ns = total_time_ns / SCORECARD_SAMPLE_COUNT as f64;
+        let variance = sample_time_ns
+            .iter()
+            .map(|sample| {
+                let delta = *sample - mean_time_ns;
+                delta * delta
+            })
+            .sum::<f64>()
+            / SCORECARD_SAMPLE_COUNT as f64;
+        let std_dev_ns = variance.sqrt();
+        let min_time_ns = sample_time_ns.iter().copied().fold(f64::INFINITY, f64::min);
+        let max_time_ns = sample_time_ns.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        let tokens_per_second = if total_time_ns > 0.0 {
+            total_tokens / (total_time_ns / 1_000_000_000.0)
+        } else {
+            0.0
+        };
+        let throughput_bytes_per_second = if total_time_ns > 0.0 {
+            (scenario.input.len() as f64 * SCORECARD_SAMPLE_COUNT as f64)
+                / (total_time_ns / 1_000_000_000.0)
+        } else {
+            0.0
+        };
+
+        families.insert(
+            scenario.name.to_string(),
+            json!({
+                "input_bytes": scenario.input.len(),
+                "sample_count": SCORECARD_SAMPLE_COUNT,
+                "total_time_ns": total_time_ns,
+                "mean_time_ns": mean_time_ns,
+                "std_dev_ns": std_dev_ns,
+                "min_time_ns": min_time_ns,
+                "max_time_ns": max_time_ns,
+                "total_tokens": total_tokens,
+                "tokens_per_second": tokens_per_second,
+                "throughput_bytes_per_second": throughput_bytes_per_second
+            }),
+        );
+    }
+
+    let output = json!({
+        "schema_version": SCORECARD_SCHEMA_VERSION,
+        "tool": "perl-lexer criterion benchmark",
+        "benchmark": "lexer_benchmarks",
+        "sample_count": SCORECARD_SAMPLE_COUNT,
+        "families": families
+    });
+
+    let output_path = scorecard_path();
+    let Some(parent) = output_path.parent() else {
+        eprintln!("failed to emit lexer scorecard: missing parent dir");
+        return;
+    };
+
+    if let Err(error) = fs::create_dir_all(parent) {
+        eprintln!("failed to emit lexer scorecard directory: {error}");
+        return;
+    }
+
+    let encoded = match serde_json::to_string_pretty(&output) {
+        Ok(value) => value,
+        Err(error) => {
+            eprintln!("failed to serialize lexer scorecard: {error}");
+            return;
+        }
+    };
+
+    if let Err(error) = fs::write(&output_path, encoded) {
+        eprintln!("failed to write lexer scorecard {}: {error}", output_path.display());
+        return;
+    }
+
+    println!("lexer scorecard written to {}", output_path.display());
+}
+
+fn configure_criterion() -> Criterion {
+    emit_scorecard();
+    Criterion::default()
 }
 
 fn bench_simple_tokens(c: &mut Criterion) {
@@ -51,7 +242,6 @@ fn bench_string_interpolation(c: &mut Criterion) {
 }
 
 fn bench_large_file(c: &mut Criterion) {
-    // Generate a large file
     let mut input = String::new();
     for i in 0..1000 {
         input.push_str(&format!("my $var{} = {};\n", i, i));
@@ -75,9 +265,9 @@ fn bench_whitespace_heavy(c: &mut Criterion) {
     let input = r#"
     # This is a comment
     my   $x   =   42  ;  # Another comment
-    
+
     print    $x    ;
-    
+
     # More comments
     "#;
 
@@ -124,15 +314,17 @@ fn bench_keyword_heavy(c: &mut Criterion) {
     });
 }
 
-criterion_group!(
-    benches,
-    bench_simple_tokens,
-    bench_slash_disambiguation,
-    bench_string_interpolation,
-    bench_large_file,
-    bench_whitespace_heavy,
-    bench_operator_heavy,
-    bench_number_parsing,
-    bench_keyword_heavy
-);
+criterion_group! {
+    name = benches;
+    config = configure_criterion();
+    targets =
+        bench_simple_tokens,
+        bench_slash_disambiguation,
+        bench_string_interpolation,
+        bench_large_file,
+        bench_whitespace_heavy,
+        bench_operator_heavy,
+        bench_number_parsing,
+        bench_keyword_heavy
+}
 criterion_main!(benches);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1225,6 +1225,15 @@ enum MetricsCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Lexer benchmark scorecard summary.
+    LexerStats {
+        /// Path to lexer scorecard JSON (default: target/criterion/lexer_scorecard.json)
+        #[arg(long)]
+        input: Option<PathBuf>,
+        /// Write output to .ci/metrics/lexer.json
+        #[arg(long)]
+        json: bool,
+    },
     /// LSP editor-intelligence scorecard — fixture inventory and pass rates.
     LspStats {
         /// Write output to .ci/metrics/editor_intelligence.json
@@ -1580,6 +1589,7 @@ fn main() -> Result<()> {
         Commands::CheckTestWiring => check_test_wiring::run(),
         Commands::Metrics { command } => match command {
             MetricsCommand::ParserStats { input, json } => metrics::parser_stats::run(input, json),
+            MetricsCommand::LexerStats { input, json } => metrics::lexer_stats::run(input, json),
             MetricsCommand::LspStats { json } => metrics::lsp_stats::run_with_json(json),
             MetricsCommand::WorkspaceStats => metrics::workspace_stats::run(),
             MetricsCommand::DiagnosticsStats => metrics::diagnostics_stats::run(),

--- a/xtask/src/tasks/metrics/lexer_stats.rs
+++ b/xtask/src/tasks/metrics/lexer_stats.rs
@@ -1,0 +1,136 @@
+//! Lexer benchmark scorecard summary subcommand.
+//!
+//! Reads `target/criterion/lexer_scorecard.json` (or `--input`) emitted by
+//! `cargo bench -p perl-lexer --bench lexer_benchmarks` and optionally writes
+//! `.ci/metrics/lexer.json` so status docs can reference one stable artifact.
+
+use crate::utils::project_root;
+use chrono::Utc;
+use color_eyre::eyre::{Context, Result, bail};
+use serde::Serialize;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Serialize)]
+struct LexerMetricsOutput {
+    schema_version: u32,
+    measured_at: String,
+    subsystem: &'static str,
+    metrics: LexerMetrics,
+}
+
+#[derive(Debug, Serialize)]
+struct LexerMetrics {
+    family_count: usize,
+    families: Vec<LexerFamily>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct LexerFamily {
+    name: String,
+    sample_count: u64,
+    total_time_ns: f64,
+    mean_time_ns: f64,
+    tokens_per_second: f64,
+}
+
+pub fn run(input: Option<PathBuf>, json: bool) -> Result<()> {
+    let root = project_root()?;
+    let input_path = input.unwrap_or_else(|| default_input_path(&root));
+
+    let raw = fs::read_to_string(&input_path)
+        .with_context(|| format!("reading benchmark file: {}", input_path.display()))?;
+    let parsed: Value =
+        serde_json::from_str(&raw).with_context(|| "parsing lexer scorecard JSON")?;
+
+    let families = parse_families(&parsed)?;
+    print_table(&families);
+
+    if json {
+        write_json_output(&root, &families)?;
+    }
+
+    Ok(())
+}
+
+fn default_input_path(root: &Path) -> PathBuf {
+    let workspace_target = root.join("target").join("criterion").join("lexer_scorecard.json");
+    if workspace_target.exists() {
+        return workspace_target;
+    }
+
+    root.join("crates")
+        .join("perl-lexer")
+        .join("target")
+        .join("criterion")
+        .join("lexer_scorecard.json")
+}
+
+fn parse_families(parsed: &Value) -> Result<Vec<LexerFamily>> {
+    let Some(families) = parsed.get("families").and_then(Value::as_object) else {
+        bail!("missing 'families' object in lexer scorecard");
+    };
+
+    let mut rows = Vec::with_capacity(families.len());
+    for (name, row) in families {
+        let sample_count = row.get("sample_count").and_then(Value::as_u64).unwrap_or(0);
+        let total_time_ns = row.get("total_time_ns").and_then(Value::as_f64).unwrap_or(0.0);
+        let mean_time_ns = row.get("mean_time_ns").and_then(Value::as_f64).unwrap_or(0.0);
+        let tokens_per_second = row.get("tokens_per_second").and_then(Value::as_f64).unwrap_or(0.0);
+
+        rows.push(LexerFamily {
+            name: name.to_string(),
+            sample_count,
+            total_time_ns,
+            mean_time_ns,
+            tokens_per_second,
+        });
+    }
+
+    rows.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(rows)
+}
+
+fn print_table(families: &[LexerFamily]) {
+    println!(
+        "{:<24} {:>10} {:>16} {:>16} {:>16}",
+        "Family", "Samples", "Total (ms)", "Mean (µs)", "Tokens/sec"
+    );
+    println!("{}", "-".repeat(88));
+
+    for family in families {
+        println!(
+            "{:<24} {:>10} {:>16.3} {:>16.3} {:>16.1}",
+            family.name,
+            family.sample_count,
+            family.total_time_ns / 1_000_000.0,
+            family.mean_time_ns / 1_000.0,
+            family.tokens_per_second,
+        );
+    }
+
+    println!();
+    println!("{} benchmark family row(s) loaded.", families.len());
+}
+
+fn write_json_output(root: &Path, families: &[LexerFamily]) -> Result<()> {
+    let metrics_dir = root.join(".ci").join("metrics");
+    fs::create_dir_all(&metrics_dir)
+        .with_context(|| format!("creating {}", metrics_dir.display()))?;
+
+    let output = LexerMetricsOutput {
+        schema_version: 1,
+        measured_at: Utc::now().to_rfc3339(),
+        subsystem: "lexer",
+        metrics: LexerMetrics { family_count: families.len(), families: families.to_vec() },
+    };
+
+    let out_path = metrics_dir.join("lexer.json");
+    let encoded =
+        serde_json::to_string_pretty(&output).with_context(|| "serializing lexer metrics")?;
+    fs::write(&out_path, encoded).with_context(|| format!("writing {}", out_path.display()))?;
+
+    println!("Wrote {}", out_path.display());
+    Ok(())
+}

--- a/xtask/src/tasks/metrics/mod.rs
+++ b/xtask/src/tasks/metrics/mod.rs
@@ -3,6 +3,7 @@
 //! Each leaf module implements one user-facing subcommand.
 
 pub mod diagnostics_stats;
+pub mod lexer_stats;
 pub mod lsp_stats;
 pub mod memory;
 pub mod parser_stats;


### PR DESCRIPTION
### Motivation
- Provide a single, stable, machine-readable lexer performance artifact so benchmark families are easy to track and reference from status docs.
- Make it trivial to compare per-family timing and throughput (tokens/sec) over time without parsing raw Criterion outputs.

### Description
- Emit a JSON scorecard from the lexer bench harness at `target/criterion/lexer_scorecard.json` (overrideable via `PERL_LEXER_SCORECARD_PATH`) containing all 8 benchmark families and per-family fields like `sample_count`, `total_time_ns`, `mean_time_ns`, `std_dev_ns`, `min_time_ns`, `max_time_ns`, `total_tokens`, `tokens_per_second`, and `throughput_bytes_per_second` (implemented in `crates/perl-lexer/benches/lexer_benchmarks.rs`).
- Add a minimal `cargo xtask` hook `metrics lexer-stats` that reads the scorecard, prints a stable table, and can write `.ci/metrics/lexer.json` for status-doc consumption (`xtask/src/tasks/metrics/lexer_stats.rs` and wiring in `xtask/src/main.rs`).
- Add `serde_json` to `crates/perl-lexer` dev-dependencies to support bench-side serialization and make small path-selection adjustments so the scorecard is discoverable from the workspace root.

### Testing
- Ran `cargo bench -p perl-lexer --bench lexer_benchmarks` and observed the bench run complete and the scorecard emitted to `target/criterion/lexer_scorecard.json` (success).
- Ran `cargo xtask metrics lexer-stats --json` which parsed the scorecard, printed the family table, and wrote `.ci/metrics/lexer.json` (success).
- Ran `cargo check --workspace --all-targets` to validate workspace build (success).
- Ran `cargo fmt --all` to ensure formatting (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c635ac88333980ba7f591d5b420)