### PR TITLE
docs(tree-sitter-perl-c): add upstream snapshot provenance and refresh workflow (#0000)

### DIFF
--- a/crates/tree-sitter-perl-c/Cargo.toml
+++ b/crates/tree-sitter-perl-c/Cargo.toml
@@ -18,6 +18,7 @@ include = [
     "build.rs",
     "Cargo.toml",
     "README.md",
+    "UPSTREAM_SNAPSHOT.md",
     "LICENSE-APACHE",
     "LICENSE-MIT",
 ]

--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -87,6 +87,33 @@ for snippet in &["my $x = 1;", "print $x;"] {
 - `parse_c` — parse a Perl file and exit with 0 (success) or 1 (error)
 - `bench_parser_c` — parse a Perl file and print timing (requires `--features test-utils`)
 
+
+## Snapshot Provenance & Refresh
+
+This crate ships a vendored C snapshot. The canonical provenance record is
+[`UPSTREAM_SNAPSHOT.md`](./UPSTREAM_SNAPSHOT.md), which captures:
+
+- upstream repository and branch/reference
+- snapshot identity (commit/ref when known, plus local artifact checksums)
+- generator version used for `parser.c`
+- the exact local refresh and validation workflow
+
+If you are updating `c-src/`, follow that file end-to-end and update it in the
+same commit as the vendored C changes.
+
+## What is vendored vs local
+
+- **Vendored upstream grammar snapshot (`c-src/`)**
+  - `parser.c`, `scanner.c`, `tsp_unicode.h`, `bsearch.h`
+  - `tree_sitter/parser.h`, `tree_sitter/array.h`, `tree_sitter/alloc.h`
+- **Local wrapper/integration code (maintained in this repo)**
+  - `build.rs` (C compilation + rerun wiring)
+  - `src/lib.rs` (FFI symbol declaration + Rust API helpers)
+  - `src/bin/*` (CLI parse and benchmark helpers)
+
+Do not hand-edit vendored grammar files under `c-src/`; regenerate/refresh them
+from upstream and record the provenance update.
+
 ## Build Requirements
 
 Only a C compiler is required. No `libclang` or other FFI-generator toolchain

--- a/crates/tree-sitter-perl-c/ROADMAP.md
+++ b/crates/tree-sitter-perl-c/ROADMAP.md
@@ -27,6 +27,23 @@ Breaking changes will follow semver.
 - The crate does not expose tree-sitter query helpers — use the
   `tree-sitter` crate directly with the `language()` return value.
 
+
+## Snapshot Governance
+
+`tree-sitter-perl-c` treats `c-src/` as a vendored upstream artifact boundary:
+
+- **Upstream-owned content:** grammar snapshot files in `c-src/`
+- **Local-owned content:** Rust wrapper/build integration in `src/` and `build.rs`
+
+Snapshot provenance and refresh instructions live in
+[`UPSTREAM_SNAPSHOT.md`](./UPSTREAM_SNAPSHOT.md).
+
+Maintenance policy:
+
+1. Grammar fixes happen upstream first.
+2. Snapshot refreshes are pull-through updates (no local edits inside `c-src/`).
+3. Every refresh commit updates provenance metadata and reruns the local validation checklist.
+
 ## Planned Work
 
 ### Maintenance (ongoing)

--- a/crates/tree-sitter-perl-c/UPSTREAM_SNAPSHOT.md
+++ b/crates/tree-sitter-perl-c/UPSTREAM_SNAPSHOT.md
@@ -1,0 +1,76 @@
+# Upstream Snapshot Provenance (`tree-sitter-perl-c`)
+
+This file is the audit record for the vendored C grammar under `c-src/`.
+Update it in the same commit whenever `c-src/` changes.
+
+## Current vendored snapshot (as checked into this repo)
+
+- Upstream repository: <https://github.com/tree-sitter-perl/tree-sitter-perl>
+- Upstream tracking reference: `main` branch
+- Upstream commit: **unknown (legacy import before provenance policy)**
+- Parser generator: `tree-sitter v0.25.9` (from banner in `c-src/parser.c`)
+
+### Artifact identity (current checkout)
+
+Use these checksums to prove exactly what snapshot is vendored today:
+
+- `c-src/parser.c`: `07b7bb23511188e97cfdbd6ac6289439f872e58504d2c51d9e24e59fae957d2a`
+- `c-src/scanner.c`: `01bbea22f0864679692fb0163b29304d346666f2181b1dbbe08f900c9bb219eb`
+- `c-src/tsp_unicode.h`: `9cbc0731f8c9bd52bd3de9644fd887f20cecea2d17634b20769db4940eadb566`
+- `c-src/bsearch.h`: `cb08206e89750c1fab700b89fc9876afb5cc689827e514ef49a5569c54635b61`
+
+> Next refresh requirement: replace the `unknown` commit with an exact upstream
+> commit SHA (or release tag + commit SHA) and keep the checksum block updated.
+
+## Ownership boundary
+
+- **Vendored upstream files:** everything under `c-src/`
+- **Local wrapper code:** `build.rs`, `src/lib.rs`, `src/bin/*`, crate docs
+
+Policy: do not hand-edit `c-src/*` for local behavior changes. Fix upstream,
+then refresh the snapshot.
+
+## Refresh procedure (local)
+
+1. Clone upstream and check out the target commit/tag.
+2. Install/use the intended `tree-sitter` CLI version.
+3. Regenerate parser artifacts upstream.
+4. Copy the generated snapshot into this crate.
+5. Update this file with upstream commit/tag, generator version, and new checksums.
+6. Run the validation checklist below.
+
+Reference command sequence:
+
+```bash
+# from repo root
+TMP_DIR="$(mktemp -d)"
+git clone https://github.com/tree-sitter-perl/tree-sitter-perl "$TMP_DIR"
+cd "$TMP_DIR"
+git checkout <upstream-commit-or-tag>
+
+# pin generator for reproducibility
+npx tree-sitter@0.25.9 generate
+
+# copy generated snapshot into this crate
+cp src/parser.c /workspace/perl-lsp/crates/tree-sitter-perl-c/c-src/parser.c
+cp src/scanner.c /workspace/perl-lsp/crates/tree-sitter-perl-c/c-src/scanner.c
+cp src/tsp_unicode.h /workspace/perl-lsp/crates/tree-sitter-perl-c/c-src/tsp_unicode.h
+cp src/bsearch.h /workspace/perl-lsp/crates/tree-sitter-perl-c/c-src/bsearch.h
+cp -r src/tree_sitter /workspace/perl-lsp/crates/tree-sitter-perl-c/c-src/
+```
+
+## Refresh validation checklist
+
+Run these checks after updating `c-src/`:
+
+- [ ] Build/check crate targets
+  - `cargo check --all-targets -p tree-sitter-perl-c`
+- [ ] Crate tests
+  - `cargo test -p tree-sitter-perl-c`
+- [ ] Query conformance against upstream query suite
+  - in upstream checkout: `tree-sitter test`
+- [ ] Benchmark sanity (no obvious regression spikes)
+  - `cargo run -p tree-sitter-perl-c --bin bench_parser_c --features test-utils -- <sample.pl>`
+
+If a check fails, do not publish the snapshot refresh until resolved or explicitly
+explained in the PR.

--- a/crates/tree-sitter-perl-c/build.rs
+++ b/crates/tree-sitter-perl-c/build.rs
@@ -4,12 +4,10 @@
 //! (`scanner.c`) via the `cc` crate and exposes the resulting static
 //! library as `tree-sitter-perl-c`.
 //!
-//! The C sources live under `c-src/` and are a snapshot of the upstream
-//! tree-sitter Perl grammar. The `c-src/` directory IS the canonical source
-//! of truth within this repository; this crate carries its own copy so the
-//! published package is self-contained and does not need paths outside the
-//! crate directory. (The old `tree-sitter-perl-rs` harness has been archived
-//! to `archive/crates/tree-sitter-perl-rs/`.)
+//! Upstream-owned vendored files are isolated under `c-src/`; local wrapper
+//! logic lives in this build script and Rust sources under `src/`.
+//! Provenance and refresh instructions are documented in
+//! `UPSTREAM_SNAPSHOT.md`.
 //!
 //! No bindgen is involved: the single symbol we need from the C library
 //! (`tree_sitter_perl`) is declared by hand in `src/lib.rs`.


### PR DESCRIPTION
### Motivation

- Make the vendored C snapshot auditable and refreshable by recording exact provenance and an explicit refresh workflow.
- Reduce maintenance mystery by clearly separating upstream-vendored grammar artifacts from local Rust wrapper/integration code.

### Description

- Add `crates/tree-sitter-perl-c/UPSTREAM_SNAPSHOT.md` containing upstream repo reference, tracking ref, generator version, artifact checksums, copy-and-refresh commands, and a validation checklist. 
- Update `crates/tree-sitter-perl-c/README.md` to point to the canonical provenance file and to enumerate which files are vendored (`c-src/*`) vs local wrapper code (`build.rs`, `src/lib.rs`, `src/bin/*`).
- Add a `Snapshot Governance` section to `crates/tree-sitter-perl-c/ROADMAP.md` describing ownership boundaries and the refresh policy.
- Clarify build script documentation in `crates/tree-sitter-perl-c/build.rs` to reference the vendored boundary and `UPSTREAM_SNAPSHOT.md`, and include `UPSTREAM_SNAPSHOT.md` in the crate `include` list in `crates/tree-sitter-perl-c/Cargo.toml` so provenance ships with the package.
- Record current artifact checksums for `c-src/parser.c`, `c-src/scanner.c`, `c-src/tsp_unicode.h`, and `c-src/bsearch.h` in the provenance file and provide example `npx tree-sitter@<version> generate` and copy commands for reproducible refreshes.

### Testing

- Ran `cargo check --all-targets -p tree-sitter-perl-c`, which completed successfully. 
- Ran `cargo test -p tree-sitter-perl-c`, which completed successfully (unit tests, BDD tests and doctests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb277bec1c833386842becf6debd7b)