### PR TITLE
fix(parser): recover incomplete string interpolation indexing without ERROR nodes (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -897,6 +897,56 @@ impl<'a> PerlLexer<'a> {
         None
     }
 
+    /// Consume a balanced segment inside a double-quoted string interpolation.
+    ///
+    /// Unlike `consume_balanced_segment`, this recovery-friendly variant stops
+    /// before the closing `"` of the containing string when the interpolation
+    /// segment is unclosed (e.g. `$hash{incomplete"`). That keeps the outer
+    /// string lexically recoverable instead of swallowing the closing quote and
+    /// turning the whole remainder into an unterminated-string error token.
+    #[inline]
+    fn consume_balanced_segment_in_dq_interpolation(
+        &mut self,
+        open: char,
+        close: char,
+    ) -> Option<usize> {
+        if self.current_char() != Some(open) {
+            return None;
+        }
+
+        let mut depth = 1usize;
+        self.advance();
+        while let Some(ch) = self.current_char() {
+            match ch {
+                '\\' => {
+                    self.advance();
+                    if self.current_char().is_some() {
+                        self.advance();
+                    }
+                }
+                '"' if depth == 1 => {
+                    // Recovery boundary: stop before consuming the enclosing
+                    // string terminator so the caller can finish the string.
+                    return None;
+                }
+                c if c == open => {
+                    depth += 1;
+                    self.advance();
+                }
+                c if c == close => {
+                    self.advance();
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(self.position);
+                    }
+                }
+                _ => self.advance(),
+            }
+        }
+
+        None
+    }
+
     /// Fast byte-level check for ASCII characters
     #[inline]
     fn peek_byte(&self, offset: usize) -> Option<u8> {
@@ -2847,13 +2897,19 @@ impl<'a> PerlLexer<'a> {
 
                                     match self.current_char() {
                                         Some('[') => {
-                                            let _ = self.consume_balanced_segment('[', ']');
+                                            let _ = self
+                                                .consume_balanced_segment_in_dq_interpolation(
+                                                    '[', ']',
+                                                );
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
                                         }
                                         Some('{') => {
-                                            let _ = self.consume_balanced_segment('{', '}');
+                                            let _ = self
+                                                .consume_balanced_segment_in_dq_interpolation(
+                                                    '{', '}',
+                                                );
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
@@ -2898,13 +2954,15 @@ impl<'a> PerlLexer<'a> {
                                     }
                                 } else if self.current_char() == Some('[') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('[', ']');
+                                    let _ =
+                                        self.consume_balanced_segment_in_dq_interpolation('[', ']');
                                     parts.push(StringPart::ArraySlice(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));
                                 } else if self.current_char() == Some('{') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('{', '}');
+                                    let _ =
+                                        self.consume_balanced_segment_in_dq_interpolation('{', '}');
                                     parts.push(StringPart::Expression(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));

--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -863,6 +863,12 @@ impl<'a> PerlLexer<'a> {
         }
     }
 
+    /// Consume a balanced segment, advancing past both delimiters.
+    ///
+    /// This is the general-purpose variant. For use inside double-quoted string
+    /// interpolation (where the outer `"` must be preserved as a recovery boundary),
+    /// use [`consume_balanced_segment_in_dq_interpolation`] instead.
+    #[allow(dead_code)]
     #[inline]
     fn consume_balanced_segment(&mut self, open: char, close: char) -> Option<usize> {
         if self.current_char() != Some(open) {
@@ -2856,7 +2862,11 @@ impl<'a> PerlLexer<'a> {
                     self.advance();
                     match self.current_char() {
                         Some('{') => {
-                            if let Some(end) = self.consume_balanced_segment('{', '}') {
+                            // Use the recovery-aware variant so an unclosed ${...}
+                            // expression doesn't swallow the enclosing string terminator.
+                            if let Some(end) =
+                                self.consume_balanced_segment_in_dq_interpolation('{', '}')
+                            {
                                 parts.push(StringPart::Expression(Arc::from(
                                     &self.input[part_start..end],
                                 )));
@@ -2915,7 +2925,10 @@ impl<'a> PerlLexer<'a> {
                                             )));
                                         }
                                         Some('(') => {
-                                            let _ = self.consume_balanced_segment('(', ')');
+                                            let _ = self
+                                                .consume_balanced_segment_in_dq_interpolation(
+                                                    '(', ')',
+                                                );
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
@@ -2940,7 +2953,10 @@ impl<'a> PerlLexer<'a> {
                                                 }
                                             }
                                             if self.current_char() == Some('(') {
-                                                let _ = self.consume_balanced_segment('(', ')');
+                                                let _ = self
+                                                    .consume_balanced_segment_in_dq_interpolation(
+                                                        '(', ')',
+                                                    );
                                             }
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],

--- a/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
+++ b/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
@@ -36,6 +36,33 @@ fn double_quote_complete_interpolation_still_works() {
     assert_clean_parse(source);
 }
 
+// Verify that a backslash-escaped quote inside an incomplete subscript is consumed
+// as an escape and does NOT trigger premature string termination.
+// Input: "$hash{key\"more" — the \" should be skipped, the final " terminates.
+#[test]
+fn double_quote_incomplete_with_escaped_quote_inside_subscript() {
+    // The \" is consumed as an escape sequence; the trailing " terminates the string.
+    let source = r#"my $x = "val: $hash{key\"more";"#;
+    assert_clean_parse(source);
+}
+
+// Verify recovery for the ${...} block-variable form, e.g. "${incomplete".
+// Before the fix, consume_balanced_segment would swallow the closing " and
+// produce an unterminated-string error.
+#[test]
+fn double_quote_incomplete_block_variable_form() {
+    let source = r#"my $x = "val: ${incomplete";"#;
+    assert_clean_parse(source);
+}
+
+// Verify recovery for an incomplete method-call argument list:
+// "$obj->method(incomplete" — the ( is never closed.
+#[test]
+fn double_quote_incomplete_method_call_args() {
+    let source = r#"my $x = "val: $obj->method(incomplete";"#;
+    assert_clean_parse(source);
+}
+
 #[test]
 fn lexer_preserves_base_variable_parts_for_incomplete_indexing() {
     let src = r#""Key: $hash{incomplete""#;

--- a/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
+++ b/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
@@ -1,0 +1,66 @@
+mod cpan_test_helpers;
+
+use std::sync::Arc;
+
+use cpan_test_helpers::assert_clean_parse;
+use perl_lexer::{PerlLexer, StringPart, TokenType};
+use perl_tdd_support::must_some;
+
+#[test]
+fn double_quote_incomplete_hash_key() {
+    let source = r#"my $msg = "Key: $hash{incomplete";"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn double_quote_incomplete_array_index() {
+    let source = r#"my $item = "Element: $array[0";"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn double_quote_incomplete_nested_arrow_hash_deref() {
+    let source = r#"my $nested = "Nested: $obj->{field";"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn double_quote_incomplete_mixed_index() {
+    let source = r#"my $mixed = "Mixed: $array[$i";"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn double_quote_complete_interpolation_still_works() {
+    let source = r#"my $ok = "Key: $hash{complete} Element: $array[0] Nested: $obj->{field} Mixed: $array[$i]";"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn lexer_preserves_base_variable_parts_for_incomplete_indexing() {
+    let src = r#""Key: $hash{incomplete""#;
+    let token = must_some(PerlLexer::new(src).next_token());
+
+    assert!(
+        matches!(
+            token.token_type,
+            TokenType::InterpolatedString(ref parts)
+                if parts.contains(&StringPart::Variable(Arc::from("$hash")))
+        ),
+        "expected variable part for $hash, got {:?}",
+        token.token_type
+    );
+
+    let src = r#""Element: $array[0""#;
+    let token = must_some(PerlLexer::new(src).next_token());
+
+    assert!(
+        matches!(
+            token.token_type,
+            TokenType::InterpolatedString(ref parts)
+                if parts.contains(&StringPart::Variable(Arc::from("$array")))
+        ),
+        "expected variable part for $array, got {:?}",
+        token.token_type
+    );
+}


### PR DESCRIPTION
### Motivation

- Double-quoted string interpolations with incomplete hash/array subscripts (e.g. `"Key: $hash{incomplete"`, `"Element: $array[0"`) could cause the lexer to swallow the closing quote and produce an unterminated-string error that poisoned top-level parsing and prevented variable-symbol extraction.
- Improve editor/typing UX by making interpolation-local failures recover without creating top-level `ERROR` nodes and by preserving the base variable parts for symbol extraction.

### Description

- Add a recovery-aware lexer helper `consume_balanced_segment_in_dq_interpolation` in `crates/perl-lexer/src/lib.rs` that stops at the enclosing `"` when a `{...` or `[...]` interpolation tail is unterminated, instead of consuming the string terminator.
- Use the new helper when scanning interpolation tails for method-call tails, array slices and hash-expression tails inside double-quoted string interpolation so incomplete tails don't turn the rest of the input into an unterminated-string `Error` token.
- Add focused regression tests in `crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs` covering incomplete hash-key, array-index, arrow-hash-deref, mixed incomplete interpolation, a complete-interpolation control case, and a lexer-level assertion that the base variable parts (`$hash`, `$array`) are preserved in incomplete cases.

### Testing

- Ran `cargo test -p perl-parser-core --test string_interpolation_incomplete_tests` and it passed (6 tests).
- Ran `cargo test -p perl-parser-core string_interpolation` and it passed for the string-interpolation test group.
- Ran `cargo test -p perl-parser-core`; an unrelated test (`test_deref_hash_subscript_regex_key`) failed on an initial run but the subsequent run completed successfully (full crate tests passed locally after re-run).
- Formatting applied with `cargo fmt`; `just parser-audit` and `just cpan-corpus-check` were not executed in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53f391d88333863ff64d42e3d555)