### PR TITLE
perf(perl-token): reduce measured token allocation overhead (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,6 +1896,9 @@ version = "0.12.4"
 [[package]]
 name = "perl-token"
 version = "0.12.4"
+dependencies = [
+ "criterion",
+]
 
 [[package]]
 name = "perl-uri"

--- a/crates/perl-parser-core/src/tokens/token_stream.rs
+++ b/crates/perl-parser-core/src/tokens/token_stream.rs
@@ -312,12 +312,7 @@ impl<'a> TokenStream<'a> {
                 LexerTokenType::Whitespace | LexerTokenType::Newline => continue,
                 LexerTokenType::Comment(_) => continue,
                 LexerTokenType::EOF => {
-                    return Ok(Token {
-                        kind: TokenKind::Eof,
-                        text: String::new().into(),
-                        start: lexer_token.start,
-                        end: lexer_token.end,
-                    });
+                    return Ok(Token::eof(lexer_token.start, lexer_token.end));
                 }
                 _ => {
                     return Ok(Self::convert_lexer_token(lexer_token));
@@ -333,7 +328,7 @@ impl<'a> TokenStream<'a> {
             // Synthesise an EOF at position 0 when the buffer is exhausted.
             // The caller (parser) makes EOF sticky so position doesn't matter
             // for correctness; using 0 is safe.
-            None => Ok(Token { kind: TokenKind::Eof, text: "".into(), start: 0, end: 0 }),
+            None => Ok(Token::eof(0, 0)),
         }
     }
 

--- a/crates/perl-token/Cargo.toml
+++ b/crates/perl-token/Cargo.toml
@@ -21,3 +21,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+criterion.workspace = true
+
+[[bench]]
+name = "token_construction_bench"
+harness = false

--- a/crates/perl-token/benches/token_construction_bench.rs
+++ b/crates/perl-token/benches/token_construction_bench.rs
@@ -1,0 +1,15 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use perl_token::{Token, TokenKind};
+
+fn bench_eof_token_construction(c: &mut Criterion) {
+    c.bench_function("token_new_eof", |b| {
+        b.iter(|| Token::new(TokenKind::Eof, "", 1024, 1024));
+    });
+
+    c.bench_function("token_eof_shared_empty_arc", |b| {
+        b.iter(|| Token::eof(1024, 1024));
+    });
+}
+
+criterion_group!(benches, bench_eof_token_construction);
+criterion_main!(benches);

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -35,7 +35,12 @@
 //! assert_eq!(TokenKind::Eof.display_name(), "end of input");
 //! ```
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+
+fn empty_token_text() -> Arc<str> {
+    static EMPTY_TOKEN_TEXT: OnceLock<Arc<str>> = OnceLock::new();
+    EMPTY_TOKEN_TEXT.get_or_init(|| Arc::<str>::from("")).clone()
+}
 
 /// Token produced by the lexer and consumed by the parser.
 ///
@@ -67,6 +72,11 @@ impl Token {
     /// ```
     pub fn new(kind: TokenKind, text: impl Into<Arc<str>>, start: usize, end: usize) -> Self {
         Token { kind, text: text.into(), start, end }
+    }
+
+    /// Create an EOF token with shared empty text storage.
+    pub fn eof(start: usize, end: usize) -> Self {
+        Token { kind: TokenKind::Eof, text: empty_token_text(), start, end }
     }
 
     /// Return the token span length in bytes.

--- a/crates/perl-token/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-token/tests/comprehensive_unit_tests.rs
@@ -51,6 +51,13 @@ fn token_new_empty_text() {
 }
 
 #[test]
+fn token_eof_reuses_empty_text_arc() {
+    let a = Token::eof(100, 100);
+    let b = Token::eof(200, 200);
+    assert!(Arc::ptr_eq(&a.text, &b.text));
+}
+
+#[test]
 fn token_new_zero_length_span() {
     let t = Token::new(TokenKind::Semicolon, ";", 42, 42);
     assert_eq!(t.start, t.end);


### PR DESCRIPTION
### Motivation

- EOF token construction in parser paths repeatedly allocated an empty `Arc<str>`, adding measurable allocation/clone overhead in hot token-construction paths.

### Description

- Add `Token::eof(start, end)` and an `empty_token_text()` helper backed by a `OnceLock<Arc<str>>` to reuse a single empty `Arc<str>` for EOF tokens, avoiding repeated empty-string allocations (`crates/perl-token/src/lib.rs`).
- Switch parser token-stream synthesis paths to use `Token::eof(...)` for both lexer-produced EOF and buffered-stream synthetic EOFs (`crates/perl-parser-core/src/tokens/token_stream.rs`).
- Add a unit test `token_eof_reuses_empty_text_arc` to assert the EOF tokens share the same `Arc` allocation (`crates/perl-token/tests/comprehensive_unit_tests.rs`).
- Add a focused Criterion benchmark `token_construction_bench` and crate bench configuration to compare old vs new EOF construction (`crates/perl-token/benches/token_construction_bench.rs` and `crates/perl-token/Cargo.toml`).

### Testing

- Ran `cargo test -p perl-token` and all `perl-token` unit tests passed.
- Ran the new micro-benchmark: `cargo bench -p perl-token --bench token_construction_bench -- --noplot` and observed:
  - `token_new_eof`: 32.268 ns – 32.709 ns
  - `token_eof_shared_empty_arc`: 17.940 ns – 18.542 ns
  - Measured improvement: ~44% faster EOF token construction in this microbenchmark.
- Ran `cargo test -p perl-lexer` and `perl-lexer` tests passed.
- Observed pre-existing failures when running `cargo test -p perl-parser-core` (failure in `test_deref_hash_subscript_regex_key`) and `cargo check --workspace --all-targets` (compile-time test-format error in `perl-semantic-analyzer`); these failures are unrelated to the EOF allocation change and were present during verification runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77dc91c483338d82c86c8aa67ca4)