### PR TITLE
fix(parser-core): preserve ternary and low-precedence binding after bare calls (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -374,6 +374,7 @@ impl<'a> Parser<'a> {
                         | TokenKind::WordAnd
                         | TokenKind::WordXor
                         | TokenKind::WordNot
+                        | TokenKind::Question
                         | TokenKind::RightBrace
                         | TokenKind::RightParen
                         | TokenKind::RightBracket

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -551,6 +551,7 @@ impl<'a> Parser<'a> {
                                                     | TokenKind::WordAnd
                                                     | TokenKind::WordXor
                                                     | TokenKind::WordNot
+                                                    | TokenKind::Question
                                             )
                                         )
                                     {
@@ -1099,6 +1100,7 @@ impl<'a> Parser<'a> {
                                                         | TokenKind::WordAnd
                                                         | TokenKind::WordXor
                                                         | TokenKind::WordNot
+                                                        | TokenKind::Question
                                                 )
                                             )
                                         {
@@ -1198,6 +1200,7 @@ impl<'a> Parser<'a> {
                 | Some(TokenKind::WordOr)
                 | Some(TokenKind::WordXor)
                 | Some(TokenKind::WordNot)
+                | Some(TokenKind::Question)
                 | Some(TokenKind::DataMarker)
                 | Some(TokenKind::Eof)
                 | None

--- a/crates/perl-parser-core/tests/named_unary_low_precedence_binding_tests.rs
+++ b/crates/perl-parser-core/tests/named_unary_low_precedence_binding_tests.rs
@@ -1,0 +1,114 @@
+mod cpan_test_helpers;
+
+use cpan_test_helpers::parse;
+use perl_parser_core::NodeKind;
+
+fn parse_program_statements(source: &str) -> Vec<perl_parser_core::Node> {
+    let ast = parse(source);
+    match ast.kind {
+        NodeKind::Program { statements } => statements,
+        other => panic!("expected Program node, got {:?}", other),
+    }
+}
+
+#[test]
+fn bare_call_condition_in_ternary_stays_outside_call() {
+    let statements = parse_program_statements("sub is_ready { 1 }; my $x = is_ready $obj ? 1 : 0;");
+    assert_eq!(statements.len(), 2, "expected sub declaration and assignment statement");
+
+    let NodeKind::VariableDeclaration { initializer: Some(initializer), .. } = &statements[1].kind
+    else {
+        panic!("expected variable declaration with initializer");
+    };
+
+    let NodeKind::Ternary { condition, .. } = &initializer.kind else {
+        panic!("expected ternary initializer");
+    };
+
+    let NodeKind::FunctionCall { name, args } = &condition.kind else {
+        panic!("expected ternary condition to be a function call");
+    };
+
+    assert_eq!(name, "is_ready");
+    assert_eq!(args.len(), 1, "bare call should consume only one high-precedence arg");
+    assert!(matches!(args[0].kind, NodeKind::Variable { .. }));
+}
+
+#[test]
+fn bare_call_with_word_or_keeps_or_outside_call() {
+    let statements = parse_program_statements("do_thing @args or die;");
+    assert_eq!(statements.len(), 1, "expected one expression statement");
+
+    let NodeKind::ExpressionStatement { expression } = &statements[0].kind else {
+        panic!("expected expression statement");
+    };
+
+    let NodeKind::Binary { op, left, .. } = &expression.kind else {
+        panic!("expected binary expression for word-or");
+    };
+
+    assert_eq!(op, "or");
+    assert!(matches!(left.kind, NodeKind::FunctionCall { .. }));
+}
+
+#[test]
+fn bare_call_with_word_and_keeps_and_outside_call() {
+    let statements = parse_program_statements("do_thing $x and return;");
+    assert_eq!(statements.len(), 1, "expected one expression statement");
+
+    let NodeKind::ExpressionStatement { expression } = &statements[0].kind else {
+        panic!("expected expression statement");
+    };
+
+    let NodeKind::Binary { op, left, .. } = &expression.kind else {
+        panic!("expected binary expression for word-and");
+    };
+
+    assert_eq!(op, "and");
+    assert!(matches!(left.kind, NodeKind::FunctionCall { .. }));
+}
+
+#[test]
+fn bare_call_with_defined_or_keeps_defined_or_outside_call() {
+    let statements = parse_program_statements("my $v = transform $x // $fallback;");
+    assert_eq!(statements.len(), 1, "expected one variable declaration statement");
+
+    let NodeKind::VariableDeclaration { initializer: Some(initializer), .. } = &statements[0].kind
+    else {
+        panic!("expected variable declaration with initializer");
+    };
+
+    let NodeKind::Binary { op, left, .. } = &initializer.kind else {
+        panic!("expected binary expression for defined-or");
+    };
+
+    assert_eq!(op, "//");
+    let NodeKind::FunctionCall { name, args } = &left.kind else {
+        panic!("expected left side of // to be function call");
+    };
+
+    assert_eq!(name, "transform");
+    assert_eq!(args.len(), 1, "bare call should consume only one high-precedence arg");
+}
+
+#[test]
+fn nested_bare_call_ternary_binds_inside_larger_expression() {
+    let statements = parse_program_statements("my $z = 1 + (is_ready $obj ? 1 : 0);");
+    assert_eq!(statements.len(), 1, "expected one variable declaration statement");
+
+    let NodeKind::VariableDeclaration { initializer: Some(initializer), .. } = &statements[0].kind
+    else {
+        panic!("expected variable declaration with initializer");
+    };
+
+    let NodeKind::Binary { op, right, .. } = &initializer.kind else {
+        panic!("expected addition expression");
+    };
+
+    assert_eq!(op, "+");
+    let NodeKind::Ternary { condition, .. } = &right.kind else {
+        panic!("expected ternary on right-hand side of addition");
+    };
+
+    assert!(matches!(condition.kind, NodeKind::FunctionCall { .. }));
+}


### PR DESCRIPTION
### Motivation

- Prevent bare unary-style / bare-call forms from greedily absorbing ternary (`? :`) and other low-precedence follow-up operators so constructs like `my $x = is_ready $obj ? 1 : 0;` parse with the ternary outside the call.

### Description

- Stop collecting indirect/bare-call arguments when a `?` token appears by adding `TokenKind::Question` to the call/indirect-call terminator checks in `crates/perl-parser-core/src/engine/parser/expressions/calls.rs`.
- Extend the same `?`-as-terminator logic and statement-end detection in `crates/perl-parser-core/src/engine/parser/expressions/postfix.rs` so `or`, `and`, `//`, and other low-precedence operators bind outside bare calls and print/send implicit-list forms.
- Add focused regression tests in `crates/perl-parser-core/tests/named_unary_low_precedence_binding_tests.rs` exercising `is_ready $obj ? 1 : 0`, `do_thing @args or die`, `do_thing $x and return`, `transform $x // $fallback`, and a nested-case inside a larger expression.
- Changed files: `calls.rs`, `postfix.rs`, and added the new test file under `tests/`.

### Testing

- Ran formatting with `cargo xtask fmt` which completed successfully.
- Ran targeted tests `cargo test -p perl-parser-core ternary`, `cargo test -p perl-parser-core indirect`, and `cargo test -p perl-parser-core named_unary_low_precedence_binding` and they passed.
- Ran full crate tests with `cargo test -p perl-parser-core` which exposed a pre-existing unrelated failure (`test_deref_hash_subscript_regex_key` in `tests/test_edge_cases_deep.rs`) and is not caused by these changes.
- `just parser-audit` and `just corpus-sweep-check` were not executed in this environment because `just` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55ac74d08333a02bbe6d3f82a30e)