### PR TITLE
fix(parser): harden transliteration parsing and ratchet regressions (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -291,6 +291,12 @@ impl<'a> Parser<'a> {
                                         c
                                     )
                                 }
+                                quote_parser::TransliterationError::InvalidDelimiter(c) => {
+                                    format!(
+                                        "Invalid delimiter '{}' after transliteration operator",
+                                        c
+                                    )
+                                }
                                 quote_parser::TransliterationError::MissingDelimiter => {
                                     "Missing delimiter after transliteration operator".to_string()
                                 }

--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -55,6 +55,8 @@ pub enum SubstitutionError {
 pub enum TransliterationError {
     /// Invalid modifier character found
     InvalidModifier(char),
+    /// Delimiter after `tr`/`y` is invalid
+    InvalidDelimiter(char),
     /// Missing delimiter after `tr`/`y`
     MissingDelimiter,
     /// Search list section is missing
@@ -302,74 +304,54 @@ pub fn extract_substitution_parts(text: &str) -> (String, String, String) {
 /// Extract search, replace, and modifiers from a transliteration token
 pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
     // Skip 'tr' or 'y' prefix
-    let content = if let Some(stripped) = text.strip_prefix("tr") {
+    let after_op = if let Some(stripped) = text.strip_prefix("tr") {
         stripped
     } else if let Some(stripped) = text.strip_prefix('y') {
         stripped
     } else {
         text
     };
+    let content = after_op.trim_start();
 
     // Get delimiter - content must be non-empty to have a delimiter
     let delimiter = match content.chars().next() {
         Some(d) => d,
         None => return (String::new(), String::new(), String::new()),
     };
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return (String::new(), String::new(), String::new());
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
     // Parse first body (search pattern)
-    let (search, rest1) = extract_delimited_content(content, delimiter, closing);
+    let (search, rest1, search_closed) =
+        extract_delimited_content_strict(content, delimiter, closing);
+    if !search_closed {
+        return (search, String::new(), String::new());
+    }
 
     // For paired delimiters, skip whitespace and allow any paired opening delimiter for the
     // replacement list. Perl accepts forms like tr[abc]{xyz} in addition to tr[abc][xyz].
-    let rest2_owned;
-    let rest2 = if is_paired {
-        rest1.trim_start()
-    } else {
-        rest2_owned = format!("{}{}", delimiter, rest1);
-        &rest2_owned
-    };
+    let rest2 = if is_paired { rest1.trim_start() } else { rest1 };
 
     // Parse second body (replacement pattern)
-    let (replacement, modifiers_str) = if !is_paired && !rest1.is_empty() {
-        // Manually parse the replacement for non-paired delimiters
-        let chars = rest1.char_indices();
-        let mut body = String::new();
-        let mut escaped = false;
-        let mut end_pos = rest1.len();
-
-        for (i, ch) in chars {
-            if escaped {
-                body.push(ch);
-                escaped = false;
-                continue;
-            }
-
-            match ch {
-                '\\' => {
-                    body.push(ch);
-                    escaped = true;
-                }
-                c if c == closing => {
-                    end_pos = i + ch.len_utf8();
-                    break;
-                }
-                _ => body.push(ch),
-            }
+    let (replacement, modifiers_str, replacement_closed) = if !is_paired {
+        if rest1.is_empty() {
+            return (search, String::new(), String::new());
         }
-
-        (body, &rest1[end_pos..])
-    } else if is_paired {
+        extract_unpaired_body_skip_strings(rest2, closing)
+    } else {
         if let Some(repl_delimiter) = starts_with_paired_delimiter(rest2) {
             let repl_closing = get_closing_delimiter(repl_delimiter);
-            extract_delimited_content(rest2, repl_delimiter, repl_closing)
+            extract_delimited_content_strict(rest2, repl_delimiter, repl_closing)
         } else {
-            (String::new(), rest2)
+            return (search, String::new(), String::new());
         }
-    } else {
-        (String::new(), rest1)
     };
+    if !replacement_closed {
+        return (search, replacement, String::new());
+    }
 
     // Extract and validate only valid transliteration modifiers
     // Security fix: Apply consistent validation for all delimiter types
@@ -409,6 +391,9 @@ pub fn extract_transliteration_parts_strict(
         Some(d) => d,
         None => return Err(TransliterationError::MissingDelimiter),
     };
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return Err(TransliterationError::InvalidDelimiter(delimiter));
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
@@ -440,10 +425,6 @@ pub fn extract_transliteration_parts_strict(
 
     if !replacement_closed {
         return Err(TransliterationError::MissingClosingDelimiter);
-    }
-
-    if search.is_empty() {
-        return Err(TransliterationError::MissingSearch);
     }
 
     // Validate transliteration modifiers strictly.

--- a/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
+++ b/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
@@ -10,10 +10,26 @@ use cpan_test_helpers::*;
 fn transliteration_allows_whitespace_before_delimiter() {
     assert_clean_parse(r#"$x =~ tr /a-z/A-Z/;"#);
     assert_clean_parse(r#"$x =~ y  {abc}{xyz}r;"#);
+    assert_clean_parse(r#"$x =~ y /αβ/γδ/c;"#);
+    assert_clean_parse(r#"$x =~ tr///;"#);
 }
 
 #[test]
 fn transliteration_rejects_invalid_modifiers() {
     assert_has_error(r#"$x =~ tr/a-z/A-Z/z;"#, "invalid transliteration modifier");
     assert_has_error(r#"$x =~ y/a-z/A-Z/1;"#, "invalid transliteration modifier");
+}
+
+#[test]
+fn transliteration_accepts_all_valid_modifiers() {
+    assert_clean_parse(r#"$x =~ tr/a-z/A-Z/c;"#);
+    assert_clean_parse(r#"$x =~ tr/a-z/A-Z/d;"#);
+    assert_clean_parse(r#"$x =~ tr/a-z/A-Z/s;"#);
+    assert_clean_parse(r#"$x =~ tr/a-z/A-Z/r;"#);
+}
+
+#[test]
+fn transliteration_reports_malformed_delimiter_closures() {
+    assert_has_error(r#"$x =~ tr/abc/xyz;"#, "missing closing delimiter in transliteration");
+    assert_has_error(r#"$x =~ tr{abc}{xyz;"#, "missing closing delimiter in transliteration");
 }

--- a/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
+++ b/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
@@ -1,18 +1,3 @@
-/// Minimal reproduction case for transliteration parsing bug discovered in fuzz testing
-///
-/// CRASH DETAILS:
-/// - Input: "tr/abc/xyz/"
-/// - Expected: ("abc", "xyz", "")
-/// - Actual: ("abc", "", "xyz")
-///
-/// This indicates a critical bug in extract_transliteration_parts where the replacement
-/// and modifiers are being swapped for non-paired delimiters.
-///
-/// IMPACT: This affects Perl transliteration operator parsing throughout the entire
-/// parser pipeline, potentially causing incorrect syntax highlighting, code analysis,
-/// and refactoring operations.
-///
-/// REPRODUCTION: Run with `cargo test -p perl-parser --test fuzz_transliteration_crash_repro`
 use perl_parser::quote_parser::extract_transliteration_parts;
 
 #[test]
@@ -20,12 +5,6 @@ fn minimal_transliteration_crash_repro() {
     let input = "tr/abc/xyz/";
     let (search, replace, modifiers) = extract_transliteration_parts(input);
 
-    println!("FUZZ BUG REPRODUCED: tr// parsing issue");
-    println!("Input: {}", input);
-    println!("Expected: ('abc', 'xyz', '')");
-    println!("Actual: ('{}', '{}', '{}')", search, replace, modifiers);
-
-    // Demonstrate the bug - these will fail due to the parsing issue
     assert_eq!(search.as_str(), "abc", "Search pattern incorrect");
     assert_eq!(replace.as_str(), "xyz", "Replace pattern incorrect");
     assert_eq!(modifiers.as_str(), "", "Modifiers incorrect");
@@ -44,13 +23,6 @@ fn fuzz_transliteration_regression_suite() {
     for (input, expected) in test_cases {
         let (search, replace, modifiers) = extract_transliteration_parts(input);
         let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
-
-        println!("Testing: {} -> expected {:?}, got {:?}", input, expected, actual);
-
-        if actual != expected {
-            println!("  BUG CONFIRMED in variant: {}", input);
-        } else {
-            println!("  PASSED: {}", input);
-        }
+        assert_eq!(actual, expected);
     }
 }

--- a/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
+++ b/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
@@ -1,0 +1,30 @@
+use perl_parser::quote_parser::extract_transliteration_parts;
+
+#[test]
+fn transliteration_regression_bank() {
+    let cases = [
+        ("tr/a\\/b/c\\/d/", ("a\\/b", "c\\/d", "")),
+        ("tr/🦀αβ/🐪γδ/cdsr", ("🦀αβ", "🐪γδ", "cdsr")),
+        ("tr///", ("", "", "")),
+        ("y{}{}r", ("", "", "r")),
+        ("tr{abc}{xyz}cdsr", ("abc", "xyz", "cdsr")),
+        ("tr[abc]{xyz}d", ("abc", "xyz", "d")),
+        ("tr{abc{def}}{xyz{uvw}}r", ("abc{def}", "xyz{uvw}", "r")),
+        ("tr/abc/xyz/z", ("abc", "xyz", "")),
+        ("tr/abc/xyz/1", ("abc", "xyz", "")),
+        ("tr foo bar baz", ("", "", "")),
+        ("tr/abc", ("abc", "", "")),
+        ("tr{abc}{xyz", ("abc", "xyz", "")),
+        ("tr<ab\\>c><xy\\>z>", ("ab\\>c", "xy\\>z", "")),
+        ("y /abc/xyz/r", ("abc", "xyz", "r")),
+    ];
+
+    for (input, expected) in cases {
+        let parsed = extract_transliteration_parts(input);
+        assert_eq!(
+            (parsed.0.as_str(), parsed.1.as_str(), parsed.2.as_str()),
+            expected,
+            "failed case: {input}"
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- A fuzz repro showed `tr///`/`y///` parsing could mis-extract search, replacement, and modifiers for malformed or non-paired delimiter forms, causing incorrect downstream analysis and potential panics. 
- The goal is to close the transliteration/quote-like failure family and prevent regressions by tightening parsing and adding focused regression coverage.

### Description
- Tightened transliteration parsing in `crates/perl-parser-core/src/syntax/quote.rs` to skip optional whitespace after `tr`/`y`, reject alphanumeric/space delimiters, use strict delimiter extraction for the search body, and handle paired and non-paired replacement delimiters consistently. 
- Added strict-mode invalid-delimiter feedback via a new `TransliterationError::InvalidDelimiter` and mapped it to a parser diagnostic in `crates/perl-parser-core/src/engine/parser/expressions/primary.rs`. 
- Improved unpaired replacement scanning by using `extract_unpaired_body_skip_strings` and `extract_delimited_content_strict` to avoid swapping replacement and modifier regions and to correctly handle escaped delimiters and inner string literals. 
- Added and updated tests: cleaned the fuzz repro (`crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs`), added a regression bank (`crates/perl-parser/tests/quote_transliteration_regression_bank.rs`), and extended strict transliteration tests (`crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs`).

### Testing
- Ran `cargo test -p perl-parser --test fuzz_transliteration_crash_repro` and it passed. 
- Ran `cargo test -p perl-parser --test quote_transliteration_regression_bank` and it passed. 
- Ran `cargo test -p perl-parser-core --test fix_transliteration_strict_parsing` (transliteration suite) and it passed. 
- Ran `cargo test -p perl-parser quote_transliteration` and `cargo test -p perl-parser fuzz_transliteration_crash_repro` as additional verification and they passed. 
- Ran `cargo fmt --all` successfully; `just parser-audit`, `just corpus-sweep-check`, and `just cpan-corpus-check` were not executed in this environment because `just` is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55b80ad08333be08dd9168d2f27c)