### PR TITLE
fix(master): normalize formatting after #6419 merge (#0000)

### DIFF
--- a/crates/perl-parser-core/tests/token_stream_conformance.rs
+++ b/crates/perl-parser-core/tests/token_stream_conformance.rs
@@ -93,4 +93,3 @@ fn hash_and_sub_sigils_as_identifier_tokens_keep_sigil_kind() {
         "bare %/& as Identifier tokens must map to sigil kinds, not operator kinds"
     );
 }
-


### PR DESCRIPTION
## Summary

- Removes trailing blank line from `crates/perl-parser-core/tests/token_stream_conformance.rs` introduced when #6419 merged
- Restores `cargo xtask fmt --check` to green on master
- 1 file changed, 1 line deleted

## Root cause

The `token_stream_conformance.rs` test file gained a trailing newline in the #6419 merge (likely from an editor or merge tool). `rustfmt` requires no trailing blank line at end of file, so the formatting gate failed.

## Verification

- `cargo xtask fmt --check` exits 0 after this fix (verified locally)
- Only `perl-parser-core/tests/token_stream_conformance.rs` was changed

## Context

This is the 10th cascade fix in the 2026-04-24/25 token-cluster session unblocking master CI for queued PRs.

## Test plan

- [x] `cargo xtask fmt --check` passes (exit 0)
- [x] Single file, 1-line deletion — no logic changes
- [x] Admin-merge candidate (formatting gate fix)