### PR TITLE
test(perl-token): ratchet TokenKind display names for diagnostics (#0000)

### DIFF
--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -542,11 +542,11 @@ impl TokenKind {
             TokenKind::HeredocStart => "heredoc (<<)",
             TokenKind::HeredocBody => "heredoc body",
             TokenKind::FormatBody => "format body",
-            TokenKind::DataMarker => "__DATA__",
-            TokenKind::DataBody => "data section",
+            TokenKind::DataMarker => "data marker (__DATA__ or __END__)",
+            TokenKind::DataBody => "data section body",
             TokenKind::VString => "version string",
-            TokenKind::UnknownRest => "unparsed content",
-            TokenKind::HeredocDepthLimit => "heredoc depth limit",
+            TokenKind::UnknownRest => "unparsed remainder",
+            TokenKind::HeredocDepthLimit => "heredoc depth limit exceeded",
 
             // Identifiers and variables
             TokenKind::Identifier => "identifier",

--- a/crates/perl-token/tests/display_name_snapshot_tests.rs
+++ b/crates/perl-token/tests/display_name_snapshot_tests.rs
@@ -1,0 +1,352 @@
+use perl_token::TokenKind;
+use std::error::Error;
+
+const SNAPSHOT_PATH: &str = "tests/snapshots/token_kind_display_names.md";
+
+#[derive(Clone, Copy)]
+enum Category {
+    Keyword,
+    Operator,
+    Delimiter,
+    Literal,
+    IdentifierOrSigil,
+    Special,
+}
+
+impl Category {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Keyword => "keyword",
+            Self::Operator => "operator",
+            Self::Delimiter => "delimiter",
+            Self::Literal => "literal",
+            Self::IdentifierOrSigil => "identifier/sigil",
+            Self::Special => "special",
+        }
+    }
+}
+
+fn all_token_kinds() -> Vec<TokenKind> {
+    vec![
+        TokenKind::My,
+        TokenKind::Our,
+        TokenKind::Local,
+        TokenKind::State,
+        TokenKind::Sub,
+        TokenKind::If,
+        TokenKind::Elsif,
+        TokenKind::Else,
+        TokenKind::Unless,
+        TokenKind::While,
+        TokenKind::Until,
+        TokenKind::For,
+        TokenKind::Foreach,
+        TokenKind::Return,
+        TokenKind::Package,
+        TokenKind::Use,
+        TokenKind::No,
+        TokenKind::Begin,
+        TokenKind::End,
+        TokenKind::Check,
+        TokenKind::Init,
+        TokenKind::Unitcheck,
+        TokenKind::Eval,
+        TokenKind::Do,
+        TokenKind::Given,
+        TokenKind::When,
+        TokenKind::Default,
+        TokenKind::Try,
+        TokenKind::Catch,
+        TokenKind::Finally,
+        TokenKind::Continue,
+        TokenKind::Next,
+        TokenKind::Last,
+        TokenKind::Redo,
+        TokenKind::Goto,
+        TokenKind::Class,
+        TokenKind::Method,
+        TokenKind::Field,
+        TokenKind::Format,
+        TokenKind::Undef,
+        TokenKind::Defer,
+        TokenKind::Assign,
+        TokenKind::Plus,
+        TokenKind::Minus,
+        TokenKind::Star,
+        TokenKind::Slash,
+        TokenKind::Percent,
+        TokenKind::Power,
+        TokenKind::LeftShift,
+        TokenKind::RightShift,
+        TokenKind::BitwiseAnd,
+        TokenKind::BitwiseOr,
+        TokenKind::BitwiseXor,
+        TokenKind::BitwiseNot,
+        TokenKind::PlusAssign,
+        TokenKind::MinusAssign,
+        TokenKind::StarAssign,
+        TokenKind::SlashAssign,
+        TokenKind::PercentAssign,
+        TokenKind::DotAssign,
+        TokenKind::AndAssign,
+        TokenKind::OrAssign,
+        TokenKind::XorAssign,
+        TokenKind::PowerAssign,
+        TokenKind::LeftShiftAssign,
+        TokenKind::RightShiftAssign,
+        TokenKind::LogicalAndAssign,
+        TokenKind::LogicalOrAssign,
+        TokenKind::DefinedOrAssign,
+        TokenKind::Equal,
+        TokenKind::NotEqual,
+        TokenKind::Match,
+        TokenKind::NotMatch,
+        TokenKind::SmartMatch,
+        TokenKind::Less,
+        TokenKind::Greater,
+        TokenKind::LessEqual,
+        TokenKind::GreaterEqual,
+        TokenKind::Spaceship,
+        TokenKind::StringCompare,
+        TokenKind::And,
+        TokenKind::Or,
+        TokenKind::Not,
+        TokenKind::DefinedOr,
+        TokenKind::WordAnd,
+        TokenKind::WordOr,
+        TokenKind::WordNot,
+        TokenKind::WordXor,
+        TokenKind::Arrow,
+        TokenKind::FatArrow,
+        TokenKind::Dot,
+        TokenKind::Range,
+        TokenKind::Ellipsis,
+        TokenKind::Increment,
+        TokenKind::Decrement,
+        TokenKind::DoubleColon,
+        TokenKind::Question,
+        TokenKind::Colon,
+        TokenKind::Backslash,
+        TokenKind::LeftParen,
+        TokenKind::RightParen,
+        TokenKind::LeftBrace,
+        TokenKind::RightBrace,
+        TokenKind::LeftBracket,
+        TokenKind::RightBracket,
+        TokenKind::Semicolon,
+        TokenKind::Comma,
+        TokenKind::Number,
+        TokenKind::String,
+        TokenKind::Regex,
+        TokenKind::Substitution,
+        TokenKind::Transliteration,
+        TokenKind::QuoteSingle,
+        TokenKind::QuoteDouble,
+        TokenKind::QuoteWords,
+        TokenKind::QuoteCommand,
+        TokenKind::HeredocStart,
+        TokenKind::HeredocBody,
+        TokenKind::FormatBody,
+        TokenKind::DataMarker,
+        TokenKind::DataBody,
+        TokenKind::VString,
+        TokenKind::UnknownRest,
+        TokenKind::HeredocDepthLimit,
+        TokenKind::Identifier,
+        TokenKind::ScalarSigil,
+        TokenKind::ArraySigil,
+        TokenKind::HashSigil,
+        TokenKind::SubSigil,
+        TokenKind::GlobSigil,
+        TokenKind::Eof,
+        TokenKind::Unknown,
+    ]
+}
+
+fn category(kind: TokenKind) -> Category {
+    match kind {
+        TokenKind::My
+        | TokenKind::Our
+        | TokenKind::Local
+        | TokenKind::State
+        | TokenKind::Sub
+        | TokenKind::If
+        | TokenKind::Elsif
+        | TokenKind::Else
+        | TokenKind::Unless
+        | TokenKind::While
+        | TokenKind::Until
+        | TokenKind::For
+        | TokenKind::Foreach
+        | TokenKind::Return
+        | TokenKind::Package
+        | TokenKind::Use
+        | TokenKind::No
+        | TokenKind::Begin
+        | TokenKind::End
+        | TokenKind::Check
+        | TokenKind::Init
+        | TokenKind::Unitcheck
+        | TokenKind::Eval
+        | TokenKind::Do
+        | TokenKind::Given
+        | TokenKind::When
+        | TokenKind::Default
+        | TokenKind::Try
+        | TokenKind::Catch
+        | TokenKind::Finally
+        | TokenKind::Continue
+        | TokenKind::Next
+        | TokenKind::Last
+        | TokenKind::Redo
+        | TokenKind::Goto
+        | TokenKind::Class
+        | TokenKind::Method
+        | TokenKind::Field
+        | TokenKind::Format
+        | TokenKind::Undef
+        | TokenKind::Defer => Category::Keyword,
+        TokenKind::Assign
+        | TokenKind::Plus
+        | TokenKind::Minus
+        | TokenKind::Star
+        | TokenKind::Slash
+        | TokenKind::Percent
+        | TokenKind::Power
+        | TokenKind::LeftShift
+        | TokenKind::RightShift
+        | TokenKind::BitwiseAnd
+        | TokenKind::BitwiseOr
+        | TokenKind::BitwiseXor
+        | TokenKind::BitwiseNot
+        | TokenKind::PlusAssign
+        | TokenKind::MinusAssign
+        | TokenKind::StarAssign
+        | TokenKind::SlashAssign
+        | TokenKind::PercentAssign
+        | TokenKind::DotAssign
+        | TokenKind::AndAssign
+        | TokenKind::OrAssign
+        | TokenKind::XorAssign
+        | TokenKind::PowerAssign
+        | TokenKind::LeftShiftAssign
+        | TokenKind::RightShiftAssign
+        | TokenKind::LogicalAndAssign
+        | TokenKind::LogicalOrAssign
+        | TokenKind::DefinedOrAssign
+        | TokenKind::Equal
+        | TokenKind::NotEqual
+        | TokenKind::Match
+        | TokenKind::NotMatch
+        | TokenKind::SmartMatch
+        | TokenKind::Less
+        | TokenKind::Greater
+        | TokenKind::LessEqual
+        | TokenKind::GreaterEqual
+        | TokenKind::Spaceship
+        | TokenKind::StringCompare
+        | TokenKind::And
+        | TokenKind::Or
+        | TokenKind::Not
+        | TokenKind::DefinedOr
+        | TokenKind::WordAnd
+        | TokenKind::WordOr
+        | TokenKind::WordNot
+        | TokenKind::WordXor
+        | TokenKind::Arrow
+        | TokenKind::FatArrow
+        | TokenKind::Dot
+        | TokenKind::Range
+        | TokenKind::Ellipsis
+        | TokenKind::Increment
+        | TokenKind::Decrement
+        | TokenKind::DoubleColon
+        | TokenKind::Question
+        | TokenKind::Colon
+        | TokenKind::Backslash => Category::Operator,
+        TokenKind::LeftParen
+        | TokenKind::RightParen
+        | TokenKind::LeftBrace
+        | TokenKind::RightBrace
+        | TokenKind::LeftBracket
+        | TokenKind::RightBracket
+        | TokenKind::Semicolon
+        | TokenKind::Comma => Category::Delimiter,
+        TokenKind::Number
+        | TokenKind::String
+        | TokenKind::Regex
+        | TokenKind::Substitution
+        | TokenKind::Transliteration
+        | TokenKind::QuoteSingle
+        | TokenKind::QuoteDouble
+        | TokenKind::QuoteWords
+        | TokenKind::QuoteCommand
+        | TokenKind::HeredocStart
+        | TokenKind::HeredocBody
+        | TokenKind::FormatBody
+        | TokenKind::DataMarker
+        | TokenKind::DataBody
+        | TokenKind::VString
+        | TokenKind::UnknownRest
+        | TokenKind::HeredocDepthLimit => Category::Literal,
+        TokenKind::Identifier
+        | TokenKind::ScalarSigil
+        | TokenKind::ArraySigil
+        | TokenKind::HashSigil
+        | TokenKind::SubSigil
+        | TokenKind::GlobSigil => Category::IdentifierOrSigil,
+        TokenKind::Eof | TokenKind::Unknown => Category::Special,
+    }
+}
+
+fn canonical_lexeme(kind: TokenKind) -> Option<&'static str> {
+    match kind {
+        TokenKind::DataMarker => Some("__DATA__|__END__"),
+        TokenKind::Eof => Some("<EOF>"),
+        TokenKind::Unknown => None,
+        other => {
+            let display = other.display_name();
+            if display.starts_with('\'') && display.ends_with('\'') {
+                Some(&display[1..display.len() - 1])
+            } else {
+                None
+            }
+        }
+    }
+}
+
+fn render_table() -> String {
+    let mut out = String::from("| TokenKind | display_name | category | canonical lexeme |\n|---|---|---|---|\n");
+    for kind in all_token_kinds() {
+        let canonical = canonical_lexeme(kind).unwrap_or("-");
+        out.push_str(&format!(
+            "| `{:?}` | `{}` | {} | `{}` |\n",
+            kind,
+            kind.display_name(),
+            category(kind).as_str(),
+            canonical
+        ));
+    }
+    out
+}
+
+#[test]
+fn display_name_table_snapshot() -> Result<(), Box<dyn Error>> {
+    let rendered = render_table();
+    if std::env::var_os("UPDATE_SNAPSHOTS").is_some() {
+        std::fs::write(SNAPSHOT_PATH, rendered)?;
+        return Ok(());
+    }
+
+    let expected = std::fs::read_to_string(SNAPSHOT_PATH)?;
+    assert_eq!(rendered, expected);
+    Ok(())
+}
+
+#[test]
+fn display_names_are_non_empty_for_all_token_kinds() -> Result<(), Box<dyn Error>> {
+    for kind in all_token_kinds() {
+        assert!(!kind.display_name().trim().is_empty(), "display name must not be empty: {kind:?}");
+    }
+    Ok(())
+}

--- a/crates/perl-token/tests/snapshots/token_kind_display_names.md
+++ b/crates/perl-token/tests/snapshots/token_kind_display_names.md
@@ -1,0 +1,134 @@
+| TokenKind | display_name | category | canonical lexeme |
+|---|---|---|---|
+| `My` | `'my'` | keyword | `my` |
+| `Our` | `'our'` | keyword | `our` |
+| `Local` | `'local'` | keyword | `local` |
+| `State` | `'state'` | keyword | `state` |
+| `Sub` | `'sub'` | keyword | `sub` |
+| `If` | `'if'` | keyword | `if` |
+| `Elsif` | `'elsif'` | keyword | `elsif` |
+| `Else` | `'else'` | keyword | `else` |
+| `Unless` | `'unless'` | keyword | `unless` |
+| `While` | `'while'` | keyword | `while` |
+| `Until` | `'until'` | keyword | `until` |
+| `For` | `'for'` | keyword | `for` |
+| `Foreach` | `'foreach'` | keyword | `foreach` |
+| `Return` | `'return'` | keyword | `return` |
+| `Package` | `'package'` | keyword | `package` |
+| `Use` | `'use'` | keyword | `use` |
+| `No` | `'no'` | keyword | `no` |
+| `Begin` | `'BEGIN'` | keyword | `BEGIN` |
+| `End` | `'END'` | keyword | `END` |
+| `Check` | `'CHECK'` | keyword | `CHECK` |
+| `Init` | `'INIT'` | keyword | `INIT` |
+| `Unitcheck` | `'UNITCHECK'` | keyword | `UNITCHECK` |
+| `Eval` | `'eval'` | keyword | `eval` |
+| `Do` | `'do'` | keyword | `do` |
+| `Given` | `'given'` | keyword | `given` |
+| `When` | `'when'` | keyword | `when` |
+| `Default` | `'default'` | keyword | `default` |
+| `Try` | `'try'` | keyword | `try` |
+| `Catch` | `'catch'` | keyword | `catch` |
+| `Finally` | `'finally'` | keyword | `finally` |
+| `Continue` | `'continue'` | keyword | `continue` |
+| `Next` | `'next'` | keyword | `next` |
+| `Last` | `'last'` | keyword | `last` |
+| `Redo` | `'redo'` | keyword | `redo` |
+| `Goto` | `'goto'` | keyword | `goto` |
+| `Class` | `'class'` | keyword | `class` |
+| `Method` | `'method'` | keyword | `method` |
+| `Field` | `'field'` | keyword | `field` |
+| `Format` | `'format'` | keyword | `format` |
+| `Undef` | `'undef'` | keyword | `undef` |
+| `Defer` | `'defer'` | keyword | `defer` |
+| `Assign` | `'='` | operator | `=` |
+| `Plus` | `'+'` | operator | `+` |
+| `Minus` | `'-'` | operator | `-` |
+| `Star` | `'*'` | operator | `*` |
+| `Slash` | `'/'` | operator | `/` |
+| `Percent` | `'%'` | operator | `%` |
+| `Power` | `'**'` | operator | `**` |
+| `LeftShift` | `'<<'` | operator | `<<` |
+| `RightShift` | `'>>'` | operator | `>>` |
+| `BitwiseAnd` | `'&'` | operator | `&` |
+| `BitwiseOr` | `'|'` | operator | `|` |
+| `BitwiseXor` | `'^'` | operator | `^` |
+| `BitwiseNot` | `'~'` | operator | `~` |
+| `PlusAssign` | `'+='` | operator | `+=` |
+| `MinusAssign` | `'-='` | operator | `-=` |
+| `StarAssign` | `'*='` | operator | `*=` |
+| `SlashAssign` | `'/='` | operator | `/=` |
+| `PercentAssign` | `'%='` | operator | `%=` |
+| `DotAssign` | `'.='` | operator | `.=` |
+| `AndAssign` | `'&='` | operator | `&=` |
+| `OrAssign` | `'|='` | operator | `|=` |
+| `XorAssign` | `'^='` | operator | `^=` |
+| `PowerAssign` | `'**='` | operator | `**=` |
+| `LeftShiftAssign` | `'<<='` | operator | `<<=` |
+| `RightShiftAssign` | `'>>='` | operator | `>>=` |
+| `LogicalAndAssign` | `'&&='` | operator | `&&=` |
+| `LogicalOrAssign` | `'||='` | operator | `||=` |
+| `DefinedOrAssign` | `'//='` | operator | `//=` |
+| `Equal` | `'=='` | operator | `==` |
+| `NotEqual` | `'!='` | operator | `!=` |
+| `Match` | `'=~'` | operator | `=~` |
+| `NotMatch` | `'!~'` | operator | `!~` |
+| `SmartMatch` | `'~~'` | operator | `~~` |
+| `Less` | `'<'` | operator | `<` |
+| `Greater` | `'>'` | operator | `>` |
+| `LessEqual` | `'<='` | operator | `<=` |
+| `GreaterEqual` | `'>='` | operator | `>=` |
+| `Spaceship` | `'<=>'` | operator | `<=>` |
+| `StringCompare` | `'cmp'` | operator | `cmp` |
+| `And` | `'&&'` | operator | `&&` |
+| `Or` | `'||'` | operator | `||` |
+| `Not` | `'!'` | operator | `!` |
+| `DefinedOr` | `'//'` | operator | `//` |
+| `WordAnd` | `'and'` | operator | `and` |
+| `WordOr` | `'or'` | operator | `or` |
+| `WordNot` | `'not'` | operator | `not` |
+| `WordXor` | `'xor'` | operator | `xor` |
+| `Arrow` | `'->'` | operator | `->` |
+| `FatArrow` | `'=>'` | operator | `=>` |
+| `Dot` | `'.'` | operator | `.` |
+| `Range` | `'..'` | operator | `..` |
+| `Ellipsis` | `'...'` | operator | `...` |
+| `Increment` | `'++'` | operator | `++` |
+| `Decrement` | `'--'` | operator | `--` |
+| `DoubleColon` | `'::'` | operator | `::` |
+| `Question` | `'?'` | operator | `?` |
+| `Colon` | `':'` | operator | `:` |
+| `Backslash` | `'\'` | operator | `\` |
+| `LeftParen` | `'('` | delimiter | `(` |
+| `RightParen` | `')'` | delimiter | `)` |
+| `LeftBrace` | `'{'` | delimiter | `{` |
+| `RightBrace` | `'}'` | delimiter | `}` |
+| `LeftBracket` | `'['` | delimiter | `[` |
+| `RightBracket` | `']'` | delimiter | `]` |
+| `Semicolon` | `';'` | delimiter | `;` |
+| `Comma` | `','` | delimiter | `,` |
+| `Number` | `number` | literal | `-` |
+| `String` | `string` | literal | `-` |
+| `Regex` | `regex` | literal | `-` |
+| `Substitution` | `substitution (s///)` | literal | `-` |
+| `Transliteration` | `transliteration (tr///)` | literal | `-` |
+| `QuoteSingle` | `q// string` | literal | `-` |
+| `QuoteDouble` | `qq// string` | literal | `-` |
+| `QuoteWords` | `qw() word list` | literal | `-` |
+| `QuoteCommand` | `qx// command` | literal | `-` |
+| `HeredocStart` | `heredoc (<<)` | literal | `-` |
+| `HeredocBody` | `heredoc body` | literal | `-` |
+| `FormatBody` | `format body` | literal | `-` |
+| `DataMarker` | `data marker (__DATA__ or __END__)` | literal | `__DATA__|__END__` |
+| `DataBody` | `data section body` | literal | `-` |
+| `VString` | `version string` | literal | `-` |
+| `UnknownRest` | `unparsed remainder` | literal | `-` |
+| `HeredocDepthLimit` | `heredoc depth limit exceeded` | literal | `-` |
+| `Identifier` | `identifier` | identifier/sigil | `-` |
+| `ScalarSigil` | `'$'` | identifier/sigil | `$` |
+| `ArraySigil` | `'@'` | identifier/sigil | `@` |
+| `HashSigil` | `'%'` | identifier/sigil | `%` |
+| `SubSigil` | `'&'` | identifier/sigil | `&` |
+| `GlobSigil` | `'*'` | identifier/sigil | `*` |
+| `Eof` | `end of input` | special | `<EOF>` |
+| `Unknown` | `unknown token` | special | `-` |

--- a/crates/perl-token/tests/token_kinds_and_display.rs
+++ b/crates/perl-token/tests/token_kinds_and_display.rs
@@ -473,10 +473,10 @@ fn display_name_literals() {
         (TokenKind::HeredocStart, "heredoc (<<)"),
         (TokenKind::HeredocBody, "heredoc body"),
         (TokenKind::FormatBody, "format body"),
-        (TokenKind::DataMarker, "__DATA__"),
-        (TokenKind::DataBody, "data section"),
-        (TokenKind::UnknownRest, "unparsed content"),
-        (TokenKind::HeredocDepthLimit, "heredoc depth limit"),
+        (TokenKind::DataMarker, "data marker (__DATA__ or __END__)"),
+        (TokenKind::DataBody, "data section body"),
+        (TokenKind::UnknownRest, "unparsed remainder"),
+        (TokenKind::HeredocDepthLimit, "heredoc depth limit exceeded"),
     ];
     for (kind, expected) in cases {
         assert_eq!(kind.display_name(), *expected, "display_name mismatch for {kind:?}");


### PR DESCRIPTION
### Motivation

- Make `TokenKind::display_name()` stable, explicit, and auditable so parser errors and diagnostics use consistent, human-friendly names for all tokens, including recovery/special tokens.

### Description

- Clarified diagnostic-facing display names in `crates/perl-token/src/lib.rs` for recovery/special literal tokens: `DataMarker`, `DataBody`, `UnknownRest`, and `HeredocDepthLimit` (more explicit wording and consistent phrasing).
- Added a compact snapshot-style audit test `crates/perl-token/tests/display_name_snapshot_tests.rs` that renders a table of `TokenKind`, `display_name`, category, and canonical lexeme and compares it to a checked-in snapshot at `crates/perl-token/tests/snapshots/token_kind_display_names.md` (regeneratable with `UPDATE_SNAPSHOTS=1`).
- Updated existing `crates/perl-token/tests/token_kinds_and_display.rs` expectations to match the clarified names so current coverage and doc-tests remain aligned.

### Testing

- Ran `UPDATE_SNAPSHOTS=1 cargo test -p perl-token display_name_table_snapshot -- --exact` to generate the snapshot, and the snapshot test passed.
- Ran `cargo test -p perl-token` and all `perl-token` tests passed.
- Ran `cargo test -p perl-parser-core error` and the parser-core error tests passed.
- Ran `cargo check --workspace --all-targets` which reported a failure in pre-existing, unrelated test code (`crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs`), so workspace-wide check is blocked by unrelated issues.

### Project Metadata

`display_name` strings are diagnostic-only and not part of the public API SemVer stability contract. Used in error messages from `perl-parser-core`. Internal API.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77e06ee4833395b438ac4ccac11f)
