### PR TITLE
fix(tree-sitter-perl-c): improve parse_perl_file error context (#5387)

### DIFF
--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -162,7 +162,13 @@ pub fn parse_perl_code(code: &str) -> Result<tree_sitter::Tree, Box<dyn std::err
 pub fn parse_perl_file<P: AsRef<Path>>(
     path: P,
 ) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    let code = std::fs::read(path)?;
+    let path_ref = path.as_ref();
+    let code = std::fs::read(path_ref).map_err(|err| {
+        format!(
+            "Failed to read Perl file '{}': {err}",
+            path_ref.display()
+        )
+    })?;
     parse_perl_bytes(&code)
 }
 

--- a/crates/tree-sitter-perl-c/tests/bdd_workflows.rs
+++ b/crates/tree-sitter-perl-c/tests/bdd_workflows.rs
@@ -139,6 +139,55 @@ fn bdd_parse_perl_file_allows_non_utf8_bytes() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn bdd_parse_perl_file_missing_path_reports_context() {
+    let scenario = Scenario::new("parse perl file missing path reports context");
+    let missing = unique_temp_file("missing_path");
+
+    scenario.given("a path that does not exist");
+    scenario.when("parse_perl_file is invoked");
+    let error = parse_perl_file(&missing).expect_err("expected missing-file parse to fail");
+    let message = error.to_string();
+
+    scenario.then("the error should include the failing path and underlying reason");
+    assert!(
+        message.contains(&missing.display().to_string()),
+        "expected error to mention missing path, got: {message}"
+    );
+    assert!(
+        message.contains("Failed to read Perl file"),
+        "expected contextual prefix, got: {message}"
+    );
+}
+
+#[test]
+fn bdd_parse_perl_file_unreadable_path_reports_context() -> Result<(), Box<dyn Error>> {
+    let scenario = Scenario::new("parse perl file unreadable path reports context");
+    let directory = std::env::temp_dir().join(format!(
+        "tree_sitter_perl_c_unreadable_{}",
+        SystemTime::now().duration_since(UNIX_EPOCH).map_or(0_u128, |duration| duration.as_nanos())
+    ));
+    fs::create_dir(&directory)?;
+
+    scenario.given("a directory path where file bytes cannot be read");
+    scenario.when("parse_perl_file is invoked");
+    let error = parse_perl_file(&directory).expect_err("expected unreadable-path parse to fail");
+    let message = error.to_string();
+
+    scenario.then("the error should include the failing path and context");
+    assert!(
+        message.contains(&directory.display().to_string()),
+        "expected error to mention unreadable path, got: {message}"
+    );
+    assert!(
+        message.contains("Failed to read Perl file"),
+        "expected contextual prefix, got: {message}"
+    );
+
+    fs::remove_dir(&directory)?;
+    Ok(())
+}
+
+#[test]
 fn bdd_injections_query_matches_inline_cpp_heredoc_content() -> Result<(), Box<dyn Error>> {
     let scenario = Scenario::new("injections query matches inline cpp heredoc content");
     let source = "use Inline CPP => <<'END_CPP';\n#include <string>\nclass Greet {};\nEND_CPP\n";


### PR DESCRIPTION
### Motivation
- `parse_perl_file` returned raw IO errors when file reads failed, which omitted the failing file path and made diagnosing missing/unreadable files harder.

### Description
- Add path context to read failures in `parse_perl_file` by calling `std::fs::read(path_ref).map_err(|err| format!("Failed to read Perl file '{}': {err}", path_ref.display()))` to produce a descriptive error string.
- Preserve the existing return type `Result<tree_sitter::Tree, Box<dyn std::error::Error>>` so the change does not conflict with any typed-error enum designs.
- Add two regression tests `bdd_parse_perl_file_missing_path_reports_context` and `bdd_parse_perl_file_unreadable_path_reports_context` to verify missing-file and unreadable-path errors include the path and contextual message.

### Testing
- Ran `cargo test -p tree-sitter-perl-c` and all tests passed (unit tests, doctests, and BDD workflows).
- Ran `cargo check --all-targets -p tree-sitter-perl-c` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2787385c833381645b20b32ee849)