### PR TITLE
feat(perl-pragma): add PragmaMap and cursor-style query APIs (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -416,42 +416,162 @@ fn conditional_pragma_target(args: &[String]) -> Option<(&str, &[String])> {
 /// Tracks pragma state throughout a Perl file
 pub struct PragmaTracker;
 
+/// Owned query map for efficient repeated pragma-state lookups.
+#[derive(Debug, Clone, Default)]
+pub struct PragmaMap {
+    ranges: Vec<(Range<usize>, PragmaState)>,
+    starts: Vec<usize>,
+    effective_states: Vec<PragmaState>,
+    default_state: PragmaState,
+    final_state: PragmaState,
+}
+
+impl PragmaMap {
+    /// Build a query map from precomputed pragma ranges.
+    #[must_use]
+    pub fn from_ranges(mut ranges: Vec<(Range<usize>, PragmaState)>) -> Self {
+        ranges.sort_by_key(|(range, _)| range.start);
+
+        let starts = ranges.iter().map(|(range, _)| range.start).collect();
+        let effective_states =
+            ranges.iter().map(|(_, state)| effective_state(state)).collect::<Vec<_>>();
+        let default_state = PragmaState::default();
+        let final_state = effective_states.last().cloned().unwrap_or_default();
+
+        Self { ranges, starts, effective_states, default_state, final_state }
+    }
+
+    /// Returns an immutable view of the underlying range/state entries.
+    #[must_use]
+    pub fn ranges(&self) -> &[(Range<usize>, PragmaState)] {
+        &self.ranges
+    }
+
+    /// Returns the number of tracked pragma transitions.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.ranges.len()
+    }
+
+    /// Returns true when there are no pragma transitions in this map.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.ranges.is_empty()
+    }
+
+    /// Consume the map and return its owned range/state entries.
+    #[must_use]
+    pub fn into_ranges(self) -> Vec<(Range<usize>, PragmaState)> {
+        self.ranges
+    }
+
+    /// Return the effective pragma state at a byte offset.
+    #[must_use]
+    pub fn state_at(&self, offset: usize) -> &PragmaState {
+        let idx = self.starts.partition_point(|start| *start <= offset);
+        if idx == 0 { &self.default_state } else { &self.effective_states[idx - 1] }
+    }
+
+    /// Return the final (top-level end-of-file) effective pragma state.
+    #[must_use]
+    pub fn final_state(&self) -> &PragmaState {
+        &self.final_state
+    }
+
+    /// Create a cursor optimized for repeated ordered queries.
+    #[must_use]
+    pub fn cursor(&self) -> PragmaCursor<'_> {
+        PragmaCursor::new(self)
+    }
+}
+
+/// Cursor-style state query helper that can avoid repeated binary searches.
+#[derive(Debug)]
+pub struct PragmaCursor<'a> {
+    map: &'a PragmaMap,
+    current_index: Option<usize>,
+}
+
+impl<'a> PragmaCursor<'a> {
+    #[must_use]
+    pub fn new(map: &'a PragmaMap) -> Self {
+        Self { map, current_index: None }
+    }
+
+    /// Return the effective pragma state at a byte offset.
+    #[must_use]
+    pub fn state_at(&mut self, offset: usize) -> &'a PragmaState {
+        if self.map.starts.is_empty() {
+            return &self.map.default_state;
+        }
+
+        let idx = match self.current_index {
+            Some(current) if self.map.starts[current] <= offset => {
+                let mut next = current;
+                while next + 1 < self.map.starts.len() && self.map.starts[next + 1] <= offset {
+                    next += 1;
+                }
+                next
+            }
+            _ => {
+                let partition = self.map.starts.partition_point(|start| *start <= offset);
+                if partition == 0 {
+                    self.current_index = None;
+                    return &self.map.default_state;
+                }
+                partition - 1
+            }
+        };
+
+        self.current_index = Some(idx);
+        &self.map.effective_states[idx]
+    }
+
+    /// Return the final (top-level end-of-file) effective pragma state.
+    #[must_use]
+    pub fn final_state(&self) -> &'a PragmaState {
+        self.map.final_state()
+    }
+}
+
+fn effective_state(state: &PragmaState) -> PragmaState {
+    let mut effective = state.clone();
+    if effective.signatures_strict {
+        effective.strict_vars = true;
+        effective.strict_subs = true;
+        effective.strict_refs = true;
+    }
+    effective
+}
+
 impl PragmaTracker {
-    /// Build a range-indexed pragma map from an AST
-    pub fn build(ast: &Node) -> Vec<(Range<usize>, PragmaState)> {
+    /// Build an owned pragma query map from an AST.
+    #[must_use]
+    pub fn build_map(ast: &Node) -> PragmaMap {
         let mut ranges = Vec::new();
         let mut current_state = PragmaState::default();
 
         // Build the pragma map by walking the AST
         Self::build_ranges(ast, &mut current_state, &mut ranges);
 
-        // Sort by start offset
-        ranges.sort_by_key(|(range, _)| range.start);
+        PragmaMap::from_ranges(ranges)
+    }
 
-        ranges
+    /// Build a range-indexed pragma map from an AST
+    ///
+    /// Compatibility wrapper around [`Self::build_map`].
+    pub fn build(ast: &Node) -> Vec<(Range<usize>, PragmaState)> {
+        Self::build_map(ast).into_ranges()
     }
 
     /// Get the pragma state at a specific byte offset
+    ///
+    /// Compatibility wrapper around [`PragmaMap::state_at`].
     pub fn state_for_offset(
         pragma_map: &[(Range<usize>, PragmaState)],
         offset: usize,
     ) -> PragmaState {
-        // Find the last pragma state that starts before this offset.
-        // pragma_map is sorted by start offset (guaranteed by build()).
-        // We use partition_point to find the first element where start > offset,
-        // then take the element before it.
-        let idx = pragma_map.partition_point(|(range, _)| range.start <= offset);
-
-        let mut state =
-            if idx > 0 { pragma_map[idx - 1].1.clone() } else { PragmaState::default() };
-
-        if state.signatures_strict {
-            state.strict_vars = true;
-            state.strict_subs = true;
-            state.strict_refs = true;
-        }
-
-        state
+        PragmaMap::from_ranges(pragma_map.to_vec()).state_at(offset).clone()
     }
 
     /// Process a lexically scoped body and then restore the caller state.

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -267,6 +267,18 @@ fn given_end_block_with_use_warnings_when_querying_after_block_then_warnings_is_
 }
 
 #[test]
+fn given_top_level_pragmas_when_querying_final_state_then_no_sentinel_offset_is_required() {
+    let ast = program(vec![use_node("strict", &[], 0, 12), use_node("warnings", &[], 13, 28)]);
+    let map = PragmaTracker::build_map(&ast);
+
+    let final_state = map.final_state();
+    assert!(final_state.strict_vars);
+    assert!(final_state.strict_subs);
+    assert!(final_state.strict_refs);
+    assert!(final_state.warnings);
+}
+
+#[test]
 fn given_init_block_with_use_strict_when_querying_after_block_then_strict_is_not_active() {
     let ast = program(vec![phase_block(
         "INIT",

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -5,7 +5,9 @@
 
 use perl_ast::SourceLocation;
 use perl_ast::ast::{Node, NodeKind};
-use perl_pragma::{PerlVersion, PragmaState, PragmaTracker, features_enabled_by_version};
+use perl_pragma::{
+    PerlVersion, PragmaMap, PragmaState, PragmaTracker, features_enabled_by_version,
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1008,6 +1010,59 @@ fn state_for_offset_between_two_pragmas() -> Result<(), Box<dyn std::error::Erro
     let state = PragmaTracker::state_for_offset(&map, 50);
     assert!(state.strict_vars);
     assert!(!state.warnings);
+    Ok(())
+}
+
+#[test]
+fn pragma_map_final_state_matches_end_of_file_state() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("strict", &[], 0, 12), use_node("warnings", &[], 13, 28)]);
+    let query = PragmaTracker::build_map(&ast);
+
+    let final_state = query.final_state();
+    assert!(final_state.strict_vars);
+    assert!(final_state.strict_subs);
+    assert!(final_state.strict_refs);
+    assert!(final_state.warnings);
+    Ok(())
+}
+
+#[test]
+fn pragma_map_cursor_tracks_state_across_ordered_offsets() -> Result<(), Box<dyn std::error::Error>>
+{
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        no_node("strict", &["refs"], 13, 29),
+        use_node("warnings", &[], 30, 45),
+    ]);
+    let query = PragmaTracker::build_map(&ast);
+    let mut cursor = query.cursor();
+
+    let start_state = cursor.state_at(5);
+    assert!(start_state.strict_refs);
+    assert!(!start_state.warnings);
+
+    let middle_state = cursor.state_at(20);
+    assert!(!middle_state.strict_refs);
+    assert!(!middle_state.warnings);
+
+    let end_state = cursor.state_at(40);
+    assert!(!end_state.strict_refs);
+    assert!(end_state.warnings);
+    Ok(())
+}
+
+#[test]
+fn compatibility_wrapper_state_for_offset_matches_query_surface()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("feature", &["'signatures'"], 0, 24)]);
+    let legacy = PragmaTracker::build(&ast);
+    let query = PragmaMap::from_ranges(legacy.clone());
+
+    let from_legacy = PragmaTracker::state_for_offset(&legacy, 12);
+    let from_query = query.state_at(12);
+
+    assert_eq!(from_legacy, *from_query);
+    assert!(from_query.strict_vars && from_query.strict_subs && from_query.strict_refs);
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Repeated consumers of the raw pragma `Vec<(Range<usize>, PragmaState)>` paid a binary-search-plus-clone cost for every query and relied on sentinel offsets (e.g. `usize::MAX`) to get final/top-level state.
- Provide an owned, efficient query surface to make repeated and ordered queries cheap while preserving exact lexical semantics.

### Description
- Added an owned query object `PragmaMap` with precomputed `starts: Vec<usize>` and `effective_states: Vec<PragmaState>` and APIs `PragmaMap::from_ranges`, `PragmaMap::state_at`, and `PragmaMap::final_state` for cheap lookups.
- Added `PragmaCursor` with `state_at` and `final_state` to efficiently handle repeated ordered offset queries without repeated binary searches.
- Introduced `PragmaTracker::build_map(ast: &Node) -> PragmaMap` and kept `PragmaTracker::build()` and `PragmaTracker::state_for_offset()` as compatibility wrappers delegating through the new query surface.
- Preserved original lexical semantics by computing `effective_state` (handles `signatures_strict`) and updated tests to cover `final_state`, cursor progression, and compatibility parity with the legacy API.

### Testing
- Ran `cargo xtask fmt` to format the workspace which completed successfully.
- Ran `cargo test -p perl-pragma` and all unit and behavior-spec tests passed (`127` tests ran, all OK).
- Ran `cargo check --all-targets -p perl-pragma` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb777f33248333b6d3e2d33e82335c)