### PR TITLE
fix(parser): classify and close delimiter recovery corpus buckets (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -64,7 +64,7 @@ impl<'a> Parser<'a> {
                         // Hash/array slice: @hash{...} or %hash{...}
                         self.tokens.next()?; // consume {
                         let key = self.parse_hash_subscript_key()?;
-                        self.expect(TokenKind::RightBrace)?;
+                        self.expect_closing_delimiter(TokenKind::RightBrace)?;
 
                         let start = expr.location.start;
                         let end = self.previous_position();
@@ -163,7 +163,7 @@ impl<'a> Parser<'a> {
                                 // ->%{...} hash slice
                                 self.tokens.next()?; // consume {
                                 let key = self.parse_hash_subscript_key()?;
-                                self.expect(TokenKind::RightBrace)?;
+                                self.expect_closing_delimiter(TokenKind::RightBrace)?;
 
                                 let start = expr.location.start;
                                 let end = self.previous_position();
@@ -326,7 +326,7 @@ impl<'a> Parser<'a> {
                             // Arrow hash dereference: $ref->{key}
                             self.tokens.next()?; // consume {
                             let key = self.parse_hash_subscript_key()?;
-                            self.expect(TokenKind::RightBrace)?;
+                            self.expect_closing_delimiter(TokenKind::RightBrace)?;
 
                             let start = expr.location.start;
                             let end = self.previous_position();
@@ -599,7 +599,7 @@ impl<'a> Parser<'a> {
                     // Hash element access
                     self.tokens.next()?; // consume {
                     let key = self.parse_hash_subscript_key()?;
-                    self.expect(TokenKind::RightBrace)?;
+                    self.expect_closing_delimiter(TokenKind::RightBrace)?;
 
                     let start = expr.location.start;
                     let end = self.previous_position();

--- a/crates/perl-parser-core/tests/recovery_missing_closer.rs
+++ b/crates/perl-parser-core/tests/recovery_missing_closer.rs
@@ -97,19 +97,75 @@ fn missing_paren_before_semicolon_emits_recovered() {
     );
 }
 
-/// `$hash{$key` — missing `}` before `;`.
-/// Note: hash subscripts use `expect()` not `expect_closing_delimiter()`, so
-/// this path does not emit `ParseError::Recovered { InsertedCloser }` yet
-/// (that is a Phase 1 extension beyond this function).  We verify that the
-/// parser does not crash and produces a partial AST.
+/// `$hash{$key` — missing `}` before `;` should recover with InsertedCloser.
 #[test]
-fn missing_hash_brace_before_semicolon_does_not_crash() {
+fn missing_hash_brace_before_semicolon_emits_recovered() {
     let src = "$hash{$key; my $x = 1;";
-    let (ast, _errors) = parse_errors(src);
-    // Parser must return a Program node (not panic or produce Err)
+    let (ast, errors) = parse_errors(src);
+    let recovered = count_inserted_closer(&errors);
+    assert!(
+        recovered >= 1,
+        "Expected InsertedCloser for missing '}}' before ';' in '{}', got errors: {:?}",
+        src,
+        errors
+    );
+
+    // Parser must return a Program node (not panic or produce Err).
     assert!(
         matches!(ast.kind, NodeKind::Program { .. }),
         "Parser must return a Program node for '{}' (partial parse is OK)",
+        src
+    );
+}
+
+/// The `Recovered` error for `}` in hash subscripts must record `RecoverySite::HashSubscript`.
+#[test]
+fn recovered_error_has_correct_site_for_hash_subscript() {
+    let src = "my $v = $hash{$key; my $x = 1;";
+    let (_ast, errors) = parse_errors(src);
+
+    let has_hash_recovery = errors.iter().any(|e| {
+        matches!(
+            e,
+            ParseError::Recovered {
+                site: RecoverySite::HashSubscript,
+                kind: RecoveryKind::InsertedCloser,
+                ..
+            }
+        )
+    });
+
+    assert!(
+        has_hash_recovery,
+        "Expected Recovered {{ site: HashSubscript, kind: InsertedCloser }} for '{}', got: {:?}",
+        src, errors
+    );
+}
+
+/// Missing `}` in arrow hash deref should also recover as `HashSubscript`.
+#[test]
+fn missing_arrow_hash_brace_before_semicolon_emits_hash_recovery() {
+    let src = "my $v = $obj->{key; my $y = 2;";
+    let (ast, errors) = parse_errors(src);
+
+    assert!(
+        errors.iter().any(|e| {
+            matches!(
+                e,
+                ParseError::Recovered {
+                    site: RecoverySite::HashSubscript,
+                    kind: RecoveryKind::InsertedCloser,
+                    ..
+                }
+            )
+        }),
+        "Expected HashSubscript InsertedCloser recovery for '{}', got: {:?}",
+        src,
+        errors
+    );
+    assert!(
+        statement_count(&ast) >= 2,
+        "Downstream statement should survive after missing '}}' in '{}'",
         src
     );
 }


### PR DESCRIPTION
### Motivation

- Reduce spurious `unclosed_*` buckets by making delimiter recovery attribute-aware so only genuinely malformed input is treated as recovery-only.
- Hash-subscript and arrow-deref sites were using hard `expect()` for `}` which collapsed many valid-but-tricky CPAN patterns into generic unclosed-brace buckets.

### Description

- Switched several `expect(TokenKind::RightBrace)` calls in `crates/perl-parser-core/src/engine/parser/expressions/postfix.rs` to the recovery-aware `expect_closing_delimiter(TokenKind::RightBrace)` so hash/array subscript and arrow-deref paths emit structured `InsertedCloser` recoveries instead of generic brace failures.
- Added and adjusted unit tests in `crates/perl-parser-core/tests/recovery_missing_closer.rs` to assert `InsertedCloser` recovery and that the recovery site is `RecoverySite::HashSubscript`, including the arrow-deref (`->{...}`) case and downstream-statement survivability.
- Change scope is limited to postfix hash/subscript ownership and focused tests; no unrelated files or test ignores were added.

### Testing

- Ran `cargo test -p perl-parser-core recovery_missing_closer` and the targeted recovery tests passed.
- Ran `cargo test -p perl-parser-core recovery`, `cargo test -p perl-parser-core unclosed`, `cargo test -p perl-parser-core paren`, and `cargo test -p perl-parser-core bracket` and all ran successfully in this environment.
- `just`-based audit commands (`just parser-audit`, `just corpus-sweep-check`, `just cpan-corpus-check`) were not available in the container (`just: command not found`) and therefore were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55c4e8f48333a9280cf209b5d4cd)