### PR TITLE
feat(parser): add recovery-salvage metrics for accuracy closeout (#0000)

### DIFF
--- a/.ci/metrics/baselines/parser.json
+++ b/.ci/metrics/baselines/parser.json
@@ -15,7 +15,7 @@
   "improvement_metrics": {
     "node_kind_coverage": 0.941,
     "error_density_per_1k_loc": null,
-    "recovery_salvage_rate": null
+    "recovery_salvage_rate": 0.0
   },
   "tolerance_pct": 0.005
 }

--- a/crates/perl-parser-core/src/syntax/error/mod.rs
+++ b/crates/perl-parser-core/src/syntax/error/mod.rs
@@ -595,6 +595,19 @@ impl ParseOutput {
     pub fn error_count(&self) -> usize {
         self.diagnostics.len()
     }
+
+    /// Returns true when all diagnostics are structured recovery markers.
+    ///
+    /// This is used by parser closeout metrics to classify salvaged parses
+    /// separately from unrecovered syntax failures.
+    pub fn has_structured_recovery_only(&self) -> bool {
+        !self.diagnostics.is_empty() && self.diagnostics.iter().all(ParseError::is_recovered)
+    }
+
+    /// Count diagnostics that are not `ParseError::Recovered`.
+    pub fn unrecovered_diagnostic_count(&self) -> usize {
+        self.diagnostics.iter().filter(|diagnostic| !diagnostic.is_recovered()).count()
+    }
 }
 
 impl ParseError {
@@ -652,6 +665,22 @@ impl ParseError {
         location: usize,
     ) -> Self {
         ParseError::UnexpectedToken { expected: expected.into(), found: found.into(), location }
+    }
+
+    /// True when this diagnostic represents successful structured recovery.
+    pub fn is_recovered(&self) -> bool {
+        matches!(self, ParseError::Recovered { .. })
+    }
+
+    /// True when the parser could not continue and returned `Err` from `parse()`.
+    pub fn is_catastrophic_failure(&self) -> bool {
+        matches!(
+            self,
+            ParseError::RecursionLimit
+                | ParseError::NestingTooDeep { .. }
+                | ParseError::Cancelled
+                | ParseError::LexerError { .. }
+        )
     }
 
     /// Get the byte location of the error if available
@@ -746,6 +775,7 @@ pub fn get_error_contexts(errors: &[ParseError], source: &str) -> Vec<ErrorConte
 #[cfg(test)]
 mod tests {
     use super::*;
+    use perl_ast::{NodeKind, SourceLocation};
 
     #[test]
     fn test_parse_budget_defaults() {
@@ -1039,5 +1069,61 @@ mod tests {
 
         assert_eq!(output.recovered_count, 1);
         assert!(!output.terminated_early);
+    }
+    #[test]
+    fn test_parse_output_structured_recovery_only() {
+        let ast = Node::new(
+            NodeKind::Program { statements: vec![] },
+            SourceLocation { start: 0, end: 0 },
+        );
+        let errors = vec![
+            ParseError::Recovered {
+                site: RecoverySite::ArgList,
+                kind: RecoveryKind::InsertedCloser,
+                location: 12,
+            },
+            ParseError::Recovered {
+                site: RecoverySite::InfixRhs,
+                kind: RecoveryKind::MissingOperand,
+                location: 25,
+            },
+        ];
+        let output = ParseOutput::with_errors(ast, errors);
+        assert!(output.has_structured_recovery_only());
+        assert_eq!(output.unrecovered_diagnostic_count(), 0);
+    }
+
+    #[test]
+    fn test_parse_output_unrecovered_diagnostic_count() {
+        let ast = Node::new(
+            NodeKind::Program { statements: vec![] },
+            SourceLocation { start: 0, end: 0 },
+        );
+        let errors = vec![
+            ParseError::Recovered {
+                site: RecoverySite::ArgList,
+                kind: RecoveryKind::InsertedCloser,
+                location: 12,
+            },
+            ParseError::syntax("missing token", 40),
+        ];
+        let output = ParseOutput::with_errors(ast, errors);
+        assert!(!output.has_structured_recovery_only());
+        assert_eq!(output.unrecovered_diagnostic_count(), 1);
+    }
+
+    #[test]
+    fn test_parse_error_catastrophic_classification() {
+        assert!(ParseError::RecursionLimit.is_catastrophic_failure());
+        assert!(ParseError::LexerError { message: "bad".to_string() }.is_catastrophic_failure());
+        assert!(!ParseError::syntax("missing ;", 5).is_catastrophic_failure());
+        assert!(
+            ParseError::Recovered {
+                site: RecoverySite::ArgList,
+                kind: RecoveryKind::InsertedCloser,
+                location: 1,
+            }
+            .is_recovered()
+        );
     }
 }

--- a/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
+++ b/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
@@ -410,3 +410,12 @@ fn parser_recovery_preserves_good_code() -> ParseResult<()> {
     }
     Ok(())
 }
+
+#[test]
+fn closeout_reports_unrecovered_diagnostics_for_error_nodes() -> ParseResult<()> {
+    let mut parser = Parser::new("my $x = ; my $y = 1;");
+    let output = parser.parse_with_recovery();
+    assert!(output.unrecovered_diagnostic_count() > 0);
+    assert!(!output.has_structured_recovery_only());
+    Ok(())
+}

--- a/crates/perl-parser-core/tests/recovery_missing_closer.rs
+++ b/crates/perl-parser-core/tests/recovery_missing_closer.rs
@@ -333,3 +333,11 @@ fn clean_inputs_produce_zero_inserted_closer() {
         );
     }
 }
+
+#[test]
+fn closeout_missing_closer_counts_as_structured_salvage() {
+    let mut parser = Parser::new("foo($x;");
+    let output = parser.parse_with_recovery();
+    assert!(output.has_structured_recovery_only());
+    assert_eq!(output.unrecovered_diagnostic_count(), 0);
+}

--- a/crates/perl-parser-core/tests/recovery_phase2_tests.rs
+++ b/crates/perl-parser-core/tests/recovery_phase2_tests.rs
@@ -303,3 +303,11 @@ fn sibling_statement_survives_after_truncated_arrow() {
         sexp
     );
 }
+
+#[test]
+fn closeout_classifies_structured_recovery_as_salvage() {
+    let mut parser = Parser::new("my $x = $a +;");
+    let output = parser.parse_with_recovery();
+    assert!(output.has_structured_recovery_only());
+    assert_eq!(output.unrecovered_diagnostic_count(), 0);
+}

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -78,6 +78,13 @@ pub struct StatusSummary {
     pub error_files: usize,
     pub timeout_files: usize,
     pub panic_files: usize,
+    pub dirty_files: usize,
+    pub structured_recovery_only_files: usize,
+    pub files_with_error_nodes: usize,
+    pub catastrophic_parse_failures: usize,
+    pub recovered_node_count: usize,
+    pub first_unrecovered_error_node: Option<String>,
+    pub recovery_salvage_rate: f64,
     pub test_corpus_files: usize,
     pub perl_corpus_files: usize,
     pub nodekind_covered: usize,
@@ -101,15 +108,57 @@ pub fn compute_status_summary(corpus_path: &Path, timeout: Duration) -> Result<S
     let mut error_files = 0usize;
     let mut timeout_files = 0usize;
     let mut panic_files = 0usize;
+    let mut dirty_files = 0usize;
+    let mut structured_recovery_only_files = 0usize;
+    let mut files_with_error_nodes = 0usize;
+    let mut recovered_node_count = 0usize;
+    let mut first_unrecovered_error_node: Option<String> = None;
 
     for outcome in parse_results.values() {
         match outcome {
-            ParseOutcome::Ok { .. } => ok_files += 1,
-            ParseOutcome::Error { .. } => error_files += 1,
-            ParseOutcome::Timeout { .. } => timeout_files += 1,
-            ParseOutcome::Panic { .. } => panic_files += 1,
+            ParseOutcome::Ok { recovered_count, unrecovered_diagnostics, error_nodes, .. } => {
+                recovered_node_count += *recovered_count;
+                let is_clean = *recovered_count == 0
+                    && *unrecovered_diagnostics == 0
+                    && error_nodes.count == 0;
+                if is_clean {
+                    ok_files += 1;
+                } else {
+                    dirty_files += 1;
+                    if *recovered_count > 0
+                        && *unrecovered_diagnostics == 0
+                        && error_nodes.count == 0
+                    {
+                        structured_recovery_only_files += 1;
+                    }
+                    if error_nodes.count > 0 {
+                        files_with_error_nodes += 1;
+                        if first_unrecovered_error_node.is_none() {
+                            first_unrecovered_error_node = error_nodes.first_message.clone();
+                        }
+                    }
+                }
+            }
+            ParseOutcome::Error { .. } => {
+                error_files += 1;
+                dirty_files += 1;
+            }
+            ParseOutcome::Timeout { .. } => {
+                timeout_files += 1;
+                dirty_files += 1;
+            }
+            ParseOutcome::Panic { .. } => {
+                panic_files += 1;
+                dirty_files += 1;
+            }
         }
     }
+    let catastrophic_parse_failures = error_files;
+    let recovery_salvage_rate = if dirty_files == 0 {
+        1.0
+    } else {
+        structured_recovery_only_files as f64 / dirty_files as f64
+    };
 
     let mut test_corpus_files = 0usize;
     let mut perl_corpus_files = 0usize;
@@ -127,6 +176,13 @@ pub fn compute_status_summary(corpus_path: &Path, timeout: Duration) -> Result<S
         error_files,
         timeout_files,
         panic_files,
+        dirty_files,
+        structured_recovery_only_files,
+        files_with_error_nodes,
+        catastrophic_parse_failures,
+        recovered_node_count,
+        first_unrecovered_error_node,
+        recovery_salvage_rate,
         test_corpus_files,
         perl_corpus_files,
         nodekind_covered: nodekind_stats.covered_count,
@@ -246,9 +302,20 @@ fn print_audit_summary(report: &AuditReport) {
     println!("   Total files: {}", report.inventory.total_files);
     println!("   Parse results:");
     println!("     - OK: {} ✅", report.parse_outcomes.ok);
-    println!("     - Error: {} ❌", report.parse_outcomes.error);
+    println!("     - Catastrophic parse failures: {} ❌", report.parse_outcomes.error);
+    println!(
+        "     - Structured recovery only: {} 🛟",
+        report.parse_outcomes.structured_recovery_only
+    );
+    println!("     - Files with ERROR nodes: {} ⚠️", report.parse_outcomes.files_with_error_nodes);
+    println!("     - Dirty total: {}", report.parse_outcomes.dirty_total);
     println!("     - Timeout: {} ⏱️", report.parse_outcomes.timeout);
     println!("     - Panic: {} 💥", report.parse_outcomes.panic);
+    println!("     - Recovered node count: {}", report.parse_outcomes.recovered_node_count);
+    println!(
+        "     - Recovery salvage rate: {:.1}%",
+        report.parse_outcomes.recovery_salvage_rate * 100.0
+    );
     println!(
         "   NodeKind coverage: {}/{} ({:.1}%)",
         report.nodekind_coverage.covered_count,

--- a/xtask/src/tasks/corpus_audit/report.rs
+++ b/xtask/src/tasks/corpus_audit/report.rs
@@ -47,14 +47,29 @@ pub struct ReportMetadata {
 pub struct ParseOutcomesSummary {
     /// Total files parsed
     pub total: usize,
-    /// Successfully parsed files
+    /// Successfully parsed files with zero diagnostics and zero ERROR nodes
     pub ok: usize,
-    /// Files with parse errors
+    /// Files with catastrophic parser failure (`Parser::parse()` returned Err)
     pub error: usize,
     /// Files that timed out
     pub timeout: usize,
     /// Files that caused panics
     pub panic: usize,
+    /// Total non-clean files across all classes.
+    pub dirty_total: usize,
+    /// Files that only used structured recovery (Recovered diagnostics only).
+    pub structured_recovery_only: usize,
+    /// Files that retained one or more ERROR nodes in the AST.
+    pub files_with_error_nodes: usize,
+    /// Catastrophic parse failures (alias of `error` for explicit closeout reporting).
+    pub catastrophic_parse_failures: usize,
+    /// Total recovered-node diagnostics across all parsed files.
+    pub recovered_node_count: usize,
+    /// First unrecovered ERROR node message seen in corpus order.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_unrecovered_error_node: Option<String>,
+    /// Fraction of dirty files that were recovered without ERROR nodes/catastrophic failure.
+    pub recovery_salvage_rate: f64,
     /// Error breakdown by category (Issue #180)
     #[serde(default)]
     pub error_by_category: HashMap<String, usize>,
@@ -211,14 +226,43 @@ fn generate_parse_outcomes_summary(
     let mut error = 0;
     let mut timeout = 0;
     let mut panic = 0;
+    let mut dirty_total = 0;
+    let mut structured_recovery_only = 0;
+    let mut files_with_error_nodes = 0;
+    let mut recovered_node_count = 0;
+    let mut first_unrecovered_error_node: Option<String> = None;
     let mut error_by_category: HashMap<String, usize> = HashMap::new();
     let mut failing_files: Vec<FailingFile> = Vec::new();
 
     for (path, outcome) in parse_results {
         match outcome {
-            ParseOutcome::Ok { .. } => ok += 1,
+            ParseOutcome::Ok { recovered_count, unrecovered_diagnostics, error_nodes, .. } => {
+                recovered_node_count += recovered_count;
+
+                let is_clean = *recovered_count == 0
+                    && *unrecovered_diagnostics == 0
+                    && error_nodes.count == 0;
+                if is_clean {
+                    ok += 1;
+                } else {
+                    dirty_total += 1;
+                    if *recovered_count > 0
+                        && *unrecovered_diagnostics == 0
+                        && error_nodes.count == 0
+                    {
+                        structured_recovery_only += 1;
+                    }
+                    if error_nodes.count > 0 {
+                        files_with_error_nodes += 1;
+                        if first_unrecovered_error_node.is_none() {
+                            first_unrecovered_error_node = error_nodes.first_message.clone();
+                        }
+                    }
+                }
+            }
             ParseOutcome::Error { message } => {
                 error += 1;
+                dirty_total += 1;
 
                 // Categorize the error
                 let source = sources.get(path).map(|s| s.as_str()).unwrap_or("");
@@ -256,9 +300,13 @@ fn generate_parse_outcomes_summary(
                     code_snippet,
                 });
             }
-            ParseOutcome::Timeout { .. } => timeout += 1,
+            ParseOutcome::Timeout { .. } => {
+                timeout += 1;
+                dirty_total += 1;
+            }
             ParseOutcome::Panic { message } => {
                 panic += 1;
+                dirty_total += 1;
                 // Panics are also added to failing files for visibility
                 failing_files.push(FailingFile {
                     path: path.display().to_string(),
@@ -277,7 +325,26 @@ fn generate_parse_outcomes_summary(
     // Sort failing files by path for consistent output
     failing_files.sort_by(|a, b| a.path.cmp(&b.path));
 
-    ParseOutcomesSummary { total, ok, error, timeout, panic, error_by_category, failing_files }
+    let catastrophic_parse_failures = error;
+    let recovery_salvage_rate =
+        if dirty_total == 0 { 1.0 } else { structured_recovery_only as f64 / dirty_total as f64 };
+
+    ParseOutcomesSummary {
+        total,
+        ok,
+        error,
+        timeout,
+        panic,
+        dirty_total,
+        structured_recovery_only,
+        files_with_error_nodes,
+        catastrophic_parse_failures,
+        recovered_node_count,
+        first_unrecovered_error_node,
+        recovery_salvage_rate,
+        error_by_category,
+        failing_files,
+    }
 }
 
 #[cfg(test)]
@@ -287,7 +354,15 @@ mod tests {
     #[test]
     fn test_generate_parse_outcomes_summary() {
         let mut results = std::collections::HashMap::new();
-        results.insert(PathBuf::from("test1.pl"), ParseOutcome::Ok { duration_ms: 100 });
+        results.insert(
+            PathBuf::from("test1.pl"),
+            ParseOutcome::Ok {
+                duration_ms: 100,
+                recovered_count: 0,
+                unrecovered_diagnostics: 0,
+                error_nodes: super::super::timeout_detection::ErrorNodeSummary::default(),
+            },
+        );
         results.insert(
             PathBuf::from("test2.pl"),
             ParseOutcome::Error { message: "error".to_string() },
@@ -305,9 +380,12 @@ mod tests {
 
         assert_eq!(summary.total, 4);
         assert_eq!(summary.ok, 1);
+        assert_eq!(summary.dirty_total, 3);
         assert_eq!(summary.error, 1);
         assert_eq!(summary.timeout, 1);
         assert_eq!(summary.panic, 1);
+        assert_eq!(summary.catastrophic_parse_failures, 1);
+        assert_eq!(summary.recovery_salvage_rate, 0.0);
         // Error should be categorized as General when no source is provided
         assert_eq!(summary.error_by_category.get("General"), Some(&1));
         assert_eq!(summary.failing_files.len(), 2); // error + panic

--- a/xtask/src/tasks/corpus_audit/timeout_detection.rs
+++ b/xtask/src/tasks/corpus_audit/timeout_detection.rs
@@ -131,15 +131,57 @@ use super::MAX_HEREDOC_SIZE;
 use super::MAX_NESTING_DEPTH;
 use super::MAX_REGEX_OPERATIONS;
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ErrorNodeSummary {
+    /// Total count of NodeKind::Error nodes in the AST.
+    pub count: usize,
+    /// Message of the earliest ERROR node by byte offset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_message: Option<String>,
+}
+
+fn collect_error_node_summary(root: &perl_parser::Node) -> ErrorNodeSummary {
+    let mut count = 0usize;
+    let mut first_start = usize::MAX;
+    let mut first_message: Option<String> = None;
+    walk_error_nodes(root, &mut count, &mut first_start, &mut first_message);
+    ErrorNodeSummary { count, first_message }
+}
+
+fn walk_error_nodes(
+    node: &perl_parser::Node,
+    count: &mut usize,
+    first_start: &mut usize,
+    first_message: &mut Option<String>,
+) {
+    if let perl_parser::NodeKind::Error { message, .. } = &node.kind {
+        *count += 1;
+        if node.location.start < *first_start {
+            *first_start = node.location.start;
+            *first_message = Some(message.clone());
+        }
+    }
+
+    node.for_each_child(|child| {
+        walk_error_nodes(child, count, first_start, first_message);
+    });
+}
+
 /// Outcome of parsing a file
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ParseOutcome {
-    /// Parse succeeded
+    /// Parse completed and returned an AST.
     Ok {
         /// Time taken to parse
         duration_ms: u64,
+        /// Number of structured recovery diagnostics emitted (`ParseError::Recovered`).
+        recovered_count: usize,
+        /// Number of non-recovered diagnostics (`UnexpectedToken`, `SyntaxError`, etc.).
+        unrecovered_diagnostics: usize,
+        /// Summary of ERROR nodes retained in the returned AST.
+        error_nodes: ErrorNodeSummary,
     },
-    /// Parse failed with error
+    /// Parse failed catastrophically with `Parser::parse()` returning Err.
     Error {
         /// Error message
         message: String,
@@ -166,7 +208,7 @@ impl ParseOutcome {
     /// Get the duration in milliseconds if parse succeeded
     pub fn duration_ms(&self) -> Option<u64> {
         match self {
-            ParseOutcome::Ok { duration_ms } => Some(*duration_ms),
+            ParseOutcome::Ok { duration_ms, .. } => Some(*duration_ms),
             _ => None,
         }
     }
@@ -215,11 +257,27 @@ pub fn parse_with_timeout(
     let handle = std::thread::spawn(move || {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut parser = Parser::new(&content_clone);
-            parser.parse()
+            parser.parse().map(|ast| {
+                let diagnostics = parser.errors();
+                let recovered_count = diagnostics
+                    .iter()
+                    .filter(|diagnostic| {
+                        matches!(diagnostic, perl_parser::ParseError::Recovered { .. })
+                    })
+                    .count();
+                let unrecovered_diagnostics = diagnostics.len().saturating_sub(recovered_count);
+                let error_nodes = collect_error_node_summary(&ast);
+                (recovered_count, unrecovered_diagnostics, error_nodes)
+            })
         }));
 
         let outcome = match result {
-            Ok(Ok(_)) => ParseOutcome::Ok { duration_ms: start.elapsed().as_millis() as u64 },
+            Ok(Ok((recovered_count, unrecovered_diagnostics, error_nodes))) => ParseOutcome::Ok {
+                duration_ms: start.elapsed().as_millis() as u64,
+                recovered_count,
+                unrecovered_diagnostics,
+                error_nodes,
+            },
             Ok(Err(e)) => ParseOutcome::Error { message: e.to_string() },
             Err(_) => ParseOutcome::Panic { message: "Parser panicked".to_string() },
         };
@@ -503,7 +561,15 @@ mod tests {
 
     #[test]
     fn test_parse_outcome_is_ok() {
-        assert!(ParseOutcome::Ok { duration_ms: 100 }.is_ok());
+        assert!(
+            ParseOutcome::Ok {
+                duration_ms: 100,
+                recovered_count: 0,
+                unrecovered_diagnostics: 0,
+                error_nodes: ErrorNodeSummary::default()
+            }
+            .is_ok()
+        );
         assert!(!ParseOutcome::Error { message: "error".to_string() }.is_ok());
         assert!(!ParseOutcome::Timeout { timeout_ms: 1000 }.is_ok());
         assert!(!ParseOutcome::Panic { message: "panic".to_string() }.is_ok());
@@ -511,7 +577,16 @@ mod tests {
 
     #[test]
     fn test_parse_outcome_duration_ms() {
-        assert_eq!(ParseOutcome::Ok { duration_ms: 100 }.duration_ms(), Some(100));
+        assert_eq!(
+            ParseOutcome::Ok {
+                duration_ms: 100,
+                recovered_count: 0,
+                unrecovered_diagnostics: 0,
+                error_nodes: ErrorNodeSummary::default()
+            }
+            .duration_ms(),
+            Some(100)
+        );
         assert_eq!(ParseOutcome::Error { message: "error".to_string() }.duration_ms(), None);
     }
 

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -131,11 +131,24 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         },
         |summary| {
             format!(
-                "| **Project corpus** | {} | Deterministic regression baseline; `{}` `test_corpus/` + `{}` `perl-corpus` files, `{}` errors, `{}` timeouts, `{}` panics, `{}/{}` NodeKinds, `{}/{}` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |",
-                format_clean_rate(summary.ok_files, summary.total_files),
+                "| **Project corpus** | {} salvage (`{}/{}`) | Deterministic regression baseline; `{}` total (`{}` `test_corpus/` + `{}` `perl-corpus`), `{}` clean, `{}` dirty, `{}` structured-only recovery, `{}` with ERROR nodes, `{}` catastrophic (`{}` parse-error files), `{}` recovered nodes, first unrecovered `{}`, `{}` timeouts, `{}` panics, `{}/{}` NodeKinds, `{}/{}` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |",
+                format!("{:.1}%", summary.recovery_salvage_rate * 100.0),
+                summary.structured_recovery_only_files,
+                summary.dirty_files,
+                summary.total_files,
                 summary.test_corpus_files,
                 summary.perl_corpus_files,
+                summary.ok_files,
+                summary.dirty_files,
+                summary.structured_recovery_only_files,
+                summary.files_with_error_nodes,
+                summary.catastrophic_parse_failures,
                 summary.error_files,
+                summary.recovered_node_count,
+                summary
+                    .first_unrecovered_error_node
+                    .as_deref()
+                    .unwrap_or("none"),
                 summary.timeout_files,
                 summary.panic_files,
                 summary.nodekind_covered,
@@ -176,7 +189,15 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
             .map_or_else(|| "?".to_string(), |r| r.files_unreadable.to_string());
         let proj_detail = metrics.project_corpus.as_ref().map_or_else(
             || "Project: UNVERIFIED".to_string(),
-            |s| format!("Project: {} timeout, {} panic, 0 unread", s.timeout_files, s.panic_files,),
+            |s| {
+                format!(
+                    "Project: {} timeout, {} panic, {} catastrophic, {} with ERROR nodes",
+                    s.timeout_files,
+                    s.panic_files,
+                    s.catastrophic_parse_failures,
+                    s.files_with_error_nodes,
+                )
+            },
         );
         format!(
             "| **Reliability** | Ubuntu: {} unread / CPAN: {} unread / {} | -- | `.ci/*-baseline.json` |",
@@ -288,6 +309,13 @@ mod tests {
             error_files: 0,
             timeout_files: 0,
             panic_files: 0,
+            dirty_files: 2,
+            structured_recovery_only_files: 1,
+            files_with_error_nodes: 1,
+            catastrophic_parse_failures: 0,
+            recovered_node_count: 3,
+            first_unrecovered_error_node: Some("Missing semicolon".to_string()),
+            recovery_salvage_rate: 0.5,
             test_corpus_files: 69,
             perl_corpus_files: 22,
             nodekind_covered: 65,
@@ -309,6 +337,9 @@ mod tests {
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
+        assert!(result.contains("50.0% salvage"), "project row missing salvage rate");
+        assert!(result.contains("1/2"), "project row missing salvage fraction");
+        assert!(result.contains("with ERROR nodes"), "project row missing ERROR-node detail");
         assert!(result.contains("65/69"), "nodekind row missing 65/69");
         assert!(result.contains("94.2"), "nodekind row missing 94.2%");
         assert!(result.contains("4 never-seen"), "nodekind row missing never-seen count");


### PR DESCRIPTION
### Motivation

- Parser closeout previously lumped all non-clean parses together which hid the difference between useful structured recovery, retained AST `ERROR` nodes, and catastrophic parser failures; accuracy closeout needs to distinguish these cases to drive remediation and baseline ratcheting.

### Description

- Enriched parse outcomes by adding `ErrorNodeSummary` and extending `ParseOutcome::Ok` to include `recovered_count`, `unrecovered_diagnostics`, and `error_nodes`, and updated `parse_with_timeout` to collect these values.
- Added `ParseOutput` helpers (`has_structured_recovery_only`, `unrecovered_diagnostic_count`) and `ParseError` helpers (`is_recovered`, `is_catastrophic_failure`) to classify recovery vs unrecovered failures and added unit tests for the new APIs.
- Updated corpus audit & report plumbing to compute and serialize new metrics: `dirty_total`, `structured_recovery_only`, `files_with_error_nodes`, `catastrophic_parse_failures`, `recovered_node_count`, `first_unrecovered_error_node`, and `recovery_salvage_rate`, and adjusted `parser` status generator to surface salvage-rate details.
- Added focused tests in the recovery suites to assert that structured recovery is classified as salvage and that ERROR-node cases are reported as unrecovered; updated `.ci/metrics/baselines/parser.json` to include a baseline `recovery_salvage_rate` value.

### Testing

- Ran `cargo test -p perl-parser-core recovery` and the recovery-focused test suite passed. 
- Ran `cargo test -p xtask parser` and the xtask parser/status tests passed. 
- Ran `cargo fmt` to format changes. 
- Note: `just parser-audit` / `just status-update --only parser` were not executed in this container because `just` is not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53d91550833391bfb2aa4c3b1dcf)