### PR TITLE
feat(parser): add recovery-salvage metrics for accuracy closeout (#0000)

### DIFF
--- a/.ci/metrics/baselines/parser.json
+++ b/.ci/metrics/baselines/parser.json
@@ -15,7 +15,7 @@
   "improvement_metrics": {
     "node_kind_coverage": 0.941,
     "error_density_per_1k_loc": null,
-    "recovery_salvage_rate": null
+    "recovery_salvage_rate": 0.0
   },
   "tolerance_pct": 0.005
 }

--- a/crates/perl-parser-core/src/engine/error/mod.rs
+++ b/crates/perl-parser-core/src/engine/error/mod.rs
@@ -27,6 +27,7 @@ pub mod recovery {
 
 /// Error types and result aliases used by the parser engine.
 pub use crate::syntax::error::{
-    BudgetTracker, ErrorContext, ParseBudget, ParseError, ParseOutput, ParseResult, RecoveryKind,
-    RecoverySite, get_error_contexts,
+    BudgetTracker, ErrorContext, ParseBudget, ParseError, ParseOutput, ParseResult,
+    RecoveryClassification, RecoveryKind, RecoverySalvageSnapshot, RecoverySite,
+    get_error_contexts,
 };

--- a/crates/perl-parser-core/src/syntax/error/mod.rs
+++ b/crates/perl-parser-core/src/syntax/error/mod.rs
@@ -489,7 +489,7 @@ pub mod classifier;
 /// Error recovery strategies and traits for the Perl parser.
 pub mod recovery;
 
-use perl_ast::Node;
+use perl_ast::{Node, NodeKind};
 
 /// Structured output from parsing, combining AST with all diagnostics.
 ///
@@ -540,6 +540,30 @@ pub struct ParseOutput {
     /// LSP providers use this as a confidence signal: `0` means a clean parse,
     /// `> 0` means at least one synthetic repair was made.
     pub recovered_count: usize,
+}
+
+/// High-level classification for parser closeout metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryClassification {
+    /// No recoveries and no AST `ERROR` nodes.
+    Clean,
+    /// Recoveries occurred but AST contains no `ERROR` nodes.
+    StructuredRecoveryOnly,
+    /// AST contains one or more unrecovered `ERROR` nodes.
+    ErrorNodesPresent,
+}
+
+/// Recovery-salvage snapshot derived from a single parse output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoverySalvageSnapshot {
+    /// Coarse classification for closeout reporting.
+    pub classification: RecoveryClassification,
+    /// Number of `ParseError::Recovered` diagnostics.
+    pub recovered_node_count: usize,
+    /// Number of AST `NodeKind::Error` nodes.
+    pub error_node_count: usize,
+    /// First unrecovered AST `ERROR` message, if one exists.
+    pub first_unrecovered_error_node: Option<String>,
 }
 
 impl ParseOutput {
@@ -595,6 +619,44 @@ impl ParseOutput {
     pub fn error_count(&self) -> usize {
         self.diagnostics.len()
     }
+
+    /// Derive recovery-salvage classification from diagnostics and AST content.
+    pub fn recovery_salvage_snapshot(&self) -> RecoverySalvageSnapshot {
+        let (error_node_count, first_unrecovered_error_node) =
+            count_error_nodes_and_first_message(&self.ast);
+        let classification = if error_node_count > 0 {
+            RecoveryClassification::ErrorNodesPresent
+        } else if self.recovered_count > 0 {
+            RecoveryClassification::StructuredRecoveryOnly
+        } else {
+            RecoveryClassification::Clean
+        };
+
+        RecoverySalvageSnapshot {
+            classification,
+            recovered_node_count: self.recovered_count,
+            error_node_count,
+            first_unrecovered_error_node,
+        }
+    }
+}
+
+fn count_error_nodes_and_first_message(ast: &Node) -> (usize, Option<String>) {
+    let mut count = 0usize;
+    let mut first_message = None;
+    let mut stack = vec![ast];
+
+    while let Some(node) = stack.pop() {
+        if let NodeKind::Error { message, .. } = &node.kind {
+            count += 1;
+            if first_message.is_none() {
+                first_message = Some(message.clone());
+            }
+        }
+        node.for_each_child(|child| stack.push(child));
+    }
+
+    (count, first_message)
 }
 
 impl ParseError {
@@ -1039,5 +1101,28 @@ mod tests {
 
         assert_eq!(output.recovered_count, 1);
         assert!(!output.terminated_early);
+    }
+
+    #[test]
+    fn test_recovery_salvage_snapshot_structured_recovery_only() {
+        let mut parser = crate::Parser::new("my $x = $a +;");
+        let output = parser.parse_with_recovery();
+        let snapshot = output.recovery_salvage_snapshot();
+
+        assert_eq!(snapshot.classification, RecoveryClassification::StructuredRecoveryOnly);
+        assert!(snapshot.recovered_node_count > 0);
+        assert_eq!(snapshot.error_node_count, 0);
+        assert!(snapshot.first_unrecovered_error_node.is_none());
+    }
+
+    #[test]
+    fn test_recovery_salvage_snapshot_with_error_nodes() {
+        let mut parser = crate::Parser::new("my @arr = (1, 2,\n");
+        let output = parser.parse_with_recovery();
+        let snapshot = output.recovery_salvage_snapshot();
+
+        assert_eq!(snapshot.classification, RecoveryClassification::ErrorNodesPresent);
+        assert!(snapshot.error_node_count > 0);
+        assert!(snapshot.first_unrecovered_error_node.is_some());
     }
 }

--- a/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
+++ b/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
@@ -3,6 +3,7 @@
 //! Tests for panic mode error recovery that allows the parser to continue
 //! parsing after encountering syntax errors by synchronizing to known points.
 
+use perl_parser_core::error::RecoveryClassification;
 use perl_parser_core::{NodeKind, ParseResult, Parser};
 
 // AC1: Parser implements synchronization point detection for Perl syntax
@@ -265,6 +266,17 @@ fn parser_ac9_performance_overhead_check() -> ParseResult<()> {
         assert!(statements.len() >= 3, "Should parse all statements");
     }
     Ok(())
+}
+
+#[test]
+fn parser_recovery_snapshot_marks_unrecovered_error_nodes() {
+    let mut parser = Parser::new("my @arr = (1, 2,\n");
+    let output = parser.parse_with_recovery();
+    let snapshot = output.recovery_salvage_snapshot();
+
+    assert_eq!(snapshot.classification, RecoveryClassification::ErrorNodesPresent);
+    assert!(snapshot.error_node_count > 0);
+    assert!(snapshot.first_unrecovered_error_node.is_some());
 }
 
 // AC10: Test suite includes panic mode recovery scenarios

--- a/crates/perl-parser-core/tests/recovery_missing_closer.rs
+++ b/crates/perl-parser-core/tests/recovery_missing_closer.rs
@@ -10,7 +10,7 @@
 
 mod cpan_test_helpers;
 use cpan_test_helpers::*;
-use perl_parser_core::error::{ParseError, RecoveryKind, RecoverySite};
+use perl_parser_core::error::{ParseError, RecoveryClassification, RecoveryKind, RecoverySite};
 use perl_parser_core::{NodeKind, Parser};
 use perl_tdd_support::must;
 
@@ -259,6 +259,17 @@ fn nested_missing_both_parens_at_eof_emits_two_recovered() {
         "Parser must return a Program node for nested missing closers in '{}'",
         src
     );
+}
+
+#[test]
+fn missing_closer_snapshot_is_structured_recovery_only() {
+    let mut parser = Parser::new("my $x = $arr[$i;");
+    let output = parser.parse_with_recovery();
+    let snapshot = output.recovery_salvage_snapshot();
+
+    assert_eq!(snapshot.classification, RecoveryClassification::StructuredRecoveryOnly);
+    assert!(snapshot.recovered_node_count > 0);
+    assert_eq!(snapshot.error_node_count, 0);
 }
 
 /// Paren missing before EOF inside a list assignment — tests truncated file recovery.

--- a/crates/perl-parser-core/tests/recovery_phase2_tests.rs
+++ b/crates/perl-parser-core/tests/recovery_phase2_tests.rs
@@ -14,7 +14,7 @@ mod cpan_test_helpers;
 use cpan_test_helpers::*;
 
 use perl_parser_core::Parser;
-use perl_parser_core::error::{ParseError, RecoveryKind, RecoverySite};
+use perl_parser_core::error::{ParseError, RecoveryClassification, RecoveryKind, RecoverySite};
 
 // ──────────────────────────────────────────────────────────────
 // Helpers
@@ -228,6 +228,17 @@ fn clean_logical_or_does_not_emit_recovered() {
 fn clean_defined_or_assign_does_not_emit_recovered() {
     let errors = parse_errors("$x //= 'default';");
     assert_not_recovered(&errors, RecoverySite::InfixRhs, RecoveryKind::MissingOperand);
+}
+
+#[test]
+fn phase2_missing_rhs_classifies_as_structured_recovery_only() {
+    let mut parser = Parser::new("my $x = $a +;");
+    let output = parser.parse_with_recovery();
+    let snapshot = output.recovery_salvage_snapshot();
+
+    assert_eq!(snapshot.classification, RecoveryClassification::StructuredRecoveryOnly);
+    assert!(snapshot.recovered_node_count > 0);
+    assert_eq!(snapshot.error_node_count, 0);
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -78,6 +78,13 @@ pub struct StatusSummary {
     pub error_files: usize,
     pub timeout_files: usize,
     pub panic_files: usize,
+    pub dirty_files: usize,
+    pub structured_recovery_only_files: usize,
+    pub files_with_error_nodes: usize,
+    pub catastrophic_parse_failure_files: usize,
+    pub recovered_node_count: usize,
+    pub first_unrecovered_error_node: Option<String>,
+    pub recovery_salvage_rate: Option<f64>,
     pub test_corpus_files: usize,
     pub perl_corpus_files: usize,
     pub nodekind_covered: usize,
@@ -101,11 +108,35 @@ pub fn compute_status_summary(corpus_path: &Path, timeout: Duration) -> Result<S
     let mut error_files = 0usize;
     let mut timeout_files = 0usize;
     let mut panic_files = 0usize;
+    let mut structured_recovery_only_files = 0usize;
+    let mut files_with_error_nodes = 0usize;
+    let mut catastrophic_parse_failure_files = 0usize;
+    let mut recovered_node_count = 0usize;
+    let mut first_unrecovered_error_node: Option<String> = None;
 
     for outcome in parse_results.values() {
         match outcome {
-            ParseOutcome::Ok { .. } => ok_files += 1,
-            ParseOutcome::Error { .. } => error_files += 1,
+            ParseOutcome::Ok {
+                recovered_node_count: file_recovered_count,
+                error_node_count,
+                first_unrecovered_error_node: file_first_error_node,
+                ..
+            } => {
+                ok_files += 1;
+                recovered_node_count += *file_recovered_count;
+                if *error_node_count > 0 {
+                    files_with_error_nodes += 1;
+                    if first_unrecovered_error_node.is_none() {
+                        first_unrecovered_error_node = file_first_error_node.clone();
+                    }
+                } else if *file_recovered_count > 0 {
+                    structured_recovery_only_files += 1;
+                }
+            }
+            ParseOutcome::Error { .. } => {
+                error_files += 1;
+                catastrophic_parse_failure_files += 1;
+            }
             ParseOutcome::Timeout { .. } => timeout_files += 1,
             ParseOutcome::Panic { .. } => panic_files += 1,
         }
@@ -121,12 +152,30 @@ pub fn compute_status_summary(corpus_path: &Path, timeout: Duration) -> Result<S
         }
     }
 
+    let dirty_files = structured_recovery_only_files
+        + files_with_error_nodes
+        + catastrophic_parse_failure_files
+        + timeout_files
+        + panic_files;
+    let recovery_salvage_rate = if dirty_files == 0 {
+        None
+    } else {
+        Some(structured_recovery_only_files as f64 / dirty_files as f64)
+    };
+
     Ok(StatusSummary {
         total_files: inventory.total_files,
         ok_files,
         error_files,
         timeout_files,
         panic_files,
+        dirty_files,
+        structured_recovery_only_files,
+        files_with_error_nodes,
+        catastrophic_parse_failure_files,
+        recovered_node_count,
+        first_unrecovered_error_node,
+        recovery_salvage_rate,
         test_corpus_files,
         perl_corpus_files,
         nodekind_covered: nodekind_stats.covered_count,
@@ -249,6 +298,21 @@ fn print_audit_summary(report: &AuditReport) {
     println!("     - Error: {} ❌", report.parse_outcomes.error);
     println!("     - Timeout: {} ⏱️", report.parse_outcomes.timeout);
     println!("     - Panic: {} 💥", report.parse_outcomes.panic);
+    println!("     - Dirty: {}", report.parse_outcomes.dirty);
+    println!("     - Structured recovery only: {}", report.parse_outcomes.structured_recovery_only);
+    println!("     - Files with ERROR nodes: {}", report.parse_outcomes.error_nodes);
+    println!(
+        "     - Catastrophic parse failures: {}",
+        report.parse_outcomes.catastrophic_parse_failure
+    );
+    println!("     - Recovered node count: {}", report.parse_outcomes.recovered_node_count);
+    println!(
+        "     - First unrecovered ERROR node: {}",
+        report.parse_outcomes.first_unrecovered_error_node.as_deref().unwrap_or("none")
+    );
+    if let Some(rate) = report.parse_outcomes.recovery_salvage_rate {
+        println!("     - Recovery salvage rate: {:.1}%", rate * 100.0);
+    }
     println!(
         "   NodeKind coverage: {}/{} ({:.1}%)",
         report.nodekind_coverage.covered_count,

--- a/xtask/src/tasks/corpus_audit/report.rs
+++ b/xtask/src/tasks/corpus_audit/report.rs
@@ -55,6 +55,22 @@ pub struct ParseOutcomesSummary {
     pub timeout: usize,
     /// Files that caused panics
     pub panic: usize,
+    /// Files that are not clean (any recovery, AST ERROR node, catastrophic failure, timeout, or panic).
+    pub dirty: usize,
+    /// Files that used structured recovery but did not retain AST ERROR nodes.
+    pub structured_recovery_only: usize,
+    /// Files whose AST still contains one or more `NodeKind::Error` nodes.
+    pub error_nodes: usize,
+    /// Files where `Parser::parse()` returned `Err`.
+    pub catastrophic_parse_failure: usize,
+    /// Total recovered diagnostic count across all parsed files.
+    pub recovered_node_count: usize,
+    /// First unrecovered AST ERROR node message encountered in corpus order.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_unrecovered_error_node: Option<String>,
+    /// Ratio of structured-recovery-only files to dirty files.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovery_salvage_rate: Option<f64>,
     /// Error breakdown by category (Issue #180)
     #[serde(default)]
     pub error_by_category: HashMap<String, usize>,
@@ -211,14 +227,36 @@ fn generate_parse_outcomes_summary(
     let mut error = 0;
     let mut timeout = 0;
     let mut panic = 0;
+    let mut structured_recovery_only = 0;
+    let mut error_nodes = 0;
+    let mut catastrophic_parse_failure = 0;
+    let mut recovered_node_count = 0usize;
+    let mut first_unrecovered_error_node: Option<String> = None;
     let mut error_by_category: HashMap<String, usize> = HashMap::new();
     let mut failing_files: Vec<FailingFile> = Vec::new();
 
     for (path, outcome) in parse_results {
         match outcome {
-            ParseOutcome::Ok { .. } => ok += 1,
+            ParseOutcome::Ok {
+                recovered_node_count: file_recovered_count,
+                error_node_count,
+                first_unrecovered_error_node: file_first_error_node,
+                ..
+            } => {
+                ok += 1;
+                recovered_node_count += *file_recovered_count;
+                if *error_node_count > 0 {
+                    error_nodes += 1;
+                    if first_unrecovered_error_node.is_none() {
+                        first_unrecovered_error_node = file_first_error_node.clone();
+                    }
+                } else if *file_recovered_count > 0 {
+                    structured_recovery_only += 1;
+                }
+            }
             ParseOutcome::Error { message } => {
                 error += 1;
+                catastrophic_parse_failure += 1;
 
                 // Categorize the error
                 let source = sources.get(path).map(|s| s.as_str()).unwrap_or("");
@@ -274,10 +312,30 @@ fn generate_parse_outcomes_summary(
         }
     }
 
+    let dirty =
+        structured_recovery_only + error_nodes + catastrophic_parse_failure + timeout + panic;
+    let recovery_salvage_rate =
+        if dirty == 0 { None } else { Some(structured_recovery_only as f64 / dirty as f64) };
+
     // Sort failing files by path for consistent output
     failing_files.sort_by(|a, b| a.path.cmp(&b.path));
 
-    ParseOutcomesSummary { total, ok, error, timeout, panic, error_by_category, failing_files }
+    ParseOutcomesSummary {
+        total,
+        ok,
+        error,
+        timeout,
+        panic,
+        dirty,
+        structured_recovery_only,
+        error_nodes,
+        catastrophic_parse_failure,
+        recovered_node_count,
+        first_unrecovered_error_node,
+        recovery_salvage_rate,
+        error_by_category,
+        failing_files,
+    }
 }
 
 #[cfg(test)]
@@ -287,10 +345,27 @@ mod tests {
     #[test]
     fn test_generate_parse_outcomes_summary() {
         let mut results = std::collections::HashMap::new();
-        results.insert(PathBuf::from("test1.pl"), ParseOutcome::Ok { duration_ms: 100 });
+        results.insert(
+            PathBuf::from("test1.pl"),
+            ParseOutcome::Ok {
+                duration_ms: 100,
+                recovered_node_count: 2,
+                error_node_count: 0,
+                first_unrecovered_error_node: None,
+            },
+        );
         results.insert(
             PathBuf::from("test2.pl"),
             ParseOutcome::Error { message: "error".to_string() },
+        );
+        results.insert(
+            PathBuf::from("test5.pl"),
+            ParseOutcome::Ok {
+                duration_ms: 50,
+                recovered_node_count: 0,
+                error_node_count: 1,
+                first_unrecovered_error_node: Some("Expected expression".to_string()),
+            },
         );
         results.insert(PathBuf::from("test3.pl"), ParseOutcome::Timeout { timeout_ms: 1000 });
         results.insert(
@@ -303,11 +378,18 @@ mod tests {
 
         let summary = generate_parse_outcomes_summary(&results, &sources);
 
-        assert_eq!(summary.total, 4);
-        assert_eq!(summary.ok, 1);
+        assert_eq!(summary.total, 5);
+        assert_eq!(summary.ok, 2);
         assert_eq!(summary.error, 1);
         assert_eq!(summary.timeout, 1);
         assert_eq!(summary.panic, 1);
+        assert_eq!(summary.dirty, 4);
+        assert_eq!(summary.structured_recovery_only, 1);
+        assert_eq!(summary.error_nodes, 1);
+        assert_eq!(summary.catastrophic_parse_failure, 1);
+        assert_eq!(summary.recovered_node_count, 2);
+        assert_eq!(summary.first_unrecovered_error_node.as_deref(), Some("Expected expression"));
+        assert_eq!(summary.recovery_salvage_rate, Some(0.25));
         // Error should be categorized as General when no source is provided
         assert_eq!(summary.error_by_category.get("General"), Some(&1));
         assert_eq!(summary.failing_files.len(), 2); // error + panic

--- a/xtask/src/tasks/corpus_audit/timeout_detection.rs
+++ b/xtask/src/tasks/corpus_audit/timeout_detection.rs
@@ -3,6 +3,7 @@
 //! This module provides timeout protection for parsing operations and
 //! detection of files that may cause timeouts or hangs.
 
+use perl_parser::NodeKind;
 use perl_parser::Parser;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -138,6 +139,12 @@ pub enum ParseOutcome {
     Ok {
         /// Time taken to parse
         duration_ms: u64,
+        /// Number of `ParseError::Recovered` diagnostics emitted by the parser.
+        recovered_node_count: usize,
+        /// Number of `NodeKind::Error` nodes still present in the AST.
+        error_node_count: usize,
+        /// Message from the first unrecovered `NodeKind::Error`, when present.
+        first_unrecovered_error_node: Option<String>,
     },
     /// Parse failed with error
     Error {
@@ -166,7 +173,7 @@ impl ParseOutcome {
     /// Get the duration in milliseconds if parse succeeded
     pub fn duration_ms(&self) -> Option<u64> {
         match self {
-            ParseOutcome::Ok { duration_ms } => Some(*duration_ms),
+            ParseOutcome::Ok { duration_ms, .. } => Some(*duration_ms),
             _ => None,
         }
     }
@@ -213,14 +220,29 @@ pub fn parse_with_timeout(
     let (tx, rx) = std::sync::mpsc::channel();
 
     let handle = std::thread::spawn(move || {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| -> (_, usize) {
             let mut parser = Parser::new(&content_clone);
-            parser.parse()
+            let parse_result = parser.parse();
+            let recovered_count = parser
+                .errors()
+                .iter()
+                .filter(|e| matches!(e, perl_parser::ParseError::Recovered { .. }))
+                .count();
+            (parse_result, recovered_count)
         }));
 
         let outcome = match result {
-            Ok(Ok(_)) => ParseOutcome::Ok { duration_ms: start.elapsed().as_millis() as u64 },
-            Ok(Err(e)) => ParseOutcome::Error { message: e.to_string() },
+            Ok((Ok(ast), recovered_node_count)) => {
+                let (error_node_count, first_unrecovered_error_node) =
+                    count_error_nodes_and_first_message(&ast);
+                ParseOutcome::Ok {
+                    duration_ms: start.elapsed().as_millis() as u64,
+                    recovered_node_count,
+                    error_node_count,
+                    first_unrecovered_error_node,
+                }
+            }
+            Ok((Err(e), _)) => ParseOutcome::Error { message: e.to_string() },
             Err(_) => ParseOutcome::Panic { message: "Parser panicked".to_string() },
         };
 
@@ -239,6 +261,24 @@ pub fn parse_with_timeout(
         }
         Err(_) => ParseOutcome::Error { message: "Channel disconnected unexpectedly".to_string() },
     }
+}
+
+fn count_error_nodes_and_first_message(ast: &perl_parser::Node) -> (usize, Option<String>) {
+    let mut count = 0usize;
+    let mut first_message: Option<String> = None;
+    let mut stack = vec![ast];
+
+    while let Some(node) = stack.pop() {
+        if let NodeKind::Error { message, .. } = &node.kind {
+            count += 1;
+            if first_message.is_none() {
+                first_message = Some(message.clone());
+            }
+        }
+        node.for_each_child(|child| stack.push(child));
+    }
+
+    (count, first_message)
 }
 
 /// Detect timeout and hang risks in corpus files
@@ -503,7 +543,15 @@ mod tests {
 
     #[test]
     fn test_parse_outcome_is_ok() {
-        assert!(ParseOutcome::Ok { duration_ms: 100 }.is_ok());
+        assert!(
+            ParseOutcome::Ok {
+                duration_ms: 100,
+                recovered_node_count: 0,
+                error_node_count: 0,
+                first_unrecovered_error_node: None,
+            }
+            .is_ok()
+        );
         assert!(!ParseOutcome::Error { message: "error".to_string() }.is_ok());
         assert!(!ParseOutcome::Timeout { timeout_ms: 1000 }.is_ok());
         assert!(!ParseOutcome::Panic { message: "panic".to_string() }.is_ok());
@@ -511,7 +559,16 @@ mod tests {
 
     #[test]
     fn test_parse_outcome_duration_ms() {
-        assert_eq!(ParseOutcome::Ok { duration_ms: 100 }.duration_ms(), Some(100));
+        assert_eq!(
+            ParseOutcome::Ok {
+                duration_ms: 100,
+                recovered_node_count: 0,
+                error_node_count: 0,
+                first_unrecovered_error_node: None,
+            }
+            .duration_ms(),
+            Some(100)
+        );
         assert_eq!(ParseOutcome::Error { message: "error".to_string() }.duration_ms(), None);
     }
 

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -85,6 +85,10 @@ fn format_clean_rate(clean_files: usize, total_files: usize) -> String {
     format!("{clean_pct:.1}% clean (`{clean_files}/{total_files}`)")
 }
 
+fn format_salvage_rate(rate: Option<f64>) -> String {
+    rate.map_or_else(|| "n/a".to_string(), |value| format!("{:.1}%", value * 100.0))
+}
+
 fn short_day(timestamp: &str) -> &str {
     timestamp.get(..10).unwrap_or(timestamp)
 }
@@ -131,11 +135,15 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         },
         |summary| {
             format!(
-                "| **Project corpus** | {} | Deterministic regression baseline; `{}` `test_corpus/` + `{}` `perl-corpus` files, `{}` errors, `{}` timeouts, `{}` panics, `{}/{}` NodeKinds, `{}/{}` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |",
+                "| **Project corpus** | {} | Deterministic regression baseline; `{}` dirty (`{}` structured-recovery-only, `{}` with ERROR nodes, `{}` catastrophic), salvage `{}`, recovered nodes `{}`, first unrecovered ERROR node `{}`, `{}` timeouts, `{}` panics, `{}/{}` NodeKinds, `{}/{}` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |",
                 format_clean_rate(summary.ok_files, summary.total_files),
-                summary.test_corpus_files,
-                summary.perl_corpus_files,
-                summary.error_files,
+                summary.dirty_files,
+                summary.structured_recovery_only_files,
+                summary.files_with_error_nodes,
+                summary.catastrophic_parse_failure_files,
+                format_salvage_rate(summary.recovery_salvage_rate),
+                summary.recovered_node_count,
+                summary.first_unrecovered_error_node.as_deref().unwrap_or("none"),
                 summary.timeout_files,
                 summary.panic_files,
                 summary.nodekind_covered,
@@ -288,6 +296,13 @@ mod tests {
             error_files: 0,
             timeout_files: 0,
             panic_files: 0,
+            dirty_files: 3,
+            structured_recovery_only_files: 2,
+            files_with_error_nodes: 1,
+            catastrophic_parse_failure_files: 0,
+            recovered_node_count: 7,
+            first_unrecovered_error_node: Some("expected expression".to_string()),
+            recovery_salvage_rate: Some(2.0 / 3.0),
             test_corpus_files: 69,
             perl_corpus_files: 22,
             nodekind_covered: 65,


### PR DESCRIPTION
### Motivation

- Parser closeout conflates useful structured recovery with unrecovered AST `ERROR` nodes and catastrophic parser failures, preventing accurate salvage metrics in accuracy reporting.
- Need lightweight per-file recovery classification so the corpus audit and status pages can distinguish recoverable editor input from real parser breakage.

### Description

- Add `RecoveryClassification` and `RecoverySalvageSnapshot` types and `ParseOutput::recovery_salvage_snapshot()` to `crates/perl-parser-core` to classify parses as `Clean`, `StructuredRecoveryOnly`, or `ErrorNodesPresent`, and to report recovered/error-node counts and first unrecovered ERROR message.
- Implement AST walk helper to count `NodeKind::Error` nodes and extract the first unrecovered error message, and re-export the new types through the engine error facade for downstream consumers.
- Instrument `xtask` corpus-audit code: extend `ParseOutcome` (timeout detection) to record `recovered_node_count`, `error_node_count`, and `first_unrecovered_error_node`, update `generate_parse_outcomes_summary()` and `SweepReport`/`StatusSummary` to expose `dirty` split (structured-recovery-only, files with ERROR nodes, catastrophic parse failures), `recovered_node_count`, `first_unrecovered_error_node`, and `recovery_salvage_rate`.
- Update `update_status` renderer to show the salvage metrics in the parser status row and update baseline `.ci/metrics/baselines/parser.json` to set an initial `recovery_salvage_rate` value.
- Add focused tests in `crates/perl-parser-core/tests` to assert classification: structured-recovery-only cases and unrecovered-error-node cases, and extend xtask report/unit tests to cover the new fields.

### Testing

- Ran `cargo test -p perl-parser-core recovery`, which completed successfully (all recovery-related unit tests passed).
- Ran `cargo test -p xtask parser`, which completed successfully (xtask parser-related tests passed).
- Attempted `just parser-audit` and `just status-update --only parser` but `just` is not available in this environment so those commands were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55e56dd083338f83f52aa3a8dd1d)