### PR TITLE
feat(perl-token): add checked token spans and invariant helpers (#6464)

### DIFF
--- a/crates/perl-parser-core/src/tokens/token_stream.rs
+++ b/crates/perl-parser-core/src/tokens/token_stream.rs
@@ -59,6 +59,7 @@ enum TokenStreamInner<'a> {
 /// and statement-boundary state management used by the recursive-descent parser.
 pub struct TokenStream<'a> {
     inner: TokenStreamInner<'a>,
+    buffered_eof_pos: usize,
     peeked: Option<Token>,
     peeked_second: Option<Token>,
     peeked_third: Option<Token>,
@@ -69,6 +70,7 @@ impl<'a> TokenStream<'a> {
     pub fn new(input: &'a str) -> Self {
         TokenStream {
             inner: TokenStreamInner::Lexer(PerlLexer::new(input)),
+            buffered_eof_pos: input.len(),
             peeked: None,
             peeked_second: None,
             peeked_third: None,
@@ -107,8 +109,14 @@ impl<'a> TokenStream<'a> {
     /// assert!(matches!(stream.peek(), Ok(t) if t.kind == TokenKind::My));
     /// ```
     pub fn from_vec(tokens: Vec<Token>) -> Self {
+        let buffered_eof_pos = tokens
+            .last()
+            .map(|token| if token.kind == TokenKind::Eof { token.start } else { token.end })
+            .unwrap_or(0);
+
         TokenStream {
             inner: TokenStreamInner::Buffered(VecDeque::from(tokens)),
+            buffered_eof_pos,
             peeked: None,
             peeked_second: None,
             peeked_third: None,
@@ -298,7 +306,9 @@ impl<'a> TokenStream<'a> {
     fn next_token(&mut self) -> ParseResult<Token> {
         match &mut self.inner {
             TokenStreamInner::Lexer(lexer) => Self::next_token_from_lexer(lexer),
-            TokenStreamInner::Buffered(buf) => Self::next_token_from_buf(buf),
+            TokenStreamInner::Buffered(buf) => {
+                Self::next_token_from_buf(buf, &mut self.buffered_eof_pos)
+            }
         }
     }
 
@@ -327,13 +337,18 @@ impl<'a> TokenStream<'a> {
     }
 
     /// Return the next token from the pre-lexed buffer.
-    fn next_token_from_buf(buf: &mut VecDeque<Token>) -> ParseResult<Token> {
+    fn next_token_from_buf(
+        buf: &mut VecDeque<Token>,
+        buffered_eof_pos: &mut usize,
+    ) -> ParseResult<Token> {
         match buf.pop_front() {
-            Some(token) => Ok(token),
-            // Synthesise an EOF at position 0 when the buffer is exhausted.
-            // The caller (parser) makes EOF sticky so position doesn't matter
-            // for correctness; using 0 is safe.
-            None => Ok(Token { kind: TokenKind::Eof, text: "".into(), start: 0, end: 0 }),
+            Some(token) => {
+                *buffered_eof_pos =
+                    if token.kind == TokenKind::Eof { token.start } else { token.end };
+                Ok(token)
+            }
+            // Synthesise EOF at the most recently known source position.
+            None => Ok(Token::eof_at(*buffered_eof_pos)),
         }
     }
 

--- a/crates/perl-parser-core/tests/token_stream_tests.rs
+++ b/crates/perl-parser-core/tests/token_stream_tests.rs
@@ -1,4 +1,4 @@
-use perl_parser_core::token_stream::TokenStream;
+use perl_parser_core::token_stream::{Token, TokenKind, TokenStream};
 use perl_tdd_support::must;
 
 #[test]
@@ -54,5 +54,21 @@ fn stream_processes_multiple_tokens() -> Result<(), Box<dyn std::error::Error>> 
         }
     }
     assert!(count >= 4, "should have at least 4 tokens, got {}", count);
+    Ok(())
+}
+
+#[test]
+fn buffered_stream_synthesizes_eof_at_last_token_end() -> Result<(), Box<dyn std::error::Error>> {
+    let mut stream = TokenStream::from_vec(vec![
+        Token::new(TokenKind::My, "my", 0, 2),
+        Token::new(TokenKind::Identifier, "x", 3, 4),
+    ]);
+
+    let _ = must(stream.next());
+    let _ = must(stream.next());
+    let eof = must(stream.next());
+    assert_eq!(eof.kind, TokenKind::Eof);
+    assert_eq!(eof.start, 4);
+    assert_eq!(eof.end, 4);
     Ok(())
 }

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -35,7 +35,71 @@
 //! assert_eq!(TokenKind::Eof.display_name(), "end of input");
 //! ```
 
-use std::sync::Arc;
+use std::{ops::Range, sync::Arc};
+
+/// Byte span carried by a [`Token`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenSpan {
+    /// Starting byte position.
+    pub start: usize,
+    /// Ending byte position.
+    pub end: usize,
+}
+
+impl TokenSpan {
+    /// Create a span from raw byte positions.
+    pub const fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+
+    /// Create a span, returning an error when `end < start`.
+    pub fn try_new(start: usize, end: usize) -> Result<Self, TokenSpanError> {
+        if end < start {
+            return Err(TokenSpanError::EndBeforeStart { start, end });
+        }
+
+        Ok(Self { start, end })
+    }
+
+    /// Span length in bytes.
+    pub const fn len(self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// Whether the span length is zero bytes.
+    pub const fn is_empty(self) -> bool {
+        self.len() == 0
+    }
+
+    /// Convert this span to a standard `Range`.
+    pub const fn range(self) -> Range<usize> {
+        self.start..self.end
+    }
+}
+
+/// Error type for checked token/span constructors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenSpanError {
+    /// End offset is before start offset.
+    EndBeforeStart { start: usize, end: usize },
+    /// Empty span is only valid for EOF or explicit synthetic tokens.
+    EmptySpanNotAllowed { kind: TokenKind, at: usize },
+}
+
+impl std::fmt::Display for TokenSpanError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EndBeforeStart { start, end } => {
+                write!(f, "token span invariant violated: end ({end}) < start ({start})")
+            }
+            Self::EmptySpanNotAllowed { kind, at } => {
+                write!(f, "empty span not allowed for token kind {kind:?} at byte {at}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TokenSpanError {}
 
 /// Borrowed view over token data for allocation-sensitive paths.
 ///
@@ -115,6 +179,69 @@ impl Token {
     /// ```
     pub fn new(kind: TokenKind, text: impl Into<Arc<str>>, start: usize, end: usize) -> Self {
         Token { kind, text: text.into(), start, end }
+    }
+
+    /// Create a token with checked span ordering.
+    ///
+    /// Unlike [`Token::new`], this rejects spans where `end < start`.
+    pub fn try_new(
+        kind: TokenKind,
+        text: impl Into<Arc<str>>,
+        start: usize,
+        end: usize,
+    ) -> Result<Self, TokenSpanError> {
+        let span = TokenSpan::try_new(start, end)?;
+        Ok(Self { kind, text: text.into(), start: span.start, end: span.end })
+    }
+
+    /// Create a token while enforcing span invariants.
+    ///
+    /// Rules:
+    /// - `start <= end`
+    /// - zero-length spans are accepted only for EOF tokens
+    pub fn new_checked(
+        kind: TokenKind,
+        text: impl Into<Arc<str>>,
+        start: usize,
+        end: usize,
+    ) -> Result<Self, TokenSpanError> {
+        let token = Self::try_new(kind, text, start, end)?;
+        if token.is_empty() && token.kind != TokenKind::Eof {
+            return Err(TokenSpanError::EmptySpanNotAllowed { kind: token.kind, at: token.start });
+        }
+
+        Ok(token)
+    }
+
+    /// Create an EOF token at `pos`.
+    pub fn eof_at(pos: usize) -> Self {
+        Self::new(TokenKind::Eof, "", pos, pos)
+    }
+
+    /// Create an unknown (synthetic) token at `start..end`.
+    pub fn unknown_at(text: impl Into<Arc<str>>, start: usize, end: usize) -> Self {
+        let bounded_end = end.max(start);
+        Self::new(TokenKind::Unknown, text, start, bounded_end)
+    }
+
+    /// Return this token's byte span.
+    pub fn span(&self) -> TokenSpan {
+        TokenSpan::new(self.start, self.end)
+    }
+
+    /// Return this token's byte span as `Range<usize>`.
+    pub fn range(&self) -> Range<usize> {
+        self.span().range()
+    }
+
+    /// Clone this token with a new checked span.
+    pub fn with_span(&self, start: usize, end: usize) -> Result<Self, TokenSpanError> {
+        Self::new_checked(self.kind, self.text.clone(), start, end)
+    }
+
+    /// Clone this token with a new token kind.
+    pub fn with_kind(&self, kind: TokenKind) -> Self {
+        Self::new(kind, self.text.clone(), self.start, self.end)
     }
 
     /// Return the token span length in bytes.

--- a/crates/perl-token/tests/span_invariant_tests.rs
+++ b/crates/perl-token/tests/span_invariant_tests.rs
@@ -1,0 +1,82 @@
+use perl_token::{Token, TokenKind, TokenSpan, TokenSpanError};
+
+#[test]
+fn try_new_rejects_end_before_start() -> Result<(), Box<dyn std::error::Error>> {
+    let err = match Token::try_new(TokenKind::Identifier, "x", 8, 3) {
+        Ok(_) => return Err("checked constructor should reject invalid ordering".into()),
+        Err(err) => err,
+    };
+    assert_eq!(err, TokenSpanError::EndBeforeStart { start: 8, end: 3 });
+    Ok(())
+}
+
+#[test]
+fn new_checked_rejects_empty_non_eof_tokens() -> Result<(), Box<dyn std::error::Error>> {
+    let err = match Token::new_checked(TokenKind::Identifier, "", 4, 4) {
+        Ok(_) => return Err("empty non-EOF token should be rejected".into()),
+        Err(err) => err,
+    };
+    assert_eq!(err, TokenSpanError::EmptySpanNotAllowed { kind: TokenKind::Identifier, at: 4 });
+    Ok(())
+}
+
+#[test]
+fn new_checked_allows_empty_eof_tokens() -> Result<(), Box<dyn std::error::Error>> {
+    let tok = Token::new_checked(TokenKind::Eof, "", 9, 9)?;
+    assert_eq!(tok.start, 9);
+    assert_eq!(tok.end, 9);
+    assert!(tok.is_empty());
+    Ok(())
+}
+
+#[test]
+fn eof_at_preserves_position() -> Result<(), Box<dyn std::error::Error>> {
+    let eof = Token::eof_at(123);
+    assert_eq!(eof.kind, TokenKind::Eof);
+    assert_eq!(eof.start, 123);
+    assert_eq!(eof.end, 123);
+    assert_eq!(&*eof.text, "");
+    Ok(())
+}
+
+#[test]
+fn unknown_at_supports_synthetic_empty_spans() -> Result<(), Box<dyn std::error::Error>> {
+    let unknown = Token::unknown_at("<synthetic>", 17, 17);
+    assert_eq!(unknown.kind, TokenKind::Unknown);
+    assert_eq!(unknown.start, 17);
+    assert_eq!(unknown.end, 17);
+    assert!(unknown.is_empty());
+    Ok(())
+}
+
+#[test]
+fn span_helpers_use_byte_offsets() -> Result<(), Box<dyn std::error::Error>> {
+    let tok = Token::new(TokenKind::Identifier, "foo", 5, 8);
+    let span = tok.span();
+
+    assert_eq!(span, TokenSpan::new(5, 8));
+    assert_eq!(span.len(), 3);
+    assert!(!span.is_empty());
+    assert_eq!(tok.range(), 5..8);
+    Ok(())
+}
+
+#[test]
+fn with_helpers_preserve_invariants() -> Result<(), Box<dyn std::error::Error>> {
+    let base = Token::new(TokenKind::Identifier, "name", 10, 14);
+
+    let changed_kind = base.with_kind(TokenKind::Sub);
+    assert_eq!(changed_kind.kind, TokenKind::Sub);
+    assert_eq!(changed_kind.range(), 10..14);
+
+    let changed_span = changed_kind.with_span(20, 24)?;
+    assert_eq!(changed_span.kind, TokenKind::Sub);
+    assert_eq!(changed_span.range(), 20..24);
+
+    let err = match changed_span.with_span(24, 20) {
+        Ok(_) => return Err("with_span should reject reversed spans".into()),
+        Err(err) => err,
+    };
+    assert_eq!(err, TokenSpanError::EndBeforeStart { start: 24, end: 20 });
+    Ok(())
+}

--- a/crates/perl-token/tests/span_invariant_tests.rs
+++ b/crates/perl-token/tests/span_invariant_tests.rs
@@ -50,6 +50,38 @@ fn unknown_at_supports_synthetic_empty_spans() -> Result<(), Box<dyn std::error:
 }
 
 #[test]
+fn unknown_at_clamps_inverted_span_to_start() -> Result<(), Box<dyn std::error::Error>> {
+    // unknown_at uses end.max(start) to silently clamp inverted spans.
+    // This is the intentional escape hatch for synthetic tokens that bypasses
+    // try_new/new_checked validation.
+    let unknown = Token::unknown_at("<inverted>", 20, 10);
+    assert_eq!(unknown.start, 20);
+    assert_eq!(unknown.end, 20, "inverted end should be clamped to start");
+    assert!(unknown.is_empty());
+    Ok(())
+}
+
+#[test]
+fn token_span_try_new_rejects_end_before_start() -> Result<(), Box<dyn std::error::Error>> {
+    // TokenSpan::try_new is the span-level checked constructor (separate from Token::try_new).
+    let err = TokenSpan::try_new(100, 50)
+        .expect_err("span-level try_new should reject end < start");
+    assert_eq!(err, TokenSpanError::EndBeforeStart { start: 100, end: 50 });
+    Ok(())
+}
+
+#[test]
+fn token_span_try_new_allows_equal_start_end() -> Result<(), Box<dyn std::error::Error>> {
+    // Equal start and end is a zero-length span — valid for EOF/synthetic uses.
+    let span = TokenSpan::try_new(42, 42)?;
+    assert_eq!(span.start, 42);
+    assert_eq!(span.end, 42);
+    assert!(span.is_empty());
+    assert_eq!(span.len(), 0);
+    Ok(())
+}
+
+#[test]
 fn span_helpers_use_byte_offsets() -> Result<(), Box<dyn std::error::Error>> {
     let tok = Token::new(TokenKind::Identifier, "foo", 5, 8);
     let span = tok.span();


### PR DESCRIPTION
### Motivation

- Make token span correctness explicit so byte offsets cannot silently be malformed, and ensure downstream parser and tooling observe sane EOF/synthetic positions.

### Description

- Add a typed span `TokenSpan` and error `TokenSpanError` with `try_new`, `len`, `is_empty`, and `range` helpers to represent byte-span invariants.  
- Add non-breaking `Token` helpers: `try_new`, `new_checked`, `eof_at`, `unknown_at`, `span`, `range`, `with_span`, and `with_kind` while preserving the existing `Token::new` API and keeping `len()` saturating for compatibility.  
- Treat empty spans as valid only for `Eof` or explicit synthetic usage and have checked constructors reject `end < start`.  
- Update buffered `TokenStream` to synthesise EOF at the last known source position (instead of `0`) and add tests to validate EOF span preservation and span invariants.  

### Testing

- Ran `cargo test -p perl-token` and all `perl-token` unit tests passed.  
- Ran `cargo test -p perl-parser-core token_stream` and `cargo test -p perl-parser-core --test token_stream_tests` and the token-stream related tests passed.  
- Ran `cargo check --workspace --all-targets` which mostly succeeded but reported a pre-existing unrelated test compile error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` (format string mismatch) that is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77cb117c8333a2cec0aee42bbcea)