### PR TITLE
feat(tree-sitter-perl-c): add typed parse error APIs [rebased onto fresh-root master] (#5386)

### DIFF
--- a/crates/tree-sitter-perl-c/README.md
+++ b/crates/tree-sitter-perl-c/README.md
@@ -70,6 +70,20 @@ for snippet in &["my $x = 1;", "print $x;"] {
 }
 ```
 
+Typed parse helpers expose a small error surface:
+
+```rust
+use tree_sitter_perl_c::{try_parse_perl_file, ParsePerlError};
+
+match try_parse_perl_file("script.pl") {
+    Ok(tree) => println!("{}", tree.root_node().kind()),
+    Err(ParsePerlError::Io(err)) => eprintln!("read failure: {err}"),
+    Err(ParsePerlError::LanguageSetup(_)) => eprintln!("parser setup failed"),
+    Err(ParsePerlError::ParseReturnedNone) => eprintln!("parse cancelled or timed out"),
+    Err(_) => eprintln!("unknown parse failure"),
+}
+```
+
 ## Public API
 
 | Function | Description |
@@ -82,6 +96,10 @@ for snippet in &["my $x = 1;", "print $x;"] {
 | `parse_perl_code(code)` | Parses a `&str` into a `tree_sitter::Tree` |
 | `parse_perl_code_with_parser(parser, code)` | Parses a `&str` with a caller-provided configured parser |
 | `parse_perl_file(path)` | Reads and parses a file (non-UTF-8 safe) |
+| `try_parse_perl_bytes(code)` | Typed parse API (`ParsePerlError`) for byte slices |
+| `try_parse_perl_code(code)` | Typed parse API (`ParsePerlError`) for `&str` |
+| `try_parse_perl_file(path)` | Typed parse API (`ParsePerlError`) for file paths |
+| `ParsePerlError` | Distinguishes setup, parse-none, and IO failures |
 | `get_scanner_config()` | Returns `"c-scanner"` |
 
 ## Binaries

--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -39,7 +39,7 @@
 //! [`perl-parser`]: https://docs.rs/perl-parser
 //! [`tree-sitter-perl-rs`]: https://docs.rs/tree-sitter-perl-rs
 
-use std::path::Path;
+use std::{fmt, path::Path};
 use tree_sitter::{Language, Parser};
 
 /// Reusable Perl parser for hot parse loops.
@@ -49,6 +49,52 @@ use tree_sitter::{Language, Parser};
 #[non_exhaustive]
 pub struct PerlParser {
     parser: Parser,
+}
+
+/// Typed errors produced by Perl parse helpers in this crate.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum ParsePerlError {
+    /// Configuring the parser with the Perl language failed.
+    LanguageSetup(tree_sitter::LanguageError),
+    /// Tree-sitter returned `None` instead of a parse tree.
+    ParseReturnedNone,
+    /// Reading source bytes from disk failed.
+    Io(std::io::Error),
+}
+
+impl fmt::Display for ParsePerlError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LanguageSetup(error) => {
+                write!(f, "failed to configure parser language: {error:?}")
+            }
+            Self::ParseReturnedNone => write!(f, "tree-sitter returned no parse tree"),
+            Self::Io(error) => write!(f, "failed to read Perl source file: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for ParsePerlError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::LanguageSetup(error) => Some(error),
+            Self::ParseReturnedNone => None,
+            Self::Io(error) => Some(error),
+        }
+    }
+}
+
+impl From<tree_sitter::LanguageError> for ParsePerlError {
+    fn from(value: tree_sitter::LanguageError) -> Self {
+        Self::LanguageSetup(value)
+    }
+}
+
+impl From<std::io::Error> for ParsePerlError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
 }
 
 /// Returns the tree-sitter [`Language`] for Perl (C grammar).
@@ -124,6 +170,16 @@ impl PerlParser {
     }
 }
 
+fn try_parse_with_parser(
+    parser: &mut Parser,
+    code: &[u8],
+) -> Result<tree_sitter::Tree, ParsePerlError> {
+    match parser.parse(code, None) {
+        Some(tree) => Ok(tree),
+        None => Err(ParsePerlError::ParseReturnedNone),
+    }
+}
+
 /// Creates a [`tree_sitter::Parser`] configured for Perl, silently ignoring
 /// language-set errors.
 ///
@@ -162,8 +218,16 @@ pub fn create_parser() -> Parser {
 /// Returns an error if the parser cannot be initialised (version mismatch) or
 /// if tree-sitter returns `None` from `parse` (cancelled or timed out).
 pub fn parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    let mut parser = PerlParser::new()?;
-    parser.parse_bytes(code)
+    try_parse_perl_bytes(code).map_err(Into::into)
+}
+
+/// Parses Perl source bytes and returns the resulting [`tree_sitter::Tree`].
+///
+/// This typed variant allows callers to distinguish parser setup failures from
+/// parse cancellation/timeouts (`None` from tree-sitter).
+pub fn try_parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, ParsePerlError> {
+    let mut parser = try_create_parser().map_err(ParsePerlError::LanguageSetup)?;
+    try_parse_with_parser(&mut parser, code)
 }
 
 /// Parses Perl source bytes using a caller-provided configured [`tree_sitter::Parser`].
@@ -202,8 +266,15 @@ pub fn parse_perl_bytes_with_parser(
 /// assert!(!tree.root_node().has_error());
 /// ```
 pub fn parse_perl_code(code: &str) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    let mut parser = try_create_parser()?;
-    parse_perl_code_with_parser(&mut parser, code)
+    try_parse_perl_code(code).map_err(Into::into)
+}
+
+/// Parses a Perl source string and returns the resulting [`tree_sitter::Tree`].
+///
+/// This typed variant allows callers to inspect whether parser setup failed or
+/// tree-sitter returned no parse tree.
+pub fn try_parse_perl_code(code: &str) -> Result<tree_sitter::Tree, ParsePerlError> {
+    try_parse_perl_bytes(code.as_bytes())
 }
 
 /// Parses a Perl source string using a caller-provided configured [`tree_sitter::Parser`].
@@ -231,8 +302,16 @@ pub fn parse_perl_code_with_parser(
 pub fn parse_perl_file<P: AsRef<Path>>(
     path: P,
 ) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    let code = std::fs::read(path)?;
-    parse_perl_bytes(&code)
+    try_parse_perl_file(path).map_err(Into::into)
+}
+
+/// Reads a file from `path` and parses it as Perl source.
+///
+/// This typed variant allows callers to distinguish IO failures from parser
+/// setup and parse-`None` outcomes.
+pub fn try_parse_perl_file<P: AsRef<Path>>(path: P) -> Result<tree_sitter::Tree, ParsePerlError> {
+    let code = std::fs::read(path).map_err(ParsePerlError::Io)?;
+    try_parse_perl_bytes(&code)
 }
 
 /// Returns the scanner backend identifier for this crate.
@@ -311,6 +390,19 @@ mod tests {
         assert!(!second.root_node().has_error());
 
         Ok(())
+    }
+
+    #[test]
+    fn test_typed_parse_none_error_variant_is_emitted() {
+        let mut parser = Parser::new();
+        let result = try_parse_with_parser(&mut parser, b"my $var = 'hello';");
+        assert!(matches!(result, Err(ParsePerlError::ParseReturnedNone)));
+    }
+
+    #[test]
+    fn test_typed_language_setup_error_variant_mapping() {
+        let error = ParsePerlError::from(tree_sitter::LanguageError::Version(0));
+        assert!(matches!(error, ParsePerlError::LanguageSetup(_)));
     }
 
     #[test]

--- a/crates/tree-sitter-perl-c/tests/bdd_workflows.rs
+++ b/crates/tree-sitter-perl-c/tests/bdd_workflows.rs
@@ -13,8 +13,8 @@ use std::{
 
 use tree_sitter::{Query, QueryCursor, StreamingIterator};
 use tree_sitter_perl_c::{
-    create_parser, get_scanner_config, language, parse_perl_code, parse_perl_file,
-    try_create_parser,
+    ParsePerlError, create_parser, get_scanner_config, language, parse_perl_code, parse_perl_file,
+    try_create_parser, try_parse_perl_file,
 };
 
 struct Scenario {
@@ -246,6 +246,19 @@ fn bdd_parse_perl_file_with_recoverable_errors_returns_tree_with_errors()
 
     fs::remove_file(&file)?;
     Ok(())
+}
+
+#[test]
+fn bdd_typed_file_parse_error_reports_io_failure_variant() {
+    let scenario = Scenario::new("typed parse reports io failure");
+    let missing = unique_temp_file("missing");
+
+    scenario.given("a missing Perl source file path");
+    scenario.when("try_parse_perl_file is invoked");
+    let error = try_parse_perl_file(&missing);
+
+    scenario.then("callers should receive the IO-specific error variant");
+    assert!(matches!(error, Err(ParsePerlError::Io(_))));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Cherry-pick recovery of #6138 onto the post-2026-04-24 fresh-root master.

The original PR was stranded by the master fresh-root rebuild — its branch had no merge-base with current master, so `gh pr update-branch` and `git merge` both failed (per `feedback_fresh_root_master_rebuild.md`).

## Conflict resolution notes

Master gained `PerlParser` (reusable parser instance) independently after the original PR's branch point. This recovery preserves both:
- `PerlParser` reusable parser (from master) — kept verbatim
- `ParsePerlError` typed error enum + `try_parse_*` helpers (from #6138) — added alongside

The two features compose: callers needing typed errors use `try_parse_perl_*`; callers needing a hot-loop parser use `PerlParser`. The BDD tests for both pre-existing recoverable-error parsing and new typed IO-failure variants now coexist.

## Change

Adds typed parse error APIs to `tree-sitter-perl-c`:

- New `ParsePerlError` enum with `LanguageSetup`, `ParseReturnedNone`, `Io` variants
- New `try_parse_perl_bytes`, `try_parse_perl_code`, `try_parse_perl_file` typed counterparts to existing untyped helpers
- Existing untyped `parse_perl_*` helpers now delegate via `Into<Box<dyn Error>>` for backward compatibility
- README documents the typed API surface
- BDD test asserts the IO-failure variant is emitted from missing-file paths
- Unit tests cover the language-setup and parse-returned-none variants

## Test plan

- [x] `cargo build -p tree-sitter-perl-c` — clean
- [x] `cargo test -p tree-sitter-perl-c` — 32 passed across unit, BDD, regression, query-conformance, doc tests
- [x] `cargo xtask fmt -p tree-sitter-perl-c` — clean

## Supersedes

#6138 (will be closed after this lands).

Closes #5386.