### PR TITLE
feat(tree-sitter-perl-c): add parser-reuse parse helpers (#5388)

### DIFF
--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -57,15 +57,15 @@ fn main() {
 }
 ```
 
-For repeated parsing, reuse a configured parser:
+For repeated parsing, reuse a configured parser with helper APIs:
 
 ```rust
-use tree_sitter_perl_c::try_create_parser;
+use tree_sitter_perl_c::{parse_perl_code_with_parser, try_create_parser};
 
 let mut parser = try_create_parser().unwrap();
 
 for snippet in &["my $x = 1;", "print $x;"] {
-    let tree = parser.parse(snippet, None).unwrap();
+    let tree = parse_perl_code_with_parser(&mut parser, snippet).unwrap();
     assert!(!tree.root_node().has_error());
 }
 ```
@@ -78,7 +78,9 @@ for snippet in &["my $x = 1;", "print $x;"] {
 | `try_create_parser()` | Creates a `tree_sitter::Parser` (returns `Result`) |
 | `create_parser()` | Creates a parser, silently ignoring language-set errors |
 | `parse_perl_bytes(code)` | Parses raw bytes (including non-UTF-8 Perl source) |
+| `parse_perl_bytes_with_parser(parser, code)` | Parses raw bytes with a reusable configured parser |
 | `parse_perl_code(code)` | Parses a `&str` into a `tree_sitter::Tree` |
+| `parse_perl_code_with_parser(parser, code)` | Parses a `&str` with a reusable configured parser |
 | `parse_perl_file(path)` | Reads and parses a file (non-UTF-8 safe) |
 | `get_scanner_config()` | Returns `"c-scanner"` |
 

--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -128,6 +128,23 @@ pub fn create_parser() -> Parser {
 /// if tree-sitter returns `None` from `parse` (cancelled or timed out).
 pub fn parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
     let mut parser = try_create_parser()?;
+    parse_perl_bytes_with_parser(&mut parser, code)
+}
+
+/// Parses Perl source bytes using an existing configured [`Parser`].
+///
+/// This is useful for performance-sensitive paths that parse repeatedly and
+/// want to reuse one parser instance instead of constructing a new parser per
+/// parse.
+///
+/// # Errors
+///
+/// Returns an error if tree-sitter returns `None` from `parse` (cancelled or
+/// timed out).
+pub fn parse_perl_bytes_with_parser(
+    parser: &mut Parser,
+    code: &[u8],
+) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
     match parser.parse(code, None) {
         Some(tree) => Ok(tree),
         None => Err("Failed to parse code".into()),
@@ -150,7 +167,24 @@ pub fn parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, Box<dyn std::e
 /// assert!(!tree.root_node().has_error());
 /// ```
 pub fn parse_perl_code(code: &str) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    parse_perl_bytes(code.as_bytes())
+    let mut parser = try_create_parser()?;
+    parse_perl_code_with_parser(&mut parser, code)
+}
+
+/// Parses a Perl source string using an existing configured [`Parser`].
+///
+/// This is the string convenience variant of [`parse_perl_bytes_with_parser`]
+/// and allows callers to reuse one parser instance across many snippets.
+///
+/// # Errors
+///
+/// Returns an error if tree-sitter returns `None` from `parse` (cancelled or
+/// timed out).
+pub fn parse_perl_code_with_parser(
+    parser: &mut Parser,
+    code: &str,
+) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
+    parse_perl_bytes_with_parser(parser, code.as_bytes())
 }
 
 /// Reads a file from `path` and parses it as Perl source.
@@ -281,6 +315,23 @@ mod tests {
     fn test_parse_bytes_empty_source() -> Result<(), Box<dyn std::error::Error>> {
         let tree = parse_perl_bytes(b"")?;
         assert_eq!(tree.root_node().kind(), "source_file");
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_reuse_parser_across_multiple_snippets() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let mut parser = try_create_parser()?;
+
+        let first = parse_perl_code_with_parser(&mut parser, "my $x = 1;")?;
+        assert!(!first.root_node().has_error());
+
+        let second = parse_perl_bytes_with_parser(&mut parser, b"print $x;")?;
+        assert!(!second.root_node().has_error());
+
+        let third = parse_perl_code_with_parser(&mut parser, "my $y = $x + 2;")?;
+        assert!(!third.root_node().has_error());
+
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Performance-sensitive callers need a reuse-friendly API so a single configured `Parser` can be reused across multiple parses instead of constructing a new parser per call. 
- The change surfaces the same parser-reuse seam previously discussed in #5388 so callers can avoid repeated parser initialization overhead.

### Description

- Added `parse_perl_bytes_with_parser(parser: &mut Parser, code: &[u8])` to parse raw bytes using an existing configured `Parser`.
- Added `parse_perl_code_with_parser(parser: &mut Parser, code: &str)` as the `&str` convenience wrapper that delegates to `parse_perl_bytes_with_parser`.
- Updated existing convenience helpers `parse_perl_bytes` and `parse_perl_code` to delegate through the new reuse-oriented APIs.
- Documented the new helpers in `crates/tree-sitter-perl-c/README.md` and added a unit test `test_parse_reuse_parser_across_multiple_snippets` that exercises parsing multiple snippets with a single `Parser` instance.

### Testing

- Ran `cargo test -p tree-sitter-perl-c`, which executed unit tests, doctests, and BDD tests, and completed successfully (`ok`, all tests passed).
- Ran `cargo check --all-targets -p tree-sitter-perl-c`, which completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb277f84c8833389c3c5a7034e95b9)