### PR TITLE
fix(perl-lsp-rs-core): block workspace perlPath/perlArgs for @INC probe [rebased onto fresh-root master] (#3729)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/mod.rs
+++ b/crates/perl-lsp-rs-core/src/config/mod.rs
@@ -541,21 +541,11 @@ impl WorkspaceConfig {
                 }
                 self.use_system_inc = use_inc;
             }
-            if let Some(perl_path) = workspace.get("perlPath").and_then(|v| v.as_str()) {
-                let next = Some(perl_path.to_string());
-                if next != self.perl_path {
-                    self.system_inc_cache = None;
-                }
-                self.perl_path = next;
-            }
-            if let Some(perl_args) = workspace.get("perlArgs").and_then(|v| v.as_array()) {
-                let next: Vec<String> =
-                    perl_args.iter().filter_map(|v| v.as_str().map(str::to_string)).collect();
-                if next != self.perl_args {
-                    self.system_inc_cache = None;
-                }
-                self.perl_args = next;
-            }
+            // Security: do NOT honour workspace-supplied perlPath / perlArgs.
+            // Allowing arbitrary Perl interpreter / argv from workspace settings
+            // would let a hostile project execute arbitrary code via the @INC
+            // probe (issue #3729). The interpreter / args remain whatever the
+            // user (not the workspace) configured globally.
             if let Some(timeout) = workspace.get("resolutionTimeout").and_then(|v| v.as_u64()) {
                 self.resolution_timeout_ms = timeout;
             }
@@ -1162,5 +1152,21 @@ perltidy_extra_args = ["-noll"]
 
         let paths = config.effective_include_paths(&["./lib/".to_string(), " ./ ".to_string()]);
         assert_eq!(paths, vec!["lib", "."]);
+    }
+
+    /// Security regression: workspace settings must not be able to redirect the
+    /// Perl interpreter / argv used for the @INC probe (issue #3729). A hostile
+    /// project could otherwise execute arbitrary code at config-load time.
+    #[test]
+    fn workspace_config_ignores_untrusted_perl_probe_settings() {
+        let mut config = WorkspaceConfig::default();
+        config.update_from_value(&serde_json::json!({
+            "workspace": {
+                "perlPath": "/opt/custom/perl",
+                "perlArgs": ["-I", "/tmp/custom/lib"]
+            }
+        }));
+        assert!(config.perl_path.is_none(), "perlPath from workspace must be ignored");
+        assert!(config.perl_args.is_empty(), "perlArgs from workspace must be ignored");
     }
 }


### PR DESCRIPTION
## Summary

Cherry-pick recovery of #6051 onto the post-2026-04-24 fresh-root master.

The original PR was stranded by the master fresh-root rebuild — its branch had no merge-base with current master, so `gh pr update-branch` and `git merge` both failed (per `feedback_fresh_root_master_rebuild.md`).

This PR ports the same security fix to its new home: `crates/perl-lsp-config/src/lib.rs` was absorbed into `crates/perl-lsp-rs-core/src/config/mod.rs` during the microcrate collapse, so the original commit could not apply cleanly. The change is identical in intent and behaviour.

## Change

Workspace-supplied `perlPath` / `perlArgs` are now ignored by `WorkspaceConfig::update_from_value`. A hostile project could otherwise direct the @INC probe to execute arbitrary code at config-load time. Only user-level (not workspace-level) configuration may choose the Perl interpreter.

## Test plan

- [x] New regression test `workspace_config_ignores_untrusted_perl_probe_settings` asserts that `perlPath` / `perlArgs` from workspace settings do NOT mutate `WorkspaceConfig`
- [x] `cargo test -p perl-lsp-rs-core --lib config::` — 18 passed
- [x] `cargo xtask fmt -p perl-lsp-rs-core` — clean

## Supersedes

#6051 (will be closed after this lands).

Closes #3729.