### PR TITLE
fix(perl-dap): harden bridge adapter lifecycle and shutdown behavior (#0000)

### DIFF
--- a/crates/perl-dap/benches/dap_benchmarks.rs
+++ b/crates/perl-dap/benches/dap_benchmarks.rs
@@ -32,6 +32,7 @@
 //! ```
 
 use criterion::{Criterion, criterion_group, criterion_main};
+use perl_dap::BridgeAdapter;
 use perl_dap::configuration::LaunchConfiguration;
 use perl_dap::debug_adapter::DebugAdapter;
 use perl_dap::platform::{
@@ -348,6 +349,49 @@ fn benchmark_dap_dispatch(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(session_benches, benchmark_dap_initialization, benchmark_dap_dispatch);
+/// Benchmark bridge spawn/shutdown lifecycle when bridge mode is available.
+fn benchmark_bridge_lifecycle(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bridge_lifecycle");
+    group.measurement_time(Duration::from_secs(10));
+
+    let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+        Ok(runtime) => runtime,
+        Err(_) => {
+            group.finish();
+            return;
+        }
+    };
+
+    let bridge_available = runtime.block_on(async {
+        let mut adapter = BridgeAdapter::new();
+        let spawn_ok = adapter.spawn_pls_dap().await.is_ok();
+        let _ = adapter.shutdown().await;
+        spawn_ok
+    });
+
+    if !bridge_available {
+        group.finish();
+        return;
+    }
+
+    group.bench_function("bridge_spawn_shutdown", |b| {
+        b.iter(|| {
+            runtime.block_on(async {
+                let mut adapter = BridgeAdapter::new();
+                let _ = adapter.spawn_pls_dap().await;
+                let _ = adapter.shutdown().await;
+            });
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    session_benches,
+    benchmark_dap_initialization,
+    benchmark_dap_dispatch,
+    benchmark_bridge_lifecycle
+);
 
 criterion_main!(configuration_benches, platform_benches, session_benches);

--- a/crates/perl-dap/src/bridge_adapter.rs
+++ b/crates/perl-dap/src/bridge_adapter.rs
@@ -37,7 +37,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, Command};
 use tokio::time::sleep;
 
-const PLS_SHUTDOWN_GRACE_MS: u64 = 250;
+const PLS_SHUTDOWN_GRACE_MS: u64 = 500;
 const PLS_SHUTDOWN_POLL_MS: u64 = 25;
 
 /// Perl debugger flag to activate DAP protocol mode in Perl::LanguageServer
@@ -64,6 +64,14 @@ impl BridgeAdapter {
     /// ```
     pub fn new() -> Self {
         Self { child_process: None }
+    }
+
+    /// Create a bridge adapter around an already spawned process.
+    ///
+    /// This constructor is mainly intended for deterministic lifecycle testing.
+    #[doc(hidden)]
+    pub fn from_spawned_child(child: Child) -> Self {
+        Self { child_process: Some(child) }
     }
 
     /// Spawn Perl::LanguageServer in DAP mode
@@ -158,31 +166,55 @@ impl BridgeAdapter {
 
         // Create bidirectional copy tasks
         // Task 1: Client (Parent Stdin) -> Server (Child Stdin)
-        let client_to_server = async move {
+        let mut client_to_server = tokio::spawn(async move {
             tokio::io::copy(&mut parent_stdin, &mut child_stdin)
                 .await
                 .context("Error copying from client to server")?;
             // Shut down child_stdin to signal EOF to the server
             let _ = child_stdin.shutdown().await;
             Ok::<(), anyhow::Error>(())
-        };
+        });
 
         // Task 2: Server (Child Stdout) -> Client (Parent Stdout)
-        let server_to_client = async move {
+        let mut server_to_client = tokio::spawn(async move {
             tokio::io::copy(&mut child_stdout, &mut parent_stdout)
                 .await
                 .context("Error copying from server to client")?;
             parent_stdout.flush().await.context("Error flushing to client")?;
             Ok::<(), anyhow::Error>(())
-        };
+        });
 
-        // Run both tasks concurrently and wait for both to finish.
-        // We use join instead of select to ensure graceful shutdown:
-        // if the client closes its input, we want to continue proxying
-        // any remaining output from the server.
-        let (res1, res2) = tokio::join!(client_to_server, server_to_client);
-        res1?;
-        res2?;
+        // Avoid hanging forever when the child exits but client stdin remains open.
+        // If the child exits first, we abort the client->server copy task.
+        tokio::select! {
+            status = child.wait() => {
+                status.context("Failed waiting for Perl::LanguageServer process")?;
+                client_to_server.abort();
+                let _ = client_to_server.await;
+                match server_to_client.await {
+                    Ok(result) => result?,
+                    Err(join_err) => anyhow::bail!("Server-to-client proxy task failed: {join_err}"),
+                }
+            }
+            res2 = &mut server_to_client => {
+                match res2 {
+                    Ok(result) => result?,
+                    Err(join_err) => anyhow::bail!("Server-to-client proxy task failed: {join_err}"),
+                }
+                client_to_server.abort();
+                let _ = client_to_server.await;
+            }
+            res1 = &mut client_to_server => {
+                match res1 {
+                    Ok(result) => result?,
+                    Err(join_err) => anyhow::bail!("Client-to-server proxy task failed: {join_err}"),
+                }
+                match server_to_client.await {
+                    Ok(result) => result?,
+                    Err(join_err) => anyhow::bail!("Server-to-client proxy task failed: {join_err}"),
+                }
+            }
+        }
 
         Ok(())
     }
@@ -194,6 +226,10 @@ impl BridgeAdapter {
     pub async fn shutdown(&mut self) -> Result<()> {
         if let Some(mut child) = self.child_process.take() {
             if !Self::wait_for_child_exit(&mut child, Duration::from_millis(0)).await {
+                if let Some(mut stdin) = child.stdin.take() {
+                    let _ = stdin.shutdown().await;
+                }
+
                 #[cfg(unix)]
                 {
                     if let Some(pid) = child.id() {
@@ -229,6 +265,10 @@ impl BridgeAdapter {
             return true;
         }
 
+        if timeout.is_zero() {
+            return false;
+        }
+
         let deadline = Instant::now() + timeout;
         while Instant::now() < deadline {
             match child.try_wait() {
@@ -241,7 +281,7 @@ impl BridgeAdapter {
             }
         }
 
-        false
+        matches!(child.try_wait(), Ok(Some(_)))
     }
 }
 

--- a/crates/perl-dap/tests/bridge_adapter_unit_tests.rs
+++ b/crates/perl-dap/tests/bridge_adapter_unit_tests.rs
@@ -14,6 +14,9 @@
 
 use anyhow::Result;
 use perl_dap::BridgeAdapter;
+use std::process::Stdio;
+use tokio::process::Command;
+use tokio::time::{Duration, timeout};
 
 /// New adapter starts with no child process; shutdown is a harmless no-op.
 #[tokio::test]
@@ -172,5 +175,40 @@ async fn test_sequential_adapters_are_independent() -> Result<()> {
     let result = second.proxy_messages().await;
     assert!(result.is_err(), "second adapter should still require spawn before proxy_messages");
     second.shutdown().await?;
+    Ok(())
+}
+
+/// proxy_messages should not hang when the child exits and client stdin stays open.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_proxy_messages_returns_after_child_exit() -> Result<()> {
+    let child = Command::new("sh")
+        .arg("-c")
+        .arg("exit 0")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    let mut adapter = BridgeAdapter::from_spawned_child(child);
+    timeout(Duration::from_secs(1), adapter.proxy_messages()).await??;
+    adapter.shutdown().await?;
+    Ok(())
+}
+
+/// shutdown should return quickly for a child that is still running.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_shutdown_terminates_running_child() -> Result<()> {
+    let child = Command::new("sh")
+        .arg("-c")
+        .arg("sleep 5")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    let mut adapter = BridgeAdapter::from_spawned_child(child);
+    timeout(Duration::from_secs(2), adapter.shutdown()).await??;
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Prevent the bridge proxy from hanging when the spawned Perl process exits while client stdin remains open. 
- Make shutdown sequencing and polling more robust and observable under race/failure conditions. 
- Provide a lightweight, conditional benchmark to measure spawn/shutdown overhead when bridge mode is available.

### Description
- Increase shutdown grace window to `500ms` and proactively close the child stdin before sending termination signals. 
- Run the bidirectional copy directions as spawned tasks and use `tokio::select!` to react to child exit or either proxy task completing, aborting the remaining client->server task when appropriate. 
- Add `BridgeAdapter::from_spawned_child(child: Child)` (hidden) to enable deterministic lifecycle tests that inject a real spawned process. 
- Tighten `wait_for_child_exit` to respect zero-timeout as immediate-fail and perform a final `try_wait` check at timeout boundary. 
- Add two Unix-focused unit tests that verify `proxy_messages` returns after child exit and that `shutdown` terminates a running child, and add a conditional `bridge_spawn_shutdown` benchmark that only runs when bridge mode is available.

### Testing
- Ran `cargo test -p perl-dap --test bridge_adapter_unit_tests` which passed (11 tests, all ok). 
- Ran `cargo test -p perl-dap --test bridge_integration_tests` which passed (16 tests, all ok). 
- Ran `cargo check --all-targets -p perl-dap` which completed successfully. 
- Ran `cargo xtask fmt` which finished without formatting issues; the new benchmark is added but is conditional and not executed as part of these tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3a60fee083339a15250dd0294d86)