### PR TITLE
fix(master): restore command_timeout stdio piping + xtask clippy allow (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/util/command_timeout.rs
+++ b/crates/perl-lsp-rs/src/util/command_timeout.rs
@@ -4,7 +4,7 @@
 //! timeout enforced by polling child process state. When the timeout
 //! expires, the child process is terminated.
 
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -16,6 +16,8 @@ use std::time::{Duration, Instant};
 pub fn run_command_with_timeout(mut cmd: Command, timeout_secs: u64) -> Result<Output, String> {
     let timeout = Duration::from_secs(timeout_secs);
     let start = Instant::now();
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
     let mut child = cmd.spawn().map_err(|error| format!("command failed to start: {error}"))?;
 
     loop {

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -2,6 +2,9 @@
 //!
 //! Owns per-crate mutation and test counts, UX scenario receipt, and quality.md generation.
 
+// LazyLock<Regex> initializers use .expect() for known-good patterns — permitted by coding standards.
+#![allow(clippy::expect_used)]
+
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;


### PR DESCRIPTION
## Summary

Two narrow master regressions fixed in a single ≤6-line diff.

**Fix 1 — command_timeout stdio piping** (`crates/perl-lsp-rs/src/util/command_timeout.rs`, +3 lines):
`run_command_with_timeout` called `cmd.spawn()` without first setting `Stdio::piped()` on stdout/stderr. The child process inherited the parent's stdio handles, so `wait_with_output()` returned an empty `Output.stdout` — no output was captured. This regression was introduced in PR #4883 (commit 79a3ae36d) and has broken both `test_valid_file_execution` in `execute_command_security_tests` and all editor-facing `executeCommand` calls that rely on captured output. Fix: add `cmd.stdout(Stdio::piped())` and `cmd.stderr(Stdio::piped())` before the spawn call.

**Fix 2 — xtask quality.rs clippy::expect_used** (`xtask/src/tasks/update_status/quality.rs`, +3 lines):
Two `LazyLock<Regex>` static initializers call `.expect()` on known-good patterns. This is an explicitly documented coding-standards exception ("static `LazyLock<Regex>` initializers may use `expect()`"). However, the `#[allow(clippy::expect_used)]` attribute on a `static` item does NOT propagate into the closure body (`LazyLock::new(|| {...})`) in Clippy 1.92 — the lint fires inside the closure regardless. The correct suppression is a file-level `#![allow(clippy::expect_used)]`. This pattern is consistent with other files in the codebase that permit `expect()` in specific well-understood contexts.

## Verification

```
cargo clippy --workspace --bins -- -D clippy::expect_used   → 0 errors (1 pre-existing warning in lsp_stats.rs)
cargo test -p perl-lsp-rs --test execute_command_security_tests -- test_valid_file_execution --exact  → 1 passed
```

Total diff: 6 insertions, 1 deletion across 2 files.