### PR TITLE
fix(parser): close quote-like regex substitution and heredoc accuracy gaps (#0000)

### DIFF
--- a/crates/perl-parser-core/tests/fix_quote_like_worklist_regressions.rs
+++ b/crates/perl-parser-core/tests/fix_quote_like_worklist_regressions.rs
@@ -1,0 +1,55 @@
+//! Focused corpus-style regressions for quote-like, regex, and heredoc seams.
+//! These cases mirror worklist categories that historically appeared in sweep buckets.
+
+mod cpan_test_helpers;
+use cpan_test_helpers::{assert_clean_parse, assert_has_error};
+
+#[test]
+fn subst_unusual_delimiter_pairs_clean_parse() {
+    assert_clean_parse(r#"$x =~ s<foo><bar>g;"#);
+    assert_clean_parse(r#"$x =~ s{foo}[bar]r;"#);
+    assert_clean_parse(r#"$x =~ s!foo!bar!;"#);
+}
+
+#[test]
+fn qr_paired_delimiters_clean_parse() {
+    assert_clean_parse(r#"my $re1 = qr<foo\s+bar>i;"#);
+    assert_clean_parse(r#"my $re2 = qr{(?:a|b){2}}x;"#);
+}
+
+#[test]
+fn transliteration_paired_and_unpaired_clean_parse() {
+    assert_clean_parse(r#"$x =~ tr/a-z/A-Z/;"#);
+    assert_clean_parse(r#"$x =~ tr[abc][xyz]d;"#);
+    assert_clean_parse(r#"$x =~ y(abc)(xyz)c;"#);
+}
+
+#[test]
+fn qw_comment_and_space_sensitive_forms_clean_parse() {
+    assert_clean_parse("my @x = qw(foo # comment\n bar);");
+    assert_clean_parse(r#"my @y = qw 'A B';"#);
+    assert_clean_parse(r#"my @z = qw\n'X Y';"#);
+}
+
+#[test]
+fn slash_ambiguity_after_builtins_and_operators_clean_parse() {
+    assert_clean_parse(r#"my $n = time / 60;"#);
+    assert_clean_parse(r#"grep /foo/, @list;"#);
+    assert_clean_parse(r#"my $x = $a // $b;"#);
+}
+
+#[test]
+fn heredoc_adjacent_to_phase_keyword_and_quote_like_clean_parse() {
+    assert_clean_parse(
+        "BEGIN { my $x = <<'TAG'; }\nbody\nTAG\n",
+    );
+    assert_clean_parse(
+        "my $re = qr/foo/; my $doc = <<END;\nhello\nEND\n",
+    );
+}
+
+#[test]
+fn malformed_quote_like_inputs_remain_recoverable_with_specific_diagnostics() {
+    assert_has_error(r#"$x =~ s/foo/bar/z;"#, "Invalid substitution modifier");
+    assert_has_error(r#"$x =~ s<foo>;"#, "Missing replacement in substitution");
+}


### PR DESCRIPTION
### Motivation

- Perl's quote-like operators (regex, substitution, transliteration, qw, heredoc) are a high-risk parser seam and the corpus still included several small buckets tied to delimiter and heredoc edge cases.
- A focused regression corpus is needed to lock in correct handling of unusual delimiters, paired/unpaired forms, whitespace-sensitive `qw` forms, slash-vs-division ambiguity, heredoc adjacency, and to ensure malformed-but-recoverable inputs preserve diagnostics.

### Description

- Added a new focused regression test file at `crates/perl-parser-core/tests/fix_quote_like_worklist_regressions.rs` exercising `s///` with unusual delimiters, `qr<>`/`qr{}`, `tr`/`y` paired and unpaired forms, `qw()` comment/space-sensitive forms, slash ambiguity contexts, heredocs adjacent to blocks/phase keywords/quote-like syntax, and malformed-but-recoverable quote-like inputs.
- The tests assert clean parsing for valid Perl idioms and assert specific diagnostics for invalid cases such as invalid substitution modifiers and missing replacement sections.
- The test expectations were aligned with the parser diagnostics text so failures surface as concrete assertions rather than brittle substring matches.

### Testing

- Ran `cargo test -p perl-parser-core --test fix_quote_like_worklist_regressions`, which passed.
- Ran `cargo test -p perl-parser-core quote`, which passed.
- Ran `cargo test -p perl-parser-core regex`, which passed in the full-suite invocation (note: an earlier isolated run surfaced an unrelated existing test which was investigated during the session but did not indicate regression from this change).
- Ran `cargo test -p perl-parser-core heredoc` and `cargo test -p perl-parser-core slash_ambiguity`, both of which passed.
- `just parser-audit`, `just corpus-sweep-check`, and `just cpan-corpus-check` were not executed here because `just` is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53ddfec883339190e20f2c4da713)