### PR TITLE
perf(cursor): unify perl-symbol cursor extraction onto a shared byte-oriented token scanner (#0000)

### DIFF
--- a/crates/perl-symbol/src/cursor/mod.rs
+++ b/crates/perl-symbol/src/cursor/mod.rs
@@ -16,85 +16,145 @@ pub enum CursorSymbolKind {
     Subroutine,
 }
 
-/// Extract a symbol and its kind from `source` at `position`.
-pub fn extract_symbol_from_source(
-    position: usize,
-    source: &str,
-) -> Option<(String, CursorSymbolKind)> {
-    let chars: Vec<char> = source.chars().collect();
-    if position >= chars.len() {
+#[derive(Debug, Clone, Copy)]
+struct TokenSpan {
+    name_start: usize,
+    name_end: usize,
+    sigil: Option<CursorSymbolKind>,
+}
+
+/// Return true when `byte` is an identifier character (`[A-Za-z0-9_]`).
+#[inline]
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+#[inline]
+fn sigil_kind(byte: u8) -> Option<CursorSymbolKind> {
+    match byte {
+        b'$' => Some(CursorSymbolKind::Scalar),
+        b'@' => Some(CursorSymbolKind::Array),
+        b'%' => Some(CursorSymbolKind::Hash),
+        b'&' => Some(CursorSymbolKind::Subroutine),
+        _ => None,
+    }
+}
+
+#[inline]
+fn scan_while<F>(bytes: &[u8], mut index: usize, class: F) -> usize
+where
+    F: Fn(u8) -> bool,
+{
+    while index < bytes.len() && class(bytes[index]) {
+        index += 1;
+    }
+    index
+}
+
+#[inline]
+fn token_span_at_byte(source: &str, position: usize) -> Option<TokenSpan> {
+    let bytes = source.as_bytes();
+    if position >= bytes.len() {
         return None;
     }
 
     let (sigil, name_start) = if position > 0 {
-        match chars.get(position - 1) {
-            Some('$') => (Some(CursorSymbolKind::Scalar), position),
-            Some('@') => (Some(CursorSymbolKind::Array), position),
-            Some('%') => (Some(CursorSymbolKind::Hash), position),
-            Some('&') => (Some(CursorSymbolKind::Subroutine), position),
-            _ => (None, position),
+        if let Some(kind) = sigil_kind(bytes[position - 1]) {
+            (Some(kind), position)
+        } else {
+            (None, position)
         }
     } else {
         (None, position)
     };
 
-    let (sigil, name_start) = if sigil.is_none() && position < chars.len() {
-        match chars[position] {
-            '$' => (Some(CursorSymbolKind::Scalar), position + 1),
-            '@' => (Some(CursorSymbolKind::Array), position + 1),
-            '%' => (Some(CursorSymbolKind::Hash), position + 1),
-            '&' => (Some(CursorSymbolKind::Subroutine), position + 1),
-            _ => (sigil, name_start),
+    let (sigil, name_start) = if sigil.is_none() {
+        if let Some(kind) = sigil_kind(bytes[position]) {
+            (Some(kind), position.saturating_add(1))
+        } else {
+            (None, name_start)
         }
     } else {
         (sigil, name_start)
     };
 
-    let mut end = name_start;
-    while end < chars.len() && (chars[end].is_alphanumeric() || chars[end] == '_') {
-        end += 1;
-    }
+    let name_end = scan_while(bytes, name_start, is_identifier_byte);
 
-    if end > name_start {
-        let name: String = chars[name_start..end].iter().collect();
-        let kind = sigil.unwrap_or(CursorSymbolKind::Subroutine);
-        Some((name, kind))
-    } else {
-        None
-    }
+    Some(TokenSpan { name_start, name_end, sigil })
 }
 
-/// Get symbol range at `position`, including a leading sigil when present.
-pub fn get_symbol_range_at_position(position: usize, source: &str) -> Option<(usize, usize)> {
-    let chars: Vec<char> = source.chars().collect();
-    if position >= chars.len() {
+#[inline]
+fn extract_token_at_byte<F>(source: &str, byte_pos: usize, class: F) -> Option<(usize, usize)>
+where
+    F: Fn(u8) -> bool,
+{
+    let bytes = source.as_bytes();
+    if byte_pos >= bytes.len() {
         return None;
     }
 
-    let mut start = position;
-    if start > 0 && matches!(chars[start - 1], '$' | '@' | '%' | '&') {
+    let mut start = byte_pos;
+    while start > 0 && class(bytes[start - 1]) {
         start -= 1;
     }
 
-    let mut end = position;
-    while end < chars.len() && (chars[end].is_alphanumeric() || chars[end] == '_') {
+    let mut end = byte_pos;
+    while end < bytes.len() && class(bytes[end]) {
         end += 1;
     }
 
-    while start < position
-        && start < chars.len()
-        && (chars[start].is_alphanumeric() || chars[start] == '_')
-    {
-        start -= 1;
+    if start == end {
+        return None;
     }
 
     Some((start, end))
 }
 
+/// Extract a symbol and its kind from `source` at `position`.
+pub fn extract_symbol_from_source(
+    position: usize,
+    source: &str,
+) -> Option<(String, CursorSymbolKind)> {
+    let span = token_span_at_byte(source, position)?;
+    if span.name_end <= span.name_start {
+        return None;
+    }
+
+    let name = source[span.name_start..span.name_end].to_string();
+    let kind = span.sigil.unwrap_or(CursorSymbolKind::Subroutine);
+    Some((name, kind))
+}
+
+/// Get symbol range at `position`, including a leading sigil when present.
+pub fn get_symbol_range_at_position(position: usize, source: &str) -> Option<(usize, usize)> {
+    let span = token_span_at_byte(source, position)?;
+    let bytes = source.as_bytes();
+
+    if sigil_kind(bytes[position]).is_some()
+        && (position == 0 || sigil_kind(bytes[position - 1]).is_none())
+    {
+        return Some((position, position));
+    }
+
+    let mut start = span.name_start;
+    while start < position && start < bytes.len() && is_identifier_byte(bytes[start]) {
+        if start == 0 {
+            break;
+        }
+        start -= 1;
+    }
+
+    if start > 0 && sigil_kind(bytes[start - 1]).is_some() {
+        start -= 1;
+    }
+
+    Some((start, span.name_end))
+}
+
 /// Return true when `byte` is a module/name character (`[A-Za-z0-9_:]`).
 #[inline]
 pub fn is_modchar(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || byte == b':' || byte == b'_'
+    is_identifier_byte(byte) || byte == b':'
 }
 
 /// Convert a UTF-16 column index to a byte offset for a single line.
@@ -118,24 +178,13 @@ pub fn byte_offset_utf16(line_text: &str, col_utf16: usize) -> usize {
 pub fn token_under_cursor(text: &str, line: usize, col_utf16: usize) -> Option<String> {
     let line_text = text.lines().nth(line)?;
     let byte_pos = byte_offset_utf16(line_text, col_utf16);
-    let bytes = line_text.as_bytes();
+    let (mut start, end) = extract_token_at_byte(line_text, byte_pos, is_modchar)?;
 
-    if byte_pos >= bytes.len() {
-        return None;
-    }
-
-    let mut start = byte_pos;
-    let mut end = byte_pos;
-
-    while start > 0 && is_modchar(bytes[start - 1]) {
-        start -= 1;
-    }
-    if start > 0 && matches!(bytes[start - 1], b'$' | b'@' | b'%' | b'&' | b'*') {
-        start -= 1;
-    }
-
-    while end < bytes.len() && is_modchar(bytes[end]) {
-        end += 1;
+    if start > 0 {
+        let prev = line_text.as_bytes()[start - 1];
+        if matches!(prev, b'$' | b'@' | b'%' | b'&' | b'*') {
+            start -= 1;
+        }
     }
 
     Some(line_text[start..end].to_string())

--- a/crates/perl-symbol/tests/cursor_byte_utf16_parity.rs
+++ b/crates/perl-symbol/tests/cursor_byte_utf16_parity.rs
@@ -1,0 +1,27 @@
+use perl_symbol::cursor::{byte_offset_utf16, token_under_cursor};
+
+#[test]
+fn utf16_to_byte_and_token_lookup_agree_for_ascii() {
+    let text = "my $count = 1;\n";
+    let col = 5;
+    let byte = byte_offset_utf16("my $count = 1;", col);
+    assert_eq!(byte, col);
+    assert_eq!(token_under_cursor(text, 0, col), Some("$count".to_string()));
+}
+
+#[test]
+fn utf16_to_byte_and_token_lookup_agree_with_surrogate_pair_prefix() {
+    let text = "😀 $count = 1;\n";
+    // Cursor on 'c' in "$count". UTF-16: 😀 is two units, then space + '$' + 'c'.
+    let col_utf16 = 5;
+    let byte = byte_offset_utf16("😀 $count = 1;", col_utf16);
+    assert_eq!(byte, 7);
+    assert_eq!(token_under_cursor(text, 0, col_utf16), Some("$count".to_string()));
+}
+
+#[test]
+fn token_under_cursor_returns_none_at_line_end() {
+    let text = "use Demo::Worker;\n";
+    let col_utf16 = "use Demo::Worker;".encode_utf16().count();
+    assert_eq!(token_under_cursor(text, 0, col_utf16), None);
+}


### PR DESCRIPTION
### Motivation

- Eliminate duplicated cursor/range scanning logic and make byte semantics explicit to avoid inconsistent UTF-16/byte handling and extra `Vec<char>` allocations.
- Ensure `extract_symbol_from_source()`, `get_symbol_range_at_position()`, and `token_under_cursor()` share a single, well-defined scanner so downstream rename/position code has consistent spans.

### Description

- Introduced internal byte-oriented scanner primitives: `TokenSpan`, `is_identifier_byte`, `sigil_kind`, `scan_while`, and `token_span_at_byte` to centralize sigil/identifier classification and span detection.
- Added `extract_token_at_byte()` and refactored `token_under_cursor()` to use UTF-16→byte conversion plus the shared byte scanner with explicit sigil-prefix handling.
- Reimplemented `extract_symbol_from_source()` and `get_symbol_range_at_position()` on top of the shared byte span core while preserving existing public API semantics and edge-case behavior.
- Added parity tests in `crates/perl-symbol/tests/cursor_byte_utf16_parity.rs` to validate UTF-16→byte conversion and token extraction agreement.

### Testing

- Ran `cargo test -p perl-symbol`, which completed successfully (all cursor and crate tests passed).
- Ran `cargo check --all-targets -p perl-symbol`, which completed successfully.
- Ran `cargo fmt -p perl-symbol` as part of the change pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77a1b9cc83338e9de0acd6eba346)