### PR TITLE
feat(perl-symbol): make SymbolIndex document-aware and remove stale-symbol drift (#0000)

### DIFF
--- a/crates/perl-symbol/src/index/mod.rs
+++ b/crates/perl-symbol/src/index/mod.rs
@@ -3,7 +3,7 @@
 //! This module has one responsibility: indexing symbol names for fast lookup
 //! across prefix and fuzzy query styles.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Symbol index for fast lookups.
 ///
@@ -12,15 +12,19 @@ pub struct SymbolIndex {
     /// Trie structure for prefix matching
     trie: SymbolTrie,
     /// Inverted index for fuzzy matching
-    inverted_index: HashMap<String, Vec<String>>,
+    inverted_index: HashMap<String, HashMap<String, usize>>,
+    /// Per-document symbol membership.
+    document_symbols: HashMap<String, HashSet<String>>,
 }
 
 /// Trie data structure for efficient prefix matching
 struct SymbolTrie {
     /// Child nodes indexed by character
     children: HashMap<char, Box<SymbolTrie>>,
-    /// Symbols stored at this node
-    symbols: Vec<String>,
+    /// Terminal symbol stored at this node.
+    symbol: Option<String>,
+    /// Number of documents that currently provide this symbol.
+    symbol_count: usize,
 }
 
 impl Default for SymbolIndex {
@@ -33,7 +37,11 @@ impl SymbolIndex {
     /// Create a new empty symbol index.
     #[must_use]
     pub fn new() -> Self {
-        Self { trie: SymbolTrie::new(), inverted_index: HashMap::new() }
+        Self {
+            trie: SymbolTrie::new(),
+            inverted_index: HashMap::new(),
+            document_symbols: HashMap::new(),
+        }
     }
 
     /// Add a symbol to the index.
@@ -42,17 +50,45 @@ impl SymbolIndex {
     /// Duplicate calls with the same symbol are idempotent: the symbol is
     /// stored exactly once in both the trie and the inverted index.
     pub fn add_symbol(&mut self, symbol: String) {
-        // Add to trie for prefix matching; returns true only when newly inserted.
-        // Deduplication here prevents the inverted index from accumulating
-        // duplicate entries, which would inflate fuzzy-match scores.
-        if !self.trie.insert(&symbol) {
-            return;
+        const LEGACY_DOC_ID: &str = "__legacy_add_symbol__";
+        let mut symbols = self.document_symbols.remove(LEGACY_DOC_ID).unwrap_or_default();
+        symbols.insert(symbol);
+        self.replace_document_symbols(LEGACY_DOC_ID, symbols);
+    }
+
+    /// Replace all symbols owned by a document.
+    ///
+    /// Existing symbols for `doc_id` are removed, then replaced by `symbols`.
+    pub fn replace_document_symbols<I>(&mut self, doc_id: &str, symbols: I)
+    where
+        I: IntoIterator<Item = String>,
+    {
+        let new_symbols: HashSet<String> = symbols.into_iter().collect();
+        let old_symbols = self.document_symbols.get(doc_id).cloned().unwrap_or_default();
+
+        for removed in old_symbols.difference(&new_symbols) {
+            self.remove_symbol_occurrence(removed);
         }
 
-        // Add to inverted index for fuzzy matching
-        let tokens = Self::tokenize(&symbol);
-        for token in tokens {
-            self.inverted_index.entry(token).or_default().push(symbol.clone());
+        for added in new_symbols.difference(&old_symbols) {
+            self.add_symbol_occurrence(added);
+        }
+
+        if new_symbols.is_empty() {
+            self.document_symbols.remove(doc_id);
+        } else {
+            self.document_symbols.insert(doc_id.to_string(), new_symbols);
+        }
+    }
+
+    /// Remove all symbols associated with a document.
+    pub fn remove_document(&mut self, doc_id: &str) {
+        let Some(symbols) = self.document_symbols.remove(doc_id) else {
+            return;
+        };
+
+        for symbol in symbols {
+            self.remove_symbol_occurrence(&symbol);
         }
     }
 
@@ -70,21 +106,58 @@ impl SymbolIndex {
     #[must_use]
     pub fn search_fuzzy(&self, query: &str) -> Vec<String> {
         let tokens = Self::tokenize(query);
-        let mut results = HashMap::new();
+        let mut results: HashMap<&str, usize> = HashMap::new();
 
         for token in tokens {
             if let Some(symbols) = self.inverted_index.get(&token) {
-                for symbol in symbols {
-                    *results.entry(symbol.clone()).or_insert(0) += 1;
+                for symbol in symbols.keys() {
+                    *results.entry(symbol.as_str()).or_insert(0) += 1;
                 }
             }
         }
 
         // Sort by relevance (number of matching tokens)
         let mut sorted: Vec<_> = results.into_iter().collect();
-        sorted.sort_by(|(_, a), (_, b)| b.cmp(a));
+        sorted.sort_by(|(name_a, score_a), (name_b, score_b)| {
+            score_b.cmp(score_a).then_with(|| name_a.cmp(name_b))
+        });
 
-        sorted.into_iter().map(|(symbol, _)| symbol).collect()
+        sorted.into_iter().map(|(symbol, _)| symbol.to_string()).collect()
+    }
+
+    fn add_symbol_occurrence(&mut self, symbol: &str) {
+        self.trie.insert(symbol);
+        for token in Self::tokenize(symbol) {
+            *self
+                .inverted_index
+                .entry(token)
+                .or_default()
+                .entry(symbol.to_string())
+                .or_insert(0) += 1;
+        }
+    }
+
+    fn remove_symbol_occurrence(&mut self, symbol: &str) {
+        if !self.trie.remove(symbol) {
+            return;
+        }
+
+        for token in Self::tokenize(symbol) {
+            let mut should_remove_token = false;
+            if let Some(token_symbols) = self.inverted_index.get_mut(&token) {
+                if let Some(count) = token_symbols.get_mut(symbol) {
+                    *count -= 1;
+                    if *count == 0 {
+                        token_symbols.remove(symbol);
+                    }
+                }
+                should_remove_token = token_symbols.is_empty();
+            }
+
+            if should_remove_token {
+                self.inverted_index.remove(&token);
+            }
+        }
     }
 
     fn tokenize(s: &str) -> Vec<String> {
@@ -119,7 +192,7 @@ impl SymbolIndex {
 
 impl SymbolTrie {
     fn new() -> Self {
-        Self { children: HashMap::new(), symbols: Vec::new() }
+        Self { children: HashMap::new(), symbol: None, symbol_count: 0 }
     }
 
     /// Insert `symbol` into the trie.
@@ -134,16 +207,48 @@ impl SymbolTrie {
             node = node.children.entry(ch).or_insert_with(|| Box::new(SymbolTrie::new()));
         }
 
-        // Deduplicate: workspace indexing may call add_symbol for the same
-        // qualified name multiple times during incremental re-index.  Storing
-        // duplicates causes search_prefix to return the same entry N times,
-        // which produces duplicate completions in the UI.
-        let owned = symbol.to_string();
-        if node.symbols.contains(&owned) {
-            return false;
+        if node.symbol_count == 0 {
+            node.symbol = Some(symbol.to_string());
         }
-        node.symbols.push(owned);
-        true
+        node.symbol_count += 1;
+        node.symbol_count == 1
+    }
+
+    /// Remove one occurrence of `symbol`.
+    ///
+    /// Returns `true` only when symbol visibility was removed entirely.
+    fn remove(&mut self, symbol: &str) -> bool {
+        let chars: Vec<char> = symbol.chars().collect();
+        let (removed, _) = Self::remove_inner(self, &chars, 0);
+        removed
+    }
+
+    fn remove_inner(node: &mut SymbolTrie, chars: &[char], idx: usize) -> (bool, bool) {
+        if idx == chars.len() {
+            if node.symbol_count == 0 {
+                return (false, false);
+            }
+
+            node.symbol_count -= 1;
+            let removed = node.symbol_count == 0;
+            if removed {
+                node.symbol = None;
+            }
+            return (removed, node.children.is_empty() && node.symbol_count == 0);
+        }
+
+        let ch = chars[idx];
+        let Some(child) = node.children.get_mut(&ch) else {
+            return (false, false);
+        };
+
+        let (removed, child_prune) = Self::remove_inner(child, chars, idx + 1);
+        if child_prune {
+            node.children.remove(&ch);
+        }
+
+        let should_prune = node.children.is_empty() && node.symbol_count == 0;
+        (removed, should_prune)
     }
 
     fn search_prefix(&self, prefix: &str) -> Vec<String> {
@@ -163,7 +268,9 @@ impl SymbolTrie {
     }
 
     fn collect_all(node: &SymbolTrie, results: &mut Vec<String>) {
-        results.extend(node.symbols.clone());
+        if let Some(symbol) = &node.symbol {
+            results.push(symbol.clone());
+        }
 
         for child in node.children.values() {
             Self::collect_all(child, results);

--- a/crates/perl-symbol/tests/index_document_aware.rs
+++ b/crates/perl-symbol/tests/index_document_aware.rs
@@ -1,0 +1,64 @@
+use perl_symbol::index::SymbolIndex;
+
+#[test]
+fn replace_document_symbols_removes_stale_entries() {
+    let mut index = SymbolIndex::new();
+
+    index.replace_document_symbols("doc-a", ["alpha_old".to_string(), "alpha_keep".to_string()]);
+
+    index.replace_document_symbols("doc-a", ["alpha_new".to_string(), "alpha_keep".to_string()]);
+
+    let prefix = index.search_prefix("alpha_");
+    assert!(prefix.contains(&"alpha_new".to_string()));
+    assert!(prefix.contains(&"alpha_keep".to_string()));
+    assert!(!prefix.contains(&"alpha_old".to_string()));
+
+    let fuzzy = index.search_fuzzy("old");
+    assert!(!fuzzy.contains(&"alpha_old".to_string()));
+}
+
+#[test]
+fn remove_document_only_removes_its_own_occurrences() {
+    let mut index = SymbolIndex::new();
+
+    index.replace_document_symbols("doc-a", ["shared_name".to_string(), "only_a".to_string()]);
+    index.replace_document_symbols("doc-b", ["shared_name".to_string(), "only_b".to_string()]);
+
+    index.remove_document("doc-a");
+
+    let prefix = index.search_prefix("shared");
+    assert_eq!(prefix, vec!["shared_name".to_string()]);
+
+    let only_a = index.search_prefix("only_a");
+    assert!(only_a.is_empty());
+
+    let only_b = index.search_prefix("only_b");
+    assert_eq!(only_b, vec!["only_b".to_string()]);
+}
+
+#[test]
+fn remove_document_clears_fuzzy_entries_without_stale_drift() {
+    let mut index = SymbolIndex::new();
+
+    index.replace_document_symbols("doc-a", ["parse_document".to_string()]);
+    index.replace_document_symbols("doc-b", ["parse_workspace".to_string()]);
+
+    index.remove_document("doc-a");
+
+    let results = index.search_fuzzy("document");
+    assert!(results.is_empty());
+
+    let workspace_results = index.search_fuzzy("workspace");
+    assert_eq!(workspace_results, vec!["parse_workspace".to_string()]);
+}
+
+#[test]
+fn add_symbol_compatibility_path_still_dedupes() {
+    let mut index = SymbolIndex::new();
+
+    index.add_symbol("legacy_symbol".to_string());
+    index.add_symbol("legacy_symbol".to_string());
+
+    let prefix = index.search_prefix("legacy");
+    assert_eq!(prefix, vec!["legacy_symbol".to_string()]);
+}


### PR DESCRIPTION
### Motivation

- The previous `SymbolIndex` was add-only and stored only symbol strings which allowed stale prefix/fuzzy entries and excess cloning during incremental workspace updates, so document-aware ownership and removal are needed to keep the index accurate and efficient.

### Description

- Added per-document membership tracking with `document_symbols: HashMap<String, HashSet<String>>` and new APIs `replace_document_symbols(doc_id, symbols)` and `remove_document(doc_id)` to enable atomic replace/remove of a document's symbols, while keeping `add_symbol()` compatible by routing it through a legacy synthetic doc id.
- Converted the trie to store a single terminal `symbol: Option<String>` with a `symbol_count: usize` reference count and implemented counted removal and node pruning to avoid duplicate clones during recursive collection.
- Reworked the inverted (fuzzy) index from `HashMap<String, Vec<String>>` to `HashMap<String, HashMap<String, usize>>` to maintain per-token per-symbol occurrence counts and safely decrement/remove token entries when documents are replaced or removed.
- Added integration tests `crates/perl-symbol/tests/index_document_aware.rs` that verify replace/remove semantics, cross-document dedupe, fuzzy cleanup, and `add_symbol()` compatibility.

### Testing

- Ran `cargo test -p perl-symbol`, and the crate's test suite passed successfully.
- Ran `cargo check --all-targets -p perl-symbol`, which completed successfully.
- Ran formatting via `cargo xtask fmt`, which completed successfully.
- Ran lints via `cargo clippy -p perl-symbol`, which completed successfully.
- `just pr-fast` was not executed in this environment because the `just` command is not available (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77a7428c8333a0a9415ad788685f)