### PR TITLE
perf(perl-dap): make framed debugger-output capture marker-aware and cheaper (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -112,6 +112,13 @@ const DEBUG_SESSION_TERMINATE_WAIT_MS: u64 = 250;
 const DEBUGGER_QUERY_WAIT_MS: u64 = 75;
 const DEBUGGER_FRAME_POLL_MS: u64 = 10;
 
+#[derive(Clone, Debug)]
+struct DebuggerOutputLine {
+    line_id: u64,
+    raw: String,
+    normalized: String,
+}
+
 fn context_re() -> Option<&'static Regex> {
     CONTEXT_RE
         .get_or_init(|| {
@@ -416,7 +423,9 @@ pub struct DebugAdapter {
     /// Output channel for sending events to client
     event_sender: Option<Sender<DapMessage>>,
     /// Bounded history of debugger output for stack/variable/evaluate parsing
-    recent_output: Arc<Mutex<VecDeque<String>>>,
+    recent_output: Arc<Mutex<VecDeque<DebuggerOutputLine>>>,
+    /// Monotonic line IDs for bounded incremental scans over recent debugger output.
+    recent_output_line_id: Arc<AtomicU64>,
     /// Function breakpoints (`setFunctionBreakpoints`) stored with REPLACE semantics
     function_breakpoints: Arc<Mutex<Vec<String>>>,
     /// Monotonic IDs for function breakpoints
@@ -545,6 +554,7 @@ impl DebugAdapter {
             thread_counter: Arc::new(Mutex::new(0)),
             event_sender: None,
             recent_output: Arc::new(Mutex::new(VecDeque::with_capacity(RECENT_OUTPUT_MAX_LINES))),
+            recent_output_line_id: Arc::new(AtomicU64::new(1)),
             function_breakpoints: Arc::new(Mutex::new(Vec::new())),
             next_function_breakpoint_id: Arc::new(Mutex::new(1)),
             exception_break_on_die: Arc::new(Mutex::new(false)),
@@ -601,7 +611,33 @@ impl DebugAdapter {
     /// Snapshot debugger output history for parsing without holding locks.
     fn snapshot_recent_output_lines(&self) -> Vec<String> {
         let output = lock_or_recover(&self.recent_output, "debug_adapter.recent_output");
-        output.iter().cloned().collect()
+        output.iter().map(|line| line.raw.clone()).collect()
+    }
+
+    #[cfg(test)]
+    fn append_recent_output_line(&self, line: &str) {
+        Self::append_recent_output_line_with_cache(
+            &self.recent_output,
+            &self.recent_output_line_id,
+            line,
+        );
+    }
+
+    fn append_recent_output_line_with_cache(
+        recent_output: &Arc<Mutex<VecDeque<DebuggerOutputLine>>>,
+        recent_output_line_id: &Arc<AtomicU64>,
+        line: &str,
+    ) {
+        let entry = DebuggerOutputLine {
+            line_id: recent_output_line_id.fetch_add(1, Ordering::Relaxed),
+            raw: line.to_string(),
+            normalized: Self::normalize_debugger_output_line(line),
+        };
+        let mut output = lock_or_recover(recent_output, "debug_adapter.recent_output_append");
+        if output.len() >= RECENT_OUTPUT_MAX_LINES {
+            let _ = output.pop_front();
+        }
+        output.push_back(entry);
     }
 
     /// Allocate a unique marker id used for framed debugger output capture.
@@ -650,6 +686,9 @@ impl DebugAdapter {
     ) -> Option<Vec<String>> {
         let deadline =
             Instant::now() + Duration::from_millis(Self::debugger_timeout_budget_ms(timeout_ms));
+        let mut last_scanned_line_id = 0_u64;
+        let mut begin_seen = false;
+        let mut framed_lines = Vec::new();
 
         loop {
             // Check for cancellation before each poll iteration
@@ -658,23 +697,36 @@ impl DebugAdapter {
                 return None;
             }
 
-            let lines = self.snapshot_recent_output_lines();
-            let normalized_lines: Vec<String> =
-                lines.iter().map(|line| Self::normalize_debugger_output_line(line)).collect();
-
-            if let Some(begin_idx) =
-                normalized_lines.iter().rposition(|line| line.contains(begin_marker))
-                && let Some(end_rel) = normalized_lines[begin_idx + 1..]
-                    .iter()
-                    .position(|line| line.contains(end_marker))
             {
-                let end_idx = begin_idx + 1 + end_rel;
-                let framed = normalized_lines[begin_idx + 1..end_idx]
-                    .iter()
-                    .filter(|line| !line.trim().is_empty())
-                    .cloned()
-                    .collect::<Vec<_>>();
-                return Some(framed);
+                let output = lock_or_recover(&self.recent_output, "capture_framed_debugger_output");
+                let mut completed_frame = None;
+                for line in output.iter() {
+                    if line.line_id <= last_scanned_line_id {
+                        continue;
+                    }
+                    last_scanned_line_id = line.line_id;
+                    let normalized = line.normalized.as_str();
+                    if normalized.contains(begin_marker) {
+                        begin_seen = true;
+                        completed_frame = None;
+                        framed_lines.clear();
+                        continue;
+                    }
+                    if !begin_seen {
+                        continue;
+                    }
+                    if normalized.contains(end_marker) {
+                        completed_frame = Some(std::mem::take(&mut framed_lines));
+                        begin_seen = false;
+                        continue;
+                    }
+                    if !normalized.trim().is_empty() {
+                        framed_lines.push(normalized.to_string());
+                    }
+                }
+                if let Some(frame) = completed_frame {
+                    return Some(frame);
+                }
             }
 
             if Instant::now() >= deadline {

--- a/crates/perl-dap/src/debug_adapter/parsing.rs
+++ b/crates/perl-dap/src/debug_adapter/parsing.rs
@@ -352,13 +352,9 @@ mod tests {
     pub(super) fn test_parse_scope_variables_from_recent_output()
     -> Result<(), Box<dyn std::error::Error>> {
         let adapter = DebugAdapter::new();
-        {
-            let mut output =
-                lock_or_recover(&adapter.recent_output, "test_parse_scope_variables.recent_output");
-            output.push_back("$foo = 42".to_string());
-            output.push_back("@arr = (1, 2, 3)".to_string());
-            output.push_back("%hash = {a => 1}".to_string());
-        }
+        adapter.append_recent_output_line("$foo = 42");
+        adapter.append_recent_output_line("@arr = (1, 2, 3)");
+        adapter.append_recent_output_line("%hash = {a => 1}");
 
         let (vars, child_cache) = adapter.parse_scope_variables_from_output(11, 0, 20);
         let names: Vec<&str> = vars.iter().map(|v| v.name.as_str()).collect();
@@ -420,19 +416,13 @@ mod tests {
     pub(super) fn test_capture_framed_debugger_output_isolated_by_marker()
     -> Result<(), Box<dyn std::error::Error>> {
         let adapter = DebugAdapter::new();
-        {
-            let mut output = lock_or_recover(
-                &adapter.recent_output,
-                "test_capture_framed_debugger_output.recent_output",
-            );
-            output.push_back("noise".to_string());
-            output.push_back(r#""DAP_BEGIN_100""#.to_string());
-            output.push_back("$a = 1".to_string());
-            output.push_back(r#""DAP_END_100""#.to_string());
-            output.push_back(r#""DAP_BEGIN_200""#.to_string());
-            output.push_back("$b = 2".to_string());
-            output.push_back(r#""DAP_END_200""#.to_string());
-        }
+        adapter.append_recent_output_line("noise");
+        adapter.append_recent_output_line(r#""DAP_BEGIN_100""#);
+        adapter.append_recent_output_line("$a = 1");
+        adapter.append_recent_output_line(r#""DAP_END_100""#);
+        adapter.append_recent_output_line(r#""DAP_BEGIN_200""#);
+        adapter.append_recent_output_line("$b = 2");
+        adapter.append_recent_output_line(r#""DAP_END_200""#);
 
         let lines = adapter
             .capture_framed_debugger_output("DAP_BEGIN_200", "DAP_END_200", 200)
@@ -442,17 +432,115 @@ mod tests {
     }
 
     #[test]
+    pub(super) fn test_capture_framed_debugger_output_with_partial_arrival_and_interleaving()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let adapter = DebugAdapter::new();
+        adapter.append_recent_output_line("noise before");
+        adapter.append_recent_output_line(r#""DAP_BEGIN_777""#);
+        adapter.append_recent_output_line("interleaved line");
+        adapter.append_recent_output_line("$inside = 1");
+
+        let recent_output = adapter.recent_output.clone();
+        let recent_output_line_id = adapter.recent_output_line_id.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(15));
+            DebugAdapter::append_recent_output_line_with_cache(
+                &recent_output,
+                &recent_output_line_id,
+                "later data",
+            );
+            DebugAdapter::append_recent_output_line_with_cache(
+                &recent_output,
+                &recent_output_line_id,
+                r#""DAP_END_777""#,
+            );
+        });
+
+        let lines = adapter
+            .capture_framed_debugger_output("DAP_BEGIN_777", "DAP_END_777", 250)
+            .ok_or("expected framed output for marker 777")?;
+        assert_eq!(
+            lines,
+            vec![
+                "interleaved line".to_string(),
+                "$inside = 1".to_string(),
+                "later data".to_string()
+            ]
+        );
+        Ok(())
+    }
+
+    fn capture_framed_debugger_output_legacy(
+        lines: &[String],
+        begin_marker: &str,
+        end_marker: &str,
+    ) -> Option<Vec<String>> {
+        let normalized_lines: Vec<String> =
+            lines.iter().map(|line| DebugAdapter::normalize_debugger_output_line(line)).collect();
+
+        if let Some(begin_idx) =
+            normalized_lines.iter().rposition(|line| line.contains(begin_marker))
+            && let Some(end_rel) =
+                normalized_lines[begin_idx + 1..].iter().position(|line| line.contains(end_marker))
+        {
+            let end_idx = begin_idx + 1 + end_rel;
+            let framed = normalized_lines[begin_idx + 1..end_idx]
+                .iter()
+                .filter(|line| !line.trim().is_empty())
+                .cloned()
+                .collect::<Vec<_>>();
+            return Some(framed);
+        }
+        None
+    }
+
+    #[test]
+    pub(super) fn test_capture_framed_debugger_output_microbenchmark_marker_aware_faster()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let adapter = DebugAdapter::new();
+        for idx in 0..1800 {
+            adapter.append_recent_output_line(&format!("noise {idx}"));
+        }
+        adapter.append_recent_output_line(r#""DAP_BEGIN_9001""#);
+        for idx in 0..128 {
+            adapter.append_recent_output_line(&format!("value {idx}"));
+        }
+        adapter.append_recent_output_line(r#""DAP_END_9001""#);
+
+        let lines = adapter.snapshot_recent_output_lines();
+
+        let legacy_start = Instant::now();
+        let mut legacy_result = None;
+        for _ in 0..120 {
+            legacy_result =
+                capture_framed_debugger_output_legacy(&lines, "DAP_BEGIN_9001", "DAP_END_9001");
+        }
+        let legacy_elapsed = legacy_start.elapsed();
+
+        let marker_start = Instant::now();
+        let mut marker_result = None;
+        for _ in 0..120 {
+            marker_result =
+                adapter.capture_framed_debugger_output("DAP_BEGIN_9001", "DAP_END_9001", 50);
+        }
+        let marker_elapsed = marker_start.elapsed();
+
+        let legacy_result = legacy_result.ok_or("legacy framing should produce lines")?;
+        let marker_result = marker_result.ok_or("marker-aware framing should produce lines")?;
+        assert_eq!(marker_result, legacy_result);
+        assert!(
+            marker_elapsed < legacy_elapsed,
+            "expected marker-aware framing to be faster (legacy={legacy_elapsed:?}, marker={marker_elapsed:?})",
+        );
+        Ok(())
+    }
+
+    #[test]
     pub(super) fn test_stack_trace_uses_recent_output_when_available()
     -> Result<(), Box<dyn std::error::Error>> {
         let mut adapter = DebugAdapter::new();
-        {
-            let mut output = lock_or_recover(
-                &adapter.recent_output,
-                "test_stack_trace_recent_output.recent_output",
-            );
-            output.push_back("# 0 main::compute at /tmp/script.pl line 20".to_string());
-            output.push_back("# 1 Foo::process called at /tmp/Foo.pm line 15".to_string());
-        }
+        adapter.append_recent_output_line("# 0 main::compute at /tmp/script.pl line 20");
+        adapter.append_recent_output_line("# 1 Foo::process called at /tmp/Foo.pm line 15");
 
         let response = adapter.handle_request(1, "stackTrace", Some(json!({"threadId": 1})));
         match response {
@@ -478,11 +566,7 @@ mod tests {
     pub(super) fn test_parse_evaluate_result_from_recent_output()
     -> Result<(), Box<dyn std::error::Error>> {
         let adapter = DebugAdapter::new();
-        {
-            let mut output =
-                lock_or_recover(&adapter.recent_output, "test_parse_evaluate_result.recent_output");
-            output.push_back("$result = 123".to_string());
-        }
+        adapter.append_recent_output_line("$result = 123");
 
         let parsed = adapter.parse_evaluate_result_from_output("$result");
         let (value, ty) = parsed.ok_or("expected parsed evaluate result")?;

--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -483,6 +483,7 @@ impl DebugAdapter {
         let seq = self.seq.clone();
         let sender = self.event_sender.clone();
         let recent_output = self.recent_output.clone();
+        let recent_output_line_id = self.recent_output_line_id.clone();
         let breakpoints = self.breakpoints.clone();
         let exception_break_on_die = self.exception_break_on_die.clone();
         let exception_break_on_warn = self.exception_break_on_warn.clone();
@@ -566,16 +567,11 @@ impl DebugAdapter {
                             normalized_text
                         };
                         tracing::trace!(output = %text, "Debugger output");
-                        {
-                            let mut output = lock_or_recover(
-                                &recent_output,
-                                "debug_adapter.recent_output_reader",
-                            );
-                            if output.len() >= RECENT_OUTPUT_MAX_LINES {
-                                let _ = output.pop_front();
-                            }
-                            output.push_back(text.clone());
-                        }
+                        DebugAdapter::append_recent_output_line_with_cache(
+                            &recent_output,
+                            &recent_output_line_id,
+                            &text,
+                        );
 
                         // Send all output to client with error handling
                         if let Some(ref sender) = sender


### PR DESCRIPTION
### Motivation

- Framed debugger-output capture rescanned and re-normalized the entire recent-output buffer on every poll, which is expensive for frequent stack/variables/evaluate queries.
- The goal was to make framed capture marker-aware and incremental while preserving the existing begin/end marker protocol and correctness under cancellation, partial arrivals, timeouts, and interleaved output.

### Description

- Introduced `DebuggerOutputLine { line_id, raw, normalized }` and replaced `recent_output: VecDeque<String>` with `recent_output: VecDeque<DebuggerOutputLine>` plus a monotonic `recent_output_line_id` counter to enable cheap incremental scans.
- Added `append_recent_output_line_with_cache` to cache normalization at ingestion time and keep the bounded ring semantics, and wired the live output reader to call this helper.
- Replaced full-buffer rescans in `capture_framed_debugger_output` with a marker-aware incremental scanner that advances from the last seen `line_id`, accumulates framed lines, and returns a completed frame when the end marker arrives.
- Updated unit tests to use the cached ingestion API and added focused tests: marker isolation, partial/interleaved arrival handling, and a microbenchmark-style comparison asserting the new approach returns identical lines and is faster than the legacy full-rescan logic.

### Testing

- Ran `cargo xtask fmt`, which completed successfully.
- Ran `cargo check --all-targets -p perl-dap`, which completed successfully.
- Ran `cargo test -p perl-dap` and observed that the vast majority of unit tests passed and all newly added framed-capture tests passed, but one existing end-to-end test failed: `test_e2e_multi_breakpoint_sequence` (assertion: expected first breakpoint at line 5 but stack frame reported 4), causing the overall test run to fail.
- Ran focused test runs and microbenchmark: `cargo test -p perl-dap test_capture_framed_debugger_output_microbenchmark_marker_aware_faster -- --exact` passed and the marker-aware framing produced identical lines and a measurable timing improvement in the microbenchmark.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3998c8b0833385e7a974a9147c91)