### PR TITLE
docs(readme): expand non-VS Code editor setup snippets [rebased onto fresh-root master] (#6842)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,30 @@ require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
              '((perl-mode cperl-mode) . ("perllsp" "--stdio")))
 ```
 
+```toml
+# Helix (~/.config/helix/languages.toml)
+[[language]]
+name = "perl"
+language-servers = ["perllsp"]
+
+[language-server.perllsp]
+command = "perllsp"
+args = ["--stdio"]
+```
+
+```json
+// Sublime Text LSP package settings
+{
+  "clients": {
+    "perllsp": {
+      "enabled": true,
+      "command": ["perllsp", "--stdio"],
+      "selector": "source.perl"
+    }
+  }
+}
+```
+
 ```text
 # Any generic LSP client
 perllsp --stdio
@@ -59,6 +83,7 @@ perllsp --health
 ```
 
 For a full walkthrough, see [docs/tutorials/GETTING_STARTED.md](docs/tutorials/GETTING_STARTED.md).
+For editor-specific setup (Neovim, Emacs, Helix, Sublime), see [docs/specs/PACKAGING_INSTALL_SPEC.md](docs/specs/PACKAGING_INSTALL_SPEC.md).
 
 > **Note:** Do not use `cargo install perl-lsp` â€” that name is owned by an unrelated project on crates.io. Use `cargo install --path crates/perllsp` to build from source.
 


### PR DESCRIPTION
Replaces #5485 which was stranded by the 2026-04-24 master fresh-root rebuild (no merge-base). Cherry-picked the topical commit onto fresh master per `feedback_fresh_root_master_rebuild.md` playbook.

### Topical commit cherry-picked
- `ad8e5a055` docs(readme): expand non-VS Code editor setup snippets

### Description
- Adds expanded non-VS Code editor setup snippets to README.md (25 line additions, no code changes).
- Auto-merged cleanly with current master.

### Testing (post-rebase, fresh master `f84521c49`)
- Documentation-only change; no code-level testing required.

Supersedes #5485.