### PR TITLE
feat(tree-sitter-perl-c): add parser-reuse parse helpers (#5388)

### DIFF
--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -57,15 +57,15 @@ fn main() {
 }
 ```
 
-For repeated parsing, reuse a configured parser:
+For repeated parsing, reuse a configured parser with the helper APIs:
 
 ```rust
-use tree_sitter_perl_c::try_create_parser;
+use tree_sitter_perl_c::{parse_perl_code_with_parser, try_create_parser};
 
 let mut parser = try_create_parser().unwrap();
 
 for snippet in &["my $x = 1;", "print $x;"] {
-    let tree = parser.parse(snippet, None).unwrap();
+    let tree = parse_perl_code_with_parser(&mut parser, snippet).unwrap();
     assert!(!tree.root_node().has_error());
 }
 ```
@@ -78,7 +78,9 @@ for snippet in &["my $x = 1;", "print $x;"] {
 | `try_create_parser()` | Creates a `tree_sitter::Parser` (returns `Result`) |
 | `create_parser()` | Creates a parser, silently ignoring language-set errors |
 | `parse_perl_bytes(code)` | Parses raw bytes (including non-UTF-8 Perl source) |
+| `parse_perl_bytes_with_parser(parser, code)` | Parses raw bytes with a caller-provided configured parser |
 | `parse_perl_code(code)` | Parses a `&str` into a `tree_sitter::Tree` |
+| `parse_perl_code_with_parser(parser, code)` | Parses a `&str` with a caller-provided configured parser |
 | `parse_perl_file(path)` | Reads and parses a file (non-UTF-8 safe) |
 | `get_scanner_config()` | Returns `"c-scanner"` |
 

--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -128,6 +128,23 @@ pub fn create_parser() -> Parser {
 /// if tree-sitter returns `None` from `parse` (cancelled or timed out).
 pub fn parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
     let mut parser = try_create_parser()?;
+    parse_perl_bytes_with_parser(&mut parser, code)
+}
+
+/// Parses Perl source bytes using a caller-provided configured [`tree_sitter::Parser`].
+///
+/// This helper is intended for performance-sensitive code paths where a single
+/// parser is reused across many snippets. The parser must already be configured
+/// with [`language`].
+///
+/// # Errors
+///
+/// Returns an error if tree-sitter returns `None` from `parse` (cancelled or
+/// timed out).
+pub fn parse_perl_bytes_with_parser(
+    parser: &mut Parser,
+    code: &[u8],
+) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
     match parser.parse(code, None) {
         Some(tree) => Ok(tree),
         None => Err("Failed to parse code".into()),
@@ -150,7 +167,24 @@ pub fn parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, Box<dyn std::e
 /// assert!(!tree.root_node().has_error());
 /// ```
 pub fn parse_perl_code(code: &str) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    parse_perl_bytes(code.as_bytes())
+    let mut parser = try_create_parser()?;
+    parse_perl_code_with_parser(&mut parser, code)
+}
+
+/// Parses a Perl source string using a caller-provided configured [`tree_sitter::Parser`].
+///
+/// This helper avoids creating and configuring a new parser for each parse call.
+/// The parser must already be configured with [`language`].
+///
+/// # Errors
+///
+/// Returns an error if tree-sitter returns `None` from `parse` (cancelled or
+/// timed out).
+pub fn parse_perl_code_with_parser(
+    parser: &mut Parser,
+    code: &str,
+) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
+    parse_perl_bytes_with_parser(parser, code.as_bytes())
 }
 
 /// Reads a file from `path` and parses it as Perl source.
@@ -215,6 +249,32 @@ mod tests {
         let code = b"my $var = 'hello';";
         let tree = parse_perl_bytes(code)?;
         assert!(!tree.root_node().has_error());
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_bytes_with_reused_parser() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = try_create_parser()?;
+
+        let first = parse_perl_bytes_with_parser(&mut parser, b"my $x = 1;")?;
+        assert!(!first.root_node().has_error());
+
+        let second = parse_perl_bytes_with_parser(&mut parser, b"my $y = 2;")?;
+        assert!(!second.root_node().has_error());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_code_with_reused_parser() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = try_create_parser()?;
+
+        let first = parse_perl_code_with_parser(&mut parser, "my $name = 'Perl';")?;
+        assert!(!first.root_node().has_error());
+
+        let second = parse_perl_code_with_parser(&mut parser, "print $name;")?;
+        assert!(!second.root_node().has_error());
+
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation
- Performance-sensitive callers need a way to reuse a configured `tree_sitter::Parser` instead of allocating and configuring a new parser per parse call. 
- Preserve existing convenience helpers while exposing reuse-friendly entry points so callers can opt-in to reuse without changing existing behavior.

### Description
- Add `parse_perl_bytes_with_parser(parser: &mut Parser, code: &[u8])` which parses raw bytes using a caller-provided, already-configured `Parser`.
- Add `parse_perl_code_with_parser(parser: &mut Parser, code: &str)` which delegates to `parse_perl_bytes_with_parser` for `&str` inputs.
- Update `parse_perl_bytes` and `parse_perl_code` to delegate through the new reuse helpers by creating a parser via `try_create_parser()` and calling the `_with_parser` variants.
- Add unit tests `test_parse_bytes_with_reused_parser` and `test_parse_code_with_reused_parser`, and update the crate `README.md` and public API table to document the reuse helpers.

### Testing
- Ran `cargo test -p tree-sitter-perl-c`, which executed unit tests, BDD workflow tests and doctests, and all tests passed.
- Ran `cargo check --all-targets -p tree-sitter-perl-c`, which completed successfully.
- Ran `cargo xtask fmt` to format code, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb277f84c8833389c3c5a7034e95b9)