### PR TITLE
fix(master): restore module completion commitCharacters (#0000)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
@@ -1323,7 +1323,7 @@ fn test_variable_completion_has_commit_characters() -> Result<(), Box<dyn std::e
 #[test]
 fn test_module_completion_has_commit_characters() -> Result<(), Box<dyn std::error::Error>> {
     let server = start_lsp_server();
-    initialize_lsp(&server);
+    initialize_lsp_with_capabilities(&server, completion_item_caps(true, true));
 
     let uri = "file:///test_commit_module.pl";
     send_notification(

--- a/crates/perl-token/tests/display_name_snapshot_tests.rs
+++ b/crates/perl-token/tests/display_name_snapshot_tests.rs
@@ -316,7 +316,9 @@ fn canonical_lexeme(kind: TokenKind) -> Option<&'static str> {
 }
 
 fn render_table() -> String {
-    let mut out = String::from("| TokenKind | display_name | category | canonical lexeme |\n|---|---|---|---|\n");
+    let mut out = String::from(
+        "| TokenKind | display_name | category | canonical lexeme |\n|---|---|---|---|\n",
+    );
     for kind in all_token_kinds() {
         let canonical = canonical_lexeme(kind).unwrap_or("-");
         out.push_str(&format!(


### PR DESCRIPTION
## Summary

- `test_module_completion_has_commit_characters` was failing with "Module completions must have commitCharacters"
- Root cause: the test called `initialize_lsp(&server)` (empty capabilities) instead of `initialize_lsp_with_capabilities(&server, completion_item_caps(true, true))`
- The server gates `commitCharacters` emission on `client_caps.completion_commit_characters_support` — without `commitCharactersSupport: true` in the initialize handshake, that flag stays `false` and the server never emits `commitCharacters`
- The `commit_chars_for_kind` function already had the correct `Module => Some(&[":", ";"])` mapping; only the test initialization was wrong
- Fix matches the identical pattern used by `test_function_completion_has_commit_characters` and `test_variable_completion_has_commit_characters`

## Root Cause

PR #6419 (token mapping helpers) touched `perl-token` and `perl-parser-core`, not `perl-lsp-rs`. The regression predates #6419 — the test was written with the wrong `initialize_lsp` call and never actually tested the capability gate.

## Test Plan

- [x] `cargo test -p perl-lsp-rs --test lsp_completion_tests -- test_module_completion_has_commit_characters --exact` passes
- [x] All 4 `commit_characters` tests pass: `cargo test -p perl-lsp-rs --test lsp_completion_tests -- commit_characters`
- [x] Full `lsp_completion_tests` suite: 36 passed
- [x] `cargo fmt --check -p perl-lsp-rs` clean
- [x] No clippy errors introduced in changed file