### PR TITLE
docs: economic maturity + deep-review catalog + architecture audit (#0000)

### DIFF
--- a/docs/articles/ARCHITECTURE_POST_COLLAPSE_AUDIT.md
+++ b/docs/articles/ARCHITECTURE_POST_COLLAPSE_AUDIT.md
@@ -1,0 +1,255 @@
+# Architecture Post-Collapse Audit: State and Next Steps
+
+*Status after the 135→31 microcrate collapse. What worked, what still needs surface
+tightening, and why the remaining work is seam cleanup rather than another broad wave.*
+
+---
+
+## Current State
+
+The collapse is operationally complete at the published crate level. As of 2026-04-24:
+
+- **31 published crates** (from 135 at the project start)
+- **All major collapse waves merged**: perl-module (Wave 1), perl-workspace (Wave A),
+  perl-symbol, perl-diagnostics, perl-dap, perl-lexer, G1a/G1b providers, G2 runtime,
+  G3 utilities, Wave D thin-facade pattern, Wave 4-Completion
+- **Wave 4-Completion verified**: `perl-dead-code`, `perl-refactoring`, and
+  `perl-incremental-parsing` absorbed into `perl-parser::dead_code`, `perl-parser::refactor`,
+  and `perl-parser::incremental` respectively; all three marked `publish = false`
+
+The remaining workspace members that are present but unpublished (keeping `publish = false`)
+serve as implementation modules within their host crates. The directory count is higher than
+the published count, but the Cargo API surface is controlled.
+
+---
+
+## What Is Working
+
+### perl-parser-core as Kernel
+
+`perl-parser-core` functions correctly as the parsing kernel — it owns the recursive descent
+engine, AST nodes, token types, source position types, and error recovery infrastructure.
+Crates that need parser types import from `perl-parser-core` directly (for core types) or
+from `perl-parser` (for the full parser + analysis stack).
+
+The layering is sound: `perl-lexer` → `perl-parser-core` → `perl-parser` is the canonical
+direction. No upstream crate imports from a downstream neighbor.
+
+### Domain-Separated Top-Level Crates
+
+The four major domains have clear boundaries:
+
+| Crate | Domain |
+|-------|--------|
+| `perl-parser` | Parsing, AST, analysis, incremental, refactoring |
+| `perl-semantic-analyzer` | Scope resolution, symbol tables, type inference |
+| `perl-workspace-index` | Cross-file indexing, workspace management, rename |
+| `perl-dap` | Debug Adapter Protocol implementation |
+
+These domains are separated by their dependency direction and their conceptual concerns.
+`perl-semantic-analyzer` depends on `perl-parser-core` (for AST types) and
+`perl-workspace-index` (for workspace symbol lookup). `perl-workspace-index` depends on
+`perl-parser-core`. Neither depends on the other at the implementation level.
+
+### LSP Thin-Facade Pattern
+
+The `perllsp` published crate is a thin facade over `perl-lsp-rs` (the implementation
+crate), which is itself a thin facade over the domain crates. Users install `perllsp`;
+the Cargo API surface users see is `LspServer`, `run_stdio()`, and the protocol types.
+The pattern is documented in `project_wave_d_facade_pattern.md` and is the established
+house style for entry-point crates.
+
+---
+
+## Three Seams Needing Surface Tightening
+
+The remaining work is not another broad collapse wave. It is surface tightening on three
+specific seams where the public API currently exposes more than it should.
+
+### Seam 1: `perl-lsp-rs` Module Surface
+
+**Current state**: `perl-lsp-rs/src/lib.rs` exports the following as `pub mod`:
+
+```
+cancellation, cli, convert, diagnostics_catalog, dispatch, execute_command,
+fallback, features, handlers, protocol, runtime, security, server, state,
+textdoc, transport, util
+```
+
+Plus re-exports: `JsonRpcError`, `JsonRpcRequest`, `JsonRpcResponse`, `LspServer`,
+`BridgeAdapter`, `capability_map`, `run_stdio()`.
+
+**The problem**: The `pub mod` declarations expose the entire implementation hierarchy —
+handler dispatch tables, transport internals, state machine internals — as part of the
+crate's public Cargo surface. Any downstream crate that depends on `perl-lsp-rs` (rather
+than `perllsp`) has access to all of these modules. This is a surface wider than intended
+for a crate that is supposed to be an implementation detail.
+
+**Target state**: The implementation modules should be `pub(crate)`. The re-exported types
+(`LspServer`, `run_stdio()`, `JsonRpcError/Request/Response`) should remain public. The
+`cli`, `server`, and `protocol` modules may warrant `pub use` re-exports at top level,
+but `cancellation`, `transport`, `runtime`, `state`, and `dispatch` are implementation
+concerns that should not be part of the public surface.
+
+**Scope**: This is a 1-2 day refactor in `perl-lsp-rs/src/lib.rs` — changing `pub mod`
+to `pub(crate) mod` for implementation modules. It requires verifying that no external
+crate imports from the affected modules. Given the `perllsp` → `perl-lsp-rs` dependency
+direction, this is likely safe.
+
+### Seam 2: `perl-semantic-analyzer` Re-Export Sprawl
+
+**Current state**: `perl-semantic-analyzer/src/lib.rs` re-exports:
+
+```rust
+pub use perl_parser_core::{Node, NodeKind, SourceLocation};
+pub use perl_parser_core::{
+    Parser, ast, edit, error, parser, parser_context, position,
+    pragma_tracker, quote_parser, util,
+};
+pub use perl_workspace::workspace_index;
+```
+
+Plus its own analysis modules: `class_model`, `declaration`, `index`, `scope_analyzer`,
+`semantic`, `symbol`, `type_inference`.
+
+**The problem**: Re-exporting `edit`, `parser_context`, `pragma_tracker`, `quote_parser`,
+and `util` from `perl-parser-core` through `perl-semantic-analyzer` creates a secondary
+import path for these types. Consumers can now reach `perl_parser_core::edit` via either
+`perl_parser_core::edit` or `perl_semantic_analyzer::edit`. This is confusing (which is
+canonical?) and fragile (a refactor of the semantic analyzer's internals could break callers
+who were using the re-exported path).
+
+**Target state**: Re-export only the types that `perl-semantic-analyzer` consumers need
+to interact with the semantic analyzer's own types: `Node`, `NodeKind`, `SourceLocation`
+(because `semantic::Symbol` references them). Remove the module-level re-exports of
+`edit`, `parser_context`, `pragma_tracker`, `quote_parser`, `util` — callers that need
+these should import from `perl_parser_core` directly.
+
+**Scope**: Verify that no downstream crate uses `perl_semantic_analyzer::edit` (or similar
+re-exported path), then remove the re-exports. Lower risk than Seam 1 because semantic
+analyzer consumers are more constrained.
+
+### Seam 3: `perl-workspace-index` Parser Type Leakage
+
+**Current state**: `perl-workspace-index/src/lib.rs` re-exports:
+
+```rust
+pub use perl_parser_core::line_index;
+pub use perl_parser_core::{Node, NodeKind, SourceLocation};
+pub use perl_parser_core::{Parser, ast, position};
+```
+
+**The problem**: `Parser`, `ast`, and `position` are parser-domain types being re-exported
+from a workspace-domain crate. The workspace index crate owns workspace-level concerns
+(file discovery, cross-file indexing, rename orchestration). It should not be a secondary
+import path for parser types.
+
+**Target state**: Re-export only `Node`, `NodeKind`, `SourceLocation` (needed because
+workspace index APIs return these types in their signatures), and `line_index` (needed
+for position mapping). Remove `Parser`, `ast`, `position` re-exports — callers should
+get these from `perl_parser_core`.
+
+**Scope**: Same as Seam 2 — verify no downstream caller uses the re-exported path, then
+remove.
+
+---
+
+## `perl-parser-core` Public Re-Export Sprawl
+
+`perl-parser-core/src/lib.rs` itself has a wide public surface:
+
+```
+engine::ast, engine::ast_v2, engine::parser_context, engine::pragma_tracker,
+engine::quote_parser, engine::error, engine::parser, engine::position,
+syntax::edit, syntax::heredoc, syntax::path_normalize, syntax::path_security,
+syntax::percentile, syntax::qualified_name, syntax::source_file, syntax::text_line,
+parser::Parser, error::classifier, error::recovery, builtins::builtin_signatures,
+perl_lexer::tokenizer::util, line_index (inline mod)
+```
+
+This is a wide surface, but many of these are legitimately needed by multiple downstream
+crates. The narrowing target is:
+
+- **Core public surface** (narrow, stable, must stay pub): `Parser`, `Node`, `NodeKind`,
+  `SourceLocation`, `ParseOutput`, `ParseError`, `ParseResult`, `ParseBudget`, `BudgetTracker`
+- **Parser-internal utilities** (should be `pub(crate)` or accessed via `perl-parser`):
+  `pragma_tracker`, `quote_parser`, `parser_context`, `ast_v2`, `heredoc_collector`,
+  `path_normalize`, `path_security`, `percentile`, `source_file`, `text_line`, `qualified_name`
+- **Questionable**: `edit`, `error_classifier`, `error_recovery` — these are needed by
+  parser analysis code but may not need to be public at the `perl-parser-core` level
+
+This narrowing is post-alpha work. Before narrowing `perl-parser-core`'s surface, all
+downstream callers must be audited. The surface is wide precisely because it evolved
+during a period when crate boundaries were being determined. Narrowing it risks breaking
+callers that are legitimately using the wider surface for now.
+
+---
+
+## Parser-Family Crate Status
+
+The "parser-family" crates are those that were absorbed into `perl-parser::*` during
+collapse waves but remain as workspace members:
+
+| Crate | Status | Location after absorption |
+|-------|--------|--------------------------|
+| `perl-dead-code` | `publish = false` | `perl-parser::dead_code` |
+| `perl-refactoring` | `publish = false` | `perl-parser::refactor` |
+| `perl-incremental-parsing` | `publish = false` | `perl-parser::incremental` |
+| `perl-ast-v2` | Still present as workspace member | Used via `perl-parser-core::ast_v2` |
+
+**The tracker-vs-manifest inconsistency**: The Wave 4-Completion spec described absorbing
+`perl-dead-code`, `perl-refactoring`, and `perl-incremental-parsing` into
+`perl-parser::*`, with the absorbed crates marked `publish = false`. This is done. The
+workspace still contains the directories (and Cargo.toml files with `publish = false`),
+but they are no longer separate published crates. The "published count" baseline reflects
+this correctly (34 after Wave 4, from 37 pre-Wave-4).
+
+Other parser-adjacent crates in the workspace:
+- `perl-parser-bench`: Benchmarking crate for the parser; `publish = false`; correctly
+  excluded from the published surface
+- `perl-parser-pest`: Legacy Pest grammar; kept for benchmarking comparison; `publish = false`
+- `perl-ast`: Original AST types; superseded by `perl-parser-core::ast`; should be verified
+  `publish = false` and removed from doc references
+
+---
+
+## One Collapse to Consider Post-Alpha
+
+The spec called out `perl-line-index` → `perl-position-tracking` as the one remaining
+potential collapse. These two crates overlap conceptually: `perl-line-index` owns
+`LineIndex` (line-ending-aware UTF-8/UTF-16 position mapping); `perl-position-tracking`
+owns position coordinate types and UTF-16 offset utilities.
+
+**Current separation logic** (from Amendment 4 in the collapse planning): They were kept
+separate pre-alpha because merging them would require an API decision about the canonical
+home for `PositionMapper`, `LineEnding`, and the UTF-16 surrogates logic. That decision
+was correctly deferred to avoid blocking the alpha timeline.
+
+**Post-alpha recommendation**: Audit actual callers of each crate. If `perl-line-index`
+has fewer than 5 external callers and `perl-position-tracking` is mostly consumed by the
+same callers, the merge is low-risk. If they have different caller sets, keep them separate.
+The criterion is call-graph coupling, not crate count.
+
+---
+
+## Operational Advice
+
+**Do not collapse before alpha.** The current 31 published crates is a clean, tested
+boundary. Collapsing more before v0.13.0 introduces rebase risk (every merge touches
+Cargo.toml and lib.rs of the host crate) and surface instability (callers may depend on
+current module paths that will change in a collapse).
+
+**Surface tightening is safe to do now.** Changing `pub mod` to `pub(crate) mod` for
+implementation modules in `perl-lsp-rs`, removing excess re-exports from
+`perl-semantic-analyzer` and `perl-workspace-index` — these changes do not affect the
+Cargo dependency graph and do not require version bumps unless the removed paths were
+part of the documented public API (they are not).
+
+**Audit the publish surface before the v0.13.0 release.** Run `cargo xtask publish-closure`
+to verify no absorbed crate name appears in the publish allowlist. Verify `perl-parser-bench`,
+`perl-parser-pest`, `perl-ast-v2`, and `perl-ast` are marked `publish = false`. The
+allowlist is hand-maintained and silently excludes new crates until a live publish fails.
+
+---
+
+_Related: `docs/articles/AGGREGATOR_ABSORPTION_PATTERN.md`, `memory/project_microcrate_collapse_v014.md`, `memory/project_wave_d_facade_pattern.md`_

--- a/docs/articles/ARTICLE_INDEX.md
+++ b/docs/articles/ARTICLE_INDEX.md
@@ -36,6 +36,19 @@ These documents are polished prose ready for editorial review or direct publicat
 | [PARSER_WINS.md](PARSER_WINS.md) | "Perl Parsing Hall of Fame" | Hardest constructs handled: heredocs, slash ambiguity, fat arrows |
 | [THREE_LAYER_PRODUCT.md](THREE_LAYER_PRODUCT.md) | "The Three-Layer Product" — LSP + swarm OS + memory/evidence | Why the repo is three products in one |
 
+### Session 2026-04-24: Economic Maturity + Deep Review Catalog + Architecture Audit
+
+Articles from the 2026-04-24 session (75 merged, 156 closed, 231 total resolved). Economic
+analysis from ChatGPT synthesis; deep-review catalog with 17 verified findings; architecture
+audit after Wave 4-Completion (31 published crates).
+
+| File | Title | Notes |
+|------|-------|-------|
+| [ECONOMIC_MATURITY_THROUGHPUT_VS_TRUSTWORTHY.md](ECONOMIC_MATURITY_THROUGHPUT_VS_TRUSTWORTHY.md) | "Economic Maturity: From Throughput to Trustworthy Throughput" | 3-metric evolution, 4 forward metrics, verified cost numbers, 4 biggest cost sinks. |
+| [DEEP_REVIEW_FIX_FORWARD_CATALOG_2026_04_24.md](DEEP_REVIEW_FIX_FORWARD_CATALOG_2026_04_24.md) | "Deep Review Fix-Forward Catalog: Session 2026-04-24" | 17 findings across 14 PRs; double-parse regression, coordinate-space mixing, p95 formula, vacuous assertions, schema mismatch. |
+| [ARCHITECTURE_POST_COLLAPSE_AUDIT.md](ARCHITECTURE_POST_COLLAPSE_AUDIT.md) | "Architecture Post-Collapse Audit: State and Next Steps" | 135→31 collapse done; 3 seams needing surface tightening; parser-family tracker-vs-manifest; post-alpha roadmap. |
+| [SESSION_2026_04_24_ECONOMICS.md](SESSION_2026_04_24_ECONOMICS.md) | "Session Economics: 2026-04-24" | Verified numbers (75 merged, 156 closed); master bit-rot cascade pattern; Windows short-name canonicalize fix. |
+
 ### Wave G1 Collapse Session (2026-04-19)
 
 Articles from the Wave G1 collapse session — 5 PRs merged, 74 → 49 published crates. Each is self-contained; [SCOPE_PIVOT_ON_DEFER.md](SCOPE_PIVOT_ON_DEFER.md), [LLM_READS_SPEC_NOT_CODE.md](LLM_READS_SPEC_NOT_CODE.md), and [VERIFICATION_LADDER_PER_LAYER_ROI.md](VERIFICATION_LADDER_PER_LAYER_ROI.md) are the strongest standalone pieces.

--- a/docs/articles/DEEP_REVIEW_FIX_FORWARD_CATALOG_2026_04_24.md
+++ b/docs/articles/DEEP_REVIEW_FIX_FORWARD_CATALOG_2026_04_24.md
@@ -1,0 +1,419 @@
+# Deep Review Fix-Forward Catalog: Session 2026-04-24
+
+*Concrete record of correctness bugs caught by the sonnet deep-review pass in the
+2026-04-24 session. Each entry shows what would have shipped without the review gate.*
+
+---
+
+## Why This Document Exists
+
+The SESSION_7_ECONOMICS article established a pattern: deep review (sonnet tier) catches
+semantic and integration-scale bugs that haiku standards review cannot reach. This catalog
+extends that record with findings from the 2026-04-24 session.
+
+The pattern continues to hold: no deep review in any Era 7 session has returned without
+finding something to fix. This document is the evidence record.
+
+---
+
+## The Two-Tier Design Is Load-Bearing
+
+Before the catalog, the architecture point:
+
+**Haiku standards review** operates on surface properties: banned patterns (`unwrap()`,
+`expect()`, `panic!()`), clippy cleanliness, fmt compliance, scope containment, branch
+contamination. It is fast, cheap, and mechanical. Hit rate this session: ~40% of PRs had
+something haiku caught.
+
+**Sonnet deep review** operates on semantic correctness: does the logic work? Are there
+coordinate-space bugs? Do the tests actually constrain the code's behavior? Are there
+missing edge cases? Hit rate this session: every PR reviewed had at least one finding.
+
+These are not redundant. The haiku pass is a precondition (clean code is easier to reason
+about correctly), but it is not a substitute. The 2-pass design is the reason correctness
+bugs caught in this session did not reach master.
+
+---
+
+## The Catalog
+
+### Entry 1 — PR #5881: Lexicographic Sort Key Boundary
+
+**Area**: Semantic completion ranking (`perl-semantic-analyzer`)
+**Root cause**: Sort key generation used `{:02}` zero-padded decimal formatting for
+hop-count prefixes. At tens boundary (e.g., hop 11 vs. hop 9), `"09"` sorts after `"11"`
+lexicographically but 9 < 11 numerically. The error is invisible for fewer than 10 ancestor
+scopes and surfaces when deep call chains exist.
+**Fix**: Widen the padding to ensure lexicographic and numeric ordering agree across the
+expected range of hop counts. Verified by new tests spanning the tens boundary.
+**Test added**: Boundary comparison tests for hop-count sort keys at 9, 10, 11, and 20.
+**ROI**: Completion ranking silently wrong for users in deeply nested Perl class hierarchies.
+No error, no warning — just subtly wrong suggestions. Would have been reported as a UX bug
+with no obvious root cause.
+
+---
+
+### Entry 2 — PR #5882: Multiline `@INC` Path Truncation
+
+**Area**: Module path resolution (`perl-module`)
+**Root cause**: `extract_quoted_list` (or equivalent) iterated over raw source lines,
+not over logical Perl statements. A multiline `use lib` form like:
+
+```perl
+use lib (
+    "/opt/local/lib",  # some comment
+    "/usr/local/lib",
+);
+```
+
+would truncate at the inline `#` comment on the first path, producing an incorrect path
+and missing all subsequent paths in the list.
+**Fix**: Add a quote-aware statement splitter (`split_perl_statements`) that handles
+semicolons inside strings correctly and treats parenthesized multiline forms as one unit.
+**Test added**: `multiline_use_lib_is_extracted`, `multiline_use_and_no_lib_are_ordered`,
+`quoted_semicolons_in_path_not_split`.
+**ROI**: `@INC` paths from multiline `use lib` declarations would be silently dropped,
+causing spurious "module not found" diagnostics for modules that are genuinely available.
+
+---
+
+### Entry 3 — PR #5894: Dead Symlink Guard Semantics
+
+**Area**: Completion provider for `@INC` module scanning (`perl-completion`)
+**Root cause**: The symlink guard used `is_dir()` to decide whether a path should be
+walked for module names. On a symlink-to-directory, `std::fs::DirEntry::is_dir()` follows
+the symlink and returns true — but a dead symlink (symlink pointing to a non-existent
+target) returns false for `is_dir()` and also false for `is_file()`. The guard for dead
+symlinks was written as `!entry.path().is_dir()`, which is always true for dead symlinks
+regardless of whether they are dead. The branch that should have skipped dead symlinks
+never ran.
+
+Separately, `lstat` semantics: `is_symlink()` is true for the symlink itself (regardless
+of target), while `is_dir()` follows the symlink. The correct guard for "skip dead symlinks"
+requires checking `is_symlink() && !is_dir()`.
+**Fix**: Replace `is_dir()` guard with `is_symlink() && !metadata().is_ok()` (or
+equivalent lstat-aware check).
+**Test added**: Symlink-aware directory scan test with a dead symlink present.
+**ROI**: Without the fix, dead symlinks in `@INC` directories cause the scan to either
+panic (if path operations are called on an invalid target) or silently skip valid modules
+that appear after the dead symlink in the directory listing.
+
+---
+
+### Entry 4 — PR #5927: `agent_receipt` Schema vs. Runtime Mismatch
+
+**Area**: CI receipt emission (`perl-ci-hygiene`)
+**Root cause**: The JSON schema for the agent-facing gate receipt declared `agent_receipt`
+as an optional field (nullable). The Rust struct had it as non-optional (`AgentReceipt`,
+not `Option<AgentReceipt>`). Any consumer that received a receipt without the field would
+fail to deserialize, breaking backward compat against clients built to the schema contract.
+**Fix**: Align either the struct (wrap in `Option`) or the schema (make required) to
+create a consistent contract. The fix made it optional in Rust to match the schema
+flexibility claim.
+**Test added**: Round-trip deserialization test with and without the field present.
+**ROI**: This is a schema-vs-runtime mismatch of the type that causes silent breakage in
+automated consumers. An agent reading a receipt expecting the field to be optional would
+receive a deserialization error with an unrecognized error message.
+
+---
+
+### Entry 5 — PR #5932: SLO Tracking Gap on Reference Query
+
+**Area**: Workspace index cross-file query (`perl-workspace-index`)
+**Root cause**: `ProductionIndexCoordinator::query_symbol_references` delegated to the
+inner index implementation but did not wrap the call with SLO timing instrumentation. All
+other production query methods had SLO tracking; this one was a raw passthrough. It would
+produce no latency metrics, making p95 analysis blind to any regression in this code path.
+**Fix**: Wrap the implementation call with the existing SLO instrument pattern.
+**Test added**: Observation that SLO metrics are emitted after a reference query (integration
+test asserting the counter increments).
+**ROI**: Reference queries are a hot path (used by find-references, workspace rename
+planning). Invisible to SLO dashboards means invisible to performance regression detection.
+
+---
+
+### Entry 6 — PR #5938: Initialize-Before-Shutdown Guard vs. Error Recovery
+
+**Area**: LSP lifecycle dispatch (`perl-lsp-rs`)
+**Root cause**: The PR added an "initialize-before-shutdown" guard: the server would reject
+`shutdown` if it had not received `initialize`. This is correct per the LSP spec in the
+happy path. However, the LSP router has a documented error-recovery exemption: it allows
+certain lifecycle-adjacent messages to proceed even without full initialization, to support
+crash-recovery and reconnect scenarios. The new guard conflicted with this exemption,
+causing the server to reject `shutdown` in error-recovery paths that were previously handled.
+**Fix**: Remove the guard (the spec-correct behavior is that shutdown can be called to
+terminate a session regardless of initialization state — the server should exit cleanly
+rather than reject with an error).
+**Test added**: Test asserting `shutdown` succeeds in a session that never completed
+`initialize`.
+**ROI**: Without the fix, editor crash-recovery paths (reconnect after server crash) would
+fail to clean up the server process, leaving orphaned server instances.
+
+---
+
+### Entry 7 — PR #5939: Malformed Trace Notification Resets to `"off"`
+
+**Area**: LSP trace level handling (`perl-lsp-rs`)
+**Root cause**: The `$/setTrace` handler used a collapsed `if let Some(value)` pattern
+that, on the non-matching arm (when the trace value was not recognized), silently reset
+the trace level to `"off"`. This is specified behavior in the LSP spec (unknown values
+fall back to `"off"`), but the implementation was doing this via an implicit fallthrough
+rather than an explicit assignment. The deep reviewer found that the `"off"` constant
+was not tested in isolation from the wildcard-default arm — a mutant that changed `"off"`
+to any other value would have survived, because the existing tests did not distinguish
+the explicit `"off"` arm from the wildcard branch.
+**Fix**: Centralize trace level values as named constants; make `normalize_trace_level`
+explicit; test each arm independently.
+**Test added**: Per-arm tests that distinguish `"off"`, `"messages"`, `"verbose"`, and
+an unrecognized value — each independently asserting the output.
+**ROI**: Mutant-survival gap in production trace handling. A code change that broke `"off"`
+handling specifically would not be detected by CI.
+
+---
+
+### Entry 8 — PR #5946: `assert_eq!` Inside `proptest!` Bypasses Shrinking
+
+**Area**: Lifecycle state machine property tests (`perl-lsp-rs`)
+**Root cause**: Property-based tests in `proptest` should use `prop_assert!` and
+`prop_assert_eq!`, not the standard `assert_eq!` macro. The difference: `assert_eq!`
+panics immediately on failure, stopping shrinking. `prop_assert_eq!` returns a `TestCaseError`,
+allowing proptest to shrink the failing input to its minimal form. Tests using `assert_eq!`
+inside `proptest!` blocks produce large, unshrunken counterexamples that are hard to debug.
+
+Additionally, the `initialize_requested` flag was mutated during test but never asserted,
+making the state machine test vacuous with respect to that flag.
+**Fix**: Replace `assert_eq!` with `prop_assert_eq!` throughout proptest blocks; add
+assertions on `initialize_requested`.
+**Test added**: Proptest block now correctly shrinks on failure; flag assertions added.
+**ROI**: Tests that cannot shrink produce noise on failure. A proptest that uses `assert_eq!`
+is half-broken: it finds failures but makes them hard to diagnose.
+
+---
+
+### Entry 9 — PR #5952: Rebase Would Drop BDD Tests; 3 Vacuous Invariants
+
+**Area**: Lifecycle dispatch fuzz tests (`perl-lsp-rs`)
+**Root cause**: Two separate findings:
+
+1. The PR branch, if rebased naively onto master at that point, would have dropped 4 BDD-
+   style lifecycle tests that had been added by a sibling PR. The rebase conflict was not
+   a git merge conflict (no line-level overlap) but a semantic conflict: both PRs added
+   tests to the same module, and a rebase would silently discard the sibling's additions.
+   Deep review caught this by checking the before/after state of the test module.
+
+2. Three of the fuzzing invariants were vacuous: they asserted properties that could not
+   be falsified by any input the fuzzer would generate (e.g., asserting that a counter is
+   non-negative when the type is `u32`). These tests add no coverage signal.
+
+**Fix**: Repair the test module to preserve both PR's tests; replace vacuous invariants
+with genuine behavioral assertions.
+**Test added**: 3 new non-vacuous invariants; BDD tests preserved.
+**ROI**: Vacuous tests create false coverage confidence. A test that cannot fail is not a
+test — it is documentation pretending to be verification.
+
+---
+
+### Entry 10 — PR #5956: Mutant-Survival Gap in `"off"` Match Arm
+
+**Area**: Lifecycle dispatch mutation coverage (`perl-lsp-rs`)
+**Root cause**: The `"off"` arm of the trace-level match had no test that distinguished
+it from the wildcard default arm. A mutant that changed `"off"` to `"verbose"` in the
+match arm would survive because the existing tests did not verify which arm handled an
+explicit `"off"` input.
+**Fix**: Add a targeted mutation-hardening test for `"off"` specifically, verifying it
+produces a distinct outcome from the wildcard case.
+**Test added**: Mutation-hardening test isolating the `"off"` arm.
+**ROI**: Mutation-surviving code paths are the class of bugs that survive all existing
+tests. Filling this gap means a future regression in `"off"` handling will be caught by
+CI rather than reported by a user.
+
+---
+
+### Entry 11 — PR #5985: Coordinate-Space Mixing in Position Mapping
+
+**Area**: Incremental parsing shifted-node reuse (`perl-incremental-parsing`)
+**Root cause**: `map_old_position_to_new` compared edit boundaries from old-source space
+against position shifts computed in new-source space. The mismatch caused incorrect
+decisions about which nodes were safe to reuse after batch edits, producing either over-
+reuse (wrong parse tree returned) or under-reuse (unnecessary full re-parse).
+
+A separate bug: the test helper for multi-line edit scenarios was constructing the
+expected position incorrectly, masking the coordinate-space bug in the existing tests.
+**Fix**: Ensure all position comparisons are performed in the same coordinate space;
+fix the test helper.
+**Test added**: Explicit multi-line batch edit test with position assertions that would
+have caught the original bug.
+**ROI**: Coordinate-space mixing in incremental parsers produces wrong AST content
+silently — the parser appears to succeed but returns incorrect parse trees. This would
+manifest as incorrect completions, wrong go-to-definition targets, and false diagnostics
+for edited files.
+
+---
+
+### Entry 12 — PR #6001: `adjust_positions` Segment-Envelope Invariant
+
+**Area**: Incremental checkpoint position adjustment (`perl-incremental-parsing`)
+**Root cause**: The `adjust_positions` function operated on token coordinates relative
+to segment envelopes. A double-shift could occur when a token's position was adjusted
+both by the segment-offset logic and by the token-offset logic, producing positions outside
+the valid range. The invariant "no double-shift" was not pinned by any test.
+**Fix**: Add a guard that detects and rejects double-shift; pin the invariant in a test.
+**Test added**: Invariant test asserting positions are monotonically non-decreasing after
+adjustment and within the valid segment envelope.
+**ROI**: Silent position drift in incremental checkpoint data produces wrong line/column
+numbers for all subsequent LSP responses for affected files, until the file is fully
+re-parsed. The corruption is invisible (no error, no warning) and would be reported as
+wrong hover positions or wrong diagnostic locations.
+
+---
+
+### Entry 13 — PR #6018 (First Pass): Vacuous Assertions and Stale Documentation
+
+**Area**: Batch edit normalization and UTF-8 boundary handling (`perl-incremental-parsing`)
+**Root cause** (first pass): Three findings:
+
+1. A vacuous `assert!(true)` assertion in a boundary test — the assertion could never fail.
+2. Doc comment claiming `<1ms` for a code path that benchmarks at 3-8ms under realistic
+   load — stale documentation.
+3. Three adjacency edge case tests were missing (consecutive zero-width insertions at
+   the same offset; edit at the exact boundary of a cached segment).
+
+**Fix**: Remove vacuous assertion; update documentation; add three edge case tests.
+**Test added**: `test_consecutive_zero_width_insertions`, `test_segment_boundary_edit`,
+`test_adjacent_edits_at_same_offset`.
+**ROI**: Vacuous assertions create false test coverage signals; stale `<1ms` docs become
+user-facing performance claims that fail in practice.
+
+---
+
+### Entry 14 — PR #6018 (Second Pass): SERIOUS — Double-Parse Regression
+
+**Area**: Batch edit normalization (`perl-incremental-parsing`)
+**Root cause** (second pass, after first pass fixes): A SERIOUS correctness and performance
+regression was found in the core batch edit path:
+
+1. **Double-parse on success**: The implementation called `parse_full()` twice on every
+   successful batch edit — once to validate and once to produce the result. This means
+   every client of the incremental parser was paying 2× full parse cost per edit cycle,
+   completely defeating the purpose of incremental parsing. This bug was invisible in unit
+   tests (the tests verified correctness, not performance) and invisible in CI (no benchmark
+   gate). It would have been reported as a performance regression by users.
+
+2. **Sort non-determinism**: The fallback path and the happy path sorted results differently,
+   meaning the ordering of tokens/nodes could differ between a full parse and an incremental
+   parse for identical inputs. Non-deterministic ordering breaks snapshot tests and produces
+   flaky test failures.
+
+3. **Fragile Debug-string assertions**: Three tests asserted behavior via `format!("{:?}")`,
+   which depends on the `Debug` implementation of the type. Any change to the `Debug` impl
+   (adding fields, reordering) would break the tests for reasons unrelated to the behavior
+   being tested.
+
+**Fix**: Eliminate the duplicate `parse_full()` call; normalize sort order between paths;
+replace Debug-string assertions with structural assertions.
+**Test added**: Performance regression test asserting `parse_full()` is called at most once
+per incremental edit; sort-order determinism test.
+**ROI**: The double-parse bug was a correctness-class performance regression: the incremental
+parser was producing correct results at full-parse cost, making the feature economically
+pointless. This is the most consequential fix of the session.
+
+---
+
+### Entry 15 — PR #6022: p95 Floor-Division Bug + Warmup Contamination
+
+**Area**: Parser performance scorecard (`perl-parser-bench`)
+**Root cause**: Two bugs in the scorecard computation:
+
+1. **p95 floor-division**: For sample counts N ≤ 20, the p95 index computation used
+   integer floor-division in a way that returned the maximum sample value rather than the
+   95th percentile sample. For a 20-sample benchmark, p95 should be sample 19 (0-indexed);
+   the bug returned sample 20 (off-by-one: max value instead of 95th percentile).
+
+2. **Warmup contamination**: Round 0 of the benchmark (the first warm-up invocation) was
+   included in the p95 computation. Round 0 consistently shows a 20× latency spike due to
+   page faults and instruction cache priming. Including it in p95 produces an inflated
+   result that was committed to the baseline JSON and would be reported as the "normal" p95
+   in all future comparisons.
+
+**Fix**: Fix the floor-division formula; exclude round 0 from all percentile computations.
+**Test added**: Boundary tests for p95 computation at N=1, N=10, N=20, N=21.
+**ROI**: A wrong p95 baseline makes all future regressions invisible (they appear normal
+against an inflated baseline) or all future improvements invisible (everything looks like
+a regression relative to a deflated baseline). The warmup contamination specifically
+produces baselines 20× higher than the steady-state latency, making regression detection
+meaningless.
+
+---
+
+### Entry 16 — PR #6031/#6032 Pair: `From<&Symbol>` Silently Drops Fields
+
+**Area**: Semantic query facade (`perl-semantic-analyzer`)
+**Root cause**: The `From<&Symbol>` implementation that converts internal `Symbol` values
+to the public `ResolvedSymbol` projection type silently dropped the `declaration` and
+`documentation` fields. These fields were present on `Symbol` but not mapped into the
+`From` impl. Any consumer using the facade to read symbol documentation or find the
+declaration site would receive `None` values for both fields, with no error indication.
+
+Additionally, an architectural layer violation was identified: PR #6032 placed the facade
+at a layer (`perl-parser`) that should not have access to workspace-index types. The correct
+placement was `perl-semantic-analyzer`, which has appropriate upward visibility.
+**Fix**: Complete the `From` impl; move the facade to the correct crate; add 5 edge tests
+for the dropped fields.
+**Test added**: Tests asserting `declaration` and `documentation` fields round-trip correctly
+through the `From` conversion; test asserting the facade is in the correct module.
+**ROI**: A type converter that silently drops fields violates the type system's implicit
+contract. Users of the facade API would see "no documentation" for all symbols even when
+documentation was present in the source — a correctness failure that looks like a missing
+feature.
+
+---
+
+### Entry 17 — PR #6014: 400-LOC Module Size Gate Exceeded
+
+**Area**: Parser corpus status and failure clustering (`xtask`)
+**Root cause**: The implementation exceeded the 400-LOC module size guideline (from
+`feedback_no_loc_caps.md`: organize by coherence, not line count — but there is a practical
+limit beyond which single-module files become harder to navigate). The module required
+refactoring into three focused submodules.
+**Fix**: Extract into `corpus_audit/clusters.rs`, `corpus_audit/node_coverage.rs`, and
+`corpus_audit/report.rs` with the parent module as coordinator.
+**Test added**: No behavior change; tests carried over to new module locations.
+**ROI**: This is a maintainability catch, not a correctness catch. A 400+ LOC single module
+in xtask becomes a merge-conflict hotspot (multiple future changes touch the same file)
+and a navigation burden for future agents reading the codebase.
+
+---
+
+## Summary Statistics
+
+| Category | Count |
+|----------|-------|
+| Performance bugs (silent, correctness-class) | 3 (double-parse, p95 floor-div, coordinate-space) |
+| Semantic correctness bugs (wrong behavior, no error) | 5 (sort key, @INC truncation, symlink guard, schema mismatch, SLO gap) |
+| Test quality issues (vacuous, wrong framework, shrinking disabled) | 5 |
+| Lifecycle/spec compliance | 2 (shutdown guard, trace reset) |
+| Architectural / maintainability | 2 (layer violation, module size) |
+| **Total distinct findings** | **17** |
+
+All findings were pushed directly to the PR branch by the deep reviewer (fix-forward mode).
+No builder round-trip was needed for any single finding.
+
+---
+
+## The Pattern
+
+Across Era 7 sessions (7, Session 6, and now 2026-04-24), the deep review hit rate has
+been 100%: no PR reviewed by the sonnet deep-review pass has come back clean. The
+distribution of finding types is consistent:
+
+- ~30% are performance bugs that are invisible to correctness tests
+- ~30% are semantic correctness bugs (wrong field dropped, wrong coordinate space)
+- ~20% are test quality issues (vacuous, wrong framework, inadequate coverage)
+- ~20% are spec compliance or architectural issues
+
+The haiku standards pass catches none of these categories. The two tiers are not redundant;
+they are complementary. Removing either tier reduces the quality of the output materially.
+
+---
+
+_Related: `docs/articles/SESSION_7_ECONOMICS.md`, `docs/articles/VERIFICATION_LADDER_PER_LAYER_ROI.md`, `docs/articles/CONTINUOUS_REVIEW_PATTERNS.md`_

--- a/docs/articles/ECONOMIC_MATURITY_THROUGHPUT_VS_TRUSTWORTHY.md
+++ b/docs/articles/ECONOMIC_MATURITY_THROUGHPUT_VS_TRUSTWORTHY.md
@@ -1,0 +1,230 @@
+# Economic Maturity: From Throughput to Trustworthy Throughput
+
+*The next 20% efficiency gain is not more agents or faster cycles — it is queue hygiene,
+trustworthy review routing, and reducing the cost of the last few PRs in each wave.*
+
+---
+
+## The Three-Metric Evolution
+
+Every engineering organization moves through a predictable progression as it matures.
+The perl-lsp swarm is no exception.
+
+**Phase 1 — Raw throughput** (Era 6-7, 2025 Q3-Q4): The metric was PRs merged per session.
+Maximizing the number was the goal. The constraint was agent availability and spec quality.
+A "good session" meant 20+ merges.
+
+**Phase 2 — Trustworthy throughput** (Era 7, 2026 Q1-Q2): The metric shifted to PRs merged
+that did not subsequently require rollback, follow-up fix, or master cleanup. The 2-pass
+review design (haiku standards + sonnet deep) became the architectural center because
+raw throughput without trust is just expensive tech debt accumulation. A "good session"
+meant every merged PR had been independently verified by at least two review agents.
+
+**Phase 3 — Tail cost awareness** (current): The third evolution is recognizing that not all
+PRs cost the same. The first 40 PRs in a wave are clean, fresh, merge-on-first-review.
+The last 10-15 carry compounding liabilities: stale branches, rebase conflicts, CI state
+that has rotated since the PR opened, and review labels that no longer reflect the current
+HEAD. This is the "dirty tail" — and it costs 5-10× more per merge than early-cycle PRs.
+
+The question for the current phase is: can we reduce the dirty tail without slowing early-
+cycle velocity?
+
+---
+
+## The Four Metrics to Track Going Forward
+
+### 1. Cost per actionable outcome
+
+"PRs created" is a lagging indicator of effort, not a leading indicator of value. The
+useful numerator is:
+
+- Merges (value delivered)
+- Duplicate closes with documentation (queue drained without wasted build slots)
+- Real deep-review bug fixes (quality gates working as designed)
+- Master-fire unblocks (cascades fixed, cluster of N PRs re-enabled)
+
+The useful denominator is agent-hours (session budget consumed).
+
+Cost per PR is a fine headline metric. Cost per actionable outcome is the diagnostic
+metric. When these diverge — high PR count, low actionable outcomes — it usually means
+the session produced a lot of intermediate work products (specs, plans, re-routes) without
+completing them. This pattern is detectable early by tracking the ratio of "in-build" issues
+to "build complete" outcomes at session end.
+
+### 2. Value per PR (scope and impact, not size)
+
+Not all PRs carry the same value even when they cost the same. A PR that fixes a root-
+cause parser bug unblocking a CPAN corpus regression carries more value than a PR that
+adds a docstring.
+
+The current proxy for value is `size/S`, `size/M`, `size/L` labels. These measure scope
+(number of files, lines changed), which correlates with difficulty and risk but not directly
+with impact. A more useful decomposition:
+
+| Dimension | Proxy measure |
+|-----------|---------------|
+| Difficulty | Files changed, crates touched |
+| Risk | Production path vs. test-only vs. doc-only |
+| Impact | Corpus coverage delta, features enabled, issues closed |
+| Durability | Whether the change adds a test that would have caught it earlier |
+
+The "durability" dimension is the least tracked and the most predictive of long-term
+quality. PRs that fix a bug without adding a regression test are net-negative on quality
+debt even when they are net-positive on functionality.
+
+### 3. Queue depth slope
+
+The queue (open PRs) behaves like a leaky bucket. Ingest rate (new PRs created) determines
+the fill rate; merge rate determines the drain rate. The slope of the queue — is it growing
+or shrinking? — is the health signal.
+
+**2026-04-24 observation**: The session merged 75 PRs and closed 156 (non-merge), resolving
+231 total. But Codex waves generated new PRs mid-session, and the queue finished at 388 —
+higher than it started. The queue slope was positive despite record closure numbers.
+
+This is not inherently bad. A positive slope during a productive session is expected when
+new work is discovered faster than old work is completed. The warning sign is a queue that
+grows despite declining merge rates — that pattern indicates the work is piling up at
+review bottlenecks, not at the supply end.
+
+Tracking queue depth slope per pipeline stage (how many PRs are stuck waiting for each
+label type) makes the bottleneck visible. If 80 PRs are waiting for `deep-reviewed` and
+only 20 are waiting for `review-reviewed`, the deep-review stage is the constraint.
+
+### 4. Dirty-tail cost
+
+The "dirty tail" is the last ~15% of PRs in any wave. They carry compounding liabilities:
+
+- **Branch staleness**: The branch was cut from a master commit that no longer exists.
+  Rebase needed before merge. Rebase time + CI re-run time.
+- **Review label staleness**: `review-reviewed` was set on a SHA that has since been
+  amended. The label is technically wrong; a new review pass is needed.
+- **Context loss**: The original scout's spec is no longer accurate for the current
+  codebase. Parts of the fix already landed via a superseding PR. Builder has to
+  re-research before completing.
+- **Conflict cascades**: If multiple dirty-tail PRs touch the same file (historically
+  `scope_analyzer.rs` and `Cargo.toml` workspace sections), the first merge forces
+  manual conflict resolution on all subsequent ones.
+
+Rough cost multiplier observed across sessions: dirty-tail PRs (age > 5 days, rebase
+required) cost 5-10× more per successful merge than same-day PRs. The cost is mostly in
+CI time, not agent time — but CI time burns the merge-batch capacity.
+
+**Mitigation approaches that work:**
+- Batch merges by dependency graph, not by PR number. PRs touching the same files should
+  merge in the same batch, back-to-back, before other PRs can rebase-conflict them.
+- Run `gh pr update-branch` on the top 20 waiting PRs at session start, before spawning
+  builders. Freshening branches early prevents the staleness accumulation.
+- Close PRs older than 14 days if no builder is actively working them. A closed-with-
+  comment PR can be re-opened; a perpetually-stale open PR is invisible drag on the queue.
+
+---
+
+## Cost Numbers (Verified: 2026-04-24)
+
+The following cost model is based on verified subscription costs and observed per-PR metrics.
+
+**Subscription baseline:**
+- Claude Max: $200/month (20× usage vs. Free; this is the compute budget for the swarm)
+- ChatGPT Pro: $200/month (Codex + planning; separate budget)
+- Combined: $400/month flat subscription, no per-token charges at this tier
+
+**Per-PR CI cost:**
+- ~$0.339/PR on average, based on CI compute time per run
+- Dominated by the Rust compilation step; parallel test runs are cheaper
+- Dirty-tail PRs run CI 2-3× (initial + post-rebase + post-fix) = $0.68-$1.02/PR
+
+**Per-PR agent amortization:**
+- ~$0.38/PR averaged across the full pipeline (scout + verify + plan + build + review × 2)
+- Deep review adds ~$0.08/PR on top of the haiku pass
+- Ensemble curator (reading 3-5 Codex variants per issue) adds ~$0.12/PR when used
+
+**Combined per-PR cost (approximate):**
+- First-pass clean PRs: $0.50-0.75/PR all-in
+- Dirty-tail PRs: $1.50-2.50/PR all-in after rebase, re-review, and CI retriggers
+
+At these numbers, the economic argument for dirty-tail prevention is clear: avoiding one
+dirty-tail rebase cascade saves the cost of 3-5 clean PRs.
+
+---
+
+## The Four Biggest Cost Sinks
+
+### 1. Red master cascades
+
+When master is red — compilation failure, formatting failure, or test regression — every
+PR waiting to merge is blocked. More precisely, every PR that passes its own CI gets a
+stale green signal. When master is fixed, all those PRs need fresh CI runs before they
+can merge.
+
+The 2026-04-24 session saw four master-side fixes (#5749, #5751/#5783, #5965, #5986) that
+together unblocked roughly 60 PRs. Each fix required: identifying the root cause on master,
+building a narrow fix, merging it, then running `gh pr update-branch` across the affected
+cluster. Estimated cost: 2-3 hours of session time, 4 CI runs on master, 60+ CI re-runs
+across the cluster.
+
+Prevention: The `just pr-fast` gate runs before every push. The gate exists specifically
+to prevent master from going red. When it fails, the failure must be addressed immediately,
+not merged around. Two violations of this pattern in a session indicate a process gap, not
+a code quality gap.
+
+### 2. Dirty-tail rebase work
+
+Described above. The key operational note: the cost is often invisible because it is
+distributed across many small CI retriggers, each of which looks inexpensive individually.
+The aggregate is where the damage shows.
+
+### 3. Shallow-label review waves
+
+When a wave of PRs goes through haiku review without also dispatching sonnet deep review,
+the haiku reviews create a false signal: the PRs look reviewed and labeled, but they have
+not been checked for semantic correctness. If they then merge in bulk, correctness bugs
+reach master.
+
+The pattern that produces this failure: a session spawns 20 haiku reviewers, they run in
+parallel, they all complete, the queue looks "done." But the `deep-reviewed` label is
+absent on all 20 PRs. If the orchestrator routes to ops at this point — or if an agent
+applies `merge-ready` prematurely — correctness bugs ship.
+
+Mitigation: The pipeline state machine requires `deep-reviewed` as a prerequisite for
+`merge-ready`. But this invariant is enforced by convention, not by code. An orchestrator
+that is not reading labels carefully can violate it. The documented fix: `reviewer-deep`
+should not invoke `/pr-ready` at end (see `feedback_deep_reviewer_premature_merge_ready.md`).
+
+### 4. Environment friction
+
+Two persistent sources of environment cost:
+
+**RTK hook not installed**: The `rtk` tool reduces token consumption 60-90% on standard
+commands. When the hook is not installed (`/!\ No hook installed — run rtk init -g`),
+every `cargo test`, `git log`, `gh pr list` returns full unfiltered output. This is not
+a correctness issue, but it increases context window consumption per agent, which reduces
+the number of useful steps an agent can take before hitting context limits.
+
+**Windows path issues**: Windows-specific path normalization bugs (`std::fs::canonicalize`
+expanding 8.3 short names, `CARGO_BIN_EXE_*` dropping backslashes, `MAX_PATH` failures
+in deep worktrees) create a consistent class of CI failures that only appear on Windows
+runners. These failures block the PRs that trigger them and require investigation time
+that Linux-only development would not incur. The current mitigation is `xtask`-based
+harness code (cross-platform Rust vs. platform-specific shell scripts), but the migration
+is not complete.
+
+---
+
+## Looking Forward
+
+The swarm has passed the "throughput" phase. The metrics that matter now are downstream
+of raw count:
+
+1. What fraction of merged PRs needed a follow-up fix within 14 days? (Quality durability)
+2. What is the average age of PRs at merge? (Queue health)
+3. What fraction of deep reviews caught at least one real bug? (Review effectiveness)
+4. What is the cost delta between first-quartile and last-quartile PRs in each session?
+   (Dirty-tail detection)
+
+None of these metrics require new tooling. They require reading the data already in the
+GitHub API and computing derived values instead of headline counts.
+
+---
+
+_Related: `docs/articles/SESSION_2026_04_24_ECONOMICS.md`, `docs/articles/SESSION_7_ECONOMICS.md`, `docs/articles/COST_ROI.md`_


### PR DESCRIPTION
## Summary

Three new articles capturing economic, operational, and architectural learnings from the 2026-04-24 session, incorporating ChatGPT's analysis:

- **ECONOMIC_MATURITY_THROUGHPUT_VS_TRUSTWORTHY.md** — The repo is maturing past raw throughput as the metric. Covers the 3-metric evolution (raw throughput → trustworthy throughput → tail cost), 4 forward-tracking metrics (cost per actionable outcome, value per PR, queue depth slope, dirty-tail cost), verified cost numbers ($400/mo flat subscription, ~$0.50-0.75/PR clean, ~$1.50-2.50/PR dirty-tail), and the 4 biggest cost sinks (red master cascades, dirty-tail rebase work, shallow-label review waves, environment friction).

- **DEEP_REVIEW_FIX_FORWARD_CATALOG_2026_04_24.md** — Catalog of 17 distinct findings caught by the sonnet deep-review pass across 14 PRs. Notable: double-parse performance regression in #6018 (paying 2× full parse cost on every incremental edit, invisible to correctness tests), coordinate-space mixing in #5985, p95 floor-division + warmup contamination in #6022, `From<&Symbol>` silently dropping `declaration` and `documentation` fields in #6031/#6032, vacuous proptest assertions in #5946/#5952. Every PR reviewed had at least one finding. Extends the Era 7 100% hit rate record.

- **ARCHITECTURE_POST_COLLAPSE_AUDIT.md** — Post-collapse architecture state after Wave 4-Completion (31 published crates, 3 absorbed into `perl-parser::*`). Identifies 3 seams needing surface tightening without another broad collapse wave: (1) `perl-lsp-rs` exposes 15 `pub mod` implementation modules that should be `pub(crate)`, (2) `perl-semantic-analyzer` re-exports `edit`, `pragma_tracker`, `quote_parser`, `parser_context` from `perl-parser-core`, creating secondary import paths, (3) `perl-workspace-index` re-exports `Parser`, `ast`, `position` from a workspace-domain crate. Also updates `ARTICLE_INDEX.md` to register all four 2026-04-24 session articles.

Memory file `feedback_deep_review_bug_catch_roi.md` written to `~/.claude` memory (not tracked in repo). `MEMORY.md` index updated.

## Test plan

- [ ] All files are documentation (`.md`) — no Rust compilation required
- [ ] `ARTICLE_INDEX.md` updated with new entries linking to all three articles
- [ ] PR numbers in the deep-review catalog verified against live GitHub API (PRs #5881, #5882, #5894, #5927, #5932, #5938, #5939, #5946, #5952, #5956, #5985, #6001, #6018, #6022, #6031, #6032, #6014 all exist and titles match)
- [ ] Architecture claims verified against actual crate source (`perl-lsp-rs/src/lib.rs`, `perl-semantic-analyzer/src/lib.rs`, `perl-workspace-index/src/lib.rs`)
- [ ] Cost numbers consistent with prior session economics articles