### PR TITLE
test(parser): close NodeKind coverage gaps for accuracy closeout (#6491)

### DIFF
--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -256,6 +256,25 @@ fn print_audit_summary(report: &AuditReport) {
         report.nodekind_coverage.coverage_percentage
     );
     println!("   Never-seen NodeKinds: {}", report.nodekind_coverage.never_seen.len());
+    if !report.nodekind_coverage.never_seen.is_empty() {
+        println!("     - {}", report.nodekind_coverage.never_seen.join(", "));
+    }
+    if !report.nodekind_coverage.intentionally_unreachable.is_empty() {
+        println!(
+            "   Intentionally unreachable (allowlist): {}",
+            report.nodekind_coverage.intentionally_unreachable.len()
+        );
+        for entry in &report.nodekind_coverage.intentionally_unreachable {
+            println!("     - {}: {}", entry.name, entry.rationale);
+        }
+    }
+    if !report.nodekind_coverage.unexpected_never_seen.is_empty() {
+        println!(
+            "   Unexpected never-seen NodeKinds requiring new corpus fixtures: {}",
+            report.nodekind_coverage.unexpected_never_seen.len()
+        );
+        println!("     - {}", report.nodekind_coverage.unexpected_never_seen.join(", "));
+    }
     println!("   At-risk NodeKinds (<5 occurrences): {}", report.nodekind_coverage.at_risk.len());
     println!(
         "   GA features covered: {}/{} ({:.1}%)",

--- a/xtask/src/tasks/corpus_audit/nodekind_analysis.rs
+++ b/xtask/src/tasks/corpus_audit/nodekind_analysis.rs
@@ -7,6 +7,25 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
+const INTENTIONALLY_UNREACHABLE_NODEKINDS: [(&str, &str); 4] = [
+    (
+        "MissingStatement",
+        "Error-recovery sentinel emitted only when a statement is missing; clean corpus excludes invalid programs.",
+    ),
+    (
+        "MissingIdentifier",
+        "Error-recovery sentinel emitted only when an identifier is missing; clean corpus excludes invalid programs.",
+    ),
+    (
+        "MissingBlock",
+        "Error-recovery sentinel emitted only when a block is missing; clean corpus excludes invalid programs.",
+    ),
+    (
+        "UnknownRest",
+        "Lexer budget-exhaustion sentinel token; deterministic fixture corpus is intentionally small and does not trigger budget exhaustion.",
+    ),
+];
+
 /// Statistics about NodeKind coverage
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeKindStats {
@@ -18,6 +37,12 @@ pub struct NodeKindStats {
     pub coverage_percentage: f64,
     /// NodeKinds that were never seen
     pub never_seen: Vec<String>,
+    /// Never-seen NodeKinds that are allowlisted as intentionally unreachable
+    #[serde(default)]
+    pub intentionally_unreachable: Vec<AllowlistedNodeKind>,
+    /// Never-seen NodeKinds that are not allowlisted and need coverage work
+    #[serde(default)]
+    pub unexpected_never_seen: Vec<String>,
     /// NodeKinds with low coverage (<5 occurrences)
     pub at_risk: Vec<AtRiskNodeKind>,
     /// Frequency of each NodeKind
@@ -33,6 +58,15 @@ pub struct AtRiskNodeKind {
     pub count: usize,
     /// Risk level
     pub risk_level: RiskLevel,
+}
+
+/// A never-seen NodeKind that is allowlisted with rationale.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AllowlistedNodeKind {
+    /// NodeKind name
+    pub name: String,
+    /// Why this NodeKind is intentionally unreachable in deterministic clean corpus runs
+    pub rationale: String,
 }
 
 /// Risk level for NodeKind coverage
@@ -76,8 +110,25 @@ pub fn analyze_nodekind_coverage(
         if total_count > 0 { (covered_count as f64 / total_count as f64) * 100.0 } else { 0.0 };
 
     // Find never-seen NodeKinds
-    let never_seen: Vec<String> =
+    let mut never_seen: Vec<String> =
         all_nodekinds.iter().filter(|nk| !nodekind_counts.contains_key(*nk)).cloned().collect();
+    never_seen.sort();
+
+    let allowlist: HashMap<&str, &str> =
+        INTENTIONALLY_UNREACHABLE_NODEKINDS.iter().copied().collect();
+
+    let mut intentionally_unreachable = Vec::new();
+    let mut unexpected_never_seen = Vec::new();
+    for nodekind in &never_seen {
+        if let Some(rationale) = allowlist.get(nodekind.as_str()) {
+            intentionally_unreachable.push(AllowlistedNodeKind {
+                name: nodekind.clone(),
+                rationale: (*rationale).to_string(),
+            });
+        } else {
+            unexpected_never_seen.push(nodekind.clone());
+        }
+    }
 
     // Find at-risk NodeKinds (low coverage)
     let at_risk: Vec<AtRiskNodeKind> = nodekind_counts
@@ -102,6 +153,8 @@ pub fn analyze_nodekind_coverage(
         covered_count,
         coverage_percentage,
         never_seen,
+        intentionally_unreachable,
+        unexpected_never_seen,
         at_risk,
         frequency: nodekind_counts,
     }
@@ -163,6 +216,14 @@ mod tests {
         assert!(nodekinds.contains("ExpressionStatement"));
         assert!(nodekinds.contains("Binary"));
         assert!(nodekinds.contains("Subroutine"));
+    }
+
+    #[test]
+    fn test_intentionally_unreachable_allowlist_consistency() {
+        let nodekinds = get_all_nodekinds();
+        for (name, _) in INTENTIONALLY_UNREACHABLE_NODEKINDS {
+            assert!(nodekinds.contains(name));
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Parser audit reported 4 never-seen NodeKinds but did not distinguish true coverage gaps from recovery sentinels.
- Make parser-audit actionable by printing missing NodeKind names and documenting intentionally unreachable variants with rationale.

### Description
- Added an explicit allowlist `INTENTIONALLY_UNREACHABLE_NODEKINDS` with rationale for `MissingStatement`, `MissingIdentifier`, `MissingBlock`, and `UnknownRest`. (`xtask/src/tasks/corpus_audit/nodekind_analysis.rs`)
- Extended `NodeKindStats` to include `intentionally_unreachable` and `unexpected_never_seen`, introduced `AllowlistedNodeKind`, and updated `analyze_nodekind_coverage` to separate allowlisted vs unexpected never-seen items. (`xtask/src/tasks/corpus_audit/nodekind_analysis.rs`)
- Updated audit output to print the list of never-seen NodeKinds, the allowlist (with rationales), and any unexpected misses so gaps are visible in one run. (`xtask/src/tasks/corpus_audit.rs`)
- Added a unit test to assert allowlisted names exist in the canonical `NodeKind` set and regenerated parser status doc to reflect current repo corpus counts. (`xtask` tests + `docs/project/status/parser.md`)

### Testing
- `cargo test -p xtask nodekind_analysis -- --nocapture` — passed.
- `cargo run -p xtask --no-default-features -- corpus-audit --fresh --corpus-path . --output corpus_audit_report.json` — ran successfully and printed never-seen NodeKinds plus the intentional allowlist (report shows `65/69` NodeKinds with 4 allowlisted entries).
- `cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt` — passed (strict-clean subset: 10/10).
- `cargo run -p xtask -- update-status --write --only parser` — passed and updated `docs/project/status/parser.md`.
- `cargo test -p perl-parser-core` — observed a pre-existing failing test `test_edge_cases_deep::test_deref_hash_subscript_regex_key` unrelated to the audit output changes (failure existed during verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53d51aec8333be23e53be60956a9)