### PR TITLE
fix(parser): harden transliteration parsing and ratchet regressions (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -291,6 +291,12 @@ impl<'a> Parser<'a> {
                                         c
                                     )
                                 }
+                                quote_parser::TransliterationError::InvalidDelimiter(c) => {
+                                    format!(
+                                        "Invalid transliteration delimiter '{}'",
+                                        c
+                                    )
+                                }
                                 quote_parser::TransliterationError::MissingDelimiter => {
                                     "Missing delimiter after transliteration operator".to_string()
                                 }

--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -337,7 +337,8 @@ pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
             return (search, String::new(), String::new());
         }
         extract_unpaired_body_skip_strings(rest1, closing)
-    } else if is_paired {
+    } else {
+        // is_paired == true: paired delimiters (tr{abc}{xyz})
         let trimmed = rest1.trim_start();
         if let Some(repl_delimiter) = starts_with_paired_delimiter(trimmed) {
             let repl_closing = get_closing_delimiter(repl_delimiter);
@@ -345,8 +346,6 @@ pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
         } else {
             return (search, String::new(), String::new());
         }
-    } else {
-        (String::new(), rest1, false)
     };
     if !replacement_closed {
         return (search, replacement, String::new());

--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -55,6 +55,8 @@ pub enum SubstitutionError {
 pub enum TransliterationError {
     /// Invalid modifier character found
     InvalidModifier(char),
+    /// Invalid delimiter character found
+    InvalidDelimiter(char),
     /// Missing delimiter after `tr`/`y`
     MissingDelimiter,
     /// Search list section is missing
@@ -301,75 +303,54 @@ pub fn extract_substitution_parts(text: &str) -> (String, String, String) {
 
 /// Extract search, replace, and modifiers from a transliteration token
 pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
-    // Skip 'tr' or 'y' prefix
-    let content = if let Some(stripped) = text.strip_prefix("tr") {
+    // Skip `tr` or `y` prefix and allow optional whitespace before delimiter.
+    let after_op = if let Some(stripped) = text.strip_prefix("tr") {
         stripped
     } else if let Some(stripped) = text.strip_prefix('y') {
         stripped
     } else {
         text
     };
+    let content = after_op.trim_start();
 
     // Get delimiter - content must be non-empty to have a delimiter
     let delimiter = match content.chars().next() {
         Some(d) => d,
         None => return (String::new(), String::new(), String::new()),
     };
+    if !is_valid_transliteration_delimiter(delimiter) {
+        return (String::new(), String::new(), String::new());
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
     // Parse first body (search pattern)
-    let (search, rest1) = extract_delimited_content(content, delimiter, closing);
-
-    // For paired delimiters, skip whitespace and allow any paired opening delimiter for the
-    // replacement list. Perl accepts forms like tr[abc]{xyz} in addition to tr[abc][xyz].
-    let rest2_owned;
-    let rest2 = if is_paired {
-        rest1.trim_start()
-    } else {
-        rest2_owned = format!("{}{}", delimiter, rest1);
-        &rest2_owned
-    };
+    let (search, rest1, search_closed) =
+        extract_delimited_content_strict(content, delimiter, closing);
+    if !search_closed {
+        return (search, String::new(), String::new());
+    }
 
     // Parse second body (replacement pattern)
-    let (replacement, modifiers_str) = if !is_paired && !rest1.is_empty() {
-        // Manually parse the replacement for non-paired delimiters
-        let chars = rest1.char_indices();
-        let mut body = String::new();
-        let mut escaped = false;
-        let mut end_pos = rest1.len();
-
-        for (i, ch) in chars {
-            if escaped {
-                body.push(ch);
-                escaped = false;
-                continue;
-            }
-
-            match ch {
-                '\\' => {
-                    body.push(ch);
-                    escaped = true;
-                }
-                c if c == closing => {
-                    end_pos = i + ch.len_utf8();
-                    break;
-                }
-                _ => body.push(ch),
-            }
+    let (replacement, modifiers_str, replacement_closed) = if !is_paired {
+        if rest1.is_empty() {
+            return (search, String::new(), String::new());
         }
-
-        (body, &rest1[end_pos..])
+        extract_unpaired_body_skip_strings(rest1, closing)
     } else if is_paired {
-        if let Some(repl_delimiter) = starts_with_paired_delimiter(rest2) {
+        let trimmed = rest1.trim_start();
+        if let Some(repl_delimiter) = starts_with_paired_delimiter(trimmed) {
             let repl_closing = get_closing_delimiter(repl_delimiter);
-            extract_delimited_content(rest2, repl_delimiter, repl_closing)
+            extract_delimited_content_strict(trimmed, repl_delimiter, repl_closing)
         } else {
-            (String::new(), rest2)
+            return (search, String::new(), String::new());
         }
     } else {
-        (String::new(), rest1)
+        (String::new(), rest1, false)
     };
+    if !replacement_closed {
+        return (search, replacement, String::new());
+    }
 
     // Extract and validate only valid transliteration modifiers
     // Security fix: Apply consistent validation for all delimiter types
@@ -409,6 +390,9 @@ pub fn extract_transliteration_parts_strict(
         Some(d) => d,
         None => return Err(TransliterationError::MissingDelimiter),
     };
+    if !is_valid_transliteration_delimiter(delimiter) {
+        return Err(TransliterationError::InvalidDelimiter(delimiter));
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
@@ -480,6 +464,10 @@ fn starts_with_paired_delimiter(text: &str) -> Option<char> {
         Some(ch) if is_paired_open(ch) => Some(ch),
         _ => None,
     }
+}
+
+fn is_valid_transliteration_delimiter(ch: char) -> bool {
+    !(ch.is_ascii_alphanumeric() || ch.is_whitespace() || ch == '\\')
 }
 
 /// Extract content between delimiters and return (content, rest)

--- a/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
+++ b/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
@@ -37,3 +37,11 @@ fn transliteration_supports_empty_bodies_without_panicking() {
     assert_has_error(r#"$x =~ tr//A-Z/;"#, "missing search list");
     assert_clean_parse(r#"$x =~ tr/a-z//;"#);
 }
+
+#[test]
+fn transliteration_angle_bracket_and_paren_delimiters() {
+    // All four ASCII bracket pairs are valid delimiters for tr/y
+    assert_clean_parse(r#"$x =~ tr<a-z><A-Z>;"#);
+    assert_clean_parse(r#"$x =~ tr(a-z)(A-Z)s;"#);
+    assert_clean_parse(r#"$x =~ tr[a-z][A-Z]d;"#);
+}

--- a/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
+++ b/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
@@ -17,3 +17,23 @@ fn transliteration_rejects_invalid_modifiers() {
     assert_has_error(r#"$x =~ tr/a-z/A-Z/z;"#, "invalid transliteration modifier");
     assert_has_error(r#"$x =~ y/a-z/A-Z/1;"#, "invalid transliteration modifier");
 }
+
+#[test]
+fn transliteration_accepts_valid_modifier_set() {
+    assert_clean_parse(r#"$x =~ tr/a-z/A-Z/c;"#);
+    assert_clean_parse(r#"$x =~ tr/a-z/A-Z/d;"#);
+    assert_clean_parse(r#"$x =~ tr/a-z/A-Z/s;"#);
+    assert_clean_parse(r#"$x =~ tr/a-z/A-Z/r;"#);
+}
+
+#[test]
+fn transliteration_rejects_invalid_delimiter_and_malformed_closures() {
+    assert_has_error(r#"$x =~ tr/a-z/A-Z;"#, "missing closing delimiter");
+    assert_has_error(r#"$x =~ tr{a-z}{A-Z;"#, "missing closing delimiter");
+}
+
+#[test]
+fn transliteration_supports_empty_bodies_without_panicking() {
+    assert_has_error(r#"$x =~ tr//A-Z/;"#, "missing search list");
+    assert_clean_parse(r#"$x =~ tr/a-z//;"#);
+}

--- a/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
+++ b/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
@@ -1,56 +1,38 @@
-/// Minimal reproduction case for transliteration parsing bug discovered in fuzz testing
-///
-/// CRASH DETAILS:
-/// - Input: "tr/abc/xyz/"
-/// - Expected: ("abc", "xyz", "")
-/// - Actual: ("abc", "", "xyz")
-///
-/// This indicates a critical bug in extract_transliteration_parts where the replacement
-/// and modifiers are being swapped for non-paired delimiters.
-///
-/// IMPACT: This affects Perl transliteration operator parsing throughout the entire
-/// parser pipeline, potentially causing incorrect syntax highlighting, code analysis,
-/// and refactoring operations.
-///
-/// REPRODUCTION: Run with `cargo test -p perl-parser --test fuzz_transliteration_crash_repro`
 use perl_parser::quote_parser::extract_transliteration_parts;
 
 #[test]
 fn minimal_transliteration_crash_repro() {
-    let input = "tr/abc/xyz/";
-    let (search, replace, modifiers) = extract_transliteration_parts(input);
+    let (search, replace, modifiers) = extract_transliteration_parts("tr/abc/xyz/");
 
-    println!("FUZZ BUG REPRODUCED: tr// parsing issue");
-    println!("Input: {}", input);
-    println!("Expected: ('abc', 'xyz', '')");
-    println!("Actual: ('{}', '{}', '{}')", search, replace, modifiers);
-
-    // Demonstrate the bug - these will fail due to the parsing issue
-    assert_eq!(search.as_str(), "abc", "Search pattern incorrect");
-    assert_eq!(replace.as_str(), "xyz", "Replace pattern incorrect");
-    assert_eq!(modifiers.as_str(), "", "Modifiers incorrect");
+    assert_eq!(search, "abc");
+    assert_eq!(replace, "xyz");
+    assert_eq!(modifiers, "");
 }
 
 #[test]
 fn fuzz_transliteration_regression_suite() {
-    // Test additional variants that likely have the same bug
-    let test_cases = vec![
+    let test_cases = [
         ("y/abc/xyz/", ("abc", "xyz", "")),
         ("tr/a/b/d", ("a", "b", "d")),
-        ("y/x/y/g", ("x", "y", "")), // 'g' is not a valid transliteration modifier
-        ("tr{abc}{xyz}d", ("abc", "xyz", "d")), // This might work correctly with paired delimiters
+        ("y/x/y/g", ("x", "y", "")),
+        ("tr{abc}{xyz}d", ("abc", "xyz", "d")),
+        ("tr /a\\//x\\//", ("a\\/", "x\\/", "")),
+        ("tr/🦀/🐪/r", ("🦀", "🐪", "r")),
     ];
 
     for (input, expected) in test_cases {
         let (search, replace, modifiers) = extract_transliteration_parts(input);
-        let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
+        assert_eq!((search.as_str(), replace.as_str(), modifiers.as_str()), expected, "{input}");
+    }
+}
 
-        println!("Testing: {} -> expected {:?}, got {:?}", input, expected, actual);
+#[test]
+fn malformed_transliteration_never_panics() {
+    let malformed_inputs =
+        ["tr", "trabc", "tr/unterminated", "tr{abc}{xyz", "tr{abc}xyz}", "y\\abc\\xyz\\"];
 
-        if actual != expected {
-            println!("  BUG CONFIRMED in variant: {}", input);
-        } else {
-            println!("  PASSED: {}", input);
-        }
+    for input in malformed_inputs {
+        let result = std::panic::catch_unwind(|| extract_transliteration_parts(input));
+        assert!(result.is_ok(), "extract_transliteration_parts panicked for {input}");
     }
 }

--- a/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
+++ b/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
@@ -28,11 +28,25 @@ fn fuzz_transliteration_regression_suite() {
 
 #[test]
 fn malformed_transliteration_never_panics() {
-    let malformed_inputs =
-        ["tr", "trabc", "tr/unterminated", "tr{abc}{xyz", "tr{abc}xyz}", "y\\abc\\xyz\\"];
+    // Each entry: (input, expected_search, expected_replace, expected_modifiers)
+    // Backslash is an invalid delimiter, so the y\\ inputs return all-empty.
+    let cases: &[(&str, &str, &str, &str)] = &[
+        ("tr", "", "", ""),
+        ("trabc", "", "", ""),          // alphanumeric delimiter rejected
+        ("tr/unterminated", "unterminated", "", ""),  // missing replacement closure
+        ("tr{abc}{xyz", "abc", "xyz", ""),  // unclosed replacement
+        ("tr{abc}xyz}", "abc", "", ""),     // replacement doesn't start with paired open
+        ("y\\abc\\xyz\\", "", "", ""),      // backslash is invalid delimiter
+    ];
 
-    for input in malformed_inputs {
+    for (input, exp_search, exp_replace, exp_mods) in cases {
         let result = std::panic::catch_unwind(|| extract_transliteration_parts(input));
         assert!(result.is_ok(), "extract_transliteration_parts panicked for {input}");
+        let (search, replace, mods) = result.unwrap();
+        assert_eq!(
+            (search.as_str(), replace.as_str(), mods.as_str()),
+            (*exp_search, *exp_replace, *exp_mods),
+            "value mismatch for malformed input {input}"
+        );
     }
 }

--- a/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
+++ b/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
@@ -23,6 +23,29 @@ fn transliteration_regression_bank() {
 }
 
 #[test]
+fn transliteration_all_four_paired_delimiter_kinds() {
+    // tr<>, tr{}, tr[], tr() — all four ASCII bracket pairs must work
+    let cases = [
+        ("tr<abc><xyz>", ("abc", "xyz", "")),
+        ("tr(abc)(xyz)s", ("abc", "xyz", "s")),
+        ("tr[abc][xyz]d", ("abc", "xyz", "d")),
+        ("tr{abc}{xyz}r", ("abc", "xyz", "r")),
+        // Nested brackets inside search/replace
+        ("tr{a{b}c}{x{y}z}", ("a{b}c", "x{y}z", "")),
+        ("tr<a<b>c><x<y>z>", ("a<b>c", "x<y>z", "")),
+    ];
+
+    for (input, expected) in cases {
+        let actual = extract_transliteration_parts(input);
+        assert_eq!(
+            (actual.0.as_str(), actual.1.as_str(), actual.2.as_str()),
+            expected,
+            "{input}",
+        );
+    }
+}
+
+#[test]
 fn strict_parser_rejects_invalid_delimiter_and_modifier() {
     let invalid_delimiter = extract_transliteration_parts_strict("trabc");
     assert_eq!(invalid_delimiter, Err(TransliterationError::InvalidDelimiter('a')));

--- a/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
+++ b/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
@@ -1,0 +1,51 @@
+use perl_parser::quote_parser::{
+    TransliterationError, extract_transliteration_parts, extract_transliteration_parts_strict,
+};
+
+#[test]
+fn transliteration_regression_bank() {
+    let cases = [
+        ("tr/a\\/b/x\\/y/", ("a\\/b", "x\\/y", "")),
+        ("tr/æøå/ÆØÅ/d", ("æøå", "ÆØÅ", "d")),
+        ("tr//foo/", ("", "foo", "")),
+        ("tr/foo//", ("foo", "", "")),
+        ("tr{abc}{xyz}cdsr", ("abc", "xyz", "cdsr")),
+        ("y[abc]{xyz}r", ("abc", "xyz", "r")),
+        ("tr/abc/xyz/zz", ("abc", "xyz", "")),
+        ("tr/abc/xyz/cz", ("abc", "xyz", "c")),
+        ("tr /a-z/A-Z/s", ("a-z", "A-Z", "s")),
+    ];
+
+    for (input, expected) in cases {
+        let actual = extract_transliteration_parts(input);
+        assert_eq!((actual.0.as_str(), actual.1.as_str(), actual.2.as_str()), expected, "{input}",);
+    }
+}
+
+#[test]
+fn strict_parser_rejects_invalid_delimiter_and_modifier() {
+    let invalid_delimiter = extract_transliteration_parts_strict("trabc");
+    assert_eq!(invalid_delimiter, Err(TransliterationError::InvalidDelimiter('a')));
+
+    let invalid_modifier = extract_transliteration_parts_strict("tr/a/b/z");
+    assert_eq!(invalid_modifier, Err(TransliterationError::InvalidModifier('z')));
+}
+
+#[test]
+fn malformed_closures_do_not_smear_modifiers_or_panic() {
+    let cases = [
+        ("tr/abc/xyz", ("abc", "xyz", "")),
+        ("tr{abc}{xyz", ("abc", "xyz", "")),
+        ("tr{abc}xyz}", ("abc", "", "")),
+    ];
+
+    for (input, expected) in cases {
+        let unwind_result = std::panic::catch_unwind(|| extract_transliteration_parts(input));
+        assert!(unwind_result.is_ok(), "panic on malformed transliteration input: {input}");
+        let parsed = match unwind_result {
+            Ok(parts) => parts,
+            Err(_) => continue,
+        };
+        assert_eq!((parsed.0.as_str(), parsed.1.as_str(), parsed.2.as_str()), expected, "{input}",);
+    }
+}


### PR DESCRIPTION
### Motivation

- A fuzz repro revealed `tr///`/`y///` parsing could mis-extract search, replacement, and modifiers for malformed or non-paired delimiter forms, leading to incorrect ASTs and downstream analysis.
- The parser must robustly handle optional whitespace, invalid delimiters, paired vs non-paired forms, escaped delimiters, Unicode, empty bodies, and only allow valid transliteration modifiers to prevent regressions.

### Description

- Hardened transliteration parsing in `crates/perl-parser-core/src/syntax/quote.rs` by allowing optional whitespace after `tr`/`y`, rejecting invalid delimiters via `is_valid_transliteration_delimiter`, and switching to strict delimiter extraction for the search and replacement segments (using `extract_delimited_content_strict` and `extract_unpaired_body_skip_strings`).
- Added `TransliterationError::InvalidDelimiter` and updated the strict API `extract_transliteration_parts_strict` to return explicit diagnostics for invalid delimiters and malformed closures.
- Propagated a clear diagnostic message for invalid delimiters into the parser front-end in `crates/perl-parser-core/src/engine/parser/expressions/primary.rs` so the parser surfaces actionable syntax errors.
- Added and updated regression tests: replaced/enhanced `crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs`, added `crates/perl-parser/tests/quote_transliteration_regression_bank.rs`, and expanded `crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs` to lock in behavior for escaped delimiters, Unicode, empty/malformed bodies, and valid/invalid modifier sets.

### Testing

- Ran formatter: `cargo xtask fmt` and it completed successfully.
- Ran unit/integration tests covering transliteration; `cargo test -p perl-parser --test fuzz_transliteration_crash_repro` passed and `cargo test -p perl-parser --test quote_transliteration_regression_bank` passed.
- Ran core tests: `cargo test -p perl-parser-core transliteration` and `cargo test -p perl-parser-core --test fix_transliteration_strict_parsing` both passed.
- Attempted repository audit checks (`just parser-audit`, `just corpus-sweep-check`, `just cpan-corpus-check`) but `just` is not available in this environment so those commands were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55b80ad08333be08dd9168d2f27c)