### PR TITLE
fix(parser-core): preserve ternary and low-precedence binding after bare calls (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -377,6 +377,7 @@ impl<'a> Parser<'a> {
                         | TokenKind::RightBrace
                         | TokenKind::RightParen
                         | TokenKind::RightBracket
+                        | TokenKind::Question
                 )
             )
         {

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -551,6 +551,7 @@ impl<'a> Parser<'a> {
                                                     | TokenKind::WordAnd
                                                     | TokenKind::WordXor
                                                     | TokenKind::WordNot
+                                                    | TokenKind::Question
                                             )
                                         )
                                     {
@@ -878,6 +879,7 @@ impl<'a> Parser<'a> {
                                                     | TokenKind::WordAnd
                                                     | TokenKind::WordXor
                                                     | TokenKind::WordNot
+                                                    | TokenKind::Question
                                             )
                                         )
                                     {
@@ -934,6 +936,7 @@ impl<'a> Parser<'a> {
                                                     | TokenKind::WordAnd
                                                     | TokenKind::WordXor
                                                     | TokenKind::WordNot
+                                                    | TokenKind::Question
                                             )
                                         )
                                     {
@@ -968,6 +971,7 @@ impl<'a> Parser<'a> {
                                                     | TokenKind::WordAnd
                                                     | TokenKind::WordXor
                                                     | TokenKind::WordNot
+                                                    | TokenKind::Question
                                             )
                                         )
                                     {
@@ -1015,6 +1019,7 @@ impl<'a> Parser<'a> {
                                                     | TokenKind::WordAnd
                                                     | TokenKind::WordXor
                                                     | TokenKind::WordNot
+                                                    | TokenKind::Question
                                             )
                                         )
                                     {
@@ -1085,6 +1090,7 @@ impl<'a> Parser<'a> {
                                                     | TokenKind::WordAnd
                                                     | TokenKind::WordXor
                                                     | TokenKind::WordNot
+                                                    | TokenKind::Question
                                             )
                                         )
                                     {
@@ -1099,6 +1105,7 @@ impl<'a> Parser<'a> {
                                                         | TokenKind::WordAnd
                                                         | TokenKind::WordXor
                                                         | TokenKind::WordNot
+                                                        | TokenKind::Question
                                                 )
                                             )
                                         {
@@ -1198,6 +1205,7 @@ impl<'a> Parser<'a> {
                 | Some(TokenKind::WordOr)
                 | Some(TokenKind::WordXor)
                 | Some(TokenKind::WordNot)
+                | Some(TokenKind::Question)
                 | Some(TokenKind::DataMarker)
                 | Some(TokenKind::Eof)
                 | None

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -120,9 +120,13 @@ impl<'a> Parser<'a> {
             | Some(TokenKind::RightBracket)
             | Some(TokenKind::Eof)
             | None => false,
-            Some(TokenKind::WordOr | TokenKind::WordAnd | TokenKind::WordXor | TokenKind::WordNot) => {
-                false
-            }
+            Some(
+                TokenKind::WordOr
+                    | TokenKind::WordAnd
+                    | TokenKind::WordXor
+                    | TokenKind::WordNot
+                    | TokenKind::Question,
+            ) => false,
             Some(kind) if Self::is_stmt_modifier_kind(kind) => self.is_keyword_before_fat_arrow(),
             _ => true,
         }

--- a/crates/perl-parser-core/tests/bare_call_binding_regression_tests.rs
+++ b/crates/perl-parser-core/tests/bare_call_binding_regression_tests.rs
@@ -1,0 +1,70 @@
+use perl_parser_core::Parser;
+use perl_tdd_support::must;
+
+fn parse_ok(src: &str) -> String {
+    let mut parser = Parser::new(src);
+    let ast = must(parser.parse());
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("ERROR"), "parse should succeed without errors for: {src}\ngot: {sexp}");
+    sexp
+}
+
+#[test]
+fn bare_call_sigil_arg_does_not_absorb_ternary() {
+    let sexp = parse_ok("sub is_ready { 1 }; my $x = is_ready $obj ? 1 : 0;");
+    assert!(sexp.contains("(ternary"), "expected ternary expression, got: {sexp}");
+    assert!(
+        !sexp.contains("ambiguous_function_call_expression (function) (ternary")
+            && !sexp.contains("(call is_ready ((ternary"),
+        "bare call greedily absorbed ternary: {sexp}"
+    );
+}
+
+#[test]
+fn bare_call_sigil_arg_does_not_absorb_word_or() {
+    let sexp = parse_ok("do_thing @args or die;");
+    assert!(sexp.contains("(binary_or"), "expected top-level word-or binding, got: {sexp}");
+    assert!(
+        !sexp.contains("(call do_thing ((binary_or")
+            && !sexp.contains("ambiguous_function_call_expression (function) (binary_or"),
+        "bare call greedily absorbed word-or: {sexp}"
+    );
+}
+
+#[test]
+fn bare_call_sigil_arg_does_not_absorb_word_and() {
+    let sexp = parse_ok("do_thing $x and return;");
+    assert!(sexp.contains("(binary_and"), "expected top-level word-and binding, got: {sexp}");
+    assert!(
+        !sexp.contains("(call do_thing ((binary_and")
+            && !sexp.contains("ambiguous_function_call_expression (function) (binary_and"),
+        "bare call greedily absorbed word-and: {sexp}"
+    );
+}
+
+#[test]
+fn bare_call_sigil_arg_does_not_absorb_defined_or() {
+    let sexp = parse_ok("my $v = transform $x // $fallback;");
+    assert!(
+        sexp.contains("binary_//") || sexp.contains("binary_defined_or"),
+        "expected defined-or expression, got: {sexp}"
+    );
+    assert!(
+        !sexp.contains("(call transform ((binary_//")
+            && !sexp.contains("(call transform ((binary_defined_or")
+            && !sexp.contains("ambiguous_function_call_expression (function) (binary_//")
+            && !sexp.contains("ambiguous_function_call_expression (function) (binary_defined_or"),
+        "bare call greedily absorbed defined-or: {sexp}"
+    );
+}
+
+#[test]
+fn nested_bare_call_condition_still_allows_outer_ternary() {
+    let sexp = parse_ok("my $y = (is_ready $obj ? 1 : 0) + 2;");
+    assert!(sexp.contains("(ternary"), "expected nested ternary, got: {sexp}");
+    assert!(sexp.contains("(binary_+"), "expected outer addition expression, got: {sexp}");
+    assert!(
+        !sexp.contains("(call is_ready ((ternary"),
+        "nested bare call greedily absorbed ternary: {sexp}"
+    );
+}


### PR DESCRIPTION
### Motivation

- Bare unary-style/bare-call parsing was greedily absorbing low-precedence follow-up operators (ternary `? :`, `or`, `and`, `//`), causing expressions like `is_ready $obj ? 1 : 0` to be parsed incorrectly.

### Description

- Stop argument-collection for indirect/bare calls at the ternary `?` token by adding `TokenKind::Question` to the terminator checks in `parse_indirect_call` (`crates/perl-parser-core/src/engine/parser/expressions/calls.rs`).
- Treat `?` as a statement/bare-call boundary in the bare-call continuation and builtin/indirect-object paths by updating checks in `postfix.rs` (`crates/perl-parser-core/src/engine/parser/expressions/postfix.rs`) and `helpers.rs` (`crates/perl-parser-core/src/engine/parser/helpers.rs`).
- Add focused regression tests in `crates/perl-parser-core/tests/bare_call_binding_regression_tests.rs` covering: `is_ready $obj ? 1 : 0;`, `do_thing @args or die;`, `do_thing $x and return;`, `transform $x // $fallback;`, and a nested bare-call-with-ternary case.

### Testing

- Ran `cargo test -p perl-parser-core --test bare_call_binding_regression_tests`, which passed.
- Ran `cargo test -p perl-parser-core ternary` and `cargo test -p perl-parser-core indirect`, both passed.
- Ran `cargo test -p perl-parser-core` but observed one unrelated existing failure in `test_edge_cases_deep::test_deref_hash_subscript_regex_key` (parsing `my $x = ${$ref}{m};`) that predates and is outside the scope of this change.
- Ran `cargo xtask fmt` successfully; `just parser-audit` and `just corpus-sweep-check` were not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55ac74d08333a02bbe6d3f82a30e)