### PR TITLE
fix(parser-core): preserve ternary and low-precedence binding after bare calls (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -91,6 +91,7 @@ impl<'a> Parser<'a> {
                 | TokenKind::RightBrace
                 | TokenKind::RightParen
                 | TokenKind::Comma
+                | TokenKind::Question
                 | TokenKind::Eof => return false,
                 _ => {}
             }
@@ -374,6 +375,7 @@ impl<'a> Parser<'a> {
                         | TokenKind::WordAnd
                         | TokenKind::WordXor
                         | TokenKind::WordNot
+                        | TokenKind::Question
                         | TokenKind::RightBrace
                         | TokenKind::RightParen
                         | TokenKind::RightBracket

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -1188,6 +1188,7 @@ impl<'a> Parser<'a> {
                 | Some(TokenKind::RightBrace)
                 | Some(TokenKind::RightParen)
                 | Some(TokenKind::RightBracket)
+                | Some(TokenKind::Question)
                 | Some(TokenKind::If)
                 | Some(TokenKind::Unless)
                 | Some(TokenKind::While)

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -118,6 +118,7 @@ impl<'a> Parser<'a> {
             | Some(TokenKind::RightBrace)
             | Some(TokenKind::RightParen)
             | Some(TokenKind::RightBracket)
+            | Some(TokenKind::Question)
             | Some(TokenKind::Eof)
             | None => false,
             Some(TokenKind::WordOr | TokenKind::WordAnd | TokenKind::WordXor | TokenKind::WordNot) => {

--- a/crates/perl-parser-core/tests/fix_bare_call_low_precedence_binding.rs
+++ b/crates/perl-parser-core/tests/fix_bare_call_low_precedence_binding.rs
@@ -1,0 +1,150 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::parse;
+use perl_parser_core::NodeKind;
+
+fn first_program_statement(ast: &perl_parser_core::Node) -> &perl_parser_core::Node {
+    match &ast.kind {
+        NodeKind::Program { statements } => {
+            assert!(!statements.is_empty(), "expected at least one statement");
+            &statements[0]
+        }
+        _ => panic!("expected Program node"),
+    }
+}
+
+fn last_program_statement(ast: &perl_parser_core::Node) -> &perl_parser_core::Node {
+    match &ast.kind {
+        NodeKind::Program { statements } => {
+            assert!(!statements.is_empty(), "expected at least one statement");
+            &statements[statements.len() - 1]
+        }
+        _ => panic!("expected Program node"),
+    }
+}
+
+#[test]
+fn test_bare_call_sigil_arg_stops_before_ternary() {
+    let ast = parse("sub is_ready { 1 }; my $x = is_ready $obj ? 1 : 0;");
+    let stmt = last_program_statement(&ast);
+
+    let initializer = match &stmt.kind {
+        NodeKind::VariableDeclaration { initializer: Some(initializer), .. } => initializer,
+        _ => panic!("expected variable declaration with initializer"),
+    };
+
+    let condition = match &initializer.kind {
+        NodeKind::Ternary { condition, .. } => condition,
+        _ => panic!("expected ternary initializer"),
+    };
+
+    match &condition.kind {
+        NodeKind::FunctionCall { name, args } => {
+            assert_eq!(name, "is_ready");
+            assert_eq!(args.len(), 1);
+        }
+        _ => panic!("expected ternary condition to be a function call"),
+    }
+}
+
+#[test]
+fn test_bare_call_sigil_arg_stops_before_word_or() {
+    let ast = parse("do_thing @args or die;");
+    let stmt = first_program_statement(&ast);
+
+    let expr = match &stmt.kind {
+        NodeKind::ExpressionStatement { expression } => expression,
+        _ => panic!("expected expression statement"),
+    };
+
+    match &expr.kind {
+        NodeKind::Binary { op, left, .. } => {
+            assert_eq!(op, "or");
+            match &left.kind {
+                NodeKind::FunctionCall { name, args } => {
+                    assert_eq!(name, "do_thing");
+                    assert_eq!(args.len(), 1);
+                }
+                _ => panic!("expected left side of `or` to be function call"),
+            }
+        }
+        _ => panic!("expected top-level binary expression"),
+    }
+}
+
+#[test]
+fn test_bare_call_sigil_arg_stops_before_word_and() {
+    let ast = parse("do_thing $x and return;");
+    let stmt = first_program_statement(&ast);
+
+    let expr = match &stmt.kind {
+        NodeKind::ExpressionStatement { expression } => expression,
+        _ => panic!("expected expression statement"),
+    };
+
+    match &expr.kind {
+        NodeKind::Binary { op, left, .. } => {
+            assert_eq!(op, "and");
+            match &left.kind {
+                NodeKind::FunctionCall { name, args } => {
+                    assert_eq!(name, "do_thing");
+                    assert_eq!(args.len(), 1);
+                }
+                _ => panic!("expected left side of `and` to be function call"),
+            }
+        }
+        _ => panic!("expected top-level binary expression"),
+    }
+}
+
+#[test]
+fn test_bare_call_sigil_arg_stops_before_defined_or() {
+    let ast = parse("my $v = transform $x // $fallback;");
+    let stmt = first_program_statement(&ast);
+
+    let initializer = match &stmt.kind {
+        NodeKind::VariableDeclaration { initializer: Some(initializer), .. } => initializer,
+        _ => panic!("expected variable declaration with initializer"),
+    };
+
+    match &initializer.kind {
+        NodeKind::Binary { op, left, .. } => {
+            assert_eq!(op, "//");
+            match &left.kind {
+                NodeKind::FunctionCall { name, args } => {
+                    assert_eq!(name, "transform");
+                    assert_eq!(args.len(), 1);
+                }
+                _ => panic!("expected left side of `//` to be function call"),
+            }
+        }
+        _ => panic!("expected defined-or binary expression"),
+    }
+}
+
+#[test]
+fn test_nested_bare_call_ternary_in_larger_expression() {
+    let ast = parse("my $z = (is_ready $obj ? 1 : 0) + 2;");
+    let stmt = first_program_statement(&ast);
+
+    let initializer = match &stmt.kind {
+        NodeKind::VariableDeclaration { initializer: Some(initializer), .. } => initializer,
+        _ => panic!("expected variable declaration with initializer"),
+    };
+
+    match &initializer.kind {
+        NodeKind::Binary { op, left, .. } => {
+            assert_eq!(op, "+");
+            match &left.kind {
+                NodeKind::Ternary { condition, .. } => match &condition.kind {
+                    NodeKind::FunctionCall { name, args } => {
+                        assert_eq!(name, "is_ready");
+                        assert_eq!(args.len(), 1);
+                    }
+                    _ => panic!("expected ternary condition to be function call"),
+                },
+                _ => panic!("expected left side of `+` to be ternary"),
+            }
+        }
+        _ => panic!("expected binary `+` initializer"),
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent bare unary-style calls from greedily absorbing low-precedence operators so expressions like `my $x = is_ready $obj ? 1 : 0;` parse as `(is_ready $obj) ? 1 : 0` rather than `is_ready($obj ? 1 : 0)`.

### Description
- Treat `TokenKind::Question` as a disqualifier/terminator for indirect/bare-call argument collection in `crates/perl-parser-core/src/engine/parser/expressions/calls.rs` so `?` no longer begins an indirect-object/argument list.
- Add `TokenKind::Question` to statement/bare-call boundary checks in `crates/perl-parser-core/src/engine/parser/expressions/postfix.rs` and `crates/perl-parser-core/src/engine/parser/helpers.rs` so bare-call flows stop before ternary and similar low-precedence operators.
- Ensure the sigil-peek bare-call path continues to parse only a high-precedence argument (`parse_shift()`), preserving the intended operator binding behavior outside the bare call.
- Add focused regression tests in `crates/perl-parser-core/tests/fix_bare_call_low_precedence_binding.rs` covering `is_ready $obj ? 1 : 0;`, `do_thing @args or die;`, `do_thing $x and return;`, `transform $x // $fallback;`, and a nested bare-call-with-ternary case.

### Testing
- Ran `cargo xtask fmt` successfully.
- Ran `cargo test -p perl-parser-core --test fix_bare_call_low_precedence_binding` and all tests passed.
- Ran `cargo test -p perl-parser-core ternary` and `cargo test -p perl-parser-core indirect` and both suites passed.
- Ran full `cargo test -p perl-parser-core`; the run completed but reported one unrelated pre-existing failing test `test_edge_cases_deep::test_deref_hash_subscript_regex_key` (not caused by these changes).
- Could not run `just parser-audit` or `just corpus-sweep-check` in this environment because `just` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53f83ed08333a8e1050da2ea5d26)