### PR TITLE
feat(perl-token): add checked token spans and invariant helpers (#0000)

### DIFF
--- a/crates/perl-parser-core/src/tokens/token_stream.rs
+++ b/crates/perl-parser-core/src/tokens/token_stream.rs
@@ -59,6 +59,7 @@ enum TokenStreamInner<'a> {
 /// and statement-boundary state management used by the recursive-descent parser.
 pub struct TokenStream<'a> {
     inner: TokenStreamInner<'a>,
+    buffered_last_end: usize,
     peeked: Option<Token>,
     peeked_second: Option<Token>,
     peeked_third: Option<Token>,
@@ -69,6 +70,7 @@ impl<'a> TokenStream<'a> {
     pub fn new(input: &'a str) -> Self {
         TokenStream {
             inner: TokenStreamInner::Lexer(PerlLexer::new(input)),
+            buffered_last_end: 0,
             peeked: None,
             peeked_second: None,
             peeked_third: None,
@@ -107,8 +109,10 @@ impl<'a> TokenStream<'a> {
     /// assert!(matches!(stream.peek(), Ok(t) if t.kind == TokenKind::My));
     /// ```
     pub fn from_vec(tokens: Vec<Token>) -> Self {
+        let buffered_last_end = tokens.last().map_or(0, |t| t.end);
         TokenStream {
             inner: TokenStreamInner::Buffered(VecDeque::from(tokens)),
+            buffered_last_end,
             peeked: None,
             peeked_second: None,
             peeked_third: None,
@@ -298,7 +302,9 @@ impl<'a> TokenStream<'a> {
     fn next_token(&mut self) -> ParseResult<Token> {
         match &mut self.inner {
             TokenStreamInner::Lexer(lexer) => Self::next_token_from_lexer(lexer),
-            TokenStreamInner::Buffered(buf) => Self::next_token_from_buf(buf),
+            TokenStreamInner::Buffered(buf) => {
+                Self::next_token_from_buf(buf, &mut self.buffered_last_end)
+            }
         }
     }
 
@@ -327,13 +333,17 @@ impl<'a> TokenStream<'a> {
     }
 
     /// Return the next token from the pre-lexed buffer.
-    fn next_token_from_buf(buf: &mut VecDeque<Token>) -> ParseResult<Token> {
+    fn next_token_from_buf(
+        buf: &mut VecDeque<Token>,
+        buffered_last_end: &mut usize,
+    ) -> ParseResult<Token> {
         match buf.pop_front() {
-            Some(token) => Ok(token),
-            // Synthesise an EOF at position 0 when the buffer is exhausted.
-            // The caller (parser) makes EOF sticky so position doesn't matter
-            // for correctness; using 0 is safe.
-            None => Ok(Token { kind: TokenKind::Eof, text: "".into(), start: 0, end: 0 }),
+            Some(token) => {
+                *buffered_last_end = token.end;
+                Ok(token)
+            }
+            // Synthesise an EOF at the current buffered cursor position.
+            None => Ok(Token::eof_at(*buffered_last_end)),
         }
     }
 

--- a/crates/perl-parser-core/tests/token_stream_extended_tests.rs
+++ b/crates/perl-parser-core/tests/token_stream_extended_tests.rs
@@ -1,4 +1,4 @@
-use perl_parser_core::token_stream::TokenStream;
+use perl_parser_core::token_stream::{Token, TokenKind, TokenStream};
 
 #[test]
 fn on_stmt_boundary_resets_peek() -> Result<(), Box<dyn std::error::Error>> {
@@ -54,5 +54,20 @@ fn enter_format_mode_does_not_crash() -> Result<(), Box<dyn std::error::Error>> 
     if let Ok(token) = stream.peek() {
         let _ = format!("{:?}", token.kind);
     }
+    Ok(())
+}
+
+#[test]
+fn from_vec_synthesized_eof_uses_last_token_end() -> Result<(), Box<dyn std::error::Error>> {
+    let tokens =
+        vec![Token::new(TokenKind::My, "my", 0, 2), Token::new(TokenKind::Identifier, "x", 3, 4)];
+    let mut stream = TokenStream::from_vec(tokens);
+    let _ = stream.next()?;
+    let _ = stream.next()?;
+    let eof = stream.next()?;
+
+    assert_eq!(eof.kind, TokenKind::Eof);
+    assert_eq!(eof.start, 4);
+    assert_eq!(eof.end, 4);
     Ok(())
 }

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -35,7 +35,63 @@
 //! assert_eq!(TokenKind::Eof.display_name(), "end of input");
 //! ```
 
-use std::sync::Arc;
+use std::{ops::Range, sync::Arc};
+
+/// Span invariant error returned by checked token constructors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenSpanError {
+    /// Starting byte offset that failed validation.
+    pub start: usize,
+    /// Ending byte offset that failed validation.
+    pub end: usize,
+}
+
+impl std::fmt::Display for TokenSpanError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid token span: start {} is greater than end {}", self.start, self.end)
+    }
+}
+
+impl std::error::Error for TokenSpanError {}
+
+/// Typed byte span for token boundaries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenSpan {
+    /// Inclusive start byte offset.
+    pub start: usize,
+    /// Exclusive end byte offset.
+    pub end: usize,
+}
+
+impl TokenSpan {
+    /// Create a checked span (`start <= end`).
+    pub fn try_new(start: usize, end: usize) -> Result<Self, TokenSpanError> {
+        if end < start {
+            return Err(TokenSpanError { start, end });
+        }
+        Ok(Self { start, end })
+    }
+
+    /// Create a checked span (`start <= end`).
+    pub fn new_checked(start: usize, end: usize) -> Result<Self, TokenSpanError> {
+        Self::try_new(start, end)
+    }
+
+    /// Return the span length in bytes.
+    pub fn len(self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// Return whether this span is empty.
+    pub fn is_empty(self) -> bool {
+        self.len() == 0
+    }
+
+    /// Convert to `std::ops::Range<usize>`.
+    pub fn range(self) -> Range<usize> {
+        self.start..self.end
+    }
+}
 
 /// Token produced by the lexer and consumed by the parser.
 ///
@@ -67,6 +123,67 @@ impl Token {
     /// ```
     pub fn new(kind: TokenKind, text: impl Into<Arc<str>>, start: usize, end: usize) -> Self {
         Token { kind, text: text.into(), start, end }
+    }
+
+    /// Create a token while enforcing span invariants.
+    ///
+    /// Invariants:
+    /// - `start <= end`
+    /// - empty spans are allowed for [`TokenKind::Eof`] and synthetic
+    ///   [`TokenKind::Unknown`] tokens
+    pub fn try_new(
+        kind: TokenKind,
+        text: impl Into<Arc<str>>,
+        start: usize,
+        end: usize,
+    ) -> Result<Self, TokenSpanError> {
+        let span = TokenSpan::try_new(start, end)?;
+        if span.is_empty() && !matches!(kind, TokenKind::Eof | TokenKind::Unknown) {
+            return Err(TokenSpanError { start, end });
+        }
+        Ok(Self { kind, text: text.into(), start, end })
+    }
+
+    /// Create a token while enforcing span invariants.
+    pub fn new_checked(
+        kind: TokenKind,
+        text: impl Into<Arc<str>>,
+        start: usize,
+        end: usize,
+    ) -> Result<Self, TokenSpanError> {
+        Self::try_new(kind, text, start, end)
+    }
+
+    /// Create an EOF token located at a specific byte position.
+    pub fn eof_at(pos: usize) -> Self {
+        Self::new(TokenKind::Eof, "", pos, pos)
+    }
+
+    /// Create an `Unknown` token at the given byte span.
+    ///
+    /// This helper is intended for synthetic/error-recovery token creation.
+    pub fn unknown_at(text: impl Into<Arc<str>>, start: usize, end: usize) -> Self {
+        Self::new(TokenKind::Unknown, text, start, end)
+    }
+
+    /// Return this token's span as a typed helper.
+    pub fn span(&self) -> TokenSpan {
+        TokenSpan { start: self.start, end: self.end }
+    }
+
+    /// Return this token span as a `Range<usize>`.
+    pub fn range(&self) -> Range<usize> {
+        self.start..self.end
+    }
+
+    /// Return a clone of this token with a new span.
+    pub fn with_span(self, span: TokenSpan) -> Self {
+        Self { start: span.start, end: span.end, ..self }
+    }
+
+    /// Return a clone of this token with a different kind.
+    pub fn with_kind(self, kind: TokenKind) -> Self {
+        Self { kind, ..self }
     }
 
     /// Return the token span length in bytes.

--- a/crates/perl-token/tests/span_invariant_tests.rs
+++ b/crates/perl-token/tests/span_invariant_tests.rs
@@ -1,0 +1,68 @@
+use perl_token::{Token, TokenKind, TokenSpan};
+
+#[test]
+fn checked_constructors_reject_reversed_spans() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(Token::try_new(TokenKind::Identifier, "x", 5, 2).is_err());
+    assert!(Token::new_checked(TokenKind::Identifier, "x", 5, 2).is_err());
+    assert!(TokenSpan::try_new(5, 2).is_err());
+    Ok(())
+}
+
+#[test]
+fn checked_constructors_reject_empty_non_synthetic_tokens() -> Result<(), Box<dyn std::error::Error>>
+{
+    assert!(Token::try_new(TokenKind::Identifier, "", 9, 9).is_err());
+    assert!(Token::new_checked(TokenKind::Semicolon, ";", 1, 1).is_err());
+    Ok(())
+}
+
+#[test]
+fn checked_constructors_allow_empty_eof_and_unknown_tokens()
+-> Result<(), Box<dyn std::error::Error>> {
+    let eof = Token::try_new(TokenKind::Eof, "", 11, 11)?;
+    let unknown = Token::new_checked(TokenKind::Unknown, "", 11, 11)?;
+    assert!(eof.is_empty());
+    assert!(unknown.is_empty());
+    Ok(())
+}
+
+#[test]
+fn eof_at_preserves_requested_position() -> Result<(), Box<dyn std::error::Error>> {
+    let eof = Token::eof_at(123);
+    assert_eq!(eof.kind, TokenKind::Eof);
+    assert_eq!(eof.start, 123);
+    assert_eq!(eof.end, 123);
+    assert!(eof.range().is_empty());
+    Ok(())
+}
+
+#[test]
+fn unknown_at_supports_synthetic_tokens() -> Result<(), Box<dyn std::error::Error>> {
+    let synthetic = Token::unknown_at("<synthetic>", 20, 31);
+    assert_eq!(synthetic.kind, TokenKind::Unknown);
+    assert_eq!(synthetic.range(), 20..31);
+    assert_eq!(synthetic.span(), TokenSpan { start: 20, end: 31 });
+    Ok(())
+}
+
+#[test]
+fn with_span_and_with_kind_are_non_destructive_helpers() -> Result<(), Box<dyn std::error::Error>> {
+    let token = Token::new(TokenKind::Identifier, "foo", 2, 5);
+    let moved = token.clone().with_span(TokenSpan::new_checked(30, 33)?);
+    let retagged = token.clone().with_kind(TokenKind::Unknown);
+
+    assert_eq!(moved.text, token.text);
+    assert_eq!(moved.range(), 30..33);
+    assert_eq!(retagged.kind, TokenKind::Unknown);
+    assert_eq!(retagged.range(), token.range());
+    Ok(())
+}
+
+#[test]
+fn token_span_range_and_len_use_byte_offsets() -> Result<(), Box<dyn std::error::Error>> {
+    let span = TokenSpan::new_checked(4, 9)?;
+    assert_eq!(span.range(), 4..9);
+    assert_eq!(span.len(), 5);
+    assert!(!span.is_empty());
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Make token span correctness explicit so downstream parser, diagnostics, and incremental parsing rely on sane byte offsets.
- Preserve the existing `Token::new` API for source-compatibility while providing checked constructors and helpers to fail fast on invalid spans.
- Ensure EOF synthesized by buffered `TokenStream` preserves intended source position instead of always using `0..0`.

### Description

- Introduced `TokenSpan` and `TokenSpanError` with `try_new`/`new_checked`, `len`, `is_empty`, and `range` helpers in `crates/perl-token/src/lib.rs`.
- Added non-breaking token helpers: `Token::try_new`, `Token::new_checked`, `Token::eof_at`, `Token::unknown_at`, `Token::span`, `Token::range`, `Token::with_span`, and `Token::with_kind` while keeping `Token::new` and `Token::len()` unchanged.
- Updated `TokenStream` buffered path to track the last consumed token end (`buffered_last_end`) and synthesise EOF at that position (in `crates/perl-parser-core/src/tokens/token_stream.rs`).
- Added focused unit tests: `crates/perl-token/tests/span_invariant_tests.rs` for span invariants and helpers, and `crates/perl-parser-core/tests/token_stream_extended_tests.rs` test to assert synthesized EOF uses the last token end.

### Testing

- Ran `cargo test -p perl-token` and all token tests passed.
- Ran `cargo test -p perl-parser-core token_stream` and the `token_stream` tests (including the new EOF regression) passed.
- Ran `cargo check --workspace --all-targets` which failed due to a pre-existing unrelated format-string error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77cb117c8333a2cec0aee42bbcea)