### PR TITLE
refactor(lsp): delegate normalize_uri_key to perl_uri::uri_key (#6820)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,6 +1641,7 @@ dependencies = [
  "perl-subprocess-runtime",
  "perl-symbol",
  "perl-tdd-support",
+ "perl-uri",
  "perl-workspace",
  "predicates",
  "proptest",

--- a/crates/perl-lsp-rs/Cargo.toml
+++ b/crates/perl-lsp-rs/Cargo.toml
@@ -63,6 +63,7 @@ perl-pod = { workspace = true }
 perl-parser-core = { workspace = true }
 perl-workspace = { workspace = true }
 perl-lexer = { workspace = true }
+perl-uri = { workspace = true }
 lsp-types.workspace = true
 serde = { workspace = true }
 serde_json.workspace = true

--- a/crates/perl-lsp-rs/src/runtime/document_access.rs
+++ b/crates/perl-lsp-rs/src/runtime/document_access.rs
@@ -33,31 +33,7 @@ impl LspServer {
 
     /// Normalize URI key for consistent document lookup
     pub(crate) fn normalize_uri_key(&self, raw: &str) -> String {
-        // Parse to Url to canonicalize, then stringify the way we store it.
-        // If parsing fails, return the raw key so we at least try the given string.
-        if let Ok(u) = url::Url::parse(raw) {
-            // On Windows, lower-case the drive letter to match how many editors send it.
-            #[cfg(windows)]
-            {
-                let s = u.as_str().to_string();
-                if let Some(rest) = s.strip_prefix("file:///") {
-                    if rest.len() > 1
-                        && rest.as_bytes()[1] == b':'
-                        && rest.as_bytes()[0].is_ascii_alphabetic()
-                    {
-                        return format!(
-                            "file:///{}{}",
-                            rest[0..1].to_ascii_lowercase(),
-                            &rest[1..]
-                        );
-                    }
-                }
-                return s;
-            }
-            #[cfg(not(windows))]
-            return u.as_str().to_string();
-        }
-        raw.to_string()
+        perl_uri::uri_key(raw)
     }
 
     /// Get document by URI with normalization fallback

--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -14,20 +14,12 @@ use crate::state::DegradationTier;
 #[cfg(feature = "workspace")]
 use perl_parser::workspace_index::{IndexPhase, IndexState};
 use perl_parser_core::source_file::is_binary_content;
-use std::path::Path;
 
 const TEMPLATE_EXTENSIONS: [&str; 4] = ["ep", "tt", "tt2", "mason"];
 
 fn is_embedded_template_uri(uri: &str) -> bool {
-    let extension = url::Url::parse(uri)
-        .ok()
-        .and_then(|url| url.to_file_path().ok())
-        .and_then(|path| path.extension().and_then(|ext| ext.to_str()).map(str::to_owned))
-        .or_else(|| Path::new(uri).extension().and_then(|ext| ext.to_str()).map(str::to_owned));
-
-    extension.is_some_and(|ext| {
-        TEMPLATE_EXTENSIONS.iter().any(|candidate| candidate.eq_ignore_ascii_case(&ext))
-    })
+    perl_uri::uri_extension(uri)
+        .is_some_and(|ext| TEMPLATE_EXTENSIONS.iter().any(|t| t.eq_ignore_ascii_case(ext)))
 }
 
 fn is_perl_language_id(language_id: &str) -> bool {


### PR DESCRIPTION
## Summary

- **Fix `file://localhost` document lookup miss**: `normalize_uri_key` reimplemented the `perl_uri::uri_key` logic but was missing the `file://localhost` → `file:///` canonicalization step. A client that opens a document with `file://localhost/tmp/foo.pl` and then sends a follow-up request with `file:///tmp/foo.pl` would get different HashMap keys, silently missing the cached document. Now both delegate to the shared `perl_uri::uri_key` which handles this correctly.
- **Remove duplicated extension extraction in `is_embedded_template_uri`**: The function manually chained `url::Url::parse` → `to_file_path` → `extension` to detect template files (`.ep`, `.tt`, `.tt2`, `.mason`). Replaced with `perl_uri::uri_extension`, which already handles percent-encoded paths, query strings, and fragments. Also removes the now-unused `std::path::Path` import.
- **Add `perl-uri` dep to `perl-lsp-rs`**: Was already a workspace dep used by `perl-workspace-index`; this makes the dependency explicit.

## Diff summary

| File | Change |
|------|--------|
| `crates/perl-lsp-rs/Cargo.toml` | Add `perl-uri = { workspace = true }` |
| `crates/perl-lsp-rs/src/runtime/document_access.rs` | Replace 24-line `normalize_uri_key` body with `perl_uri::uri_key(raw)` |
| `crates/perl-lsp-rs/src/runtime/text_sync.rs` | Replace 9-line `is_embedded_template_uri` body with `perl_uri::uri_extension` call; drop unused `Path` import |

## Test plan

- [x] `cargo check -p perl-lsp-rs` — compiles cleanly
- [x] `cargo clippy -p perl-lsp-rs --lib` — no errors
- [x] `RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --lib -- --test-threads=2` — 461 passed, 0 failed
- `perl_uri::uri_key` is already tested in `crates/perl-uri/tests/` (691-line `additional_unit_tests.rs`, covering localhost normalization)

https://claude.ai/code/session_01LyWvPvLhqcSAJgGWtMu63Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyWvPvLhqcSAJgGWtMu63Q)_