### PR TITLE
fix(ux-tests): increase default LSP response timeout from 10s to 30s (#6715)

### DIFF
--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -32,7 +32,7 @@
 //! # Environment Variables
 //!
 //! - `PERL_LSP_BIN`: Override the path to the perl-lsp binary.
-//! - `UX_TEST_TIMEOUT_MS`: Per-request timeout in milliseconds (default: 10000).
+//! - `UX_TEST_TIMEOUT_MS`: Per-request timeout in milliseconds (default: 30000).
 //! - `UX_TEST_ECHO_STDERR`: If set, echo perl-lsp stderr lines to test output.
 
 #![deny(unsafe_code)]
@@ -86,7 +86,7 @@ impl CursorPosition {
 /// requiring callers to thread individual parameters through every helper.
 #[derive(Debug, Clone)]
 pub struct ScenarioConfig {
-    /// Per-request timeout. Defaults to 10 seconds.
+    /// Per-request timeout. Defaults to 30 seconds.
     pub timeout: Duration,
     /// If `Some`, restrict PATH to only these directory entries (absolute paths).
     /// This lets scenarios simulate "perltidy not found" without touching the
@@ -112,7 +112,7 @@ impl Default for ScenarioConfig {
         let timeout_ms = std::env::var("UX_TEST_TIMEOUT_MS")
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
-            .unwrap_or(10_000);
+            .unwrap_or(30_000);
         let echo_stderr = std::env::var_os("UX_TEST_ECHO_STDERR").is_some();
         Self {
             timeout: Duration::from_millis(timeout_ms),


### PR DESCRIPTION
## Summary

- **Root cause**: The `UX Regression Gate` workflow calls `just ux-tests` from a cold cargo cache. The recipe compiles the full workspace with `CARGO_BUILD_JOBS=1` (serial), which takes ~7 minutes on Ubuntu CI runners. After this build, the runner's CPU is throttled, causing the LSP server to exceed the 10-second `initialize` response timeout — failing all three scenario_01 tests identically.
- **Fix**: Raise the default `UX_TEST_TIMEOUT_MS` fallback from 10,000ms to 30,000ms. This matches what commit `97251f4e3` ("fix(ux-tests): bump LSP client timeout from 10s to 30s for CI runner contention") previously established before `b4d1a6188` accidentally reverted it.
- **Why now**: The `UX Regression Gate` triggers on `crates/perl-dap*/**` path changes, so all 8 perl-dap PRs (#6171, #6182, #6189, #6192, #6196, #6203, #6204, #6211) fail identically. After `gh pr update-branch` on those PRs, the increased timeout will prevent the issue.

**Evidence the root cause is correct**: PR #6204 (`codex/cache-interpreter-discovery-for-launch-optimization`) was updated with `git merge master` (merge commit `e7dd25041`). Its current CI shows **UX Regression Gate: pass** while PR #6182 (same codebase, no merge commit) still shows the old failure. The difference is the merge — not a code regression.

**Why `7943a13e` was NOT the cause**: That commit only changed `crates/perl-dap/src/bridge_adapter.rs`, which is gated behind `dap-phase1` feature and not compiled into the `perl-lsp` binary. The UX tests spawn `perl-lsp --stdio` without DAP features enabled.

## Test plan

- [ ] Confirm PR CI passes the `UX Regression Gate` workflow
- [ ] After merging, run `gh pr update-branch` on the 8 affected DAP PRs from issue #6715 to pull in the fix
- [ ] Confirm the 8 PRs then pass `UX Regression Gate` on their next push

Closes #6715 (cascade fix — upstream timeout increase)