### PR TITLE
fix(perl-dap): harden bridge adapter lifecycle and shutdown behavior (#0000)

### DIFF
--- a/crates/perl-dap/benches/dap_benchmarks.rs
+++ b/crates/perl-dap/benches/dap_benchmarks.rs
@@ -32,6 +32,7 @@
 //! ```
 
 use criterion::{Criterion, criterion_group, criterion_main};
+use perl_dap::BridgeAdapter;
 use perl_dap::configuration::LaunchConfiguration;
 use perl_dap::debug_adapter::DebugAdapter;
 use perl_dap::platform::{
@@ -348,6 +349,48 @@ fn benchmark_dap_dispatch(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(session_benches, benchmark_dap_initialization, benchmark_dap_dispatch);
+/// Benchmark bridge lifecycle overhead.
+///
+/// This keeps a lightweight signal on whether bridge startup/shutdown overhead is
+/// regressing while bridge mode remains supported for existing users.
+fn benchmark_bridge_lifecycle(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bridge_lifecycle");
+    group.measurement_time(Duration::from_secs(10));
+
+    let Ok(runtime) =
+        tokio::runtime::Builder::new_current_thread().enable_io().enable_time().build()
+    else {
+        group.finish();
+        return;
+    };
+
+    group.bench_function("bridge_new_shutdown_no_child", |b| {
+        b.iter(|| {
+            runtime.block_on(async {
+                let mut adapter = BridgeAdapter::new();
+                let _ = adapter.shutdown().await;
+            });
+        })
+    });
+
+    group.bench_function("bridge_spawn_shutdown_best_effort", |b| {
+        b.iter(|| {
+            runtime.block_on(async {
+                let mut adapter = BridgeAdapter::new();
+                let _ = adapter.spawn_pls_dap().await;
+                let _ = adapter.shutdown().await;
+            });
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    session_benches,
+    benchmark_dap_initialization,
+    benchmark_dap_dispatch,
+    benchmark_bridge_lifecycle
+);
 
 criterion_main!(configuration_benches, platform_benches, session_benches);

--- a/crates/perl-dap/src/bridge_adapter.rs
+++ b/crates/perl-dap/src/bridge_adapter.rs
@@ -39,6 +39,7 @@ use tokio::time::sleep;
 
 const PLS_SHUTDOWN_GRACE_MS: u64 = 250;
 const PLS_SHUTDOWN_POLL_MS: u64 = 25;
+const PLS_FORCE_KILL_WAIT_MS: u64 = 250;
 
 /// Perl debugger flag to activate DAP protocol mode in Perl::LanguageServer
 const PLS_DAP_FLAG: &str = "-d:LanguageServer::DAP";
@@ -158,31 +159,47 @@ impl BridgeAdapter {
 
         // Create bidirectional copy tasks
         // Task 1: Client (Parent Stdin) -> Server (Child Stdin)
-        let client_to_server = async move {
+        let mut client_to_server = tokio::spawn(async move {
             tokio::io::copy(&mut parent_stdin, &mut child_stdin)
                 .await
                 .context("Error copying from client to server")?;
             // Shut down child_stdin to signal EOF to the server
             let _ = child_stdin.shutdown().await;
             Ok::<(), anyhow::Error>(())
-        };
+        });
 
         // Task 2: Server (Child Stdout) -> Client (Parent Stdout)
-        let server_to_client = async move {
+        let mut server_to_client = tokio::spawn(async move {
             tokio::io::copy(&mut child_stdout, &mut parent_stdout)
                 .await
                 .context("Error copying from server to client")?;
             parent_stdout.flush().await.context("Error flushing to client")?;
             Ok::<(), anyhow::Error>(())
-        };
+        });
 
-        // Run both tasks concurrently and wait for both to finish.
-        // We use join instead of select to ensure graceful shutdown:
-        // if the client closes its input, we want to continue proxying
-        // any remaining output from the server.
-        let (res1, res2) = tokio::join!(client_to_server, server_to_client);
-        res1?;
-        res2?;
+        // If the server side closes first, the client->server copier can block forever
+        // on stdin reads. We prefer deterministic completion and abort the input task
+        // once server->client has completed.
+        tokio::select! {
+            res = &mut server_to_client => {
+                match res {
+                    Ok(inner) => inner?,
+                    Err(e) => anyhow::bail!("Server-to-client proxy task failed: {e}"),
+                }
+                client_to_server.abort();
+                let _ = (&mut client_to_server).await;
+            }
+            res = &mut client_to_server => {
+                match res {
+                    Ok(inner) => inner?,
+                    Err(e) => anyhow::bail!("Client-to-server proxy task failed: {e}"),
+                }
+                match (&mut server_to_client).await {
+                    Ok(inner) => inner?,
+                    Err(e) => anyhow::bail!("Server-to-client proxy task failed: {e}"),
+                }
+            }
+        }
 
         Ok(())
     }
@@ -194,6 +211,10 @@ impl BridgeAdapter {
     pub async fn shutdown(&mut self) -> Result<()> {
         if let Some(mut child) = self.child_process.take() {
             if !Self::wait_for_child_exit(&mut child, Duration::from_millis(0)).await {
+                if let Some(mut stdin) = child.stdin.take() {
+                    let _ = stdin.shutdown().await;
+                }
+
                 #[cfg(unix)]
                 {
                     if let Some(pid) = child.id() {
@@ -210,10 +231,10 @@ impl BridgeAdapter {
                     }
                 }
 
-                let _ = child.kill().await;
+                let _ = child.start_kill();
                 if !Self::wait_for_child_exit(
                     &mut child,
-                    Duration::from_millis(PLS_SHUTDOWN_GRACE_MS),
+                    Duration::from_millis(PLS_FORCE_KILL_WAIT_MS),
                 )
                 .await
                 {
@@ -231,9 +252,11 @@ impl BridgeAdapter {
 
         let deadline = Instant::now() + timeout;
         while Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let delay = remaining.min(Duration::from_millis(PLS_SHUTDOWN_POLL_MS));
             match child.try_wait() {
                 Ok(Some(_)) => return true,
-                Ok(None) => sleep(Duration::from_millis(PLS_SHUTDOWN_POLL_MS)).await,
+                Ok(None) => sleep(delay).await,
                 Err(e) => {
                     tracing::error!(error = %e, "Failed to poll Perl::LanguageServer process");
                     return false;

--- a/crates/perl-dap/tests/bridge_adapter_unit_tests.rs
+++ b/crates/perl-dap/tests/bridge_adapter_unit_tests.rs
@@ -174,3 +174,21 @@ async fn test_sequential_adapters_are_independent() -> Result<()> {
     second.shutdown().await?;
     Ok(())
 }
+
+/// Calling spawn twice should not leave an orphaned process.
+///
+/// If perl / Perl::LanguageServer is unavailable, this test exits early.
+#[tokio::test]
+async fn test_respawn_replaces_previous_child_cleanly() -> Result<()> {
+    let mut adapter = BridgeAdapter::new();
+    let first_spawn = adapter.spawn_pls_dap().await;
+    if first_spawn.is_err() {
+        // Environment does not have a runnable bridge target.
+        return Ok(());
+    }
+
+    // Second spawn should force cleanup of any previous child before respawning.
+    let _ = adapter.spawn_pls_dap().await;
+    adapter.shutdown().await?;
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Bridge proxying could hang or behave nondeterministically when one side closed (open stdin reads could block the client->server copier) and shutdown escalation was imprecise.  

### Description
- Reworked `proxy_messages` to run the two copy loops as `tokio::spawn` tasks and coordinate completion with `tokio::select!`, aborting the client-input task deterministically when server output completes.  
- Improved `shutdown` to attempt an explicit child stdin shutdown, prefer `SIGTERM` on Unix, and escalate to `start_kill` with a bounded force-wait timeout via new `PLS_FORCE_KILL_WAIT_MS`.  
- Tightened `wait_for_child_exit` polling to use the remaining timeout window for sleep intervals to avoid oversleeping.  
- Added `test_respawn_replaces_previous_child_cleanly` unit test and a lightweight `bridge_lifecycle` benchmark in `dap_benchmarks` to track startup/shutdown overhead over time.  

### Testing
- Ran `cargo test -p perl-dap --test bridge_adapter_unit_tests`, which passed.  
- Ran `cargo test -p perl-dap --test bridge_integration_tests`, which passed.  
- Ran `cargo check --all-targets -p perl-dap`, which passed.  
- Ran `cargo xtask fmt` successfully; `just pr-fast` was not available in this environment so it was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3a60fee083339a15250dd0294d86)