### PR TITLE
fix(parser): close remaining comma and list-builtin corpus failures (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -572,7 +572,9 @@ impl<'a> Parser<'a> {
     ) -> ParseResult<Node> {
         let omit_optional_arg = allow_no_args
             && (self.peek_kind().is_some_and(Self::is_binary_operator)
-                || self.peek_kind() == Some(TokenKind::Slash));
+                || self.peek_kind() == Some(TokenKind::Slash)
+                || self.peek_kind() == Some(TokenKind::Comma)
+                || self.peek_kind() == Some(TokenKind::FatArrow));
 
         // String comparison operators (ne, eq, lt, le, gt, ge) are tokenized as
         // Identifier tokens, so `is_binary_operator` won't catch them. When a

--- a/crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs
@@ -144,6 +144,21 @@ fn test_comma_as_sequence_operator() {
     assert_clean_parse(source);
 }
 
+#[test]
+fn test_nullary_builtin_comma_sequence() {
+    // File::Spec::Win32 / overload.pm pattern: comma operator with nullary builtins
+    let source = r#"shift, shift;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_nullary_builtin_then_return_with_modifier() {
+    // File::Spec::Win32 pattern:
+    // shift, return _canon_cat("/", @_) if !@_ || $_[0] eq "";
+    let source = r#"shift, return _canon_cat("/", @_) if !@_ || $_[0] eq "";"#;
+    assert_clean_parse(source);
+}
+
 // === no warnings with multiple args ===
 
 #[test]


### PR DESCRIPTION
### Motivation

- Real-world corpus files were still landing in the `unexpected_comma_expr` bucket because statement-level nullary builtins (e.g. `shift`, `pop`, etc.) were being forced to parse an argument when immediately followed by `,` or `=>`, causing valid forms like `shift, shift;` or `shift, return ... if ...` to misparse.

### Description

- Treat `Comma` and `FatArrow` as valid no-argument terminators when deciding whether a statement-start nullary builtin omits its optional argument in `parse_named_unary_statement_call` (added checks for `TokenKind::Comma` and `TokenKind::FatArrow`).
- Added two focused regression tests in `crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs` to cover `shift, shift;` and `shift, return _canon_cat("/", @_) if ...` patterns.
- Scope is intentionally small: only a single conditional in `crates/perl-parser-core/src/engine/parser/statements.rs` and two tests were added.

### Testing

- Ran `cargo test -p perl-parser-core --test fix_unexpected_comma_expr` which passed (`52 passed`).
- Ran `cargo test -p perl-parser-core list_util` and `cargo test -p perl-parser-core block_list` which completed successfully in this environment.
- Ran the system corpus sweep with `cargo run -p xtask -- parser-corpus-sweep --verbose --output /tmp/system_after.json` and observed `unexpected_comma_expr` drop from 16 to 8 in the local run, with the verbose report written to `/tmp/system_after.json`.

Notes: `just`-based commands (`just corpus-sweep-check`, `just cpan-corpus-check`, `just status-update --only parser`) were not executed here because `just` or the CPAN corpus was not available in this execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53ec2d248333a59135887fd1ff9b)