### PR TITLE
test(parser): document NodeKind never-seen allowlist (#0000)

### DIFF
--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -256,6 +256,24 @@ fn print_audit_summary(report: &AuditReport) {
         report.nodekind_coverage.coverage_percentage
     );
     println!("   Never-seen NodeKinds: {}", report.nodekind_coverage.never_seen.len());
+    if !report.nodekind_coverage.never_seen.is_empty() {
+        println!("     Names: {}", report.nodekind_coverage.never_seen.join(", "));
+    }
+    if !report.nodekind_coverage.allowlisted_never_seen.is_empty() {
+        println!(
+            "   Allowlisted never-seen NodeKinds: {}",
+            report.nodekind_coverage.allowlisted_never_seen.len()
+        );
+        for item in &report.nodekind_coverage.allowlisted_never_seen {
+            println!("     - {}: {}", item.name, item.rationale);
+        }
+    }
+    if !report.nodekind_coverage.actionable_never_seen.is_empty() {
+        println!(
+            "   Actionable never-seen NodeKinds: {}",
+            report.nodekind_coverage.actionable_never_seen.join(", ")
+        );
+    }
     println!("   At-risk NodeKinds (<5 occurrences): {}", report.nodekind_coverage.at_risk.len());
     println!(
         "   GA features covered: {}/{} ({:.1}%)",

--- a/xtask/src/tasks/corpus_audit/nodekind_analysis.rs
+++ b/xtask/src/tasks/corpus_audit/nodekind_analysis.rs
@@ -18,10 +18,25 @@ pub struct NodeKindStats {
     pub coverage_percentage: f64,
     /// NodeKinds that were never seen
     pub never_seen: Vec<String>,
+    /// Never-seen NodeKinds that are allowlisted as intentionally unreachable in clean corpus
+    #[serde(default)]
+    pub allowlisted_never_seen: Vec<AllowlistedNodeKind>,
+    /// Never-seen NodeKinds that are not allowlisted
+    #[serde(default)]
+    pub actionable_never_seen: Vec<String>,
     /// NodeKinds with low coverage (<5 occurrences)
     pub at_risk: Vec<AtRiskNodeKind>,
     /// Frequency of each NodeKind
     pub frequency: HashMap<String, usize>,
+}
+
+/// A never-seen NodeKind that is explicitly allowlisted with rationale.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AllowlistedNodeKind {
+    /// NodeKind name
+    pub name: String,
+    /// Why this kind is intentionally unreachable in clean deterministic corpus
+    pub rationale: String,
 }
 
 /// A NodeKind with low coverage
@@ -79,6 +94,22 @@ pub fn analyze_nodekind_coverage(
     let never_seen: Vec<String> =
         all_nodekinds.iter().filter(|nk| !nodekind_counts.contains_key(*nk)).cloned().collect();
 
+    let allowlisted_never_seen: Vec<AllowlistedNodeKind> = never_seen
+        .iter()
+        .filter_map(|name| {
+            never_seen_allowlist_rationale(name).map(|rationale| AllowlistedNodeKind {
+                name: name.clone(),
+                rationale: rationale.to_string(),
+            })
+        })
+        .collect();
+
+    let actionable_never_seen: Vec<String> = never_seen
+        .iter()
+        .filter(|name| never_seen_allowlist_rationale(name).is_none())
+        .cloned()
+        .collect();
+
     // Find at-risk NodeKinds (low coverage)
     let at_risk: Vec<AtRiskNodeKind> = nodekind_counts
         .iter()
@@ -102,8 +133,28 @@ pub fn analyze_nodekind_coverage(
         covered_count,
         coverage_percentage,
         never_seen,
+        allowlisted_never_seen,
+        actionable_never_seen,
         at_risk,
         frequency: nodekind_counts,
+    }
+}
+
+fn never_seen_allowlist_rationale(kind: &str) -> Option<&'static str> {
+    match kind {
+        "MissingIdentifier" => Some(
+            "Synthetic parser-recovery sentinel; emitted only when identifier recovery is required.",
+        ),
+        "MissingBlock" => Some(
+            "Synthetic parser-recovery sentinel; emitted only when block recovery is required.",
+        ),
+        "MissingStatement" => Some(
+            "Synthetic parser-recovery sentinel; emitted only when statement recovery is required.",
+        ),
+        "UnknownRest" => Some(
+            "Lexer-budget sentinel token surfaced as AST node only when lexing is force-truncated.",
+        ),
+        _ => None,
     }
 }
 
@@ -174,5 +225,14 @@ mod tests {
         let nodekinds = extract_nodekinds_from_content(&path);
         assert!(!nodekinds.is_empty());
         Ok(())
+    }
+
+    #[test]
+    fn test_recovery_never_seen_allowlist() {
+        assert!(never_seen_allowlist_rationale("MissingIdentifier").is_some());
+        assert!(never_seen_allowlist_rationale("MissingBlock").is_some());
+        assert!(never_seen_allowlist_rationale("MissingStatement").is_some());
+        assert!(never_seen_allowlist_rationale("UnknownRest").is_some());
+        assert!(never_seen_allowlist_rationale("Program").is_none());
     }
 }


### PR DESCRIPTION
### Motivation
- `parser-audit` reported 65/69 NodeKinds but only printed counts, hiding which variants were never-seen and whether some are intentionally unreachable (parser-recovery / lexer-budget sentinels).
- Make the audit explicit about never-seen kinds so accuracy closeout does not leave untested AST shapes ambiguous.

### Description
- Add `allowlisted_never_seen` and `actionable_never_seen` fields to `NodeKindStats` and a new `AllowlistedNodeKind` struct to serialize allowlisted never-seen kinds with rationale in the audit report (`xtask/src/tasks/corpus_audit/nodekind_analysis.rs`).
- Implement a small allowlist mapping `never_seen_allowlist_rationale` for `MissingStatement`, `MissingIdentifier`, `MissingBlock`, and `UnknownRest` with concise rationales, and compute `allowlisted_never_seen` / `actionable_never_seen` from never-seen names.
- Emit never-seen names and printed allowlist details in the audit summary (`xtask/src/tasks/corpus_audit.rs`) so `parser-audit` output explains the 65/69 result.
- Add a focused unit test to lock the allowlist behavior and update the generated parser status (`docs/project/status/parser.md`) via `update-status` to reflect the repo scan.

### Testing
- Ran `cargo test -p xtask nodekind_analysis -- --nocapture`, which passed (unit tests for the new allowlist succeeded).
- Ran `cargo xtask corpus-audit` (via `cargo run -p xtask -- corpus-audit`) which completed and printed the never-seen names and allowlisted rationales (report written to `corpus_audit_report.json`).
- Ran `cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt`, which produced a strict-clean receipt (passed).
- Ran `cargo run -p xtask -- update-status --write --only parser`, which updated `docs/project/status/parser.md`; note that a separate full test `cargo test -p perl-parser-core` failed on an unrelated existing test (`test_deref_hash_subscript_regex_key`), not caused by these xtask changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb561174488333bea602ba5545de05)