### PR TITLE
feat(perl-token): add parser-facing token role predicates (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -87,11 +87,8 @@ impl<'a> Parser<'a> {
 
             // These tokens *cannot* start an indirect object
             match next_kind {
-                TokenKind::Semicolon
-                | TokenKind::RightBrace
-                | TokenKind::RightParen
-                | TokenKind::Comma
-                | TokenKind::Eof => return false,
+                TokenKind::Comma => return false,
+                kind if kind.is_recovery_boundary() => return false,
                 _ => {}
             }
 
@@ -287,10 +284,7 @@ impl<'a> Parser<'a> {
                         // A closing brace/paren/bracket means the call is the
                         // last expression inside a block or parenthesised list,
                         // e.g. `grep { defined $v }` — not an indirect call.
-                        if matches!(
-                            third.kind,
-                            TokenKind::RightBrace | TokenKind::RightParen | TokenKind::RightBracket
-                        ) {
+                        if third.kind.is_close_delimiter() {
                             return false;
                         }
                         // Arrow after $var means method/deref chain: func $obj->method(...)
@@ -301,15 +295,9 @@ impl<'a> Parser<'a> {
                         // Word operators after $var means regular call with low-precedence
                         // operator: func @list or die, func $arg and next, etc.
                         // These are NOT indirect method calls.
-                        if matches!(
-                            third.kind,
-                            TokenKind::WordOr
-                                | TokenKind::WordAnd
-                                | TokenKind::WordXor
-                                | TokenKind::WordNot
-                                | TokenKind::Question
-                                | TokenKind::Semicolon
-                        ) {
+                        if third.kind.is_low_precedence_word_operator()
+                            || matches!(third.kind, TokenKind::Question | TokenKind::Semicolon)
+                        {
                             return false;
                         }
                         return true;
@@ -369,15 +357,7 @@ impl<'a> Parser<'a> {
             && !self.is_statement_modifier_keyword()
             && !matches!(
                 self.peek_kind(),
-                Some(
-                    TokenKind::WordOr
-                        | TokenKind::WordAnd
-                        | TokenKind::WordXor
-                        | TokenKind::WordNot
-                        | TokenKind::RightBrace
-                        | TokenKind::RightParen
-                        | TokenKind::RightBracket
-                )
+                Some(kind) if kind.is_low_precedence_word_operator() || kind.is_close_delimiter()
             )
         {
             // Use parse_assignment instead of parse_expression to avoid grouping by comma operator

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -1182,26 +1182,19 @@ impl<'a> Parser<'a> {
 
     /// Check if we're at a statement boundary
     fn is_at_statement_end(&mut self) -> bool {
-        matches!(
-            self.peek_kind(),
-            Some(TokenKind::Semicolon)
-                | Some(TokenKind::RightBrace)
-                | Some(TokenKind::RightParen)
-                | Some(TokenKind::RightBracket)
-                | Some(TokenKind::If)
-                | Some(TokenKind::Unless)
-                | Some(TokenKind::While)
-                | Some(TokenKind::Until)
-                | Some(TokenKind::For)
-                | Some(TokenKind::Foreach)
-                | Some(TokenKind::WordAnd)
-                | Some(TokenKind::WordOr)
-                | Some(TokenKind::WordXor)
-                | Some(TokenKind::WordNot)
-                | Some(TokenKind::DataMarker)
-                | Some(TokenKind::Eof)
-                | None
-        )
+        match self.peek_kind() {
+            Some(kind) if kind.is_recovery_boundary() => true,
+            Some(kind) if kind.is_low_precedence_word_operator() => true,
+            Some(TokenKind::If)
+            | Some(TokenKind::Unless)
+            | Some(TokenKind::While)
+            | Some(TokenKind::Until)
+            | Some(TokenKind::For)
+            | Some(TokenKind::Foreach)
+            | Some(TokenKind::DataMarker)
+            | None => true,
+            _ => false,
+        }
     }
 
     /// Check whether the current peek token is a quote-op name that should be

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -1,7 +1,10 @@
 impl<'a> Parser<'a> {
     #[inline]
     fn is_statement_terminator(kind: Option<TokenKind>) -> bool {
-        matches!(kind, Some(TokenKind::Semicolon) | Some(TokenKind::Eof) | None)
+        match kind {
+            Some(token) => matches!(token, TokenKind::Semicolon | TokenKind::Eof),
+            None => true,
+        }
     }
 
     #[inline]
@@ -114,15 +117,9 @@ impl<'a> Parser<'a> {
     /// the modifier token is being autoquoted before `=>`.
     fn should_continue_bare_call_after_block(&mut self) -> bool {
         match self.peek_kind() {
-            Some(TokenKind::Semicolon)
-            | Some(TokenKind::RightBrace)
-            | Some(TokenKind::RightParen)
-            | Some(TokenKind::RightBracket)
-            | Some(TokenKind::Eof)
-            | None => false,
-            Some(TokenKind::WordOr | TokenKind::WordAnd | TokenKind::WordXor | TokenKind::WordNot) => {
-                false
-            }
+            Some(kind) if kind.is_recovery_boundary() => false,
+            None => false,
+            Some(kind) if kind.is_low_precedence_word_operator() => false,
             Some(kind) if Self::is_stmt_modifier_kind(kind) => self.is_keyword_before_fat_arrow(),
             _ => true,
         }
@@ -353,51 +350,24 @@ impl<'a> Parser<'a> {
 
     /// Check if a token kind is a binary operator that couldn't start an expression argument.
     fn is_binary_operator(kind: TokenKind) -> bool {
-        matches!(
-            kind,
-            TokenKind::Or
-                | TokenKind::And
-                | TokenKind::DefinedOr
-                | TokenKind::WordOr
-                | TokenKind::WordAnd
-                | TokenKind::WordXor
-                | TokenKind::Equal
-                | TokenKind::NotEqual
-                | TokenKind::Less
-                | TokenKind::Greater
-                | TokenKind::LessEqual
-                | TokenKind::GreaterEqual
-                | TokenKind::Spaceship
-                | TokenKind::StringCompare
-                | TokenKind::Match
-                | TokenKind::NotMatch
-                | TokenKind::SmartMatch
-                | TokenKind::Dot
-                | TokenKind::Range
-                | TokenKind::LeftShift
-                | TokenKind::RightShift
-                | TokenKind::BitwiseAnd
-                | TokenKind::BitwiseOr
-                | TokenKind::BitwiseXor
-                | TokenKind::Question
-                | TokenKind::Colon
-                | TokenKind::Assign
-                | TokenKind::PlusAssign
-                | TokenKind::MinusAssign
-                | TokenKind::StarAssign
-                | TokenKind::SlashAssign
-                | TokenKind::PercentAssign
-                | TokenKind::DotAssign
-                | TokenKind::AndAssign
-                | TokenKind::OrAssign
-                | TokenKind::XorAssign
-                | TokenKind::PowerAssign
-                | TokenKind::LeftShiftAssign
-                | TokenKind::RightShiftAssign
-                | TokenKind::LogicalAndAssign
-                | TokenKind::LogicalOrAssign
-                | TokenKind::DefinedOrAssign
-        )
+        kind.is_assignment_operator()
+            || kind.is_comparison_operator()
+            || matches!(kind, TokenKind::WordOr | TokenKind::WordAnd | TokenKind::WordXor)
+            || matches!(
+                kind,
+                TokenKind::Or
+                    | TokenKind::And
+                    | TokenKind::DefinedOr
+                    | TokenKind::Dot
+                    | TokenKind::Range
+                    | TokenKind::LeftShift
+                    | TokenKind::RightShift
+                    | TokenKind::BitwiseAnd
+                    | TokenKind::BitwiseOr
+                    | TokenKind::BitwiseXor
+                    | TokenKind::Question
+                    | TokenKind::Colon
+            )
     }
 
     /// Peek at the next token's kind
@@ -559,10 +529,7 @@ impl<'a> Parser<'a> {
             }
 
             match self.peek_kind() {
-                Some(TokenKind::Semicolon)
-                | Some(TokenKind::RightParen)
-                | Some(TokenKind::RightBrace)
-                | Some(TokenKind::RightBracket) => break,
+                Some(kind) if kind.is_recovery_boundary() && kind != TokenKind::Eof => break,
                 Some(k) if Self::is_stmt_modifier_kind(k) && !self.is_keyword_before_fat_arrow() => {
                     break;
                 }
@@ -578,10 +545,7 @@ impl<'a> Parser<'a> {
                 expressions.push(elem);
 
                 match self.peek_kind() {
-                    Some(TokenKind::Semicolon)
-                    | Some(TokenKind::RightParen)
-                    | Some(TokenKind::RightBrace)
-                    | Some(TokenKind::RightBracket) => break,
+                    Some(kind) if kind.is_recovery_boundary() && kind != TokenKind::Eof => break,
                     Some(k) if Self::is_stmt_modifier_kind(k) => break,
                     _ => expressions.push(self.parse_assignment()?),
                 }
@@ -618,33 +582,29 @@ impl<'a> Parser<'a> {
             return false;
         }
 
-        matches!(
-            self.peek_kind(),
-            Some(TokenKind::Semicolon)
-                | Some(TokenKind::RightBrace)
-                | Some(TokenKind::RightParen)
-                | Some(TokenKind::RightBracket)
-                // Statement-starter keywords cannot serve as an expression RHS.
-                // Treating them as "missing operand" allows declaration parsing
-                // to recover cleanly and resume at the next statement boundary.
-                | Some(TokenKind::My)
-                | Some(TokenKind::Our)
-                | Some(TokenKind::State)
-                | Some(TokenKind::Sub)
-                | Some(TokenKind::Package)
-                | Some(TokenKind::Use)
-                | Some(TokenKind::No)
-                | Some(TokenKind::If)
-                | Some(TokenKind::Unless)
-                | Some(TokenKind::Elsif)
-                | Some(TokenKind::Else)
-                | Some(TokenKind::While)
-                | Some(TokenKind::Until)
-                | Some(TokenKind::For)
-                | Some(TokenKind::Foreach)
-                | Some(TokenKind::Eof)
-                | None
-        )
+        match self.peek_kind() {
+            Some(k) if k.is_recovery_boundary() => true,
+            // Statement-starter keywords cannot serve as an expression RHS.
+            // Treating them as "missing operand" allows declaration parsing
+            // to recover cleanly and resume at the next statement boundary.
+            Some(TokenKind::My)
+            | Some(TokenKind::Our)
+            | Some(TokenKind::State)
+            | Some(TokenKind::Sub)
+            | Some(TokenKind::Package)
+            | Some(TokenKind::Use)
+            | Some(TokenKind::No)
+            | Some(TokenKind::If)
+            | Some(TokenKind::Unless)
+            | Some(TokenKind::Elsif)
+            | Some(TokenKind::Else)
+            | Some(TokenKind::While)
+            | Some(TokenKind::Until)
+            | Some(TokenKind::For)
+            | Some(TokenKind::Foreach)
+            | None => true,
+            _ => false,
+        }
     }
 
     /// Returns true when `sub` is followed by tokens that start an anonymous
@@ -744,7 +704,6 @@ impl<'a> Parser<'a> {
             Some(TokenKind::Semicolon)
                 | Some(TokenKind::RightBrace)
                 | Some(TokenKind::LeftBrace)
-                | Some(TokenKind::Eof)
                 | Some(TokenKind::My)
                 | Some(TokenKind::Our)
                 | Some(TokenKind::Local)
@@ -760,6 +719,7 @@ impl<'a> Parser<'a> {
                 | Some(TokenKind::Until)
                 | Some(TokenKind::For)
                 | Some(TokenKind::Foreach)
+                | Some(TokenKind::Eof)
                 | None
         )
     }
@@ -767,8 +727,7 @@ impl<'a> Parser<'a> {
     /// Check if current token is a synchronization point for error recovery
     fn is_sync_point(&mut self) -> bool {
         match self.peek_kind() {
-            Some(TokenKind::Semicolon) => true,
-            Some(TokenKind::RightBrace) => true,
+            Some(kind) if matches!(kind, TokenKind::Semicolon | TokenKind::RightBrace) => true,
             Some(TokenKind::My)
             | Some(TokenKind::Our)
             | Some(TokenKind::Local)

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -399,6 +399,127 @@ pub enum TokenKind {
 }
 
 impl TokenKind {
+    /// Return `true` when this token is an assignment operator.
+    #[inline]
+    pub fn is_assignment_operator(self) -> bool {
+        matches!(
+            self,
+            TokenKind::Assign
+                | TokenKind::PlusAssign
+                | TokenKind::MinusAssign
+                | TokenKind::StarAssign
+                | TokenKind::SlashAssign
+                | TokenKind::PercentAssign
+                | TokenKind::DotAssign
+                | TokenKind::AndAssign
+                | TokenKind::OrAssign
+                | TokenKind::XorAssign
+                | TokenKind::PowerAssign
+                | TokenKind::LeftShiftAssign
+                | TokenKind::RightShiftAssign
+                | TokenKind::LogicalAndAssign
+                | TokenKind::LogicalOrAssign
+                | TokenKind::DefinedOrAssign
+        )
+    }
+
+    /// Return `true` when this token is a comparison operator.
+    #[inline]
+    pub fn is_comparison_operator(self) -> bool {
+        matches!(
+            self,
+            TokenKind::Equal
+                | TokenKind::NotEqual
+                | TokenKind::Less
+                | TokenKind::Greater
+                | TokenKind::LessEqual
+                | TokenKind::GreaterEqual
+                | TokenKind::Spaceship
+                | TokenKind::StringCompare
+                | TokenKind::Match
+                | TokenKind::NotMatch
+                | TokenKind::SmartMatch
+        )
+    }
+
+    /// Return `true` when this token is a logical operator.
+    #[inline]
+    pub fn is_logical_operator(self) -> bool {
+        matches!(self, TokenKind::And | TokenKind::Or | TokenKind::DefinedOr | TokenKind::Not)
+    }
+
+    /// Return `true` when this token is a word-form operator (`and`, `or`, `not`, `xor`).
+    #[inline]
+    pub fn is_word_operator(self) -> bool {
+        matches!(
+            self,
+            TokenKind::WordAnd | TokenKind::WordOr | TokenKind::WordNot | TokenKind::WordXor
+        )
+    }
+
+    /// Return `true` when this token is a low-precedence word operator.
+    #[inline]
+    pub fn is_low_precedence_word_operator(self) -> bool {
+        self.is_word_operator()
+    }
+
+    /// Return `true` when this token opens a delimiter pair.
+    #[inline]
+    pub fn is_open_delimiter(self) -> bool {
+        matches!(self, TokenKind::LeftParen | TokenKind::LeftBrace | TokenKind::LeftBracket)
+    }
+
+    /// Return `true` when this token closes a delimiter pair.
+    #[inline]
+    pub fn is_close_delimiter(self) -> bool {
+        matches!(self, TokenKind::RightParen | TokenKind::RightBrace | TokenKind::RightBracket)
+    }
+
+    /// Return the matching open/close delimiter partner, if this token is a delimiter.
+    #[inline]
+    pub fn matching_delimiter(self) -> Option<TokenKind> {
+        match self {
+            TokenKind::LeftParen => Some(TokenKind::RightParen),
+            TokenKind::RightParen => Some(TokenKind::LeftParen),
+            TokenKind::LeftBrace => Some(TokenKind::RightBrace),
+            TokenKind::RightBrace => Some(TokenKind::LeftBrace),
+            TokenKind::LeftBracket => Some(TokenKind::RightBracket),
+            TokenKind::RightBracket => Some(TokenKind::LeftBracket),
+            _ => None,
+        }
+    }
+
+    /// Return `true` when this token is a quote-like literal/operator token.
+    #[inline]
+    pub fn is_quote_like(self) -> bool {
+        matches!(
+            self,
+            TokenKind::Regex
+                | TokenKind::Substitution
+                | TokenKind::Transliteration
+                | TokenKind::QuoteSingle
+                | TokenKind::QuoteDouble
+                | TokenKind::QuoteWords
+                | TokenKind::QuoteCommand
+                | TokenKind::HeredocStart
+        )
+    }
+
+    /// Return `true` when this token is a conservative expression recovery boundary.
+    ///
+    /// These tokens always end or strongly delimit the current expression context.
+    #[inline]
+    pub fn is_recovery_boundary(self) -> bool {
+        matches!(
+            self,
+            TokenKind::Semicolon
+                | TokenKind::RightParen
+                | TokenKind::RightBrace
+                | TokenKind::RightBracket
+                | TokenKind::Eof
+        )
+    }
+
     /// Return a user-friendly display name for this token kind.
     ///
     /// These names appear in parser error messages shown in the editor.

--- a/crates/perl-token/tests/token_role_tests.rs
+++ b/crates/perl-token/tests/token_role_tests.rs
@@ -1,0 +1,264 @@
+use perl_token::TokenKind;
+
+fn all_kinds() -> Vec<TokenKind> {
+    vec![
+        TokenKind::My,
+        TokenKind::Our,
+        TokenKind::Local,
+        TokenKind::State,
+        TokenKind::Sub,
+        TokenKind::If,
+        TokenKind::Elsif,
+        TokenKind::Else,
+        TokenKind::Unless,
+        TokenKind::While,
+        TokenKind::Until,
+        TokenKind::For,
+        TokenKind::Foreach,
+        TokenKind::Return,
+        TokenKind::Package,
+        TokenKind::Use,
+        TokenKind::No,
+        TokenKind::Begin,
+        TokenKind::End,
+        TokenKind::Check,
+        TokenKind::Init,
+        TokenKind::Unitcheck,
+        TokenKind::Eval,
+        TokenKind::Do,
+        TokenKind::Given,
+        TokenKind::When,
+        TokenKind::Default,
+        TokenKind::Try,
+        TokenKind::Catch,
+        TokenKind::Finally,
+        TokenKind::Continue,
+        TokenKind::Next,
+        TokenKind::Last,
+        TokenKind::Redo,
+        TokenKind::Goto,
+        TokenKind::Class,
+        TokenKind::Method,
+        TokenKind::Field,
+        TokenKind::Format,
+        TokenKind::Undef,
+        TokenKind::Defer,
+        TokenKind::Assign,
+        TokenKind::Plus,
+        TokenKind::Minus,
+        TokenKind::Star,
+        TokenKind::Slash,
+        TokenKind::Percent,
+        TokenKind::Power,
+        TokenKind::LeftShift,
+        TokenKind::RightShift,
+        TokenKind::BitwiseAnd,
+        TokenKind::BitwiseOr,
+        TokenKind::BitwiseXor,
+        TokenKind::BitwiseNot,
+        TokenKind::PlusAssign,
+        TokenKind::MinusAssign,
+        TokenKind::StarAssign,
+        TokenKind::SlashAssign,
+        TokenKind::PercentAssign,
+        TokenKind::DotAssign,
+        TokenKind::AndAssign,
+        TokenKind::OrAssign,
+        TokenKind::XorAssign,
+        TokenKind::PowerAssign,
+        TokenKind::LeftShiftAssign,
+        TokenKind::RightShiftAssign,
+        TokenKind::LogicalAndAssign,
+        TokenKind::LogicalOrAssign,
+        TokenKind::DefinedOrAssign,
+        TokenKind::Equal,
+        TokenKind::NotEqual,
+        TokenKind::Match,
+        TokenKind::NotMatch,
+        TokenKind::SmartMatch,
+        TokenKind::Less,
+        TokenKind::Greater,
+        TokenKind::LessEqual,
+        TokenKind::GreaterEqual,
+        TokenKind::Spaceship,
+        TokenKind::StringCompare,
+        TokenKind::And,
+        TokenKind::Or,
+        TokenKind::Not,
+        TokenKind::DefinedOr,
+        TokenKind::WordAnd,
+        TokenKind::WordOr,
+        TokenKind::WordNot,
+        TokenKind::WordXor,
+        TokenKind::Arrow,
+        TokenKind::FatArrow,
+        TokenKind::Dot,
+        TokenKind::Range,
+        TokenKind::Ellipsis,
+        TokenKind::Increment,
+        TokenKind::Decrement,
+        TokenKind::DoubleColon,
+        TokenKind::Question,
+        TokenKind::Colon,
+        TokenKind::Backslash,
+        TokenKind::LeftParen,
+        TokenKind::RightParen,
+        TokenKind::LeftBrace,
+        TokenKind::RightBrace,
+        TokenKind::LeftBracket,
+        TokenKind::RightBracket,
+        TokenKind::Semicolon,
+        TokenKind::Comma,
+        TokenKind::Number,
+        TokenKind::String,
+        TokenKind::Regex,
+        TokenKind::Substitution,
+        TokenKind::Transliteration,
+        TokenKind::QuoteSingle,
+        TokenKind::QuoteDouble,
+        TokenKind::QuoteWords,
+        TokenKind::QuoteCommand,
+        TokenKind::HeredocStart,
+        TokenKind::HeredocBody,
+        TokenKind::FormatBody,
+        TokenKind::DataMarker,
+        TokenKind::DataBody,
+        TokenKind::VString,
+        TokenKind::UnknownRest,
+        TokenKind::HeredocDepthLimit,
+        TokenKind::Identifier,
+        TokenKind::ScalarSigil,
+        TokenKind::ArraySigil,
+        TokenKind::HashSigil,
+        TokenKind::SubSigil,
+        TokenKind::GlobSigil,
+        TokenKind::Eof,
+        TokenKind::Unknown,
+    ]
+}
+
+#[test]
+fn token_role_predicates_are_exhaustive() {
+    for kind in all_kinds() {
+        assert_eq!(
+            kind.is_assignment_operator(),
+            matches!(
+                kind,
+                TokenKind::Assign
+                    | TokenKind::PlusAssign
+                    | TokenKind::MinusAssign
+                    | TokenKind::StarAssign
+                    | TokenKind::SlashAssign
+                    | TokenKind::PercentAssign
+                    | TokenKind::DotAssign
+                    | TokenKind::AndAssign
+                    | TokenKind::OrAssign
+                    | TokenKind::XorAssign
+                    | TokenKind::PowerAssign
+                    | TokenKind::LeftShiftAssign
+                    | TokenKind::RightShiftAssign
+                    | TokenKind::LogicalAndAssign
+                    | TokenKind::LogicalOrAssign
+                    | TokenKind::DefinedOrAssign
+            ),
+            "assignment mismatch for {kind:?}"
+        );
+
+        assert_eq!(
+            kind.is_comparison_operator(),
+            matches!(
+                kind,
+                TokenKind::Equal
+                    | TokenKind::NotEqual
+                    | TokenKind::Less
+                    | TokenKind::Greater
+                    | TokenKind::LessEqual
+                    | TokenKind::GreaterEqual
+                    | TokenKind::Spaceship
+                    | TokenKind::StringCompare
+                    | TokenKind::Match
+                    | TokenKind::NotMatch
+                    | TokenKind::SmartMatch
+            ),
+            "comparison mismatch for {kind:?}"
+        );
+
+        assert_eq!(
+            kind.is_logical_operator(),
+            matches!(kind, TokenKind::And | TokenKind::Or | TokenKind::DefinedOr | TokenKind::Not),
+            "logical mismatch for {kind:?}"
+        );
+
+        assert_eq!(
+            kind.is_word_operator(),
+            matches!(
+                kind,
+                TokenKind::WordAnd | TokenKind::WordOr | TokenKind::WordNot | TokenKind::WordXor
+            ),
+            "word-op mismatch for {kind:?}"
+        );
+
+        assert_eq!(
+            kind.is_low_precedence_word_operator(),
+            matches!(
+                kind,
+                TokenKind::WordAnd | TokenKind::WordOr | TokenKind::WordNot | TokenKind::WordXor
+            ),
+            "low-precedence word-op mismatch for {kind:?}"
+        );
+
+        assert_eq!(
+            kind.is_open_delimiter(),
+            matches!(kind, TokenKind::LeftParen | TokenKind::LeftBrace | TokenKind::LeftBracket),
+            "open-delimiter mismatch for {kind:?}"
+        );
+
+        assert_eq!(
+            kind.is_close_delimiter(),
+            matches!(kind, TokenKind::RightParen | TokenKind::RightBrace | TokenKind::RightBracket),
+            "close-delimiter mismatch for {kind:?}"
+        );
+
+        assert_eq!(
+            kind.is_quote_like(),
+            matches!(
+                kind,
+                TokenKind::Regex
+                    | TokenKind::Substitution
+                    | TokenKind::Transliteration
+                    | TokenKind::QuoteSingle
+                    | TokenKind::QuoteDouble
+                    | TokenKind::QuoteWords
+                    | TokenKind::QuoteCommand
+                    | TokenKind::HeredocStart
+            ),
+            "quote-like mismatch for {kind:?}"
+        );
+
+        assert_eq!(
+            kind.is_recovery_boundary(),
+            matches!(
+                kind,
+                TokenKind::Semicolon
+                    | TokenKind::RightParen
+                    | TokenKind::RightBrace
+                    | TokenKind::RightBracket
+                    | TokenKind::Eof
+            ),
+            "recovery-boundary mismatch for {kind:?}"
+        );
+    }
+}
+
+#[test]
+fn matching_delimiter_maps_open_and_close_pairs() {
+    assert_eq!(TokenKind::LeftParen.matching_delimiter(), Some(TokenKind::RightParen));
+    assert_eq!(TokenKind::RightParen.matching_delimiter(), Some(TokenKind::LeftParen));
+    assert_eq!(TokenKind::LeftBrace.matching_delimiter(), Some(TokenKind::RightBrace));
+    assert_eq!(TokenKind::RightBrace.matching_delimiter(), Some(TokenKind::LeftBrace));
+    assert_eq!(TokenKind::LeftBracket.matching_delimiter(), Some(TokenKind::RightBracket));
+    assert_eq!(TokenKind::RightBracket.matching_delimiter(), Some(TokenKind::LeftBracket));
+
+    assert_eq!(TokenKind::Semicolon.matching_delimiter(), None);
+    assert_eq!(TokenKind::Identifier.matching_delimiter(), None);
+}


### PR DESCRIPTION
### Motivation

- Replace repeated open-coded token-family matches in the parser with a small set of conservative, testable predicates to reduce divergence and make expression/statement boundaries easier to reason about.
- Make delimiter pairing and quote-like classification explicit so recovery and bare-call logic can reuse the same definitions.

### Description

- Added parser-facing `TokenKind` predicates in `crates/perl-token/src/lib.rs`: `is_assignment_operator`, `is_comparison_operator`, `is_logical_operator`, `is_word_operator`, `is_low_precedence_word_operator`, `is_open_delimiter`, `is_close_delimiter`, `matching_delimiter`, `is_quote_like`, and `is_recovery_boundary`.
- Added exhaustive unit tests `crates/perl-token/tests/token_role_tests.rs` validating each predicate over every `TokenKind` and testing `matching_delimiter` mappings.
- Replaced several high-value open-coded matches in parser-core with the new predicates, including bare-call argument termination, expression recovery checks, delimiter/statement boundary detection, and indirect-call termination heuristics (changes in `crates/perl-parser-core/src/engine/parser/helpers.rs`, `expressions/calls.rs`, and `expressions/postfix.rs`).
- Kept predicate logic conservative (no precedence policy embedded in `perl-token`); parser-core still controls higher-level behavior and precedence.

### Testing

- Ran formatting: `cargo xtask fmt` and `cargo fmt --all` (succeeded).
- Ran `cargo test -p perl-token` (all token crate tests passed, including the new `token_role_tests`).
- Ran `cargo test -p perl-parser-core` (most tests passed, but one existing parser-core test failed: `test_deref_hash_subscript_regex_key` produces a missing-closer error for `my $x = ${$ref}{m};`).
- `just parser-audit` was not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77d5f514833384f9d33e5c3d108b)