### PR TITLE
fix(xtask): report all fmt failures with receipt (#6853)

### DIFF
--- a/.ci/receipts/schemas/fmt.schema.json
+++ b/.ci/receipts/schemas/fmt.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/schemas/receipts/fmt.schema.json",
+  "title": "Format Check Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "check",
+    "schema_version",
+    "verdict",
+    "classification",
+    "failures",
+    "fix_forward_kind",
+    "safe_auto_fix",
+    "repro"
+  ],
+  "properties": {
+    "check": { "const": "fmt" },
+    "schema_version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+    "verdict": { "type": "string", "enum": ["pass", "fail"] },
+    "classification": { "const": "fmt_drift" },
+    "failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["tool", "crate", "path", "check_command", "fix_command"],
+        "properties": {
+          "tool": { "type": "string", "minLength": 1 },
+          "crate": { "type": "string", "minLength": 1 },
+          "path": { "type": "string", "minLength": 1 },
+          "check_command": { "type": "string", "minLength": 1 },
+          "fix_command": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "fix_forward_kind": { "const": "FMT_ONLY" },
+    "safe_auto_fix": { "const": true },
+    "repro": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "command": { "type": "string", "minLength": 1 }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "verdict": { "const": "pass" } } },
+      "then": {
+        "properties": {
+          "failures": { "maxItems": 0 }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "verdict": { "const": "fail" } } },
+      "then": {
+        "properties": {
+          "failures": { "minItems": 1 }
+        }
+      }
+    }
+  ]
+}

--- a/docs/ci/fmt-receipts.md
+++ b/docs/ci/fmt-receipts.md
@@ -1,0 +1,41 @@
+# Fmt receipt contract
+
+`cargo xtask fmt --check` now executes every configured workspace formatter check, aggregates every failure, and writes a machine-readable receipt to `target/receipts/fmt.json` before returning a non-zero exit code.
+
+## Why this exists
+
+Fmt drift can exist in multiple crates at once. Early exit behavior hides later failures and forces iterative reruns. The receipt records all failures in one pass, including exact check and fix commands, which enables typed fix-forward flows.
+
+## Receipt location
+
+- Runtime output: `target/receipts/fmt.json`
+- Schema: `.ci/receipts/schemas/fmt.schema.json`
+
+The runtime receipt is generated output and must not be committed.
+
+## Receipt shape
+
+Top-level fields:
+
+- `check`: always `fmt`
+- `schema_version`: semantic version string (currently `1.0.0`)
+- `verdict`: `pass` or `fail`
+- `classification`: always `fmt_drift`
+- `failures[]`: one entry per failing crate/file/tool tuple
+- `fix_forward_kind`: always `FMT_ONLY`
+- `safe_auto_fix`: always `true`
+- `repro.command`: exact command used to reproduce (`cargo xtask fmt --check`)
+
+Failure item fields:
+
+- `tool`: formatter tool name (`rustfmt`)
+- `crate`: crate inferred from failing manifest path
+- `path`: file path from rustfmt diff output (or manifest fallback)
+- `check_command`: exact check command that failed
+- `fix_command`: exact fix command to apply locally
+
+## Operator usage
+
+- Run `cargo xtask fmt --check` once.
+- Inspect `target/receipts/fmt.json` for the complete failure set.
+- Run each `fix_command` and rerun the check.

--- a/xtask/src/tasks/fmt.rs
+++ b/xtask/src/tasks/fmt.rs
@@ -3,8 +3,12 @@
 use color_eyre::eyre::{Context, Result, eyre};
 use duct::cmd;
 use indicatif::{ProgressBar, ProgressStyle};
-use serde::Deserialize;
-use std::collections::{HashMap, HashSet};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::process::Command;
 
 #[derive(Deserialize)]
 struct CargoMetadata {
@@ -30,27 +34,59 @@ pub fn run(check: bool, package_filters: Option<Vec<String>>) -> Result<()> {
     let action = if check { "Checking" } else { "Formatting" };
     spinner.set_message(format!("{} code", action));
 
-    for manifest_path in workspace_manifest_paths(package_filters.as_deref())? {
+    let manifest_paths = workspace_manifest_paths(package_filters.as_deref())?;
+    let mut failures = Vec::new();
+    for manifest_path in manifest_paths {
         spinner.set_message(format!("{} {}", action, manifest_path));
 
-        let mut args = vec!["fmt".to_string(), "--manifest-path".to_string(), manifest_path];
+        let mut args =
+            vec!["fmt".to_string(), "--manifest-path".to_string(), manifest_path.clone()];
         if check {
             args.push("--".to_string());
             args.push("--check".to_string());
         }
 
-        let status =
-            cmd("cargo", &args).run().with_context(|| format!("Failed to format {}", args[2]))?;
+        if check {
+            let command = run_check_command_and_stream_output(&manifest_path)
+                .with_context(|| format!("Failed to format {}", manifest_path))?;
+            if !command.success {
+                let crate_name = crate_name_from_manifest_path(&manifest_path);
+                let check_command =
+                    format!("cargo fmt --manifest-path {} -- --check", manifest_path);
+                let fix_command = format!("cargo fmt --manifest-path {}", manifest_path);
+                let mut paths = command.paths;
+                if paths.is_empty() {
+                    paths.push(manifest_path.clone());
+                }
+                for path in paths {
+                    failures.push(FmtFailure {
+                        tool: "rustfmt".to_string(),
+                        crate_name: crate_name.clone(),
+                        path,
+                        check_command: check_command.clone(),
+                        fix_command: fix_command.clone(),
+                    });
+                }
+            }
+        } else {
+            let status = cmd("cargo", &args)
+                .run()
+                .with_context(|| format!("Failed to format {}", manifest_path))?;
+            if !status.status.success() {
+                spinner.finish_with_message("❌ Code formatting failed".to_string());
+                return Err(eyre!("Code formatting failed for {}", manifest_path));
+            }
+        }
+    }
 
-        if !status.status.success() {
-            spinner.finish_with_message(format!(
-                "❌ Code {} failed",
-                if check { "check" } else { "formatting" }
-            ));
+    if check {
+        let receipt = build_fmt_receipt(failures, "cargo xtask fmt --check");
+        write_fmt_receipt(&receipt)?;
+        if receipt.verdict == "fail" {
+            spinner.finish_with_message("❌ Code check failed");
             return Err(eyre!(
-                "Code {} failed for {}",
-                if check { "check" } else { "formatting" },
-                args[2]
+                "Code check failed for {} file(s). See target/receipts/fmt.json",
+                receipt.failures.len()
             ));
         }
     }
@@ -60,6 +96,121 @@ pub fn run(check: bool, package_filters: Option<Vec<String>>) -> Result<()> {
         if check { "check passed" } else { "formatted" }
     ));
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct CheckCommandResult {
+    success: bool,
+    paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct FmtFailure {
+    tool: String,
+    #[serde(rename = "crate")]
+    crate_name: String,
+    path: String,
+    check_command: String,
+    fix_command: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct FmtRepro {
+    command: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct FmtReceipt {
+    check: String,
+    schema_version: String,
+    verdict: String,
+    classification: String,
+    failures: Vec<FmtFailure>,
+    fix_forward_kind: String,
+    safe_auto_fix: bool,
+    repro: FmtRepro,
+}
+
+fn write_fmt_receipt(receipt: &FmtReceipt) -> Result<()> {
+    let path = PathBuf::from("target/receipts/fmt.json");
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create receipt directory {}", parent.display()))?;
+    }
+    let content =
+        serde_json::to_string_pretty(receipt).context("Failed to serialize fmt receipt")?;
+    fs::write(&path, content)
+        .with_context(|| format!("Failed to write receipt to {}", path.display()))
+}
+
+fn build_fmt_receipt(mut failures: Vec<FmtFailure>, repro_command: &str) -> FmtReceipt {
+    failures.sort_by(|left, right| {
+        left.crate_name
+            .cmp(&right.crate_name)
+            .then(left.path.cmp(&right.path))
+            .then(left.tool.cmp(&right.tool))
+    });
+    FmtReceipt {
+        check: "fmt".to_string(),
+        schema_version: "1.0.0".to_string(),
+        verdict: if failures.is_empty() { "pass".to_string() } else { "fail".to_string() },
+        classification: "fmt_drift".to_string(),
+        failures,
+        fix_forward_kind: "FMT_ONLY".to_string(),
+        safe_auto_fix: true,
+        repro: FmtRepro { command: repro_command.to_string() },
+    }
+}
+
+fn run_check_command_and_stream_output(manifest_path: &str) -> Result<CheckCommandResult> {
+    let output = Command::new("cargo")
+        .arg("fmt")
+        .arg("--manifest-path")
+        .arg(manifest_path)
+        .arg("--")
+        .arg("--check")
+        .output()
+        .with_context(|| format!("Failed to execute cargo fmt --check for {manifest_path}"))?;
+
+    io::stdout().write_all(&output.stdout).context("Failed to stream cargo fmt stdout")?;
+    io::stderr().write_all(&output.stderr).context("Failed to stream cargo fmt stderr")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Ok(CheckCommandResult {
+        success: output.status.success(),
+        paths: collect_diff_paths(&stdout, &stderr),
+    })
+}
+
+fn collect_diff_paths(stdout: &str, stderr: &str) -> Vec<String> {
+    let mut paths = BTreeSet::new();
+    for source in [stdout, stderr] {
+        for line in source.lines() {
+            if let Some(path) = extract_diff_path(line) {
+                paths.insert(path.to_string());
+            }
+        }
+    }
+    paths.into_iter().collect()
+}
+
+fn extract_diff_path(line: &str) -> Option<&str> {
+    let trimmed = line.trim();
+    let rest = trimmed.strip_prefix("Diff in ")?;
+    let (path, _) = rest.split_once(':')?;
+    if path.is_empty() {
+        return None;
+    }
+    Some(path)
+}
+
+fn crate_name_from_manifest_path(manifest_path: &str) -> String {
+    let path = PathBuf::from(manifest_path);
+    path.parent()
+        .and_then(|parent| parent.file_name())
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "workspace".to_string())
 }
 
 fn workspace_manifest_paths(package_filters: Option<&[String]>) -> Result<Vec<String>> {
@@ -131,7 +282,10 @@ fn dedup_preserve_order(paths: Vec<String>) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CargoMetadata, CargoPackage, collect_workspace_manifest_paths};
+    use super::{
+        CargoMetadata, CargoPackage, FmtFailure, build_fmt_receipt, collect_diff_paths,
+        collect_workspace_manifest_paths, extract_diff_path,
+    };
     use color_eyre::eyre::Result;
 
     fn sample_metadata() -> CargoMetadata {
@@ -202,6 +356,63 @@ mod tests {
         let perl_pos = message.find("perl-parser").expect("perl-parser in error");
         let xtask_pos = message.find("xtask").expect("xtask in error");
         assert!(perl_pos < xtask_pos, "available packages must be listed in sorted order");
+        Ok(())
+    }
+
+    #[test]
+    fn check_mode_collects_multiple_diff_paths() -> Result<()> {
+        let stdout =
+            "Diff in crates/perl-parser/src/lib.rs:1:\nDiff in crates/xtask/src/main.rs:2:\n";
+        let stderr = "";
+        let paths = collect_diff_paths(stdout, stderr);
+        assert_eq!(
+            paths,
+            vec![
+                "crates/perl-parser/src/lib.rs".to_string(),
+                "crates/xtask/src/main.rs".to_string()
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn extract_diff_path_ignores_non_diff_lines() -> Result<()> {
+        assert_eq!(extract_diff_path("warning: something"), None);
+        assert_eq!(extract_diff_path("Diff in :"), None);
+        assert_eq!(
+            extract_diff_path("Diff in crates/a/src/lib.rs:10:"),
+            Some("crates/a/src/lib.rs")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn receipt_reports_fail_when_any_failures_exist() -> Result<()> {
+        let failures = vec![
+            FmtFailure {
+                tool: "rustfmt".to_string(),
+                crate_name: "xtask".to_string(),
+                path: "xtask/src/main.rs".to_string(),
+                check_command: "cargo fmt --manifest-path xtask/Cargo.toml -- --check".to_string(),
+                fix_command: "cargo fmt --manifest-path xtask/Cargo.toml".to_string(),
+            },
+            FmtFailure {
+                tool: "rustfmt".to_string(),
+                crate_name: "perl-parser".to_string(),
+                path: "crates/perl-parser/src/lib.rs".to_string(),
+                check_command: "cargo fmt --manifest-path crates/perl-parser/Cargo.toml -- --check"
+                    .to_string(),
+                fix_command: "cargo fmt --manifest-path crates/perl-parser/Cargo.toml".to_string(),
+            },
+        ];
+        let receipt = build_fmt_receipt(failures, "cargo xtask fmt --check");
+        assert_eq!(receipt.check, "fmt");
+        assert_eq!(receipt.verdict, "fail");
+        assert_eq!(receipt.classification, "fmt_drift");
+        assert_eq!(receipt.fix_forward_kind, "FMT_ONLY");
+        assert!(receipt.safe_auto_fix);
+        assert_eq!(receipt.failures.len(), 2);
+        assert_eq!(receipt.failures[0].crate_name, "perl-parser");
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- `cargo xtask fmt --check` previously aborted on the first failing crate which forced repeated runs to discover the full set of formatting violations, costing operators time.

### Description

- Run `cargo fmt --manifest-path ... -- --check` for every workspace manifest, stream existing rustfmt stdout/stderr, and collect all failing crate/file tuples instead of failing fast.
- Serialize a structured receipt to `target/receipts/fmt.json` with fields `check`, `schema_version`, `verdict`, `classification: fmt_drift`, `failures[]` (with `tool`, `crate`, `path`, `check_command`, `fix_command`), `fix_forward_kind: FMT_ONLY`, `safe_auto_fix: true`, and `repro.command`.
- Add JSON schema at `.ci/receipts/schemas/fmt.schema.json` and documentation `docs/ci/fmt-receipts.md` describing the receipt contract and operator workflow.
- Add unit tests to exercise diff-path extraction and receipt shaping to ensure multiple failures are collected and receipts sort deterministically.

### Testing

- Ran `cargo check -p xtask` which completed successfully.
- Ran `cargo xtask fmt --check` on a clean tree which produced `target/receipts/fmt.json` and returned success when no failures were present.
- Ran unit tests in the `xtask` crate (`cargo test -p xtask check_mode_collects_multiple_diff_paths` and the receipt-shape test) and they passed.

Refs #6853 — this change enables typed fix-forward flows by recording exact `check_command` and `fix_command` for each failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0800b108333ac5294e1dd369eb1)