### PR TITLE
fix(parser): harden transliteration parsing and ratchet regressions (#0000)

### DIFF
--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -302,34 +302,32 @@ pub fn extract_substitution_parts(text: &str) -> (String, String, String) {
 /// Extract search, replace, and modifiers from a transliteration token
 pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
     // Skip 'tr' or 'y' prefix
-    let content = if let Some(stripped) = text.strip_prefix("tr") {
+    let after_op = if let Some(stripped) = text.strip_prefix("tr") {
         stripped
     } else if let Some(stripped) = text.strip_prefix('y') {
         stripped
     } else {
         text
     };
+    let content = after_op.trim_start();
 
     // Get delimiter - content must be non-empty to have a delimiter
     let delimiter = match content.chars().next() {
         Some(d) => d,
         None => return (String::new(), String::new(), String::new()),
     };
+    if is_invalid_transliteration_delimiter(delimiter) {
+        return (String::new(), String::new(), String::new());
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
     // Parse first body (search pattern)
-    let (search, rest1) = extract_delimited_content(content, delimiter, closing);
-
-    // For paired delimiters, skip whitespace and allow any paired opening delimiter for the
-    // replacement list. Perl accepts forms like tr[abc]{xyz} in addition to tr[abc][xyz].
-    let rest2_owned;
-    let rest2 = if is_paired {
-        rest1.trim_start()
-    } else {
-        rest2_owned = format!("{}{}", delimiter, rest1);
-        &rest2_owned
-    };
+    let (search, rest1, search_closed) =
+        extract_delimited_content_strict(content, delimiter, closing);
+    if !search_closed {
+        return (search, String::new(), String::new());
+    }
 
     // Parse second body (replacement pattern)
     let (replacement, modifiers_str) = if !is_paired && !rest1.is_empty() {
@@ -338,6 +336,7 @@ pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
         let mut body = String::new();
         let mut escaped = false;
         let mut end_pos = rest1.len();
+        let mut found_closing = false;
 
         for (i, ch) in chars {
             if escaped {
@@ -353,19 +352,33 @@ pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
                 }
                 c if c == closing => {
                     end_pos = i + ch.len_utf8();
+                    found_closing = true;
                     break;
                 }
                 _ => body.push(ch),
             }
         }
+        if !found_closing {
+            return (search, body, String::new());
+        }
 
         (body, &rest1[end_pos..])
     } else if is_paired {
-        if let Some(repl_delimiter) = starts_with_paired_delimiter(rest2) {
+        let trimmed = rest1.trim_start();
+        if let Some(repl_delimiter) = trimmed.chars().next() {
+            if is_invalid_transliteration_delimiter(repl_delimiter) {
+                return (search, String::new(), String::new());
+            }
+
             let repl_closing = get_closing_delimiter(repl_delimiter);
-            extract_delimited_content(rest2, repl_delimiter, repl_closing)
+            let (body, rest, found_closing) =
+                extract_delimited_content_strict(trimmed, repl_delimiter, repl_closing);
+            if !found_closing {
+                return (search, body, String::new());
+            }
+            (body, rest)
         } else {
-            (String::new(), rest2)
+            (String::new(), trimmed)
         }
     } else {
         (String::new(), rest1)
@@ -409,6 +422,9 @@ pub fn extract_transliteration_parts_strict(
         Some(d) => d,
         None => return Err(TransliterationError::MissingDelimiter),
     };
+    if is_invalid_transliteration_delimiter(delimiter) {
+        return Err(TransliterationError::MissingDelimiter);
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
@@ -428,7 +444,10 @@ pub fn extract_transliteration_parts_strict(
         (body, rest, found_closing)
     } else {
         let trimmed = rest1.trim_start();
-        if let Some(repl_delimiter) = starts_with_paired_delimiter(trimmed) {
+        if let Some(repl_delimiter) = trimmed.chars().next() {
+            if is_invalid_transliteration_delimiter(repl_delimiter) {
+                return Err(TransliterationError::MissingReplacement);
+            }
             let repl_closing = get_closing_delimiter(repl_delimiter);
             let (body, rest, found_closing) =
                 extract_delimited_content_strict(trimmed, repl_delimiter, repl_closing);
@@ -480,6 +499,10 @@ fn starts_with_paired_delimiter(text: &str) -> Option<char> {
         Some(ch) if is_paired_open(ch) => Some(ch),
         _ => None,
     }
+}
+
+fn is_invalid_transliteration_delimiter(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch.is_whitespace() || ch == '\\'
 }
 
 /// Extract content between delimiters and return (content, rest)

--- a/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
+++ b/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
@@ -1,7 +1,4 @@
 //! Regression tests for strict transliteration parsing.
-//!
-//! Ensures `tr///` and `y///` parsing supports optional whitespace before
-//! delimiters and rejects invalid modifier characters with diagnostics.
 
 mod cpan_test_helpers;
 use cpan_test_helpers::*;
@@ -13,7 +10,29 @@ fn transliteration_allows_whitespace_before_delimiter() {
 }
 
 #[test]
-fn transliteration_rejects_invalid_modifiers() {
+fn transliteration_rejects_invalid_delimiter_and_modifiers() {
     assert_has_error(r#"$x =~ tr/a-z/A-Z/z;"#, "invalid transliteration modifier");
     assert_has_error(r#"$x =~ y/a-z/A-Z/1;"#, "invalid transliteration modifier");
+}
+
+#[test]
+fn transliteration_handles_empty_and_unicode_bodies() {
+    assert_has_error(r#"$x =~ tr///;"#, "missing search list in transliteration");
+    assert_clean_parse(r#"$x =~ tr/🦀α/🐪β/r;"#);
+    assert_clean_parse(r#"$x =~ tr/a\\/b/c\\/d/;"#);
+}
+
+#[test]
+fn transliteration_detects_malformed_closures() {
+    assert_has_error(r#"$x =~ tr{abc}{xyz;"#, "missing closing delimiter in transliteration");
+    assert_has_error(r#"$x =~ tr/a/b"#, "missing closing delimiter in transliteration");
+}
+
+#[test]
+fn transliteration_accepts_only_valid_flags() {
+    assert_clean_parse(r#"$x =~ tr/a/b/c;"#);
+    assert_clean_parse(r#"$x =~ tr/a/b/d;"#);
+    assert_clean_parse(r#"$x =~ tr/a/b/s;"#);
+    assert_clean_parse(r#"$x =~ tr/a/b/r;"#);
+    assert_has_error(r#"$x =~ tr/a/b/q;"#, "invalid transliteration modifier");
 }

--- a/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
+++ b/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
@@ -1,18 +1,5 @@
-/// Minimal reproduction case for transliteration parsing bug discovered in fuzz testing
-///
-/// CRASH DETAILS:
-/// - Input: "tr/abc/xyz/"
-/// - Expected: ("abc", "xyz", "")
-/// - Actual: ("abc", "", "xyz")
-///
-/// This indicates a critical bug in extract_transliteration_parts where the replacement
-/// and modifiers are being swapped for non-paired delimiters.
-///
-/// IMPACT: This affects Perl transliteration operator parsing throughout the entire
-/// parser pipeline, potentially causing incorrect syntax highlighting, code analysis,
-/// and refactoring operations.
-///
-/// REPRODUCTION: Run with `cargo test -p perl-parser --test fuzz_transliteration_crash_repro`
+//! Regression coverage for transliteration parser fuzz repros.
+
 use perl_parser::quote_parser::extract_transliteration_parts;
 
 #[test]
@@ -20,12 +7,6 @@ fn minimal_transliteration_crash_repro() {
     let input = "tr/abc/xyz/";
     let (search, replace, modifiers) = extract_transliteration_parts(input);
 
-    println!("FUZZ BUG REPRODUCED: tr// parsing issue");
-    println!("Input: {}", input);
-    println!("Expected: ('abc', 'xyz', '')");
-    println!("Actual: ('{}', '{}', '{}')", search, replace, modifiers);
-
-    // Demonstrate the bug - these will fail due to the parsing issue
     assert_eq!(search.as_str(), "abc", "Search pattern incorrect");
     assert_eq!(replace.as_str(), "xyz", "Replace pattern incorrect");
     assert_eq!(modifiers.as_str(), "", "Modifiers incorrect");
@@ -33,24 +14,19 @@ fn minimal_transliteration_crash_repro() {
 
 #[test]
 fn fuzz_transliteration_regression_suite() {
-    // Test additional variants that likely have the same bug
-    let test_cases = vec![
+    let test_cases = [
         ("y/abc/xyz/", ("abc", "xyz", "")),
         ("tr/a/b/d", ("a", "b", "d")),
-        ("y/x/y/g", ("x", "y", "")), // 'g' is not a valid transliteration modifier
-        ("tr{abc}{xyz}d", ("abc", "xyz", "d")), // This might work correctly with paired delimiters
+        ("y/x/y/g", ("x", "y", "")), // `g` is not a valid transliteration modifier.
+        ("tr{abc}{xyz}d", ("abc", "xyz", "d")),
+        ("tr{abc}/xyz/d", ("abc", "xyz", "d")),
+        ("tr{abc}xyz", ("abc", "", "")),
+        ("tr /escaped\\/slash/repl/", ("escaped\\/slash", "repl", "")),
     ];
 
     for (input, expected) in test_cases {
         let (search, replace, modifiers) = extract_transliteration_parts(input);
         let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
-
-        println!("Testing: {} -> expected {:?}, got {:?}", input, expected, actual);
-
-        if actual != expected {
-            println!("  BUG CONFIRMED in variant: {}", input);
-        } else {
-            println!("  PASSED: {}", input);
-        }
+        assert_eq!(actual, expected, "unexpected transliteration parse for `{input}`");
     }
 }

--- a/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
+++ b/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
@@ -1,0 +1,34 @@
+//! Focused transliteration regression bank used by parser accuracy ratchets.
+
+use perl_parser::quote_parser::extract_transliteration_parts;
+
+#[test]
+fn transliteration_regression_bank_cases() {
+    let cases = [
+        // Escaped delimiter in search body.
+        ("tr/a\\/b/c/", ("a\\/b", "c", "")),
+        // Unicode and multibyte content.
+        ("tr/🦀α/🐪β/", ("🦀α", "🐪β", "")),
+        // Empty search and replacement bodies (no panic; stable extraction).
+        ("tr///", ("", "", "")),
+        ("tr//x/", ("", "x", "")),
+        ("tr/x//", ("x", "", "")),
+        // Malformed closures should not leak replacement/modifiers.
+        ("tr{abc}{xyz", ("abc", "xyz", "")),
+        ("tr{abc}xyz", ("abc", "", "")),
+        // Valid transliteration modifiers.
+        ("tr/a/b/c", ("a", "b", "c")),
+        ("tr/a/b/d", ("a", "b", "d")),
+        ("tr/a/b/s", ("a", "b", "s")),
+        ("tr/a/b/r", ("a", "b", "r")),
+        ("tr/a/b/cdsr", ("a", "b", "cdsr")),
+        // Invalid modifiers are ignored by non-strict extraction.
+        ("tr/a/b/z", ("a", "b", "")),
+    ];
+
+    for (input, expected) in cases {
+        let (search, replacement, modifiers) = extract_transliteration_parts(input);
+        let actual = (search.as_str(), replacement.as_str(), modifiers.as_str());
+        assert_eq!(actual, expected, "regression case failed for `{input}`");
+    }
+}


### PR DESCRIPTION
### Motivation

- Close a fuzz-found failure where `tr///` / `y///` parsing could mis-extract search, replacement, and modifiers for malformed or non-paired delimiter forms.
- Prevent regressions by tightening delimiter handling and encoding the fixed cases into the parser accuracy ratchet.

### Description

- Trim optional whitespace after the `tr`/`y` operator and reject clearly invalid transliteration delimiters (alphanumeric, whitespace, or `\\`).
- Use strict delimiter extraction for the search list (`extract_delimited_content_strict`) and require the search delimiter to close before proceeding.
- Parse replacement lists consistently for paired and non-paired delimiters (strict paired extraction, safe unpaired parsing that skips strings), and add `is_invalid_transliteration_delimiter` guard.
- Validate transliteration modifiers consistently (allowed: `c`, `d`, `s`, `r`) and add focused regression tests: updated strict parsing tests, a fuzz repro test (`fuzz_transliteration_crash_repro.rs`), and a new regression bank (`quote_transliteration_regression_bank.rs`) covering escaped delimiters, Unicode/multibyte, empty bodies, malformed closures, and modifier cases.

### Testing

- Ran formatter: `cargo xtask fmt` (succeeded).
- Unit/test runs: `cargo test -p perl-parser quote_transliteration` (succeeded), `cargo test -p perl-parser fuzz_transliteration_crash_repro` (succeeded), and `cargo test -p perl-parser-core transliteration` (succeeded).
- Build/verification: `cargo check --all-targets -p perl-parser-core` and `cargo check --all-targets -p perl-parser` (both succeeded).
- Note: `just parser-audit`, `just corpus-sweep-check`, and `just cpan-corpus-check` were not run in this environment because `just` is not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53f030388333a6c9fd8fb9bc7439)