### PR TITLE
feat(perl-symbol): add phase-1 SymbolRef projection layer (#6466)

### DIFF
--- a/crates/perl-symbol/src/api.rs
+++ b/crates/perl-symbol/src/api.rs
@@ -24,4 +24,6 @@ pub use crate::cursor::{
 pub use crate::index::SymbolIndex;
 
 // surface — full public surface
-pub use crate::surface::{SymbolDecl, extract_symbol_decls};
+pub use crate::surface::{
+    SymbolDecl, SymbolRef, SymbolRefKind, extract_symbol_decls, extract_symbol_refs,
+};

--- a/crates/perl-symbol/src/surface/mod.rs
+++ b/crates/perl-symbol/src/surface/mod.rs
@@ -12,8 +12,8 @@
 //!   the sibling `types` module inside this crate.
 //! - **Single extraction pass** — `extract_symbol_decls` walks the entire tree
 //!   once and returns all declaration sites.
-//! - **MVP scope** — ships `SymbolDecl` only.  `SymbolRef` and
-//!   `CallSite` will follow in later phases.
+//! - **Scoped rollout** — ships `SymbolDecl` and a phase-1 `SymbolRef`
+//!   extractor. `CallSite` remains a later phase.
 //!
 //! # Quick start
 //!
@@ -28,5 +28,7 @@
 //! ```
 
 pub mod decl;
+pub mod r#ref;
 
 pub use decl::{SymbolDecl, extract_symbol_decls};
+pub use r#ref::{SymbolRef, SymbolRefKind, extract_symbol_refs};

--- a/crates/perl-symbol/src/surface/ref.rs
+++ b/crates/perl-symbol/src/surface/ref.rs
@@ -81,16 +81,26 @@ fn walk(node: &Node, out: &mut Vec<SymbolRef>) {
         }
 
         NodeKind::FunctionCall { name, args } => {
-            let (package_qualifier, bare_name, qualified_name) = split_qualified_name(name);
-            out.push(SymbolRef {
-                kind: SymbolRefKind::SubroutineCall,
-                name: bare_name,
-                qualified_name,
-                sigil: None,
-                package_qualifier,
-                full_span: (node.location.start, node.location.end),
-                anchor_span: Some((node.location.start, node.location.end)),
-            });
+            // The parser reuses FunctionCall for a few non-call constructs using
+            // sentinel names that contain non-identifier characters or are reserved
+            // keywords.  Filter them out so consumers never see synthetic nodes:
+            //   "->()": anonymous coderef invocation `$ref->(args)` — no sub name
+            //   "&{}":  coderef dereference
+            //   "field": Perl 5.38+ OOP `field $x => accessor` form — a declaration,
+            //            not a call; must not be reported as a SubroutineCall ref.
+            let is_sentinel = matches!(name.as_str(), "->()" | "&{}" | "field");
+            if !is_sentinel {
+                let (package_qualifier, bare_name, qualified_name) = split_qualified_name(name);
+                out.push(SymbolRef {
+                    kind: SymbolRefKind::SubroutineCall,
+                    name: bare_name,
+                    qualified_name,
+                    sigil: None,
+                    package_qualifier,
+                    full_span: (node.location.start, node.location.end),
+                    anchor_span: Some((node.location.start, node.location.end)),
+                });
+            }
 
             for arg in args {
                 walk(arg, out);

--- a/crates/perl-symbol/src/surface/ref.rs
+++ b/crates/perl-symbol/src/surface/ref.rs
@@ -14,6 +14,9 @@
 //! - Method calls (`$obj->method(...)`, `NodeKind::MethodCall`) — method name is not a
 //!   `Node`, so extraction requires a dedicated `MethodCallRef` kind (future phase)
 //! - Indirect-object calls (`new Class @args`, `NodeKind::IndirectCall`) — same reason
+//! - Subroutine signature parameter bindings (`MandatoryParameter`, `SlurpyParameter`,
+//!   `NamedParameter`) — these are declaration sites, not reference sites.  Optional
+//!   parameter *default values* are still walked because they are expressions.
 
 use crate::types::VarKind;
 use perl_ast::{Node, NodeKind};
@@ -63,6 +66,19 @@ fn walk(node: &Node, out: &mut Vec<SymbolRef>) {
             if let Some(init) = initializer {
                 walk(init, out);
             }
+        }
+
+        // Signature parameter nodes bind variables — skip the variable (it is a
+        // declaration site), but walk the default-value expression for optional
+        // parameters because it is evaluated in the caller's scope.
+        NodeKind::MandatoryParameter { .. }
+        | NodeKind::SlurpyParameter { .. }
+        | NodeKind::NamedParameter { .. } => {
+            // Nothing to walk: the bound variable is a declaration, not a ref.
+        }
+        NodeKind::OptionalParameter { default_value, .. } => {
+            // The default expression may reference other variables.
+            walk(default_value, out);
         }
 
         NodeKind::Variable { sigil, name } => {

--- a/crates/perl-symbol/src/surface/ref.rs
+++ b/crates/perl-symbol/src/surface/ref.rs
@@ -1,10 +1,19 @@
 //! `SymbolRef` — a projected symbol *reference/use* site from the Perl AST.
 //!
 //! This phase intentionally targets a narrow, high-confidence subset:
-//! - variable references (`$x`, `@items`, `%opts`)
-//! - subroutine call references (`foo(...)` / bareword calls)
+//! - variable references (`$x`, `@items`, `%opts`, `$#array`)
+//! - subroutine call references (`foo(...)` / bareword calls via `NodeKind::FunctionCall`)
 //! - package-qualified forms where the AST encodes them directly
 //!   (`$Pkg::var`, `Pkg::func(...)`)
+//!
+//! # Phase-1 Intentional Exclusions
+//!
+//! The following reference types are **not** emitted in this phase:
+//! - `&foo` / `\&foo` code-reference variables (sigil `&`) — `VarKind` has no `CodeRef` variant
+//! - `*foo` typeglob variables (sigil `*`) — reserved for a future phase
+//! - Method calls (`$obj->method(...)`, `NodeKind::MethodCall`) — method name is not a
+//!   `Node`, so extraction requires a dedicated `MethodCallRef` kind (future phase)
+//! - Indirect-object calls (`new Class @args`, `NodeKind::IndirectCall`) — same reason
 
 use crate::types::VarKind;
 use perl_ast::{Node, NodeKind};
@@ -27,7 +36,8 @@ pub struct SymbolRef {
     pub name: String,
     /// Package-qualified name when syntactically explicit, else bare `name`.
     pub qualified_name: String,
-    /// Variable sigil (`$`, `@`, `%`, `&`, `*`) for variable refs.
+    /// Variable sigil (`$`, `@`, `%`) for variable refs.  `&` and `*` sigils are
+    /// not emitted in phase-1 (see module-level exclusion list).
     pub sigil: Option<String>,
     /// Explicit package qualifier from syntax (for example `Some("Pkg")` for
     /// `Pkg::func` or `$Pkg::var`).
@@ -93,6 +103,11 @@ fn walk(node: &Node, out: &mut Vec<SymbolRef>) {
     }
 }
 
+/// Split a potentially package-qualified name into `(qualifier, bare, full)`.
+///
+/// Returns `(Some("Pkg::Sub"), "baz", "Pkg::Sub::baz")` for `"Pkg::Sub::baz"`.
+/// Returns `(None, name, name)` for bare names and for degenerate forms like
+/// `"Foo::"` (trailing `::`, empty bare component) or `"::bar"` (empty package).
 fn split_qualified_name(name: &str) -> (Option<String>, String, String) {
     if let Some((package, bare)) = name.rsplit_once("::")
         && !package.is_empty()
@@ -107,8 +122,11 @@ fn split_qualified_name(name: &str) -> (Option<String>, String, String) {
 fn var_kind_from_sigil(sigil: &str) -> Option<VarKind> {
     match sigil {
         "$" => Some(VarKind::Scalar),
+        // `$#array` is the last-index sigil; the value is a scalar integer.
+        "$#" => Some(VarKind::Scalar),
         "@" => Some(VarKind::Array),
         "%" => Some(VarKind::Hash),
+        // `&` (code reference) and `*` (typeglob) are phase-1 exclusions.
         _ => None,
     }
 }

--- a/crates/perl-symbol/src/surface/ref.rs
+++ b/crates/perl-symbol/src/surface/ref.rs
@@ -1,0 +1,114 @@
+//! `SymbolRef` — a projected symbol *reference/use* site from the Perl AST.
+//!
+//! This phase intentionally targets a narrow, high-confidence subset:
+//! - variable references (`$x`, `@items`, `%opts`)
+//! - subroutine call references (`foo(...)` / bareword calls)
+//! - package-qualified forms where the AST encodes them directly
+//!   (`$Pkg::var`, `Pkg::func(...)`)
+
+use crate::types::VarKind;
+use perl_ast::{Node, NodeKind};
+
+/// Classification for projected symbol references.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SymbolRefKind {
+    /// Variable usage (`$x`, `@items`, `%opts`).
+    Variable(VarKind),
+    /// Subroutine invocation (`foo(...)`).
+    SubroutineCall,
+}
+
+/// A projected view of a symbol reference/use site in Perl source.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SymbolRef {
+    /// Reference classification.
+    pub kind: SymbolRefKind,
+    /// Unqualified symbol name.
+    pub name: String,
+    /// Package-qualified name when syntactically explicit, else bare `name`.
+    pub qualified_name: String,
+    /// Variable sigil (`$`, `@`, `%`, `&`, `*`) for variable refs.
+    pub sigil: Option<String>,
+    /// Explicit package qualifier from syntax (for example `Some("Pkg")` for
+    /// `Pkg::func` or `$Pkg::var`).
+    pub package_qualifier: Option<String>,
+    /// Byte offsets `(start, end)` for the whole reference node.
+    pub full_span: (usize, usize),
+    /// Byte offsets for the reference anchor token.
+    pub anchor_span: Option<(usize, usize)>,
+}
+
+/// Walk `root` and collect a flat list of high-confidence symbol references.
+pub fn extract_symbol_refs(root: &Node) -> Vec<SymbolRef> {
+    let mut out = Vec::new();
+    walk(root, &mut out);
+    out
+}
+
+fn walk(node: &Node, out: &mut Vec<SymbolRef>) {
+    match &node.kind {
+        // Skip declaration targets; only walk initializer expressions.
+        NodeKind::VariableDeclaration { initializer, .. }
+        | NodeKind::VariableListDeclaration { initializer, .. } => {
+            if let Some(init) = initializer {
+                walk(init, out);
+            }
+        }
+
+        NodeKind::Variable { sigil, name } => {
+            if let Some(var_kind) = var_kind_from_sigil(sigil) {
+                let (package_qualifier, bare_name, qualified_name) = split_qualified_name(name);
+                out.push(SymbolRef {
+                    kind: SymbolRefKind::Variable(var_kind),
+                    name: bare_name,
+                    qualified_name,
+                    sigil: Some(sigil.clone()),
+                    package_qualifier,
+                    full_span: (node.location.start, node.location.end),
+                    anchor_span: Some((node.location.start, node.location.end)),
+                });
+            }
+        }
+
+        NodeKind::FunctionCall { name, args } => {
+            let (package_qualifier, bare_name, qualified_name) = split_qualified_name(name);
+            out.push(SymbolRef {
+                kind: SymbolRefKind::SubroutineCall,
+                name: bare_name,
+                qualified_name,
+                sigil: None,
+                package_qualifier,
+                full_span: (node.location.start, node.location.end),
+                anchor_span: Some((node.location.start, node.location.end)),
+            });
+
+            for arg in args {
+                walk(arg, out);
+            }
+        }
+
+        _ => {
+            node.for_each_child(|child| walk(child, out));
+        }
+    }
+}
+
+fn split_qualified_name(name: &str) -> (Option<String>, String, String) {
+    if let Some((package, bare)) = name.rsplit_once("::")
+        && !package.is_empty()
+        && !bare.is_empty()
+    {
+        return (Some(package.to_owned()), bare.to_owned(), name.to_owned());
+    }
+
+    (None, name.to_owned(), name.to_owned())
+}
+
+fn var_kind_from_sigil(sigil: &str) -> Option<VarKind> {
+    match sigil {
+        "$" => Some(VarKind::Scalar),
+        "@" => Some(VarKind::Array),
+        "%" => Some(VarKind::Hash),
+        _ => None,
+    }
+}

--- a/crates/perl-symbol/tests/edge_cases_and_regressions.rs
+++ b/crates/perl-symbol/tests/edge_cases_and_regressions.rs
@@ -25,7 +25,10 @@ use perl_symbol::cursor::{
     CursorSymbolKind, byte_offset_utf16, extract_symbol_from_source, get_symbol_range_at_position,
     is_modchar, is_word_boundary, token_under_cursor,
 };
-use perl_symbol::{SymbolDecl, SymbolIndex, SymbolKind, VarKind, extract_symbol_decls};
+use perl_symbol::{
+    SymbolDecl, SymbolIndex, SymbolKind, SymbolRef, SymbolRefKind, VarKind, extract_symbol_decls,
+    extract_symbol_refs,
+};
 use perl_tdd_support::must_some;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -57,6 +60,9 @@ fn api_regression_every_documented_name_is_reachable_at_crate_root() -> Result<(
     // surface — crate-root re-export of both the type and the function
     let _sd_size = std::mem::size_of::<SymbolDecl>(); // SymbolDecl at crate root
     let _f7: fn(&Node, Option<&str>) -> Vec<SymbolDecl> = extract_symbol_decls;
+    let _sr_size = std::mem::size_of::<SymbolRef>();
+    let _f8: fn(&Node) -> Vec<SymbolRef> = extract_symbol_refs;
+    let _rk = SymbolRefKind::SubroutineCall;
 
     Ok(())
 }
@@ -74,8 +80,8 @@ fn api_regression_every_documented_name_is_reachable_at_crate_root() -> Result<(
 /// public name requires deliberately updating this list *and*
 /// `facade_api_completeness.rs` — a deliberate act, not an accident.
 #[test]
-fn api_regression_crate_root_exposes_exactly_eight_reexported_items() -> Result<()> {
-    // The eight names re-exported at the crate root (from `api.rs`):
+fn api_regression_crate_root_exposes_exactly_eleven_reexported_items() -> Result<()> {
+    // The eleven names re-exported at the crate root (from `api.rs`):
     //   SymbolKind, VarKind                          — types
     //   CursorSymbolKind, byte_offset_utf16,
     //   extract_symbol_from_source,
@@ -83,7 +89,8 @@ fn api_regression_crate_root_exposes_exactly_eight_reexported_items() -> Result<
     //   is_modchar, is_word_boundary,
     //   token_under_cursor                           — cursor
     //   SymbolIndex                                  — index
-    //   SymbolDecl, extract_symbol_decls             — surface
+    //   SymbolDecl, extract_symbol_decls, SymbolRef, SymbolRefKind, extract_symbol_refs
+    //                                                — surface
     //
     // Bind each name to assert it resolves; if `api.rs` is narrowed, the
     // missing binding fails to compile. If someone switches to a wildcard
@@ -99,11 +106,13 @@ fn api_regression_crate_root_exposes_exactly_eight_reexported_items() -> Result<
     let _ = std::any::type_name::<perl_symbol::CursorSymbolKind>();
     let _ = std::any::type_name::<perl_symbol::SymbolIndex>();
     let _ = std::any::type_name::<perl_symbol::SymbolDecl>();
+    let _ = std::any::type_name::<perl_symbol::SymbolRef>();
     let _byte: fn(&str, usize) -> usize = perl_symbol::byte_offset_utf16;
     let _esfs: fn(usize, &str) -> Option<(String, perl_symbol::CursorSymbolKind)> =
         perl_symbol::extract_symbol_from_source;
     let _esd: fn(&perl_ast::Node, Option<&str>) -> Vec<perl_symbol::SymbolDecl> =
         perl_symbol::extract_symbol_decls;
+    let _esr: fn(&perl_ast::Node) -> Vec<perl_symbol::SymbolRef> = perl_symbol::extract_symbol_refs;
     let _gsp: fn(usize, &str) -> Option<(usize, usize)> = perl_symbol::get_symbol_range_at_position;
     let _im: fn(u8) -> bool = perl_symbol::is_modchar;
     let _iwb: fn(&[u8], usize, usize) -> bool = perl_symbol::is_word_boundary;

--- a/crates/perl-symbol/tests/facade_api_completeness.rs
+++ b/crates/perl-symbol/tests/facade_api_completeness.rs
@@ -6,12 +6,12 @@
 //! every microcrate-collapse facade.
 
 use perl_symbol::{
-    SymbolDecl, SymbolIndex, SymbolKind, VarKind,
+    SymbolDecl, SymbolIndex, SymbolKind, SymbolRef, SymbolRefKind, VarKind,
     cursor::{
         CursorSymbolKind, byte_offset_utf16, extract_symbol_from_source,
         get_symbol_range_at_position, is_modchar, is_word_boundary, token_under_cursor,
     },
-    extract_symbol_decls,
+    extract_symbol_decls, extract_symbol_refs,
 };
 
 #[test]
@@ -63,4 +63,10 @@ fn surface_decl_accessible() {
     // Compilation verifies the paths; the tiny runtime check binds the
     // function to a compatible type signature.
     let _fn: fn(&perl_ast::Node, Option<&str>) -> Vec<SymbolDecl> = extract_symbol_decls;
+}
+
+#[test]
+fn surface_ref_accessible() {
+    let _kind = SymbolRefKind::SubroutineCall;
+    let _fn: fn(&perl_ast::Node) -> Vec<SymbolRef> = extract_symbol_refs;
 }

--- a/crates/perl-symbol/tests/surface_refs.rs
+++ b/crates/perl-symbol/tests/surface_refs.rs
@@ -247,14 +247,10 @@ fn parser_sentinel_names_are_not_emitted_as_refs() -> Result<()> {
 fn signature_parameters_are_not_emitted_as_refs() -> Result<()> {
     // `sub foo($x, $y = $default, @rest)` — $x, $y, @rest are declaration sites;
     // only $default (the default-value expression) must be emitted as a ref.
-    let param_x = Node::new(
-        NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() },
-        loc(8, 10),
-    );
-    let mandatory = Node::new(
-        NodeKind::MandatoryParameter { variable: Box::new(param_x) },
-        loc(8, 10),
-    );
+    let param_x =
+        Node::new(NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() }, loc(8, 10));
+    let mandatory =
+        Node::new(NodeKind::MandatoryParameter { variable: Box::new(param_x) }, loc(8, 10));
 
     let param_y = Node::new(
         NodeKind::Variable { sigil: "$".to_string(), name: "y".to_string() },
@@ -276,10 +272,8 @@ fn signature_parameters_are_not_emitted_as_refs() -> Result<()> {
         NodeKind::Variable { sigil: "@".to_string(), name: "rest".to_string() },
         loc(27, 32),
     );
-    let slurpy = Node::new(
-        NodeKind::SlurpyParameter { variable: Box::new(param_rest) },
-        loc(27, 32),
-    );
+    let slurpy =
+        Node::new(NodeKind::SlurpyParameter { variable: Box::new(param_rest) }, loc(27, 32));
 
     let sig = Node::new(
         NodeKind::Signature { parameters: vec![mandatory, optional, slurpy] },

--- a/crates/perl-symbol/tests/surface_refs.rs
+++ b/crates/perl-symbol/tests/surface_refs.rs
@@ -99,3 +99,111 @@ fn package_qualified_references_are_projected() -> Result<()> {
     assert_eq!(refs[1].package_qualifier.as_deref(), Some("My::Pkg"));
     Ok(())
 }
+
+#[test]
+fn array_last_index_sigil_is_treated_as_scalar_reference() -> Result<()> {
+    // `$#array` is a valid Perl expression yielding the last index (a scalar).
+    // The parser encodes it as Variable { sigil: "$#", name: "array" }.
+    let var = Node::new(
+        NodeKind::Variable { sigil: "$#".to_string(), name: "items".to_string() },
+        loc(0, 7),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![var] }, loc(0, 7));
+
+    let refs = extract_symbol_refs(&program);
+    assert_eq!(refs.len(), 1, "$#array should be emitted as a scalar reference");
+    assert_eq!(refs[0].kind, SymbolRefKind::Variable(VarKind::Scalar));
+    assert_eq!(refs[0].name, "items");
+    assert_eq!(refs[0].sigil.as_deref(), Some("$#"));
+    assert_eq!(refs[0].package_qualifier, None);
+    Ok(())
+}
+
+#[test]
+fn code_ref_and_typeglob_sigils_are_excluded_in_phase1() -> Result<()> {
+    // `&` (code ref) and `*` (typeglob) are phase-1 exclusions documented in the
+    // module; they must not produce SymbolRef entries.
+    let code_ref = Node::new(
+        NodeKind::Variable { sigil: "&".to_string(), name: "handler".to_string() },
+        loc(0, 8),
+    );
+    let typeglob = Node::new(
+        NodeKind::Variable { sigil: "*".to_string(), name: "slot".to_string() },
+        loc(9, 14),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![code_ref, typeglob] }, loc(0, 14));
+
+    let refs = extract_symbol_refs(&program);
+    assert!(
+        refs.is_empty(),
+        "phase-1 should not emit refs for & or * sigil variables, got: {:?}",
+        refs
+    );
+    Ok(())
+}
+
+#[test]
+fn variable_with_attributes_wrapper_is_traversed() -> Result<()> {
+    // VariableWithAttributes wraps a Variable node; the inner Variable must still
+    // be discovered by the walker via for_each_child.
+    let inner_var = Node::new(
+        NodeKind::Variable { sigil: "@".to_string(), name: "data".to_string() },
+        loc(3, 8),
+    );
+    let wrapped = Node::new(
+        NodeKind::VariableWithAttributes {
+            variable: Box::new(inner_var),
+            attributes: vec!["shared".to_string()],
+        },
+        loc(0, 8),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![wrapped] }, loc(0, 8));
+
+    let refs = extract_symbol_refs(&program);
+    assert_eq!(refs.len(), 1, "inner Variable inside VariableWithAttributes must be visited");
+    assert_eq!(refs[0].kind, SymbolRefKind::Variable(VarKind::Array));
+    assert_eq!(refs[0].name, "data");
+    Ok(())
+}
+
+#[test]
+fn declaration_without_initializer_emits_no_refs() -> Result<()> {
+    // `my $x;` — declaration with no initializer should not emit any refs.
+    let decl_var =
+        Node::new(NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() }, loc(3, 5));
+    let decl = Node::new(
+        NodeKind::VariableDeclaration {
+            declarator: "my".to_string(),
+            variable: Box::new(decl_var),
+            attributes: vec![],
+            initializer: None,
+        },
+        loc(0, 6),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![decl] }, loc(0, 6));
+
+    let refs = extract_symbol_refs(&program);
+    assert!(refs.is_empty(), "declaration with no initializer must produce no refs");
+    Ok(())
+}
+
+#[test]
+fn function_call_args_are_walked_for_refs() -> Result<()> {
+    // Arguments to a function call are expression contexts — variables inside them
+    // must be emitted as refs.  Both the call site and the arg-variable must appear.
+    let arg_var =
+        Node::new(NodeKind::Variable { sigil: "$".to_string(), name: "n".to_string() }, loc(5, 7));
+    let call = Node::new(
+        NodeKind::FunctionCall { name: "print".to_string(), args: vec![arg_var] },
+        loc(0, 8),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![call] }, loc(0, 8));
+
+    let refs = extract_symbol_refs(&program);
+    assert_eq!(refs.len(), 2, "expected call ref + argument variable ref");
+    assert_eq!(refs[0].kind, SymbolRefKind::SubroutineCall);
+    assert_eq!(refs[0].name, "print");
+    assert_eq!(refs[1].kind, SymbolRefKind::Variable(VarKind::Scalar));
+    assert_eq!(refs[1].name, "n");
+    Ok(())
+}

--- a/crates/perl-symbol/tests/surface_refs.rs
+++ b/crates/perl-symbol/tests/surface_refs.rs
@@ -1,0 +1,101 @@
+//! Tests for phase-1 `SymbolRef` extraction.
+
+use perl_ast::{Node, NodeKind, SourceLocation};
+use perl_symbol::VarKind;
+use perl_symbol::surface::{SymbolRefKind, extract_symbol_refs};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+fn loc(start: usize, end: usize) -> SourceLocation {
+    SourceLocation { start, end }
+}
+
+#[test]
+fn variable_reference_is_extracted() -> Result<()> {
+    let var = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "count".to_string() },
+        loc(0, 6),
+    );
+    let expr_stmt =
+        Node::new(NodeKind::ExpressionStatement { expression: Box::new(var) }, loc(0, 7));
+    let program = Node::new(NodeKind::Program { statements: vec![expr_stmt] }, loc(0, 7));
+
+    let refs = extract_symbol_refs(&program);
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0].kind, SymbolRefKind::Variable(VarKind::Scalar));
+    assert_eq!(refs[0].name, "count");
+    assert_eq!(refs[0].qualified_name, "count");
+    assert_eq!(refs[0].sigil.as_deref(), Some("$"));
+    assert_eq!(refs[0].package_qualifier, None);
+    Ok(())
+}
+
+#[test]
+fn declaration_target_is_not_treated_as_reference() -> Result<()> {
+    let decl_var =
+        Node::new(NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() }, loc(3, 5));
+    let init_var =
+        Node::new(NodeKind::Variable { sigil: "$".to_string(), name: "y".to_string() }, loc(8, 10));
+    let decl = Node::new(
+        NodeKind::VariableDeclaration {
+            declarator: "my".to_string(),
+            variable: Box::new(decl_var),
+            attributes: vec![],
+            initializer: Some(Box::new(init_var)),
+        },
+        loc(0, 10),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![decl] }, loc(0, 10));
+
+    let refs = extract_symbol_refs(&program);
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0].name, "y");
+    Ok(())
+}
+
+#[test]
+fn subroutine_call_reference_is_extracted() -> Result<()> {
+    let call = Node::new(
+        NodeKind::FunctionCall {
+            name: "greet".to_string(),
+            args: vec![Node::new(NodeKind::Number { value: "1".to_string() }, loc(6, 7))],
+        },
+        loc(0, 8),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![call] }, loc(0, 8));
+
+    let refs = extract_symbol_refs(&program);
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0].kind, SymbolRefKind::SubroutineCall);
+    assert_eq!(refs[0].name, "greet");
+    assert_eq!(refs[0].qualified_name, "greet");
+    assert_eq!(refs[0].package_qualifier, None);
+    Ok(())
+}
+
+#[test]
+fn package_qualified_references_are_projected() -> Result<()> {
+    let call = Node::new(
+        NodeKind::FunctionCall { name: "My::Pkg::run".to_string(), args: vec![] },
+        loc(0, 12),
+    );
+    let var = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "My::Pkg::VALUE".to_string() },
+        loc(13, 28),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![call, var] }, loc(0, 28));
+
+    let refs = extract_symbol_refs(&program);
+    assert_eq!(refs.len(), 2);
+
+    assert_eq!(refs[0].kind, SymbolRefKind::SubroutineCall);
+    assert_eq!(refs[0].name, "run");
+    assert_eq!(refs[0].qualified_name, "My::Pkg::run");
+    assert_eq!(refs[0].package_qualifier.as_deref(), Some("My::Pkg"));
+
+    assert_eq!(refs[1].kind, SymbolRefKind::Variable(VarKind::Scalar));
+    assert_eq!(refs[1].name, "VALUE");
+    assert_eq!(refs[1].qualified_name, "My::Pkg::VALUE");
+    assert_eq!(refs[1].package_qualifier.as_deref(), Some("My::Pkg"));
+    Ok(())
+}

--- a/crates/perl-symbol/tests/surface_refs.rs
+++ b/crates/perl-symbol/tests/surface_refs.rs
@@ -207,3 +207,38 @@ fn function_call_args_are_walked_for_refs() -> Result<()> {
     assert_eq!(refs[1].name, "n");
     Ok(())
 }
+
+#[test]
+fn parser_sentinel_names_are_not_emitted_as_refs() -> Result<()> {
+    // The parser uses synthetic FunctionCall names for constructs that are not real
+    // subroutine calls: "->()"/\&{}\" for coderef invocations, "field" for OOP
+    // Perl 5.38+ field declarations.  None of these should appear as SubroutineCall refs.
+    let coderef_call =
+        Node::new(NodeKind::FunctionCall { name: "->()".to_string(), args: vec![] }, loc(0, 6));
+    let ampersand_deref =
+        Node::new(NodeKind::FunctionCall { name: "&{}".to_string(), args: vec![] }, loc(7, 11));
+    let field_var = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() },
+        loc(19, 21),
+    );
+    let field_decl = Node::new(
+        NodeKind::FunctionCall { name: "field".to_string(), args: vec![field_var] },
+        loc(13, 21),
+    );
+    let program = Node::new(
+        NodeKind::Program { statements: vec![coderef_call, ampersand_deref, field_decl] },
+        loc(0, 21),
+    );
+
+    let refs = extract_symbol_refs(&program);
+    // Only the $x variable inside the field args should appear (as a variable ref).
+    // The three sentinel FunctionCall nodes must not produce SubroutineCall refs.
+    let sub_refs: Vec<_> =
+        refs.iter().filter(|r| r.kind == SymbolRefKind::SubroutineCall).collect();
+    assert!(
+        sub_refs.is_empty(),
+        "sentinel FunctionCall names must not be emitted as SubroutineCall refs: {:?}",
+        sub_refs,
+    );
+    Ok(())
+}

--- a/crates/perl-symbol/tests/surface_refs.rs
+++ b/crates/perl-symbol/tests/surface_refs.rs
@@ -242,3 +242,74 @@ fn parser_sentinel_names_are_not_emitted_as_refs() -> Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn signature_parameters_are_not_emitted_as_refs() -> Result<()> {
+    // `sub foo($x, $y = $default, @rest)` — $x, $y, @rest are declaration sites;
+    // only $default (the default-value expression) must be emitted as a ref.
+    let param_x = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() },
+        loc(8, 10),
+    );
+    let mandatory = Node::new(
+        NodeKind::MandatoryParameter { variable: Box::new(param_x) },
+        loc(8, 10),
+    );
+
+    let param_y = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "y".to_string() },
+        loc(12, 14),
+    );
+    let default_var = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "default".to_string() },
+        loc(17, 25),
+    );
+    let optional = Node::new(
+        NodeKind::OptionalParameter {
+            variable: Box::new(param_y),
+            default_value: Box::new(default_var),
+        },
+        loc(12, 25),
+    );
+
+    let param_rest = Node::new(
+        NodeKind::Variable { sigil: "@".to_string(), name: "rest".to_string() },
+        loc(27, 32),
+    );
+    let slurpy = Node::new(
+        NodeKind::SlurpyParameter { variable: Box::new(param_rest) },
+        loc(27, 32),
+    );
+
+    let sig = Node::new(
+        NodeKind::Signature { parameters: vec![mandatory, optional, slurpy] },
+        loc(7, 33),
+    );
+    let body = Node::new(NodeKind::Block { statements: vec![] }, loc(34, 36));
+    let sub_node = Node::new(
+        NodeKind::Subroutine {
+            name: Some("foo".to_string()),
+            name_span: None,
+            prototype: None,
+            signature: Some(Box::new(sig)),
+            attributes: vec![],
+            body: Box::new(body),
+        },
+        loc(0, 36),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![sub_node] }, loc(0, 36));
+
+    let refs = extract_symbol_refs(&program);
+
+    // Only $default (the optional-parameter default value) should appear.
+    // $x, $y, @rest are declaration sites and must not be emitted.
+    assert_eq!(
+        refs.len(),
+        1,
+        "only $default should be a ref; got: {:?}",
+        refs.iter().map(|r| &r.name).collect::<Vec<_>>()
+    );
+    assert_eq!(refs[0].kind, SymbolRefKind::Variable(VarKind::Scalar));
+    assert_eq!(refs[0].name, "default");
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Provide a small, shared projection for symbol *references* to avoid duplicated "find symbol under/near node" logic across consumers. 
- Ship a narrow, high-confidence first phase that handles variable usages, subroutine call usages, and syntactically-explicit package-qualified forms.

### Description
- Add a new projection module `crates/perl-symbol/src/surface/ref.rs` introducing `SymbolRef`, `SymbolRefKind`, and the extraction function `extract_symbol_refs` that walks the `perl_ast::Node` tree and emits variable and call reference sites.
- Integrate the new surface into the existing surface facade by exposing `pub mod r#ref` and re-exporting `SymbolRef`, `SymbolRefKind`, and `extract_symbol_refs` from `crates/perl-symbol/src/surface/mod.rs` and the crate-level `api.rs`.
- Add focused unit tests `crates/perl-symbol/tests/surface_refs.rs` that assert extraction for variable references, subroutine calls, package-qualified names, and ensure declaration targets (e.g. `my $x`) are not reported as refs.
- Update regression/completeness tests (`facade_api_completeness.rs` and `edge_cases_and_regressions.rs`) to include the new `SymbolRef` surface in the crate-root re-export checks.

### Testing
- Ran `cargo xtask fmt` to format the workspace (completed successfully).
- Ran `cargo test -p perl-symbol` and all tests passed (unit and integration tests for the crate).
- Ran `cargo check --all-targets -p perl-symbol` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77b731288333bb779b29a2ac8b94)