### PR TITLE
feat(symbol-surface): extend SymbolDecl projection to additional AST-native declaration kinds (#0000)

### DIFF
--- a/crates/perl-symbol/src/surface/decl.rs
+++ b/crates/perl-symbol/src/surface/decl.rs
@@ -80,6 +80,8 @@ pub struct SymbolDecl {
 /// | `Class { name, .. }` | `Class` |
 /// | `Subroutine { name: Some(..), .. }` | `Subroutine` |
 /// | `Method { name, .. }` | `Method` |
+/// | `Format { name, .. }` | `Format` |
+/// | `LabeledStatement { label, .. }` | `Label` |
 /// | `VariableDeclaration { variable, .. }` | `Variable(VarKind)` |
 /// | `Use { module: "constant", args, .. }` | `Constant` |
 ///
@@ -206,6 +208,39 @@ fn walk(node: &Node, ctx: &mut WalkCtx, out: &mut Vec<SymbolDecl>) {
                 declarator: None,
             });
             walk(body, ctx, out);
+        }
+
+        // ── Format ─────────────────────────────────────────────────────────
+        NodeKind::Format { name, .. } => {
+            if !is_blank_name(name) {
+                let container = ctx.current_package.clone();
+                out.push(SymbolDecl {
+                    kind: SymbolKind::Format,
+                    name: name.clone(),
+                    qualified_name: ctx.qualify(name),
+                    full_span: (node.location.start, node.location.end),
+                    anchor_span: None, // Format has no name_span in current AST
+                    container,
+                    declarator: None,
+                });
+            }
+        }
+
+        // ── Label ──────────────────────────────────────────────────────────
+        NodeKind::LabeledStatement { label, statement } => {
+            if !is_blank_name(label) {
+                let container = ctx.current_package.clone();
+                out.push(SymbolDecl {
+                    kind: SymbolKind::Label,
+                    name: label.clone(),
+                    qualified_name: ctx.qualify(label),
+                    full_span: (node.location.start, node.location.end),
+                    anchor_span: None, // LabeledStatement has no label span in current AST
+                    container,
+                    declarator: None,
+                });
+            }
+            walk(statement, ctx, out);
         }
 
         // ── Variable declarations ──────────────────────────────────────────
@@ -356,6 +391,10 @@ fn push_unique(names: &mut Vec<String>, name: String) {
     if !names.iter().any(|existing| existing == &name) {
         names.push(name);
     }
+}
+
+fn is_blank_name(name: &str) -> bool {
+    name.trim().is_empty()
 }
 
 fn push_const_fast_decl(arg: &Node, call_node: &Node, ctx: &WalkCtx, out: &mut Vec<SymbolDecl>) {

--- a/crates/perl-symbol/tests/edge_cases_and_regressions.rs
+++ b/crates/perl-symbol/tests/edge_cases_and_regressions.rs
@@ -286,6 +286,45 @@ fn edge_case_cursor_on_sigil_itself_extracts_following_name() -> Result<()> {
 }
 
 #[test]
+fn edge_case_surface_skips_blank_format_and_label_names() -> Result<()> {
+    let blank_format = Node::new(
+        NodeKind::Format { name: "   ".to_string(), body: "@<<<".to_string() },
+        SourceLocation { start: 0, end: 14 },
+    );
+    let labeled_stmt = Node::new(
+        NodeKind::LabeledStatement {
+            label: "".to_string(),
+            statement: Box::new(Node::new(
+                NodeKind::Subroutine {
+                    name: Some("inner".to_string()),
+                    name_span: Some(SourceLocation { start: 22, end: 27 }),
+                    prototype: None,
+                    signature: None,
+                    attributes: vec![],
+                    body: Box::new(Node::new(
+                        NodeKind::Block { statements: vec![] },
+                        SourceLocation { start: 28, end: 31 },
+                    )),
+                },
+                SourceLocation { start: 18, end: 31 },
+            )),
+        },
+        SourceLocation { start: 15, end: 31 },
+    );
+    let program = Node::new(
+        NodeKind::Program { statements: vec![blank_format, labeled_stmt] },
+        SourceLocation { start: 0, end: 31 },
+    );
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 1, "blank names should be skipped conservatively");
+    assert_eq!(decls[0].kind, SymbolKind::Subroutine);
+    assert_eq!(decls[0].name, "inner");
+    Ok(())
+}
+
+#[test]
 fn edge_case_cursor_sigil_only_no_identifier_returns_none() -> Result<()> {
     // Lone sigil with no following identifier chars.
     assert!(extract_symbol_from_source(0, "$").is_none());

--- a/crates/perl-symbol/tests/surface_decl.rs
+++ b/crates/perl-symbol/tests/surface_decl.rs
@@ -503,6 +503,65 @@ fn test_class_produces_symbol_decl() {
     assert!(d.anchor_span.is_none());
 }
 
+#[test]
+fn test_format_produces_symbol_decl() {
+    // format STDOUT = ...
+    let fmt = Node::new(
+        NodeKind::Format { name: "STDOUT".to_string(), body: "@<<<".to_string() },
+        loc(0, 20),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![fmt] }, loc(0, 20));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 1);
+    let d = &decls[0];
+    assert_eq!(d.kind, SymbolKind::Format);
+    assert_eq!(d.name, "STDOUT");
+    assert_eq!(d.qualified_name, "STDOUT");
+    assert_eq!(d.full_span, (0, 20));
+    assert!(d.anchor_span.is_none());
+}
+
+#[test]
+fn test_label_produces_symbol_decl_and_walks_statement() {
+    // LOOP: sub worker { }
+    let body = Node::new(NodeKind::Block { statements: vec![] }, loc(16, 19));
+    let sub = Node::new(
+        NodeKind::Subroutine {
+            name: Some("worker".to_string()),
+            name_span: Some(loc(9, 15)),
+            prototype: None,
+            signature: None,
+            attributes: vec![],
+            body: Box::new(body),
+        },
+        loc(5, 19),
+    );
+    let labeled = Node::new(
+        NodeKind::LabeledStatement { label: "LOOP".to_string(), statement: Box::new(sub) },
+        loc(0, 19),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![labeled] }, loc(0, 19));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 2);
+    let label_decl = decls.iter().find(|d| d.kind == SymbolKind::Label);
+    assert!(label_decl.is_some(), "label declaration should be projected");
+    if let Some(label_decl) = label_decl {
+        assert_eq!(label_decl.name, "LOOP");
+        assert_eq!(label_decl.qualified_name, "LOOP");
+        assert!(label_decl.anchor_span.is_none());
+    }
+
+    let sub_decl = decls.iter().find(|d| d.kind == SymbolKind::Subroutine);
+    assert!(sub_decl.is_some(), "nested statement should still be walked");
+    if let Some(sub_decl) = sub_decl {
+        assert_eq!(sub_decl.name, "worker");
+    }
+}
+
 // ── Container tracking ────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
### Motivation

- `SymbolKind` already includes `Format` and `Label` but `extract_symbol_decls()` did not project those AST-native declaration kinds, leaving surface coverage gaps.
- Projecting these declarations conservatively (without guessing name spans or semantics the AST doesn't provide) improves IDE accuracy while avoiding unsafe semantic assumptions.

### Description

- Added projection for `NodeKind::Format` → `SymbolKind::Format` in the AST walker while leaving `anchor_span: None` because the AST has no precise name span.  Updated the declaration kinds table accordingly.
- Added projection for `NodeKind::LabeledStatement` → `SymbolKind::Label`, emitting a `SymbolDecl` for non-blank labels and continuing to recurse into the labeled statement so nested declarations are preserved.
- Introduced `is_blank_name()` guard to conservatively skip whitespace-only format/label names to avoid emitting unstable symbol identities.
- Added unit tests: happy-path tests for `Format` and `Label` projection and an edge-case test that blank/whitespace-only names are skipped and nested declarations still surface.

### Testing

- Ran `cargo test -p perl-symbol` and all tests passed in this crate.
- Ran `cargo check --all-targets -p perl-symbol` and the check passed.
- Ran formatting via `cargo xtask fmt` as part of verification and it completed successfully.
- All added tests (surface and edge-case) passed and existing tests remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77b363748333bd8516f0d79634cb)