### PR TITLE
feat(perl-token): centralize keyword and operator mapping helpers (#0000)

### DIFF
--- a/crates/perl-parser-core/src/tokens/token_stream.rs
+++ b/crates/perl-parser-core/src/tokens/token_stream.rs
@@ -343,121 +343,19 @@ impl<'a> TokenStream<'a> {
     fn convert_lexer_token(token: LexerToken) -> Token {
         let kind = match &token.token_type {
             // Keywords
-            LexerTokenType::Keyword(kw) => match kw.as_ref() {
-                "my" => TokenKind::My,
-                "our" => TokenKind::Our,
-                "local" => TokenKind::Local,
-                "state" => TokenKind::State,
-                "sub" => TokenKind::Sub,
-                "if" => TokenKind::If,
-                "elsif" => TokenKind::Elsif,
-                "else" => TokenKind::Else,
-                "unless" => TokenKind::Unless,
-                "while" => TokenKind::While,
-                "until" => TokenKind::Until,
-                "for" => TokenKind::For,
-                "foreach" => TokenKind::Foreach,
-                "return" => TokenKind::Return,
-                "package" => TokenKind::Package,
-                "use" => TokenKind::Use,
-                "no" => TokenKind::No,
-                "BEGIN" => TokenKind::Begin,
-                "END" => TokenKind::End,
-                "CHECK" => TokenKind::Check,
-                "INIT" => TokenKind::Init,
-                "UNITCHECK" => TokenKind::Unitcheck,
-                "eval" => TokenKind::Eval,
-                "do" => TokenKind::Do,
-                "given" => TokenKind::Given,
-                "when" => TokenKind::When,
-                "default" => TokenKind::Default,
-                "try" => TokenKind::Try,
-                "catch" => TokenKind::Catch,
-                "field" => TokenKind::Field,
-                "finally" => TokenKind::Finally,
-                "continue" => TokenKind::Continue,
-                "next" => TokenKind::Next,
-                "last" => TokenKind::Last,
-                "redo" => TokenKind::Redo,
-                "goto" => TokenKind::Goto,
-                "class" => TokenKind::Class,
-                "method" => TokenKind::Method,
-                "format" => TokenKind::Format,
-                "undef" => TokenKind::Undef,
-                "defer" => TokenKind::Defer,
-                "and" => TokenKind::WordAnd,
-                "or" => TokenKind::WordOr,
-                "not" => TokenKind::WordNot,
-                "xor" => TokenKind::WordXor,
-                "cmp" => TokenKind::StringCompare,
-                "qw" => TokenKind::Identifier, // Keep as identifier but handle specially
-                _ => TokenKind::Identifier,
-            },
+            LexerTokenType::Keyword(kw) => {
+                // Keep quote-like operators explicit in parser-core.
+                if kw.as_ref() == "qw" {
+                    TokenKind::Identifier
+                } else {
+                    TokenKind::from_keyword(kw).unwrap_or(TokenKind::Identifier)
+                }
+            }
 
             // Operators
-            LexerTokenType::Operator(op) => match op.as_ref() {
-                "=" => TokenKind::Assign,
-                "+" => TokenKind::Plus,
-                "-" => TokenKind::Minus,
-                "*" => TokenKind::Star,
-                "/" => TokenKind::Slash,
-                "%" => TokenKind::Percent,
-                "**" => TokenKind::Power,
-                "<<" => TokenKind::LeftShift,
-                ">>" => TokenKind::RightShift,
-                "&" => TokenKind::BitwiseAnd,
-                "|" => TokenKind::BitwiseOr,
-                "^" => TokenKind::BitwiseXor,
-                "~" => TokenKind::BitwiseNot,
-                // Compound assignments
-                "+=" => TokenKind::PlusAssign,
-                "-=" => TokenKind::MinusAssign,
-                "*=" => TokenKind::StarAssign,
-                "/=" => TokenKind::SlashAssign,
-                "%=" => TokenKind::PercentAssign,
-                ".=" => TokenKind::DotAssign,
-                "&=" => TokenKind::AndAssign,
-                "|=" => TokenKind::OrAssign,
-                "^=" => TokenKind::XorAssign,
-                "**=" => TokenKind::PowerAssign,
-                "<<=" => TokenKind::LeftShiftAssign,
-                ">>=" => TokenKind::RightShiftAssign,
-                "&&=" => TokenKind::LogicalAndAssign,
-                "||=" => TokenKind::LogicalOrAssign,
-                "//=" => TokenKind::DefinedOrAssign,
-                "==" => TokenKind::Equal,
-                "!=" => TokenKind::NotEqual,
-                "=~" => TokenKind::Match,
-                "!~" => TokenKind::NotMatch,
-                "~~" => TokenKind::SmartMatch,
-                "<" => TokenKind::Less,
-                ">" => TokenKind::Greater,
-                "<=" => TokenKind::LessEqual,
-                ">=" => TokenKind::GreaterEqual,
-                "<=>" => TokenKind::Spaceship,
-                "&&" => TokenKind::And,
-                "||" => TokenKind::Or,
-                "!" => TokenKind::Not,
-                "//" => TokenKind::DefinedOr,
-                "->" => TokenKind::Arrow,
-                "=>" => TokenKind::FatArrow,
-                "." => TokenKind::Dot,
-                ".." => TokenKind::Range,
-                "..." => TokenKind::Ellipsis,
-                "++" => TokenKind::Increment,
-                "--" => TokenKind::Decrement,
-                "::" => TokenKind::DoubleColon,
-                "?" => TokenKind::Question,
-                ":" => TokenKind::Colon,
-                "\\" => TokenKind::Backslash,
-                // Sigils (when used as operators in certain contexts)
-                "$" => TokenKind::ScalarSigil,
-                "@" => TokenKind::ArraySigil,
-                // % is already handled as Percent above
-                // & is already handled as BitwiseAnd above
-                // * is already handled as Star above
-                _ => TokenKind::Unknown,
-            },
+            LexerTokenType::Operator(op) => TokenKind::from_operator(op)
+                .or_else(|| TokenKind::from_sigil(op))
+                .unwrap_or(TokenKind::Unknown),
 
             // Arrow tokens
             LexerTokenType::Arrow => TokenKind::Arrow,
@@ -498,15 +396,13 @@ impl<'a> TokenStream<'a> {
 
             // Identifiers
             LexerTokenType::Identifier(text) => {
-                // Check if it's actually a keyword that the lexer didn't recognize
-                match text.as_ref() {
-                    "no" => TokenKind::No,
-                    "*" => TokenKind::Star, // Special case: * by itself is multiplication
-                    "$" => TokenKind::ScalarSigil,
-                    "@" => TokenKind::ArraySigil,
-                    "%" => TokenKind::HashSigil,
-                    "&" => TokenKind::SubSigil,
-                    _ => TokenKind::Identifier,
+                // Parser-core fallback for tokens that can be contextual.
+                if text.as_ref() == "no" {
+                    TokenKind::from_keyword(text).unwrap_or(TokenKind::Identifier)
+                } else if text.as_ref() == "*" {
+                    TokenKind::from_operator(text).unwrap_or(TokenKind::Identifier)
+                } else {
+                    TokenKind::from_sigil(text).unwrap_or(TokenKind::Identifier)
                 }
             }
 
@@ -517,11 +413,7 @@ impl<'a> TokenStream<'a> {
                     TokenKind::HeredocDepthLimit
                 } else {
                     // Check if it's a brace that the lexer couldn't recognize
-                    match token.text.as_ref() {
-                        "{" => TokenKind::LeftBrace,
-                        "}" => TokenKind::RightBrace,
-                        _ => TokenKind::Unknown,
-                    }
+                    TokenKind::from_delimiter(token.text.as_ref()).unwrap_or(TokenKind::Unknown)
                 }
             }
 

--- a/crates/perl-parser-core/tests/token_stream_conformance.rs
+++ b/crates/perl-parser-core/tests/token_stream_conformance.rs
@@ -1,0 +1,45 @@
+use perl_lexer::{Token as LexerToken, TokenType as LexerTokenType};
+use perl_parser_core::token_stream::{TokenKind, TokenStream};
+use perl_tdd_support::must;
+use std::sync::Arc;
+
+#[test]
+fn keyword_and_operator_tokens_use_canonical_mappings() -> Result<(), Box<dyn std::error::Error>> {
+    let tokens = vec![
+        LexerToken::new(LexerTokenType::Keyword(Arc::from("my")), "my", 0, 2),
+        LexerToken::new(LexerTokenType::Operator(Arc::from("=")), "=", 3, 4),
+        LexerToken::new(LexerTokenType::Keyword(Arc::from("and")), "and", 5, 8),
+    ];
+    let parser_tokens = TokenStream::lexer_tokens_to_parser_tokens(tokens);
+
+    assert_eq!(parser_tokens[0].kind, TokenKind::My);
+    assert_eq!(parser_tokens[1].kind, TokenKind::Assign);
+    assert_eq!(parser_tokens[2].kind, TokenKind::WordAnd);
+    Ok(())
+}
+
+#[test]
+fn delimiter_and_sigil_fallbacks_are_preserved() -> Result<(), Box<dyn std::error::Error>> {
+    let tokens = vec![
+        LexerToken::new(LexerTokenType::Identifier(Arc::from("$")), "$", 0, 1),
+        LexerToken::new(LexerTokenType::Identifier(Arc::from("&")), "&", 1, 2),
+        LexerToken::new(LexerTokenType::Error(Arc::from("unexpected")), "{", 2, 3),
+    ];
+    let parser_tokens = TokenStream::lexer_tokens_to_parser_tokens(tokens);
+
+    assert_eq!(parser_tokens[0].kind, TokenKind::ScalarSigil);
+    assert_eq!(parser_tokens[1].kind, TokenKind::SubSigil);
+    assert_eq!(parser_tokens[2].kind, TokenKind::LeftBrace);
+    Ok(())
+}
+
+#[test]
+fn quote_like_keyword_remains_identifier_in_stream() -> Result<(), Box<dyn std::error::Error>> {
+    let tokens = vec![LexerToken::new(LexerTokenType::Keyword(Arc::from("qw")), "qw", 0, 2)];
+    let parser_tokens = TokenStream::lexer_tokens_to_parser_tokens(tokens);
+    assert_eq!(parser_tokens[0].kind, TokenKind::Identifier);
+
+    let mut stream = TokenStream::new("qw");
+    assert_eq!(must(stream.next()).kind, TokenKind::Identifier);
+    Ok(())
+}

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -399,6 +399,152 @@ pub enum TokenKind {
 }
 
 impl TokenKind {
+    /// Convert a canonical Perl keyword spelling into a [`TokenKind`].
+    ///
+    /// This mapping is intentionally case-sensitive.
+    #[must_use]
+    pub fn from_keyword(spelling: &str) -> Option<TokenKind> {
+        Some(match spelling {
+            "my" => TokenKind::My,
+            "our" => TokenKind::Our,
+            "local" => TokenKind::Local,
+            "state" => TokenKind::State,
+            "sub" => TokenKind::Sub,
+            "if" => TokenKind::If,
+            "elsif" => TokenKind::Elsif,
+            "else" => TokenKind::Else,
+            "unless" => TokenKind::Unless,
+            "while" => TokenKind::While,
+            "until" => TokenKind::Until,
+            "for" => TokenKind::For,
+            "foreach" => TokenKind::Foreach,
+            "return" => TokenKind::Return,
+            "package" => TokenKind::Package,
+            "use" => TokenKind::Use,
+            "no" => TokenKind::No,
+            "BEGIN" => TokenKind::Begin,
+            "END" => TokenKind::End,
+            "CHECK" => TokenKind::Check,
+            "INIT" => TokenKind::Init,
+            "UNITCHECK" => TokenKind::Unitcheck,
+            "eval" => TokenKind::Eval,
+            "do" => TokenKind::Do,
+            "given" => TokenKind::Given,
+            "when" => TokenKind::When,
+            "default" => TokenKind::Default,
+            "try" => TokenKind::Try,
+            "catch" => TokenKind::Catch,
+            "finally" => TokenKind::Finally,
+            "continue" => TokenKind::Continue,
+            "next" => TokenKind::Next,
+            "last" => TokenKind::Last,
+            "redo" => TokenKind::Redo,
+            "goto" => TokenKind::Goto,
+            "class" => TokenKind::Class,
+            "method" => TokenKind::Method,
+            "field" => TokenKind::Field,
+            "format" => TokenKind::Format,
+            "undef" => TokenKind::Undef,
+            "defer" => TokenKind::Defer,
+            "and" => TokenKind::WordAnd,
+            "or" => TokenKind::WordOr,
+            "not" => TokenKind::WordNot,
+            "xor" => TokenKind::WordXor,
+            "cmp" => TokenKind::StringCompare,
+            _ => return None,
+        })
+    }
+
+    /// Convert a canonical Perl operator spelling into a [`TokenKind`].
+    #[must_use]
+    pub fn from_operator(spelling: &str) -> Option<TokenKind> {
+        Some(match spelling {
+            "=" => TokenKind::Assign,
+            "+" => TokenKind::Plus,
+            "-" => TokenKind::Minus,
+            "*" => TokenKind::Star,
+            "/" => TokenKind::Slash,
+            "%" => TokenKind::Percent,
+            "**" => TokenKind::Power,
+            "<<" => TokenKind::LeftShift,
+            ">>" => TokenKind::RightShift,
+            "&" => TokenKind::BitwiseAnd,
+            "|" => TokenKind::BitwiseOr,
+            "^" => TokenKind::BitwiseXor,
+            "~" => TokenKind::BitwiseNot,
+            "+=" => TokenKind::PlusAssign,
+            "-=" => TokenKind::MinusAssign,
+            "*=" => TokenKind::StarAssign,
+            "/=" => TokenKind::SlashAssign,
+            "%=" => TokenKind::PercentAssign,
+            ".=" => TokenKind::DotAssign,
+            "&=" => TokenKind::AndAssign,
+            "|=" => TokenKind::OrAssign,
+            "^=" => TokenKind::XorAssign,
+            "**=" => TokenKind::PowerAssign,
+            "<<=" => TokenKind::LeftShiftAssign,
+            ">>=" => TokenKind::RightShiftAssign,
+            "&&=" => TokenKind::LogicalAndAssign,
+            "||=" => TokenKind::LogicalOrAssign,
+            "//=" => TokenKind::DefinedOrAssign,
+            "==" => TokenKind::Equal,
+            "!=" => TokenKind::NotEqual,
+            "=~" => TokenKind::Match,
+            "!~" => TokenKind::NotMatch,
+            "~~" => TokenKind::SmartMatch,
+            "<" => TokenKind::Less,
+            ">" => TokenKind::Greater,
+            "<=" => TokenKind::LessEqual,
+            ">=" => TokenKind::GreaterEqual,
+            "<=>" => TokenKind::Spaceship,
+            "&&" => TokenKind::And,
+            "||" => TokenKind::Or,
+            "!" => TokenKind::Not,
+            "//" => TokenKind::DefinedOr,
+            "->" => TokenKind::Arrow,
+            "=>" => TokenKind::FatArrow,
+            "." => TokenKind::Dot,
+            ".." => TokenKind::Range,
+            "..." => TokenKind::Ellipsis,
+            "++" => TokenKind::Increment,
+            "--" => TokenKind::Decrement,
+            "::" => TokenKind::DoubleColon,
+            "?" => TokenKind::Question,
+            ":" => TokenKind::Colon,
+            "\\" => TokenKind::Backslash,
+            _ => return None,
+        })
+    }
+
+    /// Convert delimiter punctuation into a [`TokenKind`].
+    #[must_use]
+    pub fn from_delimiter(spelling: &str) -> Option<TokenKind> {
+        Some(match spelling {
+            "(" => TokenKind::LeftParen,
+            ")" => TokenKind::RightParen,
+            "{" => TokenKind::LeftBrace,
+            "}" => TokenKind::RightBrace,
+            "[" => TokenKind::LeftBracket,
+            "]" => TokenKind::RightBracket,
+            ";" => TokenKind::Semicolon,
+            "," => TokenKind::Comma,
+            _ => return None,
+        })
+    }
+
+    /// Convert sigil spellings into a [`TokenKind`].
+    #[must_use]
+    pub fn from_sigil(spelling: &str) -> Option<TokenKind> {
+        Some(match spelling {
+            "$" => TokenKind::ScalarSigil,
+            "@" => TokenKind::ArraySigil,
+            "%" => TokenKind::HashSigil,
+            "&" => TokenKind::SubSigil,
+            "*" => TokenKind::GlobSigil,
+            _ => return None,
+        })
+    }
+
     /// Return a user-friendly display name for this token kind.
     ///
     /// These names appear in parser error messages shown in the editor.

--- a/crates/perl-token/tests/token_kind_mapping_tests.rs
+++ b/crates/perl-token/tests/token_kind_mapping_tests.rs
@@ -1,0 +1,160 @@
+use perl_token::TokenKind;
+
+#[test]
+fn keyword_mappings_are_exhaustive_and_case_sensitive() {
+    let expected = [
+        ("my", TokenKind::My),
+        ("our", TokenKind::Our),
+        ("local", TokenKind::Local),
+        ("state", TokenKind::State),
+        ("sub", TokenKind::Sub),
+        ("if", TokenKind::If),
+        ("elsif", TokenKind::Elsif),
+        ("else", TokenKind::Else),
+        ("unless", TokenKind::Unless),
+        ("while", TokenKind::While),
+        ("until", TokenKind::Until),
+        ("for", TokenKind::For),
+        ("foreach", TokenKind::Foreach),
+        ("return", TokenKind::Return),
+        ("package", TokenKind::Package),
+        ("use", TokenKind::Use),
+        ("no", TokenKind::No),
+        ("BEGIN", TokenKind::Begin),
+        ("END", TokenKind::End),
+        ("CHECK", TokenKind::Check),
+        ("INIT", TokenKind::Init),
+        ("UNITCHECK", TokenKind::Unitcheck),
+        ("eval", TokenKind::Eval),
+        ("do", TokenKind::Do),
+        ("given", TokenKind::Given),
+        ("when", TokenKind::When),
+        ("default", TokenKind::Default),
+        ("try", TokenKind::Try),
+        ("catch", TokenKind::Catch),
+        ("finally", TokenKind::Finally),
+        ("continue", TokenKind::Continue),
+        ("next", TokenKind::Next),
+        ("last", TokenKind::Last),
+        ("redo", TokenKind::Redo),
+        ("goto", TokenKind::Goto),
+        ("class", TokenKind::Class),
+        ("method", TokenKind::Method),
+        ("field", TokenKind::Field),
+        ("format", TokenKind::Format),
+        ("undef", TokenKind::Undef),
+        ("defer", TokenKind::Defer),
+        ("and", TokenKind::WordAnd),
+        ("or", TokenKind::WordOr),
+        ("not", TokenKind::WordNot),
+        ("xor", TokenKind::WordXor),
+        ("cmp", TokenKind::StringCompare),
+    ];
+
+    for (spelling, kind) in expected {
+        assert_eq!(TokenKind::from_keyword(spelling), Some(kind));
+    }
+
+    assert_eq!(TokenKind::from_keyword("begin"), None);
+    assert_eq!(TokenKind::from_keyword("BEGIN "), None);
+    assert_eq!(TokenKind::from_keyword("qw"), None);
+}
+
+#[test]
+fn operator_mappings_are_exhaustive() {
+    let expected = [
+        ("=", TokenKind::Assign),
+        ("+", TokenKind::Plus),
+        ("-", TokenKind::Minus),
+        ("*", TokenKind::Star),
+        ("/", TokenKind::Slash),
+        ("%", TokenKind::Percent),
+        ("**", TokenKind::Power),
+        ("<<", TokenKind::LeftShift),
+        (">>", TokenKind::RightShift),
+        ("&", TokenKind::BitwiseAnd),
+        ("|", TokenKind::BitwiseOr),
+        ("^", TokenKind::BitwiseXor),
+        ("~", TokenKind::BitwiseNot),
+        ("+=", TokenKind::PlusAssign),
+        ("-=", TokenKind::MinusAssign),
+        ("*=", TokenKind::StarAssign),
+        ("/=", TokenKind::SlashAssign),
+        ("%=", TokenKind::PercentAssign),
+        (".=", TokenKind::DotAssign),
+        ("&=", TokenKind::AndAssign),
+        ("|=", TokenKind::OrAssign),
+        ("^=", TokenKind::XorAssign),
+        ("**=", TokenKind::PowerAssign),
+        ("<<=", TokenKind::LeftShiftAssign),
+        (">>=", TokenKind::RightShiftAssign),
+        ("&&=", TokenKind::LogicalAndAssign),
+        ("||=", TokenKind::LogicalOrAssign),
+        ("//=", TokenKind::DefinedOrAssign),
+        ("==", TokenKind::Equal),
+        ("!=", TokenKind::NotEqual),
+        ("=~", TokenKind::Match),
+        ("!~", TokenKind::NotMatch),
+        ("~~", TokenKind::SmartMatch),
+        ("<", TokenKind::Less),
+        (">", TokenKind::Greater),
+        ("<=", TokenKind::LessEqual),
+        (">=", TokenKind::GreaterEqual),
+        ("<=>", TokenKind::Spaceship),
+        ("&&", TokenKind::And),
+        ("||", TokenKind::Or),
+        ("!", TokenKind::Not),
+        ("//", TokenKind::DefinedOr),
+        ("->", TokenKind::Arrow),
+        ("=>", TokenKind::FatArrow),
+        (".", TokenKind::Dot),
+        ("..", TokenKind::Range),
+        ("...", TokenKind::Ellipsis),
+        ("++", TokenKind::Increment),
+        ("--", TokenKind::Decrement),
+        ("::", TokenKind::DoubleColon),
+        ("?", TokenKind::Question),
+        (":", TokenKind::Colon),
+        ("\\", TokenKind::Backslash),
+    ];
+
+    for (spelling, kind) in expected {
+        assert_eq!(TokenKind::from_operator(spelling), Some(kind));
+    }
+
+    assert_eq!(TokenKind::from_operator("and"), None);
+    assert_eq!(TokenKind::from_operator("#"), None);
+}
+
+#[test]
+fn delimiter_and_sigil_mappings_are_exhaustive() {
+    let delimiters = [
+        ("(", TokenKind::LeftParen),
+        (")", TokenKind::RightParen),
+        ("{", TokenKind::LeftBrace),
+        ("}", TokenKind::RightBrace),
+        ("[", TokenKind::LeftBracket),
+        ("]", TokenKind::RightBracket),
+        (";", TokenKind::Semicolon),
+        (",", TokenKind::Comma),
+    ];
+
+    for (spelling, kind) in delimiters {
+        assert_eq!(TokenKind::from_delimiter(spelling), Some(kind));
+    }
+
+    let sigils = [
+        ("$", TokenKind::ScalarSigil),
+        ("@", TokenKind::ArraySigil),
+        ("%", TokenKind::HashSigil),
+        ("&", TokenKind::SubSigil),
+        ("*", TokenKind::GlobSigil),
+    ];
+
+    for (spelling, kind) in sigils {
+        assert_eq!(TokenKind::from_sigil(spelling), Some(kind));
+    }
+
+    assert_eq!(TokenKind::from_delimiter(":"), None);
+    assert_eq!(TokenKind::from_sigil("+"), None);
+}


### PR DESCRIPTION
### Motivation

- Parser-core contained large ad-hoc string→`TokenKind` match tables for keywords/operators which are easy to get out of sync as `TokenKind` grows.
- `perl-token` should be the single source of truth for canonical spellings so other crates reuse the same mapping logic.
- Centralizing these mappings preserves case-sensitivity and keeps parser-core-specific contextual exceptions local to parser-core.

### Description

- Added canonical mapping helpers to `TokenKind` in `crates/perl-token/src/lib.rs`: `from_keyword`, `from_operator`, `from_delimiter`, and `from_sigil`, all returning `Option<TokenKind>` and preserving case-sensitivity.
- Replaced the large inline keyword/operator match tables in `crates/perl-parser-core/src/tokens/token_stream.rs` with calls to the new `TokenKind` helpers while retaining parser-core contextual behavior (e.g. `qw` remains treated as an identifier, `no` and `*` are handled as special contextual fallbacks, and delimiter fallbacks are preserved).
- Added exhaustive mapping unit tests in `crates/perl-token/tests/token_kind_mapping_tests.rs` to cover keywords, operators, delimiters, and sigils and their negative cases.
- Added parser-core conformance tests in `crates/perl-parser-core/tests/token_stream_conformance.rs` to verify lexer→parser token conversion now uses the canonical mappings and that quote-like keywords remain identifiers.

### Testing

- Ran `cargo test -p perl-token` and all token crate tests passed (including new mapping tests).
- Ran `cargo test -p perl-parser-core token_stream` and the parser-core token stream tests passed, and the new conformance test suite passed via `cargo test -p perl-parser-core --test token_stream_conformance`.
- Ran `cargo test -p perl-lexer` to ensure lexer behavior remains unchanged and it passed.
- Ran `cargo check --all-targets -p perl-token -p perl-parser-core` which passed; a full `cargo check --workspace --all-targets` was attempted but reported a pre-existing unrelated failure in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` (format string mismatch) outside the scope of these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77d1dea08333be77e707831301f9)