### PR TITLE
feat(queue): project labels from canonical PR state (#6853)

### DIFF
--- a/.ci/receipts/schemas/label-projection.schema.json
+++ b/.ci/receipts/schemas/label-projection.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/schemas/label-projection.schema.json",
+  "title": "Label Projection Receipt",
+  "type": "object",
+  "required": [
+    "current_labels",
+    "projected_apply",
+    "projected_remove",
+    "skipped",
+    "reason",
+    "dry_run",
+    "verdict"
+  ],
+  "properties": {
+    "current_labels": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "projected_apply": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "projected_remove": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "skipped": { "type": "boolean" },
+    "reason": { "type": "string", "minLength": 1 },
+    "dry_run": { "type": "boolean" },
+    "verdict": {
+      "type": "string",
+      "enum": ["ok", "noop", "blocked"]
+    }
+  },
+  "additionalProperties": false
+}

--- a/.ci/state/label-projection.toml
+++ b/.ci/state/label-projection.toml
@@ -1,0 +1,21 @@
+[state.NEEDS_BUILDER_FIX]
+apply = ["needs-builder-fix"]
+remove = ["review-reviewed", "ci-green", "merge-ready"]
+
+[state.NEEDS_CI_FIX]
+apply = ["needs-ci-fix"]
+remove = ["ci-green", "merge-ready"]
+
+[state.CI_GREEN]
+apply = ["ci-green"]
+remove = ["needs-ci-fix", "merge-ready"]
+
+[state.MERGE_READY]
+apply = ["merge-ready"]
+remove = [
+  "needs-builder-fix",
+  "needs-ci-fix",
+  "needs-diff-fix",
+  "needs-spec-fix",
+  "needs-red-tdd-fix",
+]

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -86,7 +86,7 @@ impl SafeEvaluator {
         }
 
         // Check for assignment operators while avoiding comparison false positives
-        if let Some(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref().ok() {
+        if let Ok(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref() {
             for mat in re.find_iter(expression) {
                 let op = mat.as_str();
                 if ASSIGNMENT_OPERATORS.contains(&op) {

--- a/docs/ci/label-projection.md
+++ b/docs/ci/label-projection.md
@@ -1,0 +1,43 @@
+# Label projection from canonical queue state
+
+`cargo xtask queue project-labels` treats labels as a projection of canonical queue state receipts.
+
+## Commands
+
+```bash
+cargo xtask queue project-labels \
+  --state target/receipts/queue-state.json \
+  --dry-run \
+  --receipt target/receipts/label-projection.json
+
+cargo xtask queue project-labels \
+  --state target/receipts/queue-state.json \
+  --apply
+```
+
+## Behavior
+
+- Default mode is dry-run (no GitHub mutations).
+- `--apply` is required for label mutations.
+- `--apply` requires `GH_TOKEN` in the environment.
+- `MERGE_READY` will not project `merge-ready` unless `merge_ready_receipt_valid` is `true` in state input.
+- Label creation is disabled by default; use `--create-labels` to opt in.
+
+## State input (initial fixture shape)
+
+```json
+{
+  "canonical_state": "NEEDS_BUILDER_FIX",
+  "current_labels": ["review-reviewed", "ci-green", "merge-ready"],
+  "pull_request": {
+    "owner": "EffortlessMetrics",
+    "repo": "perl-lsp",
+    "number": 6853
+  },
+  "merge_ready_receipt_valid": false
+}
+```
+
+## Receipt output
+
+See schema: `.ci/receipts/schemas/label-projection.schema.json`.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -831,6 +831,12 @@ enum Commands {
         command: CpanCorpusCommand,
     },
 
+    /// Queue-state based CI orchestration helpers.
+    Queue {
+        #[command(subcommand)]
+        command: QueueCommand,
+    },
+
     /// Generate canonical receipts (test summary, doc metrics, consolidated state)
     ///
     /// Runs workspace tests and doc builds, parses output, and produces
@@ -1235,6 +1241,28 @@ enum FeaturesCommand {
 }
 
 #[derive(Subcommand)]
+enum QueueCommand {
+    /// Project GitHub labels from canonical queue-state receipts.
+    ProjectLabels {
+        /// Canonical queue-state JSON input.
+        #[arg(long)]
+        state: PathBuf,
+        /// Force dry-run behavior (default mode).
+        #[arg(long)]
+        dry_run: bool,
+        /// Apply projected label operations to GitHub.
+        #[arg(long)]
+        apply: bool,
+        /// Optional projection receipt output path.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+        /// Allow creating missing labels during apply.
+        #[arg(long)]
+        create_labels: bool,
+    },
+}
+
+#[derive(Subcommand)]
 enum MetricsCommand {
     /// Emit parser phase timings and benchmark summary.
     ParserStats {
@@ -1571,6 +1599,11 @@ fn main() -> Result<()> {
                 }
             }
         }
+        Commands::Queue { command } => match command {
+            QueueCommand::ProjectLabels { state, dry_run, apply, receipt, create_labels } => {
+                label_projector::run(&state, dry_run, apply, receipt.as_deref(), create_labels)
+            }
+        },
         Commands::Receipts { tests_only, docs_only, output_dir, test_threads } => {
             receipts::run(receipts::ReceiptsConfig {
                 tests_only,

--- a/xtask/src/tasks/label_projector.rs
+++ b/xtask/src/tasks/label_projector.rs
@@ -1,0 +1,275 @@
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+const DEFAULT_CONFIG_PATH: &str = ".ci/state/label-projection.toml";
+
+#[derive(Debug, Deserialize)]
+struct LabelProjectionConfig {
+    state: BTreeMap<String, LabelRule>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LabelRule {
+    #[serde(default)]
+    apply: Vec<String>,
+    #[serde(default)]
+    remove: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct QueueState {
+    pub canonical_state: String,
+    #[serde(default)]
+    pub current_labels: Vec<String>,
+    #[serde(default)]
+    pub pull_request: Option<PullRequestRef>,
+    #[serde(default)]
+    pub merge_ready_receipt_valid: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PullRequestRef {
+    pub owner: String,
+    pub repo: String,
+    pub number: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LabelProjectionReceipt {
+    pub current_labels: Vec<String>,
+    pub projected_apply: Vec<String>,
+    pub projected_remove: Vec<String>,
+    pub skipped: bool,
+    pub reason: String,
+    pub dry_run: bool,
+    pub verdict: String,
+}
+
+pub fn run(
+    state_path: &Path,
+    dry_run_flag: bool,
+    apply_flag: bool,
+    receipt_path: Option<&Path>,
+    create_labels: bool,
+) -> Result<()> {
+    if dry_run_flag && apply_flag {
+        bail!("--dry-run and --apply are mutually exclusive");
+    }
+
+    let dry_run = !apply_flag;
+
+    let root = crate::utils::project_root()?;
+    let config_path = root.join(DEFAULT_CONFIG_PATH);
+    let config_raw = fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read config: {}", config_path.display()))?;
+    let config: LabelProjectionConfig = toml::from_str(&config_raw)
+        .with_context(|| format!("failed to parse config: {}", config_path.display()))?;
+
+    let state_raw = fs::read_to_string(state_path)
+        .with_context(|| format!("failed to read state receipt: {}", state_path.display()))?;
+    let state: QueueState = serde_json::from_str(&state_raw)
+        .with_context(|| format!("failed to parse state receipt: {}", state_path.display()))?;
+
+    let mut receipt = project_labels(&config, &state, dry_run);
+
+    if !dry_run {
+        if std::env::var("GH_TOKEN").is_err() {
+            bail!("--apply requires GH_TOKEN in environment");
+        }
+
+        if let Some(pr) = &state.pull_request {
+            apply_changes(pr, &receipt, create_labels)?;
+        } else {
+            receipt.skipped = true;
+            receipt.reason =
+                "state receipt missing pull_request metadata; cannot apply labels".to_string();
+            receipt.verdict = "blocked".to_string();
+        }
+    }
+
+    if let Some(path) = receipt_path {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create receipt dir: {}", parent.display()))?;
+        }
+        let json = serde_json::to_string_pretty(&receipt)?;
+        fs::write(path, json)
+            .with_context(|| format!("failed to write receipt: {}", path.display()))?;
+    } else {
+        println!("{}", serde_json::to_string_pretty(&receipt)?);
+    }
+
+    if receipt.verdict == "blocked" {
+        bail!("label projection blocked: {}", receipt.reason);
+    }
+
+    Ok(())
+}
+
+fn project_labels(
+    config: &LabelProjectionConfig,
+    state: &QueueState,
+    dry_run: bool,
+) -> LabelProjectionReceipt {
+    let mut current_labels = state.current_labels.clone();
+    current_labels.sort();
+
+    let Some(rule) = config.state.get(&state.canonical_state) else {
+        return LabelProjectionReceipt {
+            current_labels,
+            projected_apply: Vec::new(),
+            projected_remove: Vec::new(),
+            skipped: true,
+            reason: format!("no projection rule for state {}", state.canonical_state),
+            dry_run,
+            verdict: "noop".to_string(),
+        };
+    };
+
+    if state.canonical_state == "MERGE_READY" && !state.merge_ready_receipt_valid {
+        return LabelProjectionReceipt {
+            current_labels,
+            projected_apply: Vec::new(),
+            projected_remove: Vec::new(),
+            skipped: true,
+            reason: "merge-ready receipt missing or invalid".to_string(),
+            dry_run,
+            verdict: "blocked".to_string(),
+        };
+    }
+
+    let current_set = current_labels.iter().cloned().collect::<BTreeSet<_>>();
+    let mut projected_apply = rule
+        .apply
+        .iter()
+        .filter(|label| !current_set.contains(*label))
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut projected_remove = rule
+        .remove
+        .iter()
+        .filter(|label| current_set.contains(*label))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    projected_apply.sort();
+    projected_remove.sort();
+
+    let skipped = projected_apply.is_empty() && projected_remove.is_empty();
+    let verdict = if skipped { "noop" } else { "ok" };
+
+    LabelProjectionReceipt {
+        current_labels,
+        projected_apply,
+        projected_remove,
+        skipped,
+        reason: if skipped {
+            "already aligned with projection".to_string()
+        } else {
+            "computed from canonical state".to_string()
+        },
+        dry_run,
+        verdict: verdict.to_string(),
+    }
+}
+
+fn apply_changes(
+    pr: &PullRequestRef,
+    receipt: &LabelProjectionReceipt,
+    create_labels: bool,
+) -> Result<()> {
+    for label in &receipt.projected_apply {
+        apply_label(pr, label, create_labels)?;
+    }
+
+    for label in &receipt.projected_remove {
+        remove_label(pr, label)?;
+    }
+
+    Ok(())
+}
+
+fn apply_label(pr: &PullRequestRef, label: &str, create_labels: bool) -> Result<()> {
+    let endpoint = format!("repos/{}/{}/issues/{}/labels", pr.owner, pr.repo, pr.number);
+    run_gh_api(
+        "POST",
+        &endpoint,
+        Some(serde_json::json!({ "labels": [label] })),
+        format!("failed to apply label `{label}`"),
+    )
+    .or_else(|err| {
+        if create_labels {
+            let create_endpoint = format!("repos/{}/{}/labels", pr.owner, pr.repo);
+            run_gh_api(
+                "POST",
+                &create_endpoint,
+                Some(serde_json::json!({ "name": label, "color": "ededed" })),
+                format!("failed to create missing label `{label}`"),
+            )?;
+            run_gh_api(
+                "POST",
+                &endpoint,
+                Some(serde_json::json!({ "labels": [label] })),
+                format!("failed to apply label `{label}` after creation"),
+            )
+        } else {
+            Err(err)
+        }
+    })
+}
+
+fn remove_label(pr: &PullRequestRef, label: &str) -> Result<()> {
+    let endpoint = format!("repos/{}/{}/issues/{}/labels/{label}", pr.owner, pr.repo, pr.number);
+    run_gh_api("DELETE", &endpoint, None, format!("failed to remove label `{label}`"))
+}
+
+fn run_gh_api(
+    method: &str,
+    endpoint: &str,
+    body: Option<serde_json::Value>,
+    context: String,
+) -> Result<()> {
+    let mut cmd = Command::new("gh");
+    cmd.arg("api")
+        .arg("--method")
+        .arg(method)
+        .arg(endpoint)
+        .arg("-H")
+        .arg("Accept: application/vnd.github+json");
+
+    if let Some(payload) = body {
+        cmd.arg("--input").arg("-");
+        let payload = serde_json::to_vec(&payload)?;
+        let mut child = cmd
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .with_context(|| format!("{context}: launch gh"))?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            use std::io::Write;
+            stdin.write_all(&payload)?;
+        }
+
+        let output = child.wait_with_output()?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("{context}: {}", stderr.trim())
+        }
+    } else {
+        let output = cmd.output().with_context(|| format!("{context}: execute gh"))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("{context}: {}", stderr.trim())
+        }
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -47,6 +47,7 @@ pub mod highlight;
 pub mod hook_checks;
 pub mod ignored_tests;
 pub mod inject_sha_assets;
+pub mod label_projector;
 pub mod layer_check;
 pub mod metrics;
 pub mod parse_rust;

--- a/xtask/tests/fixtures/label-projector/merge-ready-missing-receipt.json
+++ b/xtask/tests/fixtures/label-projector/merge-ready-missing-receipt.json
@@ -1,0 +1,10 @@
+{
+  "canonical_state": "MERGE_READY",
+  "current_labels": ["needs-ci-fix", "review-reviewed"],
+  "pull_request": {
+    "owner": "EffortlessMetrics",
+    "repo": "perl-lsp",
+    "number": 6853
+  },
+  "merge_ready_receipt_valid": false
+}

--- a/xtask/tests/fixtures/label-projector/needs-builder-fix.json
+++ b/xtask/tests/fixtures/label-projector/needs-builder-fix.json
@@ -1,0 +1,10 @@
+{
+  "canonical_state": "NEEDS_BUILDER_FIX",
+  "current_labels": ["review-reviewed", "ci-green", "merge-ready"],
+  "pull_request": {
+    "owner": "EffortlessMetrics",
+    "repo": "perl-lsp",
+    "number": 6853
+  },
+  "merge_ready_receipt_valid": false
+}

--- a/xtask/tests/label_projector_cli.rs
+++ b/xtask/tests/label_projector_cli.rs
@@ -1,0 +1,78 @@
+use anyhow::{Context, Result};
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn dry_run_needs_builder_fix_projects_expected_changes() -> Result<()> {
+    let fixture = fixture_path("needs-builder-fix.json");
+    let tmp = tempfile::NamedTempFile::new()?;
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd
+        .args([
+            "queue",
+            "project-labels",
+            "--state",
+            fixture.to_string_lossy().as_ref(),
+            "--dry-run",
+            "--receipt",
+            tmp.path().to_string_lossy().as_ref(),
+        ])
+        .output()?;
+    assert!(output.status.success(), "command should succeed in dry-run mode");
+
+    let receipt_raw = fs::read_to_string(tmp.path())?;
+    let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
+
+    assert_eq!(receipt["dry_run"], true);
+    assert_eq!(receipt["verdict"], "ok");
+
+    let projected_apply =
+        receipt["projected_apply"].as_array().context("projected_apply should be array")?;
+    assert_eq!(projected_apply.len(), 1);
+    assert_eq!(projected_apply[0], "needs-builder-fix");
+
+    let projected_remove =
+        receipt["projected_remove"].as_array().context("projected_remove should be array")?;
+    assert!(projected_remove.iter().any(|v| v == "review-reviewed"));
+    assert!(projected_remove.iter().any(|v| v == "ci-green"));
+    assert!(projected_remove.iter().any(|v| v == "merge-ready"));
+
+    Ok(())
+}
+
+#[test]
+fn dry_run_merge_ready_without_receipt_is_blocked() -> Result<()> {
+    let fixture = fixture_path("merge-ready-missing-receipt.json");
+    let tmp = tempfile::NamedTempFile::new()?;
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd
+        .args([
+            "queue",
+            "project-labels",
+            "--state",
+            fixture.to_string_lossy().as_ref(),
+            "--dry-run",
+            "--receipt",
+            tmp.path().to_string_lossy().as_ref(),
+        ])
+        .output()?;
+
+    assert!(!output.status.success(), "merge-ready without receipt must be blocked");
+
+    let receipt_raw = fs::read_to_string(tmp.path())?;
+    let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
+
+    assert_eq!(receipt["verdict"], "blocked");
+    assert_eq!(receipt["skipped"], true);
+    assert_eq!(receipt["reason"], "merge-ready receipt missing or invalid");
+
+    Ok(())
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir.join("tests").join("fixtures").join("label-projector").join(name)
+}


### PR DESCRIPTION
### Motivation

- Treat GitHub labels as UI projections of a canonical queue-state receipt instead of mutable source-of-truth. Refs #6853.
- Provide a safe dry-run flow by default and an explicit `--apply` mode for narrow reconciliation guarded by receipts and token checks.

### Description

- Add `xtask queue project-labels` CLI (flags: `--state`, `--dry-run`, `--apply`, `--receipt`, `--create-labels`) and wire it into the xtask dispatcher.  
- Implement `xtask/src/tasks/label_projector.rs` which reads canonical queue-state JSON and `.ci/state/label-projection.toml`, computes `projected_apply` / `projected_remove`, emits a receipt JSON, and performs GitHub mutations only when `--apply` and `GH_TOKEN` are present.  
- Enforce guardrail: do not project `MERGE_READY` unless `merge_ready_receipt_valid` is true in the state input, and do not mutate labels unless explicitly requested; optional `--create-labels` controls label creation.  
- Add projection config `.ci/state/label-projection.toml`, JSON schema `.ci/receipts/schemas/label-projection.schema.json`, docs `docs/ci/label-projection.md`, and fixture-backed tests in `xtask/tests/` plus fixture inputs under `xtask/tests/fixtures/label-projector/`.

### Testing

- Ran `cargo check -p xtask` which completed successfully.  
- Ran unit/CLI tests with `cargo test -p xtask --test label_projector_cli` and both tests passed (dry-run projection for `NEEDS_BUILDER_FIX` and blocked `MERGE_READY` scenario).  
- Manual verification commands executed: `cargo xtask queue project-labels --state target/receipts/queue-state.json --dry-run --receipt target/receipts/label-projection.json` (produces projection receipt) and the blocked `MERGE_READY` dry-run case (refused as expected).  
- Confirmed `--apply` mode fails clearly when `GH_TOKEN` is not present, as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd07607cc8333ab549b5a5c6a3d78)