### PR TITLE
feat(perl-token): add checked token spans and invariant helpers (#0000)

### DIFF
--- a/crates/perl-parser-core/src/tokens/token_stream.rs
+++ b/crates/perl-parser-core/src/tokens/token_stream.rs
@@ -50,7 +50,7 @@ enum TokenStreamInner<'a> {
     /// Live lexer producing tokens on demand from source text.
     Lexer(PerlLexer<'a>),
     /// Pre-lexed token buffer; used by [`TokenStream::from_vec`].
-    Buffered(VecDeque<Token>),
+    Buffered { tokens: VecDeque<Token>, eof_pos: usize },
 }
 
 /// Token stream that wraps perl-lexer or a pre-lexed token buffer.
@@ -108,7 +108,10 @@ impl<'a> TokenStream<'a> {
     /// ```
     pub fn from_vec(tokens: Vec<Token>) -> Self {
         TokenStream {
-            inner: TokenStreamInner::Buffered(VecDeque::from(tokens)),
+            inner: TokenStreamInner::Buffered {
+                eof_pos: tokens.last().map_or(0, |token| token.end),
+                tokens: VecDeque::from(tokens),
+            },
             peeked: None,
             peeked_second: None,
             peeked_third: None,
@@ -298,7 +301,9 @@ impl<'a> TokenStream<'a> {
     fn next_token(&mut self) -> ParseResult<Token> {
         match &mut self.inner {
             TokenStreamInner::Lexer(lexer) => Self::next_token_from_lexer(lexer),
-            TokenStreamInner::Buffered(buf) => Self::next_token_from_buf(buf),
+            TokenStreamInner::Buffered { tokens, eof_pos } => {
+                Self::next_token_from_buf(tokens, eof_pos)
+            }
         }
     }
 
@@ -327,13 +332,13 @@ impl<'a> TokenStream<'a> {
     }
 
     /// Return the next token from the pre-lexed buffer.
-    fn next_token_from_buf(buf: &mut VecDeque<Token>) -> ParseResult<Token> {
+    fn next_token_from_buf(buf: &mut VecDeque<Token>, eof_pos: &mut usize) -> ParseResult<Token> {
         match buf.pop_front() {
-            Some(token) => Ok(token),
-            // Synthesise an EOF at position 0 when the buffer is exhausted.
-            // The caller (parser) makes EOF sticky so position doesn't matter
-            // for correctness; using 0 is safe.
-            None => Ok(Token { kind: TokenKind::Eof, text: "".into(), start: 0, end: 0 }),
+            Some(token) => {
+                *eof_pos = token.end;
+                Ok(token)
+            }
+            None => Ok(Token::eof_at(*eof_pos)),
         }
     }
 

--- a/crates/perl-parser-core/tests/token_stream_tests.rs
+++ b/crates/perl-parser-core/tests/token_stream_tests.rs
@@ -1,4 +1,4 @@
-use perl_parser_core::token_stream::TokenStream;
+use perl_parser_core::token_stream::{Token, TokenKind, TokenStream};
 use perl_tdd_support::must;
 
 #[test]
@@ -54,5 +54,19 @@ fn stream_processes_multiple_tokens() -> Result<(), Box<dyn std::error::Error>> 
         }
     }
     assert!(count >= 4, "should have at least 4 tokens, got {}", count);
+    Ok(())
+}
+
+#[test]
+fn from_vec_synthesized_eof_uses_last_token_end() -> Result<(), Box<dyn std::error::Error>> {
+    let tokens = vec![Token::new(TokenKind::Identifier, "foo", 2, 5)];
+    let mut stream = TokenStream::from_vec(tokens);
+
+    let _first = must(stream.next());
+    let eof = must(stream.next());
+
+    assert_eq!(eof.kind, TokenKind::Eof);
+    assert_eq!(eof.start, 5);
+    assert_eq!(eof.end, 5);
     Ok(())
 }

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -37,6 +37,76 @@
 
 use std::sync::Arc;
 
+/// Byte span for a token.
+///
+/// A valid span always satisfies `start <= end`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenSpan {
+    /// Starting byte position (inclusive).
+    pub start: usize,
+    /// Ending byte position (exclusive).
+    pub end: usize,
+}
+
+impl TokenSpan {
+    /// Construct a checked span.
+    pub fn new(start: usize, end: usize) -> Result<Self, TokenSpanError> {
+        if end < start {
+            return Err(TokenSpanError::Inverted { start, end });
+        }
+        Ok(Self { start, end })
+    }
+
+    /// Span width in bytes.
+    pub fn len(self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// Return whether the span is empty.
+    pub fn is_empty(self) -> bool {
+        self.len() == 0
+    }
+
+    /// Convert to a standard `start..end` range.
+    pub fn range(self) -> std::ops::Range<usize> {
+        self.start..self.end
+    }
+}
+
+/// Error returned when a checked token span is invalid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenSpanError {
+    /// Span end offset is before start offset.
+    Inverted {
+        /// Provided starting byte position.
+        start: usize,
+        /// Provided ending byte position.
+        end: usize,
+    },
+    /// Zero-length spans are reserved for EOF/synthetic tokens in checked constructors.
+    EmptySpanNotAllowed {
+        /// Token kind for which an empty span was attempted.
+        kind: TokenKind,
+        /// Byte position where the empty span was requested.
+        pos: usize,
+    },
+}
+
+impl std::fmt::Display for TokenSpanError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TokenSpanError::Inverted { start, end } => {
+                write!(f, "invalid token span: end ({end}) is before start ({start})")
+            }
+            TokenSpanError::EmptySpanNotAllowed { kind, pos } => {
+                write!(f, "invalid empty span for token kind {} at byte {pos}", kind.display_name())
+            }
+        }
+    }
+}
+
+impl std::error::Error for TokenSpanError {}
+
 /// Token produced by the lexer and consumed by the parser.
 ///
 /// Stores the token kind, original source text, and byte span. The text is kept
@@ -67,6 +137,66 @@ impl Token {
     /// ```
     pub fn new(kind: TokenKind, text: impl Into<Arc<str>>, start: usize, end: usize) -> Self {
         Token { kind, text: text.into(), start, end }
+    }
+
+    /// Create a token with checked span invariants.
+    ///
+    /// Returns an error when `end < start`.
+    pub fn try_new(
+        kind: TokenKind,
+        text: impl Into<Arc<str>>,
+        start: usize,
+        end: usize,
+    ) -> Result<Self, TokenSpanError> {
+        let span = TokenSpan::new(start, end)?;
+        if span.is_empty() && !matches!(kind, TokenKind::Eof | TokenKind::Unknown) {
+            return Err(TokenSpanError::EmptySpanNotAllowed { kind, pos: span.start });
+        }
+        Ok(Self::new(kind, text, span.start, span.end))
+    }
+
+    /// Alias for [`Token::try_new`] to make checked construction explicit at callsites.
+    pub fn new_checked(
+        kind: TokenKind,
+        text: impl Into<Arc<str>>,
+        start: usize,
+        end: usize,
+    ) -> Result<Self, TokenSpanError> {
+        Self::try_new(kind, text, start, end)
+    }
+
+    /// Construct an EOF token at a specific byte position.
+    pub fn eof_at(pos: usize) -> Self {
+        Self::new(TokenKind::Eof, "", pos, pos)
+    }
+
+    /// Construct an unknown token for synthetic/recovery scenarios.
+    pub fn unknown_at(text: impl Into<Arc<str>>, start: usize, end: usize) -> Self {
+        Self::new(TokenKind::Unknown, text, start, end)
+    }
+
+    /// Return the token byte span.
+    pub fn span(&self) -> TokenSpan {
+        TokenSpan { start: self.start, end: self.end }
+    }
+
+    /// Return the token byte range.
+    pub fn range(&self) -> std::ops::Range<usize> {
+        self.start..self.end
+    }
+
+    /// Return a new token with the same kind/text and a different span.
+    pub fn with_span(&self, start: usize, end: usize) -> Result<Self, TokenSpanError> {
+        let span = TokenSpan::new(start, end)?;
+        if span.is_empty() && !matches!(self.kind, TokenKind::Eof | TokenKind::Unknown) {
+            return Err(TokenSpanError::EmptySpanNotAllowed { kind: self.kind, pos: span.start });
+        }
+        Ok(Self::new(self.kind, self.text.clone(), span.start, span.end))
+    }
+
+    /// Return a new token with a different kind and the same text/span.
+    pub fn with_kind(&self, kind: TokenKind) -> Self {
+        Self::new(kind, self.text.clone(), self.start, self.end)
     }
 
     /// Return the token span length in bytes.

--- a/crates/perl-token/tests/span_invariant_tests.rs
+++ b/crates/perl-token/tests/span_invariant_tests.rs
@@ -1,0 +1,83 @@
+use perl_token::{Token, TokenKind, TokenSpan, TokenSpanError};
+use std::ops::Range;
+
+#[test]
+fn checked_constructor_rejects_inverted_span() {
+    let err = Token::try_new(TokenKind::Identifier, "foo", 5, 2)
+        .expect_err("checked constructors should reject end < start");
+    assert_eq!(err, TokenSpanError::Inverted { start: 5, end: 2 });
+}
+
+#[test]
+fn checked_constructor_rejects_empty_non_synthetic_token() {
+    let err = Token::new_checked(TokenKind::Identifier, "", 4, 4)
+        .expect_err("checked constructors should reject empty non-synthetic tokens");
+    assert_eq!(err, TokenSpanError::EmptySpanNotAllowed { kind: TokenKind::Identifier, pos: 4 });
+}
+
+#[test]
+fn checked_constructor_allows_empty_for_eof() {
+    let tok =
+        Token::new_checked(TokenKind::Eof, "", 9, 9).expect("EOF should allow empty checked spans");
+    assert_eq!(tok.start, 9);
+    assert_eq!(tok.end, 9);
+    assert!(tok.is_empty());
+}
+
+#[test]
+fn eof_at_preserves_position() {
+    let tok = Token::eof_at(27);
+    assert_eq!(tok.kind, TokenKind::Eof);
+    assert_eq!(tok.start, 27);
+    assert_eq!(tok.end, 27);
+    assert_eq!(tok.range(), Range { start: 27, end: 27 });
+}
+
+#[test]
+fn unknown_at_supports_synthetic_tokens() {
+    let tok = Token::unknown_at("???", 12, 12);
+    assert_eq!(tok.kind, TokenKind::Unknown);
+    assert_eq!(&*tok.text, "???");
+    assert!(tok.is_empty());
+}
+
+#[test]
+fn span_and_range_use_byte_offsets() {
+    let tok = Token::new(TokenKind::String, "hé", 10, 14);
+    let span = tok.span();
+    assert_eq!(span, TokenSpan { start: 10, end: 14 });
+    assert_eq!(span.len(), 4);
+    assert_eq!(tok.range(), 10..14);
+}
+
+#[test]
+fn with_span_returns_checked_copy() {
+    let tok = Token::new(TokenKind::Identifier, "name", 0, 4);
+    let shifted = tok.with_span(8, 12).expect("valid span should succeed");
+    assert_eq!(shifted.kind, TokenKind::Identifier);
+    assert_eq!(&*shifted.text, "name");
+    assert_eq!(shifted.range(), 8..12);
+}
+
+#[test]
+fn with_span_rejects_invalid_range() {
+    let tok = Token::new(TokenKind::Identifier, "name", 0, 4);
+    let err = tok.with_span(3, 1).expect_err("invalid range must fail");
+    assert_eq!(err, TokenSpanError::Inverted { start: 3, end: 1 });
+}
+
+#[test]
+fn with_kind_preserves_text_and_span() {
+    let tok = Token::new(TokenKind::Identifier, "foo", 2, 5);
+    let retyped = tok.with_kind(TokenKind::String);
+    assert_eq!(retyped.kind, TokenKind::String);
+    assert_eq!(&*retyped.text, "foo");
+    assert_eq!(retyped.start, 2);
+    assert_eq!(retyped.end, 5);
+}
+
+#[test]
+fn token_span_new_rejects_inverted_ranges() {
+    let err = TokenSpan::new(11, 3).expect_err("inverted span should be rejected");
+    assert_eq!(err, TokenSpanError::Inverted { start: 11, end: 3 });
+}


### PR DESCRIPTION
### Motivation

- Make token span correctness explicit to avoid silent malformed spans while preserving the existing `Token::new` API for source compatibility.
- Ensure downstream parser, diagnostics, semantic tokens, and incremental parsing rely on explicit, checked span semantics.

### Description

- Add a small typed span helper `TokenSpan` and an error type `TokenSpanError` with checked construction (`TokenSpan::new`).
- Add non-breaking checked token constructors and helpers: `Token::try_new`, `Token::new_checked`, `Token::eof_at`, `Token::unknown_at`, `Token::span`, `Token::range`, `Token::with_span`, and `Token::with_kind`, while leaving `Token::new` unchanged.
- Define invariants so `start <= end` is enforced and empty spans are rejected for non-synthetic/non-EOF tokens, with `len()` still using saturating subtraction for compatibility.
- Update `TokenStream::from_vec`/buffered path to synthesise EOF at the last observed token end instead of `0`, and add a test asserting the behaviour.
- Add focused tests in `crates/perl-token/tests/span_invariant_tests.rs` and extend `crates/perl-parser-core/tests/token_stream_tests.rs` to cover synthesized EOF positioning.

### Testing

- Ran `cargo test -p perl-token` and all token tests passed successfully.
- Ran `cargo test -p perl-parser-core token_stream` and the token-stream tests (including the new EOF-position test) passed successfully.
- Ran `cargo xtask fmt` and `cargo check --workspace --all-targets`; the workspace check failed due to a pre-existing unrelated compile error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` (format string mismatch) and not because of the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77cb117c8333a2cec0aee42bbcea)