### PR TITLE
test(perl-pragma): expand regressions for conditional, builtin, feature-bundle, and lexical-scope edges (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -286,6 +286,26 @@ fn disable_feature_name(state: &mut PragmaState, name: &str) -> bool {
 }
 
 fn apply_feature_state(state: &mut PragmaState, args: &[String], enabled: bool) -> bool {
+    const ALL_KNOWN_FEATURES: &[&str] = &[
+        "say",
+        "state",
+        "switch",
+        "unicode_strings",
+        "unicode_eval",
+        "evalbytes",
+        "current_sub",
+        "fc",
+        "postfix_deref",
+        "try",
+        "signatures",
+        "defer",
+        "isa",
+        "class",
+        "field",
+        "method",
+        "builtin",
+    ];
+
     if !enabled && args.is_empty() {
         let changed =
             !state.features.is_empty() || state.unicode_strings || state.signatures_strict;
@@ -299,6 +319,13 @@ fn apply_feature_state(state: &mut PragmaState, args: &[String], enabled: bool) 
 
     for arg in args {
         for item in feature_items(arg) {
+            if enabled && item == ":all" {
+                for feature in ALL_KNOWN_FEATURES {
+                    changed |= enable_feature_name(state, feature);
+                }
+                continue;
+            }
+
             if !enabled && item == ":all" {
                 let had_features =
                     !state.features.is_empty() || state.unicode_strings || state.signatures_strict;
@@ -581,8 +608,8 @@ impl PragmaTracker {
                             current_state.strict_refs = true;
                         } else {
                             // Parse specific categories
-                            for arg in args {
-                                match arg.as_str() {
+                            for item in args.iter().flat_map(|arg| pragma_arg_items(arg)) {
+                                match item.as_str() {
                                     "vars" | "'vars'" | "\"vars\"" => {
                                         current_state.strict_vars = true
                                     }
@@ -738,6 +765,24 @@ impl PragmaTracker {
                             }
                             return;
                         }
+                        "builtin" => {
+                            if conditional_args.is_empty() {
+                                current_state.builtin_imports.clear();
+                            } else {
+                                for arg in conditional_args {
+                                    for name in builtin_import_names(arg) {
+                                        current_state
+                                            .builtin_imports
+                                            .retain(|existing| existing != &name);
+                                    }
+                                }
+                            }
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
                         _ => return,
                     }
                 }
@@ -752,8 +797,8 @@ impl PragmaTracker {
                             current_state.strict_refs = false;
                         } else {
                             // Parse specific categories
-                            for arg in args {
-                                match arg.as_str() {
+                            for item in args.iter().flat_map(|arg| pragma_arg_items(arg)) {
+                                match item.as_str() {
                                     "vars" | "'vars'" | "\"vars\"" => {
                                         current_state.strict_vars = false
                                     }
@@ -822,6 +867,21 @@ impl PragmaTracker {
                                 current_state.clone(),
                             ));
                         }
+                    }
+                    "builtin" => {
+                        if args.is_empty() {
+                            current_state.builtin_imports.clear();
+                        } else {
+                            for arg in args {
+                                for name in builtin_import_names(arg) {
+                                    current_state
+                                        .builtin_imports
+                                        .retain(|existing| existing != &name);
+                                }
+                            }
+                        }
+                        ranges
+                            .push((node.location.start..node.location.end, current_state.clone()));
                     }
                     _ => {}
                 }

--- a/crates/perl-pragma/tests/pragma_surface_regressions.rs
+++ b/crates/perl-pragma/tests/pragma_surface_regressions.rs
@@ -1,0 +1,293 @@
+//! Focused regressions for widened pragma surface and asymmetry edge-cases.
+
+use perl_ast::SourceLocation;
+use perl_ast::ast::{Node, NodeKind};
+use perl_pragma::PragmaTracker;
+
+fn loc(start: usize, end: usize) -> SourceLocation {
+    SourceLocation { start, end }
+}
+
+fn use_node(module: &str, args: &[&str], start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::Use {
+            module: module.to_string(),
+            args: args.iter().map(|arg| arg.to_string()).collect(),
+            has_filter_risk: false,
+        },
+        location: loc(start, end),
+    }
+}
+
+fn no_node(module: &str, args: &[&str], start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::No {
+            module: module.to_string(),
+            args: args.iter().map(|arg| arg.to_string()).collect(),
+            has_filter_risk: false,
+        },
+        location: loc(start, end),
+    }
+}
+
+fn block(stmts: Vec<Node>, start: usize, end: usize) -> Node {
+    Node { kind: NodeKind::Block { statements: stmts }, location: loc(start, end) }
+}
+
+fn eval_node(body: Node, start: usize, end: usize) -> Node {
+    Node { kind: NodeKind::Eval { block: Box::new(body) }, location: loc(start, end) }
+}
+
+fn function_call(name: &str, args: Vec<Node>, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::FunctionCall { name: name.to_string(), args },
+        location: loc(start, end),
+    }
+}
+
+fn string_node(value: &str, interpolated: bool, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::String { value: value.to_string(), interpolated },
+        location: loc(start, end),
+    }
+}
+
+fn package_block(name: &str, body: Node, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::Package {
+            name: name.to_string(),
+            name_span: loc(start, start + name.len()),
+            block: Some(Box::new(body)),
+        },
+        location: loc(start, end),
+    }
+}
+
+fn phase_block(phase: &str, body: Node, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::PhaseBlock {
+            phase: phase.to_string(),
+            phase_span: Some(loc(start, start + phase.len())),
+            block: Box::new(body),
+        },
+        location: loc(start, end),
+    }
+}
+
+fn program(stmts: Vec<Node>) -> Node {
+    let end = stmts.last().map_or(0, |node| node.location.end);
+    Node { kind: NodeKind::Program { statements: stmts }, location: loc(0, end) }
+}
+
+#[test]
+fn use_strict_qw_vars_refs_enables_selected_categories() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("strict", &["qw(vars refs)"], 0, 22)]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 10);
+
+    assert!(state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(state.strict_refs);
+    Ok(())
+}
+
+#[test]
+fn no_strict_qw_vars_subs_disables_selected_categories() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        no_node("strict", &["qw(vars subs)"], 13, 35),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 24);
+
+    assert!(!state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(state.strict_refs);
+    Ok(())
+}
+
+#[test]
+fn use_feature_all_enables_known_surface_features() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("feature", &["':all'"], 0, 20)]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 10);
+
+    assert!(state.has_feature("say"));
+    assert!(state.has_feature("signatures"));
+    assert!(state.has_feature("class"));
+    assert!(state.has_feature("builtin"));
+    Ok(())
+}
+
+#[test]
+fn no_feature_all_clears_priorly_enabled_feature_set() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("feature", &["':all'"], 0, 20),
+        no_node("feature", &["':all'"], 21, 40),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 32);
+
+    assert!(state.features.is_empty());
+    assert!(!state.unicode_strings);
+    Ok(())
+}
+
+#[test]
+fn use_builtin_qw_true_floor_tracks_imported_names() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("builtin", &["qw(true floor)"], 0, 28)]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 14);
+
+    assert!(state.has_builtin_import("true"));
+    assert!(state.has_builtin_import("floor"));
+    Ok(())
+}
+
+#[test]
+fn no_builtin_removes_requested_lexical_imports() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true floor)"], 0, 28),
+        no_node("builtin", &["qw(true)"], 29, 48),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 40);
+
+    assert!(!state.has_builtin_import("true"));
+    assert!(state.has_builtin_import("floor"));
+    Ok(())
+}
+
+#[test]
+fn conditional_no_if_feature_all_clears_features() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("feature", &["':all'"], 0, 20),
+        no_node("if", &["$cond", "feature", "':all'"], 21, 55),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 40);
+
+    assert!(state.features.is_empty());
+    Ok(())
+}
+
+#[test]
+fn conditional_no_unless_locale_restores_locale_flags() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("locale", &["':not_characters'"], 0, 31),
+        no_node("unless", &["$cond", "locale", "':not_characters'"], 32, 78),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 60);
+
+    assert!(!state.locale);
+    assert!(state.locale_scope.is_none());
+    Ok(())
+}
+
+#[test]
+fn conditional_no_if_builtin_removes_requested_imports() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true floor)"], 0, 28),
+        no_node("if", &["$cond", "builtin", "qw(true)"], 29, 60),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 45);
+
+    assert!(!state.has_builtin_import("true"));
+    assert!(state.has_builtin_import("floor"));
+    Ok(())
+}
+
+#[test]
+fn version_bundle_then_explicit_no_feature_updates_feature_set_only()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast =
+        program(vec![use_node("v5.40", &[], 0, 10), no_node("feature", &["'builtin'"], 11, 32)]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 20);
+
+    assert!(state.strict_vars && state.strict_subs && state.strict_refs);
+    assert!(state.warnings);
+    assert!(!state.has_feature("builtin"));
+    Ok(())
+}
+
+#[test]
+fn nested_eval_block_state_is_restored_after_exit() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        eval_node(
+            block(
+                vec![
+                    no_node("strict", &["refs"], 20, 36),
+                    block(vec![no_node("strict", &["vars"], 40, 56)], 38, 60),
+                ],
+                18,
+                62,
+            ),
+            15,
+            64,
+        ),
+        use_node("warnings", &[], 65, 80),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let inner_eval = PragmaTracker::state_for_offset(&map, 45);
+    assert!(!inner_eval.strict_vars);
+    assert!(inner_eval.strict_subs);
+    assert!(!inner_eval.strict_refs);
+
+    let after_eval = PragmaTracker::state_for_offset(&map, 70);
+    assert!(after_eval.strict_vars);
+    assert!(after_eval.strict_subs);
+    assert!(after_eval.strict_refs);
+    assert!(after_eval.warnings);
+    Ok(())
+}
+
+#[test]
+fn eval_string_call_does_not_leak_compile_time_pragma_state()
+-> Result<(), Box<dyn std::error::Error>> {
+    let eval_string = function_call(
+        "eval",
+        vec![string_node("no strict 'refs'; use warnings;", true, 20, 55)],
+        15,
+        56,
+    );
+    let ast = program(vec![use_node("strict", &[], 0, 12), eval_string]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 58);
+    assert!(state.strict_vars);
+    assert!(state.strict_subs);
+    assert!(state.strict_refs);
+    assert!(!state.warnings);
+    Ok(())
+}
+
+#[test]
+fn package_and_phase_blocks_restore_outer_lexical_state() -> Result<(), Box<dyn std::error::Error>>
+{
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        package_block("Foo", block(vec![no_node("strict", &["subs"], 20, 36)], 18, 38), 13, 40),
+        phase_block("BEGIN", block(vec![use_node("warnings", &[], 48, 63)], 46, 65), 41, 66),
+        use_node("utf8", &[], 67, 76),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let in_package = PragmaTracker::state_for_offset(&map, 30);
+    assert!(!in_package.strict_subs);
+
+    let in_begin = PragmaTracker::state_for_offset(&map, 55);
+    assert!(in_begin.warnings);
+
+    let after_phase = PragmaTracker::state_for_offset(&map, 70);
+    assert!(after_phase.strict_vars);
+    assert!(after_phase.strict_subs);
+    assert!(after_phase.strict_refs);
+    assert!(!after_phase.warnings);
+    assert!(after_phase.utf8);
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- The widened pragma surface exposed asymmetries (qw-forms, `:all`, builtin symmetry, conditional `no` variants) and lacked a small, focused regression bank to catch regressions.  

### Description
- Added a new fixture-style regression file `crates/perl-pragma/tests/pragma_surface_regressions.rs` containing 13 focused tests for `use/no strict qw(...)`, `use/no feature ':all'`, `use/no builtin`, conditional `no if/unless` forms, version-bundle + explicit feature interaction, nested `eval` restore, eval-STRING non-leakage, and package/phase lexical restore.  
- Implemented `use feature ':all'` enable semantics by expanding to a canonical `ALL_KNOWN_FEATURES` list inside `apply_feature_state`.  
- Made `use/no strict` accept `qw(...)` argument lists by iterating `pragma_arg_items` during `strict` handling so selective categories parse correctly.  
- Added symmetric `no builtin` handling (direct and conditional) to remove requested lexical builtin imports or clear all imports when no args are provided.  

### Testing
- Ran `cargo test -p perl-pragma` and all tests (including the new regression suite) passed.  
- Ran `cargo check --all-targets -p perl-pragma` which completed successfully.  
- Ran `cargo xtask fmt` to ensure formatting consistency which completed successfully.  
- The change adds 13 new focused regressions (exceeding the required 10) and leaves the existing pragma tests green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb777808508333b9dbe001daa33a54)