### PR TITLE
fix(incremental): bound subtree cache cloning to avoid DoS (#0000)

### DIFF
--- a/crates/perl-incremental-parsing/src/incremental/incremental_document.rs
+++ b/crates/perl-incremental-parsing/src/incremental/incremental_document.rs
@@ -1394,6 +1394,70 @@ mod tests {
     }
 
     #[test]
+    fn test_depth_bounded_cache_does_not_grow_quadratically() -> ParseResult<()> {
+        // Verify that caching a deeply-nested program does not cache every
+        // intermediate node. With unbounded caching a k-deep tree produces O(k)
+        // cache entries per subtree root, leading to O(k^2) total entries.
+        // With depth <= 1 bounding the intermediate nodes are skipped, so the
+        // entry count grows roughly linearly with the number of top-level statements.
+        let deeply_nested = r#"
+            package Outer;
+
+            sub level_one {
+                if (1) {
+                    while (1) {
+                        for my $i (1..10) {
+                            foreach my $j (@items) {
+                                my $deep = $i + $j;
+                            }
+                        }
+                    }
+                }
+            }
+
+            sub level_two {
+                if (1) {
+                    while (1) {
+                        for my $x (1..5) {
+                            my $also_deep = $x * 2;
+                        }
+                    }
+                }
+            }
+        "#;
+
+        let doc = IncrementalDocument::new(deeply_nested.to_string())?;
+
+        // Without depth bounding, every node in the two deeply-nested subs
+        // would be cloned into the cache.  With depth <= 1 bounding, only the
+        // top-level package + two subs (depth 0/1) and leaves/criticals survive.
+        // The exact count is implementation-dependent, but it must be well below
+        // the O(total-nodes^2) worst case.  A generous upper bound of 50 entries
+        // accommodates the critical/leaf nodes while ruling out unbounded growth.
+        let cache_size = doc.subtree_cache.by_range.len();
+        assert!(
+            cache_size <= 50,
+            "depth-bounded cache must not clone every intermediate node; got {} entries",
+            cache_size,
+        );
+
+        // Critical nodes (package, subs) must still be cached for LSP features.
+        let critical_count = doc
+            .subtree_cache
+            .critical_symbols
+            .values()
+            .filter(|&&p| p == SymbolPriority::Critical)
+            .count();
+        assert!(
+            critical_count >= 2, // at least the two subroutine definitions
+            "critical symbols must remain cached regardless of depth; got {}",
+            critical_count,
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn test_code_lens_reference_preservation() -> ParseResult<()> {
         let source = r#"
             package MyClass;

--- a/crates/perl-incremental-parsing/src/incremental/incremental_document.rs
+++ b/crates/perl-incremental-parsing/src/incremental/incremental_document.rs
@@ -770,94 +770,117 @@ impl IncrementalDocument {
     fn cache_subtrees(&mut self) {
         self.subtree_cache.clear();
         let root = self.root.clone();
-        self.cache_node(&root);
+        self.cache_node(&root, 0);
     }
 
-    fn cache_node(&mut self, node: &Node) {
-        // Cache this subtree by range
-        let range = (node.location.start, node.location.end);
-        self.subtree_cache.by_range.insert(range, Arc::new(node.clone()));
-
-        // Cache by content hash for common patterns
-        let hash = self.hash_node(node);
+    fn cache_node(&mut self, node: &Node, depth: usize) {
+        // Avoid caching every subtree root: cloning non-leaf nodes deep-copies
+        // all descendants and can lead to quadratic memory/time growth.
+        // Keep cache entries to the top of the tree, leaf nodes, and explicitly
+        // critical symbols to preserve incremental reuse without quadratic blowup.
         let priority = self.get_symbol_priority(node);
+        if depth <= 1 || priority == SymbolPriority::Critical || self.is_leaf_node(node) {
+            let range = (node.location.start, node.location.end);
+            let hash = self.hash_node(node);
+            let cached_node = Arc::new(node.clone());
 
-        self.subtree_cache.by_content.insert(hash, Arc::new(node.clone()));
-        self.subtree_cache.critical_symbols.insert(hash, priority);
-        self.subtree_cache.lru.push_back(hash);
-        self.subtree_cache.evict_if_needed();
+            self.subtree_cache.by_range.insert(range, cached_node.clone());
+            self.subtree_cache.by_content.insert(hash, cached_node);
+            self.subtree_cache.critical_symbols.insert(hash, priority);
+            self.subtree_cache.lru.push_back(hash);
+            self.subtree_cache.evict_if_needed();
+        }
 
         // Recursively cache children
         match &node.kind {
             NodeKind::Program { statements } | NodeKind::Block { statements } => {
                 for stmt in statements {
-                    self.cache_node(stmt);
+                    self.cache_node(stmt, depth + 1);
                 }
             }
             NodeKind::Binary { left, right, .. } => {
-                self.cache_node(left);
-                self.cache_node(right);
+                self.cache_node(left, depth + 1);
+                self.cache_node(right, depth + 1);
             }
             NodeKind::Subroutine { body, .. } => {
-                self.cache_node(body);
+                self.cache_node(body, depth + 1);
             }
             NodeKind::ExpressionStatement { expression } => {
-                self.cache_node(expression);
+                self.cache_node(expression, depth + 1);
             }
             NodeKind::If { condition, then_branch, elsif_branches, else_branch } => {
-                self.cache_node(condition);
-                self.cache_node(then_branch);
+                self.cache_node(condition, depth + 1);
+                self.cache_node(then_branch, depth + 1);
                 for (cond, branch) in elsif_branches {
-                    self.cache_node(cond);
-                    self.cache_node(branch);
+                    self.cache_node(cond, depth + 1);
+                    self.cache_node(branch, depth + 1);
                 }
                 if let Some(else_b) = else_branch {
-                    self.cache_node(else_b);
+                    self.cache_node(else_b, depth + 1);
                 }
             }
             NodeKind::While { condition, body, .. } => {
-                self.cache_node(condition);
-                self.cache_node(body);
+                self.cache_node(condition, depth + 1);
+                self.cache_node(body, depth + 1);
             }
             NodeKind::For { init, condition, update, body, .. } => {
                 if let Some(i) = init {
-                    self.cache_node(i);
+                    self.cache_node(i, depth + 1);
                 }
                 if let Some(c) = condition {
-                    self.cache_node(c);
+                    self.cache_node(c, depth + 1);
                 }
                 if let Some(u) = update {
-                    self.cache_node(u);
+                    self.cache_node(u, depth + 1);
                 }
-                self.cache_node(body);
+                self.cache_node(body, depth + 1);
             }
             NodeKind::Foreach { variable, list, body, continue_block } => {
-                self.cache_node(variable);
-                self.cache_node(list);
-                self.cache_node(body);
+                self.cache_node(variable, depth + 1);
+                self.cache_node(list, depth + 1);
+                self.cache_node(body, depth + 1);
                 if let Some(cb) = continue_block {
-                    self.cache_node(cb);
+                    self.cache_node(cb, depth + 1);
                 }
             }
             NodeKind::VariableDeclaration { variable, initializer, .. } => {
-                self.cache_node(variable);
+                self.cache_node(variable, depth + 1);
                 if let Some(init) = initializer {
-                    self.cache_node(init);
+                    self.cache_node(init, depth + 1);
                 }
             }
             NodeKind::VariableListDeclaration { variables, initializer, .. } => {
                 for var in variables {
-                    self.cache_node(var);
+                    self.cache_node(var, depth + 1);
                 }
                 if let Some(init) = initializer {
-                    self.cache_node(init);
+                    self.cache_node(init, depth + 1);
                 }
             }
             NodeKind::Assignment { lhs, rhs, .. } => {
-                self.cache_node(lhs);
-                self.cache_node(rhs);
+                self.cache_node(lhs, depth + 1);
+                self.cache_node(rhs, depth + 1);
             }
             _ => {}
+        }
+    }
+
+    fn is_leaf_node(&self, node: &Node) -> bool {
+        match &node.kind {
+            NodeKind::Program { statements } | NodeKind::Block { statements } => {
+                statements.is_empty()
+            }
+            NodeKind::Binary { .. }
+            | NodeKind::Subroutine { .. }
+            | NodeKind::ExpressionStatement { .. }
+            | NodeKind::If { .. }
+            | NodeKind::While { .. }
+            | NodeKind::For { .. }
+            | NodeKind::Foreach { .. }
+            | NodeKind::VariableDeclaration { .. }
+            | NodeKind::VariableListDeclaration { .. }
+            | NodeKind::Assignment { .. } => false,
+            _ => true,
         }
     }
 


### PR DESCRIPTION
### Motivation
- Incremental subtree caching previously cloned every AST node into cache maps, which deep-copied whole subtrees and could produce O(n^2) memory/time growth on large or adversarial documents when `IncrementalDocument::new` or cache rebuilds ran.
- The intent is to preserve useful subtree reuse for incremental parsing while preventing uncontrolled deep cloning that can crash the LSP process.

### Description
- Restrict cache population in `cache_node` so entries are created only for top-level nodes (`depth <= 1`), leaf nodes, or nodes classified as `SymbolPriority::Critical` instead of caching every node.
- Add a `depth` parameter to `cache_node` and update recursive calls to track depth, and add an `is_leaf_node` helper to detect leaves without cloning.
- Ensure a single `Arc<Node>` is created per cached entry and reused when inserting into both `by_range` and `by_content` to avoid duplicate deep clones.
- Changes are localized to `crates/perl-incremental-parsing/src/incremental/incremental_document.rs` and preserve the existing incremental traversal/recursion logic.

### Testing
- Ran `cargo test -p perl-incremental-parsing` and all unit tests passed (`47 passed; 0 failed`).
- Ran `cargo check --all-targets -p perl-incremental-parsing` and it completed successfully.
- Ran `cargo clippy -p perl-incremental-parsing` (without `-D warnings`) and it completed; the stricter `-D warnings` invocation fails on pre-existing bench lints unrelated to this change.
- Ran formatting via `cargo xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb26781e288333b37b1f2db8d5e146)