### PR TITLE
test(parser): add MM_VMS colon-delimited substitution regressions (#0000)

### DIFF
--- a/crates/perl-parser-core/tests/fix_subst_unusual_delimiters_2732.rs
+++ b/crates/perl-parser-core/tests/fix_subst_unusual_delimiters_2732.rs
@@ -239,6 +239,21 @@ fn test_comma_delimited_subst_xsloader() {
     assert_clean_parse(source);
 }
 
+/// ExtUtils/MM_VMS.pm pattern: colon-delimited substitution with empty replacement
+/// and `ig` modifiers. This previously showed up in invalid_substitution_modifier.
+#[test]
+fn test_colon_delimited_empty_replacement_with_modifiers() {
+    let source = r#"$quals =~ s:/${type}i?n?e?=[^/]+::ig;"#;
+    assert_clean_parse(source);
+}
+
+/// Variant from ExtUtils/MM_VMS.pm where the delimiter appears in a character class.
+#[test]
+fn test_colon_delimited_with_character_class() {
+    let source = r#"$flags =~ s:/${qual_type}\S{0,4}=[^/]+::ig;"#;
+    assert_clean_parse(source);
+}
+
 /// XSLoader.pm full content — must parse cleanly (corpus gate regression test).
 #[test]
 fn test_xsloader_pm_full() {


### PR DESCRIPTION
### Motivation
- Corpus sweeps showed valid colon-delimited `s:...::ig` substitutions (from ExtUtils/MM_VMS) being mis-bucketed as `invalid_substitution_modifier`, so focused tests are needed to prevent regressions.

### Description
- Add two regression tests to `crates/perl-parser-core/tests/fix_subst_unusual_delimiters_2732.rs` covering an empty-replacement colon-delimited `s:...::ig` form and a character-class-heavy variant. 
- Keep change scoped to tests only to lock in correct parsing behavior for these real-world patterns.

### Testing
- Ran `cargo test -p perl-parser-core --test fix_subst_unusual_delimiters_2732`, which passed (31 tests, all ok). 
- Ran `cargo test -p perl-parser-core quote`, `cargo test -p perl-parser-core heredoc`, and `cargo test -p perl-parser-core slash_ambiguity`, which all passed. 
- Ran `cargo test -p perl-parser-core regex`, which revealed an existing failing test (`test_edge_cases_deep::test_deref_hash_subscript_regex_key`) unrelated to these test additions (pre-existing failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55e530d083339a50a059b2d81911)