### PR TITLE
test(symbol-surface): add parity bank against workspace-index (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,7 +1865,9 @@ name = "perl-symbol"
 version = "0.12.4"
 dependencies = [
  "perl-ast",
+ "perl-parser-core",
  "perl-tdd-support",
+ "perl-workspace",
  "serde",
  "serde_json",
 ]

--- a/crates/perl-symbol/Cargo.toml
+++ b/crates/perl-symbol/Cargo.toml
@@ -30,6 +30,8 @@ serde = { workspace = true }
 
 [dev-dependencies]
 perl-ast = { workspace = true }
+perl-parser-core = { workspace = true }
+perl-workspace = { workspace = true }
 perl-tdd-support = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/perl-symbol/tests/surface_workspace_parity.rs
+++ b/crates/perl-symbol/tests/surface_workspace_parity.rs
@@ -1,0 +1,245 @@
+use std::error::Error;
+
+use perl_parser_core::Parser;
+use perl_symbol::surface::{extract_symbol_decls, SymbolDecl};
+use perl_symbol::SymbolKind;
+use perl_workspace::workspace::workspace_index::{normalize_var, WorkspaceIndex};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DeclRow {
+    name: String,
+    qualified_name: Option<String>,
+    container: Option<String>,
+    kind: SymbolKind,
+    declarator: Option<String>,
+}
+
+#[derive(Debug)]
+struct Case<'a> {
+    id: &'a str,
+    source: &'a str,
+    expect_matches: Vec<DeclRow>,
+    expect_divergences: Vec<DeclRow>,
+}
+
+fn parse_program(source: &str) -> Result<perl_parser_core::Node, Box<dyn Error>> {
+    let mut parser = Parser::new(source);
+    parser.parse().map_err(|err| format!("parse failed: {err}").into())
+}
+
+fn from_surface(decl: &SymbolDecl) -> DeclRow {
+    DeclRow {
+        name: decl.name.clone(),
+        qualified_name: Some(decl.qualified_name.clone()),
+        container: decl.container.clone(),
+        kind: decl.kind.clone(),
+        declarator: decl.declarator.clone(),
+    }
+}
+
+fn from_workspace(symbol: &perl_workspace::workspace::workspace_index::WorkspaceSymbol) -> DeclRow {
+    let normalized_name = match symbol.kind {
+        SymbolKind::Variable(_) => {
+            let (_, bare_name) = normalize_var(&symbol.name);
+            bare_name.to_string()
+        }
+        _ => symbol.name.clone(),
+    };
+
+    DeclRow {
+        name: normalized_name,
+        qualified_name: symbol.qualified_name.clone(),
+        container: symbol.container_name.clone(),
+        kind: symbol.kind.clone(),
+        declarator: None,
+    }
+}
+
+fn collect_surface_rows(source: &str) -> Result<Vec<DeclRow>, Box<dyn Error>> {
+    let ast = parse_program(source)?;
+    Ok(extract_symbol_decls(&ast, None).iter().map(from_surface).collect::<Vec<_>>())
+}
+
+fn collect_workspace_rows(source: &str) -> Result<Vec<DeclRow>, Box<dyn Error>> {
+    let index = WorkspaceIndex::new();
+    index
+        .index_file_str("file:///parity.pl", source)
+        .map_err(|err| format!("index failed: {err}"))?;
+    Ok(index.search_symbols("").iter().map(from_workspace).collect::<Vec<_>>())
+}
+
+#[test]
+fn surface_workspace_parity_bank() -> Result<(), Box<dyn Error>> {
+    let cases = vec![
+        Case {
+            id: "package_and_sub",
+            source: "package Demo::Pkg;\nsub run { return 1; }\n",
+            expect_matches: vec![
+                DeclRow {
+                    name: "Demo::Pkg".to_string(),
+                    qualified_name: Some("Demo::Pkg".to_string()),
+                    container: None,
+                    kind: SymbolKind::Package,
+                    declarator: None,
+                },
+                DeclRow {
+                    name: "run".to_string(),
+                    qualified_name: Some("Demo::Pkg::run".to_string()),
+                    container: Some("Demo::Pkg".to_string()),
+                    kind: SymbolKind::Subroutine,
+                    declarator: None,
+                },
+            ],
+            expect_divergences: vec![],
+        },
+        Case {
+            id: "class_and_method",
+            source: "class Demo::Thing { method ping () { return 1; } }\n",
+            expect_matches: vec![DeclRow {
+                name: "Demo::Thing".to_string(),
+                qualified_name: Some("Demo::Thing".to_string()),
+                container: None,
+                kind: SymbolKind::Class,
+                declarator: None,
+            }],
+            expect_divergences: vec![DeclRow {
+                name: "ping".to_string(),
+                qualified_name: Some("Demo::Thing::ping".to_string()),
+                container: Some("Demo::Thing".to_string()),
+                kind: SymbolKind::Method,
+                declarator: None,
+            }],
+        },
+        Case {
+            id: "my_scalar",
+            source: "package Vars;\nmy $count = 1;\n",
+            expect_matches: vec![],
+            expect_divergences: vec![DeclRow {
+                name: "count".to_string(),
+                qualified_name: Some("Vars::count".to_string()),
+                container: Some("Vars".to_string()),
+                kind: SymbolKind::Variable(perl_symbol::VarKind::Scalar),
+                declarator: Some("my".to_string()),
+            }],
+        },
+        Case {
+            id: "array_and_hash",
+            source: "package Vars;\nmy @items;\nmy %lookup;\n",
+            expect_matches: vec![],
+            expect_divergences: vec![
+                DeclRow {
+                    name: "items".to_string(),
+                    qualified_name: Some("Vars::items".to_string()),
+                    container: Some("Vars".to_string()),
+                    kind: SymbolKind::Variable(perl_symbol::VarKind::Array),
+                    declarator: Some("my".to_string()),
+                },
+                DeclRow {
+                    name: "lookup".to_string(),
+                    qualified_name: Some("Vars::lookup".to_string()),
+                    container: Some("Vars".to_string()),
+                    kind: SymbolKind::Variable(perl_symbol::VarKind::Hash),
+                    declarator: Some("my".to_string()),
+                },
+            ],
+        },
+        Case {
+            id: "our_vs_my",
+            source: "package Vars;\nour $shared = 1;\nmy $local = 2;\n",
+            expect_matches: vec![],
+            expect_divergences: vec![
+                DeclRow {
+                    name: "shared".to_string(),
+                    qualified_name: Some("Vars::shared".to_string()),
+                    container: Some("Vars".to_string()),
+                    kind: SymbolKind::Variable(perl_symbol::VarKind::Scalar),
+                    declarator: Some("our".to_string()),
+                },
+                DeclRow {
+                    name: "local".to_string(),
+                    qualified_name: Some("Vars::local".to_string()),
+                    container: Some("Vars".to_string()),
+                    kind: SymbolKind::Variable(perl_symbol::VarKind::Scalar),
+                    declarator: Some("my".to_string()),
+                },
+            ],
+        },
+        Case {
+            id: "use_constant",
+            source: "package Demo::Const;\nuse constant LIMIT => 10;\n",
+            expect_matches: vec![],
+            expect_divergences: vec![DeclRow {
+                name: "LIMIT".to_string(),
+                qualified_name: Some("Demo::Const::LIMIT".to_string()),
+                container: Some("Demo::Const".to_string()),
+                kind: SymbolKind::Constant,
+                declarator: None,
+            }],
+        },
+        Case {
+            id: "const_fast",
+            source: "package Demo::Fast;\nuse Const::Fast;\nconst my $FAST => 1;\n",
+            expect_matches: vec![],
+            expect_divergences: vec![DeclRow {
+                name: "FAST".to_string(),
+                qualified_name: Some("Demo::Fast::FAST".to_string()),
+                container: Some("Demo::Fast".to_string()),
+                kind: SymbolKind::Constant,
+                declarator: Some("const".to_string()),
+            }],
+        },
+        Case {
+            id: "readonly",
+            source: "package Demo::RO;\nuse Readonly;\nReadonly my $LIMIT => 3;\n",
+            expect_matches: vec![],
+            expect_divergences: vec![DeclRow {
+                name: "LIMIT".to_string(),
+                qualified_name: Some("Demo::RO::LIMIT".to_string()),
+                container: Some("Demo::RO".to_string()),
+                kind: SymbolKind::Constant,
+                declarator: Some("Readonly".to_string()),
+            }],
+        },
+    ];
+
+    for case in &cases {
+        let surface = collect_surface_rows(case.source)?;
+        let workspace = collect_workspace_rows(case.source)?;
+
+        for expected_match in &case.expect_matches {
+            assert!(
+                surface.contains(expected_match),
+                "case={} expected matched row missing in surface: {:?}; surface={:?}",
+                case.id,
+                expected_match,
+                surface
+            );
+            assert!(
+                workspace.contains(expected_match),
+                "case={} expected matched row missing in workspace: {:?}; workspace={:?}",
+                case.id,
+                expected_match,
+                workspace
+            );
+        }
+
+        for expected_divergence in &case.expect_divergences {
+            assert!(
+                surface.contains(expected_divergence),
+                "case={} expected divergence row missing in surface: {:?}; surface={:?}",
+                case.id,
+                expected_divergence,
+                surface
+            );
+            assert!(
+                !workspace.contains(expected_divergence),
+                "case={} divergence should remain unresolved in workspace for row {:?}; workspace={:?}",
+                case.id,
+                expected_divergence,
+                workspace
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/perl-workspace-index/tests/surface_parity_tests.rs
+++ b/crates/perl-workspace-index/tests/surface_parity_tests.rs
@@ -1,0 +1,179 @@
+use std::error::Error;
+
+use perl_parser_core::Parser;
+use perl_symbol::surface::extract_symbol_decls;
+use perl_symbol::{SymbolKind, VarKind};
+use perl_workspace::workspace::workspace_index::{normalize_var, WorkspaceIndex};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Row {
+    name: String,
+    qualified_name: Option<String>,
+    container: Option<String>,
+    kind: SymbolKind,
+    declarator: Option<String>,
+}
+
+fn parse(source: &str) -> Result<perl_parser_core::Node, Box<dyn Error>> {
+    let mut parser = Parser::new(source);
+    parser.parse().map_err(|err| format!("parse failed: {err}").into())
+}
+
+fn surface_rows(source: &str) -> Result<Vec<Row>, Box<dyn Error>> {
+    let ast = parse(source)?;
+    let rows = extract_symbol_decls(&ast, None)
+        .into_iter()
+        .map(|decl| Row {
+            name: decl.name,
+            qualified_name: Some(decl.qualified_name),
+            container: decl.container,
+            kind: decl.kind,
+            declarator: decl.declarator,
+        })
+        .collect::<Vec<_>>();
+    Ok(rows)
+}
+
+fn workspace_rows(source: &str) -> Result<Vec<Row>, Box<dyn Error>> {
+    let index = WorkspaceIndex::new();
+    index
+        .index_file_str("file:///workspace-parity.pl", source)
+        .map_err(|err| format!("index failed: {err}"))?;
+    let rows = index
+        .search_symbols("")
+        .into_iter()
+        .map(|sym| {
+            let name = match sym.kind {
+                SymbolKind::Variable(_) => normalize_var(&sym.name).1.to_string(),
+                _ => sym.name,
+            };
+            Row {
+                name,
+                qualified_name: sym.qualified_name,
+                container: sym.container_name,
+                kind: sym.kind,
+                declarator: None,
+            }
+        })
+        .collect::<Vec<_>>();
+    Ok(rows)
+}
+
+#[test]
+fn parity_bank_surfaces_matches_and_known_divergences() -> Result<(), Box<dyn Error>> {
+    let core_match_source = "package Demo::Pkg;\nsub run { 1 }\n";
+    let surface = surface_rows(core_match_source)?;
+    let workspace = workspace_rows(core_match_source)?;
+
+    for row in [
+        Row {
+            name: "Demo::Pkg".to_string(),
+            qualified_name: Some("Demo::Pkg".to_string()),
+            container: None,
+            kind: SymbolKind::Package,
+            declarator: None,
+        },
+        Row {
+            name: "run".to_string(),
+            qualified_name: Some("Demo::Pkg::run".to_string()),
+            container: Some("Demo::Pkg".to_string()),
+            kind: SymbolKind::Subroutine,
+            declarator: None,
+        },
+    ] {
+        assert!(surface.contains(&row), "surface missing expected parity row: {:?}", row);
+        assert!(workspace.contains(&row), "workspace missing expected parity row: {:?}", row);
+    }
+
+    let class_source = "class Demo::Thing { method ping () { 1 } }\n";
+    let surface = surface_rows(class_source)?;
+    let workspace = workspace_rows(class_source)?;
+
+    let class_row = Row {
+        name: "Demo::Thing".to_string(),
+        qualified_name: Some("Demo::Thing".to_string()),
+        container: None,
+        kind: SymbolKind::Class,
+        declarator: None,
+    };
+    assert!(surface.contains(&class_row), "surface should index class declaration");
+    assert!(workspace.contains(&class_row), "workspace should index class declaration");
+
+    let method_row = Row {
+        name: "ping".to_string(),
+        qualified_name: Some("Demo::Thing::ping".to_string()),
+        container: Some("Demo::Thing".to_string()),
+        kind: SymbolKind::Method,
+        declarator: None,
+    };
+    assert!(surface.contains(&method_row), "surface should index class method declaration");
+    assert!(
+        !workspace.contains(&method_row),
+        "workspace should expose current divergence for class method declarations"
+    );
+
+    let divergence_source = "package Demo::Vars;\nmy $s;\nmy @a;\nmy %h;\nour $o;\nuse constant LIMIT => 10;\nuse Const::Fast;\nconst my $FAST => 1;\nuse Readonly;\nReadonly my $RO => 2;\n";
+    let surface = surface_rows(divergence_source)?;
+    let workspace = workspace_rows(divergence_source)?;
+
+    for row in [
+        Row {
+            name: "s".to_string(),
+            qualified_name: Some("Demo::Vars::s".to_string()),
+            container: Some("Demo::Vars".to_string()),
+            kind: SymbolKind::Variable(VarKind::Scalar),
+            declarator: Some("my".to_string()),
+        },
+        Row {
+            name: "a".to_string(),
+            qualified_name: Some("Demo::Vars::a".to_string()),
+            container: Some("Demo::Vars".to_string()),
+            kind: SymbolKind::Variable(VarKind::Array),
+            declarator: Some("my".to_string()),
+        },
+        Row {
+            name: "h".to_string(),
+            qualified_name: Some("Demo::Vars::h".to_string()),
+            container: Some("Demo::Vars".to_string()),
+            kind: SymbolKind::Variable(VarKind::Hash),
+            declarator: Some("my".to_string()),
+        },
+        Row {
+            name: "o".to_string(),
+            qualified_name: Some("Demo::Vars::o".to_string()),
+            container: Some("Demo::Vars".to_string()),
+            kind: SymbolKind::Variable(VarKind::Scalar),
+            declarator: Some("our".to_string()),
+        },
+        Row {
+            name: "LIMIT".to_string(),
+            qualified_name: Some("Demo::Vars::LIMIT".to_string()),
+            container: Some("Demo::Vars".to_string()),
+            kind: SymbolKind::Constant,
+            declarator: None,
+        },
+        Row {
+            name: "FAST".to_string(),
+            qualified_name: Some("Demo::Vars::FAST".to_string()),
+            container: Some("Demo::Vars".to_string()),
+            kind: SymbolKind::Constant,
+            declarator: Some("const".to_string()),
+        },
+        Row {
+            name: "RO".to_string(),
+            qualified_name: Some("Demo::Vars::RO".to_string()),
+            container: Some("Demo::Vars".to_string()),
+            kind: SymbolKind::Constant,
+            declarator: Some("Readonly".to_string()),
+        },
+    ] {
+        assert!(surface.contains(&row), "surface missing expected divergence row: {:?}", row);
+        assert!(
+            !workspace.contains(&row),
+            "workspace unexpectedly matched known divergence row: {:?}",
+            row
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Provide a readable, focused parity suite that documents where `perl_symbol::surface::extract_symbol_decls()` already matches the workspace index declaration walker and where they intentionally diverge, to guide future consolidation.

### Description

- Added a parity bank test in `crates/perl-symbol/tests/surface_workspace_parity.rs` that parses representative Perl snippets and compares `extract_symbol_decls()` rows to the `WorkspaceIndex` view, asserting parity on `name`, `qualified_name`, `container`, `kind`, and `declarator` where applicable.
- Added a companion test in `crates/perl-workspace-index/tests/surface_parity_tests.rs` that validates the same representative cases from the workspace index side and documents the current class-method divergence and known variable/constant wrapper gaps.
- Updated `crates/perl-symbol/Cargo.toml` dev-dependencies to include `perl-parser-core` and `perl-workspace` so the `perl-symbol` parity test can parse and index source during tests.
- Covered representative constructs: package declarations, subroutines, methods, class declarations, scalar/array/hash variables, `our` vs `my`, `use constant`, `Const::Fast` (`const` wrapper) and `Readonly` wrappers; divergences are encoded as explicit expected failures.

### Testing

- Ran `cargo test -p perl-symbol` and the `perl-symbol` test suite (including the new `surface_workspace_parity` test) passed.
- Ran `cargo test -p perl-workspace` and the `perl-workspace` test suite (including the new `surface_parity_tests` test) passed.
- Ran `cargo check --workspace --all-targets` which did not complete cleanly due to a pre-existing, unrelated format-string error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs`; this failure is unrelated to the parity tests added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb779e667c8333b638822bc0ac7e61)