### PR TITLE
perf(cursor): unify perl-symbol cursor extraction onto a shared byte-oriented token scanner (#0000)

### DIFF
--- a/crates/perl-symbol/src/cursor/mod.rs
+++ b/crates/perl-symbol/src/cursor/mod.rs
@@ -16,79 +16,133 @@ pub enum CursorSymbolKind {
     Subroutine,
 }
 
+#[inline]
+fn sigil_kind(byte: u8) -> Option<CursorSymbolKind> {
+    match byte {
+        b'$' => Some(CursorSymbolKind::Scalar),
+        b'@' => Some(CursorSymbolKind::Array),
+        b'%' => Some(CursorSymbolKind::Hash),
+        b'&' => Some(CursorSymbolKind::Subroutine),
+        _ => None,
+    }
+}
+
+#[inline]
+fn is_identifier_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TokenSpan {
+    token_start: usize,
+    token_end: usize,
+    name_start: usize,
+    name_end: usize,
+    kind: CursorSymbolKind,
+}
+
+fn token_span_at_byte(position: usize, source: &str) -> Option<TokenSpan> {
+    let bytes = source.as_bytes();
+    if position >= bytes.len() {
+        return None;
+    }
+
+    let mut name_start = position;
+    let mut kind = CursorSymbolKind::Subroutine;
+    let mut has_sigil = false;
+
+    if let Some(sigil) = sigil_kind(bytes[position]) {
+        has_sigil = true;
+        kind = sigil;
+        name_start = position + 1;
+    } else if position > 0 {
+        if let Some(sigil) = sigil_kind(bytes[position - 1]) {
+            has_sigil = true;
+            kind = sigil;
+            name_start = position;
+        } else if is_identifier_char(bytes[position]) {
+            while name_start > 0 && is_identifier_char(bytes[name_start - 1]) {
+                name_start -= 1;
+            }
+            if name_start > 0 {
+                if let Some(sigil) = sigil_kind(bytes[name_start - 1]) {
+                    has_sigil = true;
+                    kind = sigil;
+                }
+            }
+        }
+    }
+
+    let mut name_end = name_start;
+    while name_end < bytes.len() && is_identifier_char(bytes[name_end]) {
+        name_end += 1;
+    }
+
+    if name_start == name_end {
+        return Some(TokenSpan {
+            token_start: position,
+            token_end: position,
+            name_start,
+            name_end,
+            kind,
+        });
+    }
+
+    let token_start = if has_sigil { name_start - 1 } else { name_start };
+    Some(TokenSpan {
+        token_start,
+        token_end: name_end,
+        name_start,
+        name_end,
+        kind,
+    })
+}
+
+fn extract_token_at_byte(position: usize, source: &str) -> Option<(String, CursorSymbolKind)> {
+    let span = token_span_at_byte(position, source)?;
+    if span.name_start == span.name_end {
+        return None;
+    }
+
+    let name = source.get(span.name_start..span.name_end)?.to_string();
+    Some((name, span.kind))
+}
+
+fn module_token_span_at_byte(position: usize, source: &str) -> Option<(usize, usize)> {
+    let bytes = source.as_bytes();
+    if position >= bytes.len() {
+        return None;
+    }
+
+    let mut start = position;
+    while start > 0 && is_modchar(bytes[start - 1]) {
+        start -= 1;
+    }
+
+    if start > 0 && matches!(bytes[start - 1], b'$' | b'@' | b'%' | b'&' | b'*') {
+        start -= 1;
+    }
+
+    let mut end = position;
+    while end < bytes.len() && is_modchar(bytes[end]) {
+        end += 1;
+    }
+
+    Some((start, end))
+}
+
 /// Extract a symbol and its kind from `source` at `position`.
 pub fn extract_symbol_from_source(
     position: usize,
     source: &str,
 ) -> Option<(String, CursorSymbolKind)> {
-    let chars: Vec<char> = source.chars().collect();
-    if position >= chars.len() {
-        return None;
-    }
-
-    let (sigil, name_start) = if position > 0 {
-        match chars.get(position - 1) {
-            Some('$') => (Some(CursorSymbolKind::Scalar), position),
-            Some('@') => (Some(CursorSymbolKind::Array), position),
-            Some('%') => (Some(CursorSymbolKind::Hash), position),
-            Some('&') => (Some(CursorSymbolKind::Subroutine), position),
-            _ => (None, position),
-        }
-    } else {
-        (None, position)
-    };
-
-    let (sigil, name_start) = if sigil.is_none() && position < chars.len() {
-        match chars[position] {
-            '$' => (Some(CursorSymbolKind::Scalar), position + 1),
-            '@' => (Some(CursorSymbolKind::Array), position + 1),
-            '%' => (Some(CursorSymbolKind::Hash), position + 1),
-            '&' => (Some(CursorSymbolKind::Subroutine), position + 1),
-            _ => (sigil, name_start),
-        }
-    } else {
-        (sigil, name_start)
-    };
-
-    let mut end = name_start;
-    while end < chars.len() && (chars[end].is_alphanumeric() || chars[end] == '_') {
-        end += 1;
-    }
-
-    if end > name_start {
-        let name: String = chars[name_start..end].iter().collect();
-        let kind = sigil.unwrap_or(CursorSymbolKind::Subroutine);
-        Some((name, kind))
-    } else {
-        None
-    }
+    extract_token_at_byte(position, source)
 }
 
 /// Get symbol range at `position`, including a leading sigil when present.
 pub fn get_symbol_range_at_position(position: usize, source: &str) -> Option<(usize, usize)> {
-    let chars: Vec<char> = source.chars().collect();
-    if position >= chars.len() {
-        return None;
-    }
-
-    let mut start = position;
-    if start > 0 && matches!(chars[start - 1], '$' | '@' | '%' | '&') {
-        start -= 1;
-    }
-
-    let mut end = position;
-    while end < chars.len() && (chars[end].is_alphanumeric() || chars[end] == '_') {
-        end += 1;
-    }
-
-    while start < position
-        && start < chars.len()
-        && (chars[start].is_alphanumeric() || chars[start] == '_')
-    {
-        start -= 1;
-    }
-
-    Some((start, end))
+    let span = token_span_at_byte(position, source)?;
+    Some((span.token_start, span.token_end))
 }
 
 /// Return true when `byte` is a module/name character (`[A-Za-z0-9_:]`).
@@ -118,26 +172,7 @@ pub fn byte_offset_utf16(line_text: &str, col_utf16: usize) -> usize {
 pub fn token_under_cursor(text: &str, line: usize, col_utf16: usize) -> Option<String> {
     let line_text = text.lines().nth(line)?;
     let byte_pos = byte_offset_utf16(line_text, col_utf16);
-    let bytes = line_text.as_bytes();
-
-    if byte_pos >= bytes.len() {
-        return None;
-    }
-
-    let mut start = byte_pos;
-    let mut end = byte_pos;
-
-    while start > 0 && is_modchar(bytes[start - 1]) {
-        start -= 1;
-    }
-    if start > 0 && matches!(bytes[start - 1], b'$' | b'@' | b'%' | b'&' | b'*') {
-        start -= 1;
-    }
-
-    while end < bytes.len() && is_modchar(bytes[end]) {
-        end += 1;
-    }
-
+    let (start, end) = module_token_span_at_byte(byte_pos, line_text)?;
     Some(line_text[start..end].to_string())
 }
 

--- a/crates/perl-symbol/tests/cursor_byte_utf16_parity.rs
+++ b/crates/perl-symbol/tests/cursor_byte_utf16_parity.rs
@@ -1,0 +1,53 @@
+use perl_symbol::cursor::{
+    CursorSymbolKind, byte_offset_utf16, extract_symbol_from_source, get_symbol_range_at_position,
+    token_under_cursor,
+};
+use perl_tdd_support::must_some;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[test]
+fn cursor_byte_range_and_extract_share_span_on_scalar_symbol() -> Result<()> {
+    let line = "my $total_count = 1;";
+    let pos = line.find("count").ok_or("missing count")?;
+
+    let (name, kind) = must_some(extract_symbol_from_source(pos, line));
+    let (start, end) = must_some(get_symbol_range_at_position(pos, line));
+
+    assert_eq!(kind, CursorSymbolKind::Scalar);
+    assert_eq!(name, "total_count");
+    assert_eq!(&line[start..end], "$total_count");
+    Ok(())
+}
+
+#[test]
+fn token_under_cursor_matches_byte_scanner_for_ascii_module_names() -> Result<()> {
+    let line = "use Demo::Worker;";
+    let col_utf16 = line.find("Worker").ok_or("missing Worker")?;
+
+    let token_utf16 = must_some(token_under_cursor(&(line.to_string() + "\n"), 0, col_utf16));
+    let byte_pos = byte_offset_utf16(line, col_utf16);
+    let (start, end) = must_some(get_symbol_range_at_position(byte_pos, line));
+
+    // range scanner excludes module separators by design, token scanner includes them.
+    assert_eq!(token_utf16, "Demo::Worker");
+    assert_eq!(&line[start..end], "Worker");
+    Ok(())
+}
+
+#[test]
+fn utf16_to_byte_parity_holds_with_non_ascii_prefix() -> Result<()> {
+    let line = "😀 $value = 1;";
+    let utf16_col = 4; // after emoji+space+sigil -> cursor on 'v'
+    let byte_pos = byte_offset_utf16(line, utf16_col);
+
+    let (name, kind) = must_some(extract_symbol_from_source(byte_pos, line));
+    let (start, end) = must_some(get_symbol_range_at_position(byte_pos, line));
+    let token = must_some(token_under_cursor(&(line.to_string() + "\n"), 0, utf16_col));
+
+    assert_eq!(kind, CursorSymbolKind::Scalar);
+    assert_eq!(name, "value");
+    assert_eq!(&line[start..end], "$value");
+    assert_eq!(token, "$value");
+    Ok(())
+}

--- a/crates/perl-symbol/tests/cursor_comprehensive_unit_tests.rs
+++ b/crates/perl-symbol/tests/cursor_comprehensive_unit_tests.rs
@@ -137,9 +137,9 @@ fn extract_bare_word_defaults_to_subroutine() -> Result<(), String> {
 #[test]
 fn extract_bare_word_mid_position() -> Result<(), String> {
     let source = "my_func();";
-    // cursor in the middle of "my_func"
+    // cursor in the middle of "my_func" should still resolve the full token
     let (name, kind) = must_some(extract_symbol_from_source(3, source));
-    assert_eq!(name, "func");
+    assert_eq!(name, "my_func");
     assert_eq!(kind, CursorSymbolKind::Subroutine);
     Ok(())
 }
@@ -377,12 +377,10 @@ fn range_on_whitespace_returns_some_empty_range() {
 #[test]
 fn range_cursor_at_start_of_source() -> Result<(), String> {
     let source = "$abc";
-    // position 0 is '$', no sigil before (position > 0 false)
-    // forward scan: '$' is not alnum/_, so end stays at 0
-    // backward loop: start == position so no backward scan
+    // position 0 is '$' and resolves to the full symbol span.
     let (start, end) = must_some(get_symbol_range_at_position(0, source));
     assert_eq!(start, 0);
-    assert_eq!(end, 0);
+    assert_eq!(end, 4);
     Ok(())
 }
 
@@ -461,12 +459,10 @@ fn extract_numeric_name_after_sigil() -> Result<(), String> {
 
 #[test]
 fn extract_dollar_at_treats_first_as_sigil() -> Result<(), String> {
-    // "$$ref" — cursor at position 1 (second $): chars[0] is '$'
-    // so sigil = Scalar, name_start = 1, but chars[1] is '$' (not alnum/_)
-    // end stays at 1, no name → None
+    // "$$ref" — cursor at position 1 (second $) resolves to "$ref".
     let source = "$$ref";
-    let result = extract_symbol_from_source(1, source);
-    assert_eq!(result, None);
+    let result = must_some(extract_symbol_from_source(1, source));
+    assert_eq!(result, ("ref".to_string(), CursorSymbolKind::Scalar));
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- Cursor extraction and range detection used duplicated, char-indexed scanning paths and a hot `Vec<char>` allocation that diverged from byte-oriented call sites and UTF-16 conversion flow.
- Make the semantics explicit and shared so `extract_symbol_from_source`, `get_symbol_range_at_position`, and `token_under_cursor` agree and avoid unnecessary allocations.

### Description

- Introduced byte-oriented helpers `sigil_kind`, `is_identifier_char`, `token_span_at_byte`, `extract_token_at_byte`, and `module_token_span_at_byte` and the `TokenSpan` struct to represent computed spans.
- Reimplemented `extract_symbol_from_source` and `get_symbol_range_at_position` on top of the shared `token_span_at_byte`/`extract_token_at_byte` logic so both use the same byte semantics. 
- Updated `token_under_cursor` to perform UTF-16 → byte conversion with `byte_offset_utf16` and delegate to `module_token_span_at_byte` for extraction.
- Adjusted unit test expectations and added `crates/perl-symbol/tests/cursor_byte_utf16_parity.rs` to assert byte/UTF-16 parity and shared-span behavior without changing the public API surface.

### Testing

- Ran `cargo test -p perl-symbol` and all tests in the `perl-symbol` crate passed, including the new parity tests.
- Ran `cargo check --all-targets -p perl-symbol` which completed successfully.
- Verified updated cursor unit tests in `crates/perl-symbol/tests/` exercise the new shared scanner and pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77a1b9cc83338e9de0acd6eba346)