### PR TITLE
test(completion): add integration test for lexical scope-distance ranking (#5499)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
@@ -1054,6 +1054,98 @@ fn test_completion_ranking() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Test that completion ranking respects lexical scope distance.
+///
+/// The server sorts completions internally by scope-distance tier before sending
+/// the response (`deduplicate_and_sort` runs with sort_key 'a'=Immediate <
+/// 'b'=Parent < 'c'=PackageLevel < 'd'=Workspace). The list position in the
+/// response is therefore the observable ranking signal.
+///
+/// Uses **distinct** variable names with **reversed alphabetical order** so that
+/// the test is non-vacuous: `$scope_zzz_inner` (immediate, 'a' tier) would sort
+/// AFTER `$scope_aaa_outer` (file scope, 'c' tier) alphabetically. Only correct
+/// scope-distance ranking can put the inner variable first. If `compute_scope_distance`
+/// is broken and returns the same tier for both, the alphabetical tiebreaker
+/// promotes `aaa_outer` — which flips the assertion and the test fails.
+#[test]
+fn test_completion_scope_distance_ranking() -> Result<(), Box<dyn std::error::Error>> {
+    let server = start_lsp_server();
+    initialize_lsp(&server);
+
+    let uri = "file:///test_scope_ranking.pl";
+    // $scope_aaa_outer at file scope → ScopeDistance::PackageLevel (sort key 'c')
+    // $scope_zzz_inner in inner block → ScopeDistance::Immediate   (sort key 'a')
+    //
+    // Alphabetical tiebreak: "aaa" < "zzz", so if both got the same scope tier,
+    // $scope_aaa_outer would appear first — opposite of the correct ranking.
+    // Only a working scope-distance implementation can pass this assertion.
+    let code = "my $scope_aaa_outer = 1;\n{\n    my $scope_zzz_inner = 2;\n    my $x = $scope\n}\n";
+
+    send_notification(
+        &server,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "perl",
+                    "version": 1,
+                    "text": code
+                }
+            }
+        }),
+    );
+    drain_until_quiet(&server, Duration::from_millis(100), Duration::from_millis(2000));
+
+    // Line 3 (0-indexed): "    my $x = $scope" — cursor at character 18 (end of "$scope")
+    let response = send_request(
+        &server,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/completion",
+            "params": {
+                "textDocument": { "uri": uri },
+                "position": { "line": 3, "character": 18 }
+            }
+        }),
+    );
+
+    let items = completion_items(&response);
+
+    // Find list positions — position encodes the server's sort order since the
+    // server pre-sorts by scope-distance tier and does not echo sortText back.
+    let inner_pos = items
+        .iter()
+        .position(|item| item["label"].as_str().map(|s| s == "$scope_zzz_inner").unwrap_or(false));
+    let outer_pos = items
+        .iter()
+        .position(|item| item["label"].as_str().map(|s| s == "$scope_aaa_outer").unwrap_or(false));
+
+    assert!(
+        inner_pos.is_some(),
+        "$scope_zzz_inner should appear in completions (cursor is inside its declaring block)"
+    );
+    assert!(
+        outer_pos.is_some(),
+        "$scope_aaa_outer should appear in completions (file-scope `my` variable)"
+    );
+
+    let inner_pos = inner_pos.unwrap();
+    let outer_pos = outer_pos.unwrap();
+
+    // Immediate scope (sort key 'a') must sort before PackageLevel (sort key 'c').
+    // Alphabetically, "aaa" < "zzz", so without scope-distance ranking $scope_aaa_outer
+    // would come first. Only correct ranking flips this — inner must be at a lower index.
+    assert!(
+        inner_pos < outer_pos,
+        "$scope_zzz_inner (immediate scope, index {inner_pos}) must sort before \
+         $scope_aaa_outer (file scope, index {outer_pos}) in the completion list"
+    );
+
+    Ok(())
+}
+
 /// Test completion with incremental typing
 #[test]
 fn test_incremental_completion() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary

Closes #5499.

Adds `test_completion_scope_distance_ranking` to `crates/perl-lsp-rs/tests/lsp_completion_tests.rs` — an integration test that proves the LSP completion provider ranks variables from inner scopes before variables from outer/package scopes when both match the same prefix.

This fills the coverage gap identified in #5499: `compute_scope_distance()` and the `sort_key()` encoding already existed and worked, but no end-to-end test asserted that scope-nearer variables actually appeared first in the completion list returned to the client.

## What the test does

```perl
my $scope_aaa_outer = 1;
{
    my $scope_zzz_inner = 2;
    my $x = $scope   ← completion requested here
}
```

The test requests completion at the `$scope` prefix inside the inner block. Both `$scope_aaa_outer` (file scope → `PackageLevel`, sort key `'c'`) and `$scope_zzz_inner` (inner block → `Immediate`, sort key `'a'`) match. The test asserts `$scope_zzz_inner` appears before `$scope_aaa_outer` in the response.

## Why the variable names are intentionally reversed-alphabetical

An earlier attempt on the `impl/5499-completion-scope-distance` branch used shadowed variable names (`$config` at two scope depths). The plan-reviewer caught a critical flaw: `deduplicate_and_sort()` in `perl-lsp-rs-core/src/providers/completion_item/mod.rs:58` collapses same-label items, keeping only the one with the best `sort_text`. With shadowed names, only one `$config` survives dedup — the ranking assertion's `len() >= 2` branch became dead code and the test always passed vacuously.

The fix: use **distinct names with reversed alphabetical order**:
- `$scope_zzz_inner` would sort **after** `$scope_aaa_outer` alphabetically (`zzz` > `aaa`)
- Both survive `deduplicate_and_sort()` since their labels differ
- Without correct scope-distance ranking both would get `PackageLevel` tier `'c'`, producing sort texts `"1c_scope_aaa_outer"` and `"1c_scope_zzz_inner"` — alphabetical tiebreak puts `aaa_outer` first
- Only when `$scope_zzz_inner` correctly gets `Immediate` tier `'a'` does it rank before `$scope_aaa_outer`

This means a regressed or broken `compute_scope_distance()` produces a test failure rather than a silent false pass.

## Files changed

- `crates/perl-lsp-rs/tests/lsp_completion_tests.rs` — test addition only, no production code changes

## Verification

```bash
RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --test lsp_completion_tests -- test_completion_scope_distance_ranking test_completion_ranking --test-threads=2
```

Output:
```
running 2 tests
test test_completion_ranking ... ok
test test_completion_scope_distance_ranking ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 35 filtered out; finished in 0.39s
```

Full completion test suite: 37 passed, 0 failed.

## Scope boundary

**In scope:** `crates/perl-lsp-rs/tests/lsp_completion_tests.rs` only  
**Out of scope:** All production code, all other test files

## Related

- Issue #5499 (spec, red-tdd, plan-review trail)
- `compute_scope_distance()` in `crates/perl-lsp-rs-core/src/providers/completion/completion/scope_distance.rs`
- `deduplicate_and_sort()` in `crates/perl-lsp-rs-core/src/providers/completion_item/mod.rs:58` (the dedup behaviour the test design accounts for)

https://claude.ai/code/session_018X5Z6xuzZn2NYbe8YP2xZQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018X5Z6xuzZn2NYbe8YP2xZQ)_