### PR TITLE
perf(perl-dap): remove measured transport/output overhead in hot DAP paths (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -40,7 +40,7 @@ use crate::tcp_attach::{DapEvent, TcpAttachConfig, TcpAttachSession};
 use crate::types::{Source, StackFrame, Variable};
 use crate::variables::{PerlVariableRenderer, RenderedVariable, VariableParser, VariableRenderer};
 use perl_lexer::DAP_COMPLETION_KEYWORDS;
-use perl_lsp_rs_core::transport::framing::{ContentLengthFramer, frame};
+use perl_lsp_rs_core::transport::framing::ContentLengthFramer;
 use perl_module::path::module_path_to_name;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -609,13 +609,6 @@ impl DebugAdapter {
         self.debugger_output_marker.fetch_add(1, Ordering::Relaxed)
     }
 
-    /// Write a debugger command and flush immediately so output framing remains ordered.
-    fn write_debugger_command(stdin: &mut impl Write, command: &str) -> Result<(), String> {
-        stdin.write_all(command.as_bytes()).map_err(|e| format!("write debugger command: {e}"))?;
-        stdin.flush().map_err(|e| format!("flush debugger command: {e}"))?;
-        Ok(())
-    }
-
     /// Send commands wrapped with unique begin/end markers.
     ///
     /// Returns `(begin_marker, end_marker)` so callers can wait for framed output.
@@ -628,15 +621,24 @@ impl DebugAdapter {
         let begin_marker = format!("DAP_BEGIN_{marker_id}");
         let end_marker = format!("DAP_END_{marker_id}");
 
-        Self::write_debugger_command(stdin, &format!("p \"{begin_marker}\"\n"))?;
+        stdin
+            .write_all(format!("p \"{begin_marker}\"\n").as_bytes())
+            .map_err(|e| format!("write debugger command: {e}"))?;
         for command in commands {
             if command.ends_with('\n') {
-                Self::write_debugger_command(stdin, command)?;
+                stdin
+                    .write_all(command.as_bytes())
+                    .map_err(|e| format!("write debugger command: {e}"))?;
             } else {
-                Self::write_debugger_command(stdin, &format!("{command}\n"))?;
+                stdin
+                    .write_all(format!("{command}\n").as_bytes())
+                    .map_err(|e| format!("write debugger command: {e}"))?;
             }
         }
-        Self::write_debugger_command(stdin, &format!("p \"{end_marker}\"\n"))?;
+        stdin
+            .write_all(format!("p \"{end_marker}\"\n").as_bytes())
+            .map_err(|e| format!("write debugger command: {e}"))?;
+        stdin.flush().map_err(|e| format!("flush debugger command: {e}"))?;
 
         Ok((begin_marker, end_marker))
     }

--- a/crates/perl-dap/src/debug_adapter/transport.rs
+++ b/crates/perl-dap/src/debug_adapter/transport.rs
@@ -40,21 +40,25 @@ impl DebugAdapter {
 
         thread::spawn(move || {
             while let Ok(msg) = rx.recv() {
-                let framed = match serde_json::to_vec(&msg) {
-                    Ok(payload) => frame(&payload),
-                    Err(e) => {
-                        tracing::error!(error = %e, message = ?msg, "Failed to serialize DAP message");
-                        continue;
-                    }
-                };
+                let mut batched = vec![msg];
+                while let Ok(next) = rx.try_recv() {
+                    batched.push(next);
+                }
 
                 let mut writer = lock_or_recover(&event_writer, "event_writer");
-                if let Err(e) = writer.write_all(&framed) {
-                    tracing::error!(error = %e, "Failed to write DAP frame in event handler");
+                let mut write_failed = false;
+                for event in &batched {
+                    if let Err(e) = Self::write_framed_dap_message(&mut *writer, event) {
+                        tracing::error!(error = %e, message = ?event, "Failed to write DAP frame in event handler");
+                        write_failed = true;
+                        break;
+                    }
+                }
+                if write_failed {
                     continue;
                 }
                 if let Err(e) = writer.flush() {
-                    tracing::error!(error = %e, "Failed to flush DAP frame in event handler");
+                    tracing::error!(error = %e, events = batched.len(), "Failed to flush DAP frame batch");
                 }
             }
             tracing::debug!("Event handler thread terminating - channel closed");
@@ -95,17 +99,8 @@ impl DebugAdapter {
                 };
 
                 let response = self.dispatch_request(seq, &command, arguments);
-                let payload = match serde_json::to_vec(&response) {
-                    Ok(payload) => payload,
-                    Err(e) => {
-                        tracing::error!(error = %e, "Failed to serialize DAP response");
-                        continue;
-                    }
-                };
-
-                let framed = frame(&payload);
                 let mut writer = lock_or_recover(&shared_writer, "response_writer");
-                writer.write_all(&framed)?;
+                Self::write_framed_dap_message(&mut *writer, &response)?;
                 writer.flush()?;
 
                 // DAP requires this event only after initialize response is sent.
@@ -116,5 +111,11 @@ impl DebugAdapter {
                 }
             }
         }
+    }
+
+    fn write_framed_dap_message(writer: &mut impl Write, message: &DapMessage) -> io::Result<()> {
+        let payload = serde_json::to_vec(message).map_err(io::Error::other)?;
+        write!(writer, "Content-Length: {}\r\n\r\n", payload.len())?;
+        writer.write_all(&payload)
     }
 }


### PR DESCRIPTION
### Motivation

- The DAP transport and debugger-output paths performed per-message framing allocations, acquired locks per event, and flushed debugger stdin per command, which added measurable overhead under event-heavy and benchmarked paths.

### Description

- Batch queued events in the transport event thread (`run_with_io`) by draining `rx` with `recv` + `try_recv` and write the whole batch under a single mutex hold and single `flush` to reduce lock/flush churn.
- Introduced `write_framed_dap_message` to serialize a `DapMessage` once and write the `Content-Length` header plus payload directly to the writer to avoid intermediate framed buffer allocations in both event and response paths.
- Reduced debugger-command flush churn in `send_framed_debugger_commands` by writing begin marker, commands, and end marker in-order and calling `flush` once at the end while preserving exact framed semantics and ordering.
- Changes touch: `crates/perl-dap/src/debug_adapter/transport.rs` and `crates/perl-dap/src/debug_adapter/mod.rs`.

### Testing

- Ran `cargo test -p perl-dap --test dap_protocol_message_tests` which passed (all tests OK). 
- Ran `cargo test -p perl-dap --test dap_golden_transcript_tests` which passed (all tests OK).
- Ran `cargo check --all-targets -p perl-dap` which completed successfully.
- Ran `cargo fmt` to ensure formatting consistency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3a5f1f9c8333b237d9280ab54dd5)