### PR TITLE
fix(parser): tr{} with alphanumeric replacement emits correct InvalidDelimiter error (#0000)

### DIFF
--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -440,17 +440,12 @@ pub fn extract_transliteration_parts_strict(
         let trimmed = rest1.trim_start();
         if let Some(repl_delimiter) = trimmed.chars().next() {
             if repl_delimiter.is_ascii_alphanumeric() || repl_delimiter.is_whitespace() {
-                return Err(TransliterationError::MissingReplacement);
+                return Err(TransliterationError::InvalidDelimiter(repl_delimiter));
             }
             let repl_closing = get_closing_delimiter(repl_delimiter);
             let (body, rest, found_closing) =
                 extract_delimited_content_strict(trimmed, repl_delimiter, repl_closing);
             (body, rest, found_closing)
-        } else if let Some(repl_delimiter) = trimmed.chars().next() {
-            if repl_delimiter.is_ascii_alphanumeric() || repl_delimiter.is_whitespace() {
-                return Err(TransliterationError::InvalidDelimiter(repl_delimiter));
-            }
-            extract_delimited_content_strict(trimmed, repl_delimiter, repl_delimiter)
         } else {
             return Err(TransliterationError::MissingReplacement);
         }


### PR DESCRIPTION
## Summary

- Fixes a bug in `extract_transliteration_parts_strict` where `tr{abc}xyz;` (paired bracket delimiter followed by an alphanumeric replacement) emitted `MissingReplacement` instead of `InvalidDelimiter`
- Removes 5 lines of unreachable dead code: the `else if let Some(repl_delimiter) = trimmed.chars().next()` branch had an identical condition to the `if let Some(...)` above it and could never execute

## Root cause

In `crates/perl-parser-core/src/syntax/quote.rs`, the `is_paired` replacement-parsing branch (line 442) checked whether the replacement started with an alphanumeric/whitespace character but returned the wrong error variant. The dead `else if` block below it had the correct variant (`InvalidDelimiter`) but was unreachable.

## Test plan

- [ ] `cargo test -p perl-parser-core` passes (was failing on `transliteration_strict_handles_edge_cases` before this fix)
- [ ] `cargo clippy -p perl-parser-core --lib` is clean

https://claude.ai/code/session_01SvCToS5nQAf1VpX1Hx74Zk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvCToS5nQAf1VpX1Hx74Zk)_