### PR TITLE
fix(perl-token): reformat display_name_snapshot_tests for formatting gate (#0000)

### DIFF
--- a/crates/perl-token/tests/display_name_snapshot_tests.rs
+++ b/crates/perl-token/tests/display_name_snapshot_tests.rs
@@ -316,7 +316,9 @@ fn canonical_lexeme(kind: TokenKind) -> Option<&'static str> {
 }
 
 fn render_table() -> String {
-    let mut out = String::from("| TokenKind | display_name | category | canonical lexeme |\n|---|---|---|---|\n");
+    let mut out = String::from(
+        "| TokenKind | display_name | category | canonical lexeme |\n|---|---|---|---|\n",
+    );
     for kind in all_token_kinds() {
         let canonical = canonical_lexeme(kind).unwrap_or("-");
         out.push_str(&format!(


### PR DESCRIPTION
Mechanical formatting fix to unblock master CI.

The file `crates/perl-token/tests/display_name_snapshot_tests.rs` had a formatting violation that caused master CI PR Smoke to fail. This PR wraps the long string on line 319 as rustfmt requires.

This is a post-merge cleanup for PRs #6444/#6440.