### PR TITLE
test(tree-sitter-perl-c): expand upstream query conformance coverage (#0000)

### DIFF
--- a/crates/tree-sitter-perl-c/tests/query_conformance.rs
+++ b/crates/tree-sitter-perl-c/tests/query_conformance.rs
@@ -1,0 +1,148 @@
+use std::{collections::BTreeMap, error::Error};
+
+use tree_sitter::{Query, QueryCursor, StreamingIterator};
+use tree_sitter_perl_c::{language, parse_perl_code};
+
+type CaptureMap = BTreeMap<String, Vec<String>>;
+
+fn run_query(source: &str, query_source: &str) -> Result<CaptureMap, Box<dyn Error>> {
+    let tree = parse_perl_code(source)?;
+    let query = Query::new(&language(), query_source)?;
+    let mut cursor = QueryCursor::new();
+
+    let mut captures: CaptureMap = BTreeMap::new();
+    let mut matches = cursor.matches(&query, tree.root_node(), source.as_bytes());
+
+    while let Some(matched) = matches.next() {
+        for capture in matched.captures {
+            let capture_name = query
+                .capture_names()
+                .get(capture.index as usize)
+                .copied()
+                .unwrap_or_default()
+                .to_string();
+            let capture_text = capture.node.utf8_text(source.as_bytes())?;
+            captures
+                .entry(capture_name)
+                .or_default()
+                .push(format!("{}: {capture_text:?}", capture.node.kind()));
+        }
+    }
+
+    Ok(captures)
+}
+
+fn assert_capture_contains(captures: &CaptureMap, name: &str, needle: &str) {
+    let haystack = captures.get(name).cloned().unwrap_or_default();
+    assert!(
+        haystack.iter().any(|capture| capture.contains(needle)),
+        "expected capture '{name}' to include {needle:?}, got: {haystack:#?}"
+    );
+}
+
+#[test]
+fn query_conformance_injections_inline_c_and_cpp_heredocs() -> Result<(), Box<dyn Error>> {
+    let query = include_str!("../../../tree-sitter-perl/queries/injections.scm");
+    let inline_c = r#"use Inline C => <<'END_C';
+#include <math.h>
+double calc(double x) { return sqrt(x); }
+END_C
+"#;
+    let inline_cpp = r#"use Inline CPP => <<'END_CPP';
+#include <string>
+class Greet {};
+END_CPP
+"#;
+
+    let c_captures = run_query(inline_c, query)?;
+    assert_capture_contains(&c_captures, "inline.package", "\"Inline\"");
+    assert_capture_contains(&c_captures, "inline.language", "\"C\"");
+    assert_capture_contains(&c_captures, "injection.content", "#include <math.h>");
+
+    let cpp_captures = run_query(inline_cpp, query)?;
+    assert_capture_contains(&cpp_captures, "inline.package", "\"Inline\"");
+    assert_capture_contains(&cpp_captures, "inline.language", "\"CPP\"");
+    assert_capture_contains(&cpp_captures, "injection.content", "#include <string>");
+
+    Ok(())
+}
+
+#[test]
+fn query_conformance_highlights_pod_heredoc_and_quote_like() -> Result<(), Box<dyn Error>> {
+    let highlights = include_str!("../../../tree-sitter-perl/queries/highlights.scm");
+    let source = r#"=head1 NAME
+Demo - highlight capture fixture
+=cut
+
+my $value = <<'SQL';
+select * from users;
+SQL
+
+my $rx = qr/foo+/;
+my @items = qw(alpha beta);
+"#;
+
+    let pod_clause = "(pod) @text";
+    let string_clause = r#"[
+  (string_literal)
+  (interpolated_string_literal)
+  (quoted_word_list)
+  (command_string)
+  (heredoc_content)
+  (replacement)
+  (transliteration_content)
+] @string"#;
+    let regex_clause = r#"[
+ (quoted_regexp)
+ (match_regexp)
+ (regexp_content)
+] @string.regex"#;
+
+    for (label, clause) in [("pod", pod_clause), ("string", string_clause), ("regex", regex_clause)]
+    {
+        assert!(
+            highlights.contains(clause),
+            "expected upstream highlights.scm to contain {label} clause"
+        );
+    }
+
+    let focused_query = [pod_clause, string_clause, regex_clause].join("\n\n");
+    let captures = run_query(source, &focused_query)?;
+
+    assert_capture_contains(&captures, "text", "Demo - highlight capture fixture");
+    assert_capture_contains(&captures, "string", "select * from users");
+    assert_capture_contains(&captures, "string.regex", "foo+");
+    assert_capture_contains(&captures, "string", "qw(alpha beta)");
+
+    Ok(())
+}
+
+#[test]
+fn query_conformance_folds_comments_pod_heredoc_and_blocks() -> Result<(), Box<dyn Error>> {
+    let query = include_str!("../../../tree-sitter-perl/queries/folds.scm");
+    let source = r#"# heading comment
+# another comment
+
+=head1 TITLE
+Fold this POD block
+=cut
+
+my $template = <<'EOT';
+line one
+line two
+EOT
+
+sub greet {
+    my ($name) = @_;
+    return "hi $name";
+}
+"#;
+
+    let captures = run_query(source, query)?;
+    assert_capture_contains(&captures, "fold", "heading comment");
+    assert_capture_contains(&captures, "fold", "Fold this POD block");
+    assert_capture_contains(&captures, "fold", "line one");
+    assert_capture_contains(&captures, "fold", "sub greet");
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- The vendored C-backed Perl grammar had limited query-conformance coverage focused mostly on injections, leaving highlights and folds untested against the upstream query files.
- Increasing focused, human-readable tests for highlights, folds, and injection scenarios reduces regressions and makes failures easy to pinpoint for non-Rust tree-sitter consumers.

### Description
- Added a new integration test `crates/tree-sitter-perl-c/tests/query_conformance.rs` which provides helpers to run upstream Tree-sitter queries and collect captures (`run_query` and `assert_capture_contains`).
- Kept and expanded injection coverage by asserting `inline.package`, `inline.language`, and `injection.content` for both Inline::C and Inline::CPP heredocs using `tree-sitter-perl/queries/injections.scm`.
- Added focused highlights tests that first assert required clauses exist in `highlights.scm` and then run a composed focused query to check `@text`, `@string`, and `@string.regex` captures on small fixtures instead of snapshotting whole outputs.
- Added folds coverage that exercises `fold` captures for comments, POD, heredoc content, and block statements to produce targeted failures.

### Testing
- Ran `cargo test -p tree-sitter-perl-c` and all crate tests passed successfully. 
- Ran the focused suite `cargo test -p tree-sitter-perl-c --test query_conformance` and the new `query_conformance` tests passed (3/3).
- Ran `cargo check --all-targets -p tree-sitter-perl-c` which completed successfully.
- Ran `cargo fmt -p tree-sitter-perl-c` as part of verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb277313408333b6f1e38300efd7ed)