### PR TITLE
fix(fmt): apply cargo fmt to perl-pragma comprehensive_unit_tests.rs (#0000)

### DIFF
--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -1239,17 +1239,13 @@ fn duplicate_no_warnings_category_does_not_create_extra_entry()
     Ok(())
 }
 
-
 #[test]
 fn no_warnings_empty_string_category_is_ignored() -> Result<(), Box<dyn std::error::Error>> {
     // `no warnings ''` after quote-stripping yields an empty category name.
     // Error-recovery AST nodes can produce this.  The empty string must not be
     // pushed into disabled_warning_categories, and no map entry should be emitted
     // because the state did not change.
-    let ast = program(vec![
-        use_node("warnings", &[], 0, 12),
-        no_node("warnings", &["''"], 13, 28),
-    ]);
+    let ast = program(vec![use_node("warnings", &[], 0, 12), no_node("warnings", &["''"], 13, 28)]);
     let map = PragmaTracker::build(&ast);
     assert_eq!(map.len(), 1, "empty-string category should not create a map entry");
     assert!(


### PR DESCRIPTION
Master fmt drift in tests/comprehensive_unit_tests.rs (lines 1239, 1246) introduced by recent perl-pragma test merges (#6351, #6333). Causes PR Smoke (Fast Feedback) to fail on every PR via xtask fmt cascade. Same pattern as #6789. Narrow fix; admin-merge + cascade-update affected PRs after.

Note: a separate, unrelated fmt drift was observed in crates/perl-semantic-analyzer/tests/semantic_pipeline_fuzz_tests.rs (use-import ordering on lines 3 and 9). xtask fmt aborts at the first failing crate, so this only became visible once perl-pragma was clean. Out of scope for this PR — flag for separate narrow fix.