### PR TITLE
fix(parser): harden transliteration parsing and ratchet regressions (#6459)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -291,6 +291,12 @@ impl<'a> Parser<'a> {
                                         c
                                     )
                                 }
+                                quote_parser::TransliterationError::InvalidDelimiter(c) => {
+                                    format!(
+                                        "Invalid transliteration delimiter '{}'. Delimiter must be a non-alphanumeric, non-whitespace character",
+                                        c
+                                    )
+                                }
                                 quote_parser::TransliterationError::MissingDelimiter => {
                                     "Missing delimiter after transliteration operator".to_string()
                                 }

--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -55,6 +55,8 @@ pub enum SubstitutionError {
 pub enum TransliterationError {
     /// Invalid modifier character found
     InvalidModifier(char),
+    /// Invalid delimiter after `tr`/`y`
+    InvalidDelimiter(char),
     /// Missing delimiter after `tr`/`y`
     MissingDelimiter,
     /// Search list section is missing
@@ -302,19 +304,23 @@ pub fn extract_substitution_parts(text: &str) -> (String, String, String) {
 /// Extract search, replace, and modifiers from a transliteration token
 pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
     // Skip 'tr' or 'y' prefix
-    let content = if let Some(stripped) = text.strip_prefix("tr") {
+    let after_op = if let Some(stripped) = text.strip_prefix("tr") {
         stripped
     } else if let Some(stripped) = text.strip_prefix('y') {
         stripped
     } else {
         text
     };
+    let content = after_op.trim_start();
 
     // Get delimiter - content must be non-empty to have a delimiter
     let delimiter = match content.chars().next() {
         Some(d) => d,
         None => return (String::new(), String::new(), String::new()),
     };
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return (String::new(), String::new(), String::new());
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
@@ -364,6 +370,12 @@ pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
         if let Some(repl_delimiter) = starts_with_paired_delimiter(rest2) {
             let repl_closing = get_closing_delimiter(repl_delimiter);
             extract_delimited_content(rest2, repl_delimiter, repl_closing)
+        } else if let Some(repl_delimiter) = rest2.chars().next() {
+            if repl_delimiter.is_ascii_alphanumeric() || repl_delimiter.is_whitespace() {
+                (String::new(), rest2)
+            } else {
+                extract_delimited_content(rest2, repl_delimiter, repl_delimiter)
+            }
         } else {
             (String::new(), rest2)
         }
@@ -409,6 +421,9 @@ pub fn extract_transliteration_parts_strict(
         Some(d) => d,
         None => return Err(TransliterationError::MissingDelimiter),
     };
+    if delimiter.is_ascii_alphanumeric() || delimiter.is_whitespace() {
+        return Err(TransliterationError::InvalidDelimiter(delimiter));
+    }
     let closing = get_closing_delimiter(delimiter);
     let is_paired = delimiter != closing;
 
@@ -433,6 +448,11 @@ pub fn extract_transliteration_parts_strict(
             let (body, rest, found_closing) =
                 extract_delimited_content_strict(trimmed, repl_delimiter, repl_closing);
             (body, rest, found_closing)
+        } else if let Some(repl_delimiter) = trimmed.chars().next() {
+            if repl_delimiter.is_ascii_alphanumeric() || repl_delimiter.is_whitespace() {
+                return Err(TransliterationError::InvalidDelimiter(repl_delimiter));
+            }
+            extract_delimited_content_strict(trimmed, repl_delimiter, repl_delimiter)
         } else {
             return Err(TransliterationError::MissingReplacement);
         }

--- a/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
+++ b/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
@@ -17,3 +17,17 @@ fn transliteration_rejects_invalid_modifiers() {
     assert_has_error(r#"$x =~ tr/a-z/A-Z/z;"#, "invalid transliteration modifier");
     assert_has_error(r#"$x =~ y/a-z/A-Z/1;"#, "invalid transliteration modifier");
 }
+
+#[test]
+fn transliteration_strict_handles_malformed_delimiters() {
+    assert_has_error(r#"$x =~ tr{abc}xyz;"#, "invalid transliteration delimiter");
+    assert_has_error(r#"$x =~ tr{abc}{xyz;"#, "missing closing delimiter in transliteration");
+}
+
+#[test]
+fn transliteration_accepts_supported_modifiers() {
+    assert_clean_parse(r#"$x =~ tr/a/b/c;"#);
+    assert_clean_parse(r#"$x =~ tr/a/b/d;"#);
+    assert_clean_parse(r#"$x =~ tr/a/b/s;"#);
+    assert_clean_parse(r#"$x =~ tr/a/b/r;"#);
+}

--- a/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
+++ b/crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs
@@ -1,18 +1,5 @@
-/// Minimal reproduction case for transliteration parsing bug discovered in fuzz testing
-///
-/// CRASH DETAILS:
-/// - Input: "tr/abc/xyz/"
-/// - Expected: ("abc", "xyz", "")
-/// - Actual: ("abc", "", "xyz")
-///
-/// This indicates a critical bug in extract_transliteration_parts where the replacement
-/// and modifiers are being swapped for non-paired delimiters.
-///
-/// IMPACT: This affects Perl transliteration operator parsing throughout the entire
-/// parser pipeline, potentially causing incorrect syntax highlighting, code analysis,
-/// and refactoring operations.
-///
-/// REPRODUCTION: Run with `cargo test -p perl-parser --test fuzz_transliteration_crash_repro`
+//! Minimal reproduction cases for transliteration parsing issues discovered in fuzzing.
+
 use perl_parser::quote_parser::extract_transliteration_parts;
 
 #[test]
@@ -20,12 +7,6 @@ fn minimal_transliteration_crash_repro() {
     let input = "tr/abc/xyz/";
     let (search, replace, modifiers) = extract_transliteration_parts(input);
 
-    println!("FUZZ BUG REPRODUCED: tr// parsing issue");
-    println!("Input: {}", input);
-    println!("Expected: ('abc', 'xyz', '')");
-    println!("Actual: ('{}', '{}', '{}')", search, replace, modifiers);
-
-    // Demonstrate the bug - these will fail due to the parsing issue
     assert_eq!(search.as_str(), "abc", "Search pattern incorrect");
     assert_eq!(replace.as_str(), "xyz", "Replace pattern incorrect");
     assert_eq!(modifiers.as_str(), "", "Modifiers incorrect");
@@ -33,24 +14,21 @@ fn minimal_transliteration_crash_repro() {
 
 #[test]
 fn fuzz_transliteration_regression_suite() {
-    // Test additional variants that likely have the same bug
-    let test_cases = vec![
+    let test_cases = [
         ("y/abc/xyz/", ("abc", "xyz", "")),
         ("tr/a/b/d", ("a", "b", "d")),
-        ("y/x/y/g", ("x", "y", "")), // 'g' is not a valid transliteration modifier
-        ("tr{abc}{xyz}d", ("abc", "xyz", "d")), // This might work correctly with paired delimiters
+        ("y/x/y/g", ("x", "y", "")),
+        ("tr{abc}{xyz}d", ("abc", "xyz", "d")),
+        ("tr{abc}/xyz/s", ("abc", "xyz", "s")),
+        ("tr a/b/", ("", "", "")),
     ];
 
     for (input, expected) in test_cases {
-        let (search, replace, modifiers) = extract_transliteration_parts(input);
-        let actual = (search.as_str(), replace.as_str(), modifiers.as_str());
-
-        println!("Testing: {} -> expected {:?}, got {:?}", input, expected, actual);
-
-        if actual != expected {
-            println!("  BUG CONFIRMED in variant: {}", input);
-        } else {
-            println!("  PASSED: {}", input);
-        }
+        let actual = extract_transliteration_parts(input);
+        assert_eq!(
+            (actual.0.as_str(), actual.1.as_str(), actual.2.as_str()),
+            expected,
+            "Unexpected transliteration parse result for {input:?}"
+        );
     }
 }

--- a/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
+++ b/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
@@ -10,6 +10,12 @@ fn transliteration_regression_bank_valid_cases() {
         ("tr///", ("", "", "")),
         ("tr{abc}/xyz/cdsr", ("abc", "xyz", "cdsr")),
         ("y  {αβ}{γδ}r", ("αβ", "γδ", "r")),
+        // '#' is a valid non-paired, non-alphanumeric delimiter
+        ("tr#abc#xyz#", ("abc", "xyz", "")),
+        // nested brackets in search list (Perl allows depth-tracking)
+        ("tr{a{b}c}{xyz}", ("a{b}c", "xyz", "")),
+        // delete mode: no replacement characters
+        ("tr/abc//d", ("abc", "", "d")),
     ];
 
     for (input, expected) in cases {

--- a/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
+++ b/crates/perl-parser/tests/quote_transliteration_regression_bank.rs
@@ -1,0 +1,39 @@
+use perl_parser::quote_parser::{
+    TransliterationError, extract_transliteration_parts, extract_transliteration_parts_strict,
+};
+
+#[test]
+fn transliteration_regression_bank_valid_cases() {
+    let cases = [
+        ("tr/a\\/b/c\\/d/", ("a\\/b", "c\\/d", "")),
+        ("tr/🦀/🐪/", ("🦀", "🐪", "")),
+        ("tr///", ("", "", "")),
+        ("tr{abc}/xyz/cdsr", ("abc", "xyz", "cdsr")),
+        ("y  {αβ}{γδ}r", ("αβ", "γδ", "r")),
+    ];
+
+    for (input, expected) in cases {
+        let actual = extract_transliteration_parts(input);
+        assert_eq!(
+            (actual.0.as_str(), actual.1.as_str(), actual.2.as_str()),
+            expected,
+            "unexpected parse for {input:?}"
+        );
+    }
+}
+
+#[test]
+fn transliteration_regression_bank_strict_errors() {
+    let cases = [
+        ("tr/a\\/b/c\\/d/z", TransliterationError::InvalidModifier('z')),
+        ("tr a/b/", TransliterationError::InvalidDelimiter('a')),
+        ("tr/abc/xyz", TransliterationError::MissingClosingDelimiter),
+        ("tr{abc}{xyz", TransliterationError::MissingClosingDelimiter),
+        ("tr{abc}xyz", TransliterationError::InvalidDelimiter('x')),
+    ];
+
+    for (input, expected) in cases {
+        let actual = extract_transliteration_parts_strict(input);
+        assert_eq!(actual, Err(expected), "expected strict error for {input:?}");
+    }
+}


### PR DESCRIPTION
### Motivation

- A fuzz repro showed `tr///` parsing could mis-extract search, replacement and modifiers for malformed or mixed-delimiter forms, so parsing must be hardened to avoid misclassification and panics.

### Description

- Add `TransliterationError::InvalidDelimiter` and trim optional whitespace after `tr`/`y`, rejecting alphanumeric or whitespace delimiters early in both `extract_transliteration_parts` and `extract_transliteration_parts_strict`.
- Use strict search extraction and stricter replacement delimiter handling for paired and non-paired forms, and enforce transliteration modifiers to the allowed set (`c`, `d`, `s`, `r`).
- Surface the new invalid-delimiter error in the parser diagnostics via `expressions/primary.rs` so callers produce a clear syntax error message.
- Tests: update `crates/perl-parser/tests/fuzz_transliteration_crash_repro.rs`, add `crates/perl-parser/tests/quote_transliteration_regression_bank.rs`, and extend `crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs` to cover whitespace handling, malformed delimiters, Unicode, escaped delimiters, empty bodies, and modifier validation.

### Testing

- Ran `cargo test -p perl-parser quote_transliteration` which passed.
- Ran `cargo test -p perl-parser fuzz_transliteration_crash_repro` which passed.
- Ran `cargo test -p perl-parser --test quote_transliteration_regression_bank` which passed.
- Ran `cargo test -p perl-parser-core transliteration` and `cargo test -p perl-parser-core --test fix_transliteration_strict_parsing` which passed.
- Ran formatting via `cargo xtask fmt`; it completed successfully.
- Corpus / audit checks with `just parser-audit`, `just corpus-sweep-check`, and `just cpan-corpus-check` were not executed in this environment because `just` is not installed (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53f030388333a6c9fd8fb9bc7439)