### PR TITLE
test(pragma-consumers): add downstream parity coverage for lexical pragma state (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
@@ -660,4 +660,44 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn package_scoped_pragmas_do_not_suppress_file_level_missing_diagnostics() {
+        let diags =
+            strict_warnings_diags("package Inner { use strict; use warnings; }\nmy $x = 1;\n");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL100")),
+            "package-scoped strict must not suppress missing-strict (PL100)"
+        );
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL101")),
+            "package-scoped warnings must not suppress missing-warnings (PL101)"
+        );
+    }
+
+    #[test]
+    fn package_scoped_no_strict_no_warnings_restore_to_top_level_state() {
+        let diags = strict_warnings_diags(
+            "use strict;\nuse warnings;\npackage Inner { no strict; no warnings; }\nmy $x = 1;\n",
+        );
+        assert!(
+            diags.iter().all(|d| !matches!(d.code.as_deref(), Some("PL100") | Some("PL101"))),
+            "package-scoped no strict/warnings must restore to outer top-level strict/warnings"
+        );
+    }
+
+    #[test]
+    fn conditional_no_if_pragmas_make_missing_diagnostics_observable() {
+        let diags = strict_warnings_diags(
+            "use strict;\nuse warnings;\nno if 1, 'strict';\nno if 1, 'warnings';\nmy $x = 1;\n",
+        );
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL100")),
+            "conditional no-if strict should re-enable missing-strict diagnostic"
+        );
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL101")),
+            "conditional no-if warnings should re-enable missing-warnings diagnostic"
+        );
+    }
 }

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs
@@ -491,3 +491,77 @@ fn make_diagnostic_with_details(
         suggestion,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser::Parser;
+    use perl_tdd_support::must;
+
+    fn version_diags(source: &str) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let mut diags = vec![];
+        check_version_compat(&ast, &mut diags);
+        diags
+    }
+
+    #[test]
+    fn version_bundle_enables_say_without_pl900() {
+        let diags = version_diags("use v5.10;\nsay 'ok';\n");
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL900")),
+            "use v5.10 bundle should enable say without PL900"
+        );
+    }
+
+    #[test]
+    fn explicit_feature_signatures_suppresses_signature_diagnostic_on_older_version() {
+        let diags = version_diags(
+            "use v5.20;\nuse feature 'signatures';\nsub greet ($name) { return $name; }\n",
+        );
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL900")),
+            "explicit feature signatures should suppress signature PL900 under use v5.20"
+        );
+    }
+
+    #[test]
+    fn lexical_no_feature_say_is_honored_inside_block_only() {
+        let diags = version_diags("use v5.40;\n{ no feature 'say'; say 'inner'; }\nsay 'outer';\n");
+        let say_diags: Vec<&Diagnostic> = diags
+            .iter()
+            .filter(|d| d.code.as_deref() == Some("PL900") && d.message.contains("'say'"))
+            .collect();
+        assert_eq!(say_diags.len(), 1, "lexical no feature say should affect only the inner block");
+    }
+
+    #[test]
+    fn builtin_named_import_suppresses_builtin_call_diagnostic() {
+        let diags = version_diags("use v5.36;\nuse builtin 'trim';\nbuiltin::trim('  x  ');\n");
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL900")),
+            "named builtin import should suppress builtin::trim PL900 when version supports it"
+        );
+    }
+
+    #[test]
+    fn builtin_bundle_and_named_imports_are_distinguished() {
+        let diags =
+            version_diags("use v5.36;\nuse builtin 'trim';\nbuiltin::load_module('My::Thing');\n");
+        assert!(
+            diags.iter().any(|d| {
+                d.code.as_deref() == Some("PL900") && d.message.contains("builtin::load_module")
+            }),
+            "importing trim should not imply builtin bundle; load_module must still report PL900"
+        );
+    }
+
+    #[test]
+    fn eval_string_no_feature_does_not_disable_version_bundle_features() {
+        let diags = version_diags("use v5.40;\neval \"no feature 'say'\";\nsay 'ok';\n");
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL900")),
+            "eval STRING feature toggles should not alter compile-time version compatibility state"
+        );
+    }
+}

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -2130,6 +2130,63 @@ sub foo ($x) { $z = 1; }
 }
 
 #[test]
+fn signatures_with_lexical_no_strict_vars_still_flags_undeclared_in_signature_sub()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use feature 'signatures';
+{
+    no strict 'vars';
+    sub foo ($x) { $z = 1; }
+}
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        has_issue(&issues, IssueKind::UndeclaredVariable, "z"),
+        "current downstream behavior: signatures strictness remains active even with lexical no strict 'vars'"
+    );
+    Ok(())
+}
+
+#[test]
+fn signatures_with_lexical_no_strict_subs_still_flags_barewords()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use feature 'signatures';
+{
+    no strict 'subs';
+    sub foo ($x) { print FOO; }
+}
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        issues
+            .iter()
+            .any(|i| matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "FOO"),
+        "current downstream behavior: signatures strictness remains active even with lexical no strict 'subs'"
+    );
+    Ok(())
+}
+
+#[test]
+fn eval_string_no_strict_does_not_disable_downstream_strict_vars_behavior()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+eval "no strict 'vars'";
+print $unknown_var;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        has_issue(&issues, IssueKind::UndeclaredVariable, "unknown_var"),
+        "eval STRING no strict should not disable strict-vars checks in downstream scope analysis"
+    );
+    Ok(())
+}
+
+#[test]
 fn signature_parameters_are_registered_as_symbols() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 sub add ($x, $y = 1, @rest) {
@@ -3916,7 +3973,7 @@ print func();
         issues.iter().any(|issue| {
             matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "func"
         }),
-        "require inside eval { } is runtime; should not suppress strict 'subs'"
+        "require inside eval {{ }} is runtime; should not suppress strict 'subs'"
     );
     Ok(())
 }


### PR DESCRIPTION
### Motivation

- The richer lexical pragma tracking must be proven observable by downstream consumers (diagnostic lints and scope analysis) so regression boundaries are explicit.
- Tests should cover eval/package/phase/conditional/no-if cases and version-bundle vs explicit-feature and builtin import/bundle distinctions where behavior matters.
- Make failures easy to diagnose by adding focused consumer-facing tests rather than changing consumer logic.

### Description

- Added focused diagnostics tests in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs` that assert package-scoped `use`/`no` and `no if` conditional toggles do not incorrectly change file-level PL100/PL101 outcomes. 
- Added version compatibility tests in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs` that validate version-bundle vs explicit `use feature`, lexical `no feature` scoping, `builtin` named-import vs bundle distinctions, and that `eval`-STRING toggles do not alter compile-time version compatibility checks (PL900 visibility).
- Added scope analyzer tests in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` to capture current downstream behavior around `use feature 'signatures'` plus lexical `no strict 'vars'`/`no strict 'subs'` and to verify `eval`-STRING `no strict` does not disable downstream strict-vars diagnostics; also fixed a test format string to avoid a runtime format error.

### Testing

- Ran the targeted lint tests via `cargo test -p perl-lsp-rs-core` for the added `version_compat` and `strict_warnings` cases, and the new `version_compat::lexical_no_feature_say_is_honored_inside_block_only` and `strict_warnings` package/eval/conditional tests passed (targeted runs succeeded).
- Ran the scope analyzer tests via `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests` and the new signature/lexical/no/eval tests passed.
- Ran `cargo check --workspace --all-targets` which completed successfully.
- Note: a full `cargo test -p perl-lsp-rs-core` run encountered one pre-existing, unrelated failure in `green_tdd_wave_g1b_regression_hardening::test_perl_lsp_cargo_toml_removed_g1b_imports` (expected missing `crates/perl-lsp/Cargo.toml`), but the newly added tests are green and the change is limited to test coverage only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb777c6ce08333af02d693a08f8312)