### PR TITLE
fix(perl-token): resolve duplicate span() method (master bit-rot) (#0000)

### DIFF
--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -275,11 +275,6 @@ impl Token {
         self.len() == 0
     }
 
-    /// Return the token span as `(start, end)`.
-    pub fn span(&self) -> (usize, usize) {
-        (self.start, self.end)
-    }
-
     /// Return a human-readable display name for this token.
     pub fn display_name(&self) -> &'static str {
         self.kind.display_name()

--- a/crates/perl-token/tests/borrowed_token_tests.rs
+++ b/crates/perl-token/tests/borrowed_token_tests.rs
@@ -1,4 +1,4 @@
-use perl_token::{Token, TokenKind, TokenRef};
+use perl_token::{Token, TokenKind, TokenRef, TokenSpan};
 use std::error::Error;
 use std::sync::Arc;
 
@@ -25,7 +25,7 @@ fn token_ref_to_owned_token_is_explicit() -> TestResult {
 
     assert_eq!(owned.kind, TokenKind::Identifier);
     assert_eq!(&*owned.text, "value");
-    assert_eq!(owned.span(), (8, 13));
+    assert_eq!(owned.span(), TokenSpan::new(8, 13));
     assert_eq!(owned.display_name(), "identifier");
     Ok(())
 }
@@ -47,7 +47,7 @@ fn token_as_ref_token_roundtrips_without_changing_span() -> TestResult {
 
     assert_eq!(borrowed.kind, TokenKind::String);
     assert_eq!(borrowed.text, "\"abc\"");
-    assert_eq!(borrowed.span(), token.span());
+    assert_eq!(borrowed.span(), (token.start, token.end));
 
     let rebuilt = borrowed.to_owned_token();
     assert_eq!(rebuilt, token);


### PR DESCRIPTION
## Summary

- PR #6411 introduced `Token::span() -> TokenSpan` but the pre-existing `Token::span() -> (usize, usize)` was not removed, creating a duplicate method definition that fails to compile
- Remove the old tuple-returning `span()` from the `Token` impl (5 line deletion)  
- Update `borrowed_token_tests.rs` to compare against `TokenSpan::new(8, 13)` and `(token.start, token.end)` instead of the now-removed tuple API (3 line change)

## Root cause

`crates/perl-token/src/lib.rs` lines 228 and 279 both defined `pub fn span(&self)` on `Token` with different return types — Rust rejects duplicate method names on the same impl block.

## Verification

- `cargo check -p perl-token` — passes
- `cargo test -p perl-token` — 210 tests pass
- `cargo check --workspace --all-targets` — 0 errors, 220 crates compiled

## Diff stats

2 files changed, 3 insertions(+), 8 deletions(−) — well under the 30-line target.

## Note

PR title uses `(#0000)` as the issue placeholder per CI validate-title requirements. This is a master hot-fix — admin-merge after CI green.