### PR TITLE
fix(completion): include lexical use lib paths in module completion roots (#4314)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -19,11 +19,12 @@ use crate::{
     state::{completion_cap, completion_deadline},
 };
 use perl_lexer::LSP_RUNTIME_COMPLETION_KEYWORDS;
+use perl_module::resolution::use_lib::resolve_use_lib_paths_from_source;
 use perl_parser::type_inference::TypeInferenceEngine;
 use regex::Regex;
 use serde_json::{Value, json};
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 
@@ -58,7 +59,12 @@ fn commit_chars_for_kind(kind: CompletionItemKind) -> Option<&'static [&'static 
 }
 
 impl LspServer {
-    fn module_completion_roots_for_doc(&self, uri: &str) -> (Vec<PathBuf>, Vec<PathBuf>, bool) {
+    fn module_completion_roots_for_doc(
+        &self,
+        uri: &str,
+        doc_text: &str,
+        file_dir: Option<&Path>,
+    ) -> (Vec<PathBuf>, Vec<PathBuf>, bool) {
         let mut include_paths: Vec<PathBuf> = Vec::new();
         let mut seen_include: HashSet<PathBuf> = HashSet::new();
         let mut system_inc_paths: Vec<PathBuf> = Vec::new();
@@ -69,6 +75,19 @@ impl LspServer {
         let folder_root = self
             .folder_for_doc_uri(uri)
             .and_then(|folder| super::super::workspace_folder_path(&folder));
+
+        // Prepend lexical `use lib` paths extracted from the document source.
+        // These have the highest precedence (matching goto-definition behaviour).
+        if let Some(root) = folder_root.as_ref() {
+            let use_lib_strings = resolve_use_lib_paths_from_source(doc_text, root, file_dir);
+            for path_str in use_lib_strings {
+                let p = PathBuf::from(&path_str);
+                let resolved = if p.is_absolute() { p } else { root.join(&p) };
+                if seen_include.insert(resolved.clone()) {
+                    include_paths.push(resolved);
+                }
+            }
+        }
 
         // Read effective include paths from the config clone (PERL5LIB + workspace paths).
         // The clone is lightweight — it does not trigger the system @INC subprocess.
@@ -383,8 +402,10 @@ impl LspServer {
                 // Get completions, with fallback for missing AST
                 #[cfg_attr(not(feature = "workspace"), allow(unused_mut))]
                 let mut completions = if let Some(ast) = &doc.ast {
+                    let file_dir = super::super::source_path_from_uri(uri)
+                        .and_then(|p| p.parent().map(|d| d.to_path_buf()));
                     let (include_paths, system_inc_paths, include_system_inc) =
-                        self.module_completion_roots_for_doc(uri);
+                        self.module_completion_roots_for_doc(uri, &doc.text, file_dir.as_deref());
                     // Only provide workspace index when Full access is available
                     // This ensures we don't bypass routing policy
                     #[cfg(feature = "workspace")]
@@ -636,8 +657,10 @@ impl LspServer {
 
                 // Get completions with optimized cancellation support
                 let mut completions = if let Some(ast) = &doc.ast {
+                    let file_dir = super::super::source_path_from_uri(uri)
+                        .and_then(|p| p.parent().map(|d| d.to_path_buf()));
                     let (include_paths, system_inc_paths, include_system_inc) =
-                        self.module_completion_roots_for_doc(uri);
+                        self.module_completion_roots_for_doc(uri, &doc.text, file_dir.as_deref());
                     // Only provide workspace index when Full access is available
                     // This ensures we don't bypass routing policy
                     #[cfg(feature = "workspace")]
@@ -1079,6 +1102,45 @@ impl LspServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_module_completion_roots_includes_use_lib_paths()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use std::fs;
+        use tempfile::TempDir;
+        use url::Url;
+
+        let temp = TempDir::new()?;
+        let lib_dir = temp.path().join("mylibs");
+        let module_file = lib_dir.join("MyCustom").join("Widget.pm");
+        fs::create_dir_all(module_file.parent().ok_or("no parent")?)?;
+        fs::write(&module_file, "package MyCustom::Widget;\n1;\n")?;
+
+        let workspace_uri =
+            Url::from_file_path(temp.path()).map_err(|_| "bad workspace path")?.to_string();
+        let doc_uri =
+            Url::from_file_path(temp.path().join("app.pl")).map_err(|_| "bad doc uri")?.to_string();
+
+        let lib_dir_str = lib_dir.to_string_lossy();
+        let doc_text = format!("use lib '{lib_dir_str}';\nuse MyCustom::Widget;\n");
+
+        let server = LspServer::default();
+
+        // Register workspace folder so folder_for_doc_uri / config_for_doc work.
+        server.workspace_folders.lock().push(
+            crate::runtime::workspace_folder::WorkspaceFolderState::new(workspace_uri.clone()),
+        );
+
+        let file_dir = Some(temp.path().to_path_buf());
+        let (include_paths, _sys, _use_sys) =
+            server.module_completion_roots_for_doc(&doc_uri, &doc_text, file_dir.as_deref());
+
+        assert!(
+            include_paths.contains(&lib_dir),
+            "use lib path should be in include_paths; got: {include_paths:?}",
+        );
+        Ok(())
+    }
 
     #[test]
     fn test_cancellable_completion_cross_file_variable() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -19,7 +19,7 @@ use crate::{
     state::{completion_cap, completion_deadline},
 };
 use perl_lexer::LSP_RUNTIME_COMPLETION_KEYWORDS;
-use perl_module::resolution::use_lib::resolve_use_lib_paths_from_source;
+use perl_module::resolution::use_lib::resolve_use_lib_paths_from_source_at_offset;
 use perl_parser::type_inference::TypeInferenceEngine;
 use regex::Regex;
 use serde_json::{Value, json};
@@ -63,6 +63,7 @@ impl LspServer {
         &self,
         uri: &str,
         doc_text: &str,
+        cursor_offset: usize,
         file_dir: Option<&Path>,
     ) -> (Vec<PathBuf>, Vec<PathBuf>, bool) {
         let mut include_paths: Vec<PathBuf> = Vec::new();
@@ -79,7 +80,12 @@ impl LspServer {
         // Prepend lexical `use lib` paths extracted from the document source.
         // These have the highest precedence (matching goto-definition behaviour).
         if let Some(root) = folder_root.as_ref() {
-            let use_lib_strings = resolve_use_lib_paths_from_source(doc_text, root, file_dir);
+            let use_lib_strings = resolve_use_lib_paths_from_source_at_offset(
+                doc_text,
+                cursor_offset,
+                root,
+                file_dir,
+            );
             for path_str in use_lib_strings {
                 let p = PathBuf::from(&path_str);
                 let resolved = if p.is_absolute() { p } else { root.join(&p) };
@@ -405,7 +411,12 @@ impl LspServer {
                     let file_dir = super::super::source_path_from_uri(uri)
                         .and_then(|p| p.parent().map(|d| d.to_path_buf()));
                     let (include_paths, system_inc_paths, include_system_inc) =
-                        self.module_completion_roots_for_doc(uri, &doc.text, file_dir.as_deref());
+                        self.module_completion_roots_for_doc(
+                            uri,
+                            &doc.text,
+                            offset,
+                            file_dir.as_deref(),
+                        );
                     // Only provide workspace index when Full access is available
                     // This ensures we don't bypass routing policy
                     #[cfg(feature = "workspace")]
@@ -660,7 +671,12 @@ impl LspServer {
                     let file_dir = super::super::source_path_from_uri(uri)
                         .and_then(|p| p.parent().map(|d| d.to_path_buf()));
                     let (include_paths, system_inc_paths, include_system_inc) =
-                        self.module_completion_roots_for_doc(uri, &doc.text, file_dir.as_deref());
+                        self.module_completion_roots_for_doc(
+                            uri,
+                            &doc.text,
+                            offset,
+                            file_dir.as_deref(),
+                        );
                     // Only provide workspace index when Full access is available
                     // This ensures we don't bypass routing policy
                     #[cfg(feature = "workspace")]
@@ -1133,7 +1149,12 @@ mod tests {
 
         let file_dir = Some(temp.path().to_path_buf());
         let (include_paths, _sys, _use_sys) =
-            server.module_completion_roots_for_doc(&doc_uri, &doc_text, file_dir.as_deref());
+            server.module_completion_roots_for_doc(
+                &doc_uri,
+                &doc_text,
+                doc_text.len(),
+                file_dir.as_deref(),
+            );
 
         assert!(
             include_paths.contains(&lib_dir),

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -410,8 +410,8 @@ impl LspServer {
                 let mut completions = if let Some(ast) = &doc.ast {
                     let file_dir = super::super::source_path_from_uri(uri)
                         .and_then(|p| p.parent().map(|d| d.to_path_buf()));
-                    let (include_paths, system_inc_paths, include_system_inc) =
-                        self.module_completion_roots_for_doc(
+                    let (include_paths, system_inc_paths, include_system_inc) = self
+                        .module_completion_roots_for_doc(
                             uri,
                             &doc.text,
                             offset,
@@ -670,8 +670,8 @@ impl LspServer {
                 let mut completions = if let Some(ast) = &doc.ast {
                     let file_dir = super::super::source_path_from_uri(uri)
                         .and_then(|p| p.parent().map(|d| d.to_path_buf()));
-                    let (include_paths, system_inc_paths, include_system_inc) =
-                        self.module_completion_roots_for_doc(
+                    let (include_paths, system_inc_paths, include_system_inc) = self
+                        .module_completion_roots_for_doc(
                             uri,
                             &doc.text,
                             offset,
@@ -1148,13 +1148,12 @@ mod tests {
         );
 
         let file_dir = Some(temp.path().to_path_buf());
-        let (include_paths, _sys, _use_sys) =
-            server.module_completion_roots_for_doc(
-                &doc_uri,
-                &doc_text,
-                doc_text.len(),
-                file_dir.as_deref(),
-            );
+        let (include_paths, _sys, _use_sys) = server.module_completion_roots_for_doc(
+            &doc_uri,
+            &doc_text,
+            doc_text.len(),
+            file_dir.as_deref(),
+        );
 
         assert!(
             include_paths.contains(&lib_dir),


### PR DESCRIPTION
## Summary
Enhanced module completion to respect lexical `use lib` declarations in Perl source files. This allows the language server to provide accurate completions for modules added via `use lib` statements, matching the behavior of goto-definition.

Fixes #NNNN

## Changes
- **completion.rs**: 
  - Modified `module_completion_roots_for_doc()` to accept document text and file directory as parameters
  - Added logic to extract and prepend `use lib` paths from source code using `resolve_use_lib_paths_from_source()`
  - These lexical paths are given highest precedence (prepended to include_paths) to match goto-definition behavior
  - Updated both call sites in completion handlers to pass the required parameters
  - Added comprehensive unit test verifying that `use lib` paths are correctly included in completion roots

- **Imports**: Added `resolve_use_lib_paths_from_source` from `perl_module::resolution::use_lib` and `Path` from `std::path`

## Test
Added `test_module_completion_roots_includes_use_lib_paths()` which:
- Creates a temporary workspace with a custom library directory
- Writes a test module to that directory
- Verifies that a `use lib` declaration in source code results in that path being included in the completion roots
- Confirms the path is found in the returned `include_paths` vector

## Verification
- [ ] `cargo xtask fmt` — clean
- [ ] `cargo clippy -p perl-lsp-rs --tests` — clean
- [ ] `cargo test -p perl-lsp-rs` — pass (new test included)

## What I considered but didn't do
- Caching of parsed `use lib` statements: Currently re-parsed on each completion request. Could be optimized if performance becomes an issue.
- Deduplication across multiple `use lib` statements: Already handled by the `seen_include` HashSet.

## What's next
- Monitor for any edge cases with relative vs. absolute paths in `use lib` declarations
- Consider extending similar logic to other completion-related features if needed

https://claude.ai/code/session_014eVyfpJHm8EnPPWUcEeVCb