### PR TITLE
fix(parser): harden transliteration parsing and ratchet regressions (#0000)

### DIFF
--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -302,19 +302,23 @@ pub fn extract_substitution_parts(text: &str) -> (String, String, String) {
 /// Extract search, replace, and modifiers from a transliteration token
 pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
     // Skip 'tr' or 'y' prefix
-    let content = if let Some(stripped) = text.strip_prefix("tr") {
+    let after_op = if let Some(stripped) = text.strip_prefix("tr") {
         stripped
     } else if let Some(stripped) = text.strip_prefix('y') {
         stripped
     } else {
         text
     };
+    let content = after_op.trim_start();
 
     // Get delimiter - content must be non-empty to have a delimiter
     let delimiter = match content.chars().next() {
         Some(d) => d,
         None => return (String::new(), String::new(), String::new()),
     };
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return (String::new(), String::new(), String::new());
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
@@ -409,6 +413,9 @@ pub fn extract_transliteration_parts_strict(
         Some(d) => d,
         None => return Err(TransliterationError::MissingDelimiter),
     };
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return Err(TransliterationError::MissingDelimiter);
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 

--- a/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
+++ b/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
@@ -17,3 +17,17 @@ fn transliteration_rejects_invalid_modifiers() {
     assert_has_error(r#"$x =~ tr/a-z/A-Z/z;"#, "invalid transliteration modifier");
     assert_has_error(r#"$x =~ y/a-z/A-Z/1;"#, "invalid transliteration modifier");
 }
+
+#[test]
+fn transliteration_strict_handles_edge_cases() {
+    assert_clean_parse(r#"$x =~ tr/a\/b/c\/d/;"#);
+    assert_clean_parse(r#"$x =~ tr/αβγ/ΑΒΓ/;"#);
+    assert_clean_parse(r#"$x =~ tr/a/b/cdsr;"#);
+    assert_clean_parse(r#"$x =~ tr{abc}{xyz}r;"#);
+    assert_clean_parse(r#"$x =~ tr[abc]{xyz}r;"#);
+
+    assert_has_error(r#"$x =~ tr///;"#, "missing search list");
+    assert_has_error(r#"$x =~ tr/a/b/z;"#, "invalid transliteration modifier");
+    assert_has_error(r#"$x =~ tr/a/b;"#, "closing delimiter in transliteration");
+    assert_has_error(r#"$x =~ tr{abc}{xyz;"#, "closing delimiter in transliteration");
+}

--- a/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
+++ b/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
@@ -1,31 +1,10 @@
-/// Minimal reproduction case for transliteration parsing bug discovered in fuzz testing
-///
-/// CRASH DETAILS:
-/// - Input: "tr/abc/xyz/"
-/// - Expected: ("abc", "xyz", "")
-/// - Actual: ("abc", "", "xyz")
-///
-/// This indicates a critical bug in extract_transliteration_parts where the replacement
-/// and modifiers are being swapped for non-paired delimiters.
-///
-/// IMPACT: This affects Perl transliteration operator parsing throughout the entire
-/// parser pipeline, potentially causing incorrect syntax highlighting, code analysis,
-/// and refactoring operations.
-///
-/// REPRODUCTION: Run with `cargo test -p perl-parser --test fuzz_transliteration_crash_repro`
+/// Minimal regression suite for transliteration parsing bug discovered in fuzz testing.
 use perl_parser::quote_parser::extract_transliteration_parts;
 
 #[test]
 fn minimal_transliteration_crash_repro() {
     let input = "tr/abc/xyz/";
     let (search, replace, modifiers) = extract_transliteration_parts(input);
-
-    println!("FUZZ BUG REPRODUCED: tr// parsing issue");
-    println!("Input: {}", input);
-    println!("Expected: ('abc', 'xyz', '')");
-    println!("Actual: ('{}', '{}', '{}')", search, replace, modifiers);
-
-    // Demonstrate the bug - these will fail due to the parsing issue
     assert_eq!(search.as_str(), "abc", "Search pattern incorrect");
     assert_eq!(replace.as_str(), "xyz", "Replace pattern incorrect");
     assert_eq!(modifiers.as_str(), "", "Modifiers incorrect");
@@ -33,24 +12,17 @@ fn minimal_transliteration_crash_repro() {
 
 #[test]
 fn fuzz_transliteration_regression_suite() {
-    // Test additional variants that likely have the same bug
-    let test_cases = vec![
+    let test_cases = [
         ("y/abc/xyz/", ("abc", "xyz", "")),
         ("tr/a/b/d", ("a", "b", "d")),
-        ("y/x/y/g", ("x", "y", "")), // 'g' is not a valid transliteration modifier
-        ("tr{abc}{xyz}d", ("abc", "xyz", "d")), // This might work correctly with paired delimiters
+        ("y/x/y/g", ("x", "y", "")),
+        ("tr{abc}{xyz}d", ("abc", "xyz", "d")),
+        ("tr   /ab/cd/", ("ab", "cd", "")),
     ];
 
     for (input, expected) in test_cases {
         let (search, replace, modifiers) = extract_transliteration_parts(input);
         let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
-
-        println!("Testing: {} -> expected {:?}, got {:?}", input, expected, actual);
-
-        if actual != expected {
-            println!("  BUG CONFIRMED in variant: {}", input);
-        } else {
-            println!("  PASSED: {}", input);
-        }
+        assert_eq!(actual, expected, "transliteration parse mismatch for `{input}`");
     }
 }

--- a/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
+++ b/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
@@ -10,10 +10,15 @@ fn transliteration_regression_bank_non_strict_cases() {
         ("tr/a/b/z", ("a", "b", ""), "invalid modifiers are ignored by non-strict parser"),
         ("tr{abc}{xyz}d", ("abc", "xyz", "d"), "paired delimiters"),
         ("tr[abc]{xyz}r", ("abc", "xyz", "r"), "mixed paired delimiters"),
-        ("tr   /abc/xyz/", ("abc", "xyz", ""), "optional whitespace after operator"),
+        ("tr   /abc/xyz/", ("abc", "xyz", ""), "optional whitespace after tr operator"),
+        ("y   /abc/xyz/", ("abc", "xyz", ""), "optional whitespace after y operator"),
         ("tr", ("", "", ""), "missing delimiter"),
-        ("trabc/xyz/", ("", "", ""), "invalid alphanumeric delimiter rejected"),
+        ("trabc/xyz/", ("", "", ""), "invalid alphanumeric delimiter rejected after tr"),
+        ("yabc/xyz/", ("", "", ""), "invalid alphanumeric delimiter rejected after y"),
         ("tr/abc", ("abc", "", ""), "malformed missing replacement closure does not panic"),
+        // Spaces between modifiers: take_while(is_ascii_alphabetic) stops at the space,
+        // so only 'c' is collected. Perl does not allow spaces inside modifier strings.
+        ("tr/a/b/c d s r", ("a", "b", "c"), "spaces in modifier string truncates at first space"),
     ];
 
     for (input, expected, label) in cases {

--- a/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
+++ b/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
@@ -1,0 +1,27 @@
+use perl_parser::quote_parser::extract_transliteration_parts;
+
+#[test]
+fn transliteration_regression_bank_non_strict_cases() {
+    let cases = [
+        ("tr/a\\/b/c\\/d/", ("a\\/b", "c\\/d", ""), "escaped delimiter in search and replacement"),
+        ("tr/αβγ/ΑΒΓ/", ("αβγ", "ΑΒΓ", ""), "unicode multibyte bodies"),
+        ("tr///", ("", "", ""), "empty search and replacement"),
+        ("tr/a/b/cdsr", ("a", "b", "cdsr"), "all supported modifiers"),
+        ("tr/a/b/z", ("a", "b", ""), "invalid modifiers are ignored by non-strict parser"),
+        ("tr{abc}{xyz}d", ("abc", "xyz", "d"), "paired delimiters"),
+        ("tr[abc]{xyz}r", ("abc", "xyz", "r"), "mixed paired delimiters"),
+        ("tr   /abc/xyz/", ("abc", "xyz", ""), "optional whitespace after operator"),
+        ("tr", ("", "", ""), "missing delimiter"),
+        ("trabc/xyz/", ("", "", ""), "invalid alphanumeric delimiter rejected"),
+        ("tr/abc", ("abc", "", ""), "malformed missing replacement closure does not panic"),
+    ];
+
+    for (input, expected, label) in cases {
+        let actual = extract_transliteration_parts(input);
+        assert_eq!(
+            actual,
+            (expected.0.to_string(), expected.1.to_string(), expected.2.to_string()),
+            "{label}: `{input}`"
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- A fuzz repro showed `tr///`/`y///` parsing could mis-extract replacement and modifiers for malformed or non-paired delimiter forms, causing incorrect downstream analysis. 
- The parser must accept optional whitespace after `tr`/`y`, but reject invalid delimiters and validate modifiers to close the transliteration/quote-like failure family. 
- Add regression coverage so fixes are locked in for CPAN-style and malformed inputs. 

### Description
- Trim optional whitespace after the `tr`/`y` operator and reject alphanumeric or whitespace characters as delimiters in `extract_transliteration_parts` and `extract_transliteration_parts_strict` by returning empty/`MissingDelimiter` early. 
- Keep strict delimiter extraction for the search body using `extract_delimited_content_strict` and ensure consistent handling of paired vs non‑paired replacement delimiters and modifier validation (`c`, `d`, `s`, `r`). 
- Replace the noisy fuzz repro with a deterministic regression test (`crash_repro`) and add a new non-strict regression bank `quote_transliteration_regression_bank.rs` covering escaped delimiters, Unicode, empty/malformed bodies, paired/mixed delimiters, and modifier edge cases. 
- Expand strict-parser tests in `fix_transliteration_strict_parsing.rs` to assert both clean parses for valid edge cases and expected diagnostics for malformed inputs. 

### Testing
- Ran `cargo test -p perl-parser-core --test fix_transliteration_strict_parsing` and it passed (3 tests: all ok). 
- Ran `cargo test -p perl-parser quote_transliteration` and `cargo test -p perl-parser fuzz_transliteration_crash_repro` and the targeted transliteration tests completed successfully. 
- Ran `cargo test -p perl-parser-core transliteration` and targeted core transliteration tests passed. 
- Ran `cargo check --all-targets -p perl-parser-core` and `cargo check --all-targets -p perl-parser` and both succeeded. 
- Attempts to run `just parser-audit`, `just corpus-sweep-check`, and `just cpan-corpus-check` failed in this environment because `just` is not installed, so those gates were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53f030388333a6c9fd8fb9bc7439)