### PR TITLE
feat(parser): add recovery-salvage metrics for accuracy closeout (#0000)

### DIFF
--- a/.ci/metrics/baselines/parser.json
+++ b/.ci/metrics/baselines/parser.json
@@ -15,7 +15,7 @@
   "improvement_metrics": {
     "node_kind_coverage": 0.941,
     "error_density_per_1k_loc": null,
-    "recovery_salvage_rate": null
+    "recovery_salvage_rate": 0.0
   },
   "tolerance_pct": 0.005
 }

--- a/crates/perl-parser-core/src/engine/error/mod.rs
+++ b/crates/perl-parser-core/src/engine/error/mod.rs
@@ -28,5 +28,5 @@ pub mod recovery {
 /// Error types and result aliases used by the parser engine.
 pub use crate::syntax::error::{
     BudgetTracker, ErrorContext, ParseBudget, ParseError, ParseOutput, ParseResult, RecoveryKind,
-    RecoverySite, get_error_contexts,
+    RecoverySite, UnrecoveredErrorSummary, collect_unrecovered_error_summary, get_error_contexts,
 };

--- a/crates/perl-parser-core/src/syntax/error/mod.rs
+++ b/crates/perl-parser-core/src/syntax/error/mod.rs
@@ -489,7 +489,7 @@ pub mod classifier;
 /// Error recovery strategies and traits for the Perl parser.
 pub mod recovery;
 
-use perl_ast::Node;
+use perl_ast::{Node, NodeKind};
 
 /// Structured output from parsing, combining AST with all diagnostics.
 ///
@@ -540,6 +540,34 @@ pub struct ParseOutput {
     /// LSP providers use this as a confidence signal: `0` means a clean parse,
     /// `> 0` means at least one synthetic repair was made.
     pub recovered_count: usize,
+}
+
+/// Summary of unrecovered `NodeKind::Error` nodes in a parsed AST.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UnrecoveredErrorSummary {
+    /// Number of unrecovered `NodeKind::Error` nodes.
+    pub error_node_count: usize,
+    /// Message from the earliest unrecovered `NodeKind::Error` node.
+    pub first_unrecovered_error_node: Option<String>,
+}
+
+/// Collect unrecovered AST error-node metrics from a parse tree.
+pub fn collect_unrecovered_error_summary(root: &Node) -> UnrecoveredErrorSummary {
+    fn walk(node: &Node, summary: &mut UnrecoveredErrorSummary, first_start: &mut usize) {
+        if let NodeKind::Error { message, .. } = &node.kind {
+            summary.error_node_count = summary.error_node_count.saturating_add(1);
+            if node.location.start < *first_start {
+                *first_start = node.location.start;
+                summary.first_unrecovered_error_node = Some(message.clone());
+            }
+        }
+        node.for_each_child(|child| walk(child, summary, first_start));
+    }
+
+    let mut summary = UnrecoveredErrorSummary::default();
+    let mut first_start = usize::MAX;
+    walk(root, &mut summary, &mut first_start);
+    summary
 }
 
 impl ParseOutput {

--- a/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
+++ b/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
@@ -3,6 +3,7 @@
 //! Tests for panic mode error recovery that allows the parser to continue
 //! parsing after encountering syntax errors by synchronizing to known points.
 
+use perl_parser_core::error::collect_unrecovered_error_summary;
 use perl_parser_core::{NodeKind, ParseResult, Parser};
 
 // AC1: Parser implements synchronization point detection for Perl syntax
@@ -282,6 +283,19 @@ fn parser_ac10_multiple_consecutive_errors() -> ParseResult<()> {
     let errors = parser.errors();
     // We expect errors to be recorded (implementation detail may vary)
     assert!(errors.len() >= 2, "Should record multiple errors");
+    Ok(())
+}
+
+#[test]
+fn parser_recovery_classification_surfaces_error_nodes() -> ParseResult<()> {
+    let code = "my $x = ? ;";
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    let summary = collect_unrecovered_error_summary(&ast);
+    assert!(
+        summary.error_node_count > 0,
+        "invalid input should remain visible via unrecovered ERROR nodes"
+    );
     Ok(())
 }
 

--- a/crates/perl-parser-core/tests/recovery_missing_closer.rs
+++ b/crates/perl-parser-core/tests/recovery_missing_closer.rs
@@ -10,7 +10,9 @@
 
 mod cpan_test_helpers;
 use cpan_test_helpers::*;
-use perl_parser_core::error::{ParseError, RecoveryKind, RecoverySite};
+use perl_parser_core::error::{
+    ParseError, RecoveryKind, RecoverySite, collect_unrecovered_error_summary,
+};
 use perl_parser_core::{NodeKind, Parser};
 use perl_tdd_support::must;
 
@@ -231,6 +233,17 @@ fn recovered_error_has_correct_site_for_array_subscript() {
         "Expected Recovered {{ site: ArraySubscript, kind: InsertedCloser }} for '{}', got: {:?}",
         src, errors
     );
+}
+
+#[test]
+fn missing_bracket_recovery_has_no_unrecovered_error_nodes() {
+    let src = "my $x = $arr[$i; my $y = 2;";
+    let mut parser = Parser::new(src);
+    let ast_result = parser.parse();
+    assert!(ast_result.is_ok(), "expected recoverable parse for '{src}'");
+    let ast = if let Ok(ast) = ast_result { ast } else { unreachable!("checked above") };
+    let summary = collect_unrecovered_error_summary(&ast);
+    assert_eq!(summary.error_node_count, 0, "missing-closing recovery should avoid ERROR nodes");
 }
 
 /// Both inner and outer parens missing — each level independently emits InsertedCloser.

--- a/crates/perl-parser-core/tests/recovery_phase2_tests.rs
+++ b/crates/perl-parser-core/tests/recovery_phase2_tests.rs
@@ -14,7 +14,9 @@ mod cpan_test_helpers;
 use cpan_test_helpers::*;
 
 use perl_parser_core::Parser;
-use perl_parser_core::error::{ParseError, RecoveryKind, RecoverySite};
+use perl_parser_core::error::{
+    ParseError, RecoveryKind, RecoverySite, collect_unrecovered_error_summary,
+};
 
 // ──────────────────────────────────────────────────────────────
 // Helpers
@@ -176,6 +178,17 @@ fn truncated_arrow_chain_at_eof_does_not_crash() {
     let mut parser = Parser::new("$a->b->c->");
     let result = parser.parse();
     assert!(result.is_ok(), "Parser must not crash on truncated method chain at EOF");
+}
+
+#[test]
+fn truncated_arrow_recovery_exposes_unrecovered_error_nodes() {
+    let mut parser = Parser::new("my $x = $obj->;");
+    let ast_result = parser.parse();
+    assert!(ast_result.is_ok(), "recovery parse should succeed");
+    let ast = if let Ok(ast) = ast_result { ast } else { unreachable!("checked above") };
+    let summary = collect_unrecovered_error_summary(&ast);
+    assert!(summary.error_node_count > 0, "unrecovered ERROR nodes should stay visible");
+    assert!(summary.first_unrecovered_error_node.is_some(), "first ERROR node should be captured");
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/crates/perl-parser/src/lib.rs
+++ b/crates/perl-parser/src/lib.rs
@@ -528,6 +528,8 @@ pub use workspace::workspace_rename;
 pub use ast::{Node, NodeKind, SourceLocation};
 /// Parse error and result types for parser output.
 pub use error::{ParseError, ParseResult};
+/// Unrecovered AST error-node summary and collector.
+pub use error::{UnrecoveredErrorSummary, collect_unrecovered_error_summary};
 #[cfg(feature = "incremental")]
 /// Checkpointed incremental parser with simple edit tracking.
 pub use incremental_checkpoint::{CheckpointedIncrementalParser, SimpleEdit};

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -76,6 +76,13 @@ pub struct StatusSummary {
     pub total_files: usize,
     pub ok_files: usize,
     pub error_files: usize,
+    pub total_dirty_files: usize,
+    pub structured_recovery_only_files: usize,
+    pub files_with_error_nodes: usize,
+    pub catastrophic_parse_failure_files: usize,
+    pub recovered_node_count: usize,
+    pub first_unrecovered_error_node: Option<String>,
+    pub recovery_salvage_rate: f64,
     pub timeout_files: usize,
     pub panic_files: usize,
     pub test_corpus_files: usize,
@@ -99,17 +106,55 @@ pub fn compute_status_summary(corpus_path: &Path, timeout: Duration) -> Result<S
 
     let mut ok_files = 0usize;
     let mut error_files = 0usize;
+    let mut total_dirty_files = 0usize;
+    let mut structured_recovery_only_files = 0usize;
+    let mut files_with_error_nodes = 0usize;
+    let mut catastrophic_parse_failure_files = 0usize;
+    let mut recovered_node_count = 0usize;
+    let mut first_unrecovered_error_node: Option<String> = None;
     let mut timeout_files = 0usize;
     let mut panic_files = 0usize;
 
     for outcome in parse_results.values() {
         match outcome {
-            ParseOutcome::Ok { .. } => ok_files += 1,
-            ParseOutcome::Error { .. } => error_files += 1,
+            ParseOutcome::Ok {
+                recovered_node_count: file_recovered_nodes,
+                error_node_count,
+                first_unrecovered_error_node: first_node_message,
+                ..
+            } => {
+                ok_files += 1;
+                recovered_node_count += *file_recovered_nodes;
+                if *file_recovered_nodes > 0 || *error_node_count > 0 {
+                    total_dirty_files += 1;
+                }
+                if *file_recovered_nodes > 0 && *error_node_count == 0 {
+                    structured_recovery_only_files += 1;
+                }
+                if *error_node_count > 0 {
+                    files_with_error_nodes += 1;
+                    if first_unrecovered_error_node.is_none() {
+                        first_unrecovered_error_node = first_node_message.clone();
+                    }
+                }
+            }
+            ParseOutcome::Error { .. } => {
+                error_files += 1;
+                total_dirty_files += 1;
+                catastrophic_parse_failure_files += 1;
+            }
             ParseOutcome::Timeout { .. } => timeout_files += 1,
-            ParseOutcome::Panic { .. } => panic_files += 1,
+            ParseOutcome::Panic { .. } => {
+                panic_files += 1;
+                total_dirty_files += 1;
+            }
         }
     }
+    let recovery_salvage_rate = if total_dirty_files == 0 {
+        1.0
+    } else {
+        structured_recovery_only_files as f64 / total_dirty_files as f64
+    };
 
     let mut test_corpus_files = 0usize;
     let mut perl_corpus_files = 0usize;
@@ -125,6 +170,13 @@ pub fn compute_status_summary(corpus_path: &Path, timeout: Duration) -> Result<S
         total_files: inventory.total_files,
         ok_files,
         error_files,
+        total_dirty_files,
+        structured_recovery_only_files,
+        files_with_error_nodes,
+        catastrophic_parse_failure_files,
+        recovered_node_count,
+        first_unrecovered_error_node,
+        recovery_salvage_rate,
         timeout_files,
         panic_files,
         test_corpus_files,
@@ -249,6 +301,26 @@ fn print_audit_summary(report: &AuditReport) {
     println!("     - Error: {} ❌", report.parse_outcomes.error);
     println!("     - Timeout: {} ⏱️", report.parse_outcomes.timeout);
     println!("     - Panic: {} 💥", report.parse_outcomes.panic);
+    println!("     - Dirty files: {}", report.parse_outcomes.total_dirty_files);
+    println!(
+        "       · Structured recovery only: {}",
+        report.parse_outcomes.structured_recovery_only_files
+    );
+    println!("       · Files with ERROR nodes: {}", report.parse_outcomes.files_with_error_nodes);
+    println!(
+        "       · Catastrophic parse failures: {}",
+        report.parse_outcomes.catastrophic_parse_failure_files
+    );
+    println!("       · Recovered node count: {}", report.parse_outcomes.recovered_node_count);
+    println!(
+        "       · Recovery salvage rate: {:.1}% ({}/{})",
+        report.parse_outcomes.recovery_salvage_rate * 100.0,
+        report.parse_outcomes.structured_recovery_only_files,
+        report.parse_outcomes.total_dirty_files
+    );
+    if let Some(first_error_node) = &report.parse_outcomes.first_unrecovered_error_node {
+        println!("       · First unrecovered ERROR node: {first_error_node}");
+    }
     println!(
         "   NodeKind coverage: {}/{} ({:.1}%)",
         report.nodekind_coverage.covered_count,
@@ -324,6 +396,14 @@ fn validate_report_for_ci(report: &AuditReport) -> Result<()> {
     // Panics should always be zero
     if report.parse_outcomes.panic > 0 {
         failures.push(format!("Parse panics: {} files caused panics", report.parse_outcomes.panic));
+    }
+
+    if report.parse_outcomes.files_with_error_nodes > 0 {
+        println!(
+            "   ⚠️  Unrecovered ERROR nodes: {} files (first: {})",
+            report.parse_outcomes.files_with_error_nodes,
+            report.parse_outcomes.first_unrecovered_error_node.as_deref().unwrap_or("unknown")
+        );
     }
 
     // Check for critical timeout risks

--- a/xtask/src/tasks/corpus_audit/report.rs
+++ b/xtask/src/tasks/corpus_audit/report.rs
@@ -55,6 +55,27 @@ pub struct ParseOutcomesSummary {
     pub timeout: usize,
     /// Files that caused panics
     pub panic: usize,
+    /// Files with any non-clean parser result (recovery, ERROR nodes, catastrophic failures).
+    #[serde(default)]
+    pub total_dirty_files: usize,
+    /// Files that only needed structured recovery (no unrecovered ERROR nodes).
+    #[serde(default)]
+    pub structured_recovery_only_files: usize,
+    /// Files containing one or more unrecovered `NodeKind::Error` nodes.
+    #[serde(default)]
+    pub files_with_error_nodes: usize,
+    /// Files where parser returned a catastrophic failure (`parse()` returned `Err`).
+    #[serde(default)]
+    pub catastrophic_parse_failure_files: usize,
+    /// Total number of recovered nodes observed across all parsed files.
+    #[serde(default)]
+    pub recovered_node_count: usize,
+    /// Earliest unrecovered ERROR node message from the first affected file (path-sorted).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_unrecovered_error_node: Option<String>,
+    /// Ratio of structured-recovery-only files to total dirty files.
+    #[serde(default)]
+    pub recovery_salvage_rate: f64,
     /// Error breakdown by category (Issue #180)
     #[serde(default)]
     pub error_by_category: HashMap<String, usize>,
@@ -211,14 +232,45 @@ fn generate_parse_outcomes_summary(
     let mut error = 0;
     let mut timeout = 0;
     let mut panic = 0;
+    let mut total_dirty_files = 0;
+    let mut structured_recovery_only_files = 0;
+    let mut files_with_error_nodes = 0;
+    let mut catastrophic_parse_failure_files = 0;
+    let mut recovered_node_count = 0;
+    let mut first_unrecovered_error_node: Option<String> = None;
     let mut error_by_category: HashMap<String, usize> = HashMap::new();
     let mut failing_files: Vec<FailingFile> = Vec::new();
 
     for (path, outcome) in parse_results {
         match outcome {
-            ParseOutcome::Ok { .. } => ok += 1,
+            ParseOutcome::Ok {
+                recovered_node_count: file_recovered_nodes,
+                error_node_count,
+                first_unrecovered_error_node: first_node_message,
+                ..
+            } => {
+                ok += 1;
+                recovered_node_count += file_recovered_nodes;
+
+                if *file_recovered_nodes > 0 || *error_node_count > 0 {
+                    total_dirty_files += 1;
+                }
+
+                if *file_recovered_nodes > 0 && *error_node_count == 0 {
+                    structured_recovery_only_files += 1;
+                }
+
+                if *error_node_count > 0 {
+                    files_with_error_nodes += 1;
+                    if first_unrecovered_error_node.is_none() {
+                        first_unrecovered_error_node = first_node_message.clone();
+                    }
+                }
+            }
             ParseOutcome::Error { message } => {
                 error += 1;
+                total_dirty_files += 1;
+                catastrophic_parse_failure_files += 1;
 
                 // Categorize the error
                 let source = sources.get(path).map(|s| s.as_str()).unwrap_or("");
@@ -259,6 +311,7 @@ fn generate_parse_outcomes_summary(
             ParseOutcome::Timeout { .. } => timeout += 1,
             ParseOutcome::Panic { message } => {
                 panic += 1;
+                total_dirty_files += 1;
                 // Panics are also added to failing files for visibility
                 failing_files.push(FailingFile {
                     path: path.display().to_string(),
@@ -277,7 +330,28 @@ fn generate_parse_outcomes_summary(
     // Sort failing files by path for consistent output
     failing_files.sort_by(|a, b| a.path.cmp(&b.path));
 
-    ParseOutcomesSummary { total, ok, error, timeout, panic, error_by_category, failing_files }
+    let recovery_salvage_rate = if total_dirty_files == 0 {
+        1.0
+    } else {
+        structured_recovery_only_files as f64 / total_dirty_files as f64
+    };
+
+    ParseOutcomesSummary {
+        total,
+        ok,
+        error,
+        timeout,
+        panic,
+        total_dirty_files,
+        structured_recovery_only_files,
+        files_with_error_nodes,
+        catastrophic_parse_failure_files,
+        recovered_node_count,
+        first_unrecovered_error_node,
+        recovery_salvage_rate,
+        error_by_category,
+        failing_files,
+    }
 }
 
 #[cfg(test)]
@@ -287,12 +361,29 @@ mod tests {
     #[test]
     fn test_generate_parse_outcomes_summary() {
         let mut results = std::collections::HashMap::new();
-        results.insert(PathBuf::from("test1.pl"), ParseOutcome::Ok { duration_ms: 100 });
+        results.insert(
+            PathBuf::from("test1.pl"),
+            ParseOutcome::Ok {
+                duration_ms: 100,
+                recovered_node_count: 2,
+                error_node_count: 0,
+                first_unrecovered_error_node: None,
+            },
+        );
         results.insert(
             PathBuf::from("test2.pl"),
             ParseOutcome::Error { message: "error".to_string() },
         );
         results.insert(PathBuf::from("test3.pl"), ParseOutcome::Timeout { timeout_ms: 1000 });
+        results.insert(
+            PathBuf::from("test0.pl"),
+            ParseOutcome::Ok {
+                duration_ms: 60,
+                recovered_node_count: 0,
+                error_node_count: 1,
+                first_unrecovered_error_node: Some("Expected expression".to_string()),
+            },
+        );
         results.insert(
             PathBuf::from("test4.pl"),
             ParseOutcome::Panic { message: "panic".to_string() },
@@ -303,11 +394,18 @@ mod tests {
 
         let summary = generate_parse_outcomes_summary(&results, &sources);
 
-        assert_eq!(summary.total, 4);
-        assert_eq!(summary.ok, 1);
+        assert_eq!(summary.total, 5);
+        assert_eq!(summary.ok, 2);
         assert_eq!(summary.error, 1);
         assert_eq!(summary.timeout, 1);
         assert_eq!(summary.panic, 1);
+        assert_eq!(summary.total_dirty_files, 4);
+        assert_eq!(summary.structured_recovery_only_files, 1);
+        assert_eq!(summary.files_with_error_nodes, 1);
+        assert_eq!(summary.catastrophic_parse_failure_files, 1);
+        assert_eq!(summary.recovered_node_count, 2);
+        assert_eq!(summary.first_unrecovered_error_node.as_deref(), Some("Expected expression"));
+        assert!((summary.recovery_salvage_rate - 0.25).abs() < f64::EPSILON);
         // Error should be categorized as General when no source is provided
         assert_eq!(summary.error_by_category.get("General"), Some(&1));
         assert_eq!(summary.failing_files.len(), 2); // error + panic

--- a/xtask/src/tasks/corpus_audit/timeout_detection.rs
+++ b/xtask/src/tasks/corpus_audit/timeout_detection.rs
@@ -3,7 +3,7 @@
 //! This module provides timeout protection for parsing operations and
 //! detection of files that may cause timeouts or hangs.
 
-use perl_parser::Parser;
+use perl_parser::{Parser, collect_unrecovered_error_summary};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -138,6 +138,12 @@ pub enum ParseOutcome {
     Ok {
         /// Time taken to parse
         duration_ms: u64,
+        /// Number of `ParseError::Recovered` diagnostics produced by parser recovery.
+        recovered_node_count: usize,
+        /// Number of unrecovered `NodeKind::Error` nodes in the resulting AST.
+        error_node_count: usize,
+        /// Earliest unrecovered `NodeKind::Error` message by source location.
+        first_unrecovered_error_node: Option<String>,
     },
     /// Parse failed with error
     Error {
@@ -166,7 +172,7 @@ impl ParseOutcome {
     /// Get the duration in milliseconds if parse succeeded
     pub fn duration_ms(&self) -> Option<u64> {
         match self {
-            ParseOutcome::Ok { duration_ms } => Some(*duration_ms),
+            ParseOutcome::Ok { duration_ms, .. } => Some(*duration_ms),
             _ => None,
         }
     }
@@ -215,12 +221,25 @@ pub fn parse_with_timeout(
     let handle = std::thread::spawn(move || {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut parser = Parser::new(&content_clone);
-            parser.parse()
+            let parsed = parser.parse();
+            (parsed, parser.errors().to_vec())
         }));
 
         let outcome = match result {
-            Ok(Ok(_)) => ParseOutcome::Ok { duration_ms: start.elapsed().as_millis() as u64 },
-            Ok(Err(e)) => ParseOutcome::Error { message: e.to_string() },
+            Ok((Ok(ast), diagnostics)) => {
+                let recovered_node_count = diagnostics
+                    .iter()
+                    .filter(|error| matches!(error, perl_parser::ParseError::Recovered { .. }))
+                    .count();
+                let ast_error_summary = collect_unrecovered_error_summary(&ast);
+                ParseOutcome::Ok {
+                    duration_ms: start.elapsed().as_millis() as u64,
+                    recovered_node_count,
+                    error_node_count: ast_error_summary.error_node_count,
+                    first_unrecovered_error_node: ast_error_summary.first_unrecovered_error_node,
+                }
+            }
+            Ok((Err(e), _)) => ParseOutcome::Error { message: e.to_string() },
             Err(_) => ParseOutcome::Panic { message: "Parser panicked".to_string() },
         };
 
@@ -503,7 +522,15 @@ mod tests {
 
     #[test]
     fn test_parse_outcome_is_ok() {
-        assert!(ParseOutcome::Ok { duration_ms: 100 }.is_ok());
+        assert!(
+            ParseOutcome::Ok {
+                duration_ms: 100,
+                recovered_node_count: 0,
+                error_node_count: 0,
+                first_unrecovered_error_node: None,
+            }
+            .is_ok()
+        );
         assert!(!ParseOutcome::Error { message: "error".to_string() }.is_ok());
         assert!(!ParseOutcome::Timeout { timeout_ms: 1000 }.is_ok());
         assert!(!ParseOutcome::Panic { message: "panic".to_string() }.is_ok());
@@ -511,7 +538,16 @@ mod tests {
 
     #[test]
     fn test_parse_outcome_duration_ms() {
-        assert_eq!(ParseOutcome::Ok { duration_ms: 100 }.duration_ms(), Some(100));
+        assert_eq!(
+            ParseOutcome::Ok {
+                duration_ms: 100,
+                recovered_node_count: 0,
+                error_node_count: 0,
+                first_unrecovered_error_node: None,
+            }
+            .duration_ms(),
+            Some(100)
+        );
         assert_eq!(ParseOutcome::Error { message: "error".to_string() }.duration_ms(), None);
     }
 

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -131,11 +131,18 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         },
         |summary| {
             format!(
-                "| **Project corpus** | {} | Deterministic regression baseline; `{}` `test_corpus/` + `{}` `perl-corpus` files, `{}` errors, `{}` timeouts, `{}` panics, `{}/{}` NodeKinds, `{}/{}` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |",
-                format_clean_rate(summary.ok_files, summary.total_files),
+                "| **Project corpus** | {:.1}% salvage (`{}/{}` dirty) | Deterministic regression baseline; `{}` parser-ok files, `{}` parse-Err files, `{}` `test_corpus/` + `{}` `perl-corpus` files, `{}` structured-recovery-only, `{}` with ERROR nodes, `{}` catastrophic failures, `{}` recovered nodes, `{}` timeouts, `{}` panics, `{}/{}` NodeKinds, `{}/{}` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |",
+                summary.recovery_salvage_rate * 100.0,
+                summary.structured_recovery_only_files,
+                summary.total_dirty_files,
+                summary.ok_files,
+                summary.error_files,
                 summary.test_corpus_files,
                 summary.perl_corpus_files,
-                summary.error_files,
+                summary.structured_recovery_only_files,
+                summary.files_with_error_nodes,
+                summary.catastrophic_parse_failure_files,
+                summary.recovered_node_count,
                 summary.timeout_files,
                 summary.panic_files,
                 summary.nodekind_covered,
@@ -176,7 +183,13 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
             .map_or_else(|| "?".to_string(), |r| r.files_unreadable.to_string());
         let proj_detail = metrics.project_corpus.as_ref().map_or_else(
             || "Project: UNVERIFIED".to_string(),
-            |s| format!("Project: {} timeout, {} panic, 0 unread", s.timeout_files, s.panic_files,),
+            |s| {
+                let first_error = s.first_unrecovered_error_node.as_deref().unwrap_or("none");
+                format!(
+                    "Project: {} files, {} timeout, {} panic, first ERROR node: {}",
+                    s.total_files, s.timeout_files, s.panic_files, first_error
+                )
+            },
         );
         format!(
             "| **Reliability** | Ubuntu: {} unread / CPAN: {} unread / {} | -- | `.ci/*-baseline.json` |",
@@ -286,6 +299,13 @@ mod tests {
             total_files: 91,
             ok_files: 91,
             error_files: 0,
+            total_dirty_files: 12,
+            structured_recovery_only_files: 9,
+            files_with_error_nodes: 2,
+            catastrophic_parse_failure_files: 1,
+            recovered_node_count: 14,
+            first_unrecovered_error_node: Some("Expected expression".to_string()),
+            recovery_salvage_rate: 0.75,
             timeout_files: 0,
             panic_files: 0,
             test_corpus_files: 69,
@@ -312,6 +332,8 @@ mod tests {
         assert!(result.contains("65/69"), "nodekind row missing 65/69");
         assert!(result.contains("94.2"), "nodekind row missing 94.2%");
         assert!(result.contains("4 never-seen"), "nodekind row missing never-seen count");
+        assert!(result.contains("75.0% salvage"), "project row missing salvage rate");
+        assert!(result.contains("with ERROR nodes"), "project row missing ERROR-node count");
         assert!(
             result.contains("unverified"),
             "strict-clean no-receipt row should say 'unverified'"


### PR DESCRIPTION
### Motivation
- Closeout logic currently treats any non-clean parse the same, conflating benign editor-recovery with catastrophic parser failures.  
- Accuracy/ratchting needs separate signals for structured recovery vs unrecovered AST `Error` nodes so fixes and regressions are actionable.  
- Surface per-file and aggregate salvage metrics so `parser-audit` / `update-status` can report a recovery-salvage rate instead of only clean/dirty totals.

### Description
- Add `UnrecoveredErrorSummary` and `collect_unrecovered_error_summary` to `perl-parser-core::syntax::error` and re-export through engine and `perl-parser` for consumers.  
- Extend `ParseOutcome::Ok` (in `xtask` parsing path) to include `recovered_node_count`, `error_node_count`, and `first_unrecovered_error_node`, and update `parse_with_timeout` to collect these from the parser AST and diagnostics.  
- Compute new aggregates in `generate_parse_outcomes_summary` and `compute_status_summary`: `total_dirty_files`, `structured_recovery_only_files`, `files_with_error_nodes`, `catastrophic_parse_failure_files`, `recovered_node_count`, `first_unrecovered_error_node`, and `recovery_salvage_rate`, and serialize them in audit reports.  
- Surface the new metrics in console output and the parser status generator (`xtask/src/tasks/update_status/parser.rs`) and set a concrete `recovery_salvage_rate` baseline in `.ci/metrics/baselines/parser.json`.

### Testing
- Ran `cargo test -p perl-parser-core recovery` and all recovery-focused tests passed.  
- Ran `cargo test -p xtask parser` and `xtask` parser/status tests passed.  
- Ran `cargo xtask fmt` successfully; `just parser-audit` and `just status-update --only parser` were not executed because `just` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53d91550833391bfb2aa4c3b1dcf)