### PR TITLE
feat(ci): classify CI failures before routing (#6853)

### DIFF
--- a/.ci/receipts/schemas/failure-classifier.schema.json
+++ b/.ci/receipts/schemas/failure-classifier.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.github.io/perl-lsp/schemas/failure-classifier.schema.json",
+  "title": "Failure Classifier Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "check",
+    "signature",
+    "affected_prs",
+    "master_same_signature",
+    "classification",
+    "recommended_action",
+    "confidence",
+    "evidence"
+  ],
+  "properties": {
+    "check": {
+      "const": "Failure Classifier"
+    },
+    "signature": {
+      "type": "string",
+      "minLength": 1
+    },
+    "affected_prs": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 1
+      }
+    },
+    "master_sha": {
+      "type": ["string", "null"]
+    },
+    "master_same_signature": {
+      "type": "boolean"
+    },
+    "classification": {
+      "type": "string",
+      "enum": [
+        "PR_OWNED",
+        "STALE_BASE",
+        "MASTER_RED",
+        "INFRA_FAILURE",
+        "FLAKY",
+        "UNKNOWN"
+      ]
+    },
+    "recommended_action": {
+      "type": "string"
+    },
+    "confidence": {
+      "type": "string",
+      "enum": ["high", "medium", "low"]
+    },
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/docs/ci/failure-classifier.md
+++ b/docs/ci/failure-classifier.md
@@ -1,0 +1,73 @@
+# Failure Classifier
+
+`cargo xtask failure-classifier` classifies CI failures before any routing automation (for example, before a bot would apply `needs-ci-fix`).
+
+## Goals
+
+- Separate true PR-owned failures from shared incidents.
+- Detect stale-base failures when master is already green.
+- Route infra and flaky failures away from PR-owned queues.
+- Return `UNKNOWN` when evidence is insufficient, instead of over-classifying.
+
+## Commands
+
+```bash
+cargo xtask failure-classifier --snapshot target/queue/snapshot.json --receipt target/receipts/failure-classifier.json
+cargo xtask failure-classifier --fixture xtask/tests/fixtures/failure-classifier/master-red.json
+```
+
+## Input shape (snapshot/fixture)
+
+Top-level fields consumed by the classifier:
+
+- `pr.number`
+- `pr.head_sha`
+- `pr.master_sha`
+- `pr.behind_master`
+- `pr.changed_files[]`
+- `pr_checks[]` (failed checks for PR context)
+- `master_checks[]` (latest master checks for same gate)
+- `merge_group_checks[]` (optional)
+- `known_infra_signatures[]`
+- `receipt_artifacts[]`
+- `affected_prs[]` (optional cluster context)
+
+Each check may include:
+
+- `name` or `signature`
+- `sha`
+- `conclusion`
+- `files[]`
+- `flaky`
+- `attempts`
+- `recent_outcomes[]`
+
+## Receipt output
+
+The output receipt follows `.ci/receipts/schemas/failure-classifier.schema.json` and includes:
+
+- `check`
+- `signature`
+- `affected_prs`
+- `master_sha`
+- `master_same_signature`
+- `classification`
+- `recommended_action`
+- `confidence`
+- `evidence`
+
+## Routing map
+
+- `PR_OWNED` → `NEEDS_CI_FIX / builder`
+- `STALE_BASE` → `NEEDS_CASCADE_UPDATE`
+- `MASTER_RED` → `master incident / no PR-owned label`
+- `INFRA_FAILURE` → `infra/tooling route`
+- `FLAKY` → `rerun/observe`
+- `UNKNOWN` → `human classification`
+
+## Guardrails
+
+- Does **not** apply labels.
+- Does **not** update branches.
+- Does **not** merge PRs.
+- Does **not** classify PR-owned without current-head failing evidence.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -400,6 +400,21 @@ enum Commands {
         format: String,
     },
 
+    /// Classify CI failures before routing labels/actions are applied.
+    FailureClassifier {
+        /// Queue snapshot JSON containing PR/master check context.
+        #[arg(long)]
+        snapshot: Option<PathBuf>,
+
+        /// Optional output path for the classifier receipt JSON.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+
+        /// Fixture JSON path for deterministic local validation.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+    },
+
     /// Run version-sync checks from `perl-ci-hygiene`.
     CheckVersionSync,
 
@@ -1461,6 +1476,13 @@ fn main() -> Result<()> {
         }
         Commands::CiScope { base, format } => {
             ci_scope::run(ci_scope::CiScopeConfig { base, format })
+        }
+        Commands::FailureClassifier { snapshot, receipt, fixture } => {
+            failure_classifier::run(failure_classifier::FailureClassifierConfig {
+                snapshot,
+                receipt,
+                fixture,
+            })
         }
         Commands::CheckVersionSync => check_version_sync::run(),
         Commands::CheckFromRaw => ci_policy::check_from_raw(),

--- a/xtask/src/tasks/failure_classifier.rs
+++ b/xtask/src/tasks/failure_classifier.rs
@@ -1,0 +1,358 @@
+//! CI failure classifier — `cargo xtask failure-classifier`
+//!
+//! Classifies failed CI runs before routing labels/actions are applied.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+const CHECK_NAME: &str = "Failure Classifier";
+
+#[derive(Debug, Clone)]
+pub struct FailureClassifierConfig {
+    pub snapshot: Option<PathBuf>,
+    pub receipt: Option<PathBuf>,
+    pub fixture: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailureReceipt {
+    pub check: String,
+    pub signature: String,
+    pub affected_prs: Vec<u64>,
+    pub master_sha: Option<String>,
+    pub master_same_signature: bool,
+    pub classification: FailureClassification,
+    pub recommended_action: String,
+    pub confidence: String,
+    pub evidence: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum FailureClassification {
+    PrOwned,
+    StaleBase,
+    MasterRed,
+    InfraFailure,
+    Flaky,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct SnapshotInput {
+    #[serde(default)]
+    pr: PullRequestInput,
+    #[serde(default)]
+    pr_checks: Vec<CheckInput>,
+    #[serde(default)]
+    master_checks: Vec<CheckInput>,
+    #[serde(default)]
+    merge_group_checks: Vec<CheckInput>,
+    #[serde(default)]
+    known_infra_signatures: Vec<String>,
+    #[serde(default)]
+    receipt_artifacts: Vec<String>,
+    #[serde(default)]
+    affected_prs: Vec<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct PullRequestInput {
+    number: Option<u64>,
+    head_sha: Option<String>,
+    master_sha: Option<String>,
+    #[serde(default)]
+    behind_master: bool,
+    #[serde(default)]
+    changed_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct CheckInput {
+    name: Option<String>,
+    signature: Option<String>,
+    sha: Option<String>,
+    conclusion: Option<String>,
+    #[serde(default)]
+    flaky: bool,
+    #[serde(default)]
+    files: Vec<String>,
+    #[serde(default)]
+    attempts: u32,
+    #[serde(default)]
+    recent_outcomes: Vec<String>,
+}
+
+pub fn run(config: FailureClassifierConfig) -> Result<()> {
+    let input_path = config.fixture.or(config.snapshot).ok_or_else(|| {
+        color_eyre::eyre::eyre!(
+            "provide --snapshot <path> or --fixture <path> for failure classification"
+        )
+    })?;
+
+    let input = load_input(&input_path)?;
+    let receipt = classify(&input);
+    let rendered = serde_json::to_string_pretty(&receipt)?;
+
+    if let Some(receipt_path) = config.receipt {
+        if let Some(parent) = receipt_path.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        fs::write(&receipt_path, &rendered)
+            .with_context(|| format!("writing receipt {}", receipt_path.display()))?;
+        println!("Wrote failure-classifier receipt: {}", receipt_path.display());
+    } else {
+        println!("{rendered}");
+    }
+
+    Ok(())
+}
+
+fn load_input(path: &Path) -> Result<SnapshotInput> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let input: SnapshotInput =
+        serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?;
+    Ok(input)
+}
+
+fn classify(input: &SnapshotInput) -> FailureReceipt {
+    let head_sha = input.pr.head_sha.as_deref();
+    let failing_pr_checks = input
+        .pr_checks
+        .iter()
+        .filter(|check| is_failure(check.conclusion.as_deref()))
+        .filter(|check| match (head_sha, check.sha.as_deref()) {
+            (Some(head), Some(check_sha)) => head == check_sha,
+            (Some(_), None) => false,
+            (None, _) => true,
+        })
+        .collect::<Vec<_>>();
+
+    let signature = failing_pr_checks
+        .first()
+        .and_then(|check| check_signature(check))
+        .unwrap_or_else(|| "unknown-signature".to_string());
+
+    let master_same_signature = input
+        .master_checks
+        .iter()
+        .filter(|check| is_failure(check.conclusion.as_deref()))
+        .any(|master| check_signature(master).as_deref() == Some(signature.as_str()));
+
+    let mut evidence = Vec::new();
+    if let Some(pr_number) = input.pr.number {
+        evidence.push(format!("PR #{pr_number} evaluated"));
+    }
+    if let Some(head) = &input.pr.head_sha {
+        evidence.push(format!("PR head SHA: {head}"));
+    }
+    if let Some(master_sha) = &input.pr.master_sha {
+        evidence.push(format!("Master SHA: {master_sha}"));
+    }
+    evidence.push(format!("Failing checks on PR head: {}", failing_pr_checks.len()));
+
+    let has_head_evidence = !failing_pr_checks.is_empty();
+
+    let classification = if !has_head_evidence {
+        evidence.push("No failing check tied to current PR head SHA".to_string());
+        FailureClassification::Unknown
+    } else if is_infra_failure(input, &failing_pr_checks, &signature) {
+        evidence.push("Matched known infra signature/pattern".to_string());
+        FailureClassification::InfraFailure
+    } else if master_same_signature {
+        evidence.push("Master has matching failing signature".to_string());
+        FailureClassification::MasterRed
+    } else if input.pr.behind_master && master_green_for_signature(input, &signature) {
+        evidence.push("PR head is behind master while master gate is green".to_string());
+        FailureClassification::StaleBase
+    } else if looks_flaky(input, &failing_pr_checks, &signature) {
+        evidence.push("Observed flaky/retry pattern for failing signature".to_string());
+        FailureClassification::Flaky
+    } else if pr_owned_by_file_overlap(input, &failing_pr_checks) {
+        evidence.push("Failed check references files changed by PR".to_string());
+        FailureClassification::PrOwned
+    } else {
+        evidence.push("No decisive routing signal found".to_string());
+        FailureClassification::Unknown
+    };
+
+    let recommended_action = recommended_action(&classification).to_string();
+    let confidence = confidence(&classification, has_head_evidence).to_string();
+
+    let mut affected_prs =
+        if input.affected_prs.is_empty() { Vec::new() } else { input.affected_prs.clone() };
+    if let Some(number) = input.pr.number {
+        if !affected_prs.contains(&number) {
+            affected_prs.push(number);
+        }
+    }
+
+    FailureReceipt {
+        check: CHECK_NAME.to_string(),
+        signature,
+        affected_prs,
+        master_sha: input.pr.master_sha.clone(),
+        master_same_signature,
+        classification,
+        recommended_action,
+        confidence,
+        evidence,
+    }
+}
+
+fn check_signature(check: &CheckInput) -> Option<String> {
+    check
+        .signature
+        .clone()
+        .or_else(|| check.name.clone())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn is_failure(conclusion: Option<&str>) -> bool {
+    matches!(conclusion, Some("failure") | Some("timed_out") | Some("cancelled"))
+}
+
+fn is_success(conclusion: Option<&str>) -> bool {
+    matches!(conclusion, Some("success") | Some("neutral") | Some("skipped"))
+}
+
+fn is_infra_failure(input: &SnapshotInput, failing: &[&CheckInput], signature: &str) -> bool {
+    let known = input.known_infra_signatures.iter().any(|known| known == signature);
+    if known {
+        return true;
+    }
+
+    let mut all_artifacts = input.receipt_artifacts.clone();
+    all_artifacts.extend(input.merge_group_checks.iter().filter_map(check_signature));
+
+    let signatures = failing.iter().filter_map(|check| check_signature(check)).collect::<Vec<_>>();
+
+    let inferred = signatures.iter().any(|value| contains_infra_pattern(value))
+        || all_artifacts.iter().any(|value| contains_infra_pattern(value));
+
+    inferred
+}
+
+fn contains_infra_pattern(value: &str) -> bool {
+    let lowered = value.to_ascii_lowercase();
+    lowered.contains("runner lost")
+        || lowered.contains("service unavailable")
+        || lowered.contains("network timeout")
+        || lowered.contains("artifact upload")
+        || lowered.contains("github outage")
+}
+
+fn master_green_for_signature(input: &SnapshotInput, signature: &str) -> bool {
+    input
+        .master_checks
+        .iter()
+        .filter(|check| check_signature(check).as_deref() == Some(signature))
+        .any(|check| is_success(check.conclusion.as_deref()))
+}
+
+fn looks_flaky(input: &SnapshotInput, failing: &[&CheckInput], signature: &str) -> bool {
+    let on_pr = failing.iter().any(|check| {
+        check.flaky
+            || check.attempts > 1
+            || check.recent_outcomes.iter().any(|outcome| outcome == "success")
+    });
+
+    let on_master = input
+        .master_checks
+        .iter()
+        .filter(|check| check_signature(check).as_deref() == Some(signature))
+        .any(|check| check.flaky || check.attempts > 1);
+
+    on_pr || on_master
+}
+
+fn pr_owned_by_file_overlap(input: &SnapshotInput, failing: &[&CheckInput]) -> bool {
+    if input.pr.changed_files.is_empty() {
+        return false;
+    }
+
+    failing.iter().any(|check| {
+        check.files.iter().any(|file| input.pr.changed_files.iter().any(|changed| changed == file))
+    })
+}
+
+fn recommended_action(classification: &FailureClassification) -> &'static str {
+    match classification {
+        FailureClassification::PrOwned => "NEEDS_CI_FIX / builder",
+        FailureClassification::StaleBase => "NEEDS_CASCADE_UPDATE",
+        FailureClassification::MasterRed => "master incident / no PR-owned label",
+        FailureClassification::InfraFailure => "infra/tooling route",
+        FailureClassification::Flaky => "rerun/observe",
+        FailureClassification::Unknown => "human classification",
+    }
+}
+
+fn confidence(classification: &FailureClassification, has_head_evidence: bool) -> &'static str {
+    if !has_head_evidence {
+        return "low";
+    }
+
+    match classification {
+        FailureClassification::MasterRed | FailureClassification::PrOwned => "high",
+        FailureClassification::StaleBase | FailureClassification::InfraFailure => "medium",
+        FailureClassification::Flaky | FailureClassification::Unknown => "low",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use color_eyre::eyre::bail;
+
+    fn fixture(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("failure-classifier")
+            .join(name)
+    }
+
+    #[test]
+    fn fixture_master_red_classifies_master_red() -> Result<()> {
+        let input = load_input(&fixture("master-red.json"))?;
+        let receipt = classify(&input);
+        if receipt.classification != FailureClassification::MasterRed {
+            bail!("expected MASTER_RED, got {:?}", receipt.classification);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_stale_base_classifies_stale_base() -> Result<()> {
+        let input = load_input(&fixture("stale-base.json"))?;
+        let receipt = classify(&input);
+        if receipt.classification != FailureClassification::StaleBase {
+            bail!("expected STALE_BASE, got {:?}", receipt.classification);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_pr_owned_classifies_pr_owned() -> Result<()> {
+        let input = load_input(&fixture("pr-owned.json"))?;
+        let receipt = classify(&input);
+        if receipt.classification != FailureClassification::PrOwned {
+            bail!("expected PR_OWNED, got {:?}", receipt.classification);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_missing_data_classifies_unknown() -> Result<()> {
+        let input = load_input(&fixture("unknown.json"))?;
+        let receipt = classify(&input);
+        if receipt.classification != FailureClassification::Unknown {
+            bail!("expected UNKNOWN, got {:?}", receipt.classification);
+        }
+        Ok(())
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -35,6 +35,7 @@ pub mod doc;
 pub mod doc_claims;
 pub mod e2e_validate;
 pub mod edge_cases;
+pub mod failure_classifier;
 pub mod features;
 pub mod fmt;
 pub mod forbid_fatal_constructs;

--- a/xtask/tests/fixtures/failure-classifier/master-red.json
+++ b/xtask/tests/fixtures/failure-classifier/master-red.json
@@ -1,0 +1,27 @@
+{
+  "pr": {
+    "number": 7001,
+    "head_sha": "pr-head-111",
+    "master_sha": "master-aaa",
+    "behind_master": false,
+    "changed_files": ["crates/perl-lsp-rs/src/lib.rs"]
+  },
+  "pr_checks": [
+    {
+      "name": "ci / test",
+      "signature": "ci / test: parser panic",
+      "sha": "pr-head-111",
+      "conclusion": "failure",
+      "files": ["crates/perl-lsp-rs/src/lib.rs"]
+    }
+  ],
+  "master_checks": [
+    {
+      "name": "ci / test",
+      "signature": "ci / test: parser panic",
+      "sha": "master-aaa",
+      "conclusion": "failure"
+    }
+  ],
+  "affected_prs": [7001, 7004, 7008]
+}

--- a/xtask/tests/fixtures/failure-classifier/pr-owned.json
+++ b/xtask/tests/fixtures/failure-classifier/pr-owned.json
@@ -1,0 +1,29 @@
+{
+  "pr": {
+    "number": 7003,
+    "head_sha": "pr-head-333",
+    "master_sha": "master-ccc",
+    "behind_master": false,
+    "changed_files": [
+      "crates/perl-parser/src/recovery.rs",
+      "crates/perl-parser/src/errors.rs"
+    ]
+  },
+  "pr_checks": [
+    {
+      "name": "ci / parser-tests",
+      "signature": "ci / parser-tests: recovery edge case",
+      "sha": "pr-head-333",
+      "conclusion": "failure",
+      "files": ["crates/perl-parser/src/recovery.rs"]
+    }
+  ],
+  "master_checks": [
+    {
+      "name": "ci / parser-tests",
+      "signature": "ci / parser-tests: recovery edge case",
+      "sha": "master-ccc",
+      "conclusion": "success"
+    }
+  ]
+}

--- a/xtask/tests/fixtures/failure-classifier/stale-base.json
+++ b/xtask/tests/fixtures/failure-classifier/stale-base.json
@@ -1,0 +1,26 @@
+{
+  "pr": {
+    "number": 7002,
+    "head_sha": "pr-head-222",
+    "master_sha": "master-bbb",
+    "behind_master": true,
+    "changed_files": ["docs/README.md"]
+  },
+  "pr_checks": [
+    {
+      "name": "ci / test",
+      "signature": "ci / test: dependency graph mismatch",
+      "sha": "pr-head-222",
+      "conclusion": "failure",
+      "files": ["Cargo.lock"]
+    }
+  ],
+  "master_checks": [
+    {
+      "name": "ci / test",
+      "signature": "ci / test: dependency graph mismatch",
+      "sha": "master-bbb",
+      "conclusion": "success"
+    }
+  ]
+}

--- a/xtask/tests/fixtures/failure-classifier/unknown.json
+++ b/xtask/tests/fixtures/failure-classifier/unknown.json
@@ -1,0 +1,24 @@
+{
+  "pr": {
+    "number": 7005,
+    "head_sha": "pr-head-555",
+    "master_sha": "master-eee",
+    "behind_master": false
+  },
+  "pr_checks": [
+    {
+      "name": "ci / test",
+      "signature": "ci / test: parser panic",
+      "sha": "old-sha-444",
+      "conclusion": "failure"
+    }
+  ],
+  "master_checks": [
+    {
+      "name": "ci / test",
+      "signature": "ci / test: parser panic",
+      "sha": "master-eee",
+      "conclusion": "success"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- CI failures were being routed to PR owners before determining whether failures were caused by master, stale base, infra, flakiness, or the PR itself, leading to misrouting and extra toil. 
- Add a pre-routing classifier to surface a defensible classification and recommended action so downstream agents/bots can route appropriately. Refs #6853

### Description
- Add a new xtask command `failure-classifier` wired into `xtask` with flags `--snapshot`, `--receipt`, and `--fixture` and CLI dispatch in `xtask/src/main.rs`. 
- Implement classifier logic in `xtask/src/tasks/failure_classifier.rs` that emits a typed receipt including `check`, `signature`, `affected_prs`, `master_sha`, `master_same_signature`, `classification`, `recommended_action`, `confidence`, and `evidence`, and implements the requested classifications (`PR_OWNED`, `STALE_BASE`, `MASTER_RED`, `INFRA_FAILURE`, `FLAKY`, `UNKNOWN`) and routing map. 
- Add JSON schema for receipts at `.ci/receipts/schemas/failure-classifier.schema.json` and documentation at `docs/ci/failure-classifier.md` describing inputs, outputs, routing, and guardrails (the task does not apply labels, merge, or update branches). 
- Add deterministic fixtures and unit tests under `xtask/tests/fixtures/failure-classifier/` for `master-red.json`, `stale-base.json`, `pr-owned.json`, and `unknown.json` to validate core scenarios.

### Testing
- Ran `cargo check -p xtask` and `cargo check --all-targets -p xtask` which completed successfully. 
- Ran `cargo xtask failure-classifier --fixture xtask/tests/fixtures/failure-classifier/master-red.json` and validated output classified `MASTER_RED`. 
- Ran fixture validations for `stale-base.json`, `pr-owned.json`, and `unknown.json` and confirmed they classified as `STALE_BASE`, `PR_OWNED`, and `UNKNOWN` respectively. 
- Ran `cargo xtask failure-classifier --snapshot target/queue/snapshot.json --receipt target/receipts/failure-classifier.json` to emit a receipt file, and ran `cargo xtask fmt`; all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd07b190483338bcecbfc26789d9e)