### PR TITLE
fix(parser): recover delimiter handoff ownership (#6492)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -703,7 +703,7 @@ impl<'a> Parser<'a> {
             self.consume_token()?;
             return Ok(());
         }
-        if self.is_delimiter_recovery_point() {
+        if self.is_delimiter_recovery_point() || self.is_delimiter_handoff_point(kind) {
             let pos = self.current_position();
             let site = Self::recovery_site_for_closer(kind);
             self.errors.push(ParseError::Recovered {
@@ -719,6 +719,22 @@ impl<'a> Parser<'a> {
             self.peek_kind().map(|k| k.display_name()).unwrap_or("end of input"),
             pos,
         ))
+    }
+
+    /// Return true when the current token is a different closing delimiter.
+    ///
+    /// This typically means we lost ownership of an inner delimiter and are now
+    /// looking at the enclosing construct's closer (for example `)` while still
+    /// expecting `]`). In that case, we recover by inserting the expected closer
+    /// and leave the current token for the outer parser frame.
+    #[inline]
+    fn is_delimiter_handoff_point(&mut self, expected: TokenKind) -> bool {
+        matches!(
+            (expected, self.peek_kind()),
+            (TokenKind::RightParen, Some(TokenKind::RightBracket | TokenKind::RightBrace))
+                | (TokenKind::RightBracket, Some(TokenKind::RightParen | TokenKind::RightBrace))
+                | (TokenKind::RightBrace, Some(TokenKind::RightParen | TokenKind::RightBracket))
+        )
     }
 
     /// Map a closing-delimiter token to its [`RecoverySite`] for recovery annotations.

--- a/crates/perl-parser-core/tests/recovery_missing_closer.rs
+++ b/crates/perl-parser-core/tests/recovery_missing_closer.rs
@@ -286,6 +286,56 @@ fn missing_paren_at_eof_in_list_assignment_emits_recovered() {
     );
 }
 
+/// When an inner subscript is missing `]`, but we encounter `)` from the
+/// enclosing call, recover at the inner owner and keep the outer closer.
+#[test]
+fn missing_inner_bracket_handoff_to_outer_paren_emits_recovered() {
+    let src = "foo($arr[$i), $j);";
+    let (_ast, errors) = parse_errors(src);
+
+    let has_array_recovery = errors.iter().any(|e| {
+        matches!(
+            e,
+            ParseError::Recovered {
+                site: RecoverySite::ArraySubscript,
+                kind: RecoveryKind::InsertedCloser,
+                ..
+            }
+        )
+    });
+    assert!(
+        has_array_recovery,
+        "Expected array-subscript InsertedCloser handoff recovery for '{}', got: {:?}",
+        src,
+        errors
+    );
+}
+
+/// Symmetric case: when an inner call is missing `)`, but we encounter `]`
+/// from the enclosing subscript, recover at ArgList and continue.
+#[test]
+fn missing_inner_paren_handoff_to_outer_bracket_emits_recovered() {
+    let src = "my $x = $arr[foo($a, $b];";
+    let (_ast, errors) = parse_errors(src);
+
+    let has_arg_list_recovery = errors.iter().any(|e| {
+        matches!(
+            e,
+            ParseError::Recovered {
+                site: RecoverySite::ArgList,
+                kind: RecoveryKind::InsertedCloser,
+                ..
+            }
+        )
+    });
+    assert!(
+        has_arg_list_recovery,
+        "Expected arg-list InsertedCloser handoff recovery for '{}', got: {:?}",
+        src,
+        errors
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Regression: clean-parse inputs must produce zero Recovered errors
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Reduce false-positive unclosed-delimiter diagnostics when an outer closing delimiter appears while an inner closer is missing, by classifying those as ownership handoff recovery cases.

### Description
- Update `expect_closing_delimiter` to treat mismatched closing delimiters as handoff points by consulting a new helper `is_delimiter_handoff_point`, so the parser can insert the expected closer and leave the outer closer for the enclosing frame (`crates/perl-parser-core/src/engine/parser/helpers.rs`).
- Add `is_delimiter_handoff_point(expected: TokenKind)` which recognizes symmetric mismatches between `)`, `]`, and `}` and signals an InsertedCloser recovery without consuming the current token (`crates/perl-parser-core/src/engine/parser/helpers.rs`).
- Add two focused regression tests that exercise bracket↔paren handoff recovery diagnostics to lock the behavior: missing inner `]` with outer `)` and missing inner `)` with outer `]` (`crates/perl-parser-core/tests/recovery_missing_closer.rs`).

### Testing
- Ran `cargo test -p perl-parser-core recovery`, and the targeted recovery tests passed (all recovery-related tests reported OK).
- Ran `cargo test -p perl-parser-core paren` and `cargo test -p perl-parser-core bracket`, both suites passed.
- Ran `cargo test -p perl-parser-core unclosed`, which passed.
- Attempted `just parser-audit`, `just corpus-sweep-check`, and `just cpan-corpus-check` but `just` is not available in this environment; other `cargo test` verification was performed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53e6c3288333b7319bdc43d99a28)