### PR TITLE
perf(perl-dap): add framed fast path and smarter reuse for stackTrace (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/execution.rs
+++ b/crates/perl-dap/src/debug_adapter/execution.rs
@@ -23,8 +23,11 @@ impl DebugAdapter {
         {
             let _ = stdin.write_all(b"c\n");
             let _ = stdin.flush();
+            let snapshot_generation = self.bump_stack_snapshot_generation();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::Continue;
+            session.stack_frames.clear();
+            session.stack_frames_generation = snapshot_generation;
             session.variables.clear();
             thread_id = session.thread_id;
         } else if let Some(pid) = *lock_or_recover(&self.attached_pid, "debug_adapter.attached_pid")
@@ -67,8 +70,11 @@ impl DebugAdapter {
         {
             let _ = stdin.write_all(b"n\n");
             let _ = stdin.flush();
+            let snapshot_generation = self.bump_stack_snapshot_generation();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::Next;
+            session.stack_frames.clear();
+            session.stack_frames_generation = snapshot_generation;
             session.variables.clear();
             let t_id = session.thread_id;
             self.send_event(
@@ -103,8 +109,11 @@ impl DebugAdapter {
         {
             let _ = stdin.write_all(b"s\n");
             let _ = stdin.flush();
+            let snapshot_generation = self.bump_stack_snapshot_generation();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::StepIn;
+            session.stack_frames.clear();
+            session.stack_frames_generation = snapshot_generation;
             session.variables.clear();
             let t_id = session.thread_id;
             self.send_event(
@@ -140,8 +149,11 @@ impl DebugAdapter {
         {
             let _ = stdin.write_all(b"r\n");
             let _ = stdin.flush();
+            let snapshot_generation = self.bump_stack_snapshot_generation();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::StepOut;
+            session.stack_frames.clear();
+            session.stack_frames_generation = snapshot_generation;
             session.variables.clear();
             let t_id = session.thread_id;
             self.send_event(
@@ -354,8 +366,11 @@ impl DebugAdapter {
             let goto_cmd = format!("c {}\n", target_line);
             let _ = stdin.write_all(goto_cmd.as_bytes());
             let _ = stdin.flush();
+            let snapshot_generation = self.bump_stack_snapshot_generation();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::Goto;
+            session.stack_frames.clear();
+            session.stack_frames_generation = snapshot_generation;
             session.variables.clear();
             let t_id = session.thread_id;
 

--- a/crates/perl-dap/src/debug_adapter/frames.rs
+++ b/crates/perl-dap/src/debug_adapter/frames.rs
@@ -16,6 +16,33 @@ impl DebugAdapter {
             args.as_ref().and_then(|value| value.start_frame).unwrap_or(0).max(0) as usize;
         let levels = args.as_ref().and_then(|value| value.levels).unwrap_or(0);
         let requested_count = if levels <= 0 { None } else { Some(levels as usize) };
+        let current_generation = self.current_stack_snapshot_generation();
+
+        // Reuse parsed stack frames when execution state has not changed.
+        if let Some(ref session) = *lock_or_recover(&self.session, "debug_adapter.session")
+            && matches!(session.state, DebugState::Stopped)
+            && session.stack_frames_generation == current_generation
+            && !session.stack_frames.is_empty()
+        {
+            let stack_frames = Self::paginate_stack_frames(
+                Self::filter_user_visible_frames(session.stack_frames.clone()),
+                start_frame,
+                requested_count,
+            );
+
+            return DapMessage::Response {
+                seq,
+                request_seq,
+                success: true,
+                command: "stackTrace".to_string(),
+                body: Some(json!({
+                    "stackFrames": stack_frames,
+                    "totalFrames": stack_frames.len()
+                })),
+                message: None,
+            };
+        }
+
         let mut framed_output_lines = None;
 
         // Ask the debugger for an explicit stack snapshot when a live session is present.
@@ -40,36 +67,35 @@ impl DebugAdapter {
             }
         }
 
-        let parsed_frames = if let Some(lines) = framed_output_lines.as_ref() {
+        let mut parsed_frames = Vec::new();
+        let mut requires_recent_output_fallback = framed_output_lines.is_none();
+
+        if let Some(lines) = framed_output_lines.as_ref() {
             let output = lines.join("\n");
             let framed_frames =
                 Self::filter_user_visible_frames(Self::parse_stack_frames_from_text(&output));
-            if framed_frames.is_empty() {
-                let output_lines = self.snapshot_recent_output_lines();
-                if output_lines.is_empty() {
-                    Vec::new()
-                } else {
-                    let output = output_lines.join("\n");
-                    Self::filter_user_visible_frames(Self::parse_stack_frames_from_text(&output))
-                }
+            if framed_frames.is_empty() || Self::are_frames_clearly_invalid(&framed_frames) {
+                requires_recent_output_fallback = true;
             } else {
-                framed_frames
+                parsed_frames = framed_frames;
             }
-        } else {
+        }
+
+        if requires_recent_output_fallback {
             let output_lines = self.snapshot_recent_output_lines();
-            if output_lines.is_empty() {
-                Vec::new()
-            } else {
+            if !output_lines.is_empty() {
                 let output = output_lines.join("\n");
-                Self::filter_user_visible_frames(Self::parse_stack_frames_from_text(&output))
+                parsed_frames =
+                    Self::filter_user_visible_frames(Self::parse_stack_frames_from_text(&output));
             }
-        };
+        }
 
         let stack_frames = if !parsed_frames.is_empty() {
             // Keep parsed frames as best-effort latest snapshot.
             if let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session")
             {
                 session.stack_frames = parsed_frames.clone();
+                session.stack_frames_generation = current_generation;
             }
             parsed_frames
         } else if let Some(ref session) = *lock_or_recover(&self.session, "debug_adapter.session") {
@@ -184,6 +210,15 @@ impl DebugAdapter {
 }
 
 impl DebugAdapter {
+    fn are_frames_clearly_invalid(frames: &[StackFrame]) -> bool {
+        frames.iter().all(|frame| {
+            frame.name.trim().is_empty()
+                || frame.line <= 0
+                || frame.source.path.trim().is_empty()
+                || frame.source.path == "<unknown>"
+        })
+    }
+
     fn paginate_stack_frames(
         stack_frames: Vec<StackFrame>,
         start_frame: usize,
@@ -194,5 +229,38 @@ impl DebugAdapter {
             Some(limit) => iter.take(limit).collect(),
             None => iter.collect(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frame(name: &str, path: &str, line: i32) -> StackFrame {
+        StackFrame {
+            id: 1,
+            name: name.to_string(),
+            source: Source {
+                name: Some("file.pl".to_string()),
+                path: path.to_string(),
+                source_reference: None,
+            },
+            line,
+            column: 1,
+            end_line: None,
+            end_column: None,
+        }
+    }
+
+    #[test]
+    fn stack_frames_invalid_when_all_unknown_or_zero() {
+        let frames = vec![frame("main", "<unknown>", 0), frame("", "<unknown>", 1)];
+        assert!(DebugAdapter::are_frames_clearly_invalid(&frames));
+    }
+
+    #[test]
+    fn stack_frames_valid_when_any_frame_has_source_and_line() {
+        let frames = vec![frame("main::run", "/tmp/app.pl", 42), frame("helper", "<unknown>", 0)];
+        assert!(!DebugAdapter::are_frames_clearly_invalid(&frames));
     }
 }

--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -427,6 +427,8 @@ pub struct DebugAdapter {
     exception_break_on_warn: Arc<Mutex<bool>>,
     /// Unique marker IDs used to frame debugger output per command.
     debugger_output_marker: Arc<AtomicU64>,
+    /// Monotonic generation for stack snapshot cache invalidation.
+    stack_snapshot_generation: Arc<AtomicU64>,
     /// Cancellation flag for in-progress requests.
     cancel_requested: Arc<AtomicBool>,
     /// Data breakpoints (watchpoints) stored with REPLACE semantics
@@ -457,6 +459,8 @@ struct DebugSession {
     thread_id: i32,
     /// Last resume command issued while running.
     last_resume_mode: ResumeMode,
+    /// Stack snapshot generation tied to `stack_frames`.
+    stack_frames_generation: u64,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -550,6 +554,7 @@ impl DebugAdapter {
             exception_break_on_die: Arc::new(Mutex::new(false)),
             exception_break_on_warn: Arc::new(Mutex::new(false)),
             debugger_output_marker: Arc::new(AtomicU64::new(1)),
+            stack_snapshot_generation: Arc::new(AtomicU64::new(1)),
             cancel_requested: Arc::new(AtomicBool::new(false)),
             data_breakpoints: Arc::new(Mutex::new(Vec::new())),
             last_exception_message: Arc::new(Mutex::new(None)),
@@ -607,6 +612,16 @@ impl DebugAdapter {
     /// Allocate a unique marker id used for framed debugger output capture.
     fn next_debugger_marker_id(&self) -> u64 {
         self.debugger_output_marker.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Return current stack snapshot generation.
+    pub(super) fn current_stack_snapshot_generation(&self) -> u64 {
+        self.stack_snapshot_generation.load(Ordering::Relaxed)
+    }
+
+    /// Bump stack snapshot generation and return the updated value.
+    pub(super) fn bump_stack_snapshot_generation(&self) -> u64 {
+        self.stack_snapshot_generation.fetch_add(1, Ordering::Relaxed).saturating_add(1)
     }
 
     /// Write a debugger command and flush immediately so output framing remains ordered.

--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -368,6 +368,7 @@ impl DebugAdapter {
                     variables: HashMap::new(),
                     thread_id,
                     last_resume_mode: ResumeMode::Unknown,
+                    stack_frames_generation: self.current_stack_snapshot_generation(),
                 };
 
                 if let Ok(mut guard) = self.session.lock() {
@@ -489,6 +490,7 @@ impl DebugAdapter {
         let last_exception_message = self.last_exception_message.clone();
         let tcp_session = self.tcp_session.clone();
         let attached_pid = self.attached_pid.clone();
+        let stack_snapshot_generation = self.stack_snapshot_generation.clone();
 
         thread::spawn(move || {
             // Perl's debugger prompt and evaluation output are emitted on stderr.
@@ -719,6 +721,9 @@ impl DebugAdapter {
                                             end_line: None,
                                             end_column: None,
                                         }];
+                                        s.stack_frames_generation = stack_snapshot_generation
+                                            .fetch_add(1, Ordering::Relaxed)
+                                            .saturating_add(1);
                                     }
 
                                     if matches!(s.state, DebugState::Running) {
@@ -862,6 +867,9 @@ impl DebugAdapter {
                                             end_column: None,
                                         };
                                         s.stack_frames = vec![frame];
+                                        s.stack_frames_generation = stack_snapshot_generation
+                                            .fetch_add(1, Ordering::Relaxed)
+                                            .saturating_add(1);
                                     } else {
                                         // Provide a fallback frame for when we don't have perfect context
                                         let frame = StackFrame {
@@ -878,6 +886,9 @@ impl DebugAdapter {
                                             end_column: None,
                                         };
                                         s.stack_frames = vec![frame];
+                                        s.stack_frames_generation = stack_snapshot_generation
+                                            .fetch_add(1, Ordering::Relaxed)
+                                            .saturating_add(1);
                                     }
                                     s.state = DebugState::Stopped;
                                     s.thread_id
@@ -971,6 +982,7 @@ impl DebugAdapter {
 
                 // Reset existing process/tcp attachment state before switching to PID mode.
                 self.clear_active_session_state();
+                self.bump_stack_snapshot_generation();
 
                 if let Ok(mut guard) = self.attached_pid.lock() {
                     *guard = Some(pid);
@@ -1129,6 +1141,7 @@ impl DebugAdapter {
                 // Attempt to connect
                 match session.connect(&config) {
                     Ok(()) => {
+                        self.bump_stack_snapshot_generation();
                         // Store session
                         if let Ok(mut guard) = self.tcp_session.lock() {
                             *guard = Some(session);
@@ -1476,8 +1489,11 @@ impl DebugAdapter {
                 // ResumeMode::RunToBreakpoint signals the output reader to
                 // silently skip non-breakpoint stops (the implicit first-line
                 // stop) and auto-continue until a user breakpoint is hit.
+                let snapshot_generation = self.bump_stack_snapshot_generation();
                 session.state = DebugState::Running;
                 session.last_resume_mode = ResumeMode::RunToBreakpoint;
+                session.stack_frames.clear();
+                session.stack_frames_generation = snapshot_generation;
                 let _ = stdin.write_all(b"c\n");
                 let _ = stdin.flush();
             }

--- a/crates/perl-dap/tests/stack_trace_provider_tests.rs
+++ b/crates/perl-dap/tests/stack_trace_provider_tests.rs
@@ -13,6 +13,7 @@
 //! These integration tests focus on the public API behavior.
 
 use perl_dap::debug_adapter::{DapMessage, DebugAdapter};
+use serde_json::json;
 
 /// Helper to create a test adapter
 fn create_test_adapter() -> DebugAdapter {
@@ -141,6 +142,35 @@ fn test_stack_trace_response_sequence_numbers() -> Result<(), Box<dyn std::error
 
     assert_eq!(resp_req_seq, request_seq, "Response request_seq must match request");
     assert_eq!(command, "stackTrace");
+
+    Ok(())
+}
+
+#[test]
+fn test_stack_trace_attach_process_fallback_frame() -> Result<(), Box<dyn std::error::Error>> {
+    let mut adapter = create_test_adapter();
+    let _ = adapter.handle_request(1, "attach", Some(json!({ "processId": 4242 })));
+    let response = adapter.handle_request(2, "stackTrace", Some(json!({"threadId": 4242})));
+
+    let DapMessage::Response { success, body, .. } = response else {
+        return Err("Expected Response message".into());
+    };
+    assert!(success);
+
+    let body = body.ok_or("Expected body")?;
+    let frames = body
+        .get("stackFrames")
+        .and_then(|value| value.as_array())
+        .ok_or("Expected stackFrames array")?;
+    assert_eq!(frames.len(), 1, "PID attach fallback should return one synthetic frame");
+
+    let frame = frames.first().ok_or("Expected fallback frame")?;
+    assert_eq!(frame.get("name").and_then(|v| v.as_str()), Some("attached::process::4242"));
+    let source = frame
+        .get("source")
+        .and_then(|value| value.as_object())
+        .ok_or("Expected source object")?;
+    assert_eq!(source.get("path").and_then(|v| v.as_str()), Some("pid://4242"));
 
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Reduce repeated reparsing of debugger output when `stackTrace` is called against an unchanged stopped state.
- Prefer framed `T` output as the canonical fast path and avoid unnecessary fallback churn into recent-output parsing.
- Ensure stack-frame caching is invalidated correctly on resume/attach/stop transitions so responses remain correct.

### Description
- Prefer framed `T` parsing as the canonical fast path in `handle_stack_trace` and only fall back to recent-output parsing when framed results are missing, empty, or clearly invalid. (`crates/perl-dap/src/debug_adapter/frames.rs`)
- Add a monotonic `stack_snapshot_generation` to the adapter and a per-session `stack_frames_generation` to key cached parsed frames for safe reuse. (`crates/perl-dap/src/debug_adapter/mod.rs`)
- Bump generation and clear cached `stack_frames` on execution-resume commands (`continue`, `next`, `stepIn`, `stepOut`, `goto`) and relevant attach/launch transitions so cache invalidation aligns with runtime state. (`crates/perl-dap/src/debug_adapter/execution.rs`, `crates/perl-dap/src/debug_adapter/process.rs`)
- Preserve existing visibility filtering and attach/PID fallback behavior; write small heuristics to treat obviously invalid framed parse results as a signal to use recent-output fallback. Added a focused unit test helper and small regression test for PID-attach fallback. (`crates/perl-dap/tests/stack_trace_provider_tests.rs`)

### Testing
- Ran `cargo xtask fmt` successfully to format changes.
- Ran `cargo test -p perl-dap --test stack_trace_provider_tests` and it passed (all tests OK).
- Ran `cargo test -p perl-dap --test stack_malformed_debugger_output_tests` and it passed (all tests OK).
- Ran `cargo check --all-targets -p perl-dap` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb399cdfd48333b30da6fcfb53befe)