### PR TITLE
feat(tree-sitter-perl-c): expand bench_parser_c into cold/warm/reuse benchmark modes (#6584)

### DIFF
--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -85,7 +85,36 @@ for snippet in &["my $x = 1;", "print $x;"] {
 ## Binaries
 
 - `parse_c` — parse a Perl file and exit with 0 (success) or 1 (error)
-- `bench_parser_c` — parse a Perl file and print timing (requires `--features test-utils`)
+- `bench_parser_c` — benchmark parse timing (requires `--features test-utils`)
+
+### `bench_parser_c` usage
+
+```bash
+cargo run -p tree-sitter-perl-c --bin bench_parser_c --features test-utils -- path/to/file.pl
+```
+
+Default behavior is a single **cold** parse (`mode=cold`, `iterations=1`, `input=str`).
+
+Options:
+
+- `--mode cold|warm`:
+  - `cold` = create/configure a parser for each iteration
+  - `warm` = reuse one configured parser across all iterations
+- `--iterations N` (or `-n N`) = run N parses
+- `--input str|bytes`:
+  - `str` = decode file as UTF-8 and parse as `&str`
+  - `bytes` = parse raw bytes directly
+
+Output format is stable `key=value` lines:
+
+```text
+mode=warm
+input=bytes
+iterations=100
+total_us=12345
+avg_us=123
+has_error=false
+```
 
 ## Build Requirements
 

--- a/crates/tree-sitter-perl-c/ROADMAP.md
+++ b/crates/tree-sitter-perl-c/ROADMAP.md
@@ -33,6 +33,8 @@ Breaking changes will follow semver.
 
 - Periodic snapshot updates when upstream tree-sitter-perl releases new grammar versions.
 - Keep `tree-sitter` runtime dependency in sync with the workspace.
+- Keep `bench_parser_c` useful as a baseline tool (cold vs. warm parser reuse modes,
+  iteration loops, stable machine-readable output for run-to-run diffs).
 
 ### Not planned
 
@@ -46,4 +48,4 @@ Breaking changes will follow semver.
 
 [tree-sitter-perl]: https://github.com/tree-sitter-perl/tree-sitter-perl
 
-<!-- Last Updated: 2026-04-07 -->
+<!-- Last Updated: 2026-04-24 -->

--- a/crates/tree-sitter-perl-c/src/bin/bench_parser.rs
+++ b/crates/tree-sitter-perl-c/src/bin/bench_parser.rs
@@ -1,32 +1,203 @@
 use std::env;
 use std::fs;
 use std::time::Instant;
-use tree_sitter_perl_c::parse_perl_code;
+use tree_sitter_perl_c::{parse_perl_bytes, parse_perl_code, try_create_parser};
+
+#[derive(Clone, Copy)]
+enum Mode {
+    Cold,
+    Warm,
+}
+
+#[derive(Clone, Copy)]
+enum InputMode {
+    Str,
+    Bytes,
+}
+
+struct Args {
+    file_path: String,
+    mode: Mode,
+    input_mode: InputMode,
+    iterations: u64,
+}
+
+impl Args {
+    fn usage() -> &'static str {
+        "Usage: bench_parser_c [--mode cold|warm] [--iterations N] [--input str|bytes] <file>"
+    }
+
+    fn parse() -> Result<Self, String> {
+        let mut mode = Mode::Cold;
+        let mut input_mode = InputMode::Str;
+        let mut iterations: u64 = 1;
+        let mut file_path: Option<String> = None;
+
+        let mut iter = env::args().skip(1);
+        while let Some(arg) = iter.next() {
+            match arg.as_str() {
+                "--mode" => {
+                    let value =
+                        iter.next().ok_or_else(|| "Missing value for --mode".to_string())?;
+                    mode = match value.as_str() {
+                        "cold" => Mode::Cold,
+                        "warm" => Mode::Warm,
+                        _ => {
+                            return Err(format!(
+                                "Invalid --mode value '{value}', expected cold|warm"
+                            ));
+                        }
+                    };
+                }
+                "--iterations" | "-n" => {
+                    let value =
+                        iter.next().ok_or_else(|| "Missing value for --iterations".to_string())?;
+                    iterations = value
+                        .parse::<u64>()
+                        .map_err(|_| format!("Invalid --iterations value '{value}'"))?;
+                    if iterations == 0 {
+                        return Err("--iterations must be >= 1".to_string());
+                    }
+                }
+                "--input" => {
+                    let value =
+                        iter.next().ok_or_else(|| "Missing value for --input".to_string())?;
+                    input_mode = match value.as_str() {
+                        "str" => InputMode::Str,
+                        "bytes" => InputMode::Bytes,
+                        _ => {
+                            return Err(format!(
+                                "Invalid --input value '{value}', expected str|bytes"
+                            ));
+                        }
+                    };
+                }
+                "--help" | "-h" => return Err(Self::usage().to_string()),
+                _ if arg.starts_with('-') => {
+                    return Err(format!("Unknown flag '{arg}'"));
+                }
+                _ => {
+                    if file_path.is_some() {
+                        return Err("Only one file path may be provided".to_string());
+                    }
+                    file_path = Some(arg);
+                }
+            }
+        }
+
+        let file_path = file_path.ok_or_else(|| format!("{}\nMissing <file>", Self::usage()))?;
+        Ok(Self { file_path, mode, input_mode, iterations })
+    }
+}
+
+fn mode_label(mode: Mode) -> &'static str {
+    match mode {
+        Mode::Cold => "cold",
+        Mode::Warm => "warm",
+    }
+}
+
+fn input_label(input_mode: InputMode) -> &'static str {
+    match input_mode {
+        InputMode::Str => "str",
+        InputMode::Bytes => "bytes",
+    }
+}
+
+fn print_result(
+    mode: Mode,
+    input_mode: InputMode,
+    iterations: u64,
+    total_us: u128,
+    has_error: bool,
+) {
+    let avg_us = total_us / u128::from(iterations);
+    println!("mode={}", mode_label(mode));
+    println!("input={}", input_label(input_mode));
+    println!("iterations={iterations}");
+    println!("total_us={total_us}");
+    println!("avg_us={avg_us}");
+    println!("has_error={has_error}");
+}
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!("Usage: bench_parser_c <file>");
-        std::process::exit(1);
-    }
-    let file_path = &args[1];
-    let code = fs::read_to_string(file_path).unwrap_or_else(|e| {
-        eprintln!("Failed to read file: {}", e);
-        std::process::exit(1);
-    });
-    let start = Instant::now();
-    let result = parse_perl_code(&code);
-    let duration = start.elapsed().as_micros();
-    match result {
-        Ok(tree) => {
-            let has_error = tree.root_node().has_error();
-            println!("status=success error={} duration_us={}", has_error, duration);
-            // Always return success (0) - parse errors are indicated in the error field
-        }
-        Err(e) => {
-            println!("status=failure error=true duration_us={}", duration);
-            eprintln!("Parse error: {}", e);
+    let args = match Args::parse() {
+        Ok(args) => args,
+        Err(message) => {
+            eprintln!("{message}");
+            if message != Args::usage() {
+                eprintln!("{}", Args::usage());
+            }
             std::process::exit(1);
         }
-    }
+    };
+
+    let bytes = fs::read(&args.file_path).unwrap_or_else(|e| {
+        eprintln!("Failed to read file '{}': {}", args.file_path, e);
+        std::process::exit(1);
+    });
+
+    let start = Instant::now();
+    let mut has_error = false;
+    match args.mode {
+        Mode::Cold => {
+            for _ in 0..args.iterations {
+                let parse_result = match args.input_mode {
+                    InputMode::Str => match std::str::from_utf8(&bytes) {
+                        Ok(code) => parse_perl_code(code),
+                        Err(e) => {
+                            eprintln!("Failed to decode UTF-8 for --input str: {}", e);
+                            std::process::exit(1);
+                        }
+                    },
+                    InputMode::Bytes => parse_perl_bytes(&bytes),
+                };
+
+                match parse_result {
+                    Ok(tree) => {
+                        has_error |= tree.root_node().has_error();
+                    }
+                    Err(e) => {
+                        eprintln!("Parse error: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+            }
+        }
+        Mode::Warm => {
+            let mut parser = match try_create_parser() {
+                Ok(parser) => parser,
+                Err(e) => {
+                    eprintln!("Failed to create parser: {}", e);
+                    std::process::exit(1);
+                }
+            };
+
+            for _ in 0..args.iterations {
+                let parse_result = match args.input_mode {
+                    InputMode::Str => match std::str::from_utf8(&bytes) {
+                        Ok(code) => parser.parse(code, None),
+                        Err(e) => {
+                            eprintln!("Failed to decode UTF-8 for --input str: {}", e);
+                            std::process::exit(1);
+                        }
+                    },
+                    InputMode::Bytes => parser.parse(bytes.as_slice(), None),
+                };
+
+                match parse_result {
+                    Some(tree) => {
+                        has_error |= tree.root_node().has_error();
+                    }
+                    None => {
+                        eprintln!("Parse error: tree-sitter returned no tree");
+                        std::process::exit(1);
+                    }
+                }
+            }
+        }
+    };
+
+    let total_us = start.elapsed().as_micros();
+    print_result(args.mode, args.input_mode, args.iterations, total_us, has_error);
 }


### PR DESCRIPTION
### Motivation

- `bench_parser_c` previously timed only a single one-shot parse which hid parser setup costs and reuse benefits. 
- We need a simple baseline to compare cold parser setup cost vs. warm parser reuse throughput across multiple iterations. 
- Benchmark output must be stable and machine-readable so run-to-run diffs are reliable.

### Description

- Add CLI parsing and flags `--mode cold|warm`, `--iterations`/`-n N`, and `--input str|bytes` with sensible defaults and usage help in `src/bin/bench_parser.rs`. 
- Implement `cold` (create/configure a parser per iteration) and `warm` (reuse a single `try_create_parser()` across iterations) parsing flows and an N-iteration loop. 
- Emit stable `key=value` output fields: `mode`, `input`, `iterations`, `total_us`, `avg_us`, and `has_error`. 
- Document usage and output format in `README.md` and add a short roadmap note in `ROADMAP.md` to keep `bench_parser_c` maintained as a baseline tool.

### Testing

- `cargo test -p tree-sitter-perl-c` passed. 
- `cargo check --all-targets -p tree-sitter-perl-c` passed. 
- `cargo xtask fmt` completed successfully. 
- `cargo clippy -p tree-sitter-perl-c` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb276e2a208333975283fc5a41956d)