### PR TITLE
ci(parser): ratchet final parser accuracy closeout baseline (#0000)

### DIFF
--- a/.ci/GATE_REGISTRY.toml
+++ b/.ci/GATE_REGISTRY.toml
@@ -144,6 +144,38 @@ docs_url = "justfile#ci-check-no-nested-lock"
 cost_tier = "low"  # <1 second
 failure_impact = "medium"
 
+[[gate]]
+id = "system-corpus-ratchet"
+name = "System Corpus Ratchet"
+type = "correctness"
+blocking = true
+timeout_seconds = 600
+command = "cargo run --locked -p xtask -- parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt"
+evidence_pattern = "Ratchet: all checks passed"
+threshold = { type = "exit_code", pass = 0 }
+
+[gate.metadata]
+description = "Parser accuracy ratchet on Ubuntu system Perl corpus (clean-rate + ERROR-node regression guards)"
+docs_url = "justfile#corpus-sweep-check"
+cost_tier = "medium"
+failure_impact = "critical"
+
+[[gate]]
+id = "cpan-corpus-ratchet"
+name = "CPAN Corpus Ratchet"
+type = "correctness"
+blocking = true
+timeout_seconds = 900
+command = "cargo run --locked -p xtask -- cpan-corpus sweep --enforce"
+evidence_pattern = "Ratchet: all checks passed"
+threshold = { type = "exit_code", pass = 0 }
+
+[gate.metadata]
+description = "Parser accuracy ratchet on CPAN top-1000 baseline with strict known-clean manifest"
+docs_url = "justfile#cpan-corpus-check"
+cost_tier = "high"
+failure_impact = "critical"
+
 # ============================================================================
 # Extended Gates (RECOMMENDED for large changes, ci-full)
 # ============================================================================

--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -269,6 +269,42 @@ gates:
       - common
       - strict
 
+  - name: system_corpus_ratchet
+    tier: merge_gate
+    description: "System Perl corpus ratchet (clean-rate + ERROR-node regression guard)"
+    required: true
+    command: >-
+      cargo run --locked -p xtask
+      -- parser-corpus-sweep
+      --baseline .ci/parser-corpus-baseline.json --enforce --receipt
+    timeout_seconds: 600
+    retry_count: 0
+    budgets:
+      max_duration_ms: 600000
+    quarantine: false
+    tags:
+      - corpus
+      - parser
+      - ratchet
+
+  - name: cpan_corpus_ratchet
+    tier: merge_gate
+    description: "CPAN corpus ratchet + known-clean manifest strict gate"
+    required: true
+    command: >-
+      cargo run --locked -p xtask
+      -- cpan-corpus sweep --enforce
+    timeout_seconds: 900
+    retry_count: 0
+    budgets:
+      max_duration_ms: 900000
+    quarantine: false
+    tags:
+      - corpus
+      - parser
+      - cpan
+      - ratchet
+
   - name: security_audit
     tier: merge_gate
     description: "Check dependencies for known security vulnerabilities"

--- a/.ci/metrics/baselines/parser.json
+++ b/.ci/metrics/baselines/parser.json
@@ -10,12 +10,18 @@
     "system_files_unreadable": 48,
     "system_total_error_nodes": 604,
     "cpan_total_error_nodes": 3015,
-    "strict_clean_subset_pass_rate": 1.0
+    "strict_clean_subset_pass_rate": 1.0,
+    "valid_parser_gap_count": 0,
+    "parser_error_nodes_outside_allowlist": 604
   },
   "improvement_metrics": {
-    "node_kind_coverage": 0.941,
+    "node_kind_coverage": 0.942,
     "error_density_per_1k_loc": null,
-    "recovery_salvage_rate": null
+    "recovery_salvage_rate": 1.0
   },
-  "tolerance_pct": 0.005
+  "tolerance_pct": 0.005,
+  "lower_is_better": [
+    "valid_parser_gap_count",
+    "parser_error_nodes_outside_allowlist"
+  ]
 }

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`93/93`) | Deterministic regression baseline; `71` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -346,6 +346,47 @@ fn validate_report_for_ci(report: &AuditReport) -> Result<()> {
         ));
     }
 
+    // Parser closeout ratchets from committed scorecard baseline.
+    // These checks intentionally use committed baselines so parser-audit can
+    // fail fast on local regressions before CI runs the larger corpus sweeps.
+    let parser_baseline_path = std::path::Path::new(".ci/metrics/baselines/parser.json");
+    if parser_baseline_path.exists() {
+        let baseline_raw = fs::read_to_string(parser_baseline_path)
+            .context("Failed to read parser scorecard baseline")?;
+        let baseline: serde_json::Value =
+            serde_json::from_str(&baseline_raw).context("Failed to parse parser baseline JSON")?;
+
+        let nodekind_floor = baseline
+            .get("floor_metrics")
+            .and_then(|v| v.get("node_kind_coverage"))
+            .and_then(serde_json::Value::as_f64);
+
+        if let Some(floor) = nodekind_floor {
+            let current = report.nodekind_coverage.coverage_percentage / 100.0;
+            if current + f64::EPSILON < floor {
+                failures.push(format!(
+                    "NodeKind coverage regression: {:.4} < {:.4} floor",
+                    current, floor
+                ));
+            }
+        }
+
+        let valid_gap_floor = baseline
+            .get("floor_metrics")
+            .and_then(|v| v.get("valid_parser_gap_count"))
+            .and_then(serde_json::Value::as_f64);
+
+        if let Some(max_gap_count) = valid_gap_floor {
+            let current_gap_count = report.parse_outcomes.error as f64;
+            if current_gap_count > max_gap_count {
+                failures.push(format!(
+                    "Valid parser gap regression: {:.0} > {:.0} floor",
+                    current_gap_count, max_gap_count
+                ));
+            }
+        }
+    }
+
     // Print error category breakdown if there are errors (Issue #180)
     if current_errors > 0 && !report.parse_outcomes.error_by_category.is_empty() {
         println!("\n   Error breakdown by category:");


### PR DESCRIPTION
### Motivation
- Prevent accidental regressions by locking the parser closeout state into CI as firm ratchets (system + CPAN + scorecard floors). 
- Ensure future parser work cannot reopen solved gaps for NodeKind coverage, valid parser gaps, ERROR-node counts, or strict-clean pinned modules.

### Description
- Add merge-gate corpus ratchet gates to CI by updating `.ci/gate-policy.yaml` and `.ci/GATE_REGISTRY.toml` to run `parser-corpus-sweep` and `cpan-corpus` ratchets as blocking merge gates. 
- Expand the committed parser scorecard baseline `.ci/metrics/baselines/parser.json` with new floor metrics `valid_parser_gap_count` and `parser_error_nodes_outside_allowlist`, mark lower-is-better metrics, bump `node_kind_coverage`, and set `recovery_salvage_rate`. 
- Wire runtime enforcement into the corpus audit by extending `xtask/src/tasks/corpus_audit.rs::validate_report_for_ci` to read the committed parser baseline and fail on NodeKind coverage regressions and increased valid-gap counts. 
- Regenerate the parser status doc by running the status update so `docs/project/status/parser.md` reflects current receipts and the strict-clean subset state.

### Testing
- Ran `cargo run -p xtask --no-default-features -- corpus-audit --fresh --corpus-path . --output corpus_audit_report.json`, which completed and wrote `corpus_audit_report.json` (passed). 
- Ran `cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt`, which resolved the manifest and confirmed the strict-clean subset parses with zero errors (passed). 
- Ran `cargo run -p xtask -- parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt`, which exercised the system-corpus ratchet but failed in this environment because the local system corpus inventory differs from the committed baseline (expected environment-dependent regression). 
- Ran `cargo run -p xtask -- cpan-corpus sweep --enforce`, which failed here because the local CPAN install (`target/cpan-corpus/lib/perl5`) was not present (environment precondition). 
- Ran unit tests `cargo test -p xtask corpus_audit::tests::` which passed, and ran `cargo check --workspace --all-targets` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5633081c833390fca8f7f595417b)