### PR TITLE
fix(perl-parser): repair doc_lazy_continuation clippy warnings (#0000)

### DIFF
--- a/crates/perl-parser/src/incremental/incremental_checkpoint.rs
+++ b/crates/perl-parser/src/incremental/incremental_checkpoint.rs
@@ -209,6 +209,9 @@ impl TokenCache {
     /// * `edit_start` - Start byte position of the edit.
     /// * `old_len` - Length of the removed text.
     /// * `new_len` - Length of the inserted text.
+    ///
+    /// # Implementation notes
+    ///
     /// Adjust segment bounds after an edit.
     ///
     /// Only `segment.start` and `segment.end` are shifted; individual token byte


### PR DESCRIPTION
Master clippy noise — pre-existing `doc_lazy_continuation` warning in `perl-parser` blocking strict-clippy gates on downstream PRs (surfaced during PR #5513 cherry-pick recovery).

Same template as #6789/#6803 fmt fixes. Narrow + mechanical.

## Fix

`crates/perl-parser/src/incremental/incremental_checkpoint.rs:212` — two doc-comment blocks for `adjust_positions` were concatenated without a paragraph break, so clippy flagged the second summary line as a lazy continuation of the `# Arguments` bullet list.

Resolved by inserting a blank doc line + an `# Implementation notes` heading between the two blocks. No logic changes; doc text is preserved verbatim.

## Verification

- `cargo clippy --workspace --lib -- -D warnings` — clean
- `cargo build -p perl-parser` — clean
- `cargo test -p perl-parser --lib` — 136 passed, 0 failed
- `cargo xtask fmt` — clean

## Diff

3 lines added, 1 file changed.