### PR TITLE
feat(perl-symbol): add phase-1 SymbolRef projection layer (#0000)

### DIFF
--- a/crates/perl-symbol/src/api.rs
+++ b/crates/perl-symbol/src/api.rs
@@ -24,4 +24,4 @@ pub use crate::cursor::{
 pub use crate::index::SymbolIndex;
 
 // surface — full public surface
-pub use crate::surface::{SymbolDecl, extract_symbol_decls};
+pub use crate::surface::{SymbolDecl, SymbolRef, extract_symbol_decls, extract_symbol_refs};

--- a/crates/perl-symbol/src/surface/mod.rs
+++ b/crates/perl-symbol/src/surface/mod.rs
@@ -12,7 +12,7 @@
 //!   the sibling `types` module inside this crate.
 //! - **Single extraction pass** — `extract_symbol_decls` walks the entire tree
 //!   once and returns all declaration sites.
-//! - **MVP scope** — ships `SymbolDecl` only.  `SymbolRef` and
+//! - **Incremental scope** — ships `SymbolDecl` and phase-1 `SymbolRef`.
 //!   `CallSite` will follow in later phases.
 //!
 //! # Quick start
@@ -28,5 +28,7 @@
 //! ```
 
 pub mod decl;
+pub mod r#ref;
 
 pub use decl::{SymbolDecl, extract_symbol_decls};
+pub use r#ref::{SymbolRef, extract_symbol_refs};

--- a/crates/perl-symbol/src/surface/ref.rs
+++ b/crates/perl-symbol/src/surface/ref.rs
@@ -1,0 +1,103 @@
+//! `SymbolRef` — a lightweight projected symbol-reference site from the Perl AST.
+//!
+//! Phase 1 intentionally keeps scope narrow and high-confidence:
+//! variable references, function-call references, and package-qualified
+//! bareword references where the AST is explicit.
+
+use crate::types::{SymbolKind, VarKind};
+use perl_ast::{Node, NodeKind};
+
+/// A projected view of a single symbol reference (usage) site in Perl source.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SymbolRef {
+    /// Symbol classification for the reference.
+    pub kind: SymbolKind,
+    /// Unqualified symbol name (e.g. `value`, `greet`).
+    pub name: String,
+    /// Fully-qualified symbol name when explicit in source; otherwise equals `name`.
+    pub qualified_name: String,
+    /// Byte offsets `(start, end)` of the full reference node.
+    pub full_span: (usize, usize),
+    /// Byte offsets `(start, end)` of the anchor token when available.
+    pub anchor_span: Option<(usize, usize)>,
+}
+
+/// Walk `root` and collect high-confidence symbol references.
+///
+/// Phase-1 references emitted:
+///
+/// - `NodeKind::Variable` usages (outside declaration binding positions)
+/// - `NodeKind::FunctionCall` callee names
+/// - package-qualified `NodeKind::Identifier` names containing `::`
+pub fn extract_symbol_refs(root: &Node) -> Vec<SymbolRef> {
+    let mut out = Vec::new();
+    walk(root, &mut out);
+    out
+}
+
+fn walk(node: &Node, out: &mut Vec<SymbolRef>) {
+    match &node.kind {
+        NodeKind::VariableDeclaration { initializer, .. } => {
+            if let Some(init) = initializer {
+                walk(init, out);
+            }
+        }
+        NodeKind::VariableListDeclaration { initializer, .. } => {
+            if let Some(init) = initializer {
+                walk(init, out);
+            }
+        }
+        NodeKind::Variable { sigil, name } => {
+            let kind = sigil_to_symbol_kind(sigil);
+            let qualified_name = qualify_if_explicit(name);
+            out.push(SymbolRef {
+                kind,
+                name: unqualified_name(name),
+                qualified_name,
+                full_span: (node.location.start, node.location.end),
+                anchor_span: Some((node.location.start, node.location.end)),
+            });
+        }
+        NodeKind::FunctionCall { name, args } => {
+            out.push(SymbolRef {
+                kind: SymbolKind::Subroutine,
+                name: unqualified_name(name),
+                qualified_name: qualify_if_explicit(name),
+                full_span: (node.location.start, node.location.end),
+                anchor_span: None,
+            });
+
+            for arg in args {
+                walk(arg, out);
+            }
+        }
+        NodeKind::Identifier { name } if name.contains("::") => {
+            out.push(SymbolRef {
+                kind: SymbolKind::Package,
+                name: unqualified_name(name),
+                qualified_name: name.clone(),
+                full_span: (node.location.start, node.location.end),
+                anchor_span: Some((node.location.start, node.location.end)),
+            });
+        }
+        _ => {
+            node.for_each_child(|child| walk(child, out));
+        }
+    }
+}
+
+fn sigil_to_symbol_kind(sigil: &str) -> SymbolKind {
+    match sigil {
+        "@" => SymbolKind::Variable(VarKind::Array),
+        "%" => SymbolKind::Variable(VarKind::Hash),
+        _ => SymbolKind::Variable(VarKind::Scalar),
+    }
+}
+
+fn unqualified_name(name: &str) -> String {
+    name.rsplit("::").next().unwrap_or(name).to_owned()
+}
+
+fn qualify_if_explicit(name: &str) -> String {
+    name.to_owned()
+}

--- a/crates/perl-symbol/tests/facade_api_completeness.rs
+++ b/crates/perl-symbol/tests/facade_api_completeness.rs
@@ -6,12 +6,12 @@
 //! every microcrate-collapse facade.
 
 use perl_symbol::{
-    SymbolDecl, SymbolIndex, SymbolKind, VarKind,
+    SymbolDecl, SymbolIndex, SymbolKind, SymbolRef, VarKind,
     cursor::{
         CursorSymbolKind, byte_offset_utf16, extract_symbol_from_source,
         get_symbol_range_at_position, is_modchar, is_word_boundary, token_under_cursor,
     },
-    extract_symbol_decls,
+    extract_symbol_decls, extract_symbol_refs,
 };
 
 #[test]
@@ -63,4 +63,9 @@ fn surface_decl_accessible() {
     // Compilation verifies the paths; the tiny runtime check binds the
     // function to a compatible type signature.
     let _fn: fn(&perl_ast::Node, Option<&str>) -> Vec<SymbolDecl> = extract_symbol_decls;
+}
+
+#[test]
+fn surface_ref_accessible() {
+    let _fn: fn(&perl_ast::Node) -> Vec<SymbolRef> = extract_symbol_refs;
 }

--- a/crates/perl-symbol/tests/surface_refs.rs
+++ b/crates/perl-symbol/tests/surface_refs.rs
@@ -1,0 +1,96 @@
+//! Tests for phase-1 `SymbolRef` extraction.
+
+use perl_ast::{Node, NodeKind, SourceLocation};
+use perl_symbol::surface::extract_symbol_refs;
+use perl_symbol::{SymbolKind, VarKind};
+
+fn loc(start: usize, end: usize) -> SourceLocation {
+    SourceLocation { start, end }
+}
+
+#[test]
+fn variable_usage_is_projected_as_symbol_ref() {
+    let usage = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "count".to_string() },
+        loc(5, 11),
+    );
+    let stmt = Node::new(NodeKind::ExpressionStatement { expression: Box::new(usage) }, loc(5, 11));
+    let program = Node::new(NodeKind::Program { statements: vec![stmt] }, loc(0, 11));
+
+    let refs = extract_symbol_refs(&program);
+
+    assert_eq!(refs.len(), 1);
+    let symbol_ref = &refs[0];
+    assert_eq!(symbol_ref.kind, SymbolKind::Variable(VarKind::Scalar));
+    assert_eq!(symbol_ref.name, "count");
+    assert_eq!(symbol_ref.qualified_name, "count");
+    assert_eq!(symbol_ref.full_span, (5, 11));
+    assert_eq!(symbol_ref.anchor_span, Some((5, 11)));
+}
+
+#[test]
+fn declaration_binding_variable_is_not_projected_as_reference() {
+    let binding = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "decl_only".to_string() },
+        loc(3, 13),
+    );
+    let decl = Node::new(
+        NodeKind::VariableDeclaration {
+            declarator: "my".to_string(),
+            variable: Box::new(binding),
+            attributes: vec![],
+            initializer: None,
+        },
+        loc(0, 13),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![decl] }, loc(0, 13));
+
+    let refs = extract_symbol_refs(&program);
+    assert!(refs.is_empty());
+}
+
+#[test]
+fn subroutine_call_and_qualified_refs_are_projected() {
+    let pkg_ident =
+        Node::new(NodeKind::Identifier { name: "Vendor::Shared".to_string() }, loc(0, 14));
+    let call = Node::new(
+        NodeKind::FunctionCall {
+            name: "Vendor::Tools::run".to_string(),
+            args: vec![Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "Vendor::state".to_string() },
+                loc(30, 43),
+            )],
+        },
+        loc(15, 44),
+    );
+    let program = Node::new(
+        NodeKind::Program {
+            statements: vec![
+                Node::new(
+                    NodeKind::ExpressionStatement { expression: Box::new(pkg_ident) },
+                    loc(0, 14),
+                ),
+                Node::new(
+                    NodeKind::ExpressionStatement { expression: Box::new(call) },
+                    loc(15, 44),
+                ),
+            ],
+        },
+        loc(0, 44),
+    );
+
+    let refs = extract_symbol_refs(&program);
+
+    assert_eq!(refs.len(), 3);
+    assert_eq!(refs[0].kind, SymbolKind::Package);
+    assert_eq!(refs[0].qualified_name, "Vendor::Shared");
+    assert_eq!(refs[0].name, "Shared");
+
+    assert_eq!(refs[1].kind, SymbolKind::Subroutine);
+    assert_eq!(refs[1].qualified_name, "Vendor::Tools::run");
+    assert_eq!(refs[1].name, "run");
+
+    assert_eq!(refs[2].kind, SymbolKind::Variable(VarKind::Scalar));
+    assert_eq!(refs[2].qualified_name, "Vendor::state");
+    assert_eq!(refs[2].name, "state");
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, shared projection for symbol references to avoid duplicated "find symbol under/near this AST node" logic across consumers.
- Ship a conservative phase-1 surface that only includes high-confidence reference kinds (variables, function-call callees, and explicit package-qualified identifiers) as indicated by the `surface` design notes.

### Description
- Added `crates/perl-symbol/src/surface/ref.rs` implementing `SymbolRef` and `extract_symbol_refs`, which projects variable usages, `FunctionCall` callee names, and `Identifier` nodes containing `::` into a small reference model.
- Exported the new module from `crates/perl-symbol/src/surface/mod.rs` and re-exported `SymbolRef`/`extract_symbol_refs` from the crate public API in `crates/perl-symbol/src/api.rs`.
- Added focused unit tests in `crates/perl-symbol/tests/surface_refs.rs` validating variable usage projection, excluding declaration binding positions, and qualified/subroutine call cases, and extended `facade_api_completeness` to cover the new surface.

### Testing
- Ran `cargo test -p perl-symbol`, which completed successfully and the new `surface_refs` tests passed. 
- Ran `cargo check --all-targets -p perl-symbol`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77b731288333bb779b29a2ac8b94)