### PR TITLE
feat(perl-symbol): add phase-1 SymbolRef projection layer (#0000)

### DIFF
--- a/crates/perl-symbol/src/api.rs
+++ b/crates/perl-symbol/src/api.rs
@@ -24,4 +24,4 @@ pub use crate::cursor::{
 pub use crate::index::SymbolIndex;
 
 // surface — full public surface
-pub use crate::surface::{SymbolDecl, extract_symbol_decls};
+pub use crate::surface::{SymbolDecl, SymbolRef, extract_symbol_decls, extract_symbol_refs};

--- a/crates/perl-symbol/src/surface/mod.rs
+++ b/crates/perl-symbol/src/surface/mod.rs
@@ -12,8 +12,8 @@
 //!   the sibling `types` module inside this crate.
 //! - **Single extraction pass** — `extract_symbol_decls` walks the entire tree
 //!   once and returns all declaration sites.
-//! - **MVP scope** — ships `SymbolDecl` only.  `SymbolRef` and
-//!   `CallSite` will follow in later phases.
+//! - **Phased scope** — ships `SymbolDecl` and a narrow phase-1 `SymbolRef`;
+//!   richer `SymbolRef` kinds and `CallSite` will follow in later phases.
 //!
 //! # Quick start
 //!
@@ -28,5 +28,7 @@
 //! ```
 
 pub mod decl;
+pub mod r#ref;
 
 pub use decl::{SymbolDecl, extract_symbol_decls};
+pub use r#ref::{SymbolRef, extract_symbol_refs};

--- a/crates/perl-symbol/src/surface/ref.rs
+++ b/crates/perl-symbol/src/surface/ref.rs
@@ -1,0 +1,146 @@
+//! `SymbolRef` — a projected symbol reference/use site derived from the Perl AST.
+//!
+//! Phase-1 extraction is intentionally narrow and high-confidence:
+//! - variable references (`$foo`, `@items`, `%opts`)
+//! - subroutine call references (`foo()`, `Pkg::foo()`)
+//! - explicit package-qualified references where the AST already encodes `::`
+
+use crate::types::{SymbolKind, VarKind};
+use perl_ast::{Node, NodeKind};
+
+/// A projected view of a single symbol reference/use site in Perl source.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SymbolRef {
+    /// Symbol classification for the reference target.
+    pub kind: SymbolKind,
+    /// Unqualified symbol name.
+    pub name: String,
+    /// Package-qualified symbol name when known.
+    pub qualified_name: String,
+    /// Byte offsets `(start, end)` of the reference node.
+    pub span: (usize, usize),
+    /// Enclosing package name, if known from walk context.
+    pub container: Option<String>,
+    /// Explicit package qualifier parsed from the reference itself (e.g. `Foo` in `Foo::bar`).
+    pub referenced_package: Option<String>,
+}
+
+/// Walk `root` and collect high-confidence symbol references into a flat list.
+///
+/// `current_package` seeds the initial package context used to qualify unqualified
+/// references encountered during traversal.
+pub fn extract_symbol_refs(root: &Node, current_package: Option<&str>) -> Vec<SymbolRef> {
+    let mut out = Vec::new();
+    let mut ctx = WalkCtx { current_package: current_package.map(str::to_owned) };
+    walk(root, &mut ctx, &mut out);
+    out
+}
+
+struct WalkCtx {
+    current_package: Option<String>,
+}
+
+impl WalkCtx {
+    fn qualify(&self, name: &str) -> String {
+        match &self.current_package {
+            Some(pkg) => format!("{}::{}", pkg, name),
+            None => name.to_owned(),
+        }
+    }
+}
+
+fn walk(node: &Node, ctx: &mut WalkCtx, out: &mut Vec<SymbolRef>) {
+    match &node.kind {
+        NodeKind::Program { statements } | NodeKind::Block { statements } => {
+            for stmt in statements {
+                walk(stmt, ctx, out);
+            }
+        }
+
+        NodeKind::Package { name, block, .. } => {
+            if let Some(blk) = block {
+                let saved = ctx.current_package.replace(name.clone());
+                walk(blk, ctx, out);
+                ctx.current_package = saved;
+            } else {
+                ctx.current_package = Some(name.clone());
+            }
+        }
+
+        NodeKind::Class { name, body, .. } => {
+            let saved = ctx.current_package.replace(name.clone());
+            walk(body, ctx, out);
+            ctx.current_package = saved;
+        }
+
+        NodeKind::VariableDeclaration { initializer, .. }
+        | NodeKind::VariableListDeclaration { initializer, .. } => {
+            if let Some(init) = initializer {
+                walk(init, ctx, out);
+            }
+        }
+
+        NodeKind::MandatoryParameter { .. }
+        | NodeKind::SlurpyParameter { .. }
+        | NodeKind::NamedParameter { .. } => {}
+
+        NodeKind::OptionalParameter { default_value, .. } => {
+            walk(default_value, ctx, out);
+        }
+
+        NodeKind::Variable { sigil, name } => {
+            if let Some(var_kind) = var_kind_from_sigil(sigil) {
+                let (base_name, qualified_name, referenced_package) = resolve_name(name, ctx);
+                out.push(SymbolRef {
+                    kind: SymbolKind::Variable(var_kind),
+                    name: base_name,
+                    qualified_name,
+                    span: (node.location.start, node.location.end),
+                    container: ctx.current_package.clone(),
+                    referenced_package,
+                });
+            }
+        }
+
+        NodeKind::FunctionCall { name, args } => {
+            let (base_name, qualified_name, referenced_package) = resolve_name(name, ctx);
+            out.push(SymbolRef {
+                kind: SymbolKind::Subroutine,
+                name: base_name,
+                qualified_name,
+                span: (node.location.start, node.location.end),
+                container: ctx.current_package.clone(),
+                referenced_package,
+            });
+
+            for arg in args {
+                walk(arg, ctx, out);
+            }
+        }
+
+        _ => {
+            node.for_each_child(|child| walk(child, ctx, out));
+        }
+    }
+}
+
+fn var_kind_from_sigil(sigil: &str) -> Option<VarKind> {
+    match sigil {
+        "$" => Some(VarKind::Scalar),
+        "@" => Some(VarKind::Array),
+        "%" => Some(VarKind::Hash),
+        _ => None,
+    }
+}
+
+fn resolve_name(name: &str, ctx: &WalkCtx) -> (String, String, Option<String>) {
+    if let Some((package, bare_name)) = name.rsplit_once("::") {
+        return (
+            bare_name.to_owned(),
+            name.to_owned(),
+            if package.is_empty() { None } else { Some(package.to_owned()) },
+        );
+    }
+
+    (name.to_owned(), ctx.qualify(name), None)
+}

--- a/crates/perl-symbol/tests/surface_refs.rs
+++ b/crates/perl-symbol/tests/surface_refs.rs
@@ -1,0 +1,122 @@
+//! Tests for phase-1 `SymbolRef` extraction.
+
+use perl_ast::{Node, NodeKind, SourceLocation};
+use perl_symbol::surface::extract_symbol_refs;
+use perl_symbol::{SymbolKind, VarKind};
+
+fn loc(start: usize, end: usize) -> SourceLocation {
+    SourceLocation { start, end }
+}
+
+#[test]
+fn test_variable_reference_is_extracted() {
+    let var = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "count".to_string() },
+        loc(0, 6),
+    );
+    let stmt = Node::new(NodeKind::ExpressionStatement { expression: Box::new(var) }, loc(0, 6));
+    let program = Node::new(NodeKind::Program { statements: vec![stmt] }, loc(0, 6));
+
+    let refs = extract_symbol_refs(&program, Some("MyPkg"));
+
+    assert_eq!(refs.len(), 1);
+    let r = &refs[0];
+    assert_eq!(r.kind, SymbolKind::Variable(VarKind::Scalar));
+    assert_eq!(r.name, "count");
+    assert_eq!(r.qualified_name, "MyPkg::count");
+    assert_eq!(r.referenced_package, None);
+    assert_eq!(r.container.as_deref(), Some("MyPkg"));
+    assert_eq!(r.span, (0, 6));
+}
+
+#[test]
+fn test_subroutine_call_reference_is_extracted() {
+    let call = Node::new(
+        NodeKind::FunctionCall {
+            name: "greet".to_string(),
+            args: vec![Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "name".to_string() },
+                loc(7, 12),
+            )],
+        },
+        loc(0, 13),
+    );
+    let stmt = Node::new(NodeKind::ExpressionStatement { expression: Box::new(call) }, loc(0, 13));
+    let program = Node::new(NodeKind::Program { statements: vec![stmt] }, loc(0, 13));
+
+    let refs = extract_symbol_refs(&program, Some("MyPkg"));
+
+    assert_eq!(refs.len(), 2);
+    let call_ref = &refs[0];
+    assert_eq!(call_ref.kind, SymbolKind::Subroutine);
+    assert_eq!(call_ref.name, "greet");
+    assert_eq!(call_ref.qualified_name, "MyPkg::greet");
+    assert_eq!(call_ref.referenced_package, None);
+
+    let arg_ref = &refs[1];
+    assert_eq!(arg_ref.kind, SymbolKind::Variable(VarKind::Scalar));
+    assert_eq!(arg_ref.name, "name");
+    assert_eq!(arg_ref.qualified_name, "MyPkg::name");
+}
+
+#[test]
+fn test_explicit_package_qualified_refs_are_preserved() {
+    let call = Node::new(
+        NodeKind::FunctionCall {
+            name: "Other::run".to_string(),
+            args: vec![Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "Other::VALUE".to_string() },
+                loc(11, 24),
+            )],
+        },
+        loc(0, 25),
+    );
+    let stmt = Node::new(NodeKind::ExpressionStatement { expression: Box::new(call) }, loc(0, 25));
+    let program = Node::new(NodeKind::Program { statements: vec![stmt] }, loc(0, 25));
+
+    let refs = extract_symbol_refs(&program, Some("Local"));
+
+    assert_eq!(refs.len(), 2);
+
+    let call_ref = &refs[0];
+    assert_eq!(call_ref.kind, SymbolKind::Subroutine);
+    assert_eq!(call_ref.name, "run");
+    assert_eq!(call_ref.qualified_name, "Other::run");
+    assert_eq!(call_ref.referenced_package.as_deref(), Some("Other"));
+    assert_eq!(call_ref.container.as_deref(), Some("Local"));
+
+    let var_ref = &refs[1];
+    assert_eq!(var_ref.kind, SymbolKind::Variable(VarKind::Scalar));
+    assert_eq!(var_ref.name, "VALUE");
+    assert_eq!(var_ref.qualified_name, "Other::VALUE");
+    assert_eq!(var_ref.referenced_package.as_deref(), Some("Other"));
+}
+
+#[test]
+fn test_variable_declaration_sites_are_not_emitted_as_refs() {
+    let declared_var = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "declared".to_string() },
+        loc(3, 12),
+    );
+    let initializer_ref = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "source".to_string() },
+        loc(15, 21),
+    );
+    let decl = Node::new(
+        NodeKind::VariableDeclaration {
+            declarator: "my".to_string(),
+            variable: Box::new(declared_var),
+            attributes: vec![],
+            initializer: Some(Box::new(initializer_ref)),
+        },
+        loc(0, 21),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![decl] }, loc(0, 21));
+
+    let refs = extract_symbol_refs(&program, None);
+
+    assert_eq!(refs.len(), 1);
+    let r = &refs[0];
+    assert_eq!(r.name, "source");
+    assert_eq!(r.kind, SymbolKind::Variable(VarKind::Scalar));
+}


### PR DESCRIPTION
### Motivation

- Provide a shared, lightweight reference/use projection to reduce duplicated AST pattern-matching across consumers by shipping a narrow, high-confidence `SymbolRef` phase after `SymbolDecl`.
- Start with an intentionally small surface covering variable references, subroutine call references, and explicit package-qualified references so downstream consumers get reliable primitives without complex heuristics.

### Description

- Add `crates/perl-symbol/src/surface/ref.rs` implementing `SymbolRef` and `extract_symbol_refs` with a recursive walker that carries package context and resolves package-qualified names.
- Ensure the walker emits variable references and function-call references, preserves explicit `Foo::bar` qualification, and avoids emitting declaration-site variables as refs.
- Export the new projection from the surface module by updating `crates/perl-symbol/src/surface/mod.rs` and re-export it from the crate public API in `crates/perl-symbol/src/api.rs`.
- Add focused tests in `crates/perl-symbol/tests/surface_refs.rs` that cover variable refs, call refs, explicit package-qualified refs, and declaration-site filtering.

### Testing

- Ran `cargo test -p perl-symbol` and the perl-symbol test suite passed (including the 4 new `surface_refs` tests). 
- Ran `cargo check --all-targets -p perl-symbol` which completed successfully. 
- Ran `cargo xtask fmt` to format updates and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77b731288333bb779b29a2ac8b94)