### PR TITLE
test(parser): close NodeKind coverage gaps for accuracy closeout (#6490)

### DIFF
--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard
@@ -18,7 +18,7 @@
 | Metric | Value | Notes | Source |
 | --- | --- | --- | --- |
 <!-- BEGIN: PARSER_NODEKIND_ROW -->
-| **Node-kind coverage** | 65/69 (94.2%) | 4 never-seen node kinds | `corpus_audit` |
+| **Node-kind coverage** | 65/69 (94.2%) | 4 never-seen node kinds (4 allowlisted, 0 actionable) | `corpus_audit` |
 <!-- END: PARSER_NODEKIND_ROW -->
 <!-- BEGIN: PARSER_RELIABILITY_ROW -->
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -82,6 +82,8 @@ pub struct StatusSummary {
     pub perl_corpus_files: usize,
     pub nodekind_covered: usize,
     pub nodekind_total: usize,
+    pub nodekind_allowlisted_never_seen: usize,
+    pub nodekind_actionable_never_seen: usize,
     pub ga_covered: usize,
     pub ga_total: usize,
 }
@@ -131,6 +133,8 @@ pub fn compute_status_summary(corpus_path: &Path, timeout: Duration) -> Result<S
         perl_corpus_files,
         nodekind_covered: nodekind_stats.covered_count,
         nodekind_total: nodekind_stats.total_count,
+        nodekind_allowlisted_never_seen: nodekind_stats.allowlisted_never_seen.len(),
+        nodekind_actionable_never_seen: nodekind_stats.actionable_never_seen.len(),
         ga_covered: ga_coverage.covered_count,
         ga_total: ga_coverage.total_count,
     })
@@ -256,6 +260,25 @@ fn print_audit_summary(report: &AuditReport) {
         report.nodekind_coverage.coverage_percentage
     );
     println!("   Never-seen NodeKinds: {}", report.nodekind_coverage.never_seen.len());
+    if !report.nodekind_coverage.never_seen.is_empty() {
+        println!("     Names: {}", report.nodekind_coverage.never_seen.join(", "));
+    }
+    if !report.nodekind_coverage.allowlisted_never_seen.is_empty() {
+        println!(
+            "   Allowlisted never-seen NodeKinds: {}",
+            report.nodekind_coverage.allowlisted_never_seen.len()
+        );
+        for nodekind in &report.nodekind_coverage.allowlisted_never_seen {
+            println!("     - {}: {}", nodekind.name, nodekind.rationale);
+        }
+    }
+    if !report.nodekind_coverage.actionable_never_seen.is_empty() {
+        println!(
+            "   Actionable never-seen NodeKinds: {}",
+            report.nodekind_coverage.actionable_never_seen.len()
+        );
+        println!("     Names: {}", report.nodekind_coverage.actionable_never_seen.join(", "));
+    }
     println!("   At-risk NodeKinds (<5 occurrences): {}", report.nodekind_coverage.at_risk.len());
     println!(
         "   GA features covered: {}/{} ({:.1}%)",

--- a/xtask/src/tasks/corpus_audit/nodekind_analysis.rs
+++ b/xtask/src/tasks/corpus_audit/nodekind_analysis.rs
@@ -7,6 +7,17 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
+/// NodeKinds that are intentionally excluded from deterministic corpus coverage.
+///
+/// These variants are recovery/sentinel shapes used for malformed input or lexer
+/// budget exhaustion. They are validated in targeted unit tests instead.
+const NODEKIND_NEVER_SEEN_ALLOWLIST: &[(&str, &str)] = &[
+    ("MissingStatement", "Recovery sentinel emitted for malformed statements."),
+    ("MissingIdentifier", "Recovery sentinel emitted when identifiers are absent."),
+    ("MissingBlock", "Recovery sentinel emitted when block delimiters are absent."),
+    ("UnknownRest", "Fallback node emitted only after lexer UnknownRest budget exhaustion."),
+];
+
 /// Statistics about NodeKind coverage
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeKindStats {
@@ -18,10 +29,25 @@ pub struct NodeKindStats {
     pub coverage_percentage: f64,
     /// NodeKinds that were never seen
     pub never_seen: Vec<String>,
+    /// Never-seen NodeKinds explicitly allowlisted as intentionally unreachable.
+    #[serde(default)]
+    pub allowlisted_never_seen: Vec<AllowlistedNodeKind>,
+    /// Never-seen NodeKinds that are not allowlisted.
+    #[serde(default)]
+    pub actionable_never_seen: Vec<String>,
     /// NodeKinds with low coverage (<5 occurrences)
     pub at_risk: Vec<AtRiskNodeKind>,
     /// Frequency of each NodeKind
     pub frequency: HashMap<String, usize>,
+}
+
+/// A never-seen NodeKind that is intentionally allowlisted with rationale.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AllowlistedNodeKind {
+    /// NodeKind name.
+    pub name: String,
+    /// Why this node is intentionally not required in deterministic corpus coverage.
+    pub rationale: String,
 }
 
 /// A NodeKind with low coverage
@@ -76,8 +102,22 @@ pub fn analyze_nodekind_coverage(
         if total_count > 0 { (covered_count as f64 / total_count as f64) * 100.0 } else { 0.0 };
 
     // Find never-seen NodeKinds
-    let never_seen: Vec<String> =
+    let mut never_seen: Vec<String> =
         all_nodekinds.iter().filter(|nk| !nodekind_counts.contains_key(*nk)).cloned().collect();
+    never_seen.sort();
+
+    let allowlist: HashMap<&str, &str> = NODEKIND_NEVER_SEEN_ALLOWLIST.iter().copied().collect();
+    let allowlisted_never_seen: Vec<AllowlistedNodeKind> = never_seen
+        .iter()
+        .filter_map(|name| {
+            allowlist.get(name.as_str()).map(|rationale| AllowlistedNodeKind {
+                name: name.clone(),
+                rationale: (*rationale).to_string(),
+            })
+        })
+        .collect();
+    let actionable_never_seen: Vec<String> =
+        never_seen.iter().filter(|name| !allowlist.contains_key(name.as_str())).cloned().collect();
 
     // Find at-risk NodeKinds (low coverage)
     let at_risk: Vec<AtRiskNodeKind> = nodekind_counts
@@ -102,6 +142,8 @@ pub fn analyze_nodekind_coverage(
         covered_count,
         coverage_percentage,
         never_seen,
+        allowlisted_never_seen,
+        actionable_never_seen,
         at_risk,
         frequency: nodekind_counts,
     }
@@ -174,5 +216,14 @@ mod tests {
         let nodekinds = extract_nodekinds_from_content(&path);
         assert!(!nodekinds.is_empty());
         Ok(())
+    }
+
+    #[test]
+    fn test_never_seen_allowlist_covers_missing_and_unknown_rest() {
+        let entries: HashSet<&str> =
+            NODEKIND_NEVER_SEEN_ALLOWLIST.iter().map(|(name, _)| *name).collect();
+        for expected in ["MissingStatement", "MissingIdentifier", "MissingBlock", "UnknownRest"] {
+            assert!(entries.contains(expected), "allowlist should include {expected}");
+        }
     }
 }

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -159,8 +159,13 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
             };
             let never_seen = summary.nodekind_total.saturating_sub(summary.nodekind_covered);
             format!(
-                "| **Node-kind coverage** | {}/{} ({:.1}%) | {} never-seen node kinds | `corpus_audit` |",
-                summary.nodekind_covered, summary.nodekind_total, pct, never_seen,
+                "| **Node-kind coverage** | {}/{} ({:.1}%) | {} never-seen node kinds ({} allowlisted, {} actionable) | `corpus_audit` |",
+                summary.nodekind_covered,
+                summary.nodekind_total,
+                pct,
+                never_seen,
+                summary.nodekind_allowlisted_never_seen,
+                summary.nodekind_actionable_never_seen,
             )
         },
     );
@@ -292,6 +297,8 @@ mod tests {
             perl_corpus_files: 22,
             nodekind_covered: 65,
             nodekind_total: 69,
+            nodekind_allowlisted_never_seen: 4,
+            nodekind_actionable_never_seen: 0,
             ga_covered: 12,
             ga_total: 12,
         };
@@ -312,6 +319,10 @@ mod tests {
         assert!(result.contains("65/69"), "nodekind row missing 65/69");
         assert!(result.contains("94.2"), "nodekind row missing 94.2%");
         assert!(result.contains("4 never-seen"), "nodekind row missing never-seen count");
+        assert!(
+            result.contains("4 allowlisted, 0 actionable"),
+            "nodekind row missing allowlist/actionable detail"
+        );
         assert!(
             result.contains("unverified"),
             "strict-clean no-receipt row should say 'unverified'"


### PR DESCRIPTION
### Motivation
- Parser audit reported `65/69` NodeKinds but did not identify why four variants were never-seen, which hides whether those gaps are testable or intentionally unreachable.
- The goal is to make audit output actionable by either adding focused fixtures or explicitly allowlisting intentionally unreachable NodeKinds with rationale.

### Description
- Added an explicit allowlist `NODEKIND_NEVER_SEEN_ALLOWLIST` with rationales for `MissingStatement`, `MissingIdentifier`, `MissingBlock`, and `UnknownRest`, and surfaced it in the audit model (`xtask/src/tasks/corpus_audit/nodekind_analysis.rs`).
- Extended `NodeKindStats` to include `allowlisted_never_seen` and `actionable_never_seen`, and populated both lists during analysis so the audit can distinguish intentional vs actionable gaps.
- Enhanced audit reporting to print never-seen NodeKind names and, when present, the allowlisted variants plus their rationale (`xtask/src/tasks/corpus_audit.rs`), and extended `StatusSummary` and status rendering so the parser status row reports `(<allowlisted>, <actionable>)` counts (`xtask/src/tasks/update_status/parser.rs`).
- Added a unit test ensuring the allowlist contains the four expected names and updated the parser status unit test to expect the new allowlist/actionable text, and regenerated the `docs/project/status/parser.md` parser status section to reflect the new output.

### Testing
- Ran audit end-to-end with `cargo run -p xtask --no-default-features -- corpus-audit --fresh --corpus-path .` which completed successfully and wrote `corpus_audit_report.json` showing the four never-seen NodeKinds with allowlisted rationales.
- Ran the strict common-corpus check with `cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt` which succeeded (10/10 strict-clean) and produced a receipt.
- Ran `cargo run -p xtask -- update-status --write --only parser` which updated `docs/project/status/parser.md` and the parser NodeKind row now includes the allowlist/actionable breakdown.
- Ran targeted xtask unit tests with `cargo test -p xtask test_parser_nodekind_row_renders` and `cargo test -p xtask test_never_seen_allowlist_covers_missing_and_unknown_rest`, both of which passed.
- Note: `cargo test -p perl-parser-core` was executed and failed on an existing unrelated test (`test_deref_hash_subscript_regex_key` in `tests/test_edge_cases_deep.rs`), which is not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53d51aec8333be23e53be60956a9)