### PR TITLE
docs(vim): add dedicated Vim setup path [rebased onto fresh-root master] (#6845)

### DIFF
--- a/docs/EDITORS/VIM_SETUP.md
+++ b/docs/EDITORS/VIM_SETUP.md
@@ -1,0 +1,75 @@
+# Vim Setup Guide for perl-lsp
+
+This guide covers classic Vim setup (not Neovim). Use this when you want
+`perllsp` features such as diagnostics, go-to-definition, references, and
+rename directly in Vim.
+
+## Prerequisites
+
+- Vim 8.2+ (or newer)
+- `perllsp` installed and available on your `PATH`
+- one LSP client plugin:
+  - [`vim-lsp`](https://github.com/prabirshrestha/vim-lsp), or
+  - [`coc.nvim`](https://github.com/neoclide/coc.nvim)
+
+Quick verification:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Option A: vim-lsp
+
+Add this to your `.vimrc` after loading `vim-lsp`:
+
+```vim
+if executable('perllsp')
+  augroup perllsp_vim
+    autocmd!
+    autocmd User lsp_setup call lsp#register_server({
+          \ 'name': 'perllsp',
+          \ 'cmd': {server_info->['perllsp', '--stdio']},
+          \ 'allowlist': ['perl'],
+          \ })
+  augroup END
+endif
+```
+
+Useful default mappings (optional):
+
+```vim
+nmap <buffer> gd <plug>(lsp-definition)
+nmap <buffer> gr <plug>(lsp-references)
+nmap <buffer> K  <plug>(lsp-hover)
+nmap <buffer> <leader>rn <plug>(lsp-rename)
+```
+
+## Option B: coc.nvim
+
+If you already use coc.nvim, configure `perllsp` in `coc-settings.json`:
+
+```json
+{
+  "languageserver": {
+    "perl-lsp": {
+      "command": "perllsp",
+      "args": ["--stdio"],
+      "filetypes": ["perl"]
+    }
+  }
+}
+```
+
+For a full coc-focused walkthrough, see
+[COC_NEOVIM_SETUP.md](./COC_NEOVIM_SETUP.md).
+
+## Troubleshooting
+
+- If Vim reports the server is not executable, run `:echo executable('perllsp')`
+  and fix your `PATH`.
+- If the server starts but no Perl features appear, confirm filetype detection:
+  `:set filetype?` should return `filetype=perl`.
+- If features are intermittent, check client logs:
+  - vim-lsp: `:LspStatus`
+  - coc.nvim: `:CocInfo`

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -26,6 +26,7 @@ perllsp --health
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
 | Trae (ByteDance) | install the VS Code-compatible extension or set command to `perllsp --stdio` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
+| Vim | use `vim-lsp` or `coc.nvim` with `perllsp --stdio` | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Zed | install a Perl extension, then optionally point at `perllsp` | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
@@ -61,6 +62,12 @@ require('lspconfig').perl_lsp.setup({
 
 Use `lsp-mode` or `eglot` with the same `perllsp --stdio` command. The
 editor-specific guide has the full snippets for both.
+
+### Vim
+
+Use either `vim-lsp` (native LSP in Vim) or `coc.nvim` (Node-based client),
+both configured to launch `perllsp --stdio`. See
+[docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) for complete examples.
 
 ### Helix
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -306,7 +306,7 @@ main() {
     say ""
     say "Get started:"
     say "  VS Code:  install the Perl LSP extension from the marketplace"
-    say "  Neovim:   add perllsp to your LSP config"
+    say "  Vim/Neovim: add perllsp to your LSP config"
     say "  Other:    configure to use '${INSTALL_DIR}/${BIN_NAME} --stdio'"
     say ""
     say "Docs: https://github.com/$REPO"


### PR DESCRIPTION
Replaces #5480 which was stranded by the 2026-04-24 master fresh-root rebuild (no merge-base). Cherry-picked the topical commit onto fresh master per `feedback_fresh_root_master_rebuild.md` playbook.

### Topical commit cherry-picked
- `c31bf263d` docs(vim): add dedicated Vim setup path

### Description
- Adds a dedicated `docs/EDITORS/VIM_SETUP.md` (new file).
- Updates `docs/how-to/EDITOR_SETUP.md` to link the new Vim path.
- Trivial install.sh tweak: 'Neovim:' line now reads 'Vim/Neovim:' (1-line change).
- Auto-merged cleanly with current master.

### Testing (post-rebase, fresh master `f84521c49`)
- `bash -n scripts/install.sh` — clean (shell syntax OK).
- Documentation-only change otherwise; no code-level testing required.

Supersedes #5480.