### PR TITLE
fix(xtask): report all fmt failures with receipt (#6853)

### DIFF
--- a/.ci/receipts/schemas/fmt.schema.json
+++ b/.ci/receipts/schemas/fmt.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/fmt.schema.json",
+  "title": "fmt receipt",
+  "type": "object",
+  "required": [
+    "check",
+    "schema_version",
+    "verdict",
+    "classification",
+    "failures",
+    "fix_forward_kind",
+    "safe_auto_fix",
+    "repro"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "check": { "const": "fmt" },
+    "schema_version": { "type": "string" },
+    "verdict": { "enum": ["pass", "fail"] },
+    "classification": { "const": "fmt_drift" },
+    "failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["tool", "crate", "path", "check_command", "fix_command"],
+        "additionalProperties": false,
+        "properties": {
+          "tool": { "type": "string", "minLength": 1 },
+          "crate": { "type": "string", "minLength": 1 },
+          "path": { "type": "string", "minLength": 1 },
+          "check_command": { "type": "string", "minLength": 1 },
+          "fix_command": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "fix_forward_kind": { "const": "FMT_ONLY" },
+    "safe_auto_fix": { "const": true },
+    "repro": {
+      "type": "object",
+      "required": ["command"],
+      "additionalProperties": false,
+      "properties": {
+        "command": { "const": "cargo xtask fmt --check" }
+      }
+    }
+  }
+}

--- a/docs/ci/fmt-receipts.md
+++ b/docs/ci/fmt-receipts.md
@@ -1,0 +1,39 @@
+# fmt receipts
+
+`cargo xtask fmt --check` now writes a structured receipt at `target/receipts/fmt.json`.
+
+## Behavior
+
+- Runs every configured workspace formatting check target.
+- Continues after individual `rustfmt` check failures to collect the full failure set.
+- Exits non-zero only after collection and receipt emission complete.
+
+## Receipt schema
+
+Schema file: `.ci/receipts/schemas/fmt.schema.json`
+
+Top-level fields:
+
+- `check` (`"fmt"`)
+- `schema_version`
+- `verdict` (`"pass"` or `"fail"`)
+- `classification` (`"fmt_drift"`)
+- `failures[]`
+  - `tool`
+  - `crate`
+  - `path`
+  - `check_command`
+  - `fix_command`
+- `fix_forward_kind` (`"FMT_ONLY"`)
+- `safe_auto_fix` (`true`)
+- `repro.command` (`"cargo xtask fmt --check"`)
+
+## Typed fix-forward
+
+The receipt is designed for typed fix-forward tooling:
+
+- `classification=fmt_drift`
+- `fix_forward_kind=FMT_ONLY`
+- exact `fix_command` per failure entry
+
+This keeps check mode read-only while making auto-remediation planning deterministic.

--- a/xtask/src/tasks/fmt.rs
+++ b/xtask/src/tasks/fmt.rs
@@ -3,8 +3,16 @@
 use color_eyre::eyre::{Context, Result, eyre};
 use duct::cmd;
 use indicatif::{ProgressBar, ProgressStyle};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+const FMT_SCHEMA_VERSION: &str = "1.0.0";
+const FMT_RECEIPT_RELATIVE_PATH: &str = "target/receipts/fmt.json";
+const FMT_CHECK_REPRO_COMMAND: &str = "cargo xtask fmt --check";
+const FMT_CHECK_TOOL: &str = "rustfmt";
 
 #[derive(Deserialize)]
 struct CargoMetadata {
@@ -12,11 +20,44 @@ struct CargoMetadata {
     workspace_members: Vec<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 struct CargoPackage {
     id: String,
     name: String,
     manifest_path: String,
+}
+
+#[derive(Clone, Debug)]
+struct FormatTarget {
+    crate_name: String,
+    manifest_path: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct FmtReceipt {
+    check: String,
+    schema_version: String,
+    verdict: String,
+    classification: String,
+    failures: Vec<FmtFailure>,
+    fix_forward_kind: String,
+    safe_auto_fix: bool,
+    repro: FmtRepro,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct FmtFailure {
+    tool: String,
+    #[serde(rename = "crate")]
+    crate_name: String,
+    path: String,
+    check_command: String,
+    fix_command: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct FmtRepro {
+    command: String,
 }
 
 pub fn run(check: bool, package_filters: Option<Vec<String>>) -> Result<()> {
@@ -30,72 +71,144 @@ pub fn run(check: bool, package_filters: Option<Vec<String>>) -> Result<()> {
     let action = if check { "Checking" } else { "Formatting" };
     spinner.set_message(format!("{} code", action));
 
-    for manifest_path in workspace_manifest_paths(package_filters.as_deref())? {
-        spinner.set_message(format!("{} {}", action, manifest_path));
+    let targets = workspace_format_targets(package_filters.as_deref())?;
 
-        let mut args = vec!["fmt".to_string(), "--manifest-path".to_string(), manifest_path];
-        if check {
-            args.push("--".to_string());
-            args.push("--check".to_string());
-        }
+    if check {
+        let failures = run_check_targets(&spinner, &targets)?;
+        let receipt = build_receipt(failures);
+        write_receipt(&receipt)?;
 
-        let status =
-            cmd("cargo", &args).run().with_context(|| format!("Failed to format {}", args[2]))?;
-
-        if !status.status.success() {
-            spinner.finish_with_message(format!(
-                "❌ Code {} failed",
-                if check { "check" } else { "formatting" }
-            ));
+        if receipt.verdict == "fail" {
+            spinner.finish_with_message("❌ Code check failed");
             return Err(eyre!(
-                "Code {} failed for {}",
-                if check { "check" } else { "formatting" },
-                args[2]
+                "Code check failed for {} crate(s). See {} for full failure list.",
+                receipt.failures.len(),
+                FMT_RECEIPT_RELATIVE_PATH
             ));
         }
+
+        spinner.finish_with_message("✅ Code check passed");
+        return Ok(());
     }
 
-    spinner.finish_with_message(format!(
-        "✅ Code {} successfully",
-        if check { "check passed" } else { "formatted" }
-    ));
+    run_format_targets(&spinner, &targets)?;
+    spinner.finish_with_message("✅ Code formatted successfully");
     Ok(())
 }
 
-fn workspace_manifest_paths(package_filters: Option<&[String]>) -> Result<Vec<String>> {
+fn run_check_targets(spinner: &ProgressBar, targets: &[FormatTarget]) -> Result<Vec<FmtFailure>> {
+    let mut failures = Vec::new();
+
+    for target in targets {
+        spinner.set_message(format!("Checking {}", target.manifest_path));
+        let check_command =
+            format!("cargo fmt --manifest-path {} -- --check", target.manifest_path);
+        let fix_command = format!("cargo fmt --manifest-path {}", target.manifest_path);
+
+        let status = Command::new("cargo")
+            .arg("fmt")
+            .arg("--manifest-path")
+            .arg(&target.manifest_path)
+            .arg("--")
+            .arg("--check")
+            .status()
+            .with_context(|| {
+                format!("Failed to execute formatting check for {}", target.crate_name)
+            })?;
+
+        if !status.success() {
+            failures.push(FmtFailure {
+                tool: FMT_CHECK_TOOL.to_string(),
+                crate_name: target.crate_name.clone(),
+                path: target.manifest_path.clone(),
+                check_command,
+                fix_command,
+            });
+        }
+    }
+
+    Ok(failures)
+}
+
+fn run_format_targets(spinner: &ProgressBar, targets: &[FormatTarget]) -> Result<()> {
+    for target in targets {
+        spinner.set_message(format!("Formatting {}", target.manifest_path));
+
+        let args = ["fmt", "--manifest-path", target.manifest_path.as_str()];
+        let status = cmd("cargo", args)
+            .run()
+            .with_context(|| format!("Failed to format {}", target.manifest_path))?;
+
+        if !status.status.success() {
+            return Err(eyre!("Code formatting failed for {}", target.manifest_path));
+        }
+    }
+
+    Ok(())
+}
+
+fn build_receipt(failures: Vec<FmtFailure>) -> FmtReceipt {
+    let verdict = if failures.is_empty() { "pass" } else { "fail" };
+    FmtReceipt {
+        check: "fmt".to_string(),
+        schema_version: FMT_SCHEMA_VERSION.to_string(),
+        verdict: verdict.to_string(),
+        classification: "fmt_drift".to_string(),
+        failures,
+        fix_forward_kind: "FMT_ONLY".to_string(),
+        safe_auto_fix: true,
+        repro: FmtRepro { command: FMT_CHECK_REPRO_COMMAND.to_string() },
+    }
+}
+
+fn write_receipt(receipt: &FmtReceipt) -> Result<()> {
+    let receipt_path = PathBuf::from(FMT_RECEIPT_RELATIVE_PATH);
+    if let Some(parent) = receipt_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create receipt directory {}", parent.display()))?;
+    }
+
+    let payload =
+        serde_json::to_string_pretty(receipt).context("Failed to serialize fmt receipt JSON")?;
+    fs::write(&receipt_path, payload)
+        .with_context(|| format!("Failed to write receipt {}", receipt_path.display()))?;
+    println!("fmt receipt: {}", receipt_path.display());
+    Ok(())
+}
+
+fn workspace_format_targets(package_filters: Option<&[String]>) -> Result<Vec<FormatTarget>> {
     let metadata_json = cmd("cargo", ["metadata", "--format-version", "1", "--no-deps"])
         .read()
         .context("Failed to query cargo metadata for workspace formatting")?;
     let metadata: CargoMetadata =
         serde_json::from_str(&metadata_json).context("Failed to parse cargo metadata JSON")?;
 
-    collect_workspace_manifest_paths(&metadata, package_filters)
+    collect_workspace_format_targets(&metadata, package_filters)
 }
 
-fn collect_workspace_manifest_paths(
+fn collect_workspace_format_targets(
     metadata: &CargoMetadata,
     package_filters: Option<&[String]>,
-) -> Result<Vec<String>> {
-    let package_by_id: HashMap<_, _> = metadata
-        .packages
-        .iter()
-        .map(|package| (package.id.as_str(), package.manifest_path.clone()))
-        .collect();
-    let member_name_to_manifest: HashMap<_, _> = metadata
+) -> Result<Vec<FormatTarget>> {
+    let package_by_id: HashMap<_, _> =
+        metadata.packages.iter().map(|package| (package.id.as_str(), package)).collect();
+    let member_name_to_package: HashMap<_, _> = metadata
         .packages
         .iter()
         .filter(|package| metadata.workspace_members.iter().any(|member| member == &package.id))
-        .map(|package| (package.name.as_str(), package.manifest_path.clone()))
+        .map(|package| (package.name.as_str(), package))
         .collect();
 
     if let Some(filters) = package_filters {
         let mut selected = Vec::with_capacity(filters.len());
         for package_name in filters {
-            if let Some(manifest_path) = member_name_to_manifest.get(package_name.as_str()) {
-                selected.push(manifest_path.clone());
+            if let Some(package) = member_name_to_package.get(package_name.as_str()) {
+                selected.push(FormatTarget {
+                    crate_name: package.name.clone(),
+                    manifest_path: package.manifest_path.clone(),
+                });
             } else {
-                // Sort the available list so the error message is stable across runs.
-                let mut available: Vec<_> = member_name_to_manifest.keys().copied().collect();
+                let mut available: Vec<_> = member_name_to_package.keys().copied().collect();
                 available.sort_unstable();
                 return Err(eyre!(
                     "Unknown package `{package_name}`. Available workspace packages: {}",
@@ -103,27 +216,30 @@ fn collect_workspace_manifest_paths(
                 ));
             }
         }
-        return Ok(dedup_preserve_order(selected));
+        return Ok(dedup_targets_preserve_order(selected));
     }
 
     metadata
         .workspace_members
         .iter()
         .map(|member_id| {
-            package_by_id
-                .get(member_id.as_str())
-                .cloned()
-                .ok_or_else(|| eyre!("Workspace member not found in cargo metadata: {member_id}"))
+            let package = package_by_id.get(member_id.as_str()).ok_or_else(|| {
+                eyre!("Workspace member not found in cargo metadata: {member_id}")
+            })?;
+            Ok(FormatTarget {
+                crate_name: package.name.clone(),
+                manifest_path: package.manifest_path.clone(),
+            })
         })
         .collect()
 }
 
-fn dedup_preserve_order(paths: Vec<String>) -> Vec<String> {
-    let mut seen = HashSet::with_capacity(paths.len());
-    let mut deduped = Vec::with_capacity(paths.len());
-    for path in paths {
-        if seen.insert(path.clone()) {
-            deduped.push(path);
+fn dedup_targets_preserve_order(targets: Vec<FormatTarget>) -> Vec<FormatTarget> {
+    let mut seen = HashSet::with_capacity(targets.len());
+    let mut deduped = Vec::with_capacity(targets.len());
+    for target in targets {
+        if seen.insert(target.manifest_path.clone()) {
+            deduped.push(target);
         }
     }
     deduped
@@ -131,7 +247,9 @@ fn dedup_preserve_order(paths: Vec<String>) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CargoMetadata, CargoPackage, collect_workspace_manifest_paths};
+    use super::{
+        CargoMetadata, CargoPackage, FmtFailure, build_receipt, collect_workspace_format_targets,
+    };
     use color_eyre::eyre::Result;
 
     fn sample_metadata() -> CargoMetadata {
@@ -159,8 +277,10 @@ mod tests {
     fn package_filters_select_requested_manifest_paths() -> Result<()> {
         let metadata = sample_metadata();
         let filters = vec!["perl-parser".to_string()];
-        let manifests = collect_workspace_manifest_paths(&metadata, Some(&filters))?;
-        assert_eq!(manifests, vec!["/repo/crates/perl-parser/Cargo.toml".to_string()]);
+        let manifests = collect_workspace_format_targets(&metadata, Some(&filters))?;
+        assert_eq!(manifests.len(), 1);
+        assert_eq!(manifests[0].crate_name, "perl-parser");
+        assert_eq!(manifests[0].manifest_path, "/repo/crates/perl-parser/Cargo.toml");
         Ok(())
     }
 
@@ -168,8 +288,9 @@ mod tests {
     fn package_filters_are_deduplicated() -> Result<()> {
         let metadata = sample_metadata();
         let filters = vec!["xtask".to_string(), "xtask".to_string()];
-        let manifests = collect_workspace_manifest_paths(&metadata, Some(&filters))?;
-        assert_eq!(manifests, vec!["/repo/xtask/Cargo.toml".to_string()]);
+        let manifests = collect_workspace_format_targets(&metadata, Some(&filters))?;
+        assert_eq!(manifests.len(), 1);
+        assert_eq!(manifests[0].manifest_path, "/repo/xtask/Cargo.toml");
         Ok(())
     }
 
@@ -177,7 +298,7 @@ mod tests {
     fn package_filters_report_unknown_package() -> Result<()> {
         let metadata = sample_metadata();
         let filters = vec!["missing-package".to_string()];
-        let message = match collect_workspace_manifest_paths(&metadata, Some(&filters)) {
+        let message = match collect_workspace_format_targets(&metadata, Some(&filters)) {
             Ok(paths) => {
                 return Err(color_eyre::eyre::eyre!("expected error, got paths: {paths:?}"));
             }
@@ -192,16 +313,47 @@ mod tests {
     fn package_filters_error_lists_packages_in_stable_sorted_order() -> Result<()> {
         let metadata = sample_metadata();
         let filters = vec!["nonexistent".to_string()];
-        let message = match collect_workspace_manifest_paths(&metadata, Some(&filters)) {
+        let message = match collect_workspace_format_targets(&metadata, Some(&filters)) {
             Ok(paths) => {
                 return Err(color_eyre::eyre::eyre!("expected error, got paths: {paths:?}"));
             }
             Err(err) => format!("{err}"),
         };
-        // The available list must be sorted — both packages appear in alphabetical order.
-        let perl_pos = message.find("perl-parser").expect("perl-parser in error");
-        let xtask_pos = message.find("xtask").expect("xtask in error");
+        let perl_pos = message
+            .find("perl-parser")
+            .ok_or_else(|| color_eyre::eyre::eyre!("perl-parser missing from error"))?;
+        let xtask_pos = message
+            .find("xtask")
+            .ok_or_else(|| color_eyre::eyre::eyre!("xtask missing from error"))?;
         assert!(perl_pos < xtask_pos, "available packages must be listed in sorted order");
         Ok(())
+    }
+
+    #[test]
+    fn receipt_collects_multiple_failures() {
+        let receipt = build_receipt(vec![
+            FmtFailure {
+                tool: "rustfmt".to_string(),
+                crate_name: "xtask".to_string(),
+                path: "xtask/Cargo.toml".to_string(),
+                check_command: "cargo fmt --manifest-path xtask/Cargo.toml -- --check".to_string(),
+                fix_command: "cargo fmt --manifest-path xtask/Cargo.toml".to_string(),
+            },
+            FmtFailure {
+                tool: "rustfmt".to_string(),
+                crate_name: "perl-parser".to_string(),
+                path: "crates/perl-parser/Cargo.toml".to_string(),
+                check_command: "cargo fmt --manifest-path crates/perl-parser/Cargo.toml -- --check"
+                    .to_string(),
+                fix_command: "cargo fmt --manifest-path crates/perl-parser/Cargo.toml".to_string(),
+            },
+        ]);
+
+        assert_eq!(receipt.check, "fmt");
+        assert_eq!(receipt.verdict, "fail");
+        assert_eq!(receipt.classification, "fmt_drift");
+        assert_eq!(receipt.fix_forward_kind, "FMT_ONLY");
+        assert!(receipt.safe_auto_fix);
+        assert_eq!(receipt.failures.len(), 2);
     }
 }


### PR DESCRIPTION
### Motivation

- The existing `cargo xtask fmt --check` stopped at the first failing crate which forced iterative reruns to discover all formatting failures and slowed triage and fix-forward tooling.

### Description

- Change `xtask/src/tasks/fmt.rs` so check mode runs the formatting check for every workspace target, collects all failures, and emits a structured receipt at `target/receipts/fmt.json` containing `check_command` and `fix_command` per failure.
- Add a stable JSON schema for the receipt at `.ci/receipts/schemas/fmt.schema.json` and documentation at `docs/ci/fmt-receipts.md` describing fields and typed fix-forward intent (`classification=fmt_drift`, `fix_forward_kind=FMT_ONLY`, `safe_auto_fix=true`).
- Preserve existing formatting behavior: non-check mode still formats normally and check mode remains read-only (no auto-fix or commits), and existing stdout/stderr output is preserved and improved with an emitted receipt.
- Add a focused unit test in `xtask` that verifies multiple failures are collected into a single receipt payload.

### Testing

- Ran `cargo check -p xtask` and it succeeded.
- Ran `cargo xtask fmt --check` on a clean tree which completed and wrote `target/receipts/fmt.json` (verdict `pass` on this tree).
- Ran `cargo test -p xtask fmt::tests::receipt_collects_multiple_failures` and the test passed.

Refs #6853

This change enables typed fix-forward tooling to consume exact fix commands per failing crate while keeping check mode read-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0800b108333ac5294e1dd369eb1)