### PR TITLE
feat(perl-pragma): add PragmaMap and cursor-style query APIs (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -413,22 +413,126 @@ fn conditional_pragma_target(args: &[String]) -> Option<(&str, &[String])> {
     })
 }
 
+fn apply_effective_state_overrides(state: &mut PragmaState) {
+    if state.signatures_strict {
+        state.strict_vars = true;
+        state.strict_subs = true;
+        state.strict_refs = true;
+    }
+}
+
+/// Owned pragma query map for repeated state lookups.
+#[derive(Debug, Clone, Default)]
+pub struct PragmaMap {
+    ranges: Vec<(Range<usize>, PragmaState)>,
+    starts: Vec<usize>,
+    default_state: PragmaState,
+    final_state: PragmaState,
+}
+
+impl PragmaMap {
+    /// Build a query map from an AST.
+    #[must_use]
+    pub fn build(ast: &Node) -> Self {
+        let mut ranges = Vec::new();
+        let mut current_state = PragmaState::default();
+        PragmaTracker::build_ranges(ast, &mut current_state, &mut ranges);
+        Self::from_ranges(ranges)
+    }
+
+    /// Build a query map from tracker-compatible ranges.
+    #[must_use]
+    pub fn from_ranges(mut ranges: Vec<(Range<usize>, PragmaState)>) -> Self {
+        ranges.sort_by_key(|(range, _)| range.start);
+        for (_, state) in &mut ranges {
+            apply_effective_state_overrides(state);
+        }
+
+        let default_state = PragmaState::default();
+        let final_state =
+            ranges.last().map_or_else(|| default_state.clone(), |(_, state)| state.clone());
+        let starts = ranges.iter().map(|(range, _)| range.start).collect();
+
+        Self { ranges, starts, default_state, final_state }
+    }
+
+    /// Returns the effective top-level final state.
+    #[must_use]
+    pub fn final_state(&self) -> PragmaState {
+        self.final_state.clone()
+    }
+
+    /// Returns the effective state for a byte offset.
+    #[must_use]
+    pub fn state_at(&self, offset: usize) -> PragmaState {
+        let idx = self.starts.partition_point(|start| *start <= offset);
+        if idx > 0 { self.ranges[idx - 1].1.clone() } else { self.default_state.clone() }
+    }
+
+    /// Creates a cursor for cheaper repeated lookups.
+    #[must_use]
+    pub fn cursor(&self) -> PragmaCursor<'_> {
+        PragmaCursor::new(self)
+    }
+
+    /// Returns a shared view of the backing ranges.
+    #[must_use]
+    pub fn as_ranges(&self) -> &[(Range<usize>, PragmaState)] {
+        &self.ranges
+    }
+
+    /// Consumes this query map and returns tracker-compatible ranges.
+    #[must_use]
+    pub fn into_ranges(self) -> Vec<(Range<usize>, PragmaState)> {
+        self.ranges
+    }
+}
+
+/// Stateful query cursor for incremental pragma lookups.
+pub struct PragmaCursor<'a> {
+    map: &'a PragmaMap,
+    upper_bound: usize,
+}
+
+impl<'a> PragmaCursor<'a> {
+    fn new(map: &'a PragmaMap) -> Self {
+        Self { map, upper_bound: 0 }
+    }
+
+    /// Returns the effective state for a byte offset.
+    #[must_use]
+    pub fn state_at(&mut self, offset: usize) -> PragmaState {
+        if self.upper_bound < self.map.starts.len() && self.map.starts[self.upper_bound] <= offset {
+            while self.upper_bound < self.map.starts.len()
+                && self.map.starts[self.upper_bound] <= offset
+            {
+                self.upper_bound += 1;
+            }
+        } else {
+            self.upper_bound = self.map.starts.partition_point(|start| *start <= offset);
+        }
+
+        if self.upper_bound > 0 {
+            self.map.ranges[self.upper_bound - 1].1.clone()
+        } else {
+            self.map.default_state.clone()
+        }
+    }
+
+    /// Returns the effective top-level final state.
+    #[must_use]
+    pub fn final_state(&self) -> PragmaState {
+        self.map.final_state()
+    }
+}
+
 /// Tracks pragma state throughout a Perl file
 pub struct PragmaTracker;
 
 impl PragmaTracker {
     /// Build a range-indexed pragma map from an AST
     pub fn build(ast: &Node) -> Vec<(Range<usize>, PragmaState)> {
-        let mut ranges = Vec::new();
-        let mut current_state = PragmaState::default();
-
-        // Build the pragma map by walking the AST
-        Self::build_ranges(ast, &mut current_state, &mut ranges);
-
-        // Sort by start offset
-        ranges.sort_by_key(|(range, _)| range.start);
-
-        ranges
+        PragmaMap::build(ast).into_ranges()
     }
 
     /// Get the pragma state at a specific byte offset
@@ -445,11 +549,7 @@ impl PragmaTracker {
         let mut state =
             if idx > 0 { pragma_map[idx - 1].1.clone() } else { PragmaState::default() };
 
-        if state.signatures_strict {
-            state.strict_vars = true;
-            state.strict_subs = true;
-            state.strict_refs = true;
-        }
+        apply_effective_state_overrides(&mut state);
 
         state
     }

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -5,7 +5,7 @@
 
 use perl_ast::SourceLocation;
 use perl_ast::ast::{Node, NodeKind};
-use perl_pragma::{PragmaState, PragmaTracker};
+use perl_pragma::{PragmaMap, PragmaState, PragmaTracker};
 
 fn loc(start: usize, end: usize) -> SourceLocation {
     SourceLocation { start, end }
@@ -264,6 +264,18 @@ fn given_end_block_with_use_warnings_when_querying_after_block_then_warnings_is_
 
     let after_end = PragmaTracker::state_for_offset(&map, 24);
     assert!(!after_end.warnings);
+}
+
+#[test]
+fn given_new_query_map_when_asking_for_final_state_then_no_sentinel_offset_is_needed() {
+    let ast = program(vec![use_node("strict", &[], 0, 12), use_node("warnings", &[], 13, 28)]);
+    let map = PragmaMap::build(&ast);
+
+    let final_state = map.final_state();
+    assert!(final_state.strict_vars);
+    assert!(final_state.strict_subs);
+    assert!(final_state.strict_refs);
+    assert!(final_state.warnings);
 }
 
 #[test]

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -5,7 +5,9 @@
 
 use perl_ast::SourceLocation;
 use perl_ast::ast::{Node, NodeKind};
-use perl_pragma::{PerlVersion, PragmaState, PragmaTracker, features_enabled_by_version};
+use perl_pragma::{
+    PerlVersion, PragmaMap, PragmaState, PragmaTracker, features_enabled_by_version,
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1634,5 +1636,63 @@ fn package_block_pragma_inside_is_visible_at_inner_offset() -> Result<(), Box<dy
 
     let inside = PragmaTracker::state_for_offset(&map, 30);
     assert!(inside.strict_vars, "strict_vars declared inside package block must be visible");
+    Ok(())
+}
+
+#[test]
+fn pragma_map_supports_final_state_without_sentinel_offsets()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("strict", &[], 0, 12), use_node("warnings", &[], 13, 28)]);
+    let map = PragmaMap::build(&ast);
+
+    let final_state = map.final_state();
+    assert!(final_state.strict_vars);
+    assert!(final_state.strict_subs);
+    assert!(final_state.strict_refs);
+    assert!(final_state.warnings);
+    Ok(())
+}
+
+#[test]
+fn pragma_map_state_at_matches_compatibility_state_for_offset()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        no_node("strict", &["refs"], 13, 29),
+        use_node("warnings", &[], 30, 45),
+    ]);
+    let compatibility_map = PragmaTracker::build(&ast);
+    let map = PragmaMap::from_ranges(compatibility_map.clone());
+
+    for offset in [0, 8, 20, 40, 100] {
+        let expected = PragmaTracker::state_for_offset(&compatibility_map, offset);
+        let actual = map.state_at(offset);
+        assert_eq!(actual, expected, "mismatch at offset {offset}");
+    }
+    Ok(())
+}
+
+#[test]
+fn pragma_cursor_handles_forward_and_backward_queries() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        use_node("warnings", &[], 13, 28),
+        no_node("strict", &["subs"], 29, 45),
+    ]);
+    let map = PragmaMap::build(&ast);
+    let mut cursor = map.cursor();
+
+    let at_10 = cursor.state_at(10);
+    assert!(at_10.strict_subs);
+    assert!(!at_10.warnings);
+
+    let at_20 = cursor.state_at(20);
+    assert!(at_20.warnings);
+
+    let at_40 = cursor.state_at(40);
+    assert!(!at_40.strict_subs);
+
+    let at_5 = cursor.state_at(5);
+    assert!(at_5.strict_subs, "cursor must recover for backward lookup");
     Ok(())
 }


### PR DESCRIPTION
### Motivation

- Consumers of pragma ranges were repeatedly doing a binary-search-plus-clone over the raw `Vec<(Range<usize>, PragmaState)>` and using sentinel offsets to obtain final state, which is inefficient for repeated queries.
- Provide a compact, owned query surface that precomputes what callers need for cheap repeated lookups and an explicit final/top-level state API so callers no longer rely on sentinel offsets.

### Description

- Add `PragmaMap` with precomputed `starts`, `default_state`, and `final_state`, plus `PragmaMap::build`, `PragmaMap::from_ranges`, `state_at`, `final_state`, `as_ranges`, and `into_ranges` for owned/compatibility interop.
- Add `PragmaCursor` for incremental cursor-style lookups to cheaply handle repeated forward/backward queries with `state_at` and `final_state` accessors.
- Centralize the `signatures_strict` effective-state logic into `apply_effective_state_overrides` and preserve compatibility by having `PragmaTracker::build` delegate to `PragmaMap::build(...).into_ranges()` and `PragmaTracker::state_for_offset` remain available and use the same override logic.
- Update tests to exercise the new APIs and parity: import `PragmaMap` in spec/unit tests and add tests covering `final_state()`, `state_at()` parity with legacy `state_for_offset()`, and `PragmaCursor` behavior.

### Testing

- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo test -p perl-pragma` which passed (127 tests across behavior and comprehensive suites) and all tests are green.
- Ran `cargo check --all-targets -p perl-pragma` which completed successfully.
- `just pr-fast` was unavailable in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb777f33248333b6d3e2d33e82335c)