### PR TITLE
perf(tree-sitter-perl-c): remove measured wrapper overhead in hot parse path (#0000)

### DIFF
--- a/crates/tree-sitter-perl-c/src/bin/bench_parser.rs
+++ b/crates/tree-sitter-perl-c/src/bin/bench_parser.rs
@@ -1,32 +1,124 @@
 use std::env;
 use std::fs;
 use std::time::Instant;
-use tree_sitter_perl_c::parse_perl_code;
+use tree_sitter_perl_c::{parse_perl_code, try_create_parser};
+
+#[derive(Clone, Copy, Debug)]
+enum BenchMode {
+    Wrapper,
+    FreshParser,
+    ReusedParser,
+}
+
+impl BenchMode {
+    fn from_arg(arg: &str) -> Option<Self> {
+        match arg {
+            "wrapper" => Some(Self::Wrapper),
+            "fresh-parser" => Some(Self::FreshParser),
+            "reused-parser" => Some(Self::ReusedParser),
+            _ => None,
+        }
+    }
+}
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!("Usage: bench_parser_c <file>");
+    if args.len() < 2 || args.len() > 4 {
+        eprintln!(
+            "Usage: bench_parser_c <file> [mode] [iterations]\n\
+             modes: wrapper | fresh-parser | reused-parser"
+        );
         std::process::exit(1);
     }
     let file_path = &args[1];
+    let mode =
+        args.get(2).map(String::as_str).and_then(BenchMode::from_arg).unwrap_or(BenchMode::Wrapper);
+    let iterations = args.get(3).and_then(|arg| arg.parse::<u32>().ok()).unwrap_or(1_000);
+    if iterations == 0 {
+        eprintln!("iterations must be > 0");
+        std::process::exit(1);
+    }
+
     let code = fs::read_to_string(file_path).unwrap_or_else(|e| {
         eprintln!("Failed to read file: {}", e);
         std::process::exit(1);
     });
+
     let start = Instant::now();
-    let result = parse_perl_code(&code);
+    let mut error_trees = 0_u32;
+    match mode {
+        BenchMode::ReusedParser => {
+            let mut parser = try_create_parser().unwrap_or_else(|e| {
+                eprintln!("Failed to initialize parser: {}", e);
+                std::process::exit(1);
+            });
+            for _ in 0..iterations {
+                match parser.parse(code.as_bytes(), None) {
+                    Some(tree) => {
+                        if tree.root_node().has_error() {
+                            error_trees += 1;
+                        }
+                    }
+                    None => {
+                        let duration = start.elapsed().as_micros();
+                        println!(
+                            "status=failure mode={:?} iterations={} error=true duration_us={}",
+                            mode, iterations, duration
+                        );
+                        eprintln!("Parse error: Failed to parse code");
+                        std::process::exit(1);
+                    }
+                }
+            }
+        }
+        BenchMode::Wrapper | BenchMode::FreshParser => {
+            for _ in 0..iterations {
+                let has_error = match mode {
+                    BenchMode::Wrapper => parse_with_wrapper(&code),
+                    BenchMode::FreshParser => parse_with_fresh_parser(&code),
+                    BenchMode::ReusedParser => unreachable!(),
+                };
+
+                match has_error {
+                    Ok(has_error) => {
+                        if has_error {
+                            error_trees += 1;
+                        }
+                    }
+                    Err(e) => {
+                        let duration = start.elapsed().as_micros();
+                        println!(
+                            "status=failure mode={:?} iterations={} error=true duration_us={}",
+                            mode, iterations, duration
+                        );
+                        eprintln!("Parse error: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+            }
+        }
+    }
+
     let duration = start.elapsed().as_micros();
-    match result {
-        Ok(tree) => {
-            let has_error = tree.root_node().has_error();
-            println!("status=success error={} duration_us={}", has_error, duration);
-            // Always return success (0) - parse errors are indicated in the error field
-        }
-        Err(e) => {
-            println!("status=failure error=true duration_us={}", duration);
-            eprintln!("Parse error: {}", e);
-            std::process::exit(1);
-        }
+    println!(
+        "status=success mode={:?} iterations={} error_trees={} duration_us={} avg_us_per_iter={:.3}",
+        mode,
+        iterations,
+        error_trees,
+        duration,
+        duration as f64 / f64::from(iterations),
+    );
+}
+
+fn parse_with_wrapper(code: &str) -> Result<bool, Box<dyn std::error::Error>> {
+    let tree = parse_perl_code(code)?;
+    Ok(tree.root_node().has_error())
+}
+
+fn parse_with_fresh_parser(code: &str) -> Result<bool, Box<dyn std::error::Error>> {
+    let mut parser = try_create_parser()?;
+    match parser.parse(code.as_bytes(), None) {
+        Some(tree) => Ok(tree.root_node().has_error()),
+        None => Err("Failed to parse code".into()),
     }
 }

--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -39,8 +39,13 @@
 //! [`perl-parser`]: https://docs.rs/perl-parser
 //! [`tree-sitter-perl-rs`]: https://docs.rs/tree-sitter-perl-rs
 
+use std::cell::RefCell;
 use std::path::Path;
 use tree_sitter::{Language, Parser};
+
+thread_local! {
+    static THREAD_LOCAL_PARSER: RefCell<Option<Parser>> = const { RefCell::new(None) };
+}
 
 /// Returns the tree-sitter [`Language`] for Perl (C grammar).
 ///
@@ -127,11 +132,17 @@ pub fn create_parser() -> Parser {
 /// Returns an error if the parser cannot be initialised (version mismatch) or
 /// if tree-sitter returns `None` from `parse` (cancelled or timed out).
 pub fn parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    let mut parser = try_create_parser()?;
-    match parser.parse(code, None) {
-        Some(tree) => Ok(tree),
-        None => Err("Failed to parse code".into()),
-    }
+    THREAD_LOCAL_PARSER.with(|parser_slot| {
+        let mut parser_slot = parser_slot.borrow_mut();
+        if parser_slot.is_none() {
+            *parser_slot = Some(try_create_parser()?);
+        }
+
+        match parser_slot.as_mut().and_then(|parser| parser.parse(code, None)) {
+            Some(tree) => Ok(tree),
+            None => Err("Failed to parse code".into()),
+        }
+    })
 }
 
 /// Parses a Perl source string and returns the resulting [`tree_sitter::Tree`].


### PR DESCRIPTION
### Motivation

- The wrapper parse path allocated and configured a new `tree_sitter::Parser` on every call, adding avoidable setup overhead in tight benchmark loops.
- The bench binary lacked explicit modes to compare the cost of the wrapper vs fresh vs reused parsers, making the hotspot hard to quantify.

### Description

- Reuse a thread-local configured `Parser` in `parse_perl_bytes` so `parse_perl_code` no longer performs parser setup on every invocation (`crates/tree-sitter-perl-c/src/lib.rs`).
- Add explicit benchmark modes and iteration control to `bench_parser_c` (`wrapper`, `fresh-parser`, `reused-parser`) to make wrapper overhead measurable (`crates/tree-sitter-perl-c/src/bin/bench_parser.rs`).
- Keep behaviour and error semantics unchanged; tests and public helpers (`try_create_parser`, `create_parser`) remain available for callers who need fresh parser instances.

### Testing

- `cargo test -p tree-sitter-perl-c` passed (unit and BDD tests all OK). 
- `cargo check --all-targets -p tree-sitter-perl-c` passed. 
- `cargo clippy -p tree-sitter-perl-c --all-targets` completed without new lints, and `cargo xtask fmt` completed. 
- Bench runs with the new `bench_parser_c` modes (5000 iterations) show measurable improvement on a representative input (`examples/perl/complex.pl`): `fresh-parser` = 1228.602 us/iter, `wrapper` = 1136.174 us/iter (≈7.5% faster), and `reused-parser` = 1155.460 us/iter.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2792e34c8333b73f471aacc354a1)