### PR TITLE
perf(perl-dap): add framed fast path and smarter reuse for stackTrace (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/execution.rs
+++ b/crates/perl-dap/src/debug_adapter/execution.rs
@@ -26,10 +26,12 @@ impl DebugAdapter {
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::Continue;
             session.variables.clear();
+            self.invalidate_stack_trace_cache();
             thread_id = session.thread_id;
         } else if let Some(pid) = *lock_or_recover(&self.attached_pid, "debug_adapter.attached_pid")
         {
             let _ = self.send_continue_signal(pid);
+            self.invalidate_stack_trace_cache();
             thread_id = Self::i64_to_i32_saturating(i64::from(pid));
         }
 
@@ -70,6 +72,7 @@ impl DebugAdapter {
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::Next;
             session.variables.clear();
+            self.invalidate_stack_trace_cache();
             let t_id = session.thread_id;
             self.send_event(
                 "continued",
@@ -106,6 +109,7 @@ impl DebugAdapter {
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::StepIn;
             session.variables.clear();
+            self.invalidate_stack_trace_cache();
             let t_id = session.thread_id;
             self.send_event(
                 "continued",
@@ -143,6 +147,7 @@ impl DebugAdapter {
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::StepOut;
             session.variables.clear();
+            self.invalidate_stack_trace_cache();
             let t_id = session.thread_id;
             self.send_event(
                 "continued",

--- a/crates/perl-dap/src/debug_adapter/frames.rs
+++ b/crates/perl-dap/src/debug_adapter/frames.rs
@@ -16,6 +16,22 @@ impl DebugAdapter {
             args.as_ref().and_then(|value| value.start_frame).unwrap_or(0).max(0) as usize;
         let levels = args.as_ref().and_then(|value| value.levels).unwrap_or(0);
         let requested_count = if levels <= 0 { None } else { Some(levels as usize) };
+        if let Some(cached_frames) = self.cached_stack_frames() {
+            let stack_frames =
+                Self::paginate_stack_frames(cached_frames, start_frame, requested_count);
+            return DapMessage::Response {
+                seq,
+                request_seq,
+                success: true,
+                command: "stackTrace".to_string(),
+                body: Some(json!({
+                    "stackFrames": stack_frames,
+                    "totalFrames": stack_frames.len()
+                })),
+                message: None,
+            };
+        }
+
         let mut framed_output_lines = None;
 
         // Ask the debugger for an explicit stack snapshot when a live session is present.
@@ -40,21 +56,15 @@ impl DebugAdapter {
             }
         }
 
-        let parsed_frames = if let Some(lines) = framed_output_lines.as_ref() {
+        let framed_frames = if let Some(lines) = framed_output_lines.as_ref() {
             let output = lines.join("\n");
-            let framed_frames =
-                Self::filter_user_visible_frames(Self::parse_stack_frames_from_text(&output));
-            if framed_frames.is_empty() {
-                let output_lines = self.snapshot_recent_output_lines();
-                if output_lines.is_empty() {
-                    Vec::new()
-                } else {
-                    let output = output_lines.join("\n");
-                    Self::filter_user_visible_frames(Self::parse_stack_frames_from_text(&output))
-                }
-            } else {
-                framed_frames
-            }
+            Self::filter_user_visible_frames(Self::parse_stack_frames_from_text(&output))
+        } else {
+            Vec::new()
+        };
+
+        let parsed_frames = if Self::is_valid_stack_trace_snapshot(&framed_frames) {
+            framed_frames
         } else {
             let output_lines = self.snapshot_recent_output_lines();
             if output_lines.is_empty() {
@@ -71,12 +81,17 @@ impl DebugAdapter {
             {
                 session.stack_frames = parsed_frames.clone();
             }
+            self.cache_stack_frames(parsed_frames.clone());
             parsed_frames
         } else if let Some(ref session) = *lock_or_recover(&self.session, "debug_adapter.session") {
-            Self::filter_user_visible_frames(session.stack_frames.clone())
+            let cached = Self::filter_user_visible_frames(session.stack_frames.clone());
+            if !cached.is_empty() {
+                self.cache_stack_frames(cached.clone());
+            }
+            cached
         } else if let Some(pid) = *lock_or_recover(&self.attached_pid, "debug_adapter.attached_pid")
         {
-            vec![StackFrame {
+            let attached = vec![StackFrame {
                 id: Self::i64_to_i32_saturating(i64::from(pid)),
                 name: format!("attached::process::{pid}"),
                 source: Source {
@@ -88,10 +103,12 @@ impl DebugAdapter {
                 column: 1,
                 end_line: None,
                 end_column: None,
-            }]
+            }];
+            self.cache_stack_frames(attached.clone());
+            attached
         } else {
             // No session - return placeholder frame for testing
-            vec![StackFrame {
+            let placeholder = vec![StackFrame {
                 id: 1,
                 name: "main::hello".to_string(),
                 source: Source {
@@ -103,7 +120,9 @@ impl DebugAdapter {
                 column: 1,
                 end_line: None,
                 end_column: None,
-            }]
+            }];
+            self.cache_stack_frames(placeholder.clone());
+            placeholder
         };
         let stack_frames = Self::paginate_stack_frames(stack_frames, start_frame, requested_count);
 
@@ -184,6 +203,16 @@ impl DebugAdapter {
 }
 
 impl DebugAdapter {
+    fn is_valid_stack_trace_snapshot(frames: &[StackFrame]) -> bool {
+        !frames.is_empty()
+            && frames.iter().any(|frame| {
+                frame.line > 0
+                    && !frame.name.trim().is_empty()
+                    && frame.source.path != "<unknown>"
+                    && !frame.source.path.trim().is_empty()
+            })
+    }
+
     fn paginate_stack_frames(
         stack_frames: Vec<StackFrame>,
         start_frame: usize,

--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -441,6 +441,10 @@ pub struct DebugAdapter {
     next_goto_target_id: Arc<Mutex<i64>>,
     /// Workspace root for path validation (set during launch)
     workspace_root: Arc<Mutex<Option<PathBuf>>>,
+    /// Monotonic token describing execution/attach state changes relevant to stack frames.
+    stack_trace_epoch: Arc<AtomicU64>,
+    /// Cached stack frames for the current stack-trace epoch.
+    stack_trace_cache: Arc<Mutex<Option<StackTraceCache>>>,
 }
 
 /// Active debug session
@@ -457,6 +461,12 @@ struct DebugSession {
     thread_id: i32,
     /// Last resume command issued while running.
     last_resume_mode: ResumeMode,
+}
+
+#[derive(Debug, Clone)]
+struct StackTraceCache {
+    epoch: u64,
+    frames: Vec<StackFrame>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -557,6 +567,8 @@ impl DebugAdapter {
             goto_targets: Arc::new(Mutex::new(HashMap::new())),
             next_goto_target_id: Arc::new(Mutex::new(1)),
             workspace_root: Arc::new(Mutex::new(None)),
+            stack_trace_epoch: Arc::new(AtomicU64::new(1)),
+            stack_trace_cache: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -722,6 +734,27 @@ impl DebugAdapter {
                 }
             }
         }
+    }
+
+    /// Invalidate stack-frame cache whenever execution or attach state changes.
+    fn invalidate_stack_trace_cache(&self) {
+        self.stack_trace_epoch.fetch_add(1, Ordering::AcqRel);
+        let mut cache = lock_or_recover(&self.stack_trace_cache, "debug_adapter.stack_trace_cache");
+        *cache = None;
+    }
+
+    /// Cache stack frames for the current execution epoch.
+    fn cache_stack_frames(&self, frames: Vec<StackFrame>) {
+        let epoch = self.stack_trace_epoch.load(Ordering::Acquire);
+        let mut cache = lock_or_recover(&self.stack_trace_cache, "debug_adapter.stack_trace_cache");
+        *cache = Some(StackTraceCache { epoch, frames });
+    }
+
+    /// Read stack-frame cache for the current execution epoch.
+    fn cached_stack_frames(&self) -> Option<Vec<StackFrame>> {
+        let epoch = self.stack_trace_epoch.load(Ordering::Acquire);
+        let cache = lock_or_recover(&self.stack_trace_cache, "debug_adapter.stack_trace_cache");
+        cache.as_ref().filter(|entry| entry.epoch == epoch).map(|entry| entry.frames.clone())
     }
 }
 #[cfg(test)]

--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -379,6 +379,7 @@ impl DebugAdapter {
                             .to_string(),
                     );
                 }
+                self.invalidate_stack_trace_cache();
 
                 // Apply any function breakpoints configured before launch.
                 self.apply_stored_function_breakpoints();
@@ -489,6 +490,8 @@ impl DebugAdapter {
         let last_exception_message = self.last_exception_message.clone();
         let tcp_session = self.tcp_session.clone();
         let attached_pid = self.attached_pid.clone();
+        let stack_trace_epoch = self.stack_trace_epoch.clone();
+        let stack_trace_cache = self.stack_trace_cache.clone();
 
         thread::spawn(move || {
             // Perl's debugger prompt and evaluation output are emitted on stderr.
@@ -545,6 +548,10 @@ impl DebugAdapter {
                 match reader.read_line(&mut line) {
                     Ok(0) => {
                         tracing::debug!("Perl debugger process terminated");
+                        stack_trace_epoch.fetch_add(1, Ordering::AcqRel);
+                        if let Ok(mut cache) = stack_trace_cache.lock() {
+                            *cache = None;
+                        }
                         DebugAdapter::clear_active_session_state_with_state(
                             &session,
                             &tcp_session,
@@ -804,6 +811,11 @@ impl DebugAdapter {
                                 continue;
                             }
 
+                            stack_trace_epoch.fetch_add(1, Ordering::AcqRel);
+                            if let Ok(mut cache) = stack_trace_cache.lock() {
+                                *cache = None;
+                            }
+
                             if should_emit_stopped
                                 && let Some(ref sender) = sender
                                 && !emit_event_safe(
@@ -887,6 +899,10 @@ impl DebugAdapter {
                             };
 
                             // Send stopped event with robust error handling
+                            stack_trace_epoch.fetch_add(1, Ordering::AcqRel);
+                            if let Ok(mut cache) = stack_trace_cache.lock() {
+                                *cache = None;
+                            }
                             if let Some(ref sender) = sender
                                 && !emit_event_safe(
                                     sender,
@@ -975,6 +991,7 @@ impl DebugAdapter {
                 if let Ok(mut guard) = self.attached_pid.lock() {
                     *guard = Some(pid);
                 }
+                self.invalidate_stack_trace_cache();
 
                 let stop_on_entry =
                     args.get("stopOnEntry").and_then(|s| s.as_bool()).unwrap_or(false);
@@ -1133,6 +1150,7 @@ impl DebugAdapter {
                         if let Ok(mut guard) = self.tcp_session.lock() {
                             *guard = Some(session);
                         }
+                        self.invalidate_stack_trace_cache();
 
                         // Start reader thread
                         if let Ok(mut guard) = self.tcp_session.lock() {
@@ -1294,6 +1312,7 @@ impl DebugAdapter {
 
     /// Clear active process session, TCP session, and PID-attach mode state.
     pub(super) fn clear_active_session_state(&self) {
+        self.invalidate_stack_trace_cache();
         Self::clear_active_session_state_with_state(
             &self.session,
             &self.tcp_session,
@@ -1478,6 +1497,7 @@ impl DebugAdapter {
                 // stop) and auto-continue until a user breakpoint is hit.
                 session.state = DebugState::Running;
                 session.last_resume_mode = ResumeMode::RunToBreakpoint;
+                self.invalidate_stack_trace_cache();
                 let _ = stdin.write_all(b"c\n");
                 let _ = stdin.flush();
             }

--- a/crates/perl-dap/tests/stack_trace_provider_tests.rs
+++ b/crates/perl-dap/tests/stack_trace_provider_tests.rs
@@ -144,3 +144,37 @@ fn test_stack_trace_response_sequence_numbers() -> Result<(), Box<dyn std::error
 
     Ok(())
 }
+
+#[test]
+fn test_stack_trace_repeated_requests_remain_stable() -> Result<(), Box<dyn std::error::Error>> {
+    let mut adapter = create_test_adapter();
+
+    let first = adapter.handle_request(1, "stackTrace", None);
+    let second = adapter.handle_request(2, "stackTrace", None);
+
+    let DapMessage::Response { success: first_success, body: first_body, .. } = first else {
+        return Err("Expected first response message".into());
+    };
+    let DapMessage::Response { success: second_success, body: second_body, .. } = second else {
+        return Err("Expected second response message".into());
+    };
+
+    assert!(first_success);
+    assert!(second_success);
+
+    let first_frames = first_body
+        .ok_or("Expected first response body")?
+        .get("stackFrames")
+        .and_then(|v| v.as_array())
+        .ok_or("Expected first stackFrames array")?
+        .clone();
+    let second_frames = second_body
+        .ok_or("Expected second response body")?
+        .get("stackFrames")
+        .and_then(|v| v.as_array())
+        .ok_or("Expected second stackFrames array")?
+        .clone();
+
+    assert_eq!(first_frames, second_frames);
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Prefer framed `T` output as the canonical, fast path for `stackTrace` and avoid repeatedly reparsing fallback snapshots.
- Reduce work for repeated `stackTrace` requests by caching parsed frames and ensuring the cache is invalidated on execution / attach / stop lifecycle changes while preserving visibility filtering and attach fallbacks.

### Description
- Added epoch-aware caching to `DebugAdapter` (`stack_trace_epoch`, `stack_trace_cache`, and `StackTraceCache`) and helper methods `invalidate_stack_trace_cache`, `cache_stack_frames`, and `cached_stack_frames` in `crates/perl-dap/src/debug_adapter/mod.rs`.
- Reworked `handle_stack_trace` in `crates/perl-dap/src/debug_adapter/frames.rs` to consult the cache first, prefer framed `T` parsing (`send_framed_debugger_commands` + `capture_framed_debugger_output`) as the canonical snapshot, validate framed results with `is_valid_stack_trace_snapshot`, and only fallback to `snapshot_recent_output_lines` when framed parsing is empty or invalid.
- Cache parsed results (including attach/placeholder frames) and avoid unnecessary reparsing by storing the cached frames per epoch.
- Wired cache invalidation into execution and lifecycle paths (resume handlers like `handle_continue`, `handle_next`, `handle_step_in`, `handle_step_out`, launch/attach, `clear_active_session_state`, stop/prompt handling in the output reader, and `configurationDone` run-to-breakpoint) so cached frames are invalidated on state changes (see `crates/perl-dap/src/debug_adapter/execution.rs` and `process.rs`).
- Added an integration test `test_stack_trace_repeated_requests_remain_stable` in `crates/perl-dap/tests/stack_trace_provider_tests.rs` to assert repeated `stackTrace` responses are stable when state is unchanged.

### Testing
- Ran `cargo xtask fmt` successfully.
- Ran `cargo test -p perl-dap --test stack_trace_provider_tests` and all tests passed.
- Ran `cargo test -p perl-dap --test stack_malformed_debugger_output_tests` and all tests passed.
- Ran `cargo check --all-targets -p perl-dap` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb399cdfd48333b30da6fcfb53befe)