### PR TITLE
fix(tree-sitter-perl-c): improve parse error context (#5387)

### DIFF
--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -39,8 +39,26 @@
 //! [`perl-parser`]: https://docs.rs/perl-parser
 //! [`tree-sitter-perl-rs`]: https://docs.rs/tree-sitter-perl-rs
 
-use std::path::Path;
+use std::{fmt, path::Path};
 use tree_sitter::{Language, Parser};
+
+#[derive(Debug)]
+struct ParsePerlFileError {
+    path: std::path::PathBuf,
+    source: Box<dyn std::error::Error>,
+}
+
+impl fmt::Display for ParsePerlFileError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "failed to parse Perl file '{}': {}", self.path.display(), self.source)
+    }
+}
+
+impl std::error::Error for ParsePerlFileError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
 
 /// Returns the tree-sitter [`Language`] for Perl (C grammar).
 ///
@@ -162,8 +180,20 @@ pub fn parse_perl_code(code: &str) -> Result<tree_sitter::Tree, Box<dyn std::err
 pub fn parse_perl_file<P: AsRef<Path>>(
     path: P,
 ) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    let code = std::fs::read(path)?;
-    parse_perl_bytes(&code)
+    let path = path.as_ref();
+    let code = std::fs::read(path).map_err(|source| {
+        Box::new(ParsePerlFileError {
+            path: path.to_path_buf(),
+            source: Box::new(source),
+        }) as Box<dyn std::error::Error>
+    })?;
+
+    parse_perl_bytes(&code).map_err(|source| {
+        Box::new(ParsePerlFileError {
+            path: path.to_path_buf(),
+            source,
+        }) as Box<dyn std::error::Error>
+    })
 }
 
 /// Returns the scanner backend identifier for this crate.

--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -182,17 +182,13 @@ pub fn parse_perl_file<P: AsRef<Path>>(
 ) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
     let path = path.as_ref();
     let code = std::fs::read(path).map_err(|source| {
-        Box::new(ParsePerlFileError {
-            path: path.to_path_buf(),
-            source: Box::new(source),
-        }) as Box<dyn std::error::Error>
+        Box::new(ParsePerlFileError { path: path.to_path_buf(), source: Box::new(source) })
+            as Box<dyn std::error::Error>
     })?;
 
     parse_perl_bytes(&code).map_err(|source| {
-        Box::new(ParsePerlFileError {
-            path: path.to_path_buf(),
-            source,
-        }) as Box<dyn std::error::Error>
+        Box::new(ParsePerlFileError { path: path.to_path_buf(), source })
+            as Box<dyn std::error::Error>
     })
 }
 

--- a/crates/tree-sitter-perl-c/tests/bdd_workflows.rs
+++ b/crates/tree-sitter-perl-c/tests/bdd_workflows.rs
@@ -139,6 +139,50 @@ fn bdd_parse_perl_file_allows_non_utf8_bytes() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn bdd_parse_perl_file_missing_path_reports_context() -> Result<(), Box<dyn Error>> {
+    let scenario = Scenario::new("parse perl file missing path reports context");
+    let file = unique_temp_file("missing_file");
+    let file_display = file.display().to_string();
+
+    scenario.given("a missing Perl source path");
+    scenario.when("parse_perl_file is invoked");
+    let error = match parse_perl_file(&file) {
+        Ok(_) => return Err("expected parse_perl_file to fail for missing file".into()),
+        Err(error) => error,
+    };
+
+    scenario.then("the error message should contain the path and the reason");
+    let message = error.to_string();
+    assert!(message.contains(&file_display));
+    assert!(message.contains("failed to parse Perl file"));
+    Ok(())
+}
+
+#[test]
+fn bdd_parse_perl_file_unreadable_path_reports_context() -> Result<(), Box<dyn Error>> {
+    let scenario = Scenario::new("parse perl file unreadable path reports context");
+    let directory = unique_temp_file("unreadable_path");
+    let directory_display = directory.display().to_string();
+
+    scenario.given("a directory path where a file is expected");
+    fs::create_dir(&directory)?;
+
+    scenario.when("parse_perl_file is invoked");
+    let error = match parse_perl_file(&directory) {
+        Ok(_) => return Err("expected parse_perl_file to fail for directory path".into()),
+        Err(error) => error,
+    };
+
+    scenario.then("the error message should contain the path and parse context");
+    let message = error.to_string();
+    assert!(message.contains(&directory_display));
+    assert!(message.contains("failed to parse Perl file"));
+
+    fs::remove_dir(&directory)?;
+    Ok(())
+}
+
+#[test]
 fn bdd_injections_query_matches_inline_cpp_heredoc_content() -> Result<(), Box<dyn Error>> {
     let scenario = Scenario::new("injections query matches inline cpp heredoc content");
     let source = "use Inline CPP => <<'END_CPP';\n#include <string>\nclass Greet {};\nEND_CPP\n";


### PR DESCRIPTION
### Motivation
- `parse_perl_file` returned opaque errors when file read or parse failed, making it hard for callers to know which path failed and why.
- Improve diagnostics by attaching the file path to both read- and parse-time failures while keeping the crate's existing error surface.

### Description
- Add a `ParsePerlFileError` wrapper that implements `Display` and `std::error::Error` and includes the failing file path and the original source error.
- Update `parse_perl_file` to map both `std::fs::read` failures and `parse_perl_bytes` failures into `ParsePerlFileError`, preserving the `Result<_, Box<dyn std::error::Error>>` API.
- Add regression BDD tests `bdd_parse_perl_file_missing_path_reports_context` and `bdd_parse_perl_file_unreadable_path_reports_context` that assert the reported error message contains the path and context.

### Testing
- Ran `cargo test -p tree-sitter-perl-c`, and all tests passed (unit tests, BDD workflows, and doctests completed successfully).
- Ran `cargo check --all-targets -p tree-sitter-perl-c`, and the check completed successfully.
- The changes are limited to `crates/tree-sitter-perl-c/src/lib.rs` and `crates/tree-sitter-perl-c/tests/bdd_workflows.rs` and do not alter public API types beyond adding contextual error messages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2787385c833381645b20b32ee849)