### PR TITLE
perf(perl-dap): add framed fast path and smarter reuse for stackTrace (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/execution.rs
+++ b/crates/perl-dap/src/debug_adapter/execution.rs
@@ -26,6 +26,7 @@ impl DebugAdapter {
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::Continue;
             session.variables.clear();
+            session.stack_trace_cache = None;
             thread_id = session.thread_id;
         } else if let Some(pid) = *lock_or_recover(&self.attached_pid, "debug_adapter.attached_pid")
         {
@@ -70,6 +71,7 @@ impl DebugAdapter {
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::Next;
             session.variables.clear();
+            session.stack_trace_cache = None;
             let t_id = session.thread_id;
             self.send_event(
                 "continued",
@@ -106,6 +108,7 @@ impl DebugAdapter {
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::StepIn;
             session.variables.clear();
+            session.stack_trace_cache = None;
             let t_id = session.thread_id;
             self.send_event(
                 "continued",
@@ -143,6 +146,7 @@ impl DebugAdapter {
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::StepOut;
             session.variables.clear();
+            session.stack_trace_cache = None;
             let t_id = session.thread_id;
             self.send_event(
                 "continued",
@@ -357,6 +361,7 @@ impl DebugAdapter {
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::Goto;
             session.variables.clear();
+            session.stack_trace_cache = None;
             let t_id = session.thread_id;
 
             self.send_event(

--- a/crates/perl-dap/src/debug_adapter/frames.rs
+++ b/crates/perl-dap/src/debug_adapter/frames.rs
@@ -16,64 +16,77 @@ impl DebugAdapter {
             args.as_ref().and_then(|value| value.start_frame).unwrap_or(0).max(0) as usize;
         let levels = args.as_ref().and_then(|value| value.levels).unwrap_or(0);
         let requested_count = if levels <= 0 { None } else { Some(levels as usize) };
-        let mut framed_output_lines = None;
+        let mut framed_output_lines: Option<Vec<String>> = None;
+        let mut session_fallback_frames: Option<Vec<StackFrame>> = None;
 
-        // Ask the debugger for an explicit stack snapshot when a live session is present.
-        if let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session")
-            && let Some(stdin) = session.process.stdin.as_mut()
-        {
-            let commands = vec!["T".to_string()];
-            match self.send_framed_debugger_commands(stdin, &commands) {
-                Ok((begin, end)) => {
-                    framed_output_lines = self.capture_framed_debugger_output(
-                        &begin,
-                        &end,
-                        DEBUGGER_QUERY_WAIT_MS * 8,
-                    );
-                }
-                Err(error) => {
-                    tracing::warn!(%error, "Failed to send framed stackTrace command, falling back");
-                    let _ = stdin.write_all(b"T\n");
-                    let _ = stdin.flush();
-                    Self::wait_for_debugger_output_window(DEBUGGER_QUERY_WAIT_MS as u32);
+        if let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session") {
+            if let Some(cached_frames) = session.stack_trace_cache.clone() {
+                let stack_frames =
+                    Self::paginate_stack_frames(cached_frames, start_frame, requested_count);
+                return DapMessage::Response {
+                    seq,
+                    request_seq,
+                    success: true,
+                    command: "stackTrace".to_string(),
+                    body: Some(json!({
+                        "stackFrames": stack_frames,
+                        "totalFrames": stack_frames.len()
+                    })),
+                    message: None,
+                };
+            }
+
+            session_fallback_frames =
+                Some(Self::filter_user_visible_frames(session.stack_frames.clone()));
+
+            // Ask the debugger for an explicit stack snapshot when a live session is present.
+            if let Some(stdin) = session.process.stdin.as_mut() {
+                let commands = vec!["T".to_string()];
+                match self.send_framed_debugger_commands(stdin, &commands) {
+                    Ok((begin, end)) => {
+                        framed_output_lines = self.capture_framed_debugger_output(
+                            &begin,
+                            &end,
+                            DEBUGGER_QUERY_WAIT_MS * 8,
+                        );
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "Failed to send framed stackTrace command, falling back");
+                        let _ = stdin.write_all(b"T\n");
+                        let _ = stdin.flush();
+                        Self::wait_for_debugger_output_window(DEBUGGER_QUERY_WAIT_MS as u32);
+                    }
                 }
             }
         }
 
-        let parsed_frames = if let Some(lines) = framed_output_lines.as_ref() {
-            let output = lines.join("\n");
-            let framed_frames =
-                Self::filter_user_visible_frames(Self::parse_stack_frames_from_text(&output));
-            if framed_frames.is_empty() {
-                let output_lines = self.snapshot_recent_output_lines();
-                if output_lines.is_empty() {
-                    Vec::new()
-                } else {
-                    let output = output_lines.join("\n");
-                    Self::filter_user_visible_frames(Self::parse_stack_frames_from_text(&output))
-                }
-            } else {
-                framed_frames
-            }
-        } else {
-            let output_lines = self.snapshot_recent_output_lines();
-            if output_lines.is_empty() {
-                Vec::new()
-            } else {
-                let output = output_lines.join("\n");
+        let mut parsed_frames = framed_output_lines
+            .as_ref()
+            .map(|lines| {
+                let output = lines.join("\n");
                 Self::filter_user_visible_frames(Self::parse_stack_frames_from_text(&output))
+            })
+            .unwrap_or_default();
+
+        // Fall back to parsing broader output only when framed output is empty or malformed.
+        if parsed_frames.is_empty() || !Self::has_structurally_valid_stack_frames(&parsed_frames) {
+            let output_lines = self.snapshot_recent_output_lines();
+            if !output_lines.is_empty() {
+                let output = output_lines.join("\n");
+                parsed_frames =
+                    Self::filter_user_visible_frames(Self::parse_stack_frames_from_text(&output));
             }
-        };
+        }
 
         let stack_frames = if !parsed_frames.is_empty() {
-            // Keep parsed frames as best-effort latest snapshot.
             if let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session")
             {
                 session.stack_frames = parsed_frames.clone();
+                session.stack_trace_cache = Some(parsed_frames.clone());
             }
             parsed_frames
-        } else if let Some(ref session) = *lock_or_recover(&self.session, "debug_adapter.session") {
-            Self::filter_user_visible_frames(session.stack_frames.clone())
+        } else if let Some(frames) = session_fallback_frames {
+            frames
         } else if let Some(pid) = *lock_or_recover(&self.attached_pid, "debug_adapter.attached_pid")
         {
             vec![StackFrame {
@@ -184,6 +197,12 @@ impl DebugAdapter {
 }
 
 impl DebugAdapter {
+    fn has_structurally_valid_stack_frames(frames: &[StackFrame]) -> bool {
+        frames.iter().any(|frame| {
+            !frame.name.trim().is_empty() && frame.line > 0 && !frame.source.path.trim().is_empty()
+        })
+    }
+
     fn paginate_stack_frames(
         stack_frames: Vec<StackFrame>,
         start_frame: usize,

--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -451,6 +451,8 @@ struct DebugSession {
     state: DebugState,
     /// Stack frames
     stack_frames: Vec<StackFrame>,
+    /// Cached user-visible stack trace for the current paused state.
+    stack_trace_cache: Option<Vec<StackFrame>>,
     /// Variables in current scope
     variables: HashMap<i32, Vec<Variable>>,
     /// Thread ID

--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -365,6 +365,7 @@ impl DebugAdapter {
                     process: child,
                     state: DebugState::Running,
                     stack_frames: Vec::new(),
+                    stack_trace_cache: None,
                     variables: HashMap::new(),
                     thread_id,
                     last_resume_mode: ResumeMode::Unknown,
@@ -719,6 +720,7 @@ impl DebugAdapter {
                                             end_line: None,
                                             end_column: None,
                                         }];
+                                        s.stack_trace_cache = None;
                                     }
 
                                     if matches!(s.state, DebugState::Running) {
@@ -862,6 +864,7 @@ impl DebugAdapter {
                                             end_column: None,
                                         };
                                         s.stack_frames = vec![frame];
+                                        s.stack_trace_cache = None;
                                     } else {
                                         // Provide a fallback frame for when we don't have perfect context
                                         let frame = StackFrame {
@@ -878,6 +881,7 @@ impl DebugAdapter {
                                             end_column: None,
                                         };
                                         s.stack_frames = vec![frame];
+                                        s.stack_trace_cache = None;
                                     }
                                     s.state = DebugState::Stopped;
                                     s.thread_id


### PR DESCRIPTION
### Motivation
- Reduce repeated broad-output reparsing and prefer fresher framed `T` snapshots so repeated `stackTrace` requests are cheaper and more correct.
- Ensure cached parsed frames are invalidated when execution or attach state changes so stale data is not returned.

### Description
- Add `stack_trace_cache: Option<Vec<StackFrame>>` to `DebugSession` and initialize it on launch to support fast-path returns (`crates/perl-dap/src/debug_adapter/mod.rs`, `crates/perl-dap/src/debug_adapter/process.rs`).
- Update `handle_stack_trace` to return cached frames early, use framed `T` output as the canonical fast path, and only fall back to parsing `recent_output` when the framed parse is empty or structurally invalid; parsed frames are filtered for user visibility and cached (`crates/perl-dap/src/debug_adapter/frames.rs`).
- Invalidate the cache on resume/continue-like transitions (`continue`, `next`, `stepIn`, `stepOut`, `goto`) and when the output reader updates stopped-frame context, preserving attach/PID fallback and placeholder behavior (`crates/perl-dap/src/debug_adapter/execution.rs`, `crates/perl-dap/src/debug_adapter/process.rs`).
- Add a lightweight structural validity check `has_structurally_valid_stack_frames` and wire the existing framed-capture helpers without changing visibility filtering or parsing logic (`crates/perl-dap/src/debug_adapter/frames.rs`).

### Testing
- Ran `cargo test -p perl-dap --test stack_trace_provider_tests` and all tests passed.
- Ran `cargo test -p perl-dap --test stack_malformed_debugger_output_tests` and all tests passed.
- Ran `cargo check --all-targets -p perl-dap` and it succeeded, and `cargo xtask fmt` was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb399cdfd48333b30da6fcfb53befe)