### PR TITLE
fix(parser): classify and close delimiter recovery corpus buckets (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -555,12 +555,17 @@ impl<'a> Parser<'a> {
                 return Ok(vec![]);
             }
 
-            // Peek ahead: if the first token is a scalar variable ($fh) and the
+            // Peek ahead: if the first argument is an indirect filehandle and the
             // token after it is NOT a comma, fat-arrow, or `)`, treat it as the
-            // indirect filehandle (no comma before the message list).
+            // filehandle form (no comma before the message list).
+            //
+            // Supported indirect-filehandle first-arg forms:
+            // 1) scalar variable: `print($fh "msg")`
+            // 2) block filehandle: `print({ *$fh } "msg")`
             let first_is_scalar = s.tokens.peek().is_ok_and(|t| {
                 t.text.starts_with('$') && t.text.len() > 1
             });
+            let first_is_fh_block = s.peek_kind() == Some(TokenKind::LeftBrace);
             let second_is_not_separator = s.tokens.peek_second().is_ok_and(|t| {
                 !matches!(
                     t.kind,
@@ -568,7 +573,7 @@ impl<'a> Parser<'a> {
                 )
             });
 
-            if first_is_scalar && second_is_not_separator {
+            if (first_is_scalar || first_is_fh_block) && second_is_not_separator {
                 // Filehandle form: parse $fh as first argument, then remaining args
                 // without requiring a comma separator.
                 let mut args = Vec::new();

--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -381,6 +381,16 @@ impl<'a> Parser<'a> {
             end = name_token.end;
         }
 
+        // Main-stash package variable shorthand may be lexed as `$::` + `IDENT`
+        // instead of a single `$::IDENT` token. Join that tail identifier so
+        // parenthesized expressions like `($::IS_ASCII || ...)` do not leave a
+        // stray identifier that looks like an unclosed `)`.
+        if sigil == "$" && full_name == "::" && self.peek_kind() == Some(TokenKind::Identifier) {
+            let name_token = self.tokens.next()?;
+            full_name.push_str(&name_token.text);
+            end = name_token.end;
+        }
+
         // Handle :: in package-qualified variables
         while self.peek_kind() == Some(TokenKind::DoubleColon) {
             self.tokens.next()?; // consume ::
@@ -425,7 +435,7 @@ impl<'a> Parser<'a> {
         // Check if next token is an identifier or a keyword that should be treated as identifier
         let next_kind = self.peek_kind();
 
-        let (name, end) = if next_kind == Some(TokenKind::Identifier) ||
+        let (mut name, mut end) = if next_kind == Some(TokenKind::Identifier) ||
                              // Keywords can be used as variable names with any sigil
                              // e.g., %try, $default, @for, &try are all valid Perl
                              matches!(next_kind, Some(k) if Self::can_be_sub_name(k))
@@ -597,6 +607,14 @@ impl<'a> Parser<'a> {
                 }
             }
         };
+
+        // `$::IDENT` may arrive as a sigil token (`$`) followed by `::` and
+        // then an identifier token.  Attach the identifier tail eagerly.
+        if sigil == "$" && name == "::" && self.peek_kind() == Some(TokenKind::Identifier) {
+            let name_token = self.tokens.next()?;
+            name.push_str(&name_token.text);
+            end = name_token.end;
+        }
 
         // Special handling for @, %, or $ sigil followed by { - array/hash/scalar dereference
         // e.g. @{$ref}, %{$hash}, ${"${pkg}::$sym"}

--- a/crates/perl-parser-core/tests/fix_main_stash_access.rs
+++ b/crates/perl-parser-core/tests/fix_main_stash_access.rs
@@ -65,3 +65,9 @@ fn main_stash_array_sigil() {
     // @:: is the list of symbol names in the main package
     assert_clean_parse(r#"my @syms = @::;"#);
 }
+
+#[test]
+fn main_stash_symbol_in_parenthesized_condition() {
+    // Unicode::Collate pattern: `$::IS_ASCII` in a paren condition.
+    assert_clean_parse(r#"my $x = ($::IS_ASCII || $] < 5.008) ? 1 : 0;"#);
+}

--- a/crates/perl-parser-core/tests/fix_unclosed_paren_patterns.rs
+++ b/crates/perl-parser-core/tests/fix_unclosed_paren_patterns.rs
@@ -196,3 +196,10 @@ if ($self->is_valid()
 "#,
     );
 }
+
+#[test]
+fn test_print_block_filehandle_without_comma_in_parens() {
+    // Real-world pattern from Dpkg::Source::Archive:
+    // print({ *$self->{tar_input} } "$file\0")
+    assert_clean_parse(r#"print({ *$self->{tar_input} } "$file\0");"#);
+}


### PR DESCRIPTION
### Motivation

- Reduce noisy delimiter recovery buckets (unclosed_paren, unclosed_paren_identifier, unclosed_brace, unclosed_brace_semicolon, unclosed_brace_eof, unclosed_bracket) by treating valid constructs as owned by their proper syntactic parents so only truly malformed input produces inferred-closer recoveries.

### Description

- Accept block-form indirect filehandle as a valid first-argument form in parenthesized builtin calls by recognizing `LeftBrace` as an indirect-filehandle start in `parse_print_parens_args` and handling it alongside scalar-filehandle (`$fh`) cases (`crates/perl-parser-core/src/engine/parser/expressions/calls.rs`).
- Normalize main-stash tokens so `$::` followed by an identifier is attached as a single variable name (e.g. `$::IS_ASCII`) in both tokenized and sigil-first parsing paths, preventing stray identifier tokens that triggered spurious unclosed-paren errors (`crates/perl-parser-core/src/engine/parser/variables.rs`).
- Add targeted regression tests for the fixed patterns: parenthesized `print({ *$self->{tar_input} } "...")` and `$::IDENT` inside a parenthesized condition (`crates/perl-parser-core/tests/fix_unclosed_paren_patterns.rs` and `crates/perl-parser-core/tests/fix_main_stash_access.rs`).

### Testing

- Ran focused unit tests: `cargo test -p perl-parser-core recovery`, `cargo test -p perl-parser-core unclosed`, `cargo test -p perl-parser-core paren`, and `cargo test -p perl-parser-core bracket`, all of which passed in this workspace run (core parser tests show green).
- Ran the new regression tests individually: `cargo test -p perl-parser-core --test fix_unclosed_paren_patterns test_print_block_filehandle_without_comma_in_parens` and `cargo test -p perl-parser-core --test fix_main_stash_access main_stash_symbol_in_parenthesized_condition`, both passed.
- Ran a system corpus sweep: `cargo run -p xtask -- parser-corpus-sweep --receipt` which completed and reported 2835 clean / 2990 total (94.8%) with fewer delimiter-related first-error buckets (the noisy `unclosed_paren` bucket was reduced and `unclosed_paren_identifier` count shrank), and a receipt written to `target/receipts/system-corpus-sweep.json`.
- Notes: `just parser-audit` is unavailable in this environment (`just` not installed), and `cpan-corpus` checks require the CPAN corpus to be installed locally (not present here), so those higher-level or baseline-enforced checks were not executed end-to-end in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55c4e8f48333a9280cf209b5d4cd)