### PR TITLE
fix(lexer): tokenize bare v-strings like `v5` as Version, not Identifier

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1959,16 +1959,7 @@ impl<'a> PerlLexer<'a> {
             }
         }
 
-        // Require at least one dot segment to distinguish from a bare `v5` identifier.
-        // A bare `v` followed by digits but no dots (like `v5`) could be a variable
-        // name in some contexts. However, Perl treats `v5` as a v-string too, so we
-        // require the minimum: `v` + digits (which Perl interprets as chr(5)).
-        // But to avoid breaking existing identifier parsing for things like subroutine
-        // names that happen to match `v\d+`, we require at least one dot.
         let text = &self.input[start..pos];
-        if !text.contains('.') {
-            return None;
-        }
 
         self.position = pos;
         self.mode = LexerMode::ExpectOperator;

--- a/crates/perl-lexer/tests/vstring_tests.rs
+++ b/crates/perl-lexer/tests/vstring_tests.rs
@@ -141,13 +141,14 @@ fn test_v_followed_by_alpha_is_identifier() -> R {
 }
 
 #[test]
-fn test_v_digits_no_dot_is_identifier() -> R {
-    // "v5" without a dot should remain an identifier (conservative approach)
+fn test_v_digits_no_dot_is_vstring() -> R {
+    // Perl treats `v5` as a v-string (chr(5)), not an identifier.
+    // The `v` prefix with trailing digits and no dot is valid: `v5` eq "\x05".
     let toks = significant("v5");
     assert_eq!(toks.len(), 1);
     assert!(
-        matches!(&toks[0].token_type, TokenType::Identifier(_) | TokenType::Keyword(_)),
-        "expected identifier for 'v5', got: {:?}",
+        matches!(&toks[0].token_type, TokenType::Version(v) if v.as_ref() == "v5"),
+        "expected Version(v5) for bare v-string, got: {:?}",
         toks[0].token_type
     );
     Ok(())


### PR DESCRIPTION
## Summary

- Perl treats `v5` (a `v` prefix followed by digits, no dots) as a v-string literal equivalent to `chr(5)` / `"\x05"`. The lexer incorrectly returned `Identifier` for these tokens.
- Removed the "require at least one dot" guard in `try_vstring` — it was factually wrong. The existing identifier-continuation check already prevents `v5x` and `v5_test` from being mis-classified.
- Updated the test `test_v_digits_no_dot_is_identifier` → `test_v_digits_no_dot_is_vstring` to assert the correct Perl semantics.

## Root cause

`crates/perl-lexer/src/lib.rs` lines 1962–1971 had:

```rust
// Require at least one dot segment to distinguish from a bare `v5` identifier.
let text = &self.input[start..pos];
if !text.contains('.') {
    return None;
}
```

The comment itself acknowledged that Perl treats `v5` as a v-string, but chose a "conservative" approach that diverges from the language spec.

## Test plan

- [ ] `cargo test -p perl-lexer --test vstring_tests` — all 14 tests pass, including new `test_v_digits_no_dot_is_vstring`
- [ ] `cargo clippy -p perl-lexer --tests` — no warnings
- [ ] `cargo fmt -p perl-lexer` — no changes

https://claude.ai/code/session_01TTBPZzUEwBrReZsgxjbEuU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTBPZzUEwBrReZsgxjbEuU)_