### PR TITLE
fix(parser): recover incomplete string interpolation indexing without ERROR nodes (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -864,7 +864,12 @@ impl<'a> PerlLexer<'a> {
     }
 
     #[inline]
-    fn consume_balanced_segment(&mut self, open: char, close: char) -> Option<usize> {
+    fn consume_balanced_segment_with_terminator(
+        &mut self,
+        open: char,
+        close: char,
+        terminator: Option<char>,
+    ) -> Option<usize> {
         if self.current_char() != Some(open) {
             return None;
         }
@@ -872,6 +877,11 @@ impl<'a> PerlLexer<'a> {
         let mut depth = 1usize;
         self.advance();
         while let Some(ch) = self.current_char() {
+            if terminator == Some(ch) {
+                // Recovery: stop before a known outer delimiter so callers can continue.
+                return None;
+            }
+
             match ch {
                 '\\' => {
                     self.advance();
@@ -2806,7 +2816,9 @@ impl<'a> PerlLexer<'a> {
                     self.advance();
                     match self.current_char() {
                         Some('{') => {
-                            if let Some(end) = self.consume_balanced_segment('{', '}') {
+                            if let Some(end) =
+                                self.consume_balanced_segment_with_terminator('{', '}', Some('"'))
+                            {
                                 parts.push(StringPart::Expression(Arc::from(
                                     &self.input[part_start..end],
                                 )));
@@ -2847,19 +2859,31 @@ impl<'a> PerlLexer<'a> {
 
                                     match self.current_char() {
                                         Some('[') => {
-                                            let _ = self.consume_balanced_segment('[', ']');
+                                            let _ = self.consume_balanced_segment_with_terminator(
+                                                '[',
+                                                ']',
+                                                Some('"'),
+                                            );
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
                                         }
                                         Some('{') => {
-                                            let _ = self.consume_balanced_segment('{', '}');
+                                            let _ = self.consume_balanced_segment_with_terminator(
+                                                '{',
+                                                '}',
+                                                Some('"'),
+                                            );
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
                                         }
                                         Some('(') => {
-                                            let _ = self.consume_balanced_segment('(', ')');
+                                            let _ = self.consume_balanced_segment_with_terminator(
+                                                '(',
+                                                ')',
+                                                Some('"'),
+                                            );
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
@@ -2884,7 +2908,12 @@ impl<'a> PerlLexer<'a> {
                                                 }
                                             }
                                             if self.current_char() == Some('(') {
-                                                let _ = self.consume_balanced_segment('(', ')');
+                                                let _ = self
+                                                    .consume_balanced_segment_with_terminator(
+                                                        '(',
+                                                        ')',
+                                                        Some('"'),
+                                                    );
                                             }
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
@@ -2898,13 +2927,21 @@ impl<'a> PerlLexer<'a> {
                                     }
                                 } else if self.current_char() == Some('[') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('[', ']');
+                                    let _ = self.consume_balanced_segment_with_terminator(
+                                        '[',
+                                        ']',
+                                        Some('"'),
+                                    );
                                     parts.push(StringPart::ArraySlice(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));
                                 } else if self.current_char() == Some('{') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('{', '}');
+                                    let _ = self.consume_balanced_segment_with_terminator(
+                                        '{',
+                                        '}',
+                                        Some('"'),
+                                    );
                                     parts.push(StringPart::Expression(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));

--- a/crates/perl-lexer/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lexer/tests/comprehensive_unit_tests.rs
@@ -714,6 +714,34 @@ fn interpolated_string_preserves_complex_tails() -> R {
                 StringPart::MethodCall(Arc::from("->{key}")),
             ],
         ),
+        (
+            r#""$hash{incomplete""#,
+            vec![
+                StringPart::Variable(Arc::from("$hash")),
+                StringPart::Expression(Arc::from("{incomplete")),
+            ],
+        ),
+        (
+            r#""$array[0""#,
+            vec![
+                StringPart::Variable(Arc::from("$array")),
+                StringPart::ArraySlice(Arc::from("[0")),
+            ],
+        ),
+        (
+            r#""$obj->{field""#,
+            vec![
+                StringPart::Variable(Arc::from("$obj")),
+                StringPart::MethodCall(Arc::from("->{field")),
+            ],
+        ),
+        (
+            r#""$array[$i""#,
+            vec![
+                StringPart::Variable(Arc::from("$array")),
+                StringPart::ArraySlice(Arc::from("[$i")),
+            ],
+        ),
     ];
 
     for (input, expected_parts) in cases {

--- a/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
+++ b/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
@@ -1,0 +1,27 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::assert_clean_parse;
+
+#[test]
+fn double_quote_incomplete_hash_key() {
+    assert_clean_parse(r#"my $msg = "Key: $hash{incomplete";"#);
+}
+
+#[test]
+fn double_quote_incomplete_array_index() {
+    assert_clean_parse(r#"my $item = "Element: $array[0";"#);
+}
+
+#[test]
+fn double_quote_incomplete_nested_deref_field() {
+    assert_clean_parse(r#"my $item = "Nested: $obj->{field";"#);
+}
+
+#[test]
+fn double_quote_incomplete_mixed_array_index_expr() {
+    assert_clean_parse(r#"my $item = "Mixed: $array[$i";"#);
+}
+
+#[test]
+fn double_quote_complete_interpolation_still_clean() {
+    assert_clean_parse(r#"my $ok = "Key: $hash{complete} Element: $array[0]";"#);
+}


### PR DESCRIPTION
### Motivation

- While users type, double-quoted strings frequently contain incomplete interpolation tails like `$hash{incomplete` or `$array[0` that should not produce top-level `ERROR` nodes and should preserve extractable variable references.
- The lexer was consuming balanced segment scans past the closing `"`, which could collapse interpolation-local incompleteness into a catastrophic token/parse error.

### Description

- Add `consume_balanced_segment_with_terminator` to the lexer to allow balanced-segment scanning to stop early when encountering a caller-specified terminator (used to avoid consuming the surrounding `"`).
- Use the new terminator-aware routine in double-quoted interpolation handling for `${...}`, `$var[...]`, `$var{...}`, and `->` tails so incomplete `StringPart` tails like `"{incomplete"`, `"[0"`, `"-> {field"`, and `"[$i"` are preserved as partial `StringPart` entries instead of forcing an `ERROR` token (file: `crates/perl-lexer/src/lib.rs`).
- Add lexer unit-test cases and parser clean-parse regression tests to verify incomplete and complete interpolation behavior (`crates/perl-lexer/tests/comprehensive_unit_tests.rs` and new `crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs`).

### Testing

- Ran `cargo test -p perl-lexer interpolated_string_preserves_complex_tails` and it passed.
- Ran `cargo test -p perl-parser-core --test string_interpolation_incomplete_tests` and it passed.
- Ran `cargo test -p perl-parser-core string_interpolation` and it passed.
- Ran the full `cargo test -p perl-parser-core` in this environment and observed an unrelated existing test failure (`test_deref_hash_subscript_regex_key`) that pre-existed and is outside the scope of this change; the interpolation-specific tests introduced here passed.
- `just parser-audit` and `just cpan-corpus-check` were not executed because `just` is not available in this environment (error: `just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55b1097c8333818c7daf6568de7c)