### PR TITLE
fix: update stale LSP version claims in perl-parser docs (#0000)

### DIFF
--- a/crates/perl-parser/src/lib.rs
+++ b/crates/perl-parser/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! - **Tree-sitter Compatible**: AST with kinds, fields, and position tracking compatible with tree-sitter grammar
 //! - **Comprehensive Parsing**: ~100% edge case coverage for Perl 5.8-5.40 syntax
-//! - **LSP Integration**: Full Language Server Protocol feature set (~82% coverage in v0.8.6)
+//! - **LSP Integration**: Full Language Server Protocol feature set (100% compliance, LSP 3.18)
 //! - **TDD Workflow**: Intelligent test generation with return value analysis
 //! - **Incremental Parsing**: Efficient re-parsing for real-time editing
 //! - **Error Recovery**: Graceful handling of malformed input with detailed diagnostics
@@ -273,7 +273,7 @@
 //! ## Compatibility
 //!
 //! - **Perl Versions**: 5.8 through 5.40 (covers 99% of CPAN)
-//! - **LSP Protocol**: LSP 3.17 specification
+//! - **LSP Protocol**: LSP 3.18 specification
 //! - **Tree-sitter**: Compatible AST format and position tracking
 //! - **UTF-16**: Full Unicode support with correct LSP position mapping
 //!


### PR DESCRIPTION
## Summary

- `crates/perl-parser/src/lib.rs` line 10 claimed `~82% coverage in v0.8.6` — stale since the project is now at v0.12.4 with 100% LSP compliance (as declared in `features.toml` `compliance_percent = 100`)
- `crates/perl-parser/src/lib.rs` line 276 claimed `LSP 3.17 specification` — the project now targets LSP 3.18, as declared in `features.toml` (`lsp_version = "3.18"`), `feature_catalog.rs`, and `build_catalog.rs` (`LSP_VERSION: &str = "3.18"`)

Both are doc-comment inaccuracies that would mislead crate users reading the crate docs.

## Test plan

- [ ] `cargo doc -p perl-parser --no-deps` — docs render correctly with updated claims
- [ ] `cargo clippy -p perl-parser` — no warnings introduced

https://claude.ai/code/session_01GFYLdekWTBSPXEKybrxhrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFYLdekWTBSPXEKybrxhrR)_