### PR TITLE
fix(xtask): report all fmt failures with receipt (#6853)

### DIFF
--- a/.ci/receipts/schemas/fmt.schema.json
+++ b/.ci/receipts/schemas/fmt.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/p5-lang/perl-lsp/.ci/receipts/schemas/fmt.schema.json",
+  "title": "fmt receipt",
+  "type": "object",
+  "required": [
+    "check",
+    "schema_version",
+    "verdict",
+    "classification",
+    "failures",
+    "fix_forward_kind",
+    "safe_auto_fix",
+    "repro"
+  ],
+  "properties": {
+    "check": {
+      "const": "fmt"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "fail"]
+    },
+    "classification": {
+      "const": "fmt_drift"
+    },
+    "failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["tool", "crate", "path", "check_command", "fix_command"],
+        "properties": {
+          "tool": {
+            "type": "string"
+          },
+          "crate": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "check_command": {
+            "type": "string"
+          },
+          "fix_command": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "fix_forward_kind": {
+      "const": "FMT_ONLY"
+    },
+    "safe_auto_fix": {
+      "const": true
+    },
+    "repro": {
+      "type": "object",
+      "required": ["command"],
+      "properties": {
+        "command": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/ci/fmt-receipts.md
+++ b/docs/ci/fmt-receipts.md
@@ -1,0 +1,45 @@
+# `cargo xtask fmt --check` receipts
+
+`cargo xtask fmt --check` now runs every configured workspace formatting check before returning a non-zero status. The command writes a machine-readable receipt to `target/receipts/fmt.json` for both pass and fail outcomes.
+
+## Why this exists
+
+Formatting drift is often spread across multiple crates. Failing fast on the first crate forces iterative reruns and slows both local work and CI triage. The receipt captures the complete failure set in one pass so fix-forward tooling can apply deterministic remediations.
+
+## Receipt location
+
+- Runtime artifact: `target/receipts/fmt.json`
+- Schema: `.ci/receipts/schemas/fmt.schema.json`
+
+The runtime artifact is intentionally not committed.
+
+## Receipt fields
+
+Top-level fields:
+
+- `check`: always `fmt`
+- `schema_version`: receipt schema version
+- `verdict`: `pass` or `fail`
+- `classification`: always `fmt_drift`
+- `failures[]`: one item per formatting failure
+- `fix_forward_kind`: always `FMT_ONLY`
+- `safe_auto_fix`: always `true`
+- `repro.command`: exact reproducer command
+
+Per failure fields:
+
+- `tool`: formatting tool name (`rustfmt`)
+- `crate`: workspace crate name
+- `path`: drifted file path when available (falls back to crate manifest directory)
+- `check_command`: exact check command that failed
+- `fix_command`: exact command to apply formatting for that crate
+
+## Typed fix-forward support
+
+Consumers can treat this receipt as typed `FMT_ONLY` remediation input:
+
+1. Read all entries from `failures[]`.
+2. Execute each `fix_command`.
+3. Re-run `repro.command` to verify the tree is clean.
+
+This keeps formatting auto-fix bounded and safe (`safe_auto_fix: true`) without changing non-format behavior.

--- a/xtask/src/tasks/fmt.rs
+++ b/xtask/src/tasks/fmt.rs
@@ -1,10 +1,16 @@
 //! Format task implementation
 
+use crate::utils::project_root;
 use color_eyre::eyre::{Context, Result, eyre};
 use duct::cmd;
 use indicatif::{ProgressBar, ProgressStyle};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+
+const RECEIPT_SCHEMA_VERSION: &str = "1.0.0";
+const RECEIPT_PATH: &str = "target/receipts/fmt.json";
 
 #[derive(Deserialize)]
 struct CargoMetadata {
@@ -19,6 +25,39 @@ struct CargoPackage {
     manifest_path: String,
 }
 
+#[derive(Clone, Debug)]
+struct FmtTarget {
+    crate_name: String,
+    manifest_path: String,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+struct FmtReceipt {
+    check: String,
+    schema_version: String,
+    verdict: String,
+    classification: String,
+    failures: Vec<FmtFailure>,
+    fix_forward_kind: String,
+    safe_auto_fix: bool,
+    repro: FmtRepro,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+struct FmtFailure {
+    tool: String,
+    #[serde(rename = "crate")]
+    crate_field: String,
+    path: String,
+    check_command: String,
+    fix_command: String,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+struct FmtRepro {
+    command: String,
+}
+
 pub fn run(check: bool, package_filters: Option<Vec<String>>) -> Result<()> {
     let spinner = ProgressBar::new_spinner();
     spinner.set_style(
@@ -30,19 +69,39 @@ pub fn run(check: bool, package_filters: Option<Vec<String>>) -> Result<()> {
     let action = if check { "Checking" } else { "Formatting" };
     spinner.set_message(format!("{} code", action));
 
-    for manifest_path in workspace_manifest_paths(package_filters.as_deref())? {
-        spinner.set_message(format!("{} {}", action, manifest_path));
+    let targets = workspace_fmt_targets(package_filters.as_deref())?;
+    let mut failures = Vec::new();
 
-        let mut args = vec!["fmt".to_string(), "--manifest-path".to_string(), manifest_path];
+    for target in &targets {
+        spinner.set_message(format!("{} {}", action, target.manifest_path));
+
+        let mut args =
+            vec!["fmt".to_string(), "--manifest-path".to_string(), target.manifest_path.clone()];
         if check {
             args.push("--".to_string());
             args.push("--check".to_string());
         }
 
-        let status =
-            cmd("cargo", &args).run().with_context(|| format!("Failed to format {}", args[2]))?;
+        let result = cmd("cargo", &args)
+            .unchecked()
+            .run()
+            .with_context(|| format!("Failed to run {args:?}"))?;
 
-        if !status.status.success() {
+        if !result.status.success() {
+            if check {
+                let check_command =
+                    format!("cargo fmt --manifest-path {} -- --check", target.manifest_path);
+                let fix_command = format!("cargo fmt --manifest-path {}", target.manifest_path);
+                let failed_path = infer_failed_path(&result.stderr, &target.manifest_path)?;
+                failures.push(FmtFailure {
+                    tool: "rustfmt".to_string(),
+                    crate_field: target.crate_name.clone(),
+                    path: failed_path,
+                    check_command,
+                    fix_command,
+                });
+                continue;
+            }
             spinner.finish_with_message(format!(
                 "❌ Code {} failed",
                 if check { "check" } else { "formatting" }
@@ -50,7 +109,20 @@ pub fn run(check: bool, package_filters: Option<Vec<String>>) -> Result<()> {
             return Err(eyre!(
                 "Code {} failed for {}",
                 if check { "check" } else { "formatting" },
-                args[2]
+                target.manifest_path
+            ));
+        }
+    }
+
+    if check {
+        let receipt = build_receipt(&failures, package_filters.as_deref());
+        write_receipt(&receipt)?;
+        if !failures.is_empty() {
+            spinner.finish_with_message("❌ Code check failed".to_string());
+            return Err(eyre!(
+                "Formatting check failed in {} crate(s); see {}",
+                failures.len(),
+                RECEIPT_PATH
             ));
         }
     }
@@ -62,40 +134,56 @@ pub fn run(check: bool, package_filters: Option<Vec<String>>) -> Result<()> {
     Ok(())
 }
 
-fn workspace_manifest_paths(package_filters: Option<&[String]>) -> Result<Vec<String>> {
+fn workspace_fmt_targets(package_filters: Option<&[String]>) -> Result<Vec<FmtTarget>> {
     let metadata_json = cmd("cargo", ["metadata", "--format-version", "1", "--no-deps"])
         .read()
         .context("Failed to query cargo metadata for workspace formatting")?;
     let metadata: CargoMetadata =
         serde_json::from_str(&metadata_json).context("Failed to parse cargo metadata JSON")?;
 
-    collect_workspace_manifest_paths(&metadata, package_filters)
+    collect_workspace_fmt_targets(&metadata, package_filters)
 }
 
-fn collect_workspace_manifest_paths(
+fn collect_workspace_fmt_targets(
     metadata: &CargoMetadata,
     package_filters: Option<&[String]>,
-) -> Result<Vec<String>> {
+) -> Result<Vec<FmtTarget>> {
     let package_by_id: HashMap<_, _> = metadata
         .packages
         .iter()
-        .map(|package| (package.id.as_str(), package.manifest_path.clone()))
+        .map(|package| {
+            (
+                package.id.as_str(),
+                FmtTarget {
+                    crate_name: package.name.clone(),
+                    manifest_path: package.manifest_path.clone(),
+                },
+            )
+        })
         .collect();
-    let member_name_to_manifest: HashMap<_, _> = metadata
+    let member_name_to_target: HashMap<_, _> = metadata
         .packages
         .iter()
         .filter(|package| metadata.workspace_members.iter().any(|member| member == &package.id))
-        .map(|package| (package.name.as_str(), package.manifest_path.clone()))
+        .map(|package| {
+            (
+                package.name.as_str(),
+                FmtTarget {
+                    crate_name: package.name.clone(),
+                    manifest_path: package.manifest_path.clone(),
+                },
+            )
+        })
         .collect();
 
     if let Some(filters) = package_filters {
         let mut selected = Vec::with_capacity(filters.len());
         for package_name in filters {
-            if let Some(manifest_path) = member_name_to_manifest.get(package_name.as_str()) {
-                selected.push(manifest_path.clone());
+            if let Some(target) = member_name_to_target.get(package_name.as_str()) {
+                selected.push(target.clone());
             } else {
                 // Sort the available list so the error message is stable across runs.
-                let mut available: Vec<_> = member_name_to_manifest.keys().copied().collect();
+                let mut available: Vec<_> = member_name_to_target.keys().copied().collect();
                 available.sort_unstable();
                 return Err(eyre!(
                     "Unknown package `{package_name}`. Available workspace packages: {}",
@@ -118,20 +206,80 @@ fn collect_workspace_manifest_paths(
         .collect()
 }
 
-fn dedup_preserve_order(paths: Vec<String>) -> Vec<String> {
-    let mut seen = HashSet::with_capacity(paths.len());
-    let mut deduped = Vec::with_capacity(paths.len());
-    for path in paths {
-        if seen.insert(path.clone()) {
-            deduped.push(path);
+fn dedup_preserve_order(targets: Vec<FmtTarget>) -> Vec<FmtTarget> {
+    let mut seen = HashSet::with_capacity(targets.len());
+    let mut deduped = Vec::with_capacity(targets.len());
+    for target in targets {
+        if seen.insert(target.manifest_path.clone()) {
+            deduped.push(target);
         }
     }
     deduped
 }
 
+fn infer_failed_path(stderr: &[u8], manifest_path: &str) -> Result<String> {
+    let stderr_text = String::from_utf8_lossy(stderr);
+    let manifest_parent = Path::new(manifest_path)
+        .parent()
+        .ok_or_else(|| eyre!("Manifest path has no parent: {manifest_path}"))?;
+
+    for line in stderr_text.lines() {
+        if let Some(path) = line.strip_prefix("Diff in ") {
+            return to_relative_workspace_path(path.trim());
+        }
+    }
+
+    Ok(manifest_parent.to_string_lossy().to_string())
+}
+
+fn to_relative_workspace_path(path: &str) -> Result<String> {
+    let root = project_root()?;
+    let candidate = Path::new(path);
+    if let Ok(relative) = candidate.strip_prefix(&root) {
+        return Ok(relative.to_string_lossy().to_string());
+    }
+    Ok(path.to_string())
+}
+
+fn build_receipt(failures: &[FmtFailure], package_filters: Option<&[String]>) -> FmtReceipt {
+    let base_command = "cargo xtask fmt --check";
+    let command = match package_filters {
+        Some(filters) if !filters.is_empty() => {
+            let joined = filters.join(",");
+            format!("{base_command} --package {joined}")
+        }
+        _ => base_command.to_string(),
+    };
+
+    FmtReceipt {
+        check: "fmt".to_string(),
+        schema_version: RECEIPT_SCHEMA_VERSION.to_string(),
+        verdict: if failures.is_empty() { "pass" } else { "fail" }.to_string(),
+        classification: "fmt_drift".to_string(),
+        failures: failures.to_vec(),
+        fix_forward_kind: "FMT_ONLY".to_string(),
+        safe_auto_fix: true,
+        repro: FmtRepro { command },
+    }
+}
+
+fn write_receipt(receipt: &FmtReceipt) -> Result<()> {
+    let root = project_root()?;
+    let path = root.join(RECEIPT_PATH);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create receipt directory {}", parent.display()))?;
+    }
+    let content = serde_json::to_string_pretty(receipt)?;
+    fs::write(&path, content).with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{CargoMetadata, CargoPackage, collect_workspace_manifest_paths};
+    use super::{
+        CargoMetadata, CargoPackage, FmtFailure, build_receipt, collect_workspace_fmt_targets,
+    };
     use color_eyre::eyre::Result;
 
     fn sample_metadata() -> CargoMetadata {
@@ -159,8 +307,9 @@ mod tests {
     fn package_filters_select_requested_manifest_paths() -> Result<()> {
         let metadata = sample_metadata();
         let filters = vec!["perl-parser".to_string()];
-        let manifests = collect_workspace_manifest_paths(&metadata, Some(&filters))?;
-        assert_eq!(manifests, vec!["/repo/crates/perl-parser/Cargo.toml".to_string()]);
+        let manifests = collect_workspace_fmt_targets(&metadata, Some(&filters))?;
+        assert_eq!(manifests.len(), 1);
+        assert_eq!(manifests[0].manifest_path, "/repo/crates/perl-parser/Cargo.toml");
         Ok(())
     }
 
@@ -168,8 +317,9 @@ mod tests {
     fn package_filters_are_deduplicated() -> Result<()> {
         let metadata = sample_metadata();
         let filters = vec!["xtask".to_string(), "xtask".to_string()];
-        let manifests = collect_workspace_manifest_paths(&metadata, Some(&filters))?;
-        assert_eq!(manifests, vec!["/repo/xtask/Cargo.toml".to_string()]);
+        let manifests = collect_workspace_fmt_targets(&metadata, Some(&filters))?;
+        assert_eq!(manifests.len(), 1);
+        assert_eq!(manifests[0].manifest_path, "/repo/xtask/Cargo.toml");
         Ok(())
     }
 
@@ -177,7 +327,7 @@ mod tests {
     fn package_filters_report_unknown_package() -> Result<()> {
         let metadata = sample_metadata();
         let filters = vec!["missing-package".to_string()];
-        let message = match collect_workspace_manifest_paths(&metadata, Some(&filters)) {
+        let message = match collect_workspace_fmt_targets(&metadata, Some(&filters)) {
             Ok(paths) => {
                 return Err(color_eyre::eyre::eyre!("expected error, got paths: {paths:?}"));
             }
@@ -192,7 +342,7 @@ mod tests {
     fn package_filters_error_lists_packages_in_stable_sorted_order() -> Result<()> {
         let metadata = sample_metadata();
         let filters = vec!["nonexistent".to_string()];
-        let message = match collect_workspace_manifest_paths(&metadata, Some(&filters)) {
+        let message = match collect_workspace_fmt_targets(&metadata, Some(&filters)) {
             Ok(paths) => {
                 return Err(color_eyre::eyre::eyre!("expected error, got paths: {paths:?}"));
             }
@@ -202,6 +352,34 @@ mod tests {
         let perl_pos = message.find("perl-parser").expect("perl-parser in error");
         let xtask_pos = message.find("xtask").expect("xtask in error");
         assert!(perl_pos < xtask_pos, "available packages must be listed in sorted order");
+        Ok(())
+    }
+
+    #[test]
+    fn receipt_records_multiple_failures() -> Result<()> {
+        let failures = vec![
+            FmtFailure {
+                tool: "rustfmt".to_string(),
+                crate_field: "xtask".to_string(),
+                path: "xtask/src/tasks/fmt.rs".to_string(),
+                check_command: "cargo fmt --manifest-path xtask/Cargo.toml -- --check".to_string(),
+                fix_command: "cargo fmt --manifest-path xtask/Cargo.toml".to_string(),
+            },
+            FmtFailure {
+                tool: "rustfmt".to_string(),
+                crate_field: "perl-parser".to_string(),
+                path: "crates/perl-parser/src/lib.rs".to_string(),
+                check_command: "cargo fmt --manifest-path crates/perl-parser/Cargo.toml -- --check"
+                    .to_string(),
+                fix_command: "cargo fmt --manifest-path crates/perl-parser/Cargo.toml".to_string(),
+            },
+        ];
+
+        let receipt = build_receipt(&failures, None);
+        assert_eq!(receipt.check, "fmt");
+        assert_eq!(receipt.classification, "fmt_drift");
+        assert_eq!(receipt.fix_forward_kind, "FMT_ONLY");
+        assert_eq!(receipt.failures.len(), 2);
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Formatting checks previously failed fast on the first crate with drift, forcing iterative reruns to discover the full set of formatting problems.  Refs #6853.  
- The goal is to collect every formatting failure in one run and emit a machine-readable receipt so fix-forward automation can apply bounded repairs deterministically.

### Description

- Changed `xtask` fmt task to run `cargo fmt` for every workspace manifest and collect all failures instead of returning on first error.  Failures are accumulated during `--check` mode and the task exits non-zero only after collection is complete.  
- Emit a typed receipt `target/receipts/fmt.json` (schema version `1.0.0`) that lists `failures[]` with fields `tool`, `crate`, `path`, `check_command`, and `fix_command`, and top-level metadata (`check: fmt`, `classification: fmt_drift`, `fix_forward_kind: FMT_ONLY`, `safe_auto_fix: true`, `repro.command`).  
- Added JSON schema `.ci/receipts/schemas/fmt.schema.json` and documentation `docs/ci/fmt-receipts.md` explaining receipt semantics and typed fix-forward usage.  
- Added a unit test verifying the receipt shape can represent multiple failures and updated `xtask/src/tasks/fmt.rs` to implement collection, inference of failed path, receipt build/write, and to preserve existing non-auto-fix behavior for `--check` mode.

### Testing

- Ran `cargo check -p xtask` and it passed.  
- Ran `cargo xtask fmt --check` on a clean tree and it completed successfully while writing `target/receipts/fmt.json` (pass case).  
- Ran `cargo test -p xtask receipt_records_multiple_failures` and the new unit test passed.  

Note: the runtime receipt is intentionally not committed and the schema/docs were added to `.ci/receipts/schemas/fmt.schema.json` and `docs/ci/fmt-receipts.md` to enable validation and operator guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0800b108333ac5294e1dd369eb1)