### PR TITLE
perf(tree-sitter-perl-c): remove measured wrapper overhead in hot parse path

### DIFF
--- a/crates/tree-sitter-perl-c/src/bin/bench_parser.rs
+++ b/crates/tree-sitter-perl-c/src/bin/bench_parser.rs
@@ -1,32 +1,141 @@
 use std::env;
 use std::fs;
+use std::process;
 use std::time::Instant;
-use tree_sitter_perl_c::parse_perl_code;
+use tree_sitter_perl_c::{parse_perl_code, parse_perl_code_with_parser, try_create_parser};
+
+#[derive(Copy, Clone)]
+enum BenchMode {
+    Wrapper,
+    ReuseParser,
+}
+
+impl BenchMode {
+    fn parse(mode: &str) -> Result<Self, String> {
+        match mode {
+            "wrapper" => Ok(Self::Wrapper),
+            "reuse-parser" => Ok(Self::ReuseParser),
+            other => {
+                Err(format!("unknown mode '{other}', expected one of: wrapper | reuse-parser"))
+            }
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Wrapper => "wrapper",
+            Self::ReuseParser => "reuse-parser",
+        }
+    }
+}
+
+fn parse_u32(name: &str, value: &str) -> Result<u32, String> {
+    value.parse::<u32>().map_err(|e| format!("invalid {name} '{value}': {e}"))
+}
+
+fn print_usage(bin: &str) {
+    eprintln!("Usage: {bin} <file> [mode] [iterations]");
+    eprintln!("  mode: wrapper | reuse-parser (default: wrapper)");
+    eprintln!("  iterations: positive integer (default: 1)");
+}
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!("Usage: bench_parser_c <file>");
-        std::process::exit(1);
+    if args.len() < 2 || args.len() > 4 {
+        print_usage(&args[0]);
+        process::exit(1);
     }
+
     let file_path = &args[1];
-    let code = fs::read_to_string(file_path).unwrap_or_else(|e| {
-        eprintln!("Failed to read file: {}", e);
-        std::process::exit(1);
-    });
-    let start = Instant::now();
-    let result = parse_perl_code(&code);
-    let duration = start.elapsed().as_micros();
-    match result {
-        Ok(tree) => {
-            let has_error = tree.root_node().has_error();
-            println!("status=success error={} duration_us={}", has_error, duration);
-            // Always return success (0) - parse errors are indicated in the error field
-        }
+    let mode = match args.get(2) {
+        Some(raw_mode) => match BenchMode::parse(raw_mode) {
+            Ok(parsed_mode) => parsed_mode,
+            Err(message) => {
+                eprintln!("{message}");
+                print_usage(&args[0]);
+                process::exit(1);
+            }
+        },
+        None => BenchMode::Wrapper,
+    };
+
+    let iterations = match args.get(3) {
+        Some(raw_iterations) => match parse_u32("iterations", raw_iterations) {
+            Ok(parsed_iterations) if parsed_iterations > 0 => parsed_iterations,
+            Ok(_) => {
+                eprintln!("iterations must be greater than 0");
+                process::exit(1);
+            }
+            Err(message) => {
+                eprintln!("{message}");
+                process::exit(1);
+            }
+        },
+        None => 1,
+    };
+
+    let code = match fs::read_to_string(file_path) {
+        Ok(source) => source,
         Err(e) => {
-            println!("status=failure error=true duration_us={}", duration);
-            eprintln!("Parse error: {}", e);
-            std::process::exit(1);
+            eprintln!("Failed to read file: {e}");
+            process::exit(1);
+        }
+    };
+
+    let start = Instant::now();
+    let mut last_has_error = false;
+
+    match mode {
+        BenchMode::Wrapper => {
+            for _ in 0..iterations {
+                match parse_perl_code(&code) {
+                    Ok(tree) => {
+                        last_has_error = tree.root_node().has_error();
+                    }
+                    Err(error) => {
+                        fail(mode, iterations, start.elapsed().as_micros(), error.to_string());
+                    }
+                }
+            }
+        }
+        BenchMode::ReuseParser => {
+            let mut parser = match try_create_parser() {
+                Ok(configured_parser) => configured_parser,
+                Err(error) => {
+                    fail(mode, iterations, start.elapsed().as_micros(), error.to_string());
+                }
+            };
+
+            for _ in 0..iterations {
+                match parse_perl_code_with_parser(&mut parser, &code) {
+                    Ok(tree) => {
+                        last_has_error = tree.root_node().has_error();
+                    }
+                    Err(error) => {
+                        fail(mode, iterations, start.elapsed().as_micros(), error.to_string());
+                    }
+                }
+            }
         }
     }
+
+    let duration_us = start.elapsed().as_micros();
+    println!(
+        "status=success mode={} iterations={} error={} duration_us={}",
+        mode.as_str(),
+        iterations,
+        last_has_error,
+        duration_us
+    );
+}
+
+fn fail(mode: BenchMode, iterations: u32, duration_us: u128, error: String) -> ! {
+    println!(
+        "status=failure mode={} iterations={} error=true duration_us={}",
+        mode.as_str(),
+        iterations,
+        duration_us
+    );
+    eprintln!("Parse error: {error}");
+    process::exit(1);
 }

--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -109,6 +109,21 @@ pub fn create_parser() -> Parser {
     parser
 }
 
+/// Parses Perl source bytes with an already configured parser.
+///
+/// Reusing a parser avoids repeated parser/language setup in tight loops.
+///
+/// # Errors
+///
+/// Returns an error if tree-sitter returns `None` from `parse` (cancelled or
+/// timed out).
+pub fn parse_perl_bytes_with_parser(
+    parser: &mut Parser,
+    code: &[u8],
+) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
+    parser.parse(code, None).ok_or_else(|| "Failed to parse code".into())
+}
+
 /// Parses Perl source bytes and returns the resulting [`tree_sitter::Tree`].
 ///
 /// This accepts arbitrary bytes so callers can parse non-UTF-8 source files,
@@ -128,10 +143,20 @@ pub fn create_parser() -> Parser {
 /// if tree-sitter returns `None` from `parse` (cancelled or timed out).
 pub fn parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
     let mut parser = try_create_parser()?;
-    match parser.parse(code, None) {
-        Some(tree) => Ok(tree),
-        None => Err("Failed to parse code".into()),
-    }
+    parse_perl_bytes_with_parser(&mut parser, code)
+}
+
+/// Parses a Perl source string with an already configured parser.
+///
+/// # Errors
+///
+/// Returns an error if tree-sitter returns `None` from `parse` (cancelled or
+/// timed out).
+pub fn parse_perl_code_with_parser(
+    parser: &mut Parser,
+    code: &str,
+) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
+    parse_perl_bytes_with_parser(parser, code.as_bytes())
 }
 
 /// Parses a Perl source string and returns the resulting [`tree_sitter::Tree`].
@@ -214,6 +239,14 @@ mod tests {
     fn test_parse_bytes() -> Result<(), Box<dyn std::error::Error>> {
         let code = b"my $var = 'hello';";
         let tree = parse_perl_bytes(code)?;
+        assert!(!tree.root_node().has_error());
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_with_reused_parser() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = try_create_parser()?;
+        let tree = parse_perl_code_with_parser(&mut parser, "my $x = 1;")?;
         assert!(!tree.root_node().has_error());
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- The one-shot wrapper API reconstructed/configured a `tree_sitter::Parser` for every parse call which added avoidable overhead in tight benchmarking loops.

### Description
- Added reusable parse entry points `parse_perl_bytes_with_parser` and `parse_perl_code_with_parser` and wired `parse_perl_bytes` through the reusable helper so callers can amortize parser setup.  
- Added a `reuse-parser` benchmark mode and iteration control to `bench_parser_c` so wrapper overhead can be measured directly and compared to a long-lived parser.  
- Added a unit test `test_parse_with_reused_parser` to verify correctness of the reused-parser path.

### Testing
- Ran `cargo test -p tree-sitter-perl-c` and all tests passed.  
- Ran `cargo check --all-targets -p tree-sitter-perl-c` and `cargo clippy -p tree-sitter-perl-c --all-targets -- -D warnings`, both completed successfully.  
- Benchmarks: ran `cargo run -q -p tree-sitter-perl-c --features test-utils --bin bench_parser_c -- examples/perl/complex.pl <mode> 500` 5× per mode and observed averages `wrapper = 642,831 µs` vs `reuse-parser = 582,084 µs`, an improvement of ~9.45% (−60,747 µs).  
- Note: `just pr-fast` was not available in this environment so it was not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2792e34c8333b73f471aacc354a1)