### PR TITLE
perf(tree-sitter-perl-c): expand bench_parser_c into cold/warm/reuse benchmark modes (#6585)

### DIFF
--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -85,7 +85,39 @@ for snippet in &["my $x = 1;", "print $x;"] {
 ## Binaries
 
 - `parse_c` — parse a Perl file and exit with 0 (success) or 1 (error)
-- `bench_parser_c` — parse a Perl file and print timing (requires `--features test-utils`)
+- `bench_parser_c` — benchmark parse throughput with stable key=value output (requires `--features test-utils`)
+
+### `bench_parser_c` modes
+
+```bash
+# Default: single cold parse from UTF-8 string path
+cargo run -p tree-sitter-perl-c --bin bench_parser_c --features test-utils -- script.pl
+
+# Reuse a parser/tree for repeated parses
+cargo run -p tree-sitter-perl-c --bin bench_parser_c --features test-utils -- --mode warm --iterations 100 script.pl
+
+# Exercise raw bytes API path (works with non-UTF-8 source)
+cargo run -p tree-sitter-perl-c --bin bench_parser_c --features test-utils -- --mode cold --input bytes --iterations 50 script.pl
+```
+
+Supported flags:
+
+- `--mode cold|warm` (default `cold`)
+  - `cold`: parser setup + parse each iteration
+  - `warm`: reuse one parser and previous tree across iterations
+- `--iterations N` or `-n N` (default `1`)
+- `--input str|bytes` (default `str`)
+
+Output is emitted as one key=value pair per line for easy machine diffing:
+
+```text
+mode=warm
+input=str
+iterations=100
+total_us=12345
+avg_us=123.450
+has_error=false
+```
 
 ## Build Requirements
 

--- a/crates/tree-sitter-perl-c/src/bin/bench_parser.rs
+++ b/crates/tree-sitter-perl-c/src/bin/bench_parser.rs
@@ -1,31 +1,223 @@
 use std::env;
 use std::fs;
 use std::time::Instant;
-use tree_sitter_perl_c::parse_perl_code;
+
+use tree_sitter::{Parser, Tree};
+use tree_sitter_perl_c::{parse_perl_bytes, parse_perl_code, try_create_parser};
+
+#[derive(Clone, Copy)]
+enum BenchMode {
+    Cold,
+    Warm,
+}
+
+impl BenchMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Cold => "cold",
+            Self::Warm => "warm",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum InputMode {
+    Str,
+    Bytes,
+}
+
+impl InputMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Str => "str",
+            Self::Bytes => "bytes",
+        }
+    }
+}
+
+struct Config {
+    file_path: String,
+    mode: BenchMode,
+    input: InputMode,
+    iterations: u32,
+}
+
+fn print_usage() {
+    eprintln!(
+        "Usage: bench_parser_c [--mode cold|warm] [--iterations N] [--input str|bytes] <file>"
+    );
+    eprintln!("  --mode cold|warm    cold=create parser every iteration (default: cold)");
+    eprintln!("  --iterations N       number of parse iterations (default: 1)");
+    eprintln!("  --input str|bytes    parse via string or raw bytes path (default: str)");
+}
+
+fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Config, String> {
+    let mut mode = BenchMode::Cold;
+    let mut input = InputMode::Str;
+    let mut iterations = 1_u32;
+    let mut file_path: Option<String> = None;
+
+    let mut iter = args.into_iter();
+    let _binary_name = iter.next();
+
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--mode" => {
+                let value = iter.next().ok_or("missing value for --mode")?;
+                mode = match value.as_str() {
+                    "cold" => BenchMode::Cold,
+                    "warm" => BenchMode::Warm,
+                    _ => return Err(format!("invalid mode: {value}")),
+                };
+            }
+            "--iterations" | "-n" => {
+                let value = iter.next().ok_or("missing value for --iterations")?;
+                let parsed = value
+                    .parse::<u32>()
+                    .map_err(|_| format!("invalid iteration count: {value}"))?;
+                if parsed == 0 {
+                    return Err("iterations must be greater than 0".to_string());
+                }
+                iterations = parsed;
+            }
+            "--input" => {
+                let value = iter.next().ok_or("missing value for --input")?;
+                input = match value.as_str() {
+                    "str" => InputMode::Str,
+                    "bytes" => InputMode::Bytes,
+                    _ => return Err(format!("invalid input mode: {value}")),
+                };
+            }
+            "--help" | "-h" => {
+                return Err("help requested".to_string());
+            }
+            _ if arg.starts_with('-') => {
+                return Err(format!("unknown flag: {arg}"));
+            }
+            _ => {
+                if file_path.is_some() {
+                    return Err("only one file path may be provided".to_string());
+                }
+                file_path = Some(arg);
+            }
+        }
+    }
+
+    let path = file_path.ok_or("missing <file> argument")?;
+
+    Ok(Config { file_path: path, mode, input, iterations })
+}
+
+fn run_cold_str(code: &str, iterations: u32) -> Result<(bool, u128), String> {
+    let mut has_error = false;
+    let start = Instant::now();
+    for _ in 0..iterations {
+        let tree = parse_perl_code(code).map_err(|err| err.to_string())?;
+        has_error |= tree.root_node().has_error();
+    }
+    Ok((has_error, start.elapsed().as_micros()))
+}
+
+fn run_cold_bytes(code: &[u8], iterations: u32) -> Result<(bool, u128), String> {
+    let mut has_error = false;
+    let start = Instant::now();
+    for _ in 0..iterations {
+        let tree = parse_perl_bytes(code).map_err(|err| err.to_string())?;
+        has_error |= tree.root_node().has_error();
+    }
+    Ok((has_error, start.elapsed().as_micros()))
+}
+
+fn parse_with_reused_parser<T: AsRef<[u8]>>(
+    parser: &mut Parser,
+    code: T,
+    previous_tree: Option<&Tree>,
+) -> Result<Tree, String> {
+    parser.parse(code, previous_tree).ok_or_else(|| "Failed to parse code".to_string())
+}
+
+fn run_warm_bytes(code: &[u8], iterations: u32) -> Result<(bool, u128), String> {
+    let mut parser = try_create_parser().map_err(|err| err.to_string())?;
+    let mut has_error = false;
+
+    let start = Instant::now();
+    let mut tree = parse_with_reused_parser(&mut parser, code, None)?;
+    has_error |= tree.root_node().has_error();
+
+    for _ in 1..iterations {
+        tree = parse_with_reused_parser(&mut parser, code, Some(&tree))?;
+        has_error |= tree.root_node().has_error();
+    }
+
+    Ok((has_error, start.elapsed().as_micros()))
+}
+
+fn run_warm_str(code: &str, iterations: u32) -> Result<(bool, u128), String> {
+    let mut parser = try_create_parser().map_err(|err| err.to_string())?;
+    let mut has_error = false;
+
+    let start = Instant::now();
+    let mut tree = parse_with_reused_parser(&mut parser, code, None)?;
+    has_error |= tree.root_node().has_error();
+
+    for _ in 1..iterations {
+        tree = parse_with_reused_parser(&mut parser, code, Some(&tree))?;
+        has_error |= tree.root_node().has_error();
+    }
+
+    Ok((has_error, start.elapsed().as_micros()))
+}
+
+fn run(config: &Config, code: &[u8]) -> Result<(bool, u128), String> {
+    match (config.mode, config.input) {
+        (BenchMode::Cold, InputMode::Str) => {
+            let code_str = std::str::from_utf8(code)
+                .map_err(|_| "input is not valid UTF-8 for --input str".to_string())?;
+            run_cold_str(code_str, config.iterations)
+        }
+        (BenchMode::Cold, InputMode::Bytes) => run_cold_bytes(code, config.iterations),
+        (BenchMode::Warm, InputMode::Str) => {
+            let code_str = std::str::from_utf8(code)
+                .map_err(|_| "input is not valid UTF-8 for --input str".to_string())?;
+            run_warm_str(code_str, config.iterations)
+        }
+        (BenchMode::Warm, InputMode::Bytes) => run_warm_bytes(code, config.iterations),
+    }
+}
+
+fn print_metrics(config: &Config, total_us: u128, has_error: bool) {
+    let avg_us = total_us as f64 / config.iterations as f64;
+    println!("mode={}", config.mode.as_str());
+    println!("input={}", config.input.as_str());
+    println!("iterations={}", config.iterations);
+    println!("total_us={}", total_us);
+    println!("avg_us={avg_us:.3}");
+    println!("has_error={}", has_error);
+}
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!("Usage: bench_parser_c <file>");
-        std::process::exit(1);
-    }
-    let file_path = &args[1];
-    let code = fs::read_to_string(file_path).unwrap_or_else(|e| {
-        eprintln!("Failed to read file: {}", e);
+    let config = match parse_args(env::args()) {
+        Ok(config) => config,
+        Err(error) if error == "help requested" => {
+            print_usage();
+            return;
+        }
+        Err(error) => {
+            eprintln!("Argument error: {error}");
+            print_usage();
+            std::process::exit(1);
+        }
+    };
+
+    let code = fs::read(&config.file_path).unwrap_or_else(|error| {
+        eprintln!("Failed to read file: {error}");
         std::process::exit(1);
     });
-    let start = Instant::now();
-    let result = parse_perl_code(&code);
-    let duration = start.elapsed().as_micros();
-    match result {
-        Ok(tree) => {
-            let has_error = tree.root_node().has_error();
-            println!("status=success error={} duration_us={}", has_error, duration);
-            // Always return success (0) - parse errors are indicated in the error field
-        }
-        Err(e) => {
-            println!("status=failure error=true duration_us={}", duration);
-            eprintln!("Parse error: {}", e);
+
+    match run(&config, &code) {
+        Ok((has_error, total_us)) => print_metrics(&config, total_us, has_error),
+        Err(error) => {
+            eprintln!("Parse error: {error}");
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
### Motivation

- The existing `bench_parser_c` binary timed a single parse and could not show parser-reuse vs cold-setup performance or steady-throughput across iterations.

### Description

- Add CLI flags to `bench_parser_c`: `--mode cold|warm`, `--iterations N` / `-n N`, and `--input str|bytes` to control cold vs warm parsing, loop count, and string/bytes input path (file: `crates/tree-sitter-perl-c/src/bin/bench_parser.rs`).
- Implement dedicated execution paths for cold/warm and `str`/`bytes` inputs, including parser + previous-tree reuse in `warm` mode and aggregated iteration timing.
- Emit stable machine-readable metrics as one `key=value` per line including `mode`, `input`, `iterations`, `total_us`, `avg_us`, and `has_error`.
- Document usage examples, supported flags, and sample output in `crates/tree-sitter-perl-c/README.md`.

### Testing

- Ran `cargo run -p tree-sitter-perl-c --bin bench_parser_c --features test-utils -- crates/tree-sitter-perl-c/README.md` and it executed producing stable `key=value` metrics (completed successfully).
- Ran `cargo test -p tree-sitter-perl-c` and all unit/integration/doc tests passed.
- Ran `cargo check --all-targets -p tree-sitter-perl-c` and it succeeded.
- Ran `cargo xtask fmt`; formatting completed successfully in this environment, while `just pr-fast` was not available here (`just` not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb276e2a208333975283fc5a41956d)