### PR TITLE
docs(perl-pragma): sync README, roadmap, and CLAUDE guidance with current pragma surface

### DIFF
--- a/crates/perl-pragma/CLAUDE.md
+++ b/crates/perl-pragma/CLAUDE.md
@@ -1,12 +1,14 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code when working with code in this repository.
+This file provides guidance to Claude Code when working with code in this crate.
 
 ## Crate Overview
 
-`perl-pragma` is a **Tier 1 leaf crate** that tracks pragma state across Perl source files.
+`perl-pragma` is a **Tier 1 leaf crate** that tracks lexical pragma state across Perl source files.
 
-**Purpose**: Walks an AST to build a range-indexed map of `use strict`, `no strict`, `use warnings`, and `no warnings` effects, enabling scope-aware pragma queries at any byte offset.
+**Purpose**: Walk an AST and build a range-indexed map of pragma effects (strict/warnings, utf8,
+encoding, locale, feature bundles, version semantics, and builtin imports), enabling scope-aware
+queries at any byte offset.
 
 **Version**: workspace (currently 0.12.3)
 
@@ -15,6 +17,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 ```bash
 cargo build -p perl-pragma           # Build this crate
 cargo test -p perl-pragma            # Run tests
+cargo check --all-targets -p perl-pragma  # Check lib + tests + benches/examples targets
 cargo clippy -p perl-pragma          # Lint
 cargo doc -p perl-pragma --open      # View documentation
 ```
@@ -25,19 +28,23 @@ cargo doc -p perl-pragma --open      # View documentation
 
 - `perl-ast` -- AST node types (`Node`, `NodeKind`)
 
-### Key Types
+### Key Types & Functions
 
-| Type | Description |
+| Item | Description |
 |------|-------------|
-| `PragmaState` | Boolean flags: `strict_vars`, `strict_subs`, `strict_refs`, `warnings` |
-| `PragmaTracker` | Stateless struct with `build()` and `state_for_offset()` methods |
+| `PerlVersion` | Parsed major/minor version model for `use vX.Y` semantics |
+| `PragmaState` | Effective lexical state: strict flags, warnings state/categories, utf8/encoding/locale, features, builtin imports |
+| `PragmaTracker` | Stateless builder/query API: `build()` and `state_for_offset()` |
+| `parse_perl_version` | Parses lexical version declarations |
+| `version_implies_strict` / `version_implies_warnings` | Encodes version-driven pragma implications |
+| `features_enabled_by_version` | Maps version bundles to feature sets |
 
 ### How It Works
 
 1. `PragmaTracker::build(ast)` recursively walks an AST `Node`.
-2. `NodeKind::Use { module: "strict" | "warnings", .. }` and `NodeKind::No { .. }` toggle flags on a running `PragmaState`.
-3. `NodeKind::Block` saves/restores state to model lexical scoping.
-4. The result is a sorted `Vec<(Range<usize>, PragmaState)>`.
+2. `NodeKind::Use` / `NodeKind::No` update running `PragmaState` for tracked pragma modules.
+3. Scoped nodes save/restore lexical state (blocks, eval blocks, block packages, phase blocks, and other scoped bodies).
+4. The result is a sorted `Vec<(Range<usize>, PragmaState)>` keyed by source ranges.
 5. `state_for_offset()` performs a binary search (`partition_point`) to return the effective state at any byte offset.
 
 ### Downstream Consumers
@@ -48,19 +55,31 @@ cargo doc -p perl-pragma --open      # View documentation
 ## Usage
 
 ```rust
-use perl_pragma::{PragmaState, PragmaTracker};
+use perl_pragma::{PragmaTracker};
 
 let pragma_map = PragmaTracker::build(&ast);
 let state = PragmaTracker::state_for_offset(&pragma_map, byte_offset);
-if state.strict_vars {
-    // strict vars is in effect at this offset
+
+if state.has_feature("signatures") {
+    // signatures feature is lexically active
+}
+
+if state.has_builtin_import("true") {
+    // `use builtin 'true'` (or qw(...)) is active in scope
 }
 ```
 
+## Test Surface
+
+This crate has dedicated tests under `crates/perl-pragma/tests/`:
+
+- `behavior_spec_tests.rs` -- consumer-facing BDD behavior scenarios
+- `comprehensive_unit_tests.rs` -- broader API and edge-case coverage
+
 ## Important Notes
 
-- Pragmas are lexically scoped; `Block` nodes save/restore state
-- `use strict` with no args enables all three categories; with args only the named ones
-- `no strict` / `no warnings` disable the corresponding flags
-- Unrecognized modules in `use`/`no` are silently ignored
-- No tests directory exists yet; the crate is exercised through downstream integration tests
+- Pragmas are lexical; scoped bodies restore caller state on exit.
+- `use VERSION` can imply strict/warnings and feature bundles.
+- `no warnings 'category'` only disables selected categories; bare `no warnings` disables all warnings.
+- `use/no feature` updates lexical features; signatures strictness is tracked separately and applied at query time.
+- Unrecognized `use`/`no` modules are ignored unless they parse as a version pragma.

--- a/crates/perl-pragma/README.md
+++ b/crates/perl-pragma/README.md
@@ -4,24 +4,52 @@ Pragma state tracking for Perl source analysis.
 
 ## Overview
 
-`perl-pragma` walks a `perl-ast` AST to track `use strict`, `no strict`,
-`use warnings`, and `no warnings` statements. It builds a range-indexed
-pragma map so callers can query the effective pragma state at any byte offset
-in the source.
+`perl-pragma` walks a `perl-ast` AST to track lexical `use`/`no` effects and
+builds a range-indexed pragma map so callers can query the effective state at
+any byte offset in a file.
+
+The crate tracks more than the classic strict/warnings pair. Current surface
+includes:
+
+- `strict` / `no strict` (full or category-specific)
+- `warnings` / `no warnings` (including category-level disables)
+- `utf8`
+- `encoding`
+- `locale`
+- Perl version declarations (`use vX.Y`) and their implied strict/warnings rules
+- `feature` declarations, including version bundles like `:5.36`
+- `builtin` lexical imports
+- Conditional forms via `use if` / `use unless` / `no if` / `no unless`
 
 ## Public API
 
-- **`PragmaState`** -- tracks `strict_vars`, `strict_subs`, `strict_refs`,
-  and `warnings` booleans. Provides `all_strict()` and `Default`.
+- **`PerlVersion`** -- parsed major/minor version model for `use v...` handling.
+- **`PragmaState`** -- effective lexical state including strict/warnings,
+  unicode/locale/encoding state, enabled feature set, and imported builtins.
 - **`PragmaTracker`** -- walks an AST via `build()` to produce a sorted
-  `Vec<(Range<usize>, PragmaState)>`, and offers `state_for_offset()` to
-  query it.
+  `Vec<(Range<usize>, PragmaState)>`, and offers `state_for_offset()` to query
+  effective state.
+- **Version helpers** -- `parse_perl_version`, `version_implies_strict`,
+  `version_implies_warnings`, and `features_enabled_by_version`.
+
+## Scoping Model
+
+Pragmas are tracked lexically and restored when leaving scoped constructs. This
+includes regular blocks plus scoped containers such as:
+
+- braced blocks (`{ ... }`)
+- `eval { ... }`
+- block `package Foo { ... }`
+- phase blocks (`BEGIN`, `END`, `CHECK`, `INIT`, `UNITCHECK`)
+
+`state_for_offset()` always returns the effective state at the queried byte
+position after lexical restoration rules are applied.
 
 ## Workspace Role
 
 Tier 1 leaf crate. Depends only on `perl-ast`. Consumed by
-`perl-parser-core` and `perl-lsp-diagnostics` to provide scope-aware
-pragma analysis for parsing and diagnostic flows.
+`perl-parser-core` and `perl-lsp-diagnostics` to provide scope-aware pragma
+analysis for parsing and diagnostic flows.
 
 ## License
 

--- a/crates/perl-pragma/ROADMAP.md
+++ b/crates/perl-pragma/ROADMAP.md
@@ -3,24 +3,36 @@
 > **Note:** This is the component-specific roadmap for `perl-pragma`. For the project-wide roadmap, see [`docs/project/ROADMAP.md`](../../docs/project/ROADMAP.md).
 
 ## Purpose
-Perl pragma extraction and analysis primitives
+Perl pragma extraction and lexical-state analysis primitives.
 
 ## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
-## Future Milestones
+### Shipped
+- Range-indexed pragma state map (`PragmaTracker::build` + `state_for_offset`).
+- Lexical tracking for `strict`, `warnings`, `utf8`, `encoding`, and `locale`.
+- Version-aware semantics (`use vX.Y`) including implied strict/warnings and
+  feature bundles.
+- `feature` enable/disable handling (including bundle forms such as `:5.36` and
+  `:all`).
+- Lexical `builtin` import tracking.
+- Scoped restoration across block/eval/package/phase-style lexical containers.
+- Dedicated crate test surface in `crates/perl-pragma/tests/`.
 
-### Hardening
-- Address early adopter feedback.
-- Refine API contracts and error handling.
-- Improve test coverage and documentation.
+### Still Needs Hardening
+- Broaden edge-case coverage for unusual pragma argument forms and mixed quoting.
+- Add more regression tests around nested conditional pragmas (`use/no if|unless`).
+- Continue downstream validation against real-world corpus files with dense pragma
+  stacking.
+- Tighten API docs with consumer-oriented examples for feature/builtin/version
+  interactions.
 
-### v0.15.0 Stability Contract
+## v0.15.0 Stability Contract
 - Lock down public API for semantic versioning.
 - Guarantee stability across supported platforms.
 
 ## Internal Dependencies
 - Aligns with project-wide capability goals defined in `features.toml`.
 
-<!-- Last Updated: 2026-02-28 -->
+<!-- Last Updated: 2026-04-24 -->


### PR DESCRIPTION
### Motivation

- The crate docs still described a strict/warnings-only mental model while the code now tracks a broader set of lexical pragmas and features.
- Update guidance so consumers and implementation agents see the real public API, scoping model, and existing test surface.

### Description

- Updated `crates/perl-pragma/README.md` to document the full pragma surface including `utf8`, `encoding`, `locale`, version-implied semantics, `feature` bundles, `builtin` lexical imports, and conditional `use/no if|unless` forms, and added an explicit lexical scoping section.
- Updated `crates/perl-pragma/CLAUDE.md` to reflect the current API (`PerlVersion`, `PragmaState`, `PragmaTracker`, `features_enabled_by_version`, etc.), show the test files under `crates/perl-pragma/tests/`, and include `cargo check --all-targets -p perl-pragma` in recommended commands.
- Updated `crates/perl-pragma/ROADMAP.md` to separate what is already shipped (range-indexed map, utf8/encoding/locale/version/feature/builtin support, scoped restoration, and an on-disk tests directory) from items that still need hardening.
- Changes are limited to the three documentation files and keep the crate code and tests unchanged.

### Testing

- Ran `cargo check --all-targets -p perl-pragma` and it completed successfully.
- The crate's existing test files are present under `crates/perl-pragma/tests/` and were left intact (no tests were added or disabled).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb778f42a083339f0a06dce2d46358)