### PR TITLE
fix(tree-sitter-perl-c): make parse_c byte-safe and more useful for parse triage (#6582)

### DIFF
--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -84,8 +84,32 @@ for snippet in &["my $x = 1;", "print $x;"] {
 
 ## Binaries
 
-- `parse_c` — parse a Perl file and exit with 0 (success) or 1 (error)
-- `bench_parser_c` — parse a Perl file and print timing (requires `--features test-utils`)
+### `parse_c`
+
+`parse_c` reads source as raw bytes (non-UTF-8 safe), parses with the C grammar,
+and exits:
+
+- `0` when parse succeeds without tree-sitter error nodes
+- `1` when IO fails, parsing fails, or the resulting tree contains error nodes
+
+```bash
+cargo run -p tree-sitter-perl-c --bin parse_c -- path/to/file.pl
+cargo run -p tree-sitter-perl-c --bin parse_c -- --root-kind --has-error path/to/file.pl
+cargo run -p tree-sitter-perl-c --bin parse_c -- --sexp path/to/file.pl
+```
+
+Optional output flags:
+
+- `--root-kind` prints `root_kind=<kind>`
+- `--has-error` prints `has_error=<true|false>`
+- `--sexp` prints the root node s-expression
+
+When error nodes are present, `parse_c` emits an actionable diagnostic to stderr
+including file name, root kind, input byte length, and parsed span.
+
+### `bench_parser_c`
+
+- parse a Perl file and print timing (requires `--features test-utils`)
 
 ## Build Requirements
 

--- a/crates/tree-sitter-perl-c/src/bin/parse_c.rs
+++ b/crates/tree-sitter-perl-c/src/bin/parse_c.rs
@@ -2,37 +2,111 @@ use std::env;
 use std::fs;
 use std::process;
 
-fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() != 2 {
-        eprintln!("Usage: {} <perl_file>", args[0]);
-        process::exit(1);
+struct CliOptions {
+    filename: String,
+    print_root_kind: bool,
+    print_has_error: bool,
+    print_sexp: bool,
+}
+
+fn print_usage(program: &str) {
+    eprintln!("Usage: {program} [--root-kind] [--has-error] [--sexp] <perl_file>");
+    eprintln!("\nOptions:");
+    eprintln!("  --root-kind   Print root node kind");
+    eprintln!("  --has-error   Print whether the parse tree contains error nodes");
+    eprintln!("  --sexp        Print the root node s-expression");
+}
+
+fn parse_args() -> Result<CliOptions, String> {
+    let mut args = env::args();
+    let program = args.next().unwrap_or_else(|| "parse_c".to_string());
+
+    let mut filename: Option<String> = None;
+    let mut print_root_kind = false;
+    let mut print_has_error = false;
+    let mut print_sexp = false;
+
+    for arg in args {
+        match arg.as_str() {
+            "--root-kind" => print_root_kind = true,
+            "--has-error" => print_has_error = true,
+            "--sexp" => print_sexp = true,
+            "--help" | "-h" => {
+                print_usage(&program);
+                process::exit(0);
+            }
+            _ if arg.starts_with('-') => {
+                return Err(format!("Unknown option: {arg}"));
+            }
+            _ => {
+                if filename.is_some() {
+                    return Err("Expected exactly one input file".to_string());
+                }
+                filename = Some(arg);
+            }
+        }
     }
 
-    let filename = &args[1];
-    let source_code = match fs::read_to_string(filename) {
-        Ok(code) => code,
-        Err(e) => {
-            eprintln!("Error reading file: {}", e);
+    let filename = filename.ok_or_else(|| "Missing input file".to_string())?;
+
+    Ok(CliOptions { filename, print_root_kind, print_has_error, print_sexp })
+}
+
+fn main() {
+    let options = match parse_args() {
+        Ok(options) => options,
+        Err(message) => {
+            eprintln!("{message}");
+            let program = env::args().next().unwrap_or_else(|| "parse_c".to_string());
+            print_usage(&program);
             process::exit(1);
         }
     };
 
-    let mut parser = tree_sitter::Parser::new();
-    parser.set_language(&tree_sitter_perl_c::language()).unwrap_or_else(|e| {
-        eprintln!("Error loading Perl C grammar: {:?}", e);
-        process::exit(1);
-    });
-
-    match parser.parse(&source_code, None) {
-        Some(_tree) => {
-            // Success - just exit with 0
-            // In a real parser we'd output the S-expression, but for benchmarking we just parse
-            std::process::exit(0);
-        }
-        None => {
-            eprintln!("Failed to parse");
+    let bytes = match fs::read(&options.filename) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            eprintln!("Failed to read '{}': {error}", options.filename);
             process::exit(1);
         }
+    };
+
+    let tree = match tree_sitter_perl_c::parse_perl_bytes(&bytes) {
+        Ok(tree) => tree,
+        Err(error) => {
+            eprintln!("Failed to parse '{}': {error}", options.filename);
+            process::exit(1);
+        }
+    };
+
+    let root = tree.root_node();
+    let has_error = root.has_error();
+
+    if options.print_root_kind {
+        println!("root_kind={}", root.kind());
+    }
+
+    if options.print_has_error {
+        println!("has_error={has_error}");
+    }
+
+    if options.print_sexp {
+        println!("{}", root.to_sexp());
+    }
+
+    if has_error {
+        let start = root.start_position();
+        let end = root.end_position();
+        eprintln!(
+            "Parse completed with error nodes in '{}'. root_kind={} bytes={} span={}:{}-{}:{}",
+            options.filename,
+            root.kind(),
+            bytes.len(),
+            start.row,
+            start.column,
+            end.row,
+            end.column
+        );
+        process::exit(1);
     }
 }


### PR DESCRIPTION
### Motivation

- The existing `parse_c` CLI read input as UTF-8 text which made triaging non-UTF-8 Perl fixtures and corpus debugging unreliable. 
- The crate API already supports raw bytes and non-UTF-8 Perl files, so the CLI should expose the same capability for accurate fixture triage. 
- Provide quick, actionable parse diagnostics (root kind, error presence, optional s-expression) while keeping the default exit semantics simple for scripting.

### Description

- Switch `parse_c` to read raw bytes with `fs::read` and parse via `parse_perl_bytes` so non-UTF-8 input is accepted without prior decoding. 
- Add a small CLI argument parser and optional flags `--root-kind`, `--has-error`, and `--sexp` to provide targeted output for triage. 
- When error nodes are present `parse_c` prints an actionable diagnostic (file name, root kind, input byte length, parsed span) and exits `1`; IO/parse failures also exit `1`, while a clean parse exits `0`. 
- Update `crates/tree-sitter-perl-c/README.md` with examples and flag documentation showing the new byte-safe behavior and usage examples.

### Testing

- Ran `cargo test -p tree-sitter-perl-c` and all unit, BDD and doctests passed. 
- Ran `cargo check --all-targets -p tree-sitter-perl-c` which completed successfully. 
- Ran `cargo clippy -p tree-sitter-perl-c` with no blocking lints. 
- Ran `cargo xtask fmt` to ensure formatting consistency and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb276fa1ac8333b3175327847986e0)