### PR TITLE
docs(perl-pragma): sync README, roadmap, and CLAUDE guidance with current pragma surface (#6476)

### DIFF
--- a/crates/perl-pragma/CLAUDE.md
+++ b/crates/perl-pragma/CLAUDE.md
@@ -1,22 +1,23 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code when working with code in this repository.
+This file provides guidance to Claude Code when working with code in this crate.
 
 ## Crate Overview
 
-`perl-pragma` is a **Tier 1 leaf crate** that tracks pragma state across Perl source files.
+`perl-pragma` is a **Tier 1 leaf crate** that tracks lexical pragma state across Perl source files.
 
-**Purpose**: Walks an AST to build a range-indexed map of `use strict`, `no strict`, `use warnings`, and `no warnings` effects, enabling scope-aware pragma queries at any byte offset.
+**Purpose**: Walk an AST to build a range-indexed map of effective pragma state (strict/warnings, utf8/encoding/locale, feature flags, builtin imports, and version-implied semantics), enabling scope-aware queries at any byte offset.
 
-**Version**: workspace (currently 0.12.3)
+**Version**: workspace (currently 0.12.4)
 
 ## Commands
 
 ```bash
-cargo build -p perl-pragma           # Build this crate
-cargo test -p perl-pragma            # Run tests
-cargo clippy -p perl-pragma          # Lint
-cargo doc -p perl-pragma --open      # View documentation
+cargo build -p perl-pragma                    # Build this crate
+cargo test -p perl-pragma                     # Run crate tests (tests/ included)
+cargo check --all-targets -p perl-pragma      # Check all targets
+cargo clippy -p perl-pragma                   # Lint
+cargo doc -p perl-pragma --open               # View documentation
 ```
 
 ## Architecture
@@ -25,18 +26,21 @@ cargo doc -p perl-pragma --open      # View documentation
 
 - `perl-ast` -- AST node types (`Node`, `NodeKind`)
 
-### Key Types
+### Key Types and Functions
 
-| Type | Description |
+| Item | Description |
 |------|-------------|
-| `PragmaState` | Boolean flags: `strict_vars`, `strict_subs`, `strict_refs`, `warnings` |
-| `PragmaTracker` | Stateless struct with `build()` and `state_for_offset()` methods |
+| `PerlVersion` | Parsed major/minor Perl version for lexical version pragmas |
+| `PragmaState` | Effective lexical state: strict, warnings, utf8, encoding, locale, features, builtin imports |
+| `PragmaTracker` | Stateless builder/query helper with `build()` and `state_for_offset()` |
+| `parse_perl_version` | Parses `v5.36`, `5.036`, and similar forms |
+| `features_enabled_by_version` | Computes feature bundles implied by `use VERSION` |
 
 ### How It Works
 
 1. `PragmaTracker::build(ast)` recursively walks an AST `Node`.
-2. `NodeKind::Use { module: "strict" | "warnings", .. }` and `NodeKind::No { .. }` toggle flags on a running `PragmaState`.
-3. `NodeKind::Block` saves/restores state to model lexical scoping.
+2. `NodeKind::Use` / `NodeKind::No` update tracked pragma state for strict/warnings, utf8/encoding/locale, feature toggles, builtin imports, and version pragmas.
+3. Scoped containers (for example `Block`, `Eval`, `PhaseBlock`, and `Package { block: Some(..) }`) save/restore lexical state.
 4. The result is a sorted `Vec<(Range<usize>, PragmaState)>`.
 5. `state_for_offset()` performs a binary search (`partition_point`) to return the effective state at any byte offset.
 
@@ -45,22 +49,39 @@ cargo doc -p perl-pragma --open      # View documentation
 - `perl-parser-core` -- uses pragma state during parsing
 - `perl-lsp-diagnostics` -- pragma-aware diagnostic reporting
 
+## Test Surface
+
+The crate has direct tests in `crates/perl-pragma/tests/`, including:
+
+- `behavior_spec_tests.rs` -- BDD-style behavior scenarios
+- `comprehensive_unit_tests.rs` -- broad API/unit coverage
+
+Run with:
+
+```bash
+cargo test -p perl-pragma
+```
+
 ## Usage
 
 ```rust
-use perl_pragma::{PragmaState, PragmaTracker};
+use perl_pragma::{PragmaTracker, features_enabled_by_version};
 
 let pragma_map = PragmaTracker::build(&ast);
 let state = PragmaTracker::state_for_offset(&pragma_map, byte_offset);
-if state.strict_vars {
-    // strict vars is in effect at this offset
+
+if state.utf8 && state.has_feature("unicode_strings") {
+    // unicode-aware behavior is active in this lexical scope
 }
+
+let v540_features = features_enabled_by_version(perl_pragma::PerlVersion::new(5, 40));
+assert!(v540_features.contains(&"builtin"));
 ```
 
 ## Important Notes
 
-- Pragmas are lexically scoped; `Block` nodes save/restore state
-- `use strict` with no args enables all three categories; with args only the named ones
-- `no strict` / `no warnings` disable the corresponding flags
-- Unrecognized modules in `use`/`no` are silently ignored
-- No tests directory exists yet; the crate is exercised through downstream integration tests
+- Pragmas are lexically scoped; state is restored after scoped bodies.
+- `use feature 'signatures'` implies effective strictness via `signatures_strict`.
+- `no feature 'signatures'` unwinds the feature-implied strictness without removing explicit `use strict` effects.
+- `no warnings 'category'` preserves global warnings while disabling specific categories.
+- Unrecognized pragma modules in `use`/`no` are ignored by this crate.

--- a/crates/perl-pragma/README.md
+++ b/crates/perl-pragma/README.md
@@ -4,18 +4,26 @@ Pragma state tracking for Perl source analysis.
 
 ## Overview
 
-`perl-pragma` walks a `perl-ast` AST to track `use strict`, `no strict`,
-`use warnings`, and `no warnings` statements. It builds a range-indexed
-pragma map so callers can query the effective pragma state at any byte offset
-in the source.
+`perl-pragma` walks a `perl-ast` AST and builds a range-indexed pragma map so callers can query the effective lexical pragma state at any byte offset in a file.
+
+The tracker models far more than a strict/warnings-only surface. It currently tracks:
+
+- strict categories (`vars`, `subs`, `refs`)
+- warnings (global plus selectively disabled categories)
+- `utf8`
+- `encoding`
+- `locale` (including optional scope argument)
+- feature flags from explicit `use feature`/`no feature` and version bundles (`use vX.Y` / `use 5.xxx`)
+- lexical `use builtin` imports
+
+Lexical scope restoration is handled for ordinary blocks and other block-like forms, including eval blocks, package block form, and phase blocks.
 
 ## Public API
 
-- **`PragmaState`** -- tracks `strict_vars`, `strict_subs`, `strict_refs`,
-  and `warnings` booleans. Provides `all_strict()` and `Default`.
-- **`PragmaTracker`** -- walks an AST via `build()` to produce a sorted
-  `Vec<(Range<usize>, PragmaState)>`, and offers `state_for_offset()` to
-  query it.
+- **`PerlVersion`** -- parsed major/minor Perl version used for version pragma semantics.
+- **`PragmaState`** -- effective lexical state snapshot, including strict/warnings, utf8/encoding/locale, feature flags, and builtin imports.
+- **`PragmaTracker`** -- walks an AST via `build()` to produce a sorted `Vec<(Range<usize>, PragmaState)>`, and offers `state_for_offset()` to query it.
+- **Version/feature helpers** -- `parse_perl_version`, `version_implies_strict`, `version_implies_warnings`, and `features_enabled_by_version`.
 
 ## Benchmarks
 
@@ -40,8 +48,7 @@ Criterion reports per-benchmark timing statistics (including time per iteration 
 ## Workspace Role
 
 Tier 1 leaf crate. Depends only on `perl-ast`. Consumed by
-`perl-parser-core` and `perl-lsp-diagnostics` to provide scope-aware
-pragma analysis for parsing and diagnostic flows.
+`perl-parser-core` and `perl-lsp-diagnostics` for scope-aware pragma analysis.
 
 ## License
 

--- a/crates/perl-pragma/ROADMAP.md
+++ b/crates/perl-pragma/ROADMAP.md
@@ -3,24 +3,32 @@
 > **Note:** This is the component-specific roadmap for `perl-pragma`. For the project-wide roadmap, see [`docs/project/ROADMAP.md`](../../docs/project/ROADMAP.md).
 
 ## Purpose
-Perl pragma extraction and analysis primitives
+Perl pragma extraction and lexical state analysis primitives.
 
 ## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
-## Future Milestones
+## Shipped Surface (implemented)
+- Tracks strict/warnings plus warning-category disable lists.
+- Tracks `utf8`, `encoding`, and `locale` pragma state.
+- Tracks version pragmas (`use vX.Y`, `use 5.xxx`) and implied strict/warnings semantics.
+- Tracks feature bundles and explicit feature toggles (`use feature`, `no feature`, `:VERSION`, `:all`).
+- Tracks lexical `use builtin` imports.
+- Restores lexical pragma state across scoped bodies (`{}` blocks, eval blocks, package block form, phase blocks, and other block-like AST containers).
+- Includes dedicated crate tests under `tests/` that cover behavior and broader unit scenarios.
 
-### Hardening
-- Address early adopter feedback.
-- Refine API contracts and error handling.
-- Improve test coverage and documentation.
+## Hardening Backlog
+- Increase edge-case coverage for parser argument normalization in conditional pragmas (`use if`/`use unless` and `no if`/`no unless`).
+- Add explicit regression tests for mixed pragma interactions in deeply nested scoped constructs.
+- Continue tightening API/docs around version-implied feature transitions as newer Perl feature bundles are added upstream.
+- Collect downstream feedback to confirm `PragmaState` field stability before a semver stability commitment.
 
-### v0.15.0 Stability Contract
+## v0.15.0 Stability Contract
 - Lock down public API for semantic versioning.
 - Guarantee stability across supported platforms.
 
 ## Internal Dependencies
 - Aligns with project-wide capability goals defined in `features.toml`.
 
-<!-- Last Updated: 2026-02-28 -->
+<!-- Last Updated: 2026-04-24 -->


### PR DESCRIPTION
### Motivation
- Remove stale strict/warnings-only framing and ensure crate docs accurately describe the actual tracked pragma surface (utf8, encoding, locale, feature bundles, builtin imports, and lexical scoping) and the crate's test surface.

### Description
- Update `crates/perl-pragma/README.md` to document `utf8`, `encoding`, `locale`, feature bundles (`use feature` / `use vX.Y`), `use builtin` imports, and lexical scoping behavior (blocks, `eval`, package block form, and phase blocks), and to list `PerlVersion` / feature helpers in the public API.
- Update `crates/perl-pragma/CLAUDE.md` to reflect the current API and behavior, to document the crate-local `tests/` surface, and to include `features_enabled_by_version` / `parse_perl_version` usage examples.
- Update `crates/perl-pragma/ROADMAP.md` to separate shipped surface from the hardening backlog and to keep the roadmap honest about what is implemented vs. what still needs further testing/hardening.
- Bumped the `Last Updated` date in the roadmap and adjusted a version mention in `CLAUDE.md` to match the workspace state.

### Testing
- Ran `cargo check --all-targets -p perl-pragma`, which finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb778f42a083339f0a06dce2d46358)