### PR TITLE
perf(perl-pragma): add benchmark suite for build/query workloads (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,7 +1814,9 @@ dependencies = [
 name = "perl-pragma"
 version = "0.12.4"
 dependencies = [
+ "criterion",
  "perl-ast",
+ "perl-parser",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,7 +1816,6 @@ version = "0.12.4"
 dependencies = [
  "criterion",
  "perl-ast",
- "perl-parser",
 ]
 
 [[package]]

--- a/crates/perl-pragma/Cargo.toml
+++ b/crates/perl-pragma/Cargo.toml
@@ -18,7 +18,6 @@ perl-ast = { workspace = true }
 
 [dev-dependencies]
 criterion.workspace = true
-perl-parser = { workspace = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/perl-pragma/Cargo.toml
+++ b/crates/perl-pragma/Cargo.toml
@@ -16,8 +16,17 @@ categories = ["development-tools", "parser-implementations"]
 [dependencies]
 perl-ast = { workspace = true }
 
+[dev-dependencies]
+criterion.workspace = true
+perl-parser = { workspace = true }
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
+
+
+[[bench]]
+name = "pragma_benchmarks"
+harness = false

--- a/crates/perl-pragma/README.md
+++ b/crates/perl-pragma/README.md
@@ -17,6 +17,26 @@ in the source.
   `Vec<(Range<usize>, PragmaState)>`, and offers `state_for_offset()` to
   query it.
 
+## Benchmarks
+
+Run the Criterion benchmark suite for build-heavy and query-heavy pragma workloads:
+
+```bash
+cargo bench -p perl-pragma
+```
+
+Benchmarks include stable names that can be diffed over time:
+
+- `build_small_file`
+- `build_large_file`
+- `query_random_offsets`
+- `query_monotonic_offsets`
+- `final_state_lookup`
+- `version_compat_walk_style`
+- `scope_analyzer_walk_style`
+
+Criterion reports per-benchmark timing statistics (including time per iteration and total sample estimates), which can be compared between runs.
+
 ## Workspace Role
 
 Tier 1 leaf crate. Depends only on `perl-ast`. Consumed by

--- a/crates/perl-pragma/benches/pragma_benchmarks.rs
+++ b/crates/perl-pragma/benches/pragma_benchmarks.rs
@@ -1,4 +1,4 @@
-use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use perl_ast::SourceLocation;
 use perl_ast::ast::{Node, NodeKind};
 use perl_pragma::PragmaTracker;
@@ -92,16 +92,6 @@ fn synthetic_large_ast(statement_count: usize) -> Node {
     }
 
     program(statements)
-}
-
-fn realistic_parsed_ast() -> Node {
-    let source = include_str!("../../../demo_workspace/main.pl");
-    let mut parser = perl_parser::Parser::new(source);
-
-    match parser.parse() {
-        Ok(ast) => ast,
-        Err(_) => synthetic_large_ast(250),
-    }
 }
 
 fn deterministic_offsets(limit: usize, count: usize) -> Vec<usize> {
@@ -201,8 +191,37 @@ fn bench_final_state_lookup(c: &mut Criterion) {
     });
 }
 
+/// Build a synthetic AST that exercises version-implied feature bundles.
+///
+/// `demo_workspace/main.pl` only has `use strict; use warnings` — no version
+/// pragma — so `has_feature("say")` / `has_feature("builtin")` would always
+/// return false, leaving the feature-lookup branch unmeasured.  This fixture
+/// uses an explicit `use v5.36` so the feature set is populated.
+fn synthetic_version_ast() -> Node {
+    program(vec![
+        use_node("strict", &[], 0, 12),
+        use_node("warnings", &[], 13, 28),
+        // v5.36 implies: say, state, unicode_strings, unicode_eval, evalbytes,
+        // current_sub, fc, postfix_deref, try, signatures, defer, isa
+        use_node("v5.36", &[], 29, 40),
+        block(
+            vec![
+                // Explicit no-warnings experiment inside a sub-scope
+                no_node("warnings", &["experimental"], 45, 73),
+                use_node("feature", &["'signatures'"], 74, 98),
+            ],
+            42,
+            102,
+        ),
+        // builtin is a v5.40+ feature; add it explicitly so has_feature("builtin") fires
+        use_node("feature", &["'builtin'"], 103, 124),
+    ])
+}
+
 fn bench_version_compat_walk_style(c: &mut Criterion) {
-    let ast = realistic_parsed_ast();
+    // Use a synthetic AST with a version pragma so feature lookups are
+    // non-trivial (has_feature returns true for known features).
+    let ast = synthetic_version_ast();
     let map = PragmaTracker::build(&ast);
     let max_offset = map.last().map_or(512, |(range, _)| range.end).max(512);
     let offsets: Vec<usize> = (0..512).map(|idx| idx * max_offset / 512).collect();
@@ -233,12 +252,15 @@ fn bench_scope_analyzer_walk_style(c: &mut Criterion) {
     let max_offset = map.last().map_or(2_048, |(range, _)| range.end).max(2_048);
     let offsets = deterministic_offsets(max_offset, 4_096);
 
+    // Use bench_function so Criterion registers the stable ID as
+    // "scope_analyzer_walk_style" (not "scope_analyzer_walk_style/dense_offsets"
+    // which bench_with_input + BenchmarkId would produce).
     let mut group = c.benchmark_group("scope_analyzer_walk_style");
     group.throughput(Throughput::Elements(offsets.len() as u64));
-    group.bench_with_input(BenchmarkId::from_parameter("dense_offsets"), &offsets, |b, offsets| {
+    group.bench_function("scope_analyzer_walk_style", |b| {
         b.iter(|| {
             let mut scopes_with_strict = 0usize;
-            for offset in offsets {
+            for offset in &offsets {
                 let state = PragmaTracker::state_for_offset(black_box(&map), *offset);
                 if state.strict_vars && state.strict_subs && state.strict_refs {
                     scopes_with_strict = scopes_with_strict.saturating_add(1);

--- a/crates/perl-pragma/benches/pragma_benchmarks.rs
+++ b/crates/perl-pragma/benches/pragma_benchmarks.rs
@@ -1,0 +1,266 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use perl_ast::SourceLocation;
+use perl_ast::ast::{Node, NodeKind};
+use perl_pragma::PragmaTracker;
+use std::hint::black_box;
+
+fn loc(start: usize, end: usize) -> SourceLocation {
+    SourceLocation { start, end }
+}
+
+fn use_node(module: &str, args: &[&str], start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::Use {
+            module: module.to_string(),
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+            has_filter_risk: false,
+        },
+        location: loc(start, end),
+    }
+}
+
+fn no_node(module: &str, args: &[&str], start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::No {
+            module: module.to_string(),
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+            has_filter_risk: false,
+        },
+        location: loc(start, end),
+    }
+}
+
+fn block(statements: Vec<Node>, start: usize, end: usize) -> Node {
+    Node { kind: NodeKind::Block { statements }, location: loc(start, end) }
+}
+
+fn program(statements: Vec<Node>) -> Node {
+    let end = statements.last().map_or(0, |node| node.location.end);
+    Node { kind: NodeKind::Program { statements }, location: loc(0, end) }
+}
+
+fn synthetic_small_ast() -> Node {
+    program(vec![
+        use_node("strict", &[], 0, 12),
+        use_node("warnings", &[], 13, 28),
+        use_node("v5.36", &[], 29, 40),
+        block(
+            vec![
+                no_node("warnings", &["experimental"], 45, 73),
+                use_node("feature", &["'signatures'"], 74, 98),
+                no_node("strict", &["refs"], 99, 116),
+            ],
+            42,
+            120,
+        ),
+        use_node("builtin", &["qw(true false ceil)"], 121, 151),
+    ])
+}
+
+fn synthetic_large_ast(statement_count: usize) -> Node {
+    let mut statements = Vec::with_capacity(statement_count * 3);
+    let mut cursor = 0usize;
+
+    for idx in 0..statement_count {
+        let use_end = cursor + 12;
+        statements.push(use_node("strict", &[], cursor, use_end));
+        cursor = use_end + 1;
+
+        let warn_end = cursor + 15;
+        statements.push(use_node("warnings", &[], cursor, warn_end));
+        cursor = warn_end + 1;
+
+        let block_start = cursor;
+        let mut block_items = Vec::with_capacity(3);
+        let local_no_end = cursor + 18;
+        block_items.push(no_node("strict", &["refs"], cursor, local_no_end));
+        cursor = local_no_end + 1;
+
+        let feature_end = cursor + 24;
+        block_items.push(use_node("feature", &["'signatures'"], cursor, feature_end));
+        cursor = feature_end + 1;
+
+        if idx % 5 == 0 {
+            let locale_end = cursor + 22;
+            block_items.push(use_node("locale", &["':not_characters'"], cursor, locale_end));
+            cursor = locale_end + 1;
+        }
+
+        let block_end = cursor + 3;
+        statements.push(block(block_items, block_start, block_end));
+        cursor = block_end + 1;
+    }
+
+    program(statements)
+}
+
+fn realistic_parsed_ast() -> Node {
+    let source = include_str!("../../../demo_workspace/main.pl");
+    let mut parser = perl_parser::Parser::new(source);
+
+    match parser.parse() {
+        Ok(ast) => ast,
+        Err(_) => synthetic_large_ast(250),
+    }
+}
+
+fn deterministic_offsets(limit: usize, count: usize) -> Vec<usize> {
+    let mut seed = 0xA076_1D64_78BD_642Fu64;
+    let upper = limit.max(1);
+    let mut offsets = Vec::with_capacity(count);
+
+    for _ in 0..count {
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        offsets.push((seed as usize) % upper);
+    }
+
+    offsets
+}
+
+fn bench_build_small_file(c: &mut Criterion) {
+    let ast = synthetic_small_ast();
+    c.bench_function("build_small_file", |b| {
+        b.iter(|| {
+            let map = PragmaTracker::build(black_box(&ast));
+            black_box(map)
+        })
+    });
+}
+
+fn bench_build_large_file(c: &mut Criterion) {
+    let ast = synthetic_large_ast(700);
+    c.bench_function("build_large_file", |b| {
+        b.iter(|| {
+            let map = PragmaTracker::build(black_box(&ast));
+            black_box(map)
+        })
+    });
+}
+
+fn bench_query_random_offsets(c: &mut Criterion) {
+    let ast = synthetic_large_ast(700);
+    let map = PragmaTracker::build(&ast);
+    let max_offset = map.last().map_or(10_000, |(range, _)| range.end);
+    let offsets = deterministic_offsets(max_offset, 2_048);
+
+    let mut group = c.benchmark_group("query_random_offsets");
+    group.throughput(Throughput::Elements(offsets.len() as u64));
+    group.bench_function("query_random_offsets", |b| {
+        b.iter(|| {
+            let mut checksum = 0usize;
+            for offset in &offsets {
+                let state = PragmaTracker::state_for_offset(black_box(&map), *offset);
+                if state.strict_refs {
+                    checksum = checksum.saturating_add(1);
+                }
+                if state.warnings {
+                    checksum = checksum.saturating_add(1);
+                }
+            }
+            black_box(checksum)
+        })
+    });
+    group.finish();
+}
+
+fn bench_query_monotonic_offsets(c: &mut Criterion) {
+    let ast = synthetic_large_ast(700);
+    let map = PragmaTracker::build(&ast);
+    let max_offset = map.last().map_or(10_000, |(range, _)| range.end).max(4_096);
+    let step = (max_offset / 2_048).max(1);
+    let offsets: Vec<usize> = (0..2_048).map(|idx| idx * step).collect();
+
+    let mut group = c.benchmark_group("query_monotonic_offsets");
+    group.throughput(Throughput::Elements(offsets.len() as u64));
+    group.bench_function("query_monotonic_offsets", |b| {
+        b.iter(|| {
+            let mut checksum = 0usize;
+            for offset in &offsets {
+                let state = PragmaTracker::state_for_offset(black_box(&map), *offset);
+                if state.strict_subs {
+                    checksum = checksum.saturating_add(1);
+                }
+                if state.unicode_strings {
+                    checksum = checksum.saturating_add(1);
+                }
+            }
+            black_box(checksum)
+        })
+    });
+    group.finish();
+}
+
+fn bench_final_state_lookup(c: &mut Criterion) {
+    let ast = synthetic_large_ast(700);
+    let map = PragmaTracker::build(&ast);
+    c.bench_function("final_state_lookup", |b| {
+        b.iter(|| {
+            let state = PragmaTracker::state_for_offset(black_box(&map), usize::MAX / 2);
+            black_box(state)
+        })
+    });
+}
+
+fn bench_version_compat_walk_style(c: &mut Criterion) {
+    let ast = realistic_parsed_ast();
+    let map = PragmaTracker::build(&ast);
+    let max_offset = map.last().map_or(512, |(range, _)| range.end).max(512);
+    let offsets: Vec<usize> = (0..512).map(|idx| idx * max_offset / 512).collect();
+
+    c.bench_function("version_compat_walk_style", |b| {
+        b.iter(|| {
+            let mut score = 0usize;
+            for offset in &offsets {
+                let state = PragmaTracker::state_for_offset(black_box(&map), *offset);
+                if state.has_feature("say") {
+                    score = score.saturating_add(1);
+                }
+                if state.has_feature("builtin") {
+                    score = score.saturating_add(2);
+                }
+                if state.warnings {
+                    score = score.saturating_add(1);
+                }
+            }
+            black_box(score)
+        })
+    });
+}
+
+fn bench_scope_analyzer_walk_style(c: &mut Criterion) {
+    let ast = synthetic_large_ast(900);
+    let map = PragmaTracker::build(&ast);
+    let max_offset = map.last().map_or(2_048, |(range, _)| range.end).max(2_048);
+    let offsets = deterministic_offsets(max_offset, 4_096);
+
+    let mut group = c.benchmark_group("scope_analyzer_walk_style");
+    group.throughput(Throughput::Elements(offsets.len() as u64));
+    group.bench_with_input(BenchmarkId::from_parameter("dense_offsets"), &offsets, |b, offsets| {
+        b.iter(|| {
+            let mut scopes_with_strict = 0usize;
+            for offset in offsets {
+                let state = PragmaTracker::state_for_offset(black_box(&map), *offset);
+                if state.strict_vars && state.strict_subs && state.strict_refs {
+                    scopes_with_strict = scopes_with_strict.saturating_add(1);
+                }
+                if state.locale {
+                    scopes_with_strict = scopes_with_strict.saturating_add(1);
+                }
+            }
+            black_box(scopes_with_strict)
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(
+    pragma_benches,
+    bench_build_small_file,
+    bench_build_large_file,
+    bench_query_random_offsets,
+    bench_query_monotonic_offsets,
+    bench_final_state_lookup,
+    bench_version_compat_walk_style,
+    bench_scope_analyzer_walk_style
+);
+criterion_main!(pragma_benches);


### PR DESCRIPTION
### Motivation

- The `perl-pragma` crate had no benchmark surface to measure the cost of building the pragma map and servicing point queries, leaving optimizer work without objective measurements.

### Description

- Add a Criterion benchmark suite at `crates/perl-pragma/benches/pragma_benchmarks.rs` exposing stable benchmark names: `build_small_file`, `build_large_file`, `query_random_offsets`, `query_monotonic_offsets`, `final_state_lookup`, `version_compat_walk_style`, and `scope_analyzer_walk_style`.
- Provide deterministic synthetic AST fixtures and a fallback realistic parsed fixture (via `demo_workspace/main.pl`) to exercise both build and query-heavy workloads and produce repeatable measurements.
- Wire up dev dependencies and a bench target in `crates/perl-pragma/Cargo.toml` (add `criterion` and `perl-parser` under `[dev-dependencies]` and `[[bench]]` entry) and update the lockfile to record the new bench deps.
- Document how to run the suite in `crates/perl-pragma/README.md` and replace usages of the deprecated `criterion::black_box` with `std::hint::black_box` in the bench code.

### Testing

- Ran `cargo check --all-targets -p perl-pragma` which completed successfully.
- Executed `cargo bench -p perl-pragma` which completed and produced timing results for each named benchmark (per-iteration and total sample statistics).
- Ran `cargo xtask fmt` to ensure formatting; the task completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb777185b48333bed1dd367ff3c1ad)