### PR TITLE
perf(perl-dap): remove measured transport/output overhead in hot DAP paths (#6506)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -40,7 +40,7 @@ use crate::tcp_attach::{DapEvent, TcpAttachConfig, TcpAttachSession};
 use crate::types::{Source, StackFrame, Variable};
 use crate::variables::{PerlVariableRenderer, RenderedVariable, VariableParser, VariableRenderer};
 use perl_lexer::DAP_COMPLETION_KEYWORDS;
-use perl_lsp_rs_core::transport::framing::{ContentLengthFramer, frame};
+use perl_lsp_rs_core::transport::framing::ContentLengthFramer;
 use perl_module::path::module_path_to_name;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};

--- a/crates/perl-dap/src/debug_adapter/transport.rs
+++ b/crates/perl-dap/src/debug_adapter/transport.rs
@@ -1,6 +1,16 @@
 //! Transport layer: run (stdin/stdout), run_socket, run_with_io.
 
 use super::*;
+use std::sync::mpsc::TryRecvError;
+
+const EVENT_WRITE_BATCH_MAX: usize = 64;
+
+fn write_framed_payload<W: Write>(writer: &mut W, payload: &[u8]) -> io::Result<()> {
+    writer.write_all(b"Content-Length: ")?;
+    writer.write_all(payload.len().to_string().as_bytes())?;
+    writer.write_all(b"\r\n\r\n")?;
+    writer.write_all(payload)
+}
 
 impl DebugAdapter {
     /// Run the debug adapter server
@@ -39,22 +49,58 @@ impl DebugAdapter {
         self.event_sender = Some(tx.clone());
 
         thread::spawn(move || {
-            while let Ok(msg) = rx.recv() {
-                let framed = match serde_json::to_vec(&msg) {
-                    Ok(payload) => frame(&payload),
-                    Err(e) => {
-                        tracing::error!(error = %e, message = ?msg, "Failed to serialize DAP message");
-                        continue;
-                    }
-                };
+            while let Ok(first_msg) = rx.recv() {
+                let mut batch = Vec::with_capacity(EVENT_WRITE_BATCH_MAX);
+                batch.push(first_msg);
 
-                let mut writer = lock_or_recover(&event_writer, "event_writer");
-                if let Err(e) = writer.write_all(&framed) {
-                    tracing::error!(error = %e, "Failed to write DAP frame in event handler");
+                let mut disconnected = false;
+                while batch.len() < EVENT_WRITE_BATCH_MAX {
+                    match rx.try_recv() {
+                        Ok(msg) => batch.push(msg),
+                        Err(TryRecvError::Empty) => break,
+                        Err(TryRecvError::Disconnected) => {
+                            disconnected = true;
+                            break;
+                        }
+                    }
+                }
+
+                let mut payloads = Vec::with_capacity(batch.len());
+                for msg in batch {
+                    match serde_json::to_vec(&msg) {
+                        Ok(payload) => payloads.push(payload),
+                        Err(e) => {
+                            tracing::error!(
+                                error = %e,
+                                message = ?msg,
+                                "Failed to serialize DAP message"
+                            );
+                        }
+                    }
+                }
+
+                if payloads.is_empty() {
+                    if disconnected {
+                        break;
+                    }
                     continue;
                 }
-                if let Err(e) = writer.flush() {
+
+                let mut writer = lock_or_recover(&event_writer, "event_writer");
+                let mut write_failed = false;
+                for payload in &payloads {
+                    if let Err(e) = write_framed_payload(&mut *writer, payload) {
+                        tracing::error!(error = %e, "Failed to write DAP frame in event handler");
+                        write_failed = true;
+                        break;
+                    }
+                }
+                if !write_failed && let Err(e) = writer.flush() {
                     tracing::error!(error = %e, "Failed to flush DAP frame in event handler");
+                }
+
+                if disconnected {
+                    break;
                 }
             }
             tracing::debug!("Event handler thread terminating - channel closed");
@@ -103,9 +149,8 @@ impl DebugAdapter {
                     }
                 };
 
-                let framed = frame(&payload);
                 let mut writer = lock_or_recover(&shared_writer, "response_writer");
-                writer.write_all(&framed)?;
+                write_framed_payload(&mut *writer, &payload)?;
                 writer.flush()?;
 
                 // DAP requires this event only after initialize response is sent.


### PR DESCRIPTION
### Motivation
- Reduce measured transport and output overhead in hot DAP paths caused by per-message framing allocations and frequent write/flush cycles under bursty event emission.
- Preserve exact DAP Content-Length framing and delivery semantics while lowering lock contention on the shared writer.

### Description
- Batch event channel messages in the event-thread by draining up to `EVENT_WRITE_BATCH_MAX` via `try_recv` before taking the shared writer lock, reducing lock/flush churn.
- Add `write_framed_payload` to write `Content-Length` header and payload directly to the writer without allocating an intermediate framed buffer for each message.
- Emit batched payloads with a single lock acquisition and a single `flush()` per batch, preserving message order and framing semantics.
- Remove now-unused `frame` import from `mod.rs` after switching to direct framed writes.

### Testing
- Ran `cargo test -p perl-dap --test dap_protocol_message_tests` and all tests passed (41 passed). 
- Ran `cargo test -p perl-dap --test dap_golden_transcript_tests` and all tests passed (5 passed).
- Ran `cargo check --all-targets -p perl-dap` and the check completed successfully.
- Ran the `dap_dispatch` benchmark via `cargo bench -p perl-dap --bench dap_benchmarks -- dap_dispatch --measurement-time 1`; the bench completed and reported `dap_threads_request` ≈ 169–173 ns and `dap_stacktrace_request` ≈ 1.25–1.28 µs in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3a5f1f9c8333b237d9280ab54dd5)