### PR TITLE
perf(perl-dap): cache interpreter discovery and tighten the warm-launch path (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -5,16 +5,47 @@ use super::*;
 /// Try to detect the Perl interpreter available on the system and return a human-readable
 /// summary string.
 ///
-/// Uses `resolve_perl_path_with_toolchain()` to find Perl (checks perlbrew, plenv, then PATH),
+/// Uses cached `resolve_perl_path_with_toolchain_cached()` lookup to find Perl
+/// (checks perlbrew, plenv, then PATH),
 /// then runs `perl -e 'print $]'` to get the version number.  Returns a string describing what
 /// was found, or a "not found" / install-hint message suitable for inclusion in error messages.
 fn detect_perl_info() -> String {
-    match crate::platform::resolve_perl_path_with_toolchain() {
+    fn cached_perl_version(perl_path: &Path) -> Option<String> {
+        #[derive(Clone)]
+        struct CachedPerlVersion {
+            perl_path: PathBuf,
+            version: Option<String>,
+        }
+
+        static PERL_VERSION_CACHE: std::sync::LazyLock<
+            std::sync::Mutex<Option<CachedPerlVersion>>,
+        > = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+
+        let mut cache = match PERL_VERSION_CACHE.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        if let Some(entry) = cache.as_ref()
+            && entry.perl_path == perl_path
+        {
+            return entry.version.clone();
+        }
+
+        let version =
+            Command::new(perl_path).arg("-e").arg("print $]").output().ok().and_then(|out| {
+                if out.status.success() { String::from_utf8(out.stdout).ok() } else { None }
+            });
+        *cache = Some(CachedPerlVersion {
+            perl_path: perl_path.to_path_buf(),
+            version: version.clone(),
+        });
+        version
+    }
+
+    match crate::platform::resolve_perl_path_with_toolchain_cached() {
         Ok(perl_path) => {
-            let version_output =
-                Command::new(&perl_path).arg("-e").arg("print $]").output().ok().and_then(|out| {
-                    if out.status.success() { String::from_utf8(out.stdout).ok() } else { None }
-                });
+            let version_output = cached_perl_version(&perl_path);
 
             match version_output {
                 Some(v) if !v.trim().is_empty() => {

--- a/crates/perl-dap/src/platform/mod.rs
+++ b/crates/perl-dap/src/platform/mod.rs
@@ -16,6 +16,7 @@ pub use perl_lsp_rs_core::platform::{
 use std::collections::HashMap;
 use std::env;
 use std::path::PathBuf;
+use std::sync::{LazyLock, Mutex};
 
 #[cfg(windows)]
 const PATH_SEPARATOR: char = ';';
@@ -187,6 +188,46 @@ pub fn find_perl_interpreter(configured_path: Option<&str>) -> PerlInterpreterRe
     }
 
     PerlInterpreterResult::NotFound { searched }
+}
+
+#[derive(Clone)]
+struct CachedPerlPath {
+    cache_key: String,
+    result: Result<PathBuf, String>,
+}
+
+static RESOLVED_PERL_PATH_CACHE: LazyLock<Mutex<Option<CachedPerlPath>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+fn perl_discovery_cache_key() -> String {
+    let path = env::var("PATH").unwrap_or_default();
+    let perlbrew_root = env::var("PERLBREW_ROOT").unwrap_or_default();
+    let perlbrew_perl = env::var("PERLBREW_PERL").unwrap_or_default();
+    let plenv_root = env::var("PLENV_ROOT").unwrap_or_default();
+    let plenv_version = env::var("PLENV_VERSION").unwrap_or_default();
+    format!("{path}\n{perlbrew_root}\n{perlbrew_perl}\n{plenv_root}\n{plenv_version}")
+}
+
+/// Resolve Perl path with process-local caching keyed by interpreter-relevant environment.
+///
+/// This avoids repeated `PATH` scans during repeated launch failures while still
+/// recomputing when interpreter-selection env vars change.
+pub fn resolve_perl_path_with_toolchain_cached() -> anyhow::Result<PathBuf> {
+    let cache_key = perl_discovery_cache_key();
+    let mut cache = match RESOLVED_PERL_PATH_CACHE.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    if let Some(entry) = cache.as_ref()
+        && entry.cache_key == cache_key
+    {
+        return entry.result.clone().map_err(anyhow::Error::msg);
+    }
+
+    let resolved = resolve_perl_path_with_toolchain().map_err(|error| error.to_string());
+    *cache = Some(CachedPerlPath { cache_key, result: resolved.clone() });
+    resolved.map_err(anyhow::Error::msg)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Repeated initialize/launch attempts re-ran expensive Perl interpreter discovery and `perl -e 'print $]'` version probes, adding avoidable overhead during repeated failures.
- Cache interpreter discovery and version info where safe so repeated launch/attach initialization is cheaper while preserving current actionable error messages and path-resolution semantics.

### Description
- Add `resolve_perl_path_with_toolchain_cached()` in `crates/perl-dap/src/platform/mod.rs` implementing a process-local cache keyed on `PATH` and toolchain-related env vars (`PERLBREW_*`, `PLENV_*`) so interpreter resolution is skipped when the relevant environment is unchanged.
- Update `detect_perl_info()` in `crates/perl-dap/src/debug_adapter/process.rs` to call the cached resolver and add a `cached_perl_version()` helper that memoizes the `perl -e 'print $]'` result per resolved interpreter path.
- Preserve existing user-facing remediation and spawn-error strings and keep configured-path / PATH / fallback-path resolution behavior unchanged.

### Testing
- Ran `cargo test -p perl-dap --test dap_launch_error_remediation_tests` and it passed (2 passed, 0 failed).
- Ran `cargo test -p perl-dap --test platform_perl_path_edge_cases` and it passed (33 passed, 0 failed).
- Ran `cargo check --all-targets -p perl-dap`, `cargo clippy -p perl-dap`, and `cargo xtask fmt`, all of which completed successfully; `just pr-fast` was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3a590a8c8333b9ad5bd1c5181f5f)