### PR TITLE
fix(xtask-gates): demote corpus ratchet gates to advisory (#0000)

### DIFF
--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -284,10 +284,16 @@ gates:
       - common
       - strict
 
+  # NOTE (2026-04-26): demoted to advisory (required: false). Baseline
+  # `.ci/parser-corpus-baseline.json` was captured against a snapshot of the
+  # runner's `/usr/share/perl` tree and drifts whenever Ubuntu updates Perl,
+  # producing per-bucket "regressions" (e.g. unclosed_paren 2 → 4) that are
+  # purely environmental, not parser regressions. Strategic redesign tracked
+  # separately; out-of-band cron will own the ratchet going forward.
   - name: parser_corpus_ratchet
     tier: merge_gate
-    description: "System Perl corpus must not regress against parser baseline"
-    required: true
+    description: "System Perl corpus must not regress against parser baseline (advisory; baseline drifts with runner Perl)"
+    required: false
     command: >-
       cargo run --locked -p xtask
       -- parser-corpus-sweep
@@ -301,11 +307,18 @@ gates:
       - corpus
       - parser
       - ratchet
+      - advisory
 
+  # NOTE (2026-04-26): demoted to advisory (required: false). The merge-gate
+  # CI workflow does not run `cargo xtask cpan-corpus install` before this
+  # gate, so it always fails with "CPAN corpus not installed". Until the
+  # workflow is extended (or the install is moved into the gate command),
+  # this gate cannot pass on PR runners. The post-merge corpus-ratchet
+  # workflow already owns the real CPAN check.
   - name: cpan_corpus_ratchet
     tier: merge_gate
-    description: "CPAN corpus baseline + known-clean manifest must remain green"
-    required: true
+    description: "CPAN corpus baseline + known-clean manifest must remain green (advisory; CPAN corpus not installed on PR runners)"
+    required: false
     command: cargo run --locked -p xtask -- cpan-corpus sweep --enforce
     timeout_seconds: 300
     retry_count: 0


### PR DESCRIPTION
## Summary

Narrow infrastructure fix for the `CI Gate (Merge-Blocking)` failure that's blocking master and 6 in-flight PRs (#6801, #6800, #6347, #6246, #6072, #5985).

Both `parser_corpus_ratchet` and `cpan_corpus_ratchet` are failing on master and every PR for environmental reasons unrelated to the PR contents:

- **`cpan_corpus_ratchet`**: fails in 594 ms with `CPAN corpus not installed: .../target/cpan-corpus/lib/perl5 not found` — the merge-gate workflow never runs `cargo xtask cpan-corpus install`, so the corpus the gate reads doesn't exist on PR runners. The post-merge corpus-ratchet workflow already owns the real CPAN check.
- **`parser_corpus_ratchet`**: `.ci/parser-corpus-baseline.json` was captured against a snapshot of the runner's `/usr/share/perl` tree and drifts whenever Ubuntu updates Perl. Current run on master shows `+1060 clean files (improvement)` (2825 -> 3885) but 3 individual buckets crept up because the larger corpus exposed more edge cases — purely environmental, not parser regressions.

The fix sets `required: false` on both gates so failures show in the receipt (`Overall: PARTIAL`) but the runner exits 0 and CI doesn't block. The strategic redesign (move corpus ratcheting to an out-of-band cron) is tracked separately.

## Approach

Option 3 from the spec — demote both gates to advisory. 18-line YAML change, no Rust changes, no scope creep into the strategic redesign.

The "fatal: Needed a single revision" / "HEAD does not point to a branch" noise in CI logs is unrelated — those come from `git rev-parse HEAD` and `git rev-parse @{upstream}` calls in `gates.rs::collect_metadata` and `is_latest_commit`, which use `unwrap_or_else(|_| "...")` and don't cause failure. The bail at `gates.rs:516` was the corpus-ratchet failure surfacing through `has_blocking_failures`.

## Files changed

- `.ci/gate-policy.yaml` — set `required: false` on both gates, document why in inline comments

## Test plan

- [x] `cargo build -p xtask` — clean build
- [x] `cargo test -p xtask --bin xtask -- gates` — 11/11 gate tests pass
- [x] `cargo xtask gates --list --tier merge-gate` — both gates render without `*` (required) indicator
- [x] `cargo xtask gates --gate cpan_corpus_ratchet` locally — gate fails (no corpus installed), but `Overall: PARTIAL` and exit code is 0
- [ ] CI Gate (Merge-Blocking) on this PR turns green