### PR TITLE
test(perl-lsp-ux-tests): expand live-edit UX harness coverage [rebased] (#6851)

### DIFF
--- a/crates/perl-lsp-rs/src/features/implementation_provider.rs
+++ b/crates/perl-lsp-rs/src/features/implementation_provider.rs
@@ -317,7 +317,8 @@ impl ImplementationProvider {
         match &node.kind {
             NodeKind::Subroutine { name: Some(name), .. } => {
                 let (_, name_bare) = perl_parser::qualified_name::split_qualified_name(name);
-                let (_, method_bare) = perl_parser::qualified_name::split_qualified_name(method_name);
+                let (_, method_bare) =
+                    perl_parser::qualified_name::split_qualified_name(method_name);
                 if name_bare == method_bare {
                     let target_uri = parse_uri(uri);
                     results.push(LocationLink {

--- a/crates/perl-lsp-rs/src/runtime/language/hover.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover.rs
@@ -1725,7 +1725,8 @@ impl LspServer {
                 }
             }
             NodeKind::Method { name: method_name, .. } => {
-                let (_, method_bare) = perl_parser::qualified_name::split_qualified_name(method_name);
+                let (_, method_bare) =
+                    perl_parser::qualified_name::split_qualified_name(method_name);
                 let (_, name_bare) = perl_parser::qualified_name::split_qualified_name(name);
                 if method_bare == name_bare {
                     return Some(node);

--- a/crates/perl-lsp-rs/src/runtime/symbol_extraction.rs
+++ b/crates/perl-lsp-rs/src/runtime/symbol_extraction.rs
@@ -314,7 +314,10 @@ impl LspServer {
             }
 
             NodeKind::FunctionCall { name, args } => {
-                if symbol_kind == "subroutine" && perl_parser::qualified_name::split_qualified_name(name).1 == perl_parser::qualified_name::split_qualified_name(symbol_name).1 {
+                if symbol_kind == "subroutine"
+                    && perl_parser::qualified_name::split_qualified_name(name).1
+                        == perl_parser::qualified_name::split_qualified_name(symbol_name).1
+                {
                     count += 1;
                 }
                 for arg in args {
@@ -323,7 +326,10 @@ impl LspServer {
             }
 
             NodeKind::MethodCall { object, method, args } => {
-                if symbol_kind == "subroutine" && perl_parser::qualified_name::split_qualified_name(method).1 == perl_parser::qualified_name::split_qualified_name(symbol_name).1 {
+                if symbol_kind == "subroutine"
+                    && perl_parser::qualified_name::split_qualified_name(method).1
+                        == perl_parser::qualified_name::split_qualified_name(symbol_name).1
+                {
                     count += 1;
                 }
                 count += self.count_references(object, symbol_name, symbol_kind);
@@ -385,7 +391,9 @@ impl LspServer {
                 // Check if this is a reference to a subroutine (\&function)
                 if op == "\\" && symbol_kind == "subroutine" {
                     if let NodeKind::Identifier { name } = &operand.kind {
-                        if perl_parser::qualified_name::split_qualified_name(name).1 == perl_parser::qualified_name::split_qualified_name(symbol_name).1 {
+                        if perl_parser::qualified_name::split_qualified_name(name).1
+                            == perl_parser::qualified_name::split_qualified_name(symbol_name).1
+                        {
                             count += 1;
                         }
                     }

--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -476,6 +476,27 @@
         "manual_editor_smoke",
         "issue_burndown_regression_guard"
       ]
+    },
+    {
+      "id": "live_edit_feedback_loop",
+      "scenario_file": "ux_scenario_24_live_edit_feedback.rs",
+      "subsystem_owner": "text_sync",
+      "ci_tier": "pr",
+      "user_journey": "fix an undeclared variable during active editing and confirm diagnostics and navigation update",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "cross_file_definition_success_rate"
+      ],
+      "expected_outcomes": [
+        "undeclared variable diagnostic appears before edit",
+        "go-to-definition remains responsive after didChange"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
+      ]
     }
   ]
 }

--- a/crates/perl-lsp-ux-tests/src/client.rs
+++ b/crates/perl-lsp-ux-tests/src/client.rs
@@ -273,6 +273,20 @@ impl UxClient {
         self.did_open_with_language_id(uri, text, "perl")
     }
 
+    /// Send `textDocument/didChange` with explicit version and content changes.
+    pub fn did_change(&self, uri: &str, version: i32, content_changes: Vec<Value>) -> Result<()> {
+        self.notify(
+            "textDocument/didChange",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "version": version
+                },
+                "contentChanges": content_changes
+            }),
+        )
+    }
+
     /// Drain all buffered server-initiated events and decode them.
     ///
     /// After this call the internal queue is empty.  Use `peek_events` if you

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -447,10 +447,46 @@ impl UxHarness {
     }
 
     /// Wait up to `timeout` for a `textDocument/publishDiagnostics` notification
-    /// for the given file, then return all diagnostics collected for it.
+    /// for the given file, then return the first published diagnostics collected
+    /// for it.
     ///
     /// Returns an empty vec if the deadline expires with no diagnostics published.
+    /// To get the most recently published diagnostics instead, use
+    /// [`UxHarness::wait_for_latest_diagnostics`].
     pub fn wait_for_diagnostics(
+        &self,
+        relative_path: &str,
+        timeout: std::time::Duration,
+    ) -> Vec<Value> {
+        let uri = self.workspace.uri(relative_path);
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            {
+                let events = self.client.peek_events();
+                for ev in events.iter() {
+                    if let LspEvent::Diagnostics { uri: diag_uri, diagnostics } = ev {
+                        if diag_uri == &uri {
+                            return diagnostics.clone();
+                        }
+                    }
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        Vec::new()
+    }
+
+    /// Wait up to `timeout` for a `textDocument/publishDiagnostics` notification
+    /// for the given file, then return the most recently published diagnostics
+    /// for the URI, ignoring earlier buffered publications.
+    ///
+    /// Returns an empty vec if the deadline expires with no diagnostics published.
+    /// Use this when you need the latest server state after an edit; for the
+    /// initial (first published) diagnostics use [`UxHarness::wait_for_diagnostics`].
+    pub fn wait_for_latest_diagnostics(
         &self,
         relative_path: &str,
         timeout: std::time::Duration,

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -460,7 +460,7 @@ impl UxHarness {
         loop {
             {
                 let events = self.client.peek_events();
-                for ev in &events {
+                for ev in events.iter().rev() {
                     if let LspEvent::Diagnostics { uri: diag_uri, diagnostics } = ev {
                         if diag_uri == &uri {
                             return diagnostics.clone();

--- a/crates/perl-lsp-ux-tests/src/scorecard.rs
+++ b/crates/perl-lsp-ux-tests/src/scorecard.rs
@@ -155,10 +155,7 @@ mod tests {
             definition_exact_hit: def,
             symbol_correct: sym,
             cross_file_success: cross,
-            mean_latency_ms: latency
-                .iter()
-                .map(|(k, v)| ((*k).to_string(), *v))
-                .collect(),
+            mean_latency_ms: latency.iter().map(|(k, v)| ((*k).to_string(), *v)).collect(),
             ..Default::default()
         }
     }
@@ -167,12 +164,22 @@ mod tests {
     fn aggregate_editor_ux_scorecard_computes_expected_rows() -> Result<()> {
         let s1 = make_score(
             "hover-and-def",
-            Some(true), Some(false), Some(true), Some(true), Some(true), Some(true),
+            Some(true),
+            Some(false),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
             &[("hover", 12.0), ("completion", 20.0), ("definition", 30.0)],
         );
         let s2 = make_score(
             "completion-and-cross-file",
-            Some(false), Some(true), Some(true), Some(false), Some(false), Some(true),
+            Some(false),
+            Some(true),
+            Some(true),
+            Some(false),
+            Some(false),
+            Some(true),
             &[("hover", 8.0), ("completion", 40.0), ("workspace_symbols", 50.0)],
         );
 
@@ -203,7 +210,12 @@ mod tests {
     fn aggregate_editor_ux_scorecard_uses_none_when_metric_not_measured() -> Result<()> {
         let s = make_score(
             "symbols-only",
-            None, None, None, None, None, None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
             &[("document_symbols", 18.0)],
         );
 
@@ -275,7 +287,12 @@ mod tests {
     fn all_false_correctness_produces_zero_pct() -> Result<()> {
         let s = make_score(
             "all-fail",
-            Some(false), Some(false), Some(false), Some(false), Some(false), Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
             &[],
         );
 
@@ -295,7 +312,12 @@ mod tests {
     fn single_scenario_all_true_produces_100_pct() -> Result<()> {
         let s = make_score(
             "all-pass",
-            Some(true), Some(true), Some(true), Some(true), Some(true), Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
             &[("hover", 15.0), ("completion", 25.0)],
         );
 
@@ -326,7 +348,10 @@ mod tests {
         let scorecard = aggregate_editor_ux_scorecard(&scenarios);
 
         let pct = scorecard.symbol_correctness_pct;
-        assert!(pct.is_some_and(|v| (v - 66.666_666).abs() < 0.01), "expected ~66.67%, got {pct:?}");
+        assert!(
+            pct.is_some_and(|v| (v - 66.666_666).abs() < 0.01),
+            "expected ~66.67%, got {pct:?}"
+        );
 
         Ok(())
     }

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
@@ -1,0 +1,85 @@
+//! Scenario 24 — Live-edit UX feedback loop for diagnostics + definition.
+//!
+//! BDD contract:
+//! - Given a file with an undefined variable, when it is opened, then diagnostics
+//!   should surface a strict warning/error for that variable.
+//! - Given the declaration was added, when go-to-definition runs on the use-site,
+//!   then it should stay responsive and return either locations or an empty
+//!   result (degraded mode).
+
+use anyhow::Result;
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use std::time::Duration;
+
+const UNDECLARED_SOURCE: &str = r#"use strict;
+use warnings;
+
+print $name;
+"#;
+
+const DECLARED_SOURCE: &str = r#"use strict;
+use warnings;
+
+my $name = 'world';
+print $name;
+"#;
+
+fn has_global_symbol_diagnostic(diags: &[serde_json::Value], symbol: &str) -> bool {
+    diags.iter().any(|diag| {
+        let message = diag.get("message").and_then(serde_json::Value::as_str).unwrap_or_default();
+        message.contains(symbol)
+            || diag
+                .get("code")
+                .and_then(serde_json::Value::as_str)
+                .map(|code| code.contains("Global symbol"))
+                .unwrap_or(false)
+    })
+}
+
+#[test]
+fn given_undeclared_variable_when_opened_then_strict_diagnostic_is_published() -> Result<()> {
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("live_edit.pl", UNDECLARED_SOURCE))?;
+
+    harness.open_file("live_edit.pl", UNDECLARED_SOURCE)?;
+
+    let diagnostics = harness.wait_for_diagnostics("live_edit.pl", Duration::from_secs(6));
+    assert!(
+        has_global_symbol_diagnostic(&diagnostics, "$name"),
+        "expected strict diagnostics for undeclared $name, got: {:?}",
+        diagnostics
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn given_live_edit_when_variable_is_declared_then_navigation_remains_responsive() -> Result<()> {
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("live_edit.pl", UNDECLARED_SOURCE))?;
+
+    harness.open_file("live_edit.pl", UNDECLARED_SOURCE)?;
+
+    let before = harness.wait_for_diagnostics("live_edit.pl", Duration::from_secs(6));
+    assert!(
+        has_global_symbol_diagnostic(&before, "$name"),
+        "precondition failed: expected undeclared symbol diagnostic before edit, got: {:?}",
+        before
+    );
+
+    harness.change_file_full("live_edit.pl", DECLARED_SOURCE)?;
+
+    let _post_edit_diagnostics =
+        harness.wait_for_diagnostics("live_edit.pl", Duration::from_secs(6));
+
+    let definitions = harness.definition("live_edit.pl", 4, 7);
+    assert!(
+        definitions.is_ok(),
+        "expected go-to-definition to stay responsive after didChange, got: {:?}",
+        definitions
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
@@ -11,6 +11,10 @@ use anyhow::Result;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
 
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
 const UNDECLARED_SOURCE: &str = r#"use strict;
 use warnings;
 
@@ -38,6 +42,10 @@ fn has_global_symbol_diagnostic(diags: &[serde_json::Value], symbol: &str) -> bo
 
 #[test]
 fn given_undeclared_variable_when_opened_then_strict_diagnostic_is_published() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_24: perl-lsp binary not found");
+        return Ok(());
+    }
     let harness =
         UxHarness::new(ScenarioConfig::default().with_file("live_edit.pl", UNDECLARED_SOURCE))?;
 
@@ -56,6 +64,10 @@ fn given_undeclared_variable_when_opened_then_strict_diagnostic_is_published() -
 
 #[test]
 fn given_live_edit_when_variable_is_declared_then_navigation_remains_responsive() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_24: perl-lsp binary not found");
+        return Ok(());
+    }
     let harness =
         UxHarness::new(ScenarioConfig::default().with_file("live_edit.pl", UNDECLARED_SOURCE))?;
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
@@ -31,12 +31,9 @@ print $name;
 fn has_global_symbol_diagnostic(diags: &[serde_json::Value], symbol: &str) -> bool {
     diags.iter().any(|diag| {
         let message = diag.get("message").and_then(serde_json::Value::as_str).unwrap_or_default();
+        let code = diag.get("code").and_then(serde_json::Value::as_str).unwrap_or_default();
         message.contains(symbol)
-            || diag
-                .get("code")
-                .and_then(serde_json::Value::as_str)
-                .map(|code| code.contains("Global symbol"))
-                .unwrap_or(false)
+            || (code.contains("Global symbol") && message.contains(symbol))
     })
 }
 
@@ -83,7 +80,7 @@ fn given_live_edit_when_variable_is_declared_then_navigation_remains_responsive(
     harness.change_file_full("live_edit.pl", DECLARED_SOURCE)?;
 
     let _post_edit_diagnostics =
-        harness.wait_for_diagnostics("live_edit.pl", Duration::from_secs(6));
+        harness.wait_for_latest_diagnostics("live_edit.pl", Duration::from_secs(6));
 
     let definitions = harness.definition("live_edit.pl", 4, 7);
     assert!(

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
@@ -32,8 +32,7 @@ fn has_global_symbol_diagnostic(diags: &[serde_json::Value], symbol: &str) -> bo
     diags.iter().any(|diag| {
         let message = diag.get("message").and_then(serde_json::Value::as_str).unwrap_or_default();
         let code = diag.get("code").and_then(serde_json::Value::as_str).unwrap_or_default();
-        message.contains(symbol)
-            || (code.contains("Global symbol") && message.contains(symbol))
+        message.contains(symbol) || (code.contains("Global symbol") && message.contains(symbol))
     })
 }
 

--- a/xtask/src/tasks/ux_scorecard.rs
+++ b/xtask/src/tasks/ux_scorecard.rs
@@ -425,8 +425,16 @@ mod tests {
 
     #[test]
     fn computes_percentiles() {
-        let rows =
-            vec![measurement("s1", None, None, None, None, None, None, &[("hover", vec![10, 20, 30, 40])])];
+        let rows = vec![measurement(
+            "s1",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &[("hover", vec![10, 20, 30, 40])],
+        )];
 
         let latency = compute_latency_percentiles(&rows);
         let hover = latency.get("hover").expect("hover present");
@@ -437,7 +445,13 @@ mod tests {
     #[test]
     fn single_sample_latency_p50_equals_p95() {
         let rows = vec![measurement(
-            "single", None, None, None, None, None, None,
+            "single",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
             &[("definition", vec![42])],
         )];
         let latency = compute_latency_percentiles(&rows);
@@ -450,7 +464,13 @@ mod tests {
     fn two_sample_latency_percentiles() {
         // [10, 90]: p50 rank=(2-1)*0.5=0.5→1, samples[1]=90; p95 rank=(2-1)*0.95=0.95→1, samples[1]=90
         let rows = vec![measurement(
-            "two", None, None, None, None, None, None,
+            "two",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
             &[("hover", vec![10, 90])],
         )];
         let latency = compute_latency_percentiles(&rows);


### PR DESCRIPTION
Rebased recovery of #5381 onto fresh-root master per the cherry-pick recovery batch (per `feedback_fresh_root_master_rebuild.md`). Original PR was stranded with no merge-base after master became a fresh root commit.

## Summary
- Adds `UxClient::did_change` for `textDocument/didChange` notifications with explicit version/contentChanges.
- Tracks per-document versions in `UxHarness` via `document_versions: Mutex<HashMap<String,i32>>` and adds `change_file_full` plus `bump_document_version`.
- Adds BDD-style `ux_scenario_24_live_edit_feedback.rs` exercising undeclared-variable diagnostics on open and navigation responsiveness after a `didChange`.
- Registers the scenario in `fixtures/editor_ux_fixture_matrix.json` (preserved master's `workspace_folder_addition_freshness` entry alongside the new one).
- Includes the second commit (`f2cf3db2`) that adds a `binary_available` skip guard.

## Test plan
- [x] `cargo build -p perl-lsp-ux-tests` (clean)
- [x] `cargo check -p perl-lsp-ux-tests --tests` (clean)
- [ ] CI runs (full ux scenario suite)

Original PR: #5381