### PR TITLE
ci(parser): ratchet final parser accuracy closeout baseline (#0000)

### DIFF
--- a/.ci/GATE_REGISTRY.toml
+++ b/.ci/GATE_REGISTRY.toml
@@ -144,6 +144,54 @@ docs_url = "justfile#ci-check-no-nested-lock"
 cost_tier = "low"  # <1 second
 failure_impact = "medium"
 
+[[gate]]
+id = "system-corpus-ratchet"
+name = "System Corpus Ratchet"
+type = "correctness"
+blocking = true
+timeout_seconds = 600
+command = "cargo run -p xtask -- parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt"
+evidence_pattern = "Ratchet: all checks passed"
+threshold = { type = "exit_code", pass = 0 }
+
+[gate.metadata]
+description = "Enforces parser corpus clean-rate and ERROR-node ratchet against the committed system baseline"
+docs_url = "justfile#corpus-sweep-check"
+cost_tier = "medium"
+failure_impact = "high"
+
+[[gate]]
+id = "cpan-corpus-ratchet"
+name = "CPAN Corpus Ratchet"
+type = "correctness"
+blocking = true
+timeout_seconds = 900
+command = "cargo run -p xtask -- cpan-corpus sweep --enforce"
+evidence_pattern = "Ratchet: all checks passed"
+threshold = { type = "exit_code", pass = 0 }
+
+[gate.metadata]
+description = "Enforces parser corpus clean-rate and ERROR-node ratchet against the committed CPAN baseline"
+docs_url = "justfile#cpan-corpus-check"
+cost_tier = "high"
+failure_impact = "high"
+
+[[gate]]
+id = "parser-audit-ratchet"
+name = "Parser Audit Ratchet"
+type = "correctness"
+blocking = true
+timeout_seconds = 300
+command = "cargo run -p xtask --no-default-features -- corpus-audit --fresh --corpus-path . --check"
+evidence_pattern = "^✅"
+threshold = { type = "exit_code", pass = 0 }
+
+[gate.metadata]
+description = "Enforces strict-clean project corpus, valid-gap floor, and NodeKind allowlist ratchet"
+docs_url = "justfile#parser-audit"
+cost_tier = "medium"
+failure_impact = "high"
+
 # ============================================================================
 # Extended Gates (RECOMMENDED for large changes, ci-full)
 # ============================================================================

--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -269,6 +269,61 @@ gates:
       - common
       - strict
 
+  - name: system_corpus_ratchet
+    tier: merge_gate
+    description: "System Perl corpus must stay at or above parser closeout baseline"
+    required: true
+    command: >-
+      cargo run --locked -p xtask
+      -- parser-corpus-sweep
+      --baseline .ci/parser-corpus-baseline.json --enforce --receipt
+    timeout_seconds: 600
+    retry_count: 0
+    budgets:
+      max_duration_ms: 600000
+    quarantine: false
+    tags:
+      - corpus
+      - parser
+      - ratchet
+      - system
+
+  - name: cpan_corpus_ratchet
+    tier: merge_gate
+    description: "CPAN corpus must stay at or above parser closeout baseline"
+    required: true
+    command: >-
+      cargo run --locked -p xtask
+      -- cpan-corpus sweep --enforce
+    timeout_seconds: 900
+    retry_count: 0
+    budgets:
+      max_duration_ms: 900000
+    quarantine: false
+    tags:
+      - corpus
+      - parser
+      - ratchet
+      - cpan
+
+  - name: parser_audit_ratchet
+    tier: merge_gate
+    description: "Repo parser corpus must remain strict-clean with NodeKind allowlist ratchet"
+    required: true
+    command: >-
+      cargo run --locked -p xtask --no-default-features
+      -- corpus-audit --fresh --corpus-path . --check
+    timeout_seconds: 300
+    retry_count: 0
+    budgets:
+      max_duration_ms: 300000
+    quarantine: false
+    tags:
+      - corpus
+      - parser
+      - nodekind
+      - ratchet
+
   - name: security_audit
     tier: merge_gate
     description: "Check dependencies for known security vulnerabilities"
@@ -847,6 +902,9 @@ workflow_integration:
         - unit_core
         - unit_full
         - common_corpus_clean
+        - system_corpus_ratchet
+        - cpan_corpus_ratchet
+        - parser_audit_ratchet
         - lsp_tier_a
         - lsp_tier_b
         - lsp_smoke

--- a/.ci/metrics/baselines/parser.json
+++ b/.ci/metrics/baselines/parser.json
@@ -1,21 +1,23 @@
 {
   "schema_version": 1,
-  "measured_at": "2026-04-09T18:13:43Z",
+  "measured_at": "2026-04-24T00:00:00Z",
   "subsystem": "parser",
-  "commit": "3f7ede36",
+  "commit": "522c47f",
   "floor_metrics": {
     "system_clean_rate": 0.971,
     "cpan_clean_rate": 0.953,
+    "project_clean_rate": 1.0,
     "system_crash_count": 0,
     "system_files_unreadable": 48,
     "system_total_error_nodes": 604,
     "cpan_total_error_nodes": 3015,
-    "strict_clean_subset_pass_rate": 1.0
+    "strict_clean_subset_pass_rate": 1.0,
+    "valid_parser_gap_count": 0,
+    "node_kind_coverage": 0.942,
+    "recovery_salvage_rate": 1.0
   },
   "improvement_metrics": {
-    "node_kind_coverage": 0.941,
-    "error_density_per_1k_loc": null,
-    "recovery_salvage_rate": null
+    "error_density_per_1k_loc": null
   },
   "tolerance_pct": 0.005
 }

--- a/.ci/nodekind-coverage-allowlist.txt
+++ b/.ci/nodekind-coverage-allowlist.txt
@@ -1,0 +1,6 @@
+# NodeKind variants intentionally absent from the repo-owned parser corpus.
+# CI fails if any additional never-seen NodeKinds appear.
+MissingStatement
+MissingIdentifier
+MissingBlock
+UnknownRest

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard
@@ -18,7 +18,7 @@
 | Metric | Value | Notes | Source |
 | --- | --- | --- | --- |
 <!-- BEGIN: PARSER_NODEKIND_ROW -->
-| **Node-kind coverage** | 65/69 (94.2%) | 4 never-seen node kinds | `corpus_audit` |
+| **Node-kind coverage** | 65/69 (94.2%) | 4 never-seen node kinds (4 allowlisted) | `corpus_audit` + `.ci/nodekind-coverage-allowlist.txt` |
 <!-- END: PARSER_NODEKIND_ROW -->
 <!-- BEGIN: PARSER_RELIABILITY_ROW -->
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -42,6 +42,8 @@ const MAX_HEREDOC_DEPTH: usize = 100;
 
 /// Maximum heredoc content size (1MB)
 const MAX_HEREDOC_SIZE: usize = 1_000_000;
+/// NodeKind names intentionally excluded from the repo-corpus coverage floor.
+const NODEKIND_ALLOWLIST_PATH: &str = ".ci/nodekind-coverage-allowlist.txt";
 
 /// Configuration for corpus audit
 #[derive(Debug, Clone)]
@@ -346,6 +348,22 @@ fn validate_report_for_ci(report: &AuditReport) -> Result<()> {
         ));
     }
 
+    // NodeKind coverage ratchet with explicit allowlist for intentionally unreachable kinds.
+    let allowlisted = read_nodekind_allowlist(Path::new(NODEKIND_ALLOWLIST_PATH))?;
+    let unexpected_never_seen: Vec<&str> = report
+        .nodekind_coverage
+        .never_seen
+        .iter()
+        .map(String::as_str)
+        .filter(|name| !allowlisted.iter().any(|allowed| allowed == name))
+        .collect();
+    if !unexpected_never_seen.is_empty() {
+        failures.push(format!(
+            "NodeKind coverage regression: unexpected never-seen kinds: {}",
+            unexpected_never_seen.join(", ")
+        ));
+    }
+
     // Print error category breakdown if there are errors (Issue #180)
     if current_errors > 0 && !report.parse_outcomes.error_by_category.is_empty() {
         println!("\n   Error breakdown by category:");
@@ -366,6 +384,20 @@ fn validate_report_for_ci(report: &AuditReport) -> Result<()> {
         }
         Err(color_eyre::eyre::eyre!("CI gate validation failed: {}", failures.join("; ")))
     }
+}
+
+fn read_nodekind_allowlist(path: &Path) -> Result<Vec<String>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read NodeKind allowlist: {}", path.display()))?;
+    Ok(raw
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(ToOwned::to_owned)
+        .collect())
 }
 
 /// Test function to verify corpus audit functionality

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -24,6 +24,8 @@ pub(super) struct ParserMetrics {
     pub common_corpus_receipt: Option<super::super::parser_corpus_sweep::SweepReport>,
     /// Number of pinned modules in `.ci/common-corpus-manifest.txt`.
     pub common_corpus_pinned: usize,
+    /// Number of allowlisted never-seen NodeKinds.
+    pub nodekind_allowlisted: usize,
 }
 
 pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
@@ -41,12 +43,21 @@ pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
         .ok(),
         common_corpus_receipt,
         common_corpus_pinned,
+        nodekind_allowlisted: count_nodekind_allowlisted(root),
     }
 }
 
 /// Count the non-comment, non-blank lines in `.ci/common-corpus-manifest.txt`.
 pub(super) fn count_common_corpus_pinned(root: &Path) -> usize {
     let path = root.join(".ci/common-corpus-manifest.txt");
+    let Ok(raw) = fs::read_to_string(path) else {
+        return 0;
+    };
+    raw.lines().filter(|l| !l.trim().is_empty() && !l.trim_start().starts_with('#')).count()
+}
+
+fn count_nodekind_allowlisted(root: &Path) -> usize {
+    let path = root.join(".ci/nodekind-coverage-allowlist.txt");
     let Ok(raw) = fs::read_to_string(path) else {
         return 0;
     };
@@ -158,9 +169,10 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
                 100.0 * summary.nodekind_covered as f64 / summary.nodekind_total as f64
             };
             let never_seen = summary.nodekind_total.saturating_sub(summary.nodekind_covered);
+            let allowlisted = metrics.nodekind_allowlisted;
             format!(
-                "| **Node-kind coverage** | {}/{} ({:.1}%) | {} never-seen node kinds | `corpus_audit` |",
-                summary.nodekind_covered, summary.nodekind_total, pct, never_seen,
+                "| **Node-kind coverage** | {}/{} ({:.1}%) | {} never-seen node kinds ({} allowlisted) | `corpus_audit` + `.ci/nodekind-coverage-allowlist.txt` |",
+                summary.nodekind_covered, summary.nodekind_total, pct, never_seen, allowlisted,
             )
         },
     );
@@ -302,6 +314,7 @@ mod tests {
             project_corpus: Some(summary),
             common_corpus_receipt: None,
             common_corpus_pinned: 10,
+            nodekind_allowlisted: 4,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
@@ -329,6 +342,7 @@ mod tests {
             project_corpus: None,
             common_corpus_receipt: None,
             common_corpus_pinned: 10,
+            nodekind_allowlisted: 4,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
@@ -378,6 +392,7 @@ mod tests {
             project_corpus: None,
             common_corpus_receipt: Some(receipt),
             common_corpus_pinned: 10,
+            nodekind_allowlisted: 4,
         };
         let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\


### PR DESCRIPTION
### Motivation
- Lock the parser closeout state into CI so resolved parser gaps and recovery improvements cannot regress unnoticed. 
- Enforce the project promise that strict-clean modules and the repo corpus remain fully clean while tracking NodeKind coverage and ERROR-node counts.

### Description
- Add a NodeKind allowlist file `.ci/nodekind-coverage-allowlist.txt` and make `corpus-audit --check` fail if any additional never-seen NodeKinds appear outside that allowlist. 
- Wire a NodeKind allowlist check into `xtask` corpus audit (`xtask/src/tasks/corpus_audit.rs`) and surface allowlist counts in status generation (`xtask/src/tasks/update_status/parser.rs`).
- Promote parser ratchets into merge-blocking CI by adding `system_corpus_ratchet`, `cpan_corpus_ratchet`, and `parser_audit_ratchet` gates in `.ci/GATE_REGISTRY.toml` and `.ci/gate-policy.yaml` and include them in the `ci-gate` job mapping. 
- Update the committed parser floor baseline `.ci/metrics/baselines/parser.json` to include closeout-oriented metrics (`project_clean_rate`, `valid_parser_gap_count`, `node_kind_coverage`, `recovery_salvage_rate`) and refreshed metadata, and regenerate `docs/project/status/parser.md` to reflect the locked state.

### Testing
- `cargo run -p xtask --no-default-features -- corpus-audit --fresh --corpus-path . --check` — passed (CI check-mode corpus audit).
- `cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt` — passed (strict-clean common-corpus check produced receipt and zero errors).
- `cargo run -p xtask -- cpan-corpus sweep --enforce` — failed due to missing local CPAN corpus (`target/cpan-corpus/lib/perl5`) in this environment (replication requires preinstalled CPAN corpus); this is environment-specific, not a regression in the change.
- `cargo run -p xtask -- parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt` — earlier run against the checked-in baseline failed in this container because the local system corpus differs from the committed system baseline image; baseline enforcement is intended for CI nodes with the baseline corpus image.
- `cargo check --workspace --all-targets` — passed.
- `cargo run -p xtask -- update-status --only parser --check` — passed and `docs/project/status/parser.md` was updated.
- `cargo test -p xtask update_status::parser::tests::test_parser_nodekind_row_renders` — unit test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53c93ab48333b586aa72ed86c0da)