### PR TITLE
fix(parser): close declaration and block-shape corpus ambiguity buckets (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/typed_variable_declaration_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/typed_variable_declaration_tests.rs
@@ -50,3 +50,21 @@ fn test_legacy_typed_our_declaration_parses_without_error_node()
     );
     Ok(())
 }
+
+#[test]
+fn test_legacy_typed_declaration_with_qualified_type_constraint()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut parser = Parser::new("my ExtUtils::Typemaps::Type $type = shift;");
+    let ast = must(parser.parse());
+    let sexp = ast.to_sexp();
+
+    assert!(
+        !sexp.contains("ERROR"),
+        "Qualified typed declaration should parse without ERROR node, got: {sexp}",
+    );
+    assert!(
+        sexp.contains("(variable $ type)"),
+        "Expected variable `$type` after qualified type constraint, got: {sexp}",
+    );
+    Ok(())
+}

--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -169,8 +169,15 @@ impl<'a> Parser<'a> {
     ///
     /// The type constraint is intentionally ignored in the AST for now.
     fn consume_legacy_decl_type_constraint(&mut self) -> ParseResult<()> {
+        let _ = self.consume_optional_type_constraint()?;
+        Ok(())
+    }
+
+    /// Consume an optional type constraint prefix (e.g. `Type` or `Type::Name`)
+    /// before a variable in declarations/signatures.
+    fn consume_optional_type_constraint(&mut self) -> ParseResult<Option<String>> {
         if self.peek_kind() != Some(TokenKind::Identifier) {
-            return Ok(());
+            return Ok(None);
         }
 
         let looks_like_type = {
@@ -200,11 +207,20 @@ impl<'a> Parser<'a> {
             }
         };
 
-        if looks_like_type {
-            self.consume_token()?;
+        if !looks_like_type {
+            return Ok(None);
         }
 
-        Ok(())
+        let mut type_name = self.consume_token()?.text.to_string();
+        while self.peek_kind() == Some(TokenKind::DoubleColon)
+            && self.tokens.peek_second().is_ok_and(|t| t.kind == TokenKind::Identifier)
+        {
+            self.consume_token()?; // ::
+            type_name.push_str("::");
+            type_name.push_str(&self.consume_token()?.text);
+        }
+
+        Ok(Some(type_name))
     }
 
     /// Parse local statement (can localize any lvalue, not just simple variables)
@@ -791,23 +807,8 @@ impl<'a> Parser<'a> {
             false
         };
 
-        // Check for type constraint (Type $var)
-        let _type_constraint = if self.peek_kind() == Some(TokenKind::Identifier) {
-            // Look ahead to see if this is a type constraint
-            let token = self.tokens.peek()?;
-            if !token.text.starts_with('$')
-                && !token.text.starts_with('@')
-                && !token.text.starts_with('%')
-                && !token.text.starts_with('&')
-            {
-                // It's likely a type constraint
-                Some(self.tokens.next()?.text.to_string())
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+        // Check for type constraint (Type $var / Type::Name $var)
+        let _type_constraint = self.consume_optional_type_constraint()?;
 
         // Parse the variable
         let variable = self.parse_variable()?;
@@ -815,8 +816,9 @@ impl<'a> Parser<'a> {
         // Check for default value (= expression)
         let default_value = if self.peek_kind() == Some(TokenKind::Assign) {
             self.tokens.next()?; // consume =
-            // Parse a primary expression for default value to avoid parsing too far
-            Some(Box::new(self.parse_primary()?))
+            // Parse assignment-level expressions so defaults like `shift // 0`
+            // are accepted without consuming comma-separated next parameters.
+            Some(Box::new(self.parse_assignment()?))
         } else {
             None
         };

--- a/crates/perl-parser-core/tests/fix_signature_param_validation_3359.rs
+++ b/crates/perl-parser-core/tests/fix_signature_param_validation_3359.rs
@@ -165,3 +165,25 @@ fn test_empty_signature_no_diagnostics() {
     let errors = parse_and_collect_errors("sub foo () { }");
     assert!(errors.is_empty(), "Unexpected diagnostics for empty signature, got: {:?}", errors);
 }
+
+#[test]
+fn test_typed_signature_with_qualified_type_is_valid() {
+    let errors = parse_and_collect_errors("sub foo (My::Type $value) { }");
+    assert!(
+        errors.is_empty(),
+        "Unexpected diagnostics for qualified typed signature, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn test_signature_default_value_allows_expression() {
+    let errors = parse_and_collect_errors("sub foo ($x = shift // 0, $y) { }");
+    assert!(
+        !errors
+            .iter()
+            .any(|e| e.contains("Expected comma or closing parenthesis in signature")),
+        "Default expression should not trigger signature comma diagnostics, got: {:?}",
+        errors
+    );
+}


### PR DESCRIPTION
### Motivation
- Reduce parser ambiguity where valid Perl forms (typed declarations, qualified type constraints, and complex signature default expressions) were producing error buckets such as `expected_variable`, `expected_left_brace`, `expected_identifier`, and `signature_param`.

### Description
- Add a shared `consume_optional_type_constraint()` helper and use it from `consume_legacy_decl_type_constraint()` and `parse_signature_param()` so qualified types like `Type::Name $x` are recognised; change lives in `crates/perl-parser-core/src/engine/parser/variables.rs`.
- Broaden signature default parsing to use `parse_assignment()` instead of `parse_primary()` so defaults like `shift // 0` or other assignment-level expressions do not prematurely stop signature parsing; changes in `parse_signature_param()` in `variables.rs`.
- Add focused regressions: a qualified-typed declaration test in `crates/perl-parser-core/src/engine/parser/typed_variable_declaration_tests.rs` and two signature regressions in `crates/perl-parser-core/tests/fix_signature_param_validation_3359.rs` to cover qualified typed params and expression defaults.

### Testing
- Ran `cargo test -p perl-parser-core declaration` and the suite passed.
- Ran `cargo test -p perl-parser-core signature` and `cargo test -p perl-parser-core native_class` and `cargo test -p perl-parser-core variable_attributes`, all passed.
- Ran `cargo check --all-targets -p perl-parser-core` and `cargo clippy -p perl-parser-core`, both passed.
- Ran `cargo run -p xtask --no-default-features -- corpus-audit --fresh --corpus-path . --output corpus_audit_report.json` which completed successfully and produced the audit report.
- Attempted `parser-corpus-sweep` against the committed baseline (via `cargo run -p xtask -- parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt`) which reported a ratchet mismatch in this environment due to a smaller available system/CPAN corpus (environmental baseline mismatch, not a local test regression).
- Attempted CPAN corpus check (`cargo run -p xtask -- cpan-corpus sweep --enforce`) which failed because the CPAN corpus is not installed in this environment (run `cargo xtask cpan-corpus install` locally to reproduce full CPAN checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55c9b8f08333a20fb32a56c3757e)