### PR TITLE
feat(perl-token): add checked token spans and invariant helpers (#0000)

### DIFF
--- a/crates/perl-parser-core/src/tokens/token_stream.rs
+++ b/crates/perl-parser-core/src/tokens/token_stream.rs
@@ -59,6 +59,7 @@ enum TokenStreamInner<'a> {
 /// and statement-boundary state management used by the recursive-descent parser.
 pub struct TokenStream<'a> {
     inner: TokenStreamInner<'a>,
+    eof_pos: usize,
     peeked: Option<Token>,
     peeked_second: Option<Token>,
     peeked_third: Option<Token>,
@@ -69,6 +70,7 @@ impl<'a> TokenStream<'a> {
     pub fn new(input: &'a str) -> Self {
         TokenStream {
             inner: TokenStreamInner::Lexer(PerlLexer::new(input)),
+            eof_pos: 0,
             peeked: None,
             peeked_second: None,
             peeked_third: None,
@@ -107,8 +109,10 @@ impl<'a> TokenStream<'a> {
     /// assert!(matches!(stream.peek(), Ok(t) if t.kind == TokenKind::My));
     /// ```
     pub fn from_vec(tokens: Vec<Token>) -> Self {
+        let eof_pos = tokens.last().map_or(0, |token| token.end);
         TokenStream {
             inner: TokenStreamInner::Buffered(VecDeque::from(tokens)),
+            eof_pos,
             peeked: None,
             peeked_second: None,
             peeked_third: None,
@@ -298,7 +302,7 @@ impl<'a> TokenStream<'a> {
     fn next_token(&mut self) -> ParseResult<Token> {
         match &mut self.inner {
             TokenStreamInner::Lexer(lexer) => Self::next_token_from_lexer(lexer),
-            TokenStreamInner::Buffered(buf) => Self::next_token_from_buf(buf),
+            TokenStreamInner::Buffered(buf) => Self::next_token_from_buf(buf, &mut self.eof_pos),
         }
     }
 
@@ -312,12 +316,7 @@ impl<'a> TokenStream<'a> {
                 LexerTokenType::Whitespace | LexerTokenType::Newline => continue,
                 LexerTokenType::Comment(_) => continue,
                 LexerTokenType::EOF => {
-                    return Ok(Token {
-                        kind: TokenKind::Eof,
-                        text: String::new().into(),
-                        start: lexer_token.start,
-                        end: lexer_token.end,
-                    });
+                    return Ok(Token::eof_at(lexer_token.start));
                 }
                 _ => {
                     return Ok(Self::convert_lexer_token(lexer_token));
@@ -327,13 +326,13 @@ impl<'a> TokenStream<'a> {
     }
 
     /// Return the next token from the pre-lexed buffer.
-    fn next_token_from_buf(buf: &mut VecDeque<Token>) -> ParseResult<Token> {
+    fn next_token_from_buf(buf: &mut VecDeque<Token>, eof_pos: &mut usize) -> ParseResult<Token> {
         match buf.pop_front() {
-            Some(token) => Ok(token),
-            // Synthesise an EOF at position 0 when the buffer is exhausted.
-            // The caller (parser) makes EOF sticky so position doesn't matter
-            // for correctness; using 0 is safe.
-            None => Ok(Token { kind: TokenKind::Eof, text: "".into(), start: 0, end: 0 }),
+            Some(token) => {
+                *eof_pos = token.end;
+                Ok(token)
+            }
+            None => Ok(Token::eof_at(*eof_pos)),
         }
     }
 

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -37,6 +37,39 @@
 
 use std::sync::Arc;
 
+/// Byte span for a token in source text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenSpan {
+    /// Starting byte offset, inclusive.
+    pub start: usize,
+    /// Ending byte offset, exclusive.
+    pub end: usize,
+}
+
+impl TokenSpan {
+    /// Create a checked token span.
+    pub fn new(start: usize, end: usize) -> Result<Self, TokenSpanError> {
+        if end < start {
+            return Err(TokenSpanError::InvertedSpan { start, end });
+        }
+        Ok(Self { start, end })
+    }
+
+    /// Return this span as a `start..end` range.
+    pub fn range(self) -> std::ops::Range<usize> {
+        self.start..self.end
+    }
+}
+
+/// Error returned by checked token/span constructors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenSpanError {
+    /// Span had `end < start`.
+    InvertedSpan { start: usize, end: usize },
+    /// Empty span is only valid for EOF or explicitly synthetic tokens.
+    EmptySpanDisallowed { kind: TokenKind, start: usize, end: usize },
+}
+
 /// Token produced by the lexer and consumed by the parser.
 ///
 /// Stores the token kind, original source text, and byte span. The text is kept
@@ -67,6 +100,60 @@ impl Token {
     /// ```
     pub fn new(kind: TokenKind, text: impl Into<Arc<str>>, start: usize, end: usize) -> Self {
         Token { kind, text: text.into(), start, end }
+    }
+
+    /// Try to create a token while validating span invariants.
+    pub fn try_new(
+        kind: TokenKind,
+        text: impl Into<Arc<str>>,
+        start: usize,
+        end: usize,
+    ) -> Result<Self, TokenSpanError> {
+        let span = TokenSpan::new(start, end)?;
+        if span.start == span.end && !matches!(kind, TokenKind::Eof | TokenKind::Unknown) {
+            return Err(TokenSpanError::EmptySpanDisallowed { kind, start, end });
+        }
+        Ok(Self::new(kind, text, start, end))
+    }
+
+    /// Checked constructor alias for [`Self::try_new`].
+    pub fn new_checked(
+        kind: TokenKind,
+        text: impl Into<Arc<str>>,
+        start: usize,
+        end: usize,
+    ) -> Result<Self, TokenSpanError> {
+        Self::try_new(kind, text, start, end)
+    }
+
+    /// Construct an EOF token at a specific byte position.
+    pub fn eof_at(pos: usize) -> Self {
+        Self::new(TokenKind::Eof, "", pos, pos)
+    }
+
+    /// Construct an explicit synthetic unknown token.
+    pub fn unknown_at(text: impl Into<Arc<str>>, start: usize, end: usize) -> Self {
+        Self::new(TokenKind::Unknown, text, start, end)
+    }
+
+    /// Return this token's byte span.
+    pub fn span(&self) -> TokenSpan {
+        TokenSpan { start: self.start, end: self.end }
+    }
+
+    /// Return this token's byte span as `start..end`.
+    pub fn range(&self) -> std::ops::Range<usize> {
+        self.span().range()
+    }
+
+    /// Return a copy with a different span.
+    pub fn with_span(self, span: TokenSpan) -> Self {
+        Self { start: span.start, end: span.end, ..self }
+    }
+
+    /// Return a copy with a different kind.
+    pub fn with_kind(self, kind: TokenKind) -> Self {
+        Self { kind, ..self }
     }
 
     /// Return the token span length in bytes.

--- a/crates/perl-token/tests/span_invariant_tests.rs
+++ b/crates/perl-token/tests/span_invariant_tests.rs
@@ -1,0 +1,79 @@
+use perl_token::{Token, TokenKind, TokenSpan, TokenSpanError};
+
+#[test]
+fn checked_constructor_rejects_inverted_span() {
+    let result = Token::try_new(TokenKind::Identifier, "name", 8, 4);
+    assert_eq!(result, Err(TokenSpanError::InvertedSpan { start: 8, end: 4 }));
+}
+
+#[test]
+fn checked_constructor_rejects_empty_non_synthetic_span() {
+    let result = Token::new_checked(TokenKind::Identifier, "x", 10, 10);
+    assert_eq!(
+        result,
+        Err(TokenSpanError::EmptySpanDisallowed {
+            kind: TokenKind::Identifier,
+            start: 10,
+            end: 10,
+        })
+    );
+}
+
+#[test]
+fn checked_constructor_allows_empty_eof() {
+    let eof = Token::new_checked(TokenKind::Eof, "", 12, 12);
+    assert!(matches!(&eof, Ok(token) if token.kind == TokenKind::Eof && token.is_empty()));
+}
+
+#[test]
+fn checked_constructor_allows_empty_explicit_synthetic_unknown() {
+    let token = Token::new_checked(TokenKind::Unknown, "", 33, 33);
+    assert!(matches!(&token, Ok(t) if t.kind == TokenKind::Unknown && t.is_empty()));
+}
+
+#[test]
+fn eof_at_preserves_position() {
+    let eof = Token::eof_at(77);
+    assert_eq!(eof.kind, TokenKind::Eof);
+    assert_eq!(eof.start, 77);
+    assert_eq!(eof.end, 77);
+}
+
+#[test]
+fn unknown_at_creates_unknown_token_with_span() {
+    let token = Token::unknown_at("???", 9, 12);
+    assert_eq!(token.kind, TokenKind::Unknown);
+    assert_eq!(&*token.text, "???");
+    assert_eq!(token.range(), 9..12);
+}
+
+#[test]
+fn span_helpers_are_byte_range_consistent() {
+    let token = Token::new(TokenKind::Identifier, "hé", 3, 6);
+    let span = token.span();
+    assert_eq!(span, TokenSpan { start: 3, end: 6 });
+    assert_eq!(span.range(), 3..6);
+    assert_eq!(token.range(), 3..6);
+}
+
+#[test]
+fn token_with_span_and_with_kind_update_fields() {
+    let token = Token::new(TokenKind::Identifier, "name", 1, 5);
+    assert_eq!(TokenSpan::new(10, 14), Ok(TokenSpan { start: 10, end: 14 }));
+    let span = TokenSpan { start: 10, end: 14 };
+    let updated = token.clone().with_span(span);
+    assert_eq!(updated.start, 10);
+    assert_eq!(updated.end, 14);
+    assert_eq!(updated.kind, TokenKind::Identifier);
+
+    let kind_swapped = token.with_kind(TokenKind::Unknown);
+    assert_eq!(kind_swapped.kind, TokenKind::Unknown);
+    assert_eq!(kind_swapped.start, 1);
+    assert_eq!(kind_swapped.end, 5);
+}
+
+#[test]
+fn token_len_remains_saturating_for_compatibility() {
+    let token = Token::new(TokenKind::Unknown, "?", 20, 3);
+    assert_eq!(token.len(), 0);
+}


### PR DESCRIPTION
### Motivation

- Token byte spans could be malformed (for example `end < start`) and that silently allowed downstream bugs; the buffered token stream also synthesised EOF at position 0 which lost the original source EOF position.
- Make span correctness explicit and provide non-breaking, checked APIs so callers can opt into validation without changing the existing `Token::new` behavior.

### Description

- Introduced a typed `TokenSpan` and `TokenSpanError` to represent/validate byte spans and to return precise errors for inverted or disallowed spans.
- Added checked and helper APIs to `Token`: `try_new`, `new_checked`, `eof_at`, `unknown_at`, `span`, `range`, `with_span`, and `with_kind`, while keeping `Token::new` source-compatible and preserving saturating `len()` semantics.
- Updated `TokenStream` in `perl-parser-core` to track the last token end position (`eof_pos`) and synthesise EOF with `Token::eof_at(...)` so buffered-mode EOF preserves source position.
- Added focused tests in `crates/perl-token/tests/span_invariant_tests.rs` that exercise inverted spans, empty-span policy, EOF positioning, synthetic unknown tokens, and span/range helpers.

### Testing

- Ran `cargo xtask fmt` successfully to apply formatting across the workspace.
- Ran `cargo test -p perl-token` and all token tests passed (including the new span invariant tests).
- Ran `cargo test -p perl-parser-core token_stream` and the token-stream related tests passed.
- Ran `cargo check --workspace --all-targets` which failed due to a pre-existing, unrelated format-string compile error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs`; this failure is not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77cb117c8333a2cec0aee42bbcea)