### PR TITLE
fix(parser-core): preserve ternary and low-precedence binding after bare calls (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -374,6 +374,7 @@ impl<'a> Parser<'a> {
                         | TokenKind::WordAnd
                         | TokenKind::WordXor
                         | TokenKind::WordNot
+                        | TokenKind::Question
                         | TokenKind::RightBrace
                         | TokenKind::RightParen
                         | TokenKind::RightBracket

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -1198,6 +1198,7 @@ impl<'a> Parser<'a> {
                 | Some(TokenKind::WordOr)
                 | Some(TokenKind::WordXor)
                 | Some(TokenKind::WordNot)
+                | Some(TokenKind::Question)
                 | Some(TokenKind::DataMarker)
                 | Some(TokenKind::Eof)
                 | None

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -123,6 +123,7 @@ impl<'a> Parser<'a> {
             Some(TokenKind::WordOr | TokenKind::WordAnd | TokenKind::WordXor | TokenKind::WordNot) => {
                 false
             }
+            Some(TokenKind::Question) => false,
             Some(kind) if Self::is_stmt_modifier_kind(kind) => self.is_keyword_before_fat_arrow(),
             _ => true,
         }

--- a/crates/perl-parser-core/tests/named_unary_bare_call_binding_tests.rs
+++ b/crates/perl-parser-core/tests/named_unary_bare_call_binding_tests.rs
@@ -1,0 +1,127 @@
+mod cpan_test_helpers;
+
+use cpan_test_helpers::parse;
+use perl_parser_core::{Node, NodeKind};
+
+fn first_non_sub_stmt(ast: &Node) -> &Node {
+    let NodeKind::Program { statements } = &ast.kind else {
+        panic!("expected Program root, got {:?}", ast.kind);
+    };
+    let stmt = statements
+        .iter()
+        .find(|node| !matches!(node.kind, NodeKind::Subroutine { .. }))
+        .expect("expected at least one non-subroutine statement");
+    stmt
+}
+
+fn assert_call_name(node: &Node, expected: &str) {
+    let NodeKind::FunctionCall { name, .. } = &node.kind else {
+        panic!("expected function call `{expected}`, got {:?}", node.kind);
+    };
+    assert_eq!(name, expected, "unexpected function call name");
+}
+
+#[test]
+fn bare_named_unary_does_not_swallow_ternary() {
+    let ast = parse("sub is_ready { 1 }; my $x = is_ready $obj ? 1 : 0;");
+    let stmt = first_non_sub_stmt(&ast);
+
+    let NodeKind::VariableDeclaration { initializer, .. } = &stmt.kind else {
+        panic!("expected variable declaration, got {:?}", stmt.kind);
+    };
+    let Some(rhs) = initializer.as_deref() else {
+        panic!("expected declaration initializer");
+    };
+    let NodeKind::Ternary { condition, .. } = &rhs.kind else {
+        panic!("expected ternary rhs, got {:?}", rhs.kind);
+    };
+
+    assert_call_name(condition, "is_ready");
+
+    let NodeKind::FunctionCall { args, .. } = &condition.kind else {
+        unreachable!("checked by assert_call_name");
+    };
+    assert_eq!(args.len(), 1, "bare call should keep exactly one high-precedence arg");
+}
+
+#[test]
+fn bare_call_or_die_binds_or_outside_call() {
+    let ast = parse("do_thing @args or die;");
+    let stmt = first_non_sub_stmt(&ast);
+    let NodeKind::ExpressionStatement { expression } = &stmt.kind else {
+        panic!("expected expression statement, got {:?}", stmt.kind);
+    };
+    let expr = expression.as_ref();
+
+    let NodeKind::Binary { op, left, right } = &expr.kind else {
+        panic!("expected binary op for `or`, got {:?}", expr.kind);
+    };
+    assert_eq!(op, "or", "word `or` should be the outer operator");
+    assert_call_name(left, "do_thing");
+    assert_call_name(right, "die");
+}
+
+#[test]
+fn bare_call_and_return_binds_and_outside_call() {
+    let ast = parse("do_thing $x and return;");
+    let stmt = first_non_sub_stmt(&ast);
+    let NodeKind::ExpressionStatement { expression } = &stmt.kind else {
+        panic!("expected expression statement, got {:?}", stmt.kind);
+    };
+    let expr = expression.as_ref();
+
+    let NodeKind::Binary { op, left, right } = &expr.kind else {
+        panic!("expected binary op for `and`, got {:?}", expr.kind);
+    };
+    assert_eq!(op, "and", "word `and` should be the outer operator");
+    assert_call_name(left, "do_thing");
+
+    let NodeKind::Return { .. } = right.kind else {
+        panic!("expected `return` on right side of `and`, got {:?}", right.kind);
+    };
+}
+
+#[test]
+fn bare_call_defined_or_binds_outside_call() {
+    let ast = parse("my $v = transform $x // $fallback;");
+    let stmt = first_non_sub_stmt(&ast);
+
+    let NodeKind::VariableDeclaration { initializer, .. } = &stmt.kind else {
+        panic!("expected variable declaration, got {:?}", stmt.kind);
+    };
+    let Some(rhs) = initializer.as_deref() else {
+        panic!("expected declaration initializer");
+    };
+    let NodeKind::Binary { op, left, .. } = &rhs.kind else {
+        panic!("expected defined-or binary op, got {:?}", rhs.kind);
+    };
+
+    assert_eq!(op, "//", "defined-or should bind outside bare call");
+    assert_call_name(left, "transform");
+}
+
+#[test]
+fn nested_bare_call_ternary_stays_condition_only() {
+    let ast = parse("my $result = ($ok && is_ready $obj ? 1 : 0) + 2;");
+    let stmt = first_non_sub_stmt(&ast);
+
+    let NodeKind::VariableDeclaration { initializer, .. } = &stmt.kind else {
+        panic!("expected variable declaration, got {:?}", stmt.kind);
+    };
+    let Some(rhs) = initializer.as_deref() else {
+        panic!("expected declaration initializer");
+    };
+    let NodeKind::Binary { op, left, .. } = &rhs.kind else {
+        panic!("expected outer additive expression, got {:?}", rhs.kind);
+    };
+    assert_eq!(op, "+", "outer expression should remain additive");
+
+    let NodeKind::Ternary { condition, .. } = &left.kind else {
+        panic!("expected ternary on left side of addition, got {:?}", left.kind);
+    };
+    let NodeKind::Binary { op: cond_op, right, .. } = &condition.kind else {
+        panic!("expected binary condition, got {:?}", condition.kind);
+    };
+    assert_eq!(cond_op, "&&", "condition should remain `$ok && ...`");
+    assert_call_name(right, "is_ready");
+}


### PR DESCRIPTION
### Motivation
- Prevent bare unary-style calls from greedily absorbing ternary (`?:`) and other low-precedence operators so expressions like `my $x = is_ready $obj ? 1 : 0;` parse as a bare call followed by a ternary expression.
- Ensure related patterns (`do_thing @args or die`, `do_thing $x and return`, `transform $x // $fallback`) bind the low-precedence operator outside the bare call.

### Description
- Treat `TokenKind::Question` (`?`) as a terminator/disqualifier when collecting indirect-call or bare-call arguments so `?` does not get consumed into the call argument list; updated checks in `calls.rs`, `postfix.rs`, and `helpers.rs`.
- In the sigil-peek bare-call path keep parsing only a high-precedence argument via `parse_shift()` so lower-precedence operators (ternary/word-ops/`//`) remain outside the call (change is enforced by preserving the high-precedence parse for the single sigil argument).
- Add focused regression tests in `crates/perl-parser-core/tests/named_unary_bare_call_binding_tests.rs` that assert AST shapes for the targeted cases rather than only clean-parse, covering `is_ready $obj ? 1 : 0`, `do_thing @args or die`, `do_thing $x and return`, `transform $x // $fallback`, and a nested bare-call-with-ternary inside a larger expression.

### Testing
- Ran `cargo test -p perl-parser-core --test named_unary_bare_call_binding_tests` and the new focused tests passed.
- Ran `cargo test -p perl-parser-core ternary` and `cargo test -p perl-parser-core indirect` and both suites passed.
- Ran full `cargo test -p perl-parser-core`; most tests passed, but an existing unrelated test (`test_edge_cases_deep::test_deref_hash_subscript_regex_key`) failed in this environment (pre-existing failure surfaced during the run).
- Ran `cargo fmt`; `just parser-audit` and `just corpus-sweep-check` were not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53f83ed08333a8e1050da2ea5d26)