### PR TITLE
fix(perl-pragma): normalize arg parsing and complete feature/builtin symmetry (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -227,6 +227,26 @@ fn feature_items(arg: &str) -> Vec<String> {
     pragma_arg_items(arg)
 }
 
+const KNOWN_FEATURES: [&str; 17] = [
+    "say",
+    "state",
+    "switch",
+    "unicode_strings",
+    "unicode_eval",
+    "evalbytes",
+    "current_sub",
+    "fc",
+    "postfix_deref",
+    "try",
+    "signatures",
+    "defer",
+    "isa",
+    "class",
+    "field",
+    "method",
+    "builtin",
+];
+
 fn known_feature_name(name: &str) -> Option<&'static str> {
     match name {
         "say" => Some("say"),
@@ -299,6 +319,13 @@ fn apply_feature_state(state: &mut PragmaState, args: &[String], enabled: bool) 
 
     for arg in args {
         for item in feature_items(arg) {
+            if enabled && item == ":all" {
+                for feature in KNOWN_FEATURES {
+                    changed |= enable_feature_name(state, feature);
+                }
+                continue;
+            }
+
             if !enabled && item == ":all" {
                 let had_features =
                     !state.features.is_empty() || state.unicode_strings || state.signatures_strict;
@@ -346,14 +373,30 @@ fn builtin_import_names(arg: &str) -> Vec<String> {
     if name.is_empty() { Vec::new() } else { vec![name.to_string()] }
 }
 
-fn apply_builtin_imports(state: &mut PragmaState, args: &[String]) {
+fn apply_builtin_state(state: &mut PragmaState, args: &[String], enabled: bool) -> bool {
+    if !enabled && args.is_empty() {
+        let changed = !state.builtin_imports.is_empty();
+        state.builtin_imports.clear();
+        return changed;
+    }
+
+    let mut changed = false;
     for arg in args {
         for name in builtin_import_names(arg) {
-            if !state.builtin_imports.iter().any(|import| import == &name) {
-                state.builtin_imports.push(name);
+            if enabled {
+                if !state.builtin_imports.iter().any(|import| import == &name) {
+                    state.builtin_imports.push(name);
+                    changed = true;
+                }
+            } else {
+                let before = state.builtin_imports.len();
+                state.builtin_imports.retain(|import| import != &name);
+                changed |= before != state.builtin_imports.len();
             }
         }
     }
+
+    changed
 }
 
 fn pragma_arg_items(arg: &str) -> Vec<String> {
@@ -380,6 +423,24 @@ fn valid_strict_args(args: &[String]) -> bool {
         .all(|item| matches!(item.as_str(), "vars" | "subs" | "refs"))
 }
 
+fn apply_strict_state(state: &mut PragmaState, args: &[String], enabled: bool) {
+    if args.is_empty() {
+        state.strict_vars = enabled;
+        state.strict_subs = enabled;
+        state.strict_refs = enabled;
+        return;
+    }
+
+    for item in args.iter().flat_map(|arg| pragma_arg_items(arg)) {
+        match item.as_str() {
+            "vars" => state.strict_vars = enabled,
+            "subs" => state.strict_subs = enabled,
+            "refs" => state.strict_refs = enabled,
+            _ => {}
+        }
+    }
+}
+
 fn conditional_target_tail_is_valid(module: &str, tail: &[String]) -> bool {
     if parse_perl_version(module).is_some() {
         return tail.is_empty();
@@ -394,7 +455,9 @@ fn conditional_target_tail_is_valid(module: &str, tail: &[String]) -> bool {
             tail.is_empty() || (tail.len() == 1 && !normalized_pragma_token(&tail[0]).is_empty())
         }
         "feature" => !tail.is_empty(),
-        "builtin" => tail.iter().any(|arg| !builtin_import_names(arg).is_empty()),
+        "builtin" => {
+            tail.is_empty() || tail.iter().any(|arg| !builtin_import_names(arg).is_empty())
+        }
         _ => false,
     }
 }
@@ -483,20 +546,7 @@ impl PragmaTracker {
                 {
                     match conditional_module {
                         "strict" => {
-                            if conditional_args.is_empty() {
-                                current_state.strict_vars = true;
-                                current_state.strict_subs = true;
-                                current_state.strict_refs = true;
-                            } else {
-                                for arg in conditional_args {
-                                    match normalized_pragma_token(arg) {
-                                        "vars" => current_state.strict_vars = true,
-                                        "subs" => current_state.strict_subs = true,
-                                        "refs" => current_state.strict_refs = true,
-                                        _ => {}
-                                    }
-                                }
-                            }
+                            apply_strict_state(current_state, conditional_args, true);
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -551,7 +601,7 @@ impl PragmaTracker {
                             return;
                         }
                         "builtin" => {
-                            apply_builtin_imports(current_state, conditional_args);
+                            apply_builtin_state(current_state, conditional_args, true);
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -574,28 +624,7 @@ impl PragmaTracker {
                 // Handle use statements
                 match module.as_str() {
                     "strict" => {
-                        if args.is_empty() {
-                            // use strict; enables all categories
-                            current_state.strict_vars = true;
-                            current_state.strict_subs = true;
-                            current_state.strict_refs = true;
-                        } else {
-                            // Parse specific categories
-                            for arg in args {
-                                match arg.as_str() {
-                                    "vars" | "'vars'" | "\"vars\"" => {
-                                        current_state.strict_vars = true
-                                    }
-                                    "subs" | "'subs'" | "\"subs\"" => {
-                                        current_state.strict_subs = true
-                                    }
-                                    "refs" | "'refs'" | "\"refs\"" => {
-                                        current_state.strict_refs = true
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
+                        apply_strict_state(current_state, args, true);
 
                         // Record the state change at this location
                         ranges
@@ -638,7 +667,7 @@ impl PragmaTracker {
                         }
                     }
                     "builtin" => {
-                        apply_builtin_imports(current_state, args);
+                        apply_builtin_state(current_state, args, true);
                         ranges
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }
@@ -660,20 +689,7 @@ impl PragmaTracker {
                 {
                     match conditional_module {
                         "strict" => {
-                            if conditional_args.is_empty() {
-                                current_state.strict_vars = false;
-                                current_state.strict_subs = false;
-                                current_state.strict_refs = false;
-                            } else {
-                                for arg in conditional_args {
-                                    match normalized_pragma_token(arg) {
-                                        "vars" => current_state.strict_vars = false,
-                                        "subs" => current_state.strict_subs = false,
-                                        "refs" => current_state.strict_refs = false,
-                                        _ => {}
-                                    }
-                                }
-                            }
+                            apply_strict_state(current_state, conditional_args, false);
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -738,6 +754,15 @@ impl PragmaTracker {
                             }
                             return;
                         }
+                        "builtin" => {
+                            if apply_builtin_state(current_state, conditional_args, false) {
+                                ranges.push((
+                                    node.location.start..node.location.end,
+                                    current_state.clone(),
+                                ));
+                            }
+                            return;
+                        }
                         _ => return,
                     }
                 }
@@ -745,28 +770,7 @@ impl PragmaTracker {
                 // Handle no statements
                 match module.as_str() {
                     "strict" => {
-                        if args.is_empty() {
-                            // no strict; disables all categories
-                            current_state.strict_vars = false;
-                            current_state.strict_subs = false;
-                            current_state.strict_refs = false;
-                        } else {
-                            // Parse specific categories
-                            for arg in args {
-                                match arg.as_str() {
-                                    "vars" | "'vars'" | "\"vars\"" => {
-                                        current_state.strict_vars = false
-                                    }
-                                    "subs" | "'subs'" | "\"subs\"" => {
-                                        current_state.strict_subs = false
-                                    }
-                                    "refs" | "'refs'" | "\"refs\"" => {
-                                        current_state.strict_refs = false
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
+                        apply_strict_state(current_state, args, false);
 
                         // Record the state change at this location
                         ranges
@@ -817,6 +821,14 @@ impl PragmaTracker {
                     }
                     "feature" => {
                         if apply_feature_state(current_state, args, false) {
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                        }
+                    }
+                    "builtin" => {
+                        if apply_builtin_state(current_state, args, false) {
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -142,6 +142,20 @@ fn given_use_builtin_qw_when_querying_scope_then_each_imported_name_is_available
 }
 
 #[test]
+fn given_use_builtin_then_no_builtin_when_querying_scope_then_imports_are_cleared() {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true false ceil)"], 0, 30),
+        no_node("builtin", &[], 31, 43),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 40);
+    assert!(!state.has_builtin_import("true"));
+    assert!(!state.has_builtin_import("false"));
+    assert!(!state.has_builtin_import("ceil"));
+}
+
+#[test]
 fn given_use_feature_qw_when_querying_state_then_requested_features_and_unicode_strings_are_enabled()
  {
     let ast = program(vec![use_node("feature", &["'qw(signatures unicode_strings)'"], 0, 41)]);
@@ -163,6 +177,18 @@ fn given_use_if_feature_bundle_when_querying_state_then_bundle_features_are_reco
     assert!(state.has_feature("say"));
     assert!(state.has_feature("signatures"));
     assert!(state.has_feature("isa"));
+}
+
+#[test]
+fn given_use_feature_all_when_querying_state_then_full_known_feature_set_is_enabled() {
+    let ast = program(vec![use_node("feature", &["':all'"], 0, 20)]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 10);
+    assert!(state.has_feature("say"));
+    assert!(state.has_feature("signatures"));
+    assert!(state.has_feature("class"));
+    assert!(state.has_feature("builtin"));
 }
 
 #[test]

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -207,6 +207,17 @@ fn use_strict_quoted_args_double_quotes() -> Result<(), Box<dyn std::error::Erro
 }
 
 #[test]
+fn use_strict_qw_args_enable_multiple_categories() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("strict", &["qw(vars refs)"], 0, 28)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+    assert!(state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(state.strict_refs);
+    Ok(())
+}
+
+#[test]
 fn use_if_strict_conditionally_enables_strict() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("if", &["$^O", "eq", "'MSWin32'", "'strict'"], 0, 35)]);
     let map = PragmaTracker::build(&ast);
@@ -1198,6 +1209,21 @@ fn use_strict_multiple_categories_at_once() -> Result<(), Box<dyn std::error::Er
 }
 
 #[test]
+fn no_strict_mixed_list_forms_disable_expected_categories() -> Result<(), Box<dyn std::error::Error>>
+{
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        no_node("strict", &["qw(vars refs)", "\"subs\""], 13, 46),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+    assert!(!state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(!state.strict_refs);
+    Ok(())
+}
+
+#[test]
 fn no_strict_multiple_categories_at_once() -> Result<(), Box<dyn std::error::Error>> {
     let ast =
         program(vec![use_node("strict", &[], 0, 12), no_node("strict", &["vars", "subs"], 13, 35)]);
@@ -1418,6 +1444,85 @@ fn use_builtin_tracks_lexical_imports_only() -> Result<(), Box<dyn std::error::E
         !state.has_feature("builtin"),
         "lexical builtin imports should stay separate from version-implied features"
     );
+    Ok(())
+}
+
+#[test]
+fn no_builtin_without_args_clears_all_lexical_imports() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true false floor)"], 0, 35),
+        no_node("builtin", &[], 36, 48),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+    assert!(state.builtin_imports.is_empty());
+    Ok(())
+}
+
+#[test]
+fn no_builtin_with_args_removes_only_requested_imports() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true false floor)"], 0, 35),
+        no_node("builtin", &["qw(false)"], 36, 56),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+    assert!(state.has_builtin_import("true"));
+    assert!(!state.has_builtin_import("false"));
+    assert!(state.has_builtin_import("floor"));
+    Ok(())
+}
+
+#[test]
+fn no_if_builtin_conditionally_removes_imports() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true false floor)"], 0, 35),
+        no_node("if", &["$cond", "builtin", "qw(false floor)"], 36, 74),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 60);
+    assert!(state.has_builtin_import("true"));
+    assert!(!state.has_builtin_import("false"));
+    assert!(!state.has_builtin_import("floor"));
+    Ok(())
+}
+
+#[test]
+fn use_feature_all_enables_all_known_features() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("feature", &["':all'"], 0, 20)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+    assert!(state.has_feature("say"));
+    assert!(state.has_feature("class"));
+    assert!(state.has_feature("builtin"));
+    Ok(())
+}
+
+#[test]
+fn no_feature_all_clears_version_implied_bundle_features() -> Result<(), Box<dyn std::error::Error>>
+{
+    let ast = program(vec![use_node("v5.40", &[], 0, 10), no_node("feature", &["':all'"], 11, 31)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+    assert!(!state.has_feature("say"));
+    assert!(!state.has_feature("signatures"));
+    assert!(!state.has_feature("builtin"));
+    Ok(())
+}
+
+#[test]
+fn feature_bundle_can_be_disabled_then_reenabled_after_version_bundle()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("v5.40", &[], 0, 10),
+        no_node("feature", &["':5.36'"], 11, 33),
+        use_node("feature", &["':5.36'"], 34, 56),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[2].1;
+    assert!(state.has_feature("signatures"));
+    assert!(state.has_feature("isa"));
+    assert!(state.has_feature("builtin"), "higher bundle features should remain enabled");
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Pragma argument handling for `strict`/`no strict`, `feature`, and `builtin` was inconsistent across quoted, `qw(...)`, and mixed list forms and lacked symmetry between enable/disable and conditional paths.
- Feature-bundle semantics (e.g. `:all` and version-bundle interactions) were incompletely handled when enabling features.
- Lexical builtin imports were not symmetric between `use` and `no`/conditional `no` forms, making import removal/clearing surprising.

### Description
- Replaced ad-hoc `strict` token matches with a shared `apply_strict_state(state, args, enabled)` helper that uses normalized parsing (`pragma_arg_items`) so `use/no strict` now accepts quoted tokens, `qw(...)`, and mixed grouped forms consistently in direct and conditional pragmas.
- Added `apply_builtin_state(state, args, enabled)` to make `use builtin` / `no builtin` symmetric, including bare `no builtin` clearing all lexical imports and selective removal via list forms and conditional `no if/unless` paths.
- Introduced `KNOWN_FEATURES` and added `use feature ':all'` enable support so `:all` activates all tracked features while retaining existing `no feature ':all'` semantics and proper interactions with version-implied bundles.
- Updated conditional-target validation and pragma application sites to reuse the new helpers and to preserve previous version-implied feature semantics and signature-driven strictness behavior.
- Added unit and behavior tests exercising `qw(...)` and mixed list `strict` forms, `feature ':all'` enable/disable and bundle re-enable interactions, and `builtin` use/no/conditional behavior.

### Testing
- Ran `cargo test -p perl-pragma` which executed the behavior and comprehensive unit suites and succeeded (all new and existing tests passed).
- Ran `cargo check --all-targets -p perl-pragma` which completed with no errors.
- Ran `cargo xtask fmt` to format changes (completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7787c87883339cbb6a5d1d1c658a)