### PR TITLE
fix(perl-dap): harden bridge adapter lifecycle and shutdown behavior (#6505)

### DIFF
--- a/crates/perl-dap/src/bridge_adapter.rs
+++ b/crates/perl-dap/src/bridge_adapter.rs
@@ -195,8 +195,9 @@ impl BridgeAdapter {
             Ok::<(), anyhow::Error>(())
         });
 
-        tokio::pin!(client_to_server);
-        tokio::pin!(server_to_client);
+        // JoinHandle<T> is already Unpin; no pin! macro needed here.
+        let mut client_to_server = client_to_server;
+        let mut server_to_client = server_to_client;
 
         let mut client_result: Option<Result<()>> = None;
         let mut server_result: Option<Result<()>> = None;
@@ -216,11 +217,11 @@ impl BridgeAdapter {
                         .is_some()
                     {
                         if client_result.is_none() {
-                            client_to_server.as_mut().abort();
+                            client_to_server.abort();
                             client_result = Some(Ok(()));
                         }
                         if server_result.is_none() {
-                            server_to_client.as_mut().abort();
+                            server_to_client.abort();
                             server_result = Some(Ok(()));
                         }
                     }
@@ -228,11 +229,17 @@ impl BridgeAdapter {
             }
         }
 
-        if let Some(result) = client_result {
-            result?;
-        }
-        if let Some(result) = server_result {
-            result?;
+        // Propagate errors from both directions; log the secondary error so it isn't silently lost.
+        let client_err = client_result.and_then(|r| r.err());
+        let server_err = server_result.and_then(|r| r.err());
+        match (client_err, server_err) {
+            (Some(ce), Some(se)) => {
+                tracing::warn!(error = %se, "proxy server->client also failed");
+                return Err(ce);
+            }
+            (Some(ce), None) => return Err(ce),
+            (None, Some(se)) => return Err(se),
+            (None, None) => {}
         }
 
         Ok(())
@@ -387,8 +394,12 @@ mod tests {
     #[tokio::test]
     async fn proxy_returns_error_when_child_already_exited() -> Result<()> {
         let mut adapter = BridgeAdapter::new();
-        adapter.child_process = Some(spawn_short_lived_child().await?);
-        tokio::time::sleep(Duration::from_millis(40)).await;
+        let mut child = spawn_short_lived_child().await?;
+        // Wait for the process to actually exit before handing it to the adapter.
+        // A sleep-based approach is flaky on slow CI (cmd.exe on Windows can take >40ms).
+        // child.wait() guarantees the exit status is available before try_wait() is called.
+        let _ = child.wait().await?;
+        adapter.child_process = Some(child);
 
         let result =
             tokio::time::timeout(Duration::from_millis(500), adapter.proxy_messages()).await;

--- a/crates/perl-dap/src/bridge_adapter.rs
+++ b/crates/perl-dap/src/bridge_adapter.rs
@@ -39,6 +39,7 @@ use tokio::time::sleep;
 
 const PLS_SHUTDOWN_GRACE_MS: u64 = 250;
 const PLS_SHUTDOWN_POLL_MS: u64 = 25;
+const PROXY_EXIT_POLL_MS: u64 = 25;
 
 /// Perl debugger flag to activate DAP protocol mode in Perl::LanguageServer
 const PLS_DAP_FLAG: &str = "-d:LanguageServer::DAP";
@@ -109,6 +110,15 @@ impl BridgeAdapter {
             .spawn()
             .context("Failed to spawn Perl::LanguageServer DAP process")?;
 
+        let mut child = child;
+        if let Some(status) =
+            child.try_wait().context("Failed to check Perl::LanguageServer startup status")?
+        {
+            anyhow::bail!(
+                "Perl::LanguageServer DAP process exited immediately with status: {status}"
+            );
+        }
+
         self.child_process = Some(child);
         Ok(())
     }
@@ -144,6 +154,15 @@ impl BridgeAdapter {
             anyhow::bail!("Child process not spawned. Call spawn_pls_dap() first.");
         };
 
+        if let Some(status) = child
+            .try_wait()
+            .context("Failed to check Perl::LanguageServer process state before proxying")?
+        {
+            anyhow::bail!(
+                "Perl::LanguageServer DAP process exited before proxying with status: {status}"
+            );
+        }
+
         // Get handles to child stdin/stdout
         let mut child_stdin = child.stdin.take().context("Failed to capture child stdin")?;
         let mut child_stdout = child.stdout.take().context("Failed to capture child stdout")?;
@@ -158,31 +177,63 @@ impl BridgeAdapter {
 
         // Create bidirectional copy tasks
         // Task 1: Client (Parent Stdin) -> Server (Child Stdin)
-        let client_to_server = async move {
+        let client_to_server = tokio::spawn(async move {
             tokio::io::copy(&mut parent_stdin, &mut child_stdin)
                 .await
                 .context("Error copying from client to server")?;
             // Shut down child_stdin to signal EOF to the server
             let _ = child_stdin.shutdown().await;
             Ok::<(), anyhow::Error>(())
-        };
+        });
 
         // Task 2: Server (Child Stdout) -> Client (Parent Stdout)
-        let server_to_client = async move {
+        let server_to_client = tokio::spawn(async move {
             tokio::io::copy(&mut child_stdout, &mut parent_stdout)
                 .await
                 .context("Error copying from server to client")?;
             parent_stdout.flush().await.context("Error flushing to client")?;
             Ok::<(), anyhow::Error>(())
-        };
+        });
 
-        // Run both tasks concurrently and wait for both to finish.
-        // We use join instead of select to ensure graceful shutdown:
-        // if the client closes its input, we want to continue proxying
-        // any remaining output from the server.
-        let (res1, res2) = tokio::join!(client_to_server, server_to_client);
-        res1?;
-        res2?;
+        tokio::pin!(client_to_server);
+        tokio::pin!(server_to_client);
+
+        let mut client_result: Option<Result<()>> = None;
+        let mut server_result: Option<Result<()>> = None;
+
+        while client_result.is_none() || server_result.is_none() {
+            tokio::select! {
+                join_result = &mut client_to_server, if client_result.is_none() => {
+                    client_result = Some(Self::join_result_to_anyhow(join_result, "client->server"));
+                }
+                join_result = &mut server_to_client, if server_result.is_none() => {
+                    server_result = Some(Self::join_result_to_anyhow(join_result, "server->client"));
+                }
+                _ = sleep(Duration::from_millis(PROXY_EXIT_POLL_MS)) => {
+                    if child
+                        .try_wait()
+                        .context("Failed polling Perl::LanguageServer process during proxy")?
+                        .is_some()
+                    {
+                        if client_result.is_none() {
+                            client_to_server.as_mut().abort();
+                            client_result = Some(Ok(()));
+                        }
+                        if server_result.is_none() {
+                            server_to_client.as_mut().abort();
+                            server_result = Some(Ok(()));
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(result) = client_result {
+            result?;
+        }
+        if let Some(result) = server_result {
+            result?;
+        }
 
         Ok(())
     }
@@ -243,6 +294,19 @@ impl BridgeAdapter {
 
         false
     }
+
+    fn join_result_to_anyhow(
+        join_result: std::result::Result<Result<()>, tokio::task::JoinError>,
+        direction: &'static str,
+    ) -> Result<()> {
+        match join_result {
+            Ok(inner) => inner,
+            Err(join_error) if join_error.is_cancelled() => Ok(()),
+            Err(join_error) => Err(anyhow::anyhow!(
+                "Proxy task {direction} panicked or failed to join: {join_error}"
+            )),
+        }
+    }
 }
 
 impl Default for BridgeAdapter {
@@ -261,5 +325,89 @@ impl Drop for BridgeAdapter {
         if let Some(mut child) = self.child_process.take() {
             let _ = child.start_kill();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BridgeAdapter;
+    use anyhow::Result;
+    use std::process::Stdio;
+    use std::time::Duration;
+    use tokio::process::Command;
+
+    async fn spawn_short_lived_child() -> Result<tokio::process::Child> {
+        #[cfg(unix)]
+        {
+            let child = Command::new("sh")
+                .arg("-c")
+                .arg("exit 0")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()?;
+            Ok(child)
+        }
+
+        #[cfg(windows)]
+        {
+            let child = Command::new("cmd")
+                .arg("/C")
+                .arg("exit 0")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()?;
+            Ok(child)
+        }
+    }
+
+    async fn spawn_long_running_child() -> Result<tokio::process::Child> {
+        #[cfg(unix)]
+        {
+            let child = Command::new("sh")
+                .arg("-c")
+                .arg("sleep 30")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()?;
+            Ok(child)
+        }
+
+        #[cfg(windows)]
+        {
+            let child = Command::new("cmd")
+                .arg("/C")
+                .arg("timeout /T 30 /NOBREAK >NUL")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()?;
+            Ok(child)
+        }
+    }
+
+    #[tokio::test]
+    async fn proxy_returns_error_when_child_already_exited() -> Result<()> {
+        let mut adapter = BridgeAdapter::new();
+        adapter.child_process = Some(spawn_short_lived_child().await?);
+        tokio::time::sleep(Duration::from_millis(40)).await;
+
+        let result =
+            tokio::time::timeout(Duration::from_millis(500), adapter.proxy_messages()).await;
+        assert!(result.is_ok(), "proxy_messages should complete quickly for exited child");
+        let proxy_result = result?;
+        assert!(proxy_result.is_err(), "proxy_messages should error for exited child");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn shutdown_terminates_running_child() -> Result<()> {
+        let mut adapter = BridgeAdapter::new();
+        adapter.child_process = Some(spawn_long_running_child().await?);
+
+        let result = tokio::time::timeout(Duration::from_secs(2), adapter.shutdown()).await;
+        assert!(result.is_ok(), "shutdown should not hang for a running child process");
+        result??;
+
+        Ok(())
     }
 }

--- a/crates/perl-dap/src/bridge_adapter.rs
+++ b/crates/perl-dap/src/bridge_adapter.rs
@@ -421,4 +421,62 @@ mod tests {
 
         Ok(())
     }
+
+    /// Verify the poll-arm path: proxy_messages() must not hang when the child
+    /// process exits *during* active proxying (after the pre-flight liveness check
+    /// has already passed but while the I/O copy tasks are still running).
+    ///
+    /// We use a child that sleeps briefly then exits on its own, bypassing the
+    /// pre-flight check (which only fires when the child is already dead at call
+    /// time). The select! poll arm is responsible for detecting this mid-proxy
+    /// exit and aborting the I/O tasks within PROXY_EXIT_POLL_MS + margin.
+    #[tokio::test]
+    async fn proxy_completes_when_child_exits_during_proxy() -> Result<()> {
+        // Spawn a child that stays alive briefly, then exits.
+        // We need it to survive the pre-flight try_wait() call (so it must be alive
+        // at proxy_messages() entry), then exit during the poll loop.
+        #[cfg(unix)]
+        let child = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg("sleep 0.1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()?;
+
+        #[cfg(windows)]
+        let child = tokio::process::Command::new("cmd")
+            .arg("/C")
+            // ping with -n 1 exits after ~0ms; -w 100 waits 100ms for the reply
+            // (it will fail, but the process exits after the timeout).
+            .arg("ping -n 1 -w 100 127.0.0.1 >NUL")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()?;
+
+        let mut adapter = BridgeAdapter::new();
+        adapter.child_process = Some(child);
+
+        // Give the runtime a yield so the child can be scheduled; the child
+        // should still be alive at this point (it sleeps 100ms on Unix,
+        // 100ms ping timeout on Windows).
+        tokio::task::yield_now().await;
+
+        // proxy_messages() must return without hanging. Allow up to 5 seconds:
+        // 100ms child lifetime + PROXY_EXIT_POLL_MS (25ms) + generous CI margin.
+        let result = tokio::time::timeout(Duration::from_secs(5), adapter.proxy_messages()).await;
+
+        assert!(
+            result.is_ok(),
+            "proxy_messages should not hang when child exits mid-proxy; timed out"
+        );
+        // The function should return Ok(()) -- the child exited cleanly and the
+        // poll arm aborted the I/O tasks without an I/O error.
+        let proxy_result = result?;
+        assert!(
+            proxy_result.is_ok(),
+            "proxy_messages should return Ok(()) when child exits cleanly mid-proxy, got: {proxy_result:?}"
+        );
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
### Motivation
- Bridge-mode process lifecycle could become unpredictable when the child process exits immediately or during active proxying, which could leave proxy tasks hanging and complicate shutdown.

### Description
- Added a startup liveness check in `spawn_pls_dap()` to fail fast if the Perl DAP child exits immediately and avoid storing a dead handle in `child_process`.
- Tightened `proxy_messages()` by checking child liveness before proxying, running each copy direction in `tokio::spawn`, and polling the child during proxy to abort lingering tasks if the backend dies.
- Introduced `join_result_to_anyhow()` to convert spawned task join results into `anyhow::Result` and added `PROXY_EXIT_POLL_MS` for polling cadence.
- Added focused in-module tests that exercise proxy behavior when the child already exited and verify shutdown completes for a long-running child; all changes are confined to `crates/perl-dap/src/bridge_adapter.rs`.

### Testing
- Ran unit tests with `cargo test -p perl-dap --test bridge_adapter_unit_tests` and observed all tests pass (9 passed). 
- Ran integration tests with `cargo test -p perl-dap --test bridge_integration_tests` and observed all tests pass (16 passed). 
- Ran `cargo check --all-targets -p perl-dap` which completed successfully. 
- Ran formatting via `cargo xtask fmt` as part of verification which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3a60fee083339a15250dd0294d86)