### PR TITLE
docs(perl-pragma): sync README, roadmap, and CLAUDE guidance with current pragma surface

### DIFF
--- a/crates/perl-pragma/CLAUDE.md
+++ b/crates/perl-pragma/CLAUDE.md
@@ -1,22 +1,26 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code when working with code in this repository.
+This file provides guidance to Claude Code when working with code in this crate.
 
 ## Crate Overview
 
-`perl-pragma` is a **Tier 1 leaf crate** that tracks pragma state across Perl source files.
+`perl-pragma` is a **Tier 1 leaf crate** that tracks effective pragma state
+across Perl source files.
 
-**Purpose**: Walks an AST to build a range-indexed map of `use strict`, `no strict`, `use warnings`, and `no warnings` effects, enabling scope-aware pragma queries at any byte offset.
+**Purpose**: Walk a `perl-ast` tree and produce a range-indexed map of lexical
+pragma effects, including strict/warnings controls, utf8/encoding/locale,
+feature bundles, builtin imports, and version-implied semantics.
 
-**Version**: workspace (currently 0.12.3)
+**Version**: Workspace-managed (`version.workspace = true`).
 
 ## Commands
 
 ```bash
-cargo build -p perl-pragma           # Build this crate
-cargo test -p perl-pragma            # Run tests
-cargo clippy -p perl-pragma          # Lint
-cargo doc -p perl-pragma --open      # View documentation
+cargo build -p perl-pragma
+cargo test -p perl-pragma
+cargo check --all-targets -p perl-pragma
+cargo clippy -p perl-pragma
+cargo doc -p perl-pragma --open
 ```
 
 ## Architecture
@@ -25,42 +29,43 @@ cargo doc -p perl-pragma --open      # View documentation
 
 - `perl-ast` -- AST node types (`Node`, `NodeKind`)
 
-### Key Types
+### Key Types and Functions
 
-| Type | Description |
+| Item | Description |
 |------|-------------|
-| `PragmaState` | Boolean flags: `strict_vars`, `strict_subs`, `strict_refs`, `warnings` |
-| `PragmaTracker` | Stateless struct with `build()` and `state_for_offset()` methods |
+| `PragmaState` | Effective lexical state: strict flags, warnings + disabled categories, `utf8`, `encoding`, locale state, active features, builtin imports |
+| `PragmaTracker` | Stateless entry points: `build()` and `state_for_offset()` |
+| `PerlVersion` | Parsed Perl version pair used by version pragmas |
+| `parse_perl_version()` | Parses `v5.xx` / `5.xxx` declarations |
+| `features_enabled_by_version()` | Returns feature bundle implied by a version pragma |
 
-### How It Works
+### Lexical Scoping Model
 
-1. `PragmaTracker::build(ast)` recursively walks an AST `Node`.
-2. `NodeKind::Use { module: "strict" | "warnings", .. }` and `NodeKind::No { .. }` toggle flags on a running `PragmaState`.
-3. `NodeKind::Block` saves/restores state to model lexical scoping.
-4. The result is a sorted `Vec<(Range<usize>, PragmaState)>`.
-5. `state_for_offset()` performs a binary search (`partition_point`) to return the effective state at any byte offset.
+`PragmaTracker::build_ranges` applies pragma transitions and restores caller
+state at lexical boundaries. Scoped handling includes:
 
-### Downstream Consumers
+- `Block`
+- `PhaseBlock` (`BEGIN`, `END`, `INIT`, `CHECK`, `UNITCHECK`)
+- `Eval` blocks (`eval { ... }`)
+- braced package blocks (`package Foo { ... }`)
+- other scoped bodies (`sub`, `method`, `class`, loop bodies, `try` branches)
+
+`state_for_offset()` returns the effective state at an offset by selecting the
+latest preceding range and applying any derived strictness (for example,
+`feature 'signatures'` implications).
+
+## Tests
+
+This crate has first-class integration-style tests under `tests/`:
+
+- `tests/comprehensive_unit_tests.rs` -- broad API and edge-case coverage
+- `tests/behavior_spec_tests.rs` -- BDD-style scenario coverage for lexical
+  behavior and pragma interactions
+
+When changing behavior, update/add tests in this crate rather than relying only
+on downstream integration coverage.
+
+## Downstream Consumers
 
 - `perl-parser-core` -- uses pragma state during parsing
 - `perl-lsp-diagnostics` -- pragma-aware diagnostic reporting
-
-## Usage
-
-```rust
-use perl_pragma::{PragmaState, PragmaTracker};
-
-let pragma_map = PragmaTracker::build(&ast);
-let state = PragmaTracker::state_for_offset(&pragma_map, byte_offset);
-if state.strict_vars {
-    // strict vars is in effect at this offset
-}
-```
-
-## Important Notes
-
-- Pragmas are lexically scoped; `Block` nodes save/restore state
-- `use strict` with no args enables all three categories; with args only the named ones
-- `no strict` / `no warnings` disable the corresponding flags
-- Unrecognized modules in `use`/`no` are silently ignored
-- No tests directory exists yet; the crate is exercised through downstream integration tests

--- a/crates/perl-pragma/README.md
+++ b/crates/perl-pragma/README.md
@@ -4,24 +4,38 @@ Pragma state tracking for Perl source analysis.
 
 ## Overview
 
-`perl-pragma` walks a `perl-ast` AST to track `use strict`, `no strict`,
-`use warnings`, and `no warnings` statements. It builds a range-indexed
-pragma map so callers can query the effective pragma state at any byte offset
-in the source.
+`perl-pragma` walks a `perl-ast` AST and builds a range-indexed pragma map so
+callers can query effective lexical pragma state at any byte offset.
+
+The tracker currently models:
+
+- strict/warnings toggles and warning-category suppression
+- `utf8`, `encoding`, and `locale` pragmas
+- Perl version pragmas (`use v5.xx`) including implied strict/warnings behavior
+- `feature` pragma controls, including feature bundles (`:5.xx`, `:all`) and
+  feature-level effects such as `signatures`
+- `builtin` lexical imports (`use builtin ...`)
+
+Scoping follows Perl lexical behavior for ordinary blocks and scoped constructs,
+including nested blocks, phase blocks, `eval { ... }`, and braced package
+blocks.
 
 ## Public API
 
-- **`PragmaState`** -- tracks `strict_vars`, `strict_subs`, `strict_refs`,
-  and `warnings` booleans. Provides `all_strict()` and `Default`.
-- **`PragmaTracker`** -- walks an AST via `build()` to produce a sorted
-  `Vec<(Range<usize>, PragmaState)>`, and offers `state_for_offset()` to
-  query it.
+- **`PragmaState`** -- snapshot of effective pragma state, including strict
+  flags, warnings flags/categories, utf8/encoding/locale state, active
+  features, and imported builtins. Helpers include `all_strict()`,
+  `is_warning_active()`, `has_feature()`, and `has_builtin_import()`.
+- **`PragmaTracker`** -- builds `Vec<(Range<usize>, PragmaState)>` via `build()`
+  and resolves state at an offset via `state_for_offset()`.
+- **Version helpers** -- `PerlVersion`, `parse_perl_version()`,
+  `version_implies_strict()`, `version_implies_warnings()`, and
+  `features_enabled_by_version()`.
 
 ## Workspace Role
 
 Tier 1 leaf crate. Depends only on `perl-ast`. Consumed by
-`perl-parser-core` and `perl-lsp-diagnostics` to provide scope-aware
-pragma analysis for parsing and diagnostic flows.
+`perl-parser-core` and `perl-lsp-diagnostics` for scope-aware pragma analysis.
 
 ## License
 

--- a/crates/perl-pragma/ROADMAP.md
+++ b/crates/perl-pragma/ROADMAP.md
@@ -3,24 +3,45 @@
 > **Note:** This is the component-specific roadmap for `perl-pragma`. For the project-wide roadmap, see [`docs/project/ROADMAP.md`](../../docs/project/ROADMAP.md).
 
 ## Purpose
-Perl pragma extraction and analysis primitives
+Perl pragma extraction and lexical-scope analysis primitives.
 
-## Current Status (workspace version)
-- **Status:** Initial Public Alpha
-- **Integration:** Part of the `perl-lsp` workspace.
+## Shipped Surface (as of 2026-04-24)
 
-## Future Milestones
+- Tracks `use`/`no` state for:
+  - `strict` (full + category selective)
+  - `warnings` (global plus category-level disables)
+  - `utf8`
+  - `encoding`
+  - `locale`
+  - `feature` (named features, `:all`, and version bundles like `:5.36`)
+  - `builtin` lexical import lists
+- Parses Perl version pragmas and applies implied semantics:
+  - strict from `use v5.12+`
+  - warnings from `use v5.35+`
+  - version-implied feature bundles via `features_enabled_by_version`
+- Applies lexical restoration across scoped forms, including standard blocks,
+  phase blocks, `eval { ... }`, and braced package blocks.
+- Includes crate-local tests in `tests/` covering behavior scenarios and broad
+  API edge cases.
 
-### Hardening
-- Address early adopter feedback.
-- Refine API contracts and error handling.
-- Improve test coverage and documentation.
+## Hardening / Remaining Work
+
+- Expand conformance coverage for nuanced Perl edge cases (especially mixed
+  conditional pragmas and uncommon argument forms).
+- Add targeted regression fixtures for parser-shape variations that affect
+  pragma argument normalization.
+- Continue tightening API documentation and examples for downstream consumers.
+- Gather adopter feedback before declaring a stabilized public contract.
+
+## Stability Target
 
 ### v0.15.0 Stability Contract
+
 - Lock down public API for semantic versioning.
 - Guarantee stability across supported platforms.
 
 ## Internal Dependencies
+
 - Aligns with project-wide capability goals defined in `features.toml`.
 
-<!-- Last Updated: 2026-02-28 -->
+<!-- Last Updated: 2026-04-24 -->


### PR DESCRIPTION
### Motivation

- The crate docs still described a strict/warnings-only mental model and implied there was no local test surface, which is stale relative to the current implementation. 
- Align documentation with the actual pragma handling implemented in the crate so downstream consumers and contributors have accurate guidance.

### Description

- Updated `crates/perl-pragma/README.md` to document the full pragma surface including `utf8`, `encoding`, `locale`, feature bundles, `builtin` imports, version-implied features, and lexical scoping behavior. 
- Updated `crates/perl-pragma/CLAUDE.md` to reflect the current public API (`PragmaState`, `PragmaTracker`, `PerlVersion`, helpers), the lexical scoping model (blocks/eval/package/phase), and the presence of crate-local tests, and added `cargo check --all-targets -p perl-pragma` to the recommended commands. 
- Updated `crates/perl-pragma/ROADMAP.md` to clearly state the shipped surface (what is implemented) and enumerate remaining hardening tasks without overstating stability. 
- Kept changes narrowly scoped to the three documentation files to avoid unrelated churn.

### Testing

- Ran `cargo check --all-targets -p perl-pragma`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb778f42a083339f0a06dce2d46358)