### PR TITLE
feat(parser): add recovery-salvage metrics for accuracy closeout (#0000)

### DIFF
--- a/.ci/metrics/baselines/parser.json
+++ b/.ci/metrics/baselines/parser.json
@@ -15,7 +15,7 @@
   "improvement_metrics": {
     "node_kind_coverage": 0.941,
     "error_density_per_1k_loc": null,
-    "recovery_salvage_rate": null
+    "recovery_salvage_rate": 1.0
   },
   "tolerance_pct": 0.005
 }

--- a/crates/perl-parser-core/src/engine/error/mod.rs
+++ b/crates/perl-parser-core/src/engine/error/mod.rs
@@ -27,6 +27,7 @@ pub mod recovery {
 
 /// Error types and result aliases used by the parser engine.
 pub use crate::syntax::error::{
-    BudgetTracker, ErrorContext, ParseBudget, ParseError, ParseOutput, ParseResult, RecoveryKind,
-    RecoverySite, get_error_contexts,
+    BudgetTracker, ErrorContext, FirstUnrecoveredErrorNode, ParseBudget, ParseError, ParseOutput,
+    ParseResult, RecoveryKind, RecoverySalvageMetrics, RecoverySite, get_error_contexts,
+    recovery_salvage_metrics,
 };

--- a/crates/perl-parser-core/src/syntax/error/mod.rs
+++ b/crates/perl-parser-core/src/syntax/error/mod.rs
@@ -113,6 +113,7 @@
 //! }
 //! ```
 
+use perl_ast::{Node, NodeKind};
 use perl_position_tracking::LineIndex;
 use thiserror::Error;
 
@@ -489,8 +490,6 @@ pub mod classifier;
 /// Error recovery strategies and traits for the Perl parser.
 pub mod recovery;
 
-use perl_ast::Node;
-
 /// Structured output from parsing, combining AST with all diagnostics.
 ///
 /// This type replaces the simple `Result<Node, ParseError>` pattern to enable
@@ -540,6 +539,39 @@ pub struct ParseOutput {
     /// LSP providers use this as a confidence signal: `0` means a clean parse,
     /// `> 0` means at least one synthetic repair was made.
     pub recovered_count: usize,
+}
+
+/// Earliest unrecovered `ERROR` node observed in a parsed AST.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FirstUnrecoveredErrorNode {
+    /// Error message stored in the `NodeKind::Error`.
+    pub message: String,
+    /// Byte location of the error node start in source text.
+    pub location: usize,
+}
+
+/// Recovery-vs-failure closeout metrics for a single parse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoverySalvageMetrics {
+    /// Number of structured `ParseError::Recovered` diagnostics.
+    pub recovered_node_count: usize,
+    /// Number of unrecovered `NodeKind::Error` nodes in the AST.
+    pub unrecovered_error_node_count: usize,
+    /// Earliest unrecovered `ERROR` node when present.
+    pub first_unrecovered_error_node: Option<FirstUnrecoveredErrorNode>,
+}
+
+impl RecoverySalvageMetrics {
+    /// True when parsing used structured recovery only and produced no
+    /// unrecovered `ERROR` node.
+    pub fn is_structured_recovery_only(&self) -> bool {
+        self.recovered_node_count > 0 && self.unrecovered_error_node_count == 0
+    }
+
+    /// True when parsing left at least one unrecovered `ERROR` node.
+    pub fn has_unrecovered_error_nodes(&self) -> bool {
+        self.unrecovered_error_node_count > 0
+    }
 }
 
 impl ParseOutput {
@@ -595,6 +627,48 @@ impl ParseOutput {
     pub fn error_count(&self) -> usize {
         self.diagnostics.len()
     }
+
+    /// Summarize recovery salvage quality for this parse output.
+    pub fn recovery_salvage_metrics(&self) -> RecoverySalvageMetrics {
+        recovery_salvage_metrics(&self.ast, &self.diagnostics)
+    }
+}
+
+/// Compute recovery salvage metrics from a parsed AST + diagnostics list.
+pub fn recovery_salvage_metrics(ast: &Node, diagnostics: &[ParseError]) -> RecoverySalvageMetrics {
+    let recovered_node_count =
+        diagnostics.iter().filter(|e| matches!(e, ParseError::Recovered { .. })).count();
+    let (unrecovered_error_node_count, first_unrecovered_error_node) =
+        collect_unrecovered_error_nodes(ast);
+    RecoverySalvageMetrics {
+        recovered_node_count,
+        unrecovered_error_node_count,
+        first_unrecovered_error_node,
+    }
+}
+
+fn collect_unrecovered_error_nodes(ast: &Node) -> (usize, Option<FirstUnrecoveredErrorNode>) {
+    fn walk(node: &Node, count: &mut usize, earliest: &mut Option<FirstUnrecoveredErrorNode>) {
+        if let NodeKind::Error { message, .. } = &node.kind {
+            *count += 1;
+            let replace = match earliest {
+                Some(current) => node.location.start < current.location,
+                None => true,
+            };
+            if replace {
+                *earliest = Some(FirstUnrecoveredErrorNode {
+                    message: message.clone(),
+                    location: node.location.start,
+                });
+            }
+        }
+        node.for_each_child(|child| walk(child, count, earliest));
+    }
+
+    let mut count = 0usize;
+    let mut earliest = None;
+    walk(ast, &mut count, &mut earliest);
+    (count, earliest)
 }
 
 impl ParseError {
@@ -1039,5 +1113,57 @@ mod tests {
 
         assert_eq!(output.recovered_count, 1);
         assert!(!output.terminated_early);
+    }
+
+    #[test]
+    fn test_recovery_salvage_metrics_structured_only() {
+        use perl_ast::{Node, NodeKind, SourceLocation};
+
+        let ast = Node::new(
+            NodeKind::Program { statements: vec![] },
+            SourceLocation { start: 0, end: 0 },
+        );
+        let errors = vec![ParseError::Recovered {
+            site: RecoverySite::InfixRhs,
+            kind: RecoveryKind::MissingOperand,
+            location: 5,
+        }];
+        let metrics = recovery_salvage_metrics(&ast, &errors);
+        assert!(metrics.is_structured_recovery_only());
+        assert!(!metrics.has_unrecovered_error_nodes());
+    }
+
+    #[test]
+    fn test_recovery_salvage_metrics_tracks_first_unrecovered_error_node() {
+        use perl_ast::{Node, NodeKind, SourceLocation};
+
+        let first = Node::new(
+            NodeKind::Error {
+                message: "first".to_string(),
+                expected: vec![],
+                found: None,
+                partial: None,
+            },
+            SourceLocation { start: 3, end: 4 },
+        );
+        let second = Node::new(
+            NodeKind::Error {
+                message: "second".to_string(),
+                expected: vec![],
+                found: None,
+                partial: None,
+            },
+            SourceLocation { start: 8, end: 9 },
+        );
+        let ast = Node::new(
+            NodeKind::Program { statements: vec![first, second] },
+            SourceLocation { start: 0, end: 9 },
+        );
+        let metrics = recovery_salvage_metrics(&ast, &[]);
+        assert_eq!(metrics.unrecovered_error_node_count, 2);
+        assert_eq!(
+            metrics.first_unrecovered_error_node,
+            Some(FirstUnrecoveredErrorNode { message: "first".to_string(), location: 3 })
+        );
     }
 }

--- a/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
+++ b/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
@@ -3,6 +3,7 @@
 //! Tests for panic mode error recovery that allows the parser to continue
 //! parsing after encountering syntax errors by synchronizing to known points.
 
+use perl_parser_core::error::recovery_salvage_metrics;
 use perl_parser_core::{NodeKind, ParseResult, Parser};
 
 // AC1: Parser implements synchronization point detection for Perl syntax
@@ -264,6 +265,19 @@ fn parser_ac9_performance_overhead_check() -> ParseResult<()> {
     if let NodeKind::Program { statements } = &ast.kind {
         assert!(statements.len() >= 3, "Should parse all statements");
     }
+    Ok(())
+}
+
+#[test]
+fn parser_recovery_metrics_flags_unrecovered_error_nodes() -> ParseResult<()> {
+    let mut parser = Parser::new("my $x = $obj->;");
+    let ast = parser.parse()?;
+    let metrics = recovery_salvage_metrics(&ast, parser.errors());
+    assert!(metrics.has_unrecovered_error_nodes(), "expected unrecovered ERROR node visibility");
+    assert!(
+        metrics.first_unrecovered_error_node.is_some(),
+        "expected first unrecovered ERROR node message",
+    );
     Ok(())
 }
 

--- a/crates/perl-parser-core/tests/recovery_missing_closer.rs
+++ b/crates/perl-parser-core/tests/recovery_missing_closer.rs
@@ -10,6 +10,7 @@
 
 mod cpan_test_helpers;
 use cpan_test_helpers::*;
+use perl_parser_core::error::recovery_salvage_metrics;
 use perl_parser_core::error::{ParseError, RecoveryKind, RecoverySite};
 use perl_parser_core::{NodeKind, Parser};
 use perl_tdd_support::must;
@@ -259,6 +260,15 @@ fn nested_missing_both_parens_at_eof_emits_two_recovered() {
         "Parser must return a Program node for nested missing closers in '{}'",
         src
     );
+}
+
+#[test]
+fn missing_closer_counts_as_structured_recovery_only() {
+    let src = "my $v = $arr[$i";
+    let (ast, errors) = parse_errors(src);
+    let metrics = recovery_salvage_metrics(&ast, &errors);
+    assert!(metrics.is_structured_recovery_only(), "expected structured-only recovery");
+    assert_eq!(metrics.first_unrecovered_error_node, None);
 }
 
 /// Paren missing before EOF inside a list assignment — tests truncated file recovery.

--- a/crates/perl-parser-core/tests/recovery_phase2_tests.rs
+++ b/crates/perl-parser-core/tests/recovery_phase2_tests.rs
@@ -14,7 +14,8 @@ mod cpan_test_helpers;
 use cpan_test_helpers::*;
 
 use perl_parser_core::Parser;
-use perl_parser_core::error::{ParseError, RecoveryKind, RecoverySite};
+use perl_parser_core::error::{ParseError, RecoveryKind, RecoverySite, recovery_salvage_metrics};
+use perl_tdd_support::must;
 
 // ──────────────────────────────────────────────────────────────
 // Helpers
@@ -272,6 +273,15 @@ fn clean_equality_does_not_emit_recovered() {
 fn clean_relational_does_not_emit_recovered() {
     let errors = parse_errors("if ($a < $b) { print 1; }");
     assert_not_recovered(&errors, RecoverySite::InfixRhs, RecoveryKind::MissingOperand);
+}
+
+#[test]
+fn missing_rhs_is_classified_as_structured_recovery_only() {
+    let mut parser = Parser::new("my $x = $a +;");
+    let ast = must(parser.parse());
+    let metrics = recovery_salvage_metrics(&ast, parser.errors());
+    assert!(metrics.is_structured_recovery_only(), "expected structured-only recovery metrics");
+    assert!(!metrics.has_unrecovered_error_nodes(), "expected no unrecovered ERROR nodes");
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -75,9 +75,16 @@ impl Default for AuditConfig {
 pub struct StatusSummary {
     pub total_files: usize,
     pub ok_files: usize,
+    pub dirty_files: usize,
     pub error_files: usize,
     pub timeout_files: usize,
     pub panic_files: usize,
+    pub structured_recovery_only_files: usize,
+    pub files_with_error_nodes: usize,
+    pub catastrophic_parse_failure_files: usize,
+    pub recovered_node_count: usize,
+    pub first_unrecovered_error_node_files: usize,
+    pub recovery_salvage_rate: Option<f64>,
     pub test_corpus_files: usize,
     pub perl_corpus_files: usize,
     pub nodekind_covered: usize,
@@ -101,15 +108,41 @@ pub fn compute_status_summary(corpus_path: &Path, timeout: Duration) -> Result<S
     let mut error_files = 0usize;
     let mut timeout_files = 0usize;
     let mut panic_files = 0usize;
+    let mut structured_recovery_only_files = 0usize;
+    let mut files_with_error_nodes = 0usize;
+    let mut catastrophic_parse_failure_files = 0usize;
+    let mut recovered_node_count = 0usize;
+    let mut first_unrecovered_error_node_files = 0usize;
 
     for outcome in parse_results.values() {
         match outcome {
-            ParseOutcome::Ok { .. } => ok_files += 1,
-            ParseOutcome::Error { .. } => error_files += 1,
+            ParseOutcome::Ok { recovery, .. } => {
+                ok_files += 1;
+                recovered_node_count += recovery.recovered_node_count;
+
+                if recovery.unrecovered_error_node_count > 0 {
+                    files_with_error_nodes += 1;
+                    first_unrecovered_error_node_files +=
+                        usize::from(recovery.first_unrecovered_error_node.is_some());
+                } else if recovery.recovered_node_count > 0 {
+                    structured_recovery_only_files += 1;
+                }
+            }
+            ParseOutcome::Error { .. } => {
+                error_files += 1;
+                catastrophic_parse_failure_files += 1;
+            }
             ParseOutcome::Timeout { .. } => timeout_files += 1,
             ParseOutcome::Panic { .. } => panic_files += 1,
         }
     }
+    let dirty_files =
+        structured_recovery_only_files + files_with_error_nodes + catastrophic_parse_failure_files;
+    let recovery_salvage_rate = if dirty_files == 0 {
+        None
+    } else {
+        Some(structured_recovery_only_files as f64 / dirty_files as f64)
+    };
 
     let mut test_corpus_files = 0usize;
     let mut perl_corpus_files = 0usize;
@@ -124,9 +157,16 @@ pub fn compute_status_summary(corpus_path: &Path, timeout: Duration) -> Result<S
     Ok(StatusSummary {
         total_files: inventory.total_files,
         ok_files,
+        dirty_files,
         error_files,
         timeout_files,
         panic_files,
+        structured_recovery_only_files,
+        files_with_error_nodes,
+        catastrophic_parse_failure_files,
+        recovered_node_count,
+        first_unrecovered_error_node_files,
+        recovery_salvage_rate,
         test_corpus_files,
         perl_corpus_files,
         nodekind_covered: nodekind_stats.covered_count,
@@ -249,6 +289,24 @@ fn print_audit_summary(report: &AuditReport) {
     println!("     - Error: {} ❌", report.parse_outcomes.error);
     println!("     - Timeout: {} ⏱️", report.parse_outcomes.timeout);
     println!("     - Panic: {} 💥", report.parse_outcomes.panic);
+    println!("   Recovery closeout:");
+    println!("     - Dirty files: {}", report.parse_outcomes.dirty_files);
+    println!(
+        "     - Structured recovery only: {}",
+        report.parse_outcomes.structured_recovery_only_files
+    );
+    println!("     - Files with ERROR nodes: {}", report.parse_outcomes.files_with_error_nodes);
+    println!(
+        "     - Catastrophic parse failures: {}",
+        report.parse_outcomes.catastrophic_parse_failure_files
+    );
+    println!("     - Recovered node count: {}", report.parse_outcomes.recovered_node_count);
+    println!(
+        "     - First unrecovered ERROR node files: {}",
+        report.parse_outcomes.first_unrecovered_error_node_files
+    );
+    let salvage = report.parse_outcomes.recovery_salvage_rate.unwrap_or(1.0) * 100.0;
+    println!("     - Recovery salvage rate: {:.1}%", salvage);
     println!(
         "   NodeKind coverage: {}/{} ({:.1}%)",
         report.nodekind_coverage.covered_count,

--- a/xtask/src/tasks/corpus_audit/report.rs
+++ b/xtask/src/tasks/corpus_audit/report.rs
@@ -55,6 +55,27 @@ pub struct ParseOutcomesSummary {
     pub timeout: usize,
     /// Files that caused panics
     pub panic: usize,
+    /// Files that are not clean (structured recovery, error nodes, or catastrophic).
+    #[serde(default)]
+    pub dirty_files: usize,
+    /// Files that required structured recovery but emitted no `ERROR` nodes.
+    #[serde(default)]
+    pub structured_recovery_only_files: usize,
+    /// Files with at least one unrecovered `ERROR` node.
+    #[serde(default)]
+    pub files_with_error_nodes: usize,
+    /// Files that failed catastrophically (`Parser::parse()` returned `Err`).
+    #[serde(default)]
+    pub catastrophic_parse_failure_files: usize,
+    /// Total `ParseError::Recovered` count across parsed files.
+    #[serde(default)]
+    pub recovered_node_count: usize,
+    /// Count of files where an unrecovered first `ERROR` node message was captured.
+    #[serde(default)]
+    pub first_unrecovered_error_node_files: usize,
+    /// structured_recovery_only_files / dirty_files.
+    #[serde(default)]
+    pub recovery_salvage_rate: Option<f64>,
     /// Error breakdown by category (Issue #180)
     #[serde(default)]
     pub error_by_category: HashMap<String, usize>,
@@ -211,14 +232,35 @@ fn generate_parse_outcomes_summary(
     let mut error = 0;
     let mut timeout = 0;
     let mut panic = 0;
+    let mut dirty_files = 0;
+    let mut structured_recovery_only_files = 0;
+    let mut files_with_error_nodes = 0;
+    let mut catastrophic_parse_failure_files = 0;
+    let mut recovered_node_count = 0usize;
+    let mut first_unrecovered_error_node_files = 0usize;
     let mut error_by_category: HashMap<String, usize> = HashMap::new();
     let mut failing_files: Vec<FailingFile> = Vec::new();
 
     for (path, outcome) in parse_results {
         match outcome {
-            ParseOutcome::Ok { .. } => ok += 1,
+            ParseOutcome::Ok { recovery, .. } => {
+                ok += 1;
+                recovered_node_count += recovery.recovered_node_count;
+
+                if recovery.unrecovered_error_node_count > 0 {
+                    dirty_files += 1;
+                    files_with_error_nodes += 1;
+                    first_unrecovered_error_node_files +=
+                        usize::from(recovery.first_unrecovered_error_node.is_some());
+                } else if recovery.recovered_node_count > 0 {
+                    dirty_files += 1;
+                    structured_recovery_only_files += 1;
+                }
+            }
             ParseOutcome::Error { message } => {
                 error += 1;
+                dirty_files += 1;
+                catastrophic_parse_failure_files += 1;
 
                 // Categorize the error
                 let source = sources.get(path).map(|s| s.as_str()).unwrap_or("");
@@ -277,7 +319,28 @@ fn generate_parse_outcomes_summary(
     // Sort failing files by path for consistent output
     failing_files.sort_by(|a, b| a.path.cmp(&b.path));
 
-    ParseOutcomesSummary { total, ok, error, timeout, panic, error_by_category, failing_files }
+    let recovery_salvage_rate = if dirty_files == 0 {
+        None
+    } else {
+        Some(structured_recovery_only_files as f64 / dirty_files as f64)
+    };
+
+    ParseOutcomesSummary {
+        total,
+        ok,
+        error,
+        timeout,
+        panic,
+        dirty_files,
+        structured_recovery_only_files,
+        files_with_error_nodes,
+        catastrophic_parse_failure_files,
+        recovered_node_count,
+        first_unrecovered_error_node_files,
+        recovery_salvage_rate,
+        error_by_category,
+        failing_files,
+    }
 }
 
 #[cfg(test)]
@@ -287,7 +350,17 @@ mod tests {
     #[test]
     fn test_generate_parse_outcomes_summary() {
         let mut results = std::collections::HashMap::new();
-        results.insert(PathBuf::from("test1.pl"), ParseOutcome::Ok { duration_ms: 100 });
+        results.insert(
+            PathBuf::from("test1.pl"),
+            ParseOutcome::Ok {
+                duration_ms: 100,
+                recovery: super::super::timeout_detection::ParseRecoveryAudit {
+                    recovered_node_count: 0,
+                    unrecovered_error_node_count: 0,
+                    first_unrecovered_error_node: None,
+                },
+            },
+        );
         results.insert(
             PathBuf::from("test2.pl"),
             ParseOutcome::Error { message: "error".to_string() },
@@ -308,6 +381,8 @@ mod tests {
         assert_eq!(summary.error, 1);
         assert_eq!(summary.timeout, 1);
         assert_eq!(summary.panic, 1);
+        assert_eq!(summary.dirty_files, 1);
+        assert_eq!(summary.catastrophic_parse_failure_files, 1);
         // Error should be categorized as General when no source is provided
         assert_eq!(summary.error_by_category.get("General"), Some(&1));
         assert_eq!(summary.failing_files.len(), 2); // error + panic

--- a/xtask/src/tasks/corpus_audit/timeout_detection.rs
+++ b/xtask/src/tasks/corpus_audit/timeout_detection.rs
@@ -4,6 +4,7 @@
 //! detection of files that may cause timeouts or hangs.
 
 use perl_parser::Parser;
+use perl_parser::error::recovery_salvage_metrics;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -138,6 +139,8 @@ pub enum ParseOutcome {
     Ok {
         /// Time taken to parse
         duration_ms: u64,
+        /// Recovery/error-node classification for closeout metrics.
+        recovery: ParseRecoveryAudit,
     },
     /// Parse failed with error
     Error {
@@ -156,6 +159,17 @@ pub enum ParseOutcome {
     },
 }
 
+/// Recovery-vs-failure metrics for one parsed file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParseRecoveryAudit {
+    /// Number of `ParseError::Recovered` diagnostics.
+    pub recovered_node_count: usize,
+    /// Number of unrecovered `ERROR` nodes left in AST.
+    pub unrecovered_error_node_count: usize,
+    /// Message from the first unrecovered `ERROR` node, if any.
+    pub first_unrecovered_error_node: Option<String>,
+}
+
 impl ParseOutcome {
     /// Check if the parse was successful
     #[allow(dead_code)]
@@ -166,8 +180,19 @@ impl ParseOutcome {
     /// Get the duration in milliseconds if parse succeeded
     pub fn duration_ms(&self) -> Option<u64> {
         match self {
-            ParseOutcome::Ok { duration_ms } => Some(*duration_ms),
+            ParseOutcome::Ok { duration_ms, .. } => Some(*duration_ms),
             _ => None,
+        }
+    }
+}
+
+impl ParseRecoveryAudit {
+    #[cfg(test)]
+    fn clean() -> Self {
+        Self {
+            recovered_node_count: 0,
+            unrecovered_error_node_count: 0,
+            first_unrecovered_error_node: None,
         }
     }
 }
@@ -215,12 +240,26 @@ pub fn parse_with_timeout(
     let handle = std::thread::spawn(move || {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut parser = Parser::new(&content_clone);
-            parser.parse()
+            let parse_result = parser.parse();
+            let diagnostics = parser.errors().to_vec();
+            (parse_result, diagnostics)
         }));
 
         let outcome = match result {
-            Ok(Ok(_)) => ParseOutcome::Ok { duration_ms: start.elapsed().as_millis() as u64 },
-            Ok(Err(e)) => ParseOutcome::Error { message: e.to_string() },
+            Ok((Ok(ast), diagnostics)) => {
+                let metrics = recovery_salvage_metrics(&ast, &diagnostics);
+                ParseOutcome::Ok {
+                    duration_ms: start.elapsed().as_millis() as u64,
+                    recovery: ParseRecoveryAudit {
+                        recovered_node_count: metrics.recovered_node_count,
+                        unrecovered_error_node_count: metrics.unrecovered_error_node_count,
+                        first_unrecovered_error_node: metrics
+                            .first_unrecovered_error_node
+                            .map(|error| error.message),
+                    },
+                }
+            }
+            Ok((Err(e), _diagnostics)) => ParseOutcome::Error { message: e.to_string() },
             Err(_) => ParseOutcome::Panic { message: "Parser panicked".to_string() },
         };
 
@@ -503,7 +542,9 @@ mod tests {
 
     #[test]
     fn test_parse_outcome_is_ok() {
-        assert!(ParseOutcome::Ok { duration_ms: 100 }.is_ok());
+        assert!(
+            ParseOutcome::Ok { duration_ms: 100, recovery: ParseRecoveryAudit::clean() }.is_ok()
+        );
         assert!(!ParseOutcome::Error { message: "error".to_string() }.is_ok());
         assert!(!ParseOutcome::Timeout { timeout_ms: 1000 }.is_ok());
         assert!(!ParseOutcome::Panic { message: "panic".to_string() }.is_ok());
@@ -511,7 +552,11 @@ mod tests {
 
     #[test]
     fn test_parse_outcome_duration_ms() {
-        assert_eq!(ParseOutcome::Ok { duration_ms: 100 }.duration_ms(), Some(100));
+        assert_eq!(
+            ParseOutcome::Ok { duration_ms: 100, recovery: ParseRecoveryAudit::clean() }
+                .duration_ms(),
+            Some(100)
+        );
         assert_eq!(ParseOutcome::Error { message: "error".to_string() }.duration_ms(), None);
     }
 

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -85,6 +85,11 @@ fn format_clean_rate(clean_files: usize, total_files: usize) -> String {
     format!("{clean_pct:.1}% clean (`{clean_files}/{total_files}`)")
 }
 
+fn format_recovery_salvage_rate(rate: Option<f64>) -> String {
+    let pct = rate.unwrap_or(1.0) * 100.0;
+    format!("{pct:.1}% (`recovery_only/dirty`)")
+}
+
 fn short_day(timestamp: &str) -> &str {
     timestamp.get(..10).unwrap_or(timestamp)
 }
@@ -131,10 +136,17 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         },
         |summary| {
             format!(
-                "| **Project corpus** | {} | Deterministic regression baseline; `{}` `test_corpus/` + `{}` `perl-corpus` files, `{}` errors, `{}` timeouts, `{}` panics, `{}/{}` NodeKinds, `{}/{}` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |",
+                "| **Project corpus** | {} | Deterministic regression baseline; `{}` `test_corpus/` + `{}` `perl-corpus` files, recovery salvage {}, dirty `{}` (`{}` recovery-only, `{}` ERROR-node, `{}` catastrophic), recovered nodes `{}`, first-unrecovered `{}`, `{}` errors, `{}` timeouts, `{}` panics, `{}/{}` NodeKinds, `{}/{}` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |",
                 format_clean_rate(summary.ok_files, summary.total_files),
                 summary.test_corpus_files,
                 summary.perl_corpus_files,
+                format_recovery_salvage_rate(summary.recovery_salvage_rate),
+                summary.dirty_files,
+                summary.structured_recovery_only_files,
+                summary.files_with_error_nodes,
+                summary.catastrophic_parse_failure_files,
+                summary.recovered_node_count,
+                summary.first_unrecovered_error_node_files,
                 summary.error_files,
                 summary.timeout_files,
                 summary.panic_files,
@@ -285,9 +297,16 @@ mod tests {
         let summary = super::super::super::corpus_audit::StatusSummary {
             total_files: 91,
             ok_files: 91,
+            dirty_files: 0,
             error_files: 0,
             timeout_files: 0,
             panic_files: 0,
+            structured_recovery_only_files: 0,
+            files_with_error_nodes: 0,
+            catastrophic_parse_failure_files: 0,
+            recovered_node_count: 0,
+            first_unrecovered_error_node_files: 0,
+            recovery_salvage_rate: None,
             test_corpus_files: 69,
             perl_corpus_files: 22,
             nodekind_covered: 65,
@@ -312,6 +331,7 @@ mod tests {
         assert!(result.contains("65/69"), "nodekind row missing 65/69");
         assert!(result.contains("94.2"), "nodekind row missing 94.2%");
         assert!(result.contains("4 never-seen"), "nodekind row missing never-seen count");
+        assert!(result.contains("recovery salvage 100.0%"), "missing recovery salvage metric");
         assert!(
             result.contains("unverified"),
             "strict-clean no-receipt row should say 'unverified'"


### PR DESCRIPTION
### Motivation
- Improve accuracy closeout by distinguishing structured recovery (editor/incomplete input) from catastrophic parser failures and unrecovered `ERROR` nodes.
- Provide metrics that let audits and status pages show salvage rate and surface files with real AST `ERROR` nodes separately from recoverable parses.

### Description
- Add `FirstUnrecoveredErrorNode` and `RecoverySalvageMetrics` plus `recovery_salvage_metrics(...)` and `ParseOutput::recovery_salvage_metrics()` in `crates/perl-parser-core/src/syntax/error/mod.rs` to summarize recovered vs unrecovered outcomes from AST+diagnostics.
- Re-export recovery types and helper (`RecoverySalvageMetrics`, `FirstUnrecoveredErrorNode`, `recovery_salvage_metrics`) from `crate::engine::error` for downstream use.
- Extend `xtask` corpus sweep/audit to carry per-file recovery audit data: added `ParseRecoveryAudit` in `timeout_detection.rs`, compute metrics from the parser output inside `parse_with_timeout`, and include them in `ParseOutcome::Ok`.
- Expand `StatusSummary` and `ParseOutcomesSummary` with fields for `dirty_files`, `structured_recovery_only_files`, `files_with_error_nodes`, `catastrophic_parse_failure_files`, `recovered_node_count`, `first_unrecovered_error_node_files`, and `recovery_salvage_rate`, and surface these in `parser-audit` and `status-update` outputs (updates to `corpus_audit.rs`, `report.rs`, and `update_status/parser.rs`).
- Add focused tests that assert classification behavior (`recovery_*` helpers and parser tests covering structured-only recovery and unrecovered `ERROR` node detection) and update baseline JSON to include a `recovery_salvage_rate` value.

### Testing
- Ran `cargo test -p perl-parser-core recovery` and the targeted recovery tests passed (all relevant tests OK).
- Ran `cargo test -p xtask parser` and the xtask parser/audit tests passed (all relevant tests OK).
- Ran `cargo fmt` to format changes.
- `just parser-audit` and `just status-update --only parser` were not executed in this environment because `just` is not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53d91550833391bfb2aa4c3b1dcf)