### PR TITLE
perf(perl-dap): make framed debugger-output capture marker-aware and cheaper (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -391,6 +391,13 @@ struct DataBreakpointRecord {
     condition: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct RecentOutputLine {
+    id: u64,
+    raw: String,
+    normalized: String,
+}
+
 /// Check if the match is an escape sequence (preceded by backslash)
 fn is_escape_sequence(s: &str, match_start: usize) -> bool {
     if match_start == 0 {
@@ -416,7 +423,9 @@ pub struct DebugAdapter {
     /// Output channel for sending events to client
     event_sender: Option<Sender<DapMessage>>,
     /// Bounded history of debugger output for stack/variable/evaluate parsing
-    recent_output: Arc<Mutex<VecDeque<String>>>,
+    recent_output: Arc<Mutex<VecDeque<RecentOutputLine>>>,
+    /// Monotonic line IDs for incremental framed-output scans.
+    recent_output_line_id: Arc<AtomicU64>,
     /// Function breakpoints (`setFunctionBreakpoints`) stored with REPLACE semantics
     function_breakpoints: Arc<Mutex<Vec<String>>>,
     /// Monotonic IDs for function breakpoints
@@ -545,6 +554,7 @@ impl DebugAdapter {
             thread_counter: Arc::new(Mutex::new(0)),
             event_sender: None,
             recent_output: Arc::new(Mutex::new(VecDeque::with_capacity(RECENT_OUTPUT_MAX_LINES))),
+            recent_output_line_id: Arc::new(AtomicU64::new(1)),
             function_breakpoints: Arc::new(Mutex::new(Vec::new())),
             next_function_breakpoint_id: Arc::new(Mutex::new(1)),
             exception_break_on_die: Arc::new(Mutex::new(false)),
@@ -601,7 +611,23 @@ impl DebugAdapter {
     /// Snapshot debugger output history for parsing without holding locks.
     fn snapshot_recent_output_lines(&self) -> Vec<String> {
         let output = lock_or_recover(&self.recent_output, "debug_adapter.recent_output");
-        output.iter().cloned().collect()
+        output.iter().map(|line| line.raw.clone()).collect()
+    }
+
+    fn snapshot_recent_output_entries_since(&self, after_id: u64) -> Vec<RecentOutputLine> {
+        let output = lock_or_recover(&self.recent_output, "debug_adapter.recent_output");
+        output.iter().filter(|line| line.id > after_id).cloned().collect()
+    }
+
+    #[cfg(test)]
+    fn append_recent_output_line(&self, text: String) {
+        let mut output = lock_or_recover(&self.recent_output, "debug_adapter.recent_output");
+        if output.len() >= RECENT_OUTPUT_MAX_LINES {
+            let _ = output.pop_front();
+        }
+        let line_id = self.recent_output_line_id.fetch_add(1, Ordering::Relaxed);
+        let normalized = Self::normalize_debugger_output_line(&text);
+        output.push_back(RecentOutputLine { id: line_id, raw: text, normalized });
     }
 
     /// Allocate a unique marker id used for framed debugger output capture.
@@ -651,6 +677,30 @@ impl DebugAdapter {
         let deadline =
             Instant::now() + Duration::from_millis(Self::debugger_timeout_budget_ms(timeout_ms));
 
+        let mut tail_id = 0_u64;
+        let mut collecting = false;
+        let mut framed_lines = Vec::new();
+
+        let initial_entries = self.snapshot_recent_output_entries_since(tail_id);
+        if let Some(last) = initial_entries.last() {
+            tail_id = last.id;
+        }
+
+        for entry in &initial_entries {
+            let line = entry.normalized.as_str();
+            if Self::line_contains_marker(line, begin_marker) {
+                collecting = true;
+                framed_lines.clear();
+                continue;
+            }
+            if collecting && Self::line_contains_marker(line, end_marker) {
+                return Some(framed_lines);
+            }
+            if collecting && !line.trim().is_empty() {
+                framed_lines.push(line.to_string());
+            }
+        }
+
         loop {
             // Check for cancellation before each poll iteration
             if self.cancel_requested.load(Ordering::Acquire) {
@@ -658,23 +708,24 @@ impl DebugAdapter {
                 return None;
             }
 
-            let lines = self.snapshot_recent_output_lines();
-            let normalized_lines: Vec<String> =
-                lines.iter().map(|line| Self::normalize_debugger_output_line(line)).collect();
+            let new_entries = self.snapshot_recent_output_entries_since(tail_id);
+            if let Some(last) = new_entries.last() {
+                tail_id = last.id;
+            }
 
-            if let Some(begin_idx) =
-                normalized_lines.iter().rposition(|line| line.contains(begin_marker))
-                && let Some(end_rel) = normalized_lines[begin_idx + 1..]
-                    .iter()
-                    .position(|line| line.contains(end_marker))
-            {
-                let end_idx = begin_idx + 1 + end_rel;
-                let framed = normalized_lines[begin_idx + 1..end_idx]
-                    .iter()
-                    .filter(|line| !line.trim().is_empty())
-                    .cloned()
-                    .collect::<Vec<_>>();
-                return Some(framed);
+            for entry in new_entries {
+                let line = entry.normalized;
+                if Self::line_contains_marker(&line, begin_marker) {
+                    collecting = true;
+                    framed_lines.clear();
+                    continue;
+                }
+                if collecting && Self::line_contains_marker(&line, end_marker) {
+                    return Some(framed_lines);
+                }
+                if collecting && !line.trim().is_empty() {
+                    framed_lines.push(line);
+                }
             }
 
             if Instant::now() >= deadline {
@@ -692,6 +743,31 @@ impl DebugAdapter {
 
     fn wait_for_debugger_output_window(timeout_ms: u32) {
         thread::sleep(Duration::from_millis(Self::debugger_output_window_ms(timeout_ms)));
+    }
+
+    fn line_contains_marker(line: &str, marker: &str) -> bool {
+        let mut offset = 0_usize;
+        while let Some(found) = line[offset..].find(marker) {
+            let idx = offset + found;
+            let end = idx + marker.len();
+
+            let left_ok = idx == 0
+                || !line
+                    .as_bytes()
+                    .get(idx - 1)
+                    .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_');
+            let right_ok = end == line.len()
+                || !line
+                    .as_bytes()
+                    .get(end)
+                    .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_');
+
+            if left_ok && right_ok {
+                return true;
+            }
+            offset = end;
+        }
+        false
     }
 
     /// Expand debugger query budgets in heavily instrumented environments.

--- a/crates/perl-dap/src/debug_adapter/parsing.rs
+++ b/crates/perl-dap/src/debug_adapter/parsing.rs
@@ -352,13 +352,9 @@ mod tests {
     pub(super) fn test_parse_scope_variables_from_recent_output()
     -> Result<(), Box<dyn std::error::Error>> {
         let adapter = DebugAdapter::new();
-        {
-            let mut output =
-                lock_or_recover(&adapter.recent_output, "test_parse_scope_variables.recent_output");
-            output.push_back("$foo = 42".to_string());
-            output.push_back("@arr = (1, 2, 3)".to_string());
-            output.push_back("%hash = {a => 1}".to_string());
-        }
+        adapter.append_recent_output_line("$foo = 42".to_string());
+        adapter.append_recent_output_line("@arr = (1, 2, 3)".to_string());
+        adapter.append_recent_output_line("%hash = {a => 1}".to_string());
 
         let (vars, child_cache) = adapter.parse_scope_variables_from_output(11, 0, 20);
         let names: Vec<&str> = vars.iter().map(|v| v.name.as_str()).collect();
@@ -420,19 +416,13 @@ mod tests {
     pub(super) fn test_capture_framed_debugger_output_isolated_by_marker()
     -> Result<(), Box<dyn std::error::Error>> {
         let adapter = DebugAdapter::new();
-        {
-            let mut output = lock_or_recover(
-                &adapter.recent_output,
-                "test_capture_framed_debugger_output.recent_output",
-            );
-            output.push_back("noise".to_string());
-            output.push_back(r#""DAP_BEGIN_100""#.to_string());
-            output.push_back("$a = 1".to_string());
-            output.push_back(r#""DAP_END_100""#.to_string());
-            output.push_back(r#""DAP_BEGIN_200""#.to_string());
-            output.push_back("$b = 2".to_string());
-            output.push_back(r#""DAP_END_200""#.to_string());
-        }
+        adapter.append_recent_output_line("noise".to_string());
+        adapter.append_recent_output_line(r#""DAP_BEGIN_100""#.to_string());
+        adapter.append_recent_output_line("$a = 1".to_string());
+        adapter.append_recent_output_line(r#""DAP_END_100""#.to_string());
+        adapter.append_recent_output_line(r#""DAP_BEGIN_200""#.to_string());
+        adapter.append_recent_output_line("$b = 2".to_string());
+        adapter.append_recent_output_line(r#""DAP_END_200""#.to_string());
 
         let lines = adapter
             .capture_framed_debugger_output("DAP_BEGIN_200", "DAP_END_200", 200)
@@ -445,14 +435,11 @@ mod tests {
     pub(super) fn test_stack_trace_uses_recent_output_when_available()
     -> Result<(), Box<dyn std::error::Error>> {
         let mut adapter = DebugAdapter::new();
-        {
-            let mut output = lock_or_recover(
-                &adapter.recent_output,
-                "test_stack_trace_recent_output.recent_output",
-            );
-            output.push_back("# 0 main::compute at /tmp/script.pl line 20".to_string());
-            output.push_back("# 1 Foo::process called at /tmp/Foo.pm line 15".to_string());
-        }
+        adapter
+            .append_recent_output_line("# 0 main::compute at /tmp/script.pl line 20".to_string());
+        adapter.append_recent_output_line(
+            "# 1 Foo::process called at /tmp/Foo.pm line 15".to_string(),
+        );
 
         let response = adapter.handle_request(1, "stackTrace", Some(json!({"threadId": 1})));
         match response {
@@ -478,16 +465,64 @@ mod tests {
     pub(super) fn test_parse_evaluate_result_from_recent_output()
     -> Result<(), Box<dyn std::error::Error>> {
         let adapter = DebugAdapter::new();
-        {
-            let mut output =
-                lock_or_recover(&adapter.recent_output, "test_parse_evaluate_result.recent_output");
-            output.push_back("$result = 123".to_string());
-        }
+        adapter.append_recent_output_line("$result = 123".to_string());
 
         let parsed = adapter.parse_evaluate_result_from_output("$result");
         let (value, ty) = parsed.ok_or("expected parsed evaluate result")?;
         assert_eq!(value, "123");
         assert_eq!(ty, "SCALAR");
+        Ok(())
+    }
+
+    #[test]
+    pub(super) fn test_capture_framed_debugger_output_honors_cancellation() {
+        let adapter = DebugAdapter::new();
+        adapter.cancel_requested.store(true, Ordering::Release);
+        let captured =
+            adapter.capture_framed_debugger_output("DAP_BEGIN_cancel", "DAP_END_cancel", 200);
+        assert!(captured.is_none(), "capture should stop when cancellation is requested");
+    }
+
+    #[test]
+    pub(super) fn test_capture_framed_debugger_output_large_history_remains_fast()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let adapter = DebugAdapter::new();
+        for idx in 0..RECENT_OUTPUT_MAX_LINES {
+            adapter.append_recent_output_line(format!("noise line {idx}"));
+        }
+        adapter.append_recent_output_line(r#""DAP_BEGIN_9001""#.to_string());
+        adapter.append_recent_output_line("$value = 42".to_string());
+        adapter.append_recent_output_line(r#""DAP_END_9001""#.to_string());
+
+        let started = Instant::now();
+        let lines = adapter
+            .capture_framed_debugger_output("DAP_BEGIN_9001", "DAP_END_9001", 200)
+            .ok_or("expected framed output for marker 9001")?;
+        let elapsed = started.elapsed();
+
+        assert_eq!(lines, vec!["$value = 42".to_string()]);
+        assert!(
+            elapsed < Duration::from_millis(60),
+            "framed capture should avoid full-buffer rescans, elapsed={elapsed:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    pub(super) fn test_capture_framed_debugger_output_uses_exact_marker_boundaries()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let adapter = DebugAdapter::new();
+        adapter.append_recent_output_line(r#""DAP_BEGIN_200""#.to_string());
+        adapter.append_recent_output_line("$older = 1".to_string());
+        adapter.append_recent_output_line(r#""DAP_END_200""#.to_string());
+        adapter.append_recent_output_line(r#""DAP_BEGIN_20""#.to_string());
+        adapter.append_recent_output_line("$wanted = 2".to_string());
+        adapter.append_recent_output_line(r#""DAP_END_20""#.to_string());
+
+        let lines = adapter
+            .capture_framed_debugger_output("DAP_BEGIN_20", "DAP_END_20", 200)
+            .ok_or("expected framed output for marker 20")?;
+        assert_eq!(lines, vec!["$wanted = 2".to_string()]);
         Ok(())
     }
 

--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -483,6 +483,7 @@ impl DebugAdapter {
         let seq = self.seq.clone();
         let sender = self.event_sender.clone();
         let recent_output = self.recent_output.clone();
+        let recent_output_line_id = self.recent_output_line_id.clone();
         let breakpoints = self.breakpoints.clone();
         let exception_break_on_die = self.exception_break_on_die.clone();
         let exception_break_on_warn = self.exception_break_on_warn.clone();
@@ -574,7 +575,13 @@ impl DebugAdapter {
                             if output.len() >= RECENT_OUTPUT_MAX_LINES {
                                 let _ = output.pop_front();
                             }
-                            output.push_back(text.clone());
+                            let line_id = recent_output_line_id.fetch_add(1, Ordering::Relaxed);
+                            let normalized = DebugAdapter::normalize_debugger_output_line(&text);
+                            output.push_back(RecentOutputLine {
+                                id: line_id,
+                                raw: text.clone(),
+                                normalized,
+                            });
                         }
 
                         // Send all output to client with error handling


### PR DESCRIPTION
### Motivation
- Framed debugger-output capture was cloning and re-normalizing the entire recent-output buffer on every poll, causing unnecessary CPU and lock contention during frequent framed queries.
- The change aims to make capture incremental and cache-aware while keeping the existing begin/end marker protocol and correctness under cancellation, partial markers, timeouts, and interleaved output.

### Description
- Replace `VecDeque<String>` recent-output storage with `RecentOutputLine { id, raw, normalized }` and add a monotonic `recent_output_line_id` to stamp lines for incremental scans.
- Writer (output reader) now appends pre-normalized, ID-stamped `RecentOutputLine` entries to the ring buffer as lines arrive, avoiding repeated normalization during capture. (`process.rs`)
- Implement `snapshot_recent_output_entries_since` and tail-tracking in `capture_framed_debugger_output` so the capture loop only scans newly appended lines rather than rescanning the whole buffer. (`mod.rs`)
- Add exact marker-boundary matching via `line_contains_marker` to avoid false matches for similarly prefixed markers (e.g. `_20` vs `_200`). (`mod.rs`)
- Provide a test-only `append_recent_output_line` helper and update existing parsing tests to use it rather than mutating the old raw ring buffer. (`parsing.rs`)
- Add focused tests for framed capture: cancellation handling, large-history performance fast-path, and exact marker-boundary behavior. (`parsing.rs`)

### Testing
- Ran formatting: `cargo xtask fmt` — success.
- Static check: `cargo check --all-targets -p perl-dap` — success.
- Unit tests (focused): `cargo test -p perl-dap capture_framed_debugger_output` and `cargo test -p perl-dap recent_output` — both passed (new/updated tests OK).
- Full crate test: `cargo test -p perl-dap` — most unit tests passed, but `dap_e2e_workflow_tests::test_e2e_multi_breakpoint_sequence` failed with an existing assertion mismatch (expected breakpoint line 5, got 4), which appears unrelated to the framed-capture microchanges and mirrors an intermittent/e2e expectation difference observed when running the full suite.

Problem: Framed debugger-output capture repeatedly cloned and normalized the full recent-output ring on every poll, causing unnecessary overhead and marker scan work.
Fix: Store recent output as cached normalized entries with monotonic line ids, then capture framed output by incrementally scanning only newly appended lines with exact marker-boundary matching.
Verification: `cargo test -p perl-dap capture_framed_debugger_output`, `cargo test -p perl-dap recent_output`, and `cargo check --all-targets -p perl-dap` pass; full `cargo test -p perl-dap` shows one failing e2e test noted above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3998c8b0833385e7a974a9147c91)