### PR TITLE
feat(tree-sitter-perl-c): add parser-reuse parse helpers (#5388)

### DIFF
--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -57,15 +57,15 @@ fn main() {
 }
 ```
 
-For repeated parsing, reuse a configured parser:
+For repeated parsing, reuse a configured parser with helper functions:
 
 ```rust
-use tree_sitter_perl_c::try_create_parser;
+use tree_sitter_perl_c::{parse_perl_code_with_parser, try_create_parser};
 
 let mut parser = try_create_parser().unwrap();
 
 for snippet in &["my $x = 1;", "print $x;"] {
-    let tree = parser.parse(snippet, None).unwrap();
+    let tree = parse_perl_code_with_parser(&mut parser, snippet).unwrap();
     assert!(!tree.root_node().has_error());
 }
 ```
@@ -78,7 +78,9 @@ for snippet in &["my $x = 1;", "print $x;"] {
 | `try_create_parser()` | Creates a `tree_sitter::Parser` (returns `Result`) |
 | `create_parser()` | Creates a parser, silently ignoring language-set errors |
 | `parse_perl_bytes(code)` | Parses raw bytes (including non-UTF-8 Perl source) |
+| `parse_perl_bytes_with_parser(parser, code)` | Parses raw bytes with a reused configured parser |
 | `parse_perl_code(code)` | Parses a `&str` into a `tree_sitter::Tree` |
+| `parse_perl_code_with_parser(parser, code)` | Parses `&str` with a reused configured parser |
 | `parse_perl_file(path)` | Reads and parses a file (non-UTF-8 safe) |
 | `get_scanner_config()` | Returns `"c-scanner"` |
 

--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -128,6 +128,22 @@ pub fn create_parser() -> Parser {
 /// if tree-sitter returns `None` from `parse` (cancelled or timed out).
 pub fn parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
     let mut parser = try_create_parser()?;
+    parse_perl_bytes_with_parser(&mut parser, code)
+}
+
+/// Parses Perl source bytes using an already configured [`tree_sitter::Parser`].
+///
+/// Use this helper when parsing many snippets and you want to reuse a single
+/// parser instance to avoid repeated parser configuration work.
+///
+/// # Errors
+///
+/// Returns an error if tree-sitter returns `None` from `parse` (cancelled or
+/// timed out).
+pub fn parse_perl_bytes_with_parser(
+    parser: &mut Parser,
+    code: &[u8],
+) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
     match parser.parse(code, None) {
         Some(tree) => Ok(tree),
         None => Err("Failed to parse code".into()),
@@ -150,7 +166,24 @@ pub fn parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, Box<dyn std::e
 /// assert!(!tree.root_node().has_error());
 /// ```
 pub fn parse_perl_code(code: &str) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    parse_perl_bytes(code.as_bytes())
+    let mut parser = try_create_parser()?;
+    parse_perl_code_with_parser(&mut parser, code)
+}
+
+/// Parses a Perl source string using an already configured [`tree_sitter::Parser`].
+///
+/// Use this helper when parsing many snippets and you want to reuse a single
+/// parser instance to avoid repeated parser configuration work.
+///
+/// # Errors
+///
+/// Returns an error if tree-sitter returns `None` from `parse` (cancelled or
+/// timed out).
+pub fn parse_perl_code_with_parser(
+    parser: &mut Parser,
+    code: &str,
+) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
+    parse_perl_bytes_with_parser(parser, code.as_bytes())
 }
 
 /// Reads a file from `path` and parses it as Perl source.
@@ -281,6 +314,30 @@ mod tests {
     fn test_parse_bytes_empty_source() -> Result<(), Box<dyn std::error::Error>> {
         let tree = parse_perl_bytes(b"")?;
         assert_eq!(tree.root_node().kind(), "source_file");
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_perl_bytes_with_reused_parser() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = try_create_parser()?;
+
+        for code in [b"my $x = 1;" as &[u8], b"my $y = 2;"] {
+            let tree = parse_perl_bytes_with_parser(&mut parser, code)?;
+            assert!(!tree.root_node().has_error());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_perl_code_with_reused_parser() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = try_create_parser()?;
+
+        for code in ["my $x = 1;", "print $x;"] {
+            let tree = parse_perl_code_with_parser(&mut parser, code)?;
+            assert!(!tree.root_node().has_error());
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- Avoid repeated parser configuration work for performance-sensitive callers by providing helpers that accept a reusable configured `Parser` instance.
- Surface the same seam used in earlier work so callers no longer need to bypass crate helpers to reuse a parser.

### Description
- Added `parse_perl_bytes_with_parser(parser: &mut Parser, code: &[u8])` and `parse_perl_code_with_parser(parser: &mut Parser, code: &str)` to allow parser reuse. 
- Routed existing convenience helpers `parse_perl_bytes` and `parse_perl_code` through the new reuse helpers to keep behaviour identical while enabling reuse. 
- Added unit tests `test_parse_perl_bytes_with_reused_parser` and `test_parse_perl_code_with_reused_parser` that parse multiple snippets using a single `Parser` instance. 
- Updated `crates/tree-sitter-perl-c/README.md` to document the reuse path and added the new helpers to the public API table.

### Testing
- Ran `cargo test -p tree-sitter-perl-c` and all tests passed. 
- Ran `cargo check --all-targets -p tree-sitter-perl-c` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb277f84c8833389c3c5a7034e95b9)