### PR TITLE
fix(xtask): reformat perl-token span_invariant_tests.rs for formatting gate (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -1821,8 +1821,8 @@ mod tests {
     }
 
     #[test]
-    fn test_did_change_replaces_document_symbols_in_index()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_did_change_replaces_document_symbols_in_index() -> Result<(), Box<dyn std::error::Error>>
+    {
         let server = LspServer::new();
         let uri = "file:///test_symbol_reindex.pl";
 
@@ -1835,9 +1835,7 @@ mod tests {
             }
         }))?;
 
-        assert!(
-            server.symbol_index.lock().search_prefix("old_").contains(&"old_name".to_string())
-        );
+        assert!(server.symbol_index.lock().search_prefix("old_").contains(&"old_name".to_string()));
 
         server.handle_did_change(Some(json!({
             "textDocument": { "uri": uri, "version": 2 },
@@ -1852,8 +1850,8 @@ mod tests {
     }
 
     #[test]
-    fn test_did_close_removes_document_symbols_from_index()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn test_did_close_removes_document_symbols_from_index() -> Result<(), Box<dyn std::error::Error>>
+    {
         let server = LspServer::new();
         let uri = "file:///test_symbol_close.pl";
 

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -9,7 +9,6 @@
 //! - **Building/Degraded state**: Open document search only (partial results)
 
 use super::*;
-use std::collections::HashSet;
 #[cfg(feature = "workspace")]
 use crate::runtime::routing::{IndexAccessMode, route_index_access};
 use crate::state::workspace_symbol_cap;
@@ -22,6 +21,7 @@ use perl_parser_core::source_file::{is_perl_source_path, is_perl_source_uri};
 use perl_workspace::folder::extract_workspace_folder_change;
 #[cfg(feature = "workspace")]
 use perl_workspace::ignore::is_skipped_dir_name;
+use std::collections::HashSet;
 #[cfg(feature = "workspace")]
 use std::path::Path;
 use std::sync::Arc;

--- a/crates/perl-token/tests/span_invariant_tests.rs
+++ b/crates/perl-token/tests/span_invariant_tests.rs
@@ -64,8 +64,8 @@ fn unknown_at_clamps_inverted_span_to_start() -> Result<(), Box<dyn std::error::
 #[test]
 fn token_span_try_new_rejects_end_before_start() -> Result<(), Box<dyn std::error::Error>> {
     // TokenSpan::try_new is the span-level checked constructor (separate from Token::try_new).
-    let err = TokenSpan::try_new(100, 50)
-        .expect_err("span-level try_new should reject end < start");
+    let err =
+        TokenSpan::try_new(100, 50).expect_err("span-level try_new should reject end < start");
     assert_eq!(err, TokenSpanError::EndBeforeStart { start: 100, end: 50 });
     Ok(())
 }

--- a/xtask/src/tasks/corpus_audit/nodekind_analysis.rs
+++ b/xtask/src/tasks/corpus_audit/nodekind_analysis.rs
@@ -223,9 +223,18 @@ mod tests {
         // All 6 members of RECOVERY_KIND_NAMES must appear in the allowlist.
         assert!(allowlist.contains_key("Error"), "allowlist should contain Error");
         assert!(allowlist.contains_key("MissingBlock"), "allowlist should contain MissingBlock");
-        assert!(allowlist.contains_key("MissingExpression"), "allowlist should contain MissingExpression");
-        assert!(allowlist.contains_key("MissingIdentifier"), "allowlist should contain MissingIdentifier");
-        assert!(allowlist.contains_key("MissingStatement"), "allowlist should contain MissingStatement");
+        assert!(
+            allowlist.contains_key("MissingExpression"),
+            "allowlist should contain MissingExpression"
+        );
+        assert!(
+            allowlist.contains_key("MissingIdentifier"),
+            "allowlist should contain MissingIdentifier"
+        );
+        assert!(
+            allowlist.contains_key("MissingStatement"),
+            "allowlist should contain MissingStatement"
+        );
         assert!(allowlist.contains_key("UnknownRest"), "allowlist should contain UnknownRest");
         // The allowlist must have exactly as many entries as RECOVERY_KIND_NAMES (no extras, no dups).
         assert_eq!(
@@ -265,7 +274,11 @@ mod tests {
         let allowlisted_set: HashSet<&str> = allowlisted.iter().map(|s| s.as_str()).collect();
         let actionable_set: HashSet<&str> = actionable.iter().map(|s| s.as_str()).collect();
         let overlap: Vec<&&str> = allowlisted_set.intersection(&actionable_set).collect();
-        assert!(overlap.is_empty(), "allowlisted and actionable must be disjoint; overlap: {:?}", overlap);
+        assert!(
+            overlap.is_empty(),
+            "allowlisted and actionable must be disjoint; overlap: {:?}",
+            overlap
+        );
         // Recovery kinds must all land in the allowlisted bucket.
         for &kind in perl_parser::ast::NodeKind::RECOVERY_KIND_NAMES {
             assert!(


### PR DESCRIPTION
Master bit-rot: formatting gate was failing on span_invariant_tests.rs. PR Smoke check requires all files in scope to be properly formatted, even those not modified in the PR. This fix resolves the underlying master issue preventing cascaded PRs from passing CI.