### PR TITLE
perf(perl-dap): remove measured transport/output overhead in hot DAP paths (#0000)

### DIFF
--- a/crates/perl-dap/benches/dap_benchmarks.rs
+++ b/crates/perl-dap/benches/dap_benchmarks.rs
@@ -37,9 +37,11 @@ use perl_dap::debug_adapter::DebugAdapter;
 use perl_dap::platform::{
     format_command_args, normalize_path, resolve_perl_path, setup_environment,
 };
+use perl_lsp_rs_core::transport::framing::frame;
 use serde_json::json;
 use std::collections::HashMap;
 use std::hint::black_box;
+use std::io::Write;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -348,6 +350,54 @@ fn benchmark_dap_dispatch(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(session_benches, benchmark_dap_initialization, benchmark_dap_dispatch);
+/// Benchmark DAP frame writing on hot transport paths.
+///
+/// Compares the previous "frame then write" approach against streaming frame
+/// headers and payload bytes directly to the sink.
+fn benchmark_dap_transport_output(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dap_transport");
+    group.measurement_time(Duration::from_secs(10));
+
+    let message = json!({
+        "seq": 2001,
+        "type": "event",
+        "event": "output",
+        "body": {
+            "category": "stdout",
+            "output": "benchmark output event payload\n"
+        }
+    });
+    let payload = serde_json::to_vec(&message).unwrap_or_default();
+
+    group.bench_function("frame_alloc_and_write", |b| {
+        b.iter(|| {
+            let framed = frame(black_box(&payload));
+            let mut cursor = std::io::Cursor::new(Vec::with_capacity(framed.len()));
+            let _ = cursor.write_all(black_box(&framed));
+            let _ = cursor.flush();
+            black_box(cursor.position());
+        })
+    });
+
+    group.bench_function("stream_header_and_payload_write", |b| {
+        b.iter(|| {
+            let estimated_capacity = payload.len() + 32;
+            let mut cursor = std::io::Cursor::new(Vec::with_capacity(estimated_capacity));
+            let _ = write!(cursor, "Content-Length: {}\r\n\r\n", payload.len());
+            let _ = cursor.write_all(black_box(&payload));
+            let _ = cursor.flush();
+            black_box(cursor.position());
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    session_benches,
+    benchmark_dap_initialization,
+    benchmark_dap_dispatch,
+    benchmark_dap_transport_output
+);
 
 criterion_main!(configuration_benches, platform_benches, session_benches);

--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -40,7 +40,7 @@ use crate::tcp_attach::{DapEvent, TcpAttachConfig, TcpAttachSession};
 use crate::types::{Source, StackFrame, Variable};
 use crate::variables::{PerlVariableRenderer, RenderedVariable, VariableParser, VariableRenderer};
 use perl_lexer::DAP_COMPLETION_KEYWORDS;
-use perl_lsp_rs_core::transport::framing::{ContentLengthFramer, frame};
+use perl_lsp_rs_core::transport::framing::ContentLengthFramer;
 use perl_module::path::module_path_to_name;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};

--- a/crates/perl-dap/src/debug_adapter/transport.rs
+++ b/crates/perl-dap/src/debug_adapter/transport.rs
@@ -3,6 +3,16 @@
 use super::*;
 
 impl DebugAdapter {
+    fn write_framed_payload<W: Write>(writer: &mut W, payload: &[u8]) -> io::Result<()> {
+        write!(writer, "Content-Length: {}\r\n\r\n", payload.len())?;
+        writer.write_all(payload)
+    }
+
+    fn write_framed_message<W: Write>(writer: &mut W, message: &DapMessage) -> io::Result<()> {
+        let payload = serde_json::to_vec(message).map_err(io::Error::other)?;
+        Self::write_framed_payload(writer, &payload)
+    }
+
     /// Run the debug adapter server
     pub(crate) fn run(&mut self) -> io::Result<()> {
         self.run_with_io(io::stdin(), io::stdout())
@@ -40,20 +50,26 @@ impl DebugAdapter {
 
         thread::spawn(move || {
             while let Ok(msg) = rx.recv() {
-                let framed = match serde_json::to_vec(&msg) {
-                    Ok(payload) => frame(&payload),
-                    Err(e) => {
-                        tracing::error!(error = %e, message = ?msg, "Failed to serialize DAP message");
-                        continue;
-                    }
-                };
-
                 let mut writer = lock_or_recover(&event_writer, "event_writer");
-                if let Err(e) = writer.write_all(&framed) {
-                    tracing::error!(error = %e, "Failed to write DAP frame in event handler");
+                if let Err(e) = Self::write_framed_message(&mut *writer, &msg) {
+                    tracing::error!(error = %e, message = ?msg, "Failed to write DAP frame in event handler");
                     continue;
                 }
-                if let Err(e) = writer.flush() {
+
+                let mut should_flush = true;
+                while let Ok(next_msg) = rx.try_recv() {
+                    if let Err(e) = Self::write_framed_message(&mut *writer, &next_msg) {
+                        tracing::error!(
+                            error = %e,
+                            message = ?next_msg,
+                            "Failed to write queued DAP frame in event handler"
+                        );
+                        should_flush = false;
+                        break;
+                    }
+                }
+
+                if should_flush && let Err(e) = writer.flush() {
                     tracing::error!(error = %e, "Failed to flush DAP frame in event handler");
                 }
             }
@@ -103,9 +119,8 @@ impl DebugAdapter {
                     }
                 };
 
-                let framed = frame(&payload);
                 let mut writer = lock_or_recover(&shared_writer, "response_writer");
-                writer.write_all(&framed)?;
+                Self::write_framed_payload(&mut *writer, &payload)?;
                 writer.flush()?;
 
                 // DAP requires this event only after initialize response is sent.


### PR DESCRIPTION
### Motivation
- Reduce allocation and flush/lock churn on hot DAP transport paths where benchmarks showed framing/write overhead and per-event flush cost.
- Preserve exact DAP Content-Length framing semantics while lowering per-message overhead.

### Description
- Added helpers `DebugAdapter::write_framed_payload` and `DebugAdapter::write_framed_message` to stream `Content-Length` headers and payload bytes directly to the writer without building an intermediate framed buffer. 
- Changed event thread to batch-send queued events after acquiring the `event_writer` lock (draining `rx.try_recv()`), emitting a single `flush()` per batch to reduce lock/flush churn. 
- Switched response path to use `write_framed_payload` so responses stream header+payload without extra allocation. 
- Added a transport-sensitive Criterion benchmark `benchmark_dap_transport_output` that compares `frame_alloc_and_write` vs `stream_header_and_payload_write`, and removed the now-unused `frame` import from the module.

### Testing
- Ran formatting with `cargo xtask fmt` successfully. 
- Ran transport benchmark with `cargo bench -p perl-dap --bench dap_benchmarks -- dap_transport --measurement-time 3` and observed `stream_header_and_payload_write` ≈ `53.8 ns` vs `frame_alloc_and_write` ≈ `55.7 ns` in the measured run. 
- Ran protocol tests with `cargo test -p perl-dap --test dap_protocol_message_tests` and all tests passed. 
- Ran golden transcript tests with `cargo test -p perl-dap --test dap_golden_transcript_tests` and all tests passed. 
- Ran `cargo check --all-targets -p perl-dap` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3a5f1f9c8333b237d9280ab54dd5)