### PR TITLE
feat(queue): project labels from canonical PR state (#6853)

### DIFF
--- a/.ci/receipts/schemas/label-projection.schema.json
+++ b/.ci/receipts/schemas/label-projection.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/label-projection.schema.json",
+  "title": "LabelProjectionReceipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "current_labels",
+    "projected_apply",
+    "projected_remove",
+    "skipped",
+    "reason",
+    "dry_run",
+    "verdict"
+  ],
+  "properties": {
+    "current_labels": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "projected_apply": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "projected_remove": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "skipped": { "type": "boolean" },
+    "reason": { "type": "string", "minLength": 1 },
+    "dry_run": { "type": "boolean" },
+    "verdict": {
+      "type": "string",
+      "enum": ["dry-run", "applied", "skipped", "refused"]
+    }
+  }
+}

--- a/.ci/state/label-projection.toml
+++ b/.ci/state/label-projection.toml
@@ -1,0 +1,15 @@
+[state.NEEDS_BUILDER_FIX]
+apply = ["needs-builder-fix"]
+remove = ["review-reviewed", "ci-green", "merge-ready"]
+
+[state.NEEDS_CI_FIX]
+apply = ["needs-ci-fix"]
+remove = ["ci-green", "merge-ready"]
+
+[state.CI_GREEN]
+apply = ["ci-green"]
+remove = ["needs-ci-fix", "merge-ready"]
+
+[state.MERGE_READY]
+apply = ["merge-ready"]
+remove = ["needs-builder-fix", "needs-ci-fix", "needs-diff-fix", "needs-spec-fix", "needs-red-tdd-fix"]

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -86,7 +86,7 @@ impl SafeEvaluator {
         }
 
         // Check for assignment operators while avoiding comparison false positives
-        if let Some(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref().ok() {
+        if let Ok(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref() {
             for mat in re.find_iter(expression) {
                 let op = mat.as_str();
                 if ASSIGNMENT_OPERATORS.contains(&op) {

--- a/docs/ci/label-projection.md
+++ b/docs/ci/label-projection.md
@@ -1,0 +1,52 @@
+# Label projection from canonical PR state
+
+`cargo xtask queue project-labels` projects GitHub labels from canonical PR state receipts.
+
+## Default mode
+
+The command is **dry-run by default**. If `--apply` is not passed, it only prints (and optionally writes) the projection receipt.
+
+```bash
+cargo xtask queue project-labels \
+  --state target/receipts/queue-state.json \
+  --dry-run \
+  --receipt target/receipts/label-projection.json
+```
+
+## Apply mode
+
+`--apply` is explicit and required for mutation.
+
+```bash
+cargo xtask queue project-labels \
+  --state target/receipts/queue-state.json \
+  --apply
+```
+
+Apply mode requirements:
+
+- `GH_TOKEN` must be present and non-empty.
+- `pr_number` must exist in the state receipt.
+- Missing labels are **not created** unless `--create-missing-labels` is passed.
+
+## MERGE_READY safety
+
+For `MERGE_READY`, projection is refused unless the state payload confirms a valid merge-readiness receipt (`merge_ready_receipt_valid`, `has_merge_ready_receipt`, or `merge_readiness_receipt.valid`).
+
+## Config
+
+Rules are loaded from `.ci/state/label-projection.toml` by default.
+
+## Receipt schema
+
+Projection receipt fields:
+
+- `current_labels`
+- `projected_apply`
+- `projected_remove`
+- `skipped`
+- `reason`
+- `dry_run`
+- `verdict`
+
+Schema file: `.ci/receipts/schemas/label-projection.schema.json`.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -831,6 +831,12 @@ enum Commands {
         command: CpanCorpusCommand,
     },
 
+    /// Queue orchestration helpers.
+    Queue {
+        #[command(subcommand)]
+        command: QueueCommand,
+    },
+
     /// Generate canonical receipts (test summary, doc metrics, consolidated state)
     ///
     /// Runs workspace tests and doc builds, parses output, and produces
@@ -1220,6 +1226,36 @@ enum CpanCorpusCommand {
 }
 
 #[derive(Subcommand)]
+enum QueueCommand {
+    /// Project labels from canonical PR state.
+    ProjectLabels {
+        /// Path to canonical queue state receipt JSON.
+        #[arg(long)]
+        state: PathBuf,
+
+        /// Write receipt JSON to this file.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+
+        /// Optional projection config path.
+        #[arg(long)]
+        config: Option<PathBuf>,
+
+        /// Explicit dry-run mode (default behavior when --apply is absent).
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Apply projected label changes to GitHub.
+        #[arg(long)]
+        apply: bool,
+
+        /// Allow creating missing labels before applying.
+        #[arg(long)]
+        create_missing_labels: bool,
+    },
+}
+
+#[derive(Subcommand)]
 enum FeaturesCommand {
     /// Sync documentation from features.toml
     SyncDocs,
@@ -1571,6 +1607,23 @@ fn main() -> Result<()> {
                 }
             }
         }
+        Commands::Queue { command } => match command {
+            QueueCommand::ProjectLabels {
+                state,
+                receipt,
+                config,
+                dry_run,
+                apply,
+                create_missing_labels,
+            } => label_projector::run_project_labels(
+                state,
+                dry_run,
+                apply,
+                receipt,
+                config,
+                create_missing_labels,
+            ),
+        },
         Commands::Receipts { tests_only, docs_only, output_dir, test_threads } => {
             receipts::run(receipts::ReceiptsConfig {
                 tests_only,

--- a/xtask/src/tasks/label_projector.rs
+++ b/xtask/src/tasks/label_projector.rs
@@ -1,0 +1,266 @@
+use color_eyre::eyre::{Context, Result, bail, eyre};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::utils::project_root;
+
+#[derive(Debug, Clone, Deserialize)]
+struct ProjectionConfig {
+    state: BTreeMap<String, ProjectionRule>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ProjectionRule {
+    #[serde(default)]
+    apply: Vec<String>,
+    #[serde(default)]
+    remove: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct LabelProjectionReceipt {
+    current_labels: Vec<String>,
+    projected_apply: Vec<String>,
+    projected_remove: Vec<String>,
+    skipped: bool,
+    reason: String,
+    dry_run: bool,
+    verdict: String,
+}
+
+pub fn run_project_labels(
+    state_path: PathBuf,
+    dry_run: bool,
+    apply: bool,
+    receipt: Option<PathBuf>,
+    config: Option<PathBuf>,
+    create_missing_labels: bool,
+) -> Result<()> {
+    if dry_run && apply {
+        bail!("--dry-run and --apply are mutually exclusive");
+    }
+
+    let effective_dry_run = !apply;
+    let root = project_root()?;
+    let config_path = config.unwrap_or_else(|| root.join(".ci/state/label-projection.toml"));
+    let projection_config = load_projection_config(&config_path)?;
+    let state_payload = load_state_json(&state_path)?;
+
+    let canonical_state = extract_canonical_state(&state_payload).ok_or_else(|| {
+        eyre!("state receipt is missing canonical state (expected `canonical_state` or `state`)")
+    })?;
+
+    let current_labels = extract_labels(&state_payload, "current_labels");
+
+    let Some(rule) = projection_config.state.get(&canonical_state) else {
+        let receipt_payload = LabelProjectionReceipt {
+            current_labels,
+            projected_apply: Vec::new(),
+            projected_remove: Vec::new(),
+            skipped: true,
+            reason: format!("no label projection rule for state `{canonical_state}`"),
+            dry_run: effective_dry_run,
+            verdict: "skipped".to_string(),
+        };
+        write_receipt_if_requested(receipt, &receipt_payload)?;
+        print_receipt(&receipt_payload)?;
+        return Ok(());
+    };
+
+    if canonical_state == "MERGE_READY" && !has_valid_merge_ready_receipt(&state_payload) {
+        let receipt_payload = LabelProjectionReceipt {
+            current_labels,
+            projected_apply: Vec::new(),
+            projected_remove: Vec::new(),
+            skipped: true,
+            reason: "MERGE_READY projection refused: missing valid merge-ready receipt".to_string(),
+            dry_run: effective_dry_run,
+            verdict: "refused".to_string(),
+        };
+        write_receipt_if_requested(receipt, &receipt_payload)?;
+        print_receipt(&receipt_payload)?;
+        return Ok(());
+    }
+
+    let projected_apply = difference(&rule.apply, &current_labels);
+    let projected_remove = intersection(&rule.remove, &current_labels);
+
+    let mut receipt_payload = LabelProjectionReceipt {
+        current_labels,
+        projected_apply,
+        projected_remove,
+        skipped: false,
+        reason: format!("state `{canonical_state}` projection"),
+        dry_run: effective_dry_run,
+        verdict: if effective_dry_run { "dry-run".to_string() } else { "applied".to_string() },
+    };
+
+    if apply {
+        apply_projection(&state_payload, &receipt_payload, create_missing_labels)?;
+    }
+
+    write_receipt_if_requested(receipt, &receipt_payload)?;
+    print_receipt(&receipt_payload)?;
+    if apply {
+        receipt_payload.verdict = "applied".to_string();
+    }
+    Ok(())
+}
+
+fn load_projection_config(path: &Path) -> Result<ProjectionConfig> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read projection config: {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("failed to parse TOML: {}", path.display()))
+}
+
+fn load_state_json(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read state receipt: {}", path.display()))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse state receipt JSON: {}", path.display()))
+}
+
+fn extract_canonical_state(state: &Value) -> Option<String> {
+    let candidates = [
+        state.get("canonical_state").and_then(Value::as_str),
+        state.get("state").and_then(Value::as_str),
+        state.get("pr").and_then(|pr| pr.get("canonical_state")).and_then(Value::as_str),
+        state.get("pr_state").and_then(Value::as_str),
+    ];
+
+    candidates.iter().flatten().next().map(|value| value.to_string())
+}
+
+fn extract_labels(state: &Value, key: &str) -> Vec<String> {
+    let Some(array) = state.get(key).and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    array.iter().filter_map(Value::as_str).map(ToOwned::to_owned).collect()
+}
+
+fn has_valid_merge_ready_receipt(state: &Value) -> bool {
+    if state.get("merge_ready_receipt_valid").and_then(Value::as_bool).is_some_and(|v| v) {
+        return true;
+    }
+
+    if state.get("has_merge_ready_receipt").and_then(Value::as_bool).is_some_and(|v| v) {
+        return true;
+    }
+
+    state
+        .get("merge_readiness_receipt")
+        .and_then(|receipt| receipt.get("valid"))
+        .and_then(Value::as_bool)
+        .is_some_and(|v| v)
+}
+
+fn difference(expected: &[String], current: &[String]) -> Vec<String> {
+    expected.iter().filter(|item| !current.contains(*item)).cloned().collect()
+}
+
+fn intersection(expected_remove: &[String], current: &[String]) -> Vec<String> {
+    expected_remove.iter().filter(|item| current.contains(*item)).cloned().collect()
+}
+
+fn apply_projection(
+    state: &Value,
+    receipt: &LabelProjectionReceipt,
+    create_missing_labels: bool,
+) -> Result<()> {
+    let gh_token = std::env::var("GH_TOKEN").context(
+        "--apply requested but GH_TOKEN is unavailable; set GH_TOKEN and rerun with --apply",
+    )?;
+    if gh_token.trim().is_empty() {
+        bail!("--apply requested but GH_TOKEN is empty");
+    }
+
+    let pr_number = state
+        .get("pr_number")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| eyre!("--apply requires `pr_number` in state receipt"))?;
+
+    for label in &receipt.projected_apply {
+        let mut command = Command::new("gh");
+        command
+            .args(["pr", "edit", &pr_number.to_string(), "--add-label", label])
+            .env("GH_TOKEN", &gh_token);
+
+        let status = command.status().context("failed to execute `gh pr edit` for add-label")?;
+        if !status.success() {
+            if create_missing_labels {
+                create_label(label, &gh_token)?;
+                let mut retry = Command::new("gh");
+                let retry_status = retry
+                    .args(["pr", "edit", &pr_number.to_string(), "--add-label", label])
+                    .env("GH_TOKEN", &gh_token)
+                    .status()
+                    .context("failed to retry `gh pr edit` after label creation")?;
+                if !retry_status.success() {
+                    bail!("failed to apply label `{label}` to PR #{pr_number}");
+                }
+            } else {
+                bail!(
+                    "failed to apply label `{label}` to PR #{pr_number}; refusing to create labels without --create-missing-labels"
+                );
+            }
+        }
+    }
+
+    for label in &receipt.projected_remove {
+        let status = Command::new("gh")
+            .args(["pr", "edit", &pr_number.to_string(), "--remove-label", label])
+            .env("GH_TOKEN", &gh_token)
+            .status()
+            .context("failed to execute `gh pr edit` for remove-label")?;
+        if !status.success() {
+            bail!("failed to remove label `{label}` from PR #{pr_number}");
+        }
+    }
+
+    Ok(())
+}
+
+fn create_label(label: &str, gh_token: &str) -> Result<()> {
+    let status = Command::new("gh")
+        .args([
+            "label",
+            "create",
+            label,
+            "--color",
+            "ededed",
+            "--description",
+            "auto-created by xtask queue project-labels",
+        ])
+        .env("GH_TOKEN", gh_token)
+        .status()
+        .context("failed to execute `gh label create`")?;
+
+    if status.success() { Ok(()) } else { bail!("failed to create missing label `{label}`") }
+}
+
+fn write_receipt_if_requested(
+    path: Option<PathBuf>,
+    receipt: &LabelProjectionReceipt,
+) -> Result<()> {
+    let Some(path) = path else {
+        return Ok(());
+    };
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create receipt dir: {}", parent.display()))?;
+    }
+
+    let serialized = serde_json::to_string_pretty(receipt)?;
+    fs::write(&path, format!("{serialized}\n"))
+        .with_context(|| format!("failed to write receipt: {}", path.display()))
+}
+
+fn print_receipt(receipt: &LabelProjectionReceipt) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(receipt)?);
+    Ok(())
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -47,6 +47,7 @@ pub mod highlight;
 pub mod hook_checks;
 pub mod ignored_tests;
 pub mod inject_sha_assets;
+pub mod label_projector;
 pub mod layer_check;
 pub mod metrics;
 pub mod parse_rust;

--- a/xtask/tests/fixtures/label-projector/merge-ready-missing-receipt.json
+++ b/xtask/tests/fixtures/label-projector/merge-ready-missing-receipt.json
@@ -1,0 +1,9 @@
+{
+  "canonical_state": "MERGE_READY",
+  "pr_number": 6853,
+  "current_labels": [
+    "needs-ci-fix",
+    "review-reviewed"
+  ],
+  "merge_ready_receipt_valid": false
+}

--- a/xtask/tests/fixtures/label-projector/needs-builder-fix.json
+++ b/xtask/tests/fixtures/label-projector/needs-builder-fix.json
@@ -1,0 +1,9 @@
+{
+  "canonical_state": "NEEDS_BUILDER_FIX",
+  "pr_number": 6853,
+  "current_labels": [
+    "review-reviewed",
+    "ci-green",
+    "merge-ready"
+  ]
+}

--- a/xtask/tests/label_projector_tests.rs
+++ b/xtask/tests/label_projector_tests.rs
@@ -1,0 +1,72 @@
+use assert_cmd::Command;
+use color_eyre::eyre::Result;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+fn fixture_path(name: &str) -> String {
+    Path::new("tests/fixtures/label-projector").join(name).to_string_lossy().to_string()
+}
+
+#[test]
+fn dry_run_needs_builder_fix_projects_expected_add_and_remove() -> Result<()> {
+    let receipt_dir = tempdir()?;
+    let receipt_path = receipt_dir.path().join("label-projection.json");
+
+    let output = Command::cargo_bin("xtask")?
+        .args([
+            "queue",
+            "project-labels",
+            "--state",
+            &fixture_path("needs-builder-fix.json"),
+            "--dry-run",
+            "--receipt",
+            &receipt_path.to_string_lossy(),
+        ])
+        .output()?;
+
+    assert!(output.status.success(), "command failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    let receipt = fs::read_to_string(receipt_path)?;
+    let json: serde_json::Value = serde_json::from_str(&receipt)?;
+
+    assert_eq!(json["dry_run"], serde_json::json!(true));
+    assert_eq!(json["verdict"], serde_json::json!("dry-run"));
+    assert_eq!(json["projected_apply"], serde_json::json!(["needs-builder-fix"]));
+    assert_eq!(
+        json["projected_remove"],
+        serde_json::json!(["review-reviewed", "ci-green", "merge-ready"])
+    );
+
+    Ok(())
+}
+
+#[test]
+fn dry_run_merge_ready_refuses_without_merge_readiness_receipt() -> Result<()> {
+    let receipt_dir = tempdir()?;
+    let receipt_path = receipt_dir.path().join("label-projection.json");
+
+    let output = Command::cargo_bin("xtask")?
+        .args([
+            "queue",
+            "project-labels",
+            "--state",
+            &fixture_path("merge-ready-missing-receipt.json"),
+            "--dry-run",
+            "--receipt",
+            &receipt_path.to_string_lossy(),
+        ])
+        .output()?;
+
+    assert!(output.status.success(), "command failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    let receipt = fs::read_to_string(receipt_path)?;
+    let json: serde_json::Value = serde_json::from_str(&receipt)?;
+
+    assert_eq!(json["skipped"], serde_json::json!(true));
+    assert_eq!(json["verdict"], serde_json::json!("refused"));
+    let reason = json["reason"].as_str().unwrap_or_default();
+    assert!(reason.contains("missing valid merge-ready receipt"));
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Labels should be UI projections of canonical PR state rather than mutable state on their own, with a dry-run-first workflow to preview changes before applying them; Refs #6853.
- Apply mode must be explicit and guarded so label mutations never happen accidentally.

### Description

- Add a new `xtask queue project-labels` subcommand and wiring to run a label projection from a canonical state receipt with `--dry-run` (default) and explicit `--apply` behavior using `xtask/src/main.rs` and `xtask/src/tasks/label_projector.rs`.
- Load projection rules from `.ci/state/label-projection.toml` and emit a JSON receipt conforming to `.ci/receipts/schemas/label-projection.schema.json` containing `current_labels`, `projected_apply`, `projected_remove`, `skipped`, `reason`, `dry_run`, and `verdict`.
- Enforce safety for apply mode by requiring `GH_TOKEN` and `pr_number` in the state receipt and refuse `MERGE_READY` projections unless a valid merge-readiness receipt is present; missing labels are not created unless `--create-missing-labels` is passed.
- Add docs at `docs/ci/label-projection.md`, fixtures under `xtask/tests/fixtures/label-projector/`, and unit/CLI tests in `xtask/tests/label_projector_tests.rs` to cover dry-run projection and merge-ready refusal cases.

### Testing

- Ran `cargo xtask fmt` and formatting completed successfully.
- Ran `cargo check -p xtask` and the package type-checked successfully.
- Ran `cargo test -p xtask --test label_projector_tests` and the added tests (dry-run `NEEDS_BUILDER_FIX` projection and `MERGE_READY` refusal when missing a merge-readiness receipt) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd07607cc8333ab549b5a5c6a3d78)