### PR TITLE
feat(tree-sitter-perl-c): add parser-reuse parse helpers (#5388)

### DIFF
--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -60,12 +60,12 @@ fn main() {
 For repeated parsing, reuse a configured parser:
 
 ```rust
-use tree_sitter_perl_c::try_create_parser;
+use tree_sitter_perl_c::{parse_perl_code_with_parser, try_create_parser};
 
 let mut parser = try_create_parser().unwrap();
 
 for snippet in &["my $x = 1;", "print $x;"] {
-    let tree = parser.parse(snippet, None).unwrap();
+    let tree = parse_perl_code_with_parser(&mut parser, snippet).unwrap();
     assert!(!tree.root_node().has_error());
 }
 ```
@@ -78,7 +78,9 @@ for snippet in &["my $x = 1;", "print $x;"] {
 | `try_create_parser()` | Creates a `tree_sitter::Parser` (returns `Result`) |
 | `create_parser()` | Creates a parser, silently ignoring language-set errors |
 | `parse_perl_bytes(code)` | Parses raw bytes (including non-UTF-8 Perl source) |
+| `parse_perl_bytes_with_parser(parser, code)` | Parses raw bytes with a reused configured parser |
 | `parse_perl_code(code)` | Parses a `&str` into a `tree_sitter::Tree` |
+| `parse_perl_code_with_parser(parser, code)` | Parses a `&str` with a reused configured parser |
 | `parse_perl_file(path)` | Reads and parses a file (non-UTF-8 safe) |
 | `get_scanner_config()` | Returns `"c-scanner"` |
 

--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -128,6 +128,23 @@ pub fn create_parser() -> Parser {
 /// if tree-sitter returns `None` from `parse` (cancelled or timed out).
 pub fn parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
     let mut parser = try_create_parser()?;
+    parse_perl_bytes_with_parser(&mut parser, code)
+}
+
+/// Parses Perl source bytes using an already configured [`tree_sitter::Parser`].
+///
+/// This is intended for parser reuse in performance-sensitive paths where many
+/// snippets are parsed in sequence and repeated parser initialisation should be
+/// avoided.
+///
+/// # Errors
+///
+/// Returns an error if tree-sitter returns `None` from `parse` (cancelled or
+/// timed out).
+pub fn parse_perl_bytes_with_parser(
+    parser: &mut Parser,
+    code: &[u8],
+) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
     match parser.parse(code, None) {
         Some(tree) => Ok(tree),
         None => Err("Failed to parse code".into()),
@@ -150,7 +167,25 @@ pub fn parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, Box<dyn std::e
 /// assert!(!tree.root_node().has_error());
 /// ```
 pub fn parse_perl_code(code: &str) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    parse_perl_bytes(code.as_bytes())
+    let mut parser = try_create_parser()?;
+    parse_perl_code_with_parser(&mut parser, code)
+}
+
+/// Parses a Perl source string using an already configured
+/// [`tree_sitter::Parser`].
+///
+/// This helper mirrors [`parse_perl_bytes_with_parser`] for UTF-8 inputs and is
+/// useful when reusing one parser across many snippets.
+///
+/// # Errors
+///
+/// Returns an error if tree-sitter returns `None` from `parse` (cancelled or
+/// timed out).
+pub fn parse_perl_code_with_parser(
+    parser: &mut Parser,
+    code: &str,
+) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
+    parse_perl_bytes_with_parser(parser, code.as_bytes())
 }
 
 /// Reads a file from `path` and parses it as Perl source.
@@ -281,6 +316,30 @@ mod tests {
     fn test_parse_bytes_empty_source() -> Result<(), Box<dyn std::error::Error>> {
         let tree = parse_perl_bytes(b"")?;
         assert_eq!(tree.root_node().kind(), "source_file");
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_reuse_with_one_parser_for_strings() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = try_create_parser()?;
+
+        for code in ["my $x = 1;", "my $y = $x + 2;", "print $y;"] {
+            let tree = parse_perl_code_with_parser(&mut parser, code)?;
+            assert!(!tree.root_node().has_error());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_reuse_with_one_parser_for_bytes() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = try_create_parser()?;
+
+        for code in [b"my $x = 1;".as_slice(), b"my $z = $x * 3;", b"print $z;\n"] {
+            let tree = parse_perl_bytes_with_parser(&mut parser, code)?;
+            assert!(!tree.root_node().has_error());
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- Performance-sensitive callers need to reuse a configured `tree_sitter::Parser` to avoid repeated parser initialisation when parsing many small snippets.
- Provide a stable, documented seam for parser reuse that mirrors the existing convenience helpers.

### Description
- Added `parse_perl_bytes_with_parser(parser: &mut Parser, code: &[u8])` which parses raw bytes using an already-configured `Parser` and returns a `tree_sitter::Tree` or an error.
- Added `parse_perl_code_with_parser(parser: &mut Parser, code: &str)` which delegates to `parse_perl_bytes_with_parser` for UTF-8 `&str` inputs.
- Kept existing convenience helpers (`parse_perl_bytes` and `parse_perl_code`) and routed them to create a parser and delegate to the new reuse helpers.
- Updated `README.md` to document the reuse helpers and added unit tests that parse multiple snippets through a single parser instance for both `&str` and `&[u8]`.

### Testing
- Ran `cargo test -p tree-sitter-perl-c` and all unit, BDD and doctests passed (`9` unit tests + `9` bdd tests + doc-tests; overall: `ok`).
- Ran `cargo check --all-targets -p tree-sitter-perl-c` which completed successfully.
- Ran `cargo xtask fmt` which completed successfully in this environment; `just pr-fast` was not available here and was not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb277f84c8833389c3c5a7034e95b9)