### PR TITLE
perf(tree-sitter-perl-c): expand bench_parser_c into cold/warm/reuse benchmark modes (#6586)

### DIFF
--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -111,7 +111,35 @@ match try_parse_perl_file("script.pl") {
     - `--root-kind` to print the root node kind
     - `--has-error` to print `true`/`false` for parse errors
     - `--sexp` to print the full tree-sitter s-expression
-- `bench_parser_c` — parse a Perl file and print timing (requires `--features test-utils`)
+- `bench_parser_c` — benchmark parse throughput and emit stable `key=value` output (requires `--features test-utils`)
+
+### `bench_parser_c` modes
+
+`bench_parser_c` supports both one-shot and parser-reuse flows:
+
+- `--mode cold` (default): create a fresh parser for every iteration
+- `--mode warm`: reuse one parser across all iterations
+- `--iterations N` / `-n N`: run N parse iterations
+- `--input str|bytes` (default `str`): parse through UTF-8 string or raw-byte path
+- `--cold` / `--warm`: shorthand for `--mode cold|warm`
+
+Example:
+
+```bash
+cargo run -p tree-sitter-perl-c --bin bench_parser_c --features test-utils -- \
+  examples/perl/simple.pl --mode warm --iterations 200 --input bytes
+```
+
+Output is intentionally stable for run-to-run diffing:
+
+```text
+mode=warm
+input=bytes
+iterations=200
+total_us=12345
+avg_us=61
+has_error=false
+```
 
 Examples:
 

--- a/crates/tree-sitter-perl-c/src/bin/bench_parser.rs
+++ b/crates/tree-sitter-perl-c/src/bin/bench_parser.rs
@@ -1,98 +1,218 @@
 use std::env;
 use std::fs;
 use std::time::Instant;
-use tree_sitter_perl_c::{PerlParser, parse_perl_code};
+use tree_sitter_perl_c::{
+    parse_perl_bytes, parse_perl_bytes_with_parser, parse_perl_code, parse_perl_code_with_parser,
+    try_create_parser,
+};
 
 #[derive(Clone, Copy)]
 enum Mode {
-    Wrapper,
-    ReuseParser,
+    Cold,
+    Warm,
 }
 
 impl Mode {
-    fn from_arg(value: &str) -> Option<Self> {
-        match value {
-            "wrapper" => Some(Self::Wrapper),
-            "reuse-parser" => Some(Self::ReuseParser),
-            _ => None,
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Cold => "cold",
+            Self::Warm => "warm",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum InputKind {
+    Str,
+    Bytes,
+}
+
+impl InputKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Str => "str",
+            Self::Bytes => "bytes",
+        }
+    }
+}
+
+struct Config {
+    file_path: String,
+    mode: Mode,
+    input: InputKind,
+    iterations: u64,
+}
+
+struct BenchSummary {
+    mode: Mode,
+    input: InputKind,
+    iterations: u64,
+    total_us: u128,
+    avg_us: u128,
+    has_error: bool,
+}
+
+fn usage() -> &'static str {
+    "Usage: bench_parser_c <file> [--mode cold|warm] [--iterations N] [--input str|bytes]\n\
+     Defaults: --mode cold --iterations 1 --input str"
+}
+
+fn parse_config(args: &[String]) -> Result<Config, String> {
+    if args.len() < 2 {
+        return Err(usage().to_string());
+    }
+
+    let file_path = args[1].clone();
+    let mut mode = Mode::Cold;
+    let mut input = InputKind::Str;
+    let mut iterations = 1_u64;
+
+    let mut index = 2_usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--mode" => {
+                let value =
+                    args.get(index + 1).ok_or_else(|| "Missing value for --mode".to_string())?;
+                mode = match value.as_str() {
+                    "cold" => Mode::Cold,
+                    "warm" => Mode::Warm,
+                    _ => return Err(format!("Invalid mode: {value}")),
+                };
+                index += 2;
+            }
+            "--iterations" | "-n" => {
+                let value = args
+                    .get(index + 1)
+                    .ok_or_else(|| "Missing value for --iterations".to_string())?;
+                iterations = value
+                    .parse::<u64>()
+                    .map_err(|_| format!("Invalid iteration count: {value}"))?;
+                if iterations == 0 {
+                    return Err("--iterations must be greater than 0".to_string());
+                }
+                index += 2;
+            }
+            "--input" => {
+                let value =
+                    args.get(index + 1).ok_or_else(|| "Missing value for --input".to_string())?;
+                input = match value.as_str() {
+                    "str" => InputKind::Str,
+                    "bytes" => InputKind::Bytes,
+                    _ => return Err(format!("Invalid input mode: {value}")),
+                };
+                index += 2;
+            }
+            "--cold" => {
+                mode = Mode::Cold;
+                index += 1;
+            }
+            "--warm" => {
+                mode = Mode::Warm;
+                index += 1;
+            }
+            "--help" | "-h" => {
+                return Err(usage().to_string());
+            }
+            unknown => {
+                return Err(format!("Unknown argument: {unknown}"));
+            }
         }
     }
 
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Wrapper => "wrapper",
-            Self::ReuseParser => "reuse-parser",
+    Ok(Config { file_path, mode, input, iterations })
+}
+
+fn parse_cold(input: InputKind, code: &[u8]) -> Result<bool, String> {
+    let tree = match input {
+        InputKind::Str => {
+            let as_str = std::str::from_utf8(code)
+                .map_err(|err| format!("Input is not UTF-8 for --input str: {err}"))?;
+            parse_perl_code(as_str).map_err(|err| err.to_string())?
+        }
+        InputKind::Bytes => parse_perl_bytes(code).map_err(|err| err.to_string())?,
+    };
+    Ok(tree.root_node().has_error())
+}
+
+fn run_benchmark(config: &Config, code: &[u8]) -> Result<BenchSummary, String> {
+    let mut saw_error = false;
+    let start = Instant::now();
+
+    match config.mode {
+        Mode::Cold => {
+            for _ in 0..config.iterations {
+                if parse_cold(config.input, code)? {
+                    saw_error = true;
+                }
+            }
+        }
+        Mode::Warm => {
+            let mut parser = try_create_parser().map_err(|err| err.to_string())?;
+            for _ in 0..config.iterations {
+                let tree = match config.input {
+                    InputKind::Str => {
+                        let as_str = std::str::from_utf8(code)
+                            .map_err(|err| format!("Input is not UTF-8 for --input str: {err}"))?;
+                        parse_perl_code_with_parser(&mut parser, as_str)
+                            .map_err(|err| err.to_string())?
+                    }
+                    InputKind::Bytes => parse_perl_bytes_with_parser(&mut parser, code)
+                        .map_err(|err| err.to_string())?,
+                };
+                if tree.root_node().has_error() {
+                    saw_error = true;
+                }
+            }
         }
     }
+
+    let total_us = start.elapsed().as_micros();
+    let avg_us = total_us / u128::from(config.iterations);
+
+    Ok(BenchSummary {
+        mode: config.mode,
+        input: config.input,
+        iterations: config.iterations,
+        total_us,
+        avg_us,
+        has_error: saw_error,
+    })
+}
+
+fn print_summary(summary: &BenchSummary) {
+    println!("mode={}", summary.mode.as_str());
+    println!("input={}", summary.input.as_str());
+    println!("iterations={}", summary.iterations);
+    println!("total_us={}", summary.total_us);
+    println!("avg_us={}", summary.avg_us);
+    println!("has_error={}", summary.has_error);
 }
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    if args.len() < 2 || args.len() > 4 {
-        eprintln!("Usage: bench_parser_c <file> [wrapper|reuse-parser] [iterations]");
-        std::process::exit(1);
-    }
-    let file_path = &args[1];
-    let mode =
-        args.get(2).map(String::as_str).map_or(Some(Mode::Wrapper), Mode::from_arg).unwrap_or_else(
-            || {
-                eprintln!("Invalid mode. Expected one of: wrapper, reuse-parser");
-                std::process::exit(1);
-            },
-        );
-    let iterations =
-        args.get(3).map(String::as_str).map_or(Ok(100_usize), str::parse::<usize>).unwrap_or_else(
-            |_| {
-                eprintln!("Iterations must be a positive integer");
-                std::process::exit(1);
-            },
-        );
-    if iterations == 0 {
-        eprintln!("Iterations must be greater than zero");
-        std::process::exit(1);
-    }
-
-    let code = fs::read_to_string(file_path).unwrap_or_else(|e| {
-        eprintln!("Failed to read file: {}", e);
-        std::process::exit(1);
-    });
-
-    let start = Instant::now();
-    let mut had_error_node = false;
-    match mode {
-        Mode::Wrapper => {
-            for _ in 0..iterations {
-                let tree = parse_perl_code(&code).unwrap_or_else(|e| {
-                    eprintln!("Parse error: {}", e);
-                    std::process::exit(1);
-                });
-                had_error_node = tree.root_node().has_error();
-            }
+    let config = match parse_config(&args) {
+        Ok(config) => config,
+        Err(message) => {
+            eprintln!("{message}");
+            std::process::exit(1);
         }
-        Mode::ReuseParser => {
-            let mut parser = PerlParser::new().unwrap_or_else(|e| {
-                eprintln!("Failed to create parser: {}", e);
-                std::process::exit(1);
-            });
-            for _ in 0..iterations {
-                let tree = parser.parse_code(&code).unwrap_or_else(|e| {
-                    eprintln!("Parse error: {}", e);
-                    std::process::exit(1);
-                });
-                had_error_node = tree.root_node().has_error();
-            }
+    };
+
+    let code = match fs::read(&config.file_path) {
+        Ok(code) => code,
+        Err(err) => {
+            eprintln!("Failed to read file: {err}");
+            std::process::exit(1);
+        }
+    };
+
+    match run_benchmark(&config, &code) {
+        Ok(summary) => {
+            print_summary(&summary);
+        }
+        Err(err) => {
+            eprintln!("Parse error: {err}");
+            std::process::exit(1);
         }
     }
-
-    let duration = start.elapsed().as_micros();
-    let avg_duration = duration as f64 / iterations as f64;
-    println!(
-        "status=success mode={} iterations={} error={} duration_us={} avg_us={:.2}",
-        mode.as_str(),
-        iterations,
-        had_error_node,
-        duration,
-        avg_duration
-    );
-    // Always return success (0) - parse errors are indicated in the error field
 }


### PR DESCRIPTION
### Motivation

- The existing `bench_parser_c` binary was a one-shot stopwatch and could not measure parser creation overhead or parser-reuse benefits across repeated parses.
- Provide a stable, machine-readable benchmark output to make run-to-run diffs and throughput comparisons reliable between the C/FFI grammar and the native parser.

### Description

- Added a CLI-driven benchmark binary at `crates/tree-sitter-perl-c/src/bin/bench_parser.rs` with `--mode cold|warm`, `--iterations N`/`-n N`, `--input str|bytes`, and `--cold`/`--warm` shorthands.
- Implemented two execution paths: `cold` (fresh parser per iteration using `parse_perl_code`/`parse_perl_bytes`) and `warm` (single reused `tree_sitter::Parser` created by `try_create_parser` and used across iterations via `parse_with_reused_parser`).
- Emit stable `key=value` lines for `mode`, `input`, `iterations`, `total_us`, `avg_us`, and `has_error` so outputs are deterministic and diffable.
- Documented the new modes and example usage/output in `crates/tree-sitter-perl-c/README.md`.

### Testing

- Ran the updated benchmark binary manually with `cargo run -p tree-sitter-perl-c --bin bench_parser_c --features test-utils -- examples/perl/simple.pl` and with `--mode warm --iterations 50 --input bytes`, both producing the expected `key=value` output (success).
- Executed `cargo test -p tree-sitter-perl-c` and all unit, BDD, and doc tests passed (7 unit tests + 9 BDD tests + 5 doctests; all ok).
- Executed `cargo check --all-targets -p tree-sitter-perl-c` and `cargo xtask fmt` which completed successfully in this environment.
- Could not run `just pr-fast` because `just` is not installed in the environment, noted in verification steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb276e2a208333975283fc5a41956d)