### PR TITLE
fix(parser): accept phase-keyword labels in loop-control (last/next/redo) (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -1102,8 +1102,19 @@ impl<'a> Parser<'a> {
 
         self.mark_not_stmt_start();
 
-        // Check for optional label
-        let label = if let Some(TokenKind::Identifier) = self.peek_kind() {
+        // Check for optional label.
+        //
+        // Perl labels are barewords, and phase keywords (BEGIN/END/CHECK/INIT/UNITCHECK)
+        // are also valid label names in this position.
+        let label = if matches!(
+            self.peek_kind(),
+            Some(TokenKind::Identifier)
+                | Some(TokenKind::Begin)
+                | Some(TokenKind::End)
+                | Some(TokenKind::Check)
+                | Some(TokenKind::Init)
+                | Some(TokenKind::Unitcheck)
+        ) {
             let label_token = self.consume_token()?;
             Some(label_token.text.to_string())
         } else {

--- a/crates/perl-parser-core/tests/fix_phase_keyword_as_label_2389.rs
+++ b/crates/perl-parser-core/tests/fix_phase_keyword_as_label_2389.rs
@@ -44,10 +44,14 @@ fn test_unitcheck_as_label() {
 #[test]
 fn test_check_label_with_last() {
     // Labels are commonly used with `last LABEL` / `next LABEL`.
-    // Note: `last CHECK` would require loop-control to also accept keyword
-    // tokens as label names (a separate issue); test with `next` on a regular
-    // flow to verify the label statement itself parses correctly.
-    assert_clean_parse("CHECK: while (1) { last; }");
+    assert_clean_parse("CHECK: while (1) { last CHECK; }");
+}
+
+#[test]
+fn test_phase_keyword_labels_in_loop_control() {
+    assert_clean_parse(
+        "INIT: while (1) { next INIT if rand() > 0.5; redo INIT if rand() > 0.25; last INIT; }",
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- Phase-block keywords (BEGIN/END/CHECK/INIT/UNITCHECK) are valid bareword labels in Perl and must be accepted as loop-control labels to avoid spurious declaration/block-shape ambiguity errors.

### Description

- Extend `parse_loop_control` in `crates/perl-parser-core/src/engine/parser/statements.rs` to accept `TokenKind::Begin`, `TokenKind::End`, `TokenKind::Check`, `TokenKind::Init`, and `TokenKind::Unitcheck` as valid optional labels in addition to `Identifier`.
- Add and strengthen regressions in `crates/perl-parser-core/tests/fix_phase_keyword_as_label_2389.rs` to cover `last CHECK` and a combined `next/redo/last` sequence using phase-keyword labels.

### Testing

- Ran `cargo test -p perl-parser-core --test fix_phase_keyword_as_label_2389` and the test suite passed (13/13 tests OK).
- Ran `cargo test -p perl-parser-core declaration` and `cargo test -p perl-parser-core signature` and both target test groups passed.
- Ran `cargo test -p perl-parser-core native_class` and `cargo test -p perl-parser-core variable_attributes` and both passed.
- Ran `cargo run -p xtask --no-default-features -- corpus-audit --fresh --corpus-path .` and the corpus audit completed successfully and wrote `corpus_audit_report.json`.
- Ran `cargo run -p xtask -- parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt` which executed but failed ratchet enforcement due to baseline differences in this environment (local system corpus vs committed baseline), not due to the parser changes.
- Attempted CPAN sweep (`cargo run -p xtask -- cpan-corpus sweep --enforce`) which failed because the CPAN corpus is not installed in this environment (`target/cpan-corpus/lib/perl5` missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55c9b8f08333a20fb32a56c3757e)