### PR TITLE
fix: correct invalid Perl syntax in test corpus (#0000)

### DIFF
--- a/test_corpus/class_method_production_enhanced.pl
+++ b/test_corpus/class_method_production_enhanced.pl
@@ -552,7 +552,7 @@ $order->add_item('P002', 1, 49.99);
 $order->add_item('P003', 3, 5.99);
 
 print "Order created with " . scalar(@{$order->items}) . " items\n";
-print "Total: $" . sprintf('%.2f', $order->total) . "\n";
+print "Total: \$" . sprintf('%.2f', $order->total) . "\n";
 
 $order->mark_paid();
 $order->mark_shipped();

--- a/test_corpus/package_production_enhanced.pl
+++ b/test_corpus/package_production_enhanced.pl
@@ -406,7 +406,7 @@ package Singleton::Manager {
         return new('Singleton::Manager');
     }
     
-    def increment_counter {
+    sub increment_counter {
         my ($self) = @_;
         $self->{counter}++;
         return $self->{counter};


### PR DESCRIPTION
## Summary

Two inaccuracies found and fixed in the parser test corpus:

- **`test_corpus/package_production_enhanced.pl:409`** — `def` is not a Perl keyword. The correct keyword for subroutine declaration is `sub`. This appears to be a copy/paste from Python or Ruby where `def` is valid.

- **`test_corpus/class_method_production_enhanced.pl:555`** — A bare `$` at the end of a double-quoted string is invalid Perl syntax (Perl reports: *"Final $ should be \$ or $name"*). The `$` is now escaped as `\$` so it prints a literal dollar sign.

## Test plan

- [ ] `cargo test -p perl-parser` — parser tests still pass
- [ ] `cargo test --workspace --lib` — no regressions
- [ ] `just pr-fast` — fast CI gate passes

https://claude.ai/code/session_0152nao4kDe3WNLEhfqYD41j

---
_Generated by [Claude Code](https://claude.ai/code/session_0152nao4kDe3WNLEhfqYD41j)_