### PR TITLE
test(completion): prove scope-distance ranking via list position (#5499)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_code_actions_snap.rs
+++ b/crates/perl-lsp-rs/tests/lsp_code_actions_snap.rs
@@ -1,0 +1,97 @@
+//! Snapshot coverage for code action payloads.
+//!
+//! These tests focus on high-signal protocol output:
+//! - mixed quickfix + refactor action sets
+//! - `context.only` filtering behavior
+
+use insta::assert_yaml_snapshot;
+use serde_json::{Value, json};
+
+mod support;
+use support::lsp_harness::LspHarness;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn normalize_actions(response: Value) -> Result<Value, Box<dyn std::error::Error>> {
+    let actions = response.as_array().ok_or("code actions response was not an array")?;
+
+    let mut normalized: Vec<Value> = actions
+        .iter()
+        .map(|action| {
+            let kind = action.get("kind").cloned().unwrap_or(Value::Null);
+            let title = action.get("title").cloned().unwrap_or(Value::Null);
+            let has_edit = Value::Bool(action.get("edit").is_some());
+            let has_command = Value::Bool(action.get("command").is_some());
+            json!({
+                "kind": kind,
+                "title": title,
+                "has_edit": has_edit,
+                "has_command": has_command,
+            })
+        })
+        .collect();
+
+    normalized.sort_by(|left, right| {
+        let left_kind = left.get("kind").and_then(Value::as_str).unwrap_or("");
+        let right_kind = right.get("kind").and_then(Value::as_str).unwrap_or("");
+        left_kind
+            .cmp(right_kind)
+            .then_with(|| {
+                let left_title = left.get("title").and_then(Value::as_str).unwrap_or("");
+                let right_title = right.get("title").and_then(Value::as_str).unwrap_or("");
+                left_title.cmp(right_title)
+            })
+    });
+
+    Ok(Value::Array(normalized))
+}
+
+fn request_actions(harness: &mut LspHarness, uri: &str, only: Option<Vec<&str>>) -> TestResult {
+    let mut context = json!({ "diagnostics": [] });
+    if let Some(only_kinds) = only {
+        context["only"] = json!(only_kinds);
+    }
+
+    let response = harness.request(
+        "textDocument/codeAction",
+        json!({
+            "textDocument": { "uri": uri },
+            "range": {
+                "start": { "line": 3, "character": 0 },
+                "end": { "line": 3, "character": 30 }
+            },
+            "context": context
+        }),
+    )?;
+
+    let normalized = normalize_actions(response)?;
+    let snapshot_name = if context.get("only").is_some() {
+        "code_actions_refactor_only"
+    } else {
+        "code_actions_unfiltered"
+    };
+
+    assert_yaml_snapshot!(snapshot_name, normalized);
+    Ok(())
+}
+
+#[test]
+fn snapshot_code_actions_for_open_call_unfiltered_and_filtered() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+
+    let uri = "file:///code-actions-snapshot.pl";
+    harness.open_document(
+        uri,
+        r#"use strict;
+use warnings;
+
+open(my $fh, '<', 'data.txt');
+"#,
+    )?;
+
+    request_actions(&mut harness, uri, None)?;
+    request_actions(&mut harness, uri, Some(vec!["refactor"]))?;
+
+    Ok(())
+}

--- a/crates/perl-lsp-rs/tests/lsp_code_actions_snap.rs
+++ b/crates/perl-lsp-rs/tests/lsp_code_actions_snap.rs
@@ -34,13 +34,11 @@ fn normalize_actions(response: Value) -> Result<Value, Box<dyn std::error::Error
     normalized.sort_by(|left, right| {
         let left_kind = left.get("kind").and_then(Value::as_str).unwrap_or("");
         let right_kind = right.get("kind").and_then(Value::as_str).unwrap_or("");
-        left_kind
-            .cmp(right_kind)
-            .then_with(|| {
-                let left_title = left.get("title").and_then(Value::as_str).unwrap_or("");
-                let right_title = right.get("title").and_then(Value::as_str).unwrap_or("");
-                left_title.cmp(right_title)
-            })
+        left_kind.cmp(right_kind).then_with(|| {
+            let left_title = left.get("title").and_then(Value::as_str).unwrap_or("");
+            let right_title = right.get("title").and_then(Value::as_str).unwrap_or("");
+            left_title.cmp(right_title)
+        })
     });
 
     Ok(Value::Array(normalized))

--- a/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
@@ -1054,6 +1054,95 @@ fn test_completion_ranking() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Test that completion ranking respects lexical scope distance.
+/// Variables from immediate scope should rank higher than parent scope.
+#[test]
+fn test_completion_scope_distance_ranking() -> Result<(), Box<dyn std::error::Error>> {
+    let server = start_lsp_server();
+    initialize_lsp(&server);
+
+    let uri = "file:///test_scope.pl";
+    let code = r#"
+my $outer = 1;
+
+{
+    my $inner = 2;
+    my $config = 'local';
+
+    {
+        my $deep = 3;
+        my $config = 'deeper';
+
+        my $result = $c
+    }
+}
+"#;
+
+    send_notification(
+        &server,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "perl",
+                    "version": 1,
+                    "text": code
+                }
+            }
+        }),
+    );
+    drain_until_quiet(&server, Duration::from_millis(100), Duration::from_millis(2000));
+
+    let lines: Vec<&str> = code.lines().collect();
+    let target_line = lines.iter().position(|l| l.contains("$c")).unwrap_or(0);
+    let target_char = lines[target_line].rfind("$c").unwrap_or(0) + 2;
+
+    let response = send_request(
+        &server,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/completion",
+            "params": {
+                "textDocument": { "uri": uri },
+                "position": { "line": target_line as i32, "character": target_char as i32 }
+            }
+        }),
+    );
+
+    let items = completion_items(&response);
+
+    let config_items: Vec<_> = items
+        .iter()
+        .filter(|item| {
+            item["label"]
+                .as_str()
+                .map(|s| s.contains("config"))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    assert!(
+        config_items.len() >= 1,
+        "Should suggest $config from at least one scope"
+    );
+
+    let first_sort = config_items[0]["sortText"].as_str().unwrap_or("");
+
+    if config_items.len() >= 2 {
+        let second_sort = config_items[1]["sortText"].as_str().unwrap_or("");
+        assert!(
+            first_sort < second_sort,
+            "Immediate scope should rank before parent scope: '{}' vs '{}'",
+            first_sort,
+            second_sort
+        );
+    }
+
+    Ok(())
+}
+
 /// Test completion with incremental typing
 #[test]
 fn test_incremental_completion() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
@@ -1055,28 +1055,26 @@ fn test_completion_ranking() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Test that completion ranking respects lexical scope distance.
-/// Variables from immediate scope should rank higher than parent scope.
+///
+/// The server sorts completions internally by scope-distance tier before sending
+/// the response (`deduplicate_and_sort` runs with sort_key 'a'=Immediate <
+/// 'b'=Parent < 'c'=PackageLevel < 'd'=Workspace). The list position in the
+/// response is therefore the observable ranking signal.
+///
+/// Uses **distinct** variable names (`$scope_inner` vs `$scope_outer`) so that
+/// `deduplicate_and_sort()` does not collapse them into a single winner — the
+/// same-label dedup would silently discard the outer-scope entry and make any
+/// ordering assertion vacuous.
 #[test]
 fn test_completion_scope_distance_ranking() -> Result<(), Box<dyn std::error::Error>> {
     let server = start_lsp_server();
     initialize_lsp(&server);
 
-    let uri = "file:///test_scope.pl";
-    let code = r#"
-my $outer = 1;
-
-{
-    my $inner = 2;
-    my $config = 'local';
-
-    {
-        my $deep = 3;
-        my $config = 'deeper';
-
-        my $result = $c
-    }
-}
-"#;
+    let uri = "file:///test_scope_ranking.pl";
+    // $scope_outer declared at file scope   → ScopeDistance::PackageLevel (sort key 'c')
+    // $scope_inner declared in inner block  → ScopeDistance::Immediate    (sort key 'a')
+    // Both start with "scope", so both match prefix "$scope". Different labels → dedup keeps both.
+    let code = "my $scope_outer = 1;\n{\n    my $scope_inner = 2;\n    my $x = $scope\n}\n";
 
     send_notification(
         &server,
@@ -1095,10 +1093,7 @@ my $outer = 1;
     );
     drain_until_quiet(&server, Duration::from_millis(100), Duration::from_millis(2000));
 
-    let lines: Vec<&str> = code.lines().collect();
-    let target_line = lines.iter().position(|l| l.contains("$c")).unwrap_or(0);
-    let target_char = lines[target_line].rfind("$c").unwrap_or(0) + 2;
-
+    // Line 3 (0-indexed): "    my $x = $scope" — cursor at character 18 (end of "$scope")
     let response = send_request(
         &server,
         json!({
@@ -1106,39 +1101,41 @@ my $outer = 1;
             "method": "textDocument/completion",
             "params": {
                 "textDocument": { "uri": uri },
-                "position": { "line": target_line as i32, "character": target_char as i32 }
+                "position": { "line": 3, "character": 18 }
             }
         }),
     );
 
     let items = completion_items(&response);
 
-    let config_items: Vec<_> = items
+    // Find list positions — position encodes the server's sort order since the
+    // server pre-sorts by scope-distance tier and does not echo sortText back.
+    let inner_pos = items
         .iter()
-        .filter(|item| {
-            item["label"]
-                .as_str()
-                .map(|s| s.contains("config"))
-                .unwrap_or(false)
-        })
-        .collect();
+        .position(|item| item["label"].as_str().map(|s| s == "$scope_inner").unwrap_or(false));
+    let outer_pos = items
+        .iter()
+        .position(|item| item["label"].as_str().map(|s| s == "$scope_outer").unwrap_or(false));
 
     assert!(
-        config_items.len() >= 1,
-        "Should suggest $config from at least one scope"
+        inner_pos.is_some(),
+        "$scope_inner should appear in completions (cursor is inside its declaring block)"
+    );
+    assert!(
+        outer_pos.is_some(),
+        "$scope_outer should appear in completions (file-scope `my` variable)"
     );
 
-    let first_sort = config_items[0]["sortText"].as_str().unwrap_or("");
+    let inner_pos = inner_pos.unwrap();
+    let outer_pos = outer_pos.unwrap();
 
-    if config_items.len() >= 2 {
-        let second_sort = config_items[1]["sortText"].as_str().unwrap_or("");
-        assert!(
-            first_sort < second_sort,
-            "Immediate scope should rank before parent scope: '{}' vs '{}'",
-            first_sort,
-            second_sort
-        );
-    }
+    // Immediate scope ('a') must sort before PackageLevel ('c'), so $scope_inner
+    // must appear at a lower list index than $scope_outer.
+    assert!(
+        inner_pos < outer_pos,
+        "$scope_inner (immediate scope, index {inner_pos}) must sort before \
+         $scope_outer (file scope, index {outer_pos}) in the completion list"
+    );
 
     Ok(())
 }

--- a/crates/perl-lsp-rs/tests/snapshots/lsp_code_actions_snap__code_actions_refactor_only.snap
+++ b/crates/perl-lsp-rs/tests/snapshots/lsp_code_actions_snap__code_actions_refactor_only.snap
@@ -1,0 +1,12 @@
+---
+source: crates/perl-lsp-rs/tests/lsp_code_actions_snap.rs
+expression: normalized
+---
+- has_command: false
+  has_edit: true
+  kind: refactor.rewrite
+  title: "Add error checking to 'open'"
+- has_command: false
+  has_edit: true
+  kind: refactor.rewrite
+  title: "Add error checking to 'open'"

--- a/crates/perl-lsp-rs/tests/snapshots/lsp_code_actions_snap__code_actions_unfiltered.snap
+++ b/crates/perl-lsp-rs/tests/snapshots/lsp_code_actions_snap__code_actions_unfiltered.snap
@@ -1,0 +1,44 @@
+---
+source: crates/perl-lsp-rs/tests/lsp_code_actions_snap.rs
+expression: normalized
+---
+- has_command: false
+  has_edit: true
+  kind: quickfix
+  title: "Add 'package main;' declaration"
+- has_command: false
+  has_edit: true
+  kind: quickfix
+  title: Remove unused variable
+- has_command: false
+  has_edit: true
+  kind: quickfix
+  title: "Remove unused variable '$fh'"
+- has_command: false
+  has_edit: true
+  kind: quickfix
+  title: "Rename to '$_fh' (mark as intentionally unused)"
+- has_command: false
+  has_edit: true
+  kind: quickfix
+  title: "Rename to '_$fh'"
+- has_command: false
+  has_edit: true
+  kind: refactor.rewrite
+  title: "Add error checking to 'open'"
+- has_command: false
+  has_edit: true
+  kind: refactor.rewrite
+  title: "Add error checking to 'open'"
+- has_command: false
+  has_edit: true
+  kind: source.fixAll
+  title: Fix all auto-fixable issues
+- has_command: false
+  has_edit: true
+  kind: source.organizeImports
+  title: Organize imports
+- has_command: false
+  has_edit: true
+  kind: source.organizeImports
+  title: Organize imports


### PR DESCRIPTION
## Summary

Closes #5499. Replaces the red-TDD test committed by the spec-planner with a correctly-designed integration test that actually fails when scope-distance ranking is broken.

### What was wrong with the original test

The spec-planner's red test used a **shadowed variable** (`$config` declared at two block depths) to assert that the inner-scope instance ranked before the outer-scope instance:

```rust
// BROKEN: same label "$config" at two scope depths
let config_items: Vec<_> = items.iter().filter(|i| i["label"].contains("config")).collect();
if config_items.len() >= 2 {          // ← dead code
    assert!(first_sort < second_sort); // ← never reached
}
```

`deduplicate_and_sort()` in `perl-lsp-rs-core/src/providers/completion_item/mod.rs:58` deduplicates by **label**, keeping the item with the better `sort_text`. Since the inner-scope `$config` wins (sort key `'a'` < `'b'`), only one entry survives — `config_items.len()` is always `1`, the `>= 2` branch is dead, and the test always passes vacuously.

The plan-reviewer caught this flaw and redesigned the fixture. This PR implements that redesign.

### What the new test does

```rust
// CORRECT: distinct labels, both survive dedup
let code = "my $scope_outer = 1;\n{\n    my $scope_inner = 2;\n    my $x = $scope\n}\n";
```

- `$scope_outer` is declared at **file scope** → `ScopeDistance::PackageLevel` (sort key `'c'`)
- `$scope_inner` is declared in the **cursor's immediate block** → `ScopeDistance::Immediate` (sort key `'a'`)
- Both match prefix `$scope`; different labels → `deduplicate_and_sort` keeps both

The test asserts list **position** rather than `sortText` string values — the server pre-sorts by scope-distance tier and sends the ranked list without echoing `sortText` back in the JSON response. Position is therefore the correct observable signal.

```rust
assert!(inner_pos < outer_pos,
    "$scope_inner (immediate scope, index {inner_pos}) must sort before \
     $scope_outer (file scope, index {outer_pos})");
```

If `compute_scope_distance` is broken and returns the wrong tier, the positions swap and the test fails.

## Test plan

- [x] `RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --test lsp_completion_tests -- test_completion_scope_distance_ranking --test-threads=2` → **1 passed**
- [x] Full completion suite: `RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --test lsp_completion_tests -- --test-threads=2` → **36 passed** (1 pre-existing unrelated failure: `test_module_completion_has_commit_characters`)
- [x] `cargo fmt --package perl-lsp-rs` applied

## Key files changed

| File | Change |
|------|--------|
| `crates/perl-lsp-rs/tests/lsp_completion_tests.rs` | Replace vacuous shadowing fixture with distinct-name fixture; assert list position |
| `crates/perl-lsp-rs/tests/lsp_code_actions_snap.rs` | `cargo fmt` cleanup (closure chain style) |

## Why position-based assertion is correct

The LSP server does not echo `sortText` in its JSON response — it constructs the sorted list via `deduplicate_and_sort` and sends item objects containing only `label`, `kind`, `insertTextFormat`, `detail`, `insertText`, `documentation`, `commitCharacters`, and `additionalTextEdits` (see `crates/perl-lsp-rs/src/runtime/language/completion.rs:418-479`). The list order IS the ranking.

https://claude.ai/code/session_01FtyE2fwpkuL4UGVZVd2sXu

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtyE2fwpkuL4UGVZVd2sXu)_