### PR TITLE
fix(parser): harden transliteration parsing and ratchet regressions (#0000)

### DIFF
--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -301,66 +301,45 @@ pub fn extract_substitution_parts(text: &str) -> (String, String, String) {
 
 /// Extract search, replace, and modifiers from a transliteration token
 pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
-    // Skip 'tr' or 'y' prefix
-    let content = if let Some(stripped) = text.strip_prefix("tr") {
+    // Skip `tr` or `y` prefix, then allow optional whitespace before delimiter.
+    let after_op = if let Some(stripped) = text.strip_prefix("tr") {
         stripped
     } else if let Some(stripped) = text.strip_prefix('y') {
         stripped
     } else {
         text
     };
+    let content = after_op.trim_start();
 
     // Get delimiter - content must be non-empty to have a delimiter
     let delimiter = match content.chars().next() {
         Some(d) => d,
         None => return (String::new(), String::new(), String::new()),
     };
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return (String::new(), String::new(), String::new());
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
-    // Parse first body (search pattern)
-    let (search, rest1) = extract_delimited_content(content, delimiter, closing);
-
-    // For paired delimiters, skip whitespace and allow any paired opening delimiter for the
-    // replacement list. Perl accepts forms like tr[abc]{xyz} in addition to tr[abc][xyz].
-    let rest2_owned;
-    let rest2 = if is_paired {
-        rest1.trim_start()
-    } else {
-        rest2_owned = format!("{}{}", delimiter, rest1);
-        &rest2_owned
-    };
+    // Parse search with strict delimiter extraction.
+    let (search, rest1, search_closed) =
+        extract_delimited_content_strict(content, delimiter, closing);
+    if !search_closed {
+        return (search, String::new(), String::new());
+    }
 
     // Parse second body (replacement pattern)
-    let (replacement, modifiers_str) = if !is_paired && !rest1.is_empty() {
-        // Manually parse the replacement for non-paired delimiters
-        let chars = rest1.char_indices();
-        let mut body = String::new();
-        let mut escaped = false;
-        let mut end_pos = rest1.len();
-
-        for (i, ch) in chars {
-            if escaped {
-                body.push(ch);
-                escaped = false;
-                continue;
-            }
-
-            match ch {
-                '\\' => {
-                    body.push(ch);
-                    escaped = true;
-                }
-                c if c == closing => {
-                    end_pos = i + ch.len_utf8();
-                    break;
-                }
-                _ => body.push(ch),
-            }
+    let (replacement, modifiers_str) = if !is_paired {
+        if rest1.is_empty() {
+            (String::new(), "")
+        } else {
+            let (body, rest, _replacement_closed) =
+                extract_unpaired_body_skip_strings(rest1, closing);
+            (body, rest)
         }
-
-        (body, &rest1[end_pos..])
     } else if is_paired {
+        let rest2 = rest1.trim_start();
         if let Some(repl_delimiter) = starts_with_paired_delimiter(rest2) {
             let repl_closing = get_closing_delimiter(repl_delimiter);
             extract_delimited_content(rest2, repl_delimiter, repl_closing)
@@ -409,6 +388,9 @@ pub fn extract_transliteration_parts_strict(
         Some(d) => d,
         None => return Err(TransliterationError::MissingDelimiter),
     };
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return Err(TransliterationError::MissingDelimiter);
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 

--- a/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
+++ b/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
@@ -17,3 +17,17 @@ fn transliteration_rejects_invalid_modifiers() {
     assert_has_error(r#"$x =~ tr/a-z/A-Z/z;"#, "invalid transliteration modifier");
     assert_has_error(r#"$x =~ y/a-z/A-Z/1;"#, "invalid transliteration modifier");
 }
+
+#[test]
+fn transliteration_strict_handles_escaped_unicode_and_empty_bodies() {
+    assert_clean_parse(r#"$x =~ tr /a\/b/c\/d/;"#);
+    assert_clean_parse(r#"$x =~ tr/αβγ/ΑΒΓ/r;"#);
+    assert_clean_parse(r#"$x =~ tr/a//d;"#);
+    assert_has_error(r#"$x =~ tr//x/;"#, "missing search list in transliteration");
+}
+
+#[test]
+fn transliteration_strict_rejects_malformed_delimiters() {
+    assert_has_error(r#"$x =~ tr/a-z/A-Z;"#, "missing closing delimiter in transliteration");
+    assert_has_error(r#"$x =~ tr{a-z}{A-Z;"#, "missing closing delimiter in transliteration");
+}

--- a/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
+++ b/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
@@ -13,19 +13,14 @@
 /// and refactoring operations.
 ///
 /// REPRODUCTION: Run with `cargo test -p perl-parser --test fuzz_transliteration_crash_repro`
-use perl_parser::quote_parser::extract_transliteration_parts;
+use perl_parser::quote_parser::{
+    extract_transliteration_parts, extract_transliteration_parts_strict,
+};
 
 #[test]
 fn minimal_transliteration_crash_repro() {
     let input = "tr/abc/xyz/";
     let (search, replace, modifiers) = extract_transliteration_parts(input);
-
-    println!("FUZZ BUG REPRODUCED: tr// parsing issue");
-    println!("Input: {}", input);
-    println!("Expected: ('abc', 'xyz', '')");
-    println!("Actual: ('{}', '{}', '{}')", search, replace, modifiers);
-
-    // Demonstrate the bug - these will fail due to the parsing issue
     assert_eq!(search.as_str(), "abc", "Search pattern incorrect");
     assert_eq!(replace.as_str(), "xyz", "Replace pattern incorrect");
     assert_eq!(modifiers.as_str(), "", "Modifiers incorrect");
@@ -33,24 +28,29 @@ fn minimal_transliteration_crash_repro() {
 
 #[test]
 fn fuzz_transliteration_regression_suite() {
-    // Test additional variants that likely have the same bug
     let test_cases = vec![
         ("y/abc/xyz/", ("abc", "xyz", "")),
         ("tr/a/b/d", ("a", "b", "d")),
-        ("y/x/y/g", ("x", "y", "")), // 'g' is not a valid transliteration modifier
-        ("tr{abc}{xyz}d", ("abc", "xyz", "d")), // This might work correctly with paired delimiters
+        ("y/x/y/g", ("x", "y", "")),
+        ("tr{abc}{xyz}d", ("abc", "xyz", "d")),
+        ("tr /a\\/b/c\\/d/s", ("a\\/b", "c\\/d", "s")),
+        ("tr/αβγ/ΑΒΓ/r", ("αβγ", "ΑΒΓ", "r")),
     ];
 
     for (input, expected) in test_cases {
         let (search, replace, modifiers) = extract_transliteration_parts(input);
         let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
+        assert_eq!(actual, expected, "transliteration parse regression for: {}", input);
+    }
+}
 
-        println!("Testing: {} -> expected {:?}, got {:?}", input, expected, actual);
+#[test]
+fn fuzz_transliteration_malformed_inputs_do_not_panic() {
+    let malformed_cases =
+        ["tr", "tr ", "trabc", "tr/unterminated", "tr{abc", "tr{abc}{xyz", "tr[abc]/xyz/"];
 
-        if actual != expected {
-            println!("  BUG CONFIRMED in variant: {}", input);
-        } else {
-            println!("  PASSED: {}", input);
-        }
+    for input in malformed_cases {
+        let _ = extract_transliteration_parts(input);
+        let _ = extract_transliteration_parts_strict(input);
     }
 }

--- a/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
+++ b/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
@@ -1,0 +1,48 @@
+use perl_parser::quote_parser::{
+    extract_transliteration_parts, extract_transliteration_parts_strict,
+};
+
+#[test]
+fn transliteration_regression_bank_core_cases() {
+    let cases = [
+        ("tr /a\\/b/c\\/d/", ("a\\/b", "c\\/d", "")),
+        ("tr/αβγ/ΑΒΓ/r", ("αβγ", "ΑΒΓ", "r")),
+        ("tr//x/", ("", "x", "")),
+        ("tr/a//d", ("a", "", "d")),
+        ("tr{abc}{xyz}cdsr", ("abc", "xyz", "cdsr")),
+    ];
+
+    for (input, expected) in cases {
+        let parsed = extract_transliteration_parts(input);
+        assert_eq!(
+            (parsed.0.as_str(), parsed.1.as_str(), parsed.2.as_str()),
+            expected,
+            "regression in transliteration parser for input: {}",
+            input
+        );
+    }
+}
+
+#[test]
+fn transliteration_strict_rejects_invalid_forms() {
+    let invalid_cases = ["trabc", "tr a", "tr/abc/xyz/z", "y/abc/xyz/9", "tr/abc", "tr{abc}{xyz"];
+
+    for input in invalid_cases {
+        assert!(
+            extract_transliteration_parts_strict(input).is_err(),
+            "strict parser should reject malformed transliteration: {}",
+            input
+        );
+    }
+}
+
+#[test]
+fn transliteration_strict_accepts_valid_modifiers()
+-> Result<(), perl_parser::quote_parser::TransliterationError> {
+    for modifier in ['c', 'd', 's', 'r'] {
+        let input = format!("tr/a/b/{}", modifier);
+        let parsed = extract_transliteration_parts_strict(&input)?;
+        assert_eq!(parsed.2, modifier.to_string());
+    }
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Close a fuzz-discovered failure where `tr`/`y` transliteration parsing could mis-extract search, replacement, and modifiers for malformed or non-paired delimiter forms.
- Prevent regressions by adding focused regression/rachet tests covering escaped delimiters, Unicode/multibyte content, empty bodies, malformed closures, and modifier validation.

### Description
- Trim optional whitespace after the `tr`/`y` operator and reject invalid opening delimiters early in `extract_transliteration_parts` to match Perl semantics for quote-like operators.
- Use strict delimiter extraction for the search body and unify handling of paired vs non-paired replacement delimiters, using `extract_delimited_content_strict` and `extract_unpaired_body_skip_strings` where appropriate.
- Apply consistent modifier filtering for loose parsing and strict modifier validation in `extract_transliteration_parts_strict` (valid modifiers: `c`, `d`, `s`, `r`).
- Add/expand regression tests: update `fuzz_transliteration_crash_repro.rs`, add `quote_transliteration_regression_bank.rs`, and extend `fix_transliteration_strict_parsing.rs` to cover escaped delimiters, Unicode, empty bodies, malformed delimiters, valid modifiers, and ensure malformed inputs do not panic.

### Testing
- Ran `cargo test -p perl-parser --test fuzz_transliteration_crash_repro` and it passed.
- Ran `cargo test -p perl-parser --test quote_transliteration_regression_bank` and it passed.
- Ran `cargo test -p perl-parser-core transliteration` and it passed.
- Ran `cargo check --all-targets -p perl-parser-core` and it completed successfully.
- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran `cargo clippy -p perl-parser-core --all-targets -- -D warnings` which failed due to pre-existing unrelated test lints in `fix_async_await_3608.rs` (not introduced by this change).
- `just parser-audit`, `just corpus-sweep-check`, and `just cpan-corpus-check` were not executed because `just` is unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55b80ad08333be08dd9168d2f27c)