### PR TITLE
test(perl-token): ratchet TokenKind display names for diagnostics (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -46,7 +46,7 @@ impl<'a> Parser<'a> {
                     found: self
                         .peek_kind()
                         .map(|kind| kind.display_name().to_string())
-                        .unwrap_or_else(|| "EOF".to_string()),
+                        .unwrap_or_else(|| TokenKind::Eof.display_name().to_string()),
                     location: self.current_position(),
                 });
             }

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -716,7 +716,7 @@ impl<'a> Parser<'a> {
         let pos = self.current_position();
         Err(ParseError::unexpected(
             kind.display_name(),
-            self.peek_kind().map(|k| k.display_name()).unwrap_or("end of input"),
+            self.peek_kind().map(|k| k.display_name()).unwrap_or(TokenKind::Eof.display_name()),
             pos,
         ))
     }

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -41,7 +41,7 @@ impl<'a> Parser<'a> {
                     // Collect peek_kind before mutable borrow in recover_from_error
                     let peek_display = self.peek_kind()
                         .map(|k| k.display_name())
-                        .unwrap_or("end of input");
+                        .unwrap_or(TokenKind::Eof.display_name());
                     let error_node = self.recover_from_error(
                         error_msg,
                         "statement".to_string(),
@@ -1006,7 +1006,7 @@ impl<'a> Parser<'a> {
                         // Collect peek_kind before mutable borrow in recover_from_error
                         let peek_display = s.peek_kind()
                             .map(|k| k.display_name())
-                            .unwrap_or("end of input");
+                            .unwrap_or(TokenKind::Eof.display_name());
                         let error_node = s.recover_from_error(
                             error_msg,
                             "statement".to_string(),

--- a/crates/perl-token/tests/display_name_snapshot_tests.rs
+++ b/crates/perl-token/tests/display_name_snapshot_tests.rs
@@ -1,0 +1,357 @@
+use perl_token::TokenKind;
+
+fn all_token_kinds() -> Vec<TokenKind> {
+    vec![
+        // Keywords
+        TokenKind::My,
+        TokenKind::Our,
+        TokenKind::Local,
+        TokenKind::State,
+        TokenKind::Sub,
+        TokenKind::If,
+        TokenKind::Elsif,
+        TokenKind::Else,
+        TokenKind::Unless,
+        TokenKind::While,
+        TokenKind::Until,
+        TokenKind::For,
+        TokenKind::Foreach,
+        TokenKind::Return,
+        TokenKind::Package,
+        TokenKind::Use,
+        TokenKind::No,
+        TokenKind::Begin,
+        TokenKind::End,
+        TokenKind::Check,
+        TokenKind::Init,
+        TokenKind::Unitcheck,
+        TokenKind::Eval,
+        TokenKind::Do,
+        TokenKind::Given,
+        TokenKind::When,
+        TokenKind::Default,
+        TokenKind::Try,
+        TokenKind::Catch,
+        TokenKind::Finally,
+        TokenKind::Continue,
+        TokenKind::Next,
+        TokenKind::Last,
+        TokenKind::Redo,
+        TokenKind::Goto,
+        TokenKind::Class,
+        TokenKind::Method,
+        TokenKind::Field,
+        TokenKind::Format,
+        TokenKind::Undef,
+        TokenKind::Defer,
+        // Operators
+        TokenKind::Assign,
+        TokenKind::Plus,
+        TokenKind::Minus,
+        TokenKind::Star,
+        TokenKind::Slash,
+        TokenKind::Percent,
+        TokenKind::Power,
+        TokenKind::LeftShift,
+        TokenKind::RightShift,
+        TokenKind::BitwiseAnd,
+        TokenKind::BitwiseOr,
+        TokenKind::BitwiseXor,
+        TokenKind::BitwiseNot,
+        TokenKind::PlusAssign,
+        TokenKind::MinusAssign,
+        TokenKind::StarAssign,
+        TokenKind::SlashAssign,
+        TokenKind::PercentAssign,
+        TokenKind::DotAssign,
+        TokenKind::AndAssign,
+        TokenKind::OrAssign,
+        TokenKind::XorAssign,
+        TokenKind::PowerAssign,
+        TokenKind::LeftShiftAssign,
+        TokenKind::RightShiftAssign,
+        TokenKind::LogicalAndAssign,
+        TokenKind::LogicalOrAssign,
+        TokenKind::DefinedOrAssign,
+        TokenKind::Equal,
+        TokenKind::NotEqual,
+        TokenKind::Match,
+        TokenKind::NotMatch,
+        TokenKind::SmartMatch,
+        TokenKind::Less,
+        TokenKind::Greater,
+        TokenKind::LessEqual,
+        TokenKind::GreaterEqual,
+        TokenKind::Spaceship,
+        TokenKind::StringCompare,
+        TokenKind::And,
+        TokenKind::Or,
+        TokenKind::Not,
+        TokenKind::DefinedOr,
+        TokenKind::WordAnd,
+        TokenKind::WordOr,
+        TokenKind::WordNot,
+        TokenKind::WordXor,
+        TokenKind::Arrow,
+        TokenKind::FatArrow,
+        TokenKind::Dot,
+        TokenKind::Range,
+        TokenKind::Ellipsis,
+        TokenKind::Increment,
+        TokenKind::Decrement,
+        TokenKind::DoubleColon,
+        TokenKind::Question,
+        TokenKind::Colon,
+        TokenKind::Backslash,
+        // Delimiters
+        TokenKind::LeftParen,
+        TokenKind::RightParen,
+        TokenKind::LeftBrace,
+        TokenKind::RightBrace,
+        TokenKind::LeftBracket,
+        TokenKind::RightBracket,
+        TokenKind::Semicolon,
+        TokenKind::Comma,
+        // Literals
+        TokenKind::Number,
+        TokenKind::String,
+        TokenKind::Regex,
+        TokenKind::Substitution,
+        TokenKind::Transliteration,
+        TokenKind::QuoteSingle,
+        TokenKind::QuoteDouble,
+        TokenKind::QuoteWords,
+        TokenKind::QuoteCommand,
+        TokenKind::HeredocStart,
+        TokenKind::HeredocBody,
+        TokenKind::FormatBody,
+        TokenKind::DataMarker,
+        TokenKind::DataBody,
+        TokenKind::VString,
+        TokenKind::UnknownRest,
+        TokenKind::HeredocDepthLimit,
+        // Identifiers and Variables
+        TokenKind::Identifier,
+        TokenKind::ScalarSigil,
+        TokenKind::ArraySigil,
+        TokenKind::HashSigil,
+        TokenKind::SubSigil,
+        TokenKind::GlobSigil,
+        // Special
+        TokenKind::Eof,
+        TokenKind::Unknown,
+    ]
+}
+
+fn category(kind: TokenKind) -> &'static str {
+    match kind {
+        TokenKind::My
+        | TokenKind::Our
+        | TokenKind::Local
+        | TokenKind::State
+        | TokenKind::Sub
+        | TokenKind::If
+        | TokenKind::Elsif
+        | TokenKind::Else
+        | TokenKind::Unless
+        | TokenKind::While
+        | TokenKind::Until
+        | TokenKind::For
+        | TokenKind::Foreach
+        | TokenKind::Return
+        | TokenKind::Package
+        | TokenKind::Use
+        | TokenKind::No
+        | TokenKind::Begin
+        | TokenKind::End
+        | TokenKind::Check
+        | TokenKind::Init
+        | TokenKind::Unitcheck
+        | TokenKind::Eval
+        | TokenKind::Do
+        | TokenKind::Given
+        | TokenKind::When
+        | TokenKind::Default
+        | TokenKind::Try
+        | TokenKind::Catch
+        | TokenKind::Finally
+        | TokenKind::Continue
+        | TokenKind::Next
+        | TokenKind::Last
+        | TokenKind::Redo
+        | TokenKind::Goto
+        | TokenKind::Class
+        | TokenKind::Method
+        | TokenKind::Field
+        | TokenKind::Format
+        | TokenKind::Undef
+        | TokenKind::Defer => "keyword",
+        TokenKind::Assign
+        | TokenKind::Plus
+        | TokenKind::Minus
+        | TokenKind::Star
+        | TokenKind::Slash
+        | TokenKind::Percent
+        | TokenKind::Power
+        | TokenKind::LeftShift
+        | TokenKind::RightShift
+        | TokenKind::BitwiseAnd
+        | TokenKind::BitwiseOr
+        | TokenKind::BitwiseXor
+        | TokenKind::BitwiseNot
+        | TokenKind::PlusAssign
+        | TokenKind::MinusAssign
+        | TokenKind::StarAssign
+        | TokenKind::SlashAssign
+        | TokenKind::PercentAssign
+        | TokenKind::DotAssign
+        | TokenKind::AndAssign
+        | TokenKind::OrAssign
+        | TokenKind::XorAssign
+        | TokenKind::PowerAssign
+        | TokenKind::LeftShiftAssign
+        | TokenKind::RightShiftAssign
+        | TokenKind::LogicalAndAssign
+        | TokenKind::LogicalOrAssign
+        | TokenKind::DefinedOrAssign
+        | TokenKind::Equal
+        | TokenKind::NotEqual
+        | TokenKind::Match
+        | TokenKind::NotMatch
+        | TokenKind::SmartMatch
+        | TokenKind::Less
+        | TokenKind::Greater
+        | TokenKind::LessEqual
+        | TokenKind::GreaterEqual
+        | TokenKind::Spaceship
+        | TokenKind::StringCompare
+        | TokenKind::And
+        | TokenKind::Or
+        | TokenKind::Not
+        | TokenKind::DefinedOr
+        | TokenKind::WordAnd
+        | TokenKind::WordOr
+        | TokenKind::WordNot
+        | TokenKind::WordXor
+        | TokenKind::Arrow
+        | TokenKind::FatArrow
+        | TokenKind::Dot
+        | TokenKind::Range
+        | TokenKind::Ellipsis
+        | TokenKind::Increment
+        | TokenKind::Decrement
+        | TokenKind::DoubleColon
+        | TokenKind::Question
+        | TokenKind::Colon
+        | TokenKind::Backslash => "operator",
+        TokenKind::LeftParen
+        | TokenKind::RightParen
+        | TokenKind::LeftBrace
+        | TokenKind::RightBrace
+        | TokenKind::LeftBracket
+        | TokenKind::RightBracket
+        | TokenKind::Semicolon
+        | TokenKind::Comma => "delimiter",
+        TokenKind::Number
+        | TokenKind::String
+        | TokenKind::Regex
+        | TokenKind::Substitution
+        | TokenKind::Transliteration
+        | TokenKind::QuoteSingle
+        | TokenKind::QuoteDouble
+        | TokenKind::QuoteWords
+        | TokenKind::QuoteCommand
+        | TokenKind::HeredocStart
+        | TokenKind::HeredocBody
+        | TokenKind::FormatBody
+        | TokenKind::DataMarker
+        | TokenKind::DataBody
+        | TokenKind::VString
+        | TokenKind::UnknownRest
+        | TokenKind::HeredocDepthLimit => "literal/recovery",
+        TokenKind::Identifier
+        | TokenKind::ScalarSigil
+        | TokenKind::ArraySigil
+        | TokenKind::HashSigil
+        | TokenKind::SubSigil
+        | TokenKind::GlobSigil => "identifier/sigil",
+        TokenKind::Eof | TokenKind::Unknown => "special",
+    }
+}
+
+fn canonical_lexeme(kind: TokenKind) -> Option<&'static str> {
+    match kind {
+        TokenKind::Number
+        | TokenKind::String
+        | TokenKind::Regex
+        | TokenKind::Substitution
+        | TokenKind::Transliteration
+        | TokenKind::QuoteSingle
+        | TokenKind::QuoteDouble
+        | TokenKind::QuoteWords
+        | TokenKind::QuoteCommand
+        | TokenKind::HeredocStart
+        | TokenKind::HeredocBody
+        | TokenKind::FormatBody
+        | TokenKind::DataBody
+        | TokenKind::VString
+        | TokenKind::UnknownRest
+        | TokenKind::HeredocDepthLimit
+        | TokenKind::Identifier
+        | TokenKind::Unknown
+        | TokenKind::Eof => None,
+        TokenKind::DataMarker => Some("__DATA__"),
+        _ => {
+            let display = kind.display_name();
+            display.strip_prefix('\'')?.strip_suffix('\'')
+        }
+    }
+}
+
+fn render_table() -> String {
+    let mut out = String::from("| TokenKind | display_name | category | canonical lexeme |\n|---|---|---|---|\n");
+    for kind in all_token_kinds() {
+        let canonical = canonical_lexeme(kind).unwrap_or("-");
+        let display = kind.display_name().replace('|', "\\|");
+        let canonical = canonical.replace('|', "\\|");
+        out.push_str(&format!(
+            "| {:?} | {} | {} | {} |\n",
+            kind,
+            display,
+            category(kind),
+            canonical
+        ));
+    }
+    out
+}
+
+#[test]
+fn token_display_name_table_snapshot_is_stable() {
+    let table = render_table();
+    let expected = include_str!("fixtures/display_name_table_snapshot.md");
+    let normalized_table = table.replace("\\\\", "\\");
+    let normalized_expected = expected.replace("\\\\", "\\");
+    assert_eq!(
+        normalized_table, normalized_expected,
+        "Token display table changed; update snapshot intentionally"
+    );
+}
+
+#[test]
+fn token_display_names_are_non_empty_and_special_tokens_are_intentional() {
+    for kind in all_token_kinds() {
+        assert!(
+            !kind.display_name().trim().is_empty(),
+            "display_name() returned empty value for {:?}",
+            kind
+        );
+    }
+
+    assert_eq!(TokenKind::Eof.display_name(), "end of input");
+    assert_eq!(TokenKind::Unknown.display_name(), "unknown token");
+    assert_eq!(TokenKind::UnknownRest.display_name(), "unparsed content");
+    assert_eq!(TokenKind::HeredocDepthLimit.display_name(), "heredoc depth limit");
+    assert_eq!(TokenKind::DataMarker.display_name(), "__DATA__");
+    assert_eq!(TokenKind::DataBody.display_name(), "data section");
+    assert_eq!(TokenKind::FormatBody.display_name(), "format body");
+}

--- a/crates/perl-token/tests/fixtures/display_name_table_snapshot.md
+++ b/crates/perl-token/tests/fixtures/display_name_table_snapshot.md
@@ -1,0 +1,134 @@
+| TokenKind | display_name | category | canonical lexeme |
+|---|---|---|---|
+| My | 'my' | keyword | my |
+| Our | 'our' | keyword | our |
+| Local | 'local' | keyword | local |
+| State | 'state' | keyword | state |
+| Sub | 'sub' | keyword | sub |
+| If | 'if' | keyword | if |
+| Elsif | 'elsif' | keyword | elsif |
+| Else | 'else' | keyword | else |
+| Unless | 'unless' | keyword | unless |
+| While | 'while' | keyword | while |
+| Until | 'until' | keyword | until |
+| For | 'for' | keyword | for |
+| Foreach | 'foreach' | keyword | foreach |
+| Return | 'return' | keyword | return |
+| Package | 'package' | keyword | package |
+| Use | 'use' | keyword | use |
+| No | 'no' | keyword | no |
+| Begin | 'BEGIN' | keyword | BEGIN |
+| End | 'END' | keyword | END |
+| Check | 'CHECK' | keyword | CHECK |
+| Init | 'INIT' | keyword | INIT |
+| Unitcheck | 'UNITCHECK' | keyword | UNITCHECK |
+| Eval | 'eval' | keyword | eval |
+| Do | 'do' | keyword | do |
+| Given | 'given' | keyword | given |
+| When | 'when' | keyword | when |
+| Default | 'default' | keyword | default |
+| Try | 'try' | keyword | try |
+| Catch | 'catch' | keyword | catch |
+| Finally | 'finally' | keyword | finally |
+| Continue | 'continue' | keyword | continue |
+| Next | 'next' | keyword | next |
+| Last | 'last' | keyword | last |
+| Redo | 'redo' | keyword | redo |
+| Goto | 'goto' | keyword | goto |
+| Class | 'class' | keyword | class |
+| Method | 'method' | keyword | method |
+| Field | 'field' | keyword | field |
+| Format | 'format' | keyword | format |
+| Undef | 'undef' | keyword | undef |
+| Defer | 'defer' | keyword | defer |
+| Assign | '=' | operator | = |
+| Plus | '+' | operator | + |
+| Minus | '-' | operator | - |
+| Star | '*' | operator | * |
+| Slash | '/' | operator | / |
+| Percent | '%' | operator | % |
+| Power | '**' | operator | ** |
+| LeftShift | '<<' | operator | << |
+| RightShift | '>>' | operator | >> |
+| BitwiseAnd | '&' | operator | & |
+| BitwiseOr | '\|' | operator | \| |
+| BitwiseXor | '^' | operator | ^ |
+| BitwiseNot | '~' | operator | ~ |
+| PlusAssign | '+=' | operator | += |
+| MinusAssign | '-=' | operator | -= |
+| StarAssign | '*=' | operator | *= |
+| SlashAssign | '/=' | operator | /= |
+| PercentAssign | '%=' | operator | %= |
+| DotAssign | '.=' | operator | .= |
+| AndAssign | '&=' | operator | &= |
+| OrAssign | '\|=' | operator | \|= |
+| XorAssign | '^=' | operator | ^= |
+| PowerAssign | '**=' | operator | **= |
+| LeftShiftAssign | '<<=' | operator | <<= |
+| RightShiftAssign | '>>=' | operator | >>= |
+| LogicalAndAssign | '&&=' | operator | &&= |
+| LogicalOrAssign | '\|\|=' | operator | \|\|= |
+| DefinedOrAssign | '//=' | operator | //= |
+| Equal | '==' | operator | == |
+| NotEqual | '!=' | operator | != |
+| Match | '=~' | operator | =~ |
+| NotMatch | '!~' | operator | !~ |
+| SmartMatch | '~~' | operator | ~~ |
+| Less | '<' | operator | < |
+| Greater | '>' | operator | > |
+| LessEqual | '<=' | operator | <= |
+| GreaterEqual | '>=' | operator | >= |
+| Spaceship | '<=>' | operator | <=> |
+| StringCompare | 'cmp' | operator | cmp |
+| And | '&&' | operator | && |
+| Or | '\|\|' | operator | \|\| |
+| Not | '!' | operator | ! |
+| DefinedOr | '//' | operator | // |
+| WordAnd | 'and' | operator | and |
+| WordOr | 'or' | operator | or |
+| WordNot | 'not' | operator | not |
+| WordXor | 'xor' | operator | xor |
+| Arrow | '->' | operator | -> |
+| FatArrow | '=>' | operator | => |
+| Dot | '.' | operator | . |
+| Range | '..' | operator | .. |
+| Ellipsis | '...' | operator | ... |
+| Increment | '++' | operator | ++ |
+| Decrement | '--' | operator | -- |
+| DoubleColon | '::' | operator | :: |
+| Question | '?' | operator | ? |
+| Colon | ':' | operator | : |
+| Backslash | '\\' | operator | \\ |
+| LeftParen | '(' | delimiter | ( |
+| RightParen | ')' | delimiter | ) |
+| LeftBrace | '{' | delimiter | { |
+| RightBrace | '}' | delimiter | } |
+| LeftBracket | '[' | delimiter | [ |
+| RightBracket | ']' | delimiter | ] |
+| Semicolon | ';' | delimiter | ; |
+| Comma | ',' | delimiter | , |
+| Number | number | literal/recovery | - |
+| String | string | literal/recovery | - |
+| Regex | regex | literal/recovery | - |
+| Substitution | substitution (s///) | literal/recovery | - |
+| Transliteration | transliteration (tr///) | literal/recovery | - |
+| QuoteSingle | q// string | literal/recovery | - |
+| QuoteDouble | qq// string | literal/recovery | - |
+| QuoteWords | qw() word list | literal/recovery | - |
+| QuoteCommand | qx// command | literal/recovery | - |
+| HeredocStart | heredoc (<<) | literal/recovery | - |
+| HeredocBody | heredoc body | literal/recovery | - |
+| FormatBody | format body | literal/recovery | - |
+| DataMarker | __DATA__ | literal/recovery | __DATA__ |
+| DataBody | data section | literal/recovery | - |
+| VString | version string | literal/recovery | - |
+| UnknownRest | unparsed content | literal/recovery | - |
+| HeredocDepthLimit | heredoc depth limit | literal/recovery | - |
+| Identifier | identifier | identifier/sigil | - |
+| ScalarSigil | '$' | identifier/sigil | $ |
+| ArraySigil | '@' | identifier/sigil | @ |
+| HashSigil | '%' | identifier/sigil | % |
+| SubSigil | '&' | identifier/sigil | & |
+| GlobSigil | '*' | identifier/sigil | * |
+| Eof | end of input | special | - |
+| Unknown | unknown token | special | - |


### PR DESCRIPTION
### Motivation
- Make `TokenKind::display_name()` stable, auditable, and complete because these names appear in parser diagnostics and test failure messages and must not change accidentally.
- Replace ad-hoc EOF/fallback strings in parser diagnostics with the canonical `TokenKind::Eof.display_name()` so diagnostic rendering is consistent.

### Description
- Add a compact snapshot-style audit test `crates/perl-token/tests/display_name_snapshot_tests.rs` that enumerates every `TokenKind`, records `display_name`, a category, and a canonical lexeme, and compares the rendered markdown table to a committed snapshot fixture. 
- Commit the generated snapshot fixture at `crates/perl-token/tests/fixtures/display_name_table_snapshot.md` so display-name diffs require an intentional snapshot update.
- Harden the snapshot rendering to escape pipe characters and normalize backslash escapes so the table is stable across platforms and quoting.
- Normalize parser diagnostic fallbacks to use `TokenKind::Eof.display_name()` instead of hardcoded strings in `crates/perl-parser-core/src/engine/parser/helpers.rs`, `.../parser/statements.rs`, and `.../parser/declarations.rs` to ensure consistent diagnostic text when the next token is EOF.

### Testing
- Ran `cargo test -p perl-token` and the new snapshot and existing token tests passed. (2 tests in the snapshot suite, many existing tests; all green.)
- Ran `cargo test -p perl-parser-core error -- --nocapture` and the parser error/recovery tests passed. (All error-suite tests that were executed succeeded.)
- Ran `cargo check --workspace --all-targets` which failed due to a pre-existing, unrelated format-string error in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs`; this failure is not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77e06ee4833395b438ac4ccac11f)