### PR TITLE
perf(perl-token): add stable token scorecard and baselines (#0000)

### DIFF
--- a/.ci/metrics/baselines/token.json
+++ b/.ci/metrics/baselines/token.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "measured_at": "2026-04-24T04:35:11Z",
+  "subsystem": "token",
+  "source_scorecard": "docs/project/status/token_performance_scorecard.json",
+  "tolerance_pct": 0.01,
+  "metrics": {
+    "eof_and_synthetic_token_construction": {
+      "median_ns": 154,
+      "p95_ns": 158
+    },
+    "lexer_to_parser_token_conversion": {
+      "median_ns": 1526,
+      "p95_ns": 1581
+    },
+    "token_clone": {
+      "median_ns": 77,
+      "p95_ns": 84
+    },
+    "token_equality": {
+      "median_ns": 51,
+      "p95_ns": 53
+    },
+    "token_new_long": {
+      "median_ns": 118,
+      "p95_ns": 132
+    },
+    "token_new_short": {
+      "median_ns": 112,
+      "p95_ns": 130
+    },
+    "tokenkind_category_predicates": {
+      "median_ns": 54,
+      "p95_ns": 55
+    },
+    "tokenkind_display_name": {
+      "median_ns": 57,
+      "p95_ns": 59
+    }
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,6 +1896,12 @@ version = "0.12.4"
 [[package]]
 name = "perl-token"
 version = "0.12.4"
+dependencies = [
+ "perl-lexer",
+ "perl-parser-core",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "perl-uri"

--- a/crates/perl-token/Cargo.toml
+++ b/crates/perl-token/Cargo.toml
@@ -16,6 +16,16 @@ categories = ["parsing", "text-processing"]
 [dependencies]
 # No external dependencies for now (Arc is std)
 
+[dev-dependencies]
+perl-lexer = { workspace = true }
+perl-parser-core = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+
+[[bench]]
+name = "token_scorecard"
+harness = false
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/crates/perl-token/benches/support/perf_scorecard.rs
+++ b/crates/perl-token/benches/support/perf_scorecard.rs
@@ -1,0 +1,108 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use perl_parser_core::percentile::nearest_rank_percentile;
+
+const ARTIFACT_RELATIVE_PATH: &str = "docs/project/status/token_performance_scorecard.json";
+const WARMUP_ROUNDS: usize = 2;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ScoreMetric {
+    pub(crate) name: String,
+    pub(crate) iterations: usize,
+    pub(crate) median_ns: u128,
+    pub(crate) p95_ns: u128,
+    pub(crate) mean_ns: u128,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct TokenPerformanceScorecard {
+    pub(crate) schema_version: u32,
+    pub(crate) generated_at_epoch_s: u64,
+    pub(crate) metrics: BTreeMap<String, ScoreMetric>,
+}
+
+impl Default for TokenPerformanceScorecard {
+    fn default() -> Self {
+        Self { schema_version: 1, generated_at_epoch_s: 0, metrics: BTreeMap::new() }
+    }
+}
+
+pub(crate) fn sample_metric<F>(name: &str, iterations: usize, mut run: F) -> ScoreMetric
+where
+    F: FnMut(),
+{
+    let scored_rounds = iterations.max(5);
+    let warmup = WARMUP_ROUNDS.min(scored_rounds);
+
+    for _ in 0..warmup {
+        run();
+    }
+
+    let mut samples: Vec<u128> = Vec::with_capacity(scored_rounds);
+    for _ in 0..scored_rounds {
+        let start = Instant::now();
+        run();
+        samples.push(start.elapsed().as_nanos());
+    }
+
+    samples.sort_unstable();
+    let total: u128 = samples.iter().copied().sum();
+    let samples_u64: Vec<u64> = samples
+        .iter()
+        .map(|ns| (*ns).min(u64::MAX as u128) as u64)
+        .collect();
+    let median_ns = u128::from(nearest_rank_percentile(&samples_u64, 50));
+    let p95_ns = u128::from(nearest_rank_percentile(&samples_u64, 95));
+
+    ScoreMetric {
+        name: name.to_string(),
+        iterations: scored_rounds,
+        median_ns,
+        p95_ns,
+        mean_ns: if scored_rounds == 0 { 0 } else { total / scored_rounds as u128 },
+    }
+}
+
+pub(crate) fn record_metric(metric: ScoreMetric) {
+    let Some(path) = find_artifact_path() else {
+        return;
+    };
+
+    let mut scorecard = read_scorecard(&path).unwrap_or_default();
+    scorecard.generated_at_epoch_s = now_epoch_seconds();
+    scorecard.metrics.insert(metric.name.clone(), metric);
+
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    let Ok(json) = serde_json::to_string_pretty(&scorecard) else {
+        return;
+    };
+    let _ = fs::write(path, json);
+}
+
+fn find_artifact_path() -> Option<PathBuf> {
+    let mut dir = std::env::current_dir().ok()?;
+    loop {
+        let candidate = dir.join(ARTIFACT_RELATIVE_PATH);
+        if candidate.parent().is_some_and(|parent| parent.exists()) {
+            return Some(candidate);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+fn read_scorecard(path: &Path) -> Option<TokenPerformanceScorecard> {
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn now_epoch_seconds() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs())
+}

--- a/crates/perl-token/benches/token_scorecard.rs
+++ b/crates/perl-token/benches/token_scorecard.rs
@@ -1,0 +1,100 @@
+use perl_lexer::{PerlLexer, Token as LexerToken, TokenType};
+use perl_parser_core::tokens::token_stream::TokenStream;
+use perl_token::{Token, TokenKind};
+use std::hint::black_box;
+use std::sync::Arc;
+
+#[path = "support/perf_scorecard.rs"]
+mod perf_scorecard;
+
+const LONG_TOKEN_TEXT: &str = "this_is_a_long_token_text_value_used_for_scorecard_measurement_0123456789_abcdefghijklmnopqrstuvwxyz";
+const SAMPLE_SOURCE: &str = r#"
+my $x = 42;
+my $name = "perl";
+if ($x > 0) {
+    print $name;
+}
+"#;
+
+fn main() {
+    let token_new_short = perf_scorecard::sample_metric("token_new_short", 80, || {
+        let t = Token::new(TokenKind::Identifier, black_box("id"), black_box(0), black_box(2));
+        black_box(t);
+    });
+    perf_scorecard::record_metric(token_new_short);
+
+    let token_new_long = perf_scorecard::sample_metric("token_new_long", 80, || {
+        let t = Token::new(
+            TokenKind::Identifier,
+            black_box(LONG_TOKEN_TEXT),
+            black_box(0),
+            black_box(LONG_TOKEN_TEXT.len()),
+        );
+        black_box(t);
+    });
+    perf_scorecard::record_metric(token_new_long);
+
+    let base_clone = Token::new(
+        TokenKind::Identifier,
+        Arc::<str>::from(LONG_TOKEN_TEXT),
+        0,
+        LONG_TOKEN_TEXT.len(),
+    );
+    let token_clone = perf_scorecard::sample_metric("token_clone", 100, || {
+        let cloned = black_box(base_clone.clone());
+        black_box(cloned);
+    });
+    perf_scorecard::record_metric(token_clone);
+
+    let left = Token::new(TokenKind::Identifier, "equal_me", 10, 18);
+    let right = Token::new(TokenKind::Identifier, "equal_me", 10, 18);
+    let token_equality = perf_scorecard::sample_metric("token_equality", 100, || {
+        let is_equal = black_box(left == right);
+        black_box(is_equal);
+    });
+    perf_scorecard::record_metric(token_equality);
+
+    let display_name = perf_scorecard::sample_metric("tokenkind_display_name", 100, || {
+        let name = black_box(TokenKind::Sub.display_name());
+        black_box(name);
+    });
+    perf_scorecard::record_metric(display_name);
+
+    let category_predicates =
+        perf_scorecard::sample_metric("tokenkind_category_predicates", 100, || {
+            let kind = black_box(TokenKind::String);
+            let _ = black_box(kind.is_keyword());
+            let _ = black_box(kind.is_operator());
+            let _ = black_box(kind.is_delimiter());
+            let _ = black_box(kind.is_literal());
+        });
+    perf_scorecard::record_metric(category_predicates);
+
+    let lexer_tokens = collect_lexer_tokens(SAMPLE_SOURCE);
+    let conversion = perf_scorecard::sample_metric("lexer_to_parser_token_conversion", 50, || {
+        let converted = TokenStream::lexer_tokens_to_parser_tokens(black_box(lexer_tokens.clone()));
+        black_box(converted);
+    });
+    perf_scorecard::record_metric(conversion);
+
+    let eof_synthetic =
+        perf_scorecard::sample_metric("eof_and_synthetic_token_construction", 100, || {
+            let eof = Token::new(TokenKind::Eof, "", 128, 128);
+            let synthetic = Token::new(TokenKind::Unknown, "<synthetic>", 128, 128);
+            black_box((eof, synthetic));
+        });
+    perf_scorecard::record_metric(eof_synthetic);
+}
+
+fn collect_lexer_tokens(source: &str) -> Vec<LexerToken> {
+    let mut lexer = PerlLexer::new(source);
+    let mut tokens = Vec::new();
+    while let Some(token) = lexer.next_token() {
+        let is_eof = token.token_type == TokenType::EOF;
+        tokens.push(token);
+        if is_eof {
+            break;
+        }
+    }
+    tokens
+}

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -399,6 +399,158 @@ pub enum TokenKind {
 }
 
 impl TokenKind {
+    /// Return whether this token kind is a Perl keyword.
+    pub fn is_keyword(self) -> bool {
+        matches!(
+            self,
+            TokenKind::My
+                | TokenKind::Our
+                | TokenKind::Local
+                | TokenKind::State
+                | TokenKind::Sub
+                | TokenKind::If
+                | TokenKind::Elsif
+                | TokenKind::Else
+                | TokenKind::Unless
+                | TokenKind::While
+                | TokenKind::Until
+                | TokenKind::For
+                | TokenKind::Foreach
+                | TokenKind::Return
+                | TokenKind::Package
+                | TokenKind::Use
+                | TokenKind::No
+                | TokenKind::Begin
+                | TokenKind::End
+                | TokenKind::Check
+                | TokenKind::Init
+                | TokenKind::Unitcheck
+                | TokenKind::Eval
+                | TokenKind::Do
+                | TokenKind::Given
+                | TokenKind::When
+                | TokenKind::Default
+                | TokenKind::Try
+                | TokenKind::Catch
+                | TokenKind::Finally
+                | TokenKind::Continue
+                | TokenKind::Next
+                | TokenKind::Last
+                | TokenKind::Redo
+                | TokenKind::Goto
+                | TokenKind::Class
+                | TokenKind::Method
+                | TokenKind::Field
+                | TokenKind::Format
+                | TokenKind::Undef
+                | TokenKind::Defer
+        )
+    }
+
+    /// Return whether this token kind is an operator.
+    pub fn is_operator(self) -> bool {
+        matches!(
+            self,
+            TokenKind::Assign
+                | TokenKind::Plus
+                | TokenKind::Minus
+                | TokenKind::Star
+                | TokenKind::Slash
+                | TokenKind::Percent
+                | TokenKind::Power
+                | TokenKind::LeftShift
+                | TokenKind::RightShift
+                | TokenKind::BitwiseAnd
+                | TokenKind::BitwiseOr
+                | TokenKind::BitwiseXor
+                | TokenKind::BitwiseNot
+                | TokenKind::PlusAssign
+                | TokenKind::MinusAssign
+                | TokenKind::StarAssign
+                | TokenKind::SlashAssign
+                | TokenKind::PercentAssign
+                | TokenKind::DotAssign
+                | TokenKind::AndAssign
+                | TokenKind::OrAssign
+                | TokenKind::XorAssign
+                | TokenKind::PowerAssign
+                | TokenKind::LeftShiftAssign
+                | TokenKind::RightShiftAssign
+                | TokenKind::LogicalAndAssign
+                | TokenKind::LogicalOrAssign
+                | TokenKind::DefinedOrAssign
+                | TokenKind::Equal
+                | TokenKind::NotEqual
+                | TokenKind::Match
+                | TokenKind::NotMatch
+                | TokenKind::SmartMatch
+                | TokenKind::Less
+                | TokenKind::Greater
+                | TokenKind::LessEqual
+                | TokenKind::GreaterEqual
+                | TokenKind::Spaceship
+                | TokenKind::StringCompare
+                | TokenKind::And
+                | TokenKind::Or
+                | TokenKind::Not
+                | TokenKind::DefinedOr
+                | TokenKind::WordAnd
+                | TokenKind::WordOr
+                | TokenKind::WordNot
+                | TokenKind::WordXor
+                | TokenKind::Arrow
+                | TokenKind::FatArrow
+                | TokenKind::Dot
+                | TokenKind::Range
+                | TokenKind::Ellipsis
+                | TokenKind::Increment
+                | TokenKind::Decrement
+                | TokenKind::DoubleColon
+                | TokenKind::Question
+                | TokenKind::Colon
+                | TokenKind::Backslash
+        )
+    }
+
+    /// Return whether this token kind is a delimiter.
+    pub fn is_delimiter(self) -> bool {
+        matches!(
+            self,
+            TokenKind::LeftParen
+                | TokenKind::RightParen
+                | TokenKind::LeftBrace
+                | TokenKind::RightBrace
+                | TokenKind::LeftBracket
+                | TokenKind::RightBracket
+                | TokenKind::Semicolon
+                | TokenKind::Comma
+        )
+    }
+
+    /// Return whether this token kind is a literal-like token.
+    pub fn is_literal(self) -> bool {
+        matches!(
+            self,
+            TokenKind::Number
+                | TokenKind::String
+                | TokenKind::Regex
+                | TokenKind::Substitution
+                | TokenKind::Transliteration
+                | TokenKind::QuoteSingle
+                | TokenKind::QuoteDouble
+                | TokenKind::QuoteWords
+                | TokenKind::QuoteCommand
+                | TokenKind::HeredocStart
+                | TokenKind::HeredocBody
+                | TokenKind::FormatBody
+                | TokenKind::DataMarker
+                | TokenKind::DataBody
+                | TokenKind::VString
+                | TokenKind::UnknownRest
+                | TokenKind::HeredocDepthLimit
+        )
+    }
+
     /// Return a user-friendly display name for this token kind.
     ///
     /// These names appear in parser error messages shown in the editor.

--- a/crates/perl-token/tests/token_kinds_and_display.rs
+++ b/crates/perl-token/tests/token_kinds_and_display.rs
@@ -177,6 +177,16 @@ fn is_special(kind: TokenKind) -> bool {
     matches!(kind, TokenKind::Eof | TokenKind::Unknown)
 }
 
+#[test]
+fn tokenkind_category_predicates_match_reference_classification() {
+    for kind in all_kinds() {
+        assert_eq!(kind.is_keyword(), is_keyword(kind), "keyword mismatch for {kind:?}");
+        assert_eq!(kind.is_operator(), is_operator(kind), "operator mismatch for {kind:?}");
+        assert_eq!(kind.is_delimiter(), is_delimiter(kind), "delimiter mismatch for {kind:?}");
+        assert_eq!(kind.is_literal(), is_literal(kind), "literal mismatch for {kind:?}");
+    }
+}
+
 /// Every variant in TokenKind, including Field and Goto.
 fn all_kinds() -> Vec<TokenKind> {
     vec![

--- a/docs/project/status/token_performance_scorecard.json
+++ b/docs/project/status/token_performance_scorecard.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "generated_at_epoch_s": 1777040511,
+  "metrics": {
+    "eof_and_synthetic_token_construction": {
+      "name": "eof_and_synthetic_token_construction",
+      "iterations": 100,
+      "median_ns": 154,
+      "p95_ns": 158,
+      "mean_ns": 153
+    },
+    "lexer_to_parser_token_conversion": {
+      "name": "lexer_to_parser_token_conversion",
+      "iterations": 50,
+      "median_ns": 1526,
+      "p95_ns": 1581,
+      "mean_ns": 1921
+    },
+    "token_clone": {
+      "name": "token_clone",
+      "iterations": 100,
+      "median_ns": 77,
+      "p95_ns": 84,
+      "mean_ns": 78
+    },
+    "token_equality": {
+      "name": "token_equality",
+      "iterations": 100,
+      "median_ns": 51,
+      "p95_ns": 53,
+      "mean_ns": 51
+    },
+    "token_new_long": {
+      "name": "token_new_long",
+      "iterations": 80,
+      "median_ns": 118,
+      "p95_ns": 132,
+      "mean_ns": 118
+    },
+    "token_new_short": {
+      "name": "token_new_short",
+      "iterations": 80,
+      "median_ns": 112,
+      "p95_ns": 130,
+      "mean_ns": 117
+    },
+    "tokenkind_category_predicates": {
+      "name": "tokenkind_category_predicates",
+      "iterations": 100,
+      "median_ns": 54,
+      "p95_ns": 55,
+      "mean_ns": 53
+    },
+    "tokenkind_display_name": {
+      "name": "tokenkind_display_name",
+      "iterations": 100,
+      "median_ns": 57,
+      "p95_ns": 59,
+      "mean_ns": 57
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a focused, stable micro-scorecard for the hot paths in `perl-token` so regressions in Token construction, cloning, display-name lookup, category checks, and lexer→parser conversion are visible without relying on parser-level timings.

### Description

- Add `TokenKind` category predicate APIs (`is_keyword`, `is_operator`, `is_delimiter`, `is_literal`) so category checks are first-class and benchmarkable from `perl-token` itself (`crates/perl-token/src/lib.rs`).
- Introduce a dedicated bench `token_scorecard` with a small, self-contained performance harness (`crates/perl-token/benches/token_scorecard.rs`) and a reusable perf helper (`crates/perl-token/benches/support/perf_scorecard.rs`) that discards warmup rounds, computes median/p95 using the shared nearest-rank percentile helper, and emits stable JSON to `docs/project/status/token_performance_scorecard.json`.
- Keep `perl-token` free of runtime dependencies by adding bench/dev-only deps in `crates/perl-token/Cargo.toml` and updating `Cargo.lock` for bench-time artifacts only.
- Add a baseline snapshot `.ci/metrics/baselines/token.json` for CI comparison and a unit test that validates the new category predicates against the existing classification matrix (`crates/perl-token/tests/token_kinds_and_display.rs`).

### Testing

- `cargo test -p perl-token` was run and all unit tests passed.
- `cargo bench -p perl-token` was run and produced `docs/project/status/token_performance_scorecard.json` containing each benchmark's `iterations`, `median_ns`, `p95_ns`, and `mean_ns`; warmup rounds are not included in scored samples.
- `cargo check --all-targets -p perl-token` and `cargo clippy -p perl-token --all-targets -- -D warnings` were executed and passed.
- A lightweight JSON validation script was executed against the emitted scorecard to confirm schema fields and per-benchmark keys, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77bff09883338d3de5d65c8fc0c0)