### PR TITLE
perf(perl-dap): make framed debugger-output capture marker-aware and cheaper (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -391,6 +391,20 @@ struct DataBreakpointRecord {
     condition: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct DebuggerOutputLine {
+    id: u64,
+    raw: String,
+    normalized: String,
+}
+
+#[derive(Debug, Default)]
+struct FramedCaptureScanState {
+    last_scanned_line_id: u64,
+    begin_seen: bool,
+    captured_lines: Vec<String>,
+}
+
 /// Check if the match is an escape sequence (preceded by backslash)
 fn is_escape_sequence(s: &str, match_start: usize) -> bool {
     if match_start == 0 {
@@ -416,7 +430,9 @@ pub struct DebugAdapter {
     /// Output channel for sending events to client
     event_sender: Option<Sender<DapMessage>>,
     /// Bounded history of debugger output for stack/variable/evaluate parsing
-    recent_output: Arc<Mutex<VecDeque<String>>>,
+    recent_output: Arc<Mutex<VecDeque<DebuggerOutputLine>>>,
+    /// Monotonic IDs for recent debugger output lines.
+    next_recent_output_line_id: Arc<AtomicU64>,
     /// Function breakpoints (`setFunctionBreakpoints`) stored with REPLACE semantics
     function_breakpoints: Arc<Mutex<Vec<String>>>,
     /// Monotonic IDs for function breakpoints
@@ -545,6 +561,7 @@ impl DebugAdapter {
             thread_counter: Arc::new(Mutex::new(0)),
             event_sender: None,
             recent_output: Arc::new(Mutex::new(VecDeque::with_capacity(RECENT_OUTPUT_MAX_LINES))),
+            next_recent_output_line_id: Arc::new(AtomicU64::new(1)),
             function_breakpoints: Arc::new(Mutex::new(Vec::new())),
             next_function_breakpoint_id: Arc::new(Mutex::new(1)),
             exception_break_on_die: Arc::new(Mutex::new(false)),
@@ -601,7 +618,69 @@ impl DebugAdapter {
     /// Snapshot debugger output history for parsing without holding locks.
     fn snapshot_recent_output_lines(&self) -> Vec<String> {
         let output = lock_or_recover(&self.recent_output, "debug_adapter.recent_output");
-        output.iter().cloned().collect()
+        output.iter().map(|line| line.raw.clone()).collect()
+    }
+
+    #[cfg(test)]
+    fn append_recent_output_line(&self, line: &str) {
+        let normalized = Self::normalize_debugger_output_line(line);
+        Self::append_recent_output_line_with_normalized_state(
+            &self.recent_output,
+            &self.next_recent_output_line_id,
+            line,
+            normalized,
+        );
+    }
+
+    fn append_recent_output_line_with_normalized_state(
+        recent_output: &Arc<Mutex<VecDeque<DebuggerOutputLine>>>,
+        next_line_id: &AtomicU64,
+        line: &str,
+        normalized: String,
+    ) {
+        let line_id = next_line_id.fetch_add(1, Ordering::Relaxed);
+        let mut output = lock_or_recover(recent_output, "debug_adapter.recent_output.append");
+        if output.len() >= RECENT_OUTPUT_MAX_LINES {
+            let _ = output.pop_front();
+        }
+        output.push_back(DebuggerOutputLine { id: line_id, raw: line.to_string(), normalized });
+    }
+
+    fn scan_framed_output_from_tail(
+        output: &VecDeque<DebuggerOutputLine>,
+        begin_marker: &str,
+        end_marker: &str,
+        state: &mut FramedCaptureScanState,
+    ) -> Option<Vec<String>> {
+        for line in output {
+            if line.id <= state.last_scanned_line_id {
+                continue;
+            }
+            state.last_scanned_line_id = line.id;
+            let normalized = line.normalized.as_str();
+            if !state.begin_seen {
+                if normalized.contains(begin_marker) {
+                    state.begin_seen = true;
+                    state.captured_lines.clear();
+                }
+                continue;
+            }
+
+            if normalized.contains(begin_marker) {
+                state.captured_lines.clear();
+                continue;
+            }
+
+            if normalized.contains(end_marker) {
+                return Some(state.captured_lines.clone());
+            }
+
+            if !normalized.trim().is_empty() {
+                state.captured_lines.push(normalized.to_string());
+            }
+        }
+
+        None
     }
 
     /// Allocate a unique marker id used for framed debugger output capture.
@@ -651,6 +730,8 @@ impl DebugAdapter {
         let deadline =
             Instant::now() + Duration::from_millis(Self::debugger_timeout_budget_ms(timeout_ms));
 
+        let mut scan_state = FramedCaptureScanState::default();
+
         loop {
             // Check for cancellation before each poll iteration
             if self.cancel_requested.load(Ordering::Acquire) {
@@ -658,23 +739,17 @@ impl DebugAdapter {
                 return None;
             }
 
-            let lines = self.snapshot_recent_output_lines();
-            let normalized_lines: Vec<String> =
-                lines.iter().map(|line| Self::normalize_debugger_output_line(line)).collect();
-
-            if let Some(begin_idx) =
-                normalized_lines.iter().rposition(|line| line.contains(begin_marker))
-                && let Some(end_rel) = normalized_lines[begin_idx + 1..]
-                    .iter()
-                    .position(|line| line.contains(end_marker))
-            {
-                let end_idx = begin_idx + 1 + end_rel;
-                let framed = normalized_lines[begin_idx + 1..end_idx]
-                    .iter()
-                    .filter(|line| !line.trim().is_empty())
-                    .cloned()
-                    .collect::<Vec<_>>();
-                return Some(framed);
+            let framed = {
+                let output = lock_or_recover(&self.recent_output, "debug_adapter.recent_output");
+                Self::scan_framed_output_from_tail(
+                    &output,
+                    begin_marker,
+                    end_marker,
+                    &mut scan_state,
+                )
+            };
+            if framed.is_some() {
+                return framed;
             }
 
             if Instant::now() >= deadline {
@@ -751,6 +826,56 @@ mod tests {
     #[test]
     fn test_debugger_output_window_ms_honors_extended_budget() {
         assert_eq!(DebugAdapter::debugger_output_window_ms(600), 600);
+    }
+
+    #[test]
+    fn test_scan_framed_output_from_tail_only_processes_new_lines() {
+        let mut output = VecDeque::new();
+        output.push_back(DebuggerOutputLine {
+            id: 1,
+            raw: "noise".to_string(),
+            normalized: "noise".to_string(),
+        });
+        output.push_back(DebuggerOutputLine {
+            id: 2,
+            raw: "\"DAP_BEGIN_1\"".to_string(),
+            normalized: "\"DAP_BEGIN_1\"".to_string(),
+        });
+        output.push_back(DebuggerOutputLine {
+            id: 3,
+            raw: "value = 42".to_string(),
+            normalized: "value = 42".to_string(),
+        });
+        output.push_back(DebuggerOutputLine {
+            id: 4,
+            raw: "still waiting".to_string(),
+            normalized: "still waiting".to_string(),
+        });
+
+        let mut state = FramedCaptureScanState::default();
+        let first = DebugAdapter::scan_framed_output_from_tail(
+            &output,
+            "DAP_BEGIN_1",
+            "DAP_END_1",
+            &mut state,
+        );
+        assert!(first.is_none(), "end marker has not arrived yet");
+        assert_eq!(state.last_scanned_line_id, 4);
+
+        output.push_back(DebuggerOutputLine {
+            id: 5,
+            raw: "\"DAP_END_1\"".to_string(),
+            normalized: "\"DAP_END_1\"".to_string(),
+        });
+
+        let second = DebugAdapter::scan_framed_output_from_tail(
+            &output,
+            "DAP_BEGIN_1",
+            "DAP_END_1",
+            &mut state,
+        );
+        assert_eq!(second, Some(vec!["value = 42".to_string(), "still waiting".to_string()]));
+        assert_eq!(state.last_scanned_line_id, 5);
     }
 
     #[test]

--- a/crates/perl-dap/src/debug_adapter/parsing.rs
+++ b/crates/perl-dap/src/debug_adapter/parsing.rs
@@ -352,13 +352,9 @@ mod tests {
     pub(super) fn test_parse_scope_variables_from_recent_output()
     -> Result<(), Box<dyn std::error::Error>> {
         let adapter = DebugAdapter::new();
-        {
-            let mut output =
-                lock_or_recover(&adapter.recent_output, "test_parse_scope_variables.recent_output");
-            output.push_back("$foo = 42".to_string());
-            output.push_back("@arr = (1, 2, 3)".to_string());
-            output.push_back("%hash = {a => 1}".to_string());
-        }
+        adapter.append_recent_output_line("$foo = 42");
+        adapter.append_recent_output_line("@arr = (1, 2, 3)");
+        adapter.append_recent_output_line("%hash = {a => 1}");
 
         let (vars, child_cache) = adapter.parse_scope_variables_from_output(11, 0, 20);
         let names: Vec<&str> = vars.iter().map(|v| v.name.as_str()).collect();
@@ -420,19 +416,13 @@ mod tests {
     pub(super) fn test_capture_framed_debugger_output_isolated_by_marker()
     -> Result<(), Box<dyn std::error::Error>> {
         let adapter = DebugAdapter::new();
-        {
-            let mut output = lock_or_recover(
-                &adapter.recent_output,
-                "test_capture_framed_debugger_output.recent_output",
-            );
-            output.push_back("noise".to_string());
-            output.push_back(r#""DAP_BEGIN_100""#.to_string());
-            output.push_back("$a = 1".to_string());
-            output.push_back(r#""DAP_END_100""#.to_string());
-            output.push_back(r#""DAP_BEGIN_200""#.to_string());
-            output.push_back("$b = 2".to_string());
-            output.push_back(r#""DAP_END_200""#.to_string());
-        }
+        adapter.append_recent_output_line("noise");
+        adapter.append_recent_output_line(r#""DAP_BEGIN_100""#);
+        adapter.append_recent_output_line("$a = 1");
+        adapter.append_recent_output_line(r#""DAP_END_100""#);
+        adapter.append_recent_output_line(r#""DAP_BEGIN_200""#);
+        adapter.append_recent_output_line("$b = 2");
+        adapter.append_recent_output_line(r#""DAP_END_200""#);
 
         let lines = adapter
             .capture_framed_debugger_output("DAP_BEGIN_200", "DAP_END_200", 200)
@@ -445,14 +435,8 @@ mod tests {
     pub(super) fn test_stack_trace_uses_recent_output_when_available()
     -> Result<(), Box<dyn std::error::Error>> {
         let mut adapter = DebugAdapter::new();
-        {
-            let mut output = lock_or_recover(
-                &adapter.recent_output,
-                "test_stack_trace_recent_output.recent_output",
-            );
-            output.push_back("# 0 main::compute at /tmp/script.pl line 20".to_string());
-            output.push_back("# 1 Foo::process called at /tmp/Foo.pm line 15".to_string());
-        }
+        adapter.append_recent_output_line("# 0 main::compute at /tmp/script.pl line 20");
+        adapter.append_recent_output_line("# 1 Foo::process called at /tmp/Foo.pm line 15");
 
         let response = adapter.handle_request(1, "stackTrace", Some(json!({"threadId": 1})));
         match response {
@@ -478,11 +462,7 @@ mod tests {
     pub(super) fn test_parse_evaluate_result_from_recent_output()
     -> Result<(), Box<dyn std::error::Error>> {
         let adapter = DebugAdapter::new();
-        {
-            let mut output =
-                lock_or_recover(&adapter.recent_output, "test_parse_evaluate_result.recent_output");
-            output.push_back("$result = 123".to_string());
-        }
+        adapter.append_recent_output_line("$result = 123");
 
         let parsed = adapter.parse_evaluate_result_from_output("$result");
         let (value, ty) = parsed.ok_or("expected parsed evaluate result")?;

--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -483,6 +483,7 @@ impl DebugAdapter {
         let seq = self.seq.clone();
         let sender = self.event_sender.clone();
         let recent_output = self.recent_output.clone();
+        let next_recent_output_line_id = self.next_recent_output_line_id.clone();
         let breakpoints = self.breakpoints.clone();
         let exception_break_on_die = self.exception_break_on_die.clone();
         let exception_break_on_warn = self.exception_break_on_warn.clone();
@@ -563,19 +564,15 @@ impl DebugAdapter {
                         let analysis_text = if normalized_text.is_empty() {
                             sanitized_text.trim().to_string()
                         } else {
-                            normalized_text
+                            normalized_text.clone()
                         };
                         tracing::trace!(output = %text, "Debugger output");
-                        {
-                            let mut output = lock_or_recover(
-                                &recent_output,
-                                "debug_adapter.recent_output_reader",
-                            );
-                            if output.len() >= RECENT_OUTPUT_MAX_LINES {
-                                let _ = output.pop_front();
-                            }
-                            output.push_back(text.clone());
-                        }
+                        DebugAdapter::append_recent_output_line_with_normalized_state(
+                            &recent_output,
+                            &next_recent_output_line_id,
+                            &text,
+                            normalized_text.clone(),
+                        );
 
                         // Send all output to client with error handling
                         if let Some(ref sender) = sender


### PR DESCRIPTION
### Motivation

- Framed debugger-output capture rescanned and renormalized the entire recent-output ring on every poll, making repeated framed queries expensive and allocation-heavy.

### Description

- Replace `recent_output: VecDeque<String>` with a structured `DebuggerOutputLine { id, raw, normalized }` and add a monotonic `next_recent_output_line_id: AtomicU64` so each incoming line is normalized once and tagged. 
- Append normalized lines at ingestion (`start_output_reader`) via `append_recent_output_line_with_normalized_state` to avoid repeated normalization during captures. 
- Implement an incremental tail scanner `scan_framed_output_from_tail` driven by a `FramedCaptureScanState` (tracks last scanned line id, begin-seen state, and captured lines) and switch `capture_framed_debugger_output` to use bounded incremental scans instead of full-buffer rescans. 
- Preserve existing begin/end marker protocol and cancellation/timeout semantics, and add a focused unit test plus small test updates to exercise the new incremental scanning helper (`test_scan_framed_output_from_tail_only_processes_new_lines` and updates in parsing tests).

### Testing

- Ran `cargo check --all-targets -p perl-dap`, which succeeded. 
- Ran `cargo xtask fmt` to format changes, which completed. 
- Ran `cargo test -p perl-dap` (full test suite), which executed the test matrix but exposed an existing failing end-to-end test `test_e2e_multi_breakpoint_sequence` (failure observed both before and after change); other unit/integration tests passed. 
- Ran focused unit tests `cargo test -p perl-dap test_scan_framed_output_from_tail_only_processes_new_lines`, which passed and validates the incremental-scan behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3998c8b0833385e7a974a9147c91)