### PR TITLE
fix(xtask): correct ci-scope package name after perl-workspace rename (#0000)

### DIFF
--- a/xtask/src/tasks/ci_scope.rs
+++ b/xtask/src/tasks/ci_scope.rs
@@ -279,10 +279,10 @@ pub struct WidenerRule {
 /// All architectural widener rules. The order matters for lane generation
 /// (earlier rules fire first), but deduplication ensures idempotent output.
 pub static WIDENER_RULES: &[WidenerRule] = &[
-    // Rule 1: parser / lexer / parser-core → semantic, workspace-index, LSP, DAP
+    // Rule 1: parser / lexer / parser-core → semantic, workspace, LSP, DAP
     WidenerRule {
         trigger_prefixes: &["perl-parser", "perl-lexer", "perl-parser-core"],
-        targets: &["perl-semantic-analyzer", "perl-workspace-index", "perl-lsp-rs", "perl-dap"],
+        targets: &["perl-semantic-analyzer", "perl-workspace", "perl-lsp-rs", "perl-dap"],
         rule: "parser → DAP downstream smoke",
         lanes: &["lsp_smoke"],
         lane_reason: "architectural_widener",


### PR DESCRIPTION
## Summary

After the Wave A collapse, `perl-workspace-index` was renamed to `perl-workspace`. The `WIDENER_RULES` Rule 1 `targets` array in `xtask/src/tasks/ci_scope.rs` still referenced the old name, causing `cargo check -p perl-workspace-index` to exit 101 and breaking the **Compile All Targets (bit-rot guard)** on approximately 29 open PRs.

**Change:** one line — `"perl-workspace-index"` → `"perl-workspace"` in Rule 1 targets.

**Note:** `trigger_prefixes` on Rule 2 (line 292) are file-path prefixes, not package names; the directory `crates/perl-workspace-index/` still exists, so that line is left unchanged.

## Verification

- `cargo check -p xtask` — passes
- `cargo check -p perl-workspace` — confirms package name is correct
- `cargo xtask ci-scope --help` — runs without error

## Scope

Single-file change. No tests added (mechanical rename fix).