### PR TITLE
perf(perl-dap): add real caching for variables roots, children, and paging (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/evaluation.rs
+++ b/crates/perl-dap/src/debug_adapter/evaluation.rs
@@ -408,7 +408,7 @@ impl DebugAdapter {
                 let session_guard = lock_or_recover(&self.session, "debug_adapter.session");
                 if let Some(ref session) = *session_guard {
                     let mut seen = std::collections::HashSet::new();
-                    for vars in session.variables.values() {
+                    for vars in session.variable_cache.values() {
                         for var in vars {
                             if (stem.is_empty() || var.name.starts_with(stem))
                                 && seen.insert(var.name.clone())

--- a/crates/perl-dap/src/debug_adapter/execution.rs
+++ b/crates/perl-dap/src/debug_adapter/execution.rs
@@ -25,7 +25,7 @@ impl DebugAdapter {
             let _ = stdin.flush();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::Continue;
-            session.variables.clear();
+            session.variable_cache.clear();
             thread_id = session.thread_id;
         } else if let Some(pid) = *lock_or_recover(&self.attached_pid, "debug_adapter.attached_pid")
         {
@@ -69,7 +69,7 @@ impl DebugAdapter {
             let _ = stdin.flush();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::Next;
-            session.variables.clear();
+            session.variable_cache.clear();
             let t_id = session.thread_id;
             self.send_event(
                 "continued",
@@ -105,7 +105,7 @@ impl DebugAdapter {
             let _ = stdin.flush();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::StepIn;
-            session.variables.clear();
+            session.variable_cache.clear();
             let t_id = session.thread_id;
             self.send_event(
                 "continued",
@@ -142,7 +142,7 @@ impl DebugAdapter {
             let _ = stdin.flush();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::StepOut;
-            session.variables.clear();
+            session.variable_cache.clear();
             let t_id = session.thread_id;
             self.send_event(
                 "continued",
@@ -171,11 +171,15 @@ impl DebugAdapter {
         arguments: Option<Value>,
     ) -> DapMessage {
         let _args: Option<PauseArguments> = arguments.and_then(|v| serde_json::from_value(v).ok());
-        let success = if let Some(ref session) =
+        let success = if let Some(ref mut session) =
             *lock_or_recover(&self.session, "debug_adapter.session")
         {
             let pid = session.process.id();
-            self.send_interrupt_signal(pid)
+            let paused = self.send_interrupt_signal(pid);
+            if paused {
+                session.variable_cache.clear();
+            }
+            paused
         } else if let Some(pid) = *lock_or_recover(&self.attached_pid, "debug_adapter.attached_pid")
         {
             self.send_interrupt_signal(pid)
@@ -356,7 +360,7 @@ impl DebugAdapter {
             let _ = stdin.flush();
             session.state = DebugState::Running;
             session.last_resume_mode = ResumeMode::Goto;
-            session.variables.clear();
+            session.variable_cache.clear();
             let t_id = session.thread_id;
 
             self.send_event(

--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -451,12 +451,44 @@ struct DebugSession {
     state: DebugState,
     /// Stack frames
     stack_frames: Vec<StackFrame>,
-    /// Variables in current scope
-    variables: HashMap<i32, Vec<Variable>>,
+    /// Variables cache in current stopped state.
+    variable_cache: VariableCache,
     /// Thread ID
     thread_id: i32,
     /// Last resume command issued while running.
     last_resume_mode: ResumeMode,
+}
+
+/// Variable cache grouped by root scope and child expansion.
+#[derive(Default)]
+struct VariableCache {
+    /// Root scope variable lists keyed by scope `variablesReference`.
+    roots: HashMap<i32, Vec<Variable>>,
+    /// Child expansion lists keyed by child `variablesReference`.
+    children: HashMap<i32, Vec<Variable>>,
+}
+
+impl VariableCache {
+    fn clear(&mut self) {
+        self.roots.clear();
+        self.children.clear();
+    }
+
+    fn get(&self, variables_ref: i32) -> Option<&Vec<Variable>> {
+        self.roots.get(&variables_ref).or_else(|| self.children.get(&variables_ref))
+    }
+
+    fn insert_root(&mut self, variables_ref: i32, variables: Vec<Variable>) {
+        self.roots.insert(variables_ref, variables);
+    }
+
+    fn insert_children(&mut self, children: HashMap<i32, Vec<Variable>>) {
+        self.children.extend(children);
+    }
+
+    fn values(&self) -> impl Iterator<Item = &Vec<Variable>> {
+        self.roots.values().chain(self.children.values())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/perl-dap/src/debug_adapter/parsing.rs
+++ b/crates/perl-dap/src/debug_adapter/parsing.rs
@@ -116,8 +116,6 @@ impl DebugAdapter {
     pub(super) fn parse_scope_variables_from_lines(
         lines: &[String],
         variables_ref: i32,
-        start: usize,
-        count: usize,
     ) -> (Vec<Variable>, HashMap<i32, Vec<Variable>>) {
         let parser = VariableParser::new();
         let renderer = PerlVariableRenderer::new();
@@ -149,8 +147,8 @@ impl DebugAdapter {
 
         let mut top_level = Vec::new();
         let mut child_cache = HashMap::new();
-        for (idx, (name, value)) in parsed.into_iter().skip(start).take(count).enumerate() {
-            let absolute_index = start.saturating_add(idx).saturating_add(1);
+        for (idx, (name, value)) in parsed.into_iter().enumerate() {
+            let absolute_index = idx.saturating_add(1);
             let child_ref =
                 variables_ref.saturating_mul(1000).saturating_add(Self::i64_to_i32_saturating(
                     i64::try_from(absolute_index).unwrap_or(i64::from(i32::MAX)),
@@ -181,11 +179,9 @@ impl DebugAdapter {
     pub(super) fn parse_scope_variables_from_output(
         &self,
         variables_ref: i32,
-        start: usize,
-        count: usize,
     ) -> (Vec<Variable>, HashMap<i32, Vec<Variable>>) {
         let lines = self.snapshot_recent_output_lines();
-        Self::parse_scope_variables_from_lines(&lines, variables_ref, start, count)
+        Self::parse_scope_variables_from_lines(&lines, variables_ref)
     }
 
     /// Parse evaluate output from debugger lines into a DAP result payload.
@@ -360,7 +356,7 @@ mod tests {
             output.push_back("%hash = {a => 1}".to_string());
         }
 
-        let (vars, child_cache) = adapter.parse_scope_variables_from_output(11, 0, 20);
+        let (vars, child_cache) = adapter.parse_scope_variables_from_output(11);
         let names: Vec<&str> = vars.iter().map(|v| v.name.as_str()).collect();
         assert!(names.contains(&"$foo"));
         assert!(names.contains(&"@arr"));
@@ -374,8 +370,7 @@ mod tests {
     -> Result<(), Box<dyn std::error::Error>> {
         let lines = vec!["$zeta = 1".to_string(), "$alpha = 2".to_string(), "$mid = 3".to_string()];
 
-        let (vars, _child_cache) =
-            DebugAdapter::parse_scope_variables_from_lines(&lines, 11, 0, 20);
+        let (vars, _child_cache) = DebugAdapter::parse_scope_variables_from_lines(&lines, 11);
         let names = vars.iter().map(|v| v.name.as_str()).collect::<Vec<_>>();
         assert_eq!(names, vec!["$alpha", "$mid", "$zeta"]);
         Ok(())
@@ -390,10 +385,9 @@ mod tests {
             "@gamma = (5, 6)".to_string(),
         ];
 
-        let (page_one, page_one_children) =
-            DebugAdapter::parse_scope_variables_from_lines(&lines, 11, 0, 1);
-        let (page_two, page_two_children) =
-            DebugAdapter::parse_scope_variables_from_lines(&lines, 11, 1, 1);
+        let (vars, child_cache) = DebugAdapter::parse_scope_variables_from_lines(&lines, 11);
+        let page_one = vars.first().cloned().into_iter().collect::<Vec<_>>();
+        let page_two = vars.iter().skip(1).take(1).cloned().collect::<Vec<_>>();
 
         let first_ref = page_one
             .first()
@@ -406,11 +400,11 @@ mod tests {
 
         assert_ne!(first_ref, second_ref, "paged variables must not reuse child references");
         assert!(
-            page_one_children.contains_key(&first_ref),
+            child_cache.contains_key(&first_ref),
             "expected first page child cache for first reference"
         );
         assert!(
-            page_two_children.contains_key(&second_ref),
+            child_cache.contains_key(&second_ref),
             "expected second page child cache for second reference"
         );
         Ok(())

--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -365,7 +365,7 @@ impl DebugAdapter {
                     process: child,
                     state: DebugState::Running,
                     stack_frames: Vec::new(),
-                    variables: HashMap::new(),
+                    variable_cache: VariableCache::default(),
                     thread_id,
                     last_resume_mode: ResumeMode::Unknown,
                 };

--- a/crates/perl-dap/src/debug_adapter/variables.rs
+++ b/crates/perl-dap/src/debug_adapter/variables.rs
@@ -3,6 +3,100 @@
 use super::*;
 
 impl DebugAdapter {
+    fn slice_variables(variables: &[Variable], start: usize, count: usize) -> Vec<Variable> {
+        variables.iter().skip(start).take(count).cloned().collect()
+    }
+
+    fn is_scope_root_reference(variables_ref: i32) -> bool {
+        matches!(variables_ref % 10, 1..=3)
+    }
+
+    fn query_scope_variables(
+        &self,
+        session: &mut DebugSession,
+        variables_ref: i32,
+    ) -> (Vec<Variable>, HashMap<i32, Vec<Variable>>) {
+        let mut framed_scope_lines = None;
+        let frame_id = variables_ref / 10;
+        match variables_ref % 10 {
+            1 => {
+                if let Some(stdin) = session.process.stdin.as_mut() {
+                    let commands = vec![format!("V {} .", frame_id)];
+                    match self.send_framed_debugger_commands(stdin, &commands) {
+                        Ok((begin, end)) => {
+                            framed_scope_lines = self.capture_framed_debugger_output(
+                                &begin,
+                                &end,
+                                DEBUGGER_QUERY_WAIT_MS * 8,
+                            );
+                        }
+                        Err(error) => {
+                            tracing::warn!(%error, "Failed to send framed variables command, falling back");
+                            let cmd = format!("V {} .\n", frame_id);
+                            let _ = stdin.write_all(cmd.as_bytes());
+                            let _ = stdin.flush();
+                        }
+                    }
+                }
+            }
+            2 => {
+                if let Some(stdin) = session.process.stdin.as_mut() {
+                    let commands = vec![format!("V {} ::", frame_id)];
+                    match self.send_framed_debugger_commands(stdin, &commands) {
+                        Ok((begin, end)) => {
+                            framed_scope_lines = self.capture_framed_debugger_output(
+                                &begin,
+                                &end,
+                                DEBUGGER_QUERY_WAIT_MS * 8,
+                            );
+                        }
+                        Err(error) => {
+                            tracing::warn!(%error, "Failed to send framed variables command, falling back");
+                            let cmd = format!("V {} ::\n", frame_id);
+                            let _ = stdin.write_all(cmd.as_bytes());
+                            let _ = stdin.flush();
+                        }
+                    }
+                }
+            }
+            3 => {
+                if let Some(stdin) = session.process.stdin.as_mut() {
+                    let commands = vec![format!("V {} *", frame_id)];
+                    match self.send_framed_debugger_commands(stdin, &commands) {
+                        Ok((begin, end)) => {
+                            framed_scope_lines = self.capture_framed_debugger_output(
+                                &begin,
+                                &end,
+                                DEBUGGER_QUERY_WAIT_MS * 8,
+                            );
+                        }
+                        Err(error) => {
+                            tracing::warn!(%error, "Failed to send framed variables command, falling back");
+                            let cmd = format!("V {} *\n", frame_id);
+                            let _ = stdin.write_all(cmd.as_bytes());
+                            let _ = stdin.flush();
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        if let Some(lines) = framed_scope_lines.as_ref() {
+            let (framed_vars, framed_child_cache) =
+                Self::parse_scope_variables_from_lines(lines, variables_ref);
+            if framed_vars.is_empty() {
+                Self::wait_for_debugger_output_window(DEBUGGER_QUERY_WAIT_MS as u32);
+                self.parse_scope_variables_from_output(variables_ref)
+            } else {
+                (framed_vars, framed_child_cache)
+            }
+        } else {
+            Self::wait_for_debugger_output_window(DEBUGGER_QUERY_WAIT_MS as u32);
+            self.parse_scope_variables_from_output(variables_ref)
+        }
+    }
+
     /// Handle variables request
     pub(super) fn handle_variables(
         &self,
@@ -50,7 +144,6 @@ impl DebugAdapter {
         let variables_ref = args.variables_reference as i32;
         let start = args.start.unwrap_or(0) as usize;
         let count = args.count.map(|v| v as usize).unwrap_or(256).clamp(1, 1024);
-        let can_use_root_cache = start == 0 && args.count.is_none();
 
         if variables_ref == 0 {
             return DapMessage::Response {
@@ -63,124 +156,33 @@ impl DebugAdapter {
             };
         }
 
-        // AC8.4: Render scalars/arrays/hashes with lazy child expansion.
-        let parsed_from_output;
-        let mut parsed_child_cache = HashMap::new();
-        let mut used_session_cache = false;
-
+        let mut variables = None;
         if let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session") {
-            // Return cached variables first for stable references and fast repeated expansion.
-            if can_use_root_cache && let Some(vars) = session.variables.get(&variables_ref) {
-                used_session_cache = true;
-                parsed_from_output = vars.clone();
-            } else {
-                let mut framed_scope_lines = None;
-
-                // Request fresh scope output from Perl debugger for scope roots only.
-                let frame_id = variables_ref / 10;
-                match variables_ref % 10 {
-                    1 => {
-                        if let Some(stdin) = session.process.stdin.as_mut() {
-                            let commands = vec![format!("V {} .", frame_id)];
-                            match self.send_framed_debugger_commands(stdin, &commands) {
-                                Ok((begin, end)) => {
-                                    framed_scope_lines = self.capture_framed_debugger_output(
-                                        &begin,
-                                        &end,
-                                        DEBUGGER_QUERY_WAIT_MS * 8,
-                                    );
-                                }
-                                Err(error) => {
-                                    tracing::warn!(%error, "Failed to send framed variables command, falling back");
-                                    let cmd = format!("V {} .\n", frame_id);
-                                    let _ = stdin.write_all(cmd.as_bytes());
-                                    let _ = stdin.flush();
-                                }
-                            }
-                        }
-                    }
-                    2 => {
-                        if let Some(stdin) = session.process.stdin.as_mut() {
-                            let commands = vec![format!("V {} ::", frame_id)];
-                            match self.send_framed_debugger_commands(stdin, &commands) {
-                                Ok((begin, end)) => {
-                                    framed_scope_lines = self.capture_framed_debugger_output(
-                                        &begin,
-                                        &end,
-                                        DEBUGGER_QUERY_WAIT_MS * 8,
-                                    );
-                                }
-                                Err(error) => {
-                                    tracing::warn!(%error, "Failed to send framed variables command, falling back");
-                                    let cmd = format!("V {} ::\n", frame_id);
-                                    let _ = stdin.write_all(cmd.as_bytes());
-                                    let _ = stdin.flush();
-                                }
-                            }
-                        }
-                    }
-                    3 => {
-                        if let Some(stdin) = session.process.stdin.as_mut() {
-                            let commands = vec![format!("V {} *", frame_id)];
-                            match self.send_framed_debugger_commands(stdin, &commands) {
-                                Ok((begin, end)) => {
-                                    framed_scope_lines = self.capture_framed_debugger_output(
-                                        &begin,
-                                        &end,
-                                        DEBUGGER_QUERY_WAIT_MS * 8,
-                                    );
-                                }
-                                Err(error) => {
-                                    tracing::warn!(%error, "Failed to send framed variables command, falling back");
-                                    let cmd = format!("V {} *\n", frame_id);
-                                    let _ = stdin.write_all(cmd.as_bytes());
-                                    let _ = stdin.flush();
-                                }
-                            }
-                        }
-                    }
-                    _ => {}
+            if let Some(cached) = session.variable_cache.get(variables_ref) {
+                variables = Some(Self::slice_variables(cached, start, count));
+            } else if Self::is_scope_root_reference(variables_ref) {
+                let (root_variables, child_cache) =
+                    self.query_scope_variables(session, variables_ref);
+                if !root_variables.is_empty() {
+                    session.variable_cache.insert_root(variables_ref, root_variables.clone());
+                    session.variable_cache.insert_children(child_cache);
+                    variables = Some(Self::slice_variables(&root_variables, start, count));
                 }
+            }
+        }
 
-                let (vars, child_cache) = if let Some(lines) = framed_scope_lines.as_ref() {
-                    let (framed_vars, framed_child_cache) =
-                        Self::parse_scope_variables_from_lines(lines, variables_ref, start, count);
-                    if framed_vars.is_empty() {
-                        Self::wait_for_debugger_output_window(DEBUGGER_QUERY_WAIT_MS as u32);
-                        self.parse_scope_variables_from_output(variables_ref, start, count)
-                    } else {
-                        (framed_vars, framed_child_cache)
-                    }
+        let variables = variables.unwrap_or_else(|| {
+            if Self::is_scope_root_reference(variables_ref) {
+                let (vars, _child_cache) = self.parse_scope_variables_from_output(variables_ref);
+                if vars.is_empty() {
+                    Self::fallback_scope_variables(variables_ref, start, count)
                 } else {
-                    Self::wait_for_debugger_output_window(DEBUGGER_QUERY_WAIT_MS as u32);
-                    self.parse_scope_variables_from_output(variables_ref, start, count)
-                };
-
-                parsed_from_output = vars;
-                parsed_child_cache = child_cache;
+                    Self::slice_variables(&vars, start, count)
+                }
+            } else {
+                Vec::new()
             }
-        } else {
-            let (vars, _child_cache) =
-                self.parse_scope_variables_from_output(variables_ref, start, count);
-            parsed_from_output = vars;
-        }
-
-        let variables = if parsed_from_output.is_empty() {
-            Self::fallback_scope_variables(variables_ref, start, count)
-        } else {
-            parsed_from_output
-        };
-
-        // Cache parsed variables and generated child references for expansion requests.
-        if !used_session_cache
-            && can_use_root_cache
-            && let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session")
-        {
-            session.variables.insert(variables_ref, variables.clone());
-            for (reference, children) in parsed_child_cache {
-                session.variables.insert(reference, children);
-            }
-        }
+        });
 
         DapMessage::Response {
             seq,
@@ -360,6 +362,10 @@ impl DebugAdapter {
             type_: Some(rendered_type),
             variables_reference: 0,
         };
+
+        if let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session") {
+            session.variable_cache.clear();
+        }
 
         DapMessage::Response {
             seq,

--- a/crates/perl-dap/tests/dap_performance_tests.rs
+++ b/crates/perl-dap/tests/dap_performance_tests.rs
@@ -142,6 +142,28 @@ mod dap_performance {
                 "child variable expansion too slow: {:?}",
                 child_elapsed
             );
+
+            let repeated_child_start = Instant::now();
+            let repeated_child = adapter.handle_request(
+                3,
+                "variables",
+                Some(json!({
+                    "variablesReference": child_ref,
+                    "start": 0,
+                    "count": 100
+                })),
+            );
+            let repeated_child_elapsed = repeated_child_start.elapsed();
+            match repeated_child {
+                DapMessage::Response { success, .. } => assert!(success),
+                _ => anyhow::bail!("expected repeated child variables response"),
+            }
+            assert!(
+                repeated_child_elapsed <= child_elapsed + Duration::from_millis(5),
+                "repeated child expansion should be served from cache: first {:?}, repeated {:?}",
+                child_elapsed,
+                repeated_child_elapsed
+            );
         }
 
         Ok(())

--- a/crates/perl-dap/tests/variables_comprehensive.rs
+++ b/crates/perl-dap/tests/variables_comprehensive.rs
@@ -18,6 +18,21 @@ fn perl_value_default_is_undef() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn renderer_children_pagination_repeatable_boundaries() -> Result<(), Box<dyn std::error::Error>> {
+    let renderer = PerlVariableRenderer::new();
+    let val = PerlValue::Array((0..40).map(PerlValue::Integer).collect());
+
+    let first = renderer.render_children(&val, 30, 20);
+    let second = renderer.render_children(&val, 30, 20);
+
+    assert_eq!(first, second);
+    assert_eq!(first.len(), 10, "pagination should clamp to remaining elements");
+    assert_eq!(first[0].name, "[30]");
+    assert_eq!(first[9].name, "[39]");
+    Ok(())
+}
+
+#[test]
 fn perl_value_scalar_constructor() -> Result<(), Box<dyn std::error::Error>> {
     let val = PerlValue::scalar("hello");
     assert_eq!(val, PerlValue::Scalar("hello".to_string()));

--- a/crates/perl-dap/tests/variables_deep_truncation.rs
+++ b/crates/perl-dap/tests/variables_deep_truncation.rs
@@ -71,6 +71,20 @@ mod deep_truncation_tests {
     }
 
     #[test]
+    fn test_500element_array_pagination_is_stable_across_repeated_pages() {
+        let renderer = PerlVariableRenderer::new();
+        let elements: Vec<PerlValue> = (0..500).map(PerlValue::Integer).collect();
+        let value = PerlValue::Array(elements);
+
+        let page_a = renderer.render_children(&value, 120, 25);
+        let page_b = renderer.render_children(&value, 120, 25);
+        assert_eq!(page_a, page_b, "repeated page queries should be deterministic");
+        assert_eq!(page_a.len(), 25);
+        assert_eq!(page_a[0].name, "[120]");
+        assert_eq!(page_a[24].name, "[144]");
+    }
+
+    #[test]
     fn test_cyclic_reference_rendering() {
         let renderer = PerlVariableRenderer::new();
 

--- a/crates/perl-dap/tests/variables_variable_inspection.rs
+++ b/crates/perl-dap/tests/variables_variable_inspection.rs
@@ -72,6 +72,20 @@ fn hash_preview_with_nested_array() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn large_hash_preview_includes_explicit_truncation_summary()
+-> Result<(), Box<dyn std::error::Error>> {
+    let renderer = PerlVariableRenderer::new().with_max_hash_preview(3);
+    let val =
+        PerlValue::Hash((0..8).map(|idx| (format!("k{idx}"), PerlValue::Integer(idx))).collect());
+
+    let rendered = renderer.render("%large", &val);
+    assert!(rendered.value.contains("8 keys"), "hash previews should report total count");
+    assert!(rendered.value.contains("..."), "hash previews should mark truncation");
+    assert_eq!(rendered.named_variables, Some(8));
+    Ok(())
+}
+
+#[test]
 fn hash_children_show_nested_values() -> Result<(), Box<dyn std::error::Error>> {
     let renderer = PerlVariableRenderer::new();
     let inner_hash = PerlValue::Hash(vec![


### PR DESCRIPTION
### Motivation

- Reduce repeated parsing and debugger queries by replacing a root-only cache with a structured root/child/paging cache so repeated variables requests are cheaper and stable.
- Preserve stable `variablesReference` semantics while enabling efficient local paging and child expansion caching.
- Invalidate caches correctly on execution state changes (continue/next/stepIn/stepOut/pause/attach/setVariable).

### Description

- Introduced `VariableCache` and replaced the single `variables` map on `DebugSession` with `variable_cache` that stores `roots` and `children` separately and exposes lookup/insert/clear helpers (`crates/perl-dap/src/debug_adapter/mod.rs`, `process.rs`).
- Reworked `handle_variables` to prefer cached roots/children, to cache full root parses and child expansions, and to serve paged requests by locally slicing cached vectors instead of reparsing (`crates/perl-dap/src/debug_adapter/variables.rs`).
- Added helper methods `slice_variables`, `is_scope_root_reference`, and `query_scope_variables` to centralize debugger querying and paging logic (`variables.rs`).
- Adjusted parsing to produce a canonical full root vector with deterministic child `variablesReference` values so paging is stable and child caches can be stored (`crates/perl-dap/src/debug_adapter/parsing.rs`).
- Cleared the new cache on execution transitions and on `setVariable` to keep results correct across resume/attach/interrupt (`crates/perl-dap/src/debug_adapter/execution.rs`, `variables.rs`).
- Updated runtime completion population to iterate the new cache shape (`crates/perl-dap/src/debug_adapter/evaluation.rs`).
- Strengthened and added tests asserting deterministic pagination, explicit truncation summaries, and a repeated-child-latency assertion in perf tests (`crates/perl-dap/tests/*`).

### Testing

- Ran `cargo test -p perl-dap --test variables_deep_truncation` and it passed.
- Ran `cargo test -p perl-dap --test variables_comprehensive` and it passed.
- Ran `cargo test -p perl-dap --test variables_variable_inspection` and it passed.
- Ran `cargo check --all-targets -p perl-dap` and it completed successfully.
- Ran `cargo xtask fmt` to format changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3a1e25d08333afa3a9f8d2ec281c)