### PR TITLE
fix(perl-corpus): properly handle test helper results (#6729)

### DIFF
--- a/crates/perl-corpus/src/continue_redo.rs
+++ b/crates/perl-corpus/src/continue_redo.rs
@@ -497,7 +497,6 @@ mod tests {
     #[test]
     fn can_find_by_id() {
         let case = find_case("continue.while.basic");
-        must_some(case);
         assert_eq!(must_some(case).id, "continue.while.basic");
     }
 
@@ -547,11 +546,9 @@ mod tests {
     #[test]
     fn edge_cases_marked_correctly() {
         let bare_block = find_case("continue.bare.block");
-        must_some(bare_block);
         assert!(!must_some(bare_block).should_parse, "continue on bare block should be invalid");
 
         let redo_bare = find_case("redo.bare.block");
-        must_some(redo_bare);
         assert!(!must_some(redo_bare).should_parse, "redo in bare block should be invalid");
     }
 }

--- a/crates/perl-corpus/src/glob_expressions.rs
+++ b/crates/perl-corpus/src/glob_expressions.rs
@@ -544,7 +544,6 @@ mod tests {
     #[test]
     fn glob_case_lookup_by_id() {
         let case = find_glob_case("glob.function.basic");
-        must_some(case);
         assert_eq!(must_some(case).id, "glob.function.basic");
     }
 
@@ -558,7 +557,6 @@ mod tests {
     #[test]
     fn glob_case_sample_by_tag_matches() {
         let case = GlobExpressionGenerator::sample_by_tag("diamond", 7);
-        must_some(case);
         assert!(must_some(case).tags.contains(&"diamond"));
     }
 
@@ -613,7 +611,6 @@ mod tests {
     #[test]
     fn glob_generator_find_works() {
         let case = GlobExpressionGenerator::find("glob.diamond.variable");
-        must_some(case);
         assert_eq!(must_some(case).id, "glob.diamond.variable");
     }
 }

--- a/crates/perl-tdd-support/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-tdd-support/tests/comprehensive_unit_tests.rs
@@ -62,7 +62,7 @@ fn must_some_panics_on_none() {
 }
 
 #[test]
-#[should_panic(expected = "expected Err, got Ok")]
+#[should_panic(expected = "expected Err")]
 fn must_err_panics_on_ok() {
     let val: Result<i32, &str> = Ok(1);
     let _ = must_err(val);

--- a/crates/perl-tdd-support/tests/test_helper_coverage.rs
+++ b/crates/perl-tdd-support/tests/test_helper_coverage.rs
@@ -83,7 +83,7 @@ fn test_must_panic_message_contains_error_debug_repr() {
 }
 
 #[test]
-#[should_panic(expected = "unexpected Err: \"detailed error message\"")]
+#[should_panic(expected = "unexpected Err<alloc::string::String>: \"detailed error message\"")]
 fn test_must_panic_message_includes_string_error() {
     let val: Result<i32, String> = Err("detailed error message".to_string());
     let _ = must(val);
@@ -96,7 +96,8 @@ fn test_must_panic_message_includes_string_error() {
 #[test]
 fn test_must_some_with_unit_type() -> Result<(), Box<dyn std::error::Error>> {
     let val: Option<()> = Some(());
-    must_some(val);
+    #[allow(clippy::let_unit_value)]
+    let _ = must_some(val);
     Ok(())
 }
 
@@ -142,7 +143,8 @@ fn test_must_some_panic_message_is_exact() {
 #[test]
 fn test_must_err_with_unit_error() -> Result<(), Box<dyn std::error::Error>> {
     let val: Result<i32, ()> = Err(());
-    must_err(val);
+    #[allow(clippy::let_unit_value)]
+    let _ = must_err(val);
     Ok(())
 }
 
@@ -165,7 +167,7 @@ fn test_must_err_with_tuple_error() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-#[should_panic(expected = "expected Err, got Ok")]
+#[should_panic(expected = "expected Err<&str>, got Ok<alloc::vec::Vec<i32>>([1, 2, 3])")]
 fn test_must_err_panic_message_contains_ok_debug() {
     let val: Result<Vec<i32>, &str> = Ok(vec![1, 2, 3]);
     let _ = must_err(val);
@@ -179,7 +181,7 @@ fn test_must_err_panic_message_shows_ok_value() {
 }
 
 #[test]
-#[should_panic(expected = "expected Err, got Ok(42)")]
+#[should_panic(expected = "expected Err<&str>, got Ok<i32>(42)")]
 fn test_must_err_panic_message_shows_numeric_ok() {
     let val: Result<i32, &str> = Ok(42);
     let _ = must_err(val);
@@ -202,7 +204,7 @@ fn test_must_track_caller_reports_test_file_location() {
 fn test_must_some_track_caller_reports_test_file_location() {
     let result = std::panic::catch_unwind(|| {
         let val: Option<i32> = None;
-        must_some(val);
+        let _ = must_some(val);
     });
     assert!(result.is_err());
 }
@@ -211,7 +213,7 @@ fn test_must_some_track_caller_reports_test_file_location() {
 fn test_must_err_track_caller_reports_test_file_location() {
     let result = std::panic::catch_unwind(|| {
         let val: Result<i32, &str> = Ok(99);
-        must_err(val);
+        let _ = must_err(val);
     });
     assert!(result.is_err());
 }


### PR DESCRIPTION
This PR addresses unidiomatic test helper usages inside `perl-corpus` and `perl-tdd-support` that triggered `clippy` lint warnings (`unused_must_use` and `let_unit_value`).

**Changes**
* Removed redundant standalone `must_some(case);` assertions in `crates/perl-corpus/src/continue_redo.rs` and `glob_expressions.rs` because the value is implicitly validated in the immediately subsequent usage.
* In `crates/perl-tdd-support/tests/test_helper_coverage.rs`, correctly assigned the test helper results to `let _ = ...` while locally allowing `clippy::let_unit_value` when dealing with `Option<()>` or `Result<(), ()>` to avoid unused return value warnings.
* Updated several `#[should_panic]` expected strings in `comprehensive_unit_tests.rs` and `test_helper_coverage.rs` to accurately reflect the recent changes made to panic formatting in the `must`/`must_err` test helpers.

---
*PR created automatically by Jules for task [2493317630453634608](https://jules.google.com/task/2493317630453634608) started by @EffortlessSteven*