### PR TITLE
fix(fmt): apply cargo fmt to perl-semantic-analyzer fuzz tests (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/tests/semantic_pipeline_fuzz_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/semantic_pipeline_fuzz_tests.rs
@@ -3,10 +3,10 @@
 //! This suite targets the highest-impact path (editor open/change events):
 //! parse with recovery, symbol extraction, scope analysis, and semantic token generation.
 
+use perl_semantic_analyzer::Parser;
 use perl_semantic_analyzer::analysis::scope_analyzer::ScopeAnalyzer;
 use perl_semantic_analyzer::analysis::semantic::SemanticAnalyzer;
 use perl_semantic_analyzer::symbol::SymbolExtractor;
-use perl_semantic_analyzer::Parser;
 
 #[derive(Debug, Clone)]
 struct XorShift64 {


### PR DESCRIPTION
Master fmt drift in `crates/perl-semantic-analyzer/tests/semantic_pipeline_fuzz_tests.rs` (lines 3, 9 — use-import ordering: `Parser` should come before `analysis::*` per rustfmt group ordering).

Same xtask-fmt-cascade pattern as #6789 (incremental_checkpoint.rs) and #6803 (perl-pragma comprehensive_unit_tests.rs). xtask fmt aborts at first failing crate; with perl-pragma now clean (#6803 merged), the next failure becomes visible.

Narrow fix; 1 line moved. Re-running `cargo xtask fmt --check` after the fix exits clean — no further cascade exposed at this pass.