### PR TITLE
fix(parser): recover incomplete string interpolation indexing without ERROR nodes (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -864,7 +864,12 @@ impl<'a> PerlLexer<'a> {
     }
 
     #[inline]
-    fn consume_balanced_segment(&mut self, open: char, close: char) -> Option<usize> {
+    fn consume_balanced_segment(
+        &mut self,
+        open: char,
+        close: char,
+        string_delim: Option<char>,
+    ) -> Option<usize> {
         if self.current_char() != Some(open) {
             return None;
         }
@@ -872,6 +877,13 @@ impl<'a> PerlLexer<'a> {
         let mut depth = 1usize;
         self.advance();
         while let Some(ch) = self.current_char() {
+            // Recovery for incomplete interpolation tails in strings: when a quoted
+            // string closes before the interpolation segment closes, stop scanning
+            // and leave the quote for the outer string parser.
+            if string_delim.is_some() && Some(ch) == string_delim {
+                return None;
+            }
+
             match ch {
                 '\\' => {
                     self.advance();
@@ -2806,7 +2818,7 @@ impl<'a> PerlLexer<'a> {
                     self.advance();
                     match self.current_char() {
                         Some('{') => {
-                            if let Some(end) = self.consume_balanced_segment('{', '}') {
+                            if let Some(end) = self.consume_balanced_segment('{', '}', Some('"')) {
                                 parts.push(StringPart::Expression(Arc::from(
                                     &self.input[part_start..end],
                                 )));
@@ -2847,19 +2859,22 @@ impl<'a> PerlLexer<'a> {
 
                                     match self.current_char() {
                                         Some('[') => {
-                                            let _ = self.consume_balanced_segment('[', ']');
+                                            let _ =
+                                                self.consume_balanced_segment('[', ']', Some('"'));
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
                                         }
                                         Some('{') => {
-                                            let _ = self.consume_balanced_segment('{', '}');
+                                            let _ =
+                                                self.consume_balanced_segment('{', '}', Some('"'));
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
                                         }
                                         Some('(') => {
-                                            let _ = self.consume_balanced_segment('(', ')');
+                                            let _ =
+                                                self.consume_balanced_segment('(', ')', Some('"'));
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
@@ -2884,7 +2899,11 @@ impl<'a> PerlLexer<'a> {
                                                 }
                                             }
                                             if self.current_char() == Some('(') {
-                                                let _ = self.consume_balanced_segment('(', ')');
+                                                let _ = self.consume_balanced_segment(
+                                                    '(',
+                                                    ')',
+                                                    Some('"'),
+                                                );
                                             }
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
@@ -2898,13 +2917,13 @@ impl<'a> PerlLexer<'a> {
                                     }
                                 } else if self.current_char() == Some('[') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('[', ']');
+                                    let _ = self.consume_balanced_segment('[', ']', Some('"'));
                                     parts.push(StringPart::ArraySlice(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));
                                 } else if self.current_char() == Some('{') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('{', '}');
+                                    let _ = self.consume_balanced_segment('{', '}', Some('"'));
                                     parts.push(StringPart::Expression(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -71,6 +71,9 @@ impl<'a> Parser<'a> {
                 let token = self.tokens.next()?;
                 // Check if it's a double-quoted string (interpolated)
                 let interpolated = token.text.starts_with('"');
+                if interpolated {
+                    self.record_incomplete_interpolation_index_diagnostics(&token.text, token.start);
+                }
                 Ok(Node::new(
                     NodeKind::String { value: token.text.to_string(), interpolated },
                     SourceLocation { start: token.start, end: token.end },
@@ -1004,5 +1007,98 @@ impl<'a> Parser<'a> {
                 Err(ParseError::unexpected("expression", token_kind.display_name(), pos))
             }
         }
+    }
+
+    fn record_incomplete_interpolation_index_diagnostics(&mut self, text: &str, start: usize) {
+        let Some(body) = text.strip_prefix('"').and_then(|s| s.strip_suffix('"')) else {
+            return;
+        };
+
+        let bytes = body.as_bytes();
+        let mut i = 0usize;
+        while i < bytes.len() {
+            if bytes[i] == b'\\' {
+                i = i.saturating_add(2);
+                continue;
+            }
+
+            if bytes[i] != b'$' {
+                i += 1;
+                continue;
+            }
+
+            let mut j = i + 1;
+            while j < bytes.len() {
+                let b = bytes[j];
+                if (b as char).is_ascii_alphanumeric() || b == b'_' {
+                    j += 1;
+                } else {
+                    break;
+                }
+            }
+
+            // Ignore punctuation vars like $!, $$, etc.
+            if j == i + 1 {
+                i += 1;
+                continue;
+            }
+
+            if let Some((open_idx, open, close)) = Self::find_interpolation_opener(bytes, j) {
+                if Self::scan_balanced_interpolation(bytes, open_idx, open, close).is_none() {
+                    self.record_error(ParseError::syntax(
+                        format!(
+                            "Unclosed '{}' in string interpolation before closing quote",
+                            open
+                        ),
+                        start + 1 + open_idx,
+                    ));
+                    break;
+                }
+            }
+
+            i = j;
+        }
+    }
+
+    fn find_interpolation_opener(bytes: &[u8], mut idx: usize) -> Option<(usize, char, char)> {
+        if idx + 2 < bytes.len() && bytes[idx] == b'-' && bytes[idx + 1] == b'>' {
+            idx += 2;
+        }
+
+        match bytes.get(idx).copied() {
+            Some(b'{') => Some((idx, '{', '}')),
+            Some(b'[') => Some((idx, '[', ']')),
+            _ => None,
+        }
+    }
+
+    fn scan_balanced_interpolation(
+        bytes: &[u8],
+        open_idx: usize,
+        open: char,
+        close: char,
+    ) -> Option<usize> {
+        let mut depth = 0usize;
+        let mut i = open_idx;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'\\' => {
+                    i = i.saturating_add(2);
+                    continue;
+                }
+                c if c == open as u8 => {
+                    depth += 1;
+                }
+                c if c == close as u8 => {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        return Some(i);
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        None
     }
 }

--- a/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
+++ b/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
@@ -1,0 +1,71 @@
+mod cpan_test_helpers;
+
+use cpan_test_helpers::{assert_clean_parse, parse};
+
+#[test]
+fn double_quote_incomplete_hash_key() {
+    let source = "my $msg = \"Key: $hash{incomplete\";";
+    assert_clean_parse(source);
+
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("$hash"), "expected $hash to remain present in parse output: {sexp}");
+
+    let mut parser = perl_parser_core::Parser::new(source);
+    let _ = parser.parse();
+    assert!(
+        !parser.get_errors().is_empty(),
+        "expected a diagnostic for incomplete hash interpolation"
+    );
+}
+
+#[test]
+fn double_quote_incomplete_array_index() {
+    let source = "my $item = \"Element: $array[0\";";
+    assert_clean_parse(source);
+
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("$array"), "expected $array to remain present in parse output: {sexp}");
+
+    let mut parser = perl_parser_core::Parser::new(source);
+    let _ = parser.parse();
+    assert!(
+        !parser.get_errors().is_empty(),
+        "expected a diagnostic for incomplete array interpolation"
+    );
+}
+
+#[test]
+fn double_quote_incomplete_arrow_hash_field() {
+    let source = "my $msg = \"Nested: $obj->{field\";";
+    assert_clean_parse(source);
+
+    let mut parser = perl_parser_core::Parser::new(source);
+    let _ = parser.parse();
+    assert!(
+        !parser.get_errors().is_empty(),
+        "expected a diagnostic for incomplete arrow hash interpolation"
+    );
+}
+
+#[test]
+fn double_quote_incomplete_mixed_array_index() {
+    let source = "my $msg = \"Mixed: $array[$i\";";
+    assert_clean_parse(source);
+
+    let mut parser = perl_parser_core::Parser::new(source);
+    let _ = parser.parse();
+    assert!(
+        !parser.get_errors().is_empty(),
+        "expected a diagnostic for incomplete mixed array interpolation"
+    );
+}
+
+#[test]
+fn double_quote_complete_interpolation_still_clean() {
+    assert_clean_parse("my $msg = \"Key: $hash{complete}\";");
+    assert_clean_parse("my $item = \"Element: $array[0]\";");
+    assert_clean_parse("my $msg = \"Nested: $obj->{field}\";");
+    assert_clean_parse("my $msg = \"Mixed: $array[$i]\";");
+}


### PR DESCRIPTION
### Motivation
- While typing, users frequently produce incomplete interpolation indexers inside double-quoted strings (e.g. `$hash{incomplete`, `$array[0`, `$obj->{field`) and the lexer could consume the closing quote which caused the parser to emit top-level ERROR nodes and lose useful AST for symbol extraction.

### Description
- Add string-aware balanced-segment scanning in the lexer so interpolation tail scans stop at the string closing quote instead of consuming the rest of the literal; this preserves the outer string token and avoids ERROR propagation (changes in `crates/perl-lexer/src/lib.rs`).
- Add a parser-side diagnostic pass that inspects interpolated `TokenKind::String` text and records a targeted syntax diagnostic for unclosed `{` or `[` interpolation tails without converting the AST into ERROR nodes (`crates/perl-parser-core/src/engine/parser/expressions/primary.rs`).
- Add focused tests exercising incomplete and complete interpolation scenarios to ensure variables like `$hash`/`$array` remain present in the AST and diagnostics are still produced (`crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs`).

### Testing
- Ran `cargo test -p perl-parser-core --test string_interpolation_incomplete_tests` and the new focused tests passed.
- Ran `cargo test -p perl-parser-core string_interpolation` and the targeted string-interpolation test group passed.
- Ran `cargo test -p perl-parser-core -q` (full crate test); the suite mostly passed but there remains a separate existing failing test `test_deref_hash_subscript_regex_key` which predates these changes and still fails (observed during verification).
- `just parser-audit` and `just cpan-corpus-check` could not be executed in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53f391d88333863ff64d42e3d555)