### PR TITLE
feat(perl-pragma): add PragmaMap and cursor-style query APIs (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -416,42 +416,161 @@ fn conditional_pragma_target(args: &[String]) -> Option<(&str, &[String])> {
 /// Tracks pragma state throughout a Perl file
 pub struct PragmaTracker;
 
+/// Owned, query-oriented pragma state map.
+///
+/// This structure precomputes the sorted pragma range starts and final lexical
+/// state so repeated queries avoid re-reading tuple fields and callers do not
+/// need sentinel offsets (e.g. `usize::MAX`) to ask for top-level state.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct PragmaMap {
+    ranges: Vec<(Range<usize>, PragmaState)>,
+    starts: Vec<usize>,
+    final_state: PragmaState,
+}
+
+impl PragmaMap {
+    /// Create an owned query map from tracker ranges.
+    #[must_use]
+    pub fn from_ranges(mut ranges: Vec<(Range<usize>, PragmaState)>) -> Self {
+        ranges.sort_by_key(|(range, _)| range.start);
+        let starts = ranges.iter().map(|(range, _)| range.start).collect();
+        let final_state =
+            ranges.last().map_or_else(PragmaState::default, |(_, state)| effective_state(state));
+
+        Self { ranges, starts, final_state }
+    }
+
+    /// Returns `true` when there are no tracked pragma transitions.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.ranges.is_empty()
+    }
+
+    /// Returns the number of tracked pragma transitions.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.ranges.len()
+    }
+
+    /// Returns effective pragma state at `offset`.
+    #[must_use]
+    pub fn state_at(&self, offset: usize) -> PragmaState {
+        let idx = self.starts.partition_point(|start| *start <= offset);
+        self.state_from_partition_index(idx)
+    }
+
+    /// Returns final/top-level effective state without sentinel offsets.
+    #[must_use]
+    pub fn final_state(&self) -> PragmaState {
+        self.final_state.clone()
+    }
+
+    /// Borrow a cursor optimized for repeated queries against this map.
+    #[must_use]
+    pub fn cursor(&self) -> PragmaCursor<'_> {
+        PragmaCursor::new(self)
+    }
+
+    /// Returns raw range/state entries in sorted order.
+    #[must_use]
+    pub fn as_ranges(&self) -> &[(Range<usize>, PragmaState)] {
+        &self.ranges
+    }
+
+    fn state_from_partition_index(&self, idx: usize) -> PragmaState {
+        if idx == 0 {
+            return PragmaState::default();
+        }
+
+        effective_state(&self.ranges[idx - 1].1)
+    }
+}
+
+/// Cursor for repeated `state_at` lookups on a [`PragmaMap`].
+#[derive(Debug)]
+pub struct PragmaCursor<'a> {
+    map: &'a PragmaMap,
+    last_idx: usize,
+    last_offset: Option<usize>,
+}
+
+impl<'a> PragmaCursor<'a> {
+    /// Construct a new cursor for an existing map.
+    #[must_use]
+    pub fn new(map: &'a PragmaMap) -> Self {
+        Self { map, last_idx: 0, last_offset: None }
+    }
+
+    /// Returns effective pragma state at `offset`.
+    ///
+    /// For monotonically increasing offsets, this reuses the last partition
+    /// point and only scans forward through start offsets.
+    #[must_use]
+    pub fn state_at(&mut self, offset: usize) -> PragmaState {
+        let idx = if self.last_offset.is_some_and(|last_offset| offset >= last_offset) {
+            self.last_idx
+                + self.map.starts[self.last_idx..].partition_point(|start| *start <= offset)
+        } else {
+            self.map.starts.partition_point(|start| *start <= offset)
+        };
+
+        self.last_idx = idx;
+        self.last_offset = Some(offset);
+        self.map.state_from_partition_index(idx)
+    }
+
+    /// Returns final/top-level effective state for the cursor's map.
+    #[must_use]
+    pub fn final_state(&self) -> PragmaState {
+        self.map.final_state()
+    }
+}
+
+fn effective_state(state: &PragmaState) -> PragmaState {
+    let mut state = state.clone();
+
+    if state.signatures_strict {
+        state.strict_vars = true;
+        state.strict_subs = true;
+        state.strict_refs = true;
+    }
+
+    state
+}
+
 impl PragmaTracker {
-    /// Build a range-indexed pragma map from an AST
-    pub fn build(ast: &Node) -> Vec<(Range<usize>, PragmaState)> {
+    /// Build an owned query map from an AST.
+    #[must_use]
+    pub fn build_map(ast: &Node) -> PragmaMap {
         let mut ranges = Vec::new();
         let mut current_state = PragmaState::default();
 
         // Build the pragma map by walking the AST
         Self::build_ranges(ast, &mut current_state, &mut ranges);
 
-        // Sort by start offset
-        ranges.sort_by_key(|(range, _)| range.start);
+        PragmaMap::from_ranges(ranges)
+    }
 
-        ranges
+    /// Build a range-indexed pragma map from an AST
+    ///
+    /// Compatibility wrapper: prefer [`Self::build_map`] for owned query APIs.
+    pub fn build(ast: &Node) -> Vec<(Range<usize>, PragmaState)> {
+        Self::build_map(ast).ranges
     }
 
     /// Get the pragma state at a specific byte offset
+    ///
+    /// Compatibility wrapper: prefer [`PragmaMap::state_at`].
     pub fn state_for_offset(
         pragma_map: &[(Range<usize>, PragmaState)],
         offset: usize,
     ) -> PragmaState {
-        // Find the last pragma state that starts before this offset.
-        // pragma_map is sorted by start offset (guaranteed by build()).
-        // We use partition_point to find the first element where start > offset,
-        // then take the element before it.
         let idx = pragma_map.partition_point(|(range, _)| range.start <= offset);
-
-        let mut state =
-            if idx > 0 { pragma_map[idx - 1].1.clone() } else { PragmaState::default() };
-
-        if state.signatures_strict {
-            state.strict_vars = true;
-            state.strict_subs = true;
-            state.strict_refs = true;
+        if idx == 0 {
+            return PragmaState::default();
         }
 
-        state
+        effective_state(&pragma_map[idx - 1].1)
     }
 
     /// Process a lexically scoped body and then restore the caller state.

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -131,6 +131,33 @@ fn given_use_v5_40_when_querying_state_then_effective_strict_warnings_and_featur
 }
 
 #[test]
+fn given_built_query_map_when_asking_for_final_state_then_no_sentinel_offset_is_needed() {
+    let ast = program(vec![use_node("strict", &[], 0, 12), use_node("warnings", &[], 13, 28)]);
+    let query_map = PragmaTracker::build_map(&ast);
+
+    let final_state = query_map.final_state();
+    assert!(final_state.strict_vars);
+    assert!(final_state.strict_subs);
+    assert!(final_state.strict_refs);
+    assert!(final_state.warnings);
+}
+
+#[test]
+fn given_query_cursor_when_reading_forward_offsets_then_state_tracks_lexical_transitions() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        no_node("strict", &["refs"], 13, 31),
+        use_node("warnings", &[], 32, 47),
+    ]);
+    let query_map = PragmaTracker::build_map(&ast);
+    let mut cursor = query_map.cursor();
+
+    assert!(cursor.state_at(8).strict_refs);
+    assert!(!cursor.state_at(20).strict_refs);
+    assert!(cursor.state_at(40).warnings);
+}
+
+#[test]
 fn given_use_builtin_qw_when_querying_scope_then_each_imported_name_is_available() {
     let ast = program(vec![use_node("builtin", &["qw(true false ceil)"], 0, 30)]);
     let map = PragmaTracker::build(&ast);

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -5,7 +5,9 @@
 
 use perl_ast::SourceLocation;
 use perl_ast::ast::{Node, NodeKind};
-use perl_pragma::{PerlVersion, PragmaState, PragmaTracker, features_enabled_by_version};
+use perl_pragma::{
+    PerlVersion, PragmaMap, PragmaState, PragmaTracker, features_enabled_by_version,
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1008,6 +1010,49 @@ fn state_for_offset_between_two_pragmas() -> Result<(), Box<dyn std::error::Erro
     let state = PragmaTracker::state_for_offset(&map, 50);
     assert!(state.strict_vars);
     assert!(!state.warnings);
+    Ok(())
+}
+
+#[test]
+fn pragma_map_final_state_matches_legacy_high_offset_query()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("strict", &[], 0, 12), use_node("warnings", &[], 50, 65)]);
+    let map = PragmaTracker::build(&ast);
+    let query_map = PragmaTracker::build_map(&ast);
+
+    assert_eq!(query_map.final_state(), PragmaTracker::state_for_offset(&map, usize::MAX));
+    Ok(())
+}
+
+#[test]
+fn pragma_map_state_at_matches_legacy_wrapper() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        no_node("strict", &["refs"], 20, 35),
+        use_node("warnings", &[], 40, 55),
+    ]);
+    let raw_map = PragmaTracker::build(&ast);
+    let query_map = PragmaTracker::build_map(&ast);
+
+    assert_eq!(query_map.state_at(10), PragmaTracker::state_for_offset(&raw_map, 10));
+    assert_eq!(query_map.state_at(30), PragmaTracker::state_for_offset(&raw_map, 30));
+    assert_eq!(query_map.state_at(50), PragmaTracker::state_for_offset(&raw_map, 50));
+    Ok(())
+}
+
+#[test]
+fn pragma_map_cursor_supports_repeated_queries() -> Result<(), Box<dyn std::error::Error>> {
+    let query_map = PragmaMap::from_ranges(vec![
+        (0..12, PragmaState::all_strict()),
+        (20..30, PragmaState::default()),
+        (40..50, PragmaState { warnings: true, ..PragmaState::default() }),
+    ]);
+    let mut cursor = query_map.cursor();
+
+    assert!(cursor.state_at(5).strict_vars);
+    assert!(!cursor.state_at(25).strict_vars);
+    assert!(cursor.state_at(45).warnings);
+    assert!(cursor.final_state().warnings);
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- Downstream callers were repeatedly performing binary-search-plus-clone work against the raw `Vec<(Range<usize>, PragmaState)>` and were using sentinel offsets like `usize::MAX` to ask for the final/top-level pragma state.

### Description

- Add an owned query surface `PragmaMap` that precomputes sorted `starts` and caches the `final_state`, and provide `PragmaMap::from_ranges`, `PragmaMap::state_at`, `PragmaMap::final_state`, and `PragmaMap::as_ranges` for cheap repeated queries.
- Add a `PragmaCursor` with `state_at` and `final_state` optimized for monotonic forward queries to avoid repeated full binary searches.
- Add `PragmaTracker::build_map(ast) -> PragmaMap` as the new builder and keep `PragmaTracker::build()` and `PragmaTracker::state_for_offset()` as compatibility wrappers that preserve existing semantics; centralize the signatures-driven projection into `effective_state()` so all query paths behave identically.
- Updated and added tests to cover `PragmaMap` / `PragmaCursor` parity with the legacy wrappers and final-state querying; modified files: `crates/perl-pragma/src/lib.rs`, `crates/perl-pragma/tests/comprehensive_unit_tests.rs`, and `crates/perl-pragma/tests/behavior_spec_tests.rs`.

### Testing

- Ran `cargo test -p perl-pragma` and the crate test suite passed (all new and existing tests succeeded).
- Ran `cargo check --all-targets -p perl-pragma` and the crate built successfully with no errors.
- Ran `cargo xtask fmt` to format changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb777f33248333b6d3e2d33e82335c)