### PR TITLE
fix(perl-pragma): normalize arg parsing and complete feature/builtin symmetry (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -250,6 +250,26 @@ fn known_feature_name(name: &str) -> Option<&'static str> {
     }
 }
 
+const KNOWN_FEATURE_NAMES: &[&str] = &[
+    "say",
+    "state",
+    "switch",
+    "unicode_strings",
+    "unicode_eval",
+    "evalbytes",
+    "current_sub",
+    "fc",
+    "postfix_deref",
+    "try",
+    "signatures",
+    "defer",
+    "isa",
+    "class",
+    "field",
+    "method",
+    "builtin",
+];
+
 fn enable_feature_name(state: &mut PragmaState, name: &str) -> bool {
     if name == "signatures" {
         state.signatures_strict = true;
@@ -299,6 +319,13 @@ fn apply_feature_state(state: &mut PragmaState, args: &[String], enabled: bool) 
 
     for arg in args {
         for item in feature_items(arg) {
+            if enabled && item == ":all" {
+                for feature in KNOWN_FEATURE_NAMES {
+                    changed |= enable_feature_name(state, feature);
+                }
+                continue;
+            }
+
             if !enabled && item == ":all" {
                 let had_features =
                     !state.features.is_empty() || state.unicode_strings || state.signatures_strict;
@@ -356,6 +383,19 @@ fn apply_builtin_imports(state: &mut PragmaState, args: &[String]) {
     }
 }
 
+fn remove_builtin_imports(state: &mut PragmaState, args: &[String]) {
+    if args.is_empty() {
+        state.builtin_imports.clear();
+        return;
+    }
+
+    for arg in args {
+        for name in builtin_import_names(arg) {
+            state.builtin_imports.retain(|import| import != &name);
+        }
+    }
+}
+
 fn pragma_arg_items(arg: &str) -> Vec<String> {
     let trimmed = arg.trim().trim_matches('\'').trim_matches('"');
 
@@ -364,6 +404,26 @@ fn pragma_arg_items(arg: &str) -> Vec<String> {
     }
 
     vec![trimmed.to_string()]
+}
+
+fn apply_strict_args(state: &mut PragmaState, args: &[String], enabled: bool) {
+    if args.is_empty() {
+        state.strict_vars = enabled;
+        state.strict_subs = enabled;
+        state.strict_refs = enabled;
+        return;
+    }
+
+    for arg in args {
+        for item in pragma_arg_items(arg) {
+            match item.as_str() {
+                "vars" => state.strict_vars = enabled,
+                "subs" => state.strict_subs = enabled,
+                "refs" => state.strict_refs = enabled,
+                _ => {}
+            }
+        }
+    }
 }
 
 fn normalized_pragma_token(arg: &str) -> &str {
@@ -394,7 +454,9 @@ fn conditional_target_tail_is_valid(module: &str, tail: &[String]) -> bool {
             tail.is_empty() || (tail.len() == 1 && !normalized_pragma_token(&tail[0]).is_empty())
         }
         "feature" => !tail.is_empty(),
-        "builtin" => tail.iter().any(|arg| !builtin_import_names(arg).is_empty()),
+        "builtin" => {
+            tail.is_empty() || tail.iter().any(|arg| !builtin_import_names(arg).is_empty())
+        }
         _ => false,
     }
 }
@@ -483,20 +545,7 @@ impl PragmaTracker {
                 {
                     match conditional_module {
                         "strict" => {
-                            if conditional_args.is_empty() {
-                                current_state.strict_vars = true;
-                                current_state.strict_subs = true;
-                                current_state.strict_refs = true;
-                            } else {
-                                for arg in conditional_args {
-                                    match normalized_pragma_token(arg) {
-                                        "vars" => current_state.strict_vars = true,
-                                        "subs" => current_state.strict_subs = true,
-                                        "refs" => current_state.strict_refs = true,
-                                        _ => {}
-                                    }
-                                }
-                            }
+                            apply_strict_args(current_state, conditional_args, true);
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -574,28 +623,7 @@ impl PragmaTracker {
                 // Handle use statements
                 match module.as_str() {
                     "strict" => {
-                        if args.is_empty() {
-                            // use strict; enables all categories
-                            current_state.strict_vars = true;
-                            current_state.strict_subs = true;
-                            current_state.strict_refs = true;
-                        } else {
-                            // Parse specific categories
-                            for arg in args {
-                                match arg.as_str() {
-                                    "vars" | "'vars'" | "\"vars\"" => {
-                                        current_state.strict_vars = true
-                                    }
-                                    "subs" | "'subs'" | "\"subs\"" => {
-                                        current_state.strict_subs = true
-                                    }
-                                    "refs" | "'refs'" | "\"refs\"" => {
-                                        current_state.strict_refs = true
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
+                        apply_strict_args(current_state, args, true);
 
                         // Record the state change at this location
                         ranges
@@ -660,20 +688,7 @@ impl PragmaTracker {
                 {
                     match conditional_module {
                         "strict" => {
-                            if conditional_args.is_empty() {
-                                current_state.strict_vars = false;
-                                current_state.strict_subs = false;
-                                current_state.strict_refs = false;
-                            } else {
-                                for arg in conditional_args {
-                                    match normalized_pragma_token(arg) {
-                                        "vars" => current_state.strict_vars = false,
-                                        "subs" => current_state.strict_subs = false,
-                                        "refs" => current_state.strict_refs = false,
-                                        _ => {}
-                                    }
-                                }
-                            }
+                            apply_strict_args(current_state, conditional_args, false);
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -738,6 +753,14 @@ impl PragmaTracker {
                             }
                             return;
                         }
+                        "builtin" => {
+                            remove_builtin_imports(current_state, conditional_args);
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
                         _ => return,
                     }
                 }
@@ -745,28 +768,7 @@ impl PragmaTracker {
                 // Handle no statements
                 match module.as_str() {
                     "strict" => {
-                        if args.is_empty() {
-                            // no strict; disables all categories
-                            current_state.strict_vars = false;
-                            current_state.strict_subs = false;
-                            current_state.strict_refs = false;
-                        } else {
-                            // Parse specific categories
-                            for arg in args {
-                                match arg.as_str() {
-                                    "vars" | "'vars'" | "\"vars\"" => {
-                                        current_state.strict_vars = false
-                                    }
-                                    "subs" | "'subs'" | "\"subs\"" => {
-                                        current_state.strict_subs = false
-                                    }
-                                    "refs" | "'refs'" | "\"refs\"" => {
-                                        current_state.strict_refs = false
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
+                        apply_strict_args(current_state, args, false);
 
                         // Record the state change at this location
                         ranges
@@ -822,6 +824,11 @@ impl PragmaTracker {
                                 current_state.clone(),
                             ));
                         }
+                    }
+                    "builtin" => {
+                        remove_builtin_imports(current_state, args);
+                        ranges
+                            .push((node.location.start..node.location.end, current_state.clone()));
                     }
                     _ => {}
                 }

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -177,6 +177,33 @@ fn given_use_feature_signatures_when_querying_state_then_effective_strict_modes_
 }
 
 #[test]
+fn given_use_feature_all_then_no_feature_all_when_querying_after_disable_then_features_are_cleared()
+{
+    let ast =
+        program(vec![use_node("feature", &[":all"], 0, 18), no_node("feature", &[":all"], 19, 36)]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 30);
+    assert!(!state.has_feature("say"));
+    assert!(!state.has_feature("signatures"));
+    assert!(!state.has_feature("builtin"));
+}
+
+#[test]
+fn given_use_builtin_then_no_builtin_when_querying_after_disable_then_imports_are_removed() {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true false ceil)"], 0, 30),
+        no_node("builtin", &["'false'"], 31, 49),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 40);
+    assert!(state.has_builtin_import("true"));
+    assert!(!state.has_builtin_import("false"));
+    assert!(state.has_builtin_import("ceil"));
+}
+
+#[test]
 fn given_use_v5_38_when_querying_state_then_switch_feature_is_not_available_but_modern_features_are()
  {
     let ast = program(vec![use_node("v5.38", &[], 0, 10)]);

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -207,6 +207,32 @@ fn use_strict_quoted_args_double_quotes() -> Result<(), Box<dyn std::error::Erro
 }
 
 #[test]
+fn use_strict_qw_list_args_are_normalized() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("strict", &["qw(vars refs)"], 0, 28)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+    assert!(state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(state.strict_refs);
+    Ok(())
+}
+
+#[test]
+fn no_strict_mixed_grouped_and_quoted_args_are_normalized() -> Result<(), Box<dyn std::error::Error>>
+{
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        no_node("strict", &["qw(vars refs)", "'subs'"], 13, 48),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+    assert!(!state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(!state.strict_refs);
+    Ok(())
+}
+
+#[test]
 fn use_if_strict_conditionally_enables_strict() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("if", &["$^O", "eq", "'MSWin32'", "'strict'"], 0, 35)]);
     let map = PragmaTracker::build(&ast);
@@ -1418,6 +1444,87 @@ fn use_builtin_tracks_lexical_imports_only() -> Result<(), Box<dyn std::error::E
         !state.has_feature("builtin"),
         "lexical builtin imports should stay separate from version-implied features"
     );
+    Ok(())
+}
+
+#[test]
+fn use_feature_all_enables_known_feature_set() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("feature", &[":all"], 0, 18)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+
+    assert!(state.has_feature("say"));
+    assert!(state.has_feature("signatures"));
+    assert!(state.has_feature("builtin"));
+    assert!(state.unicode_strings);
+    Ok(())
+}
+
+#[test]
+fn no_feature_all_clears_version_bundle_features() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.40", &[], 0, 12), no_node("feature", &[":all"], 13, 31)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+
+    assert!(!state.has_feature("say"));
+    assert!(!state.has_feature("signatures"));
+    assert!(!state.has_feature("builtin"));
+    assert!(!state.unicode_strings);
+    Ok(())
+}
+
+#[test]
+fn no_feature_bundle_then_use_feature_bundle_reenables_expected_subset()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("v5.40", &[], 0, 12),
+        no_node("feature", &[":5.36"], 13, 33),
+        use_node("feature", &[":5.36"], 34, 55),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[2].1;
+
+    assert!(state.has_feature("signatures"));
+    assert!(state.has_feature("defer"));
+    assert!(state.has_feature("isa"));
+    assert!(state.has_feature("builtin"), "v5.40-only features should stay enabled");
+    Ok(())
+}
+
+#[test]
+fn no_builtin_removes_selected_lexical_imports() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("builtin", &["qw(true false ceil)"], 0, 30),
+        no_node("builtin", &["'false'"], 31, 49),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+    assert!(state.has_builtin_import("true"));
+    assert!(!state.has_builtin_import("false"));
+    assert!(state.has_builtin_import("ceil"));
+    Ok(())
+}
+
+#[test]
+fn no_builtin_without_args_clears_lexical_imports() -> Result<(), Box<dyn std::error::Error>> {
+    let ast =
+        program(vec![use_node("builtin", &["'true'"], 0, 20), no_node("builtin", &[], 21, 31)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+    assert!(state.builtin_imports.is_empty());
+    Ok(())
+}
+
+#[test]
+fn no_if_builtin_conditionally_clears_imports() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("builtin", &["'true'", "'ceil'"], 0, 28),
+        no_node("if", &["$debug", "'builtin'", "'ceil'"], 29, 60),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+    assert!(state.has_builtin_import("true"));
+    assert!(!state.has_builtin_import("ceil"));
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- Normalize pragma-argument parsing so `strict`/`no strict` handle `qw(...)`, quoted forms, and mixed/grouped lists consistently instead of ad-hoc string checks.
- Close feature/builtin symmetry gaps so `use feature ':all'`/`no feature ':all'`, version-bundle interactions, and `no builtin` (including conditional forms) behave predictably.

### Description

- Replaced ad-hoc `strict` argument matching with `apply_strict_args` which reuses `pragma_arg_items` to normalize `qw(...)`, quoted tokens, and grouped lists and applies enable/disable uniformly for `use strict`, `no strict`, and conditional `if`/`unless` forms.
- Added `KNOWN_FEATURE_NAMES` and extended `apply_feature_state` so `use feature ':all'` enables the canonical known set while preserving `no feature ':all'` semantics and version-bundle interactions via `:X.Y` semantics.
- Implemented `remove_builtin_imports` and wired it into `no builtin` and conditional `no if/unless ... builtin ...` handling, including support for bare `no builtin` to clear all lexical builtin imports.
- Adjusted conditional-target validation for `builtin` to allow bare conditional targets or grouped `qw(...)` imports, and removed duplicated ad-hoc token matching in the main `build_ranges` traversal.
- Added unit and behavior tests covering normalized `strict` parsing (`qw(vars refs)`, mixed grouped+quoted args), feature `:all` enable/disable and bundle re-enable interactions, and symmetric builtin removal scenarios; kept warnings handling conservative.

### Testing

- Ran formatting with `cargo xtask fmt` (succeeded).
- Ran the crate test suite with `cargo test -p perl-pragma` and all tests passed (`behavior_spec_tests` and `comprehensive_unit_tests` passed).
- Ran `cargo check --all-targets -p perl-pragma` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7787c87883339cbb6a5d1d1c658a)