### PR TITLE
docs: fix incorrect crate name in CONTRIBUTING.md (#0000)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ The workspace contains many crates organized into families. Key crates:
 | Crate | Purpose |
 |-------|---------|
 | `perl-parser` | Main parser (v3 recursive descent) |
-| `perl-lsp` | LSP server binary |
+| `perl-lsp-rs` | LSP server binary |
 | `perl-dap` | Debug Adapter Protocol server |
 | `perl-lexer` | Context-aware tokenizer |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -281,7 +281,7 @@ cargo nextest run                              # Fast parallel runner
 For LSP tests, control threading to avoid flaky results:
 
 ```bash
-RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2
+RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs -- --test-threads=2
 ```
 
 See [COMMANDS_REFERENCE.md](docs/reference/COMMANDS_REFERENCE.md) for the full command catalog.


### PR DESCRIPTION
## Summary

- Fixes wrong crate name in the Project Structure table in `CONTRIBUTING.md`
- The LSP server binary crate is `perl-lsp-rs`, not `perl-lsp` — no crate named `perl-lsp` exists in the workspace

## Test plan

- [ ] Verify `crates/perl-lsp-rs/` exists and `crates/perl-lsp/` does not

https://claude.ai/code/session_014y23U5mcx95wXMVTLA62f6

---
_Generated by [Claude Code](https://claude.ai/code/session_014y23U5mcx95wXMVTLA62f6)_