### PR TITLE
feat(semantic-tokens): add modification modifier for assignment LHS variables (#6816)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/semantic_tokens/semantic_tokens.rs
+++ b/crates/perl-lsp-rs-core/src/providers/semantic_tokens/semantic_tokens.rs
@@ -107,7 +107,7 @@
 use perl_lexer::{PerlLexer, StringPart, TokenType};
 use perl_parser_core::ast::{Node, NodeKind};
 use regex::Regex;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::VecDeque;
 use std::sync::LazyLock;
 
@@ -579,6 +579,9 @@ pub fn collect_semantic_tokens(
         .map(|((start, end), is_readonly)| (start, end, is_readonly))
         .collect::<Vec<_>>();
 
+    // 2a-ii) Collect assignment LHS spans for write-modifier tagging
+    let assignment_spans = assignment_lhs_spans(ast);
+
     // 2b) AST overlays: package/sub/variable with precise spans where available
     walk_ast_full(ast, &mut |node| {
         // For nodes with name_span, use the precise span for better highlighting
@@ -738,7 +741,11 @@ pub fn collect_semantic_tokens(
                 let mods = match decl_info {
                     Some((_, _, true)) => 1 | 4 | special_mod | sigil_mod, // declaration | readonly (our)
                     Some((_, _, false)) => 1 | special_mod | sigil_mod, // declaration (my/local/state)
-                    None => special_mod | sigil_mod,
+                    None => {
+                        // bit 7 (128) = modification: variable is being written to
+                        let write_mod = if assignment_spans.contains(&(vs, ve)) { 128 } else { 0 };
+                        special_mod | sigil_mod | write_mod
+                    }
                 };
                 ("variable", mods)
             }
@@ -879,6 +886,21 @@ fn declaration_readonly_flags(ast: &Node) -> FxHashMap<(usize, usize), bool> {
     });
 
     flags
+}
+
+/// Collect the byte-span of every variable that appears on the left-hand side of
+/// an assignment (`$x = …`, `@arr = …`, `%hash = …`).  These spans are used to
+/// apply the LSP "modification" token modifier (bit 7, value 128) so editors can
+/// visually distinguish writes from reads.
+fn assignment_lhs_spans(ast: &Node) -> FxHashSet<(usize, usize)> {
+    let mut spans = FxHashSet::default();
+    walk_ast_full(ast, &mut |node| {
+        if let NodeKind::Assignment { lhs, .. } = &node.kind {
+            spans.insert((lhs.location.start, lhs.location.end));
+        }
+        true
+    });
+    spans
 }
 
 fn ast_uses_const_fast(ast: &Node) -> bool {
@@ -1305,5 +1327,68 @@ print "ok" foreach @ys;
                 );
             }
         }
+    }
+
+    /// Build a simple byte-offset → (line, col-u16) converter for unit tests.
+    fn make_pos16(source: &str) -> impl Fn(usize) -> (u32, u32) + '_ {
+        move |offset: usize| {
+            let prefix = &source[..offset.min(source.len())];
+            let line = prefix.bytes().filter(|&b| b == b'\n').count() as u32;
+            let col = prefix.rfind('\n').map_or(offset, |p| offset - p - 1) as u32;
+            (line, col)
+        }
+    }
+
+    #[test]
+    fn test_modification_modifier_applied_on_assignment_lhs() {
+        // `$x` on line 1 (`$x = 2`) is an assignment LHS → should get bit 7 (128 = modification).
+        // `$x` on line 2 (`$x;`) is a bare read expression → should NOT get bit 7.
+        // Note: `print $x` is intentionally NOT used here because the FunctionCall AST node spans
+        // the entire expression including arguments, causing the overlap-dedup pass to drop the
+        // child Variable token (shorter span loses).
+        let source = "my $x = 1;\n$x = 2;\n$x;\n";
+        let mut parser = Parser::new(source);
+        let ast = parser.parse().expect("parse failed");
+        let pos16 = make_pos16(source);
+        let tokens = collect_semantic_tokens(&ast, source, &pos16);
+
+        // variable token type is index 11 (see lsp_semantic_tokens_e2e.rs comment)
+        // Decode back from delta encoding to find $x tokens
+        let mut line = 0u32;
+        let mut col = 0u32;
+        let mut vars: Vec<(u32, u32, u32)> = Vec::new(); // (line, col, mods)
+        for &[dl, ds, len, kind, mods] in &tokens {
+            if dl > 0 {
+                line += dl;
+                col = ds;
+            } else {
+                col += ds;
+            }
+            if kind == 11 && len == 2 {
+                // variable token of length 2 = "$x"
+                vars.push((line, col, mods));
+            }
+        }
+
+        // Line 0: declaration `my $x` — should have declaration bit (1), no modification bit
+        let decl = vars.iter().find(|&&(l, _, _)| l == 0);
+        assert!(decl.is_some(), "expected $x declaration token on line 0");
+        let (_, _, decl_mods) = decl.unwrap();
+        assert!(decl_mods & 1 != 0, "declaration token must have bit 0 (declaration)");
+        assert!(decl_mods & 128 == 0, "declaration token must NOT have modification bit");
+
+        // Line 1: assignment `$x = 2` — should have modification bit (128)
+        let write = vars.iter().find(|&&(l, _, _)| l == 1);
+        assert!(write.is_some(), "expected $x write token on line 1");
+        let (_, _, write_mods) = write.unwrap();
+        assert!(write_mods & 128 != 0, "assignment LHS must have modification bit (128)");
+        assert!(write_mods & 1 == 0, "write token must NOT have declaration bit");
+
+        // Line 2: bare read `$x;` — should have neither declaration nor modification bit
+        let read = vars.iter().find(|&&(l, _, _)| l == 2);
+        assert!(read.is_some(), "expected $x read token on line 2");
+        let (_, _, read_mods) = read.unwrap();
+        assert!(read_mods & 1 == 0, "read token must NOT have declaration bit");
+        assert!(read_mods & 128 == 0, "read token must NOT have modification bit");
     }
 }

--- a/crates/perl-parser/tests/wave4_completion_absorption_tests.rs
+++ b/crates/perl-parser/tests/wave4_completion_absorption_tests.rs
@@ -188,17 +188,25 @@ fn test_perl_incremental_parsing_not_in_allowlist() -> TestResult {
 // Section 4: Published Count Baseline Tests
 // =============================================================================
 
-/// Test that published-crate-baseline.txt is updated to 34 (down from 37)
+/// Test that published-crate-baseline.txt has not regressed above 34.
+///
+/// Wave 4-Completion reduced the count from 37 → 34 (3 parser satellites absorbed).
+/// Subsequent waves (Wave G3, Wave Final PR B) reduced it further to 31.
+/// This test enforces the ratchet: the baseline must be ≤ 34 and must be positive.
 #[test]
 fn test_published_count_baseline_is_34() -> TestResult {
     let baseline_path = ws("xtask/published-crate-baseline.txt");
     let content = fs::read_to_string(&baseline_path)?;
     let baseline_count = content.trim().parse::<u32>()?;
 
-    if baseline_count == 34 {
+    if baseline_count > 0 && baseline_count <= 34 {
         Ok(())
     } else {
-        Err(format!("published-crate-baseline.txt must be 34, got {}", baseline_count).into())
+        Err(format!(
+            "published-crate-baseline.txt must be ≤ 34 and > 0 (Wave 4-Completion ratchet), got {}",
+            baseline_count
+        )
+        .into())
     }
 }
 


### PR DESCRIPTION
## Summary

Implements the LSP 3.17 `modification` semantic token modifier (bit 7, value 128) for Perl variables that appear on the **left-hand side of an assignment**. This allows editors to visually distinguish variable writes from reads and declarations — a capability that was previously absent.

### What changed

**`crates/perl-lsp-rs-core/src/providers/semantic_tokens/semantic_tokens.rs`**

- Added `assignment_lhs_spans(ast: &Node) -> FxHashSet<(usize, usize)>` — a pre-pass that walks the AST and collects byte-spans of every Variable node that is a direct LHS of an `Assignment` node. This is consistent with the existing `declaration_readonly_flags` pre-pass pattern already in this file.
- Wired the result into `collect_semantic_tokens` as a second pre-pass (step 2a-ii), before the main AST walk.
- Applied `write_mod = 128` (bit 7) to Variable tokens whose span appears in `assignment_spans`, **only when the variable is not already in a declaration span** (declarations take priority and already carry their own modifier set).
- Added `FxHashSet` to the `rustc_hash` import alongside the existing `FxHashMap`.
- Added a hermetic unit test `test_modification_modifier_applied_on_assignment_lhs` with a helper `make_pos16` that converts byte offsets to (line, col) without pulling in any external infrastructure. The test verifies three distinct cases in a single source:
  - `my $x = 1;` → bit 0 (declaration) set, bit 7 NOT set
  - `$x = 2;` → bit 7 (modification) set, bit 0 NOT set
  - `$x;` (bare read expression) → neither bit set

**`crates/perl-parser/tests/wave4_completion_absorption_tests.rs`**

- Fixed `test_published_count_baseline_is_34` which was asserting an exact value of `34`. Subsequent Wave G3 and Final PR B crate absorptions reduced `xtask/published-crate-baseline.txt` from 34 → 31, causing this test to fail spuriously. Changed the assertion to `<= 34 && > 0` so it acts as an upper-bound ratchet rather than a point check.

### Why this matters

The LSP `modification` modifier is part of the standard token modifier vocabulary. Without it, editors that support semantic highlighting cannot visually distinguish a write (`$x = 2`) from a read (`my $y = $x`). This is particularly useful in editors like VS Code, Neovim, and Emacs that use semantic token data to drive write-highlighting, refactoring hints, and flow analysis annotations.

### Design decisions

- **Pre-pass pattern** (consistent with `declaration_readonly_flags`): collecting spans up-front avoids threading extra context through the generic `walk_ast_full` closure, keeps the Variable match arm readable, and is O(n) in AST nodes.
- **FxHashSet** over `HashSet`: already a workspace dependency via `rustc_hash`; avoids pulling in a new dep for a hot path.
- **Declarations win**: when a variable is both declared and assigned in the same statement (`my $x = 1`), the declaration modifier set takes precedence. The `match decl_info` arm already handles this — the `None` arm (where write_mod is applied) is only reached for non-declaration occurrences.
- **Test uses bare `$x;` not `print $x;`**: the `FunctionCall` AST node spans the entire call expression including arguments. The overlap-dedup pass keeps the longer token, so the child `$x` Variable token would be silently dropped. Using a bare expression statement avoids this and makes the test resilient to future changes in how function argument tokens are handled.

## Test plan

- [x] `cargo test -p perl-lsp-rs-core --lib -- test_modification_modifier_applied_on_assignment_lhs` → passes
- [x] `cargo test -p perl-lsp-rs-core --lib` → 921 tests pass, 0 failures
- [x] `cargo test -p perl-parser --test wave4_completion_absorption_tests` → 26 tests pass, 0 failures
- [x] `cargo clippy -p perl-lsp-rs-core --lib` → no warnings or errors

https://claude.ai/code/session_01Qqh5N9r4z8ZfMVSvwezE94

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qqh5N9r4z8ZfMVSvwezE94)_