### PR TITLE
test(perl-pragma): expand regressions for conditional, builtin, feature-bundle, and lexical-scope edges (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -301,6 +301,13 @@ fn apply_feature_state(state: &mut PragmaState, args: &[String], enabled: bool) 
 
     for arg in args {
         for item in feature_items(arg) {
+            if enabled && item == ":all" {
+                for feature in features_enabled_by_version(PerlVersion::new(5, 40)) {
+                    changed |= enable_feature_name(state, feature);
+                }
+                continue;
+            }
+
             if !enabled && item == ":all" {
                 let had_features =
                     !state.features.is_empty() || state.unicode_strings || state.signatures_strict;
@@ -378,6 +385,17 @@ fn add_disabled_warning_category(state: &mut PragmaState, category: &str) {
     }
 
     state.disabled_warning_categories.push(category.to_string());
+}
+
+fn remove_builtin_imports(state: &mut PragmaState, args: &[String]) {
+    if args.is_empty() {
+        state.builtin_imports.clear();
+        return;
+    }
+
+    let names_to_remove: Vec<String> =
+        args.iter().flat_map(|arg| builtin_import_names(arg)).collect();
+    state.builtin_imports.retain(|import| !names_to_remove.iter().any(|name| name == import));
 }
 
 fn pragma_arg_items(arg: &str) -> Vec<String> {
@@ -606,17 +624,19 @@ impl PragmaTracker {
                         } else {
                             // Parse specific categories
                             for arg in args {
-                                match arg.as_str() {
-                                    "vars" | "'vars'" | "\"vars\"" => {
-                                        current_state.strict_vars = true
+                                for item in pragma_arg_items(arg) {
+                                    match item.as_str() {
+                                        "vars" => {
+                                            current_state.strict_vars = true;
+                                        }
+                                        "subs" => {
+                                            current_state.strict_subs = true;
+                                        }
+                                        "refs" => {
+                                            current_state.strict_refs = true;
+                                        }
+                                        _ => {}
                                     }
-                                    "subs" | "'subs'" | "\"subs\"" => {
-                                        current_state.strict_subs = true
-                                    }
-                                    "refs" | "'refs'" | "\"refs\"" => {
-                                        current_state.strict_refs = true
-                                    }
-                                    _ => {}
                                 }
                             }
                         }
@@ -754,6 +774,14 @@ impl PragmaTracker {
                             }
                             return;
                         }
+                        "builtin" => {
+                            remove_builtin_imports(current_state, conditional_args);
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
                         _ => return,
                     }
                 }
@@ -769,17 +797,19 @@ impl PragmaTracker {
                         } else {
                             // Parse specific categories
                             for arg in args {
-                                match arg.as_str() {
-                                    "vars" | "'vars'" | "\"vars\"" => {
-                                        current_state.strict_vars = false
+                                for item in pragma_arg_items(arg) {
+                                    match item.as_str() {
+                                        "vars" => {
+                                            current_state.strict_vars = false;
+                                        }
+                                        "subs" => {
+                                            current_state.strict_subs = false;
+                                        }
+                                        "refs" => {
+                                            current_state.strict_refs = false;
+                                        }
+                                        _ => {}
                                     }
-                                    "subs" | "'subs'" | "\"subs\"" => {
-                                        current_state.strict_subs = false
-                                    }
-                                    "refs" | "'refs'" | "\"refs\"" => {
-                                        current_state.strict_refs = false
-                                    }
-                                    _ => {}
                                 }
                             }
                         }
@@ -830,6 +860,11 @@ impl PragmaTracker {
                                 current_state.clone(),
                             ));
                         }
+                    }
+                    "builtin" => {
+                        remove_builtin_imports(current_state, args);
+                        ranges
+                            .push((node.location.start..node.location.end, current_state.clone()));
                     }
                     _ => {}
                 }

--- a/crates/perl-pragma/tests/pragma_surface_regressions.rs
+++ b/crates/perl-pragma/tests/pragma_surface_regressions.rs
@@ -1,0 +1,263 @@
+use perl_ast::SourceLocation;
+use perl_ast::ast::{Node, NodeKind};
+use perl_pragma::PragmaTracker;
+
+fn loc(start: usize, end: usize) -> SourceLocation {
+    SourceLocation { start, end }
+}
+
+fn use_node(module: &str, args: &[&str], start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::Use {
+            module: module.to_string(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            has_filter_risk: false,
+        },
+        location: loc(start, end),
+    }
+}
+
+fn no_node(module: &str, args: &[&str], start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::No {
+            module: module.to_string(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            has_filter_risk: false,
+        },
+        location: loc(start, end),
+    }
+}
+
+fn block(stmts: Vec<Node>, start: usize, end: usize) -> Node {
+    Node { kind: NodeKind::Block { statements: stmts }, location: loc(start, end) }
+}
+
+fn eval_node(body_node: Node, start: usize, end: usize) -> Node {
+    Node { kind: NodeKind::Eval { block: Box::new(body_node) }, location: loc(start, end) }
+}
+
+fn string_node(value: &str, interpolated: bool, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::String { value: value.to_string(), interpolated },
+        location: loc(start, end),
+    }
+}
+
+fn package_block(name: &str, body: Node, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::Package {
+            name: name.to_string(),
+            name_span: loc(start, end),
+            block: Some(Box::new(body)),
+        },
+        location: loc(start, end),
+    }
+}
+
+fn phase_block(phase: &str, body: Node, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::PhaseBlock {
+            phase: phase.to_string(),
+            phase_span: Some(loc(start, start + phase.len())),
+            block: Box::new(body),
+        },
+        location: loc(start, end),
+    }
+}
+
+fn program(stmts: Vec<Node>) -> Node {
+    let end = stmts.last().map_or(0, |n| n.location.end);
+    Node { kind: NodeKind::Program { statements: stmts }, location: loc(0, end) }
+}
+
+#[test]
+fn use_strict_qw_vars_refs_enables_only_requested_flags() {
+    let ast = program(vec![use_node("strict", &["qw(vars refs)"], 0, 24)]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 12);
+    assert!(state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(state.strict_refs);
+}
+
+#[test]
+fn no_strict_qw_vars_subs_preserves_refs() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        no_node("strict", &["qw(vars subs)"], 13, 36),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 30);
+    assert!(!state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(state.strict_refs);
+}
+
+#[test]
+fn use_feature_all_populates_latest_bundle_surface() {
+    let ast = program(vec![use_node("feature", &["':all'"], 0, 19)]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 10);
+    assert!(state.has_feature("say"));
+    assert!(state.has_feature("signatures"));
+    assert!(state.has_feature("builtin"));
+}
+
+#[test]
+fn no_feature_all_clears_version_bundle_features() {
+    let ast = program(vec![use_node("v5.40", &[], 0, 10), no_node("feature", &["':all'"], 11, 30)]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 20);
+    assert!(!state.has_feature("say"));
+    assert!(!state.has_feature("signatures"));
+    assert!(!state.has_feature("builtin"));
+}
+
+#[test]
+fn use_builtin_qw_true_floor_tracks_lexical_imports() {
+    let ast = program(vec![use_node("builtin", &["qw(true floor)"], 0, 27)]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 15);
+    assert!(state.has_builtin_import("true"));
+    assert!(state.has_builtin_import("floor"));
+}
+
+#[test]
+fn no_builtin_qw_floor_removes_selected_import_only() {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true floor)"], 0, 27),
+        no_node("builtin", &["qw(floor)"], 28, 47),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 40);
+    assert!(state.has_builtin_import("true"));
+    assert!(!state.has_builtin_import("floor"));
+}
+
+#[test]
+fn no_if_builtin_qw_true_removes_target_import() {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true floor)"], 0, 27),
+        no_node("if", &["$cond", "builtin", "qw(true)"], 28, 58),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 50);
+    assert!(!state.has_builtin_import("true"));
+    assert!(state.has_builtin_import("floor"));
+}
+
+#[test]
+fn no_unless_feature_bundle_disables_bundle_entries() {
+    let ast = program(vec![
+        use_node("feature", &["':5.36'"], 0, 20),
+        no_node("unless", &["$cond", "feature", "':5.36'"], 21, 55),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 45);
+    assert!(!state.has_feature("say"));
+    assert!(!state.has_feature("isa"));
+}
+
+#[test]
+fn no_if_locale_scope_clears_locale_state() {
+    let ast = program(vec![
+        use_node("locale", &["':not_characters'"], 0, 28),
+        no_node("if", &["$cond", "locale", "':not_characters'"], 29, 68),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 55);
+    assert!(!state.locale);
+    assert!(state.locale_scope.is_none());
+}
+
+#[test]
+fn explicit_feature_toggle_wins_after_version_bundle() {
+    let ast = program(vec![
+        use_node("v5.40", &[], 0, 10),
+        no_node("feature", &["'builtin'"], 11, 31),
+        use_node("feature", &["'builtin'"], 32, 53),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let disabled = PragmaTracker::state_for_offset(&map, 20);
+    assert!(!disabled.has_feature("builtin"));
+
+    let reenabled = PragmaTracker::state_for_offset(&map, 45);
+    assert!(reenabled.has_feature("builtin"));
+}
+
+#[test]
+fn nested_eval_block_changes_restore_to_outer_scope() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        eval_node(
+            block(
+                vec![
+                    no_node("strict", &["refs"], 20, 36),
+                    eval_node(block(vec![no_node("strict", &["vars"], 45, 61)], 43, 63), 41, 65),
+                ],
+                18,
+                67,
+            ),
+            16,
+            69,
+        ),
+        use_node("warnings", &[], 70, 85),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let inner = PragmaTracker::state_for_offset(&map, 50);
+    assert!(!inner.strict_refs);
+    assert!(!inner.strict_vars);
+
+    let after = PragmaTracker::state_for_offset(&map, 75);
+    assert!(after.strict_vars);
+    assert!(after.strict_refs);
+    assert!(after.warnings);
+}
+
+#[test]
+fn eval_string_does_not_leak_pragma_changes_to_following_scope() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        eval_node(string_node("no strict 'refs'; use warnings;", false, 14, 44), 13, 45),
+        block(vec![], 46, 48),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state_after = PragmaTracker::state_for_offset(&map, 47);
+    assert!(state_after.strict_refs);
+    assert!(!state_after.warnings);
+}
+
+#[test]
+fn package_and_phase_blocks_restore_lexical_state_after_exit() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        package_block("P", block(vec![no_node("strict", &["subs"], 20, 36)], 18, 38), 13, 40),
+        phase_block("BEGIN", block(vec![no_node("strict", &["vars"], 50, 66)], 48, 68), 41, 69),
+        use_node("warnings", &[], 70, 85),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let in_package = PragmaTracker::state_for_offset(&map, 30);
+    assert!(!in_package.strict_subs);
+
+    let in_begin = PragmaTracker::state_for_offset(&map, 58);
+    assert!(!in_begin.strict_vars);
+
+    let after = PragmaTracker::state_for_offset(&map, 80);
+    assert!(after.strict_vars);
+    assert!(after.strict_subs);
+    assert!(after.strict_refs);
+    assert!(after.warnings);
+}

--- a/crates/perl-pragma/tests/pragma_surface_regressions.rs
+++ b/crates/perl-pragma/tests/pragma_surface_regressions.rs
@@ -261,3 +261,17 @@ fn package_and_phase_blocks_restore_lexical_state_after_exit() {
     assert!(after.strict_refs);
     assert!(after.warnings);
 }
+
+#[test]
+fn no_builtin_bare_clears_all_imports() {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true floor weaken)"], 0, 33),
+        no_node("builtin", &[], 34, 47),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 40);
+    assert!(!state.has_builtin_import("true"));
+    assert!(!state.has_builtin_import("floor"));
+    assert!(!state.has_builtin_import("weaken"));
+}


### PR DESCRIPTION
### Motivation

- The pragma test surface lacked focused regressions for widened forms and obvious asymmetries around `strict` qw-lists, feature bundles, `builtin` imports/removals, conditional `if/unless` forms, `eval` behavior, and lexical restore semantics.

### Description

- Add a dedicated regression bank `crates/perl-pragma/tests/pragma_surface_regressions.rs` with 13 small fixture-style tests covering `use/no strict qw(...)`, `use/no feature ':all'`, `use/no builtin qw(...)`, conditional `no if/unless` targets, version-bundle + explicit feature toggles, nested `eval`/`eval STRING` behavior, and package/phase lexical restore.
- Implement `remove_builtin_imports` and wire it into `no builtin ...` and conditional `no if/unless ... builtin ...` handling so lexical builtin removals are tracked.
- Extend `apply_feature_state` so `use feature ':all'` when enabling populates the latest supported bundle surface (uses v5.40 bundle for `:all`).
- Tighten `strict`/`no strict` argument parsing to handle `qw(...)` and quoted lists via `pragma_arg_items` so selective toggles behave symmetrically with the widened surface.

### Testing

- Ran `cargo test -p perl-pragma` and all tests (existing + new regressions) passed.
- Ran `cargo check --all-targets -p perl-pragma` and it completed successfully.
- Ran formatting via `cargo xtask fmt` as part of verification and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb777808508333b9dbe001daa33a54)