### PR TITLE
perf(pragma-consumers): migrate strict_warnings, version_compat, and scope_analyzer to PragmaMap (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
@@ -60,11 +60,10 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
 
     let pragma_map = PragmaTracker::build(node);
     // Query the top-level pragma state (after all scoped blocks have exited).
-    // Using usize::MAX ensures we get the last entry, which reflects the
-    // restored top-level state after any eval/sub/block scopes have closed.
-    // This avoids the false-negative from .any() which sees eval-interior ranges.
+    // This reflects the restored top-level state after any eval/sub/block
+    // scopes have closed and avoids false-negatives from eval-interior ranges.
     // signatures_strict is included to honour `use feature 'signatures'` (#4038).
-    let top_level_state = PragmaTracker::state_for_offset(&pragma_map, usize::MAX);
+    let top_level_state = PragmaTracker::final_state(&pragma_map);
     let mut has_strict = top_level_state.strict_vars
         || top_level_state.strict_subs
         || top_level_state.strict_refs
@@ -589,7 +588,8 @@ mod tests {
     #[test]
     fn eval_then_top_level_strict_then_eval_no_strict_restores_correctly() {
         // eval { no strict; } after top-level use strict.
-        // usize::MAX must land on the restore entry (strict=true), not the inner no-strict.
+        // Final-state lookup must land on the restore entry (strict=true),
+        // not the inner no-strict.
         let diags =
             strict_warnings_diags("use strict;\nuse warnings;\neval { no strict; };\nmy $x = 1;\n");
         assert!(

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs
@@ -143,10 +143,21 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
     };
 
     let pragma_map = PragmaTracker::build(node);
+    let mut pragma_cursor = 0usize;
+    let mut pragma_last_offset = None;
 
     // Second pass: walk AST for version-gated constructs.
     walk_node(node, &mut |n| {
-        let pragma_state = PragmaTracker::state_for_offset(&pragma_map, n.location.start);
+        let pragma_state = if pragma_last_offset.is_some_and(|last| n.location.start < last) {
+            PragmaTracker::state_for_offset(&pragma_map, n.location.start)
+        } else {
+            PragmaTracker::state_for_offset_with_cursor(
+                &pragma_map,
+                n.location.start,
+                &mut pragma_cursor,
+            )
+        };
+        pragma_last_offset = Some(n.location.start);
 
         match &n.kind {
             // `class Foo { }` — requires v5.38

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -442,6 +442,45 @@ impl PragmaTracker {
         // then take the element before it.
         let idx = pragma_map.partition_point(|(range, _)| range.start <= offset);
 
+        Self::normalized_state_for_index(pragma_map, idx)
+    }
+
+    /// Get the pragma state at a specific byte offset using a caller-owned cursor.
+    ///
+    /// This method is optimized for monotonic (non-decreasing) offset queries:
+    /// the cursor advances as offsets increase, avoiding repeated binary searches.
+    /// For non-monotonic queries, this method transparently falls back to a
+    /// binary search and realigns the cursor.
+    pub fn state_for_offset_with_cursor(
+        pragma_map: &[(Range<usize>, PragmaState)],
+        offset: usize,
+        cursor: &mut usize,
+    ) -> PragmaState {
+        if *cursor > pragma_map.len() {
+            *cursor = pragma_map.len();
+        }
+
+        if *cursor > 0 && offset < pragma_map[*cursor - 1].0.start {
+            *cursor = pragma_map.partition_point(|(range, _)| range.start <= offset);
+            return Self::normalized_state_for_index(pragma_map, *cursor);
+        }
+
+        while *cursor < pragma_map.len() && pragma_map[*cursor].0.start <= offset {
+            *cursor += 1;
+        }
+
+        Self::normalized_state_for_index(pragma_map, *cursor)
+    }
+
+    /// Get the effective final pragma state after all lexical scopes are closed.
+    pub fn final_state(pragma_map: &[(Range<usize>, PragmaState)]) -> PragmaState {
+        Self::normalized_state_for_index(pragma_map, pragma_map.len())
+    }
+
+    fn normalized_state_for_index(
+        pragma_map: &[(Range<usize>, PragmaState)],
+        idx: usize,
+    ) -> PragmaState {
         let mut state =
             if idx > 0 { pragma_map[idx - 1].1.clone() } else { PragmaState::default() };
 

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -567,8 +567,18 @@ impl ScopeAnalyzer {
         let mut ancestors: Vec<&Node> = Vec::new();
 
         let context = AnalysisContext::new(ast, code, pragma_map);
+        let mut pragma_cursor = 0usize;
+        let mut pragma_last_offset = None;
 
-        self.analyze_node(ast, &root_scope, &mut ancestors, &mut issues, &context);
+        self.analyze_node(
+            ast,
+            &root_scope,
+            &mut ancestors,
+            &mut issues,
+            &context,
+            &mut pragma_cursor,
+            &mut pragma_last_offset,
+        );
 
         // Collect all unused variables from all scopes
         self.collect_unused_variables(&root_scope, &mut issues, &context);
@@ -583,9 +593,20 @@ impl ScopeAnalyzer {
         ancestors: &mut Vec<&'a Node>,
         issues: &mut Vec<ScopeIssue>,
         context: &AnalysisContext<'a>,
+        pragma_cursor: &mut usize,
+        pragma_last_offset: &mut Option<usize>,
     ) {
         // Get effective pragma state at this node's location
-        let pragma_state = PragmaTracker::state_for_offset(context.pragma_map, node.location.start);
+        let pragma_state = if pragma_last_offset.is_some_and(|last| node.location.start < last) {
+            PragmaTracker::state_for_offset(context.pragma_map, node.location.start)
+        } else {
+            PragmaTracker::state_for_offset_with_cursor(
+                context.pragma_map,
+                node.location.start,
+                pragma_cursor,
+            )
+        };
+        *pragma_last_offset = Some(node.location.start);
         let strict_vars_mode = pragma_state.strict_vars || pragma_state.signatures_strict;
         let strict_subs_mode = pragma_state.strict_subs || pragma_state.signatures_strict;
         match &node.kind {
@@ -607,10 +628,10 @@ impl ScopeAnalyzer {
                     // `variable` as an Assignment node rather than in `initializer`.  Walk the
                     // variable node's children to pick up any RHS expressions.
                     if let Some(init) = initializer {
-                        self.analyze_node(init, scope, ancestors, issues, context);
+                        self.analyze_node(init, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                     }
                     if let NodeKind::Assignment { rhs, .. } = &variable.kind {
-                        self.analyze_node(rhs, scope, ancestors, issues, context);
+                        self.analyze_node(rhs, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                     }
                     return;
                 }
@@ -620,7 +641,7 @@ impl ScopeAnalyzer {
                 // Actually Perl evaluates RHS before LHS assignment, so usages in initializer refer to OUTER scope.
                 // So we analyze initializer first.
                 if let Some(init) = initializer {
-                    self.analyze_node(init, scope, ancestors, issues, context);
+                    self.analyze_node(init, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 }
 
                 if let Some(issue_kind) = self.declare_variable_parts_in_context(
@@ -674,7 +695,7 @@ impl ScopeAnalyzer {
 
                 // Analyze initializer first
                 if let Some(init) = initializer {
-                    self.analyze_node(init, scope, ancestors, issues, context);
+                    self.analyze_node(init, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 }
 
                 for variable in variables {
@@ -879,7 +900,7 @@ impl ScopeAnalyzer {
                 ancestors.push(node);
                 let declaration_arg_positions = builtin_declaration_arg_positions(name);
                 for (arg_index, arg) in args.iter().enumerate() {
-                    self.analyze_node(arg, scope, ancestors, issues, context);
+                    self.analyze_node(arg, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                     if declaration_arg_positions.contains(&arg_index) {
                         self.mark_builtin_declaration_arg_consumed(arg, scope, context);
                     }
@@ -888,7 +909,7 @@ impl ScopeAnalyzer {
             }
             NodeKind::MethodCall { object, method, args } => {
                 ancestors.push(node);
-                self.analyze_node(object, scope, ancestors, issues, context);
+                self.analyze_node(object, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 if let Some((sigil, var_name)) = self.extract_method_name_variable(method) {
                     self.record_variable_use(
                         scope,
@@ -901,13 +922,13 @@ impl ScopeAnalyzer {
                     );
                 }
                 for arg in args {
-                    self.analyze_node(arg, scope, ancestors, issues, context);
+                    self.analyze_node(arg, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 }
                 ancestors.pop();
             }
             NodeKind::Unary { op: _, operand } => {
                 ancestors.push(node);
-                self.analyze_node(operand, scope, ancestors, issues, context);
+                self.analyze_node(operand, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 ancestors.pop();
             }
             NodeKind::String { value, interpolated } => {
@@ -928,7 +949,7 @@ impl ScopeAnalyzer {
             NodeKind::Assignment { lhs, rhs, op: _ } => {
                 // Handle assignment: LHS variable becomes initialized
                 // First analyze RHS (usages)
-                self.analyze_node(rhs, scope, ancestors, issues, context);
+                self.analyze_node(rhs, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
 
                 // Optimization: Handle simple scalar assignment directly to avoid double lookup
                 // (mark_initialized + analyze_node both perform lookups)
@@ -949,25 +970,25 @@ impl ScopeAnalyzer {
 
                 // Recurse into LHS to trigger UndeclaredVariable checks
                 // Note: 'use_variable' marks as used, which is technically correct for assignment too (write usage)
-                self.analyze_node(lhs, scope, ancestors, issues, context);
+                self.analyze_node(lhs, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
             }
 
             NodeKind::Tie { variable, package, args } => {
                 ancestors.push(node);
                 // Analyze arguments first
-                self.analyze_node(package, scope, ancestors, issues, context);
+                self.analyze_node(package, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 for arg in args {
-                    self.analyze_node(arg, scope, ancestors, issues, context);
+                    self.analyze_node(arg, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 }
 
                 if let NodeKind::VariableDeclaration { .. } = variable.kind {
                     // Must analyze declaration FIRST to declare it, then mark initialized
-                    self.analyze_node(variable, scope, ancestors, issues, context);
+                    self.analyze_node(variable, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                     self.mark_initialized(variable, scope, context);
                 } else {
                     // For existing variables, mark initialized then analyze (usage)
                     self.mark_initialized(variable, scope, context);
-                    self.analyze_node(variable, scope, ancestors, issues, context);
+                    self.analyze_node(variable, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 }
 
                 ancestors.pop();
@@ -975,7 +996,7 @@ impl ScopeAnalyzer {
 
             NodeKind::Untie { variable } => {
                 ancestors.push(node);
-                self.analyze_node(variable, scope, ancestors, issues, context);
+                self.analyze_node(variable, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 ancestors.pop();
             }
 
@@ -1004,15 +1025,15 @@ impl ScopeAnalyzer {
                 // We don't need special handling for {} and [] here because NodeKind::Variable
                 // will handle the context-sensitive lookup (checking ancestors).
                 ancestors.push(node);
-                self.analyze_node(left, scope, ancestors, issues, context);
-                self.analyze_node(right, scope, ancestors, issues, context);
+                self.analyze_node(left, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
+                self.analyze_node(right, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 ancestors.pop();
             }
 
             NodeKind::ArrayLiteral { elements } => {
                 ancestors.push(node);
                 for element in elements {
-                    self.analyze_node(element, scope, ancestors, issues, context);
+                    self.analyze_node(element, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 }
                 ancestors.pop();
             }
@@ -1021,7 +1042,7 @@ impl ScopeAnalyzer {
                 let block_scope = Rc::new(Scope::with_parent(scope.clone()));
                 ancestors.push(node);
                 for stmt in statements {
-                    self.analyze_node(stmt, &block_scope, ancestors, issues, context);
+                    self.analyze_node(stmt, &block_scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 }
                 ancestors.pop();
                 self.collect_unused_variables(&block_scope, issues, context);
@@ -1030,7 +1051,7 @@ impl ScopeAnalyzer {
             NodeKind::PhaseBlock { block, .. } => {
                 let phase_scope = Rc::new(Scope::with_parent(scope.clone()));
                 ancestors.push(node);
-                self.analyze_node(block, &phase_scope, ancestors, issues, context);
+                self.analyze_node(block, &phase_scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 ancestors.pop();
                 self.collect_unused_variables(&phase_scope, issues, context);
             }
@@ -1041,15 +1062,15 @@ impl ScopeAnalyzer {
                 ancestors.push(node);
 
                 if let Some(init_node) = init {
-                    self.analyze_node(init_node, &loop_scope, ancestors, issues, context);
+                    self.analyze_node(init_node, &loop_scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 }
                 if let Some(cond) = condition {
-                    self.analyze_node(cond, &loop_scope, ancestors, issues, context);
+                    self.analyze_node(cond, &loop_scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 }
                 if let Some(upd) = update {
-                    self.analyze_node(upd, &loop_scope, ancestors, issues, context);
+                    self.analyze_node(upd, &loop_scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 }
-                self.analyze_node(body, &loop_scope, ancestors, issues, context);
+                self.analyze_node(body, &loop_scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
 
                 ancestors.pop();
 
@@ -1063,12 +1084,12 @@ impl ScopeAnalyzer {
 
                 // Declare the loop variable and immediately mark it initialized — the list
                 // provides its value at runtime so there is no uninitialized window.
-                self.analyze_node(variable, &loop_scope, ancestors, issues, context);
+                self.analyze_node(variable, &loop_scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 self.mark_initialized(variable, &loop_scope, context);
-                self.analyze_node(list, &loop_scope, ancestors, issues, context);
-                self.analyze_node(body, &loop_scope, ancestors, issues, context);
+                self.analyze_node(list, &loop_scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
+                self.analyze_node(body, &loop_scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 if let Some(cb) = continue_block {
-                    self.analyze_node(cb, &loop_scope, ancestors, issues, context);
+                    self.analyze_node(cb, &loop_scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 }
 
                 ancestors.pop();
@@ -1142,7 +1163,7 @@ impl ScopeAnalyzer {
                 }
 
                 ancestors.push(node);
-                self.analyze_node(body, &sub_scope, ancestors, issues, context);
+                self.analyze_node(body, &sub_scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 ancestors.pop();
 
                 // Check for unused parameters
@@ -1190,7 +1211,7 @@ impl ScopeAnalyzer {
 
             NodeKind::Try { body, catch_blocks, finally_block } => {
                 ancestors.push(node);
-                self.analyze_node(body, scope, ancestors, issues, context);
+                self.analyze_node(body, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
 
                 for (catch_var, catch_body) in catch_blocks {
                     let catch_scope = Rc::new(Scope::with_parent(scope.clone()));
@@ -1240,12 +1261,14 @@ impl ScopeAnalyzer {
                         ancestors,
                         issues,
                         context,
+                        pragma_cursor,
+                        pragma_last_offset,
                     );
                     self.collect_unused_variables(&catch_scope, issues, context);
                 }
 
                 if let Some(finally) = finally_block {
-                    self.analyze_node(finally, scope, ancestors, issues, context);
+                    self.analyze_node(finally, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 }
 
                 ancestors.pop();
@@ -1263,7 +1286,7 @@ impl ScopeAnalyzer {
 
                     let pkg_scope = Rc::new(Scope::with_parent(scope.clone()));
                     ancestors.push(node);
-                    self.analyze_node(block_node, &pkg_scope, ancestors, issues, context);
+                    self.analyze_node(block_node, &pkg_scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                     ancestors.pop();
                     self.collect_unused_variables(&pkg_scope, issues, context);
 
@@ -1279,14 +1302,14 @@ impl ScopeAnalyzer {
             NodeKind::Match { expr, .. } => {
                 scope.has_regex_match.set(true);
                 ancestors.push(node);
-                self.analyze_node(expr, scope, ancestors, issues, context);
+                self.analyze_node(expr, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 ancestors.pop();
             }
 
             NodeKind::Substitution { expr, .. } => {
                 scope.has_regex_match.set(true);
                 ancestors.push(node);
-                self.analyze_node(expr, scope, ancestors, issues, context);
+                self.analyze_node(expr, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 ancestors.pop();
             }
 
@@ -1299,7 +1322,7 @@ impl ScopeAnalyzer {
                 // Recursively analyze children
                 ancestors.push(node);
                 for child in node.children() {
-                    self.analyze_node(child, scope, ancestors, issues, context);
+                    self.analyze_node(child, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
                 }
                 ancestors.pop();
             }
@@ -1546,15 +1569,17 @@ impl ScopeAnalyzer {
         ancestors: &mut Vec<&'a Node>,
         issues: &mut Vec<ScopeIssue>,
         context: &AnalysisContext<'a>,
+        pragma_cursor: &mut usize,
+        pragma_last_offset: &mut Option<usize>,
     ) {
         if let NodeKind::Block { statements } = &node.kind {
             ancestors.push(node);
             for stmt in statements {
-                self.analyze_node(stmt, scope, ancestors, issues, context);
+                self.analyze_node(stmt, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
             }
             ancestors.pop();
         } else {
-            self.analyze_node(node, scope, ancestors, issues, context);
+            self.analyze_node(node, scope, ancestors, issues, context, pragma_cursor, pragma_last_offset);
         }
     }
 

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -3916,7 +3916,7 @@ print func();
         issues.iter().any(|issue| {
             matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "func"
         }),
-        "require inside eval { } is runtime; should not suppress strict 'subs'"
+        "require inside eval {{ }} is runtime; should not suppress strict 'subs'"
     );
     Ok(())
 }


### PR DESCRIPTION
### Motivation

- Replace sentinel-lookup and repeated binary-search patterns when querying pragma state with explicit APIs and a cursor-based fast path to reduce allocation/work in hot consumers while preserving existing semantics.

### Description

- Added `PragmaTracker::state_for_offset_with_cursor`, `PragmaTracker::final_state`, and an internal `normalized_state_for_index` helper to `crates/perl-pragma/src/lib.rs` and consolidated lookup normalization logic there.
- Replaced the `usize::MAX` sentinel lookup in `strict_warnings` with `PragmaTracker::final_state` to obtain the explicit final/top-level pragma state. 
- Migrated `version_compat` to use a caller-owned monotonic `pragma_cursor` with a backward-offset fallback to the binary-search path. 
- Threaded a `pragma_cursor` and a `pragma_last_offset` through `scope_analyzer` recursion and helpers so the analyzer uses the cheaper cursor path where traversal order allows; preserved non-monotonic fallbacks to maintain identical behavior. 
- Fixed a formatting literal in one semantic test message (escaped braces) to address a compile-time format-string issue.

### Testing

- Ran `cargo test -p perl-pragma` and the crate unit tests passed. 
- Ran `cargo test -p perl-lsp-rs-core strict_warnings` (targeted lints test) and it passed. 
- Ran `cargo test -p perl-semantic-analyzer` and the semantic analyzer tests (including `scope_analyzer`) passed after the migration. 
- Ran `cargo check --workspace --all-targets` and the workspace checked successfully.
- Note: a prior full `cargo test -p perl-lsp-rs-core` run showed one failing test (`test_perl_lsp_cargo_toml_removed_g1b_imports`) caused by a missing top-level fixture file unrelated to the pragma changes; targeted tests exercised by this PR are green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb778322e88333942a0295228d70aa)