### PR TITLE
feat(symbol-surface): extend SymbolDecl projection to additional AST-native declaration kinds (#0000)

### DIFF
--- a/crates/perl-symbol/src/surface/decl.rs
+++ b/crates/perl-symbol/src/surface/decl.rs
@@ -82,8 +82,16 @@ pub struct SymbolDecl {
 /// | `Method { name, .. }` | `Method` |
 /// | `VariableDeclaration { variable, .. }` | `Variable(VarKind)` |
 /// | `Use { module: "constant", args, .. }` | `Constant` |
+/// | `Format { name, .. }` | `Format` |
+/// | `LabeledStatement { label, .. }` | `Label` |
 ///
 /// Anonymous subroutines (`name: None`) are skipped.
+///
+/// # Intentionally not projected (yet)
+///
+/// `Import`, `Export`, and `Role` require semantics that are not represented
+/// directly as declaration nodes in the current AST, so this extractor
+/// conservatively skips them.
 ///
 /// # Package context propagation
 ///
@@ -206,6 +214,35 @@ fn walk(node: &Node, ctx: &mut WalkCtx, out: &mut Vec<SymbolDecl>) {
                 declarator: None,
             });
             walk(body, ctx, out);
+        }
+
+        // ── Format ─────────────────────────────────────────────────────────
+        NodeKind::Format { name, .. } => {
+            let container = ctx.current_package.clone();
+            out.push(SymbolDecl {
+                kind: SymbolKind::Format,
+                name: name.clone(),
+                qualified_name: ctx.qualify(name),
+                full_span: (node.location.start, node.location.end),
+                anchor_span: None, // Format has no name_span in current AST
+                container,
+                declarator: None,
+            });
+        }
+
+        // ── Label ──────────────────────────────────────────────────────────
+        NodeKind::LabeledStatement { label, statement } => {
+            let container = ctx.current_package.clone();
+            out.push(SymbolDecl {
+                kind: SymbolKind::Label,
+                name: label.clone(),
+                qualified_name: ctx.qualify(label),
+                full_span: (node.location.start, node.location.end),
+                anchor_span: None, // LabeledStatement has no label span in current AST
+                container,
+                declarator: None,
+            });
+            walk(statement, ctx, out);
         }
 
         // ── Variable declarations ──────────────────────────────────────────

--- a/crates/perl-symbol/tests/edge_cases_and_regressions.rs
+++ b/crates/perl-symbol/tests/edge_cases_and_regressions.rs
@@ -488,6 +488,25 @@ fn edge_case_surface_seed_package_qualifies_top_level_subs() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn edge_case_surface_plain_use_statement_is_conservatively_skipped() -> Result<()> {
+    // `use strict;` carries import semantics, but the current AST node does not
+    // expose explicit import/export declarations with stable spans.
+    let use_node = Node::new(
+        NodeKind::Use {
+            module: "strict".to_string(),
+            args: vec![],
+            has_filter_risk: false,
+        },
+        loc(0, 11),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![use_node] }, loc(0, 11));
+
+    let decls = extract_symbol_decls(&program, None);
+    assert!(decls.is_empty(), "plain use statements should not synthesize Import/Export decls");
+    Ok(())
+}
+
 // ─── Regression: CLAUDE.md banned dependencies are not transitively present ──
 
 /// Regression: `perl-symbol` must not depend on `perl-parser-core` or any

--- a/crates/perl-symbol/tests/surface_decl.rs
+++ b/crates/perl-symbol/tests/surface_decl.rs
@@ -503,6 +503,67 @@ fn test_class_produces_symbol_decl() {
     assert!(d.anchor_span.is_none());
 }
 
+// ── Format / Label ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_format_produces_symbol_decl() {
+    // format STDOUT =
+    let format_node = Node::new(
+        NodeKind::Format { name: "STDOUT".to_string(), body: "@<<<".to_string() },
+        loc(0, 18),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![format_node] }, loc(0, 18));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 1);
+    let d = &decls[0];
+    assert_eq!(d.kind, SymbolKind::Format);
+    assert_eq!(d.name, "STDOUT");
+    assert_eq!(d.qualified_name, "STDOUT");
+    assert_eq!(d.full_span, (0, 18));
+    assert!(d.anchor_span.is_none());
+}
+
+#[test]
+fn test_labeled_statement_produces_label_decl_and_walks_inner_statement() -> Result<(), String> {
+    // OUTER: my $count;
+    let var = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "count".to_string() },
+        loc(10, 16),
+    );
+    let var_decl = Node::new(
+        NodeKind::VariableDeclaration {
+            declarator: "my".to_string(),
+            variable: Box::new(var),
+            attributes: vec![],
+            initializer: None,
+        },
+        loc(7, 16),
+    );
+    let labeled = Node::new(
+        NodeKind::LabeledStatement { label: "OUTER".to_string(), statement: Box::new(var_decl) },
+        loc(0, 16),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![labeled] }, loc(0, 16));
+
+    let decls = extract_symbol_decls(&program, None);
+    assert_eq!(decls.len(), 2);
+
+    let label = decls.iter().find(|d| d.kind == SymbolKind::Label).ok_or("label decl")?;
+    assert_eq!(label.name, "OUTER");
+    assert_eq!(label.qualified_name, "OUTER");
+    assert_eq!(label.full_span, (0, 16));
+    assert!(label.anchor_span.is_none());
+
+    let variable = decls
+        .iter()
+        .find(|d| d.kind == SymbolKind::Variable(VarKind::Scalar))
+        .ok_or("variable decl")?;
+    assert_eq!(variable.name, "count");
+    Ok(())
+}
+
 // ── Container tracking ────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
### Motivation

- `SymbolKind` included `Format` and `Label` variants that were not being projected by `extract_symbol_decls()`, leaving obvious surface coverage gaps. 
- Covering AST-native declaration kinds that can be projected without extra semantic context yields an easy accuracy improvement for surface extraction. 
- Import/Export/Role semantics are not represented as clean declaration nodes in the current AST, so they must be skipped conservatively for now.

### Description

- Added projection of `NodeKind::Format` to emit `SymbolKind::Format` in `crates/perl-symbol/src/surface/decl.rs`. 
- Added projection of `NodeKind::LabeledStatement` to emit `SymbolKind::Label` and ensured the labeled inner statement is walked so nested declarations are still collected. 
- Updated the extractor documentation in `decl.rs` to list the new produced kinds and explicitly document conservative non-projection of `Import`, `Export`, and `Role`. 
- Added happy-path tests for `Format` and `LabeledStatement` in `crates/perl-symbol/tests/surface_decl.rs` and an edge-case test asserting plain `use` statements are conservatively skipped in `crates/perl-symbol/tests/edge_cases_and_regressions.rs`.

### Testing

- Ran `cargo test -p perl-symbol` and all tests completed successfully. 
- Ran `cargo check --all-targets -p perl-symbol` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77b363748333bd8516f0d79634cb)