### PR TITLE
feat(perl-token): centralize keyword and operator mapping helpers (#0000)

### DIFF
--- a/crates/perl-parser-core/src/tokens/token_stream.rs
+++ b/crates/perl-parser-core/src/tokens/token_stream.rs
@@ -343,135 +343,47 @@ impl<'a> TokenStream<'a> {
     fn convert_lexer_token(token: LexerToken) -> Token {
         let kind = match &token.token_type {
             // Keywords
-            LexerTokenType::Keyword(kw) => match kw.as_ref() {
-                "my" => TokenKind::My,
-                "our" => TokenKind::Our,
-                "local" => TokenKind::Local,
-                "state" => TokenKind::State,
-                "sub" => TokenKind::Sub,
-                "if" => TokenKind::If,
-                "elsif" => TokenKind::Elsif,
-                "else" => TokenKind::Else,
-                "unless" => TokenKind::Unless,
-                "while" => TokenKind::While,
-                "until" => TokenKind::Until,
-                "for" => TokenKind::For,
-                "foreach" => TokenKind::Foreach,
-                "return" => TokenKind::Return,
-                "package" => TokenKind::Package,
-                "use" => TokenKind::Use,
-                "no" => TokenKind::No,
-                "BEGIN" => TokenKind::Begin,
-                "END" => TokenKind::End,
-                "CHECK" => TokenKind::Check,
-                "INIT" => TokenKind::Init,
-                "UNITCHECK" => TokenKind::Unitcheck,
-                "eval" => TokenKind::Eval,
-                "do" => TokenKind::Do,
-                "given" => TokenKind::Given,
-                "when" => TokenKind::When,
-                "default" => TokenKind::Default,
-                "try" => TokenKind::Try,
-                "catch" => TokenKind::Catch,
-                "field" => TokenKind::Field,
-                "finally" => TokenKind::Finally,
-                "continue" => TokenKind::Continue,
-                "next" => TokenKind::Next,
-                "last" => TokenKind::Last,
-                "redo" => TokenKind::Redo,
-                "goto" => TokenKind::Goto,
-                "class" => TokenKind::Class,
-                "method" => TokenKind::Method,
-                "format" => TokenKind::Format,
-                "undef" => TokenKind::Undef,
-                "defer" => TokenKind::Defer,
-                "and" => TokenKind::WordAnd,
-                "or" => TokenKind::WordOr,
-                "not" => TokenKind::WordNot,
-                "xor" => TokenKind::WordXor,
-                "cmp" => TokenKind::StringCompare,
-                "qw" => TokenKind::Identifier, // Keep as identifier but handle specially
-                _ => TokenKind::Identifier,
-            },
+            LexerTokenType::Keyword(kw) => {
+                // Keep `qw` as a contextual identifier for parser-driven quote handling.
+                if kw.as_ref() == "qw" {
+                    TokenKind::Identifier
+                } else {
+                    TokenKind::from_keyword(kw.as_ref()).unwrap_or(TokenKind::Identifier)
+                }
+            }
 
             // Operators
-            LexerTokenType::Operator(op) => match op.as_ref() {
-                "=" => TokenKind::Assign,
-                "+" => TokenKind::Plus,
-                "-" => TokenKind::Minus,
-                "*" => TokenKind::Star,
-                "/" => TokenKind::Slash,
-                "%" => TokenKind::Percent,
-                "**" => TokenKind::Power,
-                "<<" => TokenKind::LeftShift,
-                ">>" => TokenKind::RightShift,
-                "&" => TokenKind::BitwiseAnd,
-                "|" => TokenKind::BitwiseOr,
-                "^" => TokenKind::BitwiseXor,
-                "~" => TokenKind::BitwiseNot,
-                // Compound assignments
-                "+=" => TokenKind::PlusAssign,
-                "-=" => TokenKind::MinusAssign,
-                "*=" => TokenKind::StarAssign,
-                "/=" => TokenKind::SlashAssign,
-                "%=" => TokenKind::PercentAssign,
-                ".=" => TokenKind::DotAssign,
-                "&=" => TokenKind::AndAssign,
-                "|=" => TokenKind::OrAssign,
-                "^=" => TokenKind::XorAssign,
-                "**=" => TokenKind::PowerAssign,
-                "<<=" => TokenKind::LeftShiftAssign,
-                ">>=" => TokenKind::RightShiftAssign,
-                "&&=" => TokenKind::LogicalAndAssign,
-                "||=" => TokenKind::LogicalOrAssign,
-                "//=" => TokenKind::DefinedOrAssign,
-                "==" => TokenKind::Equal,
-                "!=" => TokenKind::NotEqual,
-                "=~" => TokenKind::Match,
-                "!~" => TokenKind::NotMatch,
-                "~~" => TokenKind::SmartMatch,
-                "<" => TokenKind::Less,
-                ">" => TokenKind::Greater,
-                "<=" => TokenKind::LessEqual,
-                ">=" => TokenKind::GreaterEqual,
-                "<=>" => TokenKind::Spaceship,
-                "&&" => TokenKind::And,
-                "||" => TokenKind::Or,
-                "!" => TokenKind::Not,
-                "//" => TokenKind::DefinedOr,
-                "->" => TokenKind::Arrow,
-                "=>" => TokenKind::FatArrow,
-                "." => TokenKind::Dot,
-                ".." => TokenKind::Range,
-                "..." => TokenKind::Ellipsis,
-                "++" => TokenKind::Increment,
-                "--" => TokenKind::Decrement,
-                "::" => TokenKind::DoubleColon,
-                "?" => TokenKind::Question,
-                ":" => TokenKind::Colon,
-                "\\" => TokenKind::Backslash,
-                // Sigils (when used as operators in certain contexts)
-                "$" => TokenKind::ScalarSigil,
-                "@" => TokenKind::ArraySigil,
-                // % is already handled as Percent above
-                // & is already handled as BitwiseAnd above
-                // * is already handled as Star above
-                _ => TokenKind::Unknown,
-            },
+            LexerTokenType::Operator(op) => TokenKind::from_operator(op.as_ref())
+                .or_else(|| TokenKind::from_sigil(op.as_ref()))
+                .unwrap_or(TokenKind::Unknown),
 
             // Arrow tokens
             LexerTokenType::Arrow => TokenKind::Arrow,
             LexerTokenType::FatComma => TokenKind::FatArrow,
 
             // Delimiters
-            LexerTokenType::LeftParen => TokenKind::LeftParen,
-            LexerTokenType::RightParen => TokenKind::RightParen,
-            LexerTokenType::LeftBrace => TokenKind::LeftBrace,
-            LexerTokenType::RightBrace => TokenKind::RightBrace,
-            LexerTokenType::LeftBracket => TokenKind::LeftBracket,
-            LexerTokenType::RightBracket => TokenKind::RightBracket,
-            LexerTokenType::Semicolon => TokenKind::Semicolon,
-            LexerTokenType::Comma => TokenKind::Comma,
+            LexerTokenType::LeftParen => {
+                TokenKind::from_delimiter("(").unwrap_or(TokenKind::Unknown)
+            }
+            LexerTokenType::RightParen => {
+                TokenKind::from_delimiter(")").unwrap_or(TokenKind::Unknown)
+            }
+            LexerTokenType::LeftBrace => {
+                TokenKind::from_delimiter("{").unwrap_or(TokenKind::Unknown)
+            }
+            LexerTokenType::RightBrace => {
+                TokenKind::from_delimiter("}").unwrap_or(TokenKind::Unknown)
+            }
+            LexerTokenType::LeftBracket => {
+                TokenKind::from_delimiter("[").unwrap_or(TokenKind::Unknown)
+            }
+            LexerTokenType::RightBracket => {
+                TokenKind::from_delimiter("]").unwrap_or(TokenKind::Unknown)
+            }
+            LexerTokenType::Semicolon => {
+                TokenKind::from_delimiter(";").unwrap_or(TokenKind::Unknown)
+            }
+            LexerTokenType::Comma => TokenKind::from_delimiter(",").unwrap_or(TokenKind::Unknown),
 
             // Division operator (important to handle before other tokens)
             LexerTokenType::Division => TokenKind::Slash,
@@ -502,10 +414,9 @@ impl<'a> TokenStream<'a> {
                 match text.as_ref() {
                     "no" => TokenKind::No,
                     "*" => TokenKind::Star, // Special case: * by itself is multiplication
-                    "$" => TokenKind::ScalarSigil,
-                    "@" => TokenKind::ArraySigil,
-                    "%" => TokenKind::HashSigil,
-                    "&" => TokenKind::SubSigil,
+                    "$" | "@" | "%" | "&" => {
+                        TokenKind::from_sigil(text.as_ref()).unwrap_or(TokenKind::Identifier)
+                    }
                     _ => TokenKind::Identifier,
                 }
             }

--- a/crates/perl-parser-core/tests/token_stream_conformance.rs
+++ b/crates/perl-parser-core/tests/token_stream_conformance.rs
@@ -1,0 +1,42 @@
+use perl_lexer::{Token as LexerToken, TokenType as LexerTokenType};
+use perl_parser_core::token_stream::{TokenKind, TokenStream};
+
+#[test]
+fn token_stream_uses_shared_keyword_mapping() {
+    let raw = vec![LexerToken::new(LexerTokenType::Keyword("defer".into()), "defer", 0, 5)];
+    let parser_tokens = TokenStream::lexer_tokens_to_parser_tokens(raw);
+    assert_eq!(parser_tokens.len(), 1);
+    assert_eq!(parser_tokens[0].kind, TokenKind::Defer);
+}
+
+#[test]
+fn token_stream_uses_shared_operator_mapping() {
+    let raw = vec![LexerToken::new(LexerTokenType::Operator("//=".into()), "//=", 0, 3)];
+    let parser_tokens = TokenStream::lexer_tokens_to_parser_tokens(raw);
+    assert_eq!(parser_tokens.len(), 1);
+    assert_eq!(parser_tokens[0].kind, TokenKind::DefinedOrAssign);
+}
+
+#[test]
+fn token_stream_uses_shared_delimiter_mapping() {
+    let raw = vec![LexerToken::new(LexerTokenType::LeftBracket, "[", 0, 1)];
+    let parser_tokens = TokenStream::lexer_tokens_to_parser_tokens(raw);
+    assert_eq!(parser_tokens.len(), 1);
+    assert_eq!(parser_tokens[0].kind, TokenKind::LeftBracket);
+}
+
+#[test]
+fn token_stream_keeps_contextual_qw_as_identifier() {
+    let raw = vec![LexerToken::new(LexerTokenType::Keyword("qw".into()), "qw", 0, 2)];
+    let parser_tokens = TokenStream::lexer_tokens_to_parser_tokens(raw);
+    assert_eq!(parser_tokens.len(), 1);
+    assert_eq!(parser_tokens[0].kind, TokenKind::Identifier);
+}
+
+#[test]
+fn token_stream_maps_identifier_sigils_via_shared_helper() {
+    let raw = vec![LexerToken::new(LexerTokenType::Identifier("%".into()), "%", 0, 1)];
+    let parser_tokens = TokenStream::lexer_tokens_to_parser_tokens(raw);
+    assert_eq!(parser_tokens.len(), 1);
+    assert_eq!(parser_tokens[0].kind, TokenKind::HashSigil);
+}

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -399,6 +399,165 @@ pub enum TokenKind {
 }
 
 impl TokenKind {
+    /// Convert a canonical keyword spelling into its [`TokenKind`].
+    ///
+    /// Matching is case-sensitive to preserve Perl's contextual behavior.
+    #[must_use]
+    pub fn from_keyword(spelling: &str) -> Option<TokenKind> {
+        let kind = match spelling {
+            "my" => TokenKind::My,
+            "our" => TokenKind::Our,
+            "local" => TokenKind::Local,
+            "state" => TokenKind::State,
+            "sub" => TokenKind::Sub,
+            "if" => TokenKind::If,
+            "elsif" => TokenKind::Elsif,
+            "else" => TokenKind::Else,
+            "unless" => TokenKind::Unless,
+            "while" => TokenKind::While,
+            "until" => TokenKind::Until,
+            "for" => TokenKind::For,
+            "foreach" => TokenKind::Foreach,
+            "return" => TokenKind::Return,
+            "package" => TokenKind::Package,
+            "use" => TokenKind::Use,
+            "no" => TokenKind::No,
+            "BEGIN" => TokenKind::Begin,
+            "END" => TokenKind::End,
+            "CHECK" => TokenKind::Check,
+            "INIT" => TokenKind::Init,
+            "UNITCHECK" => TokenKind::Unitcheck,
+            "eval" => TokenKind::Eval,
+            "do" => TokenKind::Do,
+            "given" => TokenKind::Given,
+            "when" => TokenKind::When,
+            "default" => TokenKind::Default,
+            "try" => TokenKind::Try,
+            "catch" => TokenKind::Catch,
+            "finally" => TokenKind::Finally,
+            "continue" => TokenKind::Continue,
+            "next" => TokenKind::Next,
+            "last" => TokenKind::Last,
+            "redo" => TokenKind::Redo,
+            "goto" => TokenKind::Goto,
+            "class" => TokenKind::Class,
+            "method" => TokenKind::Method,
+            "field" => TokenKind::Field,
+            "format" => TokenKind::Format,
+            "undef" => TokenKind::Undef,
+            "defer" => TokenKind::Defer,
+            // Word operators remain keywords in lexer output.
+            "and" => TokenKind::WordAnd,
+            "or" => TokenKind::WordOr,
+            "not" => TokenKind::WordNot,
+            "xor" => TokenKind::WordXor,
+            "cmp" => TokenKind::StringCompare,
+            _ => return None,
+        };
+        Some(kind)
+    }
+
+    /// Convert a canonical operator spelling into its [`TokenKind`].
+    #[must_use]
+    pub fn from_operator(spelling: &str) -> Option<TokenKind> {
+        let kind = match spelling {
+            "=" => TokenKind::Assign,
+            "+" => TokenKind::Plus,
+            "-" => TokenKind::Minus,
+            "*" => TokenKind::Star,
+            "/" => TokenKind::Slash,
+            "%" => TokenKind::Percent,
+            "**" => TokenKind::Power,
+            "<<" => TokenKind::LeftShift,
+            ">>" => TokenKind::RightShift,
+            "&" => TokenKind::BitwiseAnd,
+            "|" => TokenKind::BitwiseOr,
+            "^" => TokenKind::BitwiseXor,
+            "~" => TokenKind::BitwiseNot,
+            "+=" => TokenKind::PlusAssign,
+            "-=" => TokenKind::MinusAssign,
+            "*=" => TokenKind::StarAssign,
+            "/=" => TokenKind::SlashAssign,
+            "%=" => TokenKind::PercentAssign,
+            ".=" => TokenKind::DotAssign,
+            "&=" => TokenKind::AndAssign,
+            "|=" => TokenKind::OrAssign,
+            "^=" => TokenKind::XorAssign,
+            "**=" => TokenKind::PowerAssign,
+            "<<=" => TokenKind::LeftShiftAssign,
+            ">>=" => TokenKind::RightShiftAssign,
+            "&&=" => TokenKind::LogicalAndAssign,
+            "||=" => TokenKind::LogicalOrAssign,
+            "//=" => TokenKind::DefinedOrAssign,
+            "==" => TokenKind::Equal,
+            "!=" => TokenKind::NotEqual,
+            "=~" => TokenKind::Match,
+            "!~" => TokenKind::NotMatch,
+            "~~" => TokenKind::SmartMatch,
+            "<" => TokenKind::Less,
+            ">" => TokenKind::Greater,
+            "<=" => TokenKind::LessEqual,
+            ">=" => TokenKind::GreaterEqual,
+            "<=>" => TokenKind::Spaceship,
+            "&&" => TokenKind::And,
+            "||" => TokenKind::Or,
+            "!" => TokenKind::Not,
+            "//" => TokenKind::DefinedOr,
+            "->" => TokenKind::Arrow,
+            "=>" => TokenKind::FatArrow,
+            "." => TokenKind::Dot,
+            ".." => TokenKind::Range,
+            "..." => TokenKind::Ellipsis,
+            "++" => TokenKind::Increment,
+            "--" => TokenKind::Decrement,
+            "::" => TokenKind::DoubleColon,
+            "?" => TokenKind::Question,
+            ":" => TokenKind::Colon,
+            "\\" => TokenKind::Backslash,
+            // Quote-like operators.
+            "q" => TokenKind::QuoteSingle,
+            "qq" => TokenKind::QuoteDouble,
+            "qw" => TokenKind::QuoteWords,
+            "qx" => TokenKind::QuoteCommand,
+            "qr" => TokenKind::Regex,
+            "tr" | "y" => TokenKind::Transliteration,
+            "s" => TokenKind::Substitution,
+            _ => return None,
+        };
+        Some(kind)
+    }
+
+    /// Convert a canonical delimiter spelling into its [`TokenKind`].
+    #[must_use]
+    pub fn from_delimiter(spelling: &str) -> Option<TokenKind> {
+        let kind = match spelling {
+            "(" => TokenKind::LeftParen,
+            ")" => TokenKind::RightParen,
+            "{" => TokenKind::LeftBrace,
+            "}" => TokenKind::RightBrace,
+            "[" => TokenKind::LeftBracket,
+            "]" => TokenKind::RightBracket,
+            ";" => TokenKind::Semicolon,
+            "," => TokenKind::Comma,
+            _ => return None,
+        };
+        Some(kind)
+    }
+
+    /// Convert a sigil spelling into its [`TokenKind`].
+    #[must_use]
+    pub fn from_sigil(spelling: &str) -> Option<TokenKind> {
+        let kind = match spelling {
+            "$" => TokenKind::ScalarSigil,
+            "@" => TokenKind::ArraySigil,
+            "%" => TokenKind::HashSigil,
+            "&" => TokenKind::SubSigil,
+            "*" => TokenKind::GlobSigil,
+            _ => return None,
+        };
+        Some(kind)
+    }
+
     /// Return a user-friendly display name for this token kind.
     ///
     /// These names appear in parser error messages shown in the editor.

--- a/crates/perl-token/tests/token_kind_mapping_tests.rs
+++ b/crates/perl-token/tests/token_kind_mapping_tests.rs
@@ -1,0 +1,176 @@
+use perl_token::TokenKind;
+
+#[test]
+fn from_keyword_maps_all_canonical_spellings() {
+    let cases = [
+        ("my", TokenKind::My),
+        ("our", TokenKind::Our),
+        ("local", TokenKind::Local),
+        ("state", TokenKind::State),
+        ("sub", TokenKind::Sub),
+        ("if", TokenKind::If),
+        ("elsif", TokenKind::Elsif),
+        ("else", TokenKind::Else),
+        ("unless", TokenKind::Unless),
+        ("while", TokenKind::While),
+        ("until", TokenKind::Until),
+        ("for", TokenKind::For),
+        ("foreach", TokenKind::Foreach),
+        ("return", TokenKind::Return),
+        ("package", TokenKind::Package),
+        ("use", TokenKind::Use),
+        ("no", TokenKind::No),
+        ("BEGIN", TokenKind::Begin),
+        ("END", TokenKind::End),
+        ("CHECK", TokenKind::Check),
+        ("INIT", TokenKind::Init),
+        ("UNITCHECK", TokenKind::Unitcheck),
+        ("eval", TokenKind::Eval),
+        ("do", TokenKind::Do),
+        ("given", TokenKind::Given),
+        ("when", TokenKind::When),
+        ("default", TokenKind::Default),
+        ("try", TokenKind::Try),
+        ("catch", TokenKind::Catch),
+        ("finally", TokenKind::Finally),
+        ("continue", TokenKind::Continue),
+        ("next", TokenKind::Next),
+        ("last", TokenKind::Last),
+        ("redo", TokenKind::Redo),
+        ("goto", TokenKind::Goto),
+        ("class", TokenKind::Class),
+        ("method", TokenKind::Method),
+        ("field", TokenKind::Field),
+        ("format", TokenKind::Format),
+        ("undef", TokenKind::Undef),
+        ("defer", TokenKind::Defer),
+        ("and", TokenKind::WordAnd),
+        ("or", TokenKind::WordOr),
+        ("not", TokenKind::WordNot),
+        ("xor", TokenKind::WordXor),
+        ("cmp", TokenKind::StringCompare),
+    ];
+
+    for (spelling, expected_kind) in cases {
+        assert_eq!(TokenKind::from_keyword(spelling), Some(expected_kind), "{spelling}");
+    }
+}
+
+#[test]
+fn from_operator_maps_all_canonical_spellings() {
+    let cases = [
+        ("=", TokenKind::Assign),
+        ("+", TokenKind::Plus),
+        ("-", TokenKind::Minus),
+        ("*", TokenKind::Star),
+        ("/", TokenKind::Slash),
+        ("%", TokenKind::Percent),
+        ("**", TokenKind::Power),
+        ("<<", TokenKind::LeftShift),
+        (">>", TokenKind::RightShift),
+        ("&", TokenKind::BitwiseAnd),
+        ("|", TokenKind::BitwiseOr),
+        ("^", TokenKind::BitwiseXor),
+        ("~", TokenKind::BitwiseNot),
+        ("+=", TokenKind::PlusAssign),
+        ("-=", TokenKind::MinusAssign),
+        ("*=", TokenKind::StarAssign),
+        ("/=", TokenKind::SlashAssign),
+        ("%=", TokenKind::PercentAssign),
+        (".=", TokenKind::DotAssign),
+        ("&=", TokenKind::AndAssign),
+        ("|=", TokenKind::OrAssign),
+        ("^=", TokenKind::XorAssign),
+        ("**=", TokenKind::PowerAssign),
+        ("<<=", TokenKind::LeftShiftAssign),
+        (">>=", TokenKind::RightShiftAssign),
+        ("&&=", TokenKind::LogicalAndAssign),
+        ("||=", TokenKind::LogicalOrAssign),
+        ("//=", TokenKind::DefinedOrAssign),
+        ("==", TokenKind::Equal),
+        ("!=", TokenKind::NotEqual),
+        ("=~", TokenKind::Match),
+        ("!~", TokenKind::NotMatch),
+        ("~~", TokenKind::SmartMatch),
+        ("<", TokenKind::Less),
+        (">", TokenKind::Greater),
+        ("<=", TokenKind::LessEqual),
+        (">=", TokenKind::GreaterEqual),
+        ("<=>", TokenKind::Spaceship),
+        ("&&", TokenKind::And),
+        ("||", TokenKind::Or),
+        ("!", TokenKind::Not),
+        ("//", TokenKind::DefinedOr),
+        ("->", TokenKind::Arrow),
+        ("=>", TokenKind::FatArrow),
+        (".", TokenKind::Dot),
+        ("..", TokenKind::Range),
+        ("...", TokenKind::Ellipsis),
+        ("++", TokenKind::Increment),
+        ("--", TokenKind::Decrement),
+        ("::", TokenKind::DoubleColon),
+        ("?", TokenKind::Question),
+        (":", TokenKind::Colon),
+        ("\\", TokenKind::Backslash),
+        ("q", TokenKind::QuoteSingle),
+        ("qq", TokenKind::QuoteDouble),
+        ("qw", TokenKind::QuoteWords),
+        ("qx", TokenKind::QuoteCommand),
+        ("qr", TokenKind::Regex),
+        ("tr", TokenKind::Transliteration),
+        ("y", TokenKind::Transliteration),
+        ("s", TokenKind::Substitution),
+    ];
+
+    for (spelling, expected_kind) in cases {
+        assert_eq!(TokenKind::from_operator(spelling), Some(expected_kind), "{spelling}");
+    }
+}
+
+#[test]
+fn from_delimiter_maps_all_canonical_spellings() {
+    let cases = [
+        ("(", TokenKind::LeftParen),
+        (")", TokenKind::RightParen),
+        ("{", TokenKind::LeftBrace),
+        ("}", TokenKind::RightBrace),
+        ("[", TokenKind::LeftBracket),
+        ("]", TokenKind::RightBracket),
+        (";", TokenKind::Semicolon),
+        (",", TokenKind::Comma),
+    ];
+
+    for (spelling, expected_kind) in cases {
+        assert_eq!(TokenKind::from_delimiter(spelling), Some(expected_kind), "{spelling}");
+    }
+}
+
+#[test]
+fn from_sigil_maps_all_canonical_spellings() {
+    let cases = [
+        ("$", TokenKind::ScalarSigil),
+        ("@", TokenKind::ArraySigil),
+        ("%", TokenKind::HashSigil),
+        ("&", TokenKind::SubSigil),
+        ("*", TokenKind::GlobSigil),
+    ];
+
+    for (spelling, expected_kind) in cases {
+        assert_eq!(TokenKind::from_sigil(spelling), Some(expected_kind), "{spelling}");
+    }
+}
+
+#[test]
+fn mapping_helpers_are_case_sensitive() {
+    assert_eq!(TokenKind::from_keyword("begin"), None);
+    assert_eq!(TokenKind::from_keyword("BEGIN"), Some(TokenKind::Begin));
+    assert_eq!(TokenKind::from_operator("QQ"), None);
+}
+
+#[test]
+fn unknown_spellings_are_rejected() {
+    assert_eq!(TokenKind::from_keyword("unknown"), None);
+    assert_eq!(TokenKind::from_operator("<~>"), None);
+    assert_eq!(TokenKind::from_delimiter("."), None);
+    assert_eq!(TokenKind::from_sigil("!"), None);
+}


### PR DESCRIPTION
### Motivation

- Reduce duplication by moving canonical string-to-`TokenKind` mapping out of `perl-parser-core` and into `perl-token` so a single crate owns the canonical spellings for keywords, operators, delimiters and sigils.

### Description

- Added mapping helpers on `TokenKind` in `crates/perl-token/src/lib.rs`: `from_keyword`, `from_operator`, `from_delimiter`, and `from_sigil`, all case-sensitive and returning `Option<TokenKind>`.
- Replaced the large ad-hoc keyword/operator/delimiter/sigil match blocks in `crates/perl-parser-core/src/tokens/token_stream.rs` with calls to the new `TokenKind::from_*` helpers while preserving parser-core contextual decisions (e.g. keep `qw` treated as an `Identifier` in parser-core where required, preserve `*` special-casing).
- Added unit tests: `crates/perl-token/tests/token_kind_mapping_tests.rs` to exhaustively cover canonical spellings and case-sensitivity, and `crates/perl-parser-core/tests/token_stream_conformance.rs` to assert parser-core uses the shared mappings and keeps contextual behavior.

### Testing

- Ran `cargo test -p perl-token` and all token crate tests passed (including new `token_kind_mapping_tests`).
- Ran `cargo test -p perl-parser-core token_stream` and relevant parser-core token-stream tests (including new conformance tests) passed.
- Ran `cargo test -p perl-lexer` which passed to ensure lexer behavior remains unchanged.
- Ran `cargo check --workspace --all-targets` which surfaced a pre-existing unrelated compile error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` (format-string positional mismatch); this failure is external to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77d1dea08333be77e707831301f9)