### PR TITLE
test(perl-dap): expand reference-client and golden-transcript conformance coverage (#0000)

### DIFF
--- a/crates/perl-dap/tests/dap_golden_transcript_tests.rs
+++ b/crates/perl-dap/tests/dap_golden_transcript_tests.rs
@@ -10,6 +10,7 @@ mod dap_golden_transcripts {
     use perl_dap::debug_adapter::{DapMessage, DebugAdapter};
     use serde_json::{Value, json};
     use std::path::PathBuf;
+    use std::sync::mpsc::{Receiver, channel};
 
     fn transcript_path(name: &str) -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -62,6 +63,14 @@ mod dap_golden_transcripts {
             _ => anyhow::bail!("expected response for {command}"),
         }
         Ok(())
+    }
+
+    fn drain_events(rx: &Receiver<DapMessage>) -> Vec<DapMessage> {
+        let mut events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            events.push(event);
+        }
+        events
     }
 
     /// Tests feature spec: DAP_IMPLEMENTATION_SPECIFICATION.md#ac13-hello-world-transcript
@@ -187,6 +196,183 @@ mod dap_golden_transcripts {
             }
             _ => anyhow::bail!("expected setBreakpoints response"),
         }
+        Ok(())
+    }
+
+    #[tokio::test]
+    // AC:13
+    async fn test_attach_lifecycle_golden_transcript_conformance() -> Result<()> {
+        let transcript = load_transcript("attach_lifecycle_sequence.json")?;
+        let messages = extract_messages(&transcript)?;
+
+        let mut adapter = DebugAdapter::new();
+        let (tx, rx) = channel();
+        adapter.set_event_sender(tx);
+
+        let mut request_seq = 1_i64;
+        let mut previous_response_seq = 0_i64;
+        let mut cursor = 0_usize;
+
+        while cursor < messages.len() {
+            let request = &messages[cursor];
+            if request["type"] != "request" {
+                anyhow::bail!("expected request at index {cursor}, got {:?}", request["type"]);
+            }
+
+            let command = request
+                .get("command")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow::anyhow!("request at index {cursor} missing command"))?;
+            let arguments = request.get("arguments").cloned();
+            let response = adapter.handle_request(request_seq, command, arguments);
+            request_seq += 1;
+
+            cursor += 1;
+            let expected_response = messages
+                .get(cursor)
+                .ok_or_else(|| anyhow::anyhow!("missing expected response after {command}"))?;
+            if expected_response["type"] != "response" {
+                anyhow::bail!(
+                    "expected response after {command}, got {:?}",
+                    expected_response["type"]
+                );
+            }
+
+            match response {
+                DapMessage::Response {
+                    seq,
+                    request_seq: echoed_request_seq,
+                    success,
+                    command: echoed_command,
+                    body,
+                    message,
+                } => {
+                    if seq <= previous_response_seq {
+                        anyhow::bail!(
+                            "{command} response seq not monotonic: {seq} <= {previous_response_seq}"
+                        );
+                    }
+                    previous_response_seq = seq;
+
+                    if echoed_request_seq != request_seq - 1 {
+                        anyhow::bail!(
+                            "{command} echoed request_seq {} does not match expected {}",
+                            echoed_request_seq,
+                            request_seq - 1
+                        );
+                    }
+
+                    if echoed_command != command {
+                        anyhow::bail!(
+                            "{command} response command echo mismatch: got {echoed_command}"
+                        );
+                    }
+
+                    let expected_success =
+                        expected_response.get("success").and_then(Value::as_bool).unwrap_or(true);
+                    if success != expected_success {
+                        anyhow::bail!(
+                            "{command} success mismatch: expected {expected_success}, got {success} with message {message:?}"
+                        );
+                    }
+
+                    if let Some(required_keys) =
+                        expected_response.get("requiredBodyKeys").and_then(Value::as_array)
+                    {
+                        let body = body.ok_or_else(|| {
+                            anyhow::anyhow!("{command} response missing body for required keys")
+                        })?;
+                        if !body.is_object() {
+                            anyhow::bail!("{command} response body is malformed (must be object)");
+                        }
+                        for key in required_keys {
+                            let key = key.as_str().ok_or_else(|| {
+                                anyhow::anyhow!("requiredBodyKeys for {command} must be strings")
+                            })?;
+                            if body.get(key).is_none() {
+                                anyhow::bail!("{command} response body missing key: {key}");
+                            }
+                        }
+                    } else if let Some(body) = body
+                        && !body.is_object()
+                    {
+                        anyhow::bail!("{command} response body is malformed (must be object)");
+                    }
+
+                    if let Some(required_message_substring) =
+                        expected_response.get("requiredMessageContains").and_then(Value::as_str)
+                    {
+                        let message = message.unwrap_or_default();
+                        if !message.contains(required_message_substring) {
+                            anyhow::bail!(
+                                "{command} response message must contain '{required_message_substring}', got: {message}"
+                            );
+                        }
+                    }
+                }
+                other => anyhow::bail!("expected response for {command}, got {other:?}"),
+            }
+
+            cursor += 1;
+            let mut expected_events = Vec::new();
+            while let Some(next) = messages.get(cursor) {
+                if next["type"] != "event" {
+                    break;
+                }
+                expected_events.push(next);
+                cursor += 1;
+            }
+
+            let actual_events = drain_events(&rx);
+            if actual_events.len() != expected_events.len() {
+                anyhow::bail!(
+                    "{command} event count mismatch: expected {}, got {}",
+                    expected_events.len(),
+                    actual_events.len()
+                );
+            }
+
+            for (event_idx, (expected, actual)) in
+                expected_events.iter().zip(actual_events.iter()).enumerate()
+            {
+                let expected_name = expected
+                    .get("event")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("expected event missing event name"))?;
+                match actual {
+                    DapMessage::Event { event, body, .. } => {
+                        if event != expected_name {
+                            anyhow::bail!(
+                                "{command} event ordering mismatch at index {event_idx}: expected {expected_name}, got {event}"
+                            );
+                        }
+                        if let Some(required_keys) =
+                            expected.get("requiredBodyKeys").and_then(Value::as_array)
+                        {
+                            let body = body.as_ref().ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "{command} event '{event}' missing body for required keys"
+                                )
+                            })?;
+                            for key in required_keys {
+                                let key = key.as_str().ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "event requiredBodyKeys entries must be strings"
+                                    )
+                                })?;
+                                if body.get(key).is_none() {
+                                    anyhow::bail!(
+                                        "{command} event '{event}' missing body key: {key}"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    other => anyhow::bail!("expected event, got {other:?}"),
+                }
+            }
+        }
+
         Ok(())
     }
 }

--- a/crates/perl-dap/tests/dap_reference_client_conformance_tests.rs
+++ b/crates/perl-dap/tests/dap_reference_client_conformance_tests.rs
@@ -1,96 +1,195 @@
 //! Reference-client conformance sweep for DAP.
 //!
-//! Replays a VS Code mock-debug-style request stream and verifies the adapter
+//! Replays VS Code mock-debug-style request streams and verifies the adapter
 //! returns spec-shaped responses across the command surface.
 
 use anyhow::{Result, anyhow};
 use perl_dap::{DapMessage, DebugAdapter};
 use serde_json::Value;
 use std::path::PathBuf;
+use std::sync::mpsc::{Receiver, channel};
 
-fn fixture_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/fixtures/reference_clients/vscode_mock_debug_smoke.json")
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/reference_clients")
 }
 
-fn load_fixture() -> Result<Value> {
-    let raw = std::fs::read_to_string(fixture_path())?;
+fn fixture_paths() -> Result<Vec<PathBuf>> {
+    let mut paths = std::fs::read_dir(fixture_dir())?
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("json"))
+        .collect::<Vec<_>>();
+    paths.sort();
+    Ok(paths)
+}
+
+fn load_fixture(path: &PathBuf) -> Result<Value> {
+    let raw = std::fs::read_to_string(path)?;
     Ok(serde_json::from_str(&raw)?)
+}
+
+fn collect_events(rx: &Receiver<DapMessage>) -> Vec<DapMessage> {
+    let mut events = Vec::new();
+    while let Ok(message) = rx.try_recv() {
+        events.push(message);
+    }
+    events
+}
+
+fn assert_expected_events(
+    command: &str,
+    request: &Value,
+    received_events: &[DapMessage],
+) -> Result<()> {
+    let expected_events = request
+        .get("expectedEventsAfterRequest")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    if expected_events.is_empty() {
+        return Ok(());
+    }
+
+    let actual_events = received_events
+        .iter()
+        .map(|msg| match msg {
+            DapMessage::Event { event, body, .. } => Some((event.as_str(), body)),
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| anyhow!("{command} emitted non-event messages in event stream"))?;
+
+    assert_eq!(
+        actual_events.len(),
+        expected_events.len(),
+        "{command} expected {} event(s) but got {}",
+        expected_events.len(),
+        actual_events.len()
+    );
+
+    for (idx, expected) in expected_events.iter().enumerate() {
+        let expected_name = expected
+            .get("event")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("expectedEventsAfterRequest[{idx}] missing event name"))?;
+        let (actual_name, actual_body) = actual_events[idx];
+        assert_eq!(actual_name, expected_name, "{command} event order mismatch at index {idx}");
+
+        if let Some(required_body_keys) = expected.get("requiredBodyKeys").and_then(Value::as_array)
+        {
+            let body = actual_body
+                .as_ref()
+                .ok_or_else(|| anyhow!("{command} event '{actual_name}' missing body"))?;
+            for key in required_body_keys {
+                let key = key
+                    .as_str()
+                    .ok_or_else(|| anyhow!("event requiredBodyKeys entries must be strings"))?;
+                assert!(
+                    body.get(key).is_some(),
+                    "{command} event '{actual_name}' body missing required key: {key}"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn assert_response_shape(command: &str, body: &Option<Value>, message: &Option<String>) {
+    if let Some(payload) = body {
+        assert!(payload.is_object(), "{command} response body must be a JSON object when present");
+    }
+
+    if let Some(text) = message {
+        assert!(
+            !text.trim().is_empty(),
+            "{command} response message must not be empty when present"
+        );
+    }
 }
 
 #[test]
 fn vscode_mock_debug_surface_conformance() -> Result<()> {
-    let fixture = load_fixture()?;
-    let requests = fixture
-        .get("requests")
-        .and_then(Value::as_array)
-        .ok_or_else(|| anyhow!("fixture requests must be an array"))?;
+    for fixture_path in fixture_paths()? {
+        let fixture = load_fixture(&fixture_path)?;
+        let requests = fixture
+            .get("requests")
+            .and_then(Value::as_array)
+            .ok_or_else(|| anyhow!("fixture requests must be an array"))?;
 
-    let mut adapter = DebugAdapter::new();
-    let mut prev_response_seq = 0_i64;
+        let mut adapter = DebugAdapter::new();
+        let (tx, rx) = channel();
+        adapter.set_event_sender(tx);
+        let mut prev_response_seq = 0_i64;
 
-    for (idx, request) in requests.iter().enumerate() {
-        let request_seq = (idx as i64) + 1;
-        let command = request
-            .get("command")
-            .and_then(Value::as_str)
-            .ok_or_else(|| anyhow!("request entry missing command"))?;
-        let arguments = request.get("arguments").cloned();
-        let expected_success =
-            request.get("expectSuccess").and_then(Value::as_bool).unwrap_or(true);
+        for (idx, request) in requests.iter().enumerate() {
+            let request_seq = (idx as i64) + 1;
+            let command = request
+                .get("command")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("request entry missing command"))?;
+            let arguments = request.get("arguments").cloned();
+            let expected_success =
+                request.get("expectSuccess").and_then(Value::as_bool).unwrap_or(true);
 
-        let response = adapter.handle_request(request_seq, command, arguments);
-        match response {
-            DapMessage::Response {
-                seq,
-                request_seq: echoed_request_seq,
-                success,
-                command: echoed_command,
-                body,
-                message,
-            } => {
-                assert!(
-                    seq > prev_response_seq,
-                    "response seq must increase monotonically for {command}"
-                );
-                prev_response_seq = seq;
-                assert_eq!(
-                    echoed_request_seq, request_seq,
-                    "request_seq echo mismatch for {command}"
-                );
-                assert_eq!(echoed_command, command, "command echo mismatch for {command}");
-                assert_eq!(
-                    success, expected_success,
-                    "success mismatch for {command}: {message:?}"
-                );
-
-                if let Some(required_message_substring) =
-                    request.get("requiredMessageContains").and_then(Value::as_str)
-                {
-                    let message = message.unwrap_or_default();
+            let response = adapter.handle_request(request_seq, command, arguments);
+            match response {
+                DapMessage::Response {
+                    seq,
+                    request_seq: echoed_request_seq,
+                    success,
+                    command: echoed_command,
+                    body,
+                    message,
+                } => {
                     assert!(
-                        message.contains(required_message_substring),
-                        "{command} response message must contain '{required_message_substring}', got: {message}"
+                        seq > prev_response_seq,
+                        "response seq must increase monotonically for {command}"
                     );
-                }
+                    prev_response_seq = seq;
+                    assert_eq!(
+                        echoed_request_seq, request_seq,
+                        "request_seq echo mismatch for {command}"
+                    );
+                    assert_eq!(echoed_command, command, "command echo mismatch for {command}");
+                    assert_eq!(
+                        success, expected_success,
+                        "success mismatch for {command}: {message:?}"
+                    );
+                    assert_response_shape(command, &body, &message);
 
-                if let Some(required_body_keys) =
-                    request.get("requiredBodyKeys").and_then(Value::as_array)
-                {
-                    let body = body.ok_or_else(|| anyhow!("{command} response missing body"))?;
-                    for key in required_body_keys {
-                        let key = key
-                            .as_str()
-                            .ok_or_else(|| anyhow!("requiredBodyKeys entries must be strings"))?;
+                    if let Some(required_message_substring) =
+                        request.get("requiredMessageContains").and_then(Value::as_str)
+                    {
+                        let message = message.unwrap_or_default();
                         assert!(
-                            body.get(key).is_some(),
-                            "{command} response body missing required key: {key}"
+                            message.contains(required_message_substring),
+                            "{command} response message must contain '{required_message_substring}', got: {message}"
                         );
                     }
+
+                    if let Some(required_body_keys) =
+                        request.get("requiredBodyKeys").and_then(Value::as_array)
+                    {
+                        let body =
+                            body.ok_or_else(|| anyhow!("{command} response missing body"))?;
+                        for key in required_body_keys {
+                            let key = key.as_str().ok_or_else(|| {
+                                anyhow!("requiredBodyKeys entries must be strings")
+                            })?;
+                            assert!(
+                                body.get(key).is_some(),
+                                "{command} response body missing required key: {key}"
+                            );
+                        }
+                    }
+
+                    let emitted_events = collect_events(&rx);
+                    assert_expected_events(command, request, &emitted_events)?;
                 }
-            }
-            other => {
-                return Err(anyhow!("expected response for {command}, got {other:?}"));
+                other => {
+                    return Err(anyhow!("expected response for {command}, got {other:?}"));
+                }
             }
         }
     }

--- a/crates/perl-dap/tests/fixtures/golden_transcripts/attach_lifecycle_sequence.json
+++ b/crates/perl-dap/tests/fixtures/golden_transcripts/attach_lifecycle_sequence.json
@@ -1,0 +1,150 @@
+{
+  "name": "attach_lifecycle_sequence",
+  "description": "Attach lifecycle with response-shape and event-order expectations",
+  "messages": [
+    {
+      "type": "request",
+      "command": "initialize",
+      "arguments": {
+        "adapterID": "perl",
+        "linesStartAt1": true,
+        "columnsStartAt1": true
+      }
+    },
+    {
+      "type": "response",
+      "command": "initialize",
+      "success": true,
+      "requiredBodyKeys": [
+        "supportsConfigurationDoneRequest",
+        "supportsSetVariable"
+      ]
+    },
+    {
+      "type": "event",
+      "event": "initialized"
+    },
+    {
+      "type": "request",
+      "command": "attach",
+      "arguments": {
+        "processId": 1,
+        "stopOnEntry": true
+      }
+    },
+    {
+      "type": "response",
+      "command": "attach",
+      "success": true,
+      "requiredBodyKeys": ["threadId", "processId", "mode"]
+    },
+    {
+      "type": "event",
+      "event": "stopped",
+      "requiredBodyKeys": ["reason", "threadId", "allThreadsStopped"]
+    },
+    {
+      "type": "event",
+      "event": "stopped",
+      "requiredBodyKeys": ["reason", "threadId", "allThreadsStopped", "description"]
+    },
+    {
+      "type": "request",
+      "command": "setBreakpoints",
+      "arguments": {
+        "source": {},
+        "breakpoints": []
+      }
+    },
+    {
+      "type": "response",
+      "command": "setBreakpoints",
+      "success": true,
+      "requiredBodyKeys": ["breakpoints"]
+    },
+    {
+      "type": "request",
+      "command": "configurationDone",
+      "arguments": {}
+    },
+    {
+      "type": "response",
+      "command": "configurationDone",
+      "success": true
+    },
+    {
+      "type": "request",
+      "command": "continue",
+      "arguments": { "threadId": 1 }
+    },
+    {
+      "type": "response",
+      "command": "continue",
+      "success": true,
+      "requiredBodyKeys": ["allThreadsContinued"]
+    },
+    {
+      "type": "event",
+      "event": "continued",
+      "requiredBodyKeys": ["threadId", "allThreadsContinued"]
+    },
+    {
+      "type": "request",
+      "command": "stackTrace",
+      "arguments": { "threadId": 1 }
+    },
+    {
+      "type": "response",
+      "command": "stackTrace",
+      "success": true,
+      "requiredBodyKeys": ["stackFrames", "totalFrames"]
+    },
+    {
+      "type": "request",
+      "command": "scopes",
+      "arguments": { "frameId": 1 }
+    },
+    {
+      "type": "response",
+      "command": "scopes",
+      "success": true,
+      "requiredBodyKeys": ["scopes"]
+    },
+    {
+      "type": "request",
+      "command": "variables",
+      "arguments": { "variablesReference": 11 }
+    },
+    {
+      "type": "response",
+      "command": "variables",
+      "success": true,
+      "requiredBodyKeys": ["variables"]
+    },
+    {
+      "type": "request",
+      "command": "evaluate",
+      "arguments": { "expression": "$x" }
+    },
+    {
+      "type": "response",
+      "command": "evaluate",
+      "success": false,
+      "requiredMessageContains": "processId attach"
+    },
+    {
+      "type": "request",
+      "command": "disconnect",
+      "arguments": {}
+    },
+    {
+      "type": "response",
+      "command": "disconnect",
+      "success": true
+    },
+    {
+      "type": "event",
+      "event": "terminated"
+    }
+  ]
+}

--- a/crates/perl-dap/tests/fixtures/reference_clients/vscode_mock_debug_attach_lifecycle.json
+++ b/crates/perl-dap/tests/fixtures/reference_clients/vscode_mock_debug_attach_lifecycle.json
@@ -1,0 +1,116 @@
+{
+  "client": "vscode-mock-debug",
+  "description": "Reference-client lifecycle sweep for attach mode with protocol-shape assertions",
+  "requests": [
+    {
+      "command": "initialize",
+      "arguments": {
+        "clientID": "vscode",
+        "clientName": "Visual Studio Code",
+        "adapterID": "mock",
+        "pathFormat": "path",
+        "linesStartAt1": true,
+        "columnsStartAt1": true,
+        "locale": "en-US"
+      },
+      "expectSuccess": true,
+      "requiredBodyKeys": [
+        "supportsConfigurationDoneRequest",
+        "supportsSetVariable",
+        "supportsCompletionsRequest"
+      ],
+      "expectedEventsAfterRequest": [
+        {
+          "event": "initialized"
+        }
+      ]
+    },
+    {
+      "command": "attach",
+      "arguments": {
+        "processId": 1,
+        "stopOnEntry": true
+      },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["threadId", "processId", "mode"],
+      "expectedEventsAfterRequest": [
+        {
+          "event": "stopped",
+          "requiredBodyKeys": ["reason", "threadId", "allThreadsStopped"]
+        },
+        {
+          "event": "stopped",
+          "requiredBodyKeys": ["reason", "threadId", "allThreadsStopped", "description"]
+        }
+      ]
+    },
+    {
+      "command": "setBreakpoints",
+      "arguments": {
+        "source": {},
+        "breakpoints": []
+      },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["breakpoints"]
+    },
+    {
+      "command": "configurationDone",
+      "expectSuccess": true
+    },
+    {
+      "command": "continue",
+      "arguments": {
+        "threadId": 1
+      },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["allThreadsContinued"],
+      "expectedEventsAfterRequest": [
+        {
+          "event": "continued",
+          "requiredBodyKeys": ["threadId", "allThreadsContinued"]
+        }
+      ]
+    },
+    {
+      "command": "stackTrace",
+      "arguments": {
+        "threadId": 1
+      },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["stackFrames", "totalFrames"]
+    },
+    {
+      "command": "scopes",
+      "arguments": {
+        "frameId": 1
+      },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["scopes"]
+    },
+    {
+      "command": "variables",
+      "arguments": {
+        "variablesReference": 11
+      },
+      "expectSuccess": true,
+      "requiredBodyKeys": ["variables"]
+    },
+    {
+      "command": "evaluate",
+      "arguments": {
+        "expression": "$x"
+      },
+      "expectSuccess": false,
+      "requiredMessageContains": "processId attach"
+    },
+    {
+      "command": "disconnect",
+      "expectSuccess": true,
+      "expectedEventsAfterRequest": [
+        {
+          "event": "terminated"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Strengthen DAP protocol accuracy by expanding the request/response/event conformance bank to cover a richer attach lifecycle and lifecycle-driven event flows.
- Make failures easier to diagnose by asserting sequencing, echoed request ids, required body/message keys, event ordering, and rejecting malformed shapes.

### Description
- Sweep reference-client fixtures (directory) rather than a single hardcoded file and add event-aware assertions via new helpers `collect_events` / `drain_events` and `assert_expected_events`.
- Add a new reference-client fixture `vscode_mock_debug_attach_lifecycle.json` exercising `initialize`, `attach`, `setBreakpoints`, `configurationDone`, `continue`, `stackTrace`, `scopes`, `variables`, `evaluate`, and `disconnect` with per-request expected events and required keys.
- Add a golden-transcript fixture `attach_lifecycle_sequence.json` and a new test `test_attach_lifecycle_golden_transcript_conformance` that replays the transcript and asserts monotonic response `seq`, correct `request_seq` echoing, required body/message keys, event ordering, and response shape validation.
- Add small test helpers and response-shape checks (`assert_response_shape`) in `dap_reference_client_conformance_tests.rs` and `dap_golden_transcript_tests.rs` to centralize conformance assertions.

### Testing
- Ran `cargo test -p perl-dap --test dap_reference_client_conformance_tests` and it passed.
- Ran `cargo test -p perl-dap --test dap_golden_transcript_tests` and it passed.
- Ran `cargo check --all-targets -p perl-dap` and it completed successfully.
- Ran `cargo xtask fmt` to format changes and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb398efe748333b40eb4243df8816a)