### PR TITLE
fix(perl-dap): harden live-session evaluate correctness and trim fast-path overhead (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/evaluation.rs
+++ b/crates/perl-dap/src/debug_adapter/evaluation.rs
@@ -2,6 +2,32 @@
 
 use super::*;
 
+fn shared_safe_evaluator() -> &'static SafeEvaluator {
+    static SAFE_EVALUATOR: OnceLock<SafeEvaluator> = OnceLock::new();
+    SAFE_EVALUATOR.get_or_init(SafeEvaluator::new)
+}
+
+fn evaluate_error_from_lines(lines: &[String]) -> Option<String> {
+    lines.iter().rev().find_map(|line| {
+        let text = DebugAdapter::normalize_debugger_output_line(line);
+        let trimmed = text.trim();
+        if trimmed.is_empty() || prompt_re().is_some_and(|re| re.is_match(trimmed)) {
+            return None;
+        }
+
+        if error_re().is_some_and(|re| re.is_match(trimmed))
+            || trimmed.starts_with("Undefined subroutine")
+            || trimmed.starts_with("Can't")
+            || trimmed.starts_with("syntax error")
+            || trimmed.contains("Compilation failed")
+        {
+            return Some(trimmed.to_string());
+        }
+
+        None
+    })
+}
+
 impl DebugAdapter {
     /// Handle evaluate request with policy validation and timeout enforcement.
     ///
@@ -73,8 +99,7 @@ impl DebugAdapter {
 
                 // Re-run through microcrate validator to keep evaluation policy aligned
                 // with shared DAP security logic.
-                let evaluator = SafeEvaluator::new();
-                if let Err(error) = evaluator.validate(expression) {
+                if let Err(error) = shared_safe_evaluator().validate(expression) {
                     return DapMessage::Response {
                         seq,
                         request_seq,
@@ -149,12 +174,25 @@ impl DebugAdapter {
             self.capture_framed_debugger_output(begin, end, u64::from(timeout_ms))
         });
 
-        let parsed = framed_lines
-            .as_ref()
-            .and_then(|lines| Self::parse_evaluate_result_from_lines(lines, expression, true))
-            .or_else(|| self.parse_evaluate_result_from_output(expression));
+        let parsed = if let Some(lines) = framed_lines.as_ref() {
+            Self::parse_evaluate_result_from_lines(lines, expression, false)
+        } else {
+            self.parse_evaluate_result_from_output(expression)
+        };
 
         let Some((result, result_type)) = parsed else {
+            if let Some(lines) = framed_lines.as_ref()
+                && let Some(message) = evaluate_error_from_lines(lines)
+            {
+                return DapMessage::Response {
+                    seq,
+                    request_seq,
+                    success: false,
+                    command: "evaluate".to_string(),
+                    body: None,
+                    message: Some(format!("evaluate failed: {message}")),
+                };
+            }
             return DapMessage::Response {
                 seq,
                 request_seq,
@@ -458,5 +496,28 @@ impl DebugAdapter {
             body: serde_json::to_value(&body).ok(),
             message: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evaluate_error_from_lines_detects_runtime_failure() {
+        let lines = vec![
+            "DB<3>".to_string(),
+            "Undefined subroutine &main::missing called at script.pl line 7.".to_string(),
+            "DB<4>".to_string(),
+        ];
+        let err = evaluate_error_from_lines(&lines);
+        assert!(err.is_some());
+        assert!(err.unwrap_or_default().contains("Undefined subroutine"));
+    }
+
+    #[test]
+    fn evaluate_error_from_lines_ignores_regular_values() {
+        let lines = vec!["$x = 42".to_string()];
+        assert!(evaluate_error_from_lines(&lines).is_none());
     }
 }

--- a/crates/perl-dap/src/eval/patterns.rs
+++ b/crates/perl-dap/src/eval/patterns.rs
@@ -123,7 +123,7 @@ pub const DANGEROUS_OPERATIONS: &[&str] = &[
 /// Assignment operators that indicate mutation
 pub const ASSIGNMENT_OPERATORS: &[&str] = &[
     "=", "+=", "-=", "*=", "/=", "%=", "**=", ".=", "&=", "|=", "^=", "<<=", ">>=", "&&=", "||=",
-    "//=",
+    "//=", "x=",
 ];
 
 /// Compiled regex for dangerous operations

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -5,6 +5,19 @@
 //! the interpreter.
 
 use super::patterns::{ASSIGNMENT_OPERATORS, DANGEROUS_OPS_RE, REGEX_MUTATION_RE};
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+static ASSIGNMENT_OPS_RE: Lazy<Result<Regex, regex::Error>> = Lazy::new(|| {
+    let mut ops: Vec<String> = ASSIGNMENT_OPERATORS
+        .iter()
+        .filter(|op| **op != "=")
+        .map(|op| regex::escape(op))
+        .collect();
+    ops.sort_by_key(|op| std::cmp::Reverse(op.len()));
+    let pattern = format!("({}|=)", ops.join("|"));
+    Regex::new(&pattern)
+});
 
 /// Error type for unsafe expression detection
 #[derive(Debug, Clone, thiserror::Error)]
@@ -83,12 +96,7 @@ impl SafeEvaluator {
             return Err(ValidationError::Backticks);
         }
 
-        // Check for assignment operators
-        for op in ASSIGNMENT_OPERATORS {
-            if expression.contains(op) {
-                return Err(ValidationError::AssignmentOperator(op.to_string()));
-            }
-        }
+        self.check_assignment_operators(expression)?;
 
         // Check for increment/decrement operators
         if expression.contains("++") || expression.contains("--") {
@@ -100,6 +108,32 @@ impl SafeEvaluator {
 
         // Check for regex mutation operators
         self.check_regex_mutation(expression)?;
+
+        Ok(())
+    }
+
+    /// Check for assignment operators while excluding comparison/match operators.
+    fn check_assignment_operators(&self, expression: &str) -> ValidationResult {
+        let Some(re) = ASSIGNMENT_OPS_RE.as_ref().ok() else {
+            // Keep permissive behavior if regex compilation fails.
+            return Ok(());
+        };
+
+        for mat in re.find_iter(expression) {
+            let op = mat.as_str();
+            let start = mat.start();
+            let end = mat.end();
+
+            if is_in_single_quotes(expression, start) {
+                continue;
+            }
+
+            if op == "=" && is_non_assignment_equals(expression, start, end) {
+                continue;
+            }
+
+            return Err(ValidationError::AssignmentOperator(op.to_string()));
+        }
 
         Ok(())
     }
@@ -298,6 +332,16 @@ fn is_escape_sequence(s: &str, match_start: usize) -> bool {
         return false;
     }
     s.as_bytes()[match_start - 1] == b'\\'
+}
+
+fn is_non_assignment_equals(s: &str, start: usize, end: usize) -> bool {
+    let bytes = s.as_bytes();
+    let prev = (start > 0).then(|| bytes[start - 1]);
+    let next = (end < bytes.len()).then(|| bytes[end]);
+
+    // Comparison/match operators that include '=' are not assignment.
+    matches!(prev, Some(b'=' | b'!' | b'<' | b'>' | b'~'))
+        || matches!(next, Some(b'=' | b'~' | b'>'))
 }
 
 #[cfg(test)]

--- a/crates/perl-dap/tests/dap_evaluate_comprehensive_tests.rs
+++ b/crates/perl-dap/tests/dap_evaluate_comprehensive_tests.rs
@@ -205,14 +205,15 @@ fn test_evaluate_string_expressions_are_safe() -> TestResult {
 #[test]
 fn test_evaluate_comparison_expressions_are_safe() -> TestResult {
     let mut adapter = new_adapter();
-    // Note: the SafeEvaluator microcrate (perl-dap-eval) does a naive
-    // `contains("=")` check for assignment operators, which means expressions
-    // containing `==`, `!=`, `<=`, `>=` are also blocked even though they are
-    // read-only comparisons.  The evaluate pipeline runs BOTH validators, so
-    // we only test expressions that pass both.
+    // Comparison operators are read-only lookups and should remain admissible
+    // in safe mode.
     for expr in [
         "$a < $b",
         "$a > $b",
+        "$a == $b",
+        "$a != $b",
+        "$a <= $b",
+        "$a >= $b",
         "$a eq $b",
         "$a ne $b",
         "$a lt $b",
@@ -232,28 +233,17 @@ fn test_evaluate_comparison_expressions_are_safe() -> TestResult {
     Ok(())
 }
 
-/// Test that the SafeEvaluator microcrate blocks equality operators that contain `=`.
-/// This is a known limitation of the perl-dap-eval crate (naive substring check).
-/// Filed separately for follow-up.
+/// Equality operators should not be misclassified as assignment in evaluate.
 #[test]
-fn test_evaluate_equality_operators_blocked_by_microcrate_validator() -> TestResult {
+fn test_evaluate_equality_operators_are_safe() -> TestResult {
     let mut adapter = new_adapter();
-    // These are read-only comparisons, but the microcrate blocks them due to
-    // substring `=` match.  This test documents the current behavior.
     for expr in ["$a == $b", "$a != $b", "$a <= $b", "$a >= $b"] {
         let response = adapter.handle_request(
             1,
             "evaluate",
             Some(json!({ "expression": expr, "allowSideEffects": false })),
         );
-        // Currently blocked — documents known microcrate limitation.
-        match response {
-            DapMessage::Response { success, command, .. } => {
-                assert_eq!(command, "evaluate");
-                assert!(!success, "expected microcrate to block {expr:?}");
-            }
-            other => return Err(format!("expected Response, got {other:?}").into()),
-        }
+        assert_evaluate_not_safe_blocked(response, "Safe evaluation mode")?;
     }
     Ok(())
 }

--- a/crates/perl-dap/tests/eval_safe_evaluator.rs
+++ b/crates/perl-dap/tests/eval_safe_evaluator.rs
@@ -63,14 +63,13 @@ fn safe_comparison_operators_without_equals() -> Result<(), ValidationError> {
 }
 
 #[test]
-fn comparison_operators_containing_equals_are_blocked() {
-    // The validator does substring matching for `=`, so ==, !=, >=, <=, <=>
-    // all trigger the assignment operator check. This is a known trade-off.
-    assert!(eval().validate("$x == $y").is_err());
-    assert!(eval().validate("$x != $y").is_err());
-    assert!(eval().validate("$x >= $y").is_err());
-    assert!(eval().validate("$x <= $y").is_err());
-    assert!(eval().validate("$x <=> $y").is_err());
+fn comparison_operators_containing_equals_are_safe() -> Result<(), ValidationError> {
+    ok("$x == $y")?;
+    ok("$x != $y")?;
+    ok("$x >= $y")?;
+    ok("$x <= $y")?;
+    ok("$x <=> $y")?;
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Live evaluate requests could misclassify read-only comparisons as assignments and could return ambiguous timeouts by falling back to stale output instead of honoring framed debugger responses.
- Repeated construction of the microcrate `SafeEvaluator` and duplicated parsing work created avoidable overhead in the hot path.
- The admission-control validator must remain strict for side-effecting ops while not blocking common read-only comparison forms.

### Description
- Reuse a single `SafeEvaluator` instance via `OnceLock` to avoid repeated allocations (`shared_safe_evaluator`).
- Prefer deterministic framed-output parsing for live evaluate requests and avoid falling back to general recent output when framed output exists, and add `evaluate_error_from_lines` to surface explicit runtime/debugger error lines instead of returning a timeout.
- Tighten assignment operator detection by introducing a compiled regex that prioritizes multi-char assignment ops and treats `=` in comparison/match contexts as non-assignment via `is_non_assignment_equals`, and add `x=` to the canonical assignment list.
- Update tests to reflect corrected behavior: treat equality/comparison operators as safe in `allowSideEffects: false` and add unit tests for the new error-detection helper.

### Testing
- Ran `cargo test -p perl-dap --test dap_evaluate_comprehensive_tests` and all tests passed.
- Ran `cargo test -p perl-dap --test eval_timeout_and_exception_tests` and all tests passed.
- Ran `cargo test -p perl-dap --test eval_safe_evaluator` and all tests passed.
- Ran `cargo check --all-targets -p perl-dap` and it completed successfully, and `cargo xtask fmt` was executed for formatting; `just pr-fast` was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3a25ed8483338d9a5dae922df1a9)