### PR TITLE
feat(ci): classify CI failures before routing (#6853)

### DIFF
--- a/.ci/receipts/schemas/failure-classifier.schema.json
+++ b/.ci/receipts/schemas/failure-classifier.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/schemas/failure-classifier.schema.json",
+  "title": "Failure Classifier Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "check",
+    "signature",
+    "affected_prs",
+    "master_same_signature",
+    "classification",
+    "recommended_action",
+    "confidence",
+    "evidence"
+  ],
+  "properties": {
+    "check": {
+      "const": "Failure Classifier"
+    },
+    "signature": {
+      "type": "string",
+      "minLength": 1
+    },
+    "affected_prs": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 1
+      }
+    },
+    "master_sha": {
+      "type": ["string", "null"]
+    },
+    "master_same_signature": {
+      "type": "boolean"
+    },
+    "classification": {
+      "type": "string",
+      "enum": [
+        "PR_OWNED",
+        "STALE_BASE",
+        "MASTER_RED",
+        "INFRA_FAILURE",
+        "FLAKY",
+        "UNKNOWN"
+      ]
+    },
+    "recommended_action": {
+      "type": "string",
+      "minLength": 1
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    }
+  }
+}

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -86,7 +86,7 @@ impl SafeEvaluator {
         }
 
         // Check for assignment operators while avoiding comparison false positives
-        if let Some(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref().ok() {
+        if let Ok(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref() {
             for mat in re.find_iter(expression) {
                 let op = mat.as_str();
                 if ASSIGNMENT_OPERATORS.contains(&op) {

--- a/docs/ci/failure-classifier.md
+++ b/docs/ci/failure-classifier.md
@@ -1,0 +1,62 @@
+# CI Failure Classifier
+
+`cargo xtask failure-classifier` classifies a failing CI gate *before* any routing labels are applied.
+
+## Why
+
+Repeated failures can indicate different root causes:
+
+- broken PR diff (`PR_OWNED`)
+- stale base (`STALE_BASE`)
+- red master (`MASTER_RED`)
+- infrastructure outage (`INFRA_FAILURE`)
+- intermittent flake (`FLAKY`)
+- insufficient data (`UNKNOWN`)
+
+Classifying first prevents accidental `needs-ci-fix` labeling when evidence points elsewhere.
+
+## Commands
+
+```bash
+cargo xtask failure-classifier --snapshot target/queue/snapshot.json --receipt target/receipts/failure-classifier.json
+cargo xtask failure-classifier --fixture xtask/tests/fixtures/failure-classifier/master-red.json
+```
+
+## Input signals
+
+The classifier consumes these signals when available:
+
+- PR current head SHA and gate status rollup
+- latest master status for the same gate/signature
+- merge-group status
+- known infra signatures
+- prior receipt artifacts
+
+## Receipt shape
+
+The output receipt contains:
+
+- `check` (`Failure Classifier`)
+- `signature`
+- `affected_prs`
+- `master_sha`
+- `master_same_signature`
+- `classification`
+- `recommended_action`
+- `confidence`
+- `evidence`
+
+See schema: `.ci/receipts/schemas/failure-classifier.schema.json`.
+
+## Routing map
+
+- `PR_OWNED` → `NEEDS_CI_FIX / builder`
+- `STALE_BASE` → `NEEDS_CASCADE_UPDATE`
+- `MASTER_RED` → open master incident (no PR-owned label)
+- `INFRA_FAILURE` → infra/tooling route
+- `FLAKY` → rerun + observe
+- `UNKNOWN` → human classification
+
+## Guardrail
+
+The classifier does **not** call failures PR-owned unless current-head evidence is present.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -400,6 +400,21 @@ enum Commands {
         format: String,
     },
 
+    /// Classify CI failures before routing labels/actions are applied.
+    FailureClassifier {
+        /// Queue snapshot JSON with PR and gate context.
+        #[arg(long)]
+        snapshot: Option<PathBuf>,
+
+        /// Optional output path for classifier receipt JSON.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+
+        /// Fixture JSON for deterministic classification testing.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+    },
+
     /// Run version-sync checks from `perl-ci-hygiene`.
     CheckVersionSync,
 
@@ -1461,6 +1476,9 @@ fn main() -> Result<()> {
         }
         Commands::CiScope { base, format } => {
             ci_scope::run(ci_scope::CiScopeConfig { base, format })
+        }
+        Commands::FailureClassifier { snapshot, receipt, fixture } => {
+            failure_classifier::run(failure_classifier::Config { snapshot, receipt, fixture })
         }
         Commands::CheckVersionSync => check_version_sync::run(),
         Commands::CheckFromRaw => ci_policy::check_from_raw(),

--- a/xtask/src/tasks/failure_classifier.rs
+++ b/xtask/src/tasks/failure_classifier.rs
@@ -1,0 +1,271 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+const CHECK_NAME: &str = "Failure Classifier";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Classification {
+    PrOwned,
+    StaleBase,
+    MasterRed,
+    InfraFailure,
+    Flaky,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FailureClassifierReceipt {
+    pub check: String,
+    pub signature: String,
+    pub affected_prs: Vec<u64>,
+    pub master_sha: Option<String>,
+    pub master_same_signature: bool,
+    pub classification: Classification,
+    pub recommended_action: String,
+    pub confidence: f64,
+    pub evidence: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct InputEnvelope {
+    #[serde(default)]
+    pr_number: Option<u64>,
+    #[serde(default)]
+    affected_prs: Vec<u64>,
+    #[serde(default)]
+    pr_head_sha: Option<String>,
+    #[serde(default)]
+    pr_status: Status,
+    #[serde(default)]
+    master_status: Option<Status>,
+    #[serde(default)]
+    merge_group_status: Option<Status>,
+    #[serde(default)]
+    infra_signatures: Vec<String>,
+    #[serde(default)]
+    receipt_artifacts: Vec<Value>,
+    #[serde(default)]
+    pr_is_behind_master: Option<bool>,
+    #[serde(default)]
+    current_head_evidence: Option<bool>,
+    #[serde(default)]
+    flaky_signal: Option<bool>,
+    #[serde(default)]
+    pr_touches_failing_diff: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct Status {
+    #[serde(default)]
+    sha: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    signature: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub snapshot: Option<PathBuf>,
+    pub receipt: Option<PathBuf>,
+    pub fixture: Option<PathBuf>,
+}
+
+pub fn run(config: Config) -> Result<()> {
+    if config.snapshot.is_some() && config.fixture.is_some() {
+        bail!("--snapshot and --fixture are mutually exclusive");
+    }
+
+    let input_path = config
+        .fixture
+        .as_ref()
+        .or(config.snapshot.as_ref())
+        .ok_or_else(|| color_eyre::eyre::eyre!("must provide --snapshot or --fixture"))?;
+
+    let input = parse_input(input_path)?;
+    let receipt = classify(input);
+
+    let rendered = serde_json::to_string_pretty(&receipt).context("serializing receipt")?;
+    println!("{rendered}");
+
+    if let Some(receipt_path) = config.receipt {
+        if let Some(parent) = receipt_path.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        fs::write(&receipt_path, format!("{rendered}\n"))
+            .with_context(|| format!("writing {}", receipt_path.display()))?;
+    }
+
+    Ok(())
+}
+
+fn parse_input(path: &Path) -> Result<InputEnvelope> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let value: Value =
+        serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?;
+
+    if value.is_object() {
+        return serde_json::from_value(value).context("decoding classifier input object");
+    }
+
+    if let Some(items) = value.as_array()
+        && let Some(first) = items.first()
+    {
+        return serde_json::from_value(first.clone()).context("decoding first fixture entry");
+    }
+
+    bail!("unsupported failure classifier input shape")
+}
+
+fn classify(input: InputEnvelope) -> FailureClassifierReceipt {
+    let mut evidence = Vec::new();
+    if let Some(pr_head_sha) = input.pr_head_sha.as_deref() {
+        evidence.push(format!("evaluated current PR head SHA {pr_head_sha}"));
+    }
+    let signature = signature_for(&input);
+    let master_signature = input.master_status.as_ref().and_then(|status| status.signature.clone());
+    let master_sha = input.master_status.as_ref().and_then(|status| status.sha.clone());
+    let master_same_signature = master_signature.as_deref() == Some(signature.as_str());
+
+    let affected_prs = affected_prs(&input);
+
+    let (classification, recommended_action, confidence) = if is_infra_failure(&input, &signature) {
+        evidence.push("failure signature matches known infrastructure signature".to_string());
+        (Classification::InfraFailure, "ROUTE_INFRA_TOOLING".to_string(), 0.95)
+    } else if master_same_signature && is_failure(input.master_status.as_ref()) {
+        evidence.push("master is red with same gate signature".to_string());
+        (Classification::MasterRed, "OPEN_MASTER_INCIDENT".to_string(), 0.93)
+    } else if input.pr_is_behind_master.unwrap_or(false)
+        && is_success(input.master_status.as_ref())
+        && is_failure(Some(&input.pr_status))
+    {
+        evidence.push("PR head is behind a green master for the same gate".to_string());
+        (Classification::StaleBase, "NEEDS_CASCADE_UPDATE".to_string(), 0.87)
+    } else if input.flaky_signal.unwrap_or(false)
+        || (is_failure(input.merge_group_status.as_ref()) && is_success(Some(&input.pr_status)))
+    {
+        evidence.push("inconsistent outcomes suggest a flaky failure".to_string());
+        (Classification::Flaky, "RERUN_AND_OBSERVE".to_string(), 0.78)
+    } else if input.current_head_evidence.unwrap_or(false)
+        && input.pr_touches_failing_diff.unwrap_or(false)
+        && is_failure(Some(&input.pr_status))
+    {
+        evidence.push("current-head failing evidence points at changed PR diff".to_string());
+        (Classification::PrOwned, "NEEDS_CI_FIX / builder".to_string(), 0.89)
+    } else {
+        evidence.push("insufficient correlated evidence for deterministic routing".to_string());
+        (Classification::Unknown, "HUMAN_CLASSIFICATION".to_string(), 0.4)
+    };
+
+    if input.current_head_evidence != Some(true) && classification == Classification::PrOwned {
+        evidence.push("PR_OWNED requires current-head evidence; downgraded to UNKNOWN".to_string());
+        return FailureClassifierReceipt {
+            check: CHECK_NAME.to_string(),
+            signature,
+            affected_prs,
+            master_sha,
+            master_same_signature,
+            classification: Classification::Unknown,
+            recommended_action: "HUMAN_CLASSIFICATION".to_string(),
+            confidence: 0.35,
+            evidence,
+        };
+    }
+
+    FailureClassifierReceipt {
+        check: CHECK_NAME.to_string(),
+        signature,
+        affected_prs,
+        master_sha,
+        master_same_signature,
+        classification,
+        recommended_action,
+        confidence,
+        evidence,
+    }
+}
+
+fn affected_prs(input: &InputEnvelope) -> Vec<u64> {
+    if !input.affected_prs.is_empty() {
+        return input.affected_prs.clone();
+    }
+    input.pr_number.into_iter().collect()
+}
+
+fn signature_for(input: &InputEnvelope) -> String {
+    input
+        .pr_status
+        .signature
+        .clone()
+        .or_else(|| input.merge_group_status.as_ref().and_then(|s| s.signature.clone()))
+        .or_else(|| signature_from_artifact(&input.receipt_artifacts))
+        .unwrap_or_else(|| "unknown-signature".to_string())
+}
+
+fn signature_from_artifact(artifacts: &[Value]) -> Option<String> {
+    artifacts.iter().find_map(|artifact| {
+        artifact.get("signature").and_then(Value::as_str).map(ToString::to_string)
+    })
+}
+
+fn is_infra_failure(input: &InputEnvelope, signature: &str) -> bool {
+    input.infra_signatures.iter().any(|infra_sig| infra_sig.eq_ignore_ascii_case(signature))
+}
+
+fn is_failure(status: Option<&Status>) -> bool {
+    matches!(
+        status.and_then(|state| state.state.as_deref()),
+        Some("failure") | Some("failed") | Some("error")
+    )
+}
+
+fn is_success(status: Option<&Status>) -> bool {
+    matches!(status.and_then(|state| state.state.as_deref()), Some("success") | Some("passed"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn master_red_wins_when_same_signature_fails() {
+        let input = InputEnvelope {
+            pr_status: Status {
+                state: Some("failure".to_string()),
+                signature: Some("gate::pr-fast::test".to_string()),
+                sha: None,
+            },
+            master_status: Some(Status {
+                state: Some("failure".to_string()),
+                signature: Some("gate::pr-fast::test".to_string()),
+                sha: Some("abc123".to_string()),
+            }),
+            ..InputEnvelope::default()
+        };
+
+        let receipt = classify(input);
+        assert_eq!(receipt.classification, Classification::MasterRed);
+    }
+
+    #[test]
+    fn never_marks_pr_owned_without_current_head_evidence() {
+        let input = InputEnvelope {
+            pr_status: Status {
+                state: Some("failure".to_string()),
+                signature: Some("gate::pr-fast::lint".to_string()),
+                sha: None,
+            },
+            current_head_evidence: Some(false),
+            pr_touches_failing_diff: Some(true),
+            ..InputEnvelope::default()
+        };
+
+        let receipt = classify(input);
+        assert_eq!(receipt.classification, Classification::Unknown);
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -35,6 +35,7 @@ pub mod doc;
 pub mod doc_claims;
 pub mod e2e_validate;
 pub mod edge_cases;
+pub mod failure_classifier;
 pub mod features;
 pub mod fmt;
 pub mod forbid_fatal_constructs;

--- a/xtask/tests/failure_classifier_cli.rs
+++ b/xtask/tests/failure_classifier_cli.rs
@@ -1,0 +1,47 @@
+use anyhow::{Context, Result};
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+
+fn run_fixture(name: &str) -> Result<Value> {
+    let fixture = format!("tests/fixtures/failure-classifier/{name}.json");
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd
+        .arg("failure-classifier")
+        .arg("--fixture")
+        .arg(&fixture)
+        .output()
+        .with_context(|| format!("running fixture {fixture}"))?;
+
+    assert!(output.status.success(), "fixture command should succeed");
+
+    let stdout = String::from_utf8(output.stdout).context("classifier stdout must be UTF-8")?;
+    serde_json::from_str::<Value>(&stdout).context("classifier output must be JSON")
+}
+
+#[test]
+fn fixture_master_red_classifies_as_master_red() -> Result<()> {
+    let json = run_fixture("master-red")?;
+    assert_eq!(json["classification"], "MASTER_RED");
+    Ok(())
+}
+
+#[test]
+fn fixture_stale_base_classifies_as_stale_base() -> Result<()> {
+    let json = run_fixture("stale-base")?;
+    assert_eq!(json["classification"], "STALE_BASE");
+    Ok(())
+}
+
+#[test]
+fn fixture_pr_owned_classifies_as_pr_owned() -> Result<()> {
+    let json = run_fixture("pr-owned")?;
+    assert_eq!(json["classification"], "PR_OWNED");
+    Ok(())
+}
+
+#[test]
+fn fixture_missing_data_classifies_as_unknown() -> Result<()> {
+    let json = run_fixture("unknown")?;
+    assert_eq!(json["classification"], "UNKNOWN");
+    Ok(())
+}

--- a/xtask/tests/fixtures/failure-classifier/master-red.json
+++ b/xtask/tests/fixtures/failure-classifier/master-red.json
@@ -1,0 +1,14 @@
+{
+  "pr_number": 7101,
+  "pr_head_sha": "prsha001",
+  "pr_status": {
+    "state": "failure",
+    "signature": "gate::pr-fast::test"
+  },
+  "master_status": {
+    "sha": "mastersha001",
+    "state": "failure",
+    "signature": "gate::pr-fast::test"
+  },
+  "current_head_evidence": true
+}

--- a/xtask/tests/fixtures/failure-classifier/pr-owned.json
+++ b/xtask/tests/fixtures/failure-classifier/pr-owned.json
@@ -1,0 +1,15 @@
+{
+  "pr_number": 7103,
+  "pr_head_sha": "prsha003",
+  "pr_status": {
+    "state": "failure",
+    "signature": "gate::pr-fast::unit"
+  },
+  "master_status": {
+    "sha": "mastersha003",
+    "state": "success",
+    "signature": "gate::pr-fast::unit"
+  },
+  "current_head_evidence": true,
+  "pr_touches_failing_diff": true
+}

--- a/xtask/tests/fixtures/failure-classifier/stale-base.json
+++ b/xtask/tests/fixtures/failure-classifier/stale-base.json
@@ -1,0 +1,15 @@
+{
+  "pr_number": 7102,
+  "pr_head_sha": "prsha002",
+  "pr_status": {
+    "state": "failure",
+    "signature": "gate::pr-fast::lint"
+  },
+  "master_status": {
+    "sha": "mastersha002",
+    "state": "success",
+    "signature": "gate::pr-fast::lint"
+  },
+  "pr_is_behind_master": true,
+  "current_head_evidence": true
+}

--- a/xtask/tests/fixtures/failure-classifier/unknown.json
+++ b/xtask/tests/fixtures/failure-classifier/unknown.json
@@ -1,0 +1,7 @@
+{
+  "pr_number": 7104,
+  "pr_status": {
+    "state": "failure"
+  },
+  "receipt_artifacts": []
+}


### PR DESCRIPTION
### Motivation

- Refs #6853: avoid routing CI failure clusters blindly by distinguishing PR-owned bugs, stale base, master-red, infra outages, flakes, or unknown situations before labeling or other automated routing.

### Description

- Add a new xtask command `failure-classifier` that ingests a snapshot or fixture JSON and emits a structured receipt classifying failures and recommending routing actions. 
- Implement classification logic with signatures, master vs PR status, merge-group, infra signatures, current-head evidence, and guardrails so `PR_OWNED` requires current-head evidence. (See `xtask/src/tasks/failure_classifier.rs`.)
- Wire the command into the CLI and tasks module and add the receipt JSON Schema and user docs at `.ci/receipts/schemas/failure-classifier.schema.json` and `docs/ci/failure-classifier.md`.
- Add fixture-backed CLI tests and example fixtures under `xtask/tests/fixtures/failure-classifier/` and a small test harness `xtask/tests/failure_classifier_cli.rs` asserting the expected classifications.

### Testing

- Ran `cargo check -p xtask` (passes).
- Ran `cargo xtask failure-classifier --snapshot target/queue/snapshot.json --receipt target/receipts/failure-classifier.json` (produced receipt successfully).
- Ran `cargo xtask failure-classifier --fixture xtask/tests/fixtures/failure-classifier/{master-red,stale-base,pr-owned,unknown}.json` and observed classifications `MASTER_RED`, `STALE_BASE`, `PR_OWNED`, `UNKNOWN` respectively.
- Ran `cargo test -p xtask --test failure_classifier_cli -- --nocapture` and all fixture-backed tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd07b190483338bcecbfc26789d9e)