### PR TITLE
fix(parser): recover incomplete string interpolation indexing (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -897,6 +897,87 @@ impl<'a> PerlLexer<'a> {
         None
     }
 
+    /// Consume a balanced segment used by interpolation tails inside a double-quoted
+    /// string. Unlike `consume_balanced_segment`, this local recovery helper stops
+    /// before an unescaped `"` that appears before the closing delimiter so the
+    /// outer string parser can still terminate the string token cleanly.
+    fn consume_interpolation_segment_in_dq(&mut self, open: char, close: char) -> Option<usize> {
+        if self.current_char() != Some(open) {
+            return None;
+        }
+
+        let mut depth = 1usize;
+        self.advance();
+
+        while let Some(ch) = self.current_char() {
+            match ch {
+                '\\' => {
+                    self.advance();
+                    if self.current_char().is_some() {
+                        self.advance();
+                    }
+                }
+                '\'' => {
+                    let quote = ch;
+                    self.advance();
+                    while let Some(inner) = self.current_char() {
+                        match inner {
+                            '\\' => {
+                                self.advance();
+                                if self.current_char().is_some() {
+                                    self.advance();
+                                }
+                            }
+                            q if q == quote => {
+                                self.advance();
+                                break;
+                            }
+                            _ => self.advance(),
+                        }
+                    }
+                }
+                '"' => {
+                    if depth > 0 {
+                        // Recover locally: interpolation tail is incomplete, but the
+                        // surrounding string can still be completed by this quote.
+                        return None;
+                    }
+                    let quote = ch;
+                    self.advance();
+                    while let Some(inner) = self.current_char() {
+                        match inner {
+                            '\\' => {
+                                self.advance();
+                                if self.current_char().is_some() {
+                                    self.advance();
+                                }
+                            }
+                            q if q == quote => {
+                                self.advance();
+                                break;
+                            }
+                            _ => self.advance(),
+                        }
+                    }
+                }
+                c if c == open => {
+                    depth += 1;
+                    self.advance();
+                }
+                c if c == close => {
+                    self.advance();
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(self.position);
+                    }
+                }
+                _ => self.advance(),
+            }
+        }
+
+        None
+    }
+
     /// Fast byte-level check for ASCII characters
     #[inline]
     fn peek_byte(&self, offset: usize) -> Option<u8> {
@@ -2847,13 +2928,15 @@ impl<'a> PerlLexer<'a> {
 
                                     match self.current_char() {
                                         Some('[') => {
-                                            let _ = self.consume_balanced_segment('[', ']');
+                                            let _ =
+                                                self.consume_interpolation_segment_in_dq('[', ']');
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
                                         }
                                         Some('{') => {
-                                            let _ = self.consume_balanced_segment('{', '}');
+                                            let _ =
+                                                self.consume_interpolation_segment_in_dq('{', '}');
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
@@ -2898,13 +2981,13 @@ impl<'a> PerlLexer<'a> {
                                     }
                                 } else if self.current_char() == Some('[') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('[', ']');
+                                    let _ = self.consume_interpolation_segment_in_dq('[', ']');
                                     parts.push(StringPart::ArraySlice(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));
                                 } else if self.current_char() == Some('{') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('{', '}');
+                                    let _ = self.consume_interpolation_segment_in_dq('{', '}');
                                     parts.push(StringPart::Expression(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));

--- a/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
+++ b/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
@@ -1,0 +1,29 @@
+mod cpan_test_helpers;
+
+use cpan_test_helpers::assert_clean_parse;
+
+#[test]
+fn double_quote_incomplete_hash_key() {
+    assert_clean_parse(r#"my $msg = "Key: $hash{incomplete";"#);
+}
+
+#[test]
+fn double_quote_incomplete_array_index() {
+    assert_clean_parse(r#"my $item = "Element: $array[0";"#);
+}
+
+#[test]
+fn double_quote_incomplete_arrow_hash_key() {
+    assert_clean_parse(r#"my $msg = "Nested: $obj->{field";"#);
+}
+
+#[test]
+fn double_quote_incomplete_mixed_index() {
+    assert_clean_parse(r#"my $msg = "Mixed: $array[$i";"#);
+}
+
+#[test]
+fn double_quote_complete_interpolation_still_clean() {
+    assert_clean_parse(r#"my $msg = "Key: $hash{complete} and $array[0]";"#);
+    assert_clean_parse(r#"my $msg = "Nested: $obj->{field}[$i]";"#);
+}

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1740,6 +1740,34 @@ my $msg = "value: ${Foo::name}";
 }
 
 #[test]
+fn incomplete_hash_index_interpolation_still_registers_reference()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $msg = "Key: $hash{incomplete";
+"#;
+    let table = parse_and_extract(code);
+    assert!(
+        table.references.contains_key("hash"),
+        "$hash in incomplete interpolation should still register a reference",
+    );
+    Ok(())
+}
+
+#[test]
+fn incomplete_array_index_interpolation_still_registers_reference()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $msg = "Element: $array[0";
+"#;
+    let table = parse_and_extract(code);
+    assert!(
+        table.references.contains_key("array"),
+        "$array in incomplete interpolation should still register a reference",
+    );
+    Ok(())
+}
+
+#[test]
 fn escaped_interpolated_variable_is_still_unused() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 my $name = "World";


### PR DESCRIPTION
### Motivation
- Incomplete indexing in double-quoted interpolations (e.g. `"Key: $hash{incomplete"`, `"Element: $array[0"`) currently lets the interpolation consume the closing quote and produce top-level `ERROR` nodes, killing downstream symbol extraction and LSP features while users type.

### Description
- Add a lexer-local recovery helper `consume_interpolation_segment_in_dq` in `crates/perl-lexer/src/lib.rs` that scans `[`/`{` interpolation tails but returns early if an unescaped `"` appears so the outer double-quoted string can terminate normally.
- Use the new helper when parsing interpolation tails for `->[...]`, `->{...}`, direct `[...]`, and direct `{...}` in double-quoted strings so incomplete subscripts are preserved as partial parts rather than forcing parser ERROR nodes.
- Add parser regression tests in `crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs` covering incomplete and complete cases (`$hash{incomplete`, `$array[0`, `$obj->{field`, `$array[$i` and baselines).
- Add semantic analyzer tests in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` to assert that `$hash` and `$array` remain extractable as symbol references from incomplete interpolations.

### Testing
- Ran `cargo test -p perl-parser-core --test string_interpolation_incomplete_tests` and it passed (5 tests).
- Ran focused semantic analyzer tests `cargo test -p perl-semantic-analyzer incomplete_hash_index_interpolation_still_registers_reference` and `... incomplete_array_index_interpolation_still_registers_reference` and both passed.
- Ran `cargo test -p perl-parser-core` which completed but reported one unrelated failing test (`test_deref_hash_subscript_regex_key`) that preexisted/appeared outside the scoped interpolation change.
- `just parser-audit` and `just cpan-corpus-check` were not executed in this environment because `just` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53f391d88333863ff64d42e3d555)