### PR TITLE
refactor(perl-dap): reuse AST validation and batch debugger sync (#0000)

### DIFF
--- a/crates/perl-dap/src/breakpoints.rs
+++ b/crates/perl-dap/src/breakpoints.rs
@@ -230,7 +230,7 @@ impl BreakpointStore {
         };
 
         // Get breakpoints array (empty if not provided)
-        let source_breakpoints = args.breakpoints.as_ref().map_or(Vec::new(), |bps| bps.clone());
+        let source_breakpoints = args.breakpoints.as_deref().unwrap_or(&[]);
 
         // Lock stores for atomic operation
         let mut breakpoints_map = self.breakpoints.lock().unwrap_or_else(|e| e.into_inner());
@@ -244,10 +244,12 @@ impl BreakpointStore {
         let validator = source_content
             .as_ref()
             .map(|content| AstBreakpointValidator::new(content).map_err(|e| e.to_string()));
+        let mut validation_cache: HashMap<(i64, Option<i64>), (bool, i64, Option<String>)> =
+            HashMap::new();
 
         let mut records = Vec::new();
         // Create new breakpoint records
-        for bp in &source_breakpoints {
+        for bp in source_breakpoints {
             let id = *next_id;
             *next_id += 1;
 
@@ -324,17 +326,24 @@ impl BreakpointStore {
             }
 
             // AC7: AST-based breakpoint validation via `perl-dap-breakpoint` microcrate.
-            let (verified, resolved_line, message) = match &validator {
-                Some(Ok(v)) => {
-                    let result = v.validate_with_column(bp.line, bp.column);
-                    (result.verified, result.line, result.message)
-                }
-                Some(Err(error)) => (false, bp.line, Some(error.clone())),
-                None => {
-                    // Can't read file - mark as unverified but still create breakpoint.
-                    (false, bp.line, Some("Unable to read source file".to_string()))
-                }
-            };
+            let (verified, resolved_line, message) =
+                if let Some(cached) = validation_cache.get(&(bp.line, bp.column)) {
+                    cached.clone()
+                } else {
+                    let result = match &validator {
+                        Some(Ok(v)) => {
+                            let result = v.validate_with_column(bp.line, bp.column);
+                            (result.verified, result.line, result.message)
+                        }
+                        Some(Err(error)) => (false, bp.line, Some(error.clone())),
+                        None => {
+                            // Can't read file - mark as unverified but still create breakpoint.
+                            (false, bp.line, Some("Unable to read source file".to_string()))
+                        }
+                    };
+                    validation_cache.insert((bp.line, bp.column), result.clone());
+                    result
+                };
 
             let record = BreakpointRecord {
                 id,

--- a/crates/perl-dap/src/debug_adapter/breakpoints.rs
+++ b/crates/perl-dap/src/debug_adapter/breakpoints.rs
@@ -46,35 +46,40 @@ impl DebugAdapter {
 
         // AC7: AST-based breakpoint validation via BreakpointStore
         let verified_breakpoints = self.breakpoints.set_breakpoints(&args);
+        let new_breakpoint_records = if let Some(ref source_path) = args.source.path {
+            self.breakpoints.get_breakpoints(source_path)
+        } else {
+            Vec::new()
+        };
 
         // If a session is active, also sync the breakpoints to the Perl debugger
         if let Ok(mut guard) = self.session.lock()
             && let Some(ref mut session) = *guard
         {
             if let Some(stdin) = session.process.stdin.as_mut() {
+                let mut sync_commands = String::new();
+
                 // Clear only the old breakpoints for this specific file
                 for old_bp in &old_breakpoints {
                     if old_bp.verified {
-                        let cmd = format!("B {}\n", old_bp.line);
-                        let _ = stdin.write_all(cmd.as_bytes());
-                        let _ = stdin.flush();
+                        sync_commands.push_str(&format!("B {}\n", old_bp.line));
                     }
                 }
 
                 // Set new breakpoints that were successfully verified
-                for bp in &verified_breakpoints {
-                    if bp.verified {
-                        // Retrieve the record to get the original condition
-                        let cmd = if let Some(record) = self.breakpoints.get_breakpoint_by_id(bp.id)
-                            && let Some(cond) = record.condition
-                        {
-                            format!("b {} {}\n", bp.line, cond)
+                for record in &new_breakpoint_records {
+                    if record.verified {
+                        if let Some(cond) = &record.condition {
+                            sync_commands.push_str(&format!("b {} {}\n", record.line, cond));
                         } else {
-                            format!("b {}\n", bp.line)
-                        };
-                        let _ = stdin.write_all(cmd.as_bytes());
-                        let _ = stdin.flush();
+                            sync_commands.push_str(&format!("b {}\n", record.line));
+                        }
                     }
+                }
+
+                if !sync_commands.is_empty() {
+                    let _ = stdin.write_all(sync_commands.as_bytes());
+                    let _ = stdin.flush();
                 }
             }
         }


### PR DESCRIPTION
### Motivation

- Bulk `setBreakpoints` was re-running AST validation for identical (line,column) entries and issuing individual `write`/`flush` calls per breakpoint, causing latency and IO churn. 
- Keep exact DAP REPLACE semantics and conditional/logpoint behavior while making 100-breakpoint operations faster and more stable.

### Description

- Avoid cloning the incoming breakpoint vector by using `args.breakpoints.as_deref().unwrap_or(&[])` in `BreakpointStore::set_breakpoints`. 
- Add a per-request `validation_cache: HashMap<(i64, Option<i64>), (bool,i64,Option<String>)>` to reuse `AstBreakpointValidator::validate_with_column` results for duplicated locations, preserving all existing validation rules. 
- Batch live-debugger sync in `handle_set_breakpoints` by building a single `sync_commands` buffer of clear/set commands (including conditional commands) and calling `write_all`/`flush` once, retaining per-file REPLACE semantics.

### Testing

- Ran `cargo test -p perl-dap --test dap_breakpoint_matrix_tests` and all tests passed. 
- Ran `cargo test -p perl-dap --test breakpoint_edge_case_tests` and all tests passed. 
- Ran `cargo test -p perl-dap --test dap_performance_tests` and all tests passed. 
- Ran `cargo check --all-targets -p perl-dap` and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3a51ad088333a75a2e14f3fd294a)