### PR TITLE
docs(tree-sitter-perl-rs): sync docs with implemented APIs (#0000)

### DIFF
--- a/crates/tree-sitter-perl-rs/CLAUDE.md
+++ b/crates/tree-sitter-perl-rs/CLAUDE.md
@@ -30,21 +30,42 @@ pub struct Tree { /* owns the v3 AST */ }
 impl Tree {
     pub fn root_node(&self) -> Node;
     pub fn source(&self) -> &str;
+    pub fn walk(&self) -> TreeCursor<'_>;
+    pub fn edit(&mut self, edit: &InputEdit);
 }
 
 pub struct Node<'tree> { /* borrows from Tree */ }
 impl<'tree> Node<'tree> {
-    pub fn kind(&self) -> &'static str;        // delegates to NodeKind::kind_name()
+    pub fn kind(&self) -> &'static str;        // v3 internal name, e.g. "Program"
+    pub fn grammar_kind(&self) -> String;      // canonical grammar name, e.g. "source_file"
     pub fn to_sexp(&self) -> String;           // delegates to perl_ast::Node::to_sexp()
     pub fn child_count(&self) -> usize;
     pub fn child(&self, i: usize) -> Option<Node<'tree>>;
     pub fn children(&self) -> impl Iterator<Item = Node<'tree>>;
     pub fn start_byte(&self) -> usize;
     pub fn end_byte(&self) -> usize;
+    pub fn start_position(&self) -> Point;
+    pub fn end_position(&self) -> Point;
     pub fn utf8_text<'a>(&self, source: &'a [u8]) -> Result<&'a str, Utf8Error>;
+    pub fn tree_source(&self) -> &'tree str;
     pub fn is_leaf(&self) -> bool;
     pub fn inner(&self) -> &'tree perl_ast::Node;  // escape hatch
+    pub fn walk(&self) -> TreeCursor<'tree>;
 }
+
+pub struct TreeCursor<'tree> { /* zero-allocation streaming traversal */ }
+impl<'tree> TreeCursor<'tree> {
+    pub fn node(&self) -> Node<'tree>;
+    pub fn goto_first_child(&mut self) -> bool;
+    pub fn goto_next_sibling(&mut self) -> bool;
+    pub fn goto_parent(&mut self) -> bool;
+    pub fn reset(&mut self, node: Node<'tree>);
+}
+
+pub use perl_parser_core::edit::Edit as InputEdit;
+pub struct PerlLanguage { /* language descriptor */ }
+pub fn language() -> PerlLanguage;
+pub static LANGUAGE: PerlLanguage;
 
 pub use perl_ast::NodeKind as PerlNodeKind;  // for pattern matching without perl-ast dep
 ```
@@ -75,8 +96,5 @@ cargo doc -p tree-sitter-perl-rs --open     # View documentation
 
 ## Backlog follow-ups
 
-- Tree cursor / walk API
-- Edit/incremental parsing API
 - Field-name accessors (named children by field name)
-- A `Language` constant compatible with the `tree_sitter::Language` shape
 - Predicate / query API

--- a/crates/tree-sitter-perl-rs/CLAUDE.md
+++ b/crates/tree-sitter-perl-rs/CLAUDE.md
@@ -59,7 +59,7 @@ impl<'tree> TreeCursor<'tree> {
     pub fn goto_first_child(&mut self) -> bool;
     pub fn goto_next_sibling(&mut self) -> bool;
     pub fn goto_parent(&mut self) -> bool;
-    pub fn reset(&mut self, node: Node<'tree>);
+    pub fn reset(&mut self);  // resets to root node (no argument)
 }
 
 pub use perl_parser_core::edit::Edit as InputEdit;

--- a/crates/tree-sitter-perl-rs/README.md
+++ b/crates/tree-sitter-perl-rs/README.md
@@ -47,16 +47,28 @@ if let Some(tree) = parser.parse("my $x = 42;") {
 | `Parser::parse(&mut self, source: &str) -> Option<Tree>` | Parse Perl source; `None` only on complete failure |
 | `Tree::root_node() -> Node<'_>` | Get the root of the syntax tree |
 | `Tree::source() -> &str` | Source text this tree was built from |
-| `Node::kind() -> &'static str` | Node type name (e.g. `"Program"`, `"Subroutine"`) |
+| `Parser::parse_with_old_tree(&mut self, source: &str, old_tree: &Tree) -> Option<Tree>` | Incremental re-parse; reuses unchanged regions of `old_tree` |
+| `Tree::walk() -> TreeCursor<'_>` | Returns a cursor for zero-allocation streaming traversal |
+| `Tree::edit(&mut self, edit: &InputEdit)` | Records a source edit; pass the updated tree to `parse_with_old_tree` |
+| `Tree::root_node() -> Node<'_>` | Get the root of the syntax tree |
+| `Tree::source() -> &str` | Source text this tree was built from |
+| `Node::kind() -> &'static str` | Node type name (v3 internal, e.g. `"Program"`) |
+| `Node::grammar_kind() -> String` | Grammar-canonical name (e.g. `"source_file"`) matching tree-sitter output |
 | `Node::to_sexp() -> String` | Tree-sitter-compatible S-expression for this subtree |
 | `Node::child_count() -> usize` | Number of direct children |
 | `Node::child(i: usize) -> Option<Node>` | `i`-th direct child |
 | `Node::children() -> impl Iterator<Item = Node>` | Iterator over direct children |
 | `Node::start_byte() -> usize` | Start byte offset in source (inclusive) |
 | `Node::end_byte() -> usize` | End byte offset in source (exclusive) |
+| `Node::start_position() -> Point` | `(row, column)` of the first byte |
+| `Node::end_position() -> Point` | `(row, column)` past the last byte |
 | `Node::utf8_text<'a>(&self, source: &'a [u8]) -> Result<&'a str, Utf8Error>` | Source slice for this node |
+| `Node::tree_source() -> &str` | Source string the enclosing tree was built from |
 | `Node::is_leaf() -> bool` | `true` if the node has no children |
 | `Node::inner() -> &perl_ast::Node` | Escape hatch to the v3 AST |
+| `TreeCursor` | Zero-allocation cursor; `node()`, `goto_first_child()`, `goto_next_sibling()`, `goto_parent()` |
+| `InputEdit` | Source-edit descriptor (re-export of `perl_parser_core::edit::Edit`) |
+| `PerlLanguage` / `language()` / `LANGUAGE` | Language descriptor for Rust-native tooling (not `tree_sitter::Language`) |
 | `PerlNodeKind` | Re-export of `perl_ast::NodeKind` for pattern matching |
 
 ## Error tolerance
@@ -71,18 +83,14 @@ This means you can pipe any Perl source through this parser and rely on getting 
 
 - `Node::children()` allocates a `Vec` internally on each call. Prefer iterating once over calling repeatedly.
 - `RecursionLimit` / `NestingTooDeep` parse errors produce `None` rather than a partial tree.
-- `Node::kind()` returns v3 internal names (e.g. `"Program"`) rather than tree-sitter grammar names (e.g. `"source_file"`). Use `Node::to_sexp()` for grammar-canonical output.
+- `Node::kind()` returns v3 internal names (e.g. `"Program"`) rather than tree-sitter grammar names (e.g. `"source_file"`). Use `Node::grammar_kind()` for the canonical name or `Node::to_sexp()` for full canonical output.
 
 ## Backlog roadmap
 
 The following APIs are not yet implemented and remain on the backlog:
 
-- Tree cursor / walk API (streaming traversal without per-call allocation)
-- Edit / incremental parsing API
 - Field-name accessors (named children by field name, as in `node.child_by_field_name("body")`)
-- A `Language` constant compatible with the `tree_sitter::Language` shape
 - Predicate / query API (pattern matching over the AST)
-- `kind()` name remapping to canonical tree-sitter grammar names
 
 ## License
 

--- a/crates/tree-sitter-perl-rs/ROADMAP.md
+++ b/crates/tree-sitter-perl-rs/ROADMAP.md
@@ -4,23 +4,16 @@
 
 - `Parser` / `Tree` / `Node<'tree>` types with tree-sitter-compatible API shape
 - `to_sexp()` — tree-sitter-compatible S-expression output
-- `kind()`, `child_count()`, `child()`, `children()` — tree traversal
-- `start_byte()`, `end_byte()`, `utf8_text()` — source location and extraction
+- `kind()`, `grammar_kind()`, `child_count()`, `child()`, `children()` — tree traversal
+- `start_byte()`, `end_byte()`, `start_position()`, `end_position()`, `utf8_text()` — source location and extraction
 - `is_leaf()`, `inner()`, `tree_source()` — utility and escape hatch
+- `TreeCursor` — zero-allocation streaming traversal (`walk()`, `goto_first_child()`, `goto_next_sibling()`, `goto_parent()`)
+- `Tree::edit()` / `Parser::parse_with_old_tree()` / `InputEdit` — incremental re-parsing
+- `PerlLanguage` descriptor, `language()` function, and `LANGUAGE` constant for Rust-native tooling
 - `PerlNodeKind` re-export for pattern matching without a direct `perl-ast` dependency
 - Snapshot tests for representative Perl constructs
 
 ## Phase 2 (planned)
-
-### Tree cursor / walk API
-
-A `TreeCursor` type for streaming traversal without per-call Vec allocation.
-Mirrors `tree_sitter::TreeCursor`.
-
-### Edit / incremental parsing
-
-`Tree::edit()` to apply `InputEdit` structures and `Parser::parse_with_old_tree()` for
-incremental re-parsing of changed source regions.
 
 ### Field-name accessors
 
@@ -28,22 +21,10 @@ incremental re-parsing of changed source regions.
 `Node::children_by_field_name(name: &str) -> impl Iterator<Item = Node>` to address named
 child slots (e.g. `"body"`, `"condition"`, `"name"`).
 
-### `Language` constant
-
-A `LANGUAGE` constant or `language()` function returning a type compatible with
-`tree_sitter::Language` (if API stability permits), enabling use with tree-sitter tooling
-that expects a language object.
-
 ### Predicate / query API
 
 `Query` and `QueryCursor` types for pattern matching over the AST, analogous to the
 tree-sitter query API.
-
-### `kind()` name remapping
-
-Map v3 internal node kind names (e.g. `"Program"`, `"Subroutine"`) to canonical tree-sitter
-grammar names (e.g. `"source_file"`, `"subroutine_declaration"`). The current `kind()` returns
-v3 internal names; `to_sexp()` already uses grammar-canonical names.
 
 ## Known limitations
 


### PR DESCRIPTION
## Summary

- `TreeCursor`/`walk`, `Tree::edit`, `Parser::parse_with_old_tree`, `Node::grammar_kind()`, `Node::start_position()`/`end_position()`, `Node::tree_source()`, `PerlLanguage`, `language()`, and `LANGUAGE` are all fully implemented and tested — but `README.md`, `ROADMAP.md`, and `CLAUDE.md` listed them as backlog/unimplemented.
- Removed the two genuinely-not-yet-implemented items (field-name accessors, query API) from all backlog lists — those remain as-is.

## Changes

- **README.md**: expanded the API overview table to include all current public methods; removed shipped items from the backlog section; updated the `kind()` limitation note to mention `grammar_kind()` as the solution
- **ROADMAP.md**: moved TreeCursor, incremental parsing, and the `PerlLanguage`/`language()`/`LANGUAGE` items from Phase 2 (planned) into Phase 1 (shipped); Phase 2 now lists only the two genuinely unimplemented items
- **CLAUDE.md**: updated the public API surface block with all current signatures; removed shipped items from backlog follow-ups

## Test plan

- [ ] No code changes — documentation only
- [ ] Verify the removed backlog items are present in `src/lib.rs` (`grep -n "TreeCursor\|parse_with_old_tree\|grammar_kind\|start_position\|PerlLanguage" crates/tree-sitter-perl-rs/src/lib.rs`)
- [ ] Confirm field-name accessors and query API are still absent (`grep -n "child_by_field_name\|QueryCursor" crates/tree-sitter-perl-rs/src/lib.rs` should return nothing)

https://claude.ai/code/session_018NBMBRJvoEP9sFXw4S11ei

---
_Generated by [Claude Code](https://claude.ai/code/session_018NBMBRJvoEP9sFXw4S11ei)_