### PR TITLE
feat(perl-token): add parser-facing TokenKind role predicates (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -544,15 +544,9 @@ impl<'a> Parser<'a> {
                                 {
                                     // No comma — treat the block as a filehandle and parse the list.
                                     while !self.is_at_statement_end()
-                                        && !matches!(
-                                            self.peek_kind(),
-                                            Some(
-                                                TokenKind::WordOr
-                                                    | TokenKind::WordAnd
-                                                    | TokenKind::WordXor
-                                                    | TokenKind::WordNot
-                                            )
-                                        )
+                                        && !self
+                                            .peek_kind()
+                                            .is_some_and(TokenKind::is_low_precedence_word_operator)
                                     {
                                         if matches!(
                                             self.peek_kind(),
@@ -871,15 +865,9 @@ impl<'a> Parser<'a> {
                                     // Word operators terminate argument collection since
                                     // they bind less tightly than list operators.
                                     while !self.is_at_statement_end()
-                                        && !matches!(
-                                            self.peek_kind(),
-                                            Some(
-                                                TokenKind::WordOr
-                                                    | TokenKind::WordAnd
-                                                    | TokenKind::WordXor
-                                                    | TokenKind::WordNot
-                                            )
-                                        )
+                                        && !self
+                                            .peek_kind()
+                                            .is_some_and(TokenKind::is_low_precedence_word_operator)
                                     {
                                         // Skip comma or fat arrow if present
                                         if matches!(
@@ -927,15 +915,9 @@ impl<'a> Parser<'a> {
                                     args.push(self.parse_ternary()?);
 
                                     while !self.is_at_statement_end()
-                                        && !matches!(
-                                            self.peek_kind(),
-                                            Some(
-                                                TokenKind::WordOr
-                                                    | TokenKind::WordAnd
-                                                    | TokenKind::WordXor
-                                                    | TokenKind::WordNot
-                                            )
-                                        )
+                                        && !self
+                                            .peek_kind()
+                                            .is_some_and(TokenKind::is_low_precedence_word_operator)
                                     {
                                         if matches!(
                                             self.peek_kind(),
@@ -961,15 +943,9 @@ impl<'a> Parser<'a> {
                                     args.push(self.parse_ternary()?);
 
                                     while !self.is_at_statement_end()
-                                        && !matches!(
-                                            self.peek_kind(),
-                                            Some(
-                                                TokenKind::WordOr
-                                                    | TokenKind::WordAnd
-                                                    | TokenKind::WordXor
-                                                    | TokenKind::WordNot
-                                            )
-                                        )
+                                        && !self
+                                            .peek_kind()
+                                            .is_some_and(TokenKind::is_low_precedence_word_operator)
                                     {
                                         if matches!(
                                             self.peek_kind(),
@@ -1081,26 +1057,19 @@ impl<'a> Parser<'a> {
                                             Some(
                                                 TokenKind::Comma
                                                     | TokenKind::FatArrow
-                                                    | TokenKind::WordOr
-                                                    | TokenKind::WordAnd
-                                                    | TokenKind::WordXor
-                                                    | TokenKind::WordNot
                                             )
                                         )
+                                        && !self
+                                            .peek_kind()
+                                            .is_some_and(TokenKind::is_low_precedence_word_operator)
                                     {
                                         // No comma after first arg — it's an indirect object
                                         // (filehandle for print/say/printf, socket for send).
                                         // Parse the remaining args.
                                         while !self.is_at_statement_end()
-                                            && !matches!(
-                                                self.peek_kind(),
-                                                Some(
-                                                    TokenKind::WordOr
-                                                        | TokenKind::WordAnd
-                                                        | TokenKind::WordXor
-                                                        | TokenKind::WordNot
-                                                )
-                                            )
+                                            && !self
+                                                .peek_kind()
+                                                .is_some_and(TokenKind::is_low_precedence_word_operator)
                                         {
                                             if matches!(
                                                 self.peek_kind(),
@@ -1182,26 +1151,22 @@ impl<'a> Parser<'a> {
 
     /// Check if we're at a statement boundary
     fn is_at_statement_end(&mut self) -> bool {
-        matches!(
-            self.peek_kind(),
-            Some(TokenKind::Semicolon)
-                | Some(TokenKind::RightBrace)
-                | Some(TokenKind::RightParen)
-                | Some(TokenKind::RightBracket)
-                | Some(TokenKind::If)
-                | Some(TokenKind::Unless)
-                | Some(TokenKind::While)
-                | Some(TokenKind::Until)
-                | Some(TokenKind::For)
-                | Some(TokenKind::Foreach)
-                | Some(TokenKind::WordAnd)
-                | Some(TokenKind::WordOr)
-                | Some(TokenKind::WordXor)
-                | Some(TokenKind::WordNot)
-                | Some(TokenKind::DataMarker)
-                | Some(TokenKind::Eof)
-                | None
-        )
+        self.peek_kind().is_some_and(|kind| {
+            kind.is_close_delimiter()
+                || kind == TokenKind::Semicolon
+                || kind == TokenKind::DataMarker
+                || kind == TokenKind::Eof
+                || kind.is_low_precedence_word_operator()
+                || matches!(
+                    kind,
+                    TokenKind::If
+                        | TokenKind::Unless
+                        | TokenKind::While
+                        | TokenKind::Until
+                        | TokenKind::For
+                        | TokenKind::Foreach
+                )
+        }) || self.peek_kind().is_none()
     }
 
     /// Check whether the current peek token is a quote-op name that should be

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -120,9 +120,7 @@ impl<'a> Parser<'a> {
             | Some(TokenKind::RightBracket)
             | Some(TokenKind::Eof)
             | None => false,
-            Some(TokenKind::WordOr | TokenKind::WordAnd | TokenKind::WordXor | TokenKind::WordNot) => {
-                false
-            }
+            Some(kind) if kind.is_low_precedence_word_operator() => false,
             Some(kind) if Self::is_stmt_modifier_kind(kind) => self.is_keyword_before_fat_arrow(),
             _ => true,
         }
@@ -618,33 +616,30 @@ impl<'a> Parser<'a> {
             return false;
         }
 
-        matches!(
-            self.peek_kind(),
-            Some(TokenKind::Semicolon)
-                | Some(TokenKind::RightBrace)
-                | Some(TokenKind::RightParen)
-                | Some(TokenKind::RightBracket)
+        self.peek_kind().is_some_and(|kind| kind == TokenKind::Semicolon || kind.is_close_delimiter())
+            || matches!(
+                self.peek_kind(),
                 // Statement-starter keywords cannot serve as an expression RHS.
                 // Treating them as "missing operand" allows declaration parsing
                 // to recover cleanly and resume at the next statement boundary.
-                | Some(TokenKind::My)
-                | Some(TokenKind::Our)
-                | Some(TokenKind::State)
-                | Some(TokenKind::Sub)
-                | Some(TokenKind::Package)
-                | Some(TokenKind::Use)
-                | Some(TokenKind::No)
-                | Some(TokenKind::If)
-                | Some(TokenKind::Unless)
-                | Some(TokenKind::Elsif)
-                | Some(TokenKind::Else)
-                | Some(TokenKind::While)
-                | Some(TokenKind::Until)
-                | Some(TokenKind::For)
-                | Some(TokenKind::Foreach)
-                | Some(TokenKind::Eof)
-                | None
-        )
+                Some(TokenKind::My)
+                    | Some(TokenKind::Our)
+                    | Some(TokenKind::State)
+                    | Some(TokenKind::Sub)
+                    | Some(TokenKind::Package)
+                    | Some(TokenKind::Use)
+                    | Some(TokenKind::No)
+                    | Some(TokenKind::If)
+                    | Some(TokenKind::Unless)
+                    | Some(TokenKind::Elsif)
+                    | Some(TokenKind::Else)
+                    | Some(TokenKind::While)
+                    | Some(TokenKind::Until)
+                    | Some(TokenKind::For)
+                    | Some(TokenKind::Foreach)
+                    | Some(TokenKind::Eof)
+                    | None
+            )
     }
 
     /// Returns true when `sub` is followed by tokens that start an anonymous

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -875,15 +875,9 @@ impl<'a> Parser<'a> {
                             // e.g., `sort @list or die` => (sort @list) or (die)
                             if Self::is_block_list_func(func_name.as_ref()) {
                                 while !self.is_at_statement_end()
-                                    && !matches!(
-                                        self.peek_kind(),
-                                        Some(
-                                            TokenKind::WordOr
-                                                | TokenKind::WordAnd
-                                                | TokenKind::WordXor
-                                                | TokenKind::WordNot
-                                        )
-                                    )
+                                    && !self
+                                        .peek_kind()
+                                        .is_some_and(TokenKind::is_low_precedence_word_operator)
                                 {
                                     // Skip optional comma or fat arrow
                                     if matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -399,6 +399,132 @@ pub enum TokenKind {
 }
 
 impl TokenKind {
+    /// Returns true for assignment operators (`=`, `+=`, `&&=`, `//=`, ...).
+    pub fn is_assignment_operator(self) -> bool {
+        matches!(
+            self,
+            TokenKind::Assign
+                | TokenKind::PlusAssign
+                | TokenKind::MinusAssign
+                | TokenKind::StarAssign
+                | TokenKind::SlashAssign
+                | TokenKind::PercentAssign
+                | TokenKind::DotAssign
+                | TokenKind::AndAssign
+                | TokenKind::OrAssign
+                | TokenKind::XorAssign
+                | TokenKind::PowerAssign
+                | TokenKind::LeftShiftAssign
+                | TokenKind::RightShiftAssign
+                | TokenKind::LogicalAndAssign
+                | TokenKind::LogicalOrAssign
+                | TokenKind::DefinedOrAssign
+        )
+    }
+
+    /// Returns true for comparison operators (`==`, `!=`, `cmp`, `=~`, ...).
+    pub fn is_comparison_operator(self) -> bool {
+        matches!(
+            self,
+            TokenKind::Equal
+                | TokenKind::NotEqual
+                | TokenKind::Less
+                | TokenKind::Greater
+                | TokenKind::LessEqual
+                | TokenKind::GreaterEqual
+                | TokenKind::Spaceship
+                | TokenKind::StringCompare
+                | TokenKind::Match
+                | TokenKind::NotMatch
+                | TokenKind::SmartMatch
+        )
+    }
+
+    /// Returns true for logical operators (`&&`, `||`, `!`, `//`).
+    pub fn is_logical_operator(self) -> bool {
+        matches!(self, TokenKind::And | TokenKind::Or | TokenKind::Not | TokenKind::DefinedOr)
+    }
+
+    /// Returns true for word-style logical operators (`and`, `or`, `not`, `xor`).
+    pub fn is_word_operator(self) -> bool {
+        matches!(
+            self,
+            TokenKind::WordAnd | TokenKind::WordOr | TokenKind::WordNot | TokenKind::WordXor
+        )
+    }
+
+    /// Returns true for low-precedence word operators (`and`, `or`, `not`, `xor`).
+    pub fn is_low_precedence_word_operator(self) -> bool {
+        self.is_word_operator()
+    }
+
+    /// Returns true for opening delimiters (`(`, `{`, `[`).
+    pub fn is_open_delimiter(self) -> bool {
+        matches!(self, TokenKind::LeftParen | TokenKind::LeftBrace | TokenKind::LeftBracket)
+    }
+
+    /// Returns true for closing delimiters (`)`, `}`, `]`).
+    pub fn is_close_delimiter(self) -> bool {
+        matches!(self, TokenKind::RightParen | TokenKind::RightBrace | TokenKind::RightBracket)
+    }
+
+    /// Returns the matching delimiter token for paired delimiters.
+    pub fn matching_delimiter(self) -> Option<TokenKind> {
+        match self {
+            TokenKind::LeftParen => Some(TokenKind::RightParen),
+            TokenKind::RightParen => Some(TokenKind::LeftParen),
+            TokenKind::LeftBrace => Some(TokenKind::RightBrace),
+            TokenKind::RightBrace => Some(TokenKind::LeftBrace),
+            TokenKind::LeftBracket => Some(TokenKind::RightBracket),
+            TokenKind::RightBracket => Some(TokenKind::LeftBracket),
+            _ => None,
+        }
+    }
+
+    /// Returns true for quote-like tokens (`q`, `qq`, `qw`, regex, heredoc start, ...).
+    pub fn is_quote_like(self) -> bool {
+        matches!(
+            self,
+            TokenKind::Regex
+                | TokenKind::Substitution
+                | TokenKind::Transliteration
+                | TokenKind::QuoteSingle
+                | TokenKind::QuoteDouble
+                | TokenKind::QuoteWords
+                | TokenKind::QuoteCommand
+                | TokenKind::HeredocStart
+        )
+    }
+
+    /// Returns true for strong parser recovery boundaries.
+    pub fn is_recovery_boundary(self) -> bool {
+        matches!(
+            self,
+            TokenKind::Semicolon
+                | TokenKind::Eof
+                | TokenKind::RightParen
+                | TokenKind::RightBrace
+                | TokenKind::RightBracket
+                | TokenKind::DataMarker
+                | TokenKind::My
+                | TokenKind::Our
+                | TokenKind::Local
+                | TokenKind::State
+                | TokenKind::Sub
+                | TokenKind::Package
+                | TokenKind::Use
+                | TokenKind::No
+                | TokenKind::If
+                | TokenKind::Unless
+                | TokenKind::Elsif
+                | TokenKind::Else
+                | TokenKind::While
+                | TokenKind::Until
+                | TokenKind::For
+                | TokenKind::Foreach
+        )
+    }
+
     /// Return a user-friendly display name for this token kind.
     ///
     /// These names appear in parser error messages shown in the editor.

--- a/crates/perl-token/tests/token_role_tests.rs
+++ b/crates/perl-token/tests/token_role_tests.rs
@@ -1,0 +1,145 @@
+use perl_token::TokenKind;
+
+#[test]
+fn assignment_operator_roles_match_expected_kinds() {
+    let yes = [
+        TokenKind::Assign,
+        TokenKind::PlusAssign,
+        TokenKind::MinusAssign,
+        TokenKind::StarAssign,
+        TokenKind::SlashAssign,
+        TokenKind::PercentAssign,
+        TokenKind::DotAssign,
+        TokenKind::AndAssign,
+        TokenKind::OrAssign,
+        TokenKind::XorAssign,
+        TokenKind::PowerAssign,
+        TokenKind::LeftShiftAssign,
+        TokenKind::RightShiftAssign,
+        TokenKind::LogicalAndAssign,
+        TokenKind::LogicalOrAssign,
+        TokenKind::DefinedOrAssign,
+    ];
+    for kind in yes {
+        assert!(kind.is_assignment_operator(), "{kind:?} should be assignment");
+    }
+    for kind in [TokenKind::Equal, TokenKind::WordAnd, TokenKind::Identifier] {
+        assert!(!kind.is_assignment_operator(), "{kind:?} should not be assignment");
+    }
+}
+
+#[test]
+fn comparison_operator_roles_match_expected_kinds() {
+    let yes = [
+        TokenKind::Equal,
+        TokenKind::NotEqual,
+        TokenKind::Less,
+        TokenKind::Greater,
+        TokenKind::LessEqual,
+        TokenKind::GreaterEqual,
+        TokenKind::Spaceship,
+        TokenKind::StringCompare,
+        TokenKind::Match,
+        TokenKind::NotMatch,
+        TokenKind::SmartMatch,
+    ];
+    for kind in yes {
+        assert!(kind.is_comparison_operator(), "{kind:?} should be comparison");
+    }
+    for kind in [TokenKind::Assign, TokenKind::WordOr, TokenKind::Identifier] {
+        assert!(!kind.is_comparison_operator(), "{kind:?} should not be comparison");
+    }
+}
+
+#[test]
+fn logical_and_word_operator_roles_match_expected_kinds() {
+    for kind in [TokenKind::And, TokenKind::Or, TokenKind::Not, TokenKind::DefinedOr] {
+        assert!(kind.is_logical_operator(), "{kind:?} should be logical");
+    }
+    for kind in [TokenKind::WordAnd, TokenKind::WordOr, TokenKind::WordNot, TokenKind::WordXor] {
+        assert!(kind.is_word_operator(), "{kind:?} should be word operator");
+        assert!(
+            kind.is_low_precedence_word_operator(),
+            "{kind:?} should be low-precedence word operator"
+        );
+    }
+
+    for kind in [TokenKind::Identifier, TokenKind::StringCompare, TokenKind::Assign] {
+        assert!(!kind.is_logical_operator(), "{kind:?} should not be logical");
+        assert!(!kind.is_word_operator(), "{kind:?} should not be word operator");
+    }
+}
+
+#[test]
+fn delimiter_roles_and_matching_are_symmetric() {
+    for (open, close) in [
+        (TokenKind::LeftParen, TokenKind::RightParen),
+        (TokenKind::LeftBrace, TokenKind::RightBrace),
+        (TokenKind::LeftBracket, TokenKind::RightBracket),
+    ] {
+        assert!(open.is_open_delimiter());
+        assert!(close.is_close_delimiter());
+        assert_eq!(open.matching_delimiter(), Some(close));
+        assert_eq!(close.matching_delimiter(), Some(open));
+    }
+
+    for kind in [TokenKind::Comma, TokenKind::Semicolon, TokenKind::Identifier] {
+        assert!(!kind.is_open_delimiter());
+        assert!(!kind.is_close_delimiter());
+        assert_eq!(kind.matching_delimiter(), None);
+    }
+}
+
+#[test]
+fn quote_like_role_matches_expected_kinds() {
+    for kind in [
+        TokenKind::Regex,
+        TokenKind::Substitution,
+        TokenKind::Transliteration,
+        TokenKind::QuoteSingle,
+        TokenKind::QuoteDouble,
+        TokenKind::QuoteWords,
+        TokenKind::QuoteCommand,
+        TokenKind::HeredocStart,
+    ] {
+        assert!(kind.is_quote_like(), "{kind:?} should be quote-like");
+    }
+
+    for kind in [TokenKind::String, TokenKind::Identifier, TokenKind::HeredocBody] {
+        assert!(!kind.is_quote_like(), "{kind:?} should not be quote-like");
+    }
+}
+
+#[test]
+fn recovery_boundary_role_matches_expected_kinds() {
+    for kind in [
+        TokenKind::Semicolon,
+        TokenKind::Eof,
+        TokenKind::RightParen,
+        TokenKind::RightBrace,
+        TokenKind::RightBracket,
+        TokenKind::DataMarker,
+        TokenKind::My,
+        TokenKind::Our,
+        TokenKind::Local,
+        TokenKind::State,
+        TokenKind::Sub,
+        TokenKind::Package,
+        TokenKind::Use,
+        TokenKind::No,
+        TokenKind::If,
+        TokenKind::Unless,
+        TokenKind::Elsif,
+        TokenKind::Else,
+        TokenKind::While,
+        TokenKind::Until,
+        TokenKind::For,
+        TokenKind::Foreach,
+    ] {
+        assert!(kind.is_recovery_boundary(), "{kind:?} should be recovery boundary");
+    }
+
+    for kind in [TokenKind::LeftBrace, TokenKind::Comma, TokenKind::Identifier] {
+        assert!(!kind.is_recovery_boundary(), "{kind:?} should not be recovery boundary");
+    }
+}


### PR DESCRIPTION
### Motivation

- Reduce repeated open-coded token-family matches in the parser and provide a single, testable location for role/ boundary semantics to avoid divergence bugs.

### Description

- Add conservative parser-facing predicates to `TokenKind` in `crates/perl-token/src/lib.rs`: `is_assignment_operator`, `is_comparison_operator`, `is_logical_operator`, `is_word_operator`, `is_low_precedence_word_operator`, `is_open_delimiter`, `is_close_delimiter`, `matching_delimiter`, `is_quote_like`, and `is_recovery_boundary`.
- Add focused unit tests validating each predicate in `crates/perl-token/tests/token_role_tests.rs` that exercise expected positive and negative variants for the new roles.
- Replace several high-risk, repeated token-family matches in parser-core with the new helpers (references in `crates/perl-parser-core/src/engine/parser/helpers.rs`, `expressions/postfix.rs`, and `statements.rs`) to centralize boundary and word-operator logic.

### Testing

- Ran `cargo test -p perl-token` and all token crate tests passed.
- Ran `cargo test -p perl-parser-core` while iterating; most test suites passed but a remaining failure was observed in this workspace run (`engine::parser::test_edge_cases_deep::test_deref_hash_subscript_regex_key`) during the parser-core full test run, which was investigated while keeping behavioral changes limited and conservative.
- Ran formatting via `cargo xtask fmt` successfully; `just parser-audit` was unavailable in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77d5f514833384f9d33e5c3d108b)