### PR TITLE
fix(parser): recover incomplete string interpolation indexing without ERROR nodes (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -897,6 +897,56 @@ impl<'a> PerlLexer<'a> {
         None
     }
 
+    /// Like `consume_balanced_segment`, but stops before an unescaped string terminator.
+    ///
+    /// This is used for interpolation tails inside double-quoted strings (e.g. `$h{key}`).
+    /// If the interpolation subscript/index is incomplete (missing `}` or `]`) and a closing
+    /// `"` is reached, we must *not* consume through that quote, otherwise the entire string
+    /// is misclassified as unterminated.
+    #[inline]
+    fn consume_balanced_segment_until_terminator(
+        &mut self,
+        open: char,
+        close: char,
+        terminator: char,
+    ) -> Option<usize> {
+        if self.current_char() != Some(open) {
+            return None;
+        }
+
+        let mut depth = 1usize;
+        self.advance();
+        while let Some(ch) = self.current_char() {
+            match ch {
+                '\\' => {
+                    self.advance();
+                    if self.current_char().is_some() {
+                        self.advance();
+                    }
+                }
+                c if c == open => {
+                    depth += 1;
+                    self.advance();
+                }
+                c if c == close => {
+                    self.advance();
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(self.position);
+                    }
+                }
+                c if c == terminator => {
+                    // Incomplete interpolation segment; leave the terminator in the stream
+                    // so the outer string parser can close the string token cleanly.
+                    return None;
+                }
+                _ => self.advance(),
+            }
+        }
+
+        None
+    }
+
     /// Fast byte-level check for ASCII characters
     #[inline]
     fn peek_byte(&self, offset: usize) -> Option<u8> {
@@ -2847,13 +2897,17 @@ impl<'a> PerlLexer<'a> {
 
                                     match self.current_char() {
                                         Some('[') => {
-                                            let _ = self.consume_balanced_segment('[', ']');
+                                            let _ = self.consume_balanced_segment_until_terminator(
+                                                '[', ']', '"',
+                                            );
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
                                         }
                                         Some('{') => {
-                                            let _ = self.consume_balanced_segment('{', '}');
+                                            let _ = self.consume_balanced_segment_until_terminator(
+                                                '{', '}', '"',
+                                            );
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
@@ -2898,13 +2952,15 @@ impl<'a> PerlLexer<'a> {
                                     }
                                 } else if self.current_char() == Some('[') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('[', ']');
+                                    let _ = self
+                                        .consume_balanced_segment_until_terminator('[', ']', '"');
                                     parts.push(StringPart::ArraySlice(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));
                                 } else if self.current_char() == Some('{') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('{', '}');
+                                    let _ = self
+                                        .consume_balanced_segment_until_terminator('{', '}', '"');
                                     parts.push(StringPart::Expression(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -1,4 +1,95 @@
 impl<'a> Parser<'a> {
+    fn record_incomplete_interpolation_indexing(&mut self, token_text: &str, token_start: usize) {
+        if !token_text.starts_with('"') || token_text.len() < 2 {
+            return;
+        }
+
+        let body = &token_text[1..token_text.len() - 1];
+        let bytes = body.as_bytes();
+        let mut i = 0usize;
+
+        while i < bytes.len() {
+            if bytes[i] == b'\\' {
+                i = i.saturating_add(2);
+                continue;
+            }
+
+            if bytes[i] != b'$' {
+                i += 1;
+                continue;
+            }
+
+            let mut j = i + 1;
+            if j >= bytes.len() {
+                break;
+            }
+
+            let starts_ident = (bytes[j] as char).is_ascii_alphabetic() || bytes[j] == b'_';
+            if !starts_ident {
+                i += 1;
+                continue;
+            }
+
+            j += 1;
+            while j < bytes.len()
+                && ((bytes[j] as char).is_ascii_alphanumeric() || bytes[j] == b'_')
+            {
+                j += 1;
+            }
+
+            let mut opener_idx = None;
+            let mut open = b' ';
+            let mut close = b' ';
+
+            if j < bytes.len() && bytes[j] == b'[' {
+                opener_idx = Some(j);
+                open = b'[';
+                close = b']';
+            } else if j < bytes.len() && bytes[j] == b'{' {
+                opener_idx = Some(j);
+                open = b'{';
+                close = b'}';
+            } else if j + 2 < bytes.len() && bytes[j] == b'-' && bytes[j + 1] == b'>' && bytes[j + 2] == b'{' {
+                opener_idx = Some(j + 2);
+                open = b'{';
+                close = b'}';
+            }
+
+            if let Some(start_idx) = opener_idx {
+                let mut depth = 1usize;
+                let mut k = start_idx + 1;
+                while k < bytes.len() {
+                    if bytes[k] == b'\\' {
+                        k = k.saturating_add(2);
+                        continue;
+                    }
+                    if bytes[k] == open {
+                        depth += 1;
+                    } else if bytes[k] == close {
+                        depth -= 1;
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    k += 1;
+                }
+
+                if depth > 0 {
+                    let delim = if open == b'{' { "{...}" } else { "[...]" };
+                    self.record_error(ParseError::syntax(
+                        format!("Incomplete interpolation indexing: missing closing delimiter for {}", delim),
+                        token_start,
+                    ));
+                    return;
+                }
+                i = k + 1;
+                continue;
+            }
+
+            i = j;
+        }
+    }
+
     /// Parse qualified identifier (may contain ::)
     fn parse_qualified_identifier(&mut self) -> ParseResult<Node> {
         // Note: qualified identifier parsing is not recursive - no guard needed
@@ -71,6 +162,9 @@ impl<'a> Parser<'a> {
                 let token = self.tokens.next()?;
                 // Check if it's a double-quoted string (interpolated)
                 let interpolated = token.text.starts_with('"');
+                if interpolated {
+                    self.record_incomplete_interpolation_indexing(&token.text, token.start);
+                }
                 Ok(Node::new(
                     NodeKind::String { value: token.text.to_string(), interpolated },
                     SourceLocation { start: token.start, end: token.end },

--- a/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
+++ b/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
@@ -1,0 +1,92 @@
+use perl_parser_core::{Node, NodeKind, Parser};
+
+fn collect_string_literals(node: &Node, out: &mut Vec<String>) {
+    if let NodeKind::String { value, .. } = &node.kind {
+        out.push(value.clone());
+    }
+    for child in node.children() {
+        collect_string_literals(child, out);
+    }
+}
+
+fn parse_and_assert_no_error_nodes(
+    code: &str,
+) -> Result<(Node, Vec<String>, usize), Box<dyn std::error::Error>> {
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("ERROR"), "Parse of `{code}` produced ERROR node(s): {sexp}");
+    let mut strings = Vec::new();
+    collect_string_literals(&ast, &mut strings);
+    let error_count = parser.errors().len();
+    Ok((ast, strings, error_count))
+}
+
+#[test]
+fn double_quote_incomplete_hash_key() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"my $msg = "Key: $hash{incomplete";"#;
+    let (_ast, strings, error_count) = parse_and_assert_no_error_nodes(code)?;
+
+    assert!(
+        strings.iter().any(|s| s.contains("$hash{incomplete")),
+        "Interpolated string content should preserve `$hash` even with incomplete hash indexing"
+    );
+    assert!(error_count > 0, "Incomplete hash interpolation should still record a diagnostic");
+    Ok(())
+}
+
+#[test]
+fn double_quote_incomplete_array_index() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"my $item = "Element: $array[0";"#;
+    let (_ast, strings, error_count) = parse_and_assert_no_error_nodes(code)?;
+
+    assert!(
+        strings.iter().any(|s| s.contains("$array[0")),
+        "Interpolated string content should preserve `$array` even with incomplete indexing"
+    );
+    assert!(error_count > 0, "Incomplete array interpolation should still record a diagnostic");
+    Ok(())
+}
+
+#[test]
+fn double_quote_incomplete_arrow_hash_index() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"my $msg = "Nested: $obj->{field";"#;
+    let (_ast, strings, error_count) = parse_and_assert_no_error_nodes(code)?;
+
+    assert!(
+        strings.iter().any(|s| s.contains("$obj->{field")),
+        "Interpolated string content should preserve `$obj` even with incomplete arrow hash dereference"
+    );
+    assert!(
+        error_count > 0,
+        "Incomplete arrow hash interpolation should still record a diagnostic"
+    );
+    Ok(())
+}
+
+#[test]
+fn double_quote_incomplete_mixed_array_index() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"my $msg = "Mixed: $array[$i";"#;
+    let (_ast, strings, error_count) = parse_and_assert_no_error_nodes(code)?;
+
+    assert!(
+        strings.iter().any(|s| s.contains("$array[$i")),
+        "Interpolated string content should preserve `$array` in mixed indexing form"
+    );
+    assert!(error_count > 0, "Incomplete mixed interpolation should still record a diagnostic");
+    Ok(())
+}
+
+#[test]
+fn double_quote_complete_interpolation_still_clean() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $ok1 = "Key: $hash{complete}";
+my $ok2 = "Element: $array[0]";
+my $ok3 = "Nested: $obj->{field}";
+my $ok4 = "Mixed: $array[$i]";
+"#;
+
+    let (_ast, _strings, error_count) = parse_and_assert_no_error_nodes(code)?;
+    assert_eq!(error_count, 0, "Complete interpolation should not produce diagnostics");
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- While users are typing, incomplete indexing inside double-quoted interpolations (e.g. `$hash{incomplete`, `$array[0`) caused the lexer to consume through the closing quote and the parser to produce top-level ERROR nodes, degrading IDE features and symbol extraction.

### Description
- Add `consume_balanced_segment_until_terminator` in the lexer to stop balanced scanning for `[...]` / `{...}` when an unescaped string terminator (`"`) is encountered so the surrounding string token is preserved (`crates/perl-lexer/src/lib.rs`).
- Use the lexer recovery when parsing interpolation tails (array/hash/arrow subscripts/method tails) so incomplete subscripts do not swallow the closing quote and remain as string parts (`crates/perl-lexer/src/lib.rs`).
- Add a parser-side helper `record_incomplete_interpolation_indexing` that emits a diagnostic for incomplete interpolation indexing without producing a propagated `ERROR` node and attach it when consuming double-quoted string tokens (`crates/perl-parser-core/src/engine/parser/expressions/primary.rs`).
- Add focused regression tests that assert no top-level `ERROR` nodes, preservation of interpolated string content, and that diagnostics are recorded for incomplete cases while complete interpolations remain clean (`crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs`).

### Testing
- Ran `cargo test -p perl-parser-core --test string_interpolation_incomplete_tests` and all new tests passed (5/5).
- Ran `cargo test -p perl-parser-core string_interpolation` and it completed successfully.
- Ran `cargo test -p perl-parser-core` which exposes an existing unrelated failing test (`test_edge_cases_deep::test_deref_hash_subscript_regex_key`) that predates this change and remains failing; this failure is unrelated to the interpolation recovery.
- Ran `cargo xtask fmt` to format code; `just parser-audit` / `just cpan-corpus-check` were not run because `just` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55b1097c8333818c7daf6568de7c)