### PR TITLE
feat(perl-symbol): add phase-1 SymbolRef projection layer (#0000)

### DIFF
--- a/crates/perl-symbol/src/api.rs
+++ b/crates/perl-symbol/src/api.rs
@@ -24,4 +24,6 @@ pub use crate::cursor::{
 pub use crate::index::SymbolIndex;
 
 // surface — full public surface
-pub use crate::surface::{SymbolDecl, extract_symbol_decls};
+pub use crate::surface::{
+    SymbolDecl, SymbolRef, SymbolRefKind, extract_symbol_decls, extract_symbol_refs,
+};

--- a/crates/perl-symbol/src/surface/mod.rs
+++ b/crates/perl-symbol/src/surface/mod.rs
@@ -12,7 +12,7 @@
 //!   the sibling `types` module inside this crate.
 //! - **Single extraction pass** — `extract_symbol_decls` walks the entire tree
 //!   once and returns all declaration sites.
-//! - **MVP scope** — ships `SymbolDecl` only.  `SymbolRef` and
+//! - **Phase-1 scope** — ships `SymbolDecl` and a narrow `SymbolRef`.
 //!   `CallSite` will follow in later phases.
 //!
 //! # Quick start
@@ -28,5 +28,7 @@
 //! ```
 
 pub mod decl;
+pub mod r#ref;
 
 pub use decl::{SymbolDecl, extract_symbol_decls};
+pub use r#ref::{SymbolRef, SymbolRefKind, extract_symbol_refs};

--- a/crates/perl-symbol/src/surface/ref.rs
+++ b/crates/perl-symbol/src/surface/ref.rs
@@ -1,0 +1,102 @@
+//! `SymbolRef` — a projected reference/use site derived from the Perl AST.
+//!
+//! This is the phase-1 reference projection and intentionally covers only
+//! high-confidence cases:
+//! - variable references (`$x`, `@items`, `%opts`)
+//! - subroutine call references (`foo(...)`)
+//! - package-qualified symbol references where the AST text is explicit
+//!   (for example `Foo::bar(...)`, `$Foo::value`, `*Foo::glob`)
+
+use crate::types::VarKind;
+use perl_ast::{Node, NodeKind};
+
+/// Narrow, high-confidence reference categories for phase-1 extraction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SymbolRefKind {
+    /// Unqualified variable usage.
+    Variable(VarKind),
+    /// Unqualified subroutine/function call usage.
+    SubroutineCall,
+    /// Package-qualified symbol usage where qualification is explicit in AST text.
+    QualifiedSymbol,
+}
+
+/// A projected view of a single symbol reference/use site in Perl source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SymbolRef {
+    /// Reference category.
+    pub kind: SymbolRefKind,
+    /// Referenced symbol name as represented by AST.
+    pub name: String,
+    /// Byte offsets `(start, end)` of the full reference node.
+    pub full_span: (usize, usize),
+    /// Byte offsets `(start, end)` of the reference anchor token.
+    pub anchor_span: (usize, usize),
+}
+
+/// Walk `root` and collect phase-1 symbol references into a flat list.
+pub fn extract_symbol_refs(root: &Node) -> Vec<SymbolRef> {
+    let mut out = Vec::new();
+    walk(root, &mut out);
+    out
+}
+
+fn walk(node: &Node, out: &mut Vec<SymbolRef>) {
+    match &node.kind {
+        NodeKind::Variable { sigil, name } => {
+            let kind = if name.contains("::") {
+                SymbolRefKind::QualifiedSymbol
+            } else if let Some(var_kind) = var_kind_from_sigil(sigil) {
+                SymbolRefKind::Variable(var_kind)
+            } else {
+                SymbolRefKind::QualifiedSymbol
+            };
+
+            out.push(SymbolRef {
+                kind,
+                name: name.clone(),
+                full_span: (node.location.start, node.location.end),
+                anchor_span: (node.location.start, node.location.end),
+            });
+        }
+
+        NodeKind::FunctionCall { name, .. } => {
+            let kind = if name.contains("::") {
+                SymbolRefKind::QualifiedSymbol
+            } else {
+                SymbolRefKind::SubroutineCall
+            };
+
+            out.push(SymbolRef {
+                kind,
+                name: name.clone(),
+                full_span: (node.location.start, node.location.end),
+                anchor_span: (node.location.start, node.location.end),
+            });
+        }
+
+        NodeKind::Typeglob { name } if name.contains("::") => {
+            out.push(SymbolRef {
+                kind: SymbolRefKind::QualifiedSymbol,
+                name: name.clone(),
+                full_span: (node.location.start, node.location.end),
+                anchor_span: (node.location.start, node.location.end),
+            });
+        }
+
+        _ => {}
+    }
+
+    for child in node.children() {
+        walk(child, out);
+    }
+}
+
+fn var_kind_from_sigil(sigil: &str) -> Option<VarKind> {
+    match sigil {
+        "$" => Some(VarKind::Scalar),
+        "@" => Some(VarKind::Array),
+        "%" => Some(VarKind::Hash),
+        _ => None,
+    }
+}

--- a/crates/perl-symbol/tests/surface_refs.rs
+++ b/crates/perl-symbol/tests/surface_refs.rs
@@ -1,0 +1,77 @@
+//! Tests for phase-1 `SymbolRef` extraction.
+
+use perl_ast::{Node, NodeKind, SourceLocation};
+use perl_symbol::surface::{SymbolRefKind, extract_symbol_refs};
+use perl_symbol::VarKind;
+
+fn loc(start: usize, end: usize) -> SourceLocation {
+    SourceLocation { start, end }
+}
+
+#[test]
+fn test_variable_reference_is_extracted() {
+    let var = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "count".to_string() },
+        loc(10, 16),
+    );
+    let stmt = Node::new(NodeKind::ExpressionStatement { expression: Box::new(var) }, loc(10, 16));
+    let program = Node::new(NodeKind::Program { statements: vec![stmt] }, loc(0, 17));
+
+    let refs = extract_symbol_refs(&program);
+
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0].kind, SymbolRefKind::Variable(VarKind::Scalar));
+    assert_eq!(refs[0].name, "count");
+    assert_eq!(refs[0].full_span, (10, 16));
+    assert_eq!(refs[0].anchor_span, (10, 16));
+}
+
+#[test]
+fn test_subroutine_call_reference_is_extracted() {
+    let call = Node::new(
+        NodeKind::FunctionCall {
+            name: "greet".to_string(),
+            args: vec![Node::new(NodeKind::Number { value: "1".to_string() }, loc(6, 7))],
+        },
+        loc(0, 8),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![call] }, loc(0, 8));
+
+    let refs = extract_symbol_refs(&program);
+
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0].kind, SymbolRefKind::SubroutineCall);
+    assert_eq!(refs[0].name, "greet");
+}
+
+#[test]
+fn test_package_qualified_references_are_extracted() {
+    let qualified_call = Node::new(
+        NodeKind::FunctionCall {
+            name: "Util::trim".to_string(),
+            args: vec![Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "Pkg::value".to_string() },
+                loc(12, 23),
+            )],
+        },
+        loc(0, 24),
+    );
+    let qualified_glob = Node::new(
+        NodeKind::Typeglob { name: "Other::Thing".to_string() },
+        loc(25, 37),
+    );
+    let program = Node::new(
+        NodeKind::Program { statements: vec![qualified_call, qualified_glob] },
+        loc(0, 37),
+    );
+
+    let refs = extract_symbol_refs(&program);
+
+    assert_eq!(refs.len(), 3);
+    assert_eq!(refs[0].kind, SymbolRefKind::QualifiedSymbol);
+    assert_eq!(refs[0].name, "Util::trim");
+    assert_eq!(refs[1].kind, SymbolRefKind::QualifiedSymbol);
+    assert_eq!(refs[1].name, "Pkg::value");
+    assert_eq!(refs[2].kind, SymbolRefKind::QualifiedSymbol);
+    assert_eq!(refs[2].name, "Other::Thing");
+}


### PR DESCRIPTION
### Motivation
- The surface projection only exposed `SymbolDecl`, which forced consumers to reimplement narrow "find reference/use-site" logic, so a small shared `SymbolRef` layer reduces duplication and enables future reference/callsite phases.

### Description
- Add a new `surface/ref.rs` with `SymbolRefKind`, `SymbolRef`, and `extract_symbol_refs` that walks the AST and captures variable usages, subroutine call sites, and explicit package-qualified symbols.
- Wire the new module into the surface facade by adding `pub mod r#ref;` and re-exporting `SymbolRef`, `SymbolRefKind`, and `extract_symbol_refs` from `crates/perl-symbol/src/surface/mod.rs`.
- Re-export the new types and API at the crate root in `crates/perl-symbol/src/api.rs` so callers can access `SymbolRef` from the facade.
- Add `crates/perl-symbol/tests/surface_refs.rs` with focused tests for variable references, subroutine calls, and package-qualified references.

### Testing
- Ran `cargo test -p perl-symbol`, which completed successfully and all tests passed.
- Ran `cargo check --all-targets -p perl-symbol`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77b731288333bb779b29a2ac8b94)