### PR TITLE
fix(perl-dap): harden bridge adapter lifecycle and shutdown behavior (#0000)

### DIFF
--- a/crates/perl-dap/benches/dap_benchmarks.rs
+++ b/crates/perl-dap/benches/dap_benchmarks.rs
@@ -32,6 +32,7 @@
 //! ```
 
 use criterion::{Criterion, criterion_group, criterion_main};
+use perl_dap::BridgeAdapter;
 use perl_dap::configuration::LaunchConfiguration;
 use perl_dap::debug_adapter::DebugAdapter;
 use perl_dap::platform::{
@@ -42,6 +43,7 @@ use std::collections::HashMap;
 use std::hint::black_box;
 use std::path::PathBuf;
 use std::time::Duration;
+use tokio::runtime::Runtime;
 
 // ========== Configuration Benchmarks (AC14) ==========
 
@@ -285,6 +287,47 @@ fn benchmark_arg_formatting(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark bridge adapter startup/shutdown lifecycle costs.
+fn benchmark_bridge_lifecycle(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bridge_lifecycle");
+    group.measurement_time(Duration::from_secs(5));
+
+    let Ok(runtime) = Runtime::new() else {
+        group.finish();
+        return;
+    };
+
+    group.bench_function("bridge_new_shutdown_no_spawn", |b| {
+        b.iter(|| {
+            runtime.block_on(async {
+                let mut adapter = BridgeAdapter::new();
+                let _ = adapter.shutdown().await;
+            });
+        })
+    });
+
+    let spawn_supported = runtime.block_on(async {
+        let mut adapter = BridgeAdapter::new();
+        let spawn_result = adapter.spawn_pls_dap().await;
+        let _ = adapter.shutdown().await;
+        spawn_result.is_ok()
+    });
+
+    if spawn_supported {
+        group.bench_function("bridge_spawn_shutdown", |b| {
+            b.iter(|| {
+                runtime.block_on(async {
+                    let mut adapter = BridgeAdapter::new();
+                    let _ = adapter.spawn_pls_dap().await;
+                    let _ = adapter.shutdown().await;
+                });
+            })
+        });
+    }
+
+    group.finish();
+}
+
 // ========== Benchmark Groups ==========
 
 criterion_group!(configuration_benches, benchmark_launch_config_validation);
@@ -294,7 +337,8 @@ criterion_group!(
     benchmark_perl_path_resolution,
     benchmark_path_normalization,
     benchmark_environment_setup,
-    benchmark_arg_formatting
+    benchmark_arg_formatting,
+    benchmark_bridge_lifecycle
 );
 
 // ========== Phase 2: Session Management Benchmarks (AC5.2) ==========

--- a/crates/perl-dap/src/bridge_adapter.rs
+++ b/crates/perl-dap/src/bridge_adapter.rs
@@ -39,6 +39,7 @@ use tokio::time::sleep;
 
 const PLS_SHUTDOWN_GRACE_MS: u64 = 250;
 const PLS_SHUTDOWN_POLL_MS: u64 = 25;
+const PLS_SHUTDOWN_KILL_WAIT_MS: u64 = 1000;
 
 /// Perl debugger flag to activate DAP protocol mode in Perl::LanguageServer
 const PLS_DAP_FLAG: &str = "-d:LanguageServer::DAP";
@@ -106,6 +107,7 @@ impl BridgeAdapter {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
+            .kill_on_drop(true)
             .spawn()
             .context("Failed to spawn Perl::LanguageServer DAP process")?;
 
@@ -181,8 +183,22 @@ impl BridgeAdapter {
         // if the client closes its input, we want to continue proxying
         // any remaining output from the server.
         let (res1, res2) = tokio::join!(client_to_server, server_to_client);
-        res1?;
-        res2?;
+        let copy_result = match (res1, res2) {
+            (Err(e), _) => Err(e),
+            (_, Err(e)) => Err(e),
+            (Ok(()), Ok(())) => Ok(()),
+        };
+
+        if let Some(child) = self.child_process.as_mut() {
+            if !Self::wait_for_child_exit(child, Duration::from_millis(PLS_SHUTDOWN_GRACE_MS)).await
+            {
+                tracing::warn!(
+                    "Perl::LanguageServer process is still running after proxy stream shutdown"
+                );
+            }
+        }
+
+        copy_result?;
 
         Ok(())
     }
@@ -193,7 +209,7 @@ impl BridgeAdapter {
     /// It should be used for cleanup in async contexts.
     pub async fn shutdown(&mut self) -> Result<()> {
         if let Some(mut child) = self.child_process.take() {
-            if !Self::wait_for_child_exit(&mut child, Duration::from_millis(0)).await {
+            if !Self::wait_for_child_exit(&mut child, Duration::ZERO).await {
                 #[cfg(unix)]
                 {
                     if let Some(pid) = child.id() {
@@ -210,14 +226,16 @@ impl BridgeAdapter {
                     }
                 }
 
-                let _ = child.kill().await;
+                let _ = child.start_kill();
                 if !Self::wait_for_child_exit(
                     &mut child,
-                    Duration::from_millis(PLS_SHUTDOWN_GRACE_MS),
+                    Duration::from_millis(PLS_SHUTDOWN_KILL_WAIT_MS),
                 )
                 .await
                 {
-                    let _ = child.wait().await?;
+                    tracing::warn!(
+                        "Timed out waiting for Perl::LanguageServer process to terminate"
+                    );
                 }
             }
         }
@@ -233,7 +251,11 @@ impl BridgeAdapter {
         while Instant::now() < deadline {
             match child.try_wait() {
                 Ok(Some(_)) => return true,
-                Ok(None) => sleep(Duration::from_millis(PLS_SHUTDOWN_POLL_MS)).await,
+                Ok(None) => {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    let delay = remaining.min(Duration::from_millis(PLS_SHUTDOWN_POLL_MS));
+                    sleep(delay).await;
+                }
                 Err(e) => {
                     tracing::error!(error = %e, "Failed to poll Perl::LanguageServer process");
                     return false;

--- a/crates/perl-dap/tests/bridge_adapter_unit_tests.rs
+++ b/crates/perl-dap/tests/bridge_adapter_unit_tests.rs
@@ -160,6 +160,21 @@ async fn test_repeated_lifecycle_cycles() -> Result<()> {
     Ok(())
 }
 
+/// Spawning twice should cleanly replace the previous child process.
+#[tokio::test]
+async fn test_spawn_twice_replaces_previous_process() -> Result<()> {
+    let mut adapter = BridgeAdapter::new();
+
+    if adapter.spawn_pls_dap().await.is_err() {
+        return Ok(());
+    }
+
+    // A second spawn should implicitly shut down any existing child first.
+    adapter.spawn_pls_dap().await?;
+    adapter.shutdown().await?;
+    Ok(())
+}
+
 /// Multiple adapters can be created sequentially without interference.
 /// This verifies no global state leaks between adapter instances.
 #[tokio::test]

--- a/crates/perl-dap/tests/bridge_integration_tests.rs
+++ b/crates/perl-dap/tests/bridge_integration_tests.rs
@@ -448,6 +448,19 @@ fn test_bridge_adapter_multiple_instances() -> Result<()> {
     Ok(())
 }
 
+/// Test: Bridge adapter spawn/shutdown lifecycle is stable when perl is available
+#[tokio::test]
+async fn test_bridge_adapter_spawn_shutdown_lifecycle() -> Result<()> {
+    use perl_dap::BridgeAdapter;
+
+    let mut adapter = BridgeAdapter::new();
+    if adapter.spawn_pls_dap().await.is_ok() {
+        adapter.shutdown().await?;
+    }
+
+    Ok(())
+}
+
 /// Test: Empty environment variables are handled correctly
 #[tokio::test]
 async fn test_empty_environment_handling() -> Result<()> {


### PR DESCRIPTION
### Motivation
- The bridge-mode child process lifecycle and proxy teardown were prone to unpredictable behavior during partial stream closure or process failure, making shutdowns flaky.
- Improve robustness so shutdown/killing of the Perl::LanguageServer child is deterministic across platforms and observable after proxy termination.
- Add a small benchmark to measure whether spawn/shutdown overhead is significant for real users.

### Description
- Enable `kill_on_drop(true)` when spawning the child and introduce `PLS_SHUTDOWN_KILL_WAIT_MS` to bound kill wait time.
- Tighten shutdown flow to first check immediate exit via `try_wait`, attempt a Unix `SIGTERM` grace phase, then use `start_kill()` and a bounded wait before warning on timeout.
- After proxy streams finish, perform a short grace wait (`PLS_SHUTDOWN_GRACE_MS`) and warn if the child is still running to make long-running child behavior visible.
- Improve `wait_for_child_exit` polling to sleep only up to the remaining deadline for more responsive shutdown timing.
- Add a unit test `test_spawn_twice_replaces_previous_process` and an integration smoke `test_bridge_adapter_spawn_shutdown_lifecycle` to cover lifecycle replacement and spawn→shutdown stability.
- Add a small benchmark group `bridge_lifecycle` exercising new adapter `new`/`spawn`/`shutdown` paths and wire it into the benchmarks suite.

### Testing
- Ran `cargo test -p perl-dap --test bridge_adapter_unit_tests` and all tests passed.
- Ran `cargo test -p perl-dap --test bridge_integration_tests` and all tests passed.
- Ran `cargo check --all-targets -p perl-dap` and it completed successfully.
- Ran `cargo xtask fmt` to format changes without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3a60fee083339a15250dd0294d86)