### PR TITLE
fix(tree-sitter-perl-c): improve parse_perl_file error context (#5387)

### DIFF
--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -39,8 +39,36 @@
 //! [`perl-parser`]: https://docs.rs/perl-parser
 //! [`tree-sitter-perl-rs`]: https://docs.rs/tree-sitter-perl-rs
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tree_sitter::{Language, Parser};
+
+#[derive(Debug)]
+enum ParsePerlFileError {
+    Read { path: PathBuf, source: std::io::Error },
+    Parse { path: PathBuf, source: Box<dyn std::error::Error> },
+}
+
+impl std::fmt::Display for ParsePerlFileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Read { path, source } => {
+                write!(f, "failed to read Perl file '{}': {source}", path.display())
+            }
+            Self::Parse { path, source } => {
+                write!(f, "failed to parse Perl file '{}': {source}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ParsePerlFileError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Read { source, .. } => Some(source),
+            Self::Parse { source, .. } => Some(source.as_ref()),
+        }
+    }
+}
 
 /// Returns the tree-sitter [`Language`] for Perl (C grammar).
 ///
@@ -162,8 +190,12 @@ pub fn parse_perl_code(code: &str) -> Result<tree_sitter::Tree, Box<dyn std::err
 pub fn parse_perl_file<P: AsRef<Path>>(
     path: P,
 ) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    let code = std::fs::read(path)?;
+    let path = path.as_ref().to_path_buf();
+    let code = std::fs::read(&path)
+        .map_err(|source| ParsePerlFileError::Read { path: path.clone(), source })?;
     parse_perl_bytes(&code)
+        .map_err(|source| ParsePerlFileError::Parse { path, source })
+        .map_err(Into::into)
 }
 
 /// Returns the scanner backend identifier for this crate.

--- a/crates/tree-sitter-perl-c/tests/bdd_workflows.rs
+++ b/crates/tree-sitter-perl-c/tests/bdd_workflows.rs
@@ -139,6 +139,40 @@ fn bdd_parse_perl_file_allows_non_utf8_bytes() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn bdd_parse_perl_file_missing_path_includes_context() {
+    let scenario = Scenario::new("parse perl file reports missing path context");
+    let missing_file = unique_temp_file("missing_file");
+
+    scenario.given("a Perl file path that does not exist");
+    scenario.when("parse_perl_file is invoked");
+    let err = parse_perl_file(&missing_file).expect_err("expected missing-file error");
+
+    scenario.then("the error should include path context for callers");
+    let error_message = err.to_string();
+    assert!(error_message.contains("failed to read Perl file"));
+    assert!(error_message.contains(&missing_file.display().to_string()));
+}
+
+#[test]
+fn bdd_parse_perl_file_directory_path_includes_context() -> Result<(), Box<dyn Error>> {
+    let scenario = Scenario::new("parse perl file reports unreadable path context");
+    let directory_path = unique_temp_file("directory_path");
+
+    scenario.given("a directory path that cannot be read as a file");
+    fs::create_dir(&directory_path)?;
+
+    scenario.when("parse_perl_file is invoked");
+    let err = parse_perl_file(&directory_path).expect_err("expected directory read error");
+
+    scenario.then("the error should include path context for callers");
+    let error_message = err.to_string();
+    assert!(error_message.contains("failed to read Perl file"));
+    assert!(error_message.contains(&directory_path.display().to_string()));
+    fs::remove_dir(&directory_path)?;
+    Ok(())
+}
+
+#[test]
 fn bdd_injections_query_matches_inline_cpp_heredoc_content() -> Result<(), Box<dyn Error>> {
     let scenario = Scenario::new("injections query matches inline cpp heredoc content");
     let source = "use Inline CPP => <<'END_CPP';\n#include <string>\nclass Greet {};\nEND_CPP\n";


### PR DESCRIPTION
### Motivation

- File-level parsing failures did not reliably include the path that caused the error, making diagnosis of missing/unreadable files harder.  

### Description

- Introduced an internal `ParsePerlFileError` enum with `Read` and `Parse` variants and implemented `Display` and `Error` so failures include the failing `PathBuf` and preserve the original source error.  
- Updated `parse_perl_file` to capture the `PathBuf` and wrap read errors and downstream parse errors with `ParsePerlFileError` before boxing the error.  
- Added regression tests `bdd_parse_perl_file_missing_path_includes_context` and `bdd_parse_perl_file_directory_path_includes_context` to assert the error messages include the path context.  
- Kept the change focused and compatible with a future typed-error surface by providing a small wrapper that preserves the original `source()` error.  

### Testing

- Ran `cargo test -p tree-sitter-perl-c` and all unit and integration tests passed.  
- Ran `cargo check --all-targets -p tree-sitter-perl-c` and the crate type-checked successfully.  
- Ran `cargo xtask fmt` to format the repository and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2787385c833381645b20b32ee849)