### PR TITLE
refactor(symbol-surface): make extract_symbol_decls authoritative baseline (#0000)

### DIFF
--- a/crates/perl-symbol/src/surface/decl.rs
+++ b/crates/perl-symbol/src/surface/decl.rs
@@ -329,6 +329,7 @@ fn constant_names_from_use_args(args: &[String]) -> Vec<String> {
 
 fn qw_names(arg: &str) -> Option<Vec<String>> {
     let content = arg.strip_prefix("qw").and_then(|rest| {
+        let rest = rest.trim_start();
         rest.strip_prefix('(')
             .and_then(|s| s.strip_suffix(')'))
             .or_else(|| rest.strip_prefix('[').and_then(|s| s.strip_suffix(']')))
@@ -511,6 +512,13 @@ mod tests {
     #[test]
     fn constant_names_supports_qw_and_deduplicates_entries() {
         let args = vec!["qw(ONE TWO ONE)".to_string()];
+
+        assert_eq!(constant_names_from_use_args(&args), vec!["ONE".to_string(), "TWO".to_string()]);
+    }
+
+    #[test]
+    fn constant_names_supports_qw_with_space_before_delimiter() {
+        let args = vec!["qw [ONE TWO]".to_string()];
 
         assert_eq!(constant_names_from_use_args(&args), vec!["ONE".to_string(), "TWO".to_string()]);
     }

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -68,6 +68,7 @@ use crate::position::{Position, Range};
 use crate::workspace::monitoring::IndexInstrumentation;
 use parking_lot::RwLock;
 use perl_position_tracking::{WireLocation, WirePosition, WireRange};
+use perl_symbol::surface::extract_symbol_decls;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
@@ -1045,13 +1046,13 @@ fn default_has_body() -> bool {
 /// Symbol kind enums used during Index/Analyze workflows.
 pub use perl_symbol::{SymbolKind, VarKind};
 
-/// Helper function to convert sigil to VarKind
-fn sigil_to_var_kind(sigil: &str) -> VarKind {
-    match sigil {
-        "@" => VarKind::Array,
-        "%" => VarKind::Hash,
-        _ => VarKind::Scalar, // Default to scalar for $ and unknown
-    }
+fn variable_symbol_name(var_kind: VarKind, bare_name: &str) -> String {
+    let sigil = match var_kind {
+        VarKind::Array => '@',
+        VarKind::Hash => '%',
+        VarKind::Scalar => '$',
+    };
+    format!("{sigil}{bare_name}")
 }
 
 #[derive(Debug, Clone)]
@@ -2903,7 +2904,68 @@ impl IndexVisitor {
     }
 
     fn visit(&mut self, node: &Node, file_index: &mut FileIndex) {
+        self.index_baseline_declarations(node, file_index);
         self.visit_node(node, file_index);
+    }
+
+    fn index_baseline_declarations(&mut self, node: &Node, file_index: &mut FileIndex) {
+        for decl in extract_symbol_decls(node, Some("main")) {
+            let mut decl_name = decl.name;
+            let kind = match decl.kind {
+                // Keep compatibility with existing workspace-index behavior:
+                // constants resolve through subroutine symbol paths.
+                SymbolKind::Constant => SymbolKind::Subroutine,
+                other => other,
+            };
+            if let SymbolKind::Variable(var_kind) = kind {
+                decl_name = variable_symbol_name(var_kind, &decl_name);
+            }
+            let (range_start, range_end) = if matches!(kind, SymbolKind::Variable(_)) {
+                decl.anchor_span.unwrap_or(decl.full_span)
+            } else {
+                decl.full_span
+            };
+            let range = self.byte_span_to_range(range_start, range_end);
+            let qualified_name = if matches!(kind, SymbolKind::Variable(_)) {
+                None
+            } else {
+                Some(decl.qualified_name)
+            };
+
+            let existing_symbol_idx = if kind == SymbolKind::Subroutine {
+                file_index.symbols.iter().position(|symbol| {
+                    symbol.kind == SymbolKind::Subroutine
+                        && symbol.name == decl_name
+                        && symbol.container_name == decl.container
+                })
+            } else {
+                None
+            };
+
+            if let Some(idx) = existing_symbol_idx {
+                file_index.symbols[idx].range = range;
+            } else {
+                file_index.symbols.push(WorkspaceSymbol {
+                    name: decl_name.clone(),
+                    kind,
+                    uri: self.uri.clone(),
+                    range,
+                    qualified_name,
+                    documentation: None,
+                    container_name: decl.container.clone(),
+                    has_body: true,
+                    workspace_folder_uri: self.workspace_folder_uri.clone(),
+                });
+            }
+
+            if matches!(kind, SymbolKind::Subroutine | SymbolKind::Variable(_)) {
+                file_index.references.entry(decl_name).or_default().push(SymbolReference {
+                    uri: self.uri.clone(),
+                    range,
+                    kind: ReferenceKind::Definition,
+                });
+            }
+        }
     }
 
     fn record_interpolated_variable_references(
@@ -2973,124 +3035,23 @@ impl IndexVisitor {
 
                 // Update the current package (replaces the previous one, not a stack)
                 self.current_package = Some(package_name.clone());
-
-                file_index.symbols.push(WorkspaceSymbol {
-                    name: package_name.clone(),
-                    kind: SymbolKind::Package,
-                    uri: self.uri.clone(),
-                    range: self.node_to_range(node),
-                    qualified_name: Some(package_name),
-                    documentation: None,
-                    container_name: None,
-                    has_body: true,
-                    workspace_folder_uri: self.workspace_folder_uri.clone(),
-                });
             }
 
             NodeKind::Subroutine { name, body, .. } => {
-                if let Some(name_str) = name.clone() {
-                    let qualified_name = if let Some(ref pkg) = self.current_package {
-                        format!("{}::{}", pkg, name_str)
-                    } else {
-                        name_str.clone()
-                    };
-
-                    // Check if this is a forward declaration or update to existing symbol
-                    let existing_symbol_idx = file_index.symbols.iter().position(|s| {
-                        s.name == name_str && s.container_name == self.current_package
-                    });
-
-                    if let Some(idx) = existing_symbol_idx {
-                        // Update existing forward declaration with body
-                        file_index.symbols[idx].range = self.node_to_range(node);
-                    } else {
-                        // New symbol
-                        file_index.symbols.push(WorkspaceSymbol {
-                            name: name_str.clone(),
-                            kind: SymbolKind::Subroutine,
-                            uri: self.uri.clone(),
-                            range: self.node_to_range(node),
-                            qualified_name: Some(qualified_name),
-                            documentation: None,
-                            container_name: self.current_package.clone(),
-                            has_body: true, // Subroutine node always has body
-                            workspace_folder_uri: self.workspace_folder_uri.clone(),
-                        });
-                    }
-
-                    // Mark as definition
-                    file_index.references.entry(name_str.clone()).or_default().push(
-                        SymbolReference {
-                            uri: self.uri.clone(),
-                            range: self.node_to_range(node),
-                            kind: ReferenceKind::Definition,
-                        },
-                    );
-                }
+                let _ = name;
 
                 // Visit body
                 self.visit_node(body, file_index);
             }
 
-            NodeKind::VariableDeclaration { variable, initializer, .. } => {
-                if let NodeKind::Variable { sigil, name } = &variable.kind {
-                    let var_name = format!("{}{}", sigil, name);
-
-                    file_index.symbols.push(WorkspaceSymbol {
-                        name: var_name.clone(),
-                        kind: SymbolKind::Variable(sigil_to_var_kind(sigil)),
-                        uri: self.uri.clone(),
-                        range: self.node_to_range(variable),
-                        qualified_name: None,
-                        documentation: None,
-                        container_name: self.current_package.clone(),
-                        has_body: true, // Variables always have body
-                        workspace_folder_uri: self.workspace_folder_uri.clone(),
-                    });
-
-                    // Mark as definition
-                    file_index.references.entry(var_name.clone()).or_default().push(
-                        SymbolReference {
-                            uri: self.uri.clone(),
-                            range: self.node_to_range(variable),
-                            kind: ReferenceKind::Definition,
-                        },
-                    );
-                }
-
+            NodeKind::VariableDeclaration { initializer, .. } => {
                 // Visit initializer
                 if let Some(init) = initializer {
                     self.visit_node(init, file_index);
                 }
             }
 
-            NodeKind::VariableListDeclaration { variables, initializer, .. } => {
-                // Handle each variable in the list declaration
-                for var in variables {
-                    if let NodeKind::Variable { sigil, name } = &var.kind {
-                        let var_name = format!("{}{}", sigil, name);
-
-                        file_index.symbols.push(WorkspaceSymbol {
-                            name: var_name.clone(),
-                            kind: SymbolKind::Variable(sigil_to_var_kind(sigil)),
-                            uri: self.uri.clone(),
-                            range: self.node_to_range(var),
-                            qualified_name: None,
-                            documentation: None,
-                            container_name: self.current_package.clone(),
-                            has_body: true,
-                            workspace_folder_uri: self.workspace_folder_uri.clone(),
-                        });
-
-                        // Mark as definition
-                        file_index.references.entry(var_name).or_default().push(SymbolReference {
-                            uri: self.uri.clone(),
-                            range: self.node_to_range(var),
-                            kind: ReferenceKind::Definition,
-                        });
-                    }
-                }
-
+            NodeKind::VariableListDeclaration { initializer, .. } => {
                 // Visit the initializer
                 if let Some(init) = initializer {
                     self.visit_node(init, file_index);
@@ -3167,35 +3128,6 @@ impl IndexVisitor {
                 if module == "parent" || module == "base" {
                     for name in extract_module_names_from_use_args(args) {
                         file_index.dependencies.insert(normalize_dependency_module_name(&name));
-                    }
-                }
-
-                // Index `use constant` declarations as subroutine-like symbols so that
-                // fully-qualified constant references (e.g. `My::Config::PI`) resolve
-                // via the workspace index just like subroutines.
-                if module == "constant" {
-                    let pkg = self.current_package.as_deref().unwrap_or("main").to_string();
-                    let const_node_range = self.node_to_range(node);
-                    for const_name in extract_constant_names_from_use_args(args) {
-                        let qualified_name = format!("{pkg}::{const_name}");
-                        file_index.symbols.push(WorkspaceSymbol {
-                            name: const_name.clone(),
-                            kind: SymbolKind::Subroutine,
-                            uri: self.uri.clone(),
-                            range: const_node_range,
-                            qualified_name: Some(qualified_name),
-                            documentation: None,
-                            container_name: Some(pkg.clone()),
-                            has_body: true,
-                            workspace_folder_uri: self.workspace_folder_uri.clone(),
-                        });
-                        file_index.references.entry(const_name).or_default().push(
-                            SymbolReference {
-                                uri: self.uri.clone(),
-                                range: self.node_to_range(node),
-                                kind: ReferenceKind::Definition,
-                            },
-                        );
                     }
                 }
 
@@ -3349,39 +3281,10 @@ impl IndexVisitor {
             NodeKind::Class { name, .. } => {
                 let class_name = name.clone();
                 self.current_package = Some(class_name.clone());
-
-                file_index.symbols.push(WorkspaceSymbol {
-                    name: class_name.clone(),
-                    kind: SymbolKind::Class,
-                    uri: self.uri.clone(),
-                    range: self.node_to_range(node),
-                    qualified_name: Some(class_name),
-                    documentation: None,
-                    container_name: None,
-                    has_body: true,
-                    workspace_folder_uri: self.workspace_folder_uri.clone(),
-                });
             }
 
             NodeKind::Method { name, body, signature, .. } => {
-                let method_name = name.clone();
-                let qualified_name = if let Some(ref pkg) = self.current_package {
-                    format!("{}::{}", pkg, method_name)
-                } else {
-                    method_name.clone()
-                };
-
-                file_index.symbols.push(WorkspaceSymbol {
-                    name: method_name.clone(),
-                    kind: SymbolKind::Method,
-                    uri: self.uri.clone(),
-                    range: self.node_to_range(node),
-                    qualified_name: Some(qualified_name),
-                    documentation: None,
-                    container_name: self.current_package.clone(),
-                    has_body: true,
-                    workspace_folder_uri: self.workspace_folder_uri.clone(),
-                });
+                let _ = name;
 
                 // Visit params
                 if let Some(sig) = signature {
@@ -3527,6 +3430,15 @@ impl IndexVisitor {
         Range {
             start: Position { byte: node.location.start, line: start_line, column: start_col },
             end: Position { byte: node.location.end, line: end_line, column: end_col },
+        }
+    }
+
+    fn byte_span_to_range(&self, start: usize, end: usize) -> Range {
+        let ((start_line, start_col), (end_line, end_col)) =
+            self.document.line_index.range(start, end);
+        Range {
+            start: Position { byte: start, line: start_line, column: start_col },
+            end: Position { byte: end, line: end_line, column: end_col },
         }
     }
 }
@@ -3786,6 +3698,7 @@ fn extract_manual_import_symbols(args: &[Node]) -> Vec<String> {
 ///   → Words inside the qw list are constant names.
 ///
 /// Returns a deduplicated list of bare constant names (e.g. `["FOO", "BAR"]`).
+#[cfg(test)]
 fn extract_constant_names_from_use_args(args: &[String]) -> Vec<String> {
     use std::collections::HashSet;
 
@@ -5761,8 +5674,8 @@ sub other_sub {
     // ========================================================================
 
     #[test]
-    fn test_require_with_variable_target_is_not_indexed()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_require_with_variable_target_is_not_indexed() -> Result<(), Box<dyn std::error::Error>>
+    {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/require-var.pl"));
         let src = r#"package Test;
@@ -5780,8 +5693,7 @@ require $loader;
     }
 
     #[test]
-    fn test_multiple_import_calls_on_same_module()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_multiple_import_calls_on_same_module() -> Result<(), Box<dyn std::error::Error>> {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/multi-import.pl"));
         let src = r#"package Test;
@@ -5801,8 +5713,7 @@ Toolkit->import(qw(func_b func_c));
     }
 
     #[test]
-    fn test_require_string_vs_bareword_normalization()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_require_string_vs_bareword_normalization() -> Result<(), Box<dyn std::error::Error>> {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/require-string.pl"));
         let src = r#"package Consumer;
@@ -5846,8 +5757,7 @@ orphaned();
     }
 
     #[test]
-    fn test_nested_blocks_preserve_require_scope()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_nested_blocks_preserve_require_scope() -> Result<(), Box<dyn std::error::Error>> {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/nested.pl"));
         let src = r#"package Test;
@@ -5871,8 +5781,7 @@ orphaned();
     }
 
     #[test]
-    fn test_require_path_without_pm_extension()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_require_path_without_pm_extension() -> Result<(), Box<dyn std::error::Error>> {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/no-ext.pl"));
         let src = r#"package Test;
@@ -5890,8 +5799,7 @@ My::Module->import('func');
     }
 
     #[test]
-    fn test_qw_with_bracket_delimiters()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_qw_with_bracket_delimiters() -> Result<(), Box<dyn std::error::Error>> {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/qw-delim.pl"));
         let src = r#"package Test;
@@ -5905,15 +5813,15 @@ DelimModule->import(qw{sym3 sym4});
             let refs = index.find_references(symbol);
             assert!(
                 !refs.is_empty(),
-                "symbols from qw with bracket delimiters should be indexed: {}", symbol
+                "symbols from qw with bracket delimiters should be indexed: {}",
+                symbol
             );
         }
         Ok(())
     }
 
     #[test]
-    fn test_array_literal_import_args()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_array_literal_import_args() -> Result<(), Box<dyn std::error::Error>> {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/array-import.pl"));
         let src = r#"package Test;
@@ -5926,7 +5834,8 @@ ArrayModule->import(['sym_x', 'sym_y']);
             let refs = index.find_references(symbol);
             assert!(
                 !refs.is_empty(),
-                "symbols from array literal import should be indexed: {}", symbol
+                "symbols from array literal import should be indexed: {}",
+                symbol
             );
         }
         Ok(())
@@ -5956,8 +5865,7 @@ if (1) {
     }
 
     #[test]
-    fn test_mixed_string_and_bareword_imports()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_mixed_string_and_bareword_imports() -> Result<(), Box<dyn std::error::Error>> {
         let index = WorkspaceIndex::new();
         let uri = must(url::Url::parse("file:///test/mixed-import.pl"));
         let src = r#"package Test;
@@ -5971,10 +5879,7 @@ MixedMod->import(qw(qw_one qw_two));
         assert!(deps.contains("MixedMod"), "require should register dependency");
         for symbol in &["string_sym", "qw_one", "qw_two"] {
             let refs = index.find_references(symbol);
-            assert!(
-                !refs.is_empty(),
-                "all import forms should index symbols: {}", symbol
-            );
+            assert!(!refs.is_empty(), "all import forms should index symbols: {}", symbol);
         }
         Ok(())
     }


### PR DESCRIPTION
### Motivation

- Remove duplicated declaration-walking logic from `perl-workspace-index` by using the existing `perl-symbol::surface::extract_symbol_decls()` projection as the authoritative baseline. 
- Reduce maintenance burden and accuracy drift caused by two separate AST-walking implementations for the same declaration forms.

### Description

- Wire `perl_symbol::surface::extract_symbol_decls` into `IndexVisitor::visit` and add `index_baseline_declarations()` to project package, class, subroutine, method, variable, and constant declarations into the file-level `FileIndex` using the shared `SymbolDecl` seam. 
- Preserve workspace-index responsibilities (references, dependencies, dual/qualified indexing and framework-specific syntheses) and map `SymbolKind::Constant` to the existing `Subroutine` indexing path for compatibility. 
- Serialize variable decls to workspace symbol names with sigils (e.g. `$x`) via `variable_symbol_name` and select appropriate ranges using `anchor_span` for variables. 
- Remove duplicated symbol insertion code from many `visit_node` arms (package/class/sub/method/variable/use constant) while keeping traversal/visit behavior intact. 
- Improve `perl-symbol` `qw` parsing to accept a space before the delimiter (e.g. `qw [FOO BAR]`) and add a focused unit test to cover that parity case. 
- Add a small helper `byte_span_to_range` and annotate `extract_constant_names_from_use_args` as `#[cfg(test)]` in workspace-index to suppress dead-code noise now that `use constant` baseline projection comes from `perl-symbol`.

### Testing

- Ran `cargo test -p perl-workspace` and the full workspace-index test suite passed (all workspace-index tests exercised; previously failing cases were addressed). 
- Ran `cargo test -p perl-symbol` and all `perl-symbol` tests passed, including the new `qw [..]` regression test. 
- Ran `cargo check --workspace --all-targets`; one run surfaced a pre-existing unrelated format-string compile error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` which is not caused by this change, but the focused crate tests above (workspace + symbol) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77b0243483339c530979a7bf4059)