### PR TITLE
fix(master): Windows path test assertions in config tests (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/mod.rs
+++ b/crates/perl-lsp-rs-core/src/config/mod.rs
@@ -1072,6 +1072,11 @@ perltidy_extra_args = ["-noll"]
         #[cfg(not(windows))]
         let input = " lib :local/lib::lib: ";
         let parsed = WorkspaceConfig::parse_perl5lib(input);
+        // normalize_include_path round-trips through PathBuf, which emits the
+        // platform-native separator.  Gate the expected value accordingly.
+        #[cfg(windows)]
+        assert_eq!(parsed, vec!["lib", "local\\lib"]);
+        #[cfg(not(windows))]
         assert_eq!(parsed, vec!["lib", "local/lib"]);
     }
 
@@ -1089,6 +1094,10 @@ perltidy_extra_args = ["-noll"]
             "vendor/lib".to_string(),
         ]);
 
+        // normalize_include_path uses PathBuf internally, so separators are platform-native.
+        #[cfg(windows)]
+        assert_eq!(paths, vec!["local\\lib", "vendor\\lib", "lib"]);
+        #[cfg(not(windows))]
         assert_eq!(paths, vec!["local/lib", "vendor/lib", "lib"]);
     }
 
@@ -1106,6 +1115,10 @@ perltidy_extra_args = ["-noll"]
             "lib".to_string(),
         ]);
 
+        // normalize_include_path uses PathBuf internally, so separators are platform-native.
+        #[cfg(windows)]
+        assert_eq!(paths, vec!["lib", "local\\lib", "vendor\\lib"]);
+        #[cfg(not(windows))]
         assert_eq!(paths, vec!["lib", "local/lib", "vendor/lib"]);
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/modernize.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/modernize.rs
@@ -906,7 +906,11 @@ mod tests {
         // so 3 newlines yield 3 empty lines (each empty string).
         // Every line_idx from enumerate() is within bounds of offsets.
         for (i, _line) in lines.iter().enumerate() {
-            assert!(i < offsets.len(), "line_idx {i} must index within offsets (len {})", offsets.len());
+            assert!(
+                i < offsets.len(),
+                "line_idx {i} must index within offsets (len {})",
+                offsets.len()
+            );
         }
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/type_hierarchy/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/type_hierarchy/mod.rs
@@ -1046,8 +1046,7 @@ our @ISA = ('A');
         let mro = provider.c3_mro(&ast, "A");
         // Must not panic, must start with A, must contain all three packages.
         assert_eq!(mro[0], "A", "MRO must start with queried package");
-        let mro_set: std::collections::BTreeSet<&str> =
-            mro.iter().map(String::as_str).collect();
+        let mro_set: std::collections::BTreeSet<&str> = mro.iter().map(String::as_str).collect();
         assert!(mro_set.contains("B"), "B must appear in MRO of 3-cycle");
         assert!(mro_set.contains("C"), "C must appear in MRO of 3-cycle");
     }
@@ -1075,12 +1074,7 @@ our @ISA = ('B', 'C');
         // C3 linearization of diamond: A, B, C, D
         assert_eq!(
             mro,
-            vec![
-                "A".to_string(),
-                "B".to_string(),
-                "C".to_string(),
-                "D".to_string(),
-            ],
+            vec!["A".to_string(), "B".to_string(), "C".to_string(), "D".to_string(),],
             "Diamond MRO must be A, B, C, D with D appearing exactly once"
         );
     }


### PR DESCRIPTION
## Summary

Three tests in `crates/perl-lsp-rs-core/src/config/mod.rs` hardcoded Unix forward-slash separators in their expected vectors, but `normalize_include_path` round-trips through `PathBuf::to_string_lossy()` which emits `\` on Windows.

**Tests fixed:**
- `parse_perl5lib_trims_and_dedupes_entries` — expected `"local/lib"` → now `#[cfg(windows)]` `"local\lib"` / `#[cfg(not(windows))]` `"local/lib"`
- `effective_include_paths_dedupes_with_prepend_precedence` — expected `"local/lib"`, `"vendor/lib"` → platform-gated
- `effective_include_paths_dedupes_with_append_precedence` — expected `"local/lib"`, `"vendor/lib"` → platform-gated

Pattern mirrors the existing convention already in the file (lines 1070–1073 gate the *input* strings; this PR gates the *expected* strings the same way).

Also includes `rustfmt` for two pre-existing formatting drift lines in `modernize.rs` and `type_hierarchy/mod.rs` (same crate) so `cargo xtask fmt --check` passes cleanly.

**Verification:** `cargo test -p perl-lsp-rs-core --lib` → 908 passed, 0 failed. `cargo xtask fmt --check` → clean.

## Test plan

- [ ] CI Windows run: `parse_perl5lib_trims_and_dedupes_entries`, `effective_include_paths_dedupes_with_prepend_precedence`, `effective_include_paths_dedupes_with_append_precedence` all pass
- [ ] CI Linux/macOS: same three tests pass (non-windows branch active)
- [ ] `cargo xtask fmt --check` passes on all platforms