### PR TITLE
feat(fix-forward): classify failures into typed repair playbooks (#6853)

### DIFF
--- a/.ci/fix-forward/playbooks.toml
+++ b/.ci/fix-forward/playbooks.toml
@@ -1,0 +1,37 @@
+[[playbook]]
+kind = "FMT_ONLY"
+safe_auto_fix = true
+command = "cargo xtask fmt"
+branch_prefix = "fix-forward/fmt"
+next_agent = "builder"
+
+[[playbook]]
+kind = "TITLE_FIX"
+safe_auto_fix = true
+mutation = "github_pr_title_only"
+next_agent = "orchestrator"
+
+[[playbook]]
+kind = "STALE_BASE_CASCADE"
+safe_auto_fix = false
+route = "cascade-update"
+next_agent = "cascade"
+
+[[playbook]]
+kind = "GENERATED_DOC_REGEN"
+safe_auto_fix = false
+command = "cargo xtask status-docs"
+route = "docs"
+next_agent = "builder"
+
+[[playbook]]
+kind = "INFRA_ADVISORY_DEMOTION"
+safe_auto_fix = false
+route = "infra"
+next_agent = "infra"
+
+[[playbook]]
+kind = "PARSER_RATCHET_REGRESSION"
+safe_auto_fix = false
+route = "parser-builder"
+next_agent = "parser-builder"

--- a/.ci/receipts/schemas/fix-forward.schema.json
+++ b/.ci/receipts/schemas/fix-forward.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/fix-forward.schema.json",
+  "title": "FixForwardReceipt",
+  "type": "object",
+  "required": [
+    "classification",
+    "fix_forward_kind",
+    "safe_auto_fix",
+    "evidence"
+  ],
+  "properties": {
+    "classification": {
+      "type": "string"
+    },
+    "fix_forward_kind": {
+      "type": "string",
+      "enum": [
+        "FMT_ONLY",
+        "TITLE_FIX",
+        "STALE_BASE_CASCADE",
+        "GENERATED_DOC_REGEN",
+        "INFRA_ADVISORY_DEMOTION",
+        "PARSER_RATCHET_REGRESSION"
+      ]
+    },
+    "safe_auto_fix": {
+      "type": "boolean"
+    },
+    "command": {
+      "type": ["string", "null"]
+    },
+    "route": {
+      "type": ["string", "null"]
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "next_agent": {
+      "type": ["string", "null"]
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/ci/typed-fix-forward.md
+++ b/docs/ci/typed-fix-forward.md
@@ -1,0 +1,41 @@
+# Typed fix-forward classification and playbooks
+
+This document introduces typed fix-forward receipts for CI failures so retries can route to precise repair lanes.
+
+## Commands
+
+```bash
+cargo xtask fix-forward classify --receipt <receipt.json> --output target/receipts/fix-forward.json
+cargo xtask fix-forward list-playbooks
+```
+
+## Output receipt fields
+
+The classifier emits the following fields:
+
+- `classification`
+- `fix_forward_kind`
+- `safe_auto_fix`
+- `command`
+- `route`
+- `evidence`
+- `next_agent`
+
+Schema: `.ci/receipts/schemas/fix-forward.schema.json`.
+
+## Initial playbooks
+
+Configured in `.ci/fix-forward/playbooks.toml`:
+
+- `FMT_ONLY` → safe auto-fix via `cargo xtask fmt`
+- `TITLE_FIX` → title-only mutation lane
+- `STALE_BASE_CASCADE` → non-auto-fix cascade update lane
+- `GENERATED_DOC_REGEN` → generated docs regen lane (manual today)
+- `INFRA_ADVISORY_DEMOTION` → infra advisory lane
+- `PARSER_RATCHET_REGRESSION` → parser builder lane
+
+## Current scope
+
+- Classifies existing CI receipts into typed fix-forward kinds.
+- Lists configured playbooks for operational visibility.
+- Does **not** mutate branches, open PRs, or apply labels yet.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -901,6 +901,12 @@ enum Commands {
         command: FeaturesCommand,
     },
 
+    /// Classify CI failures into typed fix-forward playbooks.
+    FixForward {
+        #[command(subcommand)]
+        command: FixForwardCommand,
+    },
+
     /// Update derived metrics in docs/project/status/ subsystem files.
     ///
     /// Computes workspace test counts, ignored test counts, feature catalog
@@ -1232,6 +1238,23 @@ enum FeaturesCommand {
 
     /// Generate compliance report
     Report,
+}
+
+#[derive(Subcommand)]
+enum FixForwardCommand {
+    /// Classify a CI receipt into a typed fix-forward playbook.
+    Classify {
+        /// Source CI receipt JSON path.
+        #[arg(long)]
+        receipt: PathBuf,
+
+        /// Output path for typed fix-forward receipt JSON.
+        #[arg(long)]
+        output: PathBuf,
+    },
+
+    /// List configured typed fix-forward playbooks.
+    ListPlaybooks,
 }
 
 #[derive(Subcommand)]
@@ -1597,6 +1620,12 @@ fn main() -> Result<()> {
             FeaturesCommand::Verify => features::verify(),
             FeaturesCommand::Invariants => features::invariants(),
             FeaturesCommand::Report => features::report(),
+        },
+        Commands::FixForward { command } => match command {
+            FixForwardCommand::Classify { receipt, output } => {
+                fix_forward::classify(fix_forward::ClassifyConfig { receipt, output })
+            }
+            FixForwardCommand::ListPlaybooks => fix_forward::list_playbooks(),
         },
         Commands::UpdateStatus { write, check, only } => update_status::run(write, check, only),
         Commands::SrpMicrocrates { output } => srp_microcrates::run(output),

--- a/xtask/src/tasks/fix_forward.rs
+++ b/xtask/src/tasks/fix_forward.rs
@@ -1,0 +1,250 @@
+use color_eyre::eyre::{Context, ContextCompat, Result, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::utils::project_root;
+
+const PLAYBOOKS_PATH: &str = ".ci/fix-forward/playbooks.toml";
+
+#[derive(Debug, Clone, Deserialize)]
+struct PlaybooksFile {
+    playbook: Vec<Playbook>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct Playbook {
+    kind: String,
+    safe_auto_fix: bool,
+    command: Option<String>,
+    route: Option<String>,
+    mutation: Option<String>,
+    branch_prefix: Option<String>,
+    next_agent: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ClassifyConfig {
+    pub receipt: PathBuf,
+    pub output: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+struct FixForwardReceipt {
+    classification: String,
+    fix_forward_kind: String,
+    safe_auto_fix: bool,
+    command: Option<String>,
+    route: Option<String>,
+    evidence: Vec<String>,
+    next_agent: Option<String>,
+}
+
+pub fn classify(config: ClassifyConfig) -> Result<()> {
+    let receipt_text = fs::read_to_string(&config.receipt)
+        .with_context(|| format!("Failed reading receipt {}", config.receipt.display()))?;
+    let receipt: Value = serde_json::from_str(&receipt_text)
+        .with_context(|| format!("Failed parsing receipt JSON {}", config.receipt.display()))?;
+
+    let playbooks = load_playbooks()?;
+    let (kind, evidence) = classify_receipt(&receipt);
+    let playbook =
+        playbooks.get(&kind).with_context(|| format!("Missing fix-forward playbook for {kind}"))?;
+
+    let out = FixForwardReceipt {
+        classification: kind.clone(),
+        fix_forward_kind: kind,
+        safe_auto_fix: playbook.safe_auto_fix,
+        command: playbook.command.clone(),
+        route: playbook.route.clone(),
+        evidence,
+        next_agent: playbook.next_agent.clone(),
+    };
+
+    let parent = config
+        .output
+        .parent()
+        .with_context(|| format!("Output path has no parent: {}", config.output.display()))?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("Failed creating output directory {}", parent.display()))?;
+
+    let out_json =
+        serde_json::to_string_pretty(&out).context("Failed serializing fix-forward receipt")?;
+    fs::write(&config.output, out_json)
+        .with_context(|| format!("Failed writing output {}", config.output.display()))?;
+
+    Ok(())
+}
+
+pub fn list_playbooks() -> Result<()> {
+    let playbooks = load_playbooks()?;
+    for playbook in playbooks.values() {
+        println!(
+            "{}\tsafe_auto_fix={}\tcommand={}\troute={}\tmutation={}\tbranch_prefix={}\tnext_agent={}",
+            playbook.kind,
+            playbook.safe_auto_fix,
+            playbook.command.as_deref().unwrap_or("-"),
+            playbook.route.as_deref().unwrap_or("-"),
+            playbook.mutation.as_deref().unwrap_or("-"),
+            playbook.branch_prefix.as_deref().unwrap_or("-"),
+            playbook.next_agent.as_deref().unwrap_or("-")
+        );
+    }
+    Ok(())
+}
+
+fn load_playbooks() -> Result<BTreeMap<String, Playbook>> {
+    let root = project_root()?;
+    let path = root.join(PLAYBOOKS_PATH);
+    let text = fs::read_to_string(&path)
+        .with_context(|| format!("Failed reading playbooks {}", path.display()))?;
+    let parsed: PlaybooksFile =
+        toml::from_str(&text).with_context(|| format!("Failed parsing {}", path.display()))?;
+
+    let mut map = BTreeMap::new();
+    for playbook in parsed.playbook {
+        if map.insert(playbook.kind.clone(), playbook).is_some() {
+            bail!("Duplicate playbook kind in {}", path.display());
+        }
+    }
+
+    Ok(map)
+}
+
+fn classify_receipt(receipt: &Value) -> (String, Vec<String>) {
+    let mut evidence = Vec::new();
+
+    if has_fmt_only_failure(receipt, &mut evidence) {
+        return ("FMT_ONLY".to_string(), evidence);
+    }
+
+    if has_title_failure(receipt, &mut evidence) {
+        return ("TITLE_FIX".to_string(), evidence);
+    }
+
+    if has_stale_base_cascade(receipt, &mut evidence) {
+        return ("STALE_BASE_CASCADE".to_string(), evidence);
+    }
+
+    if has_generated_docs_failure(receipt, &mut evidence) {
+        return ("GENERATED_DOC_REGEN".to_string(), evidence);
+    }
+
+    if has_infra_advisory_failure(receipt, &mut evidence) {
+        return ("INFRA_ADVISORY_DEMOTION".to_string(), evidence);
+    }
+
+    if has_parser_ratchet_regression(receipt, &mut evidence) {
+        return ("PARSER_RATCHET_REGRESSION".to_string(), evidence);
+    }
+
+    evidence.push("No typed classifier matched; defaulting to INFRA_ADVISORY_DEMOTION".to_string());
+    ("INFRA_ADVISORY_DEMOTION".to_string(), evidence)
+}
+
+fn has_fmt_only_failure(receipt: &Value, evidence: &mut Vec<String>) -> bool {
+    let failed = failed_gates(receipt);
+    if failed.len() != 1 {
+        return false;
+    }
+
+    let gate = failed.first();
+    let Some(gate) = gate else {
+        return false;
+    };
+
+    if has_keyword(gate, &["fmt"]) {
+        evidence.push("Single failing gate matches fmt".to_string());
+        return true;
+    }
+
+    false
+}
+
+fn has_title_failure(receipt: &Value, evidence: &mut Vec<String>) -> bool {
+    let failed = failed_gates(receipt);
+    if failed.iter().any(|gate| has_keyword(gate, &["title", "validate-title"])) {
+        evidence.push("Detected title validation failure".to_string());
+        return true;
+    }
+
+    false
+}
+
+fn has_stale_base_cascade(receipt: &Value, evidence: &mut Vec<String>) -> bool {
+    let failed = failed_gates(receipt);
+    if failed.iter().any(|gate| {
+        has_keyword(gate, &["stale base", "stale-base", "merge-base", "out of date", "rebase"])
+    }) {
+        evidence.push("Detected stale-base or merge-base drift failure signal".to_string());
+        return true;
+    }
+
+    false
+}
+
+fn has_generated_docs_failure(receipt: &Value, evidence: &mut Vec<String>) -> bool {
+    let failed = failed_gates(receipt);
+    if failed.iter().any(|gate| {
+        has_keyword(gate, &["status-docs", "generated docs", "status docs", "doc regen"])
+    }) {
+        evidence.push("Detected generated docs/status docs drift".to_string());
+        return true;
+    }
+
+    false
+}
+
+fn has_infra_advisory_failure(receipt: &Value, evidence: &mut Vec<String>) -> bool {
+    let failed = failed_gates(receipt);
+    if failed.iter().any(|gate| {
+        has_keyword(gate, &["network", "github api", "timeout", "rate limit", "runner"])
+    }) {
+        evidence.push("Detected infrastructure/transient failure signal".to_string());
+        return true;
+    }
+
+    false
+}
+
+fn has_parser_ratchet_regression(receipt: &Value, evidence: &mut Vec<String>) -> bool {
+    let failed = failed_gates(receipt);
+    if failed
+        .iter()
+        .any(|gate| has_keyword(gate, &["parser", "ratchet", "corpus", "ga_alignment", "nodekind"]))
+    {
+        evidence.push("Detected parser ratchet/corpus regression signal".to_string());
+        return true;
+    }
+
+    false
+}
+
+fn failed_gates(receipt: &Value) -> Vec<&Map<String, Value>> {
+    let Some(gates) = receipt.get("gates").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    gates
+        .iter()
+        .filter_map(Value::as_object)
+        .filter(|gate| {
+            gate.get("status")
+                .and_then(Value::as_str)
+                .is_some_and(|status| matches!(status, "fail" | "error" | "timeout"))
+        })
+        .collect()
+}
+
+fn has_keyword(gate: &Map<String, Value>, keywords: &[&str]) -> bool {
+    let mut haystacks = Vec::new();
+    for key in ["gate_name", "command", "output_summary"] {
+        if let Some(value) = gate.get(key).and_then(Value::as_str) {
+            haystacks.push(value.to_ascii_lowercase());
+        }
+    }
+
+    keywords.iter().any(|keyword| haystacks.iter().any(|field| field.contains(keyword)))
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -36,6 +36,7 @@ pub mod doc_claims;
 pub mod e2e_validate;
 pub mod edge_cases;
 pub mod features;
+pub mod fix_forward;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;

--- a/xtask/tests/fix_forward_cli.rs
+++ b/xtask/tests/fix_forward_cli.rs
@@ -1,0 +1,43 @@
+use anyhow::{Context, Result};
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+use std::fs;
+use tempfile::TempDir;
+
+fn classify_fixture(fixture: &str) -> Result<Value> {
+    let temp_dir = TempDir::new()?;
+    let output = temp_dir.path().join("fix-forward.json");
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    cmd.args(["fix-forward", "classify", "--receipt", fixture, "--output"])
+        .arg(&output)
+        .assert()
+        .success();
+
+    let text =
+        fs::read_to_string(&output).with_context(|| format!("reading {}", output.display()))?;
+    let value =
+        serde_json::from_str(&text).with_context(|| format!("parsing {}", output.display()))?;
+    Ok(value)
+}
+
+#[test]
+fn fmt_failure_receipt_classifies_as_fmt_only() -> Result<()> {
+    let result = classify_fixture("tests/fixtures/fix-forward/fmt-failure.json")?;
+    assert_eq!(result.get("fix_forward_kind").and_then(Value::as_str), Some("FMT_ONLY"));
+    Ok(())
+}
+
+#[test]
+fn stale_base_receipt_classifies_as_stale_base_cascade() -> Result<()> {
+    let result = classify_fixture("tests/fixtures/fix-forward/stale-base-failure.json")?;
+    assert_eq!(result.get("fix_forward_kind").and_then(Value::as_str), Some("STALE_BASE_CASCADE"));
+    Ok(())
+}
+
+#[test]
+fn generated_docs_receipt_classifies_as_generated_doc_regen() -> Result<()> {
+    let result = classify_fixture("tests/fixtures/fix-forward/generated-docs-failure.json")?;
+    assert_eq!(result.get("fix_forward_kind").and_then(Value::as_str), Some("GENERATED_DOC_REGEN"));
+    Ok(())
+}

--- a/xtask/tests/fixtures/fix-forward/fmt-failure.json
+++ b/xtask/tests/fixtures/fix-forward/fmt-failure.json
@@ -1,0 +1,10 @@
+{
+  "gates": [
+    {
+      "gate_name": "fmt",
+      "status": "fail",
+      "command": "cargo fmt --check --all",
+      "output_summary": "Diff in xtask/src/tasks/mod.rs"
+    }
+  ]
+}

--- a/xtask/tests/fixtures/fix-forward/generated-docs-failure.json
+++ b/xtask/tests/fixtures/fix-forward/generated-docs-failure.json
@@ -1,0 +1,10 @@
+{
+  "gates": [
+    {
+      "gate_name": "status-docs",
+      "status": "fail",
+      "command": "cargo xtask status-docs --check",
+      "output_summary": "generated docs drift detected"
+    }
+  ]
+}

--- a/xtask/tests/fixtures/fix-forward/stale-base-failure.json
+++ b/xtask/tests/fixtures/fix-forward/stale-base-failure.json
@@ -1,0 +1,14 @@
+{
+  "gates": [
+    {
+      "gate_name": "merge-base-check",
+      "status": "fail",
+      "command": "just ci-stale-base-check",
+      "output_summary": "stale base: branch is out of date with main"
+    },
+    {
+      "gate_name": "clippy-lib",
+      "status": "skip"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- CI failures were routed to generic retry lanes, making automated remediation noisy and imprecise; this adds typed fix-forward kinds so failures can route to targeted repair lanes (Refs #6853).
- The goal is to emit a small typed receipt (e.g. `FMT_ONLY`, `STALE_BASE_CASCADE`, `TITLE_FIX`, `GENERATED_DOC_REGEN`, etc.) so downstream agents can choose precise actions. 

### Description

- Added a new xtask task module `xtask/src/tasks/fix_forward.rs` that implements `classify` and `list_playbooks` and emits receipts with `classification`, `fix_forward_kind`, `safe_auto_fix`, `command`, `route`, `evidence`, and `next_agent`.
- Wired a `fix-forward` subcommand into the xtask CLI (`xtask/src/main.rs`) and exported the task in `xtask/src/tasks/mod.rs`.
- Added playbook configuration at `.ci/fix-forward/playbooks.toml`, the JSON schema `.ci/receipts/schemas/fix-forward.schema.json`, usage docs `docs/ci/typed-fix-forward.md`, and three fixture receipts plus a CLI test under `xtask/tests/fixtures/fix-forward` and `xtask/tests/fix_forward_cli.rs`.
- Classifier heuristics detect `FMT_ONLY`, `TITLE_FIX`, `STALE_BASE_CASCADE`, `GENERATED_DOC_REGEN`, `INFRA_ADVISORY_DEMOTION`, and `PARSER_RATCHET_REGRESSION` and map them to configured playbooks; no branches/PRs/labels are mutated by this change.

### Testing

- Ran `cargo check -p xtask` and it passed successfully.
- Verified classifier end-to-end by running `cargo xtask fix-forward classify` against fixtures and producing expected typed receipts for `fmt-failure.json`, `stale-base-failure.json`, and `generated-docs-failure.json` (all succeeded).
- Ran `cargo xtask fix-forward list-playbooks` which printed the configured playbooks (succeeded).
- Ran the fixture-backed unit test `cargo test -p xtask --test fix_forward_cli` and the three tests passed.
- Ran `cargo xtask fmt` to ensure formatting; it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0843cd48333ad34d5fb20e53ee1)