### PR TITLE
test(perl-dap): expand reference-client and golden-transcript conformance coverage (#0000)

### DIFF
--- a/crates/perl-dap/tests/dap_golden_transcript_tests.rs
+++ b/crates/perl-dap/tests/dap_golden_transcript_tests.rs
@@ -6,10 +6,11 @@
 
 #[cfg(feature = "dap-phase2")]
 mod dap_golden_transcripts {
-    use anyhow::Result;
+    use anyhow::{Result, anyhow};
     use perl_dap::debug_adapter::{DapMessage, DebugAdapter};
     use serde_json::{Value, json};
     use std::path::PathBuf;
+    use std::sync::mpsc::{Receiver, channel};
 
     fn transcript_path(name: &str) -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -62,6 +63,14 @@ mod dap_golden_transcripts {
             _ => anyhow::bail!("expected response for {command}"),
         }
         Ok(())
+    }
+
+    fn drain_events(receiver: &Receiver<DapMessage>) -> Vec<DapMessage> {
+        let mut events = Vec::new();
+        while let Ok(message) = receiver.try_recv() {
+            events.push(message);
+        }
+        events
     }
 
     /// Tests feature spec: DAP_IMPLEMENTATION_SPECIFICATION.md#ac13-hello-world-transcript
@@ -187,6 +196,152 @@ mod dap_golden_transcripts {
             }
             _ => anyhow::bail!("expected setBreakpoints response"),
         }
+        Ok(())
+    }
+
+    /// Tests richer event/response conformance with an attach-driven session flow.
+    #[tokio::test]
+    // AC:13
+    async fn test_attach_rich_session_golden_transcript() -> Result<()> {
+        let transcript = load_transcript("attach_rich_session_sequence.json")?;
+        let messages = extract_messages(&transcript)?;
+
+        let required_commands = [
+            "initialize",
+            "attach",
+            "setBreakpoints",
+            "configurationDone",
+            "stackTrace",
+            "scopes",
+            "variables",
+            "evaluate",
+            "continue",
+            "disconnect",
+        ];
+
+        for command in required_commands {
+            assert!(
+                messages.iter().any(|m| m["type"] == "request" && m["command"] == command),
+                "transcript should contain request command '{command}'"
+            );
+        }
+
+        let mut adapter = DebugAdapter::new();
+        let (event_sender, event_receiver) = channel::<DapMessage>();
+        adapter.set_event_sender(event_sender);
+
+        let mut request_seq = 1_i64;
+        let mut prev_response_seq = 0_i64;
+        let mut event_log = Vec::new();
+
+        for message in messages {
+            if message.get("type").and_then(Value::as_str) != Some("request") {
+                continue;
+            }
+
+            let command = message
+                .get("command")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("request entry missing command"))?;
+            let arguments = message.get("arguments").cloned().map(|v| resolve_workspace_vars(&v));
+
+            let response = adapter.handle_request(request_seq, command, arguments);
+            match response {
+                DapMessage::Response {
+                    seq,
+                    request_seq: echoed_request_seq,
+                    success,
+                    command: echoed_command,
+                    body,
+                    ..
+                } => {
+                    assert!(seq > prev_response_seq, "response seq must increase for {command}");
+                    prev_response_seq = seq;
+                    assert_eq!(
+                        echoed_request_seq, request_seq,
+                        "request_seq mismatch for {command}"
+                    );
+                    assert_eq!(echoed_command, command, "command echo mismatch for {command}");
+
+                    let serialized = serde_json::to_value(&DapMessage::Response {
+                        seq,
+                        request_seq: echoed_request_seq,
+                        success,
+                        command: echoed_command.clone(),
+                        body: body.clone(),
+                        message: None,
+                    })?;
+                    let object = serialized
+                        .as_object()
+                        .ok_or_else(|| anyhow!("{command} response should serialize as object"))?;
+                    for key in ["type", "seq", "request_seq", "success", "command"] {
+                        assert!(object.contains_key(key), "{command} response missing key '{key}'");
+                    }
+
+                    if let Some(expected_response) = messages.iter().find(|candidate| {
+                        candidate["type"] == "response"
+                            && candidate["command"] == command
+                            && candidate["request_seq"] == request_seq
+                    }) {
+                        let expected_success =
+                            expected_response["success"].as_bool().unwrap_or(success);
+                        assert_eq!(
+                            success, expected_success,
+                            "success mismatch for {command}; expected transcript {expected_success}, got {success}"
+                        );
+
+                        if let Some(required_body_keys) =
+                            expected_response.get("requiredBodyKeys").and_then(Value::as_array)
+                        {
+                            let response_body = body
+                                .as_ref()
+                                .ok_or_else(|| anyhow!("{command} expected response body"))?;
+                            for key in required_body_keys {
+                                let key = key.as_str().ok_or_else(|| {
+                                    anyhow!("requiredBodyKeys entry must be a string")
+                                })?;
+                                assert!(
+                                    response_body.get(key).is_some(),
+                                    "{command} response body missing key '{key}'"
+                                );
+                            }
+                        }
+                    }
+                }
+                other => anyhow::bail!("expected response for {command}, got {other:?}"),
+            }
+
+            for event in drain_events(&event_receiver) {
+                if let DapMessage::Event { event, .. } = event {
+                    event_log.push(event);
+                }
+            }
+            request_seq += 1;
+        }
+
+        let expected_event_order =
+            transcript["expectedEventOrder"].as_array().ok_or_else(|| {
+                anyhow!("attach_rich_session_sequence transcript missing expectedEventOrder")
+            })?;
+        let expected_event_order = expected_event_order
+            .iter()
+            .map(|event| {
+                event.as_str().ok_or_else(|| anyhow!("expectedEventOrder entries must be strings"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let mut cursor = 0_usize;
+        for expected_event in expected_event_order {
+            let Some(position) =
+                event_log[cursor..].iter().position(|event| event == expected_event)
+            else {
+                anyhow::bail!(
+                    "expected event '{expected_event}' not found in event log: {event_log:?}"
+                );
+            };
+            cursor += position + 1;
+        }
+
         Ok(())
     }
 }

--- a/crates/perl-dap/tests/dap_reference_client_conformance_tests.rs
+++ b/crates/perl-dap/tests/dap_reference_client_conformance_tests.rs
@@ -1,96 +1,278 @@
 //! Reference-client conformance sweep for DAP.
 //!
-//! Replays a VS Code mock-debug-style request stream and verifies the adapter
+//! Replays reference-client style request streams and verifies the adapter
 //! returns spec-shaped responses across the command surface.
 
 use anyhow::{Result, anyhow};
 use perl_dap::{DapMessage, DebugAdapter};
 use serde_json::Value;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{Receiver, channel};
 
-fn fixture_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/fixtures/reference_clients/vscode_mock_debug_smoke.json")
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/reference_clients")
 }
 
-fn load_fixture() -> Result<Value> {
-    let raw = std::fs::read_to_string(fixture_path())?;
+fn fixture_paths() -> Result<Vec<PathBuf>> {
+    let mut entries = std::fs::read_dir(fixtures_dir())?
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("json"))
+        .collect::<Vec<_>>();
+    entries.sort();
+    Ok(entries)
+}
+
+fn load_fixture(path: &Path) -> Result<Value> {
+    let raw = std::fs::read_to_string(path)?;
     Ok(serde_json::from_str(&raw)?)
 }
 
-#[test]
-fn vscode_mock_debug_surface_conformance() -> Result<()> {
-    let fixture = load_fixture()?;
-    let requests = fixture
-        .get("requests")
-        .and_then(Value::as_array)
-        .ok_or_else(|| anyhow!("fixture requests must be an array"))?;
+fn drain_events(receiver: &Receiver<DapMessage>) -> Vec<DapMessage> {
+    let mut events = Vec::new();
+    while let Ok(message) = receiver.try_recv() {
+        events.push(message);
+    }
+    events
+}
 
-    let mut adapter = DebugAdapter::new();
-    let mut prev_response_seq = 0_i64;
+fn assert_response_shape(response: &DapMessage, command: &str) -> Result<()> {
+    let serialized = serde_json::to_value(response)?;
+    let object = serialized
+        .as_object()
+        .ok_or_else(|| anyhow!("{command} response must serialize as an object"))?;
 
-    for (idx, request) in requests.iter().enumerate() {
-        let request_seq = (idx as i64) + 1;
-        let command = request
-            .get("command")
+    for key in ["type", "seq", "request_seq", "success", "command"] {
+        if !object.contains_key(key) {
+            return Err(anyhow!("{command} response missing required top-level key: {key}"));
+        }
+    }
+
+    if object.get("type").and_then(Value::as_str) != Some("response") {
+        return Err(anyhow!("{command} response must have type='response'"));
+    }
+
+    Ok(())
+}
+
+fn assert_expected_events(
+    request: &Value,
+    emitted_events: &[DapMessage],
+    command: &str,
+    event_log: &mut Vec<String>,
+) -> Result<()> {
+    let Some(expected_events) = request.get("expectedEvents").and_then(Value::as_array) else {
+        let allowed_implicit_event = match command {
+            "initialize" => "initialized",
+            "disconnect" => "terminated",
+            _ => "",
+        };
+        let command_allows_implicit_event = !allowed_implicit_event.is_empty()
+            && emitted_events.len() == 1
+            && matches!(
+                emitted_events.first(),
+                Some(DapMessage::Event { event, .. }) if event == allowed_implicit_event
+            );
+
+        if !emitted_events.is_empty() && !command_allows_implicit_event {
+            return Err(anyhow!("{command} emitted unexpected events: {emitted_events:?}"));
+        }
+        return Ok(());
+    };
+
+    if emitted_events.len() != expected_events.len() {
+        return Err(anyhow!(
+            "{command} emitted {} event(s), expected {}. Actual events: {emitted_events:?}",
+            emitted_events.len(),
+            expected_events.len(),
+        ));
+    }
+
+    for (idx, (emitted, expected)) in emitted_events.iter().zip(expected_events.iter()).enumerate()
+    {
+        let expected_name = expected
+            .get("event")
             .and_then(Value::as_str)
-            .ok_or_else(|| anyhow!("request entry missing command"))?;
-        let arguments = request.get("arguments").cloned();
-        let expected_success =
-            request.get("expectSuccess").and_then(Value::as_bool).unwrap_or(true);
+            .ok_or_else(|| anyhow!("expectedEvents[{idx}] missing event name for {command}"))?;
 
-        let response = adapter.handle_request(request_seq, command, arguments);
-        match response {
-            DapMessage::Response {
-                seq,
-                request_seq: echoed_request_seq,
-                success,
-                command: echoed_command,
-                body,
-                message,
-            } => {
-                assert!(
-                    seq > prev_response_seq,
-                    "response seq must increase monotonically for {command}"
-                );
-                prev_response_seq = seq;
-                assert_eq!(
-                    echoed_request_seq, request_seq,
-                    "request_seq echo mismatch for {command}"
-                );
-                assert_eq!(echoed_command, command, "command echo mismatch for {command}");
-                assert_eq!(
-                    success, expected_success,
-                    "success mismatch for {command}: {message:?}"
-                );
-
-                if let Some(required_message_substring) =
-                    request.get("requiredMessageContains").and_then(Value::as_str)
-                {
-                    let message = message.unwrap_or_default();
-                    assert!(
-                        message.contains(required_message_substring),
-                        "{command} response message must contain '{required_message_substring}', got: {message}"
-                    );
+        match emitted {
+            DapMessage::Event { event, body, .. } => {
+                if event != expected_name {
+                    return Err(anyhow!(
+                        "{command} event order mismatch at index {idx}: expected '{expected_name}', got '{event}'"
+                    ));
                 }
 
+                event_log.push(event.clone());
+
                 if let Some(required_body_keys) =
-                    request.get("requiredBodyKeys").and_then(Value::as_array)
+                    expected.get("requiredBodyKeys").and_then(Value::as_array)
                 {
-                    let body = body.ok_or_else(|| anyhow!("{command} response missing body"))?;
+                    let body = body
+                        .as_ref()
+                        .ok_or_else(|| anyhow!("{command} event '{event}' missing body"))?;
                     for key in required_body_keys {
-                        let key = key
-                            .as_str()
-                            .ok_or_else(|| anyhow!("requiredBodyKeys entries must be strings"))?;
-                        assert!(
-                            body.get(key).is_some(),
-                            "{command} response body missing required key: {key}"
-                        );
+                        let key = key.as_str().ok_or_else(|| {
+                            anyhow!("{command} expectedEvents requiredBodyKeys must be strings")
+                        })?;
+                        if body.get(key).is_none() {
+                            return Err(anyhow!(
+                                "{command} event '{event}' body missing required key: {key}"
+                            ));
+                        }
+                    }
+                }
+
+                if let Some(required_equals) =
+                    expected.get("requiredBodyFieldEquals").and_then(Value::as_object)
+                {
+                    let body = body
+                        .as_ref()
+                        .ok_or_else(|| anyhow!("{command} event '{event}' missing body"))?;
+                    for (key, expected_value) in required_equals {
+                        let actual = body.get(key).ok_or_else(|| {
+                            anyhow!("{command} event '{event}' body missing field: {key}")
+                        })?;
+                        if actual != expected_value {
+                            return Err(anyhow!(
+                                "{command} event '{event}' field '{key}' mismatch: expected {expected_value}, got {actual}"
+                            ));
+                        }
                     }
                 }
             }
             other => {
-                return Err(anyhow!("expected response for {command}, got {other:?}"));
+                return Err(anyhow!(
+                    "{command} expected event at index {idx}, got non-event message: {other:?}"
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn vscode_reference_clients_surface_conformance() -> Result<()> {
+    for fixture_path in fixture_paths()? {
+        let fixture = load_fixture(&fixture_path)?;
+        let fixture_name = fixture_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| anyhow!("invalid fixture name: {fixture_path:?}"))?;
+
+        let requests = fixture
+            .get("requests")
+            .and_then(Value::as_array)
+            .ok_or_else(|| anyhow!("{fixture_name}: fixture requests must be an array"))?;
+
+        let mut adapter = DebugAdapter::new();
+        let (event_sender, event_receiver) = channel::<DapMessage>();
+        adapter.set_event_sender(event_sender);
+
+        let mut prev_response_seq = 0_i64;
+        let mut event_log = Vec::new();
+
+        for (idx, request) in requests.iter().enumerate() {
+            let request_seq = (idx as i64) + 1;
+            let command = request
+                .get("command")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("{fixture_name}: request entry missing command"))?;
+            let arguments = request.get("arguments").cloned();
+            let expected_success =
+                request.get("expectSuccess").and_then(Value::as_bool).unwrap_or(true);
+
+            let response = adapter.handle_request(request_seq, command, arguments);
+            match &response {
+                DapMessage::Response {
+                    seq,
+                    request_seq: echoed_request_seq,
+                    success,
+                    command: echoed_command,
+                    body,
+                    message,
+                } => {
+                    assert!(
+                        *seq > prev_response_seq,
+                        "{fixture_name}: response seq must increase monotonically for {command}"
+                    );
+                    prev_response_seq = *seq;
+                    assert_eq!(
+                        *echoed_request_seq, request_seq,
+                        "{fixture_name}: request_seq echo mismatch for {command}"
+                    );
+                    assert_eq!(
+                        echoed_command, command,
+                        "{fixture_name}: command echo mismatch for {command}"
+                    );
+                    assert_eq!(
+                        *success, expected_success,
+                        "{fixture_name}: success mismatch for {command}: {message:?}"
+                    );
+
+                    assert_response_shape(&response, command)?;
+
+                    if let Some(required_message_substring) =
+                        request.get("requiredMessageContains").and_then(Value::as_str)
+                    {
+                        let message = message.clone().unwrap_or_default();
+                        assert!(
+                            message.contains(required_message_substring),
+                            "{fixture_name}: {command} response message must contain '{required_message_substring}', got: {message}"
+                        );
+                    }
+
+                    if let Some(required_body_keys) =
+                        request.get("requiredBodyKeys").and_then(Value::as_array)
+                    {
+                        let body = body.as_ref().ok_or_else(|| {
+                            anyhow!("{fixture_name}: {command} response missing body")
+                        })?;
+                        for key in required_body_keys {
+                            let key = key.as_str().ok_or_else(|| {
+                                anyhow!("{fixture_name}: requiredBodyKeys entries must be strings")
+                            })?;
+                            assert!(
+                                body.get(key).is_some(),
+                                "{fixture_name}: {command} response body missing required key: {key}"
+                            );
+                        }
+                    }
+                }
+                other => {
+                    return Err(anyhow!(
+                        "{fixture_name}: expected response for {command}, got {other:?}"
+                    ));
+                }
+            }
+
+            let emitted_events = drain_events(&event_receiver);
+            assert_expected_events(request, &emitted_events, command, &mut event_log)?;
+        }
+
+        if let Some(expected_event_order) =
+            fixture.get("expectedEventOrder").and_then(Value::as_array)
+        {
+            let expected = expected_event_order
+                .iter()
+                .map(|value| {
+                    value.as_str().ok_or_else(|| {
+                        anyhow!("{fixture_name}: expectedEventOrder entries must be strings")
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            let mut cursor = 0_usize;
+            for expected_name in expected {
+                if let Some(position) =
+                    event_log[cursor..].iter().position(|event| event == expected_name)
+                {
+                    cursor += position + 1;
+                } else {
+                    return Err(anyhow!(
+                        "{fixture_name}: expected event '{expected_name}' not found in emitted event log: {event_log:?}"
+                    ));
+                }
             }
         }
     }

--- a/crates/perl-dap/tests/fixtures/golden_transcripts/attach_rich_session_sequence.json
+++ b/crates/perl-dap/tests/fixtures/golden_transcripts/attach_rich_session_sequence.json
@@ -1,0 +1,170 @@
+{
+  "name": "attach_rich_session_sequence",
+  "description": "Attach handshake with stack/scopes/variables/evaluate plus continued/terminated events",
+  "expectedEventOrder": ["initialized", "stopped", "continued", "terminated"],
+  "messages": [
+    {
+      "seq": 1,
+      "type": "request",
+      "command": "initialize",
+      "arguments": {
+        "clientID": "vscode",
+        "clientName": "Visual Studio Code",
+        "adapterID": "perl",
+        "pathFormat": "path",
+        "linesStartAt1": true,
+        "columnsStartAt1": true
+      }
+    },
+    {
+      "seq": 1,
+      "type": "response",
+      "request_seq": 1,
+      "success": true,
+      "command": "initialize",
+      "requiredBodyKeys": ["supportsConfigurationDoneRequest", "supportsEvaluateForHovers"]
+    },
+    {
+      "seq": 2,
+      "type": "request",
+      "command": "attach",
+      "arguments": {
+        "processId": 4242,
+        "stopOnEntry": false
+      }
+    },
+    {
+      "seq": 2,
+      "type": "response",
+      "request_seq": 2,
+      "success": true,
+      "command": "attach",
+      "requiredBodyKeys": ["threadId", "processId", "mode"]
+    },
+    {
+      "seq": 3,
+      "type": "request",
+      "command": "setBreakpoints",
+      "arguments": {
+        "source": {
+          "path": "${workspaceFolder}/tests/fixtures/hello.pl"
+        },
+        "breakpoints": [
+          { "line": 9 }
+        ]
+      }
+    },
+    {
+      "seq": 3,
+      "type": "response",
+      "request_seq": 3,
+      "success": true,
+      "command": "setBreakpoints",
+      "requiredBodyKeys": ["breakpoints"]
+    },
+    {
+      "seq": 4,
+      "type": "request",
+      "command": "configurationDone"
+    },
+    {
+      "seq": 4,
+      "type": "response",
+      "request_seq": 4,
+      "success": true,
+      "command": "configurationDone"
+    },
+    {
+      "seq": 5,
+      "type": "request",
+      "command": "stackTrace",
+      "arguments": {
+        "threadId": 4242
+      }
+    },
+    {
+      "seq": 5,
+      "type": "response",
+      "request_seq": 5,
+      "success": true,
+      "command": "stackTrace",
+      "requiredBodyKeys": ["stackFrames", "totalFrames"]
+    },
+    {
+      "seq": 6,
+      "type": "request",
+      "command": "scopes",
+      "arguments": {
+        "frameId": 4242
+      }
+    },
+    {
+      "seq": 6,
+      "type": "response",
+      "request_seq": 6,
+      "success": true,
+      "command": "scopes",
+      "requiredBodyKeys": ["scopes"]
+    },
+    {
+      "seq": 7,
+      "type": "request",
+      "command": "variables",
+      "arguments": {
+        "variablesReference": 42421
+      }
+    },
+    {
+      "seq": 7,
+      "type": "response",
+      "request_seq": 7,
+      "success": true,
+      "command": "variables",
+      "requiredBodyKeys": ["variables"]
+    },
+    {
+      "seq": 8,
+      "type": "request",
+      "command": "evaluate",
+      "arguments": {
+        "expression": "$x"
+      }
+    },
+    {
+      "seq": 8,
+      "type": "response",
+      "request_seq": 8,
+      "success": false,
+      "command": "evaluate"
+    },
+    {
+      "seq": 9,
+      "type": "request",
+      "command": "continue",
+      "arguments": {
+        "threadId": 4242
+      }
+    },
+    {
+      "seq": 9,
+      "type": "response",
+      "request_seq": 9,
+      "success": true,
+      "command": "continue",
+      "requiredBodyKeys": ["allThreadsContinued"]
+    },
+    {
+      "seq": 10,
+      "type": "request",
+      "command": "disconnect",
+      "arguments": {}
+    },
+    {
+      "seq": 10,
+      "type": "response",
+      "request_seq": 10,
+      "success": true,
+      "command": "disconnect"
+    }
+  ]
+}

--- a/crates/perl-dap/tests/fixtures/reference_clients/vscode_mock_debug_attach_rich.json
+++ b/crates/perl-dap/tests/fixtures/reference_clients/vscode_mock_debug_attach_rich.json
@@ -1,0 +1,107 @@
+{
+  "client": "vscode-mock-debug",
+  "description": "Reference-client attach flow with response and event conformance checks",
+  "expectedEventOrder": ["initialized", "stopped", "continued", "terminated"],
+  "requests": [
+    {
+      "command": "initialize",
+      "arguments": {
+        "clientID": "vscode",
+        "clientName": "Visual Studio Code",
+        "adapterID": "mock",
+        "pathFormat": "path",
+        "linesStartAt1": true,
+        "columnsStartAt1": true,
+        "locale": "en-US"
+      },
+      "expectSuccess": true,
+      "requiredBodyKeys": [
+        "supportsConfigurationDoneRequest",
+        "supportsSetVariable",
+        "supportsCompletionsRequest",
+        "supportsLoadedSourcesRequest"
+      ],
+      "expectedEvents": [
+        {
+          "event": "initialized"
+        }
+      ]
+    },
+    {
+      "command": "attach",
+      "arguments": {
+        "processId": 4242,
+        "stopOnEntry": false
+      },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["threadId", "processId", "mode"],
+      "expectedEvents": [
+        {
+          "event": "stopped",
+          "requiredBodyKeys": ["reason", "threadId", "allThreadsStopped"],
+          "requiredBodyFieldEquals": {
+            "reason": "attach"
+          }
+        }
+      ]
+    },
+    {
+      "command": "setBreakpoints",
+      "arguments": {
+        "source": {},
+        "breakpoints": []
+      },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["breakpoints"]
+    },
+    {
+      "command": "configurationDone",
+      "expectSuccess": true
+    },
+    {
+      "command": "stackTrace",
+      "arguments": { "threadId": 4242 },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["stackFrames", "totalFrames"]
+    },
+    {
+      "command": "scopes",
+      "arguments": { "frameId": 4242 },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["scopes"]
+    },
+    {
+      "command": "variables",
+      "arguments": { "variablesReference": 42421 },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["variables"]
+    },
+    {
+      "command": "evaluate",
+      "arguments": { "expression": "$x" },
+      "expectSuccess": false,
+      "requiredMessageContains": "Evaluate is unavailable for processId attach"
+    },
+    {
+      "command": "continue",
+      "arguments": { "threadId": 4242 },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["allThreadsContinued"],
+      "expectedEvents": [
+        {
+          "event": "continued",
+          "requiredBodyKeys": ["threadId", "allThreadsContinued"]
+        }
+      ]
+    },
+    {
+      "command": "disconnect",
+      "expectSuccess": true,
+      "expectedEvents": [
+        {
+          "event": "terminated"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- The existing DAP conformance fixtures were narrowly focused and did not exercise richer attach-driven session flows, event ordering, and response-shape invariants.
- Improve protocol accuracy and make failures easier to diagnose by adding richer fixtures and stronger, fixture-driven assertions for responses and emitted events.

### Description

- Added new reference-client fixture `tests/fixtures/reference_clients/vscode_mock_debug_attach_rich.json` covering `initialize -> attach -> setBreakpoints -> configurationDone -> stackTrace/scopes/variables/evaluate -> continue -> disconnect` with per-request expected events and required-body/message checks.
- Added new golden transcript `tests/fixtures/golden_transcripts/attach_rich_session_sequence.json` exercising the same attach-driven lifecycle and declaring expected responses and event order.
- Enhanced `crates/perl-dap/tests/dap_reference_client_conformance_tests.rs` to iterate all JSON fixtures in `tests/fixtures/reference_clients`, capture adapter events via a channel, and validate monotonic response `seq`, `request_seq` echo correctness, response-shape keys, required body/message fields, and per-request event expectations while preserving backward compatibility for implicit `initialized`/`terminated` emissions.
- Extended `crates/perl-dap/tests/dap_golden_transcript_tests.rs` with `test_attach_rich_session_golden_transcript` and small helpers (`drain_events`, response/event assertions) to replay the new transcript and validate emitted event ordering.

### Testing

- Ran formatting: `cargo xtask fmt` (succeeded).
- Unit tests: `cargo test -p perl-dap --test dap_reference_client_conformance_tests` (passed).
- Golden tests: `cargo test -p perl-dap --test dap_golden_transcript_tests` (passed).
- Type/check: `cargo check --all-targets -p perl-dap` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb398efe748333b40eb4243df8816a)