### PR TITLE
feat(symbol-surface): extend SymbolDecl projection to additional AST-native declaration kinds (#0000)

### DIFF
--- a/crates/perl-symbol/src/surface/decl.rs
+++ b/crates/perl-symbol/src/surface/decl.rs
@@ -82,8 +82,16 @@ pub struct SymbolDecl {
 /// | `Method { name, .. }` | `Method` |
 /// | `VariableDeclaration { variable, .. }` | `Variable(VarKind)` |
 /// | `Use { module: "constant", args, .. }` | `Constant` |
+/// | `Format { name, .. }` | `Format` |
+/// | `LabeledStatement { label, .. }` | `Label` |
 ///
 /// Anonymous subroutines (`name: None`) are skipped.
+/// Empty/recovery names for formats and labels are also skipped.
+///
+/// # Deliberately omitted kinds
+///
+/// `Role`, `Import`, and `Export` are currently not projected from raw AST
+/// nodes because they require semantic/module-resolution context to be stable.
 ///
 /// # Package context propagation
 ///
@@ -206,6 +214,40 @@ fn walk(node: &Node, ctx: &mut WalkCtx, out: &mut Vec<SymbolDecl>) {
                 declarator: None,
             });
             walk(body, ctx, out);
+        }
+
+        // ── Format declarations ───────────────────────────────────────────
+        NodeKind::Format { name, .. } => {
+            if name.is_empty() {
+                return;
+            }
+            let container = ctx.current_package.clone();
+            out.push(SymbolDecl {
+                kind: SymbolKind::Format,
+                name: name.clone(),
+                qualified_name: ctx.qualify(name),
+                full_span: (node.location.start, node.location.end),
+                anchor_span: None, // Format has no name_span in current AST
+                container,
+                declarator: None,
+            });
+        }
+
+        // ── Labeled statements ────────────────────────────────────────────
+        NodeKind::LabeledStatement { label, statement } => {
+            if !label.is_empty() {
+                let container = ctx.current_package.clone();
+                out.push(SymbolDecl {
+                    kind: SymbolKind::Label,
+                    name: label.clone(),
+                    qualified_name: ctx.qualify(label),
+                    full_span: (node.location.start, node.location.end),
+                    anchor_span: None, // Label has no dedicated span in current AST
+                    container,
+                    declarator: None,
+                });
+            }
+            walk(statement, ctx, out);
         }
 
         // ── Variable declarations ──────────────────────────────────────────

--- a/crates/perl-symbol/tests/edge_cases_and_regressions.rs
+++ b/crates/perl-symbol/tests/edge_cases_and_regressions.rs
@@ -22,10 +22,10 @@
 
 use perl_ast::{Node, NodeKind, SourceLocation};
 use perl_symbol::cursor::{
-    CursorSymbolKind, byte_offset_utf16, extract_symbol_from_source, get_symbol_range_at_position,
-    is_modchar, is_word_boundary, token_under_cursor,
+    byte_offset_utf16, extract_symbol_from_source, get_symbol_range_at_position, is_modchar,
+    is_word_boundary, token_under_cursor, CursorSymbolKind,
 };
-use perl_symbol::{SymbolDecl, SymbolIndex, SymbolKind, VarKind, extract_symbol_decls};
+use perl_symbol::{extract_symbol_decls, SymbolDecl, SymbolIndex, SymbolKind, VarKind};
 use perl_tdd_support::must_some;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -485,6 +485,44 @@ fn edge_case_surface_seed_package_qualifies_top_level_subs() -> Result<()> {
     assert_eq!(d.name, "greet");
     assert_eq!(d.qualified_name, "Foo::greet", "seed package must qualify top-level sub");
     assert_eq!(d.container.as_deref(), Some("Foo"));
+    Ok(())
+}
+
+#[test]
+fn edge_case_surface_empty_format_name_is_skipped_conservatively() -> Result<()> {
+    let format_node =
+        Node::new(NodeKind::Format { name: String::new(), body: "@<<<".to_string() }, loc(0, 12));
+    let program = Node::new(NodeKind::Program { statements: vec![format_node] }, loc(0, 12));
+
+    let decls = extract_symbol_decls(&program, None);
+    assert!(decls.is_empty(), "empty recovery format names should not produce SymbolDecl");
+    Ok(())
+}
+
+#[test]
+fn edge_case_surface_empty_label_is_skipped_but_nested_statement_is_walked() -> Result<()> {
+    let body = Node::new(NodeKind::Block { statements: vec![] }, loc(14, 17));
+    let sub_node = Node::new(
+        NodeKind::Subroutine {
+            name: Some("inner".to_string()),
+            name_span: Some(loc(8, 13)),
+            prototype: None,
+            signature: None,
+            attributes: vec![],
+            body: Box::new(body),
+        },
+        loc(4, 17),
+    );
+    let labeled = Node::new(
+        NodeKind::LabeledStatement { label: String::new(), statement: Box::new(sub_node) },
+        loc(0, 17),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![labeled] }, loc(0, 17));
+
+    let decls = extract_symbol_decls(&program, None);
+    assert_eq!(decls.len(), 1, "only nested subroutine should be projected");
+    assert_eq!(decls[0].kind, SymbolKind::Subroutine);
+    assert_eq!(decls[0].name, "inner");
     Ok(())
 }
 

--- a/crates/perl-symbol/tests/surface_decl.rs
+++ b/crates/perl-symbol/tests/surface_decl.rs
@@ -5,7 +5,7 @@
 //! constants, and classes — without depending on `perl-parser-core`.
 
 use perl_ast::{Node, NodeKind, SourceLocation};
-use perl_symbol::surface::{SymbolDecl, extract_symbol_decls};
+use perl_symbol::surface::{extract_symbol_decls, SymbolDecl};
 use perl_symbol::{SymbolKind, VarKind};
 
 fn loc(start: usize, end: usize) -> SourceLocation {
@@ -501,6 +501,68 @@ fn test_class_produces_symbol_decl() {
     assert_eq!(d.full_span, (0, 15));
     // Class has no name_span field in AST, so anchor_span is None
     assert!(d.anchor_span.is_none());
+}
+
+// ── Format and label declarations ────────────────────────────────────────────
+
+#[test]
+fn test_format_produces_symbol_decl() {
+    // format REPORT =
+    // .
+    let format_node = Node::new(
+        NodeKind::Format { name: "REPORT".to_string(), body: "@<<<".to_string() },
+        loc(0, 18),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![format_node] }, loc(0, 18));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 1);
+    let d = &decls[0];
+    assert_eq!(d.kind, SymbolKind::Format);
+    assert_eq!(d.name, "REPORT");
+    assert_eq!(d.qualified_name, "REPORT");
+    assert_eq!(d.full_span, (0, 18));
+    assert!(d.anchor_span.is_none());
+    assert!(d.declarator.is_none());
+}
+
+#[test]
+fn test_labeled_statement_produces_label_and_nested_subroutine() -> Result<(), String> {
+    // OUTER: sub work { }
+    let sub_body = Node::new(NodeKind::Block { statements: vec![] }, loc(16, 19));
+    let sub_node = Node::new(
+        NodeKind::Subroutine {
+            name: Some("work".to_string()),
+            name_span: Some(loc(10, 14)),
+            prototype: None,
+            signature: None,
+            attributes: vec![],
+            body: Box::new(sub_body),
+        },
+        loc(6, 19),
+    );
+    let labeled = Node::new(
+        NodeKind::LabeledStatement { label: "OUTER".to_string(), statement: Box::new(sub_node) },
+        loc(0, 19),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![labeled] }, loc(0, 19));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 2);
+    let label_decl =
+        decls.iter().find(|d| d.kind == SymbolKind::Label).ok_or("missing label decl")?;
+    assert_eq!(label_decl.name, "OUTER");
+    assert_eq!(label_decl.qualified_name, "OUTER");
+    assert!(label_decl.anchor_span.is_none());
+
+    let sub_decl = decls
+        .iter()
+        .find(|d| d.kind == SymbolKind::Subroutine)
+        .ok_or("missing nested subroutine decl")?;
+    assert_eq!(sub_decl.name, "work");
+    Ok(())
 }
 
 // ── Container tracking ────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation

- Close surface-coverage gaps by projecting AST-native declaration kinds that already exist in the AST and `SymbolKind`, starting with `Format` and `Label` while avoiding guesses that require semantic/module-resolution context.

### Description

- Add projection for `NodeKind::Format` → `SymbolKind::Format` and for `NodeKind::LabeledStatement` → `SymbolKind::Label` in `extract_symbol_decls` so formats and labels are emitted as stable `SymbolDecl` values.
- Conservatively skip empty/recovery names for formats and labels while still walking nested statements inside labeled statements so nested declarations are discovered.
- Document the newly-covered kinds in the `extract_symbol_decls` doc comment and explicitly note deliberately omitted kinds (`Role`, `Import`, `Export`) that require extra semantic context.
- Add happy-path and edge tests in `crates/perl-symbol/tests/surface_decl.rs` and `crates/perl-symbol/tests/edge_cases_and_regressions.rs` for format and label extraction and conservative skip behavior.

### Testing

- Ran formatting via `cargo xtask fmt` and `rustfmt` on touched files with no issues.
- Ran `cargo test -p perl-symbol` and all tests passed (new tests `test_format_produces_symbol_decl`, `test_labeled_statement_produces_label_and_nested_subroutine`, `edge_case_surface_empty_format_name_is_skipped_conservatively`, and `edge_case_surface_empty_label_is_skipped_but_nested_statement_is_walked` included and passed). 
- Ran `cargo check --all-targets -p perl-symbol` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77b363748333bd8516f0d79634cb)