### PR TITLE
test(core): add mutation hardening tests for path security & qualified names (#0000)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,17 +1,28 @@
 timeout_multiplier = 1.25
 
-# Mutation hardening focus area: quote parsing now lives in perl-parser-core.
-# Keep this subset intentionally narrow so it stays usable in local/CI flows.
+# Mutation hardening focus areas:
+#   - quote parsing (perl-parser-core/src/syntax/quote.rs)
+#   - path traversal / workspace security (path_security.rs, path_normalize.rs)
+#   - qualified-name parsing (qualified_name.rs)
+#
+# Keep this subset intentionally bounded so it stays usable in local/CI flows.
 examine_globs = [
     "crates/perl-parser-core/src/syntax/quote.rs",
+    "crates/perl-parser-core/src/syntax/path_security.rs",
+    "crates/perl-parser-core/src/syntax/path_normalize.rs",
+    "crates/perl-parser-core/src/syntax/qualified_name.rs",
 ]
 
 # Exercise both parser-core regressions and parser-level integration tests that
-# consume quote parsing helpers via re-exports.
+# consume quote parsing helpers via re-exports.  Security-focused test files are
+# added so mutations in the path/qualified-name modules are caught promptly.
 additional_cargo_test_args = [
     "-p", "perl-parser-core",
     "--test", "fix_subst_unusual_delimiters_2732",
     "--test", "fix_subst_squote_delimiter",
+    "--test", "path_security_mutation_hardening",
+    "--test", "path_normalize_mutation_hardening",
+    "--test", "qualified_name_mutation_hardening",
     "-p", "perl-parser",
     "--test", "quote_operator_tests",
     "--test", "quote_parser_mutation_survivors_elimination",

--- a/crates/perl-parser-core/tests/path_normalize_mutation_hardening.rs
+++ b/crates/perl-parser-core/tests/path_normalize_mutation_hardening.rs
@@ -1,0 +1,149 @@
+//! Mutation hardening tests for `path_normalize.rs`.
+//!
+//! Targets the boundary comparison `stack.len() <= workspace_depth` and the
+//! component-dispatch match arms so that cargo-mutants cannot survive by
+//! flipping `<=` to `<`, removing the `stack.pop()` call, or silently
+//! discarding `ParentDir` components.
+
+use perl_parser_core::path_normalize::normalize_path_within_workspace;
+use std::path::Path;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+// ---------------------------------------------------------------------------
+// Boundary: stack.len() <= workspace_depth
+//
+// The guard fires when the stack is exactly AT the workspace root (len ==
+// workspace_depth). A mutation to `<` would allow one extra pop, letting
+// the path escape by one component.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_parent_at_workspace_boundary_is_rejected() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().canonicalize()?;
+
+    // One `..` from the workspace root must be rejected.
+    let result = normalize_path_within_workspace(Path::new(".."), &workspace);
+    assert!(result.is_err(), "single '..' at workspace root must return Err, got: {result:?}");
+    Ok(())
+}
+
+#[test]
+fn two_parents_at_workspace_boundary_are_rejected() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().canonicalize()?;
+
+    let result = normalize_path_within_workspace(Path::new("../.."), &workspace);
+    assert!(result.is_err(), "../../ at workspace root must return Err");
+    Ok(())
+}
+
+#[test]
+fn descend_then_escape_is_rejected() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().canonicalize()?;
+
+    // Going one level in and then two levels out crosses the boundary.
+    let result = normalize_path_within_workspace(Path::new("subdir/../../escape"), &workspace);
+    assert!(result.is_err(), "subdir/../../escape must be rejected");
+    Ok(())
+}
+
+#[test]
+fn descend_then_return_within_workspace_is_ok() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().canonicalize()?;
+
+    // Going in one level and back one level stays within the workspace.
+    let result = normalize_path_within_workspace(Path::new("a/b/../c"), &workspace);
+    assert!(result.is_ok(), "a/b/../c inside workspace must succeed, got {result:?}");
+    let resolved = result?;
+    assert!(resolved.starts_with(&workspace), "resolved path must stay under workspace");
+    assert!(resolved.ends_with("c"), "resolved path must end in 'c'");
+    Ok(())
+}
+
+#[test]
+fn current_dir_component_is_ignored() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().canonicalize()?;
+
+    let result = normalize_path_within_workspace(Path::new("./lib/./Foo.pm"), &workspace);
+    assert!(result.is_ok(), "./lib/./Foo.pm must succeed, got {result:?}");
+    let resolved = result?;
+    assert!(resolved.starts_with(&workspace));
+    assert!(resolved.ends_with("Foo.pm"));
+    Ok(())
+}
+
+#[test]
+fn absolute_component_in_relative_path_is_rejected() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().canonicalize()?;
+
+    // A RootDir component triggers PathTraversalAttempt.
+    // On Unix "/" appears as a RootDir component.
+    let result = normalize_path_within_workspace(Path::new("/etc/passwd"), &workspace);
+    assert!(result.is_err(), "absolute path must be rejected");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Verify precise output: the returned PathBuf is rooted at workspace_root
+// and contains exactly the components we expect.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn simple_relative_path_resolves_correctly() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().canonicalize()?;
+
+    let resolved = normalize_path_within_workspace(Path::new("lib/Module.pm"), &workspace)?;
+
+    assert!(resolved.starts_with(&workspace));
+    // The final path must contain both "lib" and "Module.pm" components.
+    let components: Vec<_> = resolved.components().collect();
+    let names: Vec<_> =
+        components.iter().map(|c| c.as_os_str().to_string_lossy().into_owned()).collect();
+    assert!(names.contains(&"lib".to_string()), "path must contain 'lib', got {names:?}");
+    assert!(
+        names.contains(&"Module.pm".to_string()),
+        "path must contain 'Module.pm', got {names:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn normalized_path_has_no_parent_dir_components() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().canonicalize()?;
+
+    let resolved = normalize_path_within_workspace(Path::new("a/b/../c/d"), &workspace)?;
+
+    for component in resolved.components() {
+        assert_ne!(
+            component,
+            std::path::Component::ParentDir,
+            "normalized path must not contain '..' components"
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Deeply nested escape — kills mutations that allow partial traversal.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deeply_nested_escape_is_rejected() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().canonicalize()?;
+
+    let result = normalize_path_within_workspace(
+        Path::new("a/b/c/d/../../../../../../../../etc/shadow"),
+        &workspace,
+    );
+    assert!(result.is_err(), "deeply nested escape must be rejected");
+    Ok(())
+}

--- a/crates/perl-parser-core/tests/path_security_mutation_hardening.rs
+++ b/crates/perl-parser-core/tests/path_security_mutation_hardening.rs
@@ -1,0 +1,374 @@
+//! Mutation hardening tests for `path_security.rs`.
+//!
+//! Covers the following mutation targets:
+//!
+//! * `validate_workspace_path` — boolean guards on `starts_with`, null-byte
+//!   / control-char predicate, `path != "/"` in absolute-path guard.
+//! * `sanitize_completion_path_input` — `ParentDir` → `None`, root-dir
+//!   guard `path != "/"`, backslash `..` string check.
+//! * `is_hidden_or_forbidden_entry_name` — `len() > 1` off-by-one.
+//! * `is_safe_completion_filename` — `len() > 255` off-by-one, control
+//!   character predicate.
+//! * `build_completion_path` — `dir_part == "."` branch, trailing slash.
+//! * `split_completion_path_components` — `!dir.is_empty()` guard.
+
+use perl_parser_core::path_security::{
+    build_completion_path, is_hidden_or_forbidden_entry_name, is_safe_completion_filename,
+    sanitize_completion_path_input, split_completion_path_components, validate_workspace_path,
+};
+use std::path::PathBuf;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+// ---------------------------------------------------------------------------
+// validate_workspace_path — null-byte / control-char guard
+//
+// Mutation: flip `is_control() && c != '\t'` to `|| c != '\t'` or remove the
+// null-byte branch entirely.  Both would allow poisoned paths through.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn null_byte_in_path_returns_invalid_characters_error() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let ws = temp.path();
+
+    let result = validate_workspace_path(&PathBuf::from("file\0.pm"), ws);
+    assert!(
+        matches!(
+            result,
+            Err(perl_parser_core::path_security::WorkspacePathError::InvalidPathCharacters)
+        ),
+        "null byte must produce InvalidPathCharacters, got {result:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn newline_in_path_returns_invalid_characters_error() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let ws = temp.path();
+
+    let result = validate_workspace_path(&PathBuf::from("lib\nfoo.pm"), ws);
+    assert!(
+        matches!(
+            result,
+            Err(perl_parser_core::path_security::WorkspacePathError::InvalidPathCharacters)
+        ),
+        "newline must produce InvalidPathCharacters, got {result:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn tab_in_path_is_not_rejected_as_invalid_characters() -> TestResult {
+    // The implementation explicitly allows \t. A mutation that changes
+    // `c != '\t'` would incorrectly reject tabs.
+    let temp = tempfile::tempdir()?;
+    let ws = temp.path();
+
+    let result = validate_workspace_path(&PathBuf::from("lib/file\t.pm"), ws);
+    assert!(
+        !matches!(
+            result,
+            Err(perl_parser_core::path_security::WorkspacePathError::InvalidPathCharacters)
+        ),
+        "tab must NOT produce InvalidPathCharacters (tabs are explicitly allowed)"
+    );
+    Ok(())
+}
+
+#[test]
+fn bell_char_in_path_returns_invalid_characters_error() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let ws = temp.path();
+
+    let result = validate_workspace_path(&PathBuf::from("lib/\x07file.pm"), ws);
+    assert!(
+        matches!(
+            result,
+            Err(perl_parser_core::path_security::WorkspacePathError::InvalidPathCharacters)
+        ),
+        "BEL char must produce InvalidPathCharacters"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// validate_workspace_path — `starts_with` workspace containment guard
+//
+// Mutation: remove the `!` in `!canonical.starts_with(...)` or
+// `!final_path.starts_with(...)`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn path_outside_workspace_returns_outside_workspace_error() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let ws = temp.path();
+
+    let result = validate_workspace_path(&PathBuf::from("../../etc/passwd"), ws);
+    assert!(result.is_err(), "escaping path must be rejected, got {result:?}");
+    // Must NOT be InvalidPathCharacters — it's a traversal, not a char issue.
+    assert!(
+        !matches!(
+            result,
+            Err(perl_parser_core::path_security::WorkspacePathError::InvalidPathCharacters)
+        ),
+        "traversal should not be reported as InvalidPathCharacters"
+    );
+    Ok(())
+}
+
+#[test]
+fn safe_relative_path_resolves_under_workspace() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let ws = temp.path();
+
+    let resolved = validate_workspace_path(&PathBuf::from("lib/Foo.pm"), ws)?;
+
+    // The resolved path must start with the workspace root.
+    let canonical_ws = ws.canonicalize()?;
+    assert!(
+        resolved.starts_with(&canonical_ws),
+        "resolved path '{resolved:?}' must be under workspace '{canonical_ws:?}'"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// sanitize_completion_path_input — ParentDir guard and "/" exception
+//
+// Mutation: remove the `Component::ParentDir => return None` arm, or flip
+// `path != "/"` to `path == "/"`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sanitize_parent_traversal_returns_none() {
+    assert!(sanitize_completion_path_input("../secret").is_none(), "'../secret' must return None");
+    assert!(sanitize_completion_path_input("..").is_none(), "'..' must return None");
+    assert!(
+        sanitize_completion_path_input("foo/../bar").is_none(),
+        "'foo/../bar' must return None"
+    );
+}
+
+#[test]
+fn sanitize_root_slash_is_the_only_allowed_absolute_path() {
+    // "/" is the single allowed absolute path (the special-case guard).
+    let result = sanitize_completion_path_input("/");
+    assert_eq!(result, Some("/".to_string()), "'/' must be allowed");
+
+    // Any other absolute path must be rejected.
+    assert!(
+        sanitize_completion_path_input("/etc/passwd").is_none(),
+        "'/etc/passwd' must return None"
+    );
+    assert!(sanitize_completion_path_input("/usr").is_none(), "'/usr' must return None");
+}
+
+#[test]
+fn sanitize_null_byte_returns_none() {
+    assert!(sanitize_completion_path_input("lib/Foo\0.pm").is_none(), "null byte must return None");
+}
+
+#[test]
+fn sanitize_valid_relative_path_returns_some() {
+    let result = sanitize_completion_path_input("lib/Foo/Bar.pm");
+    assert_eq!(result, Some("lib/Foo/Bar.pm".to_string()));
+}
+
+#[test]
+fn sanitize_backslash_windows_traversal_returns_none() {
+    // The string check `path.contains("../")` / `path.contains("..\\")`
+    // must fire on Windows-style traversal.
+    assert!(
+        sanitize_completion_path_input(r"..\secret").is_none(),
+        r"'..\secret' must return None"
+    );
+}
+
+#[test]
+fn sanitize_empty_path_returns_some_empty() {
+    // Empty string is explicitly allowed.
+    assert_eq!(sanitize_completion_path_input(""), Some(String::new()));
+}
+
+// ---------------------------------------------------------------------------
+// is_hidden_or_forbidden_entry_name — `len() > 1` boundary
+//
+// Mutation: change `> 1` to `>= 1` (allows "."), or `> 0` (same).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_dot_is_not_hidden() {
+    assert!(!is_hidden_or_forbidden_entry_name("."), "'.' must NOT be considered hidden");
+}
+
+#[test]
+fn dotgit_is_hidden() {
+    assert!(is_hidden_or_forbidden_entry_name(".git"), "'.git' must be hidden");
+}
+
+#[test]
+fn dotfile_single_char_after_dot_is_hidden() {
+    // ".x" — length is 2, so `len() > 1` passes.
+    assert!(is_hidden_or_forbidden_entry_name(".x"), "'.x' (len 2) must be hidden");
+}
+
+#[test]
+fn normal_dirname_is_not_hidden() {
+    assert!(!is_hidden_or_forbidden_entry_name("lib"));
+    assert!(!is_hidden_or_forbidden_entry_name("src"));
+    assert!(!is_hidden_or_forbidden_entry_name("t"));
+}
+
+#[test]
+fn forbidden_build_dirs_are_hidden() {
+    for name in &["node_modules", "target", "build", ".cargo", ".rustup"] {
+        assert!(is_hidden_or_forbidden_entry_name(name), "'{name}' must be in the forbidden list");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// is_safe_completion_filename — len boundary and control char predicate
+//
+// Mutations: `len() > 255` → `>= 255` (rejects 255-char names incorrectly),
+// `is_control()` predicate flip.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn filename_255_chars_is_safe() {
+    let name = "a".repeat(255);
+    assert!(is_safe_completion_filename(&name), "255-char name must be safe");
+}
+
+#[test]
+fn filename_256_chars_is_not_safe() {
+    let name = "b".repeat(256);
+    assert!(!is_safe_completion_filename(&name), "256-char name must be rejected");
+}
+
+#[test]
+fn filename_exactly_at_boundary_254_is_safe() {
+    let name = "c".repeat(254);
+    assert!(is_safe_completion_filename(&name), "254-char name must be safe");
+}
+
+#[test]
+fn empty_filename_is_not_safe() {
+    assert!(!is_safe_completion_filename(""), "empty name must be rejected");
+}
+
+#[test]
+fn null_byte_in_filename_is_not_safe() {
+    assert!(!is_safe_completion_filename("foo\0bar"), "null byte must be rejected");
+}
+
+#[test]
+fn control_char_in_filename_is_not_safe() {
+    assert!(!is_safe_completion_filename("foo\x07bar"), "BEL must be rejected");
+    assert!(!is_safe_completion_filename("foo\nbar"), "LF must be rejected");
+    assert!(!is_safe_completion_filename("foo\rbar"), "CR must be rejected");
+}
+
+#[test]
+fn normal_filename_is_safe() {
+    assert!(is_safe_completion_filename("Module.pm"));
+    assert!(is_safe_completion_filename("Foo_Bar.pl"));
+    assert!(is_safe_completion_filename("test-suite.t"));
+}
+
+#[test]
+fn windows_reserved_names_are_not_safe() {
+    for name in &["CON", "PRN", "AUX", "NUL"] {
+        assert!(!is_safe_completion_filename(name), "{name} must be rejected");
+        // Case-insensitive
+        let lower = name.to_lowercase();
+        assert!(!is_safe_completion_filename(&lower), "{lower} must be rejected");
+    }
+    for i in 1u8..=9 {
+        let com = format!("COM{i}");
+        let lpt = format!("LPT{i}");
+        assert!(!is_safe_completion_filename(&com), "{com} must be rejected");
+        assert!(!is_safe_completion_filename(&lpt), "{lpt} must be rejected");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// build_completion_path — `dir_part == "."` branch and trailing slash
+//
+// Mutation: flip `dir_part == "."` to `dir_part != "."`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_path_dot_dir_file_has_no_prefix() {
+    let result = build_completion_path(".", "Foo.pm", false);
+    assert_eq!(result, "Foo.pm", "dir='.' file must produce plain filename, got '{result}'");
+}
+
+#[test]
+fn build_path_dot_dir_subdir_has_no_prefix_but_slash() {
+    let result = build_completion_path(".", "lib", true);
+    assert_eq!(result, "lib/", "dir='.' subdir must produce 'lib/', got '{result}'");
+}
+
+#[test]
+fn build_path_non_dot_dir_prefixes_correctly() {
+    let result = build_completion_path("lib", "Foo.pm", false);
+    assert_eq!(result, "lib/Foo.pm", "lib/Foo.pm must be produced");
+}
+
+#[test]
+fn build_path_directory_entry_gets_trailing_slash() {
+    let result = build_completion_path("lib", "Sub", true);
+    assert!(result.ends_with('/'), "directory entry must end with '/', got '{result}'");
+    assert_eq!(result, "lib/Sub/");
+}
+
+#[test]
+fn build_path_file_entry_has_no_trailing_slash() {
+    let result = build_completion_path("lib", "Foo.pm", false);
+    assert!(!result.ends_with('/'), "file entry must not end with '/'");
+}
+
+#[test]
+fn build_path_strips_trailing_slash_on_dir_part() {
+    let result = build_completion_path("lib/", "Foo.pm", false);
+    assert_eq!(result, "lib/Foo.pm", "trailing slash on dir_part must be stripped");
+}
+
+// ---------------------------------------------------------------------------
+// split_completion_path_components — `!dir.is_empty()` guard
+//
+// Mutation: flip to `dir.is_empty()`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn split_nested_path_returns_correct_dir_and_file() {
+    let (dir, file) = split_completion_path_components("lib/Foo/Bar");
+    assert_eq!(dir, "lib/Foo", "dir component must be 'lib/Foo'");
+    assert_eq!(file, "Bar", "file component must be 'Bar'");
+}
+
+#[test]
+fn split_single_filename_returns_dot_dir() {
+    let (dir, file) = split_completion_path_components("Module.pm");
+    assert_eq!(dir, ".", "bare filename must produce dir='.'");
+    assert_eq!(file, "Module.pm");
+}
+
+#[test]
+fn split_single_slash_returns_dot_dir() {
+    // "lib/" → rsplit_once('/') = Some(("lib", "")) — dir is "lib" (not empty)
+    let (dir, file) = split_completion_path_components("lib/");
+    assert_eq!(dir, "lib");
+    assert_eq!(file, "");
+}
+
+#[test]
+fn split_path_with_leading_slash_only_returns_dot_dir() {
+    // "/" → rsplit_once('/') = Some(("", "")) — dir IS empty, so fallback fires:
+    // returns (".", path) where path is the original input "/".
+    let (dir, file) = split_completion_path_components("/");
+    assert_eq!(dir, ".", "leading-slash-only must produce dir='.'");
+    assert_eq!(file, "/");
+}

--- a/crates/perl-parser-core/tests/qualified_name_mutation_hardening.rs
+++ b/crates/perl-parser-core/tests/qualified_name_mutation_hardening.rs
@@ -1,0 +1,256 @@
+//! Mutation hardening tests for `qualified_name.rs`.
+//!
+//! Targets:
+//!
+//! * `split_qualified_name` — `rfind("::") + 2` offset (kills `+1` / `+3`
+//!   arithmetic mutations).
+//! * `validate_perl_qualified_name` — sigil set `['$', '@', '%', '&', '*']`
+//!   (each sigil tested separately), empty-segment guard, empty-name guard.
+//! * `is_valid_identifier_part` — `c.is_alphabetic() || c == '_'` start rule
+//!   (kills `&&` mutation and drop of `|| c == '_'`), `c.is_alphanumeric() ||
+//!   c == '_'` continuation rule.
+//! * `container_name` — returns exact slice boundary.
+
+use perl_parser_core::qualified_name::{
+    container_name, is_valid_identifier_part, split_qualified_name, validate_perl_qualified_name,
+};
+
+// ---------------------------------------------------------------------------
+// split_qualified_name — exact offset
+//
+// If `+2` is mutated to `+1`, the returned bare name starts with ":" instead
+// of the identifier. If mutated to `+3`, the first character of the bare name
+// is dropped.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn split_simple_package_returns_correct_bare_name() {
+    let (pkg, bare) = split_qualified_name("Foo::Bar");
+    assert_eq!(pkg, Some("Foo"), "package must be 'Foo'");
+    // Bare name must NOT contain ':'.
+    assert_eq!(bare, "Bar", "bare name must be 'Bar', not ':Bar' or 'ar'");
+}
+
+#[test]
+fn split_deeply_qualified_name_uses_last_separator() {
+    let (pkg, bare) = split_qualified_name("Foo::Bar::baz");
+    assert_eq!(pkg, Some("Foo::Bar"));
+    assert_eq!(bare, "baz", "bare name must be 'baz', not ':baz' or 'az'");
+}
+
+#[test]
+fn split_unqualified_name_returns_none_package() {
+    let (pkg, bare) = split_qualified_name("process");
+    assert_eq!(pkg, None, "unqualified name must have no package");
+    assert_eq!(bare, "process");
+}
+
+#[test]
+fn split_name_with_trailing_separator_returns_empty_bare() {
+    let (pkg, bare) = split_qualified_name("Package::");
+    assert_eq!(pkg, Some("Package"));
+    // The bare portion after "::" is empty — must not include the ':'s.
+    assert_eq!(bare, "", "bare name after trailing '::' must be empty, not ':'");
+}
+
+#[test]
+fn split_name_ending_in_double_colon_bare_has_no_colons() {
+    let (_, bare) = split_qualified_name("A::B::C::");
+    assert!(!bare.contains(':'), "bare name must not contain ':', got '{bare}'");
+}
+
+// ---------------------------------------------------------------------------
+// container_name — uses split_qualified_name internally
+// ---------------------------------------------------------------------------
+
+#[test]
+fn container_name_extracts_full_parent_path() {
+    assert_eq!(container_name("Foo::Bar::baz"), Some("Foo::Bar"));
+    assert_eq!(container_name("A::B"), Some("A"));
+    assert_eq!(container_name("toplevel"), None);
+    assert_eq!(container_name(""), None);
+}
+
+// ---------------------------------------------------------------------------
+// validate_perl_qualified_name — each sigil individually
+//
+// Mutation: removing one character from the sigil set `['$','@','%','&','*']`
+// would let that sigil pass validation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dollar_sigil_is_rejected() {
+    let result = validate_perl_qualified_name("$foo");
+    assert!(result.is_err(), "'$foo' must be rejected");
+    assert!(
+        matches!(
+            result,
+            Err(perl_parser_core::qualified_name::QualifiedNameError::LeadingSigil('$'))
+        ),
+        "error must be LeadingSigil('$'), got {result:?}"
+    );
+}
+
+#[test]
+fn at_sigil_is_rejected() {
+    let result = validate_perl_qualified_name("@arr");
+    assert!(result.is_err(), "'@arr' must be rejected");
+    assert!(
+        matches!(
+            result,
+            Err(perl_parser_core::qualified_name::QualifiedNameError::LeadingSigil('@'))
+        ),
+        "error must be LeadingSigil('@')"
+    );
+}
+
+#[test]
+fn percent_sigil_is_rejected() {
+    let result = validate_perl_qualified_name("%hash");
+    assert!(result.is_err(), "'%hash' must be rejected");
+    assert!(
+        matches!(
+            result,
+            Err(perl_parser_core::qualified_name::QualifiedNameError::LeadingSigil('%'))
+        ),
+        "error must be LeadingSigil('%')"
+    );
+}
+
+#[test]
+fn ampersand_sigil_is_rejected() {
+    let result = validate_perl_qualified_name("&sub");
+    assert!(result.is_err(), "'&sub' must be rejected");
+    assert!(
+        matches!(
+            result,
+            Err(perl_parser_core::qualified_name::QualifiedNameError::LeadingSigil('&'))
+        ),
+        "error must be LeadingSigil('&')"
+    );
+}
+
+#[test]
+fn asterisk_sigil_is_rejected() {
+    let result = validate_perl_qualified_name("*glob");
+    assert!(result.is_err(), "'*glob' must be rejected");
+    assert!(
+        matches!(
+            result,
+            Err(perl_parser_core::qualified_name::QualifiedNameError::LeadingSigil('*'))
+        ),
+        "error must be LeadingSigil('*')"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// validate_perl_qualified_name — empty-name and empty-segment guards
+//
+// Mutation: flip `name.is_empty()` to `!name.is_empty()`, or flip
+// `part.is_empty()` to `!part.is_empty()`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_name_returns_empty_name_error() {
+    let result = validate_perl_qualified_name("");
+    assert!(
+        matches!(result, Err(perl_parser_core::qualified_name::QualifiedNameError::EmptyName)),
+        "empty string must return EmptyName, got {result:?}"
+    );
+}
+
+#[test]
+fn valid_name_passes_validation() {
+    assert!(validate_perl_qualified_name("Foo").is_ok());
+    assert!(validate_perl_qualified_name("Foo::Bar").is_ok());
+    assert!(validate_perl_qualified_name("_Private").is_ok());
+}
+
+#[test]
+fn trailing_separator_returns_empty_segment_error() {
+    let result = validate_perl_qualified_name("Foo::");
+    assert!(
+        matches!(
+            result,
+            Err(perl_parser_core::qualified_name::QualifiedNameError::EmptySegment { .. })
+        ),
+        "'Foo::' must return EmptySegment, got {result:?}"
+    );
+}
+
+#[test]
+fn leading_separator_returns_empty_segment_error() {
+    let result = validate_perl_qualified_name("::Bar");
+    assert!(
+        matches!(
+            result,
+            Err(perl_parser_core::qualified_name::QualifiedNameError::EmptySegment { index: 0 })
+        ),
+        "'::Bar' must return EmptySegment at index 0, got {result:?}"
+    );
+}
+
+#[test]
+fn double_separator_returns_empty_segment_error() {
+    let result = validate_perl_qualified_name("Foo::::Bar");
+    assert!(result.is_err(), "'Foo::::Bar' must be rejected");
+}
+
+// ---------------------------------------------------------------------------
+// is_valid_identifier_part — start-character rule
+//
+// Mutations:
+//   `c.is_alphabetic() || c == '_'`  →  `c.is_alphabetic() && c == '_'`
+//   `c.is_alphabetic() || c == '_'`  →  `c.is_alphabetic()` (drop underscore)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn underscore_start_is_valid_identifier() {
+    // If `|| c == '_'` is removed, `_Private` would be rejected.
+    assert!(is_valid_identifier_part("_Private"), "'_Private' must be a valid identifier part");
+    assert!(is_valid_identifier_part("_"), "bare '_' must be valid");
+}
+
+#[test]
+fn alphabetic_start_is_valid_identifier() {
+    assert!(is_valid_identifier_part("Foo"));
+    assert!(is_valid_identifier_part("a"));
+    assert!(is_valid_identifier_part("MyPkg"));
+}
+
+#[test]
+fn digit_start_is_not_valid_identifier() {
+    // Neither `is_alphabetic()` nor `== '_'` matches a digit.
+    assert!(!is_valid_identifier_part("1foo"), "'1foo' must be invalid");
+    assert!(!is_valid_identifier_part("123"), "'123' must be invalid");
+}
+
+#[test]
+fn empty_string_is_not_valid_identifier() {
+    assert!(!is_valid_identifier_part(""), "empty string must be invalid");
+}
+
+// ---------------------------------------------------------------------------
+// is_valid_identifier_part — continuation-character rule
+//
+// Mutation: `c.is_alphanumeric() || c == '_'`  →  `c.is_alphanumeric()`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn underscore_in_continuation_is_valid() {
+    // If `|| c == '_'` in continuation is dropped, `foo_bar` would be invalid.
+    assert!(is_valid_identifier_part("foo_bar"), "'foo_bar' must be valid");
+    assert!(is_valid_identifier_part("My_Pkg_Name"), "'My_Pkg_Name' must be valid");
+}
+
+#[test]
+fn digits_in_continuation_are_valid() {
+    assert!(is_valid_identifier_part("Foo2"), "'Foo2' must be valid");
+    assert!(is_valid_identifier_part("pkg42"), "'pkg42' must be valid");
+}
+
+#[test]
+fn hyphen_in_continuation_is_not_valid() {
+    // Hyphens are not alphanumeric and not `_`.
+    assert!(!is_valid_identifier_part("foo-bar"), "'foo-bar' must be invalid");
+}

--- a/docs/project/status/dap.md
+++ b/docs/project/status/dap.md
@@ -20,7 +20,7 @@
 <!-- BEGIN: DAP_TEST_COUNTS -->
 | Suite | Count |
 |---|---|
-| Integration tests (`perl-dap`) | 21 test targets |
+| Integration tests (`perl-dap`) | 58 test targets |
 | Scorecard fixtures | 5 |
 <!-- END: DAP_TEST_COUNTS -->
 

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -1,10 +1,27 @@
 {
-  "schema_version": 1,
-  "receipt_kind": "planning_scaffold",
-  "scorecard": "editor_ux",
+  "confidence_signals": [
+    {
+      "name": "manual_editor_smoke",
+      "owner": "perl-lsp-ux-tests",
+      "state": "tracked",
+      "workflow_count": 21
+    },
+    {
+      "name": "first_five_minutes_harness",
+      "owner": "perl-lsp-ux-tests",
+      "state": "tracked",
+      "workflow_count": 20
+    },
+    {
+      "name": "issue_burndown_regression_guard",
+      "owner": "perl-lsp-ux-tests",
+      "state": "tracked",
+      "workflow_count": 12
+    }
+  ],
   "harness": {
     "crate": "crates/perl-lsp-ux-tests",
-    "scenario_count": 17,
+    "scenario_count": 22,
     "scenario_files": [
       "crates/perl-lsp-ux-tests/tests/ux_scenario_01_simple_file.rs",
       "crates/perl-lsp-ux-tests/tests/ux_scenario_02_missing_perltidy.rs",
@@ -22,50 +39,38 @@
       "crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs",
       "crates/perl-lsp-ux-tests/tests/ux_scenario_15_workspace_symbols.rs",
       "crates/perl-lsp-ux-tests/tests/ux_scenario_16_workspace_folder_removal.rs",
-      "crates/perl-lsp-ux-tests/tests/ux_scenario_17_deleted_file_churn.rs"
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_17_deleted_file_churn.rs",
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_18_diagnostics_after_edit.rs",
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs",
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_18_real_repo_perf.rs",
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_22_template_language_mode.rs",
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs"
     ]
   },
+  "integration_points": {
+    "ci_lane": "just ux-tests",
+    "quality_surface": "docs/project/status/quality.md",
+    "release_lane": "just ux-tests-full",
+    "status_update": "cargo xtask update-status --only quality"
+  },
+  "receipt_kind": "planning_scaffold",
+  "schema_version": 1,
+  "scorecard": "editor_ux",
   "top_line_metrics": [
     {
       "name": "workflow_pass_rate",
-      "state": "planned",
-      "owner": "perl-lsp-ux-tests"
+      "owner": "perl-lsp-ux-tests",
+      "state": "planned"
     },
     {
       "name": "workflow_stability_rate",
-      "state": "planned",
-      "owner": "perl-lsp-ux-tests"
+      "owner": "perl-lsp-ux-tests",
+      "state": "planned"
     },
     {
       "name": "p95_time_to_first_useful_result_ms",
-      "state": "planned",
-      "owner": "perl-lsp-ux-tests"
+      "owner": "perl-lsp-ux-tests",
+      "state": "planned"
     }
-  ],
-  "confidence_signals": [
-    {
-      "name": "manual_editor_smoke",
-      "state": "tracked",
-      "owner": "perl-lsp-ux-tests",
-      "workflow_count": 16
-    },
-    {
-      "name": "first_five_minutes_harness",
-      "state": "tracked",
-      "owner": "perl-lsp-ux-tests",
-      "workflow_count": 17
-    },
-    {
-      "name": "issue_burndown_regression_guard",
-      "state": "tracked",
-      "owner": "perl-lsp-ux-tests",
-      "workflow_count": 7
-    }
-  ],
-  "integration_points": {
-    "ci_lane": "just ux-tests",
-    "release_lane": "just ux-tests-full",
-    "status_update": "cargo xtask update-status --only quality",
-    "quality_surface": "docs/project/status/quality.md"
-  }
+  ]
 }

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -8,7 +8,7 @@
 
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
-- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; confidence signals (manual smoke, first-5-minutes coverage, issue-burndown regression guards) are tracked in `docs/project/status/editor_ux.json`
+- **UX workflow harness**: 22 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; confidence signals (manual smoke, first-5-minutes coverage, issue-burndown regression guards) are tracked in `docs/project/status/editor_ux.json`
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->

--- a/docs/project/status/tests.md
+++ b/docs/project/status/tests.md
@@ -6,13 +6,13 @@
 ## Test Counts
 
 <!-- BEGIN: TESTS_TABLE_ROWS -->
-| **Tier A Tests** | 3091 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
+| **Tier A Tests** | 3413 lib tests (discovered), 13 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
 <!-- END: TESTS_TABLE_ROWS -->
 
 ## Computed Metrics
 
 <!-- BEGIN: TESTS_METRICS_BULLETS -->
-- **Test Status**: 3091 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
+- **Test Status**: 3413 lib tests (Tier A), 13 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
 - **Docs (perl-parser)**: missing_docs warnings = 0 (baseline 0)
 <!-- END: TESTS_METRICS_BULLETS -->

--- a/justfile
+++ b/justfile
@@ -329,6 +329,9 @@ mutation-regression:
     @cargo test -p perl-parser --test mutation_hardening_tests
     @cargo test -p perl-parser --test parser_boolean_logic_mutation_hardening
     @cargo test -p perl-lsp-rs --test mutation_survivors_elimination
+    @cargo test -p perl-parser-core --test path_security_mutation_hardening
+    @cargo test -p perl-parser-core --test path_normalize_mutation_hardening
+    @cargo test -p perl-parser-core --test qualified_name_mutation_hardening
     @echo "✅ Mutation regression harnesses passed"
 
 # Bounded fuzz run (quick fuzzing for CI/nightly)


### PR DESCRIPTION
## Summary

Add comprehensive mutation hardening test suites for three critical security and parsing modules in `perl-parser-core`:
- `path_security.rs` — path validation and sanitization
- `path_normalize.rs` — path normalization within workspace boundaries
- `qualified_name.rs` — Perl qualified name parsing and validation

These tests are designed to catch common mutations (off-by-one errors, boolean flips, predicate changes, arithmetic mutations) that could compromise security or correctness. Fixes #0000

## Changes

**New test files:**
- `crates/perl-parser-core/tests/path_security_mutation_hardening.rs` (374 lines)
  - Tests for null-byte/control-char detection in `validate_workspace_path`
  - Tests for workspace containment guards (`starts_with` checks)
  - Tests for parent-directory traversal rejection in `sanitize_completion_path_input`
  - Tests for hidden/forbidden entry name detection (`.git`, `node_modules`, etc.)
  - Tests for filename length boundaries (255-char limit) and control characters
  - Tests for path component building and splitting logic

- `crates/perl-parser-core/tests/qualified_name_mutation_hardening.rs` (256 lines)
  - Tests for `split_qualified_name` offset arithmetic (`+2` boundary)
  - Tests for sigil rejection (`$`, `@`, `%`, `&`, `*`)
  - Tests for empty-name and empty-segment guards
  - Tests for identifier start/continuation character rules (alphabetic, underscore, alphanumeric)

- `crates/perl-parser-core/tests/path_normalize_mutation_hardening.rs` (149 lines)
  - Tests for workspace boundary enforcement (`stack.len() <= workspace_depth`)
  - Tests for parent-directory escape prevention
  - Tests for current-directory (`.`) component handling
  - Tests for absolute path rejection
  - Tests for deeply nested escape attempts

**Configuration updates:**
- `.cargo/mutants.toml` — expanded `examine_globs` to include the three new security/parsing modules and added corresponding test files to the mutation test suite
- `justfile` — added `mutation-regression` target to run the new test suites

## Test

All three test files contain 30+ focused unit tests that:
1. **Verify correct behavior** — ensure functions work as intended
2. **Catch common mutations** — each test targets specific mutation operators (boundary flips, boolean negations, arithmetic changes, predicate removals)
3. **Cover edge cases** — empty strings, boundary values (255/256 chars), special characters, deeply nested paths

Tests use `tempfile` for workspace isolation and are self-contained with no external dependencies beyond the core library.

## Verification
- [x] Tests added and organized by module
- [x] Mutation targets documented in file headers
- [x] Configuration updated to include new modules in mutation testing
- [x] All tests are deterministic and use temporary directories for isolation

https://claude.ai/code/session_01UivsfccCHGBWaWo49cRXVx