### PR TITLE
feat(perl-pragma): add PragmaMap and cursor-style query APIs (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -413,6 +413,105 @@ fn conditional_pragma_target(args: &[String]) -> Option<(&str, &[String])> {
     })
 }
 
+/// Owned, query-oriented pragma state map.
+///
+/// This wraps the raw range/state entries with precomputed lookup data so
+/// repeated `state_at` queries avoid rebuilding search inputs and post-query
+/// fixups.
+#[derive(Debug, Clone, Default)]
+pub struct PragmaMap {
+    ranges: Vec<(Range<usize>, PragmaState)>,
+    starts: Vec<usize>,
+    effective_states: Vec<PragmaState>,
+    final_state: PragmaState,
+}
+
+impl PragmaMap {
+    /// Build a query map directly from an AST.
+    #[must_use]
+    pub fn build(ast: &Node) -> Self {
+        Self::from_ranges(PragmaTracker::build(ast))
+    }
+
+    /// Build a query map from a precomputed range/state vector.
+    #[must_use]
+    pub fn from_ranges(ranges: Vec<(Range<usize>, PragmaState)>) -> Self {
+        let starts: Vec<usize> = ranges.iter().map(|(range, _)| range.start).collect();
+        let effective_states: Vec<PragmaState> =
+            ranges.iter().map(|(_, state)| effective_state(state)).collect();
+        let final_state = effective_states.last().cloned().unwrap_or_else(PragmaState::default);
+
+        Self { ranges, starts, effective_states, final_state }
+    }
+
+    /// Return the effective pragma state at `offset`.
+    #[must_use]
+    pub fn state_at(&self, offset: usize) -> PragmaState {
+        let idx = self.starts.partition_point(|start| *start <= offset);
+        if idx > 0 { self.effective_states[idx - 1].clone() } else { PragmaState::default() }
+    }
+
+    /// Return the effective top-level/final state after all tracked directives.
+    #[must_use]
+    pub fn final_state(&self) -> PragmaState {
+        self.final_state.clone()
+    }
+
+    /// Create a cursor for repeated queries.
+    #[must_use]
+    pub fn cursor(&self) -> PragmaCursor<'_> {
+        PragmaCursor { map: self, idx: 0 }
+    }
+
+    /// Return raw ranges for compatibility callers that still need them.
+    #[must_use]
+    pub fn ranges(&self) -> &[(Range<usize>, PragmaState)] {
+        &self.ranges
+    }
+}
+
+/// Cursor-style query helper that can reuse the last lookup position.
+#[derive(Debug, Clone)]
+pub struct PragmaCursor<'a> {
+    map: &'a PragmaMap,
+    idx: usize,
+}
+
+impl PragmaCursor<'_> {
+    /// Return the effective pragma state at `offset` and advance internal hints.
+    #[must_use]
+    pub fn state_at(&mut self, offset: usize) -> PragmaState {
+        while self.idx < self.map.starts.len() && self.map.starts[self.idx] <= offset {
+            self.idx += 1;
+        }
+        while self.idx > 0 && self.map.starts[self.idx - 1] > offset {
+            self.idx -= 1;
+        }
+
+        if self.idx > 0 {
+            self.map.effective_states[self.idx - 1].clone()
+        } else {
+            PragmaState::default()
+        }
+    }
+
+    /// Return the effective final state of the map.
+    #[must_use]
+    pub fn final_state(&self) -> PragmaState {
+        self.map.final_state()
+    }
+}
+
+fn effective_state(state: &PragmaState) -> PragmaState {
+    let mut effective = state.clone();
+    if effective.signatures_strict {
+        effective.strict_vars = true;
+        effective.strict_subs = true;
+        effective.strict_refs = true;
+    }
+    effective
+}
+
 /// Tracks pragma state throughout a Perl file
 pub struct PragmaTracker;
 
@@ -436,22 +535,12 @@ impl PragmaTracker {
         pragma_map: &[(Range<usize>, PragmaState)],
         offset: usize,
     ) -> PragmaState {
-        // Find the last pragma state that starts before this offset.
-        // pragma_map is sorted by start offset (guaranteed by build()).
-        // We use partition_point to find the first element where start > offset,
-        // then take the element before it.
         let idx = pragma_map.partition_point(|(range, _)| range.start <= offset);
-
-        let mut state =
-            if idx > 0 { pragma_map[idx - 1].1.clone() } else { PragmaState::default() };
-
-        if state.signatures_strict {
-            state.strict_vars = true;
-            state.strict_subs = true;
-            state.strict_refs = true;
+        if idx > 0 {
+            effective_state(&pragma_map[idx - 1].1)
+        } else {
+            PragmaState::default()
         }
-
-        state
     }
 
     /// Process a lexically scoped body and then restore the caller state.

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -5,7 +5,7 @@
 
 use perl_ast::SourceLocation;
 use perl_ast::ast::{Node, NodeKind};
-use perl_pragma::{PragmaState, PragmaTracker};
+use perl_pragma::{PragmaMap, PragmaState, PragmaTracker};
 
 fn loc(start: usize, end: usize) -> SourceLocation {
     SourceLocation { start, end }
@@ -312,4 +312,16 @@ fn given_unitcheck_block_with_use_strict_when_querying_after_block_then_strict_i
     assert!(!after_unitcheck.strict_vars);
     assert!(!after_unitcheck.strict_subs);
     assert!(!after_unitcheck.strict_refs);
+}
+
+#[test]
+fn given_top_level_pragmas_when_querying_final_state_then_no_max_offset_is_needed() {
+    let ast = program(vec![use_node("strict", &[], 0, 12), use_node("warnings", &[], 13, 28)]);
+    let query_map = PragmaMap::build(&ast);
+
+    let final_state = query_map.final_state();
+    assert!(final_state.strict_vars);
+    assert!(final_state.strict_subs);
+    assert!(final_state.strict_refs);
+    assert!(final_state.warnings);
 }

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -5,7 +5,9 @@
 
 use perl_ast::SourceLocation;
 use perl_ast::ast::{Node, NodeKind};
-use perl_pragma::{PerlVersion, PragmaState, PragmaTracker, features_enabled_by_version};
+use perl_pragma::{
+    PerlVersion, PragmaCursor, PragmaMap, PragmaState, PragmaTracker, features_enabled_by_version,
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1634,5 +1636,54 @@ fn package_block_pragma_inside_is_visible_at_inner_offset() -> Result<(), Box<dy
 
     let inside = PragmaTracker::state_for_offset(&map, 30);
     assert!(inside.strict_vars, "strict_vars declared inside package block must be visible");
+    Ok(())
+}
+
+#[test]
+fn pragma_map_final_state_matches_top_level_without_sentinel_offset()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("strict", &[], 0, 12), use_node("warnings", &[], 13, 28)]);
+    let query_map = PragmaMap::build(&ast);
+
+    let final_state = query_map.final_state();
+    assert!(final_state.strict_vars);
+    assert!(final_state.strict_subs);
+    assert!(final_state.strict_refs);
+    assert!(final_state.warnings);
+    Ok(())
+}
+
+#[test]
+fn pragma_map_state_at_matches_compatibility_wrapper() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        block(vec![no_node("strict", &["refs"], 15, 31)], 13, 33),
+        use_node("warnings", &[], 34, 49),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let query_map = PragmaMap::from_ranges(map.clone());
+
+    let via_tracker = PragmaTracker::state_for_offset(&map, 40);
+    let via_query = query_map.state_at(40);
+    assert_eq!(via_query, via_tracker);
+    Ok(())
+}
+
+#[test]
+fn pragma_cursor_supports_repeated_queries() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        no_node("strict", &["refs"], 13, 29),
+        use_node("warnings", &[], 30, 45),
+    ]);
+    let query_map = PragmaMap::build(&ast);
+    let mut cursor: PragmaCursor<'_> = query_map.cursor();
+
+    let first = cursor.state_at(10);
+    let second = cursor.state_at(35);
+
+    assert!(first.strict_refs);
+    assert!(!second.strict_refs);
+    assert!(second.warnings);
     Ok(())
 }


### PR DESCRIPTION
### Motivation

- Downstream callers repeatedly binary-searched raw range/state Vecs and applied identical post-query fixups, and many relied on sentinel offsets to obtain the top-level state, causing wasted work for repeated queries.
- Provide an owned, query-oriented surface that precomputes lookup data and exposes an explicit final/top-level API so callers can query efficiently and avoid sentinel offsets.

### Description

- Introduce `PragmaMap` which owns the `(Range<usize>, PragmaState)` vector and precomputes `starts`, `effective_states`, and `final_state`, and expose `PragmaMap::build`, `PragmaMap::from_ranges`, `state_at`, `final_state`, and `ranges` accessors.
- Add `PragmaCursor` to support cursor-style repeated queries that reuse the last lookup position via `PragmaCursor::state_at` and `final_state`.
- Factor the signature-driven post-processing into `effective_state` and ensure `PragmaTracker::state_for_offset` preserves prior semantics by delegating to the same effective-state logic.
- Add tests and update existing test imports to cover `PragmaMap` and `PragmaCursor`, including final-state queries without `usize::MAX`, parity with the compatibility wrapper, and cursor repeated-query behavior.

### Testing

- Ran `cargo test -p perl-pragma` which completed successfully; behavior tests (19) and comprehensive unit tests (108) all passed.
- Ran `cargo check --all-targets -p perl-pragma` which passed, and `cargo clippy -p perl-pragma` which passed; formatting via `cargo xtask fmt` was executed.
- Attempted `just pr-fast` but the `just` binary is not installed in this environment so that step could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb777f33248333b6d3e2d33e82335c)