### PR TITLE
fix(parser): recover incomplete string interpolation indexing without ERROR nodes (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -897,6 +897,54 @@ impl<'a> PerlLexer<'a> {
         None
     }
 
+    /// Consume a balanced segment inside a double-quoted string interpolation.
+    ///
+    /// Unlike `consume_balanced_segment`, this variant stops before an unescaped
+    /// closing double-quote so interpolation-local delimiter mistakes (like
+    /// `$hash{incomplete"`) do not consume the string terminator and poison the
+    /// whole token as "unterminated string".
+    #[inline]
+    fn consume_balanced_segment_in_double_quote(
+        &mut self,
+        open: char,
+        close: char,
+    ) -> Option<usize> {
+        if self.current_char() != Some(open) {
+            return None;
+        }
+
+        let mut depth = 1usize;
+        self.advance();
+        while let Some(ch) = self.current_char() {
+            match ch {
+                '\\' => {
+                    self.advance();
+                    if self.current_char().is_some() {
+                        self.advance();
+                    }
+                }
+                '"' => {
+                    // Keep the quote for the outer string parser.
+                    return None;
+                }
+                c if c == open => {
+                    depth += 1;
+                    self.advance();
+                }
+                c if c == close => {
+                    self.advance();
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(self.position);
+                    }
+                }
+                _ => self.advance(),
+            }
+        }
+
+        None
+    }
+
     /// Fast byte-level check for ASCII characters
     #[inline]
     fn peek_byte(&self, offset: usize) -> Option<u8> {
@@ -2847,19 +2895,22 @@ impl<'a> PerlLexer<'a> {
 
                                     match self.current_char() {
                                         Some('[') => {
-                                            let _ = self.consume_balanced_segment('[', ']');
+                                            let _ = self
+                                                .consume_balanced_segment_in_double_quote('[', ']');
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
                                         }
                                         Some('{') => {
-                                            let _ = self.consume_balanced_segment('{', '}');
+                                            let _ = self
+                                                .consume_balanced_segment_in_double_quote('{', '}');
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
                                         }
                                         Some('(') => {
-                                            let _ = self.consume_balanced_segment('(', ')');
+                                            let _ = self
+                                                .consume_balanced_segment_in_double_quote('(', ')');
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
@@ -2884,7 +2935,11 @@ impl<'a> PerlLexer<'a> {
                                                 }
                                             }
                                             if self.current_char() == Some('(') {
-                                                let _ = self.consume_balanced_segment('(', ')');
+                                                let _ = self
+                                                    .consume_balanced_segment_in_double_quote(
+                                                        '(',
+                                                        ')',
+                                                    );
                                             }
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
@@ -2898,13 +2953,13 @@ impl<'a> PerlLexer<'a> {
                                     }
                                 } else if self.current_char() == Some('[') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('[', ']');
+                                    let _ = self.consume_balanced_segment_in_double_quote('[', ']');
                                     parts.push(StringPart::ArraySlice(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));
                                 } else if self.current_char() == Some('{') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('{', '}');
+                                    let _ = self.consume_balanced_segment_in_double_quote('{', '}');
                                     parts.push(StringPart::Expression(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));

--- a/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
+++ b/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
@@ -1,0 +1,28 @@
+mod cpan_test_helpers;
+
+use cpan_test_helpers::assert_clean_parse;
+
+#[test]
+fn double_quote_incomplete_hash_key() {
+    assert_clean_parse("my $msg = \"Key: $hash{incomplete\";");
+}
+
+#[test]
+fn double_quote_incomplete_array_index() {
+    assert_clean_parse("my $item = \"Element: $array[0\";");
+}
+
+#[test]
+fn double_quote_incomplete_nested_arrow_hash_field() {
+    assert_clean_parse("my $msg = \"Nested: $obj->{field\";");
+}
+
+#[test]
+fn double_quote_incomplete_mixed_array_index_expr() {
+    assert_clean_parse("my $msg = \"Mixed: $array[$i\";");
+}
+
+#[test]
+fn double_quote_complete_interpolation_still_parses_cleanly() {
+    assert_clean_parse("my $msg = \"Key: $hash{complete}; Element: $array[0]; Nested: $obj->{field}; Mixed: $array[$i]\";");
+}

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1740,6 +1740,34 @@ my $msg = "value: ${Foo::name}";
 }
 
 #[test]
+fn incomplete_hash_subscript_interpolation_keeps_base_variable_reference()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $msg = "Key: $hash{incomplete";
+"#;
+    let table = parse_and_extract(code);
+    assert!(
+        table.references.contains_key("hash"),
+        "$hash should still register a reference when interpolation-local hash key is incomplete",
+    );
+    Ok(())
+}
+
+#[test]
+fn incomplete_array_index_interpolation_keeps_base_variable_reference()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $item = "Element: $array[0";
+"#;
+    let table = parse_and_extract(code);
+    assert!(
+        table.references.contains_key("array"),
+        "$array should still register a reference when interpolation-local index is incomplete",
+    );
+    Ok(())
+}
+
+#[test]
 fn escaped_interpolated_variable_is_still_unused() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 my $name = "World";


### PR DESCRIPTION
### Motivation

- Incomplete indexing inside double-quoted interpolation (e.g. `"Key: $hash{incomplete"` or `"Element: $array[0"`) could cause the lexer to consume the closing `"` and produce an unterminated-string/ERROR node that pollutes the top-level AST and breaks symbol extraction.

### Description

- Add `consume_balanced_segment_in_double_quote` in the lexer to parse balanced segments inside interpolations but stop before an unescaped closing `"` so the outer string token remains intact.
- Replace interpolation-tail balanced-segment calls in the double-quote interpolation path to use the new `consume_balanced_segment_in_double_quote` for `[...]`, `{...}`, and `(...)` contexts to avoid swallowing the string terminator.
- Add parser-level regression tests in `crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs` covering incomplete hash and array interpolation forms and a baseline complete case.
- Add semantic-analyzer tests in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` asserting that base variable references for `$hash` and `@array` remain extractable when their interpolation indexing is incomplete.

### Testing

- Ran `cargo test -p perl-parser-core string_interpolation` and it passed.
- Ran `cargo test -p perl-parser-core double_quote_incomplete` and the new/in-scope tests passed (`4` tests reported as passing).
- Ran `cargo test -p perl-parser-core` which mostly passed but failed one pre-existing unrelated test (`test_deref_hash_subscript_regex_key`) producing an `Error` node; this failure appears unrelated to the interpolation change.
- Ran `cargo test -p perl-semantic-analyzer` filtered to the new tests (via name prefix) and the two new semantic tests passed.
- Could not run `just parser-audit` or `just cpan-corpus-check` in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53f391d88333863ff64d42e3d555)