### PR TITLE
fix(tree-sitter-perl-c): make parse_c byte-safe and triage-friendly (#6583)

### DIFF
--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -84,8 +84,25 @@ for snippet in &["my $x = 1;", "print $x;"] {
 
 ## Binaries
 
-- `parse_c` — parse a Perl file and exit with 0 (success) or 1 (error)
+- `parse_c` — parse a Perl file as raw bytes and exit with 0 (clean parse) or 1 (I/O/parser/syntax error)
 - `bench_parser_c` — parse a Perl file and print timing (requires `--features test-utils`)
+
+### `parse_c` triage examples
+
+```bash
+# Parse a file as bytes (works even for non-UTF-8 fixtures)
+cargo run -p tree-sitter-perl-c --bin parse_c -- path/to/file.pl
+
+# Print root node kind and error status
+cargo run -p tree-sitter-perl-c --bin parse_c -- --root-kind --has-error path/to/file.pl
+
+# Print tree-sitter s-expression for deeper debugging
+cargo run -p tree-sitter-perl-c --bin parse_c -- --sexp path/to/file.pl
+```
+
+When syntax errors are present, `parse_c` exits with status 1 and prints the
+first error node including byte-range and byte-column positions so triage stays
+accurate for non-UTF-8 inputs.
 
 ## Build Requirements
 

--- a/crates/tree-sitter-perl-c/src/bin/parse_c.rs
+++ b/crates/tree-sitter-perl-c/src/bin/parse_c.rs
@@ -2,15 +2,90 @@ use std::env;
 use std::fs;
 use std::process;
 
-fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() != 2 {
-        eprintln!("Usage: {} <perl_file>", args[0]);
-        process::exit(1);
+#[derive(Default)]
+struct CliOptions {
+    path: Option<String>,
+    show_root_kind: bool,
+    show_has_error: bool,
+    show_sexp: bool,
+}
+
+impl CliOptions {
+    fn parse(args: impl IntoIterator<Item = String>) -> Result<Self, String> {
+        let mut options = Self::default();
+        let mut saw_program_name = false;
+
+        for arg in args {
+            if !saw_program_name {
+                saw_program_name = true;
+                continue;
+            }
+
+            match arg.as_str() {
+                "--root-kind" => options.show_root_kind = true,
+                "--has-error" => options.show_has_error = true,
+                "--sexp" => options.show_sexp = true,
+                "-h" | "--help" => return Err(String::new()),
+                flag if flag.starts_with('-') => {
+                    return Err(format!("Unknown flag: {flag}"));
+                }
+                _ => {
+                    if options.path.is_some() {
+                        return Err("Expected a single input file path".to_owned());
+                    }
+                    options.path = Some(arg);
+                }
+            }
+        }
+
+        if options.path.is_none() {
+            return Err("Missing required <perl_file> argument".to_owned());
+        }
+
+        Ok(options)
+    }
+}
+
+fn print_usage(program_name: &str) {
+    eprintln!("Usage: {program_name} [--root-kind] [--has-error] [--sexp] <perl_file>");
+}
+
+fn find_first_error_node(root: tree_sitter::Node<'_>) -> Option<tree_sitter::Node<'_>> {
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if node.is_error() || node.is_missing() {
+            return Some(node);
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.has_error() || child.is_error() || child.is_missing() {
+                stack.push(child);
+            }
+        }
     }
 
-    let filename = &args[1];
-    let source_code = match fs::read_to_string(filename) {
+    None
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let program_name = args.first().cloned().unwrap_or_else(|| "parse_c".to_owned());
+    let options = match CliOptions::parse(args) {
+        Ok(options) => options,
+        Err(error) if error.is_empty() => {
+            print_usage(&program_name);
+            process::exit(0);
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            print_usage(&program_name);
+            process::exit(1);
+        }
+    };
+
+    let filename = options.path.as_deref().unwrap_or_default();
+    let source_code = match fs::read(filename) {
         Ok(code) => code,
         Err(e) => {
             eprintln!("Error reading file: {}", e);
@@ -24,11 +99,43 @@ fn main() {
         process::exit(1);
     });
 
-    match parser.parse(&source_code, None) {
-        Some(_tree) => {
-            // Success - just exit with 0
-            // In a real parser we'd output the S-expression, but for benchmarking we just parse
-            std::process::exit(0);
+    match parser.parse(source_code.as_slice(), None) {
+        Some(tree) => {
+            let root = tree.root_node();
+            let has_error = root.has_error();
+
+            if options.show_root_kind {
+                println!("root_kind={}", root.kind());
+            }
+            if options.show_has_error {
+                println!("has_error={has_error}");
+            }
+            if options.show_sexp {
+                println!("{}", root.to_sexp());
+            }
+
+            if has_error {
+                if let Some(error_node) = find_first_error_node(root) {
+                    let start = error_node.start_position();
+                    let end = error_node.end_position();
+                    eprintln!(
+                        "Parse contains syntax errors: first error node kind={} bytes={}..{} row={}..{} column_bytes={}..{}",
+                        error_node.kind(),
+                        error_node.start_byte(),
+                        error_node.end_byte(),
+                        start.row + 1,
+                        end.row + 1,
+                        start.column,
+                        end.column
+                    );
+                } else {
+                    eprintln!("Parse contains syntax errors");
+                }
+
+                process::exit(1);
+            } else {
+                std::process::exit(0);
+            }
         }
         None => {
             eprintln!("Failed to parse");


### PR DESCRIPTION
### Motivation

- The existing `parse_c` CLI forced UTF-8 decoding and produced limited output, which made triaging non-UTF-8 fixtures and corpus debugging difficult.
- The crate API already supports raw bytes and non-UTF-8 Perl files, so the CLI should follow the same byte-oriented semantics and provide targeted triage output.

### Description

- Switched `parse_c` to read files as raw bytes (`fs::read`) and call `parser.parse(&[u8], ...)` so non-UTF-8 inputs are supported without UTF-8 decoding.
- Added a small CLI option parser with flags `--root-kind`, `--has-error`, and `--sexp` and a usage message to enable optional triage output while keeping the default invocation minimal.
- Improved error reporting for syntax-failing parses by printing the first error node with byte-range and byte/row positions and exiting with status `1` on parse errors.
- Updated `crates/tree-sitter-perl-c/README.md` with `parse_c` examples and notes about byte-safe behavior and triage flags.

### Testing

- Ran `cargo test -p tree-sitter-perl-c` and all tests passed (unit tests, BDD workflows, and doctests).
- Ran `cargo check --all-targets -p tree-sitter-perl-c` and it completed successfully.
- Ran `cargo clippy -p tree-sitter-perl-c --all-targets` and the lint pass completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb276fa1ac8333b3175327847986e0)