### PR TITLE
test(perl-dap): harden attach and bridge lifecycle reliability (#0000)

### DIFF
--- a/crates/perl-dap/tests/bridge_integration_tests.rs
+++ b/crates/perl-dap/tests/bridge_integration_tests.rs
@@ -468,3 +468,34 @@ async fn test_empty_environment_handling() -> Result<()> {
 
     Ok(())
 }
+
+/// Test: proxy_messages reports clear lifecycle error before spawn
+#[tokio::test]
+async fn test_bridge_proxy_requires_spawn() -> Result<()> {
+    use perl_dap::BridgeAdapter;
+
+    let mut adapter = BridgeAdapter::new();
+    let err =
+        adapter.proxy_messages().await.err().ok_or_else(|| {
+            anyhow::anyhow!("proxy_messages unexpectedly succeeded without spawn")
+        })?;
+    let message = err.to_string();
+    assert!(
+        message.contains("spawn_pls_dap"),
+        "lifecycle guidance should mention spawn_pls_dap, got: {message}"
+    );
+
+    Ok(())
+}
+
+/// Test: shutdown is idempotent even when no bridge process exists
+#[tokio::test]
+async fn test_bridge_shutdown_is_idempotent_without_spawn() -> Result<()> {
+    use perl_dap::BridgeAdapter;
+
+    let mut adapter = BridgeAdapter::new();
+    adapter.shutdown().await?;
+    adapter.shutdown().await?;
+
+    Ok(())
+}

--- a/crates/perl-dap/tests/dap_attach_e2e.rs
+++ b/crates/perl-dap/tests/dap_attach_e2e.rs
@@ -8,7 +8,7 @@ use perl_lsp_rs_core::transport::framing::frame;
 use serde_json::{Value, json};
 use std::error::Error;
 use std::io::{Read, Write};
-use std::net::TcpListener;
+use std::net::{SocketAddr, TcpListener};
 use std::sync::mpsc::{Receiver, channel};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -76,28 +76,30 @@ fn event_body(message: &DapMessage) -> Option<&Value> {
     }
 }
 
-#[test]
-fn dap_attach_e2e_tcp_loopback() -> TestResult {
+fn spawn_fake_debugger(
+    send_stopped: bool,
+) -> Result<(SocketAddr, thread::JoinHandle<()>), Box<dyn Error>> {
     let listener = TcpListener::bind(("127.0.0.1", 0))?;
-    let port = listener.local_addr()?.port();
-
+    let address = listener.local_addr()?;
     let server_handle = thread::spawn(move || {
         let result = (|| -> Result<(), Box<dyn Error + Send + Sync>> {
             let (mut socket, _) = listener.accept()?;
 
-            let stopped_event = json!({
-                "type": "event",
-                "seq": 1,
-                "event": "stopped",
-                "body": {
-                    "reason": "breakpoint",
-                    "threadId": 7,
-                    "allThreadsStopped": true
-                }
-            })
-            .to_string();
-            socket.write_all(&frame(stopped_event.as_bytes()))?;
-            socket.flush()?;
+            if send_stopped {
+                let stopped_event = json!({
+                    "type": "event",
+                    "seq": 1,
+                    "event": "stopped",
+                    "body": {
+                        "reason": "breakpoint",
+                        "threadId": 7,
+                        "allThreadsStopped": true
+                    }
+                })
+                .to_string();
+                socket.write_all(&frame(stopped_event.as_bytes()))?;
+                socket.flush()?;
+            }
 
             let mut buf = [0u8; 512];
             loop {
@@ -116,6 +118,13 @@ fn dap_attach_e2e_tcp_loopback() -> TestResult {
             panic!("fake TCP debugger server failed: {err}");
         }
     });
+    Ok((address, server_handle))
+}
+
+#[test]
+fn dap_attach_e2e_tcp_loopback() -> TestResult {
+    let (address, server_handle) = spawn_fake_debugger(true)?;
+    let port = address.port();
 
     let timeout = smoke_timeout();
     let mut adapter = DebugAdapter::new();
@@ -159,5 +168,73 @@ fn dap_attach_e2e_tcp_loopback() -> TestResult {
     let _terminated = wait_for_event(&rx, "terminated", timeout)?;
 
     server_handle.join().map_err(|_| std::io::Error::other("fake TCP debugger server panicked"))?;
+    Ok(())
+}
+
+#[test]
+fn dap_attach_e2e_reconnect_and_terminate() -> TestResult {
+    let timeout = smoke_timeout();
+    let mut adapter = DebugAdapter::new();
+    let (tx, rx) = channel();
+    adapter.set_event_sender(tx);
+
+    response_success(adapter.handle_request(1, "initialize", None), "initialize")?;
+    let _initialized = wait_for_event(&rx, "initialized", timeout)?;
+
+    let (first_address, first_server) = spawn_fake_debugger(false)?;
+    response_success(
+        adapter.handle_request(
+            2,
+            "attach",
+            Some(json!({
+                "host": "127.0.0.1",
+                "port": first_address.port(),
+                "timeout": 2000,
+                "stopOnEntry": true
+            })),
+        ),
+        "attach",
+    )?;
+
+    let first_stopped = wait_for_event(&rx, "stopped", timeout)?;
+    let first_stopped_body =
+        event_body(&first_stopped).ok_or("first stopped event missing body")?;
+    assert_eq!(first_stopped_body.get("reason").and_then(Value::as_str), Some("entry"));
+
+    response_success(
+        adapter.handle_request(3, "terminate", Some(json!({"restart": true}))),
+        "terminate",
+    )?;
+    let terminated = wait_for_event(&rx, "terminated", timeout)?;
+    let terminated_body = event_body(&terminated).ok_or("terminated event missing body")?;
+    assert_eq!(terminated_body.get("restart").and_then(Value::as_bool), Some(true));
+
+    first_server
+        .join()
+        .map_err(|_| std::io::Error::other("first fake debugger server panicked"))?;
+
+    let (second_address, second_server) = spawn_fake_debugger(true)?;
+    response_success(
+        adapter.handle_request(
+            4,
+            "attach",
+            Some(json!({
+                "host": "127.0.0.1",
+                "port": second_address.port(),
+                "timeout": 2000
+            })),
+        ),
+        "attach",
+    )?;
+
+    let second_stopped = wait_for_event(&rx, "stopped", timeout)?;
+    let second_body = event_body(&second_stopped).ok_or("second stopped event missing body")?;
+    assert_eq!(second_body.get("reason").and_then(Value::as_str), Some("breakpoint"));
+
+    response_success(adapter.handle_request(5, "disconnect", Some(json!({}))), "disconnect")?;
+    let _ = wait_for_event(&rx, "terminated", timeout)?;
+    second_server
+        .join()
+        .map_err(|_| std::io::Error::other("second fake debugger server panicked"))?;
     Ok(())
 }

--- a/crates/perl-dap/tests/tcp_attach_tests.rs
+++ b/crates/perl-dap/tests/tcp_attach_tests.rs
@@ -278,3 +278,79 @@ fn test_tcp_attach_reader_handles_concatenated_frames() {
 
     must(server_handle.join().map_err(|_| "Server thread panicked".to_string()));
 }
+
+#[test]
+fn test_tcp_attach_connect_timeout_reports_address() {
+    // Port 9 (discard) is expected to be closed in local test environments.
+    let mut session = TcpAttachSession::new();
+    let config = TcpAttachConfig::new("127.0.0.1".to_string(), 9).with_timeout(50);
+
+    let err = must(session.connect(&config).err().ok_or("connect unexpectedly succeeded"));
+    let message = err.to_string();
+    assert!(message.contains("127.0.0.1:9"), "error should include address: {message}");
+}
+
+#[test]
+fn test_tcp_attach_reader_emits_terminated_when_remote_closes() {
+    let listener = must(TcpListener::bind(("127.0.0.1", 0)));
+    let port = must(listener.local_addr()).port();
+
+    let server_handle = thread::spawn(move || {
+        let (socket, _) = must(listener.accept());
+        drop(socket);
+    });
+
+    let mut session = TcpAttachSession::new();
+    let (event_tx, event_rx) = channel::<DapEvent>();
+    session.set_event_sender(event_tx);
+    let config = TcpAttachConfig::new("127.0.0.1".to_string(), port).with_timeout(2000);
+
+    must(session.connect(&config));
+    must(session.start_reader());
+
+    let event = must(event_rx.recv_timeout(Duration::from_secs(2)));
+    match event {
+        DapEvent::Terminated { reason } => {
+            assert_eq!(reason, "connection_closed");
+        }
+        other => must(Err::<(), _>(format!("Expected Terminated event, got {other:?}"))),
+    }
+
+    must(server_handle.join().map_err(|_| "Server thread panicked".to_string()));
+}
+
+#[test]
+fn test_tcp_attach_can_reconnect_after_disconnect() {
+    let first_listener = must(TcpListener::bind(("127.0.0.1", 0)));
+    let first_port = must(first_listener.local_addr()).port();
+    let first_server = thread::spawn(move || {
+        let (socket, _) = must(first_listener.accept());
+        drop(socket);
+    });
+
+    let second_listener = must(TcpListener::bind(("127.0.0.1", 0)));
+    let second_port = must(second_listener.local_addr()).port();
+    let second_server = thread::spawn(move || {
+        let (socket, _) = must(second_listener.accept());
+        drop(socket);
+    });
+
+    let mut session = TcpAttachSession::new();
+    let first_config = TcpAttachConfig::new("127.0.0.1".to_string(), first_port).with_timeout(2000);
+    must(session.connect(&first_config));
+    assert!(session.is_connected());
+
+    must(session.disconnect());
+    assert!(!session.is_connected());
+
+    let second_config =
+        TcpAttachConfig::new("127.0.0.1".to_string(), second_port).with_timeout(2000);
+    must(session.connect(&second_config));
+    assert!(session.is_connected());
+
+    must(session.disconnect());
+    assert!(!session.is_connected());
+
+    must(first_server.join().map_err(|_| "First server panicked".to_string()));
+    must(second_server.join().map_err(|_| "Second server panicked".to_string()));
+}


### PR DESCRIPTION
### Motivation
- Improve reliability and observability of TCP attach and bridge-mode workflows by promoting previously-deferred checks into hardened end-to-end and integration tests so regressions are easier to diagnose.

### Description
- Added a reusable loopback helper `spawn_fake_debugger` and rewired the e2e attach smoke test to use it, plus a second e2e test `dap_attach_e2e_reconnect_and_terminate` that exercises stop-on-entry, terminate-with-restart, reconnect, and final disconnect lifecycle paths.
- Extended TCP attach unit/integration coverage with `test_tcp_attach_connect_timeout_reports_address`, `test_tcp_attach_reader_emits_terminated_when_remote_closes`, and `test_tcp_attach_can_reconnect_after_disconnect` to validate timeout diagnostics, terminated-event emission, and reconnect/cleanup behavior.
- Added bridge lifecycle guards `test_bridge_proxy_requires_spawn` and `test_bridge_shutdown_is_idempotent_without_spawn` to keep bridge proxying behavior and shutdown idempotence explicit while bridge mode remains supported.
- All changes are test-only (no production src changes), focused on attach/bridge behaviors to avoid scope drift.

### Testing
- Ran `cargo test -p perl-dap --test dap_attach_e2e` and all tests passed.
- Ran `cargo test -p perl-dap --test tcp_attach_tests` and all tests passed.
- Ran `cargo test -p perl-dap --test bridge_integration_tests` and all tests passed.
- Ran `cargo check --all-targets -p perl-dap` and `cargo xtask fmt` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3992f3188333947ec51a9b1a582a)