### PR TITLE
perf(perl-token): reduce measured EOF token allocation overhead (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1766,6 +1766,7 @@ dependencies = [
 name = "perl-parser-core"
 version = "0.12.4"
 dependencies = [
+ "criterion",
  "perl-ast",
  "perl-ast-v2",
  "perl-lexer",

--- a/crates/perl-parser-core/Cargo.toml
+++ b/crates/perl-parser-core/Cargo.toml
@@ -45,6 +45,7 @@ perl-tdd-support = { workspace = true }
 tempfile = { workspace = true }
 proptest = { workspace = true }
 tracing-subscriber = "0.3"
+criterion.workspace = true
 
 [features]
 default = []
@@ -56,3 +57,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [lints]
 workspace = true
 
+
+[[bench]]
+name = "token_stream_benchmarks"
+harness = false

--- a/crates/perl-parser-core/benches/token_stream_benchmarks.rs
+++ b/crates/perl-parser-core/benches/token_stream_benchmarks.rs
@@ -1,0 +1,27 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use perl_parser_core::tokens::token_stream::{Token, TokenKind, TokenStream};
+use std::hint::black_box;
+
+fn bench_buffered_empty_eof(c: &mut Criterion) {
+    c.bench_function("token_stream/buffered_empty_eof", |b| {
+        b.iter(|| {
+            let mut stream = TokenStream::from_vec(Vec::new());
+            let token = stream.next().expect("empty buffered stream should synthesize EOF");
+            black_box(token.kind == TokenKind::Eof)
+        });
+    });
+}
+
+fn bench_buffered_eof_after_token(c: &mut Criterion) {
+    c.bench_function("token_stream/buffered_eof_after_token", |b| {
+        b.iter(|| {
+            let mut stream = TokenStream::from_vec(vec![Token::new(TokenKind::My, "my", 0, 2)]);
+            let _first = stream.next().expect("first token should exist");
+            let eof = stream.next().expect("second token should be EOF");
+            black_box(eof.kind == TokenKind::Eof)
+        });
+    });
+}
+
+criterion_group!(benches, bench_buffered_empty_eof, bench_buffered_eof_after_token);
+criterion_main!(benches);

--- a/crates/perl-parser-core/src/tokens/token_stream.rs
+++ b/crates/perl-parser-core/src/tokens/token_stream.rs
@@ -312,12 +312,7 @@ impl<'a> TokenStream<'a> {
                 LexerTokenType::Whitespace | LexerTokenType::Newline => continue,
                 LexerTokenType::Comment(_) => continue,
                 LexerTokenType::EOF => {
-                    return Ok(Token {
-                        kind: TokenKind::Eof,
-                        text: String::new().into(),
-                        start: lexer_token.start,
-                        end: lexer_token.end,
-                    });
+                    return Ok(Token::eof(lexer_token.start, lexer_token.end));
                 }
                 _ => {
                     return Ok(Self::convert_lexer_token(lexer_token));
@@ -333,7 +328,7 @@ impl<'a> TokenStream<'a> {
             // Synthesise an EOF at position 0 when the buffer is exhausted.
             // The caller (parser) makes EOF sticky so position doesn't matter
             // for correctness; using 0 is safe.
-            None => Ok(Token { kind: TokenKind::Eof, text: "".into(), start: 0, end: 0 }),
+            None => Ok(Token::eof(0, 0)),
         }
     }
 

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -35,7 +35,9 @@
 //! assert_eq!(TokenKind::Eof.display_name(), "end of input");
 //! ```
 
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
+
+static EMPTY_TOKEN_TEXT: LazyLock<Arc<str>> = LazyLock::new(|| Arc::from(""));
 
 /// Token produced by the lexer and consumed by the parser.
 ///
@@ -98,6 +100,11 @@ impl Token {
     /// ```
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Create an EOF token at the provided byte position.
+    pub fn eof(start: usize, end: usize) -> Self {
+        Token { kind: TokenKind::Eof, text: Arc::clone(&EMPTY_TOKEN_TEXT), start, end }
     }
 }
 


### PR DESCRIPTION
### Motivation
- EOF token synthesis in the parser hot-path was allocating a fresh empty `Arc<str>` per synthetic EOF, creating avoidable allocations on a high-frequency path and inflating token-phase costs in the scorecard.
- Make a small, measured allocation reduction targeted at EOF construction so the token scorecard shows concrete improvement without changing public token layout or parser semantics.

### Description
- Added a shared static `EMPTY_TOKEN_TEXT: LazyLock<Arc<str>>` in `crates/perl-token/src/lib.rs` and a convenience constructor `Token::eof(start, end)` that clones that shared `Arc` for EOF tokens.
- Replaced ad-hoc EOF constructions in `crates/perl-parser-core/src/tokens/token_stream.rs` (both live-lexer EOF and buffered-exhaustion EOF) with `Token::eof(...)` to reuse the single allocation.
- Added a focused Criterion benchmark `crates/perl-parser-core/benches/token_stream_benchmarks.rs` and enabled a bench entry in `crates/perl-parser-core/Cargo.toml` to measure the token-stream EOF paths.

### Testing
- Ran the focused benches before/after and observed improvements: `token_stream/buffered_empty_eof` went from ~46.6–47.5 ns to ~32.8–33.4 ns (~29% faster), and `token_stream/buffered_eof_after_token` went from ~94.3–95.5 ns to ~69.6–70.8 ns (~26% faster).
- `cargo test -p perl-token` completed successfully (all tests passed).
- `cargo test -p perl-lexer` completed successfully (all tests passed).
- `cargo test -p perl-parser-core` was executed but a pre-existing test (`test_deref_hash_subscript_regex_key`) failed; this failure appears unrelated to the EOF allocation change.
- `cargo check --workspace --all-targets` was run but the workspace check failed due to a pre-existing compile error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` unrelated to this change.
- Formatting via `cargo xtask fmt` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77dc91c483338d82c86c8aa67ca4)