### PR TITLE
ci(perl-token): ratchet leaf-crate API and dependency guarantees (#0000)

### DIFF
--- a/.ci/GATE_REGISTRY.toml
+++ b/.ci/GATE_REGISTRY.toml
@@ -144,6 +144,22 @@ docs_url = "justfile#ci-check-no-nested-lock"
 cost_tier = "low"  # <1 second
 failure_impact = "medium"
 
+[[gate]]
+id = "perl-token-contract"
+name = "perl-token Leaf/API Contract"
+type = "correctness"
+blocking = true
+timeout_seconds = 120
+command = "cargo test -p perl-token --test api_contract --test leaf_dependency_contract --locked"
+evidence_pattern = "test result: ok"
+threshold = { type = "exit_code", pass = 0 }
+
+[gate.metadata]
+description = "Enforces perl-token as a std-only leaf crate with stable TokenKind metadata/API ratchets"
+docs_url = "crates/perl-token/README.md#stability-contract"
+cost_tier = "low"
+failure_impact = "high"
+
 # ============================================================================
 # Extended Gates (RECOMMENDED for large changes, ci-full)
 # ============================================================================

--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -269,6 +269,27 @@ gates:
       - common
       - strict
 
+  - name: perl_token_contract
+    tier: merge_gate
+    description: "Ratchet perl-token leaf dependency and TokenKind API/metadata contracts"
+    required: true
+    command: >-
+      cargo test
+      -p perl-token
+      --test api_contract
+      --test leaf_dependency_contract
+      --locked
+    timeout_seconds: 120
+    retry_count: 0
+    budgets:
+      max_duration_ms: 90000
+    quarantine: false
+    tags:
+      - test
+      - perl-token
+      - api-stability
+      - dependencies
+
   - name: security_audit
     tier: merge_gate
     description: "Check dependencies for known security vulnerabilities"

--- a/crates/perl-token/Cargo.toml
+++ b/crates/perl-token/Cargo.toml
@@ -16,6 +16,10 @@ categories = ["parsing", "text-processing"]
 [dependencies]
 # No external dependencies for now (Arc is std)
 
+[package.metadata.perl-token-contract]
+# Explicit allowlist for exceptional runtime dependencies. Keep empty by default.
+allowed-runtime-dependencies = []
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/crates/perl-token/README.md
+++ b/crates/perl-token/README.md
@@ -8,6 +8,14 @@ Core token type definitions for the Perl parser ecosystem.
 across the lexer, tokenizer, and parser crates. It has zero external
 dependencies (only `std::sync::Arc`).
 
+## Stability Contract
+
+- `perl-token` remains a tiny leaf crate with **std-only runtime dependencies**.
+- Public `Token` and `TokenKind` APIs are treated as source-stable and require
+  intentional review for breaking changes.
+- `TokenKind` metadata and conformance tests are ratcheted to stay complete.
+- TokenKind variants: 132
+
 ## Public API
 
 - **`Token`** -- a token with `kind: TokenKind`, `text: Arc<str>`, `start: usize`, `end: usize`

--- a/crates/perl-token/ROADMAP.md
+++ b/crates/perl-token/ROADMAP.md
@@ -19,6 +19,9 @@ Token definitions for Perl parser
 ### v0.15.0 Stability Contract
 - Lock down public API for semantic versioning.
 - Guarantee stability across supported platforms.
+- Keep `perl-token` as a std-only leaf crate (no runtime deps without explicit allowlisting).
+- Require TokenKind metadata + docs + conformance test updates for new variants.
+- TokenKind variants: 132
 
 ## Internal Dependencies
 - Aligns with project-wide capability goals defined in `features.toml`.

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -398,7 +398,312 @@ pub enum TokenKind {
     Unknown,
 }
 
+/// High-level category for [`TokenKind`] values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenKindCategory {
+    Keyword,
+    Operator,
+    Delimiter,
+    Literal,
+    IdentifierOrSigil,
+    Special,
+}
+
+/// Stable metadata attached to each [`TokenKind`] variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenKindMetadata {
+    pub kind: TokenKind,
+    pub category: TokenKindCategory,
+    pub display_name: &'static str,
+}
+
+const ALL_TOKEN_KINDS: [TokenKind; 132] = [
+    TokenKind::My,
+    TokenKind::Our,
+    TokenKind::Local,
+    TokenKind::State,
+    TokenKind::Sub,
+    TokenKind::If,
+    TokenKind::Elsif,
+    TokenKind::Else,
+    TokenKind::Unless,
+    TokenKind::While,
+    TokenKind::Until,
+    TokenKind::For,
+    TokenKind::Foreach,
+    TokenKind::Return,
+    TokenKind::Package,
+    TokenKind::Use,
+    TokenKind::No,
+    TokenKind::Begin,
+    TokenKind::End,
+    TokenKind::Check,
+    TokenKind::Init,
+    TokenKind::Unitcheck,
+    TokenKind::Eval,
+    TokenKind::Do,
+    TokenKind::Given,
+    TokenKind::When,
+    TokenKind::Default,
+    TokenKind::Try,
+    TokenKind::Catch,
+    TokenKind::Finally,
+    TokenKind::Continue,
+    TokenKind::Next,
+    TokenKind::Last,
+    TokenKind::Redo,
+    TokenKind::Goto,
+    TokenKind::Class,
+    TokenKind::Method,
+    TokenKind::Field,
+    TokenKind::Format,
+    TokenKind::Undef,
+    TokenKind::Defer,
+    TokenKind::Assign,
+    TokenKind::Plus,
+    TokenKind::Minus,
+    TokenKind::Star,
+    TokenKind::Slash,
+    TokenKind::Percent,
+    TokenKind::Power,
+    TokenKind::LeftShift,
+    TokenKind::RightShift,
+    TokenKind::BitwiseAnd,
+    TokenKind::BitwiseOr,
+    TokenKind::BitwiseXor,
+    TokenKind::BitwiseNot,
+    TokenKind::PlusAssign,
+    TokenKind::MinusAssign,
+    TokenKind::StarAssign,
+    TokenKind::SlashAssign,
+    TokenKind::PercentAssign,
+    TokenKind::DotAssign,
+    TokenKind::AndAssign,
+    TokenKind::OrAssign,
+    TokenKind::XorAssign,
+    TokenKind::PowerAssign,
+    TokenKind::LeftShiftAssign,
+    TokenKind::RightShiftAssign,
+    TokenKind::LogicalAndAssign,
+    TokenKind::LogicalOrAssign,
+    TokenKind::DefinedOrAssign,
+    TokenKind::Equal,
+    TokenKind::NotEqual,
+    TokenKind::Match,
+    TokenKind::NotMatch,
+    TokenKind::SmartMatch,
+    TokenKind::Less,
+    TokenKind::Greater,
+    TokenKind::LessEqual,
+    TokenKind::GreaterEqual,
+    TokenKind::Spaceship,
+    TokenKind::StringCompare,
+    TokenKind::And,
+    TokenKind::Or,
+    TokenKind::Not,
+    TokenKind::DefinedOr,
+    TokenKind::WordAnd,
+    TokenKind::WordOr,
+    TokenKind::WordNot,
+    TokenKind::WordXor,
+    TokenKind::Arrow,
+    TokenKind::FatArrow,
+    TokenKind::Dot,
+    TokenKind::Range,
+    TokenKind::Ellipsis,
+    TokenKind::Increment,
+    TokenKind::Decrement,
+    TokenKind::DoubleColon,
+    TokenKind::Question,
+    TokenKind::Colon,
+    TokenKind::Backslash,
+    TokenKind::LeftParen,
+    TokenKind::RightParen,
+    TokenKind::LeftBrace,
+    TokenKind::RightBrace,
+    TokenKind::LeftBracket,
+    TokenKind::RightBracket,
+    TokenKind::Semicolon,
+    TokenKind::Comma,
+    TokenKind::Number,
+    TokenKind::String,
+    TokenKind::Regex,
+    TokenKind::Substitution,
+    TokenKind::Transliteration,
+    TokenKind::QuoteSingle,
+    TokenKind::QuoteDouble,
+    TokenKind::QuoteWords,
+    TokenKind::QuoteCommand,
+    TokenKind::HeredocStart,
+    TokenKind::HeredocBody,
+    TokenKind::FormatBody,
+    TokenKind::DataMarker,
+    TokenKind::DataBody,
+    TokenKind::VString,
+    TokenKind::UnknownRest,
+    TokenKind::HeredocDepthLimit,
+    TokenKind::Identifier,
+    TokenKind::ScalarSigil,
+    TokenKind::ArraySigil,
+    TokenKind::HashSigil,
+    TokenKind::SubSigil,
+    TokenKind::GlobSigil,
+    TokenKind::Eof,
+    TokenKind::Unknown,
+];
+
 impl TokenKind {
+    /// Return all known token kinds in stable declaration order.
+    pub fn all() -> &'static [TokenKind] {
+        &ALL_TOKEN_KINDS
+    }
+
+    /// Return high-level metadata for this token kind.
+    pub fn metadata(self) -> TokenKindMetadata {
+        TokenKindMetadata {
+            kind: self,
+            category: self.category(),
+            display_name: self.display_name(),
+        }
+    }
+
+    /// Return the token-kind category.
+    pub fn category(self) -> TokenKindCategory {
+        match self {
+            TokenKind::My
+            | TokenKind::Our
+            | TokenKind::Local
+            | TokenKind::State
+            | TokenKind::Sub
+            | TokenKind::If
+            | TokenKind::Elsif
+            | TokenKind::Else
+            | TokenKind::Unless
+            | TokenKind::While
+            | TokenKind::Until
+            | TokenKind::For
+            | TokenKind::Foreach
+            | TokenKind::Return
+            | TokenKind::Package
+            | TokenKind::Use
+            | TokenKind::No
+            | TokenKind::Begin
+            | TokenKind::End
+            | TokenKind::Check
+            | TokenKind::Init
+            | TokenKind::Unitcheck
+            | TokenKind::Eval
+            | TokenKind::Do
+            | TokenKind::Given
+            | TokenKind::When
+            | TokenKind::Default
+            | TokenKind::Try
+            | TokenKind::Catch
+            | TokenKind::Finally
+            | TokenKind::Continue
+            | TokenKind::Next
+            | TokenKind::Last
+            | TokenKind::Redo
+            | TokenKind::Goto
+            | TokenKind::Class
+            | TokenKind::Method
+            | TokenKind::Field
+            | TokenKind::Format
+            | TokenKind::Undef
+            | TokenKind::Defer => TokenKindCategory::Keyword,
+            TokenKind::Assign
+            | TokenKind::Plus
+            | TokenKind::Minus
+            | TokenKind::Star
+            | TokenKind::Slash
+            | TokenKind::Percent
+            | TokenKind::Power
+            | TokenKind::LeftShift
+            | TokenKind::RightShift
+            | TokenKind::BitwiseAnd
+            | TokenKind::BitwiseOr
+            | TokenKind::BitwiseXor
+            | TokenKind::BitwiseNot
+            | TokenKind::PlusAssign
+            | TokenKind::MinusAssign
+            | TokenKind::StarAssign
+            | TokenKind::SlashAssign
+            | TokenKind::PercentAssign
+            | TokenKind::DotAssign
+            | TokenKind::AndAssign
+            | TokenKind::OrAssign
+            | TokenKind::XorAssign
+            | TokenKind::PowerAssign
+            | TokenKind::LeftShiftAssign
+            | TokenKind::RightShiftAssign
+            | TokenKind::LogicalAndAssign
+            | TokenKind::LogicalOrAssign
+            | TokenKind::DefinedOrAssign
+            | TokenKind::Equal
+            | TokenKind::NotEqual
+            | TokenKind::Match
+            | TokenKind::NotMatch
+            | TokenKind::SmartMatch
+            | TokenKind::Less
+            | TokenKind::Greater
+            | TokenKind::LessEqual
+            | TokenKind::GreaterEqual
+            | TokenKind::Spaceship
+            | TokenKind::StringCompare
+            | TokenKind::And
+            | TokenKind::Or
+            | TokenKind::Not
+            | TokenKind::DefinedOr
+            | TokenKind::WordAnd
+            | TokenKind::WordOr
+            | TokenKind::WordNot
+            | TokenKind::WordXor
+            | TokenKind::Arrow
+            | TokenKind::FatArrow
+            | TokenKind::Dot
+            | TokenKind::Range
+            | TokenKind::Ellipsis
+            | TokenKind::Increment
+            | TokenKind::Decrement
+            | TokenKind::DoubleColon
+            | TokenKind::Question
+            | TokenKind::Colon
+            | TokenKind::Backslash => TokenKindCategory::Operator,
+            TokenKind::LeftParen
+            | TokenKind::RightParen
+            | TokenKind::LeftBrace
+            | TokenKind::RightBrace
+            | TokenKind::LeftBracket
+            | TokenKind::RightBracket
+            | TokenKind::Semicolon
+            | TokenKind::Comma => TokenKindCategory::Delimiter,
+            TokenKind::Number
+            | TokenKind::String
+            | TokenKind::Regex
+            | TokenKind::Substitution
+            | TokenKind::Transliteration
+            | TokenKind::QuoteSingle
+            | TokenKind::QuoteDouble
+            | TokenKind::QuoteWords
+            | TokenKind::QuoteCommand
+            | TokenKind::HeredocStart
+            | TokenKind::HeredocBody
+            | TokenKind::FormatBody
+            | TokenKind::DataMarker
+            | TokenKind::DataBody
+            | TokenKind::VString
+            | TokenKind::UnknownRest
+            | TokenKind::HeredocDepthLimit => TokenKindCategory::Literal,
+            TokenKind::Identifier
+            | TokenKind::ScalarSigil
+            | TokenKind::ArraySigil
+            | TokenKind::HashSigil
+            | TokenKind::SubSigil
+            | TokenKind::GlobSigil => TokenKindCategory::IdentifierOrSigil,
+            TokenKind::Eof | TokenKind::Unknown => TokenKindCategory::Special,
+        }
+    }
+
     /// Return a user-friendly display name for this token kind.
     ///
     /// These names appear in parser error messages shown in the editor.

--- a/crates/perl-token/tests/api_contract.rs
+++ b/crates/perl-token/tests/api_contract.rs
@@ -1,0 +1,58 @@
+use perl_token::{Token, TokenKind};
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::sync::Arc;
+
+const EXPECTED_TOKEN_KIND_COUNT: usize = 132;
+const README_TOKEN_COUNT_MARKER: &str = "TokenKind variants: 132";
+const ROADMAP_TOKEN_COUNT_MARKER: &str = "TokenKind variants: 132";
+
+#[test]
+fn tokenkind_metadata_is_complete_and_in_sync_with_all() -> Result<(), Box<dyn Error>> {
+    let all = TokenKind::all();
+    assert_eq!(all.len(), EXPECTED_TOKEN_KIND_COUNT);
+
+    let mut seen = BTreeSet::new();
+    for &kind in all {
+        let metadata = kind.metadata();
+        assert_eq!(metadata.kind, kind);
+        assert_eq!(metadata.display_name, kind.display_name());
+        assert!(!metadata.display_name.is_empty());
+        assert!(seen.insert(format!("{kind:?}")), "duplicate TokenKind entry in all(): {kind:?}");
+    }
+
+    assert_eq!(seen.len(), all.len());
+    Ok(())
+}
+
+#[test]
+fn public_token_api_shape_is_stable() -> Result<(), Box<dyn Error>> {
+    let from_struct_literal =
+        Token { kind: TokenKind::Identifier, text: Arc::from("name"), start: 10, end: 14 };
+    assert_eq!(from_struct_literal.len(), 4);
+
+    let from_constructor = Token::new(TokenKind::Identifier, "name", 10, 14);
+    assert_eq!(from_constructor.kind, from_struct_literal.kind);
+    assert_eq!(from_constructor.text, from_struct_literal.text);
+    assert_eq!(from_constructor.start, from_struct_literal.start);
+    assert_eq!(from_constructor.end, from_struct_literal.end);
+
+    Ok(())
+}
+
+#[test]
+fn docs_include_tokenkind_stability_markers() -> Result<(), Box<dyn Error>> {
+    let readme = include_str!("../README.md");
+    let roadmap = include_str!("../ROADMAP.md");
+
+    assert!(
+        readme.contains(README_TOKEN_COUNT_MARKER),
+        "README must include updated TokenKind count marker: {README_TOKEN_COUNT_MARKER}",
+    );
+    assert!(
+        roadmap.contains(ROADMAP_TOKEN_COUNT_MARKER),
+        "ROADMAP must include updated TokenKind count marker: {ROADMAP_TOKEN_COUNT_MARKER}",
+    );
+
+    Ok(())
+}

--- a/crates/perl-token/tests/leaf_dependency_contract.rs
+++ b/crates/perl-token/tests/leaf_dependency_contract.rs
@@ -1,0 +1,58 @@
+use std::error::Error;
+
+#[test]
+fn perl_token_has_no_runtime_dependencies_unless_explicitly_allowed() -> Result<(), Box<dyn Error>>
+{
+    let cargo_toml = include_str!("../Cargo.toml");
+
+    let mut in_runtime_dependencies = false;
+    let mut in_allowlist = false;
+    let mut runtime_deps = Vec::new();
+    let mut allowed_runtime_deps = Vec::new();
+
+    for raw_line in cargo_toml.lines() {
+        let line = raw_line.trim();
+        if line.starts_with('#') || line.is_empty() {
+            continue;
+        }
+
+        if line.starts_with('[') && line.ends_with(']') {
+            let section = &line[1..line.len() - 1];
+            in_runtime_dependencies =
+                section == "dependencies" || section.ends_with(".dependencies");
+            in_allowlist = section == "package.metadata.perl-token-contract";
+            continue;
+        }
+
+        if in_allowlist && line.starts_with("allowed-runtime-dependencies") {
+            if let Some(start) = line.find('[') {
+                if let Some(end) = line.rfind(']') {
+                    let entries = &line[start + 1..end];
+                    for item in entries.split(',').map(str::trim).filter(|item| !item.is_empty()) {
+                        allowed_runtime_deps.push(item.trim_matches('"').to_string());
+                    }
+                }
+            }
+        }
+
+        if in_runtime_dependencies {
+            if let Some((name, _rest)) = line.split_once('=') {
+                let dep_name = name.trim().to_string();
+                if !dep_name.is_empty() {
+                    runtime_deps.push(dep_name);
+                }
+            }
+        }
+    }
+
+    let violations: Vec<String> =
+        runtime_deps.into_iter().filter(|dep| !allowed_runtime_deps.contains(dep)).collect();
+
+    assert!(
+        violations.is_empty(),
+        "perl-token must remain a leaf crate with std-only runtime dependencies. Unapproved dependencies: {:?}",
+        violations,
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Protect `perl-token` as a tiny, stable leaf crate by preventing accidental runtime dependencies and API churn for `Token`/`TokenKind`.
- Make `TokenKind` metadata and variant inventory explicit so CI can detect missing updates when variants are added.
- Enforce the crate-level policy in CI so violations fail merges rather than relying on ad-hoc review.

### Description
- Added stable inspection surfaces to `perl-token`: `TokenKind::all()`, `TokenKind::category()`, and `TokenKind::metadata()` plus `TokenKindCategory` and `TokenKindMetadata` in `crates/perl-token/src/lib.rs` to expose a canonical variant list and category metadata.
- Introduced a compile-time static `ALL_TOKEN_KINDS` array (count = 132) to pin variant order and allow conformance checks.
- Added two crate tests: `crates/perl-token/tests/api_contract.rs` (validates `TokenKind::all()` count, per-variant metadata, public `Token` shape, and README/ROADMAP markers) and `crates/perl-token/tests/leaf_dependency_contract.rs` (fails if runtime dependencies appear unless explicitly allowlisted in crate metadata).
- Added an empty allowlist table to `crates/perl-token/Cargo.toml` under `[package.metadata.perl-token-contract]` as the place to permit exceptional runtime dependencies.
- Documented the stability contract and the `TokenKind` variant count marker in `crates/perl-token/README.md` and ratcheted the roadmap in `crates/perl-token/ROADMAP.md`.
- Wired CI/merge-gate enforcement by registering the `perl_token_contract` gate in `.ci/GATE_REGISTRY.toml` and adding a `perl_token_contract` entry in `.ci/gate-policy.yaml` to run the new tests during the merge gate.

### Testing
- Ran `cargo test -p perl-token` and all existing and new tests passed (doctests and unit tests across `api_contract` and `leaf_dependency_contract`).
- Ran `cargo check -p perl-token --all-targets` which completed successfully.
- Ran the gated command `cargo test -p perl-token --test api_contract --test leaf_dependency_contract --locked` and it passed, verifying the CI-enforced checks succeed on this branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77e4c8c0833391a34e818bdb3176)