### PR TITLE
fix(parser-core): preserve ternary and low-precedence binding after bare calls (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -374,6 +374,7 @@ impl<'a> Parser<'a> {
                         | TokenKind::WordAnd
                         | TokenKind::WordXor
                         | TokenKind::WordNot
+                        | TokenKind::Question
                         | TokenKind::RightBrace
                         | TokenKind::RightParen
                         | TokenKind::RightBracket

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -551,6 +551,7 @@ impl<'a> Parser<'a> {
                                                     | TokenKind::WordAnd
                                                     | TokenKind::WordXor
                                                     | TokenKind::WordNot
+                                                    | TokenKind::Question
                                             )
                                         )
                                     {
@@ -878,6 +879,7 @@ impl<'a> Parser<'a> {
                                                     | TokenKind::WordAnd
                                                     | TokenKind::WordXor
                                                     | TokenKind::WordNot
+                                                    | TokenKind::Question
                                             )
                                         )
                                     {
@@ -934,6 +936,7 @@ impl<'a> Parser<'a> {
                                                     | TokenKind::WordAnd
                                                     | TokenKind::WordXor
                                                     | TokenKind::WordNot
+                                                    | TokenKind::Question
                                             )
                                         )
                                     {
@@ -968,6 +971,7 @@ impl<'a> Parser<'a> {
                                                     | TokenKind::WordAnd
                                                     | TokenKind::WordXor
                                                     | TokenKind::WordNot
+                                                    | TokenKind::Question
                                             )
                                         )
                                     {
@@ -1015,6 +1019,7 @@ impl<'a> Parser<'a> {
                                                     | TokenKind::WordAnd
                                                     | TokenKind::WordXor
                                                     | TokenKind::WordNot
+                                                    | TokenKind::Question
                                             )
                                         )
                                     {
@@ -1085,6 +1090,7 @@ impl<'a> Parser<'a> {
                                                     | TokenKind::WordAnd
                                                     | TokenKind::WordXor
                                                     | TokenKind::WordNot
+                                                    | TokenKind::Question
                                             )
                                         )
                                     {
@@ -1198,6 +1204,7 @@ impl<'a> Parser<'a> {
                 | Some(TokenKind::WordOr)
                 | Some(TokenKind::WordXor)
                 | Some(TokenKind::WordNot)
+                | Some(TokenKind::Question)
                 | Some(TokenKind::DataMarker)
                 | Some(TokenKind::Eof)
                 | None

--- a/crates/perl-parser-core/tests/fix_bare_call_low_precedence_binding.rs
+++ b/crates/perl-parser-core/tests/fix_bare_call_low_precedence_binding.rs
@@ -1,0 +1,98 @@
+mod cpan_test_helpers;
+
+use cpan_test_helpers::parse;
+use perl_parser_core::{Node, NodeKind};
+
+fn program_statements(ast: &Node) -> &[Node] {
+    match &ast.kind {
+        NodeKind::Program { statements } => statements,
+        other => panic!("Expected Program node, got {:?}", other),
+    }
+}
+
+fn expr_from_stmt(stmt: &Node) -> &Node {
+    match &stmt.kind {
+        NodeKind::ExpressionStatement { expression } => expression,
+        other => panic!("Expected ExpressionStatement, got {:?}", other),
+    }
+}
+
+fn initializer_from_var_decl(stmt: &Node) -> &Node {
+    match &stmt.kind {
+        NodeKind::VariableDeclaration { initializer: Some(initializer), .. } => initializer,
+        other => panic!("Expected VariableDeclaration with initializer, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_bare_call_sigil_arg_does_not_absorb_ternary() {
+    let ast = parse("sub is_ready { 1 }; my $x = is_ready $obj ? 1 : 0;");
+    let statements = program_statements(&ast);
+
+    let init = initializer_from_var_decl(&statements[1]);
+    let NodeKind::Ternary { condition, .. } = &init.kind else {
+        panic!("Expected ternary initializer, got {:?}", init.kind);
+    };
+
+    let NodeKind::FunctionCall { name, args } = &condition.kind else {
+        panic!("Expected bare call condition, got {:?}", condition.kind);
+    };
+    assert_eq!(name, "is_ready");
+    assert_eq!(args.len(), 1, "bare call should keep only one high-precedence arg");
+}
+
+#[test]
+fn test_bare_call_array_arg_or_die_binds_outside_call() {
+    let ast = parse("do_thing @args or die;");
+    let statements = program_statements(&ast);
+    let expr = expr_from_stmt(&statements[0]);
+
+    let NodeKind::Binary { op, left, right } = &expr.kind else {
+        panic!("Expected word-op binary, got {:?}", expr.kind);
+    };
+    assert_eq!(op, "or");
+    assert!(matches!(left.kind, NodeKind::FunctionCall { .. }));
+    assert!(matches!(right.kind, NodeKind::FunctionCall { name: ref n, .. } if n == "die"));
+}
+
+#[test]
+fn test_bare_call_scalar_arg_and_return_binds_outside_call() {
+    let ast = parse("do_thing $x and return;");
+    let statements = program_statements(&ast);
+    let expr = expr_from_stmt(&statements[0]);
+
+    let NodeKind::Binary { op, left, right } = &expr.kind else {
+        panic!("Expected word-op binary, got {:?}", expr.kind);
+    };
+    assert_eq!(op, "and");
+    assert!(matches!(left.kind, NodeKind::FunctionCall { .. }));
+    assert!(matches!(right.kind, NodeKind::Return { value: None }));
+}
+
+#[test]
+fn test_bare_call_defined_or_operator_binds_outside_call() {
+    let ast = parse("my $v = transform $x // $fallback;");
+    let statements = program_statements(&ast);
+
+    let init = initializer_from_var_decl(&statements[0]);
+    let NodeKind::Binary { op, left, .. } = &init.kind else {
+        panic!("Expected defined-or binary, got {:?}", init.kind);
+    };
+    assert_eq!(op, "//");
+    assert!(
+        matches!(left.kind, NodeKind::FunctionCall { name: ref n, args: ref a } if n == "transform" && a.len() == 1)
+    );
+}
+
+#[test]
+fn test_nested_bare_call_ternary_inside_larger_expression() {
+    let ast = parse("my $n = 1 + (is_ready $obj ? 1 : 0);");
+    let statements = program_statements(&ast);
+
+    let init = initializer_from_var_decl(&statements[0]);
+    let NodeKind::Binary { op, right, .. } = &init.kind else {
+        panic!("Expected top-level binary expression, got {:?}", init.kind);
+    };
+    assert_eq!(op, "+");
+    assert!(matches!(right.kind, NodeKind::Ternary { .. }));
+}


### PR DESCRIPTION
### Motivation

- Bare unary-style calls with sigil-leading arguments could greedily absorb ternary and other low-precedence operators, e.g. `my $x = is_ready $obj ? 1 : 0;` should parse as `(is_ready $obj) ? 1 : 0` but could be mis-parsed as `is_ready($obj ? 1 : 0)`.

### Description

- Treat the ternary `?` token as a terminator for indirect/bare-call argument collection by adding `TokenKind::Question` to the terminator/match sets in `calls.rs` and `postfix.rs`.
- Extend statement-end detection to consider `?` as a statement boundary so low-precedence word operators stay outside bare-call parsing.
- Ensure bare-call sigil-peek path only captures the high-precedence argument so ternary and other low-precedence operators bind outside the call (logic already uses a high-precedence parse for the sigil-peek case and is preserved with the new terminator handling).
- Add focused regression tests in `crates/perl-parser-core/tests/fix_bare_call_low_precedence_binding.rs` covering `is_ready $obj ? 1 : 0`, `do_thing @args or die`, `do_thing $x and return`, `transform $x // $fallback`, and a nested bare-call-with-ternary case.

### Testing

- `cargo xtask fmt` was run and completed successfully.
- `cargo test -p perl-parser-core --test fix_bare_call_low_precedence_binding` passed (all tests in the new test file succeeded).
- `cargo test -p perl-parser-core ternary` passed with existing ternary-suite tests succeeding.
- `cargo test -p perl-parser-core indirect` passed with indirect-call tests succeeding.
- `cargo test -p perl-parser-core` was executed and reported one unrelated test failure (`test_deref_hash_subscript_regex_key` in `tests/test_edge_cases_deep.rs`), which appears independent of these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53f83ed08333a8e1050da2ea5d26)