### PR TITLE
feat(perl-token): add parser-facing TokenKind role predicates (#6458)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -500,12 +500,10 @@ impl<'a> Parser<'a> {
                                     self.should_continue_bare_call_after_block()
                                 } else {
                                     !self.is_at_statement_end()
-                                })
-                                    && !matches!(
-                                        self.peek_kind(),
-                                        Some(TokenKind::Comma) | Some(TokenKind::FatArrow)
-                                    )
-                                {
+                                }) && !matches!(
+                                    self.peek_kind(),
+                                    Some(TokenKind::Comma) | Some(TokenKind::FatArrow)
+                                ) {
                                     args.push(self.parse_assignment_or_declaration()?);
                                 }
 
@@ -676,20 +674,14 @@ impl<'a> Parser<'a> {
                     record_postfix_layer()?;
                     expr = if matches!(&expr.kind, NodeKind::Undef) {
                         Node::new(
-                            NodeKind::FunctionCall {
-                                name: "undef".to_string(),
-                                args,
-                            },
+                            NodeKind::FunctionCall { name: "undef".to_string(), args },
                             SourceLocation { start, end },
                         )
                     } else {
                         let mut all_args = vec![expr];
                         all_args.extend(args);
                         Node::new(
-                            NodeKind::FunctionCall {
-                                name: "->()".to_string(),
-                                args: all_args,
-                            },
+                            NodeKind::FunctionCall { name: "->()".to_string(), args: all_args },
                             SourceLocation { start, end },
                         )
                     };
@@ -1182,27 +1174,22 @@ impl<'a> Parser<'a> {
 
     /// Check if we're at a statement boundary
     fn is_at_statement_end(&mut self) -> bool {
-        matches!(
-            self.peek_kind(),
-            Some(TokenKind::Semicolon)
-                | Some(TokenKind::RightBrace)
-                | Some(TokenKind::RightParen)
-                | Some(TokenKind::RightBracket)
-                | Some(TokenKind::If)
-                | Some(TokenKind::Unless)
-                | Some(TokenKind::While)
-                | Some(TokenKind::Until)
-                | Some(TokenKind::For)
-                | Some(TokenKind::Foreach)
-                | Some(TokenKind::WordAnd)
-                | Some(TokenKind::WordOr)
-                | Some(TokenKind::WordXor)
-                | Some(TokenKind::WordNot)
-                | Some(TokenKind::Question)
-                | Some(TokenKind::DataMarker)
-                | Some(TokenKind::Eof)
-                | None
-        )
+        match self.peek_kind() {
+            Some(kind) if kind.is_recovery_boundary() => true,
+            // `?` starts a ternary operator at a higher expression level; it is
+            // not a valid start of a bare-call argument so it terminates arg collection.
+            Some(TokenKind::Question) => true,
+            Some(TokenKind::If)
+            | Some(TokenKind::Unless)
+            | Some(TokenKind::While)
+            | Some(TokenKind::Until)
+            | Some(TokenKind::For)
+            | Some(TokenKind::Foreach)
+            | Some(TokenKind::DataMarker) => true,
+            Some(kind) if kind.is_low_precedence_word_operator() => true,
+            None => true,
+            _ => false,
+        }
     }
 
     /// Check whether the current peek token is a quote-op name that should be
@@ -1359,9 +1346,6 @@ impl<'a> Parser<'a> {
         }
 
         let end = elements.last().map(|n| n.location.end).unwrap_or(start);
-        Ok(Some(Node::new(
-            NodeKind::ArrayLiteral { elements },
-            SourceLocation { start, end },
-        )))
+        Ok(Some(Node::new(NodeKind::ArrayLiteral { elements }, SourceLocation { start, end })))
     }
 }

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -20,7 +20,7 @@ impl<'a> Parser<'a> {
 
     #[inline]
     fn is_logical_or(kind: Option<TokenKind>) -> bool {
-        matches!(kind, Some(TokenKind::Or) | Some(TokenKind::DefinedOr))
+        kind.is_some_and(|token| matches!(token, TokenKind::Or | TokenKind::DefinedOr))
     }
 
     /// Returns true if the token kind is a postfix increment/decrement operator.
@@ -114,16 +114,11 @@ impl<'a> Parser<'a> {
     /// the modifier token is being autoquoted before `=>`.
     fn should_continue_bare_call_after_block(&mut self) -> bool {
         match self.peek_kind() {
-            Some(TokenKind::Semicolon)
-            | Some(TokenKind::RightBrace)
-            | Some(TokenKind::RightParen)
-            | Some(TokenKind::RightBracket)
-            | Some(TokenKind::Eof)
-            | None => false,
-            Some(TokenKind::WordOr | TokenKind::WordAnd | TokenKind::WordXor | TokenKind::WordNot) => {
-                false
-            }
+            Some(kind) if kind.is_recovery_boundary() => false,
+            None => false,
+            // `?` begins a ternary on the block-call result, not an argument to it.
             Some(TokenKind::Question) => false,
+            Some(kind) if kind.is_low_precedence_word_operator() => false,
             Some(kind) if Self::is_stmt_modifier_kind(kind) => self.is_keyword_before_fat_arrow(),
             _ => true,
         }
@@ -354,51 +349,21 @@ impl<'a> Parser<'a> {
 
     /// Check if a token kind is a binary operator that couldn't start an expression argument.
     fn is_binary_operator(kind: TokenKind) -> bool {
-        matches!(
-            kind,
-            TokenKind::Or
-                | TokenKind::And
-                | TokenKind::DefinedOr
-                | TokenKind::WordOr
-                | TokenKind::WordAnd
-                | TokenKind::WordXor
-                | TokenKind::Equal
-                | TokenKind::NotEqual
-                | TokenKind::Less
-                | TokenKind::Greater
-                | TokenKind::LessEqual
-                | TokenKind::GreaterEqual
-                | TokenKind::Spaceship
-                | TokenKind::StringCompare
-                | TokenKind::Match
-                | TokenKind::NotMatch
-                | TokenKind::SmartMatch
-                | TokenKind::Dot
-                | TokenKind::Range
-                | TokenKind::LeftShift
-                | TokenKind::RightShift
-                | TokenKind::BitwiseAnd
-                | TokenKind::BitwiseOr
-                | TokenKind::BitwiseXor
-                | TokenKind::Question
-                | TokenKind::Colon
-                | TokenKind::Assign
-                | TokenKind::PlusAssign
-                | TokenKind::MinusAssign
-                | TokenKind::StarAssign
-                | TokenKind::SlashAssign
-                | TokenKind::PercentAssign
-                | TokenKind::DotAssign
-                | TokenKind::AndAssign
-                | TokenKind::OrAssign
-                | TokenKind::XorAssign
-                | TokenKind::PowerAssign
-                | TokenKind::LeftShiftAssign
-                | TokenKind::RightShiftAssign
-                | TokenKind::LogicalAndAssign
-                | TokenKind::LogicalOrAssign
-                | TokenKind::DefinedOrAssign
-        )
+        kind.is_logical_operator()
+            || kind.is_comparison_operator()
+            || kind.is_assignment_operator()
+            || matches!(
+                kind,
+                TokenKind::Dot
+                    | TokenKind::Range
+                    | TokenKind::LeftShift
+                    | TokenKind::RightShift
+                    | TokenKind::BitwiseAnd
+                    | TokenKind::BitwiseOr
+                    | TokenKind::BitwiseXor
+                    | TokenKind::Question
+                    | TokenKind::Colon
+            )
     }
 
     /// Peek at the next token's kind
@@ -564,7 +529,9 @@ impl<'a> Parser<'a> {
                 | Some(TokenKind::RightParen)
                 | Some(TokenKind::RightBrace)
                 | Some(TokenKind::RightBracket) => break,
-                Some(k) if Self::is_stmt_modifier_kind(k) && !self.is_keyword_before_fat_arrow() => {
+                Some(k)
+                    if Self::is_stmt_modifier_kind(k) && !self.is_keyword_before_fat_arrow() =>
+                {
                     break;
                 }
                 _ => {}
@@ -591,10 +558,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        let end = expressions
-            .last()
-            .map(|expr| expr.location.end)
-            .unwrap_or(start);
+        let end = expressions.last().map(|expr| expr.location.end).unwrap_or(start);
         Ok(Self::build_list_or_hash(expressions, saw_fat_arrow, start, end))
     }
 
@@ -619,33 +583,29 @@ impl<'a> Parser<'a> {
             return false;
         }
 
-        matches!(
-            self.peek_kind(),
-            Some(TokenKind::Semicolon)
-                | Some(TokenKind::RightBrace)
-                | Some(TokenKind::RightParen)
-                | Some(TokenKind::RightBracket)
-                // Statement-starter keywords cannot serve as an expression RHS.
-                // Treating them as "missing operand" allows declaration parsing
-                // to recover cleanly and resume at the next statement boundary.
-                | Some(TokenKind::My)
-                | Some(TokenKind::Our)
-                | Some(TokenKind::State)
-                | Some(TokenKind::Sub)
-                | Some(TokenKind::Package)
-                | Some(TokenKind::Use)
-                | Some(TokenKind::No)
-                | Some(TokenKind::If)
-                | Some(TokenKind::Unless)
-                | Some(TokenKind::Elsif)
-                | Some(TokenKind::Else)
-                | Some(TokenKind::While)
-                | Some(TokenKind::Until)
-                | Some(TokenKind::For)
-                | Some(TokenKind::Foreach)
-                | Some(TokenKind::Eof)
-                | None
-        )
+        match self.peek_kind() {
+            Some(kind) if kind.is_recovery_boundary() => true,
+            // Statement-starter keywords cannot serve as an expression RHS.
+            // Treating them as "missing operand" allows declaration parsing
+            // to recover cleanly and resume at the next statement boundary.
+            Some(TokenKind::My)
+            | Some(TokenKind::Our)
+            | Some(TokenKind::State)
+            | Some(TokenKind::Sub)
+            | Some(TokenKind::Package)
+            | Some(TokenKind::Use)
+            | Some(TokenKind::No)
+            | Some(TokenKind::If)
+            | Some(TokenKind::Unless)
+            | Some(TokenKind::Elsif)
+            | Some(TokenKind::Else)
+            | Some(TokenKind::While)
+            | Some(TokenKind::Until)
+            | Some(TokenKind::For)
+            | Some(TokenKind::Foreach)
+            | None => true,
+            _ => false,
+        }
     }
 
     /// Returns true when `sub` is followed by tokens that start an anonymous
@@ -748,38 +708,33 @@ impl<'a> Parser<'a> {
     /// token is sticky) so we match it explicitly alongside `None` (which covers
     /// the case where the lexer itself returns an error).
     fn is_delimiter_recovery_point(&mut self) -> bool {
-        matches!(
-            self.peek_kind(),
-            Some(TokenKind::Semicolon)
-                | Some(TokenKind::RightParen)
-                | Some(TokenKind::RightBracket)
-                | Some(TokenKind::RightBrace)
-                | Some(TokenKind::LeftBrace)
-                | Some(TokenKind::Eof)
-                | Some(TokenKind::My)
-                | Some(TokenKind::Our)
-                | Some(TokenKind::Local)
-                | Some(TokenKind::State)
-                | Some(TokenKind::Sub)
-                | Some(TokenKind::Package)
-                | Some(TokenKind::Use)
-                | Some(TokenKind::If)
-                | Some(TokenKind::Unless)
-                | Some(TokenKind::Elsif)
-                | Some(TokenKind::Else)
-                | Some(TokenKind::While)
-                | Some(TokenKind::Until)
-                | Some(TokenKind::For)
-                | Some(TokenKind::Foreach)
-                | None
-        )
+        match self.peek_kind() {
+            Some(kind) if kind.is_recovery_boundary() => true,
+            Some(TokenKind::LeftBrace)
+            | Some(TokenKind::My)
+            | Some(TokenKind::Our)
+            | Some(TokenKind::Local)
+            | Some(TokenKind::State)
+            | Some(TokenKind::Sub)
+            | Some(TokenKind::Package)
+            | Some(TokenKind::Use)
+            | Some(TokenKind::If)
+            | Some(TokenKind::Unless)
+            | Some(TokenKind::Elsif)
+            | Some(TokenKind::Else)
+            | Some(TokenKind::While)
+            | Some(TokenKind::Until)
+            | Some(TokenKind::For)
+            | Some(TokenKind::Foreach)
+            | None => true,
+            _ => false,
+        }
     }
 
     /// Check if current token is a synchronization point for error recovery
     fn is_sync_point(&mut self) -> bool {
         match self.peek_kind() {
-            Some(TokenKind::Semicolon) => true,
-            Some(TokenKind::RightBrace) => true,
+            Some(kind) if kind.is_recovery_boundary() => true,
             Some(TokenKind::My)
             | Some(TokenKind::Our)
             | Some(TokenKind::Local)
@@ -789,7 +744,7 @@ impl<'a> Parser<'a> {
             Some(TokenKind::Elsif) | Some(TokenKind::Else) => true,
             Some(TokenKind::While) | Some(TokenKind::Until) => true,
             Some(TokenKind::For) | Some(TokenKind::Foreach) => true,
-            None => true, // EOF is a sync point
+            None => true, // tokenizer failure behaves like EOF for sync purposes
             _ => false,
         }
     }
@@ -951,15 +906,12 @@ impl<'a> Parser<'a> {
     /// must NOT be a string comparison operator (`eq`, `ne`, `lt`, `gt`, etc.)
     /// or a keyword token.
     fn looks_like_bare_call(&mut self, name: &str) -> bool {
-        if self
-            .peek_kind()
-            .is_some_and(|kind| matches!(kind, TokenKind::My | TokenKind::Our | TokenKind::Local | TokenKind::State))
-        {
+        if self.peek_kind().is_some_and(|kind| {
+            matches!(kind, TokenKind::My | TokenKind::Our | TokenKind::Local | TokenKind::State)
+        }) {
             return !name.is_empty()
                 && (name.contains("::")
-                    || name.starts_with(|c: char| {
-                        c.is_ascii_alphabetic() || c == '_'
-                    }));
+                    || name.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_'));
         }
 
         // Only lowercase identifiers can be bare function calls.
@@ -1010,10 +962,8 @@ impl<'a> Parser<'a> {
                 // Special tokens like __PACKAGE__, __FILE__, __LINE__, __SUB__ are
                 // nullary builtins that produce values. They are valid bare-call arguments.
                 // e.g. `croak __PACKAGE__, ": error"` (Encode/Encoder.pm)
-                if matches!(
-                    next_text.as_ref(),
-                    "__PACKAGE__" | "__FILE__" | "__LINE__" | "__SUB__"
-                ) {
+                if matches!(next_text.as_ref(), "__PACKAGE__" | "__FILE__" | "__LINE__" | "__SUB__")
+                {
                     return true;
                 }
                 // Allow qualified names (e.g. `File::Spec`, `Scalar::Util`) as arguments.

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -890,15 +890,7 @@ impl<'a> Parser<'a> {
                             // e.g., `sort @list or die` => (sort @list) or (die)
                             if Self::is_block_list_func(func_name.as_ref()) {
                                 while !self.is_at_statement_end()
-                                    && !matches!(
-                                        self.peek_kind(),
-                                        Some(
-                                            TokenKind::WordOr
-                                                | TokenKind::WordAnd
-                                                | TokenKind::WordXor
-                                                | TokenKind::WordNot
-                                        )
-                                    )
+                                    && !self.peek_kind().is_some_and(TokenKind::is_low_precedence_word_operator)
                                 {
                                     // Skip optional comma or fat arrow
                                     if matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -800,6 +800,8 @@ impl TokenKind {
         }
     }
 
+    // --- Category-based predicates (classify by TokenCategory) ---
+
     /// Returns `true` if this token kind is a keyword.
     pub const fn is_keyword(self) -> bool {
         matches!(self.category(), TokenCategory::Keyword)
@@ -828,6 +830,137 @@ impl TokenKind {
     /// Returns `true` if this token kind is a special sentinel/recovery token.
     pub const fn is_special(self) -> bool {
         matches!(self.category(), TokenCategory::Special)
+    }
+
+    // --- Parser-facing role predicates (specific semantic roles) ---
+
+    /// Return whether this token is an assignment operator.
+    #[inline]
+    pub fn is_assignment_operator(self) -> bool {
+        matches!(
+            self,
+            TokenKind::Assign
+                | TokenKind::PlusAssign
+                | TokenKind::MinusAssign
+                | TokenKind::StarAssign
+                | TokenKind::SlashAssign
+                | TokenKind::PercentAssign
+                | TokenKind::DotAssign
+                | TokenKind::AndAssign
+                | TokenKind::OrAssign
+                | TokenKind::XorAssign
+                | TokenKind::PowerAssign
+                | TokenKind::LeftShiftAssign
+                | TokenKind::RightShiftAssign
+                | TokenKind::LogicalAndAssign
+                | TokenKind::LogicalOrAssign
+                | TokenKind::DefinedOrAssign
+        )
+    }
+
+    /// Return whether this token is a comparison operator.
+    #[inline]
+    pub fn is_comparison_operator(self) -> bool {
+        matches!(
+            self,
+            TokenKind::Equal
+                | TokenKind::NotEqual
+                | TokenKind::Less
+                | TokenKind::Greater
+                | TokenKind::LessEqual
+                | TokenKind::GreaterEqual
+                | TokenKind::Spaceship
+                | TokenKind::StringCompare
+                | TokenKind::Match
+                | TokenKind::NotMatch
+                | TokenKind::SmartMatch
+        )
+    }
+
+    /// Return whether this token is a logical operator.
+    #[inline]
+    pub fn is_logical_operator(self) -> bool {
+        matches!(
+            self,
+            TokenKind::And
+                | TokenKind::Or
+                | TokenKind::Not
+                | TokenKind::DefinedOr
+                | TokenKind::WordAnd
+                | TokenKind::WordOr
+                | TokenKind::WordNot
+                | TokenKind::WordXor
+        )
+    }
+
+    /// Return whether this token is a word-form operator token.
+    #[inline]
+    pub fn is_word_operator(self) -> bool {
+        matches!(
+            self,
+            TokenKind::StringCompare
+                | TokenKind::WordAnd
+                | TokenKind::WordOr
+                | TokenKind::WordNot
+                | TokenKind::WordXor
+        )
+    }
+
+    /// Return whether this token is a low-precedence word operator.
+    #[inline]
+    pub fn is_low_precedence_word_operator(self) -> bool {
+        matches!(
+            self,
+            TokenKind::WordAnd | TokenKind::WordOr | TokenKind::WordNot | TokenKind::WordXor
+        )
+    }
+
+    /// Return whether this token is an opening paired delimiter.
+    #[inline]
+    pub fn is_open_delimiter(self) -> bool {
+        matches!(self, TokenKind::LeftParen | TokenKind::LeftBrace | TokenKind::LeftBracket)
+    }
+
+    /// Return whether this token is a closing paired delimiter.
+    #[inline]
+    pub fn is_close_delimiter(self) -> bool {
+        matches!(self, TokenKind::RightParen | TokenKind::RightBrace | TokenKind::RightBracket)
+    }
+
+    /// Return the matching paired delimiter for this token, if any.
+    #[inline]
+    pub fn matching_delimiter(self) -> Option<Self> {
+        match self {
+            TokenKind::LeftParen => Some(TokenKind::RightParen),
+            TokenKind::RightParen => Some(TokenKind::LeftParen),
+            TokenKind::LeftBrace => Some(TokenKind::RightBrace),
+            TokenKind::RightBrace => Some(TokenKind::LeftBrace),
+            TokenKind::LeftBracket => Some(TokenKind::RightBracket),
+            TokenKind::RightBracket => Some(TokenKind::LeftBracket),
+            _ => None,
+        }
+    }
+
+    /// Return whether this token is quote-like syntax.
+    #[inline]
+    pub fn is_quote_like(self) -> bool {
+        matches!(
+            self,
+            TokenKind::Regex
+                | TokenKind::Substitution
+                | TokenKind::Transliteration
+                | TokenKind::QuoteSingle
+                | TokenKind::QuoteDouble
+                | TokenKind::QuoteWords
+                | TokenKind::QuoteCommand
+                | TokenKind::HeredocStart
+        )
+    }
+
+    /// Return whether this token is a hard recovery boundary.
+    #[inline]
+    pub fn is_recovery_boundary(self) -> bool {
+        self == TokenKind::Semicolon || self.is_close_delimiter() || self == TokenKind::Eof
     }
 
     /// Map a canonical keyword spelling to its [`TokenKind`].

--- a/crates/perl-token/tests/token_role_tests.rs
+++ b/crates/perl-token/tests/token_role_tests.rs
@@ -1,0 +1,270 @@
+use perl_token::TokenKind;
+
+fn all_token_kinds() -> Vec<TokenKind> {
+    vec![
+        TokenKind::My,
+        TokenKind::Our,
+        TokenKind::Local,
+        TokenKind::State,
+        TokenKind::Sub,
+        TokenKind::If,
+        TokenKind::Elsif,
+        TokenKind::Else,
+        TokenKind::Unless,
+        TokenKind::While,
+        TokenKind::Until,
+        TokenKind::For,
+        TokenKind::Foreach,
+        TokenKind::Return,
+        TokenKind::Package,
+        TokenKind::Use,
+        TokenKind::No,
+        TokenKind::Begin,
+        TokenKind::End,
+        TokenKind::Check,
+        TokenKind::Init,
+        TokenKind::Unitcheck,
+        TokenKind::Eval,
+        TokenKind::Do,
+        TokenKind::Given,
+        TokenKind::When,
+        TokenKind::Default,
+        TokenKind::Try,
+        TokenKind::Catch,
+        TokenKind::Finally,
+        TokenKind::Continue,
+        TokenKind::Next,
+        TokenKind::Last,
+        TokenKind::Redo,
+        TokenKind::Goto,
+        TokenKind::Class,
+        TokenKind::Method,
+        TokenKind::Field,
+        TokenKind::Format,
+        TokenKind::Undef,
+        TokenKind::Defer,
+        TokenKind::Assign,
+        TokenKind::Plus,
+        TokenKind::Minus,
+        TokenKind::Star,
+        TokenKind::Slash,
+        TokenKind::Percent,
+        TokenKind::Power,
+        TokenKind::LeftShift,
+        TokenKind::RightShift,
+        TokenKind::BitwiseAnd,
+        TokenKind::BitwiseOr,
+        TokenKind::BitwiseXor,
+        TokenKind::BitwiseNot,
+        TokenKind::PlusAssign,
+        TokenKind::MinusAssign,
+        TokenKind::StarAssign,
+        TokenKind::SlashAssign,
+        TokenKind::PercentAssign,
+        TokenKind::DotAssign,
+        TokenKind::AndAssign,
+        TokenKind::OrAssign,
+        TokenKind::XorAssign,
+        TokenKind::PowerAssign,
+        TokenKind::LeftShiftAssign,
+        TokenKind::RightShiftAssign,
+        TokenKind::LogicalAndAssign,
+        TokenKind::LogicalOrAssign,
+        TokenKind::DefinedOrAssign,
+        TokenKind::Equal,
+        TokenKind::NotEqual,
+        TokenKind::Match,
+        TokenKind::NotMatch,
+        TokenKind::SmartMatch,
+        TokenKind::Less,
+        TokenKind::Greater,
+        TokenKind::LessEqual,
+        TokenKind::GreaterEqual,
+        TokenKind::Spaceship,
+        TokenKind::StringCompare,
+        TokenKind::And,
+        TokenKind::Or,
+        TokenKind::Not,
+        TokenKind::DefinedOr,
+        TokenKind::WordAnd,
+        TokenKind::WordOr,
+        TokenKind::WordNot,
+        TokenKind::WordXor,
+        TokenKind::Arrow,
+        TokenKind::FatArrow,
+        TokenKind::Dot,
+        TokenKind::Range,
+        TokenKind::Ellipsis,
+        TokenKind::Increment,
+        TokenKind::Decrement,
+        TokenKind::DoubleColon,
+        TokenKind::Question,
+        TokenKind::Colon,
+        TokenKind::Backslash,
+        TokenKind::LeftParen,
+        TokenKind::RightParen,
+        TokenKind::LeftBrace,
+        TokenKind::RightBrace,
+        TokenKind::LeftBracket,
+        TokenKind::RightBracket,
+        TokenKind::Semicolon,
+        TokenKind::Comma,
+        TokenKind::Number,
+        TokenKind::String,
+        TokenKind::Regex,
+        TokenKind::Substitution,
+        TokenKind::Transliteration,
+        TokenKind::QuoteSingle,
+        TokenKind::QuoteDouble,
+        TokenKind::QuoteWords,
+        TokenKind::QuoteCommand,
+        TokenKind::HeredocStart,
+        TokenKind::HeredocBody,
+        TokenKind::FormatBody,
+        TokenKind::DataMarker,
+        TokenKind::DataBody,
+        TokenKind::VString,
+        TokenKind::UnknownRest,
+        TokenKind::HeredocDepthLimit,
+        TokenKind::Identifier,
+        TokenKind::ScalarSigil,
+        TokenKind::ArraySigil,
+        TokenKind::HashSigil,
+        TokenKind::SubSigil,
+        TokenKind::GlobSigil,
+        TokenKind::Eof,
+        TokenKind::Unknown,
+    ]
+}
+
+#[test]
+fn token_roles_are_consistent() {
+    for kind in all_token_kinds() {
+        if kind.is_low_precedence_word_operator() {
+            assert!(kind.is_word_operator());
+            assert!(kind.is_logical_operator());
+        }
+        if kind.is_open_delimiter() || kind.is_close_delimiter() {
+            assert!(kind.matching_delimiter().is_some());
+        }
+        if kind.is_assignment_operator() {
+            assert!(!kind.is_comparison_operator());
+        }
+    }
+}
+
+#[test]
+fn assignment_comparison_and_logical_operator_sets() {
+    for kind in all_token_kinds() {
+        assert_eq!(
+            kind.is_assignment_operator(),
+            matches!(
+                kind,
+                TokenKind::Assign
+                    | TokenKind::PlusAssign
+                    | TokenKind::MinusAssign
+                    | TokenKind::StarAssign
+                    | TokenKind::SlashAssign
+                    | TokenKind::PercentAssign
+                    | TokenKind::DotAssign
+                    | TokenKind::AndAssign
+                    | TokenKind::OrAssign
+                    | TokenKind::XorAssign
+                    | TokenKind::PowerAssign
+                    | TokenKind::LeftShiftAssign
+                    | TokenKind::RightShiftAssign
+                    | TokenKind::LogicalAndAssign
+                    | TokenKind::LogicalOrAssign
+                    | TokenKind::DefinedOrAssign
+            )
+        );
+
+        assert_eq!(
+            kind.is_comparison_operator(),
+            matches!(
+                kind,
+                TokenKind::Equal
+                    | TokenKind::NotEqual
+                    | TokenKind::Less
+                    | TokenKind::Greater
+                    | TokenKind::LessEqual
+                    | TokenKind::GreaterEqual
+                    | TokenKind::Spaceship
+                    | TokenKind::StringCompare
+                    | TokenKind::Match
+                    | TokenKind::NotMatch
+                    | TokenKind::SmartMatch
+            )
+        );
+
+        assert_eq!(
+            kind.is_logical_operator(),
+            matches!(
+                kind,
+                TokenKind::And
+                    | TokenKind::Or
+                    | TokenKind::Not
+                    | TokenKind::DefinedOr
+                    | TokenKind::WordAnd
+                    | TokenKind::WordOr
+                    | TokenKind::WordNot
+                    | TokenKind::WordXor
+            )
+        );
+    }
+}
+
+#[test]
+fn delimiter_quote_and_recovery_roles() {
+    for kind in all_token_kinds() {
+        assert_eq!(
+            kind.is_open_delimiter(),
+            matches!(kind, TokenKind::LeftParen | TokenKind::LeftBrace | TokenKind::LeftBracket)
+        );
+        assert_eq!(
+            kind.is_close_delimiter(),
+            matches!(kind, TokenKind::RightParen | TokenKind::RightBrace | TokenKind::RightBracket)
+        );
+        assert_eq!(
+            kind.is_quote_like(),
+            matches!(
+                kind,
+                TokenKind::Regex
+                    | TokenKind::Substitution
+                    | TokenKind::Transliteration
+                    | TokenKind::QuoteSingle
+                    | TokenKind::QuoteDouble
+                    | TokenKind::QuoteWords
+                    | TokenKind::QuoteCommand
+                    | TokenKind::HeredocStart
+            )
+        );
+        assert_eq!(
+            kind.is_recovery_boundary(),
+            matches!(
+                kind,
+                TokenKind::Semicolon
+                    | TokenKind::RightParen
+                    | TokenKind::RightBrace
+                    | TokenKind::RightBracket
+                    | TokenKind::Eof
+            )
+        );
+    }
+}
+
+#[test]
+fn matching_delimiters_are_bidirectional() {
+    let pairs = [
+        (TokenKind::LeftParen, TokenKind::RightParen),
+        (TokenKind::LeftBrace, TokenKind::RightBrace),
+        (TokenKind::LeftBracket, TokenKind::RightBracket),
+    ];
+
+    for (open, close) in pairs {
+        assert_eq!(open.matching_delimiter(), Some(close));
+        assert_eq!(close.matching_delimiter(), Some(open));
+    }
+
+    assert_eq!(TokenKind::Comma.matching_delimiter(), None);
+}


### PR DESCRIPTION
### Motivation

- Reduce duplicated open-coded token-family checks across the parser so boundaries are consistent and easier to reason about.
- Provide conservative, parser-facing predicates so parser-core can rely on a single source of truth for terminators/recovery/quote/delimiter roles.

### Description

- Added parser-facing predicates on `TokenKind` in `crates/perl-token/src/lib.rs`: `is_assignment_operator`, `is_comparison_operator`, `is_logical_operator`, `is_word_operator`, `is_low_precedence_word_operator`, `is_open_delimiter`, `is_close_delimiter`, `matching_delimiter`, `is_quote_like`, and `is_recovery_boundary`.
- Added exhaustive role unit tests at `crates/perl-token/tests/token_role_tests.rs` that iterate every `TokenKind` variant and validate predicate semantics and bidirectional delimiter matching.
- Replaced several high-risk, repeated token-family `matches!` blocks in parser-core with the new predicates (notably in `crates/perl-parser-core/src/engine/parser/helpers.rs`, `expressions/postfix.rs`, and `statements.rs`) to standardize bare-call argument termination, expression recovery, delimiter recovery, and statement-boundary detection.
- Kept predicate logic conservative (no parser precedence policy embedded in `perl-token`) and only changed parser behavior where predicates intentionally simplified repeated checks.

### Testing

- Ran `cargo test -p perl-token` and all token crate tests passed.
- Added and ran `crates/perl-token/tests/token_role_tests.rs` which covers every `TokenKind` and passed.
- Ran targeted parser-core tests which exercised the modified paths and passed: `cargo test -p perl-parser-core test_recovery_missing_expression`, `cargo test -p perl-parser-core test_modifier_if_after_hash_key_if`, and `cargo test -p perl-parser-core my_keyword_autoquoted_in_function_call_args`.
- Attempted full `cargo test -p perl-parser-core` in this environment but the process was terminated by SIGKILL before completion; targeted regression tests above passed.
- Ran `cargo fmt` to ensure formatting; `just parser-audit` was not available in this environment so it was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77d5f514833384f9d33e5c3d108b)