### PR TITLE
ci(perl-token): ratchet leaf-crate API and dependency guarantees (#0000)

### DIFF
--- a/.ci/GATE_REGISTRY.toml
+++ b/.ci/GATE_REGISTRY.toml
@@ -123,6 +123,22 @@ cost_tier = "low"
 failure_impact = "medium"
 
 [[gate]]
+id = "perl-token-leaf-contract"
+name = "perl-token Leaf Contract"
+type = "governance"
+blocking = true
+timeout_seconds = 120
+command = "cargo test -p perl-token --test conformance_guards --locked"
+evidence_pattern = "test result: ok"
+threshold = { type = "exit_code", pass = 0 }
+
+[gate.metadata]
+description = "Protects perl-token leaf status: no runtime deps, stable Token/TokenKind contract, complete metadata coverage"
+docs_url = "crates/perl-token/README.md#stability-contract"
+cost_tier = "low"
+failure_impact = "high"
+
+[[gate]]
 id = "no-nested-lock"
 name = "Nested Lockfile Check"
 type = "hygiene"

--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -171,6 +171,21 @@ gates:
       - test
       - unit
 
+  - name: perl_token_leaf_contract
+    tier: pr_fast
+    description: "Ratchet perl-token leaf-crate dependency and API/metadata stability"
+    required: true
+    command: cargo test -p perl-token --test conformance_guards --locked
+    timeout_seconds: 120
+    retry_count: 0
+    budgets:
+      max_duration_ms: 90000
+    quarantine: false
+    tags:
+      - test
+      - conformance
+      - perl-token
+
   # ===========================================================================
   # Tier: merge_gate
   # ===========================================================================

--- a/crates/perl-token/README.md
+++ b/crates/perl-token/README.md
@@ -8,6 +8,16 @@ Core token type definitions for the Perl parser ecosystem.
 across the lexer, tokenizer, and parser crates. It has zero external
 dependencies (only `std::sync::Arc`).
 
+## Stability Contract
+
+`perl-token` is a **tiny stable leaf crate** and should stay dependency-free at runtime.
+Public `Token`/`TokenKind` source compatibility is intentionally conservative and should
+only change with explicit, reviewed intent.
+
+- TokenKind variants: 132
+- Conformance update rule: adding a `TokenKind` variant must also update metadata,
+  this crate's docs, and the conformance guard tests.
+
 ## Public API
 
 - **`Token`** -- a token with `kind: TokenKind`, `text: Arc<str>`, `start: usize`, `end: usize`

--- a/crates/perl-token/ROADMAP.md
+++ b/crates/perl-token/ROADMAP.md
@@ -15,6 +15,10 @@ Token definitions for Perl parser
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.
+- Keep `perl-token` as a **tiny stable leaf crate** with no runtime dependencies.
+- TokenKind variants: 132
+- Conformance update rule: any new `TokenKind` must update metadata, docs, and
+  conformance tests in the same change.
 
 ### v0.15.0 Stability Contract
 - Lock down public API for semantic versioning.

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -398,7 +398,185 @@ pub enum TokenKind {
     Unknown,
 }
 
+/// Broad classification used for token metadata and conformance checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenCategory {
+    /// Reserved words and language keywords.
+    Keyword,
+    /// Operators and symbolic/word forms.
+    Operator,
+    /// Grouping and punctuation delimiters.
+    Delimiter,
+    /// Literal-like lexical forms.
+    Literal,
+    /// Identifiers and sigils.
+    Identifier,
+    /// Special sentinel and recovery tokens.
+    Special,
+}
+
+/// Metadata associated with each [`TokenKind`] variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenKindMetadata {
+    /// Stable category used in docs/tests/gates.
+    pub category: TokenCategory,
+    /// User-facing display label for diagnostics.
+    pub display_name: &'static str,
+}
+
 impl TokenKind {
+    /// Return every [`TokenKind`] variant in stable declaration order.
+    pub const fn all() -> &'static [TokenKind] {
+        &TOKEN_KIND_ALL
+    }
+
+    /// Number of token kinds expected to have metadata coverage.
+    pub const fn metadata_count() -> usize {
+        TOKEN_KIND_ALL.len()
+    }
+
+    /// Return compact metadata for this token kind.
+    pub fn metadata(self) -> TokenKindMetadata {
+        TokenKindMetadata { category: self.category(), display_name: self.display_name() }
+    }
+
+    /// Return the high-level category for this token kind.
+    pub const fn category(self) -> TokenCategory {
+        match self {
+            TokenKind::My
+            | TokenKind::Our
+            | TokenKind::Local
+            | TokenKind::State
+            | TokenKind::Sub
+            | TokenKind::If
+            | TokenKind::Elsif
+            | TokenKind::Else
+            | TokenKind::Unless
+            | TokenKind::While
+            | TokenKind::Until
+            | TokenKind::For
+            | TokenKind::Foreach
+            | TokenKind::Return
+            | TokenKind::Package
+            | TokenKind::Use
+            | TokenKind::No
+            | TokenKind::Begin
+            | TokenKind::End
+            | TokenKind::Check
+            | TokenKind::Init
+            | TokenKind::Unitcheck
+            | TokenKind::Eval
+            | TokenKind::Do
+            | TokenKind::Given
+            | TokenKind::When
+            | TokenKind::Default
+            | TokenKind::Try
+            | TokenKind::Catch
+            | TokenKind::Finally
+            | TokenKind::Continue
+            | TokenKind::Next
+            | TokenKind::Last
+            | TokenKind::Redo
+            | TokenKind::Goto
+            | TokenKind::Class
+            | TokenKind::Method
+            | TokenKind::Field
+            | TokenKind::Format
+            | TokenKind::Undef
+            | TokenKind::Defer => TokenCategory::Keyword,
+            TokenKind::Assign
+            | TokenKind::Plus
+            | TokenKind::Minus
+            | TokenKind::Star
+            | TokenKind::Slash
+            | TokenKind::Percent
+            | TokenKind::Power
+            | TokenKind::LeftShift
+            | TokenKind::RightShift
+            | TokenKind::BitwiseAnd
+            | TokenKind::BitwiseOr
+            | TokenKind::BitwiseXor
+            | TokenKind::BitwiseNot
+            | TokenKind::PlusAssign
+            | TokenKind::MinusAssign
+            | TokenKind::StarAssign
+            | TokenKind::SlashAssign
+            | TokenKind::PercentAssign
+            | TokenKind::DotAssign
+            | TokenKind::AndAssign
+            | TokenKind::OrAssign
+            | TokenKind::XorAssign
+            | TokenKind::PowerAssign
+            | TokenKind::LeftShiftAssign
+            | TokenKind::RightShiftAssign
+            | TokenKind::LogicalAndAssign
+            | TokenKind::LogicalOrAssign
+            | TokenKind::DefinedOrAssign
+            | TokenKind::Equal
+            | TokenKind::NotEqual
+            | TokenKind::Match
+            | TokenKind::NotMatch
+            | TokenKind::SmartMatch
+            | TokenKind::Less
+            | TokenKind::Greater
+            | TokenKind::LessEqual
+            | TokenKind::GreaterEqual
+            | TokenKind::Spaceship
+            | TokenKind::StringCompare
+            | TokenKind::And
+            | TokenKind::Or
+            | TokenKind::Not
+            | TokenKind::DefinedOr
+            | TokenKind::WordAnd
+            | TokenKind::WordOr
+            | TokenKind::WordNot
+            | TokenKind::WordXor
+            | TokenKind::Arrow
+            | TokenKind::FatArrow
+            | TokenKind::Dot
+            | TokenKind::Range
+            | TokenKind::Ellipsis
+            | TokenKind::Increment
+            | TokenKind::Decrement
+            | TokenKind::DoubleColon
+            | TokenKind::Question
+            | TokenKind::Colon
+            | TokenKind::Backslash => TokenCategory::Operator,
+            TokenKind::LeftParen
+            | TokenKind::RightParen
+            | TokenKind::LeftBrace
+            | TokenKind::RightBrace
+            | TokenKind::LeftBracket
+            | TokenKind::RightBracket
+            | TokenKind::Semicolon
+            | TokenKind::Comma => TokenCategory::Delimiter,
+            TokenKind::Number
+            | TokenKind::String
+            | TokenKind::Regex
+            | TokenKind::Substitution
+            | TokenKind::Transliteration
+            | TokenKind::QuoteSingle
+            | TokenKind::QuoteDouble
+            | TokenKind::QuoteWords
+            | TokenKind::QuoteCommand
+            | TokenKind::HeredocStart
+            | TokenKind::HeredocBody
+            | TokenKind::FormatBody
+            | TokenKind::DataMarker
+            | TokenKind::DataBody
+            | TokenKind::VString
+            | TokenKind::UnknownRest
+            | TokenKind::HeredocDepthLimit => TokenCategory::Literal,
+            TokenKind::Identifier
+            | TokenKind::ScalarSigil
+            | TokenKind::ArraySigil
+            | TokenKind::HashSigil
+            | TokenKind::SubSigil
+            | TokenKind::GlobSigil => TokenCategory::Identifier,
+            TokenKind::Eof | TokenKind::Unknown => TokenCategory::Special,
+        }
+    }
+
     /// Return a user-friendly display name for this token kind.
     ///
     /// These names appear in parser error messages shown in the editor.
@@ -562,3 +740,138 @@ impl TokenKind {
         }
     }
 }
+
+const TOKEN_KIND_ALL: [TokenKind; 132] = [
+    TokenKind::My,
+    TokenKind::Our,
+    TokenKind::Local,
+    TokenKind::State,
+    TokenKind::Sub,
+    TokenKind::If,
+    TokenKind::Elsif,
+    TokenKind::Else,
+    TokenKind::Unless,
+    TokenKind::While,
+    TokenKind::Until,
+    TokenKind::For,
+    TokenKind::Foreach,
+    TokenKind::Return,
+    TokenKind::Package,
+    TokenKind::Use,
+    TokenKind::No,
+    TokenKind::Begin,
+    TokenKind::End,
+    TokenKind::Check,
+    TokenKind::Init,
+    TokenKind::Unitcheck,
+    TokenKind::Eval,
+    TokenKind::Do,
+    TokenKind::Given,
+    TokenKind::When,
+    TokenKind::Default,
+    TokenKind::Try,
+    TokenKind::Catch,
+    TokenKind::Finally,
+    TokenKind::Continue,
+    TokenKind::Next,
+    TokenKind::Last,
+    TokenKind::Redo,
+    TokenKind::Goto,
+    TokenKind::Class,
+    TokenKind::Method,
+    TokenKind::Field,
+    TokenKind::Format,
+    TokenKind::Undef,
+    TokenKind::Defer,
+    TokenKind::Assign,
+    TokenKind::Plus,
+    TokenKind::Minus,
+    TokenKind::Star,
+    TokenKind::Slash,
+    TokenKind::Percent,
+    TokenKind::Power,
+    TokenKind::LeftShift,
+    TokenKind::RightShift,
+    TokenKind::BitwiseAnd,
+    TokenKind::BitwiseOr,
+    TokenKind::BitwiseXor,
+    TokenKind::BitwiseNot,
+    TokenKind::PlusAssign,
+    TokenKind::MinusAssign,
+    TokenKind::StarAssign,
+    TokenKind::SlashAssign,
+    TokenKind::PercentAssign,
+    TokenKind::DotAssign,
+    TokenKind::AndAssign,
+    TokenKind::OrAssign,
+    TokenKind::XorAssign,
+    TokenKind::PowerAssign,
+    TokenKind::LeftShiftAssign,
+    TokenKind::RightShiftAssign,
+    TokenKind::LogicalAndAssign,
+    TokenKind::LogicalOrAssign,
+    TokenKind::DefinedOrAssign,
+    TokenKind::Equal,
+    TokenKind::NotEqual,
+    TokenKind::Match,
+    TokenKind::NotMatch,
+    TokenKind::SmartMatch,
+    TokenKind::Less,
+    TokenKind::Greater,
+    TokenKind::LessEqual,
+    TokenKind::GreaterEqual,
+    TokenKind::Spaceship,
+    TokenKind::StringCompare,
+    TokenKind::And,
+    TokenKind::Or,
+    TokenKind::Not,
+    TokenKind::DefinedOr,
+    TokenKind::WordAnd,
+    TokenKind::WordOr,
+    TokenKind::WordNot,
+    TokenKind::WordXor,
+    TokenKind::Arrow,
+    TokenKind::FatArrow,
+    TokenKind::Dot,
+    TokenKind::Range,
+    TokenKind::Ellipsis,
+    TokenKind::Increment,
+    TokenKind::Decrement,
+    TokenKind::DoubleColon,
+    TokenKind::Question,
+    TokenKind::Colon,
+    TokenKind::Backslash,
+    TokenKind::LeftParen,
+    TokenKind::RightParen,
+    TokenKind::LeftBrace,
+    TokenKind::RightBrace,
+    TokenKind::LeftBracket,
+    TokenKind::RightBracket,
+    TokenKind::Semicolon,
+    TokenKind::Comma,
+    TokenKind::Number,
+    TokenKind::String,
+    TokenKind::Regex,
+    TokenKind::Substitution,
+    TokenKind::Transliteration,
+    TokenKind::QuoteSingle,
+    TokenKind::QuoteDouble,
+    TokenKind::QuoteWords,
+    TokenKind::QuoteCommand,
+    TokenKind::HeredocStart,
+    TokenKind::HeredocBody,
+    TokenKind::FormatBody,
+    TokenKind::DataMarker,
+    TokenKind::DataBody,
+    TokenKind::VString,
+    TokenKind::UnknownRest,
+    TokenKind::HeredocDepthLimit,
+    TokenKind::Identifier,
+    TokenKind::ScalarSigil,
+    TokenKind::ArraySigil,
+    TokenKind::HashSigil,
+    TokenKind::SubSigil,
+    TokenKind::GlobSigil,
+    TokenKind::Eof,
+    TokenKind::Unknown,
+];

--- a/crates/perl-token/tests/conformance_guards.rs
+++ b/crates/perl-token/tests/conformance_guards.rs
@@ -1,13 +1,18 @@
 use std::error::Error;
 use std::fs;
+use std::path::PathBuf;
 
 use perl_token::{Token, TokenCategory, TokenKind};
 
 const EXPECTED_TOKEN_KIND_COUNT: usize = 132;
 
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
 #[test]
 fn runtime_dependencies_remain_empty() -> Result<(), Box<dyn Error>> {
-    let manifest = fs::read_to_string("Cargo.toml")?;
+    let manifest = fs::read_to_string(crate_root().join("Cargo.toml"))?;
     let mut in_dependencies = false;
 
     for raw_line in manifest.lines() {
@@ -196,8 +201,8 @@ fn tokenkind_metadata_is_complete_and_in_sync() {
 
 #[test]
 fn docs_track_leaf_contract_and_variant_count() -> Result<(), Box<dyn Error>> {
-    let readme = fs::read_to_string("README.md")?;
-    let roadmap = fs::read_to_string("ROADMAP.md")?;
+    let readme = fs::read_to_string(crate_root().join("README.md"))?;
+    let roadmap = fs::read_to_string(crate_root().join("ROADMAP.md"))?;
     let expected_count_line = format!("TokenKind variants: {}", TokenKind::all().len());
 
     for doc in [&readme, &roadmap] {

--- a/crates/perl-token/tests/conformance_guards.rs
+++ b/crates/perl-token/tests/conformance_guards.rs
@@ -219,3 +219,20 @@ fn docs_track_leaf_contract_and_variant_count() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[test]
+fn token_kind_all_has_no_duplicate_variants() {
+    // TOKEN_KIND_ALL is a hand-maintained array, not derived from the enum.
+    // This test guards against the same variant appearing twice (which would
+    // silently under-count distinct kinds while keeping the length at 132).
+    let all = TokenKind::all();
+    let mut seen = std::collections::HashSet::new();
+    for kind in all {
+        let debug_name = format!("{kind:?}");
+        assert!(
+            seen.insert(debug_name.clone()),
+            "duplicate variant in TOKEN_KIND_ALL: {debug_name}"
+        );
+    }
+    assert_eq!(seen.len(), all.len());
+}

--- a/crates/perl-token/tests/conformance_guards.rs
+++ b/crates/perl-token/tests/conformance_guards.rs
@@ -1,0 +1,216 @@
+use std::error::Error;
+use std::fs;
+
+use perl_token::{Token, TokenCategory, TokenKind};
+
+const EXPECTED_TOKEN_KIND_COUNT: usize = 132;
+
+#[test]
+fn runtime_dependencies_remain_empty() -> Result<(), Box<dyn Error>> {
+    let manifest = fs::read_to_string("Cargo.toml")?;
+    let mut in_dependencies = false;
+
+    for raw_line in manifest.lines() {
+        let line = raw_line.trim();
+
+        if line.starts_with('[') {
+            in_dependencies = line == "[dependencies]";
+            continue;
+        }
+
+        if !in_dependencies || line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        return Err(format!("runtime dependency entry is not allowed in perl-token: {line}").into());
+    }
+
+    Ok(())
+}
+
+#[test]
+fn token_and_token_kind_api_snapshot_is_stable() {
+    let token = Token { kind: TokenKind::Identifier, text: "foo".into(), start: 10, end: 13 };
+    assert_eq!(token.kind, TokenKind::Identifier);
+    assert_eq!(token.start, 10);
+    assert_eq!(token.end, 13);
+
+    let names: Vec<String> = TokenKind::all().iter().map(|kind| format!("{kind:?}")).collect();
+    assert_eq!(names.len(), EXPECTED_TOKEN_KIND_COUNT);
+    assert_eq!(
+        names,
+        vec![
+            "My",
+            "Our",
+            "Local",
+            "State",
+            "Sub",
+            "If",
+            "Elsif",
+            "Else",
+            "Unless",
+            "While",
+            "Until",
+            "For",
+            "Foreach",
+            "Return",
+            "Package",
+            "Use",
+            "No",
+            "Begin",
+            "End",
+            "Check",
+            "Init",
+            "Unitcheck",
+            "Eval",
+            "Do",
+            "Given",
+            "When",
+            "Default",
+            "Try",
+            "Catch",
+            "Finally",
+            "Continue",
+            "Next",
+            "Last",
+            "Redo",
+            "Goto",
+            "Class",
+            "Method",
+            "Field",
+            "Format",
+            "Undef",
+            "Defer",
+            "Assign",
+            "Plus",
+            "Minus",
+            "Star",
+            "Slash",
+            "Percent",
+            "Power",
+            "LeftShift",
+            "RightShift",
+            "BitwiseAnd",
+            "BitwiseOr",
+            "BitwiseXor",
+            "BitwiseNot",
+            "PlusAssign",
+            "MinusAssign",
+            "StarAssign",
+            "SlashAssign",
+            "PercentAssign",
+            "DotAssign",
+            "AndAssign",
+            "OrAssign",
+            "XorAssign",
+            "PowerAssign",
+            "LeftShiftAssign",
+            "RightShiftAssign",
+            "LogicalAndAssign",
+            "LogicalOrAssign",
+            "DefinedOrAssign",
+            "Equal",
+            "NotEqual",
+            "Match",
+            "NotMatch",
+            "SmartMatch",
+            "Less",
+            "Greater",
+            "LessEqual",
+            "GreaterEqual",
+            "Spaceship",
+            "StringCompare",
+            "And",
+            "Or",
+            "Not",
+            "DefinedOr",
+            "WordAnd",
+            "WordOr",
+            "WordNot",
+            "WordXor",
+            "Arrow",
+            "FatArrow",
+            "Dot",
+            "Range",
+            "Ellipsis",
+            "Increment",
+            "Decrement",
+            "DoubleColon",
+            "Question",
+            "Colon",
+            "Backslash",
+            "LeftParen",
+            "RightParen",
+            "LeftBrace",
+            "RightBrace",
+            "LeftBracket",
+            "RightBracket",
+            "Semicolon",
+            "Comma",
+            "Number",
+            "String",
+            "Regex",
+            "Substitution",
+            "Transliteration",
+            "QuoteSingle",
+            "QuoteDouble",
+            "QuoteWords",
+            "QuoteCommand",
+            "HeredocStart",
+            "HeredocBody",
+            "FormatBody",
+            "DataMarker",
+            "DataBody",
+            "VString",
+            "UnknownRest",
+            "HeredocDepthLimit",
+            "Identifier",
+            "ScalarSigil",
+            "ArraySigil",
+            "HashSigil",
+            "SubSigil",
+            "GlobSigil",
+            "Eof",
+            "Unknown"
+        ]
+    );
+}
+
+#[test]
+fn tokenkind_metadata_is_complete_and_in_sync() {
+    assert_eq!(TokenKind::all().len(), TokenKind::metadata_count());
+
+    for kind in TokenKind::all() {
+        let metadata = kind.metadata();
+        assert!(!metadata.display_name.is_empty(), "missing display_name for {kind:?}");
+        match metadata.category {
+            TokenCategory::Keyword
+            | TokenCategory::Operator
+            | TokenCategory::Delimiter
+            | TokenCategory::Literal
+            | TokenCategory::Identifier
+            | TokenCategory::Special => {}
+        }
+    }
+}
+
+#[test]
+fn docs_track_leaf_contract_and_variant_count() -> Result<(), Box<dyn Error>> {
+    let readme = fs::read_to_string("README.md")?;
+    let roadmap = fs::read_to_string("ROADMAP.md")?;
+    let expected_count_line = format!("TokenKind variants: {}", TokenKind::all().len());
+
+    for doc in [&readme, &roadmap] {
+        if !doc.contains("tiny stable leaf crate") {
+            return Err("missing leaf-crate stability contract note".into());
+        }
+        if !doc.contains(&expected_count_line) {
+            return Err(format!("missing TokenKind count note: {expected_count_line}").into());
+        }
+        if !doc.contains("Conformance update rule") {
+            return Err("missing conformance update rule note".into());
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Prevent accidental runtime dependencies, API churn, or missing TokenKind metadata from weakening `perl-token`’s role as a tiny stable leaf crate relied on by lexer/parser crates.
- Provide an automated, fast CI gate and in-crate conformance tests so adding new variants or deps fails early unless intentionally approved.

### Description

- Added compact conformance metadata and helpers to `TokenKind`: a `TokenCategory` enum, `TokenKindMetadata` struct, `TokenKind::all()`, `TokenKind::metadata_count()`, `TokenKind::metadata()` and `TokenKind::category()` plus a stable `TOKEN_KIND_ALL` array enumerating variants in declaration order (in `crates/perl-token/src/lib.rs`).
- Introduced a new test suite `conformance_guards` (`crates/perl-token/tests/conformance_guards.rs`) that enforces no runtime dependencies in the crate manifest, asserts a Token/TokenKind API snapshot and ordering via `TokenKind::all()`, verifies metadata coverage and requires README/ROADMAP docs to mention the leaf-crate contract and the TokenKind variant count.
- Documented the leaf-crate stability contract and TokenKind variant count/update rule in `crates/perl-token/README.md` and `crates/perl-token/ROADMAP.md`.
- Registered a new fast CI gate so the conformance tests run on PRs: added `perl_token_leaf_contract` to `.ci/gate-policy.yaml` and `perl-token-leaf-contract` to `.ci/GATE_REGISTRY.toml`.

### Testing

- Ran `cargo test -p perl-token` and all unit, extended, doctests, and the new `conformance_guards` tests passed (4 conformance tests + existing suites): PASS.
- Ran `cargo check -p perl-token --all-targets` to validate all targets: PASS.
- Exercised the new CI gate locally with `cargo xtask gates --gate perl_token_leaf_contract`: PASS.
- Ran formatting checks with `cargo xtask fmt --check` after fixes: PASS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb77e4c8c0833391a34e818bdb3176)