### PR TITLE
ci(parser): ratchet final parser accuracy closeout baseline (#0000)

### DIFF
--- a/.ci/GATE_REGISTRY.toml
+++ b/.ci/GATE_REGISTRY.toml
@@ -91,6 +91,22 @@ cost_tier = "low"  # seconds
 failure_impact = "medium"
 
 [[gate]]
+id = "parser-accuracy-closeout"
+name = "Parser Accuracy Closeout Ratchet"
+type = "correctness"
+blocking = true
+timeout_seconds = 900
+command = "cargo run -p xtask -- parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt && cargo run -p xtask -- cpan-corpus sweep --enforce && cargo run -p xtask --no-default-features -- corpus-audit --fresh --corpus-path . --check"
+evidence_pattern = "Ratchet|clean"
+threshold = { type = "exit_code", pass = 0 }
+
+[gate.metadata]
+description = "Prevents parser clean-rate, gap-count, node-kind-coverage, and ERROR-node regressions after closeout"
+docs_url = "docs/project/status/parser.md"
+cost_tier = "high"
+failure_impact = "critical"
+
+[[gate]]
 id = "workflow-audit"
 name = "CI Workflow Spend Audit"
 type = "governance"

--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -269,6 +269,29 @@ gates:
       - common
       - strict
 
+  - name: parser_accuracy_closeout
+    tier: merge_gate
+    description: "Parser closeout ratchets: system/CPAN clean baselines + project gap/coverage floors"
+    required: true
+    command: >-
+      cargo run --locked -p xtask
+      -- parser-corpus-sweep
+      --baseline .ci/parser-corpus-baseline.json --enforce --receipt &&
+      cargo run --locked -p xtask
+      -- cpan-corpus sweep --enforce &&
+      cargo run --locked -p xtask --no-default-features
+      -- corpus-audit --fresh --corpus-path . --check
+    timeout_seconds: 900
+    retry_count: 0
+    budgets:
+      max_duration_ms: 840000
+    quarantine: false
+    tags:
+      - parser
+      - corpus
+      - ratchet
+      - closeout
+
   - name: security_audit
     tier: merge_gate
     description: "Check dependencies for known security vulnerabilities"

--- a/.ci/metrics/baselines/parser.json
+++ b/.ci/metrics/baselines/parser.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "measured_at": "2026-04-09T18:13:43Z",
+  "measured_at": "2026-04-24T00:00:00Z",
   "subsystem": "parser",
   "commit": "3f7ede36",
   "floor_metrics": {
@@ -10,12 +10,14 @@
     "system_files_unreadable": 48,
     "system_total_error_nodes": 604,
     "cpan_total_error_nodes": 3015,
-    "strict_clean_subset_pass_rate": 1.0
+    "strict_clean_subset_pass_rate": 1.0,
+    "valid_parser_gap_count": 0,
+    "node_kind_coverage": 0.942,
+    "recovery_salvage_rate": 1.0
   },
   "improvement_metrics": {
-    "node_kind_coverage": 0.941,
-    "error_density_per_1k_loc": null,
-    "recovery_salvage_rate": null
+    "error_density_per_1k_loc": null
   },
-  "tolerance_pct": 0.005
+  "tolerance_pct": 0.005,
+  "lower_is_better": []
 }

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard
@@ -29,6 +29,7 @@
 
 <!-- BEGIN: PARSER_METRICS_BULLETS -->
 - **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.
+- **Closeout ratchets**: CI blocks regressions on system/CPAN clean rate, ERROR-node totals, strict-clean pinned modules, valid parser gaps, node-kind coverage, and recovery-salvage rate.
 - **Strict promise lists**: `just common-corpus-check` and the CPAN known-clean manifest inside `just cpan-corpus-check` pin subsets that must remain clean on top of the broader baseline receipts.
 - **Fixture bank**: `tree-sitter-perl/test/corpus` contributes ~611 focused syntax sections for targeted parser cases.
 - **CPAN install hygiene**: `cargo xtask cpan-corpus install` reuses `target/cpan-corpus/.cpanm`; pass `--reset` only for a cold rebuild.

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -9,7 +9,7 @@
 
 use color_eyre::eyre::{Context, Result};
 use indicatif::{ProgressBar, ProgressStyle};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -286,34 +286,38 @@ fn validate_report_for_ci(report: &AuditReport) -> Result<()> {
     println!("\n🔬 Validating report for CI gate...");
 
     let mut failures = Vec::new();
+    let root = crate::utils::project_root()?;
+    let parser_baseline = crate::tasks::metrics::ratchet::load_baseline(&root, "parser")?;
+    let mut current_floor_metrics: BTreeMap<String, Option<f64>> = BTreeMap::new();
 
-    // Parse error ratchet: read baseline and compare (Issue #180)
-    let baseline_path = std::path::Path::new("ci/parse_errors_baseline.txt");
-    let current_errors = report.parse_outcomes.error;
-
-    if baseline_path.exists() {
-        let baseline_str =
-            fs::read_to_string(baseline_path).context("Failed to read parse errors baseline")?;
-        let baseline: usize =
-            baseline_str.trim().parse().context("Failed to parse baseline as number")?;
-
-        println!("   Parse errors: {} (baseline: {})", current_errors, baseline);
-
-        if current_errors > baseline {
-            failures.push(format!(
-                "Parse error regression: {} > {} baseline. Fix parser or update baseline.",
-                current_errors, baseline
-            ));
-        } else if current_errors < baseline {
-            println!(
-                "   📉 IMPROVEMENT: {} fewer errors! Update baseline: echo {} > ci/parse_errors_baseline.txt",
-                baseline - current_errors,
-                current_errors
-            );
-        }
+    let nodekind_coverage = if report.nodekind_coverage.total_count == 0 {
+        0.0
     } else {
-        // No baseline file - just report the count
-        println!("   Parse errors: {} (no baseline file)", current_errors);
+        report.nodekind_coverage.covered_count as f64 / report.nodekind_coverage.total_count as f64
+    };
+    let recovery_salvage_rate = if report.parse_outcomes.total == 0 {
+        1.0
+    } else {
+        report.parse_outcomes.ok as f64 / report.parse_outcomes.total as f64
+    };
+
+    current_floor_metrics
+        .insert("valid_parser_gap_count".to_string(), Some(report.parse_outcomes.error as f64));
+    current_floor_metrics.insert("node_kind_coverage".to_string(), Some(nodekind_coverage));
+    current_floor_metrics.insert("recovery_salvage_rate".to_string(), Some(recovery_salvage_rate));
+
+    let metric_violations = crate::tasks::metrics::ratchet::check_floor_metrics(
+        &parser_baseline,
+        &current_floor_metrics,
+    );
+    for violation in metric_violations {
+        failures.push(format!(
+            "Metric regression: {} baseline={:.4}, current={:.4} ({:.2}% regression)",
+            violation.metric,
+            violation.baseline_value,
+            violation.current_value,
+            violation.regression_pct * 100.0
+        ));
     }
 
     // Timeouts should always be zero
@@ -347,7 +351,7 @@ fn validate_report_for_ci(report: &AuditReport) -> Result<()> {
     }
 
     // Print error category breakdown if there are errors (Issue #180)
-    if current_errors > 0 && !report.parse_outcomes.error_by_category.is_empty() {
+    if report.parse_outcomes.error > 0 && !report.parse_outcomes.error_by_category.is_empty() {
         println!("\n   Error breakdown by category:");
         let mut categories: Vec<_> = report.parse_outcomes.error_by_category.iter().collect();
         categories.sort_by(|a, b| b.1.cmp(a.1)); // Sort by count descending

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -205,6 +205,7 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
 
     let parser_coverage_bullets = format!(
         "- **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.\n\
+         - **Closeout ratchets**: CI blocks regressions on system/CPAN clean rate, ERROR-node totals, strict-clean pinned modules, valid parser gaps, node-kind coverage, and recovery-salvage rate.\n\
          - **Strict promise lists**: `just common-corpus-check` and the CPAN known-clean manifest inside `just cpan-corpus-check` pin subsets that must remain clean on top of the broader baseline receipts.\n\
          - **Fixture bank**: `tree-sitter-perl/test/corpus` contributes ~{} focused syntax sections for targeted parser cases.\n\
          - **CPAN install hygiene**: `cargo xtask cpan-corpus install` reuses `target/cpan-corpus/.cpanm`; pass `--reset` only for a cold rebuild.",


### PR DESCRIPTION
### Motivation

- Lock the parser closeout state into CI so resolved parser gaps, NodeKind coverage, and recovery classifications cannot regress undetected.

### Description

- Add closeout floor metrics to `.ci/metrics/baselines/parser.json` including `valid_parser_gap_count`, `node_kind_coverage`, and `recovery_salvage_rate` and update `measured_at`/metadata.
- Enforce a new merge-gate that runs the system sweep, CPAN sweep, and corpus-audit check in sequence by adding `parser_accuracy_closeout` to `.ci/gate-policy.yaml` and registering `parser-accuracy-closeout` in `.ci/GATE_REGISTRY.toml`.
- Wire `corpus_audit` CI validation to the scorecard ratchet by loading the committed parser baseline and running `check_floor_metrics` (changed `xtask/src/tasks/corpus_audit.rs` to compute current floor metrics and report metric violations).
- Update status generation text to mention the closeout ratchets and regenerate `docs/project/status/parser.md`, and a small import tweak to use `BTreeMap` for floor metrics aggregation (`xtask/src/tasks/update_status/parser.rs`).

### Testing

- Ran `cargo run -p xtask --no-default-features -- corpus-audit --fresh --corpus-path .`, which completed and wrote `corpus_audit_report.json` (passed).
- Ran `cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt`, which completed and produced `target/receipts/common-corpus-sweep.json` (passed strict-clean check).
- `cargo run -p xtask -- parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt` failed in this environment because the local system Perl corpus is smaller than the committed baseline (expected in-container discrepancy); this is an environment limitation, not a code failure.
- `cargo run -p xtask -- cpan-corpus sweep --enforce` failed due to missing local CPAN install (`target/cpan-corpus/lib/perl5`) in this container; this is an environment dependency issue.
- `cargo check --workspace --all-targets` completed (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5633081c833390fca8f7f595417b)