### PR TITLE
ci(parser): ratchet final parser accuracy closeout baseline (#0000)

### DIFF
--- a/.ci/GATE_REGISTRY.toml
+++ b/.ci/GATE_REGISTRY.toml
@@ -107,6 +107,22 @@ cost_tier = "low"  # <5 seconds
 failure_impact = "medium"  # Cost control
 
 [[gate]]
+id = "parser-accuracy-closeout"
+name = "Parser Accuracy Closeout"
+type = "correctness"
+blocking = true
+timeout_seconds = 180
+command = "cargo run --locked -p xtask --no-default-features -- corpus-audit --fresh --corpus-path . --check --output corpus_audit_report.json"
+evidence_pattern = "^✅|^❌|NodeKind coverage regression|Valid parser gap regression|Recovery salvage regression"
+threshold = { type = "exit_code", pass = 0 }
+
+[gate.metadata]
+description = "Enforces parser closeout floors from .ci/metrics/baselines/parser.json via corpus-audit --check"
+docs_url = "docs/project/status/parser.md"
+cost_tier = "low"
+failure_impact = "high"
+
+[[gate]]
 id = "todo-compliance"
 name = "TODO Compliance"
 type = "governance"

--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -269,6 +269,26 @@ gates:
       - common
       - strict
 
+  - name: parser_accuracy_closeout
+    tier: merge_gate
+    description: "Parser closeout ratchet: lock NodeKind, parser-gap, and recovery floors from corpus-audit baseline"
+    required: true
+    command: >-
+      cargo run --locked -p xtask --no-default-features
+      -- corpus-audit --fresh --corpus-path . --check --output corpus_audit_report.json
+    timeout_seconds: 180
+    retry_count: 0
+    budgets:
+      max_duration_ms: 150000
+    quarantine: false
+    artifacts:
+      - corpus_audit_report.json
+    tags:
+      - parser
+      - corpus
+      - ratchet
+      - closeout
+
   - name: security_audit
     tier: merge_gate
     description: "Check dependencies for known security vulnerabilities"

--- a/.ci/metrics/baselines/parser.json
+++ b/.ci/metrics/baselines/parser.json
@@ -1,21 +1,22 @@
 {
   "schema_version": 1,
-  "measured_at": "2026-04-09T18:13:43Z",
+  "measured_at": "2026-04-24T00:00:00Z",
   "subsystem": "parser",
   "commit": "3f7ede36",
   "floor_metrics": {
-    "system_clean_rate": 0.971,
-    "cpan_clean_rate": 0.953,
+    "system_clean_rate": 0.971106412966878,
+    "cpan_clean_rate": 0.9529449423815621,
     "system_crash_count": 0,
     "system_files_unreadable": 48,
     "system_total_error_nodes": 604,
     "cpan_total_error_nodes": 3015,
-    "strict_clean_subset_pass_rate": 1.0
+    "strict_clean_subset_pass_rate": 1.0,
+    "valid_parser_gap_count": 0.0
   },
   "improvement_metrics": {
-    "node_kind_coverage": 0.941,
+    "node_kind_coverage": 0.9420289855072463,
     "error_density_per_1k_loc": null,
-    "recovery_salvage_rate": null
+    "recovery_salvage_rate": 1.0
   },
   "tolerance_pct": 0.005
 }

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -9,7 +9,7 @@
 
 use color_eyre::eyre::{Context, Result};
 use indicatif::{ProgressBar, ProgressStyle};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -27,6 +27,24 @@ use report::generate_report;
 use timeout_detection::{ParseOutcome, detect_timeout_risks, parse_with_timeout};
 
 pub use report::{AuditReport, FailingFile, ParseOutcomesSummary};
+
+#[derive(Debug, serde::Deserialize)]
+struct ParserScorecardBaseline {
+    floor_metrics: BTreeMap<String, Option<f64>>,
+    improvement_metrics: BTreeMap<String, Option<f64>>,
+}
+
+fn load_parser_metric_floor(metric: &str) -> Option<f64> {
+    let baseline_path = Path::new(".ci/metrics/baselines/parser.json");
+    let raw = fs::read_to_string(baseline_path).ok()?;
+    let baseline: ParserScorecardBaseline = serde_json::from_str(&raw).ok()?;
+
+    baseline
+        .floor_metrics
+        .get(metric)
+        .and_then(|v| *v)
+        .or_else(|| baseline.improvement_metrics.get(metric).and_then(|v| *v))
+}
 
 /// Default timeout for parsing individual files
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -343,6 +361,45 @@ fn validate_report_for_ci(report: &AuditReport) -> Result<()> {
         failures.push(format!(
             "Low GA feature coverage: {:.1}% (target: 80%)",
             report.ga_coverage.coverage_percentage
+        ));
+    }
+
+    // Parser scorecard ratchets.
+    let current_nodekind_coverage = if report.nodekind_coverage.total_count == 0 {
+        0.0
+    } else {
+        report.nodekind_coverage.covered_count as f64 / report.nodekind_coverage.total_count as f64
+    };
+    if let Some(nodekind_floor) = load_parser_metric_floor("node_kind_coverage")
+        && current_nodekind_coverage + f64::EPSILON < nodekind_floor
+    {
+        failures.push(format!(
+            "NodeKind coverage regression: {:.4} < {:.4} floor",
+            current_nodekind_coverage, nodekind_floor
+        ));
+    }
+
+    let current_valid_parser_gap_count = report.parse_outcomes.error as f64;
+    if let Some(valid_gap_ceiling) = load_parser_metric_floor("valid_parser_gap_count")
+        && current_valid_parser_gap_count > valid_gap_ceiling
+    {
+        failures.push(format!(
+            "Valid parser gap regression: {:.0} > {:.0} floor ceiling",
+            current_valid_parser_gap_count, valid_gap_ceiling
+        ));
+    }
+
+    let current_recovery_salvage_rate = if report.parse_outcomes.total == 0 {
+        1.0
+    } else {
+        report.parse_outcomes.ok as f64 / report.parse_outcomes.total as f64
+    };
+    if let Some(salvage_floor) = load_parser_metric_floor("recovery_salvage_rate")
+        && current_recovery_salvage_rate + f64::EPSILON < salvage_floor
+    {
+        failures.push(format!(
+            "Recovery salvage regression: {:.4} < {:.4} floor",
+            current_recovery_salvage_rate, salvage_floor
         ));
     }
 


### PR DESCRIPTION
### Motivation

- Prevent solved parser-accuracy gaps from regressing by locking the final closeout floors into CI so future parser changes cannot reopen them.

### Description

- Enforce parser scorecard floors by extending `corpus-audit --check` to load `.ci/metrics/baselines/parser.json` and ratchet-check: NodeKind coverage (`node_kind_coverage`), valid parser-gap ceiling (`valid_parser_gap_count` mapped to `parse_outcomes.error`), and recovery salvage-rate (`recovery_salvage_rate`) in `xtask/src/tasks/corpus_audit.rs`.
- Add a required merge-gate `parser_accuracy_closeout` to `.ci/gate-policy.yaml` and register the gate in `.ci/GATE_REGISTRY.toml` to run `corpus-audit --check` as a blocking closeout ratchet.
- Raise/record the committed parser baseline values in `.ci/metrics/baselines/parser.json` (precise clean rates, added `valid_parser_gap_count`, and instrumented `recovery_salvage_rate`) and regenerate the public parser status page `docs/project/status/parser.md`.
- Small robustness fix: comparison uses `f64::EPSILON` tolerance to avoid spurious equality failures when a metric equals the floor.

Files changed: `.ci/metrics/baselines/parser.json`, `.ci/gate-policy.yaml`, `.ci/GATE_REGISTRY.toml`, `xtask/src/tasks/corpus_audit.rs`, `docs/project/status/parser.md`.

### Testing

- Ran `cargo run -p xtask --no-default-features -- corpus-audit --fresh --corpus-path . --output corpus_audit_report.json` and it completed successfully (report generated).
- Ran `cargo run -p xtask --no-default-features -- corpus-audit --fresh --corpus-path . --check --output corpus_audit_report.json`; an initial strict-equality failure was observed during development and a small tolerance fix was applied, after which the check passed.
- Ran `cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt` and it passed (strict-clean subset remains 100%).
- Ran `cargo run -p xtask -- parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt` in this container and it reported a mismatch against the local system corpus (environmental corpus differs from the committed baseline), so it failed here; this failure is expected when the runner's system corpus does not match the committed baseline and does not indicate a change to the ratchet logic.
- Ran `cargo check --workspace --all-targets` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53c93ab48333b586aa72ed86c0da)