### PR TITLE
test(perl-pragma): expand regressions for conditional, builtin, feature-bundle, and lexical-scope edges (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -227,6 +227,26 @@ fn feature_items(arg: &str) -> Vec<String> {
     pragma_arg_items(arg)
 }
 
+const ALL_KNOWN_FEATURES: &[&str] = &[
+    "say",
+    "state",
+    "switch",
+    "unicode_strings",
+    "unicode_eval",
+    "evalbytes",
+    "current_sub",
+    "fc",
+    "postfix_deref",
+    "try",
+    "signatures",
+    "defer",
+    "isa",
+    "class",
+    "field",
+    "method",
+    "builtin",
+];
+
 fn known_feature_name(name: &str) -> Option<&'static str> {
     match name {
         "say" => Some("say"),
@@ -299,6 +319,13 @@ fn apply_feature_state(state: &mut PragmaState, args: &[String], enabled: bool) 
 
     for arg in args {
         for item in feature_items(arg) {
+            if enabled && item == ":all" {
+                for feature in ALL_KNOWN_FEATURES {
+                    changed |= enable_feature_name(state, feature);
+                }
+                continue;
+            }
+
             if !enabled && item == ":all" {
                 let had_features =
                     !state.features.is_empty() || state.unicode_strings || state.signatures_strict;
@@ -356,6 +383,19 @@ fn apply_builtin_imports(state: &mut PragmaState, args: &[String]) {
     }
 }
 
+fn remove_builtin_imports(state: &mut PragmaState, args: &[String]) {
+    if args.is_empty() {
+        state.builtin_imports.clear();
+        return;
+    }
+
+    for arg in args {
+        for name in builtin_import_names(arg) {
+            state.builtin_imports.retain(|import| import != &name);
+        }
+    }
+}
+
 fn pragma_arg_items(arg: &str) -> Vec<String> {
     let trimmed = arg.trim().trim_matches('\'').trim_matches('"');
 
@@ -364,6 +404,19 @@ fn pragma_arg_items(arg: &str) -> Vec<String> {
     }
 
     vec![trimmed.to_string()]
+}
+
+fn strict_modes(args: &[String]) -> Vec<String> {
+    let mut modes = Vec::new();
+    for arg in args {
+        for item in pragma_arg_items(arg) {
+            match item.as_str() {
+                "vars" | "subs" | "refs" => modes.push(item),
+                _ => {}
+            }
+        }
+    }
+    modes
 }
 
 fn normalized_pragma_token(arg: &str) -> &str {
@@ -488,8 +541,8 @@ impl PragmaTracker {
                                 current_state.strict_subs = true;
                                 current_state.strict_refs = true;
                             } else {
-                                for arg in conditional_args {
-                                    match normalized_pragma_token(arg) {
+                                for mode in strict_modes(conditional_args) {
+                                    match mode.as_str() {
                                         "vars" => current_state.strict_vars = true,
                                         "subs" => current_state.strict_subs = true,
                                         "refs" => current_state.strict_refs = true,
@@ -580,18 +633,11 @@ impl PragmaTracker {
                             current_state.strict_subs = true;
                             current_state.strict_refs = true;
                         } else {
-                            // Parse specific categories
-                            for arg in args {
-                                match arg.as_str() {
-                                    "vars" | "'vars'" | "\"vars\"" => {
-                                        current_state.strict_vars = true
-                                    }
-                                    "subs" | "'subs'" | "\"subs\"" => {
-                                        current_state.strict_subs = true
-                                    }
-                                    "refs" | "'refs'" | "\"refs\"" => {
-                                        current_state.strict_refs = true
-                                    }
+                            for mode in strict_modes(args) {
+                                match mode.as_str() {
+                                    "vars" => current_state.strict_vars = true,
+                                    "subs" => current_state.strict_subs = true,
+                                    "refs" => current_state.strict_refs = true,
                                     _ => {}
                                 }
                             }
@@ -665,8 +711,8 @@ impl PragmaTracker {
                                 current_state.strict_subs = false;
                                 current_state.strict_refs = false;
                             } else {
-                                for arg in conditional_args {
-                                    match normalized_pragma_token(arg) {
+                                for mode in strict_modes(conditional_args) {
+                                    match mode.as_str() {
                                         "vars" => current_state.strict_vars = false,
                                         "subs" => current_state.strict_subs = false,
                                         "refs" => current_state.strict_refs = false,
@@ -738,6 +784,14 @@ impl PragmaTracker {
                             }
                             return;
                         }
+                        "builtin" => {
+                            remove_builtin_imports(current_state, conditional_args);
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
                         _ => return,
                     }
                 }
@@ -751,18 +805,11 @@ impl PragmaTracker {
                             current_state.strict_subs = false;
                             current_state.strict_refs = false;
                         } else {
-                            // Parse specific categories
-                            for arg in args {
-                                match arg.as_str() {
-                                    "vars" | "'vars'" | "\"vars\"" => {
-                                        current_state.strict_vars = false
-                                    }
-                                    "subs" | "'subs'" | "\"subs\"" => {
-                                        current_state.strict_subs = false
-                                    }
-                                    "refs" | "'refs'" | "\"refs\"" => {
-                                        current_state.strict_refs = false
-                                    }
+                            for mode in strict_modes(args) {
+                                match mode.as_str() {
+                                    "vars" => current_state.strict_vars = false,
+                                    "subs" => current_state.strict_subs = false,
+                                    "refs" => current_state.strict_refs = false,
                                     _ => {}
                                 }
                             }
@@ -822,6 +869,11 @@ impl PragmaTracker {
                                 current_state.clone(),
                             ));
                         }
+                    }
+                    "builtin" => {
+                        remove_builtin_imports(current_state, args);
+                        ranges
+                            .push((node.location.start..node.location.end, current_state.clone()));
                     }
                     _ => {}
                 }

--- a/crates/perl-pragma/tests/pragma_surface_regressions.rs
+++ b/crates/perl-pragma/tests/pragma_surface_regressions.rs
@@ -1,0 +1,267 @@
+use perl_ast::SourceLocation;
+use perl_ast::ast::{Node, NodeKind};
+use perl_pragma::PragmaTracker;
+
+fn loc(start: usize, end: usize) -> SourceLocation {
+    SourceLocation { start, end }
+}
+
+fn use_node(module: &str, args: &[&str], start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::Use {
+            module: module.to_string(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            has_filter_risk: false,
+        },
+        location: loc(start, end),
+    }
+}
+
+fn no_node(module: &str, args: &[&str], start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::No {
+            module: module.to_string(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            has_filter_risk: false,
+        },
+        location: loc(start, end),
+    }
+}
+
+fn block(stmts: Vec<Node>, start: usize, end: usize) -> Node {
+    Node { kind: NodeKind::Block { statements: stmts }, location: loc(start, end) }
+}
+
+fn eval_node(body: Node, start: usize, end: usize) -> Node {
+    Node { kind: NodeKind::Eval { block: Box::new(body) }, location: loc(start, end) }
+}
+
+fn package_block(name: &str, body: Node, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::Package {
+            name: name.to_string(),
+            name_span: loc(start, end),
+            block: Some(Box::new(body)),
+        },
+        location: loc(start, end),
+    }
+}
+
+fn phase_block(phase: &str, body: Node, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::PhaseBlock {
+            phase: phase.to_string(),
+            phase_span: Some(loc(start, start + phase.len())),
+            block: Box::new(body),
+        },
+        location: loc(start, end),
+    }
+}
+
+fn string_node(value: &str, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::String { value: value.to_string(), interpolated: false },
+        location: loc(start, end),
+    }
+}
+
+fn program(stmts: Vec<Node>) -> Node {
+    let end = stmts.last().map_or(0, |n| n.location.end);
+    Node { kind: NodeKind::Program { statements: stmts }, location: loc(0, end) }
+}
+
+#[test]
+fn strict_qw_vars_refs_only_enables_those_categories() {
+    let ast = program(vec![use_node("strict", &["qw(vars refs)"], 0, 22)]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 10);
+
+    assert!(state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(state.strict_refs);
+}
+
+#[test]
+fn no_strict_qw_vars_subs_leaves_refs_enabled() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        no_node("strict", &["qw(vars subs)"], 13, 35),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 25);
+
+    assert!(!state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(state.strict_refs);
+}
+
+#[test]
+fn use_feature_all_enables_broad_feature_surface() {
+    let ast = program(vec![use_node("feature", &["':all'"], 0, 20)]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 10);
+
+    assert!(state.has_feature("say"));
+    assert!(state.has_feature("signatures"));
+    assert!(state.has_feature("builtin"));
+}
+
+#[test]
+fn no_feature_all_clears_features_after_use_feature_all() {
+    let ast = program(vec![
+        use_node("feature", &["':all'"], 0, 20),
+        no_node("feature", &["':all'"], 21, 40),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 30);
+
+    assert!(!state.has_feature("say"));
+    assert!(!state.has_feature("signatures"));
+    assert!(!state.has_feature("builtin"));
+}
+
+#[test]
+fn use_builtin_qw_true_floor_tracks_lexical_imports() {
+    let ast = program(vec![use_node("builtin", &["qw(true floor)"], 0, 28)]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 12);
+
+    assert!(state.has_builtin_import("true"));
+    assert!(state.has_builtin_import("floor"));
+}
+
+#[test]
+fn no_builtin_true_removes_only_named_lexical_import() {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true floor)"], 0, 28),
+        no_node("builtin", &["'true'"], 29, 47),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 38);
+
+    assert!(!state.has_builtin_import("true"));
+    assert!(state.has_builtin_import("floor"));
+}
+
+#[test]
+fn no_if_builtin_conditionally_removes_builtin_import() {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true floor)"], 0, 28),
+        no_node("if", &["$cond", "builtin", "'floor'"], 29, 61),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 45);
+
+    assert!(state.has_builtin_import("true"));
+    assert!(!state.has_builtin_import("floor"));
+}
+
+#[test]
+fn no_unless_locale_clears_locale_state() {
+    let ast = program(vec![
+        use_node("locale", &["':not_characters'"], 0, 28),
+        no_node("unless", &["$cond", "locale"], 29, 56),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 42);
+
+    assert!(!state.locale);
+    assert!(state.locale_scope.is_none());
+}
+
+#[test]
+fn no_if_feature_bundle_clears_version_bundle_features() {
+    let ast = program(vec![
+        use_node("v5.40", &[], 0, 10),
+        no_node("if", &["$cond", "feature", "':5.36'"], 11, 43),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 30);
+
+    assert!(state.has_feature("builtin"));
+    assert!(!state.has_feature("signatures"));
+    assert!(!state.has_feature("defer"));
+}
+
+#[test]
+fn version_bundle_and_explicit_feature_can_be_removed_and_readded() {
+    let ast = program(vec![
+        use_node("v5.40", &[], 0, 10),
+        no_node("feature", &["'builtin'"], 11, 32),
+        use_node("feature", &["'builtin'"], 33, 54),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let after_no = PragmaTracker::state_for_offset(&map, 20);
+    assert!(!after_no.has_feature("builtin"));
+
+    let after_readd = PragmaTracker::state_for_offset(&map, 45);
+    assert!(after_readd.has_feature("builtin"));
+}
+
+#[test]
+fn nested_eval_block_changes_are_lexically_restored() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        eval_node(
+            block(
+                vec![
+                    no_node("strict", &["refs"], 20, 36),
+                    eval_node(block(vec![no_node("strict", &["vars"], 42, 58)], 40, 60), 38, 61),
+                ],
+                18,
+                62,
+            ),
+            16,
+            63,
+        ),
+        use_node("warnings", &[], 64, 79),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let inner = PragmaTracker::state_for_offset(&map, 50);
+    assert!(!inner.strict_vars);
+    assert!(!inner.strict_refs);
+
+    let after = PragmaTracker::state_for_offset(&map, 70);
+    assert!(after.strict_vars);
+    assert!(after.strict_refs);
+    assert!(after.warnings);
+}
+
+#[test]
+fn eval_string_content_does_not_leak_pragmas_to_outer_scope() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        eval_node(string_node("no strict 'refs'; use warnings;", 20, 50), 18, 52),
+        block(vec![], 53, 55),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 54);
+
+    assert!(state.strict_vars);
+    assert!(state.strict_refs);
+    assert!(!state.warnings);
+}
+
+#[test]
+fn package_and_phase_blocks_restore_lexical_pragma_state() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        package_block("Foo", block(vec![no_node("strict", &["subs"], 20, 36)], 18, 38), 13, 40),
+        phase_block("BEGIN", block(vec![no_node("strict", &["refs"], 48, 64)], 46, 66), 41, 67),
+        use_node("warnings", &[], 68, 83),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let in_package = PragmaTracker::state_for_offset(&map, 30);
+    assert!(!in_package.strict_subs);
+
+    let in_phase = PragmaTracker::state_for_offset(&map, 55);
+    assert!(!in_phase.strict_refs);
+
+    let after = PragmaTracker::state_for_offset(&map, 75);
+    assert!(after.strict_subs);
+    assert!(after.strict_refs);
+    assert!(after.warnings);
+}


### PR DESCRIPTION
### Motivation

- The widened pragma surface uncovered asymmetries around `qw(...)` strict forms, `feature :all` semantics, `builtin` imports/`no builtin` paths, and lexical restoration across `eval`/`package`/phase blocks requiring focused regressions. 
- A compact, fixture-style regression bank is needed to capture and protect these edge cases without inflating existing large tests.

### Description

- Added a new focused regression test file `crates/perl-pragma/tests/pragma_surface_regressions.rs` with 13 concise tests covering `use strict qw(...)` / `no strict qw(...)`, `use/no feature ':all'`, `use/no builtin` (direct and conditional), conditional `no if/unless` forms, version-bundle vs explicit `feature` interactions, nested `eval` lexical restoration, `eval` STRING non-leakage, and package/phase block lexical restore. 
- Implemented `ALL_KNOWN_FEATURES` and extended `apply_feature_state` to enable `use feature ':all'` by enabling the full known feature set and kept symmetry for `no feature ':all'`. 
- Added `remove_builtin_imports` and wired it into `no builtin` handling (including conditional `no if/unless` paths) so lexical builtin imports can be removed selectively or entirely. 
- Introduced `strict_modes(...)` and used it to normalize parsing of strict categories (including `qw(...)` forms) for `use strict`, `no strict`, and conditional strict targets so category lists are recognized consistently.

### Testing

- Ran `cargo test -p perl-pragma` and all tests (existing and the 13 new regressions) passed. 
- Ran `cargo check --all-targets -p perl-pragma` which completed successfully. 
- Ran `cargo xtask fmt` to format changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb777808508333b9dbe001daa33a54)