### PR TITLE
test(pragma-consumers): add downstream parity coverage for lexical pragma state (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
@@ -660,4 +660,55 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn package_scoped_pragmas_do_not_satisfy_file_level_requirements() {
+        let diags =
+            strict_warnings_diags("package Inner { use strict; use warnings; }\nmy $x = 1;\n");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL100")),
+            "package-scoped strict should not suppress top-level missing-strict (PL100)"
+        );
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL101")),
+            "package-scoped warnings should not suppress top-level missing-warnings (PL101)"
+        );
+    }
+
+    #[test]
+    fn top_level_pragmas_restore_after_package_scope_no_pragmas() {
+        let diags = strict_warnings_diags(
+            "use strict;\nuse warnings;\npackage Inner { no strict; no warnings; }\nmy $x = 1;\n",
+        );
+        assert!(
+            diags.iter().all(|d| !matches!(d.code.as_deref(), Some("PL100") | Some("PL101"))),
+            "no strict/no warnings inside package scope must restore to top-level strict/warnings"
+        );
+    }
+
+    #[test]
+    fn top_level_pragmas_restore_after_phase_scope_no_pragmas() {
+        let diags = strict_warnings_diags(
+            "use strict;\nuse warnings;\nBEGIN { no strict; no warnings; }\nmy $x = 1;\n",
+        );
+        assert!(
+            diags.iter().all(|d| !matches!(d.code.as_deref(), Some("PL100") | Some("PL101"))),
+            "no strict/no warnings inside phase block must restore to top-level strict/warnings"
+        );
+    }
+
+    #[test]
+    fn conditional_no_if_can_disable_file_level_strict_and_warnings() {
+        let diags = strict_warnings_diags(
+            "use strict;\nuse warnings;\nno if 1, 'strict';\nno if 1, 'warnings';\nmy $x = 1;\n",
+        );
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL100")),
+            "conditional no-if strict should be observable as missing-strict (PL100)"
+        );
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL101")),
+            "conditional no-if warnings should be observable as missing-warnings (PL101)"
+        );
+    }
 }

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs
@@ -491,3 +491,69 @@ fn make_diagnostic_with_details(
         suggestion,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser::Parser;
+    use perl_tdd_support::must;
+
+    fn version_diags(source: &str) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let mut diags = Vec::new();
+        check_version_compat(&ast, &mut diags);
+        diags
+    }
+
+    #[test]
+    fn version_bundle_and_explicit_feature_state_are_observable() {
+        let diags = version_diags("use v5.10;\nuse feature 'state';\nstate $x = 1;\nsay 'ok';\n");
+        assert!(
+            diags.is_empty(),
+            "v5.10 bundle + explicit state feature should allow both state/say; got {diags:?}"
+        );
+    }
+
+    #[test]
+    fn explicit_no_feature_disables_bundle_for_downstream_checks() {
+        let diags = version_diags("use v5.10;\nno feature 'say';\nsay 'not allowed';\n");
+        assert!(
+            diags.iter().any(|d| d.message.contains("'say' requires Perl v5.10+")),
+            "no feature 'say' should be visible to version_compat diagnostics; got {diags:?}"
+        );
+    }
+
+    #[test]
+    fn eval_string_feature_toggles_do_not_change_static_version_analysis() {
+        let diags = version_diags("use v5.10;\neval \"no feature 'say'\";\nsay 'still allowed';\n");
+        assert!(
+            diags.is_empty(),
+            "eval STRING feature toggles must not affect static analysis; got {diags:?}"
+        );
+    }
+
+    #[test]
+    fn builtin_imports_and_bundle_have_distinct_version_requirements() {
+        let diags = version_diags(
+            "use v5.36;\nuse builtin 'true';\nbuiltin::true();\nbuiltin::load_module('X');\n",
+        );
+
+        assert!(
+            diags.iter().any(|d| d.message.contains("'builtin::load_module' requires Perl v5.40+")),
+            "non-imported builtin::load_module should still require v5.40; got {diags:?}"
+        );
+        assert!(
+            diags.iter().all(|d| !d.message.contains("'builtin::true'")),
+            "explicit builtin import should suppress builtin::true version warning; got {diags:?}"
+        );
+    }
+
+    #[test]
+    fn builtin_bundle_requirement_is_checked_separately_from_named_imports() {
+        let diags = version_diags("use v5.36;\nuse builtin;\n");
+        assert!(
+            diags.iter().any(|d| d.message.contains("'use builtin' requires Perl v5.40+")),
+            "use builtin bundle should be gated at v5.40 regardless of named-import support; got {diags:?}"
+        );
+    }
+}

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1957,8 +1957,7 @@ print helper_two();
 }
 
 #[test]
-fn strict_subs_still_flags_import_without_require()
--> Result<(), Box<dyn std::error::Error>> {
+fn strict_subs_still_flags_import_without_require() -> Result<(), Box<dyn std::error::Error>> {
     // Guard: ->import() without a preceding require should NOT suppress strict_subs.
     // Bareword identifiers (no parens) are the subject of strict 'subs' checking.
     // Use `print SOME_CONST` to produce an Identifier node rather than a FunctionCall.
@@ -2125,6 +2124,65 @@ sub foo ($x) { $z = 1; }
     assert!(
         !has_issue(&issues, IssueKind::UndeclaredVariable, "x"),
         "signature parameter $x should not be flagged as undeclared"
+    );
+    Ok(())
+}
+
+#[test]
+fn lexical_no_strict_vars_disables_vars_checks_locally() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+sub foo {
+    no strict 'vars';
+    $z = 1;
+}
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "z"),
+        "no strict 'vars' inside signature scope should suppress undeclared-variable diagnostics for $z"
+    );
+    Ok(())
+}
+
+#[test]
+fn lexical_no_strict_subs_disables_bareword_checks_locally()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+sub foo {
+    no strict 'subs';
+    print FOO;
+}
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues
+            .iter()
+            .any(|i| { matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "FOO" }),
+        "no strict 'subs' inside signature scope should suppress bareword diagnostics for FOO"
+    );
+    Ok(())
+}
+
+#[test]
+fn signature_scope_no_strict_vars_restores_after_lexical_scope()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use feature 'signatures';
+sub foo ($x) {
+    no strict 'vars';
+    $z = 1;
+}
+$outer = 2;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        has_issue(&issues, IssueKind::UndeclaredVariable, "outer"),
+        "no strict 'vars' inside signature sub must not leak; $outer should still be flagged"
     );
     Ok(())
 }
@@ -3901,8 +3959,7 @@ print get_value();
 }
 
 #[test]
-fn require_inside_eval_block_is_runtime_not_static()
--> Result<(), Box<dyn std::error::Error>> {
+fn require_inside_eval_block_is_runtime_not_static() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 eval {
@@ -3916,7 +3973,7 @@ print func();
         issues.iter().any(|issue| {
             matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "func"
         }),
-        "require inside eval { } is runtime; should not suppress strict 'subs'"
+        "require inside eval {{ }} is runtime; should not suppress strict 'subs'"
     );
     Ok(())
 }
@@ -3934,7 +3991,8 @@ print exported_func();
     let issues = scope_issues_strict(code);
     assert!(
         issues.iter().any(|issue| {
-            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "exported_func"
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "exported_func"
         }),
         "require with variable target is runtime; should not suppress strict 'subs'"
     );
@@ -3942,8 +4000,7 @@ print exported_func();
 }
 
 #[test]
-fn multiple_imports_from_same_required_module()
--> Result<(), Box<dyn std::error::Error>> {
+fn multiple_imports_from_same_required_module() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 require Toolkit;
@@ -3959,15 +4016,15 @@ print func_c();
             !issues.iter().any(|issue| {
                 matches!(issue.kind, IssueKind::UnquotedBareword) && &issue.variable_name == symbol
             }),
-            "strict 'subs' should not flag {} imported via multiple calls", symbol
+            "strict 'subs' should not flag {} imported via multiple calls",
+            symbol
         );
     }
     Ok(())
 }
 
 #[test]
-fn require_path_form_vs_bareword_normalization()
--> Result<(), Box<dyn std::error::Error>> {
+fn require_path_form_vs_bareword_normalization() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 require "Mismatched/Module.pm";
@@ -3985,8 +4042,7 @@ print exported();
 }
 
 #[test]
-fn import_on_unrequired_module_does_not_suppress()
--> Result<(), Box<dyn std::error::Error>> {
+fn import_on_unrequired_module_does_not_suppress() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 Unrelated::Module->import('orphaned_func');
@@ -3995,7 +4051,8 @@ print orphaned_func();
     let issues = scope_issues_strict(code);
     assert!(
         issues.iter().any(|issue| {
-            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "orphaned_func"
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "orphaned_func"
         }),
         "->import() without preceding require should not suppress strict 'subs'"
     );
@@ -4003,8 +4060,7 @@ print orphaned_func();
 }
 
 #[test]
-fn qw_form_with_special_delimiters()
--> Result<(), Box<dyn std::error::Error>> {
+fn qw_form_with_special_delimiters() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 require Delim::Module;
@@ -4025,8 +4081,7 @@ print sym_two();
 }
 
 #[test]
-fn require_without_subsequent_import_does_nothing()
--> Result<(), Box<dyn std::error::Error>> {
+fn require_without_subsequent_import_does_nothing() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 require Some::Module;
@@ -4035,7 +4090,8 @@ print unimported_symbol();
     let issues = scope_issues_strict(code);
     assert!(
         issues.iter().any(|issue| {
-            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "unimported_symbol"
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "unimported_symbol"
         }),
         "bare require without ->import() should not suppress unrelated symbols"
     );
@@ -4043,8 +4099,7 @@ print unimported_symbol();
 }
 
 #[test]
-fn array_literal_import_args()
--> Result<(), Box<dyn std::error::Error>> {
+fn array_literal_import_args() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 require ArrayImporter;
@@ -4058,15 +4113,15 @@ print sym_y();
             !issues.iter().any(|issue| {
                 matches!(issue.kind, IssueKind::UnquotedBareword) && &issue.variable_name == symbol
             }),
-            "array literal import should register {}", symbol
+            "array literal import should register {}",
+            symbol
         );
     }
     Ok(())
 }
 
 #[test]
-fn nested_blocks_preserve_require_scope()
--> Result<(), Box<dyn std::error::Error>> {
+fn nested_blocks_preserve_require_scope() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';
 {
@@ -4080,7 +4135,8 @@ print nested_func();
     let issues = scope_issues_strict(code);
     assert!(
         !issues.iter().any(|issue| {
-            matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "nested_func"
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "nested_func"
         }),
         "require should be visible to nested import in same program scope"
     );


### PR DESCRIPTION
### Motivation

- Prove that the expanded lexical pragma tracking (PragmaTracker) is actually observable by downstream consumers where it matters: strict/warnings diagnostics, version compatibility linting, and scope analysis.

### Description

- Added consumer-facing unit tests in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs` that exercise version-bundle vs explicit `use feature` state, `no feature` visibility, conservative handling of `eval "..."`, and `builtin` import vs bundle distinctions.
- Added consumer-facing unit tests in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs` to verify lexical restore after package/phase scopes and to assert `no if` conditional `no` is observable at file level.
- Added focused scope analyzer tests in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` to validate `no strict 'vars'` / `no strict 'subs'` behaviour inside lexical blocks and that those lexical disables do not leak beyond their scope.
- Minor test string/format fixes to satisfy formatting and message interpolation in a few existing tests.

### Testing

- Ran `cargo xtask fmt` to format workspace (completed).
- Ran the focused unit tests and they passed: `cargo test -p perl-lsp-rs-core version_bundle_and_explicit_feature_state_are_observable` (ok) and `cargo test -p perl-lsp-rs-core package_scoped_pragmas_do_not_satisfy_file_level_requirements` (ok), and the targeted `perl-semantic-analyzer` test invocations for the new/changed tests passed (e.g. `lexical_no_strict_vars_disables_vars_checks_locally`, `lexical_no_strict_subs_disables_bareword_checks_locally`, `signature_scope_no_strict_vars_restores_after_lexical_scope`).
- Ran `cargo check --workspace --all-targets` which completed successfully.
- Full test suites encountered unrelated, pre-existing failures outside the scope of this change: `cargo test -p perl-lsp-rs-core` surfaced an unrelated missing-path test (`test_perl_lsp_cargo_toml_removed_g1b_imports`) and `cargo test -p perl-semantic-analyzer` initially reported unrelated failing tests prior to focused adjustments; these failures are unrelated to the added parity tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb777c6ce08333af02d693a08f8312)