### PR TITLE
perf(pragma-consumers): migrate strict_warnings, version_compat, and scope_analyzer to PragmaMap (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs
@@ -60,11 +60,9 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
 
     let pragma_map = PragmaTracker::build(node);
     // Query the top-level pragma state (after all scoped blocks have exited).
-    // Using usize::MAX ensures we get the last entry, which reflects the
-    // restored top-level state after any eval/sub/block scopes have closed.
-    // This avoids the false-negative from .any() which sees eval-interior ranges.
+    // This avoids false-negatives from eval/sub/block interior ranges.
     // signatures_strict is included to honour `use feature 'signatures'` (#4038).
-    let top_level_state = PragmaTracker::state_for_offset(&pragma_map, usize::MAX);
+    let top_level_state = PragmaTracker::final_state(&pragma_map);
     let mut has_strict = top_level_state.strict_vars
         || top_level_state.strict_subs
         || top_level_state.strict_refs

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs
@@ -143,10 +143,15 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
     };
 
     let pragma_map = PragmaTracker::build(node);
+    let mut pragma_cursor = 0usize;
 
     // Second pass: walk AST for version-gated constructs.
     walk_node(node, &mut |n| {
-        let pragma_state = PragmaTracker::state_for_offset(&pragma_map, n.location.start);
+        let pragma_state = PragmaTracker::state_for_offset_monotonic(
+            &pragma_map,
+            n.location.start,
+            &mut pragma_cursor,
+        );
 
         match &n.kind {
             // `class Foo { }` — requires v5.38

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -436,12 +436,50 @@ impl PragmaTracker {
         pragma_map: &[(Range<usize>, PragmaState)],
         offset: usize,
     ) -> PragmaState {
-        // Find the last pragma state that starts before this offset.
-        // pragma_map is sorted by start offset (guaranteed by build()).
-        // We use partition_point to find the first element where start > offset,
-        // then take the element before it.
         let idx = pragma_map.partition_point(|(range, _)| range.start <= offset);
+        Self::effective_state_at_index(pragma_map, idx)
+    }
 
+    /// Get the pragma state at EOF / after all lexical scopes have unwound.
+    #[must_use]
+    pub fn final_state(pragma_map: &[(Range<usize>, PragmaState)]) -> PragmaState {
+        Self::effective_state_at_index(pragma_map, pragma_map.len())
+    }
+
+    /// Monotonic pragma lookup using a caller-owned cursor.
+    ///
+    /// `cursor` stores the first map index whose range start is greater than the
+    /// previous query offset. For monotonically increasing offsets this avoids
+    /// repeated binary searches and advances in O(1) amortized time.
+    ///
+    /// If offsets move backwards, this gracefully falls back to a binary search
+    /// and resets the cursor.
+    #[must_use]
+    pub fn state_for_offset_monotonic(
+        pragma_map: &[(Range<usize>, PragmaState)],
+        offset: usize,
+        cursor: &mut usize,
+    ) -> PragmaState {
+        if *cursor > pragma_map.len() {
+            *cursor = pragma_map.len();
+        }
+
+        if *cursor > 0 && pragma_map[*cursor - 1].0.start > offset {
+            *cursor = pragma_map.partition_point(|(range, _)| range.start <= offset);
+            return Self::effective_state_at_index(pragma_map, *cursor);
+        }
+
+        while *cursor < pragma_map.len() && pragma_map[*cursor].0.start <= offset {
+            *cursor += 1;
+        }
+
+        Self::effective_state_at_index(pragma_map, *cursor)
+    }
+
+    fn effective_state_at_index(
+        pragma_map: &[(Range<usize>, PragmaState)],
+        idx: usize,
+    ) -> PragmaState {
         let mut state =
             if idx > 0 { pragma_map[idx - 1].1.clone() } else { PragmaState::default() };
 

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -74,6 +74,39 @@ fn given_fresh_file_when_no_pragmas_then_default_state_applies() {
 }
 
 #[test]
+fn given_scoped_inner_changes_when_querying_final_state_then_outer_state_is_returned() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        block(vec![no_node("strict", &["refs"], 15, 31)], 13, 33),
+        use_node("warnings", &[], 34, 49),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let final_state = PragmaTracker::final_state(&map);
+    assert!(final_state.strict_vars);
+    assert!(final_state.strict_subs);
+    assert!(final_state.strict_refs);
+    assert!(final_state.warnings);
+}
+
+#[test]
+fn given_monotonic_queries_when_reading_multiple_offsets_then_states_match_binary_search() {
+    let ast = program(vec![
+        use_node("strict", &["refs"], 0, 17),
+        no_node("strict", &["refs"], 18, 34),
+        use_node("warnings", &[], 35, 50),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let mut cursor = 0usize;
+
+    for offset in [0usize, 10, 20, 40, 60] {
+        let monotonic = PragmaTracker::state_for_offset_monotonic(&map, offset, &mut cursor);
+        let baseline = PragmaTracker::state_for_offset(&map, offset);
+        assert_eq!(monotonic, baseline);
+    }
+}
+
+#[test]
 fn given_use_strict_when_querying_after_statement_then_all_strict_modes_are_enabled() {
     let ast = program(vec![use_node("strict", &[], 0, 12)]);
     let map = PragmaTracker::build(&ast);

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -359,6 +359,7 @@ enum ExtractedName<'a> {
 struct AnalysisContext<'a> {
     code: &'a str,
     pragma_map: &'a [(Range<usize>, PragmaState)],
+    pragma_cursor: Cell<usize>,
     imported_barewords: HashSet<String>,
     line_starts: RefCell<Option<Vec<usize>>>,
     /// Current package name, updated as `package` statements are traversed.
@@ -370,10 +371,18 @@ impl<'a> AnalysisContext<'a> {
         Self {
             code,
             pragma_map,
+            pragma_cursor: Cell::new(0),
             imported_barewords: collect_imported_barewords(ast),
             line_starts: RefCell::new(None),
             current_package: RefCell::new("main".to_string()),
         }
+    }
+
+    fn pragma_state_for_offset(&self, offset: usize) -> PragmaState {
+        let mut cursor = self.pragma_cursor.get();
+        let state = PragmaTracker::state_for_offset_monotonic(self.pragma_map, offset, &mut cursor);
+        self.pragma_cursor.set(cursor);
+        state
     }
 
     fn has_imported_bareword(&self, name: &str) -> bool {
@@ -585,7 +594,7 @@ impl ScopeAnalyzer {
         context: &AnalysisContext<'a>,
     ) {
         // Get effective pragma state at this node's location
-        let pragma_state = PragmaTracker::state_for_offset(context.pragma_map, node.location.start);
+        let pragma_state = context.pragma_state_for_offset(node.location.start);
         let strict_vars_mode = pragma_state.strict_vars || pragma_state.signatures_strict;
         let strict_subs_mode = pragma_state.strict_subs || pragma_state.signatures_strict;
         match &node.kind {


### PR DESCRIPTION
### Motivation

- Hot pragma consumers relied on repeated binary-search lookups and `usize::MAX` sentinel queries to infer final/top-level pragma state, which is awkward and suboptimal for forward walks. 
- Introduce explicit final-state and monotonic query APIs so callers can express intent and avoid repeated binary searches when visiting nodes in walk order.

### Description

- Added `PragmaTracker::final_state`, `PragmaTracker::state_for_offset_monotonic`, and an internal `effective_state_at_index` helper to centralize final-state logic and enable caller-owned cursor lookups in `crates/perl-pragma/src/lib.rs` without changing the computed `PragmaState` (including `signatures_strict` handling). 
- Replaced the `usize::MAX` sentinel usage in `strict_warnings` with `PragmaTracker::final_state` so top-level/EOF state is queried explicitly in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/strict_warnings.rs`. 
- Switched `version_compat` to use a monotonic cursor and `state_for_offset_monotonic` while walking the AST to amortize lookups in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/version_compat.rs`. 
- Updated `scope_analyzer` to store a `pragma_cursor` in `AnalysisContext` and use a small `pragma_state_for_offset` helper that calls the monotonic API to avoid repeated binary searches during recursive analysis in `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs`. 
- Added two BDD-style tests to `crates/perl-pragma/tests/behavior_spec_tests.rs` to cover `final_state` and parity between monotonic queries and the legacy binary-search lookup.

### Testing

- Ran `cargo test -p perl-pragma` and all pragma unit/behavior tests passed. 
- Ran `cargo test -p perl-lsp-rs-core strict_warnings` and the strict/warnings diagnostics tests passed. 
- Ran `cargo test -p perl-semantic-analyzer --lib` and library tests passed. 
- Ran `cargo test -p perl-lsp-rs-core` and `cargo check --workspace --all-targets`; both are blocked by pre-existing unrelated test/workspace issues (one test expecting `crates/perl-lsp/Cargo.toml` and a format-string error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs`), not by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb778322e88333942a0295228d70aa)