### PR TITLE
fix(parser): classify and close delimiter recovery corpus buckets (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -733,7 +733,15 @@ impl<'a> Parser<'a> {
     }
 
     /// Check if current token is a strong follower at which a missing closer can
-    /// be inferred.  The set covers hard statement boundaries and EOF.
+    /// be inferred.  The set covers two categories:
+    ///
+    /// - **Statement boundaries**: `;`, `}`, `{`, keywords (`my`, `if`, `while`,
+    ///   etc.), and EOF — tokens that cannot appear inside a well-formed
+    ///   delimiter pair.
+    /// - **Sibling closers**: `)` and `]` — a closer owned by an *outer* nesting
+    ///   level that proves the *current* closer is missing.  When
+    ///   `expect_closing_delimiter` fires recovery here it does **not** consume
+    ///   the sibling token so the outer frame can consume it normally.
     ///
     /// `peek_kind()` returns `Some(TokenKind::Eof)` at end-of-input (the EOF
     /// token is sticky) so we match it explicitly alongside `None` (which covers

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -742,6 +742,8 @@ impl<'a> Parser<'a> {
         matches!(
             self.peek_kind(),
             Some(TokenKind::Semicolon)
+                | Some(TokenKind::RightParen)
+                | Some(TokenKind::RightBracket)
                 | Some(TokenKind::RightBrace)
                 | Some(TokenKind::LeftBrace)
                 | Some(TokenKind::Eof)

--- a/crates/perl-parser-core/tests/recovery_missing_closer.rs
+++ b/crates/perl-parser-core/tests/recovery_missing_closer.rs
@@ -286,6 +286,57 @@ fn missing_paren_at_eof_in_list_assignment_emits_recovered() {
     );
 }
 
+/// Missing `]` recovered when parser sees a `)` owned by the outer call.
+/// This prevents ownership loss in postfix-deref/call chains.
+#[test]
+fn missing_bracket_before_outer_paren_emits_recovered() {
+    assert_clean_parse("foo($arr[$i]);");
+
+    let src = "foo($arr[$i));";
+    let (_ast, errors) = parse_errors(src);
+
+    let has_array_recovery = errors.iter().any(|e| {
+        matches!(
+            e,
+            ParseError::Recovered {
+                site: RecoverySite::ArraySubscript,
+                kind: RecoveryKind::InsertedCloser,
+                ..
+            }
+        )
+    });
+    assert!(
+        has_array_recovery,
+        "Expected array-subscript InsertedCloser before outer ')', got: {:?}",
+        errors
+    );
+}
+
+/// Missing `)` in declaration list recovered when `]` closes an outer index.
+#[test]
+fn missing_paren_before_outer_bracket_emits_recovered() {
+    assert_clean_parse("my $x = $list[(foo($a))];");
+
+    let src = "my $x = $list[(foo($a)];";
+    let (_ast, errors) = parse_errors(src);
+
+    let has_arg_recovery = errors.iter().any(|e| {
+        matches!(
+            e,
+            ParseError::Recovered {
+                site: RecoverySite::ArgList,
+                kind: RecoveryKind::InsertedCloser,
+                ..
+            }
+        )
+    });
+    assert!(
+        has_arg_recovery,
+        "Expected arg-list InsertedCloser before outer ']', got: {:?}",
+        errors
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Regression: clean-parse inputs must produce zero Recovered errors
 // ---------------------------------------------------------------------------

--- a/crates/perl-parser-core/tests/recovery_missing_closer.rs
+++ b/crates/perl-parser-core/tests/recovery_missing_closer.rs
@@ -337,6 +337,49 @@ fn missing_paren_before_outer_bracket_emits_recovered() {
     );
 }
 
+/// Triple-nested mismatch: `foo(bar($arr[$i))` — innermost `]` missing before
+/// the outer `)` owned by `bar`.  Both `bar`'s `]` recovery and `foo`'s inner
+/// `)` must fire; the final `)` belonging to `foo` is consumed normally.
+#[test]
+fn triple_nested_mismatch_outer_paren_emits_recovered() {
+    // Balanced baseline
+    assert_clean_parse("foo(bar($arr[$i]));");
+
+    // Missing `]` — outer `)` of bar triggers sibling-closer recovery.
+    let src = "foo(bar($arr[$i)));";
+    let (_ast, errors) = parse_errors(src);
+
+    let has_array_recovery = errors.iter().any(|e| {
+        matches!(
+            e,
+            ParseError::Recovered {
+                site: RecoverySite::ArraySubscript,
+                kind: RecoveryKind::InsertedCloser,
+                ..
+            }
+        )
+    });
+    assert!(
+        has_array_recovery,
+        "Expected ArraySubscript InsertedCloser in triple-nested mismatch '{}', got: {:?}",
+        src, errors
+    );
+}
+
+/// Sanity check: `if` with fully-matched delimiters parses clean.
+/// The `LeftBrace` arm in `is_delimiter_recovery_point` is a pre-existing
+/// entry intended for cases where an expression parser returns *without*
+/// consuming `{`; in practice the postfix/primary parsers tend to consume `{`
+/// first (as a hash subscript or hash-ref constructor), so that arm is a
+/// latent guard rather than an active test target.  This test simply confirms
+/// the happy path is unaffected by the PR.
+#[test]
+fn if_condition_clean_parse_unaffected() {
+    assert_clean_parse("if ($x > 0) { print 1; }");
+    assert_clean_parse("while ($x > 0) { $x--; }");
+    assert_clean_parse("for (my $i = 0; $i < 10; $i++) { print $i; }");
+}
+
 // ---------------------------------------------------------------------------
 // Regression: clean-parse inputs must produce zero Recovered errors
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Prevent delimiter recovery from losing ownership when sibling closers (e.g. `)` vs `]`) appear, which caused valid nested call/subscript patterns to be classified into unclosed-* error buckets instead of being recovered.

### Description
- Treat `RightParen` and `RightBracket` as delimiter recovery sync points in `is_delimiter_recovery_point` so `expect_closing_delimiter` can emit `InsertedCloser` and preserve ownership; add focused regression tests asserting `InsertedCloser` for (a) missing `]` before an outer `)`, and (b) missing `)` before an outer `]` in `recovery_missing_closer.rs`.

### Testing
- Ran `cargo test -p perl-parser-core --test recovery_missing_closer` (19 tests) and it passed; ran `cargo test -p perl-parser-core unclosed` and `cargo test -p perl-parser-core bracket` and both passed; `just parser-audit` / `just corpus-sweep-check` / `just cpan-corpus-check` were not run because `just` is unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55c4e8f48333a9280cf209b5d4cd)