### PR TITLE
refactor(cursor): unify perl-symbol cursor extraction onto a shared byte-oriented token scanner (#0000)

### DIFF
--- a/crates/perl-symbol/src/cursor/mod.rs
+++ b/crates/perl-symbol/src/cursor/mod.rs
@@ -16,79 +16,100 @@ pub enum CursorSymbolKind {
     Subroutine,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TokenSpan {
+    start: usize,
+    name_start: usize,
+    end: usize,
+    sigil: Option<CursorSymbolKind>,
+}
+
+#[inline]
+fn is_identifier_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+#[inline]
+fn is_symbol_sigil(byte: u8) -> bool {
+    matches!(byte, b'$' | b'@' | b'%' | b'&')
+}
+
+#[inline]
+fn sigil_to_kind(byte: u8) -> Option<CursorSymbolKind> {
+    match byte {
+        b'$' => Some(CursorSymbolKind::Scalar),
+        b'@' => Some(CursorSymbolKind::Array),
+        b'%' => Some(CursorSymbolKind::Hash),
+        b'&' => Some(CursorSymbolKind::Subroutine),
+        _ => None,
+    }
+}
+
+fn token_span_at_byte(source: &str, position: usize) -> Option<TokenSpan> {
+    let bytes = source.as_bytes();
+    let current = *bytes.get(position)?;
+
+    if is_symbol_sigil(current) {
+        let name_start = position + 1;
+        let mut end = name_start;
+        while end < bytes.len() && is_identifier_char(bytes[end]) {
+            end += 1;
+        }
+
+        if end == name_start {
+            return None;
+        }
+
+        return Some(TokenSpan { start: position, name_start, end, sigil: sigil_to_kind(current) });
+    }
+
+    if !is_identifier_char(current) {
+        return None;
+    }
+
+    let mut name_start = position;
+    while name_start > 0 && is_identifier_char(bytes[name_start - 1]) {
+        name_start -= 1;
+    }
+
+    let mut end = position;
+    while end < bytes.len() && is_identifier_char(bytes[end]) {
+        end += 1;
+    }
+
+    let (start, sigil) = if name_start > 0 {
+        let before = bytes[name_start - 1];
+        if is_symbol_sigil(before) {
+            (name_start - 1, sigil_to_kind(before))
+        } else {
+            (name_start, None)
+        }
+    } else {
+        (name_start, None)
+    };
+
+    Some(TokenSpan { start, name_start, end, sigil })
+}
+
+fn extract_token_at_byte(source: &str, position: usize) -> Option<(String, CursorSymbolKind)> {
+    let span = token_span_at_byte(source, position)?;
+    let name = source.get(span.name_start..span.end)?.to_string();
+    let kind = span.sigil.unwrap_or(CursorSymbolKind::Subroutine);
+    Some((name, kind))
+}
+
 /// Extract a symbol and its kind from `source` at `position`.
 pub fn extract_symbol_from_source(
     position: usize,
     source: &str,
 ) -> Option<(String, CursorSymbolKind)> {
-    let chars: Vec<char> = source.chars().collect();
-    if position >= chars.len() {
-        return None;
-    }
-
-    let (sigil, name_start) = if position > 0 {
-        match chars.get(position - 1) {
-            Some('$') => (Some(CursorSymbolKind::Scalar), position),
-            Some('@') => (Some(CursorSymbolKind::Array), position),
-            Some('%') => (Some(CursorSymbolKind::Hash), position),
-            Some('&') => (Some(CursorSymbolKind::Subroutine), position),
-            _ => (None, position),
-        }
-    } else {
-        (None, position)
-    };
-
-    let (sigil, name_start) = if sigil.is_none() && position < chars.len() {
-        match chars[position] {
-            '$' => (Some(CursorSymbolKind::Scalar), position + 1),
-            '@' => (Some(CursorSymbolKind::Array), position + 1),
-            '%' => (Some(CursorSymbolKind::Hash), position + 1),
-            '&' => (Some(CursorSymbolKind::Subroutine), position + 1),
-            _ => (sigil, name_start),
-        }
-    } else {
-        (sigil, name_start)
-    };
-
-    let mut end = name_start;
-    while end < chars.len() && (chars[end].is_alphanumeric() || chars[end] == '_') {
-        end += 1;
-    }
-
-    if end > name_start {
-        let name: String = chars[name_start..end].iter().collect();
-        let kind = sigil.unwrap_or(CursorSymbolKind::Subroutine);
-        Some((name, kind))
-    } else {
-        None
-    }
+    extract_token_at_byte(source, position)
 }
 
 /// Get symbol range at `position`, including a leading sigil when present.
 pub fn get_symbol_range_at_position(position: usize, source: &str) -> Option<(usize, usize)> {
-    let chars: Vec<char> = source.chars().collect();
-    if position >= chars.len() {
-        return None;
-    }
-
-    let mut start = position;
-    if start > 0 && matches!(chars[start - 1], '$' | '@' | '%' | '&') {
-        start -= 1;
-    }
-
-    let mut end = position;
-    while end < chars.len() && (chars[end].is_alphanumeric() || chars[end] == '_') {
-        end += 1;
-    }
-
-    while start < position
-        && start < chars.len()
-        && (chars[start].is_alphanumeric() || chars[start] == '_')
-    {
-        start -= 1;
-    }
-
-    Some((start, end))
+    let span = token_span_at_byte(source, position)?;
+    Some((span.start, span.end))
 }
 
 /// Return true when `byte` is a module/name character (`[A-Za-z0-9_:]`).
@@ -114,30 +135,45 @@ pub fn byte_offset_utf16(line_text: &str, col_utf16: usize) -> usize {
     line_text.len()
 }
 
-/// Extract the module/symbol token under the cursor (UTF-16 aware).
-pub fn token_under_cursor(text: &str, line: usize, col_utf16: usize) -> Option<String> {
-    let line_text = text.lines().nth(line)?;
-    let byte_pos = byte_offset_utf16(line_text, col_utf16);
-    let bytes = line_text.as_bytes();
+fn token_span_with_rules<F>(text: &str, position: usize, is_body_char: F) -> Option<(usize, usize)>
+where
+    F: Fn(u8) -> bool,
+{
+    let bytes = text.as_bytes();
+    let current = *bytes.get(position)?;
 
-    if byte_pos >= bytes.len() {
+    if !is_body_char(current) && !matches!(current, b'$' | b'@' | b'%' | b'&' | b'*') {
         return None;
     }
 
-    let mut start = byte_pos;
-    let mut end = byte_pos;
-
-    while start > 0 && is_modchar(bytes[start - 1]) {
-        start -= 1;
+    let mut start = position;
+    if is_body_char(current) {
+        while start > 0 && is_body_char(bytes[start - 1]) {
+            start -= 1;
+        }
     }
+
     if start > 0 && matches!(bytes[start - 1], b'$' | b'@' | b'%' | b'&' | b'*') {
         start -= 1;
     }
 
-    while end < bytes.len() && is_modchar(bytes[end]) {
+    let mut end = if is_body_char(current) { position } else { position + 1 };
+    while end < bytes.len() && is_body_char(bytes[end]) {
         end += 1;
     }
 
+    if end <= start {
+        return None;
+    }
+
+    Some((start, end))
+}
+
+/// Extract the module/symbol token under the cursor (UTF-16 aware).
+pub fn token_under_cursor(text: &str, line: usize, col_utf16: usize) -> Option<String> {
+    let line_text = text.lines().nth(line)?;
+    let byte_pos = byte_offset_utf16(line_text, col_utf16);
+    let (start, end) = token_span_with_rules(line_text, byte_pos, is_modchar)?;
     Some(line_text[start..end].to_string())
 }
 

--- a/crates/perl-symbol/tests/cursor_byte_utf16_parity.rs
+++ b/crates/perl-symbol/tests/cursor_byte_utf16_parity.rs
@@ -1,0 +1,50 @@
+use perl_symbol::cursor::{
+    extract_symbol_from_source, get_symbol_range_at_position, token_under_cursor,
+};
+use perl_tdd_support::must_some;
+
+#[test]
+fn token_under_cursor_matches_byte_scanner_for_scalar_symbol() -> Result<(), String> {
+    let text = "my $value = 1;\n";
+    let line = text.lines().next().ok_or_else(|| "missing line".to_string())?;
+    let byte_pos = line.find('v').ok_or_else(|| "missing symbol".to_string())?;
+
+    let from_line = must_some(token_under_cursor(text, 0, byte_pos));
+    let (name, _) = must_some(extract_symbol_from_source(byte_pos, line));
+    let (start, end) = must_some(get_symbol_range_at_position(byte_pos, line));
+
+    assert_eq!(from_line, "$value");
+    assert_eq!(&line[start..end], "$value");
+    assert_eq!(name, "value");
+    Ok(())
+}
+
+#[test]
+fn utf16_column_conversion_keeps_parity_for_non_ascii_prefix() -> Result<(), String> {
+    let text = "😀 $alpha = 1;\n";
+    let line = text.lines().next().ok_or_else(|| "missing line".to_string())?;
+    let byte_pos = line.find('a').ok_or_else(|| "missing symbol".to_string())?;
+
+    // col 4 = emoji surrogate pair (2 UTF-16 units) + space + '$'
+    let from_utf16 = must_some(token_under_cursor(text, 0, 4));
+    let (start, end) = must_some(get_symbol_range_at_position(byte_pos, line));
+
+    assert_eq!(from_utf16, "$alpha");
+    assert_eq!(&line[start..end], "$alpha");
+    Ok(())
+}
+
+#[test]
+fn module_token_parity_between_utf16_and_byte_range() -> Result<(), String> {
+    let text = "use Demo::Worker;\n";
+    let line = text.lines().next().ok_or_else(|| "missing line".to_string())?;
+    let byte_pos = line.find("Demo").ok_or_else(|| "missing token".to_string())? + 2;
+
+    let utf16_token = must_some(token_under_cursor(text, 0, 8));
+
+    // For module names, range scanner is identifier-oriented and stops at ':'
+    let (start, end) = must_some(get_symbol_range_at_position(byte_pos, line));
+    assert_eq!(utf16_token, "Demo::Worker");
+    assert_eq!(&line[start..end], "Demo");
+    Ok(())
+}

--- a/crates/perl-symbol/tests/cursor_comprehensive_unit_tests.rs
+++ b/crates/perl-symbol/tests/cursor_comprehensive_unit_tests.rs
@@ -6,7 +6,7 @@
 //! - `get_symbol_range_at_position` — range extraction with sigils
 
 use perl_symbol::cursor::{
-    CursorSymbolKind, extract_symbol_from_source, get_symbol_range_at_position,
+    extract_symbol_from_source, get_symbol_range_at_position, CursorSymbolKind,
 };
 use perl_tdd_support::must_some;
 
@@ -139,7 +139,7 @@ fn extract_bare_word_mid_position() -> Result<(), String> {
     let source = "my_func();";
     // cursor in the middle of "my_func"
     let (name, kind) = must_some(extract_symbol_from_source(3, source));
-    assert_eq!(name, "func");
+    assert_eq!(name, "my_func");
     assert_eq!(kind, CursorSymbolKind::Subroutine);
     Ok(())
 }
@@ -365,24 +365,18 @@ fn range_position_at_exact_length_returns_none() {
 #[test]
 fn range_on_whitespace_returns_some_empty_range() {
     let source = "a b";
-    // position 1 is space, no sigil at position 0 (it's 'a' not a sigil)
+    // position 1 is space, which is not tokenizable
     let result = get_symbol_range_at_position(1, source);
-    // start stays at 1, end stays at 1 (space is not alnum/_)
-    assert!(result.is_some());
-    if let Some((start, end)) = result {
-        assert_eq!(start, end);
-    }
+    assert_eq!(result, None);
 }
 
 #[test]
 fn range_cursor_at_start_of_source() -> Result<(), String> {
     let source = "$abc";
-    // position 0 is '$', no sigil before (position > 0 false)
-    // forward scan: '$' is not alnum/_, so end stays at 0
-    // backward loop: start == position so no backward scan
+    // position 0 is '$', and the span includes "$abc"
     let (start, end) = must_some(get_symbol_range_at_position(0, source));
     assert_eq!(start, 0);
-    assert_eq!(end, 0);
+    assert_eq!(end, 4);
     Ok(())
 }
 
@@ -460,13 +454,11 @@ fn extract_numeric_name_after_sigil() -> Result<(), String> {
 // ─── Consecutive sigils ─────────────────────────────────────────────────────
 
 #[test]
-fn extract_dollar_at_treats_first_as_sigil() -> Result<(), String> {
-    // "$$ref" — cursor at position 1 (second $): chars[0] is '$'
-    // so sigil = Scalar, name_start = 1, but chars[1] is '$' (not alnum/_)
-    // end stays at 1, no name → None
+fn extract_dollar_at_treats_second_as_sigil() -> Result<(), String> {
+    // "$$ref" — cursor at position 1 (second $) resolves the sigil/name pair.
     let source = "$$ref";
     let result = extract_symbol_from_source(1, source);
-    assert_eq!(result, None);
+    assert_eq!(result, Some(("ref".to_string(), CursorSymbolKind::Scalar)));
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- Existing cursor logic duplicated scanning across UTF-16/char and byte-oriented paths and performed an unnecessary `Vec<char>` allocation in the common path, making semantics implicit and error-prone.
- The goal is to centralize token/span scanning with explicit byte semantics so all cursor- and range-oriented APIs share the same rules and produce byte-correct results.

### Description

- Introduced a small shared byte-oriented scanner core with `TokenSpan` plus helpers: `is_identifier_char`, `is_symbol_sigil`, `sigil_to_kind`, `token_span_at_byte`, and `extract_token_at_byte` in `crates/perl-symbol/src/cursor/mod.rs`.
- Rewired `extract_symbol_from_source` and `get_symbol_range_at_position` to use the shared byte scanner and preserved their public signatures.
- Kept `token_under_cursor` as a UTF-16-aware entrypoint that converts to a byte offset via `byte_offset_utf16` and then uses the shared span rules via `token_span_with_rules`.
- Removed the `Vec<char>`-based scanning path from the hot path and added byte/UTF-16 parity helpers and tests; updated existing cursor tests to align with unified span behavior.

### Testing

- Ran `cargo test -p perl-symbol` and all tests passed successfully.
- Ran `cargo check --all-targets -p perl-symbol` and the check completed without errors.
- Added `crates/perl-symbol/tests/cursor_byte_utf16_parity.rs` and updated `crates/perl-symbol/tests/cursor_comprehensive_unit_tests.rs` to validate byte/UTF-16 parity and the unified scanner behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77a1b9cc83338e9de0acd6eba346)