### PR TITLE
fix(parser): classify and close delimiter recovery corpus buckets (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/hashes.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/hashes.rs
@@ -20,7 +20,7 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            s.expect(TokenKind::RightBrace)?;
+            s.expect_closing_delimiter(TokenKind::RightBrace)?;
             let end = s.previous_position();
 
             // Always return a block node for builtin functions
@@ -76,7 +76,7 @@ impl<'a> Parser<'a> {
                     statements.push(self.parse_statement()?);
                 }
 
-                self.expect(TokenKind::RightBrace)?;
+                self.expect_closing_delimiter(TokenKind::RightBrace)?;
                 let end = self.previous_position();
 
                 self.exit_recursion();
@@ -228,7 +228,7 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            self.expect(TokenKind::RightBrace)?;
+            self.expect_closing_delimiter(TokenKind::RightBrace)?;
             let end = self.previous_position();
 
             self.exit_recursion();
@@ -259,7 +259,7 @@ impl<'a> Parser<'a> {
                 statements.push(self.parse_statement()?);
             }
 
-            self.expect(TokenKind::RightBrace)?;
+            self.expect_closing_delimiter(TokenKind::RightBrace)?;
             let end = self.previous_position();
 
             self.exit_recursion();

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -64,7 +64,7 @@ impl<'a> Parser<'a> {
                         // Hash/array slice: @hash{...} or %hash{...}
                         self.tokens.next()?; // consume {
                         let key = self.parse_hash_subscript_key()?;
-                        self.expect(TokenKind::RightBrace)?;
+                        self.expect_closing_delimiter(TokenKind::RightBrace)?;
 
                         let start = expr.location.start;
                         let end = self.previous_position();
@@ -163,7 +163,7 @@ impl<'a> Parser<'a> {
                                 // ->%{...} hash slice
                                 self.tokens.next()?; // consume {
                                 let key = self.parse_hash_subscript_key()?;
-                                self.expect(TokenKind::RightBrace)?;
+                                self.expect_closing_delimiter(TokenKind::RightBrace)?;
 
                                 let start = expr.location.start;
                                 let end = self.previous_position();
@@ -326,7 +326,7 @@ impl<'a> Parser<'a> {
                             // Arrow hash dereference: $ref->{key}
                             self.tokens.next()?; // consume {
                             let key = self.parse_hash_subscript_key()?;
-                            self.expect(TokenKind::RightBrace)?;
+                            self.expect_closing_delimiter(TokenKind::RightBrace)?;
 
                             let start = expr.location.start;
                             let end = self.previous_position();
@@ -599,7 +599,7 @@ impl<'a> Parser<'a> {
                     // Hash element access
                     self.tokens.next()?; // consume {
                     let key = self.parse_hash_subscript_key()?;
-                    self.expect(TokenKind::RightBrace)?;
+                    self.expect_closing_delimiter(TokenKind::RightBrace)?;
 
                     let start = expr.location.start;
                     let end = self.previous_position();

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -692,7 +692,7 @@ impl<'a> Parser<'a> {
                     }
 
                     if has_parens {
-                        self.expect(TokenKind::RightParen)?;
+                        self.expect_closing_delimiter(TokenKind::RightParen)?;
                     }
 
                     let end = self.previous_position();
@@ -1038,7 +1038,7 @@ impl<'a> Parser<'a> {
 
             // Handle unclosed block at EOF: emit error but return partial block
             if s.peek_kind() == Some(TokenKind::RightBrace) {
-                s.expect(TokenKind::RightBrace)?;
+                s.expect_closing_delimiter(TokenKind::RightBrace)?;
             } else {
                 // Missing closing brace (EOF or recovery break)
                 let pos = s.current_position();

--- a/crates/perl-parser-core/tests/recovery_missing_closer.rs
+++ b/crates/perl-parser-core/tests/recovery_missing_closer.rs
@@ -287,6 +287,85 @@ fn missing_paren_at_eof_in_list_assignment_emits_recovered() {
 }
 
 // ---------------------------------------------------------------------------
+// Bucket coverage — nearest syntactic owner
+// ---------------------------------------------------------------------------
+
+/// Declaration-list owner: `tie(my %h, ...)` with missing `)` before `;`.
+#[test]
+fn missing_tie_decl_list_closer_emits_recovered() {
+    let src = "tie(my %h, 'Tie::IxHash', foo => 1; my $after = 1;";
+    let (ast, errors) = parse_errors(src);
+
+    assert!(
+        count_inserted_closer(&errors) >= 1,
+        "Expected InsertedCloser for tie() declaration-list owner in '{}', got: {:?}",
+        src,
+        errors
+    );
+    assert!(
+        statement_count(&ast) >= 2,
+        "Recovery should keep downstream statements alive for '{}'",
+        src
+    );
+}
+
+/// Hash-literal owner: missing `}` before statement terminator stays recoverable.
+#[test]
+fn missing_hash_literal_brace_before_semicolon_emits_recovered() {
+    let src = "my $cfg = { key => 1; my $after = 2;";
+    let (ast, errors) = parse_errors(src);
+
+    let recovered_hash = errors.iter().any(|e| {
+        matches!(
+            e,
+            ParseError::Recovered {
+                site: RecoverySite::HashSubscript,
+                kind: RecoveryKind::InsertedCloser,
+                ..
+            }
+        )
+    });
+    assert!(
+        recovered_hash,
+        "Expected HashSubscript InsertedCloser for hash-literal owner in '{}', got: {:?}",
+        src,
+        errors
+    );
+    assert!(
+        matches!(ast.kind, NodeKind::Program { .. }),
+        "Hash-literal recovery should still produce a Program node for '{}'",
+        src
+    );
+}
+
+/// Postfix-deref owner: missing `}` in `->%{...}` recovers at semicolon.
+#[test]
+fn missing_postfix_deref_brace_before_semicolon_emits_recovered() {
+    let src = "my $v = $obj->%{key; my $after = 3;";
+    let (_ast, errors) = parse_errors(src);
+
+    assert!(
+        count_inserted_closer(&errors) >= 1,
+        "Expected InsertedCloser for postfix deref owner in '{}', got: {:?}",
+        src,
+        errors
+    );
+}
+
+/// Quote-like owner: unclosed `qq{...` remains a syntax diagnostic (not silent clean parse).
+#[test]
+fn unclosed_quote_like_still_reports_diagnostic() {
+    let src = "my $s = qq{hello;";
+    let (_ast, errors) = parse_errors(src);
+
+    assert!(
+        !errors.is_empty(),
+        "Unclosed quote-like input must keep diagnostics for '{}'",
+        src
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Regression: clean-parse inputs must produce zero Recovered errors
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
### Motivation

- Reduce noisy unclosed-delimiter buckets by making delimiter recovery owned by the correct surrounding construct (call args, decl lists, hash literal vs block, postfix deref, etc.).
- Preserve diagnostics for genuinely malformed quote-like inputs while making typical incomplete/edit-in-progress cases recoverable and well-scoped.

### Description

- Replace plain `expect(TokenKind::RightBrace)` / `expect(TokenKind::RightParen)` calls in owner sites with `expect_closing_delimiter(...)` so missing closers at strong followers produce structured `InsertedCloser` recoveries instead of hard failures in the following parsers: `expressions/postfix.rs`, `expressions/hashes.rs`, and `statements.rs`.
- Add focused recovery tests in `tests/recovery_missing_closer.rs` that exercise declaration-list owner (`tie(...)`), hash-literal owner, postfix-deref owner (`->%{...}`), and confirm quote-like unclosed inputs still produce diagnostics.
- Keep changes narrowly scoped to delimiter handling and recovery reporting; existing parse semantics are preserved for clean inputs.

### Testing

- Ran `cargo test -p perl-parser-core recovery` and related per-bucket test runs (`paren`, `bracket`, `unclosed`) and observed passing tests for the modified areas.
- Ran the new/updated bucket tests via `cargo test -p perl-parser-core --test recovery_missing_closer` and confirmed all added tests pass.
- `just parser-audit`, `just corpus-sweep-check`, and `just cpan-corpus-check` could not be executed in this environment because `just` is not installed; all `cargo` test verification listed above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53e6c3288333b7319bdc43d99a28)