### PR TITLE
docs(tree-sitter-perl-c): add upstream snapshot provenance and refresh workflow (#6533)

### DIFF
--- a/crates/tree-sitter-perl-c/Cargo.toml
+++ b/crates/tree-sitter-perl-c/Cargo.toml
@@ -18,6 +18,7 @@ include = [
     "build.rs",
     "Cargo.toml",
     "README.md",
+    "UPSTREAM_SNAPSHOT.md",
     "LICENSE-APACHE",
     "LICENSE-MIT",
 ]

--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -87,6 +87,33 @@ for snippet in &["my $x = 1;", "print $x;"] {
 - `parse_c` — parse a Perl file and exit with 0 (success) or 1 (error)
 - `bench_parser_c` — parse a Perl file and print timing (requires `--features test-utils`)
 
+## Snapshot provenance and refresh
+
+Snapshot provenance and the refresh workflow are tracked in
+[`UPSTREAM_SNAPSHOT.md`](UPSTREAM_SNAPSHOT.md).
+
+That document records:
+
+- upstream repository/reference
+- generator version used for `parser.c`
+- file fingerprints for auditability
+- the exact local refresh + validation checklist
+
+## Vendored files vs local wrapper code
+
+**Vendored from upstream snapshot (`c-src/`):**
+
+- `parser.c`, `scanner.c`
+- `bsearch.h`, `tsp_unicode.h`
+- `tree_sitter/{parser.h,array.h,alloc.h}`
+
+**Maintained locally in this crate:**
+
+- `src/lib.rs` (Rust FFI wrapper + helpers)
+- `build.rs` (C compilation/link wiring)
+- `tests/` and `src/bin/` (integration and sanity tooling)
+- crate docs (`README.md`, `ROADMAP.md`, `UPSTREAM_SNAPSHOT.md`)
+
 ## Build Requirements
 
 Only a C compiler is required. No `libclang` or other FFI-generator toolchain

--- a/crates/tree-sitter-perl-c/ROADMAP.md
+++ b/crates/tree-sitter-perl-c/ROADMAP.md
@@ -27,6 +27,22 @@ Breaking changes will follow semver.
 - The crate does not expose tree-sitter query helpers — use the
   `tree-sitter` crate directly with the `language()` return value.
 
+## Snapshot Governance
+
+The vendored C snapshot provenance is tracked in
+[`UPSTREAM_SNAPSHOT.md`](UPSTREAM_SNAPSHOT.md).
+
+That file is the canonical maintenance contract for:
+
+- upstream source reference
+- generator version pinning
+- local refresh procedure
+- required refresh validation checks (build, tests, query conformance,
+  benchmark sanity)
+
+Grammar fixes belong upstream in tree-sitter-perl. This crate only vendors,
+validates, and exposes the snapshot through a stable Rust wrapper API.
+
 ## Planned Work
 
 ### Maintenance (ongoing)

--- a/crates/tree-sitter-perl-c/UPSTREAM_SNAPSHOT.md
+++ b/crates/tree-sitter-perl-c/UPSTREAM_SNAPSHOT.md
@@ -1,0 +1,107 @@
+# Upstream Snapshot Provenance (`tree-sitter-perl-c`)
+
+This file is the auditable record for the vendored C snapshot in `c-src/`.
+
+## Current vendored snapshot
+
+- **Upstream grammar repository:** `tree-sitter-perl/tree-sitter-perl`
+  (`https://github.com/tree-sitter-perl/tree-sitter-perl`)
+- **Upstream tracking ref for refreshes:** `master` (resolve to a specific commit
+  at refresh time)
+- **Generator version used by current `parser.c`:** `tree-sitter v0.25.9`
+  (from the generated header comment in `c-src/parser.c`)
+- **Import provenance in this repository:** snapshot introduced in commit
+  `c57aadcba61cf295c6abc2b2a9c85cdf13de9cbb` by copying the archived C sources
+  from `archive/crates/tree-sitter-perl-rs/src/` into `crates/tree-sitter-perl-c/c-src/`.
+
+### Snapshot fingerprints (for audit/diff checks)
+
+- `c-src/parser.c` SHA-256:
+  `07b7bb23511188e97cfdbd6ac6289439f872e58504d2c51d9e24e59fae957d2a`
+- `c-src/scanner.c` SHA-256:
+  `01bbea22f0864679692fb0163b29304d346666f2181b1dbbe08f900c9bb219eb`
+- `c-src/tsp_unicode.h` SHA-256:
+  `9cbc0731f8c9bd52bd3de9644fd887f20cecea2d17634b20769db4940eadb566`
+- `c-src/bsearch.h` SHA-256:
+  `cb08206e89750c1fab700b89fc9876afb5cc689827e514ef49a5569c54635b61`
+
+> **Important:** This snapshot predates explicit provenance tracking in this
+> crate. During the next refresh, record the exact upstream commit SHA used to
+> generate/copy `parser.c` and `scanner.c` in this file.
+
+## What is vendored vs local
+
+### Vendored from upstream grammar snapshot
+
+- `c-src/parser.c` (generated parser)
+- `c-src/scanner.c` (external scanner)
+- `c-src/bsearch.h`
+- `c-src/tsp_unicode.h`
+- `c-src/tree_sitter/parser.h`
+- `c-src/tree_sitter/array.h`
+- `c-src/tree_sitter/alloc.h`
+
+### Local wrapper/maintenance code in this crate
+
+- `src/lib.rs` (FFI declaration + Rust API)
+- `build.rs` (compile/link vendored C sources)
+- `tests/` (Rust-level behavior/query integration tests)
+- `src/bin/` (CLI helpers for parse and benchmark smoke checks)
+- `README.md`, `ROADMAP.md`, and this file
+
+## Refresh procedure
+
+1. **Choose upstream commit/ref and record it first**
+
+   ```bash
+   UPSTREAM_REF=<commit-or-tag>
+   ```
+
+2. **Fetch upstream grammar sources**
+
+   ```bash
+   git clone https://github.com/tree-sitter-perl/tree-sitter-perl /tmp/tree-sitter-perl
+   cd /tmp/tree-sitter-perl
+   git checkout "$UPSTREAM_REF"
+   ```
+
+3. **Regenerate parser with pinned CLI (if `src/parser.c` is not committed upstream)**
+
+   ```bash
+   tree-sitter --version  # record exact version in this file
+   tree-sitter generate
+   ```
+
+4. **Copy vendored C snapshot files into this crate**
+
+   ```bash
+   cp src/parser.c /workspace/perl-lsp/crates/tree-sitter-perl-c/c-src/parser.c
+   cp src/scanner.c /workspace/perl-lsp/crates/tree-sitter-perl-c/c-src/scanner.c
+   cp src/bsearch.h /workspace/perl-lsp/crates/tree-sitter-perl-c/c-src/bsearch.h
+   cp src/tsp_unicode.h /workspace/perl-lsp/crates/tree-sitter-perl-c/c-src/tsp_unicode.h
+   cp src/tree_sitter/parser.h /workspace/perl-lsp/crates/tree-sitter-perl-c/c-src/tree_sitter/parser.h
+   cp src/tree_sitter/array.h /workspace/perl-lsp/crates/tree-sitter-perl-c/c-src/tree_sitter/array.h
+   cp src/tree_sitter/alloc.h /workspace/perl-lsp/crates/tree-sitter-perl-c/c-src/tree_sitter/alloc.h
+   ```
+
+5. **Update this file**
+
+   - Upstream repo + exact commit/tag
+   - Generator version
+   - New SHA-256 fingerprints
+   - Date of refresh (UTC)
+
+## Refresh validation checklist
+
+Run these checks from repo root after refreshing:
+
+- [ ] **Build / compile sanity**
+  - `cargo check --all-targets -p tree-sitter-perl-c`
+- [ ] **Tests**
+  - `cargo test -p tree-sitter-perl-c`
+- [ ] **Query conformance (injections/highlights behavior)**
+  - `cargo test -p tree-sitter-perl-c bdd_injections_query`
+- [ ] **Benchmark sanity (non-regression smoke)**
+  - `cargo run -p tree-sitter-perl-c --bin bench_parser_c --features test-utils -- tree-sitter-perl/test/corpus/statements`
+
+If any step fails, do not ship the snapshot update without documenting the delta.

--- a/crates/tree-sitter-perl-c/build.rs
+++ b/crates/tree-sitter-perl-c/build.rs
@@ -4,12 +4,12 @@
 //! (`scanner.c`) via the `cc` crate and exposes the resulting static
 //! library as `tree-sitter-perl-c`.
 //!
-//! The C sources live under `c-src/` and are a snapshot of the upstream
-//! tree-sitter Perl grammar. The `c-src/` directory IS the canonical source
-//! of truth within this repository; this crate carries its own copy so the
-//! published package is self-contained and does not need paths outside the
-//! crate directory. (The old `tree-sitter-perl-rs` harness has been archived
-//! to `archive/crates/tree-sitter-perl-rs/`.)
+//! The C sources live under `c-src/` and are a vendored snapshot of the
+//! upstream tree-sitter Perl grammar. Provenance + refresh procedure are
+//! documented in `UPSTREAM_SNAPSHOT.md`.
+//!
+//! `c-src/` = vendored upstream C grammar files.
+//! `src/`, `tests/`, and this build script = local Rust wrapper code.
 //!
 //! No bindgen is involved: the single symbol we need from the C library
 //! (`tree_sitter_perl`) is declared by hand in `src/lib.rs`.


### PR DESCRIPTION
### Motivation

- Make the vendored C snapshot in `crates/tree-sitter-perl-c/c-src/` auditable and refreshable by recording upstream provenance, fingerprints, and a reproducible refresh procedure.
- Reduce maintenance mystery by clearly separating what is vendored from upstream (`c-src/`) vs. what is local Rust wrapper and tooling (`src/`, `tests/`, `build.rs`, docs).
- Provide a short validation checklist so maintainers can safely refresh the snapshot and verify build, tests, query conformance, and benchmark sanity.

### Description

- Add `crates/tree-sitter-perl-c/UPSTREAM_SNAPSHOT.md` documenting upstream repo, tracking ref policy, generator version, import provenance, SHA-256 fingerprints, a step-by-step refresh procedure, and a refresh validation checklist.
- Update `crates/tree-sitter-perl-c/README.md` to reference the provenance document and to list which files are vendored vs local wrapper code.
- Add a `Snapshot Governance` section in `crates/tree-sitter-perl-c/ROADMAP.md` pointing to `UPSTREAM_SNAPSHOT.md` as the canonical maintenance contract.
- Clarify build-level documentation in `crates/tree-sitter-perl-c/build.rs` and include `UPSTREAM_SNAPSHOT.md` in `crates/tree-sitter-perl-c/Cargo.toml` `include` so provenance ships with the crate.

### Testing

- Ran `cargo check --all-targets -p tree-sitter-perl-c`, which completed successfully.
- Ran `cargo test -p tree-sitter-perl-c` (unit, BDD workflows, and doctests), which passed all tests.
- Ran the query-focused test `cargo test -p tree-sitter-perl-c bdd_injections_query`, which passed.
- Ran the benchmark smoke `cargo run -p tree-sitter-perl-c --bin bench_parser_c --features test-utils -- tree-sitter-perl/test/corpus/statements`, which executed successfully as a non-regression smoke check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb277bec1c833386842becf6debd7b)