### PR TITLE
fix(master): resolve fmt + format-string bit-rot blocking 30+ PRs (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -3825,15 +3825,8 @@ sub helper { }
         let root = temp.path().join("lib");
 
         // Build a path 9 levels deep: root/a/b/c/d/e/f/g/h/
-        let deep_dir = root
-            .join("a")
-            .join("b")
-            .join("c")
-            .join("d")
-            .join("e")
-            .join("f")
-            .join("g")
-            .join("h"); // depth 8 — should be scanned
+        let deep_dir =
+            root.join("a").join("b").join("c").join("d").join("e").join("f").join("g").join("h"); // depth 8 — should be scanned
         let too_deep = deep_dir.join("x"); // depth 9 — must be skipped
         fs::create_dir_all(&too_deep)?;
         fs::write(deep_dir.join("AtLimit.pm"), "package A::B::C::D::E::F::G::H::AtLimit;\n1;\n")?;

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -102,9 +102,8 @@ impl LspServer {
         // use_system_inc=true would spawn `perl -e 'print join("\n", @INC)'`.
         if include_system_inc {
             let mut folders = self.workspace_folders.lock();
-            if let Some(folder) = folders
-                .iter_mut()
-                .find(|f| super::super::workspace_folder_matches_doc_uri(f, uri))
+            if let Some(folder) =
+                folders.iter_mut().find(|f| super::super::workspace_folder_matches_doc_uri(f, uri))
             {
                 for path in folder.effective_workspace_config.get_system_inc() {
                     if seen_system.insert(path.clone()) {

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1957,8 +1957,7 @@ print helper_two();
 }
 
 #[test]
-fn strict_subs_still_flags_import_without_require()
--> Result<(), Box<dyn std::error::Error>> {
+fn strict_subs_still_flags_import_without_require() -> Result<(), Box<dyn std::error::Error>> {
     // Guard: ->import() without a preceding require should NOT suppress strict_subs.
     // Bareword identifiers (no parens) are the subject of strict 'subs' checking.
     // Use `print SOME_CONST` to produce an Identifier node rather than a FunctionCall.
@@ -3901,8 +3900,7 @@ print get_value();
 }
 
 #[test]
-fn require_inside_eval_block_is_runtime_not_static()
--> Result<(), Box<dyn std::error::Error>> {
+fn require_inside_eval_block_is_runtime_not_static() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 eval {
@@ -3916,7 +3914,7 @@ print func();
         issues.iter().any(|issue| {
             matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "func"
         }),
-        "require inside eval { } is runtime; should not suppress strict 'subs'"
+        "require inside eval {{}} is runtime; should not suppress strict 'subs'"
     );
     Ok(())
 }
@@ -3934,7 +3932,8 @@ print exported_func();
     let issues = scope_issues_strict(code);
     assert!(
         issues.iter().any(|issue| {
-            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "exported_func"
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "exported_func"
         }),
         "require with variable target is runtime; should not suppress strict 'subs'"
     );
@@ -3942,8 +3941,7 @@ print exported_func();
 }
 
 #[test]
-fn multiple_imports_from_same_required_module()
--> Result<(), Box<dyn std::error::Error>> {
+fn multiple_imports_from_same_required_module() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 require Toolkit;
@@ -3959,15 +3957,15 @@ print func_c();
             !issues.iter().any(|issue| {
                 matches!(issue.kind, IssueKind::UnquotedBareword) && &issue.variable_name == symbol
             }),
-            "strict 'subs' should not flag {} imported via multiple calls", symbol
+            "strict 'subs' should not flag {} imported via multiple calls",
+            symbol
         );
     }
     Ok(())
 }
 
 #[test]
-fn require_path_form_vs_bareword_normalization()
--> Result<(), Box<dyn std::error::Error>> {
+fn require_path_form_vs_bareword_normalization() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 require "Mismatched/Module.pm";
@@ -3985,8 +3983,7 @@ print exported();
 }
 
 #[test]
-fn import_on_unrequired_module_does_not_suppress()
--> Result<(), Box<dyn std::error::Error>> {
+fn import_on_unrequired_module_does_not_suppress() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 Unrelated::Module->import('orphaned_func');
@@ -3995,7 +3992,8 @@ print orphaned_func();
     let issues = scope_issues_strict(code);
     assert!(
         issues.iter().any(|issue| {
-            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "orphaned_func"
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "orphaned_func"
         }),
         "->import() without preceding require should not suppress strict 'subs'"
     );
@@ -4003,8 +4001,7 @@ print orphaned_func();
 }
 
 #[test]
-fn qw_form_with_special_delimiters()
--> Result<(), Box<dyn std::error::Error>> {
+fn qw_form_with_special_delimiters() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 require Delim::Module;
@@ -4025,8 +4022,7 @@ print sym_two();
 }
 
 #[test]
-fn require_without_subsequent_import_does_nothing()
--> Result<(), Box<dyn std::error::Error>> {
+fn require_without_subsequent_import_does_nothing() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 require Some::Module;
@@ -4035,7 +4031,8 @@ print unimported_symbol();
     let issues = scope_issues_strict(code);
     assert!(
         issues.iter().any(|issue| {
-            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "unimported_symbol"
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "unimported_symbol"
         }),
         "bare require without ->import() should not suppress unrelated symbols"
     );
@@ -4043,8 +4040,7 @@ print unimported_symbol();
 }
 
 #[test]
-fn array_literal_import_args()
--> Result<(), Box<dyn std::error::Error>> {
+fn array_literal_import_args() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 require ArrayImporter;
@@ -4058,15 +4054,15 @@ print sym_y();
             !issues.iter().any(|issue| {
                 matches!(issue.kind, IssueKind::UnquotedBareword) && &issue.variable_name == symbol
             }),
-            "array literal import should register {}", symbol
+            "array literal import should register {}",
+            symbol
         );
     }
     Ok(())
 }
 
 #[test]
-fn nested_blocks_preserve_require_scope()
--> Result<(), Box<dyn std::error::Error>> {
+fn nested_blocks_preserve_require_scope() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 {
@@ -4080,7 +4076,8 @@ print nested_func();
     let issues = scope_issues_strict(code);
     assert!(
         !issues.iter().any(|issue| {
-            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "nested_func"
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "nested_func"
         }),
         "require should be visible to nested import in same program scope"
     );

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -5761,8 +5761,8 @@ sub other_sub {
     // ========================================================================
 
     #[test]
-    fn test_require_with_variable_target_is_not_indexed()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_require_with_variable_target_is_not_indexed() -> Result<(), Box<dyn std::error::Error>>
+    {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/require-var.pl"));
         let src = r#"package Test;
@@ -5780,8 +5780,7 @@ require $loader;
     }
 
     #[test]
-    fn test_multiple_import_calls_on_same_module()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_multiple_import_calls_on_same_module() -> Result<(), Box<dyn std::error::Error>> {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/multi-import.pl"));
         let src = r#"package Test;
@@ -5801,8 +5800,7 @@ Toolkit->import(qw(func_b func_c));
     }
 
     #[test]
-    fn test_require_string_vs_bareword_normalization()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_require_string_vs_bareword_normalization() -> Result<(), Box<dyn std::error::Error>> {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/require-string.pl"));
         let src = r#"package Consumer;
@@ -5846,8 +5844,7 @@ orphaned();
     }
 
     #[test]
-    fn test_nested_blocks_preserve_require_scope()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_nested_blocks_preserve_require_scope() -> Result<(), Box<dyn std::error::Error>> {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/nested.pl"));
         let src = r#"package Test;
@@ -5871,8 +5868,7 @@ orphaned();
     }
 
     #[test]
-    fn test_require_path_without_pm_extension()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_require_path_without_pm_extension() -> Result<(), Box<dyn std::error::Error>> {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/no-ext.pl"));
         let src = r#"package Test;
@@ -5890,8 +5886,7 @@ My::Module->import('func');
     }
 
     #[test]
-    fn test_qw_with_bracket_delimiters()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_qw_with_bracket_delimiters() -> Result<(), Box<dyn std::error::Error>> {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/qw-delim.pl"));
         let src = r#"package Test;
@@ -5905,15 +5900,15 @@ DelimModule->import(qw{sym3 sym4});
             let refs = index.find_references(symbol);
             assert!(
                 !refs.is_empty(),
-                "symbols from qw with bracket delimiters should be indexed: {}", symbol
+                "symbols from qw with bracket delimiters should be indexed: {}",
+                symbol
             );
         }
         Ok(())
     }
 
     #[test]
-    fn test_array_literal_import_args()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_array_literal_import_args() -> Result<(), Box<dyn std::error::Error>> {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/array-import.pl"));
         let src = r#"package Test;
@@ -5926,7 +5921,8 @@ ArrayModule->import(['sym_x', 'sym_y']);
             let refs = index.find_references(symbol);
             assert!(
                 !refs.is_empty(),
-                "symbols from array literal import should be indexed: {}", symbol
+                "symbols from array literal import should be indexed: {}",
+                symbol
             );
         }
         Ok(())
@@ -5956,8 +5952,7 @@ if (1) {
     }
 
     #[test]
-    fn test_mixed_string_and_bareword_imports()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_mixed_string_and_bareword_imports() -> Result<(), Box<dyn std::error::Error>> {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/mixed-import.pl"));
         let src = r#"package Test;
@@ -5971,10 +5966,7 @@ MixedMod->import(qw(qw_one qw_two));
         assert!(deps.contains("MixedMod"), "require should register dependency");
         for symbol in &["string_sym", "qw_one", "qw_two"] {
             let refs = index.find_references(symbol);
-            assert!(
-                !refs.is_empty(),
-                "all import forms should index symbols: {}", symbol
-            );
+            assert!(!refs.is_empty(), "all import forms should index symbols: {}", symbol);
         }
         Ok(())
     }

--- a/xtask/src/tasks/ux_scorecard.rs
+++ b/xtask/src/tasks/ux_scorecard.rs
@@ -341,9 +341,7 @@ mod tests {
                 definition_exact_hit: None,
                 symbol_correct: Some(true),
                 cross_file_success: None,
-                latency_ms_by_request: BTreeMap::from([
-                    ("hover".to_string(), vec![10, 20, 30]),
-                ]),
+                latency_ms_by_request: BTreeMap::from([("hover".to_string(), vec![10, 20, 30])]),
             },
             ScenarioMeasurement {
                 scenario_id: "completion_test".to_string(),
@@ -415,22 +413,16 @@ mod tests {
             provenance: serde_json::json!({"input": "fixture", "generator": "test"}),
         };
 
-        let json_str = serde_json::to_string_pretty(&artifact)
-            .expect("artifact must serialize without error");
+        let json_str =
+            serde_json::to_string_pretty(&artifact).expect("artifact must serialize without error");
         let parsed: serde_json::Value =
             serde_json::from_str(&json_str).expect("serialized artifact must parse back");
 
         assert_eq!(parsed["schema_version"], 1);
         assert_eq!(parsed["subsystem"], "editor_ux");
         // PercentMetric serializes as {"value": <f64>}.
-        assert_eq!(
-            parsed["rows"]["hover_correctness_pct"]["value"],
-            serde_json::json!(50.0)
-        );
-        assert_eq!(
-            parsed["rows"]["symbol_correctness_pct"]["value"],
-            serde_json::json!(50.0)
-        );
+        assert_eq!(parsed["rows"]["hover_correctness_pct"]["value"], serde_json::json!(50.0));
+        assert_eq!(parsed["rows"]["symbol_correctness_pct"]["value"], serde_json::json!(50.0));
         // Latency is serialized nested under latency_by_request_class.
         assert!(parsed["latency_by_request_class"]["hover"]["p50_ms"].is_number());
         assert!(parsed["latency_by_request_class"]["completion"]["p95_ms"].is_number());


### PR DESCRIPTION
## Summary

Two master bit-rot fixes required before any waiting PR can merge cleanly:

1. **Format-string mismatch** (`crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs:3919`): `assert!` failure message contained a literal `{ }` which Rust parsed as a positional `{}` placeholder with zero arguments — compile error. Fixed by escaping to `{{}}`.

2. **Formatting violations** (`crates/perl-workspace-index/src/workspace/workspace_index.rs` and 3 other files): `cargo xtask fmt --check` failed. Applied `cargo xtask fmt` to bring all files into compliance. Affected files:
   - `crates/perl-workspace-index/src/workspace/workspace_index.rs`
   - `crates/perl-lsp-rs-core/src/providers/completion/completion.rs`
   - `crates/perl-lsp-rs/src/runtime/language/completion.rs`
   - `xtask/src/tasks/ux_scorecard.rs`

## Verification

- `cargo check -p perl-semantic-analyzer --tests` → clean (0 errors)
- `cargo xtask fmt --check` → exit 0
- `cargo check --all-targets` → 0 errors (pre-existing warnings only)

## Unblocked PRs

Estimated ~30 waiting PRs that fail `cargo check --tests` or `cargo xtask fmt --check` on master are unblocked by this fix.

## Test plan

- [ ] CI passes `cargo check --all-targets`
- [ ] CI passes `cargo xtask fmt --check`
- [ ] CI passes `cargo test -p perl-semantic-analyzer`