### PR TITLE
fix(completion): serialize sortText field and add scope-distance ranking test (#5499)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -527,6 +527,10 @@ impl LspServer {
                             item["commitCharacters"] = json!(chars);
                         }
 
+                        if let Some(sort_text) = c.sort_text {
+                            item["sortText"] = json!(sort_text);
+                        }
+
                         // Serialize additionalTextEdits (e.g. auto-import `use Module;`)
                         if !c.additional_edits.is_empty() {
                             let edits: Vec<Value> = c
@@ -743,6 +747,10 @@ impl LspServer {
 
                         if commit_chars_support && let Some(chars) = commit_chars_for_kind(c.kind) {
                             item["commitCharacters"] = json!(chars);
+                        }
+
+                        if let Some(sort_text) = c.sort_text {
+                            item["sortText"] = json!(sort_text);
                         }
 
                         // Serialize additionalTextEdits (e.g. auto-import `use Module;`)

--- a/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
@@ -1054,6 +1054,95 @@ fn test_completion_ranking() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Test that completion ranking respects lexical scope distance.
+///
+/// A variable declared in the immediately-enclosing block (Immediate scope,
+/// sort key 'a') must rank before a variable declared at file scope
+/// (PackageLevel, sort key 'c') when both share the same completion prefix.
+///
+/// Uses *distinct* variable names (`$scope_inner` vs `$scope_outer`) so
+/// `deduplicate_and_sort()` keeps both items — the critical design fix
+/// identified in plan-review: shadowed same-name variables collapse to one
+/// entry and make the ranking assertion dead code.
+#[test]
+fn test_completion_scope_distance_ranking() -> Result<(), Box<dyn std::error::Error>> {
+    let server = start_lsp_server();
+    initialize_lsp(&server);
+
+    let uri = "file:///test_scope_ranking.pl";
+    // $scope_outer declared at file scope → PackageLevel distance from inner block.
+    // $scope_inner declared inside the block → Immediate distance from the cursor.
+    // Both match the "$scope" prefix; distinct labels survive deduplicate_and_sort().
+    let code = "my $scope_outer = 1;\n{\n    my $scope_inner = 2;\n    my $x = $scope\n}\n";
+
+    send_notification(
+        &server,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "perl",
+                    "version": 1,
+                    "text": code
+                }
+            }
+        }),
+    );
+    drain_until_quiet(&server, Duration::from_millis(100), Duration::from_millis(2000));
+
+    // Line 3 is "    my $x = $scope" (18 chars); character 18 places the cursor
+    // immediately after '$scope', triggering prefix-based completion.
+    let target_line = code.lines().position(|l| l.ends_with("$scope")).unwrap_or(3);
+    let target_char = code.lines().nth(target_line).map(|l| l.len()).unwrap_or(18);
+
+    let response = send_request(
+        &server,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/completion",
+            "params": {
+                "textDocument": { "uri": uri },
+                "position": { "line": target_line as i32, "character": target_char as i32 }
+            }
+        }),
+    );
+
+    let items = completion_items(&response);
+
+    let inner_item = items
+        .iter()
+        .find(|item| item["label"].as_str().map(|s| s == "$scope_inner").unwrap_or(false));
+    let outer_item = items
+        .iter()
+        .find(|item| item["label"].as_str().map(|s| s == "$scope_outer").unwrap_or(false));
+
+    assert!(inner_item.is_some(), "$scope_inner should appear in completions");
+    assert!(outer_item.is_some(), "$scope_outer should appear in completions");
+
+    let inner_sort = inner_item.unwrap()["sortText"].as_str().unwrap_or("");
+    let outer_sort = outer_item.unwrap()["sortText"].as_str().unwrap_or("");
+
+    // Immediate scope → sort key 'a' → sort_text "1a_scope_inner"
+    // PackageLevel (file-scope `my`) → sort key 'c' → sort_text "1c_scope_outer"
+    assert!(
+        inner_sort.starts_with("1a_"),
+        "$scope_inner should have Immediate scope sort_text (\"1a_...\"), got: '{inner_sort}'"
+    );
+    assert!(
+        !outer_sort.starts_with("1a_"),
+        "$scope_outer should NOT have Immediate scope sort_text, got: '{outer_sort}'"
+    );
+    assert!(
+        inner_sort < outer_sort,
+        "$scope_inner (immediate) should sort before $scope_outer (package): \
+         '{inner_sort}' vs '{outer_sort}'"
+    );
+
+    Ok(())
+}
+
 /// Test completion with incremental typing
 #[test]
 fn test_incremental_completion() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
@@ -1126,6 +1126,20 @@ fn test_completion_scope_distance_ranking() -> Result<(), Box<dyn std::error::Er
 
     // Immediate scope → sort key 'a' → sort_text "1a_scope_inner"
     // PackageLevel (file-scope `my`) → sort key 'c' → sort_text "1c_scope_outer"
+    //
+    // Guard that sortText is actually present in the wire response.  Without
+    // this check the `!outer_sort.starts_with("1a_")` assertion passes vacuously
+    // when sortText is absent (empty string does not start with "1a_").
+    assert!(
+        !inner_sort.is_empty(),
+        "$scope_inner must have a non-empty sortText — check that completion.rs \
+         serializes sort_text to the LSP wire response"
+    );
+    assert!(
+        !outer_sort.is_empty(),
+        "$scope_outer must have a non-empty sortText — check that completion.rs \
+         serializes sort_text to the LSP wire response"
+    );
     assert!(
         inner_sort.starts_with("1a_"),
         "$scope_inner should have Immediate scope sort_text (\"1a_...\"), got: '{inner_sort}'"


### PR DESCRIPTION
## Summary

Fixes a silent bug where `sortText` was computed correctly by every completion provider but **never emitted to the LSP wire response**. Adds a BDD integration test that proves scope-distance ranking works end-to-end.

Closes #5499.

---

## The Bug: sortText Was Silently Dropped

Every completion provider (variables, functions, keywords, builtins) correctly computes `sort_text` using the scope-distance ranking system:

```rust
// variables.rs — already correct
sort_text: Some(format!("1{}_{}", distance.sort_key(), name)),
// sort keys: 'a' = Immediate, 'b' = Parent, 'c' = PackageLevel, 'd' = Workspace
```

But both JSON serialization paths in `completion.rs` built the item object without ever including `sortText`:

```rust
// BEFORE — sortText completely absent from the wire response
let mut item = json!({
    "label": c.label,
    "kind": ...,
    "insertTextFormat": ...,
});
// detail, insertText, documentation, commitCharacters were all added...
// but sort_text was silently discarded
```

The result: VS Code and other LSP clients received completion lists with no `sortText` field, so they applied their own (usually alphabetical) ordering — silently defeating the scope-distance ranking that `compute_scope_distance()` worked to produce.

## The Fix

Added `sortText` emission to **both** serialization paths:

```rust
// Standard handler (line ~531)
if let Some(sort_text) = c.sort_text {
    item["sortText"] = json!(sort_text);
}

// Cancellable handler (line ~753) — same pattern
if let Some(sort_text) = c.sort_text {
    item["sortText"] = json!(sort_text);
}
```

---

## The Test: Scope-Distance Ranking End-to-End

Added `test_completion_scope_distance_ranking` to `lsp_completion_tests.rs`.

### What it tests

```perl
my $scope_outer = 1;       # file scope → PackageLevel distance ('c')
{
    my $scope_inner = 2;   # block scope → Immediate distance ('a')
    my $x = $scope         # cursor here — trigger completion for "$scope" prefix
}
```

Both `$scope_inner` and `$scope_outer` match the prefix `$scope`. The test asserts:

1. `$scope_inner` appears in completions
2. `$scope_outer` appears in completions  
3. `$scope_inner` has sort_text starting with `"1a_"` (Immediate scope)
4. `$scope_outer` does NOT have `"1a_"` sort_text (it's at PackageLevel = `'c'`)
5. `inner_sort < outer_sort` — lexicographic ordering puts immediate scope first

### Key design decision (from plan-review #5499)

The original red test on `impl/5499-completion-scope-distance` used **shadowed same-name variables** (`$config` at two depths). The plan-reviewer identified a critical flaw: `deduplicate_and_sort()` in `completion_item/mod.rs` collapses same-label items to one winner, making the `len() >= 2` branch dead code — a vacuous always-pass test.

This test uses **distinct names** (`$scope_inner` vs `$scope_outer`) so both items survive deduplication, making the ranking assertion live and meaningful.

---

## Files Changed

| File | Change |
|------|--------|
| `crates/perl-lsp-rs/src/runtime/language/completion.rs` | +4 lines in each of 2 serialization paths — emit `sortText` to JSON |
| `crates/perl-lsp-rs/tests/lsp_completion_tests.rs` | +89 lines — `test_completion_scope_distance_ranking` integration test |

## Test Results

```
test test_completion_scope_distance_ranking ... ok
test test_completion_ranking ... ok
test test_scalar_variable_completion ... ok
test test_variable_completion_has_commit_characters ... ok

test result: ok. 4 passed; 0 failed
```

Full workspace lib suite: all pass.

Note: `test_module_completion_has_commit_characters` fails but is pre-existing (present on master, unrelated to this change).

## Acceptance Criteria (from issue #5499)

- [x] Test verifies that `$scope_inner` (immediate scope) has `sortText` starting with `"1a_"`
- [x] Test verifies that `$scope_outer` (package level) does NOT have `"1a_"` sort_text
- [x] Test verifies `inner_sort < outer_sort` — scope-distance ordering is preserved
- [x] Test runs without panic under `RUST_TEST_THREADS=2`
- [x] Underlying bug fixed: `sortText` now emitted over LSP wire

https://claude.ai/code/session_013mR55Yhoj4Xprp8zR6bXjb

---
_Generated by [Claude Code](https://claude.ai/code/session_013mR55Yhoj4Xprp8zR6bXjb)_