### PR TITLE
test(perl-dap): harden attach and bridge lifecycle reliability (#0000)

### DIFF
--- a/crates/perl-dap/src/tcp_attach.rs
+++ b/crates/perl-dap/src/tcp_attach.rs
@@ -122,6 +122,7 @@ impl TcpAttachSession {
     /// Connect to the debugger via TCP
     pub fn connect(&mut self, config: &TcpAttachConfig) -> Result<()> {
         config.validate()?;
+        let _ = self.disconnect();
 
         let address = format!("{}:{}", config.host, config.port);
         tracing::info!(address, "Connecting to Perl debugger");
@@ -149,9 +150,10 @@ impl TcpAttachSession {
 
     /// Disconnect from the debugger
     pub fn disconnect(&mut self) -> Result<()> {
+        *self.connected.lock().unwrap_or_else(|e| e.into_inner()) = false;
+
         if let Some(stream) = self.stream.take() {
             stream.shutdown(std::net::Shutdown::Both)?;
-            *self.connected.lock().unwrap_or_else(|e| e.into_inner()) = false;
             tracing::info!("Disconnected from Perl debugger");
         }
         Ok(())

--- a/crates/perl-dap/tests/bridge_integration_tests.rs
+++ b/crates/perl-dap/tests/bridge_integration_tests.rs
@@ -448,6 +448,33 @@ fn test_bridge_adapter_multiple_instances() -> Result<()> {
     Ok(())
 }
 
+/// Test: Bridge proxy rejects use before process spawn
+#[tokio::test]
+async fn test_bridge_proxy_requires_spawned_process() -> Result<()> {
+    use perl_dap::BridgeAdapter;
+
+    let mut adapter = BridgeAdapter::new();
+    let result = adapter.proxy_messages().await;
+    assert!(result.is_err(), "proxy should fail before spawn_pls_dap()");
+
+    let message = format!("{:?}", result.err());
+    assert!(message.contains("Child process not spawned"), "unexpected error message: {message}");
+
+    Ok(())
+}
+
+/// Test: Bridge shutdown is idempotent when no child process exists
+#[tokio::test]
+async fn test_bridge_shutdown_without_spawn_is_safe() -> Result<()> {
+    use perl_dap::BridgeAdapter;
+
+    let mut adapter = BridgeAdapter::new();
+    adapter.shutdown().await?;
+    adapter.shutdown().await?;
+
+    Ok(())
+}
+
 /// Test: Empty environment variables are handled correctly
 #[tokio::test]
 async fn test_empty_environment_handling() -> Result<()> {

--- a/crates/perl-dap/tests/dap_attach_e2e.rs
+++ b/crates/perl-dap/tests/dap_attach_e2e.rs
@@ -161,3 +161,119 @@ fn dap_attach_e2e_tcp_loopback() -> TestResult {
     server_handle.join().map_err(|_| std::io::Error::other("fake TCP debugger server panicked"))?;
     Ok(())
 }
+
+#[test]
+fn dap_attach_e2e_stop_on_entry_and_terminate() -> TestResult {
+    let listener = TcpListener::bind(("127.0.0.1", 0))?;
+    let port = listener.local_addr()?.port();
+
+    let server_handle = thread::spawn(move || {
+        let result = (|| -> Result<(), Box<dyn Error + Send + Sync>> {
+            let (mut socket, _) = listener.accept()?;
+
+            let stopped_event = json!({
+                "type": "event",
+                "seq": 1,
+                "event": "stopped",
+                "body": {
+                    "reason": "step",
+                    "threadId": 12,
+                    "allThreadsStopped": true
+                }
+            })
+            .to_string();
+            socket.write_all(&frame(stopped_event.as_bytes()))?;
+            socket.flush()?;
+
+            let mut buf = [0u8; 256];
+            loop {
+                match socket.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(_) => continue,
+                    Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+                    Err(err) => return Err(Box::new(err)),
+                }
+            }
+            Ok(())
+        })();
+
+        if let Err(err) = result {
+            panic!("fake TCP debugger server failed: {err}");
+        }
+    });
+
+    let timeout = smoke_timeout();
+    let mut adapter = DebugAdapter::new();
+    let (tx, rx) = channel();
+    adapter.set_event_sender(tx);
+
+    response_success(adapter.handle_request(1, "initialize", None), "initialize")?;
+    let _initialized = wait_for_event(&rx, "initialized", timeout)?;
+
+    response_success(
+        adapter.handle_request(
+            2,
+            "attach",
+            Some(json!({
+                "host": "127.0.0.1",
+                "port": port,
+                "timeout": 2000,
+                "stopOnEntry": true
+            })),
+        ),
+        "attach",
+    )?;
+
+    let entry_stopped = wait_for_event(&rx, "stopped", timeout)?;
+    let entry_stopped_body =
+        event_body(&entry_stopped).ok_or("entry stopped event missing body")?;
+    assert_eq!(entry_stopped_body.get("reason").and_then(Value::as_str), Some("entry"));
+
+    let remote_stopped = wait_for_event(&rx, "stopped", timeout)?;
+    let remote_stopped_body =
+        event_body(&remote_stopped).ok_or("remote stopped event missing body")?;
+    assert_eq!(remote_stopped_body.get("reason").and_then(Value::as_str), Some("step"));
+    assert_eq!(remote_stopped_body.get("threadId").and_then(Value::as_i64), Some(12));
+
+    response_success(adapter.handle_request(3, "terminate", Some(json!({}))), "terminate")?;
+    let _terminated = wait_for_event(&rx, "terminated", timeout)?;
+
+    server_handle.join().map_err(|_| std::io::Error::other("fake TCP debugger server panicked"))?;
+    Ok(())
+}
+
+#[test]
+fn dap_attach_e2e_timeout_reports_attach_failure() -> TestResult {
+    let mut adapter = DebugAdapter::new();
+    let (tx, _rx) = channel();
+    adapter.set_event_sender(tx);
+
+    response_success(adapter.handle_request(1, "initialize", None), "initialize")?;
+
+    let response = adapter.handle_request(
+        2,
+        "attach",
+        Some(json!({
+            "host": "203.0.113.1",
+            "port": 9,
+            "timeout": 25
+        })),
+    );
+
+    match response {
+        DapMessage::Response { success, command, message, .. } => {
+            assert_eq!(command, "attach");
+            assert!(!success);
+            let text = message.unwrap_or_default().to_lowercase();
+            assert!(text.contains("cannot attach"));
+            assert!(
+                text.contains("timeout")
+                    || text.contains("timed out")
+                    || text.contains("unreachable")
+            );
+        }
+        other => return Err(format!("expected attach failure response, got {other:?}").into()),
+    }
+
+    Ok(())
+}

--- a/crates/perl-dap/tests/tcp_attach_tests.rs
+++ b/crates/perl-dap/tests/tcp_attach_tests.rs
@@ -12,7 +12,7 @@
 use perl_dap::tcp_attach::{DapEvent, TcpAttachConfig, TcpAttachSession};
 use perl_lsp_rs_core::transport::framing::frame;
 use perl_tdd_support::must;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::sync::mpsc::channel;
 use std::thread;
@@ -275,6 +275,97 @@ fn test_tcp_attach_reader_handles_concatenated_frames() {
         }
         other => must(Err::<(), _>(format!("Expected Continued event, got {other:?}"))),
     }
+
+    must(server_handle.join().map_err(|_| "Server thread panicked".to_string()));
+}
+
+#[test]
+fn test_tcp_attach_reader_emits_stopped_and_terminated_events() {
+    let listener = must(TcpListener::bind(("127.0.0.1", 0)));
+    let port = must(listener.local_addr()).port();
+
+    let server_handle = thread::spawn(move || {
+        let (mut socket, _) = must(listener.accept());
+
+        let stopped_event = serde_json::json!({
+            "type": "event",
+            "seq": 1,
+            "event": "stopped",
+            "body": {
+                "reason": "breakpoint",
+                "threadId": 41
+            }
+        })
+        .to_string();
+        let terminated_event = serde_json::json!({
+            "type": "event",
+            "seq": 2,
+            "event": "terminated",
+            "body": {
+                "reason": "completed"
+            }
+        })
+        .to_string();
+
+        let mut bytes = frame(stopped_event.as_bytes());
+        bytes.extend_from_slice(&frame(terminated_event.as_bytes()));
+        must(socket.write_all(&bytes));
+        must(socket.flush());
+    });
+
+    let mut session = TcpAttachSession::new();
+    let (event_tx, event_rx) = channel::<DapEvent>();
+    session.set_event_sender(event_tx);
+
+    let config = TcpAttachConfig::new("127.0.0.1".to_string(), port).with_timeout(2000);
+    must(session.connect(&config));
+    must(session.start_reader());
+
+    match must(event_rx.recv_timeout(Duration::from_secs(2))) {
+        DapEvent::Stopped { reason, thread_id } => {
+            assert_eq!(reason, "breakpoint");
+            assert_eq!(thread_id, 41);
+        }
+        other => must(Err::<(), _>(format!("Expected Stopped event, got {other:?}"))),
+    }
+
+    match must(event_rx.recv_timeout(Duration::from_secs(2))) {
+        DapEvent::Terminated { reason } => {
+            assert_eq!(reason, "completed");
+        }
+        other => must(Err::<(), _>(format!("Expected Terminated event, got {other:?}"))),
+    }
+
+    must(server_handle.join().map_err(|_| "Server thread panicked".to_string()));
+}
+
+#[test]
+fn test_tcp_attach_disconnect_after_start_reader_clears_connection_state() {
+    let listener = must(TcpListener::bind(("127.0.0.1", 0)));
+    let port = must(listener.local_addr()).port();
+
+    let server_handle = thread::spawn(move || {
+        let (mut socket, _) = must(listener.accept());
+        let mut buf = [0u8; 8];
+        loop {
+            match socket.read(&mut buf) {
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+    });
+
+    let mut session = TcpAttachSession::new();
+    let config = TcpAttachConfig::new("127.0.0.1".to_string(), port).with_timeout(2000);
+    must(session.connect(&config));
+    assert!(session.is_connected());
+
+    must(session.start_reader());
+    assert!(session.is_connected());
+
+    must(session.disconnect());
+    assert!(!session.is_connected());
 
     must(server_handle.join().map_err(|_| "Server thread panicked".to_string()));
 }


### PR DESCRIPTION
### Motivation

- Improve reliability of the TCP attach code path so reconnects and disconnects start from a clean, deterministic state and do not leave stale in-memory connection flags when a reader thread has taken ownership of the stream.
- Keep the bridge-mode code observable and easier to diagnose by adding focused tests that assert expected failure modes and idempotent shutdown behavior.

### Description

- Hardened `TcpAttachSession::connect` to proactively call `disconnect` before opening a new socket so reconnect attempts start from a clean state (`crates/perl-dap/src/tcp_attach.rs`).
- Ensured `TcpAttachSession::disconnect` clears the internal connected flag immediately so callers and tests observe the correct state even after `start_reader()` has taken the stream (`crates/perl-dap/src/tcp_attach.rs`).
- Added end-to-end attach scenarios: a `stopOnEntry` + remote `stopped` + `terminate` flow and an attach-timeout/failure assertion to `dap_attach_e2e.rs` to improve happy/failure path coverage (`crates/perl-dap/tests/dap_attach_e2e.rs`).
- Expanded TCP attach unit tests to assert parsed `stopped` and `terminated` events and to verify `disconnect` clears connection state after `start_reader()` handoff, and added bridge lifecycle tests that exercise proxy-before-spawn and idempotent shutdown (`crates/perl-dap/tests/tcp_attach_tests.rs`, `crates/perl-dap/tests/bridge_integration_tests.rs`).

### Testing

- Ran `cargo test -p perl-dap --test dap_attach_e2e` and all tests passed.
- Ran `cargo test -p perl-dap --test tcp_attach_tests` and all tests passed.
- Ran `cargo test -p perl-dap --test bridge_integration_tests` and all tests passed.
- Ran `cargo check --all-targets -p perl-dap` and `cargo xtask fmt` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3992f3188333947ec51a9b1a582a)