### PR TITLE
test(symbol-surface): add parity bank against workspace-index declaration extraction (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,6 +1865,7 @@ name = "perl-symbol"
 version = "0.12.4"
 dependencies = [
  "perl-ast",
+ "perl-parser-core",
  "perl-tdd-support",
  "serde",
  "serde_json",

--- a/crates/perl-symbol/Cargo.toml
+++ b/crates/perl-symbol/Cargo.toml
@@ -30,6 +30,7 @@ serde = { workspace = true }
 
 [dev-dependencies]
 perl-ast = { workspace = true }
+perl-parser-core = { workspace = true }
 perl-tdd-support = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/perl-symbol/tests/surface_workspace_parity.rs
+++ b/crates/perl-symbol/tests/surface_workspace_parity.rs
@@ -1,0 +1,135 @@
+//! Bank of declaration-shape fixtures used by the workspace parity suite.
+//!
+//! This file focuses on what `perl_symbol::surface::extract_symbol_decls` emits
+//! for representative constructs that `perl-workspace-index` also indexes.
+
+use perl_parser_core::Parser;
+use perl_symbol::surface::extract_symbol_decls;
+use perl_symbol::{SymbolKind, VarKind};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SurfaceRow {
+    name: String,
+    qualified_name: String,
+    container: Option<String>,
+    kind: SymbolKind,
+    declarator: Option<String>,
+}
+
+fn surface_rows(source: &str) -> Result<Vec<SurfaceRow>, Box<dyn std::error::Error>> {
+    let mut parser = Parser::new(source);
+    let ast = parser.parse()?;
+
+    Ok(extract_symbol_decls(&ast, None)
+        .into_iter()
+        .map(|decl| SurfaceRow {
+            name: decl.name,
+            qualified_name: decl.qualified_name,
+            container: decl.container,
+            kind: decl.kind,
+            declarator: decl.declarator,
+        })
+        .collect())
+}
+
+#[test]
+fn parity_fixture_bank_covers_representative_constructs() -> Result<(), Box<dyn std::error::Error>>
+{
+    let source = r#"
+package Alpha;
+sub run { }
+
+class App::Model {
+    method save ($self) { }
+}
+
+my $lex = 1;
+our @EXPORT = qw(run);
+my %cfg = ();
+use constant PI => 3.14;
+use Const::Fast;
+const my $CF_RATE => 7;
+use Readonly;
+Readonly my $RO_LIMIT => 10;
+"#;
+
+    let rows = surface_rows(source)?;
+
+    assert!(rows.iter().any(|row| {
+        row.name == "Alpha"
+            && row.qualified_name == "Alpha"
+            && row.container.is_none()
+            && row.kind == SymbolKind::Package
+    }));
+
+    assert!(rows.iter().any(|row| {
+        row.name == "run"
+            && row.qualified_name == "Alpha::run"
+            && row.container.as_deref() == Some("Alpha")
+            && row.kind == SymbolKind::Subroutine
+    }));
+
+    assert!(rows.iter().any(|row| {
+        row.name == "App::Model"
+            && row.qualified_name == "Alpha::App::Model"
+            && row.container.as_deref() == Some("Alpha")
+            && row.kind == SymbolKind::Class
+    }));
+
+    assert!(rows.iter().any(|row| {
+        row.name == "save"
+            && row.qualified_name == "App::Model::save"
+            && row.container.as_deref() == Some("App::Model")
+            && row.kind == SymbolKind::Method
+    }));
+
+    assert!(rows.iter().any(|row| {
+        row.name == "lex"
+            && row.qualified_name == "Alpha::lex"
+            && row.container.as_deref() == Some("Alpha")
+            && row.kind == SymbolKind::Variable(VarKind::Scalar)
+            && row.declarator.as_deref() == Some("my")
+    }));
+
+    assert!(rows.iter().any(|row| {
+        row.name == "EXPORT"
+            && row.qualified_name == "Alpha::EXPORT"
+            && row.container.as_deref() == Some("Alpha")
+            && row.kind == SymbolKind::Variable(VarKind::Array)
+            && row.declarator.as_deref() == Some("our")
+    }));
+
+    assert!(rows.iter().any(|row| {
+        row.name == "cfg"
+            && row.qualified_name == "Alpha::cfg"
+            && row.container.as_deref() == Some("Alpha")
+            && row.kind == SymbolKind::Variable(VarKind::Hash)
+            && row.declarator.as_deref() == Some("my")
+    }));
+
+    assert!(rows.iter().any(|row| {
+        row.name == "PI"
+            && row.qualified_name == "Alpha::PI"
+            && row.container.as_deref() == Some("Alpha")
+            && row.kind == SymbolKind::Constant
+            && row.declarator.is_none()
+    }));
+
+    assert!(rows.iter().any(|row| {
+        row.name == "CF_RATE"
+            && row.qualified_name == "Alpha::CF_RATE"
+            && row.container.as_deref() == Some("Alpha")
+            && row.kind == SymbolKind::Constant
+            && row.declarator.as_deref() == Some("const")
+    }));
+
+    assert!(rows.iter().any(|row| {
+        row.name == "RO_LIMIT"
+            && row.qualified_name == "Alpha::RO_LIMIT"
+            && row.container.as_deref() == Some("Alpha")
+            && row.kind == SymbolKind::Constant
+            && row.declarator.as_deref() == Some("Readonly")
+    }));
+
+    Ok(())
+}

--- a/crates/perl-workspace-index/tests/surface_workspace_parity_tests.rs
+++ b/crates/perl-workspace-index/tests/surface_workspace_parity_tests.rs
@@ -1,0 +1,269 @@
+//! Parity and divergence bank between `perl-symbol` surface extraction and
+//! `perl-workspace-index` declaration extraction.
+
+use perl_parser_core::Parser;
+use perl_symbol::surface::extract_symbol_decls;
+use perl_symbol::{SymbolKind, VarKind};
+use perl_workspace::workspace::workspace_index::WorkspaceIndex;
+use url::Url;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DeclRow {
+    name: String,
+    qualified_name: String,
+    container: Option<String>,
+    kind: SymbolKind,
+    declarator: Option<String>,
+}
+
+fn sort_rows(rows: &mut [DeclRow]) {
+    rows.sort_by(|left, right| {
+        (
+            left.container.clone(),
+            left.qualified_name.clone(),
+            format!("{:?}", left.kind),
+            left.declarator.clone(),
+        )
+            .cmp(&(
+                right.container.clone(),
+                right.qualified_name.clone(),
+                format!("{:?}", right.kind),
+                right.declarator.clone(),
+            ))
+    });
+}
+
+fn parse_surface_rows(source: &str) -> Result<Vec<DeclRow>, Box<dyn std::error::Error>> {
+    let mut parser = Parser::new(source);
+    let ast = parser.parse()?;
+    let mut rows = extract_symbol_decls(&ast, None)
+        .into_iter()
+        .map(|decl| DeclRow {
+            name: decl.name,
+            qualified_name: decl.qualified_name,
+            container: decl.container,
+            kind: decl.kind,
+            declarator: decl.declarator,
+        })
+        .collect::<Vec<_>>();
+    sort_rows(&mut rows);
+    Ok(rows)
+}
+
+fn parse_workspace_rows(source: &str) -> Result<Vec<DeclRow>, Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let uri = Url::parse("file:///parity/sample.pm")?;
+    index.index_file(uri.clone(), source.to_string())?;
+
+    let mut rows = index
+        .file_symbols(uri.as_str())
+        .into_iter()
+        .map(|symbol| {
+            let (name, qualified_name, kind) = match symbol.kind {
+                SymbolKind::Variable(kind) => {
+                    let sigil = match kind {
+                        VarKind::Scalar => '$',
+                        VarKind::Array => '@',
+                        VarKind::Hash => '%',
+                    };
+                    let bare_name = symbol.name.trim_start_matches(sigil).to_string();
+                    let qualified = symbol.container_name.as_ref().map_or_else(
+                        || bare_name.clone(),
+                        |container| format!("{container}::{bare_name}"),
+                    );
+                    (bare_name, qualified, SymbolKind::Variable(kind))
+                }
+                other => {
+                    let qualified = symbol.qualified_name.clone().unwrap_or_else(|| {
+                        symbol.container_name.as_ref().map_or_else(
+                            || symbol.name.clone(),
+                            |container| format!("{container}::{}", symbol.name),
+                        )
+                    });
+                    (symbol.name, qualified, other)
+                }
+            };
+
+            DeclRow {
+                name,
+                qualified_name,
+                container: symbol.container_name,
+                kind,
+                declarator: None,
+            }
+        })
+        .collect::<Vec<_>>();
+    sort_rows(&mut rows);
+    Ok(rows)
+}
+
+fn has_row(rows: &[DeclRow], needle: &DeclRow) -> bool {
+    rows.iter().any(|row| row == needle)
+}
+
+#[test]
+fn surface_and_workspace_match_for_core_named_declarations()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+package Alpha;
+sub run { }
+"#;
+
+    let surface_rows = parse_surface_rows(source)?;
+    let workspace_rows = parse_workspace_rows(source)?;
+
+    let expected_rows = vec![
+        DeclRow {
+            name: "Alpha".to_string(),
+            qualified_name: "Alpha".to_string(),
+            container: None,
+            kind: SymbolKind::Package,
+            declarator: None,
+        },
+        DeclRow {
+            name: "run".to_string(),
+            qualified_name: "Alpha::run".to_string(),
+            container: Some("Alpha".to_string()),
+            kind: SymbolKind::Subroutine,
+            declarator: None,
+        },
+    ];
+
+    for expected in expected_rows {
+        assert!(has_row(&surface_rows, &expected), "surface missing expected row: {expected:?}");
+        assert!(
+            has_row(&workspace_rows, &expected),
+            "workspace-index missing expected row: {expected:?}"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn surface_and_workspace_divergence_bank_is_explicit_and_actionable()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+package Alpha;
+class App::Model {
+    method save ($self) { }
+}
+my $lex = 1;
+our @exports = qw(run);
+my %cfg = ();
+use constant PI => 3.14;
+use Const::Fast;
+const my $CF_RATE => 7;
+use Readonly;
+Readonly my $RO_LIMIT => 10;
+"#;
+
+    let surface_rows = parse_surface_rows(source)?;
+    let workspace_rows = parse_workspace_rows(source)?;
+
+    let my_lex_surface = DeclRow {
+        name: "lex".to_string(),
+        qualified_name: "Alpha::lex".to_string(),
+        container: Some("Alpha".to_string()),
+        kind: SymbolKind::Variable(VarKind::Scalar),
+        declarator: Some("my".to_string()),
+    };
+    assert!(has_row(&surface_rows, &my_lex_surface));
+    assert!(
+        !has_row(&workspace_rows, &my_lex_surface),
+        "workspace-index does not preserve variable declarator yet (expected divergence: add declarator to workspace symbol model)"
+    );
+
+    let our_exports_surface = DeclRow {
+        name: "exports".to_string(),
+        qualified_name: "Alpha::exports".to_string(),
+        container: Some("Alpha".to_string()),
+        kind: SymbolKind::Variable(VarKind::Array),
+        declarator: Some("our".to_string()),
+    };
+    assert!(has_row(&surface_rows, &our_exports_surface));
+    assert!(
+        !has_row(&workspace_rows, &our_exports_surface),
+        "workspace-index does not distinguish `our` vs `my` declarators yet"
+    );
+
+    let hash_surface = DeclRow {
+        name: "cfg".to_string(),
+        qualified_name: "Alpha::cfg".to_string(),
+        container: Some("Alpha".to_string()),
+        kind: SymbolKind::Variable(VarKind::Hash),
+        declarator: Some("my".to_string()),
+    };
+    assert!(has_row(&surface_rows, &hash_surface));
+    assert!(
+        !has_row(&workspace_rows, &hash_surface),
+        "workspace-index does not preserve variable declarator for hash declarations"
+    );
+
+    let use_constant_surface = DeclRow {
+        name: "PI".to_string(),
+        qualified_name: "Alpha::PI".to_string(),
+        container: Some("Alpha".to_string()),
+        kind: SymbolKind::Constant,
+        declarator: None,
+    };
+    assert!(has_row(&surface_rows, &use_constant_surface));
+    assert!(
+        !has_row(&workspace_rows, &use_constant_surface),
+        "workspace-index indexes `use constant` as Subroutine; align SymbolKind to Constant for parity"
+    );
+
+    let const_fast_surface = DeclRow {
+        name: "CF_RATE".to_string(),
+        qualified_name: "Alpha::CF_RATE".to_string(),
+        container: Some("Alpha".to_string()),
+        kind: SymbolKind::Constant,
+        declarator: Some("const".to_string()),
+    };
+    assert!(has_row(&surface_rows, &const_fast_surface));
+    assert!(
+        !has_row(&workspace_rows, &const_fast_surface),
+        "workspace-index currently misses Const::Fast constant extraction; add const-call handling"
+    );
+
+    let readonly_surface = DeclRow {
+        name: "RO_LIMIT".to_string(),
+        qualified_name: "Alpha::RO_LIMIT".to_string(),
+        container: Some("Alpha".to_string()),
+        kind: SymbolKind::Constant,
+        declarator: Some("Readonly".to_string()),
+    };
+    assert!(has_row(&surface_rows, &readonly_surface));
+    assert!(
+        !has_row(&workspace_rows, &readonly_surface),
+        "workspace-index currently misses Readonly constant extraction; add Readonly-call handling"
+    );
+
+    let class_surface = DeclRow {
+        name: "App::Model".to_string(),
+        qualified_name: "Alpha::App::Model".to_string(),
+        container: Some("Alpha".to_string()),
+        kind: SymbolKind::Class,
+        declarator: None,
+    };
+    assert!(has_row(&surface_rows, &class_surface));
+    assert!(
+        !has_row(&workspace_rows, &class_surface),
+        "workspace-index class declaration uses unqualified class name and drops package container; align class qualification semantics"
+    );
+
+    let method_surface = DeclRow {
+        name: "save".to_string(),
+        qualified_name: "App::Model::save".to_string(),
+        container: Some("App::Model".to_string()),
+        kind: SymbolKind::Method,
+        declarator: None,
+    };
+    assert!(has_row(&surface_rows, &method_surface));
+    assert!(
+        !has_row(&workspace_rows, &method_surface),
+        "workspace-index does not walk class bodies when indexing methods; descend into `NodeKind::Class` body for parity"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Codify parity (and intentional divergences) between `perl_symbol::surface::extract_symbol_decls()` and the `perl-workspace-index` declaration walker so the two extractors can be reconciled safely.

### Description
- Add a small fixture bank and unit test in `crates/perl-symbol/tests/surface_workspace_parity.rs` that parses representative Perl snippets and asserts what `extract_symbol_decls()` emits (package, sub, class, method, variables, `use constant`, `Const::Fast`, `Readonly`, declarators).
- Add a cross-crate parity/divergence suite in `crates/perl-workspace-index/tests/surface_workspace_parity_tests.rs` that indexes the same snippets with `WorkspaceIndex` and compares rows (name, `qualified_name`, `container`, `kind`, `declarator` when applicable), asserting parity where present and expressing actionable divergence messages where not.
- Enumerate explicit divergence expectations for the workspace index: loss of variable declarator (`my`/`our`), `use constant` being indexed as `Subroutine` instead of `Constant`, missing `Const::Fast` and `Readonly` constant extraction, class qualification/container semantics mismatch, and methods inside `class` bodies not being indexed.
- Add `perl-parser-core` as a `dev-dependency` to `crates/perl-symbol/Cargo.toml` so the new `perl-symbol` test can parse the inline source fixtures with `Parser`.

### Testing
- Ran `cargo test -p perl-symbol`, which completed successfully and all tests passed.
- Ran `cargo test -p perl-workspace` (the workspace-index crate tests), which completed successfully and the new parity tests passed.
- Ran `cargo check --workspace --all-targets`, which surfaced a pre-existing, unrelated compile-time test error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` (format string mismatch); this is not caused by these changes and blocks a clean full-workspace check in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb779e667c8333b638822bc0ac7e61)