### PR TITLE
perf(perl-token): add borrowed token view for allocation-sensitive paths (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,6 +1896,9 @@ version = "0.12.4"
 [[package]]
 name = "perl-token"
 version = "0.12.4"
+dependencies = [
+ "criterion",
+]
 
 [[package]]
 name = "perl-uri"

--- a/crates/perl-token/Cargo.toml
+++ b/crates/perl-token/Cargo.toml
@@ -16,6 +16,13 @@ categories = ["parsing", "text-processing"]
 [dependencies]
 # No external dependencies for now (Arc is std)
 
+[dev-dependencies]
+criterion.workspace = true
+
+[[bench]]
+name = "token_scorecard"
+harness = false
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/crates/perl-token/README.md
+++ b/crates/perl-token/README.md
@@ -11,15 +11,20 @@ dependencies (only `std::sync::Arc`).
 ## Public API
 
 - **`Token`** -- a token with `kind: TokenKind`, `text: Arc<str>`, `start: usize`, `end: usize`
+- **`TokenRef<'src>`** -- borrowed token view with `text: &'src str` for allocation-sensitive paths
 - **`TokenKind`** -- enum classifying every Perl token: keywords, operators, delimiters, literals, sigils, and special tokens
 
 ## Usage
 
 ```rust
-use perl_token::{Token, TokenKind};
+use perl_token::{Token, TokenKind, TokenRef};
 
 let tok = Token::new(TokenKind::Identifier, "foo", 0, 3);
 assert_eq!(tok.kind, TokenKind::Identifier);
+
+let borrowed = TokenRef::new(TokenKind::Identifier, "foo", 0, 3);
+let owned_again = borrowed.to_owned_token();
+assert_eq!(owned_again, tok);
 ```
 
 ## Workspace Role

--- a/crates/perl-token/benches/token_scorecard.rs
+++ b/crates/perl-token/benches/token_scorecard.rs
@@ -1,0 +1,94 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use perl_token::{Token, TokenKind, TokenRef};
+
+struct CountingAlloc;
+
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static DEALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: delegating directly to system allocator with same layout.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        DEALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: delegating directly to system allocator with same ptr/layout pair.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+fn reset_alloc_counters() {
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    DEALLOCATIONS.store(0, Ordering::Relaxed);
+}
+
+fn allocation_scorecard_owned(iterations: usize) -> usize {
+    reset_alloc_counters();
+    for _ in 0..iterations {
+        black_box(Token::new(TokenKind::Identifier, "classification_target", 10, 31));
+    }
+    ALLOCATIONS.load(Ordering::Relaxed)
+}
+
+fn allocation_scorecard_borrowed(iterations: usize) -> usize {
+    reset_alloc_counters();
+    for _ in 0..iterations {
+        black_box(TokenRef::new(TokenKind::Identifier, "classification_target", 10, 31));
+    }
+    ALLOCATIONS.load(Ordering::Relaxed)
+}
+
+fn token_construction_scorecard(c: &mut Criterion) {
+    let iterations = 100_000;
+    let owned_allocs = allocation_scorecard_owned(iterations);
+    let borrowed_allocs = allocation_scorecard_borrowed(iterations);
+
+    assert!(owned_allocs > borrowed_allocs);
+
+    let mut group = c.benchmark_group("token_construction_scorecard");
+    group.throughput(Throughput::Elements(iterations as u64));
+
+    group.bench_with_input(
+        BenchmarkId::new("owned_token_new", format!("allocs={owned_allocs}")),
+        &iterations,
+        |b, &input| {
+            b.iter(|| {
+                for _ in 0..input {
+                    black_box(Token::new(TokenKind::Identifier, "classification_target", 10, 31));
+                }
+            });
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("borrowed_token_new", format!("allocs={borrowed_allocs}")),
+        &iterations,
+        |b, &input| {
+            b.iter(|| {
+                for _ in 0..input {
+                    black_box(TokenRef::new(
+                        TokenKind::Identifier,
+                        "classification_target",
+                        10,
+                        31,
+                    ));
+                }
+            });
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, token_construction_scorecard);
+criterion_main!(benches);

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -25,6 +25,16 @@
 //! assert_eq!(&*num.text, "42");
 //! ```
 //!
+//! Use a borrowed token view in allocation-sensitive paths:
+//!
+//! ```rust
+//! use perl_token::{Token, TokenKind, TokenRef};
+//!
+//! let borrowed = TokenRef::new(TokenKind::Identifier, "value", 0, 5);
+//! let owned: Token = borrowed.into();
+//! assert_eq!(owned.kind, TokenKind::Identifier);
+//! ```
+//!
 //! Use [`TokenKind::display_name`] for user-facing error messages:
 //!
 //! ```rust
@@ -47,6 +57,22 @@ pub struct Token {
     pub kind: TokenKind,
     /// Original source text for precise reconstruction
     pub text: Arc<str>,
+    /// Starting byte position for error reporting and location tracking
+    pub start: usize,
+    /// Ending byte position for span calculation and navigation
+    pub end: usize,
+}
+
+/// Borrowed token view for allocation-sensitive hot paths.
+///
+/// This mirrors [`Token`] but keeps token text as `&str`, avoiding any `Arc`
+/// allocation until ownership is explicitly requested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenRef<'src> {
+    /// Token classification for parser decision making
+    pub kind: TokenKind,
+    /// Borrowed token text from source input
+    pub text: &'src str,
     /// Starting byte position for error reporting and location tracking
     pub start: usize,
     /// Ending byte position for span calculation and navigation
@@ -98,6 +124,59 @@ impl Token {
     /// ```
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Return token span as `(start, end)` byte offsets.
+    pub fn span(&self) -> (usize, usize) {
+        (self.start, self.end)
+    }
+
+    /// Return the human-readable token name for diagnostics.
+    pub fn display_name(&self) -> &'static str {
+        self.kind.display_name()
+    }
+
+    /// Return a borrowed token view that avoids additional allocation.
+    pub fn as_ref_token(&self) -> TokenRef<'_> {
+        TokenRef { kind: self.kind, text: self.text.as_ref(), start: self.start, end: self.end }
+    }
+}
+
+impl<'src> TokenRef<'src> {
+    /// Create a borrowed token view with the given kind, text, and byte span.
+    pub fn new(kind: TokenKind, text: &'src str, start: usize, end: usize) -> Self {
+        Self { kind, text, start, end }
+    }
+
+    /// Return the token span length in bytes.
+    pub fn len(&self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// Return whether the token span is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Return token span as `(start, end)` byte offsets.
+    pub fn span(&self) -> (usize, usize) {
+        (self.start, self.end)
+    }
+
+    /// Return the human-readable token name for diagnostics.
+    pub fn display_name(&self) -> &'static str {
+        self.kind.display_name()
+    }
+
+    /// Convert the borrowed token into an owned [`Token`].
+    pub fn to_owned_token(self) -> Token {
+        Token::new(self.kind, self.text, self.start, self.end)
+    }
+}
+
+impl From<TokenRef<'_>> for Token {
+    fn from(value: TokenRef<'_>) -> Self {
+        value.to_owned_token()
     }
 }
 

--- a/crates/perl-token/tests/borrowed_token_tests.rs
+++ b/crates/perl-token/tests/borrowed_token_tests.rs
@@ -1,0 +1,63 @@
+//! Tests for borrowed token views.
+
+use perl_token::{Token, TokenKind, TokenRef};
+
+#[test]
+fn borrowed_token_fields_and_helpers() -> Result<(), Box<dyn std::error::Error>> {
+    let tok = TokenRef::new(TokenKind::Identifier, "hello", 3, 8);
+
+    assert_eq!(tok.kind, TokenKind::Identifier);
+    assert_eq!(tok.text, "hello");
+    assert_eq!(tok.len(), 5);
+    assert!(!tok.is_empty());
+    assert_eq!(tok.span(), (3, 8));
+    assert_eq!(tok.display_name(), "identifier");
+
+    Ok(())
+}
+
+#[test]
+fn borrowed_token_handles_empty_and_malformed_spans() -> Result<(), Box<dyn std::error::Error>> {
+    let empty = TokenRef::new(TokenKind::Eof, "", 10, 10);
+    assert!(empty.is_empty());
+
+    let malformed = TokenRef::new(TokenKind::Unknown, "?", 20, 10);
+    assert_eq!(malformed.len(), 0);
+
+    Ok(())
+}
+
+#[test]
+fn borrowed_token_to_owned_conversion_is_explicit() -> Result<(), Box<dyn std::error::Error>> {
+    let borrowed = TokenRef::new(TokenKind::My, "my", 0, 2);
+
+    let owned = borrowed.to_owned_token();
+    assert_eq!(owned, Token::new(TokenKind::My, "my", 0, 2));
+
+    let via_from: Token = borrowed.into();
+    assert_eq!(via_from, Token::new(TokenKind::My, "my", 0, 2));
+
+    Ok(())
+}
+
+#[test]
+fn owned_token_can_be_viewed_as_borrowed() -> Result<(), Box<dyn std::error::Error>> {
+    let owned = Token::new(TokenKind::String, "\"abc\"", 11, 16);
+
+    let borrowed = owned.as_ref_token();
+    assert_eq!(borrowed.kind, TokenKind::String);
+    assert_eq!(borrowed.text, "\"abc\"");
+    assert_eq!(borrowed.span(), (11, 16));
+    assert_eq!(borrowed.display_name(), "string");
+
+    Ok(())
+}
+
+#[test]
+fn owned_token_helpers_still_match_kind_and_span() -> Result<(), Box<dyn std::error::Error>> {
+    let tok = Token::new(TokenKind::LeftBrace, "{", 42, 43);
+    assert_eq!(tok.span(), (42, 43));
+    assert_eq!(tok.display_name(), "'{'");
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Hot paths that only need to inspect tokens should avoid allocating `Arc<str>` for transient classification or diagnostics. 
- Provide a lightweight borrowed view so callers can operate on `&str` and convert to owned `Token` only when necessary.

### Description
- Add `TokenRef<'src>` with fields `kind`, `text: &'src str`, `start`, and `end`, and helper methods `len()`, `is_empty()`, `span()`, and `display_name()` (non-breaking to existing API). 
- Add explicit conversions: `TokenRef::to_owned_token()` and `impl From<TokenRef<'_>> for Token`, plus `Token::as_ref_token()` for borrowing from an owned `Token`. 
- Add focused unit tests in `crates/perl-token/tests/borrowed_token_tests.rs` covering helpers, malformed spans, and conversions. 
- Add a Criterion bench `crates/perl-token/benches/token_scorecard.rs` and a dev-dependency/bench entry in `crates/perl-token/Cargo.toml` to demonstrate allocation difference; update `README.md` and docs with usage example. 

### Testing
- Ran `cargo test -p perl-token`, which passed (all `perl-token` unit tests and doctests succeeded). 
- Ran benchmark `cargo bench -p perl-token --bench token_scorecard -- --noplot`, which executed and reported the expected allocation difference (owned construction shows allocations while `TokenRef` construction reports zero allocations). 
- Ran `cargo check --workspace --all-targets`, which failed due to a pre-existing, unrelated formatting/format-string error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` and not due to changes in `perl-token`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77d93b5c8333a32e3f440e7f53c7)