### PR TITLE
perf(pragma-consumers): migrate strict_warnings, version_compat, and scope_analyzer to PragmaMap (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
@@ -60,11 +60,8 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
 
     let pragma_map = PragmaTracker::build(node);
     // Query the top-level pragma state (after all scoped blocks have exited).
-    // Using usize::MAX ensures we get the last entry, which reflects the
-    // restored top-level state after any eval/sub/block scopes have closed.
-    // This avoids the false-negative from .any() which sees eval-interior ranges.
     // signatures_strict is included to honour `use feature 'signatures'` (#4038).
-    let top_level_state = PragmaTracker::state_for_offset(&pragma_map, usize::MAX);
+    let top_level_state = PragmaTracker::final_state(&pragma_map);
     let mut has_strict = top_level_state.strict_vars
         || top_level_state.strict_subs
         || top_level_state.strict_refs

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs
@@ -16,7 +16,7 @@
 
 use perl_diagnostics::codes::DiagnosticCode;
 use perl_parser_core::ast::{Node, NodeKind};
-use perl_pragma::{PerlVersion, PragmaTracker, parse_perl_version};
+use perl_pragma::{parse_perl_version, PerlVersion, PragmaQueryCursor, PragmaTracker};
 
 use super::super::internal_types::Diagnostic;
 use super::super::walker::walk_node;
@@ -143,10 +143,15 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
     };
 
     let pragma_map = PragmaTracker::build(node);
+    let mut pragma_cursor = PragmaQueryCursor::default();
 
     // Second pass: walk AST for version-gated constructs.
     walk_node(node, &mut |n| {
-        let pragma_state = PragmaTracker::state_for_offset(&pragma_map, n.location.start);
+        let pragma_state = PragmaTracker::state_for_offset_monotonic(
+            &pragma_map,
+            &mut pragma_cursor,
+            n.location.start,
+        );
 
         match &n.kind {
             // `class Foo { }` — requires v5.38

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -416,6 +416,15 @@ fn conditional_pragma_target(args: &[String]) -> Option<(&str, &[String])> {
 /// Tracks pragma state throughout a Perl file
 pub struct PragmaTracker;
 
+/// Incremental cursor for monotonic pragma-map queries.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PragmaQueryCursor {
+    index: usize,
+    last_offset: usize,
+    initialized: bool,
+}
+
 impl PragmaTracker {
     /// Build a range-indexed pragma map from an AST
     pub fn build(ast: &Node) -> Vec<(Range<usize>, PragmaState)> {
@@ -442,16 +451,65 @@ impl PragmaTracker {
         // then take the element before it.
         let idx = pragma_map.partition_point(|(range, _)| range.start <= offset);
 
-        let mut state =
-            if idx > 0 { pragma_map[idx - 1].1.clone() } else { PragmaState::default() };
+        if idx > 0 { Self::effective_state(&pragma_map[idx - 1].1) } else { PragmaState::default() }
+    }
 
-        if state.signatures_strict {
-            state.strict_vars = true;
-            state.strict_subs = true;
-            state.strict_refs = true;
+    /// Get the final pragma state after all lexical scopes have unwound.
+    #[must_use]
+    pub fn final_state(pragma_map: &[(Range<usize>, PragmaState)]) -> PragmaState {
+        pragma_map
+            .last()
+            .map_or_else(PragmaState::default, |(_, state)| Self::effective_state(state))
+    }
+
+    /// Get pragma state using a cursor optimized for monotonic offset queries.
+    ///
+    /// Callers that query offsets in nondecreasing order can reuse `cursor` to
+    /// avoid repeatedly searching from the beginning of the pragma map.
+    #[must_use]
+    pub fn state_for_offset_monotonic(
+        pragma_map: &[(Range<usize>, PragmaState)],
+        cursor: &mut PragmaQueryCursor,
+        offset: usize,
+    ) -> PragmaState {
+        if pragma_map.is_empty() {
+            cursor.initialized = true;
+            cursor.last_offset = offset;
+            cursor.index = 0;
+            return PragmaState::default();
         }
 
-        state
+        if !cursor.initialized || offset < cursor.last_offset {
+            cursor.index = pragma_map.partition_point(|(range, _)| range.start <= offset);
+            cursor.last_offset = offset;
+            cursor.initialized = true;
+            return if cursor.index > 0 {
+                Self::effective_state(&pragma_map[cursor.index - 1].1)
+            } else {
+                PragmaState::default()
+            };
+        }
+
+        while cursor.index < pragma_map.len() && pragma_map[cursor.index].0.start <= offset {
+            cursor.index += 1;
+        }
+
+        cursor.last_offset = offset;
+        if cursor.index > 0 {
+            Self::effective_state(&pragma_map[cursor.index - 1].1)
+        } else {
+            PragmaState::default()
+        }
+    }
+
+    fn effective_state(state: &PragmaState) -> PragmaState {
+        let mut effective = state.clone();
+        if effective.signatures_strict {
+            effective.strict_vars = true;
+            effective.strict_subs = true;
+            effective.strict_refs = true;
+        }
+        effective
     }
 
     /// Process a lexically scoped body and then restore the caller state.

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -5,7 +5,9 @@
 
 use perl_ast::SourceLocation;
 use perl_ast::ast::{Node, NodeKind};
-use perl_pragma::{PerlVersion, PragmaState, PragmaTracker, features_enabled_by_version};
+use perl_pragma::{
+    PerlVersion, PragmaQueryCursor, PragmaState, PragmaTracker, features_enabled_by_version,
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1634,5 +1636,43 @@ fn package_block_pragma_inside_is_visible_at_inner_offset() -> Result<(), Box<dy
 
     let inside = PragmaTracker::state_for_offset(&map, 30);
     assert!(inside.strict_vars, "strict_vars declared inside package block must be visible");
+    Ok(())
+}
+
+#[test]
+fn final_state_matches_far_future_offset_lookup() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        Node {
+            kind: NodeKind::Block {
+                statements: vec![no_node("strict", &["refs"], 16, 34)],
+            },
+            location: loc(14, 36),
+        },
+        use_node("warnings", &[], 40, 55),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let final_state = PragmaTracker::final_state(&map);
+    let legacy_state = PragmaTracker::state_for_offset(&map, usize::MAX);
+    assert_eq!(final_state, legacy_state);
+    Ok(())
+}
+
+#[test]
+fn monotonic_cursor_matches_state_for_offset() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        use_node("warnings", &[], 20, 35),
+        no_node("strict", &["subs"], 40, 58),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let mut cursor = PragmaQueryCursor::default();
+
+    for offset in [0usize, 10, 25, 45, 80] {
+        let expected = PragmaTracker::state_for_offset(&map, offset);
+        let actual = PragmaTracker::state_for_offset_monotonic(&map, &mut cursor, offset);
+        assert_eq!(actual, expected, "offset {offset} should match monotonic query");
+    }
     Ok(())
 }

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -50,7 +50,7 @@
 //! ```
 
 use crate::ast::{Node, NodeKind};
-use crate::pragma_tracker::{PragmaState, PragmaTracker};
+use crate::pragma_tracker::{PragmaQueryCursor, PragmaState, PragmaTracker};
 use perl_module::import::resolve_known_export_tag;
 use rustc_hash::FxHashMap;
 use std::cell::{Cell, RefCell};
@@ -359,6 +359,7 @@ enum ExtractedName<'a> {
 struct AnalysisContext<'a> {
     code: &'a str,
     pragma_map: &'a [(Range<usize>, PragmaState)],
+    pragma_cursor: RefCell<PragmaQueryCursor>,
     imported_barewords: HashSet<String>,
     line_starts: RefCell<Option<Vec<usize>>>,
     /// Current package name, updated as `package` statements are traversed.
@@ -370,6 +371,7 @@ impl<'a> AnalysisContext<'a> {
         Self {
             code,
             pragma_map,
+            pragma_cursor: RefCell::new(PragmaQueryCursor::default()),
             imported_barewords: collect_imported_barewords(ast),
             line_starts: RefCell::new(None),
             current_package: RefCell::new("main".to_string()),
@@ -585,7 +587,14 @@ impl ScopeAnalyzer {
         context: &AnalysisContext<'a>,
     ) {
         // Get effective pragma state at this node's location
-        let pragma_state = PragmaTracker::state_for_offset(context.pragma_map, node.location.start);
+        let pragma_state = {
+            let mut cursor = context.pragma_cursor.borrow_mut();
+            PragmaTracker::state_for_offset_monotonic(
+                context.pragma_map,
+                &mut cursor,
+                node.location.start,
+            )
+        };
         let strict_vars_mode = pragma_state.strict_vars || pragma_state.signatures_strict;
         let strict_subs_mode = pragma_state.strict_subs || pragma_state.signatures_strict;
         match &node.kind {


### PR DESCRIPTION
### Motivation

- Remove the sentinel `usize::MAX` and repeated full-map lookups in hot pragma consumers in favor of explicit final-state and monotonic query APIs to reduce query cost and make intent explicit.
- Provide a cheap monotonic query path for callers that walk the AST in document order.

### Description

- Added `PragmaQueryCursor`, `PragmaTracker::final_state`, and `PragmaTracker::state_for_offset_monotonic` to `perl-pragma` and centralized the signatures-driven effective-state logic into a small helper. (files: `crates/perl-pragma/src/lib.rs`)
- Replaced the `usize::MAX` sentinel lookup in `strict_warnings` with `PragmaTracker::final_state` to obtain the post-unwind top-level state. (file: `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs`)
- Switched `version_compat` to use a `PragmaQueryCursor` and `state_for_offset_monotonic` while walking the AST to avoid repeated binary searches. (file: `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs`)
- Plumbed a `PragmaQueryCursor` into `AnalysisContext` and updated `scope_analyzer` to use the monotonic query path for per-node lookups. (file: `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs`)
- Added unit tests in `perl-pragma` validating parity of `final_state` with the legacy far-future lookup and correctness of the monotonic cursor behavior. (file: `crates/perl-pragma/tests/comprehensive_unit_tests.rs`)

### Testing

- Ran `cargo test -p perl-pragma`, which completed successfully with all new and existing `perl-pragma` tests passing.
- Ran `cargo test -p perl-lsp-rs-core`, which exercised many tests and largely passed, but one pre-existing test in the suite (`green_tdd_wave_g1b_regression_hardening`) failed due to a missing-path expectation referencing `crates/perl-lsp/Cargo.toml` (pre-existing test failure outside these changes).
- Running `cargo test -p perl-semantic-analyzer` and `cargo check --workspace --all-targets` hit a pre-existing test compile error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` (a format-string literal issue) unrelated to the pragma API changes and not introduced by this PR.
- Ran project formatting via `cargo xtask fmt` as part of verification.

Problem: Hot pragma consumers still used sentinel or repeated lookups causing unnecessary work.
Fix: Introduced explicit final-state and monotonic cursor APIs and migrated three hot consumers to use them while preserving behavior.
Verification: `cargo test -p perl-pragma` passes; other workspace checks ran but encountered pre-existing test issues unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb778322e88333942a0295228d70aa)