### PR TITLE
docs(editors): add Codex Desktop setup guide [rebased] (#6848)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ code --install-extension effortlessmetrics.perl-lsp-rs
 
 The extension auto-downloads the matching `perllsp` binary for your platform.
 
-**Other editors:** download a prebuilt binary from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases), add it to your `PATH`, then point your LSP client at it:
+**Codex Desktop** — add a custom Perl language server command that runs `perllsp --stdio` (guide: [docs/EDITORS/CODEX_DESKTOP_SETUP.md](docs/EDITORS/CODEX_DESKTOP_SETUP.md)).
+
+**Other editors** â€” download a prebuilt binary from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases), add it to your `PATH`, then point your LSP client at it:
 
 ```lua
 -- Neovim (nvim-lspconfig)

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@
 
 ---
 
-A native Rust LSP and DAP server for Perl 5, with its own parser and lexer. No Perl runtime is required for IDE features.
+Perl has lacked a proper modern LSP implementation. Other languages — Rust, TypeScript, Go, Python — have mature language servers with fast completions, reliable navigation, and full debugger integration. Perl's existing options were slow, incomplete, or required a working Perl runtime just to get basic editor features. `perl-lsp` fills that gap: a native Rust implementation of the Language Server Protocol and Debug Adapter Protocol for Perl 5, with its own parser and lexer, no Perl runtime required for IDE features.
 
 ## What It Is
 
-A workspace of Rust crates: an LSP server (`perllsp`) wired to 119 capabilities catalogued in `features.toml` (88 LSP, 24 DAP, 7 extension), a DAP debug adapter, a recursive-descent parser, a context-aware lexer, and a semantic analyzer. Single native binary, runs on Windows, macOS, and Linux.
+`perl-lsp` is a workspace of Rust crates delivering a complete Perl 5 tooling stack: an LSP server (`perllsp`) implementing all 119 capabilities catalogued in `features.toml` (88 LSP + 24 DAP + 7 extension features), a DAP debug adapter, a recursive-descent parser, a context-aware lexer, and a semantic analyzer — packaged as a single native binary you can drop into any editor. It runs on Windows, macOS, and Linux.
 
 ## Quick Start
 
-**VS Code:** install the extension:
+**VS Code** — install the extension and you are done:
 
 ```bash
 code --install-extension effortlessmetrics.perl-lsp-rs
@@ -36,7 +36,7 @@ The extension auto-downloads the matching `perllsp` binary for your platform.
 
 **Codex Desktop** — add a custom Perl language server command that runs `perllsp --stdio` (guide: [docs/EDITORS/CODEX_DESKTOP_SETUP.md](docs/EDITORS/CODEX_DESKTOP_SETUP.md)).
 
-**Other editors** â€” download a prebuilt binary from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases), add it to your `PATH`, then point your LSP client at it:
+**Other editors** — download a prebuilt binary from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases), add it to your `PATH`, then point your LSP client at it:
 
 ```lua
 -- Neovim (nvim-lspconfig)
@@ -96,58 +96,39 @@ perllsp --health
 For a full walkthrough, see [docs/tutorials/GETTING_STARTED.md](docs/tutorials/GETTING_STARTED.md).
 For editor-specific setup (Neovim, Emacs, Helix, Sublime), see [docs/specs/PACKAGING_INSTALL_SPEC.md](docs/specs/PACKAGING_INSTALL_SPEC.md).
 
-> **Note:** Do not use `cargo install perl-lsp`. That name is owned by an unrelated project on crates.io. Use `cargo install --path crates/perllsp` to build from source.
+> **Note:** Do not use `cargo install perl-lsp` — that name is owned by an unrelated project on crates.io. Use `cargo install --path crates/perllsp` to build from source.
 
 ## Key Features
 
-See [what the numbers mean](#what-the-numbers-mean-and-dont) for the scope of each claim.
-
-- **LSP capabilities wired up:** completions, diagnostics, hover, goto-definition, find references, rename, formatting, semantic tokens, inlay hints, code actions, code lens, workspace symbols
-- **Native debug adapter:** DAP breakpoints, stepping, stack frames, variable inspection, evaluate; no wrapper script
-- **Native parser:** recursive-descent v3 parser with a context-aware lexer, validated against a curated CPAN corpus
-- **Semantic analysis:** symbol resolution, scope tracking, Moose/Moo method modifiers and role composition
-- **Refactoring:** extract variable, extract subroutine, workspace-scoped rename, subroutine inlining
-- **Diagnostics:** dead code highlighting, strict/warnings, perlcritic integration with walk-up discovery
-- **No Perl runtime required** for IDE features. Single native binary.
-- **Windows first-class:** install, path handling, and shell interactions are part of the release surface.
+- **Full LSP surface** — completions, diagnostics, hover, go-to-definition, find references, rename, formatting, semantic tokens, inlay hints, code actions, code lens, workspace symbols; every capability in `features.toml` has an implementation wired up (see [what the numbers mean](#what-the-numbers-mean-and-dont))
+- **Native debug adapter** — DAP breakpoints, stepping, stack frames, variable inspection, and evaluate; no wrapper script required
+- **Fast native parser** — recursive-descent v3 parser with a context-aware lexer; validated against a curated CPAN corpus
+- **Semantic analysis** — symbol resolution, scope tracking, Moose/Moo method modifiers and role composition
+- **Refactoring** — extract variable, extract subroutine, workspace-scoped rename, subroutine inlining
+- **Diagnostics** — dead code highlighting, strict/warnings diagnostics, perlcritic integration with walk-up discovery and explicit tooling warnings
+- **Zero-Perl dependency** for IDE features — the server is a single native binary
+- **Windows first-class** — install, path handling, and shell interactions are part of the release surface
 
 ## Architecture
 
-The native Rust parser stack is the center of the workspace. LSP server, diagnostics, hover, completion, and every other IDE feature read from it directly. Tree-sitter integration is an interop surface layered over that core, not a dependency of it.
-
-### Repository map (at a glance)
-
-If you're new to the repo, use this as a quick orientation map before diving into crate-level docs:
-
-| Path | What lives there |
-| --- | --- |
-| `crates/` | Rust workspace crates (LSP server, parser/lexer, semantic analysis, refactoring, DAP, UX tests, and supporting libraries) |
-| `docs/` | User guides, architecture docs, reference material, project status, ADRs, and roadmap docs |
-| `test_corpus/` | Regression fixtures, parser corpora, and workspace-scale test projects |
-| `vscode-extension/` | VS Code extension packaging and integration assets |
-| `xtask/` | Project maintenance automation (`cargo xtask ...`) for checks, reports, and release/status helpers |
-| `scripts/` | Contributor and CI helper scripts not bundled into `xtask` |
-| `features.toml` | Canonical LSP/DAP/extension capability catalog used by governance checks |
-| `Cargo.toml` | Workspace manifest (members, shared dependency policy, and release metadata) |
-
-For the full crate-by-crate map (with role explanations), start with [docs/README.md](docs/README.md) and then [docs/reference/CRATE_ARCHITECTURE_GUIDE.md](docs/reference/CRATE_ARCHITECTURE_GUIDE.md).
+The native Rust parser stack is the architectural center of the workspace — the LSP server, diagnostics, hover, completion, and every other IDE feature read from it directly. Tree-sitter integration is an interop surface layered over that core, not a dependency of it.
 
 ### Entry points for external consumers
 
 Different users walk in through different doors. Pick the one that matches your use case:
 
-| You want to | Use |
+| You want to… | Use |
 | --- | --- |
 | Get Perl IDE features in an editor | VS Code extension (`perl-lsp-rs`) or the `perllsp` binary from [Releases](https://github.com/EffortlessMetrics/perl-lsp/releases) |
-| Perl tree-sitter grammar (Neovim, Helix, GitHub) | [`tree-sitter-perl-c`](crates/tree-sitter-perl-c): conventional C grammar binding |
-| Tree-sitter ergonomics from Rust | [`tree-sitter-perl-rs`](crates/tree-sitter-perl-rs): Rust facade over the v3 parser *(in development)* |
-| Parse Perl from Rust directly | [`perl-parser`](crates/perl-parser) + [`perl-lexer`](crates/perl-lexer): the recursive-descent v3 parser |
-| Tokenize Perl only | [`perl-lexer`](crates/perl-lexer): context-aware tokenizer, no parse tree |
-| Resolve symbols and scopes (incl. Moose/Moo) | [`perl-semantic-analyzer`](crates/perl-semantic-analyzer): scope tracking, symbol extraction, role composition |
-| Index symbols across a project | [`perl-workspace-index`](crates/perl-workspace-index): cross-file symbol index and refactoring orchestration |
-| Validate regex for ReDoS / backtracking / embedded code | [`perl-regex`](crates/perl-regex): safety and complexity checks (not a regex parser) |
-| Generate fixtures or test against a curated corpus | [`perl-corpus`](crates/perl-corpus): library plus CLI for proptest strategies and deterministic codegen |
-| Debug Perl from a DAP editor | [`perl-dap`](crates/perl-dap) via `perllsp`'s DAP server mode |
+| Perl syntax support for tree-sitter consumers (Neovim, Helix, GitHub) | [`tree-sitter-perl-c`](crates/tree-sitter-perl-c) — conventional C grammar binding |
+| Query a Perl AST from Rust with tree-sitter-style ergonomics | [`tree-sitter-perl-rs`](crates/tree-sitter-perl-rs) — Rust-native facade over the v3 parser *(in development)* |
+| Parse Perl from Rust directly with full fidelity | [`perl-parser`](crates/perl-parser) (+ [`perl-lexer`](crates/perl-lexer)) — the recursive-descent v3 parser |
+| Tokenize Perl only | [`perl-lexer`](crates/perl-lexer) — context-aware tokenizer, no parse tree |
+| Resolve symbols and track scopes over a parsed Perl AST (including Moose/Moo method modifiers) | [`perl-semantic-analyzer`](crates/perl-semantic-analyzer) — scope tracking, symbol extraction, role composition |
+| Index and search Perl symbols across a whole project | [`perl-workspace-index`](crates/perl-workspace-index) — cross-file symbol index and refactoring orchestration |
+| Validate Perl regex patterns for ReDoS, catastrophic backtracking, or embedded code execution | [`perl-regex`](crates/perl-regex) — safety/complexity checks (not a regex parser) |
+| Generate Perl fixtures or test against a curated corpus | [`perl-corpus`](crates/perl-corpus) — library plus `perl-corpus` CLI for proptest strategies, edge cases, and deterministic codegen |
+| Debug Perl from a DAP-speaking editor | [`perl-dap`](crates/perl-dap) via the `perllsp` binary's DAP server mode |
 
 ### Workspace layers
 
@@ -155,16 +136,16 @@ Different users walk in through different doors. Pick the one that matches your 
 | --- | --- | --- |
 | LSP server binary | `crates/perllsp`, `crates/perl-lsp-rs` | Protocol loop, request dispatch |
 | Debug adapter | `crates/perl-dap` | DAP server for stepping, breakpoints, evaluate |
-| **Parser stack (center)** | `crates/perl-parser`, `crates/perl-lexer`, `crates/perl-parser-core` | Recursive-descent v3 parser and context-aware lexer; all IDE features read from this |
+| **Parser stack (center)** | `crates/perl-parser`, `crates/perl-lexer`, `crates/perl-parser-core` | Recursive-descent v3 parser and context-aware lexer — all IDE features read from this |
 | Semantic analysis | `crates/perl-semantic-analyzer` | Scope tracking, symbol resolution, Moose/Moo handling |
 | Workspace indexing | `crates/perl-workspace-index` | Cross-file symbol index |
-| LSP feature providers | `crates/perl-lsp-*` | Per-feature crates (hover, definition, rename, ...) |
+| LSP feature providers | `crates/perl-lsp-*` | Per-feature crates (hover, definition, rename, …) |
 | Tree-sitter interop | `crates/tree-sitter-perl-c`, `crates/tree-sitter-perl-rs` | See split below |
 
 **Tree-sitter split.** Two crates share the family name but play different roles:
 
-- **`tree-sitter-perl-c`:** conventional C grammar binding. Maintained for tree-sitter consumers and as a reference point. Not on the LSP's critical path.
-- **`tree-sitter-perl-rs`:** Rust facade over the v3 parser, exposing tree-sitter ergonomics without the C grammar. In development.
+- **`tree-sitter-perl-c`** — the conventional C grammar binding, maintained for compatibility with tree-sitter consumers and as a reference point for comparison. Not on the LSP's critical path.
+- **`tree-sitter-perl-rs`** — a Rust-native facade over the v3 parser that exposes tree-sitter-compatible ergonomics without the C grammar. In development.
 
 See [docs/README.md](docs/README.md) for the full crate map and design notes.
 
@@ -202,7 +183,7 @@ gh issue list --label "good-first-issue" --state open
 
 ## Status
 
-**Current release: v0.12.4** (public alpha). The 0.12.x line is building parser corpus confidence, diagnostic hardening, and distribution coverage toward the v0.13.0 public alpha announcement. See [docs/project/ROADMAP.md](docs/project/ROADMAP.md) for the milestone ladder and [docs/project/status/index.md](docs/project/status/index.md) for live metrics.
+**Current release: v0.12.4** — public alpha. The 0.12.x line is building parser corpus confidence, diagnostic hardening, and distribution coverage toward the v0.13.0 public alpha announcement. See [docs/project/ROADMAP.md](docs/project/ROADMAP.md) for the milestone ladder and [docs/project/status/index.md](docs/project/status/index.md) for live metrics.
 
 ### What the numbers mean (and don't)
 
@@ -210,11 +191,11 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 
 | Metric | Current | What it measures | What it does **not** measure |
 | --- | --- | --- | --- |
-| LSP/DAP capability coverage | 119 / 119 | Every capability catalogued in `features.toml` has an implementation wired up | Per-capability correctness, edge cases, or subjective UX quality |
-| Parser corpus: CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate (no errors recorded) | AST semantic fidelity, cross-file analysis, or LSP correctness |
-| Parser corpus: Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl baseline | Same |
-| Parser corpus: project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
-| End-to-end UX confidence | *qualitative* | Tracked via manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down. Not a published number. | Parser breadth, protocol catalog size, or capability count |
+| LSP/DAP capability coverage | 119 / 119 | Every capability catalogued in `features.toml` has an implementation wired up | Per-capability correctness, completeness on edge cases, or subjective UX quality |
+| Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
+| Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
+| Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |
+| End-to-end UX confidence | *qualitative* | Currently covered by manual editor smoke workflows, the `perl-lsp-ux-tests` first-5-minutes harness, and open-issue burn-down — not a published number | Anything about parser breadth, protocol catalog size, or capability count |
 
 None of the automated metrics measure whether a real editing session feels good. That is validated through workflow smoke tests, the `perl-lsp-ux-tests` harness, and the list of known gaps below.
 
@@ -226,21 +207,24 @@ The honest state of v0.13.0 rough edges. None block basic use; all affect realis
 
 #### Must land for v0.13.0
 
-- **Workspace-wide rename slice.** Multi-root workspace support shipped in 0.12.x ([#3984](https://github.com/EffortlessMetrics/perl-lsp/pull/3984): per-folder config loading, `WorkspaceFolderState`, cross-folder integration). Workspace-wide rename and module-move are roughly 30% complete, conditionally in scope pending verification ([#3522](https://github.com/EffortlessMetrics/perl-lsp/issues/3522)).
+- **Workspace-wide rename slice** — multi-root workspace support shipped in 0.12.x ([#3984](https://github.com/EffortlessMetrics/perl-lsp/pull/3984): per-folder config loading, `WorkspaceFolderState`, cross-folder integration); workspace-wide rename and module-move are roughly 30% complete, conditionally in scope pending verification ([#3522](https://github.com/EffortlessMetrics/perl-lsp/issues/3522))
 
 #### Nice to land
 
-- **Dynamic require / literal import.** `require Module; Module->import('sym')` with static string names: goto-def on the bareword should resolve to the definition site. `@ISA` / `use parent` / `use base` chains and `use Module qw(...)` list imports already work. This is the remaining slice of the import visibility lane ([#3476](https://github.com/EffortlessMetrics/perl-lsp/issues/3476), tracked by umbrella [#4246](https://github.com/EffortlessMetrics/perl-lsp/issues/4246)).
+- **Dynamic require / literal import** — `require Module; Module->import('sym')` with static string names: goto-def on the bareword should resolve to the definition site; `@ISA` / `use parent` / `use base` chains and `use Module qw(...)` list imports already work; this is the remaining slice of the import visibility lane ([#3476](https://github.com/EffortlessMetrics/perl-lsp/issues/3476), tracked by umbrella [#4246](https://github.com/EffortlessMetrics/perl-lsp/issues/4246))
 
 #### What shipped this cycle (v0.12.x)
 
 Previously listed as rough edges, now landed:
 
-- Dynamic workspace configuration via the `workspace/configuration` reverse-request flow, merged over per-folder `.perl-lsp.toml` base config ([#3515](https://github.com/EffortlessMetrics/perl-lsp/issues/3515)).
-- Parser error recovery: unclosed block recovery ([PR #4079](https://github.com/EffortlessMetrics/perl-lsp/pull/4079)) and symbol-extractor descent into partial `Error` nodes ([PR #4071](https://github.com/EffortlessMetrics/perl-lsp/pull/4071)). Closed [#3499](https://github.com/EffortlessMetrics/perl-lsp/issues/3499).
-- Import list bareword resolution for `use Module qw(...)` and tag imports. Closed [#3472](https://github.com/EffortlessMetrics/perl-lsp/issues/3472).
-- `use constant` symbols tracked in visible symbol table. Closed [#3475](https://github.com/EffortlessMetrics/perl-lsp/issues/3475).
-- Pragma tracker: `use if`, feature bundles, eval/sub-scoped pragma leakage (PRs #4050, #4038, #4052), conservative `eval STRING` handling (PR #4052). Addresses [#3489](https://github.com/EffortlessMetrics/perl-lsp/issues/3489).
+- Dynamic workspace configuration via the `workspace/configuration`
+  reverse-request flow is now implemented and merged over per-folder
+  `.perl-lsp.toml` base config ([#3515](https://github.com/EffortlessMetrics/perl-lsp/issues/3515))
+
+- Parser error recovery: unclosed block recovery ([PR #4079](https://github.com/EffortlessMetrics/perl-lsp/pull/4079)), symbol extractor descends into partial `Error` nodes ([PR #4071](https://github.com/EffortlessMetrics/perl-lsp/pull/4071)) — [#3499](https://github.com/EffortlessMetrics/perl-lsp/issues/3499) closed (docs(readme): mark dynamic workspace config as shipped (#3515))
+- Import list bareword resolution for `use Module qw(...)` and tag imports — [#3472](https://github.com/EffortlessMetrics/perl-lsp/issues/3472) closed
+- `use constant` symbols tracked in visible symbol table — [#3475](https://github.com/EffortlessMetrics/perl-lsp/issues/3475) closed
+- Pragma tracker: `use if`, feature bundles, eval/sub-scoped pragma leakage (PRs #4050, #4038, #4052), conservative `eval STRING` handling (PR #4052) — [#3489 Improve](https://github.com/EffortlessMetrics/perl-lsp/issues/3489)
 
 ## Security
 

--- a/docs/EDITORS/CODEX_DESKTOP_SETUP.md
+++ b/docs/EDITORS/CODEX_DESKTOP_SETUP.md
@@ -1,0 +1,40 @@
+# Codex Desktop Setup
+
+This guide configures `perllsp` for OpenAI Codex Desktop using the same stdio
+server command used by other editors.
+
+## Prerequisites
+
+- `perllsp` is installed and available on your `PATH`
+- Codex Desktop is installed and signed in
+- You opened a workspace/folder containing Perl files
+
+Verify your server first:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Configure perllsp as a custom language server
+
+In Codex Desktop, add a custom language server for Perl and set:
+
+- **Command**: `perllsp`
+- **Arguments**: `--stdio`
+- **Language / file match**: Perl (`*.pl`, `*.pm`, `*.t`)
+- **Workspace root**: your project root folder
+
+> If your Codex Desktop version labels this area differently, look for settings
+> that configure an external language server process over stdio.
+
+## Verify It Works
+
+Open a Perl file and confirm you get:
+
+- diagnostics (squiggles / problems)
+- hover details on built-ins like `print`
+- symbol navigation (definition / references)
+
+If the server does not start, run `perllsp --health` in the same shell
+environment and then follow [troubleshooting](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -34,6 +34,7 @@ perllsp --health
 | Amazon Kiro | register a Perl LSP client using `perllsp --stdio` | [docs/EDITORS/KIRO_SETUP.md](../EDITORS/KIRO_SETUP.md) |
 | Claude Code | provide a plugin `.lsp.json` pointing to `perllsp --stdio` | [docs/EDITORS/CLAUDE_CODE_SETUP.md](../EDITORS/CLAUDE_CODE_SETUP.md) |
 | Codex CLI | connect an MCP LSP bridge to `perllsp --stdio` | [docs/EDITORS/CODEX_CLI_SETUP.md](../EDITORS/CODEX_CLI_SETUP.md) |
+| Codex Desktop | add a custom Perl server command `perllsp --stdio` | [docs/EDITORS/CODEX_DESKTOP_SETUP.md](../EDITORS/CODEX_DESKTOP_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -140,3 +141,9 @@ example config and troubleshooting flow.
   and confirm the workspace root is correct.
 - If completions or diagnostics are missing, move to
   [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for the next steps.
+
+
+### Codex Desktop
+
+Configure a custom Perl language server process that runs `perllsp --stdio`.
+See the dedicated guide for the exact fields and verification steps.

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -16,12 +16,12 @@ just editor-specific setup and feature discovery.
 
 ## What is a Language Server?
 
-A **language server** is a program that runs alongside your editor and gives it deep understanding of your code. Instead of each editor re-implementing features like "go to definition" or "show all references," the [Language Server Protocol (LSP)](https://microsoft.github.io/language-server-protocol/) defines a standard way for any editor to talk to a language-specific backend. `perllsp` is the native Perl 5 language server CLI from the perl-lsp project: it parses your code, builds an index of symbols, and responds to editor requests over JSON-RPC -- so you get IDE-grade navigation, completion, diagnostics, and refactoring in VS Code, Neovim, Emacs, Helix, or any other LSP-capable editor. No Perl runtime is required; the server is a single native binary.
+A **language server** is a program that runs alongside your editor and gives it deep understanding of your code. Instead of each editor re-implementing features like "go to definition" or "show all references," the [Language Server Protocol (LSP)](https://microsoft.github.io/language-server-protocol/) defines a standard way for any editor to talk to a language-specific backend. `perllsp` is the native Perl 5 language server CLI from the perl-lsp project: it parses your code, builds an index of symbols, and responds to editor requests over JSON-RPC -- so you get IDE-grade navigation, completion, diagnostics, and refactoring in VS Code, Neovim, Emacs, Helix, Codex Desktop, or any other LSP-capable editor. No Perl runtime is required; the server is a single native binary.
 
 ## Prerequisites
 
 - **Rust 1.92+** (for building from source)
-- **A supported editor**: VS Code, Amazon Kiro, Neovim, Emacs, Helix, or Sublime Text
+- **A supported editor**: VS Code, Amazon Kiro, Neovim, Emacs, Helix, Codex Desktop, or Sublime Text
 
 ## Installation
 


### PR DESCRIPTION
Rebased recovery of #5560 onto fresh-root master per the cherry-pick recovery batch (per `feedback_fresh_root_master_rebuild.md`). Original PR was stranded with no merge-base after master became a fresh root commit.

## Summary
- Adds `docs/EDITORS/CODEX_DESKTOP_SETUP.md` with prerequisites, the `perllsp --stdio` command, and verification/troubleshooting.
- Links the guide from `README.md`, `docs/how-to/EDITOR_SETUP.md`, and `docs/tutorials/GETTING_STARTED.md`.
- Includes the README em-dash mojibake fix from the original PR's second commit (`345fa517`).
- Conflict resolution preserved master's broader contributor / Gemini CLI text and combined the editor table additions (Kiro + Claude Code + Codex CLI + Codex Desktop).

## Test plan
- [x] Docs-only — no build needed
- [ ] CI runs

Original PR: #5560