### PR TITLE
feat(symbol-surface): extend SymbolDecl projection to additional AST-native declaration kinds (#6467)

### DIFF
--- a/crates/perl-symbol/src/surface/decl.rs
+++ b/crates/perl-symbol/src/surface/decl.rs
@@ -80,10 +80,16 @@ pub struct SymbolDecl {
 /// | `Class { name, .. }` | `Class` |
 /// | `Subroutine { name: Some(..), .. }` | `Subroutine` |
 /// | `Method { name, .. }` | `Method` |
+/// | `Format { name, .. }` | `Format` |
+/// | `LabeledStatement { label, .. }` | `Label` |
 /// | `VariableDeclaration { variable, .. }` | `Variable(VarKind)` |
 /// | `Use { module: "constant", args, .. }` | `Constant` |
 ///
 /// Anonymous subroutines (`name: None`) are skipped.
+///
+/// `Role`, `Import`, and `Export` are intentionally not projected here:
+/// the current AST does not expose those declaration categories with stable
+/// declaration-site semantics.
 ///
 /// # Package context propagation
 ///
@@ -206,6 +212,35 @@ fn walk(node: &Node, ctx: &mut WalkCtx, out: &mut Vec<SymbolDecl>) {
                 declarator: None,
             });
             walk(body, ctx, out);
+        }
+
+        // ── Format declarations ───────────────────────────────────────────
+        NodeKind::Format { name, .. } => {
+            let container = ctx.current_package.clone();
+            out.push(SymbolDecl {
+                kind: SymbolKind::Format,
+                name: name.clone(),
+                qualified_name: ctx.qualify(name),
+                full_span: (node.location.start, node.location.end),
+                anchor_span: None, // Format has no name_span in current AST
+                container,
+                declarator: None,
+            });
+        }
+
+        // ── Labels ────────────────────────────────────────────────────────
+        NodeKind::LabeledStatement { label, statement } => {
+            let container = ctx.current_package.clone();
+            out.push(SymbolDecl {
+                kind: SymbolKind::Label,
+                name: label.clone(),
+                qualified_name: ctx.qualify(label),
+                full_span: (node.location.start, node.location.end),
+                anchor_span: None, // LabeledStatement has no label span in current AST
+                container,
+                declarator: None,
+            });
+            walk(statement, ctx, out);
         }
 
         // ── Variable declarations ──────────────────────────────────────────

--- a/crates/perl-symbol/src/surface/decl.rs
+++ b/crates/perl-symbol/src/surface/decl.rs
@@ -91,6 +91,15 @@ pub struct SymbolDecl {
 /// the current AST does not expose those declaration categories with stable
 /// declaration-site semantics.
 ///
+/// ## Label scoping note
+///
+/// Perl labels (`LOOP:`, `OUTER:`) are lexically scoped and are **not**
+/// stored in the package stash.  `goto LOOP` resolves in the enclosing
+/// lexical scope, never as `Foo::LOOP`.  Therefore `Label` declarations
+/// always have `qualified_name == name`, even when emitted inside a
+/// package block.  The `container` field still records the enclosing
+/// package for informational purposes.
+///
 /// # Package context propagation
 ///
 /// The walker tracks the innermost `package` declaration linearly (statement
@@ -229,12 +238,16 @@ fn walk(node: &Node, ctx: &mut WalkCtx, out: &mut Vec<SymbolDecl>) {
         }
 
         // ── Labels ────────────────────────────────────────────────────────
+        // Note: Perl labels are lexically scoped (not stored in the package
+        // stash), so `qualified_name` is always the bare label name regardless
+        // of the current package context.  `goto LOOP` never resolves via
+        // `Foo::LOOP`; the label must be visible in the enclosing lexical scope.
         NodeKind::LabeledStatement { label, statement } => {
             let container = ctx.current_package.clone();
             out.push(SymbolDecl {
                 kind: SymbolKind::Label,
                 name: label.clone(),
-                qualified_name: ctx.qualify(label),
+                qualified_name: label.clone(), // labels are lexically scoped — never package-qualified
                 full_span: (node.location.start, node.location.end),
                 anchor_span: None, // LabeledStatement has no label span in current AST
                 container,

--- a/crates/perl-symbol/tests/edge_cases_and_regressions.rs
+++ b/crates/perl-symbol/tests/edge_cases_and_regressions.rs
@@ -488,6 +488,33 @@ fn edge_case_surface_seed_package_qualifies_top_level_subs() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn edge_case_surface_conservatively_skips_non_ast_native_decl_kinds() -> Result<()> {
+    // `use`/`no` statements are module-loading forms and do not encode
+    // declaration-site semantics for SymbolKind::Import / ::Export / ::Role.
+    let use_node = Node::new(
+        NodeKind::Use {
+            module: "strict".to_string(),
+            args: vec!["subs".to_string()],
+            has_filter_risk: false,
+        },
+        loc(0, 16),
+    );
+    let no_node = Node::new(
+        NodeKind::No {
+            module: "warnings".to_string(),
+            args: vec!["once".to_string()],
+            has_filter_risk: false,
+        },
+        loc(17, 36),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![use_node, no_node] }, loc(0, 36));
+
+    let decls = extract_symbol_decls(&program, None);
+    assert!(decls.is_empty());
+    Ok(())
+}
+
 // ─── Regression: CLAUDE.md banned dependencies are not transitively present ──
 
 /// Regression: `perl-symbol` must not depend on `perl-parser-core` or any

--- a/crates/perl-symbol/tests/surface_decl.rs
+++ b/crates/perl-symbol/tests/surface_decl.rs
@@ -563,6 +563,47 @@ fn test_labeled_statement_produces_label_decl_and_walks_inner_statement() -> Res
     Ok(())
 }
 
+#[test]
+fn test_label_inside_package_is_not_package_qualified() -> Result<(), String> {
+    // Perl labels are lexically scoped, not stored in the package stash.
+    // `goto LOOP` never resolves as `Foo::LOOP`.
+    // package Foo; LOOP: while (1) { last LOOP; }
+    let body = Node::new(NodeKind::Block { statements: vec![] }, loc(30, 32));
+    let while_node = Node::new(
+        NodeKind::While {
+            condition: Box::new(Node::new(NodeKind::Number { value: "1".to_string() }, loc(25, 26))),
+            body: Box::new(body),
+            continue_block: None,
+        },
+        loc(20, 32),
+    );
+    let labeled = Node::new(
+        NodeKind::LabeledStatement {
+            label: "LOOP".to_string(),
+            statement: Box::new(while_node),
+        },
+        loc(14, 32),
+    );
+    let pkg_node = Node::new(
+        NodeKind::Package { name: "Foo".to_string(), name_span: loc(8, 11), block: None },
+        loc(0, 14),
+    );
+    let program = Node::new(
+        NodeKind::Program { statements: vec![pkg_node, labeled] },
+        loc(0, 32),
+    );
+
+    let decls = extract_symbol_decls(&program, None);
+
+    let label_decl =
+        decls.iter().find(|d| d.kind == SymbolKind::Label).ok_or("expected label decl")?;
+    assert_eq!(label_decl.name, "LOOP");
+    // Labels are lexically scoped — qualified_name must NOT be "Foo::LOOP"
+    assert_eq!(label_decl.qualified_name, "LOOP", "label must not be package-qualified");
+    assert_eq!(label_decl.container.as_deref(), Some("Foo"), "container should reflect enclosing package");
+    Ok(())
+}
+
 // ── Container tracking ────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/perl-symbol/tests/surface_decl.rs
+++ b/crates/perl-symbol/tests/surface_decl.rs
@@ -571,27 +571,24 @@ fn test_label_inside_package_is_not_package_qualified() -> Result<(), String> {
     let body = Node::new(NodeKind::Block { statements: vec![] }, loc(30, 32));
     let while_node = Node::new(
         NodeKind::While {
-            condition: Box::new(Node::new(NodeKind::Number { value: "1".to_string() }, loc(25, 26))),
+            condition: Box::new(Node::new(
+                NodeKind::Number { value: "1".to_string() },
+                loc(25, 26),
+            )),
             body: Box::new(body),
             continue_block: None,
         },
         loc(20, 32),
     );
     let labeled = Node::new(
-        NodeKind::LabeledStatement {
-            label: "LOOP".to_string(),
-            statement: Box::new(while_node),
-        },
+        NodeKind::LabeledStatement { label: "LOOP".to_string(), statement: Box::new(while_node) },
         loc(14, 32),
     );
     let pkg_node = Node::new(
         NodeKind::Package { name: "Foo".to_string(), name_span: loc(8, 11), block: None },
         loc(0, 14),
     );
-    let program = Node::new(
-        NodeKind::Program { statements: vec![pkg_node, labeled] },
-        loc(0, 32),
-    );
+    let program = Node::new(NodeKind::Program { statements: vec![pkg_node, labeled] }, loc(0, 32));
 
     let decls = extract_symbol_decls(&program, None);
 
@@ -600,7 +597,11 @@ fn test_label_inside_package_is_not_package_qualified() -> Result<(), String> {
     assert_eq!(label_decl.name, "LOOP");
     // Labels are lexically scoped — qualified_name must NOT be "Foo::LOOP"
     assert_eq!(label_decl.qualified_name, "LOOP", "label must not be package-qualified");
-    assert_eq!(label_decl.container.as_deref(), Some("Foo"), "container should reflect enclosing package");
+    assert_eq!(
+        label_decl.container.as_deref(),
+        Some("Foo"),
+        "container should reflect enclosing package"
+    );
     Ok(())
 }
 

--- a/crates/perl-symbol/tests/surface_decl.rs
+++ b/crates/perl-symbol/tests/surface_decl.rs
@@ -503,6 +503,66 @@ fn test_class_produces_symbol_decl() {
     assert!(d.anchor_span.is_none());
 }
 
+#[test]
+fn test_format_produces_symbol_decl() {
+    // format REPORT =
+    // .
+    let format_node = Node::new(
+        NodeKind::Format { name: "REPORT".to_string(), body: "@<<<".to_string() },
+        loc(0, 18),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![format_node] }, loc(0, 18));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 1);
+    let d = &decls[0];
+    assert_eq!(d.kind, SymbolKind::Format);
+    assert_eq!(d.name, "REPORT");
+    assert_eq!(d.qualified_name, "REPORT");
+    assert_eq!(d.full_span, (0, 18));
+    assert!(d.anchor_span.is_none());
+}
+
+#[test]
+fn test_labeled_statement_produces_label_decl_and_walks_inner_statement() -> Result<(), String> {
+    // LOOP: sub inner { }
+    let sub_body = Node::new(NodeKind::Block { statements: vec![] }, loc(15, 18));
+    let sub_node = Node::new(
+        NodeKind::Subroutine {
+            name: Some("inner".to_string()),
+            name_span: Some(loc(10, 15)),
+            prototype: None,
+            signature: None,
+            attributes: vec![],
+            body: Box::new(sub_body),
+        },
+        loc(6, 18),
+    );
+    let labeled = Node::new(
+        NodeKind::LabeledStatement { label: "LOOP".to_string(), statement: Box::new(sub_node) },
+        loc(0, 18),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![labeled] }, loc(0, 18));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 2);
+
+    let label_decl =
+        decls.iter().find(|d| d.kind == SymbolKind::Label).ok_or("expected label decl")?;
+    assert_eq!(label_decl.name, "LOOP");
+    assert_eq!(label_decl.qualified_name, "LOOP");
+    assert!(label_decl.anchor_span.is_none());
+
+    let sub_decl = decls
+        .iter()
+        .find(|d| d.kind == SymbolKind::Subroutine)
+        .ok_or("expected inner subroutine decl")?;
+    assert_eq!(sub_decl.name, "inner");
+    Ok(())
+}
+
 // ── Container tracking ────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
### Motivation

- `SymbolKind` already models `Format` and `Label` but `extract_symbol_decls()` did not project those AST-native declaration kinds, leaving surface coverage gaps.
- The change aims for a conservative, high-confidence expansion of projected declaration kinds without guessing import/export/role semantics that the AST does not encode.

### Description

- Added `Format` and `LabeledStatement` entries to the documented projection table in `crates/perl-symbol/src/surface/decl.rs` and documented that `Role`/`Import`/`Export` are intentionally not projected due to missing AST declaration-site semantics.
- Implemented projection of `NodeKind::Format` → `SymbolKind::Format` and `NodeKind::LabeledStatement` → `SymbolKind::Label` inside the `walk` function in `crates/perl-symbol/src/surface/decl.rs`.
- For labeled statements the walker now also descends into the inner `statement` so nested declarations (e.g. a labeled `sub`) are still discovered.
- Added focused tests: `test_format_produces_symbol_decl` and `test_labeled_statement_produces_label_decl_and_walks_inner_statement` in `crates/perl-symbol/tests/surface_decl.rs`, and a conservative-skip test `edge_case_surface_conservatively_skips_non_ast_native_decl_kinds` in `crates/perl-symbol/tests/edge_cases_and_regressions.rs`.

### Testing

- Ran `cargo test -p perl-symbol`, and the test suite completed successfully (all tests passed).
- Ran `cargo check --all-targets -p perl-symbol`, which completed without errors.
- Ran formatting via `cargo xtask fmt`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77b363748333bd8516f0d79634cb)