### PR TITLE
docs(perl-pragma): sync README, roadmap, and CLAUDE guidance with current pragma surface (#0000)

### DIFF
--- a/crates/perl-pragma/CLAUDE.md
+++ b/crates/perl-pragma/CLAUDE.md
@@ -6,17 +6,18 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 `perl-pragma` is a **Tier 1 leaf crate** that tracks pragma state across Perl source files.
 
-**Purpose**: Walks an AST to build a range-indexed map of `use strict`, `no strict`, `use warnings`, and `no warnings` effects, enabling scope-aware pragma queries at any byte offset.
+**Purpose**: Walks an AST to build a range-indexed map of lexical pragma effects (`use`/`no`) so downstream consumers can query effective state at any byte offset.
 
 **Version**: workspace (currently 0.12.3)
 
 ## Commands
 
 ```bash
-cargo build -p perl-pragma           # Build this crate
-cargo test -p perl-pragma            # Run tests
-cargo clippy -p perl-pragma          # Lint
-cargo doc -p perl-pragma --open      # View documentation
+cargo build -p perl-pragma                    # Build this crate
+cargo test -p perl-pragma                     # Run crate tests
+cargo check --all-targets -p perl-pragma      # Check all targets for this crate
+cargo clippy -p perl-pragma                   # Lint
+cargo doc -p perl-pragma --open               # View documentation
 ```
 
 ## Architecture
@@ -29,16 +30,17 @@ cargo doc -p perl-pragma --open      # View documentation
 
 | Type | Description |
 |------|-------------|
-| `PragmaState` | Boolean flags: `strict_vars`, `strict_subs`, `strict_refs`, `warnings` |
-| `PragmaTracker` | Stateless struct with `build()` and `state_for_offset()` methods |
+| `PragmaState` | Strict/warnings flags plus `utf8`, `encoding`, `locale`, warning-category suppression, enabled features, and builtin imports |
+| `PerlVersion` | Parsed Perl version used by version-implied semantics |
+| `PragmaTracker` | Builder/query surface via `build()` and `state_for_offset()` |
 
-### How It Works
+### Core Behavior
 
 1. `PragmaTracker::build(ast)` recursively walks an AST `Node`.
-2. `NodeKind::Use { module: "strict" | "warnings", .. }` and `NodeKind::No { .. }` toggle flags on a running `PragmaState`.
-3. `NodeKind::Block` saves/restores state to model lexical scoping.
-4. The result is a sorted `Vec<(Range<usize>, PragmaState)>`.
-5. `state_for_offset()` performs a binary search (`partition_point`) to return the effective state at any byte offset.
+2. `NodeKind::Use` / `NodeKind::No` apply lexical effects for `strict`, `warnings`, `utf8`, `encoding`, `locale`, `feature`, `builtin`, and version pragmas.
+3. Conditional pragma wrappers (`use if`, `use unless`, `no if`, `no unless`) are interpreted when they target pragma-like modules.
+4. Block-like forms (`Block`, `Eval` block form, `PhaseBlock`, package block form, and other scoped containers) save/restore `PragmaState` to model lexical scope.
+5. The result is a sorted `Vec<(Range<usize>, PragmaState)>`; `state_for_offset()` uses binary search (`partition_point`) to return the effective state.
 
 ### Downstream Consumers
 
@@ -52,15 +54,33 @@ use perl_pragma::{PragmaState, PragmaTracker};
 
 let pragma_map = PragmaTracker::build(&ast);
 let state = PragmaTracker::state_for_offset(&pragma_map, byte_offset);
-if state.strict_vars {
-    // strict vars is in effect at this offset
+
+if state.utf8 || state.has_feature("unicode_strings") {
+    // unicode-sensitive analysis path
 }
+
+if state.has_builtin_import("true") {
+    // builtin::true is available in this lexical scope
+}
+```
+
+## Tests
+
+This crate has a dedicated test surface in `crates/perl-pragma/tests`:
+
+- `comprehensive_unit_tests.rs` -- broad API/state transition coverage
+- `behavior_spec_tests.rs` -- scenario-style lexical behavior coverage
+
+Run with:
+
+```bash
+cargo test -p perl-pragma
 ```
 
 ## Important Notes
 
-- Pragmas are lexically scoped; `Block` nodes save/restore state
-- `use strict` with no args enables all three categories; with args only the named ones
-- `no strict` / `no warnings` disable the corresponding flags
-- Unrecognized modules in `use`/`no` are silently ignored
-- No tests directory exists yet; the crate is exercised through downstream integration tests
+- Pragmas are lexically scoped; scope-exit restores outer state.
+- `use vX.Y` and `use 5.xxx` can imply strictness, warnings, and feature bundles.
+- `no warnings 'CATEGORY'` records category disables while keeping global warnings active.
+- `use feature 'signatures'` toggles strictness implication via dedicated state tracking.
+- Unknown modules in `use`/`no` are ignored unless recognized as version pragmas.

--- a/crates/perl-pragma/README.md
+++ b/crates/perl-pragma/README.md
@@ -4,24 +4,45 @@ Pragma state tracking for Perl source analysis.
 
 ## Overview
 
-`perl-pragma` walks a `perl-ast` AST to track `use strict`, `no strict`,
-`use warnings`, and `no warnings` statements. It builds a range-indexed
-pragma map so callers can query the effective pragma state at any byte offset
-in the source.
+`perl-pragma` walks a `perl-ast` AST to track lexical `use`/`no` effects and
+builds a range-indexed pragma map so callers can query effective state at any
+byte offset in a file.
+
+The tracked pragma surface includes:
+
+- `strict` and `warnings` (including per-category warning disables)
+- `utf8`
+- `encoding`
+- `locale` (including optional locale scope arguments)
+- `feature` toggles and feature bundles (`:5.xx`, `:all`, individual features)
+- lexical `builtin` imports
+- version pragmas (`use vX.Y` / `use 5.xxx`) that imply strictness, warnings,
+  and feature bundles
+- conditional forms (`use if`, `use unless`, `no if`, `no unless`) when they
+  target pragma-like modules
+
+Lexical scoping is modeled across ordinary blocks and scoped constructs such as
+`eval { ... }`, package block forms (`package Foo { ... }`), and phase blocks
+(`BEGIN`, `END`, `CHECK`, `INIT`, `UNITCHECK`) so inner pragma changes are
+restored when scope exits.
 
 ## Public API
 
-- **`PragmaState`** -- tracks `strict_vars`, `strict_subs`, `strict_refs`,
-  and `warnings` booleans. Provides `all_strict()` and `Default`.
+- **`PragmaState`** -- captures strict/warnings flags plus UTF-8, encoding,
+  locale, feature set, and builtin imports for the active lexical scope.
+  Includes helpers like `all_strict()`, `is_warning_active()`,
+  `has_feature()`, and `has_builtin_import()`.
 - **`PragmaTracker`** -- walks an AST via `build()` to produce a sorted
-  `Vec<(Range<usize>, PragmaState)>`, and offers `state_for_offset()` to
-  query it.
+  `Vec<(Range<usize>, PragmaState)>`, and offers `state_for_offset()` to query
+  effective state at arbitrary byte offsets.
+- **Version/feature helpers** -- `PerlVersion`, `parse_perl_version()`,
+  `version_implies_strict()`, `version_implies_warnings()`, and
+  `features_enabled_by_version()`.
 
 ## Workspace Role
 
-Tier 1 leaf crate. Depends only on `perl-ast`. Consumed by
-`perl-parser-core` and `perl-lsp-diagnostics` to provide scope-aware
-pragma analysis for parsing and diagnostic flows.
+Tier 1 leaf crate. Depends only on `perl-ast`. Consumed by parser and language
+feature crates that need scope-aware pragma state when analyzing Perl source.
 
 ## License
 

--- a/crates/perl-pragma/ROADMAP.md
+++ b/crates/perl-pragma/ROADMAP.md
@@ -3,24 +3,36 @@
 > **Note:** This is the component-specific roadmap for `perl-pragma`. For the project-wide roadmap, see [`docs/project/ROADMAP.md`](../../docs/project/ROADMAP.md).
 
 ## Purpose
-Perl pragma extraction and analysis primitives
+Perl pragma extraction and lexical-state analysis primitives.
 
 ## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
-## Future Milestones
+### Shipped in current surface
+- Lexical tracking for `strict`, `warnings`, `utf8`, `encoding`, `locale`,
+  `feature`, `builtin`, and version pragmas.
+- Category-aware warning suppression (`no warnings 'category'`) with
+  query-time checks.
+- Feature bundle support (including `:5.xx` bundles and version-implied
+  features) plus signatures-related strictness behavior.
+- Scope restoration across block-like forms, including lexical `eval { ... }`,
+  package block form (`package Name { ... }`), and phase blocks.
+- Dedicated crate test suite under `crates/perl-pragma/tests` covering
+  comprehensive unit and behavior-spec scenarios.
 
-### Hardening
-- Address early adopter feedback.
-- Refine API contracts and error handling.
-- Improve test coverage and documentation.
+## Hardening still needed
+- Expand conformance coverage for pragma argument edge cases found in real-world
+  CPAN corpora.
+- Add more adversarial tests around nested conditional pragma forms
+  (`use if` / `no if`) and mixed pragma interactions in deep scope trees.
+- Continue API contract review before the next stability ratchet.
 
-### v0.15.0 Stability Contract
+## v0.15.0 Stability Contract
 - Lock down public API for semantic versioning.
 - Guarantee stability across supported platforms.
 
 ## Internal Dependencies
 - Aligns with project-wide capability goals defined in `features.toml`.
 
-<!-- Last Updated: 2026-02-28 -->
+<!-- Last Updated: 2026-04-24 -->


### PR DESCRIPTION
### Motivation

- The crate docs and local guidance still described a strict/warnings-only mental model while the implementation tracks a wider pragma surface (features, utf8, encoding, locale, builtin imports, version-implied semantics, and lexical scoping); the documentation should match the current code. 
- The CLAUDE guidance also implied there was no local test surface, which is stale and hinders accurate maintenance guidance.

### Description

- Updated `crates/perl-pragma/README.md` to document the full tracked pragma surface including `utf8`, `encoding`, `locale`, `feature` bundles, `builtin` imports, version-implied features/strictness, conditional `use if`/`unless`, and lexical scoping across block/eval/package/phase boundaries. 
- Updated `crates/perl-pragma/CLAUDE.md` to describe the current API (`PragmaState`, `PerlVersion`, `PragmaTracker`, helpers), the broader pragma behavior, and to include accurate local commands (`cargo check --all-targets -p perl-pragma`) and explicit test location notes. 
- Updated `crates/perl-pragma/ROADMAP.md` to separate what is already shipped (the current pragma surface and dedicated tests) from remaining hardening work and to refresh the "Last Updated" timestamp. 
- Files changed: `crates/perl-pragma/README.md`, `crates/perl-pragma/CLAUDE.md`, and `crates/perl-pragma/ROADMAP.md`.

### Testing

- Ran `cargo check --all-targets -p perl-pragma`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb778f42a083339f0a06dce2d46358)