### PR TITLE
fix(tree-sitter-perl-c): improve parse_perl_file error context (#5387)

### DIFF
--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -162,8 +162,13 @@ pub fn parse_perl_code(code: &str) -> Result<tree_sitter::Tree, Box<dyn std::err
 pub fn parse_perl_file<P: AsRef<Path>>(
     path: P,
 ) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    let code = std::fs::read(path)?;
+    let path = path.as_ref();
+    let path_display = path.display();
+
+    let code = std::fs::read(path)
+        .map_err(|error| format!("Failed to read Perl file '{}': {error}", path_display))?;
     parse_perl_bytes(&code)
+        .map_err(|error| format!("Failed to parse Perl file '{}': {error}", path_display).into())
 }
 
 /// Returns the scanner backend identifier for this crate.
@@ -282,6 +287,35 @@ mod tests {
         let tree = parse_perl_bytes(b"")?;
         assert_eq!(tree.root_node().kind(), "source_file");
         Ok(())
+    }
+
+    #[test]
+    fn test_parse_file_missing_includes_path_context() {
+        let missing_path = Path::new("tests/fixtures/does-not-exist.pl");
+        let result = parse_perl_file(missing_path);
+        assert!(result.is_err(), "expected missing file to error");
+        let error_text = match result {
+            Ok(_) => String::new(),
+            Err(error) => error.to_string(),
+        };
+
+        assert!(error_text.contains("Failed to read Perl file"));
+        assert!(error_text.contains("tests/fixtures/does-not-exist.pl"));
+    }
+
+    #[test]
+    fn test_parse_file_directory_includes_path_context() {
+        let dir_path = Path::new(".");
+
+        let result = parse_perl_file(dir_path);
+        assert!(result.is_err(), "expected directory read to error");
+        let error_text = match result {
+            Ok(_) => String::new(),
+            Err(error) => error.to_string(),
+        };
+
+        assert!(error_text.contains("Failed to read Perl file"));
+        assert!(error_text.contains(&dir_path.display().to_string()));
     }
 }
 


### PR DESCRIPTION
### Motivation

- `parse_perl_file` previously returned raw IO/parse errors without the file path, making diagnostics and debugging difficult.
- The change aims to surface which file path failed and why while preserving the existing `Result<..., Box<dyn Error>>` API so callers and any typed-error migration are not blocked.

### Description

- Augment `parse_perl_file` to capture the passed `path` and attach a path-aware error message on read failures using `map_err` and formatted messages. 
- Attach the same path context to downstream parse failures by mapping parse errors into a boxed, path-prefixed error string. 
- Add two regression tests: `test_parse_file_missing_includes_path_context` to assert missing-file errors include the path, and `test_parse_file_directory_includes_path_context` to assert unreadable inputs (directory) include the path. 
- Keep the public function signature unchanged (`Result<Tree, Box<dyn Error>>`) so the path-context design does not conflict with the typed-error work and can be migrated later if a typed error enum is adopted.

### Testing

- Ran `cargo test -p tree-sitter-perl-c`, and all tests passed (unit, integration, and doctests). 
- Ran `cargo check --all-targets -p tree-sitter-perl-c`, which completed successfully. 
- Ran `cargo xtask fmt`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2787385c833381645b20b32ee849)