### PR TITLE
docs(neovim): improve lspconfig setup guidance [rebased onto fresh-root master] (#6843)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,16 @@ The extension auto-downloads the matching `perllsp` binary for your platform.
 
 ```lua
 -- Neovim (nvim-lspconfig)
-require('lspconfig').perl_ls.setup { cmd = { "perllsp", "--stdio" } }
+local capabilities = vim.lsp.protocol.make_client_capabilities()
+local ok_cmp, cmp_lsp = pcall(require, "cmp_nvim_lsp")
+if ok_cmp then
+  capabilities = cmp_lsp.default_capabilities(capabilities)
+end
+
+require("lspconfig").perl_lsp.setup({
+  cmd = { "perllsp", "--stdio" },
+  capabilities = capabilities,
+})
 ```
 
 ```elisp

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -51,9 +51,16 @@ panel, or configure a generic language server command as `perllsp --stdio`.
 ### Neovim
 
 ```lua
-require('lspconfig').perl_lsp.setup({
-  cmd = { 'perllsp', '--stdio' },
-  filetypes = { 'perl' },
+local capabilities = vim.lsp.protocol.make_client_capabilities()
+local ok_cmp, cmp_lsp = pcall(require, "cmp_nvim_lsp")
+if ok_cmp then
+  capabilities = cmp_lsp.default_capabilities(capabilities)
+end
+
+require("lspconfig").perl_lsp.setup({
+  cmd = { "perllsp", "--stdio" },
+  filetypes = { "perl" },
+  capabilities = capabilities,
 })
 ```
 


### PR DESCRIPTION
Replaces #5473 which was stranded by the 2026-04-24 master fresh-root rebuild (no merge-base). Cherry-picked the topical commit onto fresh master per `feedback_fresh_root_master_rebuild.md` playbook.

### Topical commit cherry-picked
- `98b83223e` docs(neovim): improve lspconfig setup guidance

### Description
- Adds improved lspconfig setup guidance for Neovim users (README.md + docs/how-to/EDITOR_SETUP.md, 20 line additions / 4 deletions).
- Auto-merged cleanly with current master.

### Testing (post-rebase, fresh master `f84521c49`)
- Documentation-only change; no code-level testing required.

Supersedes #5473.