### PR TITLE
fix(tree-sitter-perl-c): make parse_c byte-safe and triage-friendly (#0000)

### DIFF
--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -84,8 +84,24 @@ for snippet in &["my $x = 1;", "print $x;"] {
 
 ## Binaries
 
-- `parse_c` — parse a Perl file and exit with 0 (success) or 1 (error)
+- `parse_c` — parse a Perl file as raw bytes and exit with 0 (clean parse) or 1 (parse/read errors). Optional flags:
+  - `--root-kind` prints the root node kind
+  - `--has-error` prints `true`/`false` for `root_node().has_error()`
+  - `--sexp` prints the full parse s-expression
 - `bench_parser_c` — parse a Perl file and print timing (requires `--features test-utils`)
+
+Examples:
+
+```bash
+# Default triage flow: parse and return shell-friendly status code
+cargo run -p tree-sitter-perl-c --bin parse_c -- path/to/file.pl
+
+# Parse non-UTF-8 fixtures safely and print high-level diagnostics
+cargo run -p tree-sitter-perl-c --bin parse_c -- --root-kind --has-error path/to/fixture.pl
+
+# Inspect the full tree when narrowing down an error node
+cargo run -p tree-sitter-perl-c --bin parse_c -- --sexp path/to/file.pl
+```
 
 ## Build Requirements
 

--- a/crates/tree-sitter-perl-c/src/bin/parse_c.rs
+++ b/crates/tree-sitter-perl-c/src/bin/parse_c.rs
@@ -1,38 +1,149 @@
 use std::env;
+use std::ffi::OsString;
 use std::fs;
+use std::path::{Path, PathBuf};
 use std::process;
 
-fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() != 2 {
-        eprintln!("Usage: {} <perl_file>", args[0]);
-        process::exit(1);
+#[derive(Debug)]
+struct CliOptions {
+    file: PathBuf,
+    show_root_kind: bool,
+    show_has_error: bool,
+    show_sexp: bool,
+}
+
+impl CliOptions {
+    fn parse() -> Result<Self, String> {
+        let mut file: Option<PathBuf> = None;
+        let mut show_root_kind = false;
+        let mut show_has_error = false;
+        let mut show_sexp = false;
+
+        for arg in env::args_os().skip(1) {
+            match arg.to_str() {
+                Some("--root-kind") => show_root_kind = true,
+                Some("--has-error") => show_has_error = true,
+                Some("--sexp") => show_sexp = true,
+                Some("--help") | Some("-h") => return Err(String::new()),
+                Some(flag) if flag.starts_with('-') => {
+                    return Err(format!("Unknown flag: {flag}"));
+                }
+                _ => {
+                    if file.is_some() {
+                        return Err("Only one input file can be provided".to_string());
+                    }
+                    file = Some(PathBuf::from(arg));
+                }
+            }
+        }
+
+        match file {
+            Some(file) => Ok(Self { file, show_root_kind, show_has_error, show_sexp }),
+            None => Err("Missing input file".to_string()),
+        }
+    }
+}
+
+fn usage(program: &str) -> String {
+    format!(
+        "Usage: {program} [--root-kind] [--has-error] [--sexp] <perl_file>\n\n\
+         Parses Perl source bytes using the tree-sitter C grammar.\n\
+         Exit status is 0 on clean parse and 1 on parse failure or syntax errors."
+    )
+}
+
+fn format_path(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn parse_diagnostics(tree: &tree_sitter::Tree) -> Vec<String> {
+    let mut stack = vec![tree.root_node()];
+    let mut diagnostics = Vec::new();
+
+    while let Some(node) = stack.pop() {
+        if node.is_error() || node.is_missing() {
+            let start = node.start_position();
+            let end = node.end_position();
+            diagnostics.push(format!(
+                "{} node `{}` at bytes {}..{} (line {}, byte_col {} to line {}, byte_col {})",
+                if node.is_missing() { "Missing" } else { "Error" },
+                node.kind(),
+                node.start_byte(),
+                node.end_byte(),
+                start.row + 1,
+                start.column + 1,
+                end.row + 1,
+                end.column + 1
+            ));
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
     }
 
-    let filename = &args[1];
-    let source_code = match fs::read_to_string(filename) {
-        Ok(code) => code,
-        Err(e) => {
-            eprintln!("Error reading file: {}", e);
+    diagnostics
+}
+
+fn print_error_and_exit(message: &str) -> ! {
+    eprintln!("{message}");
+    process::exit(1);
+}
+
+fn main() {
+    let program = env::args()
+        .next()
+        .unwrap_or_else(|| OsString::from("parse_c").to_string_lossy().into_owned());
+
+    let options = match CliOptions::parse() {
+        Ok(opts) => opts,
+        Err(err) if err.is_empty() => {
+            eprintln!("{}", usage(&program));
+            process::exit(1);
+        }
+        Err(err) => {
+            eprintln!("{err}\n\n{}", usage(&program));
             process::exit(1);
         }
     };
 
-    let mut parser = tree_sitter::Parser::new();
-    parser.set_language(&tree_sitter_perl_c::language()).unwrap_or_else(|e| {
-        eprintln!("Error loading Perl C grammar: {:?}", e);
-        process::exit(1);
-    });
+    let source_bytes = match fs::read(&options.file) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            print_error_and_exit(&format!("Failed to read `{}`: {err}", format_path(&options.file)))
+        }
+    };
 
-    match parser.parse(&source_code, None) {
-        Some(_tree) => {
-            // Success - just exit with 0
-            // In a real parser we'd output the S-expression, but for benchmarking we just parse
-            std::process::exit(0);
-        }
-        None => {
-            eprintln!("Failed to parse");
-            process::exit(1);
-        }
+    let tree = match tree_sitter_perl_c::parse_perl_bytes(&source_bytes) {
+        Ok(tree) => tree,
+        Err(err) => print_error_and_exit(&format!(
+            "Failed to parse `{}`: {err}",
+            format_path(&options.file)
+        )),
+    };
+
+    let root = tree.root_node();
+
+    if options.show_root_kind {
+        println!("{}", root.kind());
     }
+    if options.show_has_error {
+        println!("{}", root.has_error());
+    }
+    if options.show_sexp {
+        println!("{}", root.to_sexp());
+    }
+
+    let diagnostics = parse_diagnostics(&tree);
+    if diagnostics.is_empty() {
+        process::exit(0);
+    }
+
+    eprintln!("Found {} parse issue(s) in `{}`:", diagnostics.len(), format_path(&options.file));
+    for diagnostic in diagnostics {
+        eprintln!("- {diagnostic}");
+    }
+    eprintln!("Tip: rerun with `--sexp` to inspect the full parse tree.");
+    process::exit(1);
 }


### PR DESCRIPTION
### Motivation

- The crate API already supports parsing raw bytes (non-UTF-8 Perl files) but the `parse_c` CLI used UTF-8 string decoding and provided minimal triage output which made debugging non-UTF-8 fixtures awkward.
- Improve the CLI so it is useful for accuracy triage and corpus debugging while preserving a simple default UX (exit 0/1 and actionable errors).

### Description

- Switch `parse_c` to a byte-oriented parse path by reading files with `fs::read` and calling `parse_perl_bytes` so non-UTF-8 input is handled safely (`crates/tree-sitter-perl-c/src/bin/parse_c.rs`).
- Add a small `CliOptions` parser using `env::args_os()` and support flags `--root-kind`, `--has-error`, and `--sexp` plus a single file operand to keep the default flow simple.
- Produce actionable, byte-safe parse diagnostics by walking the tree and reporting `ERROR`/`MISSING` nodes with byte ranges and byte-column positions, and print optional s-expression output when `--sexp` is requested.
- Update `crates/tree-sitter-perl-c/README.md` to document the new flags and show example invocations for triage and inspection.

### Testing

- Ran `cargo test -p tree-sitter-perl-c` and all unit, BDD, and doctests passed.
- Ran `cargo check --all-targets -p tree-sitter-perl-c` which completed successfully.
- Ran `cargo clippy -p tree-sitter-perl-c --all-targets` and `cargo xtask fmt` which completed cleanly (one trivial clippy suggestion was fixed).
- Executed `cargo run -p tree-sitter-perl-c --bin parse_c -- --root-kind --has-error /tmp/parse_c_non_utf8.pl` against a crafted non-UTF-8 fixture and observed the expected `root kind`, `true` for `has_error`, printed byte-range diagnostics and an exit status of `1` for parse issues.

Note: `just pr-fast` was not available in this execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb276fa1ac8333b3175327847986e0)