### PR TITLE
test(pragma-consumers): add downstream parity coverage for lexical pragma state (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
@@ -660,4 +660,23 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn lexical_no_inside_eval_package_and_phase_restores_file_scope_state() {
+        let diags = strict_warnings_diags(
+            "use strict;\n\
+             use warnings;\n\
+             eval { no strict; no warnings; };\n\
+             package Inner {\n\
+                 no strict;\n\
+                 no warnings;\n\
+             }\n\
+             BEGIN { no strict; no warnings; }\n\
+             my $x = 1;\n",
+        );
+        assert!(
+            diags.iter().all(|d| !matches!(d.code.as_deref(), Some("PL100") | Some("PL101"))),
+            "lexical no strict/warnings in eval/package/BEGIN should restore and preserve top-level pragma state; got: {diags:?}"
+        );
+    }
 }

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs
@@ -491,3 +491,58 @@ fn make_diagnostic_with_details(
         suggestion,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser::Parser;
+    use perl_tdd_support::must;
+
+    fn version_compat_diags(source: &str) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let mut diags = vec![];
+        check_version_compat(&ast, &mut diags);
+        diags
+    }
+
+    #[test]
+    fn version_bundle_state_is_visible_to_downstream_feature_checks() {
+        let diags = version_compat_diags("use v5.36;\nsub greet ($name) { say $name; }\n");
+        assert!(
+            diags.is_empty(),
+            "use v5.36 feature bundle should satisfy signatures/say checks; got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn explicit_feature_state_is_visible_to_downstream_feature_checks() {
+        let diags =
+            version_compat_diags("use v5.20;\nuse feature 'signatures';\nsub greet ($name) { }\n");
+        assert!(
+            diags.is_empty(),
+            "explicit feature pragma should satisfy signatures check under lower declared versions; got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn builtin_named_import_is_distinct_from_builtin_bundle() {
+        let only_named_import = version_compat_diags(
+            "use v5.36;\nuse builtin 'true';\nmy $x = builtin::true();\nmy $y = builtin::inf();\n",
+        );
+        assert!(
+            only_named_import.iter().any(|d| d.message.contains("builtin::inf")),
+            "named import should not act like the full builtin bundle; expected builtin::inf warning, got: {only_named_import:?}"
+        );
+        assert!(
+            only_named_import.iter().all(|d| !d.message.contains("builtin::true")),
+            "named import should satisfy builtin::true call; got: {only_named_import:?}"
+        );
+
+        let bundle_decl =
+            version_compat_diags("use v5.36;\nuse builtin;\nmy $x = builtin::inf();\n");
+        assert!(
+            bundle_decl.iter().any(|d| d.message.contains("'use builtin' requires Perl v5.40+")),
+            "bundle import should be validated separately and warn below v5.40; got: {bundle_decl:?}"
+        );
+    }
+}

--- a/crates/perl-semantic-analyzer/tests/pragma_consumer_scope_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/pragma_consumer_scope_tests.rs
@@ -1,0 +1,91 @@
+use perl_semantic_analyzer::Parser;
+use perl_semantic_analyzer::analysis::scope_analyzer::{IssueKind, ScopeAnalyzer, ScopeIssue};
+use perl_semantic_analyzer::pragma_tracker::PragmaTracker;
+use perl_tdd_support::must;
+
+fn scope_issues_with_pragmas(code: &str) -> Vec<ScopeIssue> {
+    let ast = must(Parser::new(code).parse());
+    let pragma_map = PragmaTracker::build(&ast);
+    ScopeAnalyzer::new().analyze(&ast, code, &pragma_map)
+}
+
+fn has_issue(issues: &[ScopeIssue], kind: IssueKind, needle: &str) -> bool {
+    issues.iter().any(|issue| issue.kind == kind && issue.variable_name.contains(needle))
+}
+
+#[test]
+fn signatures_enable_strict_vars_and_strict_subs_checks() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = r#"
+use feature 'signatures';
+sub run ($arg) {
+    $undeclared = $arg;
+    bareword_call;
+}
+"#;
+
+    let issues = scope_issues_with_pragmas(code);
+    assert!(
+        has_issue(&issues, IssueKind::UndeclaredVariable, "undeclared"),
+        "signatures_strict should enable strict vars behavior; issues: {issues:?}"
+    );
+    assert!(
+        has_issue(&issues, IssueKind::UnquotedBareword, "bareword_call"),
+        "signatures_strict should enable strict subs behavior; issues: {issues:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn lexical_no_strict_vars_disables_checks_only_inside_its_scope()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+{
+    no strict 'vars';
+    $inside = 1;
+}
+$outside = 2;
+"#;
+
+    let issues = scope_issues_with_pragmas(code);
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "inside"),
+        "lexical no strict 'vars' should suppress undeclared-variable checks in block; issues: {issues:?}"
+    );
+    assert!(
+        has_issue(&issues, IssueKind::UndeclaredVariable, "outside"),
+        "strict vars should be restored after block and catch outside usage; issues: {issues:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn conditional_no_and_eval_string_changes_are_visible_in_scope_analysis()
+-> Result<(), Box<dyn std::error::Error>> {
+    let conditional_disable = r#"
+use strict;
+no if 1, 'strict', 'vars';
+$conditional = 1;
+"#;
+    let conditional_issues = scope_issues_with_pragmas(conditional_disable);
+    assert!(
+        !has_issue(&conditional_issues, IssueKind::UndeclaredVariable, "conditional"),
+        "conditional no strict vars should disable strict-vars checks downstream; issues: {conditional_issues:?}"
+    );
+
+    let eval_string_disable = r#"
+use strict;
+eval "no strict 'vars';";
+$still_strict = 1;
+"#;
+    let eval_string_issues = scope_issues_with_pragmas(eval_string_disable);
+    assert!(
+        has_issue(&eval_string_issues, IssueKind::UndeclaredVariable, "still_strict"),
+        "eval STRING pragma text should not relax outer strict-vars checks; issues: {eval_string_issues:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Ensure the richer `PragmaTracker` surface is observable by downstream consumers where it matters (diagnostics and scope analysis). 
- Prove lexical `no`/`use` restores and phase/package/eval distinctions do not silently leak top-level pragma state. 
- Capture parity for version-bundle vs explicit `use feature` behavior and `builtin` named-import vs bundle semantics.

### Description

- Added a strict/warnings consumer test in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs` that verifies top-level pragma state is preserved/restored after `eval`, `package`, and phase (`BEGIN`) scoped `no strict`/`no warnings` uses. 
- Added downstream `version_compat` tests in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs` verifying `use v5.36` bundle, explicit `use feature 'signatures'`, and `use builtin 'name'` vs `use builtin;` semantics. 
- Added new consumer-focused scope tests in `crates/perl-semantic-analyzer/tests/pragma_consumer_scope_tests.rs` validating that `signatures` enables `strict_vars`/`strict_subs` behavior, lexical `no strict 'vars'` is scoped to a block, and that conditional `no` vs `eval` STRING differences are observable by the `ScopeAnalyzer`.
- Changes are limited to tests only; no production code logic was modified.

### Testing

- Ran `cargo test -p perl-lsp-rs-core lexical_no_inside_eval_package_and_phase_restores_file_scope_state` and the new strict/warnings test passed. 
- Ran the focused `version_compat` unit test (`cargo test -p perl-lsp-rs-core builtin_named_import_is_distinct_from_builtin_bundle`) and it passed. 
- Ran the new semantic-analyzer test binary with `cargo test -p perl-semantic-analyzer --test pragma_consumer_scope_tests` and all tests in that file passed. 
- Ran `cargo xtask fmt` (format) successfully, but `cargo check --workspace --all-targets` and full `cargo test -p perl-semantic-analyzer` / `cargo test -p perl-lsp-rs-core` revealed pre-existing unrelated failures (a format-string error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` and a missing path asserted by an existing test), so the workspace-wide gate did not complete green; the failing items are pre-existing and unrelated to these test additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb777c6ce08333af02d693a08f8312)