### PR TITLE
test(perl-token): ratchet TokenKind display names for diagnostics (#0000)

### DIFF
--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -398,7 +398,445 @@ pub enum TokenKind {
     Unknown,
 }
 
+/// Coarse token grouping used by diagnostics and audit tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TokenCategory {
+    Keyword,
+    Operator,
+    Delimiter,
+    Literal,
+    IdentifierOrSigil,
+    Recovery,
+    Special,
+}
+
+impl TokenCategory {
+    /// Stable lowercase name used in snapshot tests and debug reporting.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TokenCategory::Keyword => "keyword",
+            TokenCategory::Operator => "operator",
+            TokenCategory::Delimiter => "delimiter",
+            TokenCategory::Literal => "literal",
+            TokenCategory::IdentifierOrSigil => "identifier_or_sigil",
+            TokenCategory::Recovery => "recovery",
+            TokenCategory::Special => "special",
+        }
+    }
+}
+
 impl TokenKind {
+    /// Stable token kind listing for exhaustive tests and audits.
+    pub const ALL: &[Self] = &[
+        TokenKind::My,
+        TokenKind::Our,
+        TokenKind::Local,
+        TokenKind::State,
+        TokenKind::Sub,
+        TokenKind::If,
+        TokenKind::Elsif,
+        TokenKind::Else,
+        TokenKind::Unless,
+        TokenKind::While,
+        TokenKind::Until,
+        TokenKind::For,
+        TokenKind::Foreach,
+        TokenKind::Return,
+        TokenKind::Package,
+        TokenKind::Use,
+        TokenKind::No,
+        TokenKind::Begin,
+        TokenKind::End,
+        TokenKind::Check,
+        TokenKind::Init,
+        TokenKind::Unitcheck,
+        TokenKind::Eval,
+        TokenKind::Do,
+        TokenKind::Given,
+        TokenKind::When,
+        TokenKind::Default,
+        TokenKind::Try,
+        TokenKind::Catch,
+        TokenKind::Finally,
+        TokenKind::Continue,
+        TokenKind::Next,
+        TokenKind::Last,
+        TokenKind::Redo,
+        TokenKind::Goto,
+        TokenKind::Class,
+        TokenKind::Method,
+        TokenKind::Field,
+        TokenKind::Format,
+        TokenKind::Undef,
+        TokenKind::Defer,
+        TokenKind::Assign,
+        TokenKind::Plus,
+        TokenKind::Minus,
+        TokenKind::Star,
+        TokenKind::Slash,
+        TokenKind::Percent,
+        TokenKind::Power,
+        TokenKind::LeftShift,
+        TokenKind::RightShift,
+        TokenKind::BitwiseAnd,
+        TokenKind::BitwiseOr,
+        TokenKind::BitwiseXor,
+        TokenKind::BitwiseNot,
+        TokenKind::PlusAssign,
+        TokenKind::MinusAssign,
+        TokenKind::StarAssign,
+        TokenKind::SlashAssign,
+        TokenKind::PercentAssign,
+        TokenKind::DotAssign,
+        TokenKind::AndAssign,
+        TokenKind::OrAssign,
+        TokenKind::XorAssign,
+        TokenKind::PowerAssign,
+        TokenKind::LeftShiftAssign,
+        TokenKind::RightShiftAssign,
+        TokenKind::LogicalAndAssign,
+        TokenKind::LogicalOrAssign,
+        TokenKind::DefinedOrAssign,
+        TokenKind::Equal,
+        TokenKind::NotEqual,
+        TokenKind::Match,
+        TokenKind::NotMatch,
+        TokenKind::SmartMatch,
+        TokenKind::Less,
+        TokenKind::Greater,
+        TokenKind::LessEqual,
+        TokenKind::GreaterEqual,
+        TokenKind::Spaceship,
+        TokenKind::StringCompare,
+        TokenKind::And,
+        TokenKind::Or,
+        TokenKind::Not,
+        TokenKind::DefinedOr,
+        TokenKind::WordAnd,
+        TokenKind::WordOr,
+        TokenKind::WordNot,
+        TokenKind::WordXor,
+        TokenKind::Arrow,
+        TokenKind::FatArrow,
+        TokenKind::Dot,
+        TokenKind::Range,
+        TokenKind::Ellipsis,
+        TokenKind::Increment,
+        TokenKind::Decrement,
+        TokenKind::DoubleColon,
+        TokenKind::Question,
+        TokenKind::Colon,
+        TokenKind::Backslash,
+        TokenKind::LeftParen,
+        TokenKind::RightParen,
+        TokenKind::LeftBrace,
+        TokenKind::RightBrace,
+        TokenKind::LeftBracket,
+        TokenKind::RightBracket,
+        TokenKind::Semicolon,
+        TokenKind::Comma,
+        TokenKind::Number,
+        TokenKind::String,
+        TokenKind::Regex,
+        TokenKind::Substitution,
+        TokenKind::Transliteration,
+        TokenKind::QuoteSingle,
+        TokenKind::QuoteDouble,
+        TokenKind::QuoteWords,
+        TokenKind::QuoteCommand,
+        TokenKind::HeredocStart,
+        TokenKind::HeredocBody,
+        TokenKind::FormatBody,
+        TokenKind::DataMarker,
+        TokenKind::DataBody,
+        TokenKind::VString,
+        TokenKind::UnknownRest,
+        TokenKind::HeredocDepthLimit,
+        TokenKind::Identifier,
+        TokenKind::ScalarSigil,
+        TokenKind::ArraySigil,
+        TokenKind::HashSigil,
+        TokenKind::SubSigil,
+        TokenKind::GlobSigil,
+        TokenKind::Eof,
+        TokenKind::Unknown,
+    ];
+
+    /// Coarse category used to keep token display naming audits compact.
+    pub fn category(self) -> TokenCategory {
+        match self {
+            TokenKind::My
+            | TokenKind::Our
+            | TokenKind::Local
+            | TokenKind::State
+            | TokenKind::Sub
+            | TokenKind::If
+            | TokenKind::Elsif
+            | TokenKind::Else
+            | TokenKind::Unless
+            | TokenKind::While
+            | TokenKind::Until
+            | TokenKind::For
+            | TokenKind::Foreach
+            | TokenKind::Return
+            | TokenKind::Package
+            | TokenKind::Use
+            | TokenKind::No
+            | TokenKind::Begin
+            | TokenKind::End
+            | TokenKind::Check
+            | TokenKind::Init
+            | TokenKind::Unitcheck
+            | TokenKind::Eval
+            | TokenKind::Do
+            | TokenKind::Given
+            | TokenKind::When
+            | TokenKind::Default
+            | TokenKind::Try
+            | TokenKind::Catch
+            | TokenKind::Finally
+            | TokenKind::Continue
+            | TokenKind::Next
+            | TokenKind::Last
+            | TokenKind::Redo
+            | TokenKind::Goto
+            | TokenKind::Class
+            | TokenKind::Method
+            | TokenKind::Field
+            | TokenKind::Format
+            | TokenKind::Undef
+            | TokenKind::Defer => TokenCategory::Keyword,
+            TokenKind::Assign
+            | TokenKind::Plus
+            | TokenKind::Minus
+            | TokenKind::Star
+            | TokenKind::Slash
+            | TokenKind::Percent
+            | TokenKind::Power
+            | TokenKind::LeftShift
+            | TokenKind::RightShift
+            | TokenKind::BitwiseAnd
+            | TokenKind::BitwiseOr
+            | TokenKind::BitwiseXor
+            | TokenKind::BitwiseNot
+            | TokenKind::PlusAssign
+            | TokenKind::MinusAssign
+            | TokenKind::StarAssign
+            | TokenKind::SlashAssign
+            | TokenKind::PercentAssign
+            | TokenKind::DotAssign
+            | TokenKind::AndAssign
+            | TokenKind::OrAssign
+            | TokenKind::XorAssign
+            | TokenKind::PowerAssign
+            | TokenKind::LeftShiftAssign
+            | TokenKind::RightShiftAssign
+            | TokenKind::LogicalAndAssign
+            | TokenKind::LogicalOrAssign
+            | TokenKind::DefinedOrAssign
+            | TokenKind::Equal
+            | TokenKind::NotEqual
+            | TokenKind::Match
+            | TokenKind::NotMatch
+            | TokenKind::SmartMatch
+            | TokenKind::Less
+            | TokenKind::Greater
+            | TokenKind::LessEqual
+            | TokenKind::GreaterEqual
+            | TokenKind::Spaceship
+            | TokenKind::StringCompare
+            | TokenKind::And
+            | TokenKind::Or
+            | TokenKind::Not
+            | TokenKind::DefinedOr
+            | TokenKind::WordAnd
+            | TokenKind::WordOr
+            | TokenKind::WordNot
+            | TokenKind::WordXor
+            | TokenKind::Arrow
+            | TokenKind::FatArrow
+            | TokenKind::Dot
+            | TokenKind::Range
+            | TokenKind::Ellipsis
+            | TokenKind::Increment
+            | TokenKind::Decrement
+            | TokenKind::DoubleColon
+            | TokenKind::Question
+            | TokenKind::Colon
+            | TokenKind::Backslash => TokenCategory::Operator,
+            TokenKind::LeftParen
+            | TokenKind::RightParen
+            | TokenKind::LeftBrace
+            | TokenKind::RightBrace
+            | TokenKind::LeftBracket
+            | TokenKind::RightBracket
+            | TokenKind::Semicolon
+            | TokenKind::Comma => TokenCategory::Delimiter,
+            TokenKind::Number
+            | TokenKind::String
+            | TokenKind::Regex
+            | TokenKind::Substitution
+            | TokenKind::Transliteration
+            | TokenKind::QuoteSingle
+            | TokenKind::QuoteDouble
+            | TokenKind::QuoteWords
+            | TokenKind::QuoteCommand
+            | TokenKind::HeredocStart
+            | TokenKind::HeredocBody
+            | TokenKind::FormatBody
+            | TokenKind::DataMarker
+            | TokenKind::DataBody
+            | TokenKind::VString => TokenCategory::Literal,
+            TokenKind::UnknownRest | TokenKind::HeredocDepthLimit => TokenCategory::Recovery,
+            TokenKind::Identifier
+            | TokenKind::ScalarSigil
+            | TokenKind::ArraySigil
+            | TokenKind::HashSigil
+            | TokenKind::SubSigil
+            | TokenKind::GlobSigil => TokenCategory::IdentifierOrSigil,
+            TokenKind::Eof | TokenKind::Unknown => TokenCategory::Special,
+        }
+    }
+
+    /// Canonical source lexeme for fixed-syntax tokens.
+    pub fn canonical_lexeme(self) -> Option<&'static str> {
+        match self {
+            TokenKind::My => Some("my"),
+            TokenKind::Our => Some("our"),
+            TokenKind::Local => Some("local"),
+            TokenKind::State => Some("state"),
+            TokenKind::Sub => Some("sub"),
+            TokenKind::If => Some("if"),
+            TokenKind::Elsif => Some("elsif"),
+            TokenKind::Else => Some("else"),
+            TokenKind::Unless => Some("unless"),
+            TokenKind::While => Some("while"),
+            TokenKind::Until => Some("until"),
+            TokenKind::For => Some("for"),
+            TokenKind::Foreach => Some("foreach"),
+            TokenKind::Return => Some("return"),
+            TokenKind::Package => Some("package"),
+            TokenKind::Use => Some("use"),
+            TokenKind::No => Some("no"),
+            TokenKind::Begin => Some("BEGIN"),
+            TokenKind::End => Some("END"),
+            TokenKind::Check => Some("CHECK"),
+            TokenKind::Init => Some("INIT"),
+            TokenKind::Unitcheck => Some("UNITCHECK"),
+            TokenKind::Eval => Some("eval"),
+            TokenKind::Do => Some("do"),
+            TokenKind::Given => Some("given"),
+            TokenKind::When => Some("when"),
+            TokenKind::Default => Some("default"),
+            TokenKind::Try => Some("try"),
+            TokenKind::Catch => Some("catch"),
+            TokenKind::Finally => Some("finally"),
+            TokenKind::Continue => Some("continue"),
+            TokenKind::Next => Some("next"),
+            TokenKind::Last => Some("last"),
+            TokenKind::Redo => Some("redo"),
+            TokenKind::Goto => Some("goto"),
+            TokenKind::Class => Some("class"),
+            TokenKind::Method => Some("method"),
+            TokenKind::Field => Some("field"),
+            TokenKind::Format => Some("format"),
+            TokenKind::Undef => Some("undef"),
+            TokenKind::Defer => Some("defer"),
+            TokenKind::Assign => Some("="),
+            TokenKind::Plus => Some("+"),
+            TokenKind::Minus => Some("-"),
+            TokenKind::Star => Some("*"),
+            TokenKind::Slash => Some("/"),
+            TokenKind::Percent => Some("%"),
+            TokenKind::Power => Some("**"),
+            TokenKind::LeftShift => Some("<<"),
+            TokenKind::RightShift => Some(">>"),
+            TokenKind::BitwiseAnd => Some("&"),
+            TokenKind::BitwiseOr => Some("|"),
+            TokenKind::BitwiseXor => Some("^"),
+            TokenKind::BitwiseNot => Some("~"),
+            TokenKind::PlusAssign => Some("+="),
+            TokenKind::MinusAssign => Some("-="),
+            TokenKind::StarAssign => Some("*="),
+            TokenKind::SlashAssign => Some("/="),
+            TokenKind::PercentAssign => Some("%="),
+            TokenKind::DotAssign => Some(".="),
+            TokenKind::AndAssign => Some("&="),
+            TokenKind::OrAssign => Some("|="),
+            TokenKind::XorAssign => Some("^="),
+            TokenKind::PowerAssign => Some("**="),
+            TokenKind::LeftShiftAssign => Some("<<="),
+            TokenKind::RightShiftAssign => Some(">>="),
+            TokenKind::LogicalAndAssign => Some("&&="),
+            TokenKind::LogicalOrAssign => Some("||="),
+            TokenKind::DefinedOrAssign => Some("//="),
+            TokenKind::Equal => Some("=="),
+            TokenKind::NotEqual => Some("!="),
+            TokenKind::Match => Some("=~"),
+            TokenKind::NotMatch => Some("!~"),
+            TokenKind::SmartMatch => Some("~~"),
+            TokenKind::Less => Some("<"),
+            TokenKind::Greater => Some(">"),
+            TokenKind::LessEqual => Some("<="),
+            TokenKind::GreaterEqual => Some(">="),
+            TokenKind::Spaceship => Some("<=>"),
+            TokenKind::StringCompare => Some("cmp"),
+            TokenKind::And => Some("&&"),
+            TokenKind::Or => Some("||"),
+            TokenKind::Not => Some("!"),
+            TokenKind::DefinedOr => Some("//"),
+            TokenKind::WordAnd => Some("and"),
+            TokenKind::WordOr => Some("or"),
+            TokenKind::WordNot => Some("not"),
+            TokenKind::WordXor => Some("xor"),
+            TokenKind::Arrow => Some("->"),
+            TokenKind::FatArrow => Some("=>"),
+            TokenKind::Dot => Some("."),
+            TokenKind::Range => Some(".."),
+            TokenKind::Ellipsis => Some("..."),
+            TokenKind::Increment => Some("++"),
+            TokenKind::Decrement => Some("--"),
+            TokenKind::DoubleColon => Some("::"),
+            TokenKind::Question => Some("?"),
+            TokenKind::Colon => Some(":"),
+            TokenKind::Backslash => Some("\\"),
+            TokenKind::LeftParen => Some("("),
+            TokenKind::RightParen => Some(")"),
+            TokenKind::LeftBrace => Some("{"),
+            TokenKind::RightBrace => Some("}"),
+            TokenKind::LeftBracket => Some("["),
+            TokenKind::RightBracket => Some("]"),
+            TokenKind::Semicolon => Some(";"),
+            TokenKind::Comma => Some(","),
+            TokenKind::DataMarker => Some("__DATA__"),
+            TokenKind::ScalarSigil => Some("$"),
+            TokenKind::ArraySigil => Some("@"),
+            TokenKind::HashSigil => Some("%"),
+            TokenKind::SubSigil => Some("&"),
+            TokenKind::GlobSigil => Some("*"),
+            TokenKind::Number
+            | TokenKind::String
+            | TokenKind::Regex
+            | TokenKind::Substitution
+            | TokenKind::Transliteration
+            | TokenKind::QuoteSingle
+            | TokenKind::QuoteDouble
+            | TokenKind::QuoteWords
+            | TokenKind::QuoteCommand
+            | TokenKind::HeredocStart
+            | TokenKind::HeredocBody
+            | TokenKind::FormatBody
+            | TokenKind::DataBody
+            | TokenKind::VString
+            | TokenKind::UnknownRest
+            | TokenKind::HeredocDepthLimit
+            | TokenKind::Identifier
+            | TokenKind::Eof
+            | TokenKind::Unknown => None,
+        }
+    }
+
     /// Return a user-friendly display name for this token kind.
     ///
     /// These names appear in parser error messages shown in the editor.

--- a/crates/perl-token/tests/display_name_snapshot_tests.rs
+++ b/crates/perl-token/tests/display_name_snapshot_tests.rs
@@ -1,0 +1,47 @@
+use perl_token::TokenKind;
+
+fn build_table() -> String {
+    let mut table = String::from("| TokenKind | display_name | category | canonical lexeme |\n");
+    table.push_str("| --- | --- | --- | --- |\n");
+
+    for kind in TokenKind::ALL {
+        let canonical = kind.canonical_lexeme().unwrap_or("-");
+        table.push_str(&format!(
+            "| {:?} | {} | {} | {} |\n",
+            kind,
+            kind.display_name(),
+            kind.category().as_str(),
+            canonical
+        ));
+    }
+
+    table
+}
+
+fn fnv1a_64(input: &str) -> String {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for &byte in input.as_bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+#[test]
+fn display_name_table_snapshot_is_stable() {
+    let table = build_table();
+    let fingerprint = fnv1a_64(&table);
+
+    assert_eq!(
+        fingerprint, "18c10ba4e8b96fdb",
+        "TokenKind display table changed. If intentional, update the fingerprint and review table:\n{}",
+        table
+    );
+}
+
+#[test]
+fn display_name_is_non_empty_for_every_token_kind() {
+    for kind in TokenKind::ALL {
+        assert!(!kind.display_name().is_empty(), "display_name() returned empty for {kind:?}");
+    }
+}

--- a/crates/perl-token/tests/token_kinds_and_display.rs
+++ b/crates/perl-token/tests/token_kinds_and_display.rs
@@ -156,6 +156,7 @@ fn is_literal(kind: TokenKind) -> bool {
             | TokenKind::FormatBody
             | TokenKind::DataMarker
             | TokenKind::DataBody
+            | TokenKind::VString
             | TokenKind::UnknownRest
             | TokenKind::HeredocDepthLimit
     )
@@ -305,6 +306,7 @@ fn all_kinds() -> Vec<TokenKind> {
         TokenKind::FormatBody,
         TokenKind::DataMarker,
         TokenKind::DataBody,
+        TokenKind::VString,
         TokenKind::UnknownRest,
         TokenKind::HeredocDepthLimit,
         // Identifiers/Sigils (6)
@@ -475,6 +477,7 @@ fn display_name_literals() {
         (TokenKind::FormatBody, "format body"),
         (TokenKind::DataMarker, "__DATA__"),
         (TokenKind::DataBody, "data section"),
+        (TokenKind::VString, "version string"),
         (TokenKind::UnknownRest, "unparsed content"),
         (TokenKind::HeredocDepthLimit, "heredoc depth limit"),
     ];
@@ -692,7 +695,7 @@ fn delimiter_classification_count() {
 #[test]
 fn literal_classification_count() {
     let count = all_kinds().iter().filter(|k| is_literal(**k)).count();
-    assert_eq!(count, 16, "expected 16 literal variants");
+    assert_eq!(count, 17, "expected 17 literal variants");
 }
 
 #[test]
@@ -709,8 +712,8 @@ fn special_classification_count() {
 
 #[test]
 fn total_variant_count() {
-    // 41 keywords + 58 operators + 8 delimiters + 16 literals + 6 ident/sigil + 2 special = 131
-    assert_eq!(all_kinds().len(), 131, "expected 131 total TokenKind variants");
+    // 41 keywords + 58 operators + 8 delimiters + 17 literals + 6 ident/sigil + 2 special = 132
+    assert_eq!(all_kinds().len(), 132, "expected 132 total TokenKind variants");
 }
 
 // ===========================================================================


### PR DESCRIPTION
### Motivation

- Make token display names and diagnostic-facing names stable, auditable, and complete so parser errors and test output are easy to triage.
- Provide a compact, reviewable snapshot that forces intentional updates when display strings change and ensure recovery/special tokens are intentionally named.

### Description

- Add `TokenCategory` enum with stable `as_str()` values and a `TokenKind::ALL` constant to provide a single authoritative list of all token variants.
- Add `TokenKind::category()` to map every variant to a coarse category and `TokenKind::canonical_lexeme()` to expose canonical lexemes for fixed-syntax tokens.
- Add a compact snapshot-style test `display_name_snapshot_tests.rs` that emits a table (`TokenKind | display_name | category | canonical lexeme`) and checks an FNV-1a fingerprint so changes require an intentional test update.
- Update exhaustive display/category tests in `token_kinds_and_display.rs` to include the previously-missing `VString` variant and adjust literal/total-variant counts accordingly.

### Testing

- Ran `cargo test -p perl-token` and all tests (unit, extended, and the new snapshot test) passed.
- Ran `cargo test -p perl-parser-core error` and the error-focused parser tests passed.
- Ran `cargo xtask fmt` and formatted the workspace; `cargo check --workspace --all-targets` was attempted but failed due to a pre-existing, unrelated format-string error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77e06ee4833395b438ac4ccac11f)