### PR TITLE
fix(parser): recover incomplete string interpolation indexing without ERROR nodes (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -897,6 +897,48 @@ impl<'a> PerlLexer<'a> {
         None
     }
 
+    #[inline]
+    fn consume_balanced_segment_with_stop(
+        &mut self,
+        open: char,
+        close: char,
+        stop: char,
+    ) -> Option<usize> {
+        if self.current_char() != Some(open) {
+            return None;
+        }
+
+        let mut depth = 1usize;
+        self.advance();
+        while let Some(ch) = self.current_char() {
+            match ch {
+                '\\' => {
+                    self.advance();
+                    if self.current_char().is_some() {
+                        self.advance();
+                    }
+                }
+                c if c == open => {
+                    depth += 1;
+                    self.advance();
+                }
+                c if c == close => {
+                    self.advance();
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(self.position);
+                    }
+                }
+                c if c == stop => {
+                    return None;
+                }
+                _ => self.advance(),
+            }
+        }
+
+        None
+    }
+
     /// Fast byte-level check for ASCII characters
     #[inline]
     fn peek_byte(&self, offset: usize) -> Option<u8> {
@@ -2847,13 +2889,15 @@ impl<'a> PerlLexer<'a> {
 
                                     match self.current_char() {
                                         Some('[') => {
-                                            let _ = self.consume_balanced_segment('[', ']');
+                                            let _ = self
+                                                .consume_balanced_segment_with_stop('[', ']', '"');
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
                                         }
                                         Some('{') => {
-                                            let _ = self.consume_balanced_segment('{', '}');
+                                            let _ = self
+                                                .consume_balanced_segment_with_stop('{', '}', '"');
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
@@ -2898,13 +2942,13 @@ impl<'a> PerlLexer<'a> {
                                     }
                                 } else if self.current_char() == Some('[') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('[', ']');
+                                    let _ = self.consume_balanced_segment_with_stop('[', ']', '"');
                                     parts.push(StringPart::ArraySlice(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));
                                 } else if self.current_char() == Some('{') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('{', '}');
+                                    let _ = self.consume_balanced_segment_with_stop('{', '}', '"');
                                     parts.push(StringPart::Expression(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));

--- a/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
+++ b/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
@@ -1,0 +1,74 @@
+mod cpan_test_helpers;
+
+use cpan_test_helpers::assert_clean_parse;
+use perl_lexer::{PerlLexer, StringPart, TokenType};
+use perl_tdd_support::must_some;
+
+#[test]
+fn double_quote_incomplete_hash_key() {
+    assert_clean_parse(r#"my $msg = "Key: $hash{incomplete";"#);
+}
+
+#[test]
+fn double_quote_incomplete_array_index() {
+    assert_clean_parse(r#"my $item = "Element: $array[0";"#);
+}
+
+#[test]
+fn double_quote_incomplete_arrow_hash_key() {
+    assert_clean_parse(r#"my $nested = "Nested: $obj->{field";"#);
+}
+
+#[test]
+fn double_quote_mixed_incomplete_array_index_expr() {
+    assert_clean_parse(r#"my $mixed = "Mixed: $array[$i";"#);
+}
+
+#[test]
+fn double_quote_complete_interpolation_still_parses() {
+    assert_clean_parse(
+        r#"my $ok = "Key: $hash{complete} Element: $array[0] Nested: $obj->{field} Mixed: $array[$i]";"#,
+    );
+}
+
+#[test]
+fn incomplete_interpolation_still_emits_variable_parts() {
+    let source = r#"my $msg = "Key: $hash{incomplete"; my $item = "Element: $array[0";"#;
+    let mut lexer = PerlLexer::new(source);
+    let tokens = lexer.collect_tokens();
+    let token_texts: Vec<String> = tokens.iter().map(|t| t.text.to_string()).collect();
+
+    let hash_token =
+        must_some(tokens.iter().find(|t| t.text.as_ref() == "\"Key: $hash{incomplete\""));
+    let array_token = must_some(tokens.iter().find(|t| t.text.as_ref() == "\"Element: $array[0\""));
+
+    assert!(
+        matches!(&hash_token.token_type, TokenType::InterpolatedString(_)),
+        "Expected interpolated string token for hash case. token stream: {:?}",
+        token_texts
+    );
+    if let TokenType::InterpolatedString(parts) = &hash_token.token_type {
+        assert!(
+            parts
+                .iter()
+                .any(|part| matches!(part, StringPart::Variable(v) if v.as_ref() == "$hash")),
+            "Expected $hash interpolation part. token stream: {:?}",
+            token_texts
+        );
+    }
+
+    assert!(
+        matches!(&array_token.token_type, TokenType::InterpolatedString(_)),
+        "Expected interpolated string token for array case. token stream: {:?}",
+        token_texts
+    );
+    if let TokenType::InterpolatedString(parts) = &array_token.token_type {
+        assert!(
+            parts
+                .iter()
+                .any(|part| matches!(part, StringPart::Variable(v) if v.as_ref() == "$array")),
+            "Expected $array interpolation part. token stream: {:?}",
+            token_texts
+        );
+    }
+}


### PR DESCRIPTION
### Motivation

- In-progress double-quoted interpolation with unclosed `{` or `[` could cause the lexer to treat the whole string as unterminated and propagate a top-level ERROR into the parser, breaking AST-based symbol extraction while users are typing.

### Description

- Added `consume_balanced_segment_with_stop(open, close, stop)` to the lexer to parse balanced `{...}` / `[...]` segments but stop early if the string terminator (`"`) is encountered, avoiding consumption to EOF. (`crates/perl-lexer/src/lib.rs`)
- Wired the new stop-aware balanced-segment helper into interpolation-tail parsing so `->[...]`, `->{...}`, `[...]`, and `{...}` tail fragments inside interpolated variables stop at the string close, preserving the `InterpolatedString` token and its constituent `StringPart`s. (`crates/perl-lexer/src/lib.rs`) 
- Added parser-core regression tests covering incomplete and complete interpolations to assert clean parse and to verify the lexer still emits `InterpolatedString` parts containing variable parts for incomplete cases: `double_quote_incomplete_hash_key`, `double_quote_incomplete_array_index`, `double_quote_incomplete_arrow_hash_key`, `double_quote_mixed_incomplete_array_index_expr`, a complete-case control, and a token-level assertion that `$hash` / `$array` parts are present. (`crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs`)

### Testing

- Ran `cargo test -p perl-parser-core --test string_interpolation_incomplete_tests`, and all tests in that file passed.
- Ran `cargo test -p perl-parser-core string_interpolation` and selected test invocations; the new tests passed and the interpolated-string behavior was validated via lexer token checks.
- Ran the full crate test suite `cargo test -p perl-parser-core`; most tests passed but a pre-existing test failed (`test_edge_cases_deep::test_deref_hash_subscript_regex_key`) in this environment (failure appears unrelated to the new lexer recovery and exists in the branch state).
- Ran `cargo fmt --all`; formatting applied.
- `just`-based audit commands were not executed because `just` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55b1097c8333818c7daf6568de7c)