### PR TITLE
fix(workspace-index): store MethodCall references under bare name AND qualified form (#6799)

### DIFF
--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -3227,15 +3227,27 @@ impl IndexVisitor {
                 // Object is a read context
                 self.visit_node(object, file_index);
 
-                // Track method call with qualified name if applicable
-                let method_key = qualified_method.as_ref().unwrap_or(method);
-                file_index.references.entry(method_key.clone()).or_default().push(
-                    SymbolReference {
-                        uri: self.uri.clone(),
-                        range: self.node_to_range(node),
-                        kind: ReferenceKind::Usage,
-                    },
-                );
+                // Track method call under BOTH the qualified form (for static calls
+                // like `Pkg->method`) AND the bare method name. This mirrors the
+                // FunctionCall dual-key storage above (PR #122 dual-indexing pattern)
+                // so that bare-name lookups (e.g. `find_unused_symbols`,
+                // `count_usages("method")`) consistently find static method call sites.
+                // See #6799 for the original asymmetric-storage bug report.
+                let location = self.node_to_range(node);
+                if let Some(qualified_method) = qualified_method.as_ref() {
+                    file_index.references.entry(qualified_method.clone()).or_default().push(
+                        SymbolReference {
+                            uri: self.uri.clone(),
+                            range: location,
+                            kind: ReferenceKind::Usage,
+                        },
+                    );
+                }
+                file_index.references.entry(method.clone()).or_default().push(SymbolReference {
+                    uri: self.uri.clone(),
+                    range: location,
+                    kind: ReferenceKind::Usage,
+                });
 
                 if method == "import"
                     && let NodeKind::Identifier { name: module_name } = &object.kind

--- a/crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs
+++ b/crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs
@@ -191,8 +191,7 @@ fn static_method_callee_is_not_flagged_unused() -> Result<(), Box<dyn std::error
         "package Caller;\nHelper->process();\n".to_string(),
     )?;
 
-    let unused: Vec<String> =
-        index.find_unused_symbols().iter().map(|s| s.name.clone()).collect();
+    let unused: Vec<String> = index.find_unused_symbols().iter().map(|s| s.name.clone()).collect();
     assert!(
         !unused.contains(&"process".to_string()),
         "Helper::process is called via Helper->process() in Caller.pm and must not be \

--- a/crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs
+++ b/crates/perl-workspace-index/tests/cross_file_reference_query_tests.rs
@@ -141,3 +141,63 @@ fn query_symbol_references_avoids_false_positives_for_ambiguous_bare_symbols()
 
     Ok(())
 }
+
+// --- regression tests for #6799 ---
+
+#[test]
+fn static_method_calls_found_by_bare_name_query() -> Result<(), Box<dyn std::error::Error>> {
+    // Regression test for #6799: MethodCall references must be stored under both the
+    // qualified form (when static) AND the bare method name, mirroring the
+    // FunctionCall storage pattern (workspace_index.rs:3127-3138).
+    //
+    // A bare-name reference query for `process` must find the static call
+    // `Helper->process()` in Caller.pm. This passes today via the iterator-fallback
+    // path in `find_references` (which scans `*::process` keys), but the underlying
+    // storage asymmetry is what this test pins.
+    let index = WorkspaceIndex::new();
+    index.index_file(
+        file_url("/lib/Helper.pm")?,
+        "package Helper;\nsub process { 1 }\n".to_string(),
+    )?;
+    index.index_file(
+        file_url("/lib/Caller.pm")?,
+        "package Caller;\nHelper->process();\n".to_string(),
+    )?;
+
+    let refs = index.find_references("process");
+    assert!(
+        refs.iter().any(|loc| loc.uri.contains("Caller.pm")),
+        "expected Helper->process() in Caller.pm to appear in bare-name reference query, \
+         got refs: {:?}",
+        refs.iter().map(|loc| loc.uri.as_str()).collect::<Vec<_>>(),
+    );
+    Ok(())
+}
+
+#[test]
+fn static_method_callee_is_not_flagged_unused() -> Result<(), Box<dyn std::error::Error>> {
+    // Regression test for #6799 (storage-shape demonstration): `find_unused_symbols`
+    // performs an exact-key lookup of `fi.references.get(&symbol.name)` for the bare
+    // sub name. Before the fix, MethodCall stored static method references only under
+    // the qualified key (`Helper::process`), so the bare-key lookup `process` returned
+    // None for Caller.pm, and `process` was incorrectly flagged as unused.
+    let index = WorkspaceIndex::new();
+    index.index_file(
+        file_url("/lib/Helper.pm")?,
+        "package Helper;\nsub process { 1 }\n".to_string(),
+    )?;
+    index.index_file(
+        file_url("/lib/Caller.pm")?,
+        "package Caller;\nHelper->process();\n".to_string(),
+    )?;
+
+    let unused: Vec<String> =
+        index.find_unused_symbols().iter().map(|s| s.name.clone()).collect();
+    assert!(
+        !unused.contains(&"process".to_string()),
+        "Helper::process is called via Helper->process() in Caller.pm and must not be \
+         flagged unused; got unused={:?}",
+        unused,
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes #6799 — MethodCall references in `IndexVisitor` were stored asymmetrically (only one of `qualified` / bare name), violating the dual-indexing invariant established for FunctionCall in PR #122. This silently broke bare-name lookups for static method callees.

### Root cause

`crates/perl-workspace-index/src/workspace/workspace_index.rs` MethodCall handler (was lines 3315-3323) wrote a single key:

```rust
let method_key = qualified_method.as_ref().unwrap_or(method);
file_index.references.entry(method_key.clone()).or_default().push(...)
```

So for `Helper->process()`:
- Static call: only `Helper::process` stored
- Instance call (`$obj->method`): only `method` stored

Compare to FunctionCall (lines 3127-3138) which always stores both bare and qualified forms.

### User-visible failure

`find_unused_symbols` does an exact bare-key lookup `fi.references.get(&symbol.name)`. When `process` was called only as `Helper->process()`, the bare-name key was missing in Caller.pm's references map, and `process` was incorrectly flagged unused. This is a #6053-class silent miss.

`find_references` and `count_usages` happen to mask this in their public API via an iterator-fallback path that scans all `*::name` keys, but the underlying storage was still inconsistent. The fix removes the asymmetry at the source.

### Fix

Mirror FunctionCall's dual-key storage: always insert under the bare method name, and additionally under the `Pkg::method` qualified key when the call is static.

## Test plan

- [x] New test `static_method_calls_found_by_bare_name_query` documents the storage shape (passes today via iterator fallback, pinned for regression)
- [x] New test `static_method_callee_is_not_flagged_unused` FAILS on master, PASSES after the fix — proves the user-visible defect
- [x] All existing `cross_file_reference_query_tests.rs` tests still pass (8/8)
- [x] `cargo test -p perl-workspace` clean (672/672, 28 suites)
- [x] `cargo clippy -p perl-workspace --lib` no new warnings
- [x] `cargo xtask fmt` clean
- [ ] CI passes

## Notes

- The issue's spec-suggested test (`find_references("process")` finding `Helper->process()`) actually passes on master because `find_references` has an iterator-fallback path. I kept that test for documentation but added a stronger test using `find_unused_symbols` that genuinely fails on master and demonstrates the user-visible bug. Noted in commit messages.
- Workspace-wide `cargo test --workspace --lib` shows 2 failures in `perl-lsp-rs` runtime tests (Windows path normalization in `runtime::tests::source_path_from_uri_accepts_absolute_filesystem_paths` and `runtime::lifecycle::capabilities::tests::initialize_with_workspace_folders_sets_root_path_from_first_folder`). These are pre-existing master bit-rot unrelated to this change.
- Scope intentionally narrow: storage path + tests only. No unrelated cleanups.