### PR TITLE
fix(parser-core): preserve ternary and low-precedence binding after bare calls (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -377,6 +377,7 @@ impl<'a> Parser<'a> {
                         | TokenKind::RightBrace
                         | TokenKind::RightParen
                         | TokenKind::RightBracket
+                        | TokenKind::Question
                 )
             )
         {
@@ -391,6 +392,7 @@ impl<'a> Parser<'a> {
                 self.tokens.next()?; // consume , or =>
             } else if Self::is_statement_terminator(self.peek_kind())
                 || self.is_statement_modifier_keyword()
+                || self.peek_kind() == Some(TokenKind::Question)
             {
                 break;
             }

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -1198,6 +1198,7 @@ impl<'a> Parser<'a> {
                 | Some(TokenKind::WordOr)
                 | Some(TokenKind::WordXor)
                 | Some(TokenKind::WordNot)
+                | Some(TokenKind::Question)
                 | Some(TokenKind::DataMarker)
                 | Some(TokenKind::Eof)
                 | None

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -120,9 +120,13 @@ impl<'a> Parser<'a> {
             | Some(TokenKind::RightBracket)
             | Some(TokenKind::Eof)
             | None => false,
-            Some(TokenKind::WordOr | TokenKind::WordAnd | TokenKind::WordXor | TokenKind::WordNot) => {
-                false
-            }
+            Some(
+                TokenKind::WordOr
+                    | TokenKind::WordAnd
+                    | TokenKind::WordXor
+                    | TokenKind::WordNot
+                    | TokenKind::Question,
+            ) => false,
             Some(kind) if Self::is_stmt_modifier_kind(kind) => self.is_keyword_before_fat_arrow(),
             _ => true,
         }

--- a/crates/perl-parser-core/tests/fix_bare_call_low_precedence_binding.rs
+++ b/crates/perl-parser-core/tests/fix_bare_call_low_precedence_binding.rs
@@ -1,0 +1,76 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+fn parse_ok(src: &str) -> String {
+    let ast = parse(src);
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("ERROR"), "parse should succeed without errors for: {src}\ngot: {sexp}");
+    sexp
+}
+
+#[test]
+fn bare_call_sigil_arg_keeps_ternary_outside_call() {
+    let sexp = parse_ok("sub is_ready { 1 }; my $x = is_ready $obj ? 1 : 0;");
+    assert!(sexp.contains("(ternary"), "expected ternary in AST, got: {sexp}");
+    assert!(
+        sexp.contains("(ambiguous_function_call_expression (function) (variable $ obj))"),
+        "expected bare unary-style call node in AST, got: {sexp}"
+    );
+    assert!(
+        !sexp.contains("(ambiguous_function_call_expression (function) (ternary"),
+        "is_ready bare call swallowed ternary argument: {sexp}"
+    );
+}
+
+#[test]
+fn bare_call_list_arg_keeps_word_or_outside_call() {
+    let sexp = parse_ok("do_thing @args or die;");
+    assert!(
+        sexp.contains("(ambiguous_function_call_expression"),
+        "expected bare unary-style call node in AST, got: {sexp}"
+    );
+    assert!(
+        !sexp.contains("(ambiguous_function_call_expression (function) (binary"),
+        "do_thing bare call swallowed low-precedence operator: {sexp}"
+    );
+}
+
+#[test]
+fn bare_call_scalar_arg_keeps_word_and_outside_call() {
+    let sexp = parse_ok("do_thing $x and return;");
+    assert!(
+        sexp.contains("(ambiguous_function_call_expression"),
+        "expected bare unary-style call node in AST, got: {sexp}"
+    );
+    assert!(
+        !sexp.contains("(ambiguous_function_call_expression (function) (binary"),
+        "do_thing bare call swallowed low-precedence operator: {sexp}"
+    );
+}
+
+#[test]
+fn bare_call_scalar_arg_keeps_defined_or_outside_call() {
+    let sexp = parse_ok("my $v = transform $x // $fallback;");
+    assert!(
+        sexp.contains("(ambiguous_function_call_expression"),
+        "expected bare unary-style call node in AST, got: {sexp}"
+    );
+    assert!(
+        !sexp.contains("(ambiguous_function_call_expression (function) (binary"),
+        "transform bare call swallowed low-precedence operator: {sexp}"
+    );
+}
+
+#[test]
+fn nested_bare_call_ternary_in_larger_expression() {
+    let sexp = parse_ok("my $n = (is_ready $obj ? 1 : 0) + 1;");
+    assert!(sexp.contains("(ternary"), "expected ternary in AST, got: {sexp}");
+    assert!(
+        sexp.contains("(ambiguous_function_call_expression (function) (variable $ obj))"),
+        "expected bare unary-style call node in AST, got: {sexp}"
+    );
+    assert!(
+        !sexp.contains("(ambiguous_function_call_expression (function) (ternary"),
+        "is_ready bare call swallowed ternary inside larger expression: {sexp}"
+    );
+}


### PR DESCRIPTION
### Motivation

- Bare unary-style calls (e.g. `is_ready $obj ? 1 : 0`) could greedily consume a following ternary or other low-precedence operator as their argument, producing incorrect ASTs.

### Description

- Treat `TokenKind::Question` as a terminator for bare/indirect call argument collection in `parse_indirect_call` so `?` stops indirect-call arg parsing.
- Treat `TokenKind::Question` as a statement/bare-call boundary in `should_continue_bare_call_after_block` and `is_at_statement_end` so low-precedence word operators and `?` bind outside bare calls.
- Add focused regression tests in `crates/perl-parser-core/tests/fix_bare_call_low_precedence_binding.rs` covering `is_ready $obj ? 1 : 0`, `do_thing @args or die`, `do_thing $x and return`, `transform $x // $fallback`, and a nested bare-call-with-ternary case.

### Testing

- `cargo test -p perl-parser-core ternary` ran and passed.
- `cargo test -p perl-parser-core indirect` ran and passed.
- The new focused test binary `cargo test -p perl-parser-core --test fix_bare_call_low_precedence_binding` ran and passed.
- `cargo test -p perl-parser-core` was run; the change is correct for the introduced regressions but one unrelated existing test (`test_deref_hash_subscript_regex_key`) failed in this environment and should be investigated separately.
- `cargo xtask fmt` completed successfully and `just`-based checks were not runnable in this environment (`just` not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53f83ed08333a8e1050da2ea5d26)