### PR TITLE
fix(xtask): report all fmt failures with receipt (#6853)

### DIFF
--- a/.ci/receipts/schemas/fmt.schema.json
+++ b/.ci/receipts/schemas/fmt.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/schemas/fmt.schema.json",
+  "title": "Formatting Check Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "check",
+    "schema_version",
+    "verdict",
+    "classification",
+    "failures",
+    "fix_forward_kind",
+    "safe_auto_fix",
+    "repro"
+  ],
+  "properties": {
+    "check": { "const": "fmt" },
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "fail"]
+    },
+    "classification": { "const": "fmt_drift" },
+    "failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["tool", "crate", "path", "check_command", "fix_command"],
+        "properties": {
+          "tool": { "type": "string", "minLength": 1 },
+          "crate": { "type": "string", "minLength": 1 },
+          "path": { "type": "string", "minLength": 1 },
+          "check_command": { "type": "string", "minLength": 1 },
+          "fix_command": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "fix_forward_kind": { "const": "FMT_ONLY" },
+    "safe_auto_fix": { "type": "boolean", "const": true },
+    "repro": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "command": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/docs/ci/fmt-receipts.md
+++ b/docs/ci/fmt-receipts.md
@@ -1,0 +1,56 @@
+# Fmt receipts
+
+`cargo xtask fmt --check` now writes a structured receipt to:
+
+- `target/receipts/fmt.json`
+
+The command still runs every configured workspace formatting check and still exits non-zero when formatting drift exists. The difference is that it now waits until all checks complete, then emits one receipt containing every failure.
+
+## Receipt contract
+
+Schema: `.ci/receipts/schemas/fmt.schema.json`
+
+Top-level fields:
+
+- `check`: always `fmt`
+- `schema_version`: receipt schema version
+- `verdict`: `pass` or `fail`
+- `classification`: always `fmt_drift`
+- `failures[]`: one entry per failing package check
+  - `tool`
+  - `crate`
+  - `path`
+  - `check_command`
+  - `fix_command`
+- `fix_forward_kind`: always `FMT_ONLY`
+- `safe_auto_fix`: always `true`
+- `repro.command`: exact command to rerun the check
+
+## Typed fix-forward support
+
+`fix_forward_kind=FMT_ONLY` and `safe_auto_fix=true` let automation and operators route these failures to safe formatting-only fix-forward flows without guessing from raw logs.
+
+## Example
+
+```json
+{
+  "check": "fmt",
+  "schema_version": "1.0.0",
+  "verdict": "fail",
+  "classification": "fmt_drift",
+  "failures": [
+    {
+      "tool": "cargo fmt",
+      "crate": "xtask",
+      "path": "/repo/xtask/Cargo.toml",
+      "check_command": "cargo fmt --manifest-path /repo/xtask/Cargo.toml -- --check",
+      "fix_command": "cargo fmt --manifest-path /repo/xtask/Cargo.toml"
+    }
+  ],
+  "fix_forward_kind": "FMT_ONLY",
+  "safe_auto_fix": true,
+  "repro": {
+    "command": "cargo xtask fmt --check"
+  }
+}
+```

--- a/xtask/src/tasks/fmt.rs
+++ b/xtask/src/tasks/fmt.rs
@@ -3,8 +3,15 @@
 use color_eyre::eyre::{Context, Result, eyre};
 use duct::cmd;
 use indicatif::{ProgressBar, ProgressStyle};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+#[cfg(test)]
+use std::path::PathBuf;
+
+const FMT_RECEIPT_PATH: &str = "target/receipts/fmt.json";
+const FMT_SCHEMA_VERSION: &str = "1.0.0";
 
 #[derive(Deserialize)]
 struct CargoMetadata {
@@ -30,29 +37,45 @@ pub fn run(check: bool, package_filters: Option<Vec<String>>) -> Result<()> {
     let action = if check { "Checking" } else { "Formatting" };
     spinner.set_message(format!("{} code", action));
 
-    for manifest_path in workspace_manifest_paths(package_filters.as_deref())? {
-        spinner.set_message(format!("{} {}", action, manifest_path));
+    let mut failures = Vec::new();
+    let packages = workspace_packages(package_filters.as_deref())?;
+    for package in &packages {
+        spinner.set_message(format!("{} {}", action, package.manifest_path));
 
-        let mut args = vec!["fmt".to_string(), "--manifest-path".to_string(), manifest_path];
-        if check {
-            args.push("--".to_string());
-            args.push("--check".to_string());
-        }
-
-        let status =
-            cmd("cargo", &args).run().with_context(|| format!("Failed to format {}", args[2]))?;
+        let check_command = fmt_check_command(&package.manifest_path);
+        let fix_command = fmt_fix_command(&package.manifest_path);
+        let args = fmt_args(&package.manifest_path, check);
+        let status = cmd("cargo", &args)
+            .run()
+            .with_context(|| format!("Failed to run {}", check_command))?;
 
         if !status.status.success() {
-            spinner.finish_with_message(format!(
-                "❌ Code {} failed",
-                if check { "check" } else { "formatting" }
-            ));
-            return Err(eyre!(
-                "Code {} failed for {}",
-                if check { "check" } else { "formatting" },
-                args[2]
-            ));
+            failures.push(FmtFailure {
+                tool: "cargo fmt".to_string(),
+                crate_name: package.name.clone(),
+                path: package.manifest_path.clone(),
+                check_command,
+                fix_command,
+            });
         }
+    }
+
+    if check {
+        let receipt = build_fmt_receipt(&failures);
+        write_fmt_receipt(&receipt)?;
+        eprintln!("Fmt receipt written to: {FMT_RECEIPT_PATH}");
+    }
+
+    if !failures.is_empty() {
+        spinner.finish_with_message(format!(
+            "❌ Code {} failed",
+            if check { "check" } else { "formatting" }
+        ));
+        return Err(eyre!(
+            "Code {} failed for {} package(s)",
+            if check { "check" } else { "formatting" },
+            failures.len()
+        ));
     }
 
     spinner.finish_with_message(format!(
@@ -62,40 +85,56 @@ pub fn run(check: bool, package_filters: Option<Vec<String>>) -> Result<()> {
     Ok(())
 }
 
-fn workspace_manifest_paths(package_filters: Option<&[String]>) -> Result<Vec<String>> {
+fn workspace_packages(package_filters: Option<&[String]>) -> Result<Vec<WorkspacePackage>> {
     let metadata_json = cmd("cargo", ["metadata", "--format-version", "1", "--no-deps"])
         .read()
         .context("Failed to query cargo metadata for workspace formatting")?;
     let metadata: CargoMetadata =
         serde_json::from_str(&metadata_json).context("Failed to parse cargo metadata JSON")?;
 
-    collect_workspace_manifest_paths(&metadata, package_filters)
+    collect_workspace_packages(&metadata, package_filters)
 }
 
-fn collect_workspace_manifest_paths(
+fn collect_workspace_packages(
     metadata: &CargoMetadata,
     package_filters: Option<&[String]>,
-) -> Result<Vec<String>> {
+) -> Result<Vec<WorkspacePackage>> {
     let package_by_id: HashMap<_, _> = metadata
         .packages
         .iter()
-        .map(|package| (package.id.as_str(), package.manifest_path.clone()))
+        .map(|package| {
+            (
+                package.id.as_str(),
+                WorkspacePackage {
+                    name: package.name.clone(),
+                    manifest_path: package.manifest_path.clone(),
+                },
+            )
+        })
         .collect();
-    let member_name_to_manifest: HashMap<_, _> = metadata
+    let member_name_to_package: HashMap<_, _> = metadata
         .packages
         .iter()
         .filter(|package| metadata.workspace_members.iter().any(|member| member == &package.id))
-        .map(|package| (package.name.as_str(), package.manifest_path.clone()))
+        .map(|package| {
+            (
+                package.name.as_str(),
+                WorkspacePackage {
+                    name: package.name.clone(),
+                    manifest_path: package.manifest_path.clone(),
+                },
+            )
+        })
         .collect();
 
     if let Some(filters) = package_filters {
         let mut selected = Vec::with_capacity(filters.len());
         for package_name in filters {
-            if let Some(manifest_path) = member_name_to_manifest.get(package_name.as_str()) {
-                selected.push(manifest_path.clone());
+            if let Some(package) = member_name_to_package.get(package_name.as_str()) {
+                selected.push(package.clone());
             } else {
                 // Sort the available list so the error message is stable across runs.
-                let mut available: Vec<_> = member_name_to_manifest.keys().copied().collect();
+                let mut available: Vec<_> = member_name_to_package.keys().copied().collect();
                 available.sort_unstable();
                 return Err(eyre!(
                     "Unknown package `{package_name}`. Available workspace packages: {}",
@@ -118,21 +157,114 @@ fn collect_workspace_manifest_paths(
         .collect()
 }
 
-fn dedup_preserve_order(paths: Vec<String>) -> Vec<String> {
-    let mut seen = HashSet::with_capacity(paths.len());
-    let mut deduped = Vec::with_capacity(paths.len());
-    for path in paths {
-        if seen.insert(path.clone()) {
-            deduped.push(path);
+fn dedup_preserve_order(packages: Vec<WorkspacePackage>) -> Vec<WorkspacePackage> {
+    let mut seen = HashSet::with_capacity(packages.len());
+    let mut deduped = Vec::with_capacity(packages.len());
+    for package in packages {
+        if seen.insert(package.manifest_path.clone()) {
+            deduped.push(package);
         }
     }
     deduped
 }
 
+fn fmt_args(manifest_path: &str, check: bool) -> Vec<String> {
+    let mut args =
+        vec!["fmt".to_string(), "--manifest-path".to_string(), manifest_path.to_string()];
+    if check {
+        args.push("--".to_string());
+        args.push("--check".to_string());
+    }
+    args
+}
+
+fn fmt_check_command(manifest_path: &str) -> String {
+    format!("cargo fmt --manifest-path {manifest_path} -- --check")
+}
+
+fn fmt_fix_command(manifest_path: &str) -> String {
+    format!("cargo fmt --manifest-path {manifest_path}")
+}
+
+fn write_fmt_receipt(receipt: &FmtReceipt) -> Result<()> {
+    let receipt_path = Path::new(FMT_RECEIPT_PATH);
+    if let Some(parent) = receipt_path.parent() {
+        fs::create_dir_all(parent).context("Failed to create fmt receipt directory")?;
+    }
+    let json = serde_json::to_string_pretty(receipt).context("Failed to serialize fmt receipt")?;
+    fs::write(receipt_path, format!("{json}\n")).context("Failed to write fmt receipt")
+}
+
+fn build_fmt_receipt(failures: &[FmtFailure]) -> FmtReceipt {
+    let verdict = if failures.is_empty() { "pass" } else { "fail" };
+    FmtReceipt {
+        check: "fmt".to_string(),
+        schema_version: FMT_SCHEMA_VERSION.to_string(),
+        verdict: verdict.to_string(),
+        classification: "fmt_drift".to_string(),
+        failures: failures.to_vec(),
+        fix_forward_kind: "FMT_ONLY".to_string(),
+        safe_auto_fix: true,
+        repro: ReproCommand { command: "cargo xtask fmt --check".to_string() },
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct WorkspacePackage {
+    name: String,
+    manifest_path: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct FmtFailure {
+    tool: String,
+    #[serde(rename = "crate")]
+    crate_name: String,
+    path: String,
+    check_command: String,
+    fix_command: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ReproCommand {
+    command: String,
+}
+
+#[derive(Debug, Serialize)]
+struct FmtReceipt {
+    check: String,
+    schema_version: String,
+    verdict: String,
+    classification: String,
+    failures: Vec<FmtFailure>,
+    fix_forward_kind: String,
+    safe_auto_fix: bool,
+    repro: ReproCommand,
+}
+
+#[cfg(test)]
+fn temp_receipt_path(dir: &Path) -> PathBuf {
+    dir.join("fmt.json")
+}
+
+#[cfg(test)]
+fn write_fmt_receipt_to_path(receipt: &FmtReceipt, path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).context("Failed to create fmt receipt directory")?;
+    }
+    let json = serde_json::to_string_pretty(receipt).context("Failed to serialize fmt receipt")?;
+    fs::write(path, format!("{json}\n")).context("Failed to write fmt receipt")
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{CargoMetadata, CargoPackage, collect_workspace_manifest_paths};
+    use super::{
+        CargoMetadata, CargoPackage, FmtFailure, build_fmt_receipt, collect_workspace_packages,
+        temp_receipt_path, write_fmt_receipt_to_path,
+    };
     use color_eyre::eyre::Result;
+    use serde_json::Value;
+    use tempfile::TempDir;
 
     fn sample_metadata() -> CargoMetadata {
         CargoMetadata {
@@ -159,8 +291,8 @@ mod tests {
     fn package_filters_select_requested_manifest_paths() -> Result<()> {
         let metadata = sample_metadata();
         let filters = vec!["perl-parser".to_string()];
-        let manifests = collect_workspace_manifest_paths(&metadata, Some(&filters))?;
-        assert_eq!(manifests, vec!["/repo/crates/perl-parser/Cargo.toml".to_string()]);
+        let manifests = collect_workspace_packages(&metadata, Some(&filters))?;
+        assert_eq!(manifests[0].manifest_path, "/repo/crates/perl-parser/Cargo.toml".to_string());
         Ok(())
     }
 
@@ -168,8 +300,9 @@ mod tests {
     fn package_filters_are_deduplicated() -> Result<()> {
         let metadata = sample_metadata();
         let filters = vec!["xtask".to_string(), "xtask".to_string()];
-        let manifests = collect_workspace_manifest_paths(&metadata, Some(&filters))?;
-        assert_eq!(manifests, vec!["/repo/xtask/Cargo.toml".to_string()]);
+        let manifests = collect_workspace_packages(&metadata, Some(&filters))?;
+        assert_eq!(manifests.len(), 1);
+        assert_eq!(manifests[0].manifest_path, "/repo/xtask/Cargo.toml".to_string());
         Ok(())
     }
 
@@ -177,7 +310,7 @@ mod tests {
     fn package_filters_report_unknown_package() -> Result<()> {
         let metadata = sample_metadata();
         let filters = vec!["missing-package".to_string()];
-        let message = match collect_workspace_manifest_paths(&metadata, Some(&filters)) {
+        let message = match collect_workspace_packages(&metadata, Some(&filters)) {
             Ok(paths) => {
                 return Err(color_eyre::eyre::eyre!("expected error, got paths: {paths:?}"));
             }
@@ -192,16 +325,66 @@ mod tests {
     fn package_filters_error_lists_packages_in_stable_sorted_order() -> Result<()> {
         let metadata = sample_metadata();
         let filters = vec!["nonexistent".to_string()];
-        let message = match collect_workspace_manifest_paths(&metadata, Some(&filters)) {
+        let message = match collect_workspace_packages(&metadata, Some(&filters)) {
             Ok(paths) => {
                 return Err(color_eyre::eyre::eyre!("expected error, got paths: {paths:?}"));
             }
             Err(err) => format!("{err}"),
         };
         // The available list must be sorted — both packages appear in alphabetical order.
-        let perl_pos = message.find("perl-parser").expect("perl-parser in error");
-        let xtask_pos = message.find("xtask").expect("xtask in error");
+        let perl_pos = message
+            .find("perl-parser")
+            .ok_or_else(|| color_eyre::eyre::eyre!("perl-parser missing from error"))?;
+        let xtask_pos = message
+            .find("xtask")
+            .ok_or_else(|| color_eyre::eyre::eyre!("xtask missing from error"))?;
         assert!(perl_pos < xtask_pos, "available packages must be listed in sorted order");
+        Ok(())
+    }
+
+    #[test]
+    fn fmt_receipt_captures_multiple_failures() -> Result<()> {
+        let receipt = build_fmt_receipt(&[
+            FmtFailure {
+                tool: "cargo fmt".to_string(),
+                crate_name: "xtask".to_string(),
+                path: "/repo/xtask/Cargo.toml".to_string(),
+                check_command: "cargo fmt --manifest-path /repo/xtask/Cargo.toml -- --check"
+                    .to_string(),
+                fix_command: "cargo fmt --manifest-path /repo/xtask/Cargo.toml".to_string(),
+            },
+            FmtFailure {
+                tool: "cargo fmt".to_string(),
+                crate_name: "perl-parser".to_string(),
+                path: "/repo/crates/perl-parser/Cargo.toml".to_string(),
+                check_command:
+                    "cargo fmt --manifest-path /repo/crates/perl-parser/Cargo.toml -- --check"
+                        .to_string(),
+                fix_command: "cargo fmt --manifest-path /repo/crates/perl-parser/Cargo.toml"
+                    .to_string(),
+            },
+        ]);
+        assert_eq!(receipt.verdict, "fail");
+        assert_eq!(receipt.failures.len(), 2);
+        assert_eq!(receipt.fix_forward_kind, "FMT_ONLY");
+        assert!(receipt.safe_auto_fix);
+        Ok(())
+    }
+
+    #[test]
+    fn fmt_receipt_write_round_trip_contains_required_fields() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let path = temp_receipt_path(tmp.path());
+        let receipt = build_fmt_receipt(&[]);
+        write_fmt_receipt_to_path(&receipt, &path)?;
+        let raw = std::fs::read_to_string(&path)?;
+        let parsed: Value = serde_json::from_str(&raw)?;
+        assert_eq!(parsed["check"], "fmt");
+        assert_eq!(parsed["schema_version"], "1.0.0");
+        assert_eq!(parsed["classification"], "fmt_drift");
+        assert_eq!(parsed["fix_forward_kind"], "FMT_ONLY");
+        assert_eq!(parsed["safe_auto_fix"], true);
+        assert_eq!(parsed["repro"]["command"], "cargo xtask fmt --check");
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- The `cargo xtask fmt --check` flow previously stopped at the first failing package, forcing operators to re-run checks iteratively to discover the full set of formatting drift; this change collects every failure in one pass. 
- Produce a machine-readable receipt so automation can route safe formatting-only fixes (typed fix-forward) reliably instead of parsing log tails.

### Description

- Change `xtask/src/tasks/fmt.rs` to run `cargo fmt` for every workspace package, collect any failures, and only decide exit status after the sweep completes, preserving `--check` semantics (no auto-fix or commits). Refs #6853.
- When `--check` is requested the task writes `target/receipts/fmt.json` containing per-failure `tool`, `crate`, `path`, `check_command`, and `fix_command`, plus receipt metadata including `classification=fmt_drift`, `fix_forward_kind=FMT_ONLY`, `safe_auto_fix=true`, and `repro.command` to support typed fix-forward flows.
- Add a JSON schema at `.ci/receipts/schemas/fmt.schema.json` that defines the fmt receipt contract and add user-facing documentation at `docs/ci/fmt-receipts.md` describing the contract and usage.
- Add focused unit tests in `xtask` that exercise multi-failure receipt construction and a write/read round-trip for required receipt fields; internal helper refactors support package->manifest mapping and stable deduplication.

### Testing

- Ran `cargo check -p xtask` which completed successfully.
- Ran `cargo test -p xtask` and the new unit tests `fmt_receipt_captures_multiple_failures` and `fmt_receipt_write_round_trip_contains_required_fields` passed.
- Executed `cargo xtask fmt --check` on a clean tree and observed `Fmt receipt written to: target/receipts/fmt.json` and the command exits according to the collected verdict (receipt written then non-zero when failures exist).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0800b108333ac5294e1dd369eb1)