### PR TITLE
docs(helix): fix perllsp command examples [rebased onto fresh-root master] (#6841)

### DIFF
--- a/docs/EDITORS/HELIX_SETUP.md
+++ b/docs/EDITORS/HELIX_SETUP.md
@@ -104,7 +104,7 @@ indent = { tab-width = 4, unit = "    " }
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
-command = "perl-lsp"
+command = "perllsp"
 args = ["--stdio"]
 ```
 
@@ -137,7 +137,7 @@ indent = { tab-width = 4, unit = "    " }
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
-command = "perl-lsp"
+command = "perllsp"
 args = ["--stdio"]
 
 [language-server.perl-lsp.config.perl]
@@ -356,8 +356,8 @@ h = { i = ":inlay_hints" }
 
 1. **Verify binary is in PATH**:
    ```bash
-   which perl-lsp
-   # Should output: /usr/local/bin/perl-lsp or similar
+   which perllsp
+   # Should output: /usr/local/bin/perllsp or similar
    ```
 
 2. **Check LSP status**:
@@ -511,7 +511,7 @@ Set environment variables for the LSP server:
 ```toml
 [language-server.perl-lsp]
 command = "env"
-args = ["PERL5LIB=lib", "PERL_MB_OPT=--install_base local", "perl-lsp", "--stdio"]
+args = ["PERL5LIB=lib", "PERL_MB_OPT=--install_base local", "perllsp", "--stdio"]
 ```
 
 ### Custom Formatter
@@ -606,7 +606,7 @@ indent = { tab-width = 4, unit = "    " }
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
-command = "perl-lsp"
+command = "perllsp"
 args = ["--stdio"]
 
 [language-server.perl-lsp.config.perl]


### PR DESCRIPTION
Replaces #5450 which was stranded by the 2026-04-24 master fresh-root rebuild (no merge-base). Cherry-picked the topical commit onto fresh master per `feedback_fresh_root_master_rebuild.md` playbook.

### Topical commit cherry-picked
- `622d292bd` docs(helix): fix perllsp command examples

### Original Motivation
- Helix documentation referred to the wrong binary name (`perl-lsp`) which prevents users from launching the server with the intended `perllsp` CLI.
- The compact Helix snippet in the general editor setup guide used an invalid shape and omitted the required `[[language]]` to `[language-server.<name>]` mapping.

### Description
- Replaced `perl-lsp` examples with `perllsp` in `docs/EDITORS/HELIX_SETUP.md`.
- The other file (`docs/how-to/EDITOR_SETUP.md`) auto-merged cleanly — the relevant change was already on master from #5568.

### Testing (post-rebase, fresh master `f84521c49`)
- Documentation-only change; no code-level testing required.
- Manual review confirms all `perl-lsp` references in HELIX_SETUP.md are now `perllsp`.

Supersedes #5450.