### PR TITLE
fix(include-roots): honour PERL5LIB in diagnostics and use doc-scoped workspace root

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1756,8 +1756,7 @@ mod tests {
     /// build_context must use the workspace root of the folder that owns the document,
     /// not the global root_path (which points to the first workspace folder).
     #[test]
-    fn build_context_uses_doc_scoped_workspace_root()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn build_context_uses_doc_scoped_workspace_root() -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let folder_a = temp.path().join("folder-a");
         let folder_b = temp.path().join("folder-b");
@@ -1766,8 +1765,7 @@ mod tests {
         std::fs::create_dir_all(&folder_b)?;
         std::fs::write(&script_b, "use strict;\n")?;
 
-        let doc_uri =
-            url::Url::from_file_path(&script_b).map_err(|_| "bad uri")?.to_string();
+        let doc_uri = url::Url::from_file_path(&script_b).map_err(|_| "bad uri")?.to_string();
 
         let (server, _buf) = make_server_with_capture();
         // root_path points to folder_a (the "primary" folder)

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -94,8 +94,12 @@ impl PullDiagnosticsOrchestrator {
         let profile =
             perlcritic_profile.and_then(|p| if p.trim().is_empty() { None } else { Some(p) });
 
-        // Get workspace root
-        let workspace_root = server.root_path.lock().clone();
+        // Get workspace root for this document's containing folder (multi-root aware).
+        // Falls back to the global root_path when no specific folder matches.
+        let workspace_root = server
+            .folder_for_doc_uri(uri)
+            .and_then(|folder| folder.path.or_else(|| source_path_from_uri(&folder.uri)))
+            .or_else(|| server.root_path.lock().clone());
 
         // Get include paths for the document
         let include_paths: Vec<String> = server
@@ -1745,5 +1749,93 @@ mod tests {
         let diagnostic = builtin_violation_to_diagnostic(&violation);
         assert_eq!(diagnostic.severity, InternalDiagnosticSeverity::Error);
         assert_eq!(diagnostic.code.as_deref(), Some("GentlePolicy"));
+    }
+
+    // --- build_context workspace root tests ---
+
+    /// build_context must use the workspace root of the folder that owns the document,
+    /// not the global root_path (which points to the first workspace folder).
+    #[test]
+    fn build_context_uses_doc_scoped_workspace_root()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let folder_a = temp.path().join("folder-a");
+        let folder_b = temp.path().join("folder-b");
+        let script_b = folder_b.join("script.pl");
+        std::fs::create_dir_all(&folder_a)?;
+        std::fs::create_dir_all(&folder_b)?;
+        std::fs::write(&script_b, "use strict;\n")?;
+
+        let doc_uri =
+            url::Url::from_file_path(&script_b).map_err(|_| "bad uri")?.to_string();
+
+        let (server, _buf) = make_server_with_capture();
+        // root_path points to folder_a (the "primary" folder)
+        *server.root_path.lock() = Some(folder_a.clone());
+        {
+            let mut folders = server.workspace_folders.lock();
+            folders.push(
+                crate::runtime::workspace_folder::WorkspaceFolderState::new(
+                    url::Url::from_directory_path(&folder_a).map_err(|_| "bad uri_a")?.to_string(),
+                )
+                .with_path(folder_a.clone()),
+            );
+            folders.push(
+                crate::runtime::workspace_folder::WorkspaceFolderState::new(
+                    url::Url::from_directory_path(&folder_b).map_err(|_| "bad uri_b")?.to_string(),
+                )
+                .with_path(folder_b.clone()),
+            );
+        }
+
+        let orchestrator = PullDiagnosticsOrchestrator::new();
+        let context = orchestrator.build_context(&server, &doc_uri);
+
+        assert_eq!(
+            context.workspace_root.as_deref(),
+            Some(folder_b.as_path()),
+            "workspace_root must be the folder containing the document, not root_path"
+        );
+        Ok(())
+    }
+
+    /// When no workspace folder contains the document, build_context must fall back
+    /// to the global root_path.
+    #[test]
+    fn build_context_falls_back_to_root_path_when_no_folder_matches()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path().join("workspace");
+        let outside = temp.path().join("outside");
+        let script = outside.join("script.pl");
+        std::fs::create_dir_all(&workspace)?;
+        std::fs::create_dir_all(&outside)?;
+        std::fs::write(&script, "use strict;\n")?;
+
+        let doc_uri = url::Url::from_file_path(&script).map_err(|_| "bad uri")?.to_string();
+
+        let (server, _buf) = make_server_with_capture();
+        *server.root_path.lock() = Some(workspace.clone());
+        {
+            let mut folders = server.workspace_folders.lock();
+            folders.push(
+                crate::runtime::workspace_folder::WorkspaceFolderState::new(
+                    url::Url::from_directory_path(&workspace)
+                        .map_err(|_| "bad folder uri")?
+                        .to_string(),
+                )
+                .with_path(workspace.clone()),
+            );
+        }
+
+        let orchestrator = PullDiagnosticsOrchestrator::new();
+        let context = orchestrator.build_context(&server, &doc_uri);
+
+        assert_eq!(
+            context.workspace_root.as_deref(),
+            Some(workspace.as_path()),
+            "workspace_root must fall back to root_path when no folder contains the document"
+        );
+        Ok(())
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/mod.rs
@@ -521,30 +521,38 @@ impl LspServer {
 
     /// Get all include paths for a document (from its folder and others).
     ///
-    /// Returns a vector of include paths from all workspace folders, with the
-    /// current folder's paths first. This ordering is useful for module resolution
-    /// where the current folder should take precedence.
+    /// Returns a vector of resolved absolute include paths from all workspace folders,
+    /// with the current folder's paths first. Merges `PERL5LIB` entries according to
+    /// each folder's `use_perl5lib` / `perl5lib_precedence` settings so that module
+    /// resolution and diagnostics agree on which paths are searchable.
     #[must_use]
     pub fn include_paths_for_doc(&self, doc_uri: &str) -> Vec<std::path::PathBuf> {
+        let perl5lib_paths = std::env::var("PERL5LIB")
+            .map(|v| perl_lsp_rs_core::config::WorkspaceConfig::parse_perl5lib(&v))
+            .unwrap_or_default();
+
         let mut paths = Vec::new();
         let folders = self.workspace_folders.lock();
 
-        // Add current folder's include paths first
+        // Resolve one effective include path string to an absolute PathBuf.
+        let resolve_one = |include_path: &str, folder: &WorkspaceFolderState| -> PathBuf {
+            if std::path::Path::new(include_path).is_absolute() {
+                PathBuf::from(include_path)
+            } else if let Some(folder_path) = workspace_folder_path(folder) {
+                folder_path.join(include_path)
+            } else {
+                PathBuf::from(include_path)
+            }
+        };
+
+        // Add current folder's paths first (effective_include_paths merges PERL5LIB)
         if let Some(current_folder) =
             folders.iter().find(|folder| workspace_folder_matches_doc_uri(folder, doc_uri))
         {
-            for include_path in &current_folder.effective_workspace_config.include_paths {
-                // Resolve relative paths against the folder path
-                let resolved = if let Some(folder_path) = workspace_folder_path(current_folder) {
-                    if std::path::Path::new(include_path).is_absolute() {
-                        std::path::PathBuf::from(include_path)
-                    } else {
-                        folder_path.join(include_path)
-                    }
-                } else {
-                    std::path::PathBuf::from(include_path)
-                };
-
+            let effective =
+                current_folder.effective_workspace_config.effective_include_paths(&perl5lib_paths);
+            for include_path in &effective {
+                let resolved = resolve_one(include_path, current_folder);
                 if !paths.contains(&resolved) {
                     paths.push(resolved);
                 }
@@ -554,17 +562,10 @@ impl LspServer {
         // Add other folders' include paths
         for folder in folders.iter() {
             if !workspace_folder_matches_doc_uri(folder, doc_uri) {
-                for include_path in &folder.effective_workspace_config.include_paths {
-                    let resolved = if let Some(folder_path) = workspace_folder_path(folder) {
-                        if std::path::Path::new(include_path).is_absolute() {
-                            std::path::PathBuf::from(include_path)
-                        } else {
-                            folder_path.join(include_path)
-                        }
-                    } else {
-                        std::path::PathBuf::from(include_path)
-                    };
-
+                let effective =
+                    folder.effective_workspace_config.effective_include_paths(&perl5lib_paths);
+                for include_path in &effective {
+                    let resolved = resolve_one(include_path, folder);
                     if !paths.contains(&resolved) {
                         paths.push(resolved);
                     }
@@ -1019,5 +1020,131 @@ mod tests {
             LspServer::resolve_ai_api_key_with(&config, read_env).as_deref(),
             Some("gemini-key")
         );
+    }
+
+    // --- include_paths_for_doc tests ---
+
+    #[test]
+    fn include_paths_for_doc_resolves_relative_paths_against_folder_root()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace)?;
+        let doc_uri = url::Url::from_file_path(workspace.join("script.pl"))
+            .map_err(|_| "bad uri")?
+            .to_string();
+
+        let server = LspServer::new();
+        let workspace_uri =
+            url::Url::from_directory_path(&workspace).map_err(|_| "bad folder uri")?.to_string();
+        {
+            let mut folders = server.workspace_folders.lock();
+            let mut config = perl_lsp_rs_core::config::WorkspaceConfig::default();
+            config.include_paths = vec!["lib".to_string(), "t/lib".to_string()];
+            config.use_perl5lib = false;
+            folders.push(
+                WorkspaceFolderState::new(workspace_uri)
+                    .with_path(workspace.clone())
+                    .with_effective_workspace_config(config),
+            );
+        }
+
+        let paths = server.include_paths_for_doc(&doc_uri);
+        assert!(
+            paths.contains(&workspace.join("lib")),
+            "expected workspace/lib in paths, got: {paths:?}"
+        );
+        assert!(
+            paths.contains(&workspace.join("t/lib")),
+            "expected workspace/t/lib in paths, got: {paths:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn include_paths_for_doc_deduplicates_across_folders()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let folder_a = temp.path().join("a");
+        let folder_b = temp.path().join("b");
+        std::fs::create_dir_all(&folder_a)?;
+        std::fs::create_dir_all(&folder_b)?;
+
+        let doc_uri = url::Url::from_file_path(folder_a.join("script.pl"))
+            .map_err(|_| "bad uri")?
+            .to_string();
+
+        let server = LspServer::new();
+        {
+            let mut folders = server.workspace_folders.lock();
+            let mut config_a = perl_lsp_rs_core::config::WorkspaceConfig::default();
+            config_a.include_paths = vec!["lib".to_string()];
+            config_a.use_perl5lib = false;
+            let mut config_b = perl_lsp_rs_core::config::WorkspaceConfig::default();
+            config_b.include_paths = vec!["lib".to_string()];
+            config_b.use_perl5lib = false;
+            folders.push(
+                WorkspaceFolderState::new(
+                    url::Url::from_directory_path(&folder_a).map_err(|_| "bad uri")?.to_string(),
+                )
+                .with_path(folder_a.clone())
+                .with_effective_workspace_config(config_a),
+            );
+            folders.push(
+                WorkspaceFolderState::new(
+                    url::Url::from_directory_path(&folder_b).map_err(|_| "bad uri")?.to_string(),
+                )
+                .with_path(folder_b.clone())
+                .with_effective_workspace_config(config_b),
+            );
+        }
+
+        let paths = server.include_paths_for_doc(&doc_uri);
+        let lib_a = folder_a.join("lib");
+        let lib_b = folder_b.join("lib");
+        // Both resolved, but they're different absolute paths — no dedup expected here
+        assert!(paths.contains(&lib_a), "expected folder_a/lib");
+        assert!(paths.contains(&lib_b), "expected folder_b/lib");
+        // No duplicates in the result
+        assert_eq!(
+            paths.len(),
+            paths.iter().collect::<std::collections::HashSet<_>>().len(),
+            "include_paths_for_doc must not contain duplicate entries"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn include_paths_for_doc_respects_use_perl5lib_false()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // When use_perl5lib=false, effective_include_paths must not inject PERL5LIB entries.
+        // We verify this by building a WorkspaceConfig with an explicit include_paths list and
+        // use_perl5lib=false, then ensuring the result matches exactly that list (resolved).
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace)?;
+        let doc_uri = url::Url::from_file_path(workspace.join("script.pl"))
+            .map_err(|_| "bad uri")?
+            .to_string();
+
+        let server = LspServer::new();
+        let workspace_uri =
+            url::Url::from_directory_path(&workspace).map_err(|_| "bad folder uri")?.to_string();
+        {
+            let mut folders = server.workspace_folders.lock();
+            let mut config = perl_lsp_rs_core::config::WorkspaceConfig::default();
+            config.include_paths = vec!["lib".to_string()];
+            config.use_perl5lib = false; // env PERL5LIB must be ignored
+            folders.push(
+                WorkspaceFolderState::new(workspace_uri)
+                    .with_path(workspace.clone())
+                    .with_effective_workspace_config(config),
+            );
+        }
+
+        let paths = server.include_paths_for_doc(&doc_uri);
+        // Only the configured "lib" path should appear; no PERL5LIB injections.
+        assert_eq!(paths, vec![workspace.join("lib")]);
+        Ok(())
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/mod.rs
@@ -1062,8 +1062,8 @@ mod tests {
     }
 
     #[test]
-    fn include_paths_for_doc_deduplicates_across_folders()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn include_paths_for_doc_deduplicates_across_folders() -> Result<(), Box<dyn std::error::Error>>
+    {
         let temp = tempfile::tempdir()?;
         let folder_a = temp.path().join("a");
         let folder_b = temp.path().join("b");
@@ -1115,8 +1115,8 @@ mod tests {
     }
 
     #[test]
-    fn include_paths_for_doc_respects_use_perl5lib_false()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn include_paths_for_doc_respects_use_perl5lib_false() -> Result<(), Box<dyn std::error::Error>>
+    {
         // When use_perl5lib=false, effective_include_paths must not inject PERL5LIB entries.
         // We verify this by building a WorkspaceConfig with an explicit include_paths list and
         // use_perl5lib=false, then ensuring the result matches exactly that list (resolved).


### PR DESCRIPTION
## Summary

- **PERL5LIB false positives fixed**: `include_paths_for_doc` was reading raw `include_paths` and ignoring `use_perl5lib`/`perl5lib_precedence`. Modules visible only through `PERL5LIB` triggered PL701 "module not found" in diagnostics even though goto-definition and hover resolved them correctly. Now delegates to `effective_include_paths(&perl5lib_paths)` so all three consumers agree.
- **Multi-root workspace root fix**: `build_context` was passing the global `root_path` (first workspace folder) as `workspace_root` for every document. In a multi-root project, `use lib 'lib'` in a secondary-folder document was resolved against the wrong directory. Now looks up the owning folder via `folder_for_doc_uri` and falls back to `root_path` only when no folder matches.

## Test plan

- [ ] `cargo test -p perl-lsp-rs --lib -- include_paths_for_doc` — 3 new unit tests (relative path resolution, dedup across folders, `use_perl5lib=false` gate)
- [ ] `cargo test -p perl-lsp-rs --lib -- build_context` — 2 new unit tests (doc-scoped root, fallback to root_path)
- [ ] `RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --lib -- --test-threads=2` — full lib suite (466 passed, 0 failed)
- [ ] `cargo clippy -p perl-lsp-rs --lib` — no errors in production code

https://claude.ai/code/session_01Bw8SgeGFeRcnxYFgs5PdBJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bw8SgeGFeRcnxYFgs5PdBJ)_