### PR TITLE
test(perl-dap): harden attach and bridge lifecycle reliability (#0000)

### DIFF
--- a/crates/perl-dap/src/tcp_attach.rs
+++ b/crates/perl-dap/src/tcp_attach.rs
@@ -151,9 +151,9 @@ impl TcpAttachSession {
     pub fn disconnect(&mut self) -> Result<()> {
         if let Some(stream) = self.stream.take() {
             stream.shutdown(std::net::Shutdown::Both)?;
-            *self.connected.lock().unwrap_or_else(|e| e.into_inner()) = false;
             tracing::info!("Disconnected from Perl debugger");
         }
+        *self.connected.lock().unwrap_or_else(|e| e.into_inner()) = false;
         Ok(())
     }
 

--- a/crates/perl-dap/tests/bridge_integration_tests.rs
+++ b/crates/perl-dap/tests/bridge_integration_tests.rs
@@ -448,6 +448,34 @@ fn test_bridge_adapter_multiple_instances() -> Result<()> {
     Ok(())
 }
 
+/// Test: proxy_messages requires an active bridge child process
+#[tokio::test]
+async fn test_bridge_proxy_messages_requires_spawn() -> Result<()> {
+    use perl_dap::BridgeAdapter;
+
+    let mut adapter = BridgeAdapter::new();
+    let err = match adapter.proxy_messages().await {
+        Ok(()) => anyhow::bail!("proxy_messages should fail when child process is not started"),
+        Err(err) => err,
+    };
+    assert!(
+        err.to_string().contains("Child process not spawned"),
+        "error should explain missing child process: {err}"
+    );
+    Ok(())
+}
+
+/// Test: bridge shutdown is safe and idempotent without a running child process
+#[tokio::test]
+async fn test_bridge_shutdown_without_spawn_is_idempotent() -> Result<()> {
+    use perl_dap::BridgeAdapter;
+
+    let mut adapter = BridgeAdapter::new();
+    adapter.shutdown().await?;
+    adapter.shutdown().await?;
+    Ok(())
+}
+
 /// Test: Empty environment variables are handled correctly
 #[tokio::test]
 async fn test_empty_environment_handling() -> Result<()> {

--- a/crates/perl-dap/tests/dap_attach_e2e.rs
+++ b/crates/perl-dap/tests/dap_attach_e2e.rs
@@ -161,3 +161,110 @@ fn dap_attach_e2e_tcp_loopback() -> TestResult {
     server_handle.join().map_err(|_| std::io::Error::other("fake TCP debugger server panicked"))?;
     Ok(())
 }
+
+#[test]
+fn dap_attach_e2e_tcp_loopback_stop_on_entry() -> TestResult {
+    let listener = TcpListener::bind(("127.0.0.1", 0))?;
+    let port = listener.local_addr()?.port();
+
+    let server_handle = thread::spawn(move || {
+        let result = (|| -> Result<(), Box<dyn Error + Send + Sync>> {
+            let (mut socket, _) = listener.accept()?;
+
+            let stopped_event = json!({
+                "type": "event",
+                "seq": 2,
+                "event": "stopped",
+                "body": {
+                    "reason": "step",
+                    "threadId": 99,
+                    "allThreadsStopped": true
+                }
+            })
+            .to_string();
+            socket.write_all(&frame(stopped_event.as_bytes()))?;
+            socket.flush()?;
+            Ok(())
+        })();
+
+        if let Err(err) = result {
+            panic!("fake TCP debugger server failed: {err}");
+        }
+    });
+
+    let timeout = smoke_timeout();
+    let mut adapter = DebugAdapter::new();
+    let (tx, rx) = channel();
+    adapter.set_event_sender(tx);
+
+    response_success(adapter.handle_request(1, "initialize", None), "initialize")?;
+    let _initialized = wait_for_event(&rx, "initialized", timeout)?;
+
+    response_success(
+        adapter.handle_request(
+            2,
+            "attach",
+            Some(json!({
+                "host": "127.0.0.1",
+                "port": port,
+                "timeout": 2000,
+                "stopOnEntry": true
+            })),
+        ),
+        "attach",
+    )?;
+
+    let stopped_a = wait_for_event(&rx, "stopped", timeout)?;
+    let stopped_b = wait_for_event(&rx, "stopped", timeout)?;
+    let reasons = [
+        event_body(&stopped_a)
+            .and_then(|body| body.get("reason"))
+            .and_then(Value::as_str)
+            .ok_or("first stopped event missing reason")?,
+        event_body(&stopped_b)
+            .and_then(|body| body.get("reason"))
+            .and_then(Value::as_str)
+            .ok_or("second stopped event missing reason")?,
+    ];
+    assert!(reasons.contains(&"entry"), "one stopped event should be stopOnEntry");
+    assert!(reasons.contains(&"step"), "one stopped event should come from TCP debugger");
+
+    response_success(adapter.handle_request(3, "disconnect", Some(json!({}))), "disconnect")?;
+    let _terminated = wait_for_event(&rx, "terminated", timeout)?;
+
+    server_handle.join().map_err(|_| std::io::Error::other("fake TCP debugger server panicked"))?;
+    Ok(())
+}
+
+#[test]
+fn dap_attach_e2e_tcp_timeout_error_includes_context() -> TestResult {
+    let mut adapter = DebugAdapter::new();
+    response_success(adapter.handle_request(1, "initialize", None), "initialize")?;
+
+    let attach = adapter.handle_request(
+        2,
+        "attach",
+        Some(json!({
+            "host": "203.0.113.1",
+            "port": 9,
+            "timeout": 50
+        })),
+    );
+
+    match attach {
+        DapMessage::Response { success, command, message, .. } => {
+            assert!(!success, "attach should fail for an unreachable target");
+            assert_eq!(command, "attach");
+            let details = message.ok_or("attach failure missing message")?;
+            assert!(
+                details.contains("Cannot attach to Perl debugger"),
+                "message should include attach failure context"
+            );
+            assert!(details.contains("50ms timeout"), "message should report timeout settings");
+            assert!(details.contains("203.0.113.1:9"), "message should include connection target");
+        }
+        _ => return Err("expected attach response".into()),
+    }
+
+    Ok(())
+}

--- a/crates/perl-dap/tests/tcp_attach_tests.rs
+++ b/crates/perl-dap/tests/tcp_attach_tests.rs
@@ -16,7 +16,7 @@ use std::io::Write;
 use std::net::TcpListener;
 use std::sync::mpsc::channel;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Test helper to create a valid TCP attach configuration
 fn create_valid_config() -> TcpAttachConfig {
@@ -277,4 +277,110 @@ fn test_tcp_attach_reader_handles_concatenated_frames() {
     }
 
     must(server_handle.join().map_err(|_| "Server thread panicked".to_string()));
+}
+
+#[test]
+fn test_tcp_attach_reader_emits_stopped_event() {
+    let listener = must(TcpListener::bind(("127.0.0.1", 0)));
+    let port = must(listener.local_addr()).port();
+
+    let server_handle = thread::spawn(move || {
+        let (mut socket, _) = must(listener.accept());
+        let stopped_event = serde_json::json!({
+            "type": "event",
+            "seq": 1,
+            "event": "stopped",
+            "body": {
+                "reason": "pause",
+                "threadId": 13
+            }
+        })
+        .to_string();
+
+        must(socket.write_all(&frame(stopped_event.as_bytes())));
+        must(socket.flush());
+    });
+
+    let mut session = TcpAttachSession::new();
+    let (event_tx, event_rx) = channel::<DapEvent>();
+    session.set_event_sender(event_tx);
+    let config = TcpAttachConfig::new("127.0.0.1".to_string(), port).with_timeout(2000);
+
+    must(session.connect(&config));
+    must(session.start_reader());
+
+    let event = must(event_rx.recv_timeout(Duration::from_secs(2)));
+    match event {
+        DapEvent::Stopped { reason, thread_id } => {
+            assert_eq!(reason, "pause");
+            assert_eq!(thread_id, 13);
+        }
+        other => must(Err::<(), _>(format!("Expected Stopped event, got {other:?}"))),
+    }
+
+    must(server_handle.join().map_err(|_| "Server thread panicked".to_string()));
+}
+
+#[test]
+fn test_tcp_attach_reader_emits_terminated_on_remote_close() {
+    let listener = must(TcpListener::bind(("127.0.0.1", 0)));
+    let port = must(listener.local_addr()).port();
+
+    let server_handle = thread::spawn(move || {
+        let (_socket, _) = must(listener.accept());
+    });
+
+    let mut session = TcpAttachSession::new();
+    let (event_tx, event_rx) = channel::<DapEvent>();
+    session.set_event_sender(event_tx);
+    let config = TcpAttachConfig::new("127.0.0.1".to_string(), port).with_timeout(2000);
+
+    must(session.connect(&config));
+    must(session.start_reader());
+
+    let terminated = must(event_rx.recv_timeout(Duration::from_secs(2)));
+    match terminated {
+        DapEvent::Terminated { reason } => assert_eq!(reason, "connection_closed"),
+        other => must(Err::<(), _>(format!("Expected Terminated event, got {other:?}"))),
+    }
+
+    assert!(!session.is_connected(), "Session should mark disconnected after EOF");
+    must(server_handle.join().map_err(|_| "Server thread panicked".to_string()));
+}
+
+#[test]
+fn test_tcp_attach_session_can_reconnect_after_remote_close() {
+    let listener1 = must(TcpListener::bind(("127.0.0.1", 0)));
+    let port1 = must(listener1.local_addr()).port();
+    let server1 = thread::spawn(move || {
+        let (_socket, _) = must(listener1.accept());
+    });
+
+    let listener2 = must(TcpListener::bind(("127.0.0.1", 0)));
+    let port2 = must(listener2.local_addr()).port();
+    let server2 = thread::spawn(move || {
+        let (_socket, _) = must(listener2.accept());
+    });
+
+    let mut session = TcpAttachSession::new();
+    let (event_tx, event_rx) = channel::<DapEvent>();
+    session.set_event_sender(event_tx);
+
+    must(session.connect(&TcpAttachConfig::new("127.0.0.1".to_string(), port1).with_timeout(2000)));
+    must(session.start_reader());
+    let _ = must(event_rx.recv_timeout(Duration::from_secs(2)));
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while session.is_connected() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert!(!session.is_connected(), "Session should reset connected state after reader EOF");
+
+    must(session.connect(&TcpAttachConfig::new("127.0.0.1".to_string(), port2).with_timeout(2000)));
+    assert!(session.is_connected(), "Session should reconnect after a previous closure");
+    must(session.disconnect());
+    assert!(!session.is_connected(), "Disconnect should clear connected state");
+
+    must(server1.join().map_err(|_| "Server1 thread panicked".to_string()));
+    must(server2.join().map_err(|_| "Server2 thread panicked".to_string()));
 }


### PR DESCRIPTION
### Motivation
- Improve robustness of TCP attach lifecycle and make bridge-mode behavior easier to diagnose by promoting a deferred attach state change into the hardened disconnect path and by adding focused integration tests.

### Description
- Ensure `TcpAttachSession::disconnect()` always clears the internal `connected` flag even when the socket handle has been moved into the reader thread (`crates/perl-dap/src/tcp_attach.rs`).
- Add an e2e attach smoke test that exercises `stopOnEntry` and verifies both the synthetic entry `stopped` and the debugger-emitted `stopped` event, and add an attach timeout diagnostic assertion (`crates/perl-dap/tests/dap_attach_e2e.rs`).
- Add targeted TCP lifecycle tests that assert `stopped` propagation, `terminated` emission on remote EOF, and reconnect/cleanup behavior after a remote close (`crates/perl-dap/tests/tcp_attach_tests.rs`).
- Add bridge lifecycle tests to assert `proxy_messages()` returns a helpful error when no child is spawned and that `shutdown()` is safe/idempotent without a running child (`crates/perl-dap/tests/bridge_integration_tests.rs`).

### Testing
- Ran `cargo xtask fmt` successfully.
- Ran `cargo test -p perl-dap --test dap_attach_e2e` and all tests passed.
- Ran `cargo test -p perl-dap --test tcp_attach_tests` and all tests passed.
- Ran `cargo test -p perl-dap --test bridge_integration_tests` and all tests passed.
- Ran `cargo check --all-targets -p perl-dap` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3992f3188333947ec51a9b1a582a)