### PR TITLE
perf(perl-token): reduce measured token allocation overhead (#0000)

### DIFF
--- a/crates/perl-parser-core/src/tokens/token_stream.rs
+++ b/crates/perl-parser-core/src/tokens/token_stream.rs
@@ -312,12 +312,7 @@ impl<'a> TokenStream<'a> {
                 LexerTokenType::Whitespace | LexerTokenType::Newline => continue,
                 LexerTokenType::Comment(_) => continue,
                 LexerTokenType::EOF => {
-                    return Ok(Token {
-                        kind: TokenKind::Eof,
-                        text: String::new().into(),
-                        start: lexer_token.start,
-                        end: lexer_token.end,
-                    });
+                    return Ok(Token::eof_with_span(lexer_token.start, lexer_token.end));
                 }
                 _ => {
                     return Ok(Self::convert_lexer_token(lexer_token));
@@ -333,7 +328,7 @@ impl<'a> TokenStream<'a> {
             // Synthesise an EOF at position 0 when the buffer is exhausted.
             // The caller (parser) makes EOF sticky so position doesn't matter
             // for correctness; using 0 is safe.
-            None => Ok(Token { kind: TokenKind::Eof, text: "".into(), start: 0, end: 0 }),
+            None => Ok(Token::eof_at(0)),
         }
     }
 

--- a/crates/perl-token/examples/token_scorecard.rs
+++ b/crates/perl-token/examples/token_scorecard.rs
@@ -1,0 +1,42 @@
+use perl_token::{Token, TokenKind};
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+const ITERATIONS: usize = 2_000_000;
+const ROUNDS: usize = 5;
+
+fn time_it<F>(label: &str, mut f: F) -> Duration
+where
+    F: FnMut() -> Token,
+{
+    let mut best = Duration::MAX;
+    for _ in 0..ROUNDS {
+        let start = Instant::now();
+        for i in 0..ITERATIONS {
+            let token = f();
+            black_box((token.start, token.end, token.kind));
+            black_box(i);
+        }
+        let elapsed = start.elapsed();
+        if elapsed < best {
+            best = elapsed;
+        }
+    }
+
+    println!("{label}: best={best:?} for {ITERATIONS} iters");
+    best
+}
+
+fn main() {
+    let baseline = time_it("baseline_token_new_eof", || {
+        Token::new(TokenKind::Eof, "", black_box(0), black_box(0))
+    });
+
+    let optimized = time_it("optimized_token_eof_at", || Token::eof_at(black_box(0)));
+
+    let speedup = baseline.as_secs_f64() / optimized.as_secs_f64();
+    let delta_pct =
+        ((baseline.as_secs_f64() - optimized.as_secs_f64()) / baseline.as_secs_f64()) * 100.0;
+
+    println!("speedup: {speedup:.3}x, improvement: {delta_pct:.2}%");
+}

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -35,7 +35,14 @@
 //! assert_eq!(TokenKind::Eof.display_name(), "end of input");
 //! ```
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+
+static EMPTY_TEXT_ARC: OnceLock<Arc<str>> = OnceLock::new();
+
+#[inline]
+fn empty_text_arc() -> Arc<str> {
+    EMPTY_TEXT_ARC.get_or_init(|| Arc::from("")).clone()
+}
 
 /// Token produced by the lexer and consumed by the parser.
 ///
@@ -67,6 +74,21 @@ impl Token {
     /// ```
     pub fn new(kind: TokenKind, text: impl Into<Arc<str>>, start: usize, end: usize) -> Self {
         Token { kind, text: text.into(), start, end }
+    }
+
+    /// Create an EOF token for the given source position.
+    ///
+    /// Uses a shared empty `Arc<str>` to avoid repeated empty-string allocations
+    /// in hot token-stream EOF paths.
+    pub fn eof_at(position: usize) -> Self {
+        Token { kind: TokenKind::Eof, text: empty_text_arc(), start: position, end: position }
+    }
+
+    /// Create an EOF token with an explicit byte span.
+    ///
+    /// This is useful when preserving source end offsets from lexer tokens.
+    pub fn eof_with_span(start: usize, end: usize) -> Self {
+        Token { kind: TokenKind::Eof, text: empty_text_arc(), start, end }
     }
 
     /// Return the token span length in bytes.

--- a/crates/perl-token/tests/token_kinds_and_display.rs
+++ b/crates/perl-token/tests/token_kinds_and_display.rs
@@ -1158,3 +1158,58 @@ fn display_name_returns_static_str() {
         );
     }
 }
+
+// ===========================================================================
+// eof_at / eof_with_span: shared empty Arc optimization
+// ===========================================================================
+
+#[test]
+fn eof_at_reuses_shared_empty_arc() {
+    // The key optimization guarantee: both calls must share the SAME Arc allocation
+    // (same pointer), proving EMPTY_TEXT_ARC is actually reused.
+    let a = Token::eof_at(0);
+    let b = Token::eof_at(42);
+    assert!(
+        Arc::ptr_eq(&a.text, &b.text),
+        "eof_at must reuse the shared empty Arc — allocation churn defeats the purpose"
+    );
+}
+
+#[test]
+fn eof_with_span_reuses_shared_empty_arc() {
+    let a = Token::eof_with_span(0, 0);
+    let b = Token::eof_with_span(5, 10);
+    assert!(
+        Arc::ptr_eq(&a.text, &b.text),
+        "eof_with_span must reuse the shared empty Arc"
+    );
+}
+
+#[test]
+fn eof_at_produces_correct_fields() {
+    let tok = Token::eof_at(99);
+    assert_eq!(tok.kind, TokenKind::Eof);
+    assert_eq!(&*tok.text, "");
+    assert_eq!(tok.start, 99);
+    assert_eq!(tok.end, 99);
+}
+
+#[test]
+fn eof_with_span_produces_correct_fields() {
+    let tok = Token::eof_with_span(10, 15);
+    assert_eq!(tok.kind, TokenKind::Eof);
+    assert_eq!(&*tok.text, "");
+    assert_eq!(tok.start, 10);
+    assert_eq!(tok.end, 15);
+}
+
+#[test]
+fn eof_helpers_share_arc_with_each_other() {
+    // Across both constructors — same static backing
+    let via_at = Token::eof_at(0);
+    let via_span = Token::eof_with_span(0, 0);
+    assert!(
+        Arc::ptr_eq(&via_at.text, &via_span.text),
+        "eof_at and eof_with_span must share the same static Arc"
+    );
+}


### PR DESCRIPTION
### Motivation
- EOF token construction in hot token-stream paths repeatedly created fresh empty `Arc<str>` values, causing measurable allocation churn in micro-benchmarks.
- Reusing a single shared empty `Arc<str>` for synthesized EOF tokens avoids that repeated work while keeping public `Token` layout and semantics unchanged.

### Description
- Added a process-global `OnceLock<Arc<str>>` and `empty_text_arc()` helper to `crates/perl-token/src/lib.rs` and introduced `Token::eof_at` and `Token::eof_with_span` constructors that reuse the shared empty text.
- Updated parser-core EOF synthesis in `crates/perl-parser-core/src/tokens/token_stream.rs` to call the new `Token` helpers in both lexer-backed and buffered EOF paths.
- Added a focused example benchmark `crates/perl-token/examples/token_scorecard.rs` that compares `Token::new(TokenKind::Eof, "", ...)` vs `Token::eof_at(...)` to produce before/after numbers.

### Testing
- Ran the focused example with `cargo run -p perl-token --release --example token_scorecard` and observed baseline 57.496943ms → optimized 29.568769ms for 2,000,000 iterations (1.945x, ~48.57% improvement). 
- `cargo test -p perl-token` passed (all token unit tests and doctests succeeded).
- `cargo test -p perl-lexer` passed (lexer tests succeeded).
- `cargo test -p perl-parser-core` was executed; most tests passed but one existing parser test (`test_deref_hash_subscript_regex_key`) failed in this environment and appears unrelated to the EOF-text change. 
- `cargo check --workspace --all-targets` was run and failed due to an unrelated compile error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` (format-string placeholder issue) that predates this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77dc91c483338d82c86c8aa67ca4)