### PR TITLE
perf(perl-dap): add real caching for variables roots, children, and paging (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/evaluation.rs
+++ b/crates/perl-dap/src/debug_adapter/evaluation.rs
@@ -408,7 +408,11 @@ impl DebugAdapter {
                 let session_guard = lock_or_recover(&self.session, "debug_adapter.session");
                 if let Some(ref session) = *session_guard {
                     let mut seen = std::collections::HashSet::new();
-                    for vars in session.variables.values() {
+                    for vars in session
+                        .root_variables
+                        .values()
+                        .chain(session.child_variables.values())
+                    {
                         for var in vars {
                             if (stem.is_empty() || var.name.starts_with(stem))
                                 && seen.insert(var.name.clone())

--- a/crates/perl-dap/src/debug_adapter/execution.rs
+++ b/crates/perl-dap/src/debug_adapter/execution.rs
@@ -25,7 +25,8 @@ impl DebugAdapter {
             let _ = stdin.flush();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::Continue;
-            session.variables.clear();
+            session.root_variables.clear();
+            session.child_variables.clear();
             thread_id = session.thread_id;
         } else if let Some(pid) = *lock_or_recover(&self.attached_pid, "debug_adapter.attached_pid")
         {
@@ -69,7 +70,8 @@ impl DebugAdapter {
             let _ = stdin.flush();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::Next;
-            session.variables.clear();
+            session.root_variables.clear();
+            session.child_variables.clear();
             let t_id = session.thread_id;
             self.send_event(
                 "continued",
@@ -105,7 +107,8 @@ impl DebugAdapter {
             let _ = stdin.flush();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::StepIn;
-            session.variables.clear();
+            session.root_variables.clear();
+            session.child_variables.clear();
             let t_id = session.thread_id;
             self.send_event(
                 "continued",
@@ -142,7 +145,8 @@ impl DebugAdapter {
             let _ = stdin.flush();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::StepOut;
-            session.variables.clear();
+            session.root_variables.clear();
+            session.child_variables.clear();
             let t_id = session.thread_id;
             self.send_event(
                 "continued",
@@ -171,6 +175,10 @@ impl DebugAdapter {
         arguments: Option<Value>,
     ) -> DapMessage {
         let _args: Option<PauseArguments> = arguments.and_then(|v| serde_json::from_value(v).ok());
+        if let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session") {
+            session.root_variables.clear();
+            session.child_variables.clear();
+        }
         let success = if let Some(ref session) =
             *lock_or_recover(&self.session, "debug_adapter.session")
         {
@@ -356,7 +364,8 @@ impl DebugAdapter {
             let _ = stdin.flush();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::Goto;
-            session.variables.clear();
+            session.root_variables.clear();
+            session.child_variables.clear();
             let t_id = session.thread_id;
 
             self.send_event(

--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -451,8 +451,10 @@ struct DebugSession {
     state: DebugState,
     /// Stack frames
     stack_frames: Vec<StackFrame>,
-    /// Variables in current scope
-    variables: HashMap<i32, Vec<Variable>>,
+    /// Cached root scope variables keyed by scope `variablesReference`.
+    root_variables: HashMap<i32, Vec<Variable>>,
+    /// Cached child expansions keyed by child `variablesReference`.
+    child_variables: HashMap<i32, Vec<Variable>>,
     /// Thread ID
     thread_id: i32,
     /// Last resume command issued while running.

--- a/crates/perl-dap/src/debug_adapter/parsing.rs
+++ b/crates/perl-dap/src/debug_adapter/parsing.rs
@@ -138,7 +138,7 @@ impl DebugAdapter {
                 if seen.insert(name.clone()) {
                     parsed.push((name, value));
                 }
-                if parsed.len() >= 256 {
+                if parsed.len() >= DebugAdapter::MAX_VARIABLE_CACHE_ENTRIES {
                     break;
                 }
             }
@@ -164,7 +164,7 @@ impl DebugAdapter {
 
             if value.is_expandable() {
                 let children = renderer
-                    .render_children(&value, 0, 256)
+                    .render_children(&value, 0, DebugAdapter::MAX_VARIABLE_CACHE_ENTRIES)
                     .into_iter()
                     .map(Self::rendered_to_variable)
                     .collect::<Vec<_>>();

--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -365,7 +365,8 @@ impl DebugAdapter {
                     process: child,
                     state: DebugState::Running,
                     stack_frames: Vec::new(),
-                    variables: HashMap::new(),
+                    root_variables: HashMap::new(),
+                    child_variables: HashMap::new(),
                     thread_id,
                     last_resume_mode: ResumeMode::Unknown,
                 };

--- a/crates/perl-dap/src/debug_adapter/variables.rs
+++ b/crates/perl-dap/src/debug_adapter/variables.rs
@@ -3,6 +3,16 @@
 use super::*;
 
 impl DebugAdapter {
+    pub(super) const MAX_VARIABLE_CACHE_ENTRIES: usize = 1024;
+
+    fn is_scope_root_reference(variables_ref: i32) -> bool {
+        matches!(variables_ref % 10, 1..=3)
+    }
+
+    fn slice_cached_variables(variables: &[Variable], start: usize, count: usize) -> Vec<Variable> {
+        variables.iter().skip(start).take(count).cloned().collect()
+    }
+
     /// Handle variables request
     pub(super) fn handle_variables(
         &self,
@@ -50,8 +60,6 @@ impl DebugAdapter {
         let variables_ref = args.variables_reference as i32;
         let start = args.start.unwrap_or(0) as usize;
         let count = args.count.map(|v| v as usize).unwrap_or(256).clamp(1, 1024);
-        let can_use_root_cache = start == 0 && args.count.is_none();
-
         if variables_ref == 0 {
             return DapMessage::Response {
                 seq,
@@ -63,16 +71,46 @@ impl DebugAdapter {
             };
         }
 
-        // AC8.4: Render scalars/arrays/hashes with lazy child expansion.
+        // Child expansion path: serve from child cache with local slicing.
+        if !Self::is_scope_root_reference(variables_ref) {
+            if let Some(ref session) = *lock_or_recover(&self.session, "debug_adapter.session")
+                && let Some(children) = session.child_variables.get(&variables_ref)
+            {
+                let variables = Self::slice_cached_variables(children, start, count);
+                return DapMessage::Response {
+                    seq,
+                    request_seq,
+                    success: true,
+                    command: "variables".to_string(),
+                    body: Some(json!({ "variables": variables })),
+                    message: None,
+                };
+            }
+
+            return DapMessage::Response {
+                seq,
+                request_seq,
+                success: true,
+                command: "variables".to_string(),
+                body: Some(json!({ "variables": Vec::<Variable>::new() })),
+                message: None,
+            };
+        }
+
+        // Scope root path: use root cache, otherwise parse once then cache roots + children.
         let parsed_from_output;
         let mut parsed_child_cache = HashMap::new();
-        let mut used_session_cache = false;
-
         if let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session") {
-            // Return cached variables first for stable references and fast repeated expansion.
-            if can_use_root_cache && let Some(vars) = session.variables.get(&variables_ref) {
-                used_session_cache = true;
-                parsed_from_output = vars.clone();
+            if let Some(cached) = session.root_variables.get(&variables_ref) {
+                let variables = Self::slice_cached_variables(cached, start, count);
+                return DapMessage::Response {
+                    seq,
+                    request_seq,
+                    success: true,
+                    command: "variables".to_string(),
+                    body: Some(json!({ "variables": variables })),
+                    message: None,
+                };
             } else {
                 let mut framed_scope_lines = None;
 
@@ -144,16 +182,29 @@ impl DebugAdapter {
 
                 let (vars, child_cache) = if let Some(lines) = framed_scope_lines.as_ref() {
                     let (framed_vars, framed_child_cache) =
-                        Self::parse_scope_variables_from_lines(lines, variables_ref, start, count);
+                        Self::parse_scope_variables_from_lines(
+                            lines,
+                            variables_ref,
+                            0,
+                            Self::MAX_VARIABLE_CACHE_ENTRIES,
+                        );
                     if framed_vars.is_empty() {
                         Self::wait_for_debugger_output_window(DEBUGGER_QUERY_WAIT_MS as u32);
-                        self.parse_scope_variables_from_output(variables_ref, start, count)
+                        self.parse_scope_variables_from_output(
+                            variables_ref,
+                            0,
+                            Self::MAX_VARIABLE_CACHE_ENTRIES,
+                        )
                     } else {
                         (framed_vars, framed_child_cache)
                     }
                 } else {
                     Self::wait_for_debugger_output_window(DEBUGGER_QUERY_WAIT_MS as u32);
-                    self.parse_scope_variables_from_output(variables_ref, start, count)
+                    self.parse_scope_variables_from_output(
+                        variables_ref,
+                        0,
+                        Self::MAX_VARIABLE_CACHE_ENTRIES,
+                    )
                 };
 
                 parsed_from_output = vars;
@@ -161,24 +212,27 @@ impl DebugAdapter {
             }
         } else {
             let (vars, _child_cache) =
-                self.parse_scope_variables_from_output(variables_ref, start, count);
+                self.parse_scope_variables_from_output(
+                    variables_ref,
+                    0,
+                    Self::MAX_VARIABLE_CACHE_ENTRIES,
+                );
             parsed_from_output = vars;
         }
 
-        let variables = if parsed_from_output.is_empty() {
+        let uncached_variables = if parsed_from_output.is_empty() {
             Self::fallback_scope_variables(variables_ref, start, count)
         } else {
-            parsed_from_output
+            Self::slice_cached_variables(&parsed_from_output, start, count)
         };
 
         // Cache parsed variables and generated child references for expansion requests.
-        if !used_session_cache
-            && can_use_root_cache
-            && let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session")
+        if let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session")
+            && !parsed_from_output.is_empty()
         {
-            session.variables.insert(variables_ref, variables.clone());
+            session.root_variables.insert(variables_ref, parsed_from_output);
             for (reference, children) in parsed_child_cache {
-                session.variables.insert(reference, children);
+                session.child_variables.insert(reference, children);
             }
         }
 
@@ -188,7 +242,7 @@ impl DebugAdapter {
             success: true,
             command: "variables".to_string(),
             body: Some(json!({
-                "variables": variables
+                "variables": uncached_variables
             })),
             message: None,
         }

--- a/crates/perl-dap/tests/dap_performance_tests.rs
+++ b/crates/perl-dap/tests/dap_performance_tests.rs
@@ -121,10 +121,31 @@ mod dap_performance {
             first_elapsed
         );
 
+        let repeat_start = Instant::now();
+        let repeat = adapter.handle_request(
+            2,
+            "variables",
+            Some(json!({
+                "variablesReference": 11,
+                "start": 0,
+                "count": 50
+            })),
+        );
+        let repeat_elapsed = repeat_start.elapsed();
+        match repeat {
+            DapMessage::Response { success, .. } => assert!(success),
+            _ => anyhow::bail!("expected repeated variables response"),
+        }
+        assert!(
+            repeat_elapsed <= Duration::from_millis(100),
+            "repeated variables request should be cache-fast: {:?}",
+            repeat_elapsed
+        );
+
         if child_ref > 0 {
             let child_start = Instant::now();
             let child = adapter.handle_request(
-                2,
+                3,
                 "variables",
                 Some(json!({
                     "variablesReference": child_ref,
@@ -141,6 +162,27 @@ mod dap_performance {
                 child_elapsed < Duration::from_millis(100),
                 "child variable expansion too slow: {:?}",
                 child_elapsed
+            );
+
+            let child_repeat_start = Instant::now();
+            let child_repeat = adapter.handle_request(
+                4,
+                "variables",
+                Some(json!({
+                    "variablesReference": child_ref,
+                    "start": 50,
+                    "count": 50
+                })),
+            );
+            let child_repeat_elapsed = child_repeat_start.elapsed();
+            match child_repeat {
+                DapMessage::Response { success, .. } => assert!(success),
+                _ => anyhow::bail!("expected repeated child variables response"),
+            }
+            assert!(
+                child_repeat_elapsed < Duration::from_millis(100),
+                "repeated child variable expansion should be cache-fast: {:?}",
+                child_repeat_elapsed
             );
         }
 

--- a/crates/perl-dap/tests/variables_deep_truncation.rs
+++ b/crates/perl-dap/tests/variables_deep_truncation.rs
@@ -71,6 +71,28 @@ mod deep_truncation_tests {
     }
 
     #[test]
+    fn test_500element_array_pagination_windows_do_not_overlap() {
+        let renderer = PerlVariableRenderer::new();
+        let elements: Vec<PerlValue> = (0..500).map(PerlValue::Integer).collect();
+        let value = PerlValue::Array(elements);
+
+        let first_window = renderer.render_children(&value, 0, 128);
+        let second_window = renderer.render_children(&value, 128, 128);
+        let near_end_window = renderer.render_children(&value, 384, 200);
+
+        assert_eq!(first_window.len(), 128);
+        assert_eq!(second_window.len(), 128);
+        assert_eq!(near_end_window.len(), 116);
+
+        assert_eq!(first_window.first().map(|child| child.name.as_str()), Some("[0]"));
+        assert_eq!(first_window.last().map(|child| child.name.as_str()), Some("[127]"));
+        assert_eq!(second_window.first().map(|child| child.name.as_str()), Some("[128]"));
+        assert_eq!(second_window.last().map(|child| child.name.as_str()), Some("[255]"));
+        assert_eq!(near_end_window.first().map(|child| child.name.as_str()), Some("[384]"));
+        assert_eq!(near_end_window.last().map(|child| child.name.as_str()), Some("[499]"));
+    }
+
+    #[test]
     fn test_cyclic_reference_rendering() {
         let renderer = PerlVariableRenderer::new();
 


### PR DESCRIPTION
### Motivation

- Variable expansion previously cached only root requests without robust paging which caused repeated root/child requests to re-parse debugger output and wasted latency.
- Need stable `variablesReference` behavior while making repeated variable requests (root and child) cheaper and more accurate.

### Description

- Replace the single `variables` map with explicit per-session `root_variables` and `child_variables` caches stored on `DebugSession` and wired through `DebugAdapter`.
- `handle_variables` now distinguishes scope-root refs vs child refs, serves cached child slices locally using `start/count` slicing, and parses+caches full root sets once up to a bounded cap (`MAX_VARIABLE_CACHE_ENTRIES`).
- Parsing logic now renders children at cache scale and stores child vectors so subsequent paged requests are served from `child_variables` without reparsing.
- Cache invalidation is applied broadly on execution state changes (`continue`, `next`, `stepIn`, `stepOut`, `goto`, `pause`, and attach transitions) to avoid stale expansions, and completions were updated to read names from both root and child caches.
- Added test assertions: non-overlapping pagination windows for large arrays and repeated-root/child latency checks in the performance test to validate cache-fast follow-ups.

### Testing

- Ran `cargo test -p perl-dap --test variables_deep_truncation` and all tests passed.
- Ran `cargo test -p perl-dap --test variables_comprehensive` and all tests passed.
- Ran `cargo test -p perl-dap --test variables_variable_inspection` and all tests passed.
- Ran `cargo check --all-targets -p perl-dap` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3a1e25d08333afa3a9f8d2ec281c)