### PR TITLE
feat(queue): add canonical PR state builder dry-run (#6853)

### DIFF
--- a/.ci/receipts/schemas/queue-state.schema.json
+++ b/.ci/receipts/schemas/queue-state.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/queue-state.schema.json",
+  "title": "Queue State Receipt",
+  "type": "object",
+  "required": [
+    "receipt_version",
+    "mode",
+    "evaluated_at",
+    "results"
+  ],
+  "properties": {
+    "receipt_version": { "type": "string" },
+    "mode": { "type": "string", "enum": ["dry-run"] },
+    "evaluated_at": { "type": "string", "format": "date-time" },
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "number",
+          "canonical_state",
+          "blockers",
+          "stale_receipts",
+          "projected_next_routes",
+          "projected_labels",
+          "contradictions"
+        ],
+        "properties": {
+          "number": { "type": "integer", "minimum": 1 },
+          "canonical_state": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "NEW",
+              "NEEDS_STANDARDS_REVIEW",
+              "NEEDS_DEEP_REVIEW",
+              "NEEDS_DIFF_AUDIT",
+              "NEEDS_MAINTAINER_REVIEW",
+              "NEEDS_BUILDER_FIX",
+              "NEEDS_DIFF_FIX",
+              "NEEDS_CI_FIX",
+              "NEEDS_CASCADE_UPDATE",
+              "NEEDS_INFRA_FIX",
+              "REVIEWED_WAITING_CI",
+              "CI_GREEN",
+              "MERGE_READY",
+              "QUEUED",
+              "MERGED",
+              "SUPERSEDED",
+              "BLOCKED_UNKNOWN"
+            ]
+          },
+          "blockers": { "type": "array", "items": { "type": "string" } },
+          "stale_receipts": { "type": "array", "items": { "type": "string" } },
+          "projected_next_routes": { "type": "array", "items": { "type": "string" } },
+          "projected_labels": { "type": "array", "items": { "type": "string" } },
+          "contradictions": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/.ci/state/pr-states.toml
+++ b/.ci/state/pr-states.toml
@@ -1,0 +1,71 @@
+[states.DRAFT]
+next_routes = ["await-ready-for-review"]
+projected_labels = ["draft"]
+
+[states.NEW]
+next_routes = ["standards-review"]
+projected_labels = ["new"]
+
+[states.NEEDS_STANDARDS_REVIEW]
+next_routes = ["standards-review"]
+projected_labels = ["needs-standards-review"]
+
+[states.NEEDS_DEEP_REVIEW]
+next_routes = ["deep-review"]
+projected_labels = ["needs-deep-review"]
+
+[states.NEEDS_DIFF_AUDIT]
+next_routes = ["diff-audit"]
+projected_labels = ["needs-diff-audit"]
+
+[states.NEEDS_MAINTAINER_REVIEW]
+next_routes = ["maintainer-review"]
+projected_labels = ["needs-maintainer-review"]
+
+[states.NEEDS_BUILDER_FIX]
+next_routes = ["builder-fix"]
+projected_labels = ["needs-builder-fix"]
+
+[states.NEEDS_DIFF_FIX]
+next_routes = ["diff-fix"]
+projected_labels = ["needs-diff-fix"]
+
+[states.NEEDS_CI_FIX]
+next_routes = ["ci-fix"]
+projected_labels = ["needs-ci-fix"]
+
+[states.NEEDS_CASCADE_UPDATE]
+next_routes = ["cascade-update"]
+projected_labels = ["needs-cascade-update"]
+
+[states.NEEDS_INFRA_FIX]
+next_routes = ["infra-fix"]
+projected_labels = ["needs-infra-fix"]
+
+[states.REVIEWED_WAITING_CI]
+next_routes = ["wait-for-ci"]
+projected_labels = ["review-reviewed"]
+
+[states.CI_GREEN]
+next_routes = ["prepare-merge-readiness"]
+projected_labels = ["ci-green"]
+
+[states.MERGE_READY]
+next_routes = ["enqueue"]
+projected_labels = ["merge-ready"]
+
+[states.QUEUED]
+next_routes = ["wait-merge"]
+projected_labels = ["queued"]
+
+[states.MERGED]
+next_routes = ["done"]
+projected_labels = ["merged"]
+
+[states.SUPERSEDED]
+next_routes = ["close"]
+projected_labels = ["superseded"]
+
+[states.BLOCKED_UNKNOWN]
+next_routes = ["triage"]
+projected_labels = ["blocked-unknown"]

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -86,7 +86,7 @@ impl SafeEvaluator {
         }
 
         // Check for assignment operators while avoiding comparison false positives
-        if let Some(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref().ok() {
+        if let Ok(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref() {
             for mat in re.find_iter(expression) {
                 let op = mat.as_str();
                 if ASSIGNMENT_OPERATORS.contains(&op) {

--- a/docs/ci/queue-state-machine.md
+++ b/docs/ci/queue-state-machine.md
@@ -1,0 +1,38 @@
+# Queue State Machine (Dry-Run)
+
+Refs #6853.
+
+This document describes the first **dry-run** canonical PR state builder.
+
+## Commands
+
+```bash
+cargo xtask queue snapshot --out target/queue/snapshot.json
+cargo xtask queue state --snapshot target/queue/snapshot.json --dry-run --receipt target/receipts/queue-state.json
+```
+
+## Inputs
+
+- PR facts from GitHub event payload when available.
+- Snapshot fixture JSON in tests.
+- Labels, `head_sha`, `base_sha`, and status rollup.
+- Receipts (from snapshot-provided paths).
+
+## Outputs
+
+The dry-run receipt emits:
+
+- `canonical_state`
+- `blockers`
+- `stale_receipts`
+- `projected_next_routes`
+- `projected_labels` (projection only; no apply)
+- `contradictions`
+
+## Dry-run guarantees
+
+- No label mutations.
+- No PR comments.
+- No merge operations.
+- No label projector apply mode in this phase.
+

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1152,6 +1152,12 @@ enum Commands {
         /// Current receipt JSON path.
         current: PathBuf,
     },
+
+    /// Build queue snapshots and canonical dry-run queue state receipts.
+    Queue {
+        #[command(subcommand)]
+        command: QueueCommand,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1300,6 +1306,28 @@ enum MetricsCommand {
         /// `target/receipts/system-corpus-sweep.json`.
         #[arg(long)]
         input: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
+enum QueueCommand {
+    /// Build a queue snapshot from available GitHub event facts.
+    Snapshot {
+        /// Output path for the generated snapshot JSON.
+        #[arg(long, default_value = "target/queue/snapshot.json")]
+        out: PathBuf,
+    },
+    /// Build canonical PR states from a queue snapshot and emit a dry-run receipt.
+    State {
+        /// Input snapshot JSON path.
+        #[arg(long)]
+        snapshot: PathBuf,
+        /// Required in this phase; apply mode is intentionally unsupported.
+        #[arg(long)]
+        dry_run: bool,
+        /// Output queue-state receipt path.
+        #[arg(long, default_value = "target/receipts/queue-state.json")]
+        receipt: PathBuf,
     },
 }
 
@@ -1686,6 +1714,12 @@ fn main() -> Result<()> {
         Commands::CompareBuildTiming { baseline, current } => {
             build_timing::run_compare(baseline, current)
         }
+        Commands::Queue { command } => match command {
+            QueueCommand::Snapshot { out } => queue_snapshot::run(out),
+            QueueCommand::State { snapshot, dry_run, receipt } => {
+                queue_state::run(snapshot, dry_run, receipt)
+            }
+        },
     }
 }
 

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -59,6 +59,8 @@ pub mod publish;
 pub mod publish_closure;
 pub mod publish_manifest_check;
 pub mod publish_receipts;
+pub mod queue_snapshot;
+pub mod queue_state;
 pub mod receipts;
 pub mod release;
 pub mod release_notes;

--- a/xtask/src/tasks/queue_snapshot.rs
+++ b/xtask/src/tasks/queue_snapshot.rs
@@ -1,0 +1,122 @@
+use color_eyre::eyre::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct QueueSnapshot {
+    pub generated_at: String,
+    pub prs: Vec<PrSnapshot>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PrSnapshot {
+    pub number: u64,
+    pub draft: bool,
+    pub merged: bool,
+    pub head_sha: String,
+    pub base_sha: String,
+    pub labels: Vec<String>,
+    pub status_rollup: StatusRollup,
+    #[serde(default)]
+    pub receipts: Vec<ReceiptRef>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum StatusRollup {
+    Green,
+    Red,
+    Pending,
+    Unknown,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReceiptRef {
+    pub kind: String,
+    pub path: PathBuf,
+    #[serde(default)]
+    pub head_sha: Option<String>,
+    #[serde(default)]
+    pub base_sha: Option<String>,
+    #[serde(default)]
+    pub valid: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubEvent {
+    pull_request: Option<GitHubPullRequest>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubPullRequest {
+    number: u64,
+    draft: bool,
+    merged: Option<bool>,
+    head: GitRef,
+    base: GitRef,
+    labels: Vec<GitLabel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitRef {
+    sha: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitLabel {
+    name: String,
+}
+
+pub fn run(out: PathBuf) -> Result<()> {
+    let snapshot = snapshot_from_github_event_or_empty()?;
+    write_snapshot(&out, &snapshot)
+}
+
+fn snapshot_from_github_event_or_empty() -> Result<QueueSnapshot> {
+    let generated_at = chrono::Utc::now().to_rfc3339();
+    let event_path = std::env::var_os("GITHUB_EVENT_PATH").map(PathBuf::from);
+
+    let prs =
+        if let Some(path) = event_path { read_single_pr_from_event(&path)? } else { Vec::new() };
+
+    Ok(QueueSnapshot { generated_at, prs })
+}
+
+fn read_single_pr_from_event(path: &Path) -> Result<Vec<PrSnapshot>> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read GitHub event payload at {}", path.display()))?;
+    let event: GitHubEvent = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse GitHub event payload at {}", path.display()))?;
+
+    let Some(pr) = event.pull_request else {
+        return Ok(Vec::new());
+    };
+
+    let labels = pr.labels.into_iter().map(|l| l.name).collect::<Vec<_>>();
+    Ok(vec![PrSnapshot {
+        number: pr.number,
+        draft: pr.draft,
+        merged: pr.merged.unwrap_or(false),
+        head_sha: pr.head.sha,
+        base_sha: pr.base.sha,
+        labels,
+        status_rollup: StatusRollup::Unknown,
+        receipts: Vec::new(),
+    }])
+}
+
+fn write_snapshot(out: &Path, snapshot: &QueueSnapshot) -> Result<()> {
+    if let Some(parent) = out.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!("failed to create snapshot output dir {}", parent.display())
+        })?;
+    }
+
+    let json =
+        serde_json::to_string_pretty(snapshot).context("failed to serialize queue snapshot")?;
+    fs::write(out, format!("{json}\n"))
+        .with_context(|| format!("failed to write queue snapshot to {}", out.display()))?;
+    println!("Wrote queue snapshot to {}", out.display());
+    Ok(())
+}

--- a/xtask/src/tasks/queue_state.rs
+++ b/xtask/src/tasks/queue_state.rs
@@ -1,0 +1,248 @@
+use crate::tasks::queue_snapshot::{PrSnapshot, QueueSnapshot, StatusRollup};
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const STATE_CONFIG_PATH: &str = ".ci/state/pr-states.toml";
+
+#[derive(Debug, Deserialize)]
+struct StateConfig {
+    states: BTreeMap<String, StateProjection>,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+struct StateProjection {
+    #[serde(default)]
+    next_routes: Vec<String>,
+    #[serde(default)]
+    projected_labels: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct QueueStateReceipt {
+    pub receipt_version: String,
+    pub mode: String,
+    pub evaluated_at: String,
+    pub results: Vec<PrStateResult>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PrStateResult {
+    pub number: u64,
+    pub canonical_state: String,
+    pub blockers: Vec<String>,
+    pub stale_receipts: Vec<String>,
+    pub projected_next_routes: Vec<String>,
+    pub projected_labels: Vec<String>,
+    pub contradictions: Vec<String>,
+}
+
+pub fn run(snapshot: PathBuf, dry_run: bool, receipt: PathBuf) -> Result<()> {
+    if !dry_run {
+        bail!("queue state only supports --dry-run in this phase");
+    }
+
+    let snapshot = read_snapshot(&snapshot)?;
+    let config = read_state_config(Path::new(STATE_CONFIG_PATH))?;
+
+    let mut results = Vec::with_capacity(snapshot.prs.len());
+    for pr in &snapshot.prs {
+        results.push(build_state(pr, &config));
+    }
+
+    let output = QueueStateReceipt {
+        receipt_version: "1.0.0".to_string(),
+        mode: "dry-run".to_string(),
+        evaluated_at: chrono::Utc::now().to_rfc3339(),
+        results,
+    };
+
+    if let Some(parent) = receipt.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create receipt dir {}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(&output).context("failed to serialize queue state")?;
+    fs::write(&receipt, format!("{json}\n"))
+        .with_context(|| format!("failed to write queue state receipt to {}", receipt.display()))?;
+    println!("Wrote queue state receipt to {}", receipt.display());
+    Ok(())
+}
+
+fn read_snapshot(path: &Path) -> Result<QueueSnapshot> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed reading queue snapshot {}", path.display()))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("failed parsing queue snapshot {}", path.display()))
+}
+
+fn read_state_config(path: &Path) -> Result<StateConfig> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed reading state config {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("failed parsing state config {}", path.display()))
+}
+
+fn build_state(pr: &PrSnapshot, config: &StateConfig) -> PrStateResult {
+    let label_set = pr.labels.iter().map(|s| s.as_str()).collect::<BTreeSet<_>>();
+    let mut blockers = Vec::new();
+    let mut contradictions = Vec::new();
+
+    let blocker_state = detect_blocker_state(&label_set, &mut blockers);
+
+    let stale_receipts = pr
+        .receipts
+        .iter()
+        .filter_map(|receipt| {
+            let Some(head_sha) = &receipt.head_sha else {
+                return None;
+            };
+            if head_sha != &pr.head_sha { Some(receipt.kind.clone()) } else { None }
+        })
+        .collect::<Vec<_>>();
+
+    if !stale_receipts.is_empty() {
+        contradictions.push("one or more receipts are stale against current head_sha".to_string());
+    }
+
+    let has_reviewed = label_set.contains("review-reviewed");
+    let has_merge_ready_label = label_set.contains("merge-ready");
+
+    let merge_ready_receipt_valid = pr.receipts.iter().any(|receipt| {
+        receipt.kind == "merge-readiness"
+            && receipt.valid.unwrap_or(false)
+            && receipt.base_sha.as_deref() == Some(pr.base_sha.as_str())
+    });
+
+    if has_merge_ready_label && !merge_ready_receipt_valid {
+        contradictions
+            .push("merge-ready label present without valid merge-readiness receipt".to_string());
+    }
+
+    let canonical_state = if pr.merged {
+        "MERGED".to_string()
+    } else if label_set.contains("superseded") {
+        "SUPERSEDED".to_string()
+    } else if pr.draft {
+        "DRAFT".to_string()
+    } else if let Some(blocker) = blocker_state {
+        if pr.status_rollup == StatusRollup::Green {
+            contradictions.push("blocker labels conflict with green CI rollup".to_string());
+        }
+        blocker
+    } else {
+        match pr.status_rollup {
+            StatusRollup::Red => {
+                let classifier = pr.receipts.iter().find(|receipt| receipt.kind == "ci-classifier");
+                if let Some(classifier) = classifier {
+                    if classifier.valid.unwrap_or(false) {
+                        "NEEDS_CI_FIX".to_string()
+                    } else {
+                        "NEEDS_INFRA_FIX".to_string()
+                    }
+                } else {
+                    "BLOCKED_UNKNOWN".to_string()
+                }
+            }
+            StatusRollup::Pending => {
+                if has_reviewed {
+                    "REVIEWED_WAITING_CI".to_string()
+                } else {
+                    "NEW".to_string()
+                }
+            }
+            StatusRollup::Green => {
+                if has_merge_ready_label && merge_ready_receipt_valid {
+                    "MERGE_READY".to_string()
+                } else if has_reviewed {
+                    "CI_GREEN".to_string()
+                } else {
+                    "NEW".to_string()
+                }
+            }
+            StatusRollup::Unknown => "BLOCKED_UNKNOWN".to_string(),
+        }
+    };
+
+    if !blockers.is_empty() && (canonical_state == "CI_GREEN" || canonical_state == "MERGE_READY") {
+        contradictions
+            .push("needs-* blockers cannot coexist with CI_GREEN/MERGE_READY".to_string());
+    }
+
+    let projection = config.states.get(&canonical_state).cloned().unwrap_or_default();
+
+    PrStateResult {
+        number: pr.number,
+        canonical_state,
+        blockers,
+        stale_receipts,
+        projected_next_routes: projection.next_routes,
+        projected_labels: projection.projected_labels,
+        contradictions,
+    }
+}
+
+fn detect_blocker_state(labels: &BTreeSet<&str>, blockers: &mut Vec<String>) -> Option<String> {
+    let ordered = [
+        ("needs-standards-review", "NEEDS_STANDARDS_REVIEW"),
+        ("needs-deep-review", "NEEDS_DEEP_REVIEW"),
+        ("needs-diff-audit", "NEEDS_DIFF_AUDIT"),
+        ("needs-maintainer-review", "NEEDS_MAINTAINER_REVIEW"),
+        ("needs-builder-fix", "NEEDS_BUILDER_FIX"),
+        ("needs-diff-fix", "NEEDS_DIFF_FIX"),
+        ("needs-ci-fix", "NEEDS_CI_FIX"),
+        ("needs-cascade-update", "NEEDS_CASCADE_UPDATE"),
+        ("needs-infra-fix", "NEEDS_INFRA_FIX"),
+    ];
+
+    let mut matched = None;
+    for (label, state) in ordered {
+        if labels.contains(label) {
+            blockers.push(label.to_string());
+            if matched.is_none() {
+                matched = Some(state.to_string());
+            }
+        }
+    }
+
+    matched
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn fixture(path: &str) -> Result<PrStateResult> {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let raw = std::fs::read_to_string(root.join(path))?;
+        let pr: PrSnapshot = serde_json::from_str(&raw)?;
+        let config = read_state_config(&root.join("../").join(STATE_CONFIG_PATH))?;
+        Ok(build_state(&pr, &config))
+    }
+
+    #[test]
+    fn review_reviewed_and_needs_builder_fix_prefers_blocker_with_contradiction() -> Result<()> {
+        let state = fixture("tests/fixtures/queue-state/review-reviewed-needs-builder-fix.json")?;
+        assert_eq!(state.canonical_state, "NEEDS_BUILDER_FIX");
+        assert!(state.blockers.iter().any(|b| b == "needs-builder-fix"));
+        assert!(!state.contradictions.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn all_signoffs_ci_green_no_blockers_is_ci_green() -> Result<()> {
+        let state = fixture("tests/fixtures/queue-state/all-signoffs-ci-green.json")?;
+        assert_eq!(state.canonical_state, "CI_GREEN");
+        assert!(state.blockers.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn merge_ready_label_with_stale_base_receipt_is_not_merge_ready() -> Result<()> {
+        let state = fixture("tests/fixtures/queue-state/merge-ready-stale-base-receipt.json")?;
+        assert_ne!(state.canonical_state, "MERGE_READY");
+        assert!(state.contradictions.iter().any(|c| c.contains("merge-ready")));
+        Ok(())
+    }
+}

--- a/xtask/tests/fixtures/queue-state/all-signoffs-ci-green.json
+++ b/xtask/tests/fixtures/queue-state/all-signoffs-ci-green.json
@@ -1,0 +1,18 @@
+{
+  "number": 7001,
+  "draft": false,
+  "merged": false,
+  "head_sha": "head-2",
+  "base_sha": "base-2",
+  "labels": ["review-reviewed"],
+  "status_rollup": "GREEN",
+  "receipts": [
+    {
+      "kind": "review",
+      "path": "target/receipts/review.json",
+      "head_sha": "head-2",
+      "base_sha": "base-2",
+      "valid": true
+    }
+  ]
+}

--- a/xtask/tests/fixtures/queue-state/merge-ready-stale-base-receipt.json
+++ b/xtask/tests/fixtures/queue-state/merge-ready-stale-base-receipt.json
@@ -1,0 +1,18 @@
+{
+  "number": 7002,
+  "draft": false,
+  "merged": false,
+  "head_sha": "head-3",
+  "base_sha": "base-current",
+  "labels": ["review-reviewed", "merge-ready"],
+  "status_rollup": "GREEN",
+  "receipts": [
+    {
+      "kind": "merge-readiness",
+      "path": "target/receipts/merge-ready.json",
+      "head_sha": "head-3",
+      "base_sha": "base-stale",
+      "valid": true
+    }
+  ]
+}

--- a/xtask/tests/fixtures/queue-state/review-reviewed-needs-builder-fix.json
+++ b/xtask/tests/fixtures/queue-state/review-reviewed-needs-builder-fix.json
@@ -1,0 +1,18 @@
+{
+  "number": 6853,
+  "draft": false,
+  "merged": false,
+  "head_sha": "head-1",
+  "base_sha": "base-1",
+  "labels": ["review-reviewed", "needs-builder-fix"],
+  "status_rollup": "GREEN",
+  "receipts": [
+    {
+      "kind": "review",
+      "path": "target/receipts/review.json",
+      "head_sha": "head-1",
+      "base_sha": "base-1",
+      "valid": true
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Replace ad-hoc label/comment/log-driven queue reasoning with a canonical PR state derived from GitHub facts plus machine-readable receipts.
- Provide a first dry-run-only implementation to emit receipts, detect contradictions/stale receipts, and project next routes without mutating GitHub state (Refs #6853).

### Description

- Add `xtask queue` command group with `queue snapshot` (creates PR facts snapshot from `GITHUB_EVENT_PATH`) and `queue state` (consumes a snapshot and emits a dry-run queue-state receipt).
- Implemented `xtask/src/tasks/queue_snapshot.rs` and `xtask/src/tasks/queue_state.rs` with canonical-state logic including `needs-*` blocker precedence, stale receipt detection via `head_sha`, merge-ready gating by merge-readiness receipt/base SHA validity, contradiction reporting, and projection-only `projected_labels`/`projected_next_routes` (no apply).
- Add configuration and schemas: `.ci/state/pr-states.toml` for state→projection mapping and `.ci/receipts/schemas/queue-state.schema.json` for the receipt shape and canonical-state enum list, plus docs at `docs/ci/queue-state-machine.md` and fixture inputs under `xtask/tests/fixtures/queue-state/`.
- Register new modules in `xtask/src/tasks/mod.rs` and wire commands into the CLI in `xtask/src/main.rs`; `queue state` enforces `--dry-run` in this phase.

### Testing

- Ran `cargo xtask queue snapshot --out target/queue/snapshot.json` and it produced `target/queue/snapshot.json` (success).
- Ran `cargo xtask queue state --snapshot target/queue/snapshot.json --dry-run --receipt target/receipts/queue-state.json` and it produced `target/receipts/queue-state.json` (success).
- `cargo check -p xtask` completed successfully.
- Unit tests: `cargo test -p xtask queue_state::tests::` executed the three fixture-backed tests and all passed, validating the scenarios: `review-reviewed + needs-builder-fix` → `NEEDS_BUILDER_FIX` + contradiction, all signoffs + CI green → `CI_GREEN`, and `merge-ready` with stale base receipt → not `MERGE_READY` (all passed).
- Formatting and lint: `cargo xtask fmt` ran and `cargo clippy -p xtask -- -D warnings` completed successfully.
- Note: `just pr-fast` was not available in the execution environment and was not run here.

Refs #6853. This PR is dry-run only and does not mutate labels, comments, or merge state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0717eb483339f0a69eb78381f49)