### PR TITLE
perf(tree-sitter-perl-c): expand bench_parser_c into cold/warm/reuse benchmark modes

### DIFF
--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -85,7 +85,47 @@ for snippet in &["my $x = 1;", "print $x;"] {
 ## Binaries
 
 - `parse_c` — parse a Perl file and exit with 0 (success) or 1 (error)
-- `bench_parser_c` — parse a Perl file and print timing (requires `--features test-utils`)
+- `bench_parser_c` — benchmark parse throughput and print stable `key=value` output (requires `--features test-utils`)
+
+### `bench_parser_c` modes
+
+Run a one-shot cold parse (default):
+
+```bash
+cargo run -p tree-sitter-perl-c --bin bench_parser_c --features test-utils -- path/to/file.pl
+```
+
+Run warm parser-reuse mode for 100 iterations:
+
+```bash
+cargo run -p tree-sitter-perl-c --bin bench_parser_c --features test-utils -- --mode warm --iterations 100 path/to/file.pl
+```
+
+Select input path (`str` default, or raw `bytes`):
+
+```bash
+cargo run -p tree-sitter-perl-c --bin bench_parser_c --features test-utils -- --input bytes path/to/file.pl
+```
+
+Supported flags:
+
+- `--mode <cold|warm>`
+  - `cold`: constructs a parser for each iteration
+  - `warm`: reuses a single configured parser across iterations
+- `--iterations <N>` / `-n <N>`: repeat parse loop `N` times
+- `--input <str|bytes>`
+  - `str`: parse through UTF-8 `&str` path
+  - `bytes`: parse via raw byte slice path
+
+Output format is stable `key=value` lines, ordered as:
+
+- `mode`
+- `input_mode`
+- `iterations`
+- `total_us`
+- `avg_us`
+- `has_error`
+- `status`
 
 ## Build Requirements
 

--- a/crates/tree-sitter-perl-c/src/bin/bench_parser.rs
+++ b/crates/tree-sitter-perl-c/src/bin/bench_parser.rs
@@ -1,32 +1,258 @@
 use std::env;
 use std::fs;
 use std::time::Instant;
-use tree_sitter_perl_c::parse_perl_code;
+
+use tree_sitter::Parser;
+use tree_sitter_perl_c::{parse_perl_bytes, try_create_parser};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BenchMode {
+    Cold,
+    Warm,
+}
+
+impl BenchMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Cold => "cold",
+            Self::Warm => "warm",
+        }
+    }
+
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "cold" => Some(Self::Cold),
+            "warm" => Some(Self::Warm),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InputMode {
+    Str,
+    Bytes,
+}
+
+impl InputMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Str => "str",
+            Self::Bytes => "bytes",
+        }
+    }
+
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "str" => Some(Self::Str),
+            "bytes" => Some(Self::Bytes),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BenchConfig {
+    file_path: String,
+    mode: BenchMode,
+    input_mode: InputMode,
+    iterations: u32,
+}
+
+fn print_usage() {
+    eprintln!(
+        "Usage: bench_parser_c [--mode <cold|warm>] [--input <str|bytes>] [--iterations <N>] <file>"
+    );
+}
+
+fn parse_args(args: &[String]) -> Result<BenchConfig, String> {
+    let mut mode = BenchMode::Cold;
+    let mut input_mode = InputMode::Str;
+    let mut iterations = 1_u32;
+    let mut file_path: Option<String> = None;
+
+    let mut idx = 0;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--mode" => {
+                let value =
+                    args.get(idx + 1).ok_or_else(|| "Missing value for --mode".to_string())?;
+                mode = BenchMode::from_str(value)
+                    .ok_or_else(|| format!("Invalid --mode value: {value}"))?;
+                idx += 2;
+            }
+            "--input" => {
+                let value =
+                    args.get(idx + 1).ok_or_else(|| "Missing value for --input".to_string())?;
+                input_mode = InputMode::from_str(value)
+                    .ok_or_else(|| format!("Invalid --input value: {value}"))?;
+                idx += 2;
+            }
+            "--iterations" | "-n" => {
+                let value = args
+                    .get(idx + 1)
+                    .ok_or_else(|| "Missing value for --iterations".to_string())?;
+                let parsed_iterations = value
+                    .parse::<u32>()
+                    .map_err(|_| format!("Invalid --iterations value: {value}"))?;
+                if parsed_iterations == 0 {
+                    return Err("--iterations must be >= 1".to_string());
+                }
+                iterations = parsed_iterations;
+                idx += 2;
+            }
+            "--help" | "-h" => {
+                return Err("help requested".to_string());
+            }
+            value if value.starts_with('-') => {
+                return Err(format!("Unknown flag: {value}"));
+            }
+            value => {
+                if file_path.is_some() {
+                    return Err(format!("Unexpected positional argument: {value}"));
+                }
+                file_path = Some(value.to_string());
+                idx += 1;
+            }
+        }
+    }
+
+    let file_path = file_path.ok_or_else(|| "Missing <file> argument".to_string())?;
+
+    Ok(BenchConfig { file_path, mode, input_mode, iterations })
+}
+
+fn parse_once_with_reused_parser(
+    parser: &mut Parser,
+    input_mode: InputMode,
+    code: &[u8],
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let tree = match input_mode {
+        InputMode::Str => {
+            let source = std::str::from_utf8(code)?;
+            parser.parse(source, None)
+        }
+        InputMode::Bytes => parser.parse(code, None),
+    }
+    .ok_or_else(|| "Failed to parse code".to_string())?;
+
+    Ok(tree.root_node().has_error())
+}
+
+fn run_benchmark(
+    config: &BenchConfig,
+    code: &[u8],
+) -> Result<(u128, bool), Box<dyn std::error::Error>> {
+    let mut has_error = false;
+    let start = Instant::now();
+
+    match config.mode {
+        BenchMode::Cold => {
+            for _ in 0..config.iterations {
+                let tree = match config.input_mode {
+                    InputMode::Str => {
+                        let source = std::str::from_utf8(code)?;
+                        parse_perl_bytes(source.as_bytes())?
+                    }
+                    InputMode::Bytes => parse_perl_bytes(code)?,
+                };
+                has_error |= tree.root_node().has_error();
+            }
+        }
+        BenchMode::Warm => {
+            let mut parser = try_create_parser()?;
+            for _ in 0..config.iterations {
+                has_error |= parse_once_with_reused_parser(&mut parser, config.input_mode, code)?;
+            }
+        }
+    }
+
+    Ok((start.elapsed().as_micros(), has_error))
+}
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!("Usage: bench_parser_c <file>");
-        std::process::exit(1);
-    }
-    let file_path = &args[1];
-    let code = fs::read_to_string(file_path).unwrap_or_else(|e| {
-        eprintln!("Failed to read file: {}", e);
-        std::process::exit(1);
-    });
-    let start = Instant::now();
-    let result = parse_perl_code(&code);
-    let duration = start.elapsed().as_micros();
-    match result {
-        Ok(tree) => {
-            let has_error = tree.root_node().has_error();
-            println!("status=success error={} duration_us={}", has_error, duration);
-            // Always return success (0) - parse errors are indicated in the error field
-        }
-        Err(e) => {
-            println!("status=failure error=true duration_us={}", duration);
-            eprintln!("Parse error: {}", e);
+    let raw_args: Vec<String> = env::args().skip(1).collect();
+    let config = match parse_args(&raw_args) {
+        Ok(config) => config,
+        Err(message) => {
+            print_usage();
+            eprintln!("Error: {message}");
             std::process::exit(1);
         }
+    };
+
+    let code = match fs::read(&config.file_path) {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("Failed to read file: {error}");
+            std::process::exit(1);
+        }
+    };
+
+    let (total_us, has_error) = match run_benchmark(&config, &code) {
+        Ok(result) => result,
+        Err(error) => {
+            println!("mode={}", config.mode.as_str());
+            println!("input_mode={}", config.input_mode.as_str());
+            println!("iterations={}", config.iterations);
+            println!("total_us=0");
+            println!("avg_us=0");
+            println!("has_error=true");
+            println!("status=failure");
+            eprintln!("Parse error: {error}");
+            std::process::exit(1);
+        }
+    };
+
+    let avg_us = total_us / u128::from(config.iterations);
+
+    println!("mode={}", config.mode.as_str());
+    println!("input_mode={}", config.input_mode.as_str());
+    println!("iterations={}", config.iterations);
+    println!("total_us={total_us}");
+    println!("avg_us={avg_us}");
+    println!("has_error={has_error}");
+    println!("status=success");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_args_defaults_to_cold_str_one_iteration() -> Result<(), String> {
+        let args = vec!["sample.pl".to_string()];
+        let config = parse_args(&args)?;
+        assert_eq!(config.mode, BenchMode::Cold);
+        assert_eq!(config.input_mode, InputMode::Str);
+        assert_eq!(config.iterations, 1);
+        assert_eq!(config.file_path, "sample.pl");
+        Ok(())
+    }
+
+    #[test]
+    fn parse_args_supports_warm_and_iterations() -> Result<(), String> {
+        let args = vec![
+            "--mode".to_string(),
+            "warm".to_string(),
+            "--input".to_string(),
+            "bytes".to_string(),
+            "-n".to_string(),
+            "20".to_string(),
+            "sample.pl".to_string(),
+        ];
+        let config = parse_args(&args)?;
+        assert_eq!(config.mode, BenchMode::Warm);
+        assert_eq!(config.input_mode, InputMode::Bytes);
+        assert_eq!(config.iterations, 20);
+        assert_eq!(config.file_path, "sample.pl");
+        Ok(())
+    }
+
+    #[test]
+    fn parse_args_rejects_unknown_flag() {
+        let args = vec!["--unknown".to_string(), "sample.pl".to_string()];
+        let result = parse_args(&args);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
### Motivation

- The existing `bench_parser_c` was a one-shot stopwatch and could not compare parser startup (cold) vs parser-reuse (warm) throughput.
- We need stable, machine-readable benchmark output and simple CLI controls so the crate can serve as a reliable baseline for performance comparisons.

### Description

- Added a richer benchmark binary `bench_parser_c` with `--mode <cold|warm>`, `--iterations/-n <N>`, and `--input <str|bytes>` flags and a small `BenchConfig` CLI parser.
- Implemented `cold` mode (creates a parser for each iteration) and `warm` mode (reuses a single `Parser` via `try_create_parser()`), and an iterations loop driven by the `iterations` config.
- Switched to stable ordered `key=value` output lines (`mode`, `input_mode`, `iterations`, `total_us`, `avg_us`, `has_error`, `status`) to make results diffable between runs.
- Added focused unit tests for the argument parser and documented the new modes and sample invocations in the crate `README.md`.

### Testing

- `cargo test -p tree-sitter-perl-c` ran and all tests passed.
- `cargo check --all-targets -p tree-sitter-perl-c` completed successfully.
- `cargo clippy -p tree-sitter-perl-c` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb276e2a208333975283fc5a41956d)