### PR TITLE
fix(tree-sitter-perl-rs): correct docs claiming walk/edit/grammar_kind unimplemented

### DIFF
--- a/crates/tree-sitter-perl-rs/CLAUDE.md
+++ b/crates/tree-sitter-perl-rs/CLAUDE.md
@@ -30,21 +30,35 @@ pub struct Tree { /* owns the v3 AST */ }
 impl Tree {
     pub fn root_node(&self) -> Node;
     pub fn source(&self) -> &str;
+    pub fn edit(&mut self, edit: &InputEdit);
+    pub fn walk(&self) -> TreeCursor<'_>;
 }
 
 pub struct Node<'tree> { /* borrows from Tree */ }
 impl<'tree> Node<'tree> {
-    pub fn kind(&self) -> &'static str;        // delegates to NodeKind::kind_name()
+    pub fn kind(&self) -> &'static str;        // v3 internal name (e.g. "Program")
+    pub fn grammar_kind(&self) -> String;      // tree-sitter grammar name (e.g. "source_file")
     pub fn to_sexp(&self) -> String;           // delegates to perl_ast::Node::to_sexp()
     pub fn child_count(&self) -> usize;
     pub fn child(&self, i: usize) -> Option<Node<'tree>>;
     pub fn children(&self) -> impl Iterator<Item = Node<'tree>>;
+    pub fn walk(&self) -> TreeCursor<'tree>;
     pub fn start_byte(&self) -> usize;
     pub fn end_byte(&self) -> usize;
     pub fn utf8_text<'a>(&self, source: &'a [u8]) -> Result<&'a str, Utf8Error>;
     pub fn is_leaf(&self) -> bool;
     pub fn inner(&self) -> &'tree perl_ast::Node;  // escape hatch
 }
+
+pub struct PerlLanguage { /* node kind descriptor, NOT tree_sitter::Language */ }
+impl PerlLanguage {
+    pub fn node_kind_count(&self) -> usize;
+    pub fn node_kind_names(&self) -> &[&'static str];
+    pub fn node_kind_is_named(&self, kind: &str) -> bool;
+}
+
+pub fn language() -> PerlLanguage;
+pub static LANGUAGE: PerlLanguage;
 
 pub use perl_ast::NodeKind as PerlNodeKind;  // for pattern matching without perl-ast dep
 ```
@@ -75,8 +89,6 @@ cargo doc -p tree-sitter-perl-rs --open     # View documentation
 
 ## Backlog follow-ups
 
-- Tree cursor / walk API
-- Edit/incremental parsing API
-- Field-name accessors (named children by field name)
-- A `Language` constant compatible with the `tree_sitter::Language` shape
-- Predicate / query API
+- Field-name accessors (named children by field name, as in `node.child_by_field_name("body")`)
+- Predicate / query API (pattern matching over the AST)
+- True incremental re-parsing (skipping unchanged regions in `Parser::parse_with_old_tree`)

--- a/crates/tree-sitter-perl-rs/README.md
+++ b/crates/tree-sitter-perl-rs/README.md
@@ -47,17 +47,24 @@ if let Some(tree) = parser.parse("my $x = 42;") {
 | `Parser::parse(&mut self, source: &str) -> Option<Tree>` | Parse Perl source; `None` only on complete failure |
 | `Tree::root_node() -> Node<'_>` | Get the root of the syntax tree |
 | `Tree::source() -> &str` | Source text this tree was built from |
-| `Node::kind() -> &'static str` | Node type name (e.g. `"Program"`, `"Subroutine"`) |
+| `Parser::parse_with_old_tree(&mut self, source: &str, old_tree: &Tree) -> Option<Tree>` | Re-parse with incremental hint (API-compatible; full re-parse in current impl) |
+| `Tree::edit(&mut self, edit: &InputEdit)` | Record a source edit for incremental re-parsing |
+| `Tree::walk() -> TreeCursor<'_>` | Cursor for stateful tree traversal |
+| `Node::kind() -> &'static str` | Node type name (v3 internal name, e.g. `"Program"`, `"Subroutine"`) |
+| `Node::grammar_kind() -> String` | Tree-sitter grammar-canonical name (e.g. `"source_file"`, `"sub"`) |
 | `Node::to_sexp() -> String` | Tree-sitter-compatible S-expression for this subtree |
 | `Node::child_count() -> usize` | Number of direct children |
 | `Node::child(i: usize) -> Option<Node>` | `i`-th direct child |
 | `Node::children() -> impl Iterator<Item = Node>` | Iterator over direct children |
+| `Node::walk() -> TreeCursor<'_>` | Cursor rooted at this node |
 | `Node::start_byte() -> usize` | Start byte offset in source (inclusive) |
 | `Node::end_byte() -> usize` | End byte offset in source (exclusive) |
 | `Node::utf8_text<'a>(&self, source: &'a [u8]) -> Result<&'a str, Utf8Error>` | Source slice for this node |
 | `Node::is_leaf() -> bool` | `true` if the node has no children |
 | `Node::inner() -> &perl_ast::Node` | Escape hatch to the v3 AST |
 | `PerlNodeKind` | Re-export of `perl_ast::NodeKind` for pattern matching |
+| `language() -> PerlLanguage` | Returns the `PerlLanguage` descriptor |
+| `LANGUAGE: PerlLanguage` | Static `PerlLanguage` constant |
 
 ## Error tolerance
 
@@ -67,22 +74,21 @@ The v3 parser is highly error-tolerant. `Parser::parse()` returns `Option<Tree>`
 
 This means you can pipe any Perl source through this parser and rely on getting a tree back.
 
-## Known limitations (Phase 1)
+## Known limitations
 
 - `Node::children()` allocates a `Vec` internally on each call. Prefer iterating once over calling repeatedly.
 - `RecursionLimit` / `NestingTooDeep` parse errors produce `None` rather than a partial tree.
-- `Node::kind()` returns v3 internal names (e.g. `"Program"`) rather than tree-sitter grammar names (e.g. `"source_file"`). Use `Node::to_sexp()` for grammar-canonical output.
+- `Node::kind()` returns v3 internal PascalCase names (e.g. `"Program"`). Use `Node::grammar_kind()` for the tree-sitter grammar-canonical name (e.g. `"source_file"`), or `Node::to_sexp()` for full S-expression output.
+- `Parser::parse_with_old_tree()` accepts the old tree for API compatibility but currently performs a full re-parse; true incremental region-skipping is a planned optimization.
+- `PerlLanguage` is not a `tree_sitter::Language` — it cannot be passed to `tree_sitter::Parser::set_language`. Use `tree-sitter-perl-c` for C ecosystem compatibility.
 
 ## Backlog roadmap
 
 The following APIs are not yet implemented and remain on the backlog:
 
-- Tree cursor / walk API (streaming traversal without per-call allocation)
-- Edit / incremental parsing API
 - Field-name accessors (named children by field name, as in `node.child_by_field_name("body")`)
-- A `Language` constant compatible with the `tree_sitter::Language` shape
 - Predicate / query API (pattern matching over the AST)
-- `kind()` name remapping to canonical tree-sitter grammar names
+- True incremental re-parsing (skipping unchanged regions in `parse_with_old_tree`)
 
 ## License
 

--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -960,11 +960,8 @@ mod tests {
 
         // Navigate to first statement
         assert!(cursor.goto_first_child());
-        let mut count = 1;
         // Keep advancing siblings until we can't
-        while cursor.goto_next_sibling() {
-            count += 1;
-        }
+        while cursor.goto_next_sibling() {}
         // After last goto_next_sibling returns false, cursor should still be valid
         // and still have a node (the last sibling).
         let node = cursor.node();


### PR DESCRIPTION
## Summary

- README.md and CLAUDE.md both listed tree cursor/walk, edit/incremental parsing, `grammar_kind()`, and `PerlLanguage` as "not yet implemented" backlog items — but all four are shipped in `src/lib.rs`
- Removed those items from the backlog sections and updated the API overview and known limitations to reflect reality
- Removed an unused `count` variable in the TreeCursor exhaustion test that was triggering a compiler warning

## What was wrong

The `## Backlog roadmap` in README.md stated these were unimplemented:

| Claimed unimplemented | Actually exists |
|---|---|
| Tree cursor / walk API | `Tree::walk()`, `Node::walk()` → `TreeCursor` |
| Edit / incremental parsing API | `Tree::edit()`, `Parser::parse_with_old_tree()` |
| `kind()` name remapping | `Node::grammar_kind()` returning canonical grammar names |
| A `Language` constant | `PerlLanguage`, `language()`, `LANGUAGE` |

## Changes

- **README.md**: Updated API overview table to include `grammar_kind`, `walk`, `edit`, `parse_with_old_tree`, `language()`, `LANGUAGE`; fixed "Known limitations" to point users at `grammar_kind()` and note `PerlLanguage ≠ tree_sitter::Language`; stripped shipped items from backlog, replaced with true remaining work (field-name accessors, query API, true incremental region-skipping)
- **CLAUDE.md**: Updated Public API surface and Backlog follow-ups to match
- **src/lib.rs**: Removed unused `count` variable from TreeCursor sibling exhaustion test

## Test plan

- [x] `cargo test -p tree-sitter-perl-rs` — all 82 tests pass
- [x] `cargo clippy -p tree-sitter-perl-rs` — no warnings

https://claude.ai/code/session_016bG3TndzQQCZCtn7FoMNMX

---
_Generated by [Claude Code](https://claude.ai/code/session_016bG3TndzQQCZCtn7FoMNMX)_