### PR TITLE
fix(perl-pragma): normalize arg parsing and complete feature/builtin symmetry (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -223,9 +223,49 @@ fn enable_effective_version_semantics(state: &mut PragmaState, version: PerlVers
     state.signatures_strict = false;
 }
 
+fn apply_strict_categories(state: &mut PragmaState, args: &[String], enabled: bool) {
+    if args.is_empty() {
+        state.strict_vars = enabled;
+        state.strict_subs = enabled;
+        state.strict_refs = enabled;
+        return;
+    }
+
+    for arg in args {
+        for item in pragma_arg_items(arg) {
+            match item.as_str() {
+                "vars" => state.strict_vars = enabled,
+                "subs" => state.strict_subs = enabled,
+                "refs" => state.strict_refs = enabled,
+                _ => {}
+            }
+        }
+    }
+}
+
 fn feature_items(arg: &str) -> Vec<String> {
     pragma_arg_items(arg)
 }
+
+const ALL_KNOWN_FEATURES: &[&str] = &[
+    "say",
+    "state",
+    "switch",
+    "unicode_strings",
+    "unicode_eval",
+    "evalbytes",
+    "current_sub",
+    "fc",
+    "postfix_deref",
+    "try",
+    "signatures",
+    "defer",
+    "isa",
+    "class",
+    "field",
+    "method",
+    "builtin",
+];
 
 fn known_feature_name(name: &str) -> Option<&'static str> {
     match name {
@@ -299,13 +339,20 @@ fn apply_feature_state(state: &mut PragmaState, args: &[String], enabled: bool) 
 
     for arg in args {
         for item in feature_items(arg) {
-            if !enabled && item == ":all" {
-                let had_features =
-                    !state.features.is_empty() || state.unicode_strings || state.signatures_strict;
-                state.features.clear();
-                state.unicode_strings = false;
-                state.signatures_strict = false;
-                changed |= had_features;
+            if item == ":all" {
+                if enabled {
+                    for feature in ALL_KNOWN_FEATURES {
+                        changed |= enable_feature_name(state, feature);
+                    }
+                } else {
+                    let had_features = !state.features.is_empty()
+                        || state.unicode_strings
+                        || state.signatures_strict;
+                    state.features.clear();
+                    state.unicode_strings = false;
+                    state.signatures_strict = false;
+                    changed |= had_features;
+                }
                 continue;
             }
 
@@ -346,14 +393,31 @@ fn builtin_import_names(arg: &str) -> Vec<String> {
     if name.is_empty() { Vec::new() } else { vec![name.to_string()] }
 }
 
-fn apply_builtin_imports(state: &mut PragmaState, args: &[String]) {
+fn apply_builtin_state(state: &mut PragmaState, args: &[String], enabled: bool) -> bool {
+    if !enabled && args.is_empty() {
+        let changed = !state.builtin_imports.is_empty();
+        state.builtin_imports.clear();
+        return changed;
+    }
+
+    let mut changed = false;
+
     for arg in args {
         for name in builtin_import_names(arg) {
-            if !state.builtin_imports.iter().any(|import| import == &name) {
-                state.builtin_imports.push(name);
+            if enabled {
+                if !state.builtin_imports.iter().any(|import| import == &name) {
+                    state.builtin_imports.push(name);
+                    changed = true;
+                }
+            } else {
+                let before = state.builtin_imports.len();
+                state.builtin_imports.retain(|import| import != &name);
+                changed |= before != state.builtin_imports.len();
             }
         }
     }
+
+    changed
 }
 
 fn pragma_arg_items(arg: &str) -> Vec<String> {
@@ -394,7 +458,9 @@ fn conditional_target_tail_is_valid(module: &str, tail: &[String]) -> bool {
             tail.is_empty() || (tail.len() == 1 && !normalized_pragma_token(&tail[0]).is_empty())
         }
         "feature" => !tail.is_empty(),
-        "builtin" => tail.iter().any(|arg| !builtin_import_names(arg).is_empty()),
+        "builtin" => {
+            tail.is_empty() || tail.iter().any(|arg| !builtin_import_names(arg).is_empty())
+        }
         _ => false,
     }
 }
@@ -483,20 +549,7 @@ impl PragmaTracker {
                 {
                     match conditional_module {
                         "strict" => {
-                            if conditional_args.is_empty() {
-                                current_state.strict_vars = true;
-                                current_state.strict_subs = true;
-                                current_state.strict_refs = true;
-                            } else {
-                                for arg in conditional_args {
-                                    match normalized_pragma_token(arg) {
-                                        "vars" => current_state.strict_vars = true,
-                                        "subs" => current_state.strict_subs = true,
-                                        "refs" => current_state.strict_refs = true,
-                                        _ => {}
-                                    }
-                                }
-                            }
+                            apply_strict_categories(current_state, conditional_args, true);
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -551,11 +604,12 @@ impl PragmaTracker {
                             return;
                         }
                         "builtin" => {
-                            apply_builtin_imports(current_state, conditional_args);
-                            ranges.push((
-                                node.location.start..node.location.end,
-                                current_state.clone(),
-                            ));
+                            if apply_builtin_state(current_state, conditional_args, true) {
+                                ranges.push((
+                                    node.location.start..node.location.end,
+                                    current_state.clone(),
+                                ));
+                            }
                             return;
                         }
                         _ => {
@@ -574,28 +628,7 @@ impl PragmaTracker {
                 // Handle use statements
                 match module.as_str() {
                     "strict" => {
-                        if args.is_empty() {
-                            // use strict; enables all categories
-                            current_state.strict_vars = true;
-                            current_state.strict_subs = true;
-                            current_state.strict_refs = true;
-                        } else {
-                            // Parse specific categories
-                            for arg in args {
-                                match arg.as_str() {
-                                    "vars" | "'vars'" | "\"vars\"" => {
-                                        current_state.strict_vars = true
-                                    }
-                                    "subs" | "'subs'" | "\"subs\"" => {
-                                        current_state.strict_subs = true
-                                    }
-                                    "refs" | "'refs'" | "\"refs\"" => {
-                                        current_state.strict_refs = true
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
+                        apply_strict_categories(current_state, args, true);
 
                         // Record the state change at this location
                         ranges
@@ -638,9 +671,12 @@ impl PragmaTracker {
                         }
                     }
                     "builtin" => {
-                        apply_builtin_imports(current_state, args);
-                        ranges
-                            .push((node.location.start..node.location.end, current_state.clone()));
+                        if apply_builtin_state(current_state, args, true) {
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                        }
                     }
                     _ => {
                         if let Some(version) = parse_perl_version(module) {
@@ -660,20 +696,7 @@ impl PragmaTracker {
                 {
                     match conditional_module {
                         "strict" => {
-                            if conditional_args.is_empty() {
-                                current_state.strict_vars = false;
-                                current_state.strict_subs = false;
-                                current_state.strict_refs = false;
-                            } else {
-                                for arg in conditional_args {
-                                    match normalized_pragma_token(arg) {
-                                        "vars" => current_state.strict_vars = false,
-                                        "subs" => current_state.strict_subs = false,
-                                        "refs" => current_state.strict_refs = false,
-                                        _ => {}
-                                    }
-                                }
-                            }
+                            apply_strict_categories(current_state, conditional_args, false);
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -738,6 +761,15 @@ impl PragmaTracker {
                             }
                             return;
                         }
+                        "builtin" => {
+                            if apply_builtin_state(current_state, conditional_args, false) {
+                                ranges.push((
+                                    node.location.start..node.location.end,
+                                    current_state.clone(),
+                                ));
+                            }
+                            return;
+                        }
                         _ => return,
                     }
                 }
@@ -745,28 +777,7 @@ impl PragmaTracker {
                 // Handle no statements
                 match module.as_str() {
                     "strict" => {
-                        if args.is_empty() {
-                            // no strict; disables all categories
-                            current_state.strict_vars = false;
-                            current_state.strict_subs = false;
-                            current_state.strict_refs = false;
-                        } else {
-                            // Parse specific categories
-                            for arg in args {
-                                match arg.as_str() {
-                                    "vars" | "'vars'" | "\"vars\"" => {
-                                        current_state.strict_vars = false
-                                    }
-                                    "subs" | "'subs'" | "\"subs\"" => {
-                                        current_state.strict_subs = false
-                                    }
-                                    "refs" | "'refs'" | "\"refs\"" => {
-                                        current_state.strict_refs = false
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
+                        apply_strict_categories(current_state, args, false);
 
                         // Record the state change at this location
                         ranges
@@ -817,6 +828,14 @@ impl PragmaTracker {
                     }
                     "feature" => {
                         if apply_feature_state(current_state, args, false) {
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                        }
+                    }
+                    "builtin" => {
+                        if apply_builtin_state(current_state, args, false) {
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -85,6 +85,17 @@ fn given_use_strict_when_querying_after_statement_then_all_strict_modes_are_enab
 }
 
 #[test]
+fn given_use_strict_qw_and_quoted_args_when_querying_then_normalized_categories_are_enabled() {
+    let ast = program(vec![use_node("strict", &["qw(vars refs)", "'subs'"], 0, 36)]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 20);
+    assert!(state.strict_vars);
+    assert!(state.strict_subs);
+    assert!(state.strict_refs);
+}
+
+#[test]
 fn given_use_strict_when_no_strict_refs_in_inner_block_then_refs_is_restored_outside_block() {
     let ast = program(vec![
         use_node("strict", &[], 0, 12),
@@ -139,6 +150,34 @@ fn given_use_builtin_qw_when_querying_scope_then_each_imported_name_is_available
     assert!(state.has_builtin_import("true"));
     assert!(state.has_builtin_import("false"));
     assert!(state.has_builtin_import("ceil"));
+}
+
+#[test]
+fn given_conditional_no_builtin_when_querying_scope_then_requested_import_is_removed() {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true false ceil)"], 0, 30),
+        no_node("if", &["$cond", "builtin", "'false'"], 31, 60),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 50);
+    assert!(state.has_builtin_import("true"));
+    assert!(!state.has_builtin_import("false"));
+    assert!(state.has_builtin_import("ceil"));
+}
+
+#[test]
+fn given_use_feature_all_when_no_feature_all_then_features_are_cleared_symmetrically() {
+    let ast = program(vec![
+        use_node("feature", &["':all'"], 0, 20),
+        no_node("feature", &["':all'"], 21, 40),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 32);
+    assert!(state.features.is_empty());
+    assert!(!state.unicode_strings);
+    assert!(!state.signatures_strict);
 }
 
 #[test]

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -207,6 +207,28 @@ fn use_strict_quoted_args_double_quotes() -> Result<(), Box<dyn std::error::Erro
 }
 
 #[test]
+fn use_strict_qw_list_enables_requested_categories() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("strict", &["qw(vars refs)"], 0, 28)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+    assert!(state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(state.strict_refs);
+    Ok(())
+}
+
+#[test]
+fn use_strict_mixed_grouped_and_quoted_args() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("strict", &["qw(vars refs)", "'subs'"], 0, 36)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+    assert!(state.strict_vars);
+    assert!(state.strict_subs);
+    assert!(state.strict_refs);
+    Ok(())
+}
+
+#[test]
 fn use_if_strict_conditionally_enables_strict() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("if", &["$^O", "eq", "'MSWin32'", "'strict'"], 0, 35)]);
     let map = PragmaTracker::build(&ast);
@@ -347,6 +369,20 @@ fn no_strict_quoted_double() -> Result<(), Box<dyn std::error::Error>> {
     let state = &map[1].1;
     assert!(state.strict_vars);
     assert!(!state.strict_subs);
+    Ok(())
+}
+
+#[test]
+fn no_strict_qw_list_disables_requested_categories() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        no_node("strict", &["qw(vars refs)"], 13, 39),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+    assert!(!state.strict_vars);
+    assert!(state.strict_subs);
+    assert!(!state.strict_refs);
     Ok(())
 }
 
@@ -1418,6 +1454,55 @@ fn use_builtin_tracks_lexical_imports_only() -> Result<(), Box<dyn std::error::E
         !state.has_feature("builtin"),
         "lexical builtin imports should stay separate from version-implied features"
     );
+    Ok(())
+}
+
+#[test]
+fn no_builtin_disables_specific_imports() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true false ceil)"], 0, 30),
+        no_node("builtin", &["'false'"], 31, 50),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 45);
+    assert!(state.has_builtin_import("true"));
+    assert!(!state.has_builtin_import("false"));
+    assert!(state.has_builtin_import("ceil"));
+    Ok(())
+}
+
+#[test]
+fn no_builtin_without_args_clears_all_imports() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true false)"], 0, 24),
+        no_node("builtin", &[], 25, 35),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 30);
+    assert!(!state.has_builtin_import("true"));
+    assert!(!state.has_builtin_import("false"));
+    assert!(state.builtin_imports.is_empty());
+    Ok(())
+}
+
+#[test]
+fn use_feature_all_can_be_disabled_by_bundle_and_all() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("feature", &["':all'"], 0, 20),
+        no_node("feature", &["':5.36'"], 21, 42),
+        no_node("feature", &["':all'"], 43, 62),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let after_bundle_disable = PragmaTracker::state_for_offset(&map, 35);
+    assert!(after_bundle_disable.has_feature("class"));
+    assert!(!after_bundle_disable.has_feature("signatures"));
+    assert!(!after_bundle_disable.signatures_strict);
+
+    let after_all_disable = PragmaTracker::state_for_offset(&map, 55);
+    assert!(after_all_disable.features.is_empty());
+    assert!(!after_all_disable.unicode_strings);
+    assert!(!after_all_disable.signatures_strict);
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Unify and normalize pragma argument parsing so `strict`/`no strict` accept grouped (`qw(...)`), quoted, and mixed list forms consistently instead of ad-hoc string matches. 
- Close asymmetries in `feature` handling so `use feature ':all'` and `no feature ':all'` behave predictably and symmetrically with bundle and version-disable flows. 
- Make `builtin` handling lexically symmetric so `use builtin` and `no builtin` (including conditional and bare-clear forms) consistently add, remove, or clear lexical imports.

### Description
- Introduced `apply_strict_categories(state, args, enabled)` and replaced ad-hoc `strict`/`no strict` branches to reuse `pragma_arg_items` parsing for `vars`, `subs`, and `refs`. 
- Added `ALL_KNOWN_FEATURES` and updated `apply_feature_state` so `:all` enables the full canonical feature list while preserving existing disable semantics for `no feature` and version-bundle interactions. 
- Replaced one-way `builtin` import logic with `apply_builtin_state(state, args, enabled)` to support add/remove/clear semantics and wired it into both `use` / `no` and conditional pragma handling and validation. 
- Updated conditional target validation to accept empty-tail `no builtin`/`use builtin` forms where appropriate and replaced repeated token-normalization code with shared helpers. 
- Added new unit and behavior tests exercising `strict` parsing with `qw(...)` and mixed/quoted args, `feature ':all'` enable/disable symmetry, and `builtin` add/remove/clear behavior.

### Testing
- Ran `cargo test -p perl-pragma` and all crate tests completed successfully. 
- Ran `cargo check --all-targets -p perl-pragma` which completed without errors. 
- Ran `cargo xtask fmt` to format the tree; formatting completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7787c87883339cbb6a5d1d1c658a)