### PR TITLE
feat(ci): classify CI failures before routing (#6853)

### DIFF
--- a/.ci/receipts/schemas/failure-classifier.schema.json
+++ b/.ci/receipts/schemas/failure-classifier.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.github.io/perl-lsp/schemas/failure-classifier.schema.json",
+  "title": "Failure Classifier Receipt",
+  "type": "object",
+  "required": [
+    "check",
+    "signature",
+    "affected_prs",
+    "master_sha",
+    "master_same_signature",
+    "classification",
+    "recommended_action",
+    "confidence",
+    "evidence"
+  ],
+  "properties": {
+    "check": {
+      "const": "Failure Classifier"
+    },
+    "signature": {
+      "type": "string",
+      "minLength": 1
+    },
+    "affected_prs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "master_sha": {
+      "type": ["string", "null"]
+    },
+    "master_same_signature": {
+      "type": "boolean"
+    },
+    "classification": {
+      "type": "string",
+      "enum": [
+        "PR_OWNED",
+        "STALE_BASE",
+        "MASTER_RED",
+        "INFRA_FAILURE",
+        "FLAKY",
+        "UNKNOWN"
+      ]
+    },
+    "recommended_action": {
+      "type": "string"
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -86,7 +86,7 @@ impl SafeEvaluator {
         }
 
         // Check for assignment operators while avoiding comparison false positives
-        if let Some(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref().ok() {
+        if let Ok(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref() {
             for mat in re.find_iter(expression) {
                 let op = mat.as_str();
                 if ASSIGNMENT_OPERATORS.contains(&op) {

--- a/docs/ci/failure-classifier.md
+++ b/docs/ci/failure-classifier.md
@@ -1,0 +1,66 @@
+# Failure Classifier (pre-routing)
+
+`green-ci` should run failure classification before applying `needs-ci-fix`.
+
+## Purpose
+
+This classifier distinguishes between:
+
+- `PR_OWNED`
+- `STALE_BASE`
+- `MASTER_RED`
+- `INFRA_FAILURE`
+- `FLAKY`
+- `UNKNOWN`
+
+The goal is to avoid incorrectly routing ecosystem-wide incidents as PR-owned failures.
+
+## CLI
+
+```bash
+cargo xtask failure-classifier --snapshot target/queue/snapshot.json --receipt target/receipts/failure-classifier.json
+cargo xtask failure-classifier --fixture xtask/tests/fixtures/failure-classifier/master-red.json
+```
+
+## Input signals
+
+- PR current head SHA
+- PR check rollup / gate status
+- Latest master status for the same gate when available
+- Merge group status when available
+- Known infra failure signatures
+- Existing receipt artifacts and signatures
+
+## Receipt output
+
+The classifier emits a receipt matching:
+
+- `.ci/receipts/schemas/failure-classifier.schema.json`
+
+Fields:
+
+- `check` (`Failure Classifier`)
+- `signature`
+- `affected_prs`
+- `master_sha`
+- `master_same_signature`
+- `classification`
+- `recommended_action`
+- `confidence`
+- `evidence`
+
+## Routing table
+
+- `PR_OWNED` -> `NEEDS_CI_FIX / builder`
+- `STALE_BASE` -> `NEEDS_CASCADE_UPDATE`
+- `MASTER_RED` -> master incident workflow (no PR-owned label)
+- `INFRA_FAILURE` -> infra/tooling route
+- `FLAKY` -> rerun/observe
+- `UNKNOWN` -> human classification
+
+## Guardrails
+
+- The classifier does **not** apply labels.
+- The classifier does **not** update branches.
+- The classifier does **not** merge PRs.
+- `PR_OWNED` requires current-head evidence (observed failing head must match PR current head and overlap changed/failed files).

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -751,6 +751,21 @@ enum Commands {
         args: Vec<String>,
     },
 
+    /// Classify CI failures before applying routing labels.
+    FailureClassifier {
+        /// Queue snapshot JSON (live payload from green-ci orchestration).
+        #[arg(long, conflicts_with = "fixture")]
+        snapshot: Option<PathBuf>,
+
+        /// Fixture JSON for local testing.
+        #[arg(long, conflicts_with = "snapshot")]
+        fixture: Option<PathBuf>,
+
+        /// Optional output path for the failure-classifier receipt JSON.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+    },
+
     /// Publish a review receipt bundle in `review/receipts/YYYY-MM-DD/`.
     PublishReceipts {
         /// Optional date override in `YYYY-MM-DD` format.
@@ -1504,6 +1519,13 @@ fn main() -> Result<()> {
         Commands::HookTests => hook_checks::run_hook_tests(),
         Commands::ForbidFatalConstructs { args } => forbid_fatal_constructs::run(args),
         Commands::CiHygiene { command, args } => ci_hygiene::run(command, args),
+        Commands::FailureClassifier { snapshot, fixture, receipt } => {
+            failure_classifier::run(failure_classifier::FailureClassifierConfig {
+                snapshot,
+                fixture,
+                receipt,
+            })
+        }
         Commands::PublishVscode { yes, token } => publish::publish_vscode(yes, token),
         Commands::PublishClosure { crate_name } => publish_closure::run(crate_name),
         Commands::PublishedCrateCount => count_ratchet::run(),

--- a/xtask/src/tasks/failure_classifier.rs
+++ b/xtask/src/tasks/failure_classifier.rs
@@ -1,0 +1,348 @@
+use std::fs;
+use std::path::PathBuf;
+
+use color_eyre::eyre::{Context, ContextCompat, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone)]
+pub struct FailureClassifierConfig {
+    pub snapshot: Option<PathBuf>,
+    pub fixture: Option<PathBuf>,
+    pub receipt: Option<PathBuf>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FailureClassifierInput {
+    current_head_sha: String,
+    gate: Option<String>,
+    pr: RunStatus,
+    master: Option<RunStatus>,
+    merge_group: Option<RunStatus>,
+    #[serde(default)]
+    known_infra_signatures: Vec<String>,
+    #[serde(default)]
+    receipt_artifacts: Vec<ReceiptArtifact>,
+    #[serde(default)]
+    affected_prs: Vec<String>,
+    #[serde(default)]
+    base_behind_master: bool,
+    #[serde(default)]
+    flaky_indicators: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RunStatus {
+    sha: Option<String>,
+    status: JobStatus,
+    signature: Option<String>,
+    #[serde(default)]
+    observed_head_sha: Option<String>,
+    #[serde(default)]
+    changed_files: Vec<String>,
+    #[serde(default)]
+    failed_files: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReceiptArtifact {
+    signature: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum JobStatus {
+    Success,
+    Failure,
+    Pending,
+    Missing,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum Classification {
+    PrOwned,
+    StaleBase,
+    MasterRed,
+    InfraFailure,
+    Flaky,
+    Unknown,
+}
+
+#[derive(Debug, Serialize)]
+struct FailureClassifierReceipt {
+    check: String,
+    signature: String,
+    affected_prs: Vec<String>,
+    master_sha: Option<String>,
+    master_same_signature: bool,
+    classification: Classification,
+    recommended_action: String,
+    confidence: f64,
+    evidence: Vec<String>,
+}
+
+pub fn run(config: FailureClassifierConfig) -> Result<()> {
+    let input_path = config.fixture.or(config.snapshot).context(
+        "provide either --snapshot <path> (queue payload) or --fixture <path> (test payload)",
+    )?;
+
+    let raw = fs::read_to_string(&input_path)
+        .with_context(|| format!("reading failure-classifier input: {}", input_path.display()))?;
+    let input: FailureClassifierInput = serde_json::from_str(&raw)
+        .with_context(|| format!("parsing failure-classifier input: {}", input_path.display()))?;
+
+    let receipt = classify(input);
+    let receipt_json = serde_json::to_string_pretty(&receipt)
+        .context("serializing failure-classifier receipt JSON")?;
+
+    if let Some(path) = config.receipt {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("creating receipt directory: {}", parent.display()))?;
+        }
+        fs::write(&path, format!("{receipt_json}\n"))
+            .with_context(|| format!("writing failure-classifier receipt: {}", path.display()))?;
+    }
+
+    println!("{receipt_json}");
+    Ok(())
+}
+
+fn classify(input: FailureClassifierInput) -> FailureClassifierReceipt {
+    let signature = derive_signature(&input);
+    let mut evidence = vec![format!("current_head_sha={}", input.current_head_sha)];
+    if let Some(gate) = &input.gate {
+        evidence.push(format!("gate={gate}"));
+    }
+
+    let master_same_signature = input.master.as_ref().is_some_and(|master| {
+        master.status == JobStatus::Failure
+            && master
+                .signature
+                .as_ref()
+                .is_some_and(|master_signature| master_signature == &signature)
+    });
+
+    if input.pr.status != JobStatus::Failure {
+        evidence.push("pr status is not failure".to_string());
+        return finalize(
+            signature,
+            input.affected_prs,
+            input.master.and_then(|m| m.sha),
+            master_same_signature,
+            Classification::Unknown,
+            0.25,
+            evidence,
+        );
+    }
+
+    if input.known_infra_signatures.iter().any(|known_signature| known_signature == &signature) {
+        evidence.push("signature matched known infra signature".to_string());
+        return finalize(
+            signature,
+            input.affected_prs,
+            input.master.and_then(|m| m.sha),
+            master_same_signature,
+            Classification::InfraFailure,
+            0.98,
+            evidence,
+        );
+    }
+
+    if master_same_signature {
+        evidence.push("master failed on same gate/signature".to_string());
+        return finalize(
+            signature,
+            input.affected_prs,
+            input.master.and_then(|m| m.sha),
+            master_same_signature,
+            Classification::MasterRed,
+            0.97,
+            evidence,
+        );
+    }
+
+    if input.base_behind_master
+        && input.master.as_ref().is_some_and(|m| m.status == JobStatus::Success)
+    {
+        evidence.push("PR base is behind green master".to_string());
+        return finalize(
+            signature,
+            input.affected_prs,
+            input.master.and_then(|m| m.sha),
+            master_same_signature,
+            Classification::StaleBase,
+            0.9,
+            evidence,
+        );
+    }
+
+    if !input.flaky_indicators.is_empty() {
+        evidence.push(format!("flaky indicators: {}", input.flaky_indicators.join(",")));
+        return finalize(
+            signature,
+            input.affected_prs,
+            input.master.and_then(|m| m.sha),
+            master_same_signature,
+            Classification::Flaky,
+            0.7,
+            evidence,
+        );
+    }
+
+    if let Some(merge_group) = &input.merge_group {
+        evidence.push(format!("merge_group status={}", as_str(merge_group.status)));
+    }
+
+    if is_pr_owned(&input, &mut evidence) {
+        return finalize(
+            signature,
+            input.affected_prs,
+            input.master.and_then(|m| m.sha),
+            master_same_signature,
+            Classification::PrOwned,
+            0.92,
+            evidence,
+        );
+    }
+
+    evidence.push("insufficient evidence for PR ownership".to_string());
+    finalize(
+        signature,
+        input.affected_prs,
+        input.master.and_then(|m| m.sha),
+        master_same_signature,
+        Classification::Unknown,
+        0.35,
+        evidence,
+    )
+}
+
+fn derive_signature(input: &FailureClassifierInput) -> String {
+    if let Some(signature) = &input.pr.signature {
+        return signature.clone();
+    }
+
+    for artifact in &input.receipt_artifacts {
+        if let Some(signature) = &artifact.signature {
+            return signature.clone();
+        }
+    }
+
+    "unknown-signature".to_string()
+}
+
+fn is_pr_owned(input: &FailureClassifierInput, evidence: &mut Vec<String>) -> bool {
+    let Some(observed_head_sha) = &input.pr.observed_head_sha else {
+        evidence.push("missing pr.observed_head_sha".to_string());
+        return false;
+    };
+
+    if observed_head_sha != &input.current_head_sha {
+        evidence.push(format!(
+            "head mismatch: observed={} current={}",
+            observed_head_sha, input.current_head_sha
+        ));
+        return false;
+    }
+
+    let changed_matches_failure = input.pr.failed_files.iter().any(|failed_file| {
+        input.pr.changed_files.iter().any(|changed_file| changed_file == failed_file)
+    });
+
+    if !changed_matches_failure {
+        evidence.push("failed files do not overlap changed files".to_string());
+        return false;
+    }
+
+    evidence.push(
+        "current head matches failing run and failed files overlap changed files".to_string(),
+    );
+    true
+}
+
+fn finalize(
+    signature: String,
+    affected_prs: Vec<String>,
+    master_sha: Option<String>,
+    master_same_signature: bool,
+    classification: Classification,
+    confidence: f64,
+    evidence: Vec<String>,
+) -> FailureClassifierReceipt {
+    FailureClassifierReceipt {
+        check: "Failure Classifier".to_string(),
+        signature,
+        affected_prs,
+        master_sha,
+        master_same_signature,
+        recommended_action: recommended_action(&classification).to_string(),
+        classification,
+        confidence,
+        evidence,
+    }
+}
+
+fn recommended_action(classification: &Classification) -> &'static str {
+    match classification {
+        Classification::PrOwned => "NEEDS_CI_FIX / builder",
+        Classification::StaleBase => "NEEDS_CASCADE_UPDATE",
+        Classification::MasterRed => "master incident / no PR-owned label",
+        Classification::InfraFailure => "infra/tooling route",
+        Classification::Flaky => "rerun/observe",
+        Classification::Unknown => "human classification",
+    }
+}
+
+fn as_str(status: JobStatus) -> &'static str {
+    match status {
+        JobStatus::Success => "success",
+        JobStatus::Failure => "failure",
+        JobStatus::Pending => "pending",
+        JobStatus::Missing => "missing",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load_fixture(name: &str) -> Result<FailureClassifierInput> {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/failure-classifier")
+            .join(name);
+        let raw = fs::read_to_string(&path)
+            .with_context(|| format!("reading fixture file: {}", path.display()))?;
+        let input = serde_json::from_str(&raw)
+            .with_context(|| format!("parsing fixture file: {}", path.display()))?;
+        Ok(input)
+    }
+
+    #[test]
+    fn fixture_master_red_classifies_correctly() -> Result<()> {
+        let receipt = classify(load_fixture("master-red.json")?);
+        assert_eq!(receipt.classification, Classification::MasterRed);
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_stale_base_classifies_correctly() -> Result<()> {
+        let receipt = classify(load_fixture("stale-base.json")?);
+        assert_eq!(receipt.classification, Classification::StaleBase);
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_pr_owned_classifies_correctly() -> Result<()> {
+        let receipt = classify(load_fixture("pr-owned.json")?);
+        assert_eq!(receipt.classification, Classification::PrOwned);
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_unknown_classifies_correctly() -> Result<()> {
+        let receipt = classify(load_fixture("unknown-missing-data.json")?);
+        assert_eq!(receipt.classification, Classification::Unknown);
+        Ok(())
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -35,6 +35,7 @@ pub mod doc;
 pub mod doc_claims;
 pub mod e2e_validate;
 pub mod edge_cases;
+pub mod failure_classifier;
 pub mod features;
 pub mod fmt;
 pub mod forbid_fatal_constructs;

--- a/xtask/tests/fixtures/failure-classifier/master-red.json
+++ b/xtask/tests/fixtures/failure-classifier/master-red.json
@@ -1,0 +1,27 @@
+{
+  "current_head_sha": "abc111",
+  "gate": "pr-fast",
+  "pr": {
+    "sha": "abc111",
+    "status": "failure",
+    "signature": "cargo-test:perl-parser:panic",
+    "observed_head_sha": "abc111",
+    "changed_files": ["crates/perl-parser/src/parser.rs"],
+    "failed_files": ["crates/perl-parser/src/parser.rs"]
+  },
+  "master": {
+    "sha": "master999",
+    "status": "failure",
+    "signature": "cargo-test:perl-parser:panic"
+  },
+  "merge_group": {
+    "sha": "mg123",
+    "status": "failure",
+    "signature": "cargo-test:perl-parser:panic"
+  },
+  "known_infra_signatures": [],
+  "receipt_artifacts": [],
+  "affected_prs": ["6821", "6841"],
+  "base_behind_master": false,
+  "flaky_indicators": []
+}

--- a/xtask/tests/fixtures/failure-classifier/pr-owned.json
+++ b/xtask/tests/fixtures/failure-classifier/pr-owned.json
@@ -1,0 +1,30 @@
+{
+  "current_head_sha": "ghi333",
+  "gate": "pr-fast",
+  "pr": {
+    "sha": "ghi333",
+    "status": "failure",
+    "signature": "test:perl-lsp-rs:definition-regression",
+    "observed_head_sha": "ghi333",
+    "changed_files": [
+      "crates/perl-lsp-rs/src/handlers/goto_definition.rs",
+      "crates/perl-lsp-rs/src/handlers/hover.rs"
+    ],
+    "failed_files": ["crates/perl-lsp-rs/src/handlers/goto_definition.rs"]
+  },
+  "master": {
+    "sha": "master1001",
+    "status": "success",
+    "signature": ""
+  },
+  "known_infra_signatures": ["runner:timeout", "gha:service-unavailable"],
+  "receipt_artifacts": [
+    {
+      "name": "junit",
+      "signature": "test:perl-lsp-rs:definition-regression"
+    }
+  ],
+  "affected_prs": ["6853"],
+  "base_behind_master": false,
+  "flaky_indicators": []
+}

--- a/xtask/tests/fixtures/failure-classifier/stale-base.json
+++ b/xtask/tests/fixtures/failure-classifier/stale-base.json
@@ -1,0 +1,27 @@
+{
+  "current_head_sha": "def222",
+  "gate": "merge-gate",
+  "pr": {
+    "sha": "def222",
+    "status": "failure",
+    "signature": "compile:error:E0433",
+    "observed_head_sha": "def222",
+    "changed_files": ["crates/perl-lsp-rs/src/server.rs"],
+    "failed_files": ["crates/perl-lsp-rs/src/server.rs"]
+  },
+  "master": {
+    "sha": "master1000",
+    "status": "success",
+    "signature": ""
+  },
+  "merge_group": {
+    "sha": "mg224",
+    "status": "failure",
+    "signature": "compile:error:E0433"
+  },
+  "known_infra_signatures": [],
+  "receipt_artifacts": [],
+  "affected_prs": ["6853"],
+  "base_behind_master": true,
+  "flaky_indicators": []
+}

--- a/xtask/tests/fixtures/failure-classifier/unknown-missing-data.json
+++ b/xtask/tests/fixtures/failure-classifier/unknown-missing-data.json
@@ -1,0 +1,17 @@
+{
+  "current_head_sha": "jkl444",
+  "gate": "pr-fast",
+  "pr": {
+    "sha": "jkl444",
+    "status": "failure",
+    "signature": null,
+    "changed_files": [],
+    "failed_files": []
+  },
+  "master": null,
+  "known_infra_signatures": [],
+  "receipt_artifacts": [],
+  "affected_prs": ["6853"],
+  "base_behind_master": false,
+  "flaky_indicators": []
+}


### PR DESCRIPTION
### Motivation
- CI gating occasionally routed clustered failures as PR-owned without distinguishing stale base, master incidents, infra issues, flakiness, or missing evidence.  
- Introduce a pre-routing classifier so automation can pick the correct route instead of immediately applying `needs-ci-fix`.  
- The classifier must be conservative (do not label or merge) and require explicit current-head evidence before declaring `PR_OWNED`.

### Description
- Added a new `xtask` subcommand `failure-classifier` implemented in `xtask/src/tasks/failure_classifier.rs` and wired into the CLI in `xtask/src/main.rs`, with module registration in `xtask/src/tasks/mod.rs`.  
- Added a JSON schema for receipts at `.ci/receipts/schemas/failure-classifier.schema.json`, operator docs at `docs/ci/failure-classifier.md`, and fixtures under `xtask/tests/fixtures/failure-classifier/` for `master-red`, `stale-base`, `pr-owned`, and `unknown` scenarios.  
- The classifier emits a receipt containing `check`, `signature`, `affected_prs`, `master_sha`, `master_same_signature`, `classification`, `recommended_action`, `confidence`, and `evidence`, and maps classifications to routing suggestions per the provided table.  
- Guardrails: the implementation never applies labels/merges/branch updates and only returns `PR_OWNED` when the failing run observed head matches the PR current head and failing files overlap changed files.

### Testing
- Ran `cargo check -p xtask` which completed successfully.  
- Ran the classifier end-to-end via `cargo xtask failure-classifier --snapshot target/queue/snapshot.json --receipt target/receipts/failure-classifier.json` and via fixtures `cargo xtask failure-classifier --fixture xtask/tests/fixtures/failure-classifier/<name>.json`, which produced receipts for the `PR_OWNED`, `MASTER_RED`, and `STALE_BASE` scenarios as expected.  
- Executed unit tests with `cargo test -p xtask failure_classifier -- --nocapture` which passed (4 tests: master-red, stale-base, pr-owned, unknown).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd07b190483338bcecbfc26789d9e)