### PR TITLE
feat(dap-status): promote deferred DAP session metrics into scorecard (#0000)

### DIFF
--- a/crates/perl-dap/tests/dap_scorecard_harness.rs
+++ b/crates/perl-dap/tests/dap_scorecard_harness.rs
@@ -1,16 +1,8 @@
-//! DAP launch-success scorecard harness.
+//! DAP scorecard harness.
 //!
-//! Measures the launch success rate across the five standard fixture debuggees:
-//! hello.pl, loops.pl, eval.pl, args.pl, breakpoints_begin_end.pl.
-//!
-//! For each fixture: initialize → launch (stopOnEntry=true) → wait for
-//! `stopped` event.  Records elapsed time from launch request to first
-//! `stopped` event for latency percentiles.  Asserts that ≥4/5 (80%) of
-//! launches succeed.
-//!
-//! Emits human-readable scorecard output via `eprintln!` so it surfaces in
-//! `cargo test -- --nocapture` and CI logs without asserting on exact timing
-//! numbers.
+//! Tracks launch reliability plus real-session debugger quality probes for:
+//! attach workflows, variables pane correctness, evaluate correctness,
+//! deep variable pagination, and a best-effort memory baseline proxy.
 //!
 //! # Running
 //!
@@ -22,14 +14,19 @@
 
 mod common;
 
-use common::perl_available;
+use common::{DapWorkflowSession, perl_available, workflow_timeout};
 use perl_dap::{DapMessage, DebugAdapter};
-use serde_json::json;
-use std::path::Path;
+use serde::Serialize;
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Receiver, channel};
 use std::time::{Duration, Instant};
+use tempfile::tempdir;
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+const RECEIPT_PATH: &str = "target/receipts/dap-scorecard.json";
 
 // ─── Timeout helpers ──────────────────────────────────────────────────────────
 
@@ -44,7 +41,41 @@ fn smoke_timeout() -> Duration {
     }
 }
 
-// ─── Low-level event waiter (copied from dap_smoke_e2e.rs) ───────────────────
+// ─── Scorecard data model ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct FixtureResult {
+    name: &'static str,
+    elapsed_ms: Option<u128>,
+    error: Option<String>,
+}
+
+impl FixtureResult {
+    fn passed(&self) -> bool {
+        self.error.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct MetricRow {
+    metric: String,
+    value: String,
+    target: String,
+    status: String,
+    detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ScorecardReceipt {
+    schema_version: u32,
+    scorecard: String,
+    generated_at_utc: String,
+    perl_available: bool,
+    launch_rows: Vec<MetricRow>,
+    session_rows: Vec<MetricRow>,
+}
+
+// ─── Low-level event waiter ───────────────────────────────────────────────────
 
 fn wait_for_event(
     rx: &Receiver<DapMessage>,
@@ -71,26 +102,8 @@ fn wait_for_event(
     }
 }
 
-// ─── Per-fixture result ───────────────────────────────────────────────────────
+// ─── Launch probes ────────────────────────────────────────────────────────────
 
-struct FixtureResult {
-    name: &'static str,
-    elapsed_ms: Option<u128>,
-    error: Option<String>,
-}
-
-impl FixtureResult {
-    fn passed(&self) -> bool {
-        self.error.is_none()
-    }
-}
-
-// ─── Single fixture launch probe ─────────────────────────────────────────────
-
-/// Launch `script_path` with stopOnEntry=true; wait for `stopped` event.
-///
-/// Returns elapsed milliseconds from launch request to `stopped` event, or an
-/// error string describing what went wrong.
 fn probe_launch(script_path: &Path, timeout: Duration) -> Result<u128, String> {
     let script_str =
         script_path.to_str().ok_or("fixture path contains non-UTF-8 characters")?.to_string();
@@ -99,7 +112,6 @@ fn probe_launch(script_path: &Path, timeout: Duration) -> Result<u128, String> {
     let (tx, rx) = channel();
     adapter.set_event_sender(tx);
 
-    // initialize
     let init_resp = adapter.handle_request(1, "initialize", None);
     match init_resp {
         DapMessage::Response { success: true, .. } => {}
@@ -113,7 +125,6 @@ fn probe_launch(script_path: &Path, timeout: Duration) -> Result<u128, String> {
     }
     wait_for_event(&rx, "initialized", timeout)?;
 
-    // launch with stopOnEntry=true — measure from here to first `stopped`
     let t_launch = Instant::now();
     let launch_resp = adapter.handle_request(
         2,
@@ -143,42 +154,21 @@ fn probe_launch(script_path: &Path, timeout: Duration) -> Result<u128, String> {
 
     wait_for_event(&rx, "stopped", timeout)?;
     let elapsed_ms = t_launch.elapsed().as_millis();
-
-    // Clean disconnect
     let _ = adapter.handle_request(3, "disconnect", Some(json!({})));
 
     Ok(elapsed_ms)
 }
 
-// ─── Percentile helper ────────────────────────────────────────────────────────
-
-/// Compute a percentile over a sorted slice of `u128` values.
-///
-/// `pct` must be in `[0, 100]`.  Returns `None` if `values` is empty.
 fn percentile(sorted: &[u128], pct: u8) -> Option<u128> {
     if sorted.is_empty() {
         return None;
     }
-    // Nearest-rank method
     let rank = ((pct as f64 / 100.0) * sorted.len() as f64).ceil() as usize;
     let idx = rank.saturating_sub(1).min(sorted.len() - 1);
     Some(sorted[idx])
 }
 
-// ─── Scorecard test ───────────────────────────────────────────────────────────
-
-/// DAP launch-success rate across 5 standard fixture debuggees.
-///
-/// Asserts ≥ 80 % pass rate (≥4/5).  Emits p50/p95 latency to stdout for
-/// inclusion in the dap.md metrics table.
-#[test]
-fn scorecard_launch_success_rate() -> TestResult {
-    if !perl_available() {
-        eprintln!("scorecard_launch_success_rate: skipping — perl not on PATH");
-        return Ok(());
-    }
-
-    // Resolve fixture directory relative to this file's Cargo manifest.
+fn probe_launch_scorecard() -> (Vec<FixtureResult>, Vec<MetricRow>, usize, usize) {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
     let fixture_dir = Path::new(&manifest_dir).join("tests").join("fixtures");
 
@@ -202,54 +192,490 @@ fn scorecard_launch_success_rate() -> TestResult {
         results.push(FixtureResult { name, elapsed_ms, error });
     }
 
-    // ── Print scorecard table ─────────────────────────────────────────────────
-    eprintln!();
-    eprintln!("┌─────────────────── DAP Launch Scorecard ────────────────────────────────┐");
-    eprintln!("│ Fixture              │ Result    │ Latency (ms) │ Detail                 │");
-    eprintln!("├──────────────────────┼───────────┼──────────────┼────────────────────────┤");
-    for r in &results {
-        let status = if r.passed() { "PASS" } else { "FAIL" };
-        let latency = r.elapsed_ms.map(|ms| ms.to_string()).unwrap_or_else(|| "—".to_string());
-        let detail = r.error.as_deref().unwrap_or("");
-        // Truncate detail to keep the table readable
-        let detail_trunc = if detail.len() > 22 { &detail[..22] } else { detail };
-        eprintln!("│ {:<20} │ {:<9} │ {:>12} │ {:<22} │", r.name, status, latency, detail_trunc);
-    }
-    eprintln!("└─────────────────────────────────────────────────────────────────────────┘");
-
-    // ── Latency percentiles ───────────────────────────────────────────────────
-    let mut latencies: Vec<u128> = results.iter().filter_map(|r| r.elapsed_ms).collect();
-    latencies.sort_unstable();
-
-    if let (Some(p50), Some(p95)) = (percentile(&latencies, 50), percentile(&latencies, 95)) {
-        eprintln!();
-        eprintln!(
-            "  cold_launch_p50 = {}ms   cold_launch_p95 = {}ms   (n={})",
-            p50,
-            p95,
-            latencies.len()
-        );
-    }
-    eprintln!();
-
-    // ── Assertion: ≥ 80 % pass rate ──────────────────────────────────────────
     let passed = results.iter().filter(|r| r.passed()).count();
     let total = results.len();
-    let threshold = (total * 4).div_ceil(5); // ceil(80 %) = 4 out of 5
 
+    let mut latencies: Vec<u128> = results.iter().filter_map(|r| r.elapsed_ms).collect();
+    latencies.sort_unstable();
+    let p50 = percentile(&latencies, 50);
+    let p95 = percentile(&latencies, 95);
+
+    let mut rows = vec![MetricRow {
+        metric: "Launch success rate".to_string(),
+        value: format!("{passed}/{total} ({} %)", (passed * 100) / total.max(1)),
+        target: "≥ 80 %".to_string(),
+        status: if passed * 5 >= total * 4 { "PASS" } else { "FAIL" }.to_string(),
+        detail: None,
+    }];
+
+    rows.push(MetricRow {
+        metric: "Fixtures tested".to_string(),
+        value: fixtures.iter().map(|(name, _)| *name).collect::<Vec<_>>().join(", "),
+        target: "5".to_string(),
+        status: "—".to_string(),
+        detail: None,
+    });
+
+    rows.push(MetricRow {
+        metric: "cold_launch_p50".to_string(),
+        value: p50.map_or_else(|| "—".to_string(), |v| format!("{v} ms")),
+        target: "≤ 2 000 ms".to_string(),
+        status: p50.map_or("SKIP", |v| if v <= 2000 { "PASS" } else { "FAIL" }).to_string(),
+        detail: None,
+    });
+
+    rows.push(MetricRow {
+        metric: "cold_launch_p95".to_string(),
+        value: p95.map_or_else(|| "—".to_string(), |v| format!("{v} ms")),
+        target: "≤ 5 000 ms".to_string(),
+        status: p95.map_or("SKIP", |v| if v <= 5000 { "PASS" } else { "FAIL" }).to_string(),
+        detail: None,
+    });
+
+    (results, rows, passed, total)
+}
+
+// ─── Session probes ───────────────────────────────────────────────────────────
+
+fn launch_with_breakpoint(
+    script_path: &Path,
+    break_line: u64,
+) -> Result<DapWorkflowSession, String> {
+    let timeout = workflow_timeout();
+    let mut session = DapWorkflowSession::new(timeout)?;
+
+    let script_str = script_path.to_str().ok_or("script path is not valid UTF-8")?.to_string();
+
+    session.launch(&script_str)?;
+    session.set_breakpoints(&script_str, &[break_line])?;
+    session.configuration_done()?;
+
+    Ok(session)
+}
+
+fn probe_attach_success_rate() -> MetricRow {
+    let timeout = workflow_timeout();
+    let mut passed = 0usize;
+    let mut total = 0usize;
+    let mut failures = Vec::new();
+
+    for stop_on_entry in [false, true] {
+        total += 1;
+        let result = (|| -> Result<(), String> {
+            let mut session = DapWorkflowSession::new(timeout)?;
+            session.attach(std::process::id(), stop_on_entry)?;
+
+            let first = session.wait_stopped()?;
+            if first.reason != "attach" {
+                return Err(format!("first stop reason `{}`", first.reason));
+            }
+
+            if stop_on_entry {
+                let second = session.wait_stopped()?;
+                if second.reason != "entry" {
+                    return Err(format!("second stop reason `{}`", second.reason));
+                }
+            }
+
+            session.disconnect()?;
+            Ok(())
+        })();
+
+        if result.is_ok() {
+            passed += 1;
+        } else if let Err(error) = result {
+            failures.push(format!("stopOnEntry={stop_on_entry}: {error}"));
+        }
+    }
+
+    MetricRow {
+        metric: "Attach success rate".to_string(),
+        value: format!("{passed}/{total} ({} %)", (passed * 100) / total.max(1)),
+        target: "100 % (2/2)".to_string(),
+        status: if passed == total { "PASS" } else { "FAIL" }.to_string(),
+        detail: (!failures.is_empty()).then(|| failures.join("; ")),
+    }
+}
+
+fn probe_variables_correctness() -> MetricRow {
+    let result = (|| -> Result<String, String> {
+        let workspace = tempdir().map_err(|e| e.to_string())?;
+        let script = workspace.path().join("variables_scorecard.pl");
+        fs::write(
+            &script,
+            "use strict;\nuse warnings;\n\nmy $x = 10;\nmy $y = 20;\nmy $sum = $x + $y;\nmy $product = $x * $y;\nprint \"$sum/$product\\n\";\n",
+        )
+        .map_err(|e| e.to_string())?;
+
+        let mut session = launch_with_breakpoint(&script, 8)?;
+        let stopped = session.wait_stopped()?;
+        let (frame_id, _, _) = session.stack_trace(stopped.thread_id)?;
+        let locals_ref = session.scopes_locals_ref(frame_id)?;
+        let vars = session.variables(locals_ref)?;
+        let mut names = vars
+            .iter()
+            .filter_map(|v| v.get("name").and_then(Value::as_str))
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        names.sort_unstable();
+
+        let has_sum = names.iter().any(|name| name == "$sum");
+        let has_product = names.iter().any(|name| name == "$product");
+        session.disconnect()?;
+
+        if has_sum && has_product {
+            Ok(format!("locals include $sum/$product ({} vars)", names.len()))
+        } else {
+            Err(format!("locals missing expected vars; got [{}]", names.join(", ")))
+        }
+    })();
+
+    match result {
+        Ok(detail) => MetricRow {
+            metric: "Variables pane correctness (session)".to_string(),
+            value: "PASS".to_string(),
+            target: "Locals include computed vars".to_string(),
+            status: "PASS".to_string(),
+            detail: Some(detail),
+        },
+        Err(error) => MetricRow {
+            metric: "Variables pane correctness (session)".to_string(),
+            value: "FAIL".to_string(),
+            target: "Locals include computed vars".to_string(),
+            status: "FAIL".to_string(),
+            detail: Some(error),
+        },
+    }
+}
+
+fn probe_evaluate_correctness() -> MetricRow {
+    let result = (|| -> Result<String, String> {
+        let workspace = tempdir().map_err(|e| e.to_string())?;
+        let script = workspace.path().join("evaluate_scorecard.pl");
+        fs::write(
+            &script,
+            "use strict;\nuse warnings;\n\nmy $x = 10;\nmy $y = 20;\nmy $sum = $x + $y;\nprint \"$sum\\n\";\n",
+        )
+        .map_err(|e| e.to_string())?;
+
+        let mut session = launch_with_breakpoint(&script, 7)?;
+        let stop = session.wait_stopped()?;
+
+        let response = session.request(
+            "evaluate",
+            Some(json!({
+                "expression": "$sum",
+                "frameId": 1,
+                "context": "watch"
+            })),
+        );
+
+        let body = session.expect_success(&response, "evaluate")?;
+        session.disconnect()?;
+
+        let body = body.ok_or("evaluate response missing body")?;
+        let result_text = body
+            .get("result")
+            .and_then(Value::as_str)
+            .ok_or("evaluate result missing `result`")?
+            .to_string();
+
+        if result_text.contains("30") {
+            Ok(format!("evaluate($sum) => {result_text}; thread={}", stop.thread_id))
+        } else {
+            Err(format!("evaluate($sum) expected 30, got `{result_text}`"))
+        }
+    })();
+
+    match result {
+        Ok(detail) => MetricRow {
+            metric: "Evaluate correctness (session)".to_string(),
+            value: "PASS".to_string(),
+            target: "evaluate($sum) includes 30".to_string(),
+            status: "PASS".to_string(),
+            detail: Some(detail),
+        },
+        Err(error) => MetricRow {
+            metric: "Evaluate correctness (session)".to_string(),
+            value: "FAIL".to_string(),
+            target: "evaluate($sum) includes 30".to_string(),
+            status: "FAIL".to_string(),
+            detail: Some(error),
+        },
+    }
+}
+
+fn probe_deep_pagination() -> MetricRow {
+    let result = (|| -> Result<String, String> {
+        let workspace = tempdir().map_err(|e| e.to_string())?;
+        let script = workspace.path().join("pagination_scorecard.pl");
+        fs::write(
+            &script,
+            "use strict;\nuse warnings;\n\nmy @items = (1..300);\nmy $count = scalar @items;\nprint \"$count\\n\";\n",
+        )
+        .map_err(|e| e.to_string())?;
+
+        let mut session = launch_with_breakpoint(&script, 6)?;
+        let stop = session.wait_stopped()?;
+        let (frame_id, _, _) = session.stack_trace(stop.thread_id)?;
+        let locals_ref = session.scopes_locals_ref(frame_id)?;
+        let locals = session.variables(locals_ref)?;
+
+        let array_var = locals
+            .iter()
+            .find(|var| var.get("name").and_then(Value::as_str) == Some("@items"))
+            .ok_or("@items not found in locals")?;
+
+        let children_ref = array_var
+            .get("variablesReference")
+            .and_then(Value::as_i64)
+            .ok_or("@items missing variablesReference")?;
+        if children_ref <= 0 {
+            return Err("@items is not expandable".to_string());
+        }
+
+        let page_0_resp = session.request(
+            "variables",
+            Some(json!({"variablesReference": children_ref, "start": 0, "count": 5})),
+        );
+        let page_200_resp = session.request(
+            "variables",
+            Some(json!({"variablesReference": children_ref, "start": 200, "count": 5})),
+        );
+
+        let page_0_body =
+            session.expect_success(&page_0_resp, "variables")?.ok_or("page 0 missing body")?;
+        let page_200_body =
+            session.expect_success(&page_200_resp, "variables")?.ok_or("page 200 missing body")?;
+
+        let page_0 = page_0_body
+            .get("variables")
+            .and_then(Value::as_array)
+            .ok_or("page 0 missing variables")?;
+        let page_200 = page_200_body
+            .get("variables")
+            .and_then(Value::as_array)
+            .ok_or("page 200 missing variables")?;
+
+        let first_0 = page_0
+            .first()
+            .and_then(|v| v.get("name"))
+            .and_then(Value::as_str)
+            .unwrap_or("?")
+            .to_string();
+        let first_200 = page_200
+            .first()
+            .and_then(|v| v.get("name"))
+            .and_then(Value::as_str)
+            .unwrap_or("?")
+            .to_string();
+
+        session.disconnect()?;
+
+        if page_0.is_empty() || page_200.is_empty() {
+            return Err("pagination returned empty page(s)".to_string());
+        }
+        if page_0.len() > 5 || page_200.len() > 5 {
+            return Err(format!(
+                "pagination ignored count=5 (sizes: {}, {})",
+                page_0.len(),
+                page_200.len()
+            ));
+        }
+        if first_0 == first_200 {
+            return Err(format!("page 0 and page 200 overlap at `{first_0}`"));
+        }
+
+        Ok(format!("page0_first={first_0}, page200_first={first_200}"))
+    })();
+
+    match result {
+        Ok(detail) => MetricRow {
+            metric: "Deep truncation/pagination correctness".to_string(),
+            value: "PASS".to_string(),
+            target: "Distinct pages (start=0 vs 200, count=5)".to_string(),
+            status: "PASS".to_string(),
+            detail: Some(detail),
+        },
+        Err(error) => MetricRow {
+            metric: "Deep truncation/pagination correctness".to_string(),
+            value: "FAIL".to_string(),
+            target: "Distinct pages (start=0 vs 200, count=5)".to_string(),
+            status: "FAIL".to_string(),
+            detail: Some(error),
+        },
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn probe_memory_baseline() -> MetricRow {
+    fn rss_kib() -> Option<u64> {
+        let statm = fs::read_to_string("/proc/self/statm").ok()?;
+        let fields = statm.split_whitespace().collect::<Vec<_>>();
+        let resident_pages = fields.get(1)?.parse::<u64>().ok()?;
+        let page_size = 4096u64;
+        Some((resident_pages * page_size) / 1024)
+    }
+
+    let before = rss_kib();
+    let launch_result = (|| -> Result<(), String> {
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+        let script = Path::new(&manifest_dir).join("tests").join("fixtures").join("hello.pl");
+        let _ = probe_launch(&script, smoke_timeout())?;
+        Ok(())
+    })();
+    let after = rss_kib();
+
+    match (before, after, launch_result) {
+        (Some(start), Some(end), Ok(())) => MetricRow {
+            metric: "Memory footprint baseline (best effort)".to_string(),
+            value: format!(
+                "rss_before={} KiB, rss_after={} KiB, delta={} KiB",
+                start,
+                end,
+                end.saturating_sub(start)
+            ),
+            target: "Informational baseline".to_string(),
+            status: "MEASURED".to_string(),
+            detail: Some("Linux /proc/self/statm proxy".to_string()),
+        },
+        (_, _, Err(error)) => MetricRow {
+            metric: "Memory footprint baseline (best effort)".to_string(),
+            value: "SKIP".to_string(),
+            target: "Informational baseline".to_string(),
+            status: "SKIP".to_string(),
+            detail: Some(error),
+        },
+        _ => MetricRow {
+            metric: "Memory footprint baseline (best effort)".to_string(),
+            value: "SKIP".to_string(),
+            target: "Informational baseline".to_string(),
+            status: "SKIP".to_string(),
+            detail: Some("rss snapshot unavailable".to_string()),
+        },
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn probe_memory_baseline() -> MetricRow {
+    MetricRow {
+        metric: "Memory footprint baseline (best effort)".to_string(),
+        value: "SKIP".to_string(),
+        target: "Informational baseline".to_string(),
+        status: "SKIP".to_string(),
+        detail: Some("portable RSS baseline currently implemented only on Linux".to_string()),
+    }
+}
+
+fn receipt_path() -> PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+    Path::new(&manifest_dir).join("..").join("..").join(RECEIPT_PATH)
+}
+
+fn generated_at_utc_iso8601() -> String {
+    let now = std::time::SystemTime::now();
+    match now.duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => format!("unix:{}", duration.as_secs()),
+        Err(_) => "unix:0".to_string(),
+    }
+}
+
+fn write_receipt(receipt: &ScorecardReceipt) -> Result<(), String> {
+    let path = receipt_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let json = serde_json::to_string_pretty(receipt).map_err(|e| e.to_string())?;
+    fs::write(&path, json).map_err(|e| e.to_string())?;
+    eprintln!("  wrote DAP scorecard receipt: {}", path.display());
+    Ok(())
+}
+
+fn print_table(title: &str, rows: &[MetricRow]) {
+    eprintln!();
+    eprintln!("{title}");
+    eprintln!("| Metric | Value | Target | Status |");
+    eprintln!("|---|---|---|---|");
+    for row in rows {
+        eprintln!("| {} | {} | {} | {} |", row.metric, row.value, row.target, row.status);
+    }
+}
+
+fn print_details(rows: &[MetricRow]) {
+    for row in rows {
+        if let Some(detail) = &row.detail {
+            eprintln!("  - {}: {}", row.metric, detail);
+        }
+    }
+}
+
+#[test]
+fn scorecard_launch_and_session_quality() -> TestResult {
+    if !perl_available() {
+        eprintln!("scorecard_launch_and_session_quality: skipping — perl not on PATH");
+        let skip_row = MetricRow {
+            metric: "Perl runtime availability".to_string(),
+            value: "SKIP".to_string(),
+            target: "perl on PATH".to_string(),
+            status: "SKIP".to_string(),
+            detail: Some("perl not on PATH".to_string()),
+        };
+        let receipt = ScorecardReceipt {
+            schema_version: 1,
+            scorecard: "dap".to_string(),
+            generated_at_utc: generated_at_utc_iso8601(),
+            perl_available: false,
+            launch_rows: vec![skip_row.clone()],
+            session_rows: vec![skip_row],
+        };
+        write_receipt(&receipt)?;
+        return Ok(());
+    }
+
+    let (launch_fixture_results, launch_rows, launch_passed, launch_total) =
+        probe_launch_scorecard();
+
+    let session_rows = vec![
+        probe_attach_success_rate(),
+        probe_variables_correctness(),
+        probe_evaluate_correctness(),
+        probe_deep_pagination(),
+        probe_memory_baseline(),
+    ];
+
+    print_table("DAP Launch Scorecard", &launch_rows);
+    for result in &launch_fixture_results {
+        let status = if result.passed() { "PASS" } else { "FAIL" };
+        let latency = result.elapsed_ms.map_or_else(|| "—".to_string(), |v| format!("{v} ms"));
+        let detail = result.error.clone().unwrap_or_default();
+        eprintln!("  - fixture={} status={} latency={} {}", result.name, status, latency, detail);
+    }
+
+    print_table("DAP Session Quality Scorecard", &session_rows);
+    print_details(&session_rows);
+
+    let receipt = ScorecardReceipt {
+        schema_version: 1,
+        scorecard: "dap".to_string(),
+        generated_at_utc: generated_at_utc_iso8601(),
+        perl_available: true,
+        launch_rows,
+        session_rows,
+    };
+    write_receipt(&receipt)?;
+
+    let threshold = (launch_total * 4).div_ceil(5);
     assert!(
-        passed >= threshold,
-        "DAP launch success rate below threshold: {passed}/{total} passed (need ≥{threshold}). \
+        launch_passed >= threshold,
+        "DAP launch success rate below threshold: {launch_passed}/{launch_total} passed (need ≥{threshold}). \
          Failed fixtures: {}",
-        results
+        launch_fixture_results
             .iter()
             .filter(|r| !r.passed())
             .map(|r| format!("{} ({})", r.name, r.error.as_deref().unwrap_or("?")))
             .collect::<Vec<_>>()
             .join(", ")
     );
-
-    eprintln!("  scorecard_launch_success_rate: {passed}/{total} passed");
 
     Ok(())
 }

--- a/docs/project/status/dap.md
+++ b/docs/project/status/dap.md
@@ -10,9 +10,9 @@
 | Metric | Value | Target | Status |
 |---|---|---|---|
 | Launch success rate | 5/5 (100 %) | ≥ 80 % | PASS |
-| Fixtures tested | hello, loops, eval, args, begin\_end | 5 | — |
-| cold\_launch\_p50 | 35 ms | ≤ 2 000 ms | PASS |
-| cold\_launch\_p95 | 161 ms | ≤ 5 000 ms | PASS |
+| Fixtures tested | hello, loops, eval, args, begin_end | 5 | — |
+| cold_launch_p50 | 15 ms | ≤ 2 000 ms | PASS |
+| cold_launch_p95 | 18 ms | ≤ 5 000 ms | PASS |
 <!-- END: DAP_LAUNCH_SCORECARD -->
 
 ## Test Coverage
@@ -20,21 +20,21 @@
 <!-- BEGIN: DAP_TEST_COUNTS -->
 | Suite | Count |
 |---|---|
-| Integration tests (`perl-dap`) | 21 test targets |
+| Integration tests (`perl-dap`) | 58 test targets |
 | Scorecard fixtures | 5 |
 <!-- END: DAP_TEST_COUNTS -->
 
-## Deferred Metrics
+## Session Quality Scorecard
 
-The following metrics are defined in #4069 but deferred to follow-up PRs:
-
-| Metric | Issue | Reason |
-|---|---|---|
-| Attach success rate | #4069 | Requires live Perl process on TCP socket — deferred post-alpha |
-| Variables pane correctness | #3487 | Needs integration test with real `perl -d` variables |
-| Evaluate correctness (session) | #3481 | Existing mocked tests; real-session E2E deferred |
-| Truncation/pagination on deep data | #3487 | No test with 200+ array elements yet |
-| Memory footprint baseline | #4069 | OS-level RSS measurement non-trivial to make portable |
+<!-- BEGIN: DAP_SESSION_SCORECARD -->
+| Metric | Value | Target | Status |
+|---|---|---|---|
+| Attach success rate | 2/2 (100 %) | 100 % (2/2) | PASS |
+| Variables pane correctness (session) | FAIL | Locals include computed vars | FAIL |
+| Evaluate correctness (session) | PASS | evaluate($sum) includes 30 | PASS |
+| Deep truncation/pagination correctness | FAIL | Distinct pages (start=0 vs 200, count=5) | FAIL |
+| Memory footprint baseline (best effort) | rss_before=10948 KiB, rss_after=10972 KiB, delta=24 KiB | Informational baseline | MEASURED |
+<!-- END: DAP_SESSION_SCORECARD -->
 
 ## How to Update
 

--- a/xtask/src/tasks/update_status/dap.rs
+++ b/xtask/src/tasks/update_status/dap.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::path::Path;
 
 use color_eyre::eyre::Result;
+use serde::Deserialize;
 
 use super::replace_block;
 
@@ -19,6 +20,21 @@ pub(super) struct DapTestCounts {
     pub integration_test_targets: usize,
     /// Number of `#[test]` functions found across all `perl-dap-*` test files.
     pub scorecard_fixtures: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct DapScorecardReceipt {
+    perl_available: bool,
+    launch_rows: Vec<DapMetricRow>,
+    session_rows: Vec<DapMetricRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DapMetricRow {
+    metric: String,
+    value: String,
+    target: String,
+    status: String,
 }
 
 /// Count DAP test targets and scorecard fixtures without running cargo.
@@ -51,12 +67,64 @@ pub(super) fn count_dap_tests(root: &Path) -> DapTestCounts {
     DapTestCounts { integration_test_targets, scorecard_fixtures }
 }
 
+fn read_dap_scorecard_receipt(root: &Path) -> Option<DapScorecardReceipt> {
+    let receipt_path = root.join("target/receipts/dap-scorecard.json");
+    let raw = fs::read_to_string(receipt_path).ok()?;
+    serde_json::from_str::<DapScorecardReceipt>(&raw).ok()
+}
+
+fn render_metric_rows(rows: &[DapMetricRow]) -> String {
+    let mut output = String::from("| Metric | Value | Target | Status |\n|---|---|---|---|");
+    for row in rows {
+        output.push_str(&format!(
+            "\n| {} | {} | {} | {} |",
+            row.metric, row.value, row.target, row.status
+        ));
+    }
+    output
+}
+
 // ---------------------------------------------------------------------------
 // Generator
 // ---------------------------------------------------------------------------
 
 /// Regenerate the marker blocks in `docs/project/status/dap.md`.
 pub(super) fn generate_dap_status(counts: &DapTestCounts, original: &str) -> Result<String> {
+    let scorecard = read_dap_scorecard_receipt(&crate::utils::project_root()?);
+    let launch_table = scorecard.as_ref().map_or_else(
+        || {
+            render_metric_rows(&[DapMetricRow {
+                metric: "Launch success rate".to_string(),
+                value: "UNVERIFIED".to_string(),
+                target: "Run dap_scorecard_harness".to_string(),
+                status: "SKIP".to_string(),
+            }])
+        },
+        |receipt| render_metric_rows(&receipt.launch_rows),
+    );
+    let session_table = scorecard.as_ref().map_or_else(
+        || {
+            render_metric_rows(&[DapMetricRow {
+                metric: "Session quality metrics".to_string(),
+                value: "UNVERIFIED".to_string(),
+                target: "Run dap_scorecard_harness".to_string(),
+                status: "SKIP".to_string(),
+            }])
+        },
+        |receipt| {
+            if receipt.perl_available {
+                render_metric_rows(&receipt.session_rows)
+            } else {
+                render_metric_rows(&[DapMetricRow {
+                    metric: "Session quality metrics".to_string(),
+                    value: "SKIP".to_string(),
+                    target: "perl on PATH".to_string(),
+                    status: "SKIP".to_string(),
+                }])
+            }
+        },
+    );
+
     let test_counts_table = format!(
         "| Suite | Count |\n\
          |---|---|\n\
@@ -66,6 +134,18 @@ pub(super) fn generate_dap_status(counts: &DapTestCounts, original: &str) -> Res
     );
 
     let mut text = original.to_string();
+    text = replace_block(
+        &text,
+        "<!-- BEGIN: DAP_LAUNCH_SCORECARD -->",
+        "<!-- END: DAP_LAUNCH_SCORECARD -->",
+        &launch_table,
+    )?;
+    text = replace_block(
+        &text,
+        "<!-- BEGIN: DAP_SESSION_SCORECARD -->",
+        "<!-- END: DAP_SESSION_SCORECARD -->",
+        &session_table,
+    )?;
     text = replace_block(
         &text,
         "<!-- BEGIN: DAP_TEST_COUNTS -->",
@@ -105,6 +185,12 @@ mod tests {
     fn test_generate_dap_status_roundtrip() -> Result<()> {
         let counts = DapTestCounts { integration_test_targets: 20, scorecard_fixtures: 5 };
         let template = "# DAP\n\
+                        <!-- BEGIN: DAP_LAUNCH_SCORECARD -->\n\
+                        old launch\n\
+                        <!-- END: DAP_LAUNCH_SCORECARD -->\n\
+                        <!-- BEGIN: DAP_SESSION_SCORECARD -->\n\
+                        old session\n\
+                        <!-- END: DAP_SESSION_SCORECARD -->\n\
                         <!-- BEGIN: DAP_TEST_COUNTS -->\n\
                         old content\n\
                         <!-- END: DAP_TEST_COUNTS -->\n\


### PR DESCRIPTION
### Motivation

- The DAP status page only published launch smoke and left several important runtime checks deferred (attach, variables, evaluate, pagination, memory), so real-session failure modes were not measured.
- Make the scorecard produce machine-readable, CI-friendly metrics so status generation and regressions can track real DAP behaviors, not just launch success.

### Description

- Extended the DAP scorecard harness in `crates/perl-dap/tests/dap_scorecard_harness.rs` to run real-session probes for attach success rate, variables-pane correctness, evaluate correctness, deep truncation/pagination, and a best-effort memory-RSS baseline, while keeping the existing launch success/latency metrics and gracefully skipping when `perl` is unavailable.
- The harness now emits a JSON receipt at `target/receipts/dap-scorecard.json` (schema'd `ScorecardReceipt`) and prints both human tables and details for CI consumption.
- Updated the status generator `xtask/src/tasks/update_status/dap.rs` to read the scorecard receipt and regenerate two marker blocks in `docs/project/status/dap.md`: `DAP_LAUNCH_SCORECARD` and the new `DAP_SESSION_SCORECARD` (with portable skip behavior when Perl is missing), falling back to UNVERIFIED/SKIP rows if the receipt is absent.
- Replaced the old "Deferred Metrics" narrative block in `docs/project/status/dap.md` with the generated `DAP_SESSION_SCORECARD` block and refreshed generated content via `xtask update-status`.

### Testing

- Ran `cargo test -p perl-dap --test dap_scorecard_harness -- --nocapture` which completed successfully and produced `target/receipts/dap-scorecard.json` (test passed).
- Ran `cargo xtask update-status --only dap` and `cargo xtask update-status --only dap --write` to refresh `docs/project/status/dap.md`, and both ran successfully (file updated when expected).
- Ran `cargo check --workspace --all-targets` which completed without errors.
- Ran `cargo xtask fmt` to format xtask artifacts (completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3980f0448333a7cc04be82e50249)