### PR TITLE
refactor(perl-pragma): remove measured build/query overhead (#6478)

### DIFF
--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -1226,6 +1226,39 @@ fn no_warnings_with_category_disables_only_that_category() -> Result<(), Box<dyn
 }
 
 #[test]
+fn duplicate_no_warnings_category_does_not_create_extra_entry()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("warnings", &[], 0, 12),
+        no_node("warnings", &["'deprecated'"], 13, 36),
+        no_node("warnings", &["'deprecated'"], 37, 60),
+    ]);
+
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 2, "duplicate category disable should not add a redundant map entry");
+    Ok(())
+}
+
+
+#[test]
+fn no_warnings_empty_string_category_is_ignored() -> Result<(), Box<dyn std::error::Error>> {
+    // `no warnings ''` after quote-stripping yields an empty category name.
+    // Error-recovery AST nodes can produce this.  The empty string must not be
+    // pushed into disabled_warning_categories, and no map entry should be emitted
+    // because the state did not change.
+    let ast = program(vec![
+        use_node("warnings", &[], 0, 12),
+        no_node("warnings", &["''"], 13, 28),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 1, "empty-string category should not create a map entry");
+    assert!(
+        map[0].1.disabled_warning_categories.is_empty(),
+        "empty-string category must not enter the disabled list"
+    );
+    Ok(())
+}
+#[test]
 fn no_warnings_bare_disables_all_warnings() -> Result<(), Box<dyn std::error::Error>> {
     // `no warnings;` (no args) must still disable the global warnings flag.
     let ast = program(vec![use_node("warnings", &[], 0, 15), no_node("warnings", &[], 16, 28)]);


### PR DESCRIPTION
### Motivation
- Benchmarks revealed avoidable work during pragma-map construction and queries that produced measurable build/query overhead. 
- The goal was to remove redundant map writes and unnecessary allocations without changing semantics.

### Description
- Add a focused Criterion benchmark suite (`pragma_benchmarks`) exercising `build_large_file`, `query_monotonic_offsets`, `scope_analyzer_walk_style`, and `version_compat_walk_style` and wire it into the crate manifest via a dev-dependency. 
- Avoid redundant map writes by: recording `use builtin` entries only when new imports are added, recording `no warnings 'CATEGORY'` only when a category is newly disabled, and emitting scoped-body restore entries only when the scoped walk produced pragma transitions. 
- Add helper functions `apply_builtin_imports_if_changed` and `disable_warning_category_if_new` to surface whether a state change occurred, and update the walker to consult those before pushing a map entry. 
- Add regression tests confirming duplicate `no warnings` category disables and duplicate `use builtin` imports do not create redundant map entries.

### Testing
- Ran `cargo test -p perl-pragma` and all tests passed. ✅
- Ran `cargo check --all-targets -p perl-pragma` and it succeeded. ✅
- Ran the Criterion benches before/after using `cargo bench -p perl-pragma --bench pragma_benchmarks -- --sample-size 30` and observed measurable improvements (median):
  - `build_large_file`: 2.7975 ms -> 2.5382 ms (~9.3% faster)
  - `query_monotonic_offsets/2000`: 282.60 µs -> 271.60 µs (~3.9% faster)
  - `scope_analyzer_walk_style`: 2.9872 ms -> 2.7590 ms (~7.6% faster)
  - `query_monotonic_offsets/40000`: 5.6521 ms -> 5.5679 ms (~1.5% faster)
All automated checks and benchmarks completed successfully. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb778b4d888333ad22a3c08085a741)