### PR TITLE
test(perl-dap): expand reference-client and golden-transcript conformance coverage (#0000)

### DIFF
--- a/crates/perl-dap/tests/dap_golden_transcript_tests.rs
+++ b/crates/perl-dap/tests/dap_golden_transcript_tests.rs
@@ -9,7 +9,9 @@ mod dap_golden_transcripts {
     use anyhow::Result;
     use perl_dap::debug_adapter::{DapMessage, DebugAdapter};
     use serde_json::{Value, json};
+    use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::sync::mpsc::channel;
 
     fn transcript_path(name: &str) -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -60,6 +62,22 @@ mod dap_golden_transcripts {
                 }
             }
             _ => anyhow::bail!("expected response for {command}"),
+        }
+        Ok(())
+    }
+
+    fn assert_required_body_keys(
+        body: &Value,
+        required_body_keys: &[Value],
+        context: &str,
+    ) -> Result<()> {
+        for key in required_body_keys {
+            let key = key
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("requiredBodyKeys entries must be strings"))?;
+            if body.get(key).is_none() {
+                anyhow::bail!("{context} body missing required key: {key}");
+            }
         }
         Ok(())
     }
@@ -187,6 +205,155 @@ mod dap_golden_transcripts {
             }
             _ => anyhow::bail!("expected setBreakpoints response"),
         }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_reference_attach_full_sequence_conformance() -> Result<()> {
+        let transcript = load_transcript("reference_attach_full_sequence.json")?;
+        let messages = extract_messages(&transcript)?;
+
+        let required_commands = [
+            "initialize",
+            "attach",
+            "setBreakpoints",
+            "configurationDone",
+            "stackTrace",
+            "scopes",
+            "variables",
+            "evaluate",
+            "disconnect",
+        ];
+        for command in required_commands {
+            assert!(
+                messages.iter().any(|m| m["type"] == "request" && m["command"] == command),
+                "golden transcript must include request command: {command}"
+            );
+        }
+
+        let expected_events: Vec<&Value> =
+            messages.iter().filter(|m| m["type"] == "event").collect();
+
+        let mut response_expectations: HashMap<String, &Value> = HashMap::new();
+        for message in messages {
+            if message["type"] == "response" {
+                let command = message
+                    .get("command")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("response message missing command"))?;
+                response_expectations.insert(command.to_string(), message);
+            }
+        }
+
+        let mut adapter = DebugAdapter::new();
+        let (sender, receiver) = channel();
+        adapter.set_event_sender(sender);
+
+        let mut next_request_seq = 1_i64;
+        let mut prev_response_seq = 0_i64;
+        let mut observed_events: Vec<DapMessage> = Vec::new();
+
+        for request in messages.iter().filter(|m| m["type"] == "request") {
+            let command = request
+                .get("command")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow::anyhow!("request message missing command"))?;
+            let arguments = request.get("arguments").map(resolve_workspace_vars);
+
+            let response = adapter.handle_request(next_request_seq, command, arguments);
+            match response {
+                DapMessage::Response {
+                    seq,
+                    request_seq,
+                    success,
+                    command: echoed_command,
+                    body,
+                    message,
+                } => {
+                    assert!(
+                        seq > prev_response_seq,
+                        "response seq must be monotonic for {command}"
+                    );
+                    prev_response_seq = seq;
+
+                    assert_eq!(
+                        request_seq, next_request_seq,
+                        "request_seq echo mismatch for {command}"
+                    );
+                    assert_eq!(echoed_command, command, "command echo mismatch for {command}");
+
+                    let expected = response_expectations
+                        .get(command)
+                        .ok_or_else(|| anyhow::anyhow!("no response expectation for {command}"))?;
+                    let expected_success =
+                        expected.get("success").and_then(Value::as_bool).ok_or_else(|| {
+                            anyhow::anyhow!("response expectation missing success for {command}")
+                        })?;
+                    assert_eq!(success, expected_success, "success mismatch for {command}");
+
+                    if let Some(required_body_keys) =
+                        expected.get("requiredBodyKeys").and_then(Value::as_array)
+                    {
+                        let body =
+                            body.ok_or_else(|| anyhow::anyhow!("{command} response missing body"))?;
+                        assert!(body.is_object(), "{command} response body must be an object");
+                        assert_required_body_keys(&body, required_body_keys, command)?;
+                    }
+
+                    if let Some(expected_message) =
+                        expected.get("requiredMessageContains").and_then(Value::as_str)
+                    {
+                        let actual_message = message.unwrap_or_default();
+                        assert!(
+                            actual_message.contains(expected_message),
+                            "{command} message must contain '{expected_message}', got: {actual_message}"
+                        );
+                    }
+                }
+                other => anyhow::bail!("expected response for {command}, got {other:?}"),
+            }
+
+            observed_events.extend(receiver.try_iter());
+            next_request_seq += 1;
+        }
+
+        assert_eq!(
+            observed_events.len(),
+            expected_events.len(),
+            "event count mismatch between replay and golden transcript"
+        );
+
+        let mut prev_event_seq = 0_i64;
+        for (idx, (actual, expected)) in
+            observed_events.iter().zip(expected_events.iter()).enumerate()
+        {
+            match actual {
+                DapMessage::Event { seq, event, body } => {
+                    assert!(
+                        *seq > prev_event_seq,
+                        "event seq must increase monotonically at index {idx}"
+                    );
+                    prev_event_seq = *seq;
+
+                    let expected_event = expected
+                        .get("event")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| anyhow::anyhow!("event expectation missing event name"))?;
+                    assert_eq!(event, expected_event, "event ordering mismatch at index {idx}");
+
+                    if let Some(required_body_keys) =
+                        expected.get("requiredBodyKeys").and_then(Value::as_array)
+                    {
+                        let body = body
+                            .as_ref()
+                            .ok_or_else(|| anyhow::anyhow!("expected body for event {event}"))?;
+                        assert_required_body_keys(body, required_body_keys, event)?;
+                    }
+                }
+                other => anyhow::bail!("expected DAP event at index {idx}, got {other:?}"),
+            }
+        }
+
         Ok(())
     }
 }

--- a/crates/perl-dap/tests/dap_reference_client_conformance_tests.rs
+++ b/crates/perl-dap/tests/dap_reference_client_conformance_tests.rs
@@ -1,32 +1,124 @@
 //! Reference-client conformance sweep for DAP.
 //!
-//! Replays a VS Code mock-debug-style request stream and verifies the adapter
-//! returns spec-shaped responses across the command surface.
+//! Replays representative reference-client request streams and verifies the
+//! adapter returns spec-shaped responses with correctly ordered side-band events.
 
 use anyhow::{Result, anyhow};
 use perl_dap::{DapMessage, DebugAdapter};
 use serde_json::Value;
 use std::path::PathBuf;
+use std::sync::mpsc::{Receiver, channel};
 
-fn fixture_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/fixtures/reference_clients/vscode_mock_debug_smoke.json")
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/reference_clients").join(name)
 }
 
-fn load_fixture() -> Result<Value> {
-    let raw = std::fs::read_to_string(fixture_path())?;
+fn load_fixture(name: &str) -> Result<Value> {
+    let raw = std::fs::read_to_string(fixture_path(name))?;
     Ok(serde_json::from_str(&raw)?)
 }
 
-#[test]
-fn vscode_mock_debug_surface_conformance() -> Result<()> {
-    let fixture = load_fixture()?;
+fn resolve_workspace_vars(value: &Value) -> Value {
+    let workspace_root =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..").to_string_lossy().to_string();
+    match value {
+        Value::String(s) => Value::String(s.replace("${workspaceFolder}", &workspace_root)),
+        Value::Array(items) => Value::Array(items.iter().map(resolve_workspace_vars).collect()),
+        Value::Object(map) => {
+            Value::Object(map.iter().map(|(k, v)| (k.clone(), resolve_workspace_vars(v))).collect())
+        }
+        _ => value.clone(),
+    }
+}
+
+fn drain_events(receiver: &Receiver<DapMessage>) -> Vec<DapMessage> {
+    receiver.try_iter().collect()
+}
+
+fn assert_required_body_keys(
+    command: &str,
+    body: &Value,
+    required_body_keys: &[Value],
+) -> Result<()> {
+    for key in required_body_keys {
+        let key =
+            key.as_str().ok_or_else(|| anyhow!("requiredBodyKeys entries must be strings"))?;
+        if body.get(key).is_none() {
+            return Err(anyhow!("{command} response body missing required key: {key}"));
+        }
+    }
+    Ok(())
+}
+
+fn assert_expected_events(
+    command: &str,
+    expected_events: Option<&Vec<Value>>,
+    emitted_events: &[DapMessage],
+) -> Result<()> {
+    let expected_events = expected_events.cloned().unwrap_or_default();
+    if emitted_events.len() != expected_events.len() {
+        return Err(anyhow!(
+            "{command} emitted {} event(s) but fixture expected {}",
+            emitted_events.len(),
+            expected_events.len()
+        ));
+    }
+
+    let mut prev_event_seq = 0_i64;
+    for (event_idx, (expected_event, actual_event)) in
+        expected_events.iter().zip(emitted_events.iter()).enumerate()
+    {
+        let expected_name = expected_event
+            .get("event")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("expectedEvents[{event_idx}] missing event name"))?;
+
+        match actual_event {
+            DapMessage::Event { seq, event, body } => {
+                if *seq <= prev_event_seq {
+                    return Err(anyhow!(
+                        "{command} event seq must increase monotonically: {seq} <= {prev_event_seq}"
+                    ));
+                }
+                prev_event_seq = *seq;
+
+                if event != expected_name {
+                    return Err(anyhow!(
+                        "{command} event ordering mismatch at index {event_idx}: expected {expected_name}, got {event}"
+                    ));
+                }
+
+                if let Some(required_body_keys) =
+                    expected_event.get("requiredBodyKeys").and_then(Value::as_array)
+                {
+                    let body = body
+                        .as_ref()
+                        .ok_or_else(|| anyhow!("{event} event missing required body"))?;
+                    assert_required_body_keys(event, body, required_body_keys)?;
+                }
+            }
+            other => {
+                return Err(anyhow!(
+                    "{command} expected DAP event at index {event_idx}, got {other:?}"
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn run_fixture(fixture_name: &str) -> Result<()> {
+    let fixture = load_fixture(fixture_name)?;
     let requests = fixture
         .get("requests")
         .and_then(Value::as_array)
         .ok_or_else(|| anyhow!("fixture requests must be an array"))?;
 
     let mut adapter = DebugAdapter::new();
+    let (sender, receiver) = channel();
+    adapter.set_event_sender(sender);
+
     let mut prev_response_seq = 0_i64;
 
     for (idx, request) in requests.iter().enumerate() {
@@ -35,7 +127,7 @@ fn vscode_mock_debug_surface_conformance() -> Result<()> {
             .get("command")
             .and_then(Value::as_str)
             .ok_or_else(|| anyhow!("request entry missing command"))?;
-        let arguments = request.get("arguments").cloned();
+        let arguments = request.get("arguments").map(resolve_workspace_vars);
         let expected_success =
             request.get("expectSuccess").and_then(Value::as_bool).unwrap_or(true);
 
@@ -64,6 +156,13 @@ fn vscode_mock_debug_surface_conformance() -> Result<()> {
                     "success mismatch for {command}: {message:?}"
                 );
 
+                if let Some(ref response_body) = body {
+                    assert!(
+                        response_body.is_object(),
+                        "{command} response body must be an object when present"
+                    );
+                }
+
                 if let Some(required_message_substring) =
                     request.get("requiredMessageContains").and_then(Value::as_str)
                 {
@@ -77,23 +176,33 @@ fn vscode_mock_debug_surface_conformance() -> Result<()> {
                 if let Some(required_body_keys) =
                     request.get("requiredBodyKeys").and_then(Value::as_array)
                 {
-                    let body = body.ok_or_else(|| anyhow!("{command} response missing body"))?;
-                    for key in required_body_keys {
-                        let key = key
-                            .as_str()
-                            .ok_or_else(|| anyhow!("requiredBodyKeys entries must be strings"))?;
-                        assert!(
-                            body.get(key).is_some(),
-                            "{command} response body missing required key: {key}"
-                        );
-                    }
+                    let response_body =
+                        body.ok_or_else(|| anyhow!("{command} response missing body"))?;
+                    assert_required_body_keys(command, &response_body, required_body_keys)?;
                 }
             }
             other => {
                 return Err(anyhow!("expected response for {command}, got {other:?}"));
             }
         }
+
+        let emitted_events = drain_events(&receiver);
+        assert_expected_events(
+            command,
+            request.get("expectedEvents").and_then(Value::as_array),
+            &emitted_events,
+        )?;
     }
 
     Ok(())
+}
+
+#[test]
+fn vscode_mock_debug_surface_conformance() -> Result<()> {
+    run_fixture("vscode_mock_debug_smoke.json")
+}
+
+#[test]
+fn vscode_attach_protocol_conformance() -> Result<()> {
+    run_fixture("vscode_attach_conformance.json")
 }

--- a/crates/perl-dap/tests/fixtures/golden_transcripts/reference_attach_full_sequence.json
+++ b/crates/perl-dap/tests/fixtures/golden_transcripts/reference_attach_full_sequence.json
@@ -1,0 +1,148 @@
+{
+  "name": "reference_attach_full_sequence",
+  "description": "Golden transcript for attach-mode lifecycle with inspection and evaluate fallback",
+  "messages": [
+    {
+      "type": "request",
+      "command": "initialize",
+      "arguments": {
+        "clientID": "vscode",
+        "clientName": "Visual Studio Code",
+        "adapterID": "perl",
+        "pathFormat": "path",
+        "linesStartAt1": true,
+        "columnsStartAt1": true
+      }
+    },
+    {
+      "type": "response",
+      "command": "initialize",
+      "success": true,
+      "requiredBodyKeys": [
+        "supportsConfigurationDoneRequest",
+        "supportsEvaluateForHovers"
+      ]
+    },
+    {
+      "type": "event",
+      "event": "initialized"
+    },
+    {
+      "type": "request",
+      "command": "attach",
+      "arguments": {
+        "processId": 9999,
+        "stopOnEntry": false
+      }
+    },
+    {
+      "type": "response",
+      "command": "attach",
+      "success": true,
+      "requiredBodyKeys": ["threadId", "processId", "mode"]
+    },
+    {
+      "type": "event",
+      "event": "stopped",
+      "requiredBodyKeys": ["reason", "threadId", "allThreadsStopped"]
+    },
+    {
+      "type": "request",
+      "command": "setBreakpoints",
+      "arguments": {
+        "source": {
+          "path": "${workspaceFolder}/crates/perl-dap/tests/fixtures/hello.pl"
+        },
+        "breakpoints": [{ "line": 9 }]
+      }
+    },
+    {
+      "type": "response",
+      "command": "setBreakpoints",
+      "success": true,
+      "requiredBodyKeys": ["breakpoints"]
+    },
+    {
+      "type": "request",
+      "command": "configurationDone"
+    },
+    {
+      "type": "response",
+      "command": "configurationDone",
+      "success": true
+    },
+    {
+      "type": "request",
+      "command": "continue",
+      "arguments": { "threadId": 9999 }
+    },
+    {
+      "type": "response",
+      "command": "continue",
+      "success": true,
+      "requiredBodyKeys": ["allThreadsContinued"]
+    },
+    {
+      "type": "event",
+      "event": "continued",
+      "requiredBodyKeys": ["threadId", "allThreadsContinued"]
+    },
+    {
+      "type": "request",
+      "command": "stackTrace",
+      "arguments": { "threadId": 9999 }
+    },
+    {
+      "type": "response",
+      "command": "stackTrace",
+      "success": true,
+      "requiredBodyKeys": ["stackFrames", "totalFrames"]
+    },
+    {
+      "type": "request",
+      "command": "scopes",
+      "arguments": { "frameId": 9999 }
+    },
+    {
+      "type": "response",
+      "command": "scopes",
+      "success": true,
+      "requiredBodyKeys": ["scopes"]
+    },
+    {
+      "type": "request",
+      "command": "variables",
+      "arguments": { "variablesReference": 99991 }
+    },
+    {
+      "type": "response",
+      "command": "variables",
+      "success": true,
+      "requiredBodyKeys": ["variables"]
+    },
+    {
+      "type": "request",
+      "command": "evaluate",
+      "arguments": { "expression": "$x" }
+    },
+    {
+      "type": "response",
+      "command": "evaluate",
+      "success": false,
+      "requiredMessageContains": "without an active debugger transport"
+    },
+    {
+      "type": "request",
+      "command": "disconnect"
+    },
+    {
+      "type": "response",
+      "command": "disconnect",
+      "success": true
+    },
+    {
+      "type": "event",
+      "event": "terminated"
+    }
+  ]
+}

--- a/crates/perl-dap/tests/fixtures/reference_clients/vscode_attach_conformance.json
+++ b/crates/perl-dap/tests/fixtures/reference_clients/vscode_attach_conformance.json
@@ -1,0 +1,104 @@
+{
+  "client": "vscode-reference",
+  "description": "Richer attach-mode request/response/event conformance sweep",
+  "requests": [
+    {
+      "command": "initialize",
+      "arguments": {
+        "clientID": "vscode",
+        "clientName": "Visual Studio Code",
+        "adapterID": "perl",
+        "pathFormat": "path",
+        "linesStartAt1": true,
+        "columnsStartAt1": true,
+        "locale": "en-US"
+      },
+      "expectSuccess": true,
+      "requiredBodyKeys": [
+        "supportsConfigurationDoneRequest",
+        "supportsEvaluateForHovers",
+        "supportsSetVariable"
+      ],
+      "expectedEvents": [
+        {
+          "event": "initialized"
+        }
+      ]
+    },
+    {
+      "command": "attach",
+      "arguments": {
+        "processId": 4242,
+        "stopOnEntry": false
+      },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["threadId", "processId", "mode"],
+      "expectedEvents": [
+        {
+          "event": "stopped",
+          "requiredBodyKeys": ["reason", "threadId", "allThreadsStopped"]
+        }
+      ]
+    },
+    {
+      "command": "setBreakpoints",
+      "arguments": {
+        "source": {
+          "path": "${workspaceFolder}/crates/perl-dap/tests/fixtures/hello.pl"
+        },
+        "breakpoints": [{ "line": 9 }]
+      },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["breakpoints"]
+    },
+    {
+      "command": "configurationDone",
+      "expectSuccess": true
+    },
+    {
+      "command": "continue",
+      "arguments": { "threadId": 4242 },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["allThreadsContinued"],
+      "expectedEvents": [
+        {
+          "event": "continued",
+          "requiredBodyKeys": ["threadId", "allThreadsContinued"]
+        }
+      ]
+    },
+    {
+      "command": "stackTrace",
+      "arguments": { "threadId": 4242 },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["stackFrames", "totalFrames"]
+    },
+    {
+      "command": "scopes",
+      "arguments": { "frameId": 4242 },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["scopes"]
+    },
+    {
+      "command": "variables",
+      "arguments": { "variablesReference": 42421 },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["variables"]
+    },
+    {
+      "command": "evaluate",
+      "arguments": { "expression": "$x" },
+      "expectSuccess": false,
+      "requiredMessageContains": "without an active debugger transport"
+    },
+    {
+      "command": "disconnect",
+      "expectSuccess": true,
+      "expectedEvents": [
+        {
+          "event": "terminated"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/perl-dap/tests/fixtures/reference_clients/vscode_mock_debug_smoke.json
+++ b/crates/perl-dap/tests/fixtures/reference_clients/vscode_mock_debug_smoke.json
@@ -19,18 +19,29 @@
         "supportsSetVariable",
         "supportsCompletionsRequest",
         "supportsLoadedSourcesRequest"
+      ],
+      "expectedEvents": [
+        {
+          "event": "initialized"
+        }
       ]
     },
     {
       "command": "threads",
       "expectSuccess": true,
-      "requiredBodyKeys": ["threads"]
+      "requiredBodyKeys": [
+        "threads"
+      ]
     },
     {
       "command": "setExceptionBreakpoints",
-      "arguments": { "filters": [] },
+      "arguments": {
+        "filters": []
+      },
       "expectSuccess": true,
-      "requiredBodyKeys": ["breakpoints"]
+      "requiredBodyKeys": [
+        "breakpoints"
+      ]
     },
     {
       "command": "setBreakpoints",
@@ -39,7 +50,9 @@
         "breakpoints": []
       },
       "expectSuccess": true,
-      "requiredBodyKeys": ["breakpoints"]
+      "requiredBodyKeys": [
+        "breakpoints"
+      ]
     },
     {
       "command": "configurationDone",
@@ -47,42 +60,69 @@
     },
     {
       "command": "stackTrace",
-      "arguments": { "threadId": 1 },
+      "arguments": {
+        "threadId": 1
+      },
       "expectSuccess": true,
-      "requiredBodyKeys": ["stackFrames", "totalFrames"]
+      "requiredBodyKeys": [
+        "stackFrames",
+        "totalFrames"
+      ]
     },
     {
       "command": "scopes",
-      "arguments": { "frameId": 1 },
+      "arguments": {
+        "frameId": 1
+      },
       "expectSuccess": true,
-      "requiredBodyKeys": ["scopes"]
+      "requiredBodyKeys": [
+        "scopes"
+      ]
     },
     {
       "command": "variables",
-      "arguments": { "variablesReference": 1 },
+      "arguments": {
+        "variablesReference": 1
+      },
       "expectSuccess": true,
-      "requiredBodyKeys": ["variables"]
+      "requiredBodyKeys": [
+        "variables"
+      ]
     },
     {
       "command": "evaluate",
-      "arguments": { "expression": "$x" },
+      "arguments": {
+        "expression": "$x"
+      },
       "expectSuccess": false,
       "requiredMessageContains": "No debugger session"
     },
     {
       "command": "completions",
-      "arguments": { "text": "$foo", "column": 2 },
+      "arguments": {
+        "text": "$foo",
+        "column": 2
+      },
       "expectSuccess": true,
-      "requiredBodyKeys": ["targets"]
+      "requiredBodyKeys": [
+        "targets"
+      ]
     },
     {
       "command": "loadedSources",
       "expectSuccess": true,
-      "requiredBodyKeys": ["sources"]
+      "requiredBodyKeys": [
+        "sources"
+      ]
     },
     {
       "command": "disconnect",
-      "expectSuccess": true
+      "expectSuccess": true,
+      "expectedEvents": [
+        {
+          "event": "terminated"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Motivation

- Broaden DAP protocol conformance checks to catch subtle request/response/event shape and ordering regressions across an attach-mode lifecycle.
- Make failures more diagnostic by explicitly asserting event emission and response shape instead of relying on implicit smoke checks.

### Description

- Added richer reference-client fixtures `vscode_attach_conformance.json` and updated `vscode_mock_debug_smoke.json` to declare expected lifecycle events and required response keys.
- Added a golden transcript `reference_attach_full_sequence.json` that covers initialize→attach→setBreakpoints→configurationDone→continue→stackTrace→scopes→variables→evaluate→disconnect with event expectations.
- Extended test harnesses in `tests/dap_reference_client_conformance_tests.rs` and `tests/dap_golden_transcript_tests.rs` to resolve workspace vars, capture adapter events via an `mpsc` sender, and assert monotonic `seq`, `request_seq` echo correctness, required response body keys, event ordering, and message-content expectations.
- Preserved existing behavior while improving shape/ordering guards and added new test entries and replay checks with minimal API changes to `DebugAdapter` usage in tests.

### Testing

- Ran `cargo test -p perl-dap --test dap_reference_client_conformance_tests` and all tests passed.
- Ran `cargo test -p perl-dap --test dap_golden_transcript_tests` and all tests passed.
- Ran `cargo check --all-targets -p perl-dap` which completed successfully (with existing non-fatal test warnings in `tests/common/mod.rs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb398efe748333b40eb4243df8816a)