### PR TITLE
perf(workspace-symbols): wire perl-symbol SymbolIndex into production candidate search (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/workspace_symbols/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/workspace_symbols/mod.rs
@@ -113,6 +113,8 @@ struct SymbolInfo {
 pub struct WorkspaceSymbolsProvider {
     /// Map of document URI to its extracted symbols.
     documents: HashMap<String, Vec<SymbolInfo>>,
+    /// Map of symbol name to (document URI, symbol index in document vec).
+    symbol_name_index: HashMap<String, Vec<(String, usize)>>,
 }
 
 impl Default for WorkspaceSymbolsProvider {
@@ -125,7 +127,7 @@ impl WorkspaceSymbolsProvider {
     /// Creates a new empty workspace symbols provider.
     #[must_use]
     pub fn new() -> Self {
-        Self { documents: HashMap::new() }
+        Self { documents: HashMap::new(), symbol_name_index: HashMap::new() }
     }
 
     /// Indexes all symbols from a parsed document.
@@ -133,6 +135,7 @@ impl WorkspaceSymbolsProvider {
     /// Extracts symbols from the AST and stores them for later search queries.
     /// Replaces any previously indexed symbols for the same URI.
     pub fn index_document(&mut self, uri: &str, ast: &Node, source: &str) {
+        self.remove_document(uri);
         let extractor = SymbolExtractor::new_with_source(source);
         let table = extractor.extract(ast);
 
@@ -152,6 +155,13 @@ impl WorkspaceSymbolsProvider {
             }
         }
 
+        for (index, symbol) in symbols.iter().enumerate() {
+            self.symbol_name_index
+                .entry(symbol.name.clone())
+                .or_default()
+                .push((uri.to_string(), index));
+        }
+
         self.documents.insert(uri.to_string(), symbols);
     }
 
@@ -159,7 +169,16 @@ impl WorkspaceSymbolsProvider {
     ///
     /// Called when a file is deleted or closed in the workspace.
     pub fn remove_document(&mut self, uri: &str) {
-        self.documents.remove(uri);
+        if let Some(symbols) = self.documents.remove(uri) {
+            for symbol in symbols {
+                if let Some(entries) = self.symbol_name_index.get_mut(&symbol.name) {
+                    entries.retain(|(entry_uri, _)| entry_uri != uri);
+                    if entries.is_empty() {
+                        self.symbol_name_index.remove(&symbol.name);
+                    }
+                }
+            }
+        }
     }
 
     /// Returns all indexed symbols as LSP WorkspaceSymbols.
@@ -203,24 +222,25 @@ impl WorkspaceSymbolsProvider {
         candidates: &[String],
     ) -> Vec<WorkspaceSymbol> {
         let mut results = Vec::new();
-
-        // Create a set of candidate names for fast lookup
-        let candidate_set: std::collections::HashSet<_> =
-            candidates.iter().map(|s| s.to_lowercase()).collect();
-
-        for (uri, symbols) in &self.documents {
-            // Get source for this document to convert offsets
-            let source = match source_map.get(uri) {
-                Some(s) => s,
-                None => continue,
-            };
-
-            for symbol in symbols {
-                // Check if this symbol is in our candidate set
-                if candidate_set.contains(&symbol.name.to_lowercase())
-                    && matches_query(&symbol.name, query)
-                {
-                    results.push(self.symbol_to_workspace_symbol(uri, symbol, source));
+        let mut seen = std::collections::HashSet::new();
+        for candidate in candidates {
+            if let Some(symbol_refs) = self.symbol_name_index.get(candidate) {
+                for (uri, symbol_index) in symbol_refs {
+                    if !seen.insert((uri.clone(), *symbol_index)) {
+                        continue;
+                    }
+                    let Some(symbols) = self.documents.get(uri) else {
+                        continue;
+                    };
+                    let Some(symbol) = symbols.get(*symbol_index) else {
+                        continue;
+                    };
+                    let Some(source) = source_map.get(uri) else {
+                        continue;
+                    };
+                    if matches_query(&symbol.name, query) {
+                        results.push(self.symbol_to_workspace_symbol(uri, symbol, source));
+                    }
                 }
             }
         }

--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -153,6 +153,7 @@ impl LspServer {
                         incremental_state: None,
                     },
                 );
+                self.symbol_index.lock().remove_document(&normalized_uri);
 
                 if let Err(e) = self.notify(
                     "textDocument/publishDiagnostics",
@@ -200,6 +201,7 @@ impl LspServer {
                         incremental_state: None,
                     },
                 );
+                self.symbol_index.lock().remove_document(&normalized_uri);
 
                 if let Err(e) = self.notify(
                     "textDocument/publishDiagnostics",
@@ -243,6 +245,7 @@ impl LspServer {
                         incremental_state: None,
                     },
                 );
+                self.symbol_index.lock().remove_document(&normalized_uri);
 
                 if let Err(e) = self.notify(
                     "textDocument/publishDiagnostics",
@@ -373,31 +376,7 @@ impl LspServer {
             );
 
             // Index symbols for workspace search
-            // Note: Indexing is a MUTATION operation - use coordinator.index() directly
-            // This must happen BEFORE notify_parse_complete to keep work inside the tracking window
             if let Some(ref _ast) = ast_arc {
-                // Update the fast symbol index with symbols from workspace index
-                #[cfg(feature = "workspace")]
-                if let Some(coordinator) = self.coordinator() {
-                    let workspace_index = coordinator.index();
-                    let index_symbols = workspace_index.find_symbols("");
-                    let symbols = index_symbols
-                        .into_iter()
-                        .filter(|s| s.uri == uri)
-                        .map(|s| s.name.clone())
-                        .collect::<Vec<_>>();
-
-                    let mut index = self.symbol_index.lock();
-                    for symbol in symbols {
-                        index.add_symbol(symbol);
-                    }
-                }
-                #[cfg(not(feature = "workspace"))]
-                {
-                    let _index = self.symbol_index.lock();
-                    // Just ensure the index exists even without workspace feature
-                }
-
                 // Update the workspace-wide index for cross-file features.
                 // Indexing runs in a background task so the handler returns
                 // immediately without blocking on file I/O or symbol extraction.
@@ -409,12 +388,23 @@ impl LspServer {
                         let coordinator_clone = Arc::clone(coordinator);
                         let text_owned = text.to_string();
                         let uri_owned = uri.to_string();
+                        let normalized_uri_owned = normalized_uri.clone();
+                        let symbol_index = Arc::clone(&self.symbol_index);
                         let task_counter = Arc::clone(&self.pending_index_task_count);
                         task_counter.fetch_add(1, Ordering::SeqCst);
 
                         let task = move || {
                             match workspace_index.index_file(url, text_owned) {
                                 Ok(()) => {
+                                    let symbols = workspace_index
+                                        .find_symbols("")
+                                        .into_iter()
+                                        .filter(|symbol| symbol.uri == uri_owned)
+                                        .map(|symbol| symbol.name)
+                                        .collect::<Vec<_>>();
+                                    symbol_index
+                                        .lock()
+                                        .replace_document_symbols(&normalized_uri_owned, symbols);
                                     if matches!(
                                         coordinator_clone.state(),
                                         IndexState::Building { phase: IndexPhase::Idle, .. }
@@ -464,6 +454,9 @@ impl LspServer {
             #[cfg(feature = "workspace")]
             if let Some(coordinator) = self.coordinator() {
                 coordinator.notify_parse_complete(uri);
+            }
+            if ast_arc.is_none() {
+                self.symbol_index.lock().remove_document(&normalized_uri);
             }
 
             // Send diagnostics (use original URI for client notification)
@@ -652,6 +645,7 @@ impl LspServer {
                     };
                     documents.insert(normalized_uri.clone(), doc_state);
                     drop(documents);
+                    self.symbol_index.lock().remove_document(&normalized_uri);
 
                     if let Err(e) = self.notify(
                         "textDocument/publishDiagnostics",
@@ -697,6 +691,7 @@ impl LspServer {
                     };
                     documents.insert(normalized_uri.clone(), doc_state);
                     drop(documents);
+                    self.symbol_index.lock().remove_document(&normalized_uri);
 
                     if let Err(e) = self.notify(
                         "textDocument/publishDiagnostics",
@@ -738,6 +733,7 @@ impl LspServer {
                     };
                     documents.insert(normalized_uri.clone(), doc_state);
                     drop(documents);
+                    self.symbol_index.lock().remove_document(&normalized_uri);
 
                     if let Err(e) = self.notify(
                         "textDocument/publishDiagnostics",
@@ -976,12 +972,24 @@ impl LspServer {
                             let coordinator_clone = Arc::clone(coordinator);
                             let doc_content = text.clone();
                             let uri_owned = uri.to_string();
+                            let normalized_uri_owned = normalized_uri.clone();
+                            let symbol_index = Arc::clone(&self.symbol_index);
                             let task_counter = Arc::clone(&self.pending_index_task_count);
                             task_counter.fetch_add(1, Ordering::SeqCst);
 
                             let task = move || {
                                 if let Err(e) = workspace_index.index_file(url, doc_content) {
                                     tracing::warn!("Failed to index file {}: {}", uri_owned, e);
+                                } else {
+                                    let symbols = workspace_index
+                                        .find_symbols("")
+                                        .into_iter()
+                                        .filter(|symbol| symbol.uri == uri_owned)
+                                        .map(|symbol| symbol.name)
+                                        .collect::<Vec<_>>();
+                                    symbol_index
+                                        .lock()
+                                        .replace_document_symbols(&normalized_uri_owned, symbols);
                                 }
                                 coordinator_clone.notify_parse_complete(&uri_owned);
                                 task_counter.fetch_sub(1, Ordering::SeqCst);
@@ -1011,6 +1019,9 @@ impl LspServer {
                 #[cfg(feature = "workspace")]
                 if let Some(coordinator) = self.coordinator() {
                     coordinator.notify_parse_complete(uri);
+                }
+                if ast_arc.is_none() {
+                    self.symbol_index.lock().remove_document(&normalized_uri);
                 }
 
                 // Fast path: immediately publish parse-error diagnostics.
@@ -1056,6 +1067,7 @@ impl LspServer {
             // Remove from documents
             let mut documents = self.documents.lock();
             documents.remove(&normalized_uri).or_else(|| documents.remove(uri));
+            self.symbol_index.lock().remove_document(&normalized_uri);
 
             // Cancel any in-progress parse and clean up the cancellation flag.
             {

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -435,50 +435,56 @@ impl LspServer {
         query: &str,
         cap: usize,
     ) -> Result<Option<Value>, JsonRpcError> {
-        let mut all_symbols = Vec::new();
-
-        // Collect lightweight snapshots without holding lock during iteration.
-        // Only clone the fields needed for symbol extraction (uri, text, ast Arc),
-        // avoiding expensive Rope, ParentMap, LineStartsCache, and parse_errors clones.
         let docs_snapshot: Vec<(String, String, Option<Arc<perl_parser::ast::Node>>)> = {
             let documents = self.documents.lock();
             documents.iter().map(|(k, v)| (k.clone(), v.text.clone(), v.ast.clone())).collect()
         };
 
-        // Pre-compute lowercased query once, outside the document loop
-        let query_lower = query.to_lowercase();
-
-        for (i, (uri, text, ast)) in docs_snapshot.iter().enumerate() {
-            // Cooperative yield every 8 documents
-            if i & 0x7 == 0 {
-                std::thread::yield_now();
-            }
-
-            // Early exit if we've hit the result cap
-            if all_symbols.len() >= cap {
-                break;
-            }
-
+        let mut provider =
+            perl_lsp_rs_core::providers::workspace_symbols::WorkspaceSymbolsProvider::new();
+        let mut source_map = std::collections::HashMap::new();
+        let mut text_fallback_docs = Vec::new();
+        for (uri, text, ast) in &docs_snapshot {
+            source_map.insert(uri.clone(), text.clone());
             if let Some(ast) = ast {
-                let doc_symbols = self.extract_document_symbols(ast, text, uri);
-
-                for sym in doc_symbols {
-                    if sym.name.to_lowercase().contains(&query_lower) {
-                        all_symbols.push(sym);
-                        if all_symbols.len() >= cap {
-                            break;
-                        }
-                    }
-                }
+                provider.index_document(uri, ast, text);
             } else {
-                // Text-based fallback when AST is not available
-                let text_symbols = self.extract_text_based_symbols(text, uri, query);
-                let remaining = cap.saturating_sub(all_symbols.len());
-                all_symbols.extend(text_symbols.into_iter().take(remaining));
+                text_fallback_docs.push((uri.clone(), text.clone()));
             }
         }
 
-        // Truncate to cap in case we went slightly over
+        let candidates = if query.is_empty() {
+            Vec::new()
+        } else {
+            let index = self.symbol_index.lock();
+            let mut merged = index.search_prefix(query);
+            merged.extend(index.search_fuzzy(query));
+            let mut seen = std::collections::HashSet::new();
+            merged.retain(|symbol| seen.insert(symbol.clone()));
+            merged
+        };
+
+        let provider_symbols = if candidates.is_empty() {
+            provider.search(query, &source_map)
+        } else {
+            provider.search_with_candidates(query, &source_map, &candidates)
+        };
+        let mut all_symbols: Vec<Value> =
+            provider_symbols.into_iter().map(|symbol| json!(symbol)).collect();
+
+        for (uri, text) in text_fallback_docs {
+            if all_symbols.len() >= cap {
+                break;
+            }
+            let remaining = cap.saturating_sub(all_symbols.len());
+            all_symbols.extend(
+                self.extract_text_based_symbols(&text, &uri, query)
+                    .into_iter()
+                    .take(remaining)
+                    .map(|symbol| json!(symbol)),
+            );
+        }
+
         all_symbols.truncate(cap);
         tracing::debug!(
             count = all_symbols.len(),

--- a/crates/perl-symbol/src/index/mod.rs
+++ b/crates/perl-symbol/src/index/mod.rs
@@ -13,6 +13,8 @@ pub struct SymbolIndex {
     trie: SymbolTrie,
     /// Inverted index for fuzzy matching
     inverted_index: HashMap<String, Vec<String>>,
+    /// Per-document symbol membership used for replace/remove operations.
+    document_symbols: HashMap<String, Vec<String>>,
 }
 
 /// Trie data structure for efficient prefix matching
@@ -33,7 +35,11 @@ impl SymbolIndex {
     /// Create a new empty symbol index.
     #[must_use]
     pub fn new() -> Self {
-        Self { trie: SymbolTrie::new(), inverted_index: HashMap::new() }
+        Self {
+            trie: SymbolTrie::new(),
+            inverted_index: HashMap::new(),
+            document_symbols: HashMap::new(),
+        }
     }
 
     /// Add a symbol to the index.
@@ -42,17 +48,64 @@ impl SymbolIndex {
     /// Duplicate calls with the same symbol are idempotent: the symbol is
     /// stored exactly once in both the trie and the inverted index.
     pub fn add_symbol(&mut self, symbol: String) {
+        let global_doc_symbols = self.document_symbols.entry("__global__".to_string()).or_default();
+        if global_doc_symbols.contains(&symbol) {
+            return;
+        }
+        global_doc_symbols.push(symbol.clone());
+        self.index_symbol(&symbol);
+    }
+
+    /// Replace all symbols for a given document.
+    ///
+    /// This is the primary API for live-editor indexing where each didOpen /
+    /// didChange notification should overwrite prior symbol membership.
+    pub fn replace_document_symbols(&mut self, document_uri: &str, symbols: Vec<String>) {
+        let mut deduped = Vec::with_capacity(symbols.len());
+        for symbol in symbols {
+            if !deduped.contains(&symbol) {
+                deduped.push(symbol);
+            }
+        }
+        self.document_symbols.insert(document_uri.to_string(), deduped);
+        self.rebuild();
+    }
+
+    /// Remove all symbols contributed by a document.
+    pub fn remove_document(&mut self, document_uri: &str) {
+        if self.document_symbols.remove(document_uri).is_some() {
+            self.rebuild();
+        }
+    }
+
+    fn index_symbol(&mut self, symbol: &str) {
         // Add to trie for prefix matching; returns true only when newly inserted.
         // Deduplication here prevents the inverted index from accumulating
         // duplicate entries, which would inflate fuzzy-match scores.
-        if !self.trie.insert(&symbol) {
+        if !self.trie.insert(symbol) {
             return;
         }
 
         // Add to inverted index for fuzzy matching
-        let tokens = Self::tokenize(&symbol);
+        let tokens = Self::tokenize(symbol);
         for token in tokens {
-            self.inverted_index.entry(token).or_default().push(symbol.clone());
+            self.inverted_index.entry(token).or_default().push(symbol.to_string());
+        }
+    }
+
+    fn rebuild(&mut self) {
+        self.trie = SymbolTrie::new();
+        self.inverted_index.clear();
+        let mut seen = std::collections::HashSet::new();
+        let all_symbols = self
+            .document_symbols
+            .values()
+            .flat_map(|symbols| symbols.iter().cloned())
+            .collect::<Vec<_>>();
+        for symbol in all_symbols {
+            if seen.insert(symbol.clone()) {
+                self.index_symbol(&symbol);
+            }
         }
     }
 
@@ -190,5 +243,26 @@ mod tests {
 
         let fuzzy_results = index.search_fuzzy("user name");
         assert!(fuzzy_results.contains(&"get_user_name".to_string()));
+    }
+
+    #[test]
+    fn replace_and_remove_document_symbols_evict_stale_entries() {
+        let mut index = SymbolIndex::new();
+
+        index.replace_document_symbols(
+            "file:///a.pl",
+            vec!["old_name".to_string(), "shared_name".to_string()],
+        );
+        index.replace_document_symbols("file:///b.pl", vec!["shared_name".to_string()]);
+        assert!(index.search_prefix("old").contains(&"old_name".to_string()));
+        assert!(index.search_prefix("shared").contains(&"shared_name".to_string()));
+
+        index.replace_document_symbols("file:///a.pl", vec!["new_name".to_string()]);
+        assert!(!index.search_prefix("old").contains(&"old_name".to_string()));
+        assert!(index.search_prefix("new").contains(&"new_name".to_string()));
+        assert!(index.search_prefix("shared").contains(&"shared_name".to_string()));
+
+        index.remove_document("file:///b.pl");
+        assert!(!index.search_prefix("shared").contains(&"shared_name".to_string()));
     }
 }


### PR DESCRIPTION
### Motivation

- Workspace symbol lookup still scanned open documents directly and used an add-only SymbolIndex, which left stale names after edits/closers and made degraded searches expensive.
- Make the in-memory fast index the authoritative candidate source so degraded/open-doc searches avoid scanning every document.

### Description

- Made `perl-symbol::SymbolIndex` document-aware by adding `replace_document_symbols`, `remove_document`, per-document membership, and a `rebuild` pass to evict stale entries and keep trie/inverted-index structures consistent.
- Wire the runtime text-sync lifecycle to keep `SymbolIndex` in sync by removing document membership when parsing is skipped/AST missing or document closed, and by replacing per-document symbols after workspace indexing completes (background task) for didOpen/didChange paths.
- Route degraded/open-doc `workspace/symbol` searches to build a `WorkspaceSymbolsProvider` from open docs and narrow its candidates using `SymbolIndex` (`search_prefix` + `search_fuzzy`) before falling back to text-based extraction.
- Optimize `WorkspaceSymbolsProvider::search_with_candidates()` by adding a name→(uri,index) reference map so candidate filtering materializes only matching symbols instead of lowercasing/scanning every document, and make `index_document` remove prior document entries before inserting.
- Add a unit test to `perl-symbol` verifying that `replace_document_symbols` and `remove_document` correctly evict stale entries.

### Testing

- Ran `cargo fmt` (succeeded).
- Ran `cargo test -p perl-symbol` (all tests passed).
- Ran `cargo test -p perl-lsp-rs-core providers::workspace_symbols::tests::search_with_candidates_filters_results` (passed).
- Ran `cargo check -p perl-symbol -p perl-lsp-rs-core -p perl-lsp-rs --all-targets` (succeeded for those crates).
- Note: `cargo check --workspace --all-targets` currently fails due to unrelated pre-existing test/fixture issues in other crates (`perl-semantic-analyzer` format-string test and a separate test expecting a missing top-level Cargo.toml); these failures are outside the scope of this change and were observed during verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77aa9674833399f9e6de51804c0e)