### PR TITLE
ci(parser): stabilize CPAN corpus ratchet for accuracy closeout (#0000)

### DIFF
--- a/xtask/src/tasks/cpan_corpus.rs
+++ b/xtask/src/tasks/cpan_corpus.rs
@@ -36,7 +36,7 @@ const CPANM_STANDALONE_URL: &str = "https://cpanmin.us";
 const METACPAN_API: &str = "https://fastapi.metacpan.org/v1/distribution/_search";
 /// Hard timeout for a batch cpanm invocation. Batch installs fall back to
 /// per-distribution retries when one distribution wedges inside configure/build.
-const CPANM_BATCH_TIMEOUT: Duration = Duration::from_secs(120);
+const CPANM_BATCH_TIMEOUT: Duration = Duration::from_secs(300);
 /// Hard timeout for a single-distribution retry. Native-heavy distributions
 /// such as `PDL` legitimately need more wall-clock time than a whole batch
 /// should get before we split it apart.
@@ -264,7 +264,7 @@ pub fn install(config: &CpanCorpusConfig) -> Result<()> {
     fs::create_dir_all(&cpanm_home).context("Failed to create cpanm cache directory")?;
 
     // Install in batches to avoid overly long command lines
-    let batch_size = 50;
+    let batch_size = 25;
     let mut installed = 0usize;
     let mut failed = 0usize;
 


### PR DESCRIPTION
### Motivation
- Batch CPAN installs were timing out at 120s for 50-distribution batches, causing expensive per-distribution retries and noisy nightly ratchet signals that undermine accuracy closeout.

### Description
- Increase the batch cpanm hard timeout from `Duration::from_secs(120)` to `Duration::from_secs(300)` and reduce the install batch size from `50` to `25` in `xtask/src/tasks/cpan_corpus.rs`, leaving ratchet, cache, and known-clean manifest behavior unchanged.

### Testing
- `cargo build -p xtask` succeeded; `cargo xtask cpan-corpus install --reset` (observed run) printed `Batch 1/40: installing 25 distributions...`, confirming the new batch size; `just cpan-corpus-check` was not available in this environment so the equivalent `cargo run -p xtask -- cpan-corpus sweep --enforce` was executed and completed but reported a ratchet regression against the committed baseline due to a partial local corpus rather than this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55aaa4c083338bf587cc643739bf)