### PR TITLE
fix(parser): close declaration and block-shape corpus ambiguity buckets (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/control_flow.rs
+++ b/crates/perl-parser-core/src/engine/parser/control_flow.rs
@@ -614,6 +614,28 @@ impl<'a> Parser<'a> {
                 self.expect_closing_delimiter(TokenKind::RightParen)?;
                 var_name
             } else {
+                // Typed catch clauses from Try::Tiny-like ecosystems can appear as:
+                //   catch Some::Error with { ... }
+                // Consume the type/filter tokens until the handler block starts.
+                while let Some(kind) = self.peek_kind() {
+                    if kind == TokenKind::LeftBrace {
+                        break;
+                    }
+
+                    match kind {
+                        TokenKind::Identifier
+                        | TokenKind::DoubleColon
+                        | TokenKind::Colon
+                        | TokenKind::Comma
+                        | TokenKind::String
+                        | TokenKind::Number
+                        | TokenKind::LeftParen
+                        | TokenKind::RightParen => {
+                            self.consume_token()?;
+                        }
+                        _ => break,
+                    }
+                }
                 None
             };
 

--- a/crates/perl-parser-core/tests/fix_catch_typed_with_block_shape.rs
+++ b/crates/perl-parser-core/tests/fix_catch_typed_with_block_shape.rs
@@ -1,0 +1,14 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::assert_clean_parse;
+
+#[test]
+fn catch_typed_with_parses_cleanly() {
+    assert_clean_parse(
+        r#"try { $out = $search->command([qw(rev-parse --is-bare-repository --git-dir)], STDERR => 0); } catch Git::Error::Command with { throw Error::Simple('fatal'); };"#,
+    );
+}
+
+#[test]
+fn catch_typed_without_with_parses_cleanly() {
+    assert_clean_parse(r#"try { die 'x' } catch Error::Simple { warn 'handled' };"#);
+}


### PR DESCRIPTION
### Motivation

- Valid Perl typed catch handlers (e.g., `catch Git::Error::Command with { ... }` or `catch Type { ... }`) were being misparsed as malformed block-shape constructs and contributed to corpus buckets like `expected_left_brace`/block-shape failures. 

### Description

- Extend `parse_try` in `crates/perl-parser-core/src/engine/parser/control_flow.rs` to consume optional typed/filter tokens (identifiers, `::`, `:`, commas, strings, numbers, and parenthesized segments) up to the handler block so typed `catch` forms are recognized correctly. 
- Add focused regression tests in `crates/perl-parser-core/tests/fix_catch_typed_with_block_shape.rs` that assert clean parsing for both `catch Type with { ... }` and `catch Type { ... }` forms. 
- Run `cargo fmt --all` to keep formatting consistent. 

### Testing

- Ran targeted unit tests: `cargo test -p perl-parser-core --test fix_catch_typed_with_block_shape --test fix_phase_keyword_as_label_2389 --test fix_signature_param_validation_3359 --test fix_signature_span_4243 --test native_class_isa_tests --test object_pad_adjust_tests --test fix_variable_attributes_label_syntax` and all selected tests passed. 
- Ran crate-level test sets `cargo test -p perl-parser-core declaration`, `cargo test -p perl-parser-core signature`, `cargo test -p perl-parser-core native_class`, and `cargo test -p perl-parser-core variable_attributes`, and they completed successfully. 
- Could not run `just parser-audit`, `just corpus-sweep-check`, or `just cpan-corpus-check` in this environment because the `just` binary is not installed here, so those corpus-level checks were not executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55c9b8f08333a20fb32a56c3757e)