### PR TITLE
fix(perl-lexer): recognize v-strings without dot (v5 = chr(5)) (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1959,16 +1959,8 @@ impl<'a> PerlLexer<'a> {
             }
         }
 
-        // Require at least one dot segment to distinguish from a bare `v5` identifier.
-        // A bare `v` followed by digits but no dots (like `v5`) could be a variable
-        // name in some contexts. However, Perl treats `v5` as a v-string too, so we
-        // require the minimum: `v` + digits (which Perl interprets as chr(5)).
-        // But to avoid breaking existing identifier parsing for things like subroutine
-        // names that happen to match `v\d+`, we require at least one dot.
+        // `v5` (no dots) is a valid Perl v-string meaning chr(5).
         let text = &self.input[start..pos];
-        if !text.contains('.') {
-            return None;
-        }
 
         self.position = pos;
         self.mode = LexerMode::ExpectOperator;

--- a/crates/perl-lexer/tests/vstring_tests.rs
+++ b/crates/perl-lexer/tests/vstring_tests.rs
@@ -141,13 +141,13 @@ fn test_v_followed_by_alpha_is_identifier() -> R {
 }
 
 #[test]
-fn test_v_digits_no_dot_is_identifier() -> R {
-    // "v5" without a dot should remain an identifier (conservative approach)
+fn test_v_digits_no_dot_is_vstring() -> R {
+    // "v5" without a dot is a valid Perl v-string meaning chr(5)
     let toks = significant("v5");
-    assert_eq!(toks.len(), 1);
+    assert_eq!(toks.len(), 1, "expected single token, got: {:?}", toks);
     assert!(
-        matches!(&toks[0].token_type, TokenType::Identifier(_) | TokenType::Keyword(_)),
-        "expected identifier for 'v5', got: {:?}",
+        matches!(&toks[0].token_type, TokenType::Version(v) if v.as_ref() == "v5"),
+        "expected Version(v5) for bare v-string, got: {:?}",
         toks[0].token_type
     );
     Ok(())


### PR DESCRIPTION
## Summary

- Perl treats `v5` (a `v` followed by digits, no dots) as a valid v-string equivalent to `chr(5)`, but the lexer was silently falling through to identifier parsing instead
- The inaccuracy was self-documented: the code comment explicitly said "Perl treats `v5` as a v-string too" before immediately rejecting it with `if !text.contains('.')`
- Remove the artificial dot guard in `try_vstring()` and update the test that encoded the wrong behavior

## Details

In `crates/perl-lexer/src/lib.rs`, the `try_vstring` method had this check:

```rust
// … However, Perl treats `v5` as a v-string too …
// But to avoid breaking existing identifier parsing … we require at least one dot.
let text = &self.input[start..pos];
if !text.contains('.') {
    return None;   // ← bug: rejects valid Perl syntax
}
```

The guard was dropped. `v5x` and `v5_test` remain identifiers (excluded by the pre-existing alpha/underscore check), so the fix is narrow.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p perl-lexer --tests` — no warnings
- [x] `cargo test -p perl-lexer` — all pass, including renamed `test_v_digits_no_dot_is_vstring` which now asserts `Version("v5")` instead of `Identifier`

https://claude.ai/code/session_01SoD5uJkJQvkGAzbzU5BLno

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoD5uJkJQvkGAzbzU5BLno)_