### PR TITLE
fix(parser): close remaining comma and list-builtin corpus failures (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -572,7 +572,8 @@ impl<'a> Parser<'a> {
     ) -> ParseResult<Node> {
         let omit_optional_arg = allow_no_args
             && (self.peek_kind().is_some_and(Self::is_binary_operator)
-                || self.peek_kind() == Some(TokenKind::Slash));
+                || self.peek_kind() == Some(TokenKind::Slash)
+                || self.peek_kind() == Some(TokenKind::Comma));
 
         // String comparison operators (ne, eq, lt, le, gt, ge) are tokenized as
         // Identifier tokens, so `is_binary_operator` won't catch them. When a

--- a/crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs
@@ -144,6 +144,13 @@ fn test_comma_as_sequence_operator() {
     assert_clean_parse(source);
 }
 
+#[test]
+fn test_shift_then_return_sequence_operator() {
+    // Seen in File::Spec::Win32 (`shift, return ...`)
+    let source = r#"shift, return _canon_cat("/", @_);"#;
+    assert_clean_parse(source);
+}
+
 // === no warnings with multiple args ===
 
 #[test]
@@ -273,6 +280,12 @@ fn test_map_with_comma_expr() {
 #[test]
 fn test_sort_with_custom_comparison() {
     let source = r#"my @sorted = sort { $a->{name} cmp $b->{name} } @items;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_sort_subname_list_form() {
+    let source = r#"my @sorted = sort by_name @items;"#;
     assert_clean_parse(source);
 }
 


### PR DESCRIPTION
### Motivation

- Reduce `unexpected_comma_expr` noise from system and CPAN corpus runs by correctly handling valid comma-sequence and list-builtin forms that were being misparsed at statement start.

### Description

- Treat a following `,` as an argument terminator for statement-start named-unary/nullary calls by adding `|| self.peek_kind() == Some(TokenKind::Comma)` to the omit-optional-arg check in `parse_named_unary_statement_call` in `crates/perl-parser-core/src/engine/parser/statements.rs`.
- Add a regression test for the real-world sequence `shift, return _canon_cat("/", @_);` to lock in correct sequence-operator handling in `crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs`.
- Add a regression for the `sort SUBNAME LIST` form (`sort by_name @items`) to keep nearby list-expression behavior covered in `crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs`.

### Testing

- Ran `cargo test -p perl-parser-core --test fix_unexpected_comma_expr` and all tests passed (`52 passed`).
- Ran `cargo test -p perl-parser-core list_util` and `cargo test -p perl-parser-core block_list` and the targeted suites passed (`list_util` tests and `block_list` tests passed as shown in the run output).
- Ran targeted corpus checks with the local xtask sweep: `cargo run -p xtask -- parser-corpus-sweep --roots /usr/lib/x86_64-linux-gnu/perl/5.38/File/Spec/Win32.pm --verbose --output /tmp/win32_after.json` which made that file clean, and `cargo run -p xtask -- parser-corpus-sweep --output /tmp/system_after.json` which reduced `unexpected_comma_expr` in the system sweep from 16 to 8 in this environment.
- CPAN corpus sweep (`cargo run -p xtask -- cpan-corpus sweep --enforce`) and `just cpan-corpus-check` were not run here because the CPAN corpus is not installed in the environment (`target/cpan-corpus/lib/perl5` missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53ec2d248333a59135887fd1ff9b)