### PR TITLE
feat(parser): add recovery-salvage metrics for accuracy closeout (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/error/mod.rs
+++ b/crates/perl-parser-core/src/engine/error/mod.rs
@@ -28,5 +28,5 @@ pub mod recovery {
 /// Error types and result aliases used by the parser engine.
 pub use crate::syntax::error::{
     BudgetTracker, ErrorContext, ParseBudget, ParseError, ParseOutput, ParseResult, RecoveryKind,
-    RecoverySite, get_error_contexts,
+    RecoverySalvageClass, RecoverySalvageProfile, RecoverySite, get_error_contexts,
 };

--- a/crates/perl-parser-core/src/lib.rs
+++ b/crates/perl-parser-core/src/lib.rs
@@ -148,7 +148,10 @@ pub use position::{LineEnding, PositionMapper};
 /// Core AST types re-exported for convenience.
 pub use ast::{Node, NodeKind, SourceLocation};
 /// Parse error, budget, and output types.
-pub use error::{BudgetTracker, ParseBudget, ParseError, ParseOutput, ParseResult};
+pub use error::{
+    BudgetTracker, ParseBudget, ParseError, ParseOutput, ParseResult, RecoverySalvageClass,
+    RecoverySalvageProfile,
+};
 
 /// Builtin function signature lookup tables.
 pub use builtins::builtin_signatures;

--- a/crates/perl-parser-core/src/syntax/error/mod.rs
+++ b/crates/perl-parser-core/src/syntax/error/mod.rs
@@ -542,6 +542,86 @@ pub struct ParseOutput {
     pub recovered_count: usize,
 }
 
+/// Closeout classification for a parsed file.
+///
+/// Used by corpus-level reporting to distinguish successful structured
+/// recovery from unrecovered parser damage and catastrophic failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoverySalvageClass {
+    /// No diagnostics and no `ERROR` AST nodes.
+    Clean,
+    /// Only structured recovery diagnostics were emitted; no `ERROR` nodes.
+    StructuredRecoveryOnly,
+    /// Parse produced one or more `ERROR` AST nodes.
+    ErrorNodesPresent,
+    /// Parse failed catastrophically (`parse()` returned `Err`).
+    CatastrophicFailure,
+}
+
+/// Per-file recovery/salvage summary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoverySalvageProfile {
+    /// Whether this parse was a catastrophic failure.
+    pub catastrophic: bool,
+    /// Number of `ParseError::Recovered` diagnostics observed.
+    pub recovered_count: usize,
+    /// Number of `NodeKind::Error` nodes observed in the AST.
+    pub error_node_count: usize,
+    /// Message from the earliest unrecovered `ERROR` node, if any.
+    pub first_unrecovered_error_node: Option<String>,
+    /// Coarse classification used by corpus closeout reports.
+    pub class: RecoverySalvageClass,
+}
+
+impl RecoverySalvageProfile {
+    /// Build a recovery/salvage profile for one parsed file.
+    pub fn from_parse(ast: &Node, diagnostics: &[ParseError], catastrophic: bool) -> Self {
+        let mut error_node_count = 0usize;
+        let mut first_start = usize::MAX;
+        let mut first_unrecovered_error_node: Option<String> = None;
+
+        fn walk(
+            node: &Node,
+            error_node_count: &mut usize,
+            first_start: &mut usize,
+            first_unrecovered_error_node: &mut Option<String>,
+        ) {
+            if let perl_ast::NodeKind::Error { message, .. } = &node.kind {
+                *error_node_count = error_node_count.saturating_add(1);
+                if node.location.start < *first_start {
+                    *first_start = node.location.start;
+                    *first_unrecovered_error_node = Some(message.clone());
+                }
+            }
+            node.for_each_child(|child| {
+                walk(child, error_node_count, first_start, first_unrecovered_error_node);
+            });
+        }
+        walk(ast, &mut error_node_count, &mut first_start, &mut first_unrecovered_error_node);
+
+        let recovered_count =
+            diagnostics.iter().filter(|e| matches!(e, ParseError::Recovered { .. })).count();
+
+        let class = if catastrophic {
+            RecoverySalvageClass::CatastrophicFailure
+        } else if error_node_count > 0 {
+            RecoverySalvageClass::ErrorNodesPresent
+        } else if recovered_count > 0 {
+            RecoverySalvageClass::StructuredRecoveryOnly
+        } else {
+            RecoverySalvageClass::Clean
+        };
+
+        Self {
+            catastrophic,
+            recovered_count,
+            error_node_count,
+            first_unrecovered_error_node,
+            class,
+        }
+    }
+}
+
 impl ParseOutput {
     /// Create a successful parse output with no errors.
     pub fn success(ast: Node) -> Self {

--- a/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
+++ b/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
@@ -418,12 +418,26 @@ fn parser_recovery_profiles_error_nodes_as_accuracy_issue() -> ParseResult<()> {
     let mut parser = Parser::new("my $x = 1 + ; my $y = 2;");
     let ast = parser.parse()?;
     let profile = RecoverySalvageProfile::from_parse(&ast, parser.errors(), false);
+    // The class must not be Clean — the parser saw a malformed expression.
+    assert_ne!(
+        profile.class,
+        RecoverySalvageClass::Clean,
+        "recovery profile must not be Clean for malformed input: {:?}",
+        profile.class
+    );
+    // At least one recovery signal must be present: either an ERROR node or a
+    // Recovered diagnostic.  Both counts together prove `from_parse` walked the
+    // AST and scanned diagnostics rather than returning a zero-filled struct.
     assert!(
-        matches!(
-            profile.class,
-            RecoverySalvageClass::ErrorNodesPresent | RecoverySalvageClass::StructuredRecoveryOnly
-        ),
-        "recovery profile should classify malformed expression as dirty: {:?}",
+        profile.error_node_count > 0 || profile.recovered_count > 0,
+        "profile must record at least one error or recovery signal: {:?}",
+        profile
+    );
+    // Catastrophic is also wrong — parse() returned Ok above.
+    assert_ne!(
+        profile.class,
+        RecoverySalvageClass::CatastrophicFailure,
+        "parse() succeeded so catastrophic must not be set: {:?}",
         profile.class
     );
     Ok(())

--- a/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
+++ b/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
@@ -3,7 +3,9 @@
 //! Tests for panic mode error recovery that allows the parser to continue
 //! parsing after encountering syntax errors by synchronizing to known points.
 
-use perl_parser_core::{NodeKind, ParseResult, Parser};
+use perl_parser_core::{
+    NodeKind, ParseResult, Parser, RecoverySalvageClass, RecoverySalvageProfile,
+};
 
 // AC1: Parser implements synchronization point detection for Perl syntax
 #[test]
@@ -408,5 +410,21 @@ fn parser_recovery_preserves_good_code() -> ParseResult<()> {
             }
         }
     }
+    Ok(())
+}
+
+#[test]
+fn parser_recovery_profiles_error_nodes_as_accuracy_issue() -> ParseResult<()> {
+    let mut parser = Parser::new("my $x = 1 + ; my $y = 2;");
+    let ast = parser.parse()?;
+    let profile = RecoverySalvageProfile::from_parse(&ast, parser.errors(), false);
+    assert!(
+        matches!(
+            profile.class,
+            RecoverySalvageClass::ErrorNodesPresent | RecoverySalvageClass::StructuredRecoveryOnly
+        ),
+        "recovery profile should classify malformed expression as dirty: {:?}",
+        profile.class
+    );
     Ok(())
 }

--- a/crates/perl-parser-core/tests/recovery_missing_closer.rs
+++ b/crates/perl-parser-core/tests/recovery_missing_closer.rs
@@ -11,7 +11,7 @@
 mod cpan_test_helpers;
 use cpan_test_helpers::*;
 use perl_parser_core::error::{ParseError, RecoveryKind, RecoverySite};
-use perl_parser_core::{NodeKind, Parser};
+use perl_parser_core::{NodeKind, Parser, RecoverySalvageClass, RecoverySalvageProfile};
 use perl_tdd_support::must;
 
 // ---------------------------------------------------------------------------
@@ -332,4 +332,14 @@ fn clean_inputs_produce_zero_inserted_closer() {
             src, recovered
         );
     }
+}
+
+#[test]
+fn missing_closer_profiles_as_structured_recovery_only() {
+    let mut parser = Parser::new("my @arr = ($a, $b;");
+    let ast = must(parser.parse());
+    let profile = RecoverySalvageProfile::from_parse(&ast, parser.errors(), false);
+    assert_eq!(profile.class, RecoverySalvageClass::StructuredRecoveryOnly);
+    assert!(profile.recovered_count >= 1);
+    assert_eq!(profile.error_node_count, 0);
 }

--- a/crates/perl-parser-core/tests/recovery_phase2_tests.rs
+++ b/crates/perl-parser-core/tests/recovery_phase2_tests.rs
@@ -15,6 +15,7 @@ use cpan_test_helpers::*;
 
 use perl_parser_core::Parser;
 use perl_parser_core::error::{ParseError, RecoveryKind, RecoverySite};
+use perl_parser_core::{RecoverySalvageClass, RecoverySalvageProfile};
 
 // ──────────────────────────────────────────────────────────────
 // Helpers
@@ -25,6 +26,21 @@ fn parse_errors(source: &str) -> Vec<ParseError> {
     let mut parser = Parser::new(source);
     let _ = parser.parse(); // ignore Ok/Err — we want errors()
     parser.errors().to_vec()
+}
+
+fn classify(source: &str) -> RecoverySalvageProfile {
+    let mut parser = Parser::new(source);
+    let (ast, catastrophic) = match parser.parse() {
+        Ok(ast) => (ast, false),
+        Err(_) => (
+            perl_parser_core::Node::new(
+                perl_parser_core::NodeKind::Program { statements: vec![] },
+                perl_parser_core::SourceLocation { start: 0, end: 0 },
+            ),
+            true,
+        ),
+    };
+    RecoverySalvageProfile::from_parse(&ast, parser.errors(), catastrophic)
 }
 
 /// Assert at least one `ParseError::Recovered` with the given site+kind.
@@ -216,6 +232,14 @@ fn clean_hash_subscript_does_not_emit_recovered() {
 fn clean_chained_methods_does_not_emit_recovered() {
     let errors = parse_errors("my $x = $obj->foo->bar->baz;");
     assert_not_recovered(&errors, RecoverySite::PostfixChain, RecoveryKind::TruncatedChain);
+}
+
+#[test]
+fn missing_rhs_classifies_as_structured_recovery_only() {
+    let profile = classify("my $x = $a +;");
+    assert_eq!(profile.class, RecoverySalvageClass::StructuredRecoveryOnly);
+    assert_eq!(profile.error_node_count, 0);
+    assert!(profile.recovered_count >= 1);
 }
 
 #[test]

--- a/crates/perl-parser/src/lib.rs
+++ b/crates/perl-parser/src/lib.rs
@@ -527,7 +527,7 @@ pub use workspace::workspace_rename;
 /// AST node, node kind enum, and source location types.
 pub use ast::{Node, NodeKind, SourceLocation};
 /// Parse error and result types for parser output.
-pub use error::{ParseError, ParseResult};
+pub use error::{ParseError, ParseResult, RecoverySalvageClass, RecoverySalvageProfile};
 #[cfg(feature = "incremental")]
 /// Checkpointed incremental parser with simple edit tracking.
 pub use incremental_checkpoint::{CheckpointedIncrementalParser, SimpleEdit};

--- a/xtask/src/tasks/parser_corpus_sweep.rs
+++ b/xtask/src/tasks/parser_corpus_sweep.rs
@@ -7,7 +7,9 @@
 
 use color_eyre::eyre::{Context, Result};
 use indicatif::{ProgressBar, ProgressStyle};
-use perl_parser::{Node, NodeKind, Parser};
+#[cfg(test)]
+use perl_parser::{Node, NodeKind};
+use perl_parser::{ParseError, Parser, RecoverySalvageClass, RecoverySalvageProfile};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -159,7 +161,19 @@ pub struct SweepReport {
     pub files_unreadable: usize,
     pub clean_files: usize,
     pub files_with_errors: usize,
+    #[serde(default)]
+    pub total_dirty_files: usize,
+    #[serde(default)]
+    pub files_with_structured_recovery_only: usize,
+    #[serde(default)]
+    pub files_with_error_nodes: usize,
+    #[serde(default)]
+    pub files_with_catastrophic_parse_failure: usize,
     pub total_error_nodes: usize,
+    #[serde(default)]
+    pub recovered_node_count: usize,
+    #[serde(default)]
+    pub first_unrecovered_error_node_buckets: BTreeMap<String, usize>,
     pub first_error_buckets: BTreeMap<String, usize>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub files_by_bucket: BTreeMap<String, Vec<String>>,
@@ -178,6 +192,8 @@ pub struct SweepReport {
     /// line count (older verbose=false receipts, or empty corpora).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub median_error_density_per_1k_loc: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub recovery_salvage_rate: Option<f64>,
     /// Top slowest files by parse duration (always captured, regardless of verbose mode).
     ///
     /// Introduced in schema 1.3.0. Always present when phase timings are
@@ -246,6 +262,8 @@ pub struct FileResult {
     pub error_node_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub first_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub recovered_count: Option<usize>,
     /// Wall time spent parsing this file, in milliseconds.
     ///
     /// Introduced in schema 1.3.0. Absent for `status == "unreadable"`
@@ -309,6 +327,7 @@ fn get_perl_version() -> String {
 }
 
 /// Summary of Error nodes found in an AST.
+#[cfg(test)]
 struct ErrorSummary {
     /// Total count of NodeKind::Error nodes in the tree
     count: usize,
@@ -321,6 +340,7 @@ struct ErrorSummary {
 /// Counts all `NodeKind::Error` nodes and captures the raw message from
 /// the earliest error by byte offset. Uses `for_each_child` to traverse
 /// the full tree including `partial` subtrees of Error nodes.
+#[cfg(test)]
 fn collect_error_summary(root: &Node) -> ErrorSummary {
     let mut count = 0usize;
     let mut first_start = usize::MAX;
@@ -329,6 +349,7 @@ fn collect_error_summary(root: &Node) -> ErrorSummary {
     ErrorSummary { count, first_message }
 }
 
+#[cfg(test)]
 fn walk_errors(
     node: &Node,
     count: &mut usize,
@@ -679,7 +700,13 @@ pub fn run(config: SweepConfig) -> Result<()> {
     let mut files_unreadable = 0usize;
     let mut clean_files = 0usize;
     let mut files_with_errors = 0usize;
+    let mut total_dirty_files = 0usize;
+    let mut files_with_structured_recovery_only = 0usize;
+    let mut files_with_error_nodes = 0usize;
+    let mut files_with_catastrophic_parse_failure = 0usize;
     let mut total_error_nodes = 0usize;
+    let mut recovered_node_count = 0usize;
+    let mut first_unrecovered_error_node_buckets: BTreeMap<String, usize> = BTreeMap::new();
     let mut first_error_buckets: BTreeMap<String, usize> = BTreeMap::new();
     let mut files_by_bucket: BTreeMap<String, Vec<String>> = BTreeMap::new();
     let mut file_results: Vec<FileResult> = Vec::new();
@@ -716,6 +743,7 @@ pub fn run(config: SweepConfig) -> Result<()> {
                         status: "unreadable".to_string(),
                         error_node_count: 0,
                         first_error: None,
+                        recovered_count: None,
                         parse_duration_ms: None,
                         line_count: None,
                     });
@@ -738,24 +766,23 @@ pub fn run(config: SweepConfig) -> Result<()> {
         let ast = match parse_result {
             Ok(ast) => ast,
             Err(_) => {
-                // Catastrophic failure (recursion limit etc.) — count as error
+                // Catastrophic failure (recursion limit etc.) — separate from AST ERROR nodes.
                 files_with_errors += 1;
-                total_error_nodes += 1;
-                let bucket = "catastrophic_parse_failure".to_string();
-                *first_error_buckets.entry(bucket.clone()).or_default() += 1;
-                files_by_bucket.entry(bucket.clone()).or_default().push(portable_path.clone());
+                total_dirty_files += 1;
+                files_with_catastrophic_parse_failure += 1;
                 measurements.push(FileMeasurement {
                     path: portable_path.clone(),
                     parse_duration_ms,
                     line_count,
-                    error_node_count: 1,
+                    error_node_count: 0,
                 });
                 if config.verbose {
                     file_results.push(FileResult {
                         path: portable_path.clone(),
-                        status: "errors".to_string(),
-                        error_node_count: 1,
-                        first_error: Some(bucket),
+                        status: "catastrophic".to_string(),
+                        error_node_count: 0,
+                        first_error: None,
+                        recovered_count: Some(0),
                         parse_duration_ms: Some(parse_duration_ms),
                         line_count: Some(line_count),
                     });
@@ -765,44 +792,74 @@ pub fn run(config: SweepConfig) -> Result<()> {
             }
         };
 
-        // Count ERROR nodes via AST walk
-        let summary = collect_error_summary(&ast);
+        let errors: Vec<ParseError> = parser.errors().to_vec();
+        let salvage = RecoverySalvageProfile::from_parse(&ast, &errors, false);
 
         measurements.push(FileMeasurement {
             path: portable_path.clone(),
             parse_duration_ms,
             line_count,
-            error_node_count: summary.count,
+            error_node_count: salvage.error_node_count,
         });
 
-        if summary.count == 0 {
-            clean_files += 1;
-            if config.verbose {
-                file_results.push(FileResult {
-                    path: portable_path.clone(),
-                    status: "clean".to_string(),
-                    error_node_count: 0,
-                    first_error: None,
-                    parse_duration_ms: Some(parse_duration_ms),
-                    line_count: Some(line_count),
-                });
+        recovered_node_count = recovered_node_count.saturating_add(salvage.recovered_count);
+        match salvage.class {
+            RecoverySalvageClass::Clean => {
+                clean_files += 1;
+                if config.verbose {
+                    file_results.push(FileResult {
+                        path: portable_path.clone(),
+                        status: "clean".to_string(),
+                        error_node_count: 0,
+                        first_error: None,
+                        recovered_count: Some(0),
+                        parse_duration_ms: Some(parse_duration_ms),
+                        line_count: Some(line_count),
+                    });
+                }
             }
-        } else {
-            files_with_errors += 1;
-            total_error_nodes += summary.count;
-            let first = summary.first_message.as_deref().unwrap_or("unknown");
-            let bucket = normalize_error_bucket(first);
-            *first_error_buckets.entry(bucket.clone()).or_default() += 1;
-            files_by_bucket.entry(bucket.clone()).or_default().push(portable_path.clone());
-            if config.verbose {
-                file_results.push(FileResult {
-                    path: portable_path,
-                    status: "errors".to_string(),
-                    error_node_count: summary.count,
-                    first_error: Some(bucket),
-                    parse_duration_ms: Some(parse_duration_ms),
-                    line_count: Some(line_count),
-                });
+            RecoverySalvageClass::StructuredRecoveryOnly => {
+                files_with_errors += 1;
+                total_dirty_files += 1;
+                files_with_structured_recovery_only += 1;
+                if config.verbose {
+                    file_results.push(FileResult {
+                        path: portable_path.clone(),
+                        status: "recovered".to_string(),
+                        error_node_count: 0,
+                        first_error: None,
+                        recovered_count: Some(salvage.recovered_count),
+                        parse_duration_ms: Some(parse_duration_ms),
+                        line_count: Some(line_count),
+                    });
+                }
+            }
+            RecoverySalvageClass::ErrorNodesPresent => {
+                files_with_errors += 1;
+                total_dirty_files += 1;
+                files_with_error_nodes += 1;
+                total_error_nodes = total_error_nodes.saturating_add(salvage.error_node_count);
+                let first = salvage.first_unrecovered_error_node.as_deref().unwrap_or("unknown");
+                let bucket = normalize_error_bucket(first);
+                *first_unrecovered_error_node_buckets.entry(bucket.clone()).or_default() += 1;
+                *first_error_buckets.entry(bucket.clone()).or_default() += 1;
+                files_by_bucket.entry(bucket.clone()).or_default().push(portable_path.clone());
+                if config.verbose {
+                    file_results.push(FileResult {
+                        path: portable_path.clone(),
+                        status: "errors".to_string(),
+                        error_node_count: salvage.error_node_count,
+                        first_error: Some(bucket),
+                        recovered_count: Some(salvage.recovered_count),
+                        parse_duration_ms: Some(parse_duration_ms),
+                        line_count: Some(line_count),
+                    });
+                }
+            }
+            RecoverySalvageClass::CatastrophicFailure => {
+                files_with_errors += 1;
+                total_dirty_files += 1;
+                files_with_catastrophic_parse_failure += 1;
             }
         }
 
@@ -821,6 +878,11 @@ pub fn run(config: SweepConfig) -> Result<()> {
         total_ms: elapsed.as_millis() as u64,
     };
     let median_error_density_per_1k_loc = compute_median_error_density(&measurements);
+    let recovery_salvage_rate = if total_dirty_files == 0 {
+        None
+    } else {
+        Some(files_with_structured_recovery_only as f64 / total_dirty_files as f64)
+    };
     let slowest_files = top_n_slowest(&measurements, SLOWEST_FILES_LIMIT);
 
     let report = SweepReport {
@@ -839,13 +901,20 @@ pub fn run(config: SweepConfig) -> Result<()> {
         files_unreadable,
         clean_files,
         files_with_errors,
+        total_dirty_files,
+        files_with_structured_recovery_only,
+        files_with_error_nodes,
+        files_with_catastrophic_parse_failure,
         total_error_nodes,
+        recovered_node_count,
+        first_unrecovered_error_node_buckets,
         first_error_buckets,
         files_by_bucket,
         file_results: if config.verbose { file_results } else { Vec::new() },
         elapsed_secs: elapsed.as_secs_f64(),
         phase_timings: Some(phase_timings),
         median_error_density_per_1k_loc,
+        recovery_salvage_rate,
         slowest_files,
     };
 
@@ -951,8 +1020,7 @@ pub fn enforce_ratchet(report: &SweepReport, baseline: &SweepReport) -> Vec<Ratc
     let mut violations = Vec::new();
 
     // 1. Crash count must be 0
-    let crash_count =
-        report.first_error_buckets.get("catastrophic_parse_failure").copied().unwrap_or(0);
+    let crash_count = report.files_with_catastrophic_parse_failure;
     if crash_count > 0 {
         violations.push(RatchetViolation {
             metric: "crash_count".to_string(),
@@ -1076,7 +1144,12 @@ pub fn print_summary(report: &SweepReport) {
     println!("Total files:       {}", report.total_files);
     println!("Unreadable:        {}", report.files_unreadable);
     println!("Clean (no errors): {} ({:.1}%)", report.clean_files, clean_pct);
+    println!("Dirty files:       {}", report.total_dirty_files);
     println!("With errors:       {}", report.files_with_errors);
+    println!("  - Structured recovery only: {}", report.files_with_structured_recovery_only);
+    println!("  - With ERROR nodes:         {}", report.files_with_error_nodes);
+    println!("  - Catastrophic parse fail:  {}", report.files_with_catastrophic_parse_failure);
+    println!("Recovered nodes:   {}", report.recovered_node_count);
     println!("Total ERROR nodes: {}", report.total_error_nodes);
     println!("Elapsed:           {:.1}s", report.elapsed_secs);
 
@@ -1090,6 +1163,9 @@ pub fn print_summary(report: &SweepReport) {
 
     if let Some(density) = report.median_error_density_per_1k_loc {
         println!("\nMedian error density (dirty files): {density:.2} errors / 1k LOC");
+    }
+    if let Some(salvage_rate) = report.recovery_salvage_rate {
+        println!("Recovery salvage rate: {:.1}%", salvage_rate * 100.0);
     }
 
     if !report.slowest_files.is_empty() {
@@ -1120,9 +1196,9 @@ pub fn print_summary(report: &SweepReport) {
         }
     }
 
-    if !report.first_error_buckets.is_empty() {
-        println!("\n--- First-error buckets (top 20) ---");
-        let mut sorted: Vec<_> = report.first_error_buckets.iter().collect();
+    if !report.first_unrecovered_error_node_buckets.is_empty() {
+        println!("\n--- First unrecovered ERROR-node buckets (top 20) ---");
+        let mut sorted: Vec<_> = report.first_unrecovered_error_node_buckets.iter().collect();
         sorted.sort_by(|a, b| b.1.cmp(a.1));
         for (i, (bucket, count)) in sorted.iter().enumerate() {
             if i >= 20 {
@@ -1160,13 +1236,20 @@ mod tests {
             files_unreadable,
             clean_files,
             files_with_errors,
+            total_dirty_files: files_with_errors,
+            files_with_structured_recovery_only: 0,
+            files_with_error_nodes: files_with_errors,
+            files_with_catastrophic_parse_failure: 0,
             total_error_nodes,
+            recovered_node_count: 0,
+            first_unrecovered_error_node_buckets: first_error_buckets.clone(),
             first_error_buckets,
             files_by_bucket: BTreeMap::new(),
             file_results: vec![],
             elapsed_secs: 1.0,
             phase_timings: None,
             median_error_density_per_1k_loc: None,
+            recovery_salvage_rate: None,
             slowest_files: vec![],
         }
     }
@@ -1486,10 +1569,7 @@ mod tests {
     fn test_enforce_ratchet_crash_count() {
         let baseline = test_report(80, 20, 20, 0, BTreeMap::new());
 
-        let report = SweepReport {
-            first_error_buckets: BTreeMap::from([("catastrophic_parse_failure".to_string(), 2)]),
-            ..baseline.clone()
-        };
+        let report = SweepReport { files_with_catastrophic_parse_failure: 2, ..baseline.clone() };
 
         let violations = enforce_ratchet(&report, &baseline);
         let crash_violation = violations.iter().find(|v| v.metric == "crash_count");

--- a/xtask/src/tasks/parser_corpus_sweep.rs
+++ b/xtask/src/tasks/parser_corpus_sweep.rs
@@ -857,6 +857,11 @@ pub fn run(config: SweepConfig) -> Result<()> {
                 }
             }
             RecoverySalvageClass::CatastrophicFailure => {
+                // This arm is unreachable in this branch: `from_parse` is always
+                // called with `catastrophic=false` here.  True catastrophic failures
+                // are handled above via the `Err(_)` arm which calls `continue`.
+                // Keeping the arm to satisfy the exhaustive match; clippy will flag
+                // it as unreachable if the enum ever gains a structural invariant.
                 files_with_errors += 1;
                 total_dirty_files += 1;
                 files_with_catastrophic_parse_failure += 1;

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -85,6 +85,13 @@ fn format_clean_rate(clean_files: usize, total_files: usize) -> String {
     format!("{clean_pct:.1}% clean (`{clean_files}/{total_files}`)")
 }
 
+fn format_salvage_rate(salvage_rate: Option<f64>) -> String {
+    match salvage_rate {
+        Some(rate) => format!("{:.1}% salvage", rate * 100.0),
+        None => "n/a salvage".to_string(),
+    }
+}
+
 fn short_day(timestamp: &str) -> &str {
     timestamp.get(..10).unwrap_or(timestamp)
 }
@@ -100,11 +107,14 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         },
         |report| {
             format!(
-                "| **Ubuntu system Perl** | {} | Compatibility baseline; Perl `{}`, `{}` unreadable, `{}` with errors, baseline `{}` | `.ci/parser-corpus-baseline.json` |",
+                "| **Ubuntu system Perl** | {} / {} | Compatibility baseline; Perl `{}`, `{}` unreadable, `{}` recovery-only, `{}` ERROR-node files, `{}` catastrophic, baseline `{}` | `.ci/parser-corpus-baseline.json` |",
                 format_clean_rate(report.clean_files, report.total_files),
+                format_salvage_rate(report.recovery_salvage_rate),
                 report.perl_version,
                 report.files_unreadable,
-                report.files_with_errors,
+                report.files_with_structured_recovery_only,
+                report.files_with_error_nodes,
+                report.files_with_catastrophic_parse_failure,
                 short_day(&report.timestamp),
             )
         },
@@ -116,10 +126,13 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         },
         |report| {
             format!(
-                "| **CPAN top 1000** | {} | Ecosystem breadth baseline; `{}` unreadable, `{}` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `{}` | `.ci/cpan-corpus-baseline.json` |",
+                "| **CPAN top 1000** | {} / {} | Ecosystem breadth baseline; `{}` unreadable, `{}` recovery-only, `{}` ERROR-node files, `{}` catastrophic, cached downloads in `target/cpan-corpus/.cpanm`, baseline `{}` | `.ci/cpan-corpus-baseline.json` |",
                 format_clean_rate(report.clean_files, report.total_files),
+                format_salvage_rate(report.recovery_salvage_rate),
                 report.files_unreadable,
-                report.files_with_errors,
+                report.files_with_structured_recovery_only,
+                report.files_with_error_nodes,
+                report.files_with_catastrophic_parse_failure,
                 short_day(&report.timestamp),
             )
         },
@@ -362,13 +375,20 @@ mod tests {
             files_unreadable: 0,
             clean_files: 10,
             files_with_errors: 0,
+            total_dirty_files: 0,
+            files_with_structured_recovery_only: 0,
+            files_with_error_nodes: 0,
+            files_with_catastrophic_parse_failure: 0,
             total_error_nodes: 0,
+            recovered_node_count: 0,
+            first_unrecovered_error_node_buckets: BTreeMap::new(),
             first_error_buckets: BTreeMap::new(),
             files_by_bucket: BTreeMap::new(),
             file_results: vec![],
             elapsed_secs: 1.0,
             phase_timings: None,
             median_error_density_per_1k_loc: None,
+            recovery_salvage_rate: None,
             slowest_files: vec![],
         };
         let metrics = ParserMetrics {


### PR DESCRIPTION
### Motivation
- Corpus closeout treated all non-clean parses as a single `dirty` bucket, which conflated benign structured recovery with unrecovered ERROR-node parses and catastrophic parser failures, obscuring accuracy signals.

### Description
- Add a per-file closeout classification API in `perl-parser-core`: `RecoverySalvageClass` and `RecoverySalvageProfile` that count recovered diagnostics, ERROR node counts, first unrecovered ERROR message, and classify into Clean / StructuredRecoveryOnly / ErrorNodesPresent / CatastrophicFailure.
- Wire the new profile into the corpus sweep (`xtask/src/tasks/parser_corpus_sweep.rs`) and extend `SweepReport` with metrics: `total_dirty_files`, `files_with_structured_recovery_only`, `files_with_error_nodes`, `files_with_catastrophic_parse_failure`, `recovered_node_count`, `first_unrecovered_error_node_buckets`, and `recovery_salvage_rate`.
- Update report printing and `update_status` generator (`xtask/src/tasks/update_status/parser.rs`) to display salvage-rate and split dirty-file details for system/CPAN receipts.
- Add focused tests that assert recovery classification (in `crates/perl-parser-core/tests/*`), and re-export the new types through public crates so downstream tasks can consume them.

### Testing
- Ran `cargo test -p perl-parser-core recovery` and the recovery-focused test suites passed (tests exercising `RecoverySalvageProfile`).
- Ran `cargo test -p xtask parser` and `cargo test -p xtask parser_corpus_sweep` and all xtask parser tests passed.
- Ran `cargo check` / `cargo fmt --all` to ensure build and formatting are clean; both completed successfully.
- Note: `just parser-audit` and `just status-update --only parser` were not executed because `just` is not available in the environment (`/bin/bash: just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55e56dd083338f83f52aa3a8dd1d)