### PR TITLE
docs(agents): mention Claude Code in onboarding docs [rebased] (#6850)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — Implementation Agent Operating Manual
 
-You are an **implementation agent** (Codex, Jules, or similar). Your job is to make a
+You are an **implementation agent** (Codex, Claude Code, Jules, or similar). Your job is to make a
 scoped change, test it, and open a PR. You are not the orchestrator. You will not be
 routing work or reading CI pipelines — just implement the thing you were asked to implement.
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ See [docs/README.md](docs/README.md) for the full crate map and design notes.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow. If you are an AI implementation agent (Codex, Jules, Gemini CLI), read [AGENTS.md](AGENTS.md) first. Gemini CLI users should also read [GEMINI.md](GEMINI.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow. If you are an AI implementation agent (Codex, Claude Code, Jules, Gemini CLI), read [AGENTS.md](AGENTS.md) first. Gemini CLI users should also read [GEMINI.md](GEMINI.md).
 
 ```bash
 cargo test --workspace --lib
@@ -145,7 +145,7 @@ Find beginner-friendly issues:
 gh issue list --label "good-first-issue" --state open
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow. If you are an AI implementation agent (Codex, Jules), read [AGENTS.md](AGENTS.md) first.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow. If you are an AI implementation agent (Codex, Claude Code, Jules), read [AGENTS.md](AGENTS.md) first.
 
 ## Status
 


### PR DESCRIPTION
Rebased recovery of #5563 onto fresh-root master per the cherry-pick recovery batch (per `feedback_fresh_root_master_rebuild.md`). Original PR was stranded with no merge-base after master became a fresh root commit.

## Summary
- Cherry-picks the original `ffb7ef3f` commit which adds "Claude Code" to `AGENTS.md` and `README.md` contributor sections.
- AGENTS.md change is a no-op against current master (already mentions Claude Code).
- README change extends both contributor blurbs to include Claude Code alongside existing Codex / Jules / Gemini CLI mentions.
- The original PR's UTF-8 commit (`c76966e2`) was redundant — master was already covered by other em-dash fixes.

## Test plan
- [x] Docs-only — no build needed
- [ ] CI runs

Original PR: #5563