### PR TITLE
fix(fmt): apply cargo xtask fmt post 16-PR ops-drain (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -505,14 +505,9 @@ impl VariableCache {
         self.entries
             .values()
             .filter(|entry| entry.kind == VariableCacheKind::Root)
-            .chain(
-                self.entries
-                    .values()
-                    .filter(|entry| entry.kind == VariableCacheKind::Child),
-            )
+            .chain(self.entries.values().filter(|entry| entry.kind == VariableCacheKind::Child))
             .flat_map(|entry| entry.full.iter())
     }
-
 }
 
 fn slice_variables(variables: &[Variable], start: usize, count: usize) -> Vec<Variable> {

--- a/crates/perl-dap/src/debug_adapter/variables.rs
+++ b/crates/perl-dap/src/debug_adapter/variables.rs
@@ -161,11 +161,8 @@ impl DebugAdapter {
                 parsed_child_cache = child_cache;
             }
         } else {
-            let (full_roots, _child_cache) = self.parse_scope_variables_from_output(
-                variables_ref,
-                0,
-                1024,
-            );
+            let (full_roots, _child_cache) =
+                self.parse_scope_variables_from_output(variables_ref, 0, 1024);
             parsed_from_output = slice_variables(&full_roots, start, count);
         }
 
@@ -180,7 +177,11 @@ impl DebugAdapter {
             && !parsed_full_roots.is_empty()
             && let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session")
         {
-            session.variable_cache.upsert(variables_ref, VariableCacheKind::Root, parsed_full_roots);
+            session.variable_cache.upsert(
+                variables_ref,
+                VariableCacheKind::Root,
+                parsed_full_roots,
+            );
             for (reference, children) in parsed_child_cache {
                 session.variable_cache.upsert(reference, VariableCacheKind::Child, children);
             }

--- a/crates/perl-dap/tests/dap_scorecard_harness.rs
+++ b/crates/perl-dap/tests/dap_scorecard_harness.rs
@@ -271,7 +271,11 @@ print "marker=$marker\n";
             return Err("globals scope contains variables with empty names".to_string());
         }
         let n = globals.len();
-        Ok(format!("globals scope returned {} named {}", n, if n == 1 { "variable" } else { "variables" }))
+        Ok(format!(
+            "globals scope returned {} named {}",
+            n,
+            if n == 1 { "variable" } else { "variables" }
+        ))
     })());
 
     let eval_metric = metric_from_result((|| {

--- a/crates/perl-dap/tests/variables_comprehensive.rs
+++ b/crates/perl-dap/tests/variables_comprehensive.rs
@@ -1424,8 +1424,8 @@ fn renderer_with_max_array_preview() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn array_preview_truncation_keeps_child_pagination_precise() -> Result<(), Box<dyn std::error::Error>>
-{
+fn array_preview_truncation_keeps_child_pagination_precise()
+-> Result<(), Box<dyn std::error::Error>> {
     let renderer = PerlVariableRenderer::new().with_max_array_preview(1);
     let val = PerlValue::Array((0..6).map(PerlValue::Integer).collect());
 

--- a/crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs
+++ b/crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs
@@ -989,12 +989,7 @@ fn lexer_slash_comment_adjacent_division_and_defined_or() -> TestResult {
 fn lexer_slash_expression_keyword_contexts_stay_expect_term() -> TestResult {
     // `return /re/`, `die /re/`, `warn /re/`, `eval /re/` are all
     // valid Perl and must produce a RegexMatch token, not a Division token.
-    let cases = [
-        "return /ok/",
-        "die /ok/",
-        "warn /ok/",
-        "eval /ok/",
-    ];
+    let cases = ["return /ok/", "die /ok/", "warn /ok/", "eval /ok/"];
 
     for code in cases {
         let mut lexer = PerlLexer::new(code);

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -1609,9 +1609,7 @@ impl CompletionProvider {
         // Check for `->` immediately before the `{` (hashref deref — out of scope).
         // Use byte comparison to avoid slicing at a non-char-boundary when a multi-byte
         // character immediately precedes `{`.
-        if brace_pos >= 2
-            && source.as_bytes().get(brace_pos - 2..brace_pos) == Some(b"->")
-        {
+        if brace_pos >= 2 && source.as_bytes().get(brace_pos - 2..brace_pos) == Some(b"->") {
             return None;
         }
 

--- a/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
@@ -560,9 +560,8 @@ mod tests {
             }
         });
 
-        let response = server
-            .handle_initialize(Some(params))?
-            .ok_or("initialize should return payload")?;
+        let response =
+            server.handle_initialize(Some(params))?.ok_or("initialize should return payload")?;
 
         let workspace_folders = response
             .pointer("/capabilities/workspace/workspaceFolders/supported")

--- a/crates/perl-lsp-rs/tests/lsp_workspace_file_ops_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_workspace_file_ops_tests.rs
@@ -1417,8 +1417,8 @@ fn test_will_rename_files_updates_package_declaration_in_renamed_file()
 /// store → disk) ensures those files receive edits.  This test validates the
 /// open-then-close lifecycle does not break the handler for other open files.
 #[test]
-fn test_will_rename_files_graceful_with_closed_dependent()
--> Result<(), Box<dyn std::error::Error>> {
+fn test_will_rename_files_graceful_with_closed_dependent() -> Result<(), Box<dyn std::error::Error>>
+{
     let server = create_test_server();
 
     let init_params = json!({

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -968,29 +968,27 @@ impl SymbolExtractor {
                 self.visit_node(variable);
             }
 
-            NodeKind::Goto { target } => {
-                match &target.kind {
-                    NodeKind::Identifier { name } => {
-                        self.table.add_reference(SymbolReference {
-                            name: name.clone(),
-                            kind: SymbolKind::Label,
-                            location: target.location,
-                            scope_id: self.table.current_scope(),
-                            is_write: false,
-                        });
-                    }
-                    NodeKind::Variable { sigil, name } if sigil == "&" => {
-                        self.table.add_reference(SymbolReference {
-                            name: name.clone(),
-                            kind: SymbolKind::Subroutine,
-                            location: target.location,
-                            scope_id: self.table.current_scope(),
-                            is_write: false,
-                        });
-                    }
-                    _ => self.visit_node(target),
+            NodeKind::Goto { target } => match &target.kind {
+                NodeKind::Identifier { name } => {
+                    self.table.add_reference(SymbolReference {
+                        name: name.clone(),
+                        kind: SymbolKind::Label,
+                        location: target.location,
+                        scope_id: self.table.current_scope(),
+                        is_write: false,
+                    });
                 }
-            }
+                NodeKind::Variable { sigil, name } if sigil == "&" => {
+                    self.table.add_reference(SymbolReference {
+                        name: name.clone(),
+                        kind: SymbolKind::Subroutine,
+                        location: target.location,
+                        scope_id: self.table.current_scope(),
+                        is_write: false,
+                    });
+                }
+                _ => self.visit_node(target),
+            },
 
             // Regex related nodes - we recurse into expression
             NodeKind::Regex { .. } => {}

--- a/crates/perl-symbol/src/cursor/mod.rs
+++ b/crates/perl-symbol/src/cursor/mod.rs
@@ -127,19 +127,16 @@ pub fn token_under_cursor(text: &str, line: usize, col_utf16: usize) -> Option<S
     // Prefer the character at the cursor. If the cursor is positioned at the
     // end of a token (or line), snap to the previous byte when that byte is
     // part of an identifier/module token or sigil.
-    let anchor = if byte_pos < bytes.len() {
-        byte_pos
-    } else {
-        bytes.len().saturating_sub(1)
-    };
+    let anchor = if byte_pos < bytes.len() { byte_pos } else { bytes.len().saturating_sub(1) };
 
-    let cursor = if is_modchar(bytes[anchor]) || matches!(bytes[anchor], b'$' | b'@' | b'%' | b'&' | b'*') {
-        anchor
-    } else if anchor > 0 && is_modchar(bytes[anchor - 1]) {
-        anchor - 1
-    } else {
-        return None;
-    };
+    let cursor =
+        if is_modchar(bytes[anchor]) || matches!(bytes[anchor], b'$' | b'@' | b'%' | b'&' | b'*') {
+            anchor
+        } else if anchor > 0 && is_modchar(bytes[anchor - 1]) {
+            anchor - 1
+        } else {
+            return None;
+        };
 
     let mut start = cursor;
     let mut end = cursor;

--- a/crates/perl-symbol/tests/index_document_aware.rs
+++ b/crates/perl-symbol/tests/index_document_aware.rs
@@ -4,19 +4,35 @@ use perl_symbol::index::SymbolIndex;
 fn removing_document_removes_only_its_symbols() -> Result<(), Box<dyn std::error::Error>> {
     let mut index = SymbolIndex::new();
 
-    index.replace_document_symbols("doc-a", vec!["alpha::one".to_string(), "shared::name".to_string()]);
-    index.replace_document_symbols("doc-b", vec!["beta::two".to_string(), "shared::name".to_string()]);
+    index.replace_document_symbols(
+        "doc-a",
+        vec!["alpha::one".to_string(), "shared::name".to_string()],
+    );
+    index.replace_document_symbols(
+        "doc-b",
+        vec!["beta::two".to_string(), "shared::name".to_string()],
+    );
 
     index.remove_document("doc-a");
 
     let prefix_results = index.search_prefix("alpha");
-    assert!(prefix_results.is_empty(), "alpha prefix should return no results after doc-a is removed");
+    assert!(
+        prefix_results.is_empty(),
+        "alpha prefix should return no results after doc-a is removed"
+    );
 
     let shared_results = index.search_prefix("shared");
-    assert_eq!(shared_results, vec!["shared::name".to_string()], "shared prefix should still find symbol from doc-b");
+    assert_eq!(
+        shared_results,
+        vec!["shared::name".to_string()],
+        "shared prefix should still find symbol from doc-b"
+    );
 
     let fuzzy_results = index.search_fuzzy("alpha");
-    assert!(fuzzy_results.is_empty(), "alpha fuzzy should return no results after doc-a is removed");
+    assert!(
+        fuzzy_results.is_empty(),
+        "alpha fuzzy should return no results after doc-a is removed"
+    );
 
     Ok(())
 }
@@ -30,26 +46,48 @@ fn replacing_document_symbols_drops_stale_entries() -> Result<(), Box<dyn std::e
     index.replace_document_symbols("doc-a", vec!["StillHere".to_string(), "NewThing".to_string()]);
 
     assert!(index.search_prefix("Old").is_empty(), "Old prefix should be empty after replacement");
-    assert_eq!(index.search_prefix("New"), vec!["NewThing".to_string()], "New prefix should find NewThing");
-    assert_eq!(index.search_fuzzy("old"), Vec::<String>::new(), "fuzzy 'old' should find nothing after replacement");
-    assert!(index.search_fuzzy("new").contains(&"NewThing".to_string()), "fuzzy 'new' should contain NewThing");
+    assert_eq!(
+        index.search_prefix("New"),
+        vec!["NewThing".to_string()],
+        "New prefix should find NewThing"
+    );
+    assert_eq!(
+        index.search_fuzzy("old"),
+        Vec::<String>::new(),
+        "fuzzy 'old' should find nothing after replacement"
+    );
+    assert!(
+        index.search_fuzzy("new").contains(&"NewThing".to_string()),
+        "fuzzy 'new' should contain NewThing"
+    );
 
     Ok(())
 }
 
 #[test]
-fn duplicate_symbols_across_documents_remain_until_last_document_removed() -> Result<(), Box<dyn std::error::Error>> {
+fn duplicate_symbols_across_documents_remain_until_last_document_removed()
+-> Result<(), Box<dyn std::error::Error>> {
     let mut index = SymbolIndex::new();
 
     index.replace_document_symbols("doc-a", vec!["common_symbol".to_string()]);
     index.replace_document_symbols("doc-b", vec!["common_symbol".to_string()]);
 
     index.remove_document("doc-a");
-    assert_eq!(index.search_prefix("common"), vec!["common_symbol".to_string()], "symbol should remain after first document removed");
+    assert_eq!(
+        index.search_prefix("common"),
+        vec!["common_symbol".to_string()],
+        "symbol should remain after first document removed"
+    );
 
     index.remove_document("doc-b");
-    assert!(index.search_prefix("common").is_empty(), "symbol should be removed after last document removed");
-    assert!(index.search_fuzzy("common").is_empty(), "fuzzy search should be empty after last document removed");
+    assert!(
+        index.search_prefix("common").is_empty(),
+        "symbol should be removed after last document removed"
+    );
+    assert!(
+        index.search_fuzzy("common").is_empty(),
+        "fuzzy search should be empty after last document removed"
+    );
 
     Ok(())
 }
@@ -60,7 +98,11 @@ fn add_symbol_remains_idempotent() -> Result<(), Box<dyn std::error::Error>> {
     index.add_symbol("legacy_name".to_string());
     index.add_symbol("legacy_name".to_string());
 
-    assert_eq!(index.search_prefix("legacy"), vec!["legacy_name".to_string()], "idempotent adds should return single result");
+    assert_eq!(
+        index.search_prefix("legacy"),
+        vec!["legacy_name".to_string()],
+        "idempotent adds should return single result"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Master PR Smoke is failing on d31334d9 after the 16-PR ops-drain wave (#6363, #6196, #6192, #6166, #6159, #6157, #6095, #6091, #6088, #5728, #5569, #5566, #5558, #5545, #5525, #5384). Same xtask-fmt-cascade pattern as #6789, #6803, #6807, #6810.

`cargo xtask fmt --check` aborted at first failure (`crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs:989`), but a full `cargo xtask fmt` run revealed drift across 11 files in 6 crates. Pure formatting only — line wrapping, brace collapsing for nested matches, no logic or behavior changes.

## Files changed (11)

- `crates/perl-dap/src/debug_adapter/mod.rs` (7)
- `crates/perl-dap/src/debug_adapter/variables.rs` (13)
- `crates/perl-dap/tests/dap_scorecard_harness.rs` (6)
- `crates/perl-dap/tests/variables_comprehensive.rs` (4)
- `crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs` (7)
- `crates/perl-lsp-rs-core/src/providers/completion/completion.rs` (4)
- `crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs` (5)
- `crates/perl-lsp-rs/tests/lsp_workspace_file_ops_tests.rs` (4)
- `crates/perl-semantic-analyzer/src/analysis/symbol.rs` (42)
- `crates/perl-symbol/src/cursor/mod.rs` (23)
- `crates/perl-symbol/tests/index_document_aware.rs` (68)

Total: 11 files, 106 insertions, 77 deletions.

## Verification

- `cargo xtask fmt --check` exits 0 after fix (was failing on master at d31334d9)
- `cargo build -p perl-lexer -p perl-symbol -p perl-semantic-analyzer -p perl-dap -p perl-lsp-rs-core -p perl-lsp-rs --tests` clean (only pre-existing dead-code warnings in perl-dap test helpers)

## Test plan

- [x] `cargo xtask fmt --check` passes locally
- [x] Affected crates build with `--tests`
- [ ] CI PR Smoke green
- [ ] Admin-merge once green
- [ ] Cascade-update affected open PRs

## Other failures NOT touched this pass

Compile All Targets and Windows module-separator gates were reported failing on some PRs; per master state check at d31334d9, those gates are GREEN on master. Those PR-side failures are stale CI and require `gh pr update-branch` after this fmt fix lands, not a master fix.