### PR TITLE
fix(master): restore token_scorecard.rs and escape format string (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -3914,7 +3914,7 @@ print func();
         issues.iter().any(|issue| {
             matches!(issue.kind, IssueKind::UnquotedBareword) && issue.variable_name == "func"
         }),
-        "require inside eval { } is runtime; should not suppress strict 'subs'"
+        "require inside eval {{ }} is runtime; should not suppress strict 'subs'"
     );
     Ok(())
 }

--- a/crates/perl-token/benches/token_scorecard.rs
+++ b/crates/perl-token/benches/token_scorecard.rs
@@ -1,1 +1,47 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use perl_token::{Token, TokenKind, TokenRef};
+use std::hint::black_box;
 
+const START: usize = 12;
+const END: usize = 18;
+
+fn bench_borrowed_token_construction(c: &mut Criterion) {
+    c.bench_function("token/borrowed_construction", |b| {
+        b.iter(|| {
+            black_box(TokenRef::new(
+                TokenKind::Identifier,
+                black_box("foobar"),
+                black_box(START),
+                black_box(END),
+            ))
+        });
+    });
+}
+
+fn bench_owned_token_construction(c: &mut Criterion) {
+    c.bench_function("token/owned_construction", |b| {
+        b.iter(|| {
+            black_box(Token::new(
+                TokenKind::Identifier,
+                black_box("foobar"),
+                black_box(START),
+                black_box(END),
+            ))
+        });
+    });
+}
+
+fn bench_borrowed_to_owned_conversion(c: &mut Criterion) {
+    let borrowed = TokenRef::new(TokenKind::Identifier, "foobar", START, END);
+    c.bench_function("token/borrowed_to_owned_conversion", |b| {
+        b.iter(|| black_box(borrowed).to_owned_token());
+    });
+}
+
+criterion_group!(
+    token_scorecard,
+    bench_borrowed_token_construction,
+    bench_owned_token_construction,
+    bench_borrowed_to_owned_conversion
+);
+criterion_main!(token_scorecard);


### PR DESCRIPTION
Two bit-rot fixes blocking merge-ready queue:

1. token_scorecard.rs was emptied by #6457 - restored 47-line benchmark
2. scope_and_symbol_tests.rs line 3917 had unescaped { } in assert message - double-escaped to {{ }}

Verified: cargo check --all-targets passes