### PR TITLE
perf(perl-pragma): remove measured build/query overhead in hot paths (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,6 +1814,7 @@ dependencies = [
 name = "perl-pragma"
 version = "0.12.4"
 dependencies = [
+ "criterion",
  "perl-ast",
 ]
 

--- a/crates/perl-pragma/Cargo.toml
+++ b/crates/perl-pragma/Cargo.toml
@@ -16,6 +16,13 @@ categories = ["development-tools", "parser-implementations"]
 [dependencies]
 perl-ast = { workspace = true }
 
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "pragma_benchmarks"
+harness = false
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/crates/perl-pragma/benches/pragma_benchmarks.rs
+++ b/crates/perl-pragma/benches/pragma_benchmarks.rs
@@ -1,0 +1,138 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use perl_ast::SourceLocation;
+use perl_ast::ast::{Node, NodeKind};
+use perl_pragma::PragmaTracker;
+use std::hint::black_box;
+
+fn loc(start: usize, end: usize) -> SourceLocation {
+    SourceLocation { start, end }
+}
+
+fn use_node(module: &str, args: &[&str], start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::Use {
+            module: module.to_string(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            has_filter_risk: false,
+        },
+        location: loc(start, end),
+    }
+}
+
+fn no_node(module: &str, args: &[&str], start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::No {
+            module: module.to_string(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            has_filter_risk: false,
+        },
+        location: loc(start, end),
+    }
+}
+
+fn build_large_file_ast(size: usize) -> Node {
+    let mut statements = Vec::with_capacity(size * 4);
+    let mut offset = 0;
+
+    for idx in 0..size {
+        statements.push(use_node("strict", &[], offset, offset + 10));
+        offset += 12;
+        statements.push(use_node("warnings", &[], offset, offset + 12));
+        offset += 14;
+        statements.push(use_node("feature", &[":5.40"], offset, offset + 16));
+        offset += 18;
+        if idx % 3 == 0 {
+            statements.push(no_node("warnings", &["deprecated"], offset, offset + 19));
+            offset += 21;
+        }
+    }
+
+    Node { kind: NodeKind::Program { statements }, location: loc(0, offset) }
+}
+
+fn nested_scope_ast(depth: usize) -> Node {
+    let mut offset = 0;
+    let mut current =
+        Node { kind: NodeKind::Block { statements: Vec::new() }, location: loc(0, 0) };
+
+    for _ in 0..depth {
+        let inner = Node {
+            kind: NodeKind::Block {
+                statements: vec![
+                    use_node("strict", &[], offset, offset + 10),
+                    use_node("warnings", &[], offset + 11, offset + 23),
+                    use_node("feature", &["signatures"], offset + 24, offset + 44),
+                ],
+            },
+            location: loc(offset, offset + 50),
+        };
+        offset += 51;
+
+        current = Node {
+            kind: NodeKind::Block { statements: vec![inner, current] },
+            location: loc(0, offset),
+        };
+    }
+
+    Node { kind: NodeKind::Program { statements: vec![current] }, location: loc(0, offset) }
+}
+
+fn version_compat_ast(size: usize) -> Node {
+    let mut statements = Vec::with_capacity(size * 2);
+    let mut offset = 0;
+
+    for idx in 0..size {
+        let version = if idx % 2 == 0 { "v5.36" } else { "v5.40" };
+        statements.push(use_node(version, &[], offset, offset + 8));
+        offset += 10;
+        statements.push(use_node("feature", &[":5.40"], offset, offset + 16));
+        offset += 18;
+    }
+
+    Node { kind: NodeKind::Program { statements }, location: loc(0, offset) }
+}
+
+fn bench_build_large_file(c: &mut Criterion) {
+    let ast = build_large_file_ast(4_000);
+    c.bench_function("build_large_file", |b| {
+        b.iter(|| black_box(PragmaTracker::build(black_box(&ast))))
+    });
+}
+
+fn bench_query_monotonic_offsets(c: &mut Criterion) {
+    let ast = build_large_file_ast(4_000);
+    let map = PragmaTracker::build(&ast);
+    let end = ast.location.end;
+    let offsets: Vec<usize> = (0..end).step_by(37).collect();
+
+    c.bench_function("query_monotonic_offsets", |b| {
+        b.iter(|| {
+            for offset in &offsets {
+                black_box(PragmaTracker::state_for_offset(black_box(&map), black_box(*offset)));
+            }
+        })
+    });
+}
+
+fn bench_scope_analyzer_walk_style(c: &mut Criterion) {
+    let ast = nested_scope_ast(2_000);
+    c.bench_function("scope_analyzer_walk_style", |b| {
+        b.iter(|| black_box(PragmaTracker::build(black_box(&ast))))
+    });
+}
+
+fn bench_version_compat_walk_style(c: &mut Criterion) {
+    let ast = version_compat_ast(6_000);
+    c.bench_function("version_compat_walk_style", |b| {
+        b.iter(|| black_box(PragmaTracker::build(black_box(&ast))))
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_build_large_file,
+    bench_query_monotonic_offsets,
+    bench_scope_analyzer_walk_style,
+    bench_version_compat_walk_style
+);
+criterion_main!(benches);

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -223,8 +223,19 @@ fn enable_effective_version_semantics(state: &mut PragmaState, version: PerlVers
     state.signatures_strict = false;
 }
 
-fn feature_items(arg: &str) -> Vec<String> {
-    pragma_arg_items(arg)
+fn for_each_pragma_arg_item(arg: &str, mut f: impl FnMut(&str)) {
+    let trimmed = arg.trim().trim_matches('\'').trim_matches('"');
+
+    if let Some(inner) = trimmed.strip_prefix("qw(").and_then(|s| s.strip_suffix(')')) {
+        for item in inner.split_whitespace() {
+            f(item);
+        }
+        return;
+    }
+
+    if !trimmed.is_empty() {
+        f(trimmed);
+    }
 }
 
 fn known_feature_name(name: &str) -> Option<&'static str> {
@@ -298,7 +309,7 @@ fn apply_feature_state(state: &mut PragmaState, args: &[String], enabled: bool) 
     let mut changed = false;
 
     for arg in args {
-        for item in feature_items(arg) {
+        for_each_pragma_arg_item(arg, |item| {
             if !enabled && item == ":all" {
                 let had_features =
                     !state.features.is_empty() || state.unicode_strings || state.signatures_strict;
@@ -306,7 +317,7 @@ fn apply_feature_state(state: &mut PragmaState, args: &[String], enabled: bool) 
                 state.unicode_strings = false;
                 state.signatures_strict = false;
                 changed |= had_features;
-                continue;
+                return;
             }
 
             if let Some(version) = item.strip_prefix(':').and_then(parse_perl_version) {
@@ -317,53 +328,47 @@ fn apply_feature_state(state: &mut PragmaState, args: &[String], enabled: bool) 
                         disable_feature_name(state, feature)
                     };
                 }
-                continue;
+                return;
             }
 
             changed |= if enabled {
-                enable_feature_name(state, &item)
+                enable_feature_name(state, item)
             } else {
-                disable_feature_name(state, &item)
+                disable_feature_name(state, item)
             };
-        }
+        });
     }
 
     changed
 }
 
-fn builtin_import_names(arg: &str) -> Vec<String> {
+fn for_each_builtin_import_name(arg: &str, mut f: impl FnMut(&str)) {
     let trimmed = arg.trim();
 
     if let Some(inner) = trimmed.strip_prefix("qw(").and_then(|s| s.strip_suffix(')')) {
-        return inner
-            .split_whitespace()
-            .filter(|name| !name.is_empty())
-            .map(|name| name.trim_matches('\'').trim_matches('"').to_string())
-            .collect();
+        for name in inner.split_whitespace() {
+            let name = name.trim_matches('\'').trim_matches('"');
+            if !name.is_empty() {
+                f(name);
+            }
+        }
+        return;
     }
 
     let name = trimmed.trim_matches('\'').trim_matches('"');
-    if name.is_empty() { Vec::new() } else { vec![name.to_string()] }
+    if !name.is_empty() {
+        f(name);
+    }
 }
 
 fn apply_builtin_imports(state: &mut PragmaState, args: &[String]) {
     for arg in args {
-        for name in builtin_import_names(arg) {
-            if !state.builtin_imports.iter().any(|import| import == &name) {
-                state.builtin_imports.push(name);
+        for_each_builtin_import_name(arg, |name| {
+            if !state.builtin_imports.iter().any(|import| import == name) {
+                state.builtin_imports.push(name.to_string());
             }
-        }
+        });
     }
-}
-
-fn pragma_arg_items(arg: &str) -> Vec<String> {
-    let trimmed = arg.trim().trim_matches('\'').trim_matches('"');
-
-    if let Some(inner) = trimmed.strip_prefix("qw(").and_then(|s| s.strip_suffix(')')) {
-        return inner.split_whitespace().map(|item| item.to_string()).collect();
-    }
-
-    vec![trimmed.to_string()]
 }
 
 fn normalized_pragma_token(arg: &str) -> &str {
@@ -375,9 +380,15 @@ fn is_tracked_pragma_module(module: &str) -> bool {
 }
 
 fn valid_strict_args(args: &[String]) -> bool {
-    args.iter()
-        .flat_map(|arg| pragma_arg_items(arg))
-        .all(|item| matches!(item.as_str(), "vars" | "subs" | "refs"))
+    args.iter().all(|arg| {
+        let mut all_valid = true;
+        for_each_pragma_arg_item(arg, |item| {
+            if !matches!(item, "vars" | "subs" | "refs") {
+                all_valid = false;
+            }
+        });
+        all_valid
+    })
 }
 
 fn conditional_target_tail_is_valid(module: &str, tail: &[String]) -> bool {
@@ -394,7 +405,16 @@ fn conditional_target_tail_is_valid(module: &str, tail: &[String]) -> bool {
             tail.is_empty() || (tail.len() == 1 && !normalized_pragma_token(&tail[0]).is_empty())
         }
         "feature" => !tail.is_empty(),
-        "builtin" => tail.iter().any(|arg| !builtin_import_names(arg).is_empty()),
+        "builtin" => {
+            let mut has_any = false;
+            for arg in tail {
+                for_each_builtin_import_name(arg, |_| has_any = true);
+                if has_any {
+                    break;
+                }
+            }
+            has_any
+        }
         _ => false,
     }
 }
@@ -425,8 +445,11 @@ impl PragmaTracker {
         // Build the pragma map by walking the AST
         Self::build_ranges(ast, &mut current_state, &mut ranges);
 
-        // Sort by start offset
-        ranges.sort_by_key(|(range, _)| range.start);
+        // Entries are already emitted in lexical order for parser-produced ASTs.
+        // Keep a fallback sort for malformed or externally-constructed ASTs.
+        if ranges.windows(2).any(|w| w[0].0.start > w[1].0.start) {
+            ranges.sort_by_key(|(range, _)| range.start);
+        }
 
         ranges
     }

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -139,6 +139,17 @@ fn program_without_pragmas_yields_empty_map() -> Result<(), Box<dyn std::error::
     Ok(())
 }
 
+#[test]
+fn build_sorts_ranges_for_out_of_order_ast_input() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("strict", &[], 20, 30), use_node("warnings", &[], 0, 12)]);
+
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 2);
+    assert_eq!(map[0].0.start, 0);
+    assert_eq!(map[1].0.start, 20);
+    Ok(())
+}
+
 // ===========================================================================
 // use strict / no strict — full and selective
 // ===========================================================================


### PR DESCRIPTION
### Motivation
- Reduce measurable build/query overhead in `PragmaTracker` hot paths identified by new benchmarks (per-item temporary allocations while tokenizing pragma args and an always-on final sort). 

### Description
- Add a Criterion benchmark suite `benches/pragma_benchmarks.rs` exercising `build_large_file`, `query_monotonic_offsets`, `scope_analyzer_walk_style`, and `version_compat_walk_style` and wire it into the crate via `[[bench]]` + `criterion` dev-dependency. 
- Replace temporary `Vec<String>` builders for feature/builtin/pragma token parsing with callback-based iteration (`for_each_pragma_arg_item` / `for_each_builtin_import_name`) to avoid short-lived allocations on hot paths. 
- Make the final range `sort` conditional: only sort if an out-of-order start is detected to avoid unnecessary cost for well-ordered parser-produced ASTs while preserving correct fallback semantics. 
- Add a unit test `build_sorts_ranges_for_out_of_order_ast_input` to assert fallback sort behavior for out-of-order AST input.

### Testing
- `cargo bench -p perl-pragma --bench pragma_benchmarks` (bench compare run): `build_large_file` improved from ~15.73 ms to ~13.60 ms (~12–14% faster) and `scope_analyzer_walk_style` improved from ~2.34 ms to ~2.20 ms (~5–7% faster); `query_monotonic_offsets` showed no statistically significant change in that run. 
- `cargo bench -p perl-pragma` completed successfully. 
- `cargo test -p perl-pragma` succeeded (`106` unit tests + behavior specs all passed). 
- `cargo check --all-targets -p perl-pragma` succeeded. 
- `cargo clippy -p perl-pragma` and `cargo fmt --all --check` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb778b4d888333ad22a3c08085a741)