### PR TITLE
perf(workspace-symbols): wire perl-symbol SymbolIndex into production candidate search (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/workspace_symbols/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/workspace_symbols/mod.rs
@@ -113,6 +113,8 @@ struct SymbolInfo {
 pub struct WorkspaceSymbolsProvider {
     /// Map of document URI to its extracted symbols.
     documents: HashMap<String, Vec<SymbolInfo>>,
+    /// Fast lookup map from symbol name to symbol occurrences.
+    symbols_by_name: HashMap<String, Vec<(String, SymbolInfo)>>,
 }
 
 impl Default for WorkspaceSymbolsProvider {
@@ -125,7 +127,7 @@ impl WorkspaceSymbolsProvider {
     /// Creates a new empty workspace symbols provider.
     #[must_use]
     pub fn new() -> Self {
-        Self { documents: HashMap::new() }
+        Self { documents: HashMap::new(), symbols_by_name: HashMap::new() }
     }
 
     /// Indexes all symbols from a parsed document.
@@ -133,6 +135,8 @@ impl WorkspaceSymbolsProvider {
     /// Extracts symbols from the AST and stores them for later search queries.
     /// Replaces any previously indexed symbols for the same URI.
     pub fn index_document(&mut self, uri: &str, ast: &Node, source: &str) {
+        self.remove_document(uri);
+
         let extractor = SymbolExtractor::new_with_source(source);
         let table = extractor.extract(ast);
 
@@ -152,6 +156,13 @@ impl WorkspaceSymbolsProvider {
             }
         }
 
+        for symbol in &symbols {
+            self.symbols_by_name
+                .entry(symbol.name.clone())
+                .or_default()
+                .push((uri.to_string(), symbol.clone()));
+        }
+
         self.documents.insert(uri.to_string(), symbols);
     }
 
@@ -160,6 +171,10 @@ impl WorkspaceSymbolsProvider {
     /// Called when a file is deleted or closed in the workspace.
     pub fn remove_document(&mut self, uri: &str) {
         self.documents.remove(uri);
+        self.symbols_by_name.retain(|_, entries| {
+            entries.retain(|(entry_uri, _)| entry_uri != uri);
+            !entries.is_empty()
+        });
     }
 
     /// Returns all indexed symbols as LSP WorkspaceSymbols.
@@ -203,24 +218,15 @@ impl WorkspaceSymbolsProvider {
         candidates: &[String],
     ) -> Vec<WorkspaceSymbol> {
         let mut results = Vec::new();
-
-        // Create a set of candidate names for fast lookup
-        let candidate_set: std::collections::HashSet<_> =
-            candidates.iter().map(|s| s.to_lowercase()).collect();
-
-        for (uri, symbols) in &self.documents {
-            // Get source for this document to convert offsets
-            let source = match source_map.get(uri) {
-                Some(s) => s,
-                None => continue,
-            };
-
-            for symbol in symbols {
-                // Check if this symbol is in our candidate set
-                if candidate_set.contains(&symbol.name.to_lowercase())
-                    && matches_query(&symbol.name, query)
-                {
-                    results.push(self.symbol_to_workspace_symbol(uri, symbol, source));
+        for candidate in candidates {
+            if let Some(entries) = self.symbols_by_name.get(candidate) {
+                for (uri, symbol) in entries {
+                    if matches_query(&symbol.name, query) {
+                        let Some(source) = source_map.get(uri) else {
+                            continue;
+                        };
+                        results.push(self.symbol_to_workspace_symbol(uri, symbol, source));
+                    }
                 }
             }
         }

--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -87,6 +87,17 @@ fn build_incremental_edit_set(
 }
 
 impl LspServer {
+    fn reindex_document_symbols(&self, uri: &str, ast: &Node, source: &str) {
+        let extractor = crate::symbol::SymbolExtractor::new_with_source(source);
+        let table = extractor.extract(ast);
+        let symbols = table.symbols.keys().cloned().collect::<Vec<_>>();
+        self.symbol_index.lock().replace_document_symbols(uri, symbols);
+    }
+
+    fn clear_document_symbols(&self, uri: &str) {
+        self.symbol_index.lock().remove_document(uri);
+    }
+
     /// Handle textDocument/didOpen notification.
     ///
     /// Delegates to [`Self::handle_did_open_with_cancellation`] with no token.
@@ -163,6 +174,7 @@ impl LspServer {
                 ) {
                     tracing::warn!("Failed to publish diagnostics for {}: {}", uri, e);
                 }
+                self.clear_document_symbols(uri);
 
                 return Ok(());
             }
@@ -210,6 +222,7 @@ impl LspServer {
                 ) {
                     tracing::warn!("Failed to publish diagnostics for {}: {}", uri, e);
                 }
+                self.clear_document_symbols(uri);
 
                 return Ok(());
             }
@@ -265,6 +278,7 @@ impl LspServer {
                         e
                     );
                 }
+                self.clear_document_symbols(uri);
 
                 return Ok(());
             }
@@ -372,32 +386,8 @@ impl LspServer {
                 },
             );
 
-            // Index symbols for workspace search
-            // Note: Indexing is a MUTATION operation - use coordinator.index() directly
-            // This must happen BEFORE notify_parse_complete to keep work inside the tracking window
-            if let Some(ref _ast) = ast_arc {
-                // Update the fast symbol index with symbols from workspace index
-                #[cfg(feature = "workspace")]
-                if let Some(coordinator) = self.coordinator() {
-                    let workspace_index = coordinator.index();
-                    let index_symbols = workspace_index.find_symbols("");
-                    let symbols = index_symbols
-                        .into_iter()
-                        .filter(|s| s.uri == uri)
-                        .map(|s| s.name.clone())
-                        .collect::<Vec<_>>();
-
-                    let mut index = self.symbol_index.lock();
-                    for symbol in symbols {
-                        index.add_symbol(symbol);
-                    }
-                }
-                #[cfg(not(feature = "workspace"))]
-                {
-                    let _index = self.symbol_index.lock();
-                    // Just ensure the index exists even without workspace feature
-                }
-
+            if let Some(ref ast) = ast_arc {
+                self.reindex_document_symbols(uri, ast, text);
                 // Update the workspace-wide index for cross-file features.
                 // Indexing runs in a background task so the handler returns
                 // immediately without blocking on file I/O or symbol extraction.
@@ -457,6 +447,8 @@ impl LspServer {
                         return Ok(());
                     }
                 }
+            } else {
+                self.clear_document_symbols(uri);
             }
 
             // Notify coordinator that all work (parse + index) is complete (may trigger recovery)
@@ -662,6 +654,7 @@ impl LspServer {
                     ) {
                         tracing::warn!("Failed to publish diagnostics for {}: {}", uri, e);
                     }
+                    self.clear_document_symbols(uri);
 
                     return Ok(());
                 }
@@ -707,6 +700,7 @@ impl LspServer {
                     ) {
                         tracing::warn!("Failed to publish diagnostics for {}: {}", uri, e);
                     }
+                    self.clear_document_symbols(uri);
 
                     return Ok(());
                 }
@@ -760,6 +754,7 @@ impl LspServer {
                             e
                         );
                     }
+                    self.clear_document_symbols(uri);
 
                     return Ok(());
                 }
@@ -965,6 +960,12 @@ impl LspServer {
                 // Must drop the lock before calling publish_diagnostics
                 drop(documents);
 
+                if let Some(ref ast) = ast_arc {
+                    self.reindex_document_symbols(uri, ast, &text);
+                } else {
+                    self.clear_document_symbols(uri);
+                }
+
                 // Index symbols for workspace search.
                 // Indexing runs in a background task so the handler returns
                 // immediately; `notify_parse_complete` is called inside the task.
@@ -1075,6 +1076,8 @@ impl LspServer {
             if let Some(coordinator) = self.coordinator() {
                 coordinator.index().clear_file(uri);
             }
+
+            self.clear_document_symbols(uri);
 
             // Notify coordinator that cleanup is complete
             #[cfg(feature = "workspace")]
@@ -1814,6 +1817,62 @@ mod tests {
             "did_close must remove the URI entry from parse_cancel_flags"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_did_change_replaces_document_symbols_in_index()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let uri = "file:///test_symbol_reindex.pl";
+
+        server.did_open(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": "sub old_name { 1 }\n"
+            }
+        }))?;
+
+        assert!(
+            server.symbol_index.lock().search_prefix("old_").contains(&"old_name".to_string())
+        );
+
+        server.handle_did_change(Some(json!({
+            "textDocument": { "uri": uri, "version": 2 },
+            "contentChanges": [{ "text": "sub new_name { 2 }\n" }]
+        })))?;
+
+        let index = server.symbol_index.lock();
+        assert!(index.search_prefix("old_").is_empty());
+        assert!(index.search_prefix("new_").contains(&"new_name".to_string()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_did_close_removes_document_symbols_from_index()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let uri = "file:///test_symbol_close.pl";
+
+        server.did_open(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": "sub close_me { 1 }\n"
+            }
+        }))?;
+
+        assert!(
+            server.symbol_index.lock().search_prefix("close_").contains(&"close_me".to_string())
+        );
+
+        server.handle_did_close(Some(json!({"textDocument": {"uri": uri}})))?;
+
+        assert!(server.symbol_index.lock().search_prefix("close_").is_empty());
         Ok(())
     }
 

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -9,6 +9,7 @@
 //! - **Building/Degraded state**: Open document search only (partial results)
 
 use super::*;
+use std::collections::HashSet;
 #[cfg(feature = "workspace")]
 use crate::runtime::routing::{IndexAccessMode, route_index_access};
 use crate::state::workspace_symbol_cap;
@@ -435,50 +436,48 @@ impl LspServer {
         query: &str,
         cap: usize,
     ) -> Result<Option<Value>, JsonRpcError> {
-        let mut all_symbols = Vec::new();
-
-        // Collect lightweight snapshots without holding lock during iteration.
-        // Only clone the fields needed for symbol extraction (uri, text, ast Arc),
-        // avoiding expensive Rope, ParentMap, LineStartsCache, and parse_errors clones.
         let docs_snapshot: Vec<(String, String, Option<Arc<perl_parser::ast::Node>>)> = {
             let documents = self.documents.lock();
             documents.iter().map(|(k, v)| (k.clone(), v.text.clone(), v.ast.clone())).collect()
         };
 
-        // Pre-compute lowercased query once, outside the document loop
-        let query_lower = query.to_lowercase();
+        let mut provider =
+            perl_lsp_rs_core::providers::workspace_symbols::WorkspaceSymbolsProvider::new();
+        let mut source_map = std::collections::HashMap::new();
+        let mut text_fallback_symbols = Vec::new();
 
         for (i, (uri, text, ast)) in docs_snapshot.iter().enumerate() {
-            // Cooperative yield every 8 documents
             if i & 0x7 == 0 {
                 std::thread::yield_now();
             }
-
-            // Early exit if we've hit the result cap
-            if all_symbols.len() >= cap {
-                break;
-            }
-
+            source_map.insert(uri.clone(), text.clone());
             if let Some(ast) = ast {
-                let doc_symbols = self.extract_document_symbols(ast, text, uri);
-
-                for sym in doc_symbols {
-                    if sym.name.to_lowercase().contains(&query_lower) {
-                        all_symbols.push(sym);
-                        if all_symbols.len() >= cap {
-                            break;
-                        }
-                    }
-                }
+                provider.index_document(uri, ast, text);
             } else {
-                // Text-based fallback when AST is not available
-                let text_symbols = self.extract_text_based_symbols(text, uri, query);
-                let remaining = cap.saturating_sub(all_symbols.len());
-                all_symbols.extend(text_symbols.into_iter().take(remaining));
+                text_fallback_symbols.extend(self.extract_text_based_symbols(text, uri, query));
             }
         }
 
-        // Truncate to cap in case we went slightly over
+        let mut candidates = self.symbol_index.lock().search_prefix(query);
+        if candidates.is_empty() && !query.is_empty() {
+            candidates = self.symbol_index.lock().search_fuzzy(query);
+        }
+        let mut dedup = HashSet::new();
+        candidates.retain(|candidate| dedup.insert(candidate.clone()));
+
+        let mut provider_results = provider.search_with_candidates(query, &source_map, &candidates);
+        if provider_results.is_empty() && !query.is_empty() {
+            provider_results = provider.search(query, &source_map);
+        }
+        let mut all_symbols: Vec<Value> = provider_results
+            .into_iter()
+            .filter_map(|symbol| serde_json::to_value(symbol).ok())
+            .collect();
+        all_symbols.extend(
+            text_fallback_symbols
+                .into_iter()
+                .filter_map(|symbol| serde_json::to_value(symbol).ok()),
+        );
         all_symbols.truncate(cap);
         tracing::debug!(
             count = all_symbols.len(),
@@ -528,7 +527,17 @@ impl LspServer {
             source_map.insert(uri.clone(), text.clone());
         }
 
-        let mut symbols = provider.search(query, &source_map);
+        let mut candidates = self.symbol_index.lock().search_prefix(query);
+        if candidates.is_empty() && !query.is_empty() {
+            candidates = self.symbol_index.lock().search_fuzzy(query);
+        }
+        let mut dedup = HashSet::new();
+        candidates.retain(|candidate| dedup.insert(candidate.clone()));
+
+        let mut symbols = provider.search_with_candidates(query, &source_map, &candidates);
+        if symbols.is_empty() && !query.is_empty() {
+            symbols = provider.search(query, &source_map);
+        }
         symbols.truncate(cap);
 
         tracing::debug!(count = symbols.len(), cap, "Found symbols total");

--- a/crates/perl-symbol/src/index/mod.rs
+++ b/crates/perl-symbol/src/index/mod.rs
@@ -334,4 +334,29 @@ mod tests {
         index.replace_document_symbols("file:///a.pl", vec!["new_sub".to_string()]);
         assert!(index.search_prefix("new_sub").contains(&"new_sub".to_string()));
     }
+
+    #[test]
+    fn document_symbols_are_fuzzy_searchable_after_replace() {
+        // Symbols added via replace_document_symbols must appear in fuzzy results,
+        // not only in prefix results. The inverted index must be populated.
+        let mut index = SymbolIndex::new();
+        index.replace_document_symbols(
+            "file:///a.pl",
+            vec!["get_user_name".to_string()],
+        );
+
+        let results = index.search_fuzzy("user name");
+        assert!(
+            results.contains(&"get_user_name".to_string()),
+            "document symbols must be fuzzy-searchable"
+        );
+
+        // After replacing the document, the old symbol must not appear in fuzzy results.
+        index.replace_document_symbols("file:///a.pl", vec!["set_password".to_string()]);
+        let results = index.search_fuzzy("user name");
+        assert!(
+            !results.contains(&"get_user_name".to_string()),
+            "replaced symbol must be removed from fuzzy index"
+        );
+    }
 }

--- a/crates/perl-symbol/src/index/mod.rs
+++ b/crates/perl-symbol/src/index/mod.rs
@@ -13,6 +13,10 @@ pub struct SymbolIndex {
     trie: SymbolTrie,
     /// Inverted index for fuzzy matching
     inverted_index: HashMap<String, Vec<String>>,
+    /// Reference count for each symbol across indexed documents.
+    symbol_ref_counts: HashMap<String, usize>,
+    /// Per-document symbol sets for replace/remove updates.
+    document_symbols: HashMap<String, Vec<String>>,
 }
 
 /// Trie data structure for efficient prefix matching
@@ -33,7 +37,12 @@ impl SymbolIndex {
     /// Create a new empty symbol index.
     #[must_use]
     pub fn new() -> Self {
-        Self { trie: SymbolTrie::new(), inverted_index: HashMap::new() }
+        Self {
+            trie: SymbolTrie::new(),
+            inverted_index: HashMap::new(),
+            symbol_ref_counts: HashMap::new(),
+            document_symbols: HashMap::new(),
+        }
     }
 
     /// Add a symbol to the index.
@@ -42,17 +51,35 @@ impl SymbolIndex {
     /// Duplicate calls with the same symbol are idempotent: the symbol is
     /// stored exactly once in both the trie and the inverted index.
     pub fn add_symbol(&mut self, symbol: String) {
-        // Add to trie for prefix matching; returns true only when newly inserted.
-        // Deduplication here prevents the inverted index from accumulating
-        // duplicate entries, which would inflate fuzzy-match scores.
-        if !self.trie.insert(&symbol) {
-            return;
+        self.add_symbol_occurrence(&symbol);
+    }
+
+    /// Replace all symbols for a specific document.
+    ///
+    /// This operation is idempotent and removes stale symbols that no longer
+    /// exist in the latest version of the document.
+    pub fn replace_document_symbols(&mut self, uri: &str, symbols: Vec<String>) {
+        self.remove_document(uri);
+
+        let mut unique_symbols: Vec<String> = Vec::new();
+        for symbol in symbols {
+            if !unique_symbols.contains(&symbol) {
+                self.add_symbol_occurrence(&symbol);
+                unique_symbols.push(symbol);
+            }
         }
 
-        // Add to inverted index for fuzzy matching
-        let tokens = Self::tokenize(&symbol);
-        for token in tokens {
-            self.inverted_index.entry(token).or_default().push(symbol.clone());
+        if !unique_symbols.is_empty() {
+            self.document_symbols.insert(uri.to_string(), unique_symbols);
+        }
+    }
+
+    /// Remove all symbols for a specific document.
+    pub fn remove_document(&mut self, uri: &str) {
+        if let Some(existing) = self.document_symbols.remove(uri) {
+            for symbol in existing {
+                self.remove_symbol_occurrence(&symbol);
+            }
         }
     }
 
@@ -115,6 +142,45 @@ impl SymbolIndex {
 
         tokens
     }
+
+    fn add_symbol_occurrence(&mut self, symbol: &str) {
+        let count = self.symbol_ref_counts.entry(symbol.to_string()).or_insert(0);
+        *count += 1;
+        if *count > 1 {
+            return;
+        }
+
+        self.trie.insert(symbol);
+        let tokens = Self::tokenize(symbol);
+        for token in tokens {
+            self.inverted_index.entry(token).or_default().push(symbol.to_string());
+        }
+    }
+
+    fn remove_symbol_occurrence(&mut self, symbol: &str) {
+        let Some(count) = self.symbol_ref_counts.get_mut(symbol) else {
+            return;
+        };
+
+        if *count > 1 {
+            *count -= 1;
+            return;
+        }
+
+        self.symbol_ref_counts.remove(symbol);
+        self.trie.remove(symbol);
+        let tokens = Self::tokenize(symbol);
+        for token in tokens {
+            let mut should_prune = false;
+            if let Some(symbols) = self.inverted_index.get_mut(&token) {
+                symbols.retain(|candidate| candidate != symbol);
+                should_prune = symbols.is_empty();
+            }
+            if should_prune {
+                self.inverted_index.remove(&token);
+            }
+        }
+    }
 }
 
 impl SymbolTrie {
@@ -162,6 +228,24 @@ impl SymbolTrie {
         results
     }
 
+    fn remove(&mut self, symbol: &str) {
+        let chars: Vec<char> = symbol.chars().collect();
+        self.remove_recursive(&chars, 0, symbol);
+    }
+
+    fn remove_recursive(&mut self, chars: &[char], idx: usize, symbol: &str) -> bool {
+        if idx == chars.len() {
+            self.symbols.retain(|value| value != symbol);
+        } else if let Some(child) = self.children.get_mut(&chars[idx]) {
+            let prune_child = child.remove_recursive(chars, idx + 1, symbol);
+            if prune_child {
+                self.children.remove(&chars[idx]);
+            }
+        }
+
+        self.children.is_empty() && self.symbols.is_empty()
+    }
+
     fn collect_all(node: &SymbolTrie, results: &mut Vec<String>) {
         results.extend(node.symbols.clone());
 
@@ -190,5 +274,35 @@ mod tests {
 
         let fuzzy_results = index.search_fuzzy("user name");
         assert!(fuzzy_results.contains(&"get_user_name".to_string()));
+    }
+
+    #[test]
+    fn replace_document_symbols_removes_stale_entries() {
+        let mut index = SymbolIndex::new();
+        index.replace_document_symbols(
+            "file:///a.pl",
+            vec!["old_name".to_string(), "shared".to_string()],
+        );
+        index.replace_document_symbols(
+            "file:///a.pl",
+            vec!["new_name".to_string(), "shared".to_string()],
+        );
+
+        assert!(index.search_prefix("old").is_empty());
+        assert!(index.search_prefix("new").contains(&"new_name".to_string()));
+        assert!(index.search_prefix("sha").contains(&"shared".to_string()));
+    }
+
+    #[test]
+    fn remove_document_preserves_symbols_from_other_documents() {
+        let mut index = SymbolIndex::new();
+        index.replace_document_symbols("file:///a.pl", vec!["shared".to_string(), "only_a".to_string()]);
+        index.replace_document_symbols("file:///b.pl", vec!["shared".to_string(), "only_b".to_string()]);
+        index.remove_document("file:///a.pl");
+
+        let shared = index.search_prefix("shared");
+        assert_eq!(shared, vec!["shared".to_string()]);
+        assert!(index.search_prefix("only_a").is_empty());
+        assert_eq!(index.search_prefix("only_b"), vec!["only_b".to_string()]);
     }
 }

--- a/crates/perl-symbol/src/index/mod.rs
+++ b/crates/perl-symbol/src/index/mod.rs
@@ -3,7 +3,7 @@
 //! This module has one responsibility: indexing symbol names for fast lookup
 //! across prefix and fuzzy query styles.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Symbol index for fast lookups.
 ///
@@ -61,9 +61,10 @@ impl SymbolIndex {
     pub fn replace_document_symbols(&mut self, uri: &str, symbols: Vec<String>) {
         self.remove_document(uri);
 
+        let mut seen: HashSet<String> = HashSet::new();
         let mut unique_symbols: Vec<String> = Vec::new();
         for symbol in symbols {
-            if !unique_symbols.contains(&symbol) {
+            if seen.insert(symbol.clone()) {
                 self.add_symbol_occurrence(&symbol);
                 unique_symbols.push(symbol);
             }
@@ -304,5 +305,33 @@ mod tests {
         assert_eq!(shared, vec!["shared".to_string()]);
         assert!(index.search_prefix("only_a").is_empty());
         assert_eq!(index.search_prefix("only_b"), vec!["only_b".to_string()]);
+    }
+
+    #[test]
+    fn trie_remove_preserves_symbols_with_shared_prefix() {
+        // Removing "foo" must not evict "foobar" from the trie.
+        let mut index = SymbolIndex::new();
+        index.replace_document_symbols(
+            "file:///a.pl",
+            vec!["foo".to_string(), "foobar".to_string()],
+        );
+        index.replace_document_symbols("file:///a.pl", vec!["foobar".to_string()]);
+
+        assert!(index.search_prefix("foo").contains(&"foobar".to_string()));
+        assert!(!index.search_prefix("foo").contains(&"foo".to_string()));
+    }
+
+    #[test]
+    fn replace_with_empty_list_clears_document_symbols() {
+        // A file edited to contain no symbols must have its prior symbols removed.
+        let mut index = SymbolIndex::new();
+        index.replace_document_symbols("file:///a.pl", vec!["old_sub".to_string()]);
+        index.replace_document_symbols("file:///a.pl", vec![]);
+
+        assert!(index.search_prefix("old_sub").is_empty());
+
+        // A subsequent replace with real symbols must work correctly.
+        index.replace_document_symbols("file:///a.pl", vec!["new_sub".to_string()]);
+        assert!(index.search_prefix("new_sub").contains(&"new_sub".to_string()));
     }
 }

--- a/crates/perl-symbol/src/index/mod.rs
+++ b/crates/perl-symbol/src/index/mod.rs
@@ -297,8 +297,14 @@ mod tests {
     #[test]
     fn remove_document_preserves_symbols_from_other_documents() {
         let mut index = SymbolIndex::new();
-        index.replace_document_symbols("file:///a.pl", vec!["shared".to_string(), "only_a".to_string()]);
-        index.replace_document_symbols("file:///b.pl", vec!["shared".to_string(), "only_b".to_string()]);
+        index.replace_document_symbols(
+            "file:///a.pl",
+            vec!["shared".to_string(), "only_a".to_string()],
+        );
+        index.replace_document_symbols(
+            "file:///b.pl",
+            vec!["shared".to_string(), "only_b".to_string()],
+        );
         index.remove_document("file:///a.pl");
 
         let shared = index.search_prefix("shared");
@@ -340,10 +346,7 @@ mod tests {
         // Symbols added via replace_document_symbols must appear in fuzzy results,
         // not only in prefix results. The inverted index must be populated.
         let mut index = SymbolIndex::new();
-        index.replace_document_symbols(
-            "file:///a.pl",
-            vec!["get_user_name".to_string()],
-        );
+        index.replace_document_symbols("file:///a.pl", vec!["get_user_name".to_string()]);
 
         let results = index.search_fuzzy("user name");
         assert!(

--- a/crates/perl-symbol/tests/facade_api_completeness.rs
+++ b/crates/perl-symbol/tests/facade_api_completeness.rs
@@ -57,6 +57,22 @@ fn symbol_index_accessible() {
 }
 
 #[test]
+fn symbol_index_document_api_accessible() {
+    // replace_document_symbols, remove_document, and search_fuzzy must be
+    // callable at the documented paths on SymbolIndex.
+    let mut idx = SymbolIndex::new();
+    idx.replace_document_symbols(
+        "file:///a.pl",
+        vec!["get_user".to_string(), "set_user".to_string()],
+    );
+    assert!(!idx.search_prefix("get_").is_empty());
+    assert!(!idx.search_fuzzy("user").is_empty());
+
+    idx.remove_document("file:///a.pl");
+    assert!(idx.search_prefix("get_").is_empty());
+}
+
+#[test]
 fn surface_decl_accessible() {
     // SymbolDecl and extract_symbol_decls must be callable at perl_symbol
     // (crate-root re-export) and at perl_symbol::surface (module path).


### PR DESCRIPTION
### Motivation

- Workspace symbol search still scanned open documents even though a runtime `SymbolIndex` existed, and index entries could become stale on document updates or removals.  
- Make `SymbolIndex` a first-class, document-aware candidate source so prefix/fuzzy narrowing avoids expensive per-document scans.  
- Ensure index entries are removed/replaced on `didChange` / `didClose` and preserved when symbols are shared across files.  

### Description

- Extended `perl-symbol::SymbolIndex` with per-document bookkeeping and reference-counted lifetimes via `replace_document_symbols`, `remove_document`, `add_symbol_occurrence`, and `remove_symbol_occurrence`, and added trie deletion to avoid stale prefix hits.  
- Changed `WorkspaceSymbolsProvider` to keep a `symbols_by_name: HashMap<String, Vec<(String, SymbolInfo)>>` and use it inside `search_with_candidates` so candidate-limited searches do not scan every document.  
- Wired runtime text-sync to call `reindex_document_symbols` (which invokes `SymbolIndex::replace_document_symbols`) when a parsed AST is available and `clear_document_symbols` (which invokes `SymbolIndex::remove_document`) on no-AST paths and on `didClose`.  
- Rewired the fallback open-doc workspace-symbol path to first ask the runtime `SymbolIndex` for candidates via `search_prefix` / `search_fuzzy` and then pass those into `WorkspaceSymbolsProvider::search_with_candidates`, with safe fallbacks to full `search` and text-based symbols when needed.  

### Testing

- Ran `cargo test -p perl-symbol` and all unit tests passed.  
- Ran `cargo test -p perl-lsp-rs-core workspace_symbols` and the provider tests passed.  
- Ran targeted runtime tests in `perl-lsp-rs` (`test_did_change_replaces_document_symbols_in_index` and `test_did_close_removes_document_symbols_from_index`) and both passed.  
- Attempted `cargo check --workspace --all-targets` during verification but the run initially failed due to an out-of-disk error (`No space left on device`); disk cleanup was performed before committing (no subsequent full workspace check was completed in this rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77aa9674833399f9e6de51804c0e)