### PR TITLE
fix(parser): disambiguate quote-like hash key after deref (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1834,6 +1834,15 @@ impl<'a> PerlLexer<'a> {
         (None, None)
     }
 
+    /// Return the previous non-whitespace character before `index`.
+    fn previous_nonspace_before(&self, index: usize) -> Option<char> {
+        self.input
+            .get(..index)?
+            .chars()
+            .rev()
+            .find(|c| !c.is_whitespace())
+    }
+
     /// Is `c` a valid quote-like delimiter? (non-alnum, including paired)
     fn is_quote_delim(c: char) -> bool {
         // Perl allows any non-alphanumeric, non-whitespace character as delimiter,
@@ -2154,6 +2163,11 @@ impl<'a> PerlLexer<'a> {
                             // Fat-arrow autoquoting: `s => value` — `=` followed by `>` is '=>',
                             // not a valid substitution delimiter. Treat as identifier.
                             let is_fat_arrow = next == '=' && char_after_next == Some('>');
+                            // Ambiguity guard: `{m}` is commonly a hash-subscript key.
+                            // If `m` appears immediately after `{` and is immediately
+                            // followed by `}`, prefer bareword tokenization over `m}`.
+                            let is_likely_hash_key = next == '}'
+                                && self.previous_nonspace_before(start) == Some('{');
 
                             // When whitespace precedes the delimiter, only unambiguous
                             // delimiters are accepted:
@@ -2167,6 +2181,7 @@ impl<'a> PerlLexer<'a> {
                             let is_quote_char = matches!(next, '\'' | '"') && op != "s";
                             let is_valid_delim = Self::is_quote_delim(next)
                                 && !is_fat_arrow
+                                && !is_likely_hash_key
                                 && (!has_whitespace || is_paired_delim || is_quote_char);
 
                             if is_valid_delim {

--- a/crates/perl-parser-core/tests/token_stream_tests.rs
+++ b/crates/perl-parser-core/tests/token_stream_tests.rs
@@ -56,3 +56,15 @@ fn stream_processes_multiple_tokens() -> Result<(), Box<dyn std::error::Error>> 
     assert!(count >= 4, "should have at least 4 tokens, got {}", count);
     Ok(())
 }
+
+#[test]
+fn tokenizes_scalar_deref_then_hash_subscript() -> Result<(), Box<dyn std::error::Error>> {
+    let mut stream = TokenStream::new(r#"${$ref}{m};"#);
+    let mut tokens = Vec::new();
+    while !stream.is_eof() {
+        let token = must(stream.next());
+        tokens.push(token.text.to_string());
+    }
+    assert_eq!(tokens, vec!["$", "{", "$ref", "}", "{", "m", "}", ";"]);
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Prevent valid Perl `${$ref}{m}` from being tokenized as a malformed quote-like operator (`m};`) which caused spurious parse errors and error-bucket noise.

### Description
- Add a lexer ambiguity guard in `crates/perl-lexer/src/lib.rs` that detects `{m}`-style sequences immediately following `{` and prevents the lexer from treating `m}` as a quote-like delimiter start by checking the previous non-space character (`previous_nonspace_before`).
- Add a token-stream regression test `tokenizes_scalar_deref_then_hash_subscript` in `crates/perl-parser-core/tests/token_stream_tests.rs` asserting the expected token sequence for `${$ref}{m};`.

### Testing
- Ran `cargo test -p perl-parser-core --test token_stream_tests tokenizes_scalar_deref_then_hash_subscript` which passed.
- Ran `cargo test -p perl-parser-core --test test_edge_cases_deep test_deref_hash_subscript_regex_key` which passed.
- Ran the relevant parser suites: `cargo test -p perl-parser-core regex`, `cargo test -p perl-parser-core quote`, `cargo test -p perl-parser-core heredoc`, and `cargo test -p perl-parser-core slash_ambiguity`; these suites passed locally.
- `just parser-audit`, `just corpus-sweep-check`, and `just cpan-corpus-check` were not executed because `just` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55e530d083339a50a059b2d81911)