### PR TITLE
perf(perl-token): add borrowed token view for allocation-sensitive paths

### DIFF
--- a/crates/perl-token/Cargo.toml
+++ b/crates/perl-token/Cargo.toml
@@ -16,8 +16,15 @@ categories = ["parsing", "text-processing"]
 [dependencies]
 # No external dependencies for now (Arc is std)
 
+[dev-dependencies]
+criterion.workspace = true
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "token_borrowed_scorecard"
+harness = false

--- a/crates/perl-token/README.md
+++ b/crates/perl-token/README.md
@@ -5,21 +5,34 @@ Core token type definitions for the Perl parser ecosystem.
 ## Overview
 
 `perl-token` is a Tier 1 leaf crate that defines the shared token types used
-across the lexer, tokenizer, and parser crates. It has zero external
-dependencies (only `std::sync::Arc`).
+across the lexer, tokenizer, and parser crates.
 
 ## Public API
 
 - **`Token`** -- a token with `kind: TokenKind`, `text: Arc<str>`, `start: usize`, `end: usize`
+- **`TokenRef<'src>`** -- a borrowed token view with `text: &'src str` for allocation-sensitive hot paths
 - **`TokenKind`** -- enum classifying every Perl token: keywords, operators, delimiters, literals, sigils, and special tokens
 
 ## Usage
 
 ```rust
-use perl_token::{Token, TokenKind};
+use perl_token::{Token, TokenKind, TokenRef};
 
 let tok = Token::new(TokenKind::Identifier, "foo", 0, 3);
 assert_eq!(tok.kind, TokenKind::Identifier);
+
+let borrowed = TokenRef::new(TokenKind::Identifier, "foo", 0, 3);
+let owned_again = borrowed.to_owned_token();
+assert_eq!(tok, owned_again);
+```
+
+## Performance scorecard
+
+Use the token scorecard benchmark to compare borrowed vs owned token
+construction:
+
+```bash
+cargo bench -p perl-token --bench token_borrowed_scorecard
 ```
 
 ## Workspace Role

--- a/crates/perl-token/benches/token_borrowed_scorecard.rs
+++ b/crates/perl-token/benches/token_borrowed_scorecard.rs
@@ -1,0 +1,49 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use perl_token::{Token, TokenKind, TokenRef};
+use std::hint::black_box;
+
+fn bench_token_construction(c: &mut Criterion) {
+    let inputs = [
+        (TokenKind::My, "my", 0usize, 2usize),
+        (TokenKind::ScalarSigil, "$", 3usize, 4usize),
+        (TokenKind::Identifier, "value", 4usize, 9usize),
+        (TokenKind::Assign, "=", 10usize, 11usize),
+        (TokenKind::Number, "42", 12usize, 14usize),
+    ];
+
+    c.bench_function("token_scorecard/construct_owned", |b| {
+        b.iter(|| {
+            inputs
+                .iter()
+                .map(|(kind, text, start, end)| {
+                    Token::new(*kind, black_box(*text), black_box(*start), black_box(*end))
+                })
+                .collect::<Vec<_>>()
+        });
+    });
+
+    c.bench_function("token_scorecard/construct_borrowed", |b| {
+        b.iter(|| {
+            inputs
+                .iter()
+                .map(|(kind, text, start, end)| {
+                    TokenRef::new(*kind, black_box(*text), black_box(*start), black_box(*end))
+                })
+                .collect::<Vec<_>>()
+        });
+    });
+
+    c.bench_function("token_scorecard/borrowed_to_owned", |b| {
+        b.iter(|| {
+            inputs
+                .iter()
+                .map(|(kind, text, start, end)| {
+                    TokenRef::new(*kind, text, *start, *end).to_owned_token()
+                })
+                .collect::<Vec<_>>()
+        });
+    });
+}
+
+criterion_group!(benches, bench_token_construction);
+criterion_main!(benches);

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -53,6 +53,23 @@ pub struct Token {
     pub end: usize,
 }
 
+/// Borrowed token view for allocation-sensitive paths.
+///
+/// `TokenRef` mirrors [`Token`] but borrows source text instead of storing
+/// an owned `Arc<str>`. This avoids allocation for short-lived flows that only
+/// need classification, spans, or diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenRef<'src> {
+    /// Token classification for parser decision making
+    pub kind: TokenKind,
+    /// Borrowed source text slice for zero-allocation inspection
+    pub text: &'src str,
+    /// Starting byte position for error reporting and location tracking
+    pub start: usize,
+    /// Ending byte position for span calculation and navigation
+    pub end: usize,
+}
+
 impl Token {
     /// Create a new token with the given kind, source text, and byte span.
     ///
@@ -98,6 +115,59 @@ impl Token {
     /// ```
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Return this token's byte span as `(start, end)`.
+    pub fn span(&self) -> (usize, usize) {
+        (self.start, self.end)
+    }
+
+    /// Return a display-friendly token name.
+    pub fn display_name(&self) -> &'static str {
+        self.kind.display_name()
+    }
+
+    /// Build a borrowed token view from this owned token.
+    pub fn as_ref_token(&self) -> TokenRef<'_> {
+        TokenRef { kind: self.kind, text: &self.text, start: self.start, end: self.end }
+    }
+}
+
+impl<'src> TokenRef<'src> {
+    /// Create a borrowed token view with kind, text, and byte span.
+    pub fn new(kind: TokenKind, text: &'src str, start: usize, end: usize) -> Self {
+        Self { kind, text, start, end }
+    }
+
+    /// Return the token span length in bytes.
+    pub fn len(&self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// Return whether the token span is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Return this token's byte span as `(start, end)`.
+    pub fn span(&self) -> (usize, usize) {
+        (self.start, self.end)
+    }
+
+    /// Return a display-friendly token name.
+    pub fn display_name(&self) -> &'static str {
+        self.kind.display_name()
+    }
+
+    /// Convert this borrowed token into an owned [`Token`].
+    pub fn to_owned_token(self) -> Token {
+        Token::new(self.kind, self.text, self.start, self.end)
+    }
+}
+
+impl From<TokenRef<'_>> for Token {
+    fn from(value: TokenRef<'_>) -> Self {
+        value.to_owned_token()
     }
 }
 

--- a/crates/perl-token/tests/borrowed_token_tests.rs
+++ b/crates/perl-token/tests/borrowed_token_tests.rs
@@ -1,0 +1,70 @@
+use perl_token::{Token, TokenKind, TokenRef};
+use std::sync::Arc;
+
+#[test]
+fn token_ref_construction_and_helpers() -> Result<(), Box<dyn std::error::Error>> {
+    let token = TokenRef::new(TokenKind::Identifier, "alpha", 4, 9);
+
+    assert_eq!(token.kind, TokenKind::Identifier);
+    assert_eq!(token.text, "alpha");
+    assert_eq!(token.len(), 5);
+    assert!(!token.is_empty());
+    assert_eq!(token.span(), (4, 9));
+    assert_eq!(token.display_name(), "identifier");
+
+    Ok(())
+}
+
+#[test]
+fn token_ref_to_owned_explicit_conversion() -> Result<(), Box<dyn std::error::Error>> {
+    let borrowed = TokenRef::new(TokenKind::My, "my", 0, 2);
+
+    let owned = borrowed.to_owned_token();
+
+    assert_eq!(owned.kind, TokenKind::My);
+    assert_eq!(&*owned.text, "my");
+    assert_eq!(owned.span(), (0, 2));
+    assert_eq!(owned.display_name(), "'my'");
+
+    Ok(())
+}
+
+#[test]
+fn token_ref_from_impl_matches_explicit() -> Result<(), Box<dyn std::error::Error>> {
+    let borrowed = TokenRef::new(TokenKind::Number, "42", 11, 13);
+
+    let from_impl: Token = borrowed.into();
+    let explicit = borrowed.to_owned_token();
+
+    assert_eq!(from_impl, explicit);
+
+    Ok(())
+}
+
+#[test]
+fn owned_token_as_ref_token_preserves_fields() -> Result<(), Box<dyn std::error::Error>> {
+    let shared_text = Arc::<str>::from("value");
+    let owned = Token::new(TokenKind::Identifier, Arc::clone(&shared_text), 30, 35);
+
+    let borrowed = owned.as_ref_token();
+
+    assert_eq!(borrowed.kind, TokenKind::Identifier);
+    assert_eq!(borrowed.text, "value");
+    assert_eq!(borrowed.span(), (30, 35));
+    assert_eq!(borrowed.display_name(), "identifier");
+
+    let round_trip = borrowed.to_owned_token();
+    assert_eq!(round_trip, owned);
+
+    Ok(())
+}
+
+#[test]
+fn borrowed_token_len_saturates_for_malformed_span() -> Result<(), Box<dyn std::error::Error>> {
+    let malformed = TokenRef::new(TokenKind::Unknown, "", 10, 3);
+
+    assert_eq!(malformed.len(), 0);
+    assert!(malformed.is_empty());
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Hot paths currently represent token text with an owned `Arc<str>` which forces an allocation even when only temporary inspection or classification is needed.
- A non-breaking borrowed view enables allocation-free token handling in benchmarks, diagnostics, tests, and future lexer/parser integration while keeping the existing `Token` API stable.

### Description
- Added `TokenRef<'src>` as a borrowed token view with fields `kind`, `text: &'src str`, `start`, and `end`, and helper methods `len()`, `is_empty()`, `span()`, and `display_name()`.
- Added explicit conversion helpers: `TokenRef::to_owned_token()`, `impl From<TokenRef<'_>> for Token`, and `Token::as_ref_token()` to create borrowed views from owned tokens.
- Added tests `crates/perl-token/tests/borrowed_token_tests.rs` exercising construction, helper parity, owned↔borrowed round-trip, and malformed-span saturation.
- Added a Criterion benchmark `crates/perl-token/benches/token_borrowed_scorecard.rs` and updated `crates/perl-token/Cargo.toml` to include the bench and `criterion` dev-dependency, and updated the crate README to document the new API and bench command.

### Testing
- Ran `cargo test -p perl-token` and all tests in `perl-token` passed (unit tests, extended/comprehensive suites, and the new borrowed-token tests).
- Ran the token scorecard: `cargo bench -p perl-token --bench token_borrowed_scorecard -- --sample-size 30`, which completed and showed borrowed construction much faster than owned construction in this run (construct_borrowed ≈ 28–29ns vs construct_owned ≈ 181–185ns, borrowed→owned ≈ 241–251ns).
- Ran `cargo clippy -p perl-token --all-targets -- -D warnings` which passed for the modified crate.
- Ran `cargo check --workspace --all-targets` which failed due to an unrelated, pre-existing formatting/format-string error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` and is outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77d93b5c8333a32e3f440e7f53c7)