### PR TITLE
docs(tree-sitter-perl-c): add upstream snapshot provenance and refresh workflow (#0000)

### DIFF
--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -17,6 +17,28 @@ The crate is self-contained: the C sources live under `c-src/` and are shipped
 in the published package. There is no `bindgen` or `libclang` dependency — the
 single symbol we need (`tree_sitter_perl`) is declared by hand in `src/lib.rs`.
 
+## Snapshot Provenance and Refresh
+
+The vendored grammar snapshot is tracked in [`UPSTREAM_SNAPSHOT.md`](UPSTREAM_SNAPSHOT.md).
+That file is the audit source for:
+
+- upstream repository URL
+- pinned upstream ref/commit (or explicit legacy-unknown status)
+- tree-sitter generator version used for `parser.c`
+- reproducible refresh procedure and validation checklist
+
+### Vendored vs local code ownership
+
+| Path | Ownership | Notes |
+|---|---|---|
+| `c-src/parser.c` | Vendored upstream artifact | Generated C parser (do not hand-edit) |
+| `c-src/scanner.c` | Vendored upstream artifact | External scanner C code (do not hand-edit) |
+| `c-src/bsearch.h`, `c-src/tsp_unicode.h` | Vendored upstream artifacts | Scanner support headers |
+| `c-src/tree_sitter/*.h` | Vendored upstream runtime headers | Required to compile parser/scanner |
+| `build.rs` | Local wrapper code | Compiles vendored C with `cc` |
+| `src/lib.rs` | Local wrapper code | Rust API + FFI declaration for `tree_sitter_perl` |
+| `tests/`, `src/bin/` | Local wrapper code | Behavior tests, parser/benchmark binaries |
+
 ## This crate vs. `tree-sitter-perl-rs`
 
 | | `tree-sitter-perl-c` (this crate) | `tree-sitter-perl-rs` |

--- a/crates/tree-sitter-perl-c/ROADMAP.md
+++ b/crates/tree-sitter-perl-c/ROADMAP.md
@@ -20,6 +20,10 @@ This crate tracks the upstream [tree-sitter-perl] C grammar. The public API
 (`language()`, `try_create_parser()`, `parse_perl_code()`, etc.) is stable.
 Breaking changes will follow semver.
 
+Snapshot provenance is tracked in [`UPSTREAM_SNAPSHOT.md`](UPSTREAM_SNAPSHOT.md),
+including the pinned upstream reference, generator version, file fingerprints,
+and the refresh+validation workflow.
+
 **Known limitations vs. upstream grammar:**
 
 - The vendored `c-src/` is a periodic snapshot; it may lag behind upstream by
@@ -32,6 +36,7 @@ Breaking changes will follow semver.
 ### Maintenance (ongoing)
 
 - Periodic snapshot updates when upstream tree-sitter-perl releases new grammar versions.
+- Keep [`UPSTREAM_SNAPSHOT.md`](UPSTREAM_SNAPSHOT.md) current for every snapshot refresh.
 - Keep `tree-sitter` runtime dependency in sync with the workspace.
 
 ### Not planned

--- a/crates/tree-sitter-perl-c/UPSTREAM_SNAPSHOT.md
+++ b/crates/tree-sitter-perl-c/UPSTREAM_SNAPSHOT.md
@@ -1,0 +1,81 @@
+# tree-sitter-perl-c Upstream Snapshot
+
+This document is the canonical provenance + refresh log for the vendored C
+snapshot in `crates/tree-sitter-perl-c/c-src/`.
+
+## Current vendored snapshot
+
+- **Upstream repository:** <https://github.com/tree-sitter-perl/tree-sitter-perl>
+- **Upstream branch/reference policy:** `master` (refreshes are pulled from upstream
+  default branch unless a specific release/tag is requested)
+- **Pinned upstream commit:** **LEGACY-UNKNOWN** for the currently vendored
+  baseline introduced in `c57aadcba61cf295c6abc2b2a9c85cdf13de9cbb` on
+  **2026-04-23**.
+- **tree-sitter generator version (from `c-src/parser.c` header):** `v0.25.9`
+
+### Snapshot fingerprints (current baseline)
+
+Use these to verify the exact C snapshot currently shipped by this crate.
+
+```text
+c-src/parser.c                    sha256 07b7bb23511188e97cfdbd6ac6289439f872e58504d2c51d9e24e59fae957d2a
+c-src/scanner.c                   sha256 01bbea22f0864679692fb0163b29304d346666f2181b1dbbe08f900c9bb219eb
+c-src/bsearch.h                   sha256 cb08206e89750c1fab700b89fc9876afb5cc689827e514ef49a5569c54635b61
+c-src/tsp_unicode.h               sha256 9cbc0731f8c9bd52bd3de9644fd887f20cecea2d17634b20769db4940eadb566
+c-src/tree_sitter/parser.h        sha256 2d5f15e194c8f52f96645ebf9e647f322f6eb8f8daa7135af79f76bf0ec77fcd
+c-src/tree_sitter/array.h         sha256 d230d6f16f045be8fddf6f69a78f38db37f6db49fce4df410d11f7d1655ab0be
+c-src/tree_sitter/alloc.h         sha256 b83867de8b96f30f2bbf2ca30cdf9f8f7efff761f4f2fccc743789aec98bdd95
+```
+
+## Vendored vs local files
+
+### Vendored from upstream grammar snapshot
+
+- `c-src/parser.c`
+- `c-src/scanner.c`
+- `c-src/bsearch.h`
+- `c-src/tsp_unicode.h`
+- `c-src/tree_sitter/parser.h`
+- `c-src/tree_sitter/array.h`
+- `c-src/tree_sitter/alloc.h`
+
+### Local wrapper/runtime integration (this repository)
+
+- `build.rs`
+- `src/lib.rs`
+- `src/bin/*`
+- `tests/*`
+- `README.md`, `ROADMAP.md`, this file
+
+## Refresh procedure
+
+1. **Select upstream ref**
+   - Choose a concrete upstream commit/tag from
+     `https://github.com/tree-sitter-perl/tree-sitter-perl`.
+   - Record it in this file before opening the PR.
+2. **Regenerate parser artifacts**
+   - In an upstream checkout at that commit, run:
+     - `tree-sitter --version` (record exact version here)
+     - `tree-sitter generate`
+3. **Copy vendored files into this crate**
+   - Copy `src/parser.c`, `src/scanner.c`, `src/bsearch.h`, `src/tsp_unicode.h`.
+   - Copy `src/tree_sitter/{parser.h,array.h,alloc.h}`.
+4. **Update metadata in this file**
+   - Update pinned commit/tag and all SHA-256 fingerprints.
+
+## Refresh validation checklist
+
+Run these before commit/PR:
+
+- [ ] Build check: `cargo check --all-targets -p tree-sitter-perl-c`
+- [ ] Crate tests: `cargo test -p tree-sitter-perl-c`
+- [ ] Query conformance:
+  `cargo test -p tree-sitter-perl-c bdd_query_parsing_succeeds_for_injections_query`
+- [ ] Benchmark sanity (non-regression smoke):
+  `cargo run -p tree-sitter-perl-c --bin bench_parser_c --features test-utils -- <sample.pl>`
+
+## Provenance hardening follow-up
+
+The current baseline was imported before provenance metadata was added. On the
+next snapshot refresh, replace `LEGACY-UNKNOWN` with the exact upstream commit
+or release tag and keep that value immutable for future audits.

--- a/crates/tree-sitter-perl-c/build.rs
+++ b/crates/tree-sitter-perl-c/build.rs
@@ -4,12 +4,16 @@
 //! (`scanner.c`) via the `cc` crate and exposes the resulting static
 //! library as `tree-sitter-perl-c`.
 //!
-//! The C sources live under `c-src/` and are a snapshot of the upstream
-//! tree-sitter Perl grammar. The `c-src/` directory IS the canonical source
-//! of truth within this repository; this crate carries its own copy so the
-//! published package is self-contained and does not need paths outside the
-//! crate directory. (The old `tree-sitter-perl-rs` harness has been archived
-//! to `archive/crates/tree-sitter-perl-rs/`.)
+//! The C sources live under `c-src/` and are vendored upstream artifacts.
+//! Local Rust wrapper code (`build.rs`, `src/lib.rs`, tests, bins) is
+//! maintained separately from those vendored C files.
+//!
+//! Snapshot provenance (upstream repo/ref, generator version, fingerprints,
+//! and refresh workflow) is tracked in `UPSTREAM_SNAPSHOT.md`.
+//!
+//! The `c-src/` directory IS the canonical source of truth within this
+//! repository; this crate carries its own copy so the published package is
+//! self-contained and does not need paths outside the crate directory.
 //!
 //! No bindgen is involved: the single symbol we need from the C library
 //! (`tree_sitter_perl`) is declared by hand in `src/lib.rs`.


### PR DESCRIPTION
### Motivation

- Make the vendored C grammar snapshot auditable and refreshable by recording upstream provenance, fingerprints, and a reproducible refresh workflow so maintainers can safely update the snapshot.
- Clarify which files are upstream/vendored versus which are local Rust wrapper and test code to avoid accidental edits of generated artifacts.

### Description

- Add `crates/tree-sitter-perl-c/UPSTREAM_SNAPSHOT.md` with upstream repository URL, pinned ref status (`LEGACY-UNKNOWN` for the current baseline), tree-sitter generator version, SHA-256 fingerprints for shipped C/header files, a step-by-step refresh procedure, and a refresh validation checklist.
- Update `crates/tree-sitter-perl-c/README.md` to link to the snapshot ledger and add a vendored-vs-local ownership table describing which files are upstream artifacts and which are local wrapper/runtime code.
- Update `crates/tree-sitter-perl-c/ROADMAP.md` to require keeping `UPSTREAM_SNAPSHOT.md` current and reference the provenance workflow.
- Clarify `crates/tree-sitter-perl-c/build.rs` documentation to mention provenance tracking in `UPSTREAM_SNAPSHOT.md` and to separate vendored C artifacts from local Rust wrapper code.

### Testing

- Ran `cargo check --all-targets -p tree-sitter-perl-c`, which completed successfully.
- Verified file edits and new `UPSTREAM_SNAPSHOT.md` were added and compiled into the workspace without build-time regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb277bec1c833386842becf6debd7b)