### PR TITLE
perf(perl-token): add borrowed token view for allocation-sensitive paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,6 +1896,9 @@ version = "0.12.4"
 [[package]]
 name = "perl-token"
 version = "0.12.4"
+dependencies = [
+ "criterion",
+]
 
 [[package]]
 name = "perl-uri"

--- a/crates/perl-token/Cargo.toml
+++ b/crates/perl-token/Cargo.toml
@@ -16,8 +16,15 @@ categories = ["parsing", "text-processing"]
 [dependencies]
 # No external dependencies for now (Arc is std)
 
+[dev-dependencies]
+criterion.workspace = true
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "token_borrowed_scorecard"
+harness = false

--- a/crates/perl-token/README.md
+++ b/crates/perl-token/README.md
@@ -11,6 +11,7 @@ dependencies (only `std::sync::Arc`).
 ## Public API
 
 - **`Token`** -- a token with `kind: TokenKind`, `text: Arc<str>`, `start: usize`, `end: usize`
+- **`TokenRef<'src>`** -- borrowed token view with `text: &'src str` for allocation-sensitive paths
 - **`TokenKind`** -- enum classifying every Perl token: keywords, operators, delimiters, literals, sigils, and special tokens
 
 ## Usage
@@ -20,6 +21,22 @@ use perl_token::{Token, TokenKind};
 
 let tok = Token::new(TokenKind::Identifier, "foo", 0, 3);
 assert_eq!(tok.kind, TokenKind::Identifier);
+```
+
+Borrowed view for hot paths:
+
+```rust
+use perl_token::{Token, TokenKind, TokenRef};
+
+let borrowed = TokenRef::new(TokenKind::Identifier, "foo", 0, 3);
+let owned: Token = borrowed.into(); // explicit conversion to Arc-backed Token
+assert_eq!(&*owned.text, "foo");
+```
+
+Run the allocation scorecard benchmark:
+
+```bash
+cargo bench -p perl-token --bench token_borrowed_scorecard
 ```
 
 ## Workspace Role

--- a/crates/perl-token/benches/token_borrowed_scorecard.rs
+++ b/crates/perl-token/benches/token_borrowed_scorecard.rs
@@ -1,0 +1,92 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use perl_token::{Token, TokenKind, TokenRef};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct CountingAllocator;
+
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+// SAFETY: This allocator only forwards operations to `System` while keeping
+// allocation counters for benchmark scorecard output.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: Delegates to the system allocator with an unchanged layout.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: Delegates deallocation with the same pointer/layout pair.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: Delegates reallocation to the system allocator.
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: Delegates zeroed allocation to the system allocator.
+        unsafe { System.alloc_zeroed(layout) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+const SAMPLE_SIZE: usize = 16_384;
+
+fn count_allocations<F>(mut f: F) -> usize
+where
+    F: FnMut(),
+{
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    f();
+    ALLOCATIONS.load(Ordering::Relaxed)
+}
+
+fn benchmark_borrowed_vs_owned(c: &mut Criterion) {
+    let mut group = c.benchmark_group("token_borrowed_scorecard");
+
+    group.bench_function("construct_borrowed_token_ref", |b| {
+        b.iter(|| {
+            let token = TokenRef::new(TokenKind::Identifier, "hot_path_value", 20, 34);
+            std::hint::black_box(token);
+        })
+    });
+
+    group.bench_function("construct_owned_token", |b| {
+        b.iter(|| {
+            let token = Token::new(TokenKind::Identifier, "hot_path_value", 20, 34);
+            std::hint::black_box(token);
+        })
+    });
+
+    let borrowed_allocs = count_allocations(|| {
+        for _ in 0..SAMPLE_SIZE {
+            let token = TokenRef::new(TokenKind::Identifier, "hot_path_value", 20, 34);
+            std::hint::black_box(token);
+        }
+    });
+
+    let owned_allocs = count_allocations(|| {
+        for _ in 0..SAMPLE_SIZE {
+            let token = Token::new(TokenKind::Identifier, "hot_path_value", 20, 34);
+            std::hint::black_box(token);
+        }
+    });
+
+    eprintln!(
+        "Token allocation scorecard: borrowed={} owned={} samples={}",
+        borrowed_allocs, owned_allocs, SAMPLE_SIZE
+    );
+
+    assert!(borrowed_allocs < owned_allocs);
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_borrowed_vs_owned);
+criterion_main!(benches);

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -99,6 +99,75 @@ impl Token {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Return the token byte span as `(start, end)`.
+    pub fn span(&self) -> (usize, usize) {
+        (self.start, self.end)
+    }
+
+    /// Return the user-facing display name for this token.
+    pub fn display_name(&self) -> &'static str {
+        self.kind.display_name()
+    }
+
+    /// Borrow this token as a [`TokenRef`] without allocating.
+    pub fn as_ref_token(&self) -> TokenRef<'_> {
+        TokenRef { kind: self.kind, text: self.text.as_ref(), start: self.start, end: self.end }
+    }
+}
+
+/// Borrowed token view for allocation-sensitive hot paths.
+///
+/// Unlike [`Token`], this view borrows text from the source (`&str`) and can be
+/// constructed without creating an `Arc<str>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenRef<'src> {
+    /// Token classification for parser decision making.
+    pub kind: TokenKind,
+    /// Borrowed source text for temporary token inspection.
+    pub text: &'src str,
+    /// Starting byte position for error reporting and location tracking.
+    pub start: usize,
+    /// Ending byte position for span calculation and navigation.
+    pub end: usize,
+}
+
+impl<'src> TokenRef<'src> {
+    /// Create a new borrowed token view.
+    pub const fn new(kind: TokenKind, text: &'src str, start: usize, end: usize) -> Self {
+        Self { kind, text, start, end }
+    }
+
+    /// Convert this borrowed view into an owned [`Token`].
+    pub fn to_owned_token(self) -> Token {
+        Token::new(self.kind, self.text, self.start, self.end)
+    }
+
+    /// Return the token span length in bytes.
+    pub fn len(self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// Return whether the token span is empty.
+    pub fn is_empty(self) -> bool {
+        self.len() == 0
+    }
+
+    /// Return the token byte span as `(start, end)`.
+    pub fn span(self) -> (usize, usize) {
+        (self.start, self.end)
+    }
+
+    /// Return the user-facing display name for this token.
+    pub fn display_name(self) -> &'static str {
+        self.kind.display_name()
+    }
+}
+
+impl From<TokenRef<'_>> for Token {
+    fn from(value: TokenRef<'_>) -> Self {
+        value.to_owned_token()
+    }
 }
 
 /// Token classification for Perl parsing.

--- a/crates/perl-token/tests/borrowed_token_tests.rs
+++ b/crates/perl-token/tests/borrowed_token_tests.rs
@@ -1,0 +1,110 @@
+//! Tests for borrowed token views (`TokenRef`).
+
+use perl_token::{Token, TokenKind, TokenRef};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct CountingAllocator;
+
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+// SAFETY: This allocator forwards all allocation operations to `System` while
+// recording allocation call counts for scorecard-style assertions in tests.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: Delegates to the system allocator with the same `layout`.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: Delegates deallocation for the pointer/layout pair from `alloc`.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: Delegates reallocation to the system allocator.
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: Delegates zeroed allocation to the system allocator.
+        unsafe { System.alloc_zeroed(layout) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn allocation_delta<F>(mut f: F) -> usize
+where
+    F: FnMut(),
+{
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    f();
+    ALLOCATIONS.load(Ordering::Relaxed)
+}
+
+#[test]
+fn token_ref_construction_fields_and_helpers() {
+    let tok = TokenRef::new(TokenKind::Identifier, "example", 5, 12);
+    assert_eq!(tok.kind, TokenKind::Identifier);
+    assert_eq!(tok.text, "example");
+    assert_eq!(tok.len(), 7);
+    assert!(!tok.is_empty());
+    assert_eq!(tok.span(), (5, 12));
+    assert_eq!(tok.display_name(), "identifier");
+}
+
+#[test]
+fn token_ref_to_owned_token_is_explicit() {
+    let borrowed = TokenRef::new(TokenKind::My, "my", 0, 2);
+    let owned = borrowed.to_owned_token();
+
+    assert_eq!(owned.kind, TokenKind::My);
+    assert_eq!(&*owned.text, "my");
+    assert_eq!(owned.span(), (0, 2));
+}
+
+#[test]
+fn token_ref_from_into_token_matches_explicit_conversion() {
+    let borrowed = TokenRef::new(TokenKind::Sub, "sub", 10, 13);
+    let from_impl: Token = borrowed.into();
+
+    assert_eq!(from_impl.kind, TokenKind::Sub);
+    assert_eq!(&*from_impl.text, "sub");
+    assert_eq!(from_impl.span(), (10, 13));
+}
+
+#[test]
+fn token_as_ref_token_reuses_existing_text() {
+    let owned = Token::new(TokenKind::Identifier, "alpha", 1, 6);
+    let borrowed = owned.as_ref_token();
+
+    assert_eq!(borrowed.kind, TokenKind::Identifier);
+    assert_eq!(borrowed.text, "alpha");
+    assert_eq!(borrowed.span(), (1, 6));
+    assert_eq!(borrowed.display_name(), "identifier");
+}
+
+#[test]
+fn borrowed_token_construction_avoids_arc_allocation() {
+    let borrowed_allocations = allocation_delta(|| {
+        for _ in 0..4096 {
+            let tok = TokenRef::new(TokenKind::Identifier, "static_text", 3, 14);
+            std::hint::black_box(tok);
+        }
+    });
+
+    let owned_allocations = allocation_delta(|| {
+        for _ in 0..4096 {
+            let tok = Token::new(TokenKind::Identifier, "static_text", 3, 14);
+            std::hint::black_box(tok);
+        }
+    });
+
+    assert_eq!(borrowed_allocations, 0);
+    assert!(owned_allocations > borrowed_allocations);
+}


### PR DESCRIPTION
### Motivation

- Reduce allocations on hot token-processing paths by providing a borrowed view that avoids constructing `Arc<str>`-backed `Token` values for temporary inspection and classification.
- Preserve the existing `Token` API and make conversion to an owned `Token` explicit so callers opt into allocation only when needed.

### Description

- Add `TokenRef<'src>` as a non-breaking borrowed token view with fields `kind`, `text: &'src str`, `start`, and `end`, plus helpers `new`, `to_owned_token`, `len`, `is_empty`, `span`, and `display_name` and `impl From<TokenRef<'_>> for Token`.
- Add ergonomic helpers on `Token`: `span()`, `display_name()`, and `as_ref_token()` which returns a `TokenRef<'_>` without allocating.
- Add allocation-focused unit tests at `crates/perl-token/tests/borrowed_token_tests.rs`, a Criterion bench `crates/perl-token/benches/token_borrowed_scorecard.rs`, update `crates/perl-token/Cargo.toml`, and document `TokenRef<'src>` and the bench in `crates/perl-token/README.md`.

### Testing

- Ran `cargo test -p perl-token`, which passed (all new and existing `perl-token` tests succeeded).
- Ran `cargo bench -p perl-token --bench token_borrowed_scorecard`, which passed and reported an allocation scorecard showing `borrowed=0` vs `owned=16384` over the sample set.
- Ran `cargo check --all-targets -p perl-token`, which passed; `cargo check --workspace --all-targets` fails due to a pre-existing unrelated compile error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs:3919` and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77d93b5c8333a32e3f440e7f53c7)