### PR TITLE
fix(parser-core): accept mixed quote-like replacement delimiters and sync modifiers (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -227,7 +227,7 @@ impl<'a> Parser<'a> {
                             let message = match e {
                                 quote_parser::SubstitutionError::InvalidModifier(c) => {
                                     format!(
-                                        "Invalid substitution modifier '{}'. Valid modifiers are: g, i, m, s, x, o, e, r",
+                                        "Invalid substitution modifier '{}'. Valid modifiers are: g, i, m, s, x, o, e, r, a, d, l, u, n, p, c",
                                         c
                                     )
                                 }

--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -123,22 +123,23 @@ pub fn extract_substitution_parts_strict(
         let (body, rest, found_closing) = extract_unpaired_body_skip_strings(rest1, closing);
         (body, rest, found_closing)
     } else {
-        // Paired delimiters
+        // Paired delimiters.
+        // Perl allows replacement delimiters to differ from the pattern delimiter,
+        // including unpaired forms like `s{pat}/repl/`.
         let trimmed = rest1.trim_start();
-        // For paired delimiters, check what delimiter the replacement uses
-        // It may be the same as pattern or a different paired delimiter
-        // e.g., s[pattern]{replacement} uses [] for pattern and {} for replacement
         if let Some(rd) = trimmed.chars().next() {
-            // Check if it's a valid paired opening delimiter
-            if rd == '{' || rd == '[' || rd == '(' || rd == '<' {
+            if is_paired_open(rd) {
                 let repl_closing = get_closing_delimiter(rd);
                 extract_delimited_content_strict(trimmed, rd, repl_closing)
+            } else if is_valid_quote_delimiter(rd) {
+                let after_open = &trimmed[rd.len_utf8()..];
+                let (body, rest, found_closing) =
+                    extract_unpaired_body_skip_strings(after_open, rd);
+                (body, rest, found_closing)
             } else {
-                // Not a valid paired delimiter - malformed
                 return Err(SubstitutionError::MissingReplacement);
             }
         } else {
-            // No more content - missing replacement
             return Err(SubstitutionError::MissingReplacement);
         }
     };
@@ -433,6 +434,15 @@ pub fn extract_transliteration_parts_strict(
             let (body, rest, found_closing) =
                 extract_delimited_content_strict(trimmed, repl_delimiter, repl_closing);
             (body, rest, found_closing)
+        } else if let Some(repl_delimiter) = trimmed.chars().next() {
+            if is_valid_quote_delimiter(repl_delimiter) {
+                let after_open = &trimmed[repl_delimiter.len_utf8()..];
+                let (body, rest, found_closing) =
+                    extract_unpaired_body_skip_strings(after_open, repl_delimiter);
+                (body, rest, found_closing)
+            } else {
+                return Err(TransliterationError::MissingReplacement);
+            }
         } else {
             return Err(TransliterationError::MissingReplacement);
         }
@@ -472,6 +482,10 @@ fn get_closing_delimiter(open: char) -> char {
 
 fn is_paired_open(ch: char) -> bool {
     matches!(ch, '{' | '[' | '(' | '<')
+}
+
+fn is_valid_quote_delimiter(ch: char) -> bool {
+    !ch.is_ascii_alphanumeric() && !ch.is_whitespace() && ch != '\\'
 }
 
 fn starts_with_paired_delimiter(text: &str) -> Option<char> {

--- a/crates/perl-parser-core/tests/fix_subst_unusual_delimiters_2732.rs
+++ b/crates/perl-parser-core/tests/fix_subst_unusual_delimiters_2732.rs
@@ -340,3 +340,32 @@ sub bootstrap_inherit {
 fn test_file_size_test_with_string_literal() {
     assert_clean_parse(r#"if (-s 'config.txt') { 1 }"#);
 }
+
+// ── Mixed replacement delimiter forms (paired pattern, unpaired replacement) ──
+
+#[test]
+fn test_subst_brace_pattern_slash_replacement() {
+    assert_clean_parse(r#"$x =~ s{foo}/bar/;"#);
+}
+
+#[test]
+fn test_subst_brace_pattern_pipe_replacement() {
+    assert_clean_parse(r#"$x =~ s{foo}|bar|g;"#);
+}
+
+#[test]
+fn test_transliteration_brace_pattern_slash_replacement() {
+    assert_clean_parse(r#"$x =~ tr{abc}/xyz/;"#);
+}
+
+#[test]
+fn test_transliteration_brace_pattern_pipe_replacement() {
+    assert_clean_parse(r#"$x =~ y{abc}|xyz|d;"#);
+}
+
+// ── Diagnostics guardrails (malformed forms still report errors, no panic) ──
+
+#[test]
+fn test_subst_invalid_modifier_still_reports_error() {
+    assert_has_error(r#"$x =~ s/foo/bar/z;"#, "Invalid substitution modifier");
+}


### PR DESCRIPTION
### Motivation

- The strict substitution/transliteration parsing rejected valid Perl forms where a paired-pattern is followed by an unpaired replacement delimiter (e.g. `s{pat}/repl/`).
- Transliteration (`tr`/`y`) and other quote-like paths had the same gap and could misreport or fail on valid idioms.
- The substitution modifier diagnostic text was narrower than the validator’s accepted set and needed to be kept in sync.

### Description

- Relax `extract_substitution_parts_strict` to allow an unpaired replacement delimiter after a paired pattern (accept `s{pat}/repl/`, `s{pat}|repl|`, etc.) while preserving strict error paths for malformed forms.
- Apply the same mixed-delimiter acceptance to `extract_transliteration_parts_strict` so `tr`/`y` with paired search and unpaired replacement delimiters parses correctly.
- Add `is_valid_quote_delimiter` helper used by strict parsing to centralize what constitutes a valid non-alphanumeric, non-whitespace delimiter.
- Update substitution invalid-modifier diagnostic text in the parser host (`expressions/primary.rs`) to include the full accepted modifier set and add focused regression tests that cover mixed-delimiter forms and invalid-modifier guardrails.

### Testing

- Ran `cargo test -p perl-parser-core --test fix_subst_unusual_delimiters_2732`, which passed (new mixed-delimiter tests and guards OK).
- Ran `cargo test -p perl-parser-core quote`, `cargo test -p perl-parser-core slash_ambiguity`, and `cargo test -p perl-parser-core heredoc`, which all passed.
- `cargo test -p perl-parser-core regex` reported a failing test (`test_edge_cases_deep::test_deref_hash_subscript_regex_key`) that appears to be a pre-existing edge-case unrelated to these changes; it did not fail due to the mixed-delimiter work.
- `just parser-audit`, `just corpus-sweep-check`, and `just cpan-corpus-check` were not run in this environment because `just` is not available here (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55e530d083339a50a059b2d81911)