### PR TITLE
fix(parser): handle catch TYPE with block shape (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/control_flow.rs
+++ b/crates/perl-parser-core/src/engine/parser/control_flow.rs
@@ -617,6 +617,34 @@ impl<'a> Parser<'a> {
                 None
             };
 
+            // Legacy/alternative catch shape used by Error.pm style code:
+            //   catch Exception::Type with { ... }
+            // We do not currently model the exception type in the AST, but we
+            // should consume the optional matcher clause so the following block
+            // parses cleanly instead of reporting expected_left_brace.
+            if self.peek_kind() != Some(TokenKind::LeftBrace) {
+                while let Some(kind) = self.peek_kind() {
+                    if kind == TokenKind::LeftBrace {
+                        break;
+                    }
+
+                    if kind == TokenKind::Identifier && self.tokens.peek()?.text.as_ref() == "with" {
+                        self.consume_token()?; // consume 'with'
+                        break;
+                    }
+
+                    match kind {
+                        TokenKind::Catch
+                        | TokenKind::Finally
+                        | TokenKind::Semicolon
+                        | TokenKind::RightBrace => break,
+                        _ => {
+                            self.consume_token()?;
+                        }
+                    }
+                }
+            }
+
             let block = self.parse_block()?;
             catch_blocks.push((var, block));
         }

--- a/crates/perl-parser-core/tests/fix_try_catch_with_block_shape.rs
+++ b/crates/perl-parser-core/tests/fix_try_catch_with_block_shape.rs
@@ -1,0 +1,30 @@
+mod cpan_test_helpers;
+
+use cpan_test_helpers::assert_clean_parse;
+
+#[test]
+fn catch_type_with_block_parses_clean() {
+    assert_clean_parse(
+        r#"
+try { 1; }
+catch Git::Error::Command with {
+    1;
+}
+"#,
+    );
+}
+
+#[test]
+fn catch_type_with_block_and_finally_parses_clean() {
+    assert_clean_parse(
+        r#"
+try { 1; }
+catch My::Error with {
+    1;
+}
+finally {
+    1;
+}
+"#,
+    );
+}


### PR DESCRIPTION
### Motivation
- Valid Perl using Error.pm-style catch matchers like `catch Exception::Type with { ... }` was being mis-parsed and contributed to `expected_left_brace` / block-shape ambiguity noise in the corpus.

### Description
- Teach `parse_try` to consume an optional Error.pm-style matcher clause (e.g., `Exception::Type with`) before parsing the catch block so the block is recognized instead of emitting `expected_left_brace`.
- The change intentionally does not model the exception type in the AST and only consumes tokens to recover the correct block-shape parsing.
- Add focused regression tests in `crates/perl-parser-core/tests/fix_try_catch_with_block_shape.rs` to cover `catch ... with { ... }` both with and without a trailing `finally`.
- Modified file: `crates/perl-parser-core/src/engine/parser/control_flow.rs`; Added file: `crates/perl-parser-core/tests/fix_try_catch_with_block_shape.rs`.

### Testing
- Ran `cargo test -p perl-parser-core fix_try_catch_with_block_shape` and the new regression tests passed.
- Ran `cargo test -p perl-parser-core declaration`, `cargo test -p perl-parser-core signature`, `cargo test -p perl-parser-core native_class`, and `cargo test -p perl-parser-core variable_attributes` and they passed in this environment.
- Ran `cargo run -p xtask -- parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt` which produced a sweep and showed the `expected_left_brace` first-error count improved in this run, but enforcement failed due to local vs committed baseline size mismatch in this environment.
- `cargo run -p xtask -- cpan-corpus sweep --enforce` could not be completed in this environment because the CPAN corpus is not installed (install step required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55c9b8f08333a20fb32a56c3757e)