### PR TITLE
feat(parser): add recovery-salvage metrics for accuracy closeout (#0000)

### DIFF
--- a/.ci/metrics/baselines/parser.json
+++ b/.ci/metrics/baselines/parser.json
@@ -15,7 +15,7 @@
   "improvement_metrics": {
     "node_kind_coverage": 0.941,
     "error_density_per_1k_loc": null,
-    "recovery_salvage_rate": null
+    "recovery_salvage_rate": 0.0
   },
   "tolerance_pct": 0.005
 }

--- a/crates/perl-parser-core/src/engine/error/mod.rs
+++ b/crates/perl-parser-core/src/engine/error/mod.rs
@@ -27,6 +27,6 @@ pub mod recovery {
 
 /// Error types and result aliases used by the parser engine.
 pub use crate::syntax::error::{
-    BudgetTracker, ErrorContext, ParseBudget, ParseError, ParseOutput, ParseResult, RecoveryKind,
-    RecoverySite, get_error_contexts,
+    BudgetTracker, ErrorContext, ParseBudget, ParseCloseoutClass, ParseError, ParseOutput,
+    ParseResult, RecoveryKind, RecoverySite, get_error_contexts,
 };

--- a/crates/perl-parser-core/src/syntax/error/mod.rs
+++ b/crates/perl-parser-core/src/syntax/error/mod.rs
@@ -489,7 +489,7 @@ pub mod classifier;
 /// Error recovery strategies and traits for the Perl parser.
 pub mod recovery;
 
-use perl_ast::Node;
+use perl_ast::{Node, NodeKind};
 
 /// Structured output from parsing, combining AST with all diagnostics.
 ///
@@ -540,6 +540,19 @@ pub struct ParseOutput {
     /// LSP providers use this as a confidence signal: `0` means a clean parse,
     /// `> 0` means at least one synthetic repair was made.
     pub recovered_count: usize,
+}
+
+/// Per-file closeout classification used by parser accuracy metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParseCloseoutClass {
+    /// No diagnostics and no `ERROR` nodes.
+    Clean,
+    /// Structured recovery diagnostics only (no unrecovered `ERROR` nodes).
+    StructuredRecoveryOnly,
+    /// Parse completed but left one or more unrecovered `ERROR` nodes in AST.
+    HasErrorNodes,
+    /// Parse failed catastrophically (no usable AST, non-recovery diagnostic).
+    CatastrophicFailure,
 }
 
 impl ParseOutput {
@@ -594,6 +607,46 @@ impl ParseOutput {
     /// Get the error count.
     pub fn error_count(&self) -> usize {
         self.diagnostics.len()
+    }
+
+    /// Count unrecovered `NodeKind::Error` nodes left in the AST.
+    pub fn error_node_count(&self) -> usize {
+        fn count(node: &Node) -> usize {
+            let here = usize::from(matches!(node.kind, NodeKind::Error { .. }));
+            here + node.children().into_iter().map(count).sum::<usize>()
+        }
+        count(&self.ast)
+    }
+
+    /// Return the byte offset of the first unrecovered `NodeKind::Error` node.
+    pub fn first_unrecovered_error_node_location(&self) -> Option<usize> {
+        fn first(node: &Node) -> Option<usize> {
+            if matches!(node.kind, NodeKind::Error { .. }) {
+                return Some(node.location.start);
+            }
+            for child in node.children() {
+                if let Some(location) = first(child) {
+                    return Some(location);
+                }
+            }
+            None
+        }
+        first(&self.ast)
+    }
+
+    /// Classify this parse for recovery-salvage closeout reporting.
+    pub fn closeout_class(&self) -> ParseCloseoutClass {
+        let error_node_count = self.error_node_count();
+        if self.terminated_early && self.ast.count_nodes() <= 1 {
+            return ParseCloseoutClass::CatastrophicFailure;
+        }
+        if error_node_count > 0 {
+            return ParseCloseoutClass::HasErrorNodes;
+        }
+        if self.recovered_count > 0 {
+            return ParseCloseoutClass::StructuredRecoveryOnly;
+        }
+        ParseCloseoutClass::Clean
     }
 }
 

--- a/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
+++ b/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
@@ -3,6 +3,7 @@
 //! Tests for panic mode error recovery that allows the parser to continue
 //! parsing after encountering syntax errors by synchronizing to known points.
 
+use perl_parser_core::error::ParseCloseoutClass;
 use perl_parser_core::{NodeKind, ParseResult, Parser};
 
 // AC1: Parser implements synchronization point detection for Perl syntax
@@ -265,6 +266,24 @@ fn parser_ac9_performance_overhead_check() -> ParseResult<()> {
         assert!(statements.len() >= 3, "Should parse all statements");
     }
     Ok(())
+}
+
+#[test]
+fn closeout_class_marks_error_nodes_as_accuracy_issue() {
+    let candidates =
+        ["my @arr = (1, 2,\n", "my $x = (;\n", "sub f { my $x = ; ; ; }", "my $x = $obj->->foo;"];
+
+    for source in candidates {
+        let mut parser = Parser::new(source);
+        let output = parser.parse_with_recovery();
+        if output.closeout_class() == ParseCloseoutClass::HasErrorNodes {
+            assert!(output.error_node_count() > 0);
+            assert!(output.first_unrecovered_error_node_location().is_some());
+            return;
+        }
+    }
+
+    panic!("expected at least one candidate to yield unrecovered ERROR nodes");
 }
 
 // AC10: Test suite includes panic mode recovery scenarios

--- a/crates/perl-parser-core/tests/recovery_missing_closer.rs
+++ b/crates/perl-parser-core/tests/recovery_missing_closer.rs
@@ -10,7 +10,7 @@
 
 mod cpan_test_helpers;
 use cpan_test_helpers::*;
-use perl_parser_core::error::{ParseError, RecoveryKind, RecoverySite};
+use perl_parser_core::error::{ParseCloseoutClass, ParseError, RecoveryKind, RecoverySite};
 use perl_parser_core::{NodeKind, Parser};
 use perl_tdd_support::must;
 
@@ -231,6 +231,15 @@ fn recovered_error_has_correct_site_for_array_subscript() {
         "Expected Recovered {{ site: ArraySubscript, kind: InsertedCloser }} for '{}', got: {:?}",
         src, errors
     );
+}
+
+#[test]
+fn missing_closer_recovery_is_not_catastrophic() {
+    let mut parser = Parser::new("my $v = $arr[$i;");
+    let output = parser.parse_with_recovery();
+    assert_eq!(output.closeout_class(), ParseCloseoutClass::StructuredRecoveryOnly);
+    assert!(output.recovered_count > 0);
+    assert_eq!(output.error_node_count(), 0);
 }
 
 /// Both inner and outer parens missing — each level independently emits InsertedCloser.

--- a/crates/perl-parser-core/tests/recovery_phase2_tests.rs
+++ b/crates/perl-parser-core/tests/recovery_phase2_tests.rs
@@ -14,7 +14,7 @@ mod cpan_test_helpers;
 use cpan_test_helpers::*;
 
 use perl_parser_core::Parser;
-use perl_parser_core::error::{ParseError, RecoveryKind, RecoverySite};
+use perl_parser_core::error::{ParseCloseoutClass, ParseError, RecoveryKind, RecoverySite};
 
 // ──────────────────────────────────────────────────────────────
 // Helpers
@@ -228,6 +228,15 @@ fn clean_logical_or_does_not_emit_recovered() {
 fn clean_defined_or_assign_does_not_emit_recovered() {
     let errors = parse_errors("$x //= 'default';");
     assert_not_recovered(&errors, RecoverySite::InfixRhs, RecoveryKind::MissingOperand);
+}
+
+#[test]
+fn phase2_recovery_is_classified_as_structured_salvage() {
+    let mut parser = Parser::new("my $x = $a +;");
+    let output = parser.parse_with_recovery();
+    assert_eq!(output.closeout_class(), ParseCloseoutClass::StructuredRecoveryOnly);
+    assert_eq!(output.error_node_count(), 0);
+    assert!(output.recovered_count > 0);
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `37` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard
@@ -24,8 +24,11 @@
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |
 <!-- END: PARSER_RELIABILITY_ROW -->
 <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->
-| **Strict-clean subset** | 10/10 (100%) | 10 pinned modules, zero-error gate | `.ci/common-corpus-manifest.txt` |
+| **Strict-clean subset** | 10 modules (unverified) | run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |
 <!-- END: PARSER_STRICT_CLEAN_ROW -->
+<!-- BEGIN: PARSER_RECOVERY_ROW -->
+| **Recovery salvage** | 2.7% | dirty `37`, structured-only `1`, ERROR-node files `36`, catastrophic `0`, recovered nodes `12` | `corpus_audit` |
+<!-- END: PARSER_RECOVERY_ROW -->
 
 <!-- BEGIN: PARSER_METRICS_BULLETS -->
 - **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -75,9 +75,14 @@ impl Default for AuditConfig {
 pub struct StatusSummary {
     pub total_files: usize,
     pub ok_files: usize,
-    pub error_files: usize,
+    pub dirty_files: usize,
+    pub structured_recovery_only_files: usize,
+    pub error_node_files: usize,
+    pub catastrophic_parse_failure_files: usize,
+    pub recovered_node_count: usize,
     pub timeout_files: usize,
     pub panic_files: usize,
+    pub salvage_rate: Option<f64>,
     pub test_corpus_files: usize,
     pub perl_corpus_files: usize,
     pub nodekind_covered: usize,
@@ -98,18 +103,50 @@ pub fn compute_status_summary(corpus_path: &Path, timeout: Duration) -> Result<S
     let ga_coverage = check_ga_feature_alignment(&corpus_files)?;
 
     let mut ok_files = 0usize;
-    let mut error_files = 0usize;
+    let mut dirty_files = 0usize;
+    let mut structured_recovery_only_files = 0usize;
+    let mut error_node_files = 0usize;
+    let mut catastrophic_parse_failure_files = 0usize;
+    let mut recovered_node_count = 0usize;
     let mut timeout_files = 0usize;
     let mut panic_files = 0usize;
 
     for outcome in parse_results.values() {
         match outcome {
-            ParseOutcome::Ok { .. } => ok_files += 1,
-            ParseOutcome::Error { .. } => error_files += 1,
-            ParseOutcome::Timeout { .. } => timeout_files += 1,
-            ParseOutcome::Panic { .. } => panic_files += 1,
+            ParseOutcome::Ok { recovered_count, error_node_count, .. } => {
+                ok_files += 1;
+                recovered_node_count += *recovered_count;
+                if *recovered_count > 0 || *error_node_count > 0 {
+                    dirty_files += 1;
+                }
+                if *recovered_count > 0 && *error_node_count == 0 {
+                    structured_recovery_only_files += 1;
+                }
+                if *error_node_count > 0 {
+                    error_node_files += 1;
+                }
+            }
+            ParseOutcome::Error { .. } => {
+                dirty_files += 1;
+                catastrophic_parse_failure_files += 1;
+            }
+            ParseOutcome::Timeout { .. } => {
+                timeout_files += 1;
+                dirty_files += 1;
+                catastrophic_parse_failure_files += 1;
+            }
+            ParseOutcome::Panic { .. } => {
+                panic_files += 1;
+                dirty_files += 1;
+                catastrophic_parse_failure_files += 1;
+            }
         }
     }
+    let salvage_rate = if dirty_files == 0 {
+        None
+    } else {
+        Some(structured_recovery_only_files as f64 / dirty_files as f64)
+    };
 
     let mut test_corpus_files = 0usize;
     let mut perl_corpus_files = 0usize;
@@ -124,9 +161,14 @@ pub fn compute_status_summary(corpus_path: &Path, timeout: Duration) -> Result<S
     Ok(StatusSummary {
         total_files: inventory.total_files,
         ok_files,
-        error_files,
+        dirty_files,
+        structured_recovery_only_files,
+        error_node_files,
+        catastrophic_parse_failure_files,
+        recovered_node_count,
         timeout_files,
         panic_files,
+        salvage_rate,
         test_corpus_files,
         perl_corpus_files,
         nodekind_covered: nodekind_stats.covered_count,
@@ -246,7 +288,24 @@ fn print_audit_summary(report: &AuditReport) {
     println!("   Total files: {}", report.inventory.total_files);
     println!("   Parse results:");
     println!("     - OK: {} ✅", report.parse_outcomes.ok);
-    println!("     - Error: {} ❌", report.parse_outcomes.error);
+    println!("     - Dirty files: {} ⚠️", report.parse_outcomes.dirty_files);
+    println!(
+        "     - Structured recovery only: {} 🛟",
+        report.parse_outcomes.structured_recovery_only_files
+    );
+    println!("     - Files with ERROR nodes: {} ❌", report.parse_outcomes.error_node_files);
+    println!(
+        "     - Catastrophic parse failures: {} 💥",
+        report.parse_outcomes.catastrophic_parse_failure_files
+    );
+    println!("     - Recovered node count: {} 🔧", report.parse_outcomes.recovered_node_count);
+    if let Some(first) = &report.parse_outcomes.first_unrecovered_error_node {
+        println!("     - First unrecovered ERROR node: {} @ {}", first.path, first.location);
+    }
+    if let Some(rate) = report.parse_outcomes.salvage_rate {
+        println!("     - Recovery salvage rate: {:.1}%", rate * 100.0);
+    }
+    println!("     - Catastrophic errors (Err): {} ❌", report.parse_outcomes.error);
     println!("     - Timeout: {} ⏱️", report.parse_outcomes.timeout);
     println!("     - Panic: {} 💥", report.parse_outcomes.panic);
     println!(

--- a/xtask/src/tasks/corpus_audit/report.rs
+++ b/xtask/src/tasks/corpus_audit/report.rs
@@ -55,6 +55,27 @@ pub struct ParseOutcomesSummary {
     pub timeout: usize,
     /// Files that caused panics
     pub panic: usize,
+    /// Files that were not clean (`structured recovery`, `ERROR` nodes, or catastrophic failures).
+    #[serde(default)]
+    pub dirty_files: usize,
+    /// Files with structured recovery only (recovered diagnostics, no `ERROR` nodes).
+    #[serde(default)]
+    pub structured_recovery_only_files: usize,
+    /// Files that still contain one or more unrecovered `ERROR` nodes.
+    #[serde(default)]
+    pub error_node_files: usize,
+    /// Files with catastrophic parser failures (`Err`, timeout, or panic).
+    #[serde(default)]
+    pub catastrophic_parse_failure_files: usize,
+    /// Total count of structured recovered nodes (via `ParseError::Recovered`).
+    #[serde(default)]
+    pub recovered_node_count: usize,
+    /// First unrecovered `ERROR` node observed while scanning corpus files.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_unrecovered_error_node: Option<FirstUnrecoveredErrorNode>,
+    /// Fraction of dirty files that were salvaged with structured recovery only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub salvage_rate: Option<f64>,
     /// Error breakdown by category (Issue #180)
     #[serde(default)]
     pub error_by_category: HashMap<String, usize>,
@@ -87,6 +108,15 @@ pub struct FailingFile {
     /// Code snippet around the error (1-2 lines)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub code_snippet: Option<String>,
+}
+
+/// Location of the first unrecovered AST `ERROR` node in corpus order.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirstUnrecoveredErrorNode {
+    /// Path to the file containing the first unrecovered `ERROR` node.
+    pub path: String,
+    /// Byte offset within the file where the `ERROR` node starts.
+    pub location: usize,
 }
 
 /// Parse byte offset from error message (e.g., "at 334")
@@ -214,11 +244,48 @@ fn generate_parse_outcomes_summary(
     let mut error_by_category: HashMap<String, usize> = HashMap::new();
     let mut failing_files: Vec<FailingFile> = Vec::new();
 
-    for (path, outcome) in parse_results {
+    let mut ordered_results: Vec<_> = parse_results.iter().collect();
+    ordered_results.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    let mut dirty_files = 0usize;
+    let mut structured_recovery_only_files = 0usize;
+    let mut error_node_files = 0usize;
+    let mut catastrophic_parse_failure_files = 0usize;
+    let mut recovered_node_count = 0usize;
+    let mut first_unrecovered_error_node: Option<FirstUnrecoveredErrorNode> = None;
+
+    for (path, outcome) in ordered_results {
         match outcome {
-            ParseOutcome::Ok { .. } => ok += 1,
+            ParseOutcome::Ok {
+                recovered_count,
+                error_node_count,
+                first_error_node_location,
+                ..
+            } => {
+                ok += 1;
+                recovered_node_count += recovered_count;
+                if *recovered_count > 0 || *error_node_count > 0 {
+                    dirty_files += 1;
+                    if *recovered_count > 0 && *error_node_count == 0 {
+                        structured_recovery_only_files += 1;
+                    }
+                    if *error_node_count > 0 {
+                        error_node_files += 1;
+                        if first_unrecovered_error_node.is_none()
+                            && let Some(location) = first_error_node_location
+                        {
+                            first_unrecovered_error_node = Some(FirstUnrecoveredErrorNode {
+                                path: path.display().to_string(),
+                                location: *location,
+                            });
+                        }
+                    }
+                }
+            }
             ParseOutcome::Error { message } => {
                 error += 1;
+                dirty_files += 1;
+                catastrophic_parse_failure_files += 1;
 
                 // Categorize the error
                 let source = sources.get(path).map(|s| s.as_str()).unwrap_or("");
@@ -256,9 +323,15 @@ fn generate_parse_outcomes_summary(
                     code_snippet,
                 });
             }
-            ParseOutcome::Timeout { .. } => timeout += 1,
+            ParseOutcome::Timeout { .. } => {
+                timeout += 1;
+                dirty_files += 1;
+                catastrophic_parse_failure_files += 1;
+            }
             ParseOutcome::Panic { message } => {
                 panic += 1;
+                dirty_files += 1;
+                catastrophic_parse_failure_files += 1;
                 // Panics are also added to failing files for visibility
                 failing_files.push(FailingFile {
                     path: path.display().to_string(),
@@ -277,7 +350,28 @@ fn generate_parse_outcomes_summary(
     // Sort failing files by path for consistent output
     failing_files.sort_by(|a, b| a.path.cmp(&b.path));
 
-    ParseOutcomesSummary { total, ok, error, timeout, panic, error_by_category, failing_files }
+    let salvage_rate = if dirty_files == 0 {
+        None
+    } else {
+        Some(structured_recovery_only_files as f64 / dirty_files as f64)
+    };
+
+    ParseOutcomesSummary {
+        total,
+        ok,
+        error,
+        timeout,
+        panic,
+        dirty_files,
+        structured_recovery_only_files,
+        error_node_files,
+        catastrophic_parse_failure_files,
+        recovered_node_count,
+        first_unrecovered_error_node,
+        salvage_rate,
+        error_by_category,
+        failing_files,
+    }
 }
 
 #[cfg(test)]
@@ -287,15 +381,36 @@ mod tests {
     #[test]
     fn test_generate_parse_outcomes_summary() {
         let mut results = std::collections::HashMap::new();
-        results.insert(PathBuf::from("test1.pl"), ParseOutcome::Ok { duration_ms: 100 });
+        results.insert(
+            PathBuf::from("test1.pl"),
+            ParseOutcome::Ok {
+                duration_ms: 100,
+                recovered_count: 0,
+                error_node_count: 0,
+                first_error_node_location: None,
+            },
+        );
         results.insert(
             PathBuf::from("test2.pl"),
-            ParseOutcome::Error { message: "error".to_string() },
+            ParseOutcome::Ok {
+                duration_ms: 50,
+                recovered_count: 2,
+                error_node_count: 0,
+                first_error_node_location: None,
+            },
         );
-        results.insert(PathBuf::from("test3.pl"), ParseOutcome::Timeout { timeout_ms: 1000 });
+        results.insert(
+            PathBuf::from("test3.pl"),
+            ParseOutcome::Ok {
+                duration_ms: 40,
+                recovered_count: 1,
+                error_node_count: 2,
+                first_error_node_location: Some(11),
+            },
+        );
         results.insert(
             PathBuf::from("test4.pl"),
-            ParseOutcome::Panic { message: "panic".to_string() },
+            ParseOutcome::Error { message: "error".to_string() },
         );
 
         // Create empty sources map for test
@@ -304,13 +419,19 @@ mod tests {
         let summary = generate_parse_outcomes_summary(&results, &sources);
 
         assert_eq!(summary.total, 4);
-        assert_eq!(summary.ok, 1);
+        assert_eq!(summary.ok, 3);
         assert_eq!(summary.error, 1);
-        assert_eq!(summary.timeout, 1);
-        assert_eq!(summary.panic, 1);
+        assert_eq!(summary.timeout, 0);
+        assert_eq!(summary.panic, 0);
+        assert_eq!(summary.dirty_files, 3);
+        assert_eq!(summary.structured_recovery_only_files, 1);
+        assert_eq!(summary.error_node_files, 1);
+        assert_eq!(summary.catastrophic_parse_failure_files, 1);
+        assert_eq!(summary.recovered_node_count, 3);
+        assert_eq!(summary.first_unrecovered_error_node.as_ref().map(|n| n.location), Some(11));
         // Error should be categorized as General when no source is provided
         assert_eq!(summary.error_by_category.get("General"), Some(&1));
-        assert_eq!(summary.failing_files.len(), 2); // error + panic
+        assert_eq!(summary.failing_files.len(), 1); // catastrophic error
     }
 
     #[test]

--- a/xtask/src/tasks/corpus_audit/timeout_detection.rs
+++ b/xtask/src/tasks/corpus_audit/timeout_detection.rs
@@ -3,7 +3,7 @@
 //! This module provides timeout protection for parsing operations and
 //! detection of files that may cause timeouts or hangs.
 
-use perl_parser::Parser;
+use perl_parser::{Node, NodeKind, ParseError, Parser};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -138,8 +138,14 @@ pub enum ParseOutcome {
     Ok {
         /// Time taken to parse
         duration_ms: u64,
+        /// Number of structured recovery diagnostics (`ParseError::Recovered`).
+        recovered_count: usize,
+        /// Number of unrecovered `NodeKind::Error` nodes left in the AST.
+        error_node_count: usize,
+        /// Byte offset for the first unrecovered `NodeKind::Error`, if present.
+        first_error_node_location: Option<usize>,
     },
-    /// Parse failed with error
+    /// Parse failed catastrophically and did not yield a useful AST.
     Error {
         /// Error message
         message: String,
@@ -166,7 +172,7 @@ impl ParseOutcome {
     /// Get the duration in milliseconds if parse succeeded
     pub fn duration_ms(&self) -> Option<u64> {
         match self {
-            ParseOutcome::Ok { duration_ms } => Some(*duration_ms),
+            ParseOutcome::Ok { duration_ms, .. } => Some(*duration_ms),
             _ => None,
         }
     }
@@ -215,12 +221,27 @@ pub fn parse_with_timeout(
     let handle = std::thread::spawn(move || {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut parser = Parser::new(&content_clone);
-            parser.parse()
+            let parse_result = parser.parse();
+            let recovered_count = parser
+                .errors()
+                .iter()
+                .filter(|error| matches!(error, ParseError::Recovered { .. }))
+                .count();
+            (parse_result, recovered_count)
         }));
 
         let outcome = match result {
-            Ok(Ok(_)) => ParseOutcome::Ok { duration_ms: start.elapsed().as_millis() as u64 },
-            Ok(Err(e)) => ParseOutcome::Error { message: e.to_string() },
+            Ok((Ok(ast), recovered_count)) => {
+                let first_error_node_location = first_error_node_location(&ast);
+                let error_node_count = count_error_nodes(&ast);
+                ParseOutcome::Ok {
+                    duration_ms: start.elapsed().as_millis() as u64,
+                    recovered_count,
+                    error_node_count,
+                    first_error_node_location,
+                }
+            }
+            Ok((Err(e), _)) => ParseOutcome::Error { message: e.to_string() },
             Err(_) => ParseOutcome::Panic { message: "Parser panicked".to_string() },
         };
 
@@ -239,6 +260,29 @@ pub fn parse_with_timeout(
         }
         Err(_) => ParseOutcome::Error { message: "Channel disconnected unexpectedly".to_string() },
     }
+}
+
+fn count_error_nodes(node: &Node) -> usize {
+    let mut total = 0usize;
+    if matches!(node.kind, NodeKind::Error { .. }) {
+        total += 1;
+    }
+    for child in node.children() {
+        total += count_error_nodes(child);
+    }
+    total
+}
+
+fn first_error_node_location(node: &Node) -> Option<usize> {
+    if matches!(node.kind, NodeKind::Error { .. }) {
+        return Some(node.location.start);
+    }
+    for child in node.children() {
+        if let Some(location) = first_error_node_location(child) {
+            return Some(location);
+        }
+    }
+    None
 }
 
 /// Detect timeout and hang risks in corpus files
@@ -503,7 +547,15 @@ mod tests {
 
     #[test]
     fn test_parse_outcome_is_ok() {
-        assert!(ParseOutcome::Ok { duration_ms: 100 }.is_ok());
+        assert!(
+            ParseOutcome::Ok {
+                duration_ms: 100,
+                recovered_count: 0,
+                error_node_count: 0,
+                first_error_node_location: None
+            }
+            .is_ok()
+        );
         assert!(!ParseOutcome::Error { message: "error".to_string() }.is_ok());
         assert!(!ParseOutcome::Timeout { timeout_ms: 1000 }.is_ok());
         assert!(!ParseOutcome::Panic { message: "panic".to_string() }.is_ok());
@@ -511,7 +563,16 @@ mod tests {
 
     #[test]
     fn test_parse_outcome_duration_ms() {
-        assert_eq!(ParseOutcome::Ok { duration_ms: 100 }.duration_ms(), Some(100));
+        assert_eq!(
+            ParseOutcome::Ok {
+                duration_ms: 100,
+                recovered_count: 0,
+                error_node_count: 0,
+                first_error_node_location: None
+            }
+            .duration_ms(),
+            Some(100)
+        );
         assert_eq!(ParseOutcome::Error { message: "error".to_string() }.duration_ms(), None);
     }
 

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -85,6 +85,10 @@ fn format_clean_rate(clean_files: usize, total_files: usize) -> String {
     format!("{clean_pct:.1}% clean (`{clean_files}/{total_files}`)")
 }
 
+fn format_pct(value: Option<f64>) -> String {
+    value.map_or_else(|| "N/A".to_string(), |v| format!("{:.1}%", v * 100.0))
+}
+
 fn short_day(timestamp: &str) -> &str {
     timestamp.get(..10).unwrap_or(timestamp)
 }
@@ -135,7 +139,7 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
                 format_clean_rate(summary.ok_files, summary.total_files),
                 summary.test_corpus_files,
                 summary.perl_corpus_files,
-                summary.error_files,
+                summary.dirty_files,
                 summary.timeout_files,
                 summary.panic_files,
                 summary.nodekind_covered,
@@ -161,6 +165,23 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
             format!(
                 "| **Node-kind coverage** | {}/{} ({:.1}%) | {} never-seen node kinds | `corpus_audit` |",
                 summary.nodekind_covered, summary.nodekind_total, pct, never_seen,
+            )
+        },
+    );
+
+    let recovery_row = metrics.project_corpus.as_ref().map_or_else(
+        || {
+            "| **Recovery salvage** | UNVERIFIED | run `just parser-audit` for recovery breakdown | `corpus_audit` |".to_string()
+        },
+        |summary| {
+            format!(
+                "| **Recovery salvage** | {} | dirty `{}`, structured-only `{}`, ERROR-node files `{}`, catastrophic `{}`, recovered nodes `{}` | `corpus_audit` |",
+                format_pct(summary.salvage_rate),
+                summary.dirty_files,
+                summary.structured_recovery_only_files,
+                summary.error_node_files,
+                summary.catastrophic_parse_failure_files,
+                summary.recovered_node_count,
             )
         },
     );
@@ -242,6 +263,12 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         "<!-- END: PARSER_STRICT_CLEAN_ROW -->",
         &strict_clean_row,
     )?;
+    text = replace_block(
+        &text,
+        "<!-- BEGIN: PARSER_RECOVERY_ROW -->",
+        "<!-- END: PARSER_RECOVERY_ROW -->",
+        &recovery_row,
+    )?;
     Ok(text)
 }
 
@@ -285,9 +312,14 @@ mod tests {
         let summary = super::super::super::corpus_audit::StatusSummary {
             total_files: 91,
             ok_files: 91,
-            error_files: 0,
+            dirty_files: 0,
+            structured_recovery_only_files: 0,
+            error_node_files: 0,
+            catastrophic_parse_failure_files: 0,
+            recovered_node_count: 0,
             timeout_files: 0,
             panic_files: 0,
+            salvage_rate: None,
             test_corpus_files: 69,
             perl_corpus_files: 22,
             nodekind_covered: 65,
@@ -307,6 +339,7 @@ mod tests {
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_RECOVERY_ROW -->\nold\n<!-- END: PARSER_RECOVERY_ROW -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(result.contains("65/69"), "nodekind row missing 65/69");
@@ -334,6 +367,7 @@ mod tests {
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_RECOVERY_ROW -->\nold\n<!-- END: PARSER_RECOVERY_ROW -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(
@@ -383,6 +417,7 @@ mod tests {
                         <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
                         <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
                         <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_RECOVERY_ROW -->\nold\n<!-- END: PARSER_RECOVERY_ROW -->\n\
                         <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
         let result = generate_parser_status(&metrics, template)?;
         assert!(result.contains("10/10"), "strict-clean row missing 10/10");


### PR DESCRIPTION
### Motivation

- Parser closeout and corpus status treated any non-clean parse as a single "dirty" bucket, which hides useful distinctions between recoverable editor/input truncation and catastrophic parser failures.
- Closeout needs to surface recovery vs unrecovered ERROR nodes vs catastrophic failures so accuracy gates and triage focus can be more actionable.

### Description

- Add per-ParseOutput recovery classification: new `ParseCloseoutClass` enum and helpers `error_node_count`, `first_unrecovered_error_node_location`, and `closeout_class` in `crates/perl-parser-core/src/syntax/error/mod.rs`, and re-export the class from the engine facade.  (classifies Clean / StructuredRecoveryOnly / HasErrorNodes / CatastrophicFailure)
- Extend corpus-audit parsing outcomes (`xtask/src/tasks/corpus_audit/timeout_detection.rs`) to return structured metrics per file: `recovered_count`, `error_node_count`, and `first_error_node_location`, and added helpers to count/locate AST `ERROR` nodes.
- Aggregate and persist recovery-salvage metrics in the audit report (`xtask/src/tasks/corpus_audit/report.rs`): added `dirty_files`, `structured_recovery_only_files`, `error_node_files`, `catastrophic_parse_failure_files`, `recovered_node_count`, `first_unrecovered_error_node`, and `salvage_rate` to `ParseOutcomesSummary` and report generation logic.
- Wire recovery metrics into status reporting: `xtask/src/tasks/corpus_audit.rs` `StatusSummary` updated, `xtask/src/tasks/update_status/parser.rs` renders a new "Recovery salvage" row into `docs/project/status/parser.md`, and the docs template marker was added/updated.
- Add focused tests that assert classification behavior for common recovery cases: updated/added tests in `crates/perl-parser-core/tests/recovery_phase2_tests.rs`, `recovery_missing_closer.rs`, and `parser_panic_mode_recovery.rs` to ensure structured recoveries are not considered catastrophic and ERROR-node cases are visible to closeout.
- Update baseline metrics to include `recovery_salvage_rate` (`.ci/metrics/baselines/parser.json`).

### Testing

- Ran formatting: `cargo xtask fmt` — succeeded.
- Parser unit tests (recovery-focused): `cargo test -p perl-parser-core recovery` — all recovery tests passed.
- Xtask parser/status tests: `cargo test -p xtask parser` — passed.
- Full corpus audit exercise: `cargo xtask corpus-audit --fresh` — completed and produced report with new recovery metrics.
- Status update generation: `cargo xtask update-status --only parser --write` — updated `docs/project/status/parser.md` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55e56dd083338f83f52aa3a8dd1d)