### PR TITLE
fix(vscode-extension): cleanup #6780 — correct idris→perl reference and apply manifest change (#0000)

### DIFF
--- a/docs/performance-activation-fix.md
+++ b/docs/performance-activation-fix.md
@@ -1,17 +1,17 @@
 // Remove redundant onStartupFinished activation event.
-// The extension activates on language:idris command which covers all use cases.
+// The extension activates on language:perl command which covers all use cases.
 // This change reduces unnecessary eager activation, improving startup performance.
 
 // BEFORE:
 // "activationEvents": [
 //   "onStartupFinished",
-//   "onLanguage:idris"
+//   "onLanguage:perl"
 // ],
 
 // AFTER:
 {
   "activationEvents": [
-    "onLanguage:idris",
+    "onLanguage:perl",
     "onCommand:perl-lsp.restart",
     "onCommand:perl-lsp.showOutput"
   ]

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -60,8 +60,7 @@
   "activationEvents": [
     "onLanguage:perl",
     "onLanguage:gherkin",
-    "onWalkthrough:perl-lsp.gettingStarted",
-    "onStartupFinished"
+    "onWalkthrough:perl-lsp.gettingStarted"
   ],
   "contributes": {
     "languages": [


### PR DESCRIPTION
Follow-up cleanup of #6780 which was merged 2026-04-26 carrying bugs per standards review's NEEDS BUILDER comment.

## Bugs fixed

1. **Wrong language reference**: `docs/performance-activation-fix.md` referenced `onLanguage:idris` (cargo-cult from another extension) — corrected to `onLanguage:perl`.
2. **Missing manifest change**: PR #6780's title claimed a vscode-extension fix but only added the doc; the actual `vscode-extension/package.json` was never modified. This PR applies the change the original PR title claimed by removing `onStartupFinished` from the `activationEvents` array.

## Why onStartupFinished is redundant

The remaining activation events provide complete coverage:
- `onLanguage:perl` — fires on opening any Perl file (the LSP's actual trigger)
- `onLanguage:gherkin` — fires on opening Gherkin/Cucumber files
- `onWalkthrough:perl-lsp.gettingStarted` — fires when user starts the walkthrough

`onStartupFinished` was eagerly activating the extension on every VS Code session even when no Perl file was opened, which is the unnecessary cost the original PR's doc described.

## Root cause

Standards reviewer flagged both bugs at 04:46 with NEEDS BUILDER FIX, but also applied `review-reviewed` label. Conflicting labels confused the merge gate, manual merge proceeded carrying the bugs.