### PR TITLE
fix(parser): recover incomplete interpolation indexing in strings (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -863,6 +863,11 @@ impl<'a> PerlLexer<'a> {
         }
     }
 
+    /// General-purpose balanced-segment consumer (no quote-boundary recovery).
+    ///
+    /// For use inside double-quoted string interpolation where the outer `"` must
+    /// act as a recovery boundary, use [`consume_balanced_segment_in_string`] instead.
+    #[allow(dead_code)]
     #[inline]
     fn consume_balanced_segment(&mut self, open: char, close: char) -> Option<usize> {
         if self.current_char() != Some(open) {
@@ -2905,7 +2910,8 @@ impl<'a> PerlLexer<'a> {
                                             )));
                                         }
                                         Some('(') => {
-                                            let _ = self.consume_balanced_segment('(', ')');
+                                            let _ = self
+                                                .consume_balanced_segment_in_string('(', ')', '"');
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
@@ -2930,7 +2936,9 @@ impl<'a> PerlLexer<'a> {
                                                 }
                                             }
                                             if self.current_char() == Some('(') {
-                                                let _ = self.consume_balanced_segment('(', ')');
+                                                let _ = self.consume_balanced_segment_in_string(
+                                                    '(', ')', '"',
+                                                );
                                             }
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],

--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -897,6 +897,51 @@ impl<'a> PerlLexer<'a> {
         None
     }
 
+    #[inline]
+    fn consume_balanced_segment_in_string(
+        &mut self,
+        open: char,
+        close: char,
+        terminator: char,
+    ) -> Option<usize> {
+        if self.current_char() != Some(open) {
+            return None;
+        }
+
+        let mut depth = 1usize;
+        self.advance();
+        while let Some(ch) = self.current_char() {
+            match ch {
+                '\\' => {
+                    self.advance();
+                    if self.current_char().is_some() {
+                        self.advance();
+                    }
+                }
+                c if c == terminator => {
+                    // Local recovery for interpolation tails in quoted strings:
+                    // stop at the closing quote so the outer string parser can
+                    // still terminate this token cleanly.
+                    return None;
+                }
+                c if c == open => {
+                    depth += 1;
+                    self.advance();
+                }
+                c if c == close => {
+                    self.advance();
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(self.position);
+                    }
+                }
+                _ => self.advance(),
+            }
+        }
+
+        None
+    }
+
     /// Fast byte-level check for ASCII characters
     #[inline]
     fn peek_byte(&self, offset: usize) -> Option<u8> {
@@ -2806,11 +2851,10 @@ impl<'a> PerlLexer<'a> {
                     self.advance();
                     match self.current_char() {
                         Some('{') => {
-                            if let Some(end) = self.consume_balanced_segment('{', '}') {
-                                parts.push(StringPart::Expression(Arc::from(
-                                    &self.input[part_start..end],
-                                )));
-                            }
+                            let _ = self.consume_balanced_segment_in_string('{', '}', '"');
+                            parts.push(StringPart::Expression(Arc::from(
+                                &self.input[part_start..self.position],
+                            )));
                         }
                         Some(ch) if is_perl_identifier_start(ch) => {
                             let var_start = self.position;
@@ -2847,13 +2891,15 @@ impl<'a> PerlLexer<'a> {
 
                                     match self.current_char() {
                                         Some('[') => {
-                                            let _ = self.consume_balanced_segment('[', ']');
+                                            let _ = self
+                                                .consume_balanced_segment_in_string('[', ']', '"');
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
                                         }
                                         Some('{') => {
-                                            let _ = self.consume_balanced_segment('{', '}');
+                                            let _ = self
+                                                .consume_balanced_segment_in_string('{', '}', '"');
                                             parts.push(StringPart::MethodCall(Arc::from(
                                                 &self.input[tail_start..self.position],
                                             )));
@@ -2898,13 +2944,13 @@ impl<'a> PerlLexer<'a> {
                                     }
                                 } else if self.current_char() == Some('[') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('[', ']');
+                                    let _ = self.consume_balanced_segment_in_string('[', ']', '"');
                                     parts.push(StringPart::ArraySlice(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));
                                 } else if self.current_char() == Some('{') {
                                     let tail_start = self.position;
-                                    let _ = self.consume_balanced_segment('{', '}');
+                                    let _ = self.consume_balanced_segment_in_string('{', '}', '"');
                                     parts.push(StringPart::Expression(Arc::from(
                                         &self.input[tail_start..self.position],
                                     )));

--- a/crates/perl-lexer/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lexer/tests/comprehensive_unit_tests.rs
@@ -742,6 +742,20 @@ fn interpolated_string_preserves_complex_tails() -> R {
                 StringPart::ArraySlice(Arc::from("[$i")),
             ],
         ),
+        (
+            r#""$obj->method(arg""#,
+            vec![
+                StringPart::Variable(Arc::from("$obj")),
+                StringPart::MethodCall(Arc::from("->method(arg")),
+            ],
+        ),
+        (
+            r#""$obj->(incomplete""#,
+            vec![
+                StringPart::Variable(Arc::from("$obj")),
+                StringPart::MethodCall(Arc::from("->(incomplete")),
+            ],
+        ),
     ];
 
     for (input, expected_parts) in cases {

--- a/crates/perl-lexer/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lexer/tests/comprehensive_unit_tests.rs
@@ -714,6 +714,34 @@ fn interpolated_string_preserves_complex_tails() -> R {
                 StringPart::MethodCall(Arc::from("->{key}")),
             ],
         ),
+        (
+            r#""$hash{incomplete""#,
+            vec![
+                StringPart::Variable(Arc::from("$hash")),
+                StringPart::Expression(Arc::from("{incomplete")),
+            ],
+        ),
+        (
+            r#""$array[0""#,
+            vec![
+                StringPart::Variable(Arc::from("$array")),
+                StringPart::ArraySlice(Arc::from("[0")),
+            ],
+        ),
+        (
+            r#""$obj->{field""#,
+            vec![
+                StringPart::Variable(Arc::from("$obj")),
+                StringPart::MethodCall(Arc::from("->{field")),
+            ],
+        ),
+        (
+            r#""$array[$i""#,
+            vec![
+                StringPart::Variable(Arc::from("$array")),
+                StringPart::ArraySlice(Arc::from("[$i")),
+            ],
+        ),
     ];
 
     for (input, expected_parts) in cases {

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -45,6 +45,139 @@ impl<'a> Parser<'a> {
         self.with_recursion_guard(|s| s.parse_primary_inner())
     }
 
+    fn record_unclosed_interpolation_delimiter(&mut self, text: &str, token_start: usize) {
+        if let Some(delim) = Self::find_unclosed_interpolation_delimiter(text) {
+            self.record_error(ParseError::syntax(
+                format!(
+                    "Unclosed {} delimiter in interpolated string before closing quote",
+                    delim
+                ),
+                token_start,
+            ));
+        }
+    }
+
+    fn find_unclosed_interpolation_delimiter(text: &str) -> Option<char> {
+        let bytes = text.as_bytes();
+        if bytes.len() < 2 || bytes.first() != Some(&b'"') {
+            return None;
+        }
+
+        let mut i = 1usize;
+        let quote_end = bytes.len() - 1;
+        while i < quote_end {
+            let ch = bytes[i] as char;
+            if ch == '\\' {
+                i = i.saturating_add(2);
+                continue;
+            }
+
+            if ch == '$' {
+                i += 1;
+                if i >= quote_end {
+                    break;
+                }
+
+                if bytes[i] == b'{' {
+                    if !Self::consume_balanced_in_interpolated_string(bytes, i, b'{', b'}', quote_end)
+                    {
+                        return Some('{');
+                    }
+                    continue;
+                }
+
+                if Self::is_identifier_start(bytes[i]) {
+                    i += 1;
+                    while i < quote_end && Self::is_identifier_continue(bytes[i]) {
+                        i += 1;
+                    }
+
+                    if i + 1 < quote_end && bytes[i] == b'-' && bytes[i + 1] == b'>' {
+                        i += 2;
+                        if i < quote_end && bytes[i] == b'{' {
+                            if !Self::consume_balanced_in_interpolated_string(
+                                bytes, i, b'{', b'}', quote_end,
+                            ) {
+                                return Some('{');
+                            }
+                            continue;
+                        }
+                        if i < quote_end && bytes[i] == b'[' {
+                            if !Self::consume_balanced_in_interpolated_string(
+                                bytes, i, b'[', b']', quote_end,
+                            ) {
+                                return Some('[');
+                            }
+                            continue;
+                        }
+                    }
+
+                    if i < quote_end && bytes[i] == b'{' {
+                        if !Self::consume_balanced_in_interpolated_string(
+                            bytes, i, b'{', b'}', quote_end,
+                        ) {
+                            return Some('{');
+                        }
+                        continue;
+                    }
+
+                    if i < quote_end && bytes[i] == b'[' {
+                        if !Self::consume_balanced_in_interpolated_string(
+                            bytes, i, b'[', b']', quote_end,
+                        ) {
+                            return Some('[');
+                        }
+                        continue;
+                    }
+
+                    continue;
+                }
+            }
+
+            i += 1;
+        }
+
+        None
+    }
+
+    fn consume_balanced_in_interpolated_string(
+        bytes: &[u8],
+        start: usize,
+        open: u8,
+        close: u8,
+        quote_end: usize,
+    ) -> bool {
+        let mut i = start + 1;
+        let mut depth = 1usize;
+
+        while i < quote_end {
+            let b = bytes[i];
+            if b == b'\\' {
+                i = i.saturating_add(2);
+                continue;
+            }
+            if b == open {
+                depth += 1;
+            } else if b == close {
+                depth -= 1;
+                if depth == 0 {
+                    return true;
+                }
+            }
+            i += 1;
+        }
+
+        false
+    }
+
+    fn is_identifier_start(byte: u8) -> bool {
+        byte.is_ascii_alphabetic() || byte == b'_'
+    }
+
+    fn is_identifier_continue(byte: u8) -> bool {
+        byte.is_ascii_alphanumeric() || byte == b'_'
+    }
+
     /// Inner implementation of parse_primary (called under recursion guard)
     fn parse_primary_inner(&mut self) -> ParseResult<Node> {
         let token = self.tokens.peek()?;
@@ -71,6 +204,9 @@ impl<'a> Parser<'a> {
                 let token = self.tokens.next()?;
                 // Check if it's a double-quoted string (interpolated)
                 let interpolated = token.text.starts_with('"');
+                if interpolated {
+                    self.record_unclosed_interpolation_delimiter(&token.text, token.start);
+                }
                 Ok(Node::new(
                     NodeKind::String { value: token.text.to_string(), interpolated },
                     SourceLocation { start: token.start, end: token.end },

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -110,6 +110,28 @@ impl<'a> Parser<'a> {
                             }
                             continue;
                         }
+                        if i < quote_end && bytes[i] == b'(' {
+                            if !Self::consume_balanced_in_interpolated_string(
+                                bytes, i, b'(', b')', quote_end,
+                            ) {
+                                return Some('(');
+                            }
+                            continue;
+                        }
+                        // bare method name: $obj->method(...) — scan the name, then check for (
+                        if i < quote_end && Self::is_identifier_start(bytes[i]) {
+                            while i < quote_end && Self::is_identifier_continue(bytes[i]) {
+                                i += 1;
+                            }
+                            if i < quote_end && bytes[i] == b'(' {
+                                if !Self::consume_balanced_in_interpolated_string(
+                                    bytes, i, b'(', b')', quote_end,
+                                ) {
+                                    return Some('(');
+                                }
+                                continue;
+                            }
+                        }
                     }
 
                     if i < quote_end && bytes[i] == b'{' {

--- a/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
+++ b/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
@@ -73,6 +73,24 @@ fn double_quote_incomplete_mixed_array_index() -> R {
 }
 
 #[test]
+fn double_quote_incomplete_arrow_paren_call() -> R {
+    // "$obj->method(arg" — paren-call tail swallowed closing quote before fix
+    let source = r#"my $msg = "Call: $obj->method(arg";"#;
+    assert_clean_sexp_without_error_nodes(source)?;
+    assert_has_unclosed_interpolation_diagnostic(source)?;
+    Ok(())
+}
+
+#[test]
+fn double_quote_incomplete_block_deref() -> R {
+    // "${incomplete" — block-dereference form (${expr}) with missing closing brace
+    let source = r#"my $msg = "Deref: ${incomplete";"#;
+    assert_clean_sexp_without_error_nodes(source)?;
+    assert_has_unclosed_interpolation_diagnostic(source)?;
+    Ok(())
+}
+
+#[test]
 fn double_quote_complete_interpolation_cases() -> R {
     let source = r#"my $msg = "Complete: $hash{key} $array[0] $obj->{field}";"#;
     assert_clean_sexp_without_error_nodes(source)?;

--- a/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
+++ b/crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs
@@ -1,0 +1,96 @@
+use perl_parser_core::Parser;
+
+type R = Result<(), Box<dyn std::error::Error>>;
+
+fn assert_clean_sexp_without_error_nodes(source: &str) -> R {
+    let mut parser = Parser::new(source);
+    let parsed = parser.parse_with_recovery();
+    let sexp = parsed.ast.to_sexp();
+
+    let error_markers = ["(error ", "(Error ", "(missing_expression", " ERROR "];
+    for marker in error_markers {
+        if sexp.contains(marker) {
+            return Err(format!(
+                "Expected parse without ERROR-like nodes for source:\n{source}\n\nS-expression:\n{sexp}"
+            )
+            .into());
+        }
+    }
+
+    Ok(())
+}
+
+fn assert_has_unclosed_interpolation_diagnostic(source: &str) -> R {
+    let mut parser = Parser::new(source);
+    let parsed = parser.parse_with_recovery();
+
+    let has_expected = parsed
+        .diagnostics
+        .iter()
+        .map(ToString::to_string)
+        .any(|diag| diag.contains("Unclosed") && diag.contains("interpolated"));
+    if !has_expected {
+        return Err(format!(
+            "Expected unclosed interpolation diagnostic for source:\n{source}\n\nDiagnostics:\n{:?}",
+            parsed.diagnostics
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+#[test]
+fn double_quote_incomplete_hash_key() -> R {
+    let source = r#"my $msg = "Key: $hash{incomplete";"#;
+    assert_clean_sexp_without_error_nodes(source)?;
+    assert_has_unclosed_interpolation_diagnostic(source)?;
+    Ok(())
+}
+
+#[test]
+fn double_quote_incomplete_array_index() -> R {
+    let source = r#"my $item = "Element: $array[0";"#;
+    assert_clean_sexp_without_error_nodes(source)?;
+    assert_has_unclosed_interpolation_diagnostic(source)?;
+    Ok(())
+}
+
+#[test]
+fn double_quote_incomplete_arrow_hash_field() -> R {
+    let source = r#"my $msg = "Nested: $obj->{field";"#;
+    assert_clean_sexp_without_error_nodes(source)?;
+    assert_has_unclosed_interpolation_diagnostic(source)?;
+    Ok(())
+}
+
+#[test]
+fn double_quote_incomplete_mixed_array_index() -> R {
+    let source = r#"my $msg = "Mixed: $array[$i";"#;
+    assert_clean_sexp_without_error_nodes(source)?;
+    assert_has_unclosed_interpolation_diagnostic(source)?;
+    Ok(())
+}
+
+#[test]
+fn double_quote_complete_interpolation_cases() -> R {
+    let source = r#"my $msg = "Complete: $hash{key} $array[0] $obj->{field}";"#;
+    assert_clean_sexp_without_error_nodes(source)?;
+
+    let mut parser = Parser::new(source);
+    let parsed = parser.parse_with_recovery();
+    let has_unclosed = parsed
+        .diagnostics
+        .iter()
+        .map(ToString::to_string)
+        .any(|diag| diag.contains("Unclosed") && diag.contains("interpolated"));
+    if has_unclosed {
+        return Err(format!(
+            "Did not expect unclosed interpolation diagnostics for complete interpolation. Diagnostics: {:?}",
+            parsed.diagnostics
+        )
+        .into());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Improve IDE/editing experience by preventing unterminated interpolation tails inside double-quoted strings from producing top-level ERROR nodes that poison the AST and block symbol extraction for the sigil target.

### Description

- Add a quote-aware lexer helper `consume_balanced_segment_in_string` and use it when scanning interpolation tails inside double-quoted strings so incomplete `{`/`[`/`->` tails stop at the closing quote and preserve the variable part as a token (`crates/perl-lexer/src/lib.rs`).
- Make the lexer emit `InterpolatedString` parts for incomplete tails (e.g. `StringPart::Expression("{incomplete")`, `StringPart::ArraySlice("[0")`) and extend lexer unit tests accordingly (`crates/perl-lexer/tests/comprehensive_unit_tests.rs`).
- Add parser-side, non-fatal diagnostics for unclosed interpolation delimiters detected inside string tokens while continuing to return a normal `String` AST node so the parse does not produce a top-level `ERROR` node (`crates/perl-parser-core/src/engine/parser/expressions/primary.rs`).
- Add focused parser tests that assert incomplete interpolation cases produce a clean AST (no ERROR nodes) and a diagnostic, plus a completeness case to ensure no regressions (`crates/perl-parser-core/tests/string_interpolation_incomplete_tests.rs`).

### Testing

- Ran `cargo test -p perl-parser-core --test string_interpolation_incomplete_tests` and it passed (all new parser tests OK).
- Ran `cargo test -p perl-lexer interpolated_string_preserves_complex_tails` and it passed (lexer tests OK).
- Ran `cargo test -p perl-parser-core string_interpolation` and it passed (filtered suite OK).
- Ran full `cargo test -p perl-parser-core` which revealed an unrelated existing regression in `test_edge_cases_deep::test_deref_hash_subscript_regex_key` (one failing test) that is not introduced by these changes.
- Ran `cargo fmt --all` successfully and left code formatted; `just parser-audit` / `just cpan-corpus-check` were not executed in this environment because `just` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55b1097c8333818c7daf6568de7c)