### PR TITLE
fix(parser): correct InvalidDelimiter error for tr{abc}xyz paired-delimiter forms (#6748)

### DIFF
--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -439,18 +439,17 @@ pub fn extract_transliteration_parts_strict(
     } else {
         let trimmed = rest1.trim_start();
         if let Some(repl_delimiter) = trimmed.chars().next() {
+            // After a paired search delimiter (e.g. `{...}`), the replacement must
+            // also start with a valid non-alphanumeric, non-whitespace delimiter.
+            // An alphanumeric character here (e.g. `tr{abc}xyz`) is an invalid
+            // delimiter, not merely a missing replacement section.
             if repl_delimiter.is_ascii_alphanumeric() || repl_delimiter.is_whitespace() {
-                return Err(TransliterationError::MissingReplacement);
+                return Err(TransliterationError::InvalidDelimiter(repl_delimiter));
             }
             let repl_closing = get_closing_delimiter(repl_delimiter);
             let (body, rest, found_closing) =
                 extract_delimited_content_strict(trimmed, repl_delimiter, repl_closing);
             (body, rest, found_closing)
-        } else if let Some(repl_delimiter) = trimmed.chars().next() {
-            if repl_delimiter.is_ascii_alphanumeric() || repl_delimiter.is_whitespace() {
-                return Err(TransliterationError::InvalidDelimiter(repl_delimiter));
-            }
-            extract_delimited_content_strict(trimmed, repl_delimiter, repl_delimiter)
         } else {
             return Err(TransliterationError::MissingReplacement);
         }


### PR DESCRIPTION
## Summary

- Fix wrong error type returned when `tr{abc}xyz` has an alphanumeric character after a paired search delimiter — was `MissingReplacement`, should be `InvalidDelimiter`
- Remove dead code: the duplicate `else if let Some(repl_delimiter)` branch in `extract_transliteration_parts_strict` was unreachable (the preceding `if let Some(...)` already consumed any non-empty `trimmed` string)

## Root Cause

In `crates/perl-parser-core/src/syntax/quote.rs`, `extract_transliteration_parts_strict`, the `is_paired` branch (line ~441) had two issues:

1. **Wrong error variant**: `tr{abc}xyz` correctly hits the alphanumeric check but returned `TransliterationError::MissingReplacement`. The replacement character (`x`) is present — it's just invalid. The correct error is `InvalidDelimiter('x')`.
2. **Dead code**: The `else if let Some(repl_delimiter) = trimmed.chars().next()` branch could never be reached because the immediately preceding `if let Some(repl_delimiter) = trimmed.chars().next()` already matched the same condition.

## Test plan

- [ ] `cargo test -p perl-parser-core` — all transliteration strict tests pass, no regressions
- [ ] `cargo clippy -p perl-parser-core --lib` — clean
- [ ] `cargo xtask fmt` — clean

https://claude.ai/code/session_01WWbA5Wd8zL7FSMvNnsPUVL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWbA5Wd8zL7FSMvNnsPUVL)_