### PR TITLE
docs(commands): wire master-green + sign-off-as-routing principles into 4 key decision skills (#0000)

### DIFF
--- a/.claude/commands/diff-audit-comment.md
+++ b/.claude/commands/diff-audit-comment.md
@@ -7,6 +7,21 @@ user-invocable: false
 
 Post your findings and set the appropriate label.
 
+## Operating principle (per the 2026-04-26 directive)
+
+Sign-off IS one of the routing decisions. Each pass produces ONE outcome:
+
+- **CLEAN** → apply `diff-audited` (and only `diff-audited`)
+- **ARTIFACTS / REGRESSION / SCOPE DRIFT / CONTAMINATION** → apply `needs-diff-fix` (and only `needs-diff-fix`); do **NOT** also apply `diff-audited`
+
+Default posture: every PR is potentially problematic. "CLEAN, nothing to flag" on a 500+ line diff is almost never right — find a specific concrete observation (regression risk, artifact, test gap, contamination, sketchy commit). Mechanical box-checking output without substantive observations is itself a signal you didn't look hard enough.
+
+## Pre-comment checks (must run before deciding verdict)
+
+1. **Cross-PR source-file contamination** (per `feedback_agent_audit_trail_directories.md` 2026-04-25 update + 2026-04-26 #5870 incident): contamination can live in regular source/test files, not just `.hermes/`. For each file in the diff, ask: "does this path/content align with the PR's stated scope (title + body + linked issue)?" If diff adds tests for crate X but the title is about crate Y (and they aren't named in the spec), flag as CONTAMINATION. Tell-tale: PR title claims a small change but `--stat` shows >100 lines outside the named scope.
+
+2. **Master-green guard** (per the 2026-04-26 master-green directive): verify the PR's CI includes workspace-wide checks SUCCESS (`Compile All Targets`, `PR Smoke` with workspace fmt, `Windows Guardrails`), not just per-crate. Per-crate green is necessary but not sufficient — workspace-wide cascades break master after merge. If `PR Smoke` shows fmt drift in any file (PR's own OR a recently-merged unrelated file the branch hasn't picked up), route to needs-ci-fix with cascade-update instruction.
+
 ## Steps
 
 1. Post comment:

--- a/.claude/commands/ops-check-queue.md
+++ b/.claude/commands/ops-check-queue.md
@@ -36,20 +36,27 @@ Classify and act:
    ```
 
 2. Filter for merge candidates:
-   - MERGEABLE + CLEAN or UNSTABLE (CI may be running)
+   - **mergeStateStatus = CLEAN** (NOT UNSTABLE, NOT UNKNOWN, NOT DIRTY). UNSTABLE means non-required check failing or in flight — wait, don't merge.
    - Not a draft (or promote with `gh pr ready` if appropriate)
    - reviewDecision: APPROVED or no review required
+   - **No active `needs-*` routing label** (per the 2026-04-26 sign-off-as-routing rule). Filter out PRs with any of: `needs-builder-fix`, `needs-ci-fix`, `needs-diff-fix`, `needs-spec-fix`, `needs-red-tdd-fix`. Sign-off and routing labels are mutually exclusive at the same gate; presence of `needs-*` means the gate has not actually cleared.
 
-3. Check CI on each candidate:
+   Filter command (post-Step-1 list narrowing):
    ```bash
-   gh pr view <number> --json statusCheckRollup --jq '[.statusCheckRollup[] | select(.conclusion == "FAILURE") | (.context // .name)]'
+   gh pr list --state open --label merge-ready --limit 50 --json number,labels,mergeStateStatus,isDraft -q '[.[] | select(.isDraft | not) | select(.mergeStateStatus == "CLEAN") | select(.labels | map(.name) | (contains(["needs-builder-fix"]) or contains(["needs-ci-fix"]) or contains(["needs-diff-fix"]) or contains(["needs-spec-fix"]) or contains(["needs-red-tdd-fix"])) | not)] | .[].number'
+   ```
+
+3. Check CI on each candidate using **latest-per-check filter** (per `feedback_status_check_rollup_stale_entries.md`):
+   ```bash
+   gh pr view <number> --json statusCheckRollup --jq '.statusCheckRollup | group_by(.name // .context) | map(sort_by(.completedAt // .startedAt) | last) | [.[] | select(.conclusion == "FAILURE") | (.context // .name)]'
    ```
 
 4. Classify:
-   - **MERGE NOW**: MERGEABLE + CI green + `just pre-merge-check <number>` passes
-   - **WAIT**: CI still running
-   - **BLOCKED**: CI failures — note which check failed
-   - **NEEDS REBASE**: CONFLICTING
+   - **MERGE NOW**: CLEAN + latest CI all green + no `needs-*` + `just pre-merge-check <number>` passes
+   - **WAIT**: CI still running (mergeStateStatus = UNSTABLE / UNKNOWN)
+   - **BLOCKED**: CI failures on latest run — note which check failed
+   - **NEEDS REBASE**: CONFLICTING / DIRTY
+   - **CONTRADICTORY**: has `merge-ready` AND a `needs-*` label — strip `merge-ready` and route to the appropriate fixer
 
 ## Output
 

--- a/.claude/commands/ops-merge-batch.md
+++ b/.claude/commands/ops-merge-batch.md
@@ -17,13 +17,15 @@ Merge up to 3 PRs from the candidates identified in step 1.
 
 2. **Fresh green check** — immediately before each merge, verify live state:
    ```bash
-   gh pr view <number> --json isDraft,mergeable,headRefOid,reviewDecision,statusCheckRollup
+   gh pr view <number> --json isDraft,mergeable,mergeStateStatus,labels,headRefOid,reviewDecision,statusCheckRollup
    ```
    All of these must be true AT MERGE TIME (not remembered from earlier):
    - Not draft
-   - Mergeable now
-   - CI checks green on the current HEAD SHA
+   - mergeStateStatus = CLEAN (NOT UNSTABLE, NOT UNKNOWN, NOT DIRTY)
+   - CI checks green on the current HEAD SHA using **latest-per-check filter** (per `feedback_status_check_rollup_stale_entries.md`)
    - No blocking review comments
+   - **NO active `needs-*` label** (per the 2026-04-26 sign-off-as-routing rule: presence of `needs-builder-fix` / `needs-ci-fix` / `needs-diff-fix` / `needs-spec-fix` / `needs-red-tdd-fix` MUST block merge regardless of `merge-ready`). Sign-off is one of the routing decisions; if any gate ALSO bounced, the PR is not actually signed off.
+   - **Workspace-wide CI checks SUCCESS** (Compile All Targets, PR Smoke including workspace fmt, Windows Guardrails compile/module-separator/sandbox), not just per-crate. Per the 2026-04-26 master-green directive: per-crate gates miss workspace drift.
 
 3. **Policy gate (defense-in-depth)** — run the scripted pre-merge guard:
    ```bash
@@ -72,6 +74,18 @@ Merge up to 3 PRs from the candidates identified in step 1.
    - CI green on old SHA → skip, note "stale CI — needs rerun"
    - Draft → skip, note "still in review"
    - Missing `deep-reviewed` on a non-docs PR → skip, note "missing deep review signal"
+   - **Active `needs-*` label** → skip, note "sign-off contradicted by needs-* routing label; gate has not actually cleared"
+   - mergeStateStatus = UNSTABLE → skip, note "non-required check failing or in flight; verify which before forcing"
+
+8. **After each batch of 3** — verify master is genuinely green BEFORE starting the next batch:
+   ```bash
+   gh run list --workflow=CI --branch=master --limit=3 --json conclusion,headSha,event,name
+   ```
+   Required: latest master CI run on the merged SHA = SUCCESS. If master goes red post-merge:
+   - Halt the queue immediately
+   - Report which merge introduced the regression (compare master CI logs to recent merges)
+   - Dispatch a master-fix path (narrow fix PR, admin-merge, cascade-update queued PRs)
+   - Do NOT continue merging until master is verified green
 
 ## Rules
 

--- a/.claude/commands/reviewer-decide.md
+++ b/.claude/commands/reviewer-decide.md
@@ -7,6 +7,18 @@ user-invocable: false
 
 Based on steps 1-3, make a decision.
 
+## Operating principle (per the 2026-04-26 directive)
+
+Sign-off IS one of the routing decisions. Each pass produces exactly ONE outcome:
+
+- **Gate clean** → apply `review-reviewed` (and only `review-reviewed`)
+- **Mechanical fix applied** → push the fix; the post-fix state is gate-clean → apply `review-reviewed`
+- **Bounce back (blocker found)** → apply `needs-builder-fix` (and only `needs-builder-fix`); do **NOT** also apply `review-reviewed`
+
+The contradictory state of `review-reviewed` AND `needs-builder-fix` simultaneously (the 2026-04-26 #6780 incident) is forbidden — it lets unfixed bugs ride the merge gate.
+
+**Default posture**: every PR is potentially problematic until you've substantively cleared it. "Approved with no changes" is almost never right — find something concrete to flag, fix, or improve. Thin LGTM-shaped output without a single substantive observation is itself a signal you didn't look hard enough.
+
 ## Decision tree
 
 ### Docs-only PRs → Fast-track without `deep-reviewed`
@@ -51,16 +63,40 @@ Then write a version-bound receipt:
 
 **Do NOT call `gh pr review --approve`.** The reviewer's job is the standards pass only. Deep review is the approval gate.
 
+### Blocker found → Send back WITHOUT sign-off
+
+When you find substantive blocking issues that you cannot mechanically fix forward:
+- Wrong language reference, hallucinated API call, scope mismatch between title and diff
+- Missing required code that the title claims (e.g., title says "fix manifest" but diff is docs-only)
+- Test regression a fix-forward would mask
+- Cross-PR contamination in source/test files (not just `.hermes/`)
+- Banned production patterns the builder must address
+
+Apply ONLY the routing label, NOT the sign-off:
+```bash
+gh pr edit <number> --add-label "needs-builder-fix"
+gh pr comment <number> --body "Standards review: NEEDS BUILDER — <specific blockers>.
+
+Blockers:
+1. <file:line> — <what's wrong> — <what to do>
+2. ...
+
+Not signing off (\`review-reviewed\` not applied) per the 2026-04-26 sign-off-as-routing rule. Will re-run after fix."
+```
+
+**DO NOT also apply `review-reviewed`.** Sign-off and bounce are mutually exclusive — they are the same routing decision with different outcomes. Applying both is the #6780 failure mode (let unfixed bugs ride to merge).
+
 ### Structural problems → Send back to builder
 
-**Only send back when:**
+**Only send back at this severity when:**
 - The approach is fundamentally wrong (wrong crate, wrong architecture)
 - The issue has been flagged with critical review states in earlier pipeline stages
 - The codebase has moved so much the PR can't be salvaged with local fixes
 
-If you must send back:
+If you must send back at structural severity:
 1. Leave specific, actionable review comments
-2. `SendMessage({to: "builder"})` with the blocker list
+2. Apply `needs-builder-fix` (NOT `review-reviewed`)
+3. `SendMessage({to: "builder"})` with the blocker list
 
 ## Rules
 


### PR DESCRIPTION
## Summary

PR #6808 landed the master-green / sign-off-as-routing / oppositional-throughout principles in agent definitions + CLAUDE.md. **This PR carries those principles into the actual playbook skills agents invoke at decision points** — without skill updates, the rules sit in the agent prompts but the runtime steps still allow contradictory states.

## What's in this PR

4 key decision-point skills updated with operating-principle blocks + procedural changes:

### `ops-check-queue.md`
- Filter requires `mergeStateStatus = CLEAN` (rejects UNSTABLE/UNKNOWN)
- Filter excludes any active `needs-*` routing label
- Latest-per-check filter for CI status
- New CONTRADICTORY classification for `merge-ready` + `needs-*`

### `ops-merge-batch.md`
- Pre-merge requires CLEAN, no `needs-*`, workspace-wide CI SUCCESS
- New skip conditions for `needs-*` and UNSTABLE
- New Step 8: master-green re-verification after each batch
- Halt-and-report protocol on post-merge master regression

### `reviewer-decide.md`
- Operating principle: sign-off IS one of the routing decisions
- Default posture: every PR potentially problematic
- New explicit \"Blocker found → send back WITHOUT sign-off\" branch

### `diff-audit-comment.md`
- Operating principle: CLEAN OR needs-diff-fix, never both
- Pre-comment checks: cross-PR source-file contamination (not just \`.hermes/\`); master-green guard

## Why these 4

These are the actual runtime decision points. PR #6808 stated the rules in agent definitions; this PR enforces them in the playbooks the agents read while operating.

## Test plan

- [ ] No production code touched (skill markdown only)
- [ ] CI passes (docs-only, green by construction)
- [ ] Future agent dispatches reference the new procedural enforcement