### PR TITLE
fix(tree-sitter-perl-c): harden autoquoted scanner handling around comments and POD (#0000)

### DIFF
--- a/crates/tree-sitter-perl-c/c-src/scanner.c
+++ b/crates/tree-sitter-perl-c/c-src/scanner.c
@@ -261,6 +261,39 @@ static void skip_whitespace(TSLexer *lexer) {
   }
 }
 
+static void scan_pod_block(TSLexer *lexer, int32_t *c) {
+  /* Keep going until the linefeed after a line beginning `=cut` */
+  static const char *cut_marker = "=cut";
+  int stage = -1;
+
+  while (!lexer->eof(lexer)) {
+    if (*c == '\r')
+      ; /* ignore */
+    else if (stage < 1 && *c == '\n')
+      stage = 0;
+    else if (stage >= 0 && stage < 4 && *c == cut_marker[stage])
+      stage++;
+    else if (stage == 4 && (*c == ' ' || *c == '\t'))
+      stage = 5;
+    else if (stage == 4 && *c == '\n')
+      stage = 6;
+    else
+      stage = -1;
+
+    if (stage > 4) break;
+
+    lexer->advance(lexer, true);
+    *c = lexer->lookahead;
+  }
+  if (stage < 6)
+    while (!lexer->eof(lexer)) {
+      if (*c == '\n') break;
+
+      lexer->advance(lexer, true);
+      *c = lexer->lookahead;
+    }
+}
+
 static void skip_ws_to_eol(TSLexer *lexer) {
   while (1) {
     int32_t c = lexer->lookahead;
@@ -625,35 +658,7 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
     int column = lexer->get_column(lexer);
     if (column == 0 && c == '=') {
       DEBUG("POD started...\n", 0);
-
-      /* Keep going until the linefeed after a line beginning `=cut` */
-      static const char *cut_marker = "=cut";
-      int stage = -1;
-
-      while (!lexer->eof(lexer)) {
-        if (c == '\r')
-          ; /* ignore */
-        else if (stage < 1 && c == '\n')
-          stage = 0;
-        else if (stage >= 0 && stage < 4 && c == cut_marker[stage])
-          stage++;
-        else if (stage == 4 && (c == ' ' || c == '\t'))
-          stage = 5;
-        else if (stage == 4 && c == '\n')
-          stage = 6;
-        else
-          stage = -1;
-
-        if (stage > 4) break;
-
-        ADVANCE_C;
-      }
-      if (stage < 6)
-        while (!lexer->eof(lexer)) {
-          if (c == '\n') break;
-
-          ADVANCE_C;
-        }
+      scan_pod_block(lexer, &c);
       /* If we got this far then either we reached stage 6, or we're at EOF */
       TOKEN(TOKEN_POD);
     }
@@ -917,7 +922,7 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
 
     // NOTE - TS is annoying about skipping chars after you've hit done
     // mark_end, so we have to do the regular advance so our token actually shows up
-    while (is_tsp_whitespace(c) || c == '#') {
+    while (is_tsp_whitespace(c) || c == '#' || (c == '=' && lexer->get_column(lexer) == 0)) {
       while (is_tsp_whitespace(c)) ADVANCE_C;
       // now we need to skip comments - we get in a funny way if we have a quotelike
       // operator followed by a comment as the quote char
@@ -925,8 +930,12 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
         ADVANCE_C;
         while (lexer->get_column(lexer)) ADVANCE_C;
       }
+      // POD is an extra token in this grammar, so keep autoquote lookahead consistent with
+      // whitespace/comment skipping by scanning the same POD shape we emit as TOKEN_POD.
+      if (c == '=' && lexer->get_column(lexer) == 0) {
+        scan_pod_block(lexer, &c);
+      }
       if (lexer->eof(lexer)) return false;
-      // TODO - in theory there could be POD here that we needa skip over (EYES ROLL)
     }
     c1 = lexer->lookahead;
     ADVANCE_C;

--- a/crates/tree-sitter-perl-c/tests/scanner_autoquote_regressions.rs
+++ b/crates/tree-sitter-perl-c/tests/scanner_autoquote_regressions.rs
@@ -1,0 +1,35 @@
+use std::error::Error;
+
+use tree_sitter::Node;
+use tree_sitter_perl_c::parse_perl_code;
+
+fn count_kind(node: Node<'_>, wanted: &str) -> usize {
+    let mut total = usize::from(node.kind() == wanted);
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        total += count_kind(child, wanted);
+    }
+    total
+}
+
+#[test]
+fn brace_autoquote_skips_comment_and_pod_extras() -> Result<(), Box<dyn Error>> {
+    let source = "my $value = $h{foo # trailing comment\n=pod\nignored\n=cut\n};\n";
+    let tree = parse_perl_code(source)?;
+
+    assert!(!tree.root_node().has_error());
+    assert!(
+        count_kind(tree.root_node(), "autoquoted_bareword") >= 1,
+        "expected autoquoted_bareword for foo in hash subscript"
+    );
+    Ok(())
+}
+
+#[test]
+fn fat_comma_autoquote_does_not_cross_pod_directives() -> Result<(), Box<dyn Error>> {
+    let source = "my %h = (foo # trailing comment\n=pod\nignored\n=cut\n=> 1);\n";
+    let tree = parse_perl_code(source)?;
+
+    assert_eq!(count_kind(tree.root_node(), "autoquoted_bareword"), 0);
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- The vendored C scanner inconsistently handled identifier autoquoting when comments or POD directives intervened, producing incorrect tokenization for `=>`/`}` autoquote lookahead paths.
- Make the scanner treat POD blocks the same way it emits `TOKEN_POD` so autoquote detection is stable and matches tree-sitter grammar expectations.

### Description

- Extracted the POD-scanning loop into a shared helper `scan_pod_block(TSLexer*, int32_t*)` and reused it for `TOKEN_POD` emission to centralize POD handling. 
- Hardened the post-identifier lookahead used for `TOKEN_FAT_COMMA_AUTOQUOTED` and `TOKEN_BRACE_AUTOQUOTED` by extending the whitespace/comment skip to also detect and consume POD blocks (checks for `c == '=' && lexer->get_column(lexer) == 0` and calls `scan_pod_block`).
- Added focused regression tests `scanner_autoquote_regressions.rs` that verify brace autoquoting skips comments+POD and that fat-comma autoquote does not cross POD directives (documenting the intended behavior).

### Testing

- Ran `cargo test -p tree-sitter-perl-c` and all crate tests (including new regressions) passed. 
- Ran `cargo check --all-targets -p tree-sitter-perl-c` which completed successfully. 
- Ran `cargo fmt --all --check` which succeeded with no formatting changes required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb278ac7308333a82402adc2592546)