### PR TITLE
feat(fix-forward): classify failures into typed repair playbooks (#6853)

### DIFF
--- a/.ci/fix-forward/playbooks.toml
+++ b/.ci/fix-forward/playbooks.toml
@@ -1,0 +1,42 @@
+[[playbooks]]
+kind = "FMT_ONLY"
+safe_auto_fix = true
+command = "cargo xtask fmt"
+branch_prefix = "fix-forward/fmt"
+match_gate_names = ["fmt"]
+match_output_contains = ["cargo fmt", "rustfmt"]
+
+[[playbooks]]
+kind = "TITLE_FIX"
+safe_auto_fix = true
+mutation = "github_pr_title_only"
+match_gate_names = ["validate-title", "title"]
+match_output_contains = ["validate-title", "title format", "(#NNNN)"]
+
+[[playbooks]]
+kind = "STALE_BASE_CASCADE"
+safe_auto_fix = false
+route = "cascade-update"
+match_gate_names = ["stale-base", "stale_base"]
+match_output_contains = ["stale base", "base branch moved", "rebase required"]
+
+[[playbooks]]
+kind = "GENERATED_DOC_REGEN"
+safe_auto_fix = false
+command = "cargo xtask status-docs"
+match_gate_names = ["status-docs", "generated-docs", "docs-regen"]
+match_output_contains = ["generated docs", "status docs", "CURRENT_STATUS"]
+
+[[playbooks]]
+kind = "INFRA_ADVISORY_DEMOTION"
+safe_auto_fix = false
+route = "infra"
+match_gate_names = ["infra"]
+match_output_contains = ["infra advisory", "runner outage", "network flake"]
+
+[[playbooks]]
+kind = "PARSER_RATCHET_REGRESSION"
+safe_auto_fix = false
+route = "parser-builder"
+match_gate_names = ["parser-ratchet", "ratchet"]
+match_output_contains = ["parser ratchet", "ratchet regression"]

--- a/.ci/receipts/schemas/fix-forward.schema.json
+++ b/.ci/receipts/schemas/fix-forward.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/fix-forward.schema.json",
+  "title": "Fix Forward Receipt",
+  "type": "object",
+  "required": [
+    "classification",
+    "fix_forward_kind",
+    "safe_auto_fix",
+    "evidence",
+    "next_agent"
+  ],
+  "properties": {
+    "classification": {
+      "type": "string",
+      "const": "typed_fix_forward"
+    },
+    "fix_forward_kind": {
+      "type": "string",
+      "enum": [
+        "FMT_ONLY",
+        "TITLE_FIX",
+        "STALE_BASE_CASCADE",
+        "GENERATED_DOC_REGEN",
+        "INFRA_ADVISORY_DEMOTION",
+        "PARSER_RATCHET_REGRESSION"
+      ]
+    },
+    "safe_auto_fix": {
+      "type": "boolean"
+    },
+    "command": {
+      "type": ["string", "null"]
+    },
+    "route": {
+      "type": ["string", "null"]
+    },
+    "evidence": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "next_agent": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/crates/perl-lsp-rs/src/features/implementation_provider.rs
+++ b/crates/perl-lsp-rs/src/features/implementation_provider.rs
@@ -317,7 +317,8 @@ impl ImplementationProvider {
         match &node.kind {
             NodeKind::Subroutine { name: Some(name), .. } => {
                 let (_, name_bare) = perl_parser::qualified_name::split_qualified_name(name);
-                let (_, method_bare) = perl_parser::qualified_name::split_qualified_name(method_name);
+                let (_, method_bare) =
+                    perl_parser::qualified_name::split_qualified_name(method_name);
                 if name_bare == method_bare {
                     let target_uri = parse_uri(uri);
                     results.push(LocationLink {

--- a/crates/perl-lsp-rs/src/runtime/language/hover.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover.rs
@@ -1725,7 +1725,8 @@ impl LspServer {
                 }
             }
             NodeKind::Method { name: method_name, .. } => {
-                let (_, method_bare) = perl_parser::qualified_name::split_qualified_name(method_name);
+                let (_, method_bare) =
+                    perl_parser::qualified_name::split_qualified_name(method_name);
                 let (_, name_bare) = perl_parser::qualified_name::split_qualified_name(name);
                 if method_bare == name_bare {
                     return Some(node);

--- a/crates/perl-lsp-rs/src/runtime/symbol_extraction.rs
+++ b/crates/perl-lsp-rs/src/runtime/symbol_extraction.rs
@@ -314,7 +314,10 @@ impl LspServer {
             }
 
             NodeKind::FunctionCall { name, args } => {
-                if symbol_kind == "subroutine" && perl_parser::qualified_name::split_qualified_name(name).1 == perl_parser::qualified_name::split_qualified_name(symbol_name).1 {
+                if symbol_kind == "subroutine"
+                    && perl_parser::qualified_name::split_qualified_name(name).1
+                        == perl_parser::qualified_name::split_qualified_name(symbol_name).1
+                {
                     count += 1;
                 }
                 for arg in args {
@@ -323,7 +326,10 @@ impl LspServer {
             }
 
             NodeKind::MethodCall { object, method, args } => {
-                if symbol_kind == "subroutine" && perl_parser::qualified_name::split_qualified_name(method).1 == perl_parser::qualified_name::split_qualified_name(symbol_name).1 {
+                if symbol_kind == "subroutine"
+                    && perl_parser::qualified_name::split_qualified_name(method).1
+                        == perl_parser::qualified_name::split_qualified_name(symbol_name).1
+                {
                     count += 1;
                 }
                 count += self.count_references(object, symbol_name, symbol_kind);
@@ -385,7 +391,9 @@ impl LspServer {
                 // Check if this is a reference to a subroutine (\&function)
                 if op == "\\" && symbol_kind == "subroutine" {
                     if let NodeKind::Identifier { name } = &operand.kind {
-                        if perl_parser::qualified_name::split_qualified_name(name).1 == perl_parser::qualified_name::split_qualified_name(symbol_name).1 {
+                        if perl_parser::qualified_name::split_qualified_name(name).1
+                            == perl_parser::qualified_name::split_qualified_name(symbol_name).1
+                        {
                             count += 1;
                         }
                     }

--- a/crates/perl-lsp-ux-tests/src/scorecard.rs
+++ b/crates/perl-lsp-ux-tests/src/scorecard.rs
@@ -155,10 +155,7 @@ mod tests {
             definition_exact_hit: def,
             symbol_correct: sym,
             cross_file_success: cross,
-            mean_latency_ms: latency
-                .iter()
-                .map(|(k, v)| ((*k).to_string(), *v))
-                .collect(),
+            mean_latency_ms: latency.iter().map(|(k, v)| ((*k).to_string(), *v)).collect(),
             ..Default::default()
         }
     }
@@ -167,12 +164,22 @@ mod tests {
     fn aggregate_editor_ux_scorecard_computes_expected_rows() -> Result<()> {
         let s1 = make_score(
             "hover-and-def",
-            Some(true), Some(false), Some(true), Some(true), Some(true), Some(true),
+            Some(true),
+            Some(false),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
             &[("hover", 12.0), ("completion", 20.0), ("definition", 30.0)],
         );
         let s2 = make_score(
             "completion-and-cross-file",
-            Some(false), Some(true), Some(true), Some(false), Some(false), Some(true),
+            Some(false),
+            Some(true),
+            Some(true),
+            Some(false),
+            Some(false),
+            Some(true),
             &[("hover", 8.0), ("completion", 40.0), ("workspace_symbols", 50.0)],
         );
 
@@ -203,7 +210,12 @@ mod tests {
     fn aggregate_editor_ux_scorecard_uses_none_when_metric_not_measured() -> Result<()> {
         let s = make_score(
             "symbols-only",
-            None, None, None, None, None, None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
             &[("document_symbols", 18.0)],
         );
 
@@ -275,7 +287,12 @@ mod tests {
     fn all_false_correctness_produces_zero_pct() -> Result<()> {
         let s = make_score(
             "all-fail",
-            Some(false), Some(false), Some(false), Some(false), Some(false), Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
             &[],
         );
 
@@ -295,7 +312,12 @@ mod tests {
     fn single_scenario_all_true_produces_100_pct() -> Result<()> {
         let s = make_score(
             "all-pass",
-            Some(true), Some(true), Some(true), Some(true), Some(true), Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
             &[("hover", 15.0), ("completion", 25.0)],
         );
 
@@ -326,7 +348,10 @@ mod tests {
         let scorecard = aggregate_editor_ux_scorecard(&scenarios);
 
         let pct = scorecard.symbol_correctness_pct;
-        assert!(pct.is_some_and(|v| (v - 66.666_666).abs() < 0.01), "expected ~66.67%, got {pct:?}");
+        assert!(
+            pct.is_some_and(|v| (v - 66.666_666).abs() < 0.01),
+            "expected ~66.67%, got {pct:?}"
+        );
 
         Ok(())
     }

--- a/docs/ci/typed-fix-forward.md
+++ b/docs/ci/typed-fix-forward.md
@@ -1,0 +1,38 @@
+# Typed fix-forward playbooks
+
+`cargo xtask fix-forward` classifies a failing CI receipt into a typed repair lane.
+
+## Commands
+
+```bash
+cargo xtask fix-forward classify --receipt <receipt.json> --output target/receipts/fix-forward.json
+cargo xtask fix-forward list-playbooks
+```
+
+## Receipt output
+
+The classifier writes:
+
+- `classification`
+- `fix_forward_kind`
+- `safe_auto_fix`
+- `command`
+- `route`
+- `evidence`
+- `next_agent`
+
+The output schema lives at `.ci/receipts/schemas/fix-forward.schema.json`.
+
+## Initial playbooks
+
+- `FMT_ONLY` → safe auto-fix (`cargo xtask fmt`)
+- `TITLE_FIX` → safe title-only mutation lane
+- `STALE_BASE_CASCADE` → cascade update route
+- `GENERATED_DOC_REGEN` → generated docs regeneration lane
+- `INFRA_ADVISORY_DEMOTION` → infra route
+- `PARSER_RATCHET_REGRESSION` → parser-builder route
+
+## Current scope
+
+This phase only classifies and emits a receipt. It does **not** mutate branches,
+open PRs, or label PRs.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -998,6 +998,12 @@ enum Commands {
         command: AgentCommand,
     },
 
+    /// Classify failed CI receipts into typed fix-forward playbooks.
+    FixForward {
+        #[command(subcommand)]
+        command: FixForwardCommand,
+    },
+
     /// Update derived metrics in docs/project/status/ subsystem files.
     ///
     /// Computes workspace test counts, ignored test counts, feature catalog
@@ -1453,6 +1459,23 @@ enum ReleaseCommand {
         #[arg(long)]
         bundle_dir: Option<PathBuf>,
     },
+}
+
+#[derive(Subcommand)]
+enum FixForwardCommand {
+    /// Classify a failing receipt into a typed fix-forward playbook.
+    Classify {
+        /// Path to a CI receipt JSON.
+        #[arg(long)]
+        receipt: PathBuf,
+
+        /// Output path for fix-forward receipt JSON.
+        #[arg(long)]
+        output: PathBuf,
+    },
+
+    /// List configured fix-forward playbooks.
+    ListPlaybooks,
 }
 
 #[derive(Subcommand)]
@@ -1957,6 +1980,12 @@ fn main() -> Result<()> {
                 AgentReceiptCommand::Validate { receipt } => agent_receipt::validate(&receipt),
             },
             AgentCommand::Worktree { command } => worktree_allocator::run(command),
+        },
+        Commands::FixForward { command } => match command {
+            FixForwardCommand::Classify { receipt, output } => {
+                fix_forward::classify(receipt, output)
+            }
+            FixForwardCommand::ListPlaybooks => fix_forward::list_playbooks(),
         },
         Commands::UpdateStatus { write, check, only } => update_status::run(write, check, only),
         Commands::SrpMicrocrates { output } => srp_microcrates::run(output),

--- a/xtask/src/tasks/fix_forward.rs
+++ b/xtask/src/tasks/fix_forward.rs
@@ -1,0 +1,174 @@
+use color_eyre::eyre::{Context, Result, eyre};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::utils::project_root;
+
+#[derive(Debug, Deserialize)]
+struct PlaybookConfig {
+    playbooks: Vec<Playbook>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Playbook {
+    kind: String,
+    safe_auto_fix: bool,
+    command: Option<String>,
+    route: Option<String>,
+    mutation: Option<String>,
+    branch_prefix: Option<String>,
+    #[serde(default)]
+    match_gate_names: Vec<String>,
+    #[serde(default)]
+    match_output_contains: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Receipt {
+    #[serde(default)]
+    gates: Vec<ReceiptGate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReceiptGate {
+    gate_name: String,
+    status: String,
+    #[serde(default)]
+    output_summary: Option<String>,
+    #[serde(default)]
+    command: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct FixForwardReceipt {
+    classification: String,
+    fix_forward_kind: String,
+    safe_auto_fix: bool,
+    command: Option<String>,
+    route: Option<String>,
+    evidence: Vec<String>,
+    next_agent: String,
+}
+
+pub fn classify(receipt_path: PathBuf, output_path: PathBuf) -> Result<()> {
+    let playbooks = load_playbooks()?;
+
+    let receipt_text = fs::read_to_string(&receipt_path)
+        .with_context(|| format!("Failed to read receipt {}", receipt_path.display()))?;
+    let receipt: Receipt = serde_json::from_str(&receipt_text)
+        .with_context(|| format!("Failed to parse receipt {}", receipt_path.display()))?;
+
+    let (playbook, evidence) = select_playbook(&playbooks, &receipt)
+        .ok_or_else(|| eyre!("No matching fix-forward playbook found for failed gates"))?;
+
+    let fix_forward_receipt = FixForwardReceipt {
+        classification: "typed_fix_forward".to_string(),
+        fix_forward_kind: playbook.kind.clone(),
+        safe_auto_fix: playbook.safe_auto_fix,
+        command: playbook.command.clone(),
+        route: playbook.route.clone(),
+        evidence,
+        next_agent: next_agent(playbook),
+    };
+
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create output directory {}", parent.display()))?;
+    }
+
+    let output_json = serde_json::to_string_pretty(&fix_forward_receipt)
+        .context("Failed to serialize fix-forward receipt")?;
+    fs::write(&output_path, output_json)
+        .with_context(|| format!("Failed to write receipt {}", output_path.display()))?;
+
+    Ok(())
+}
+
+pub fn list_playbooks() -> Result<()> {
+    let playbooks = load_playbooks()?;
+    for playbook in playbooks {
+        println!(
+            "{}\tsafe_auto_fix={}\tcommand={}\troute={}\tmutation={}\tbranch_prefix={}",
+            playbook.kind,
+            playbook.safe_auto_fix,
+            playbook.command.as_deref().unwrap_or("-"),
+            playbook.route.as_deref().unwrap_or("-"),
+            playbook.mutation.as_deref().unwrap_or("-"),
+            playbook.branch_prefix.as_deref().unwrap_or("-")
+        );
+    }
+    Ok(())
+}
+
+fn load_playbooks() -> Result<Vec<Playbook>> {
+    let root = project_root()?;
+    let playbook_path = root.join(".ci/fix-forward/playbooks.toml");
+    let content = fs::read_to_string(&playbook_path)
+        .with_context(|| format!("Failed to read {}", playbook_path.display()))?;
+    let config: PlaybookConfig = toml::from_str(&content)
+        .with_context(|| format!("Failed to parse {}", playbook_path.display()))?;
+    Ok(config.playbooks)
+}
+
+fn select_playbook<'a>(
+    playbooks: &'a [Playbook],
+    receipt: &Receipt,
+) -> Option<(&'a Playbook, Vec<String>)> {
+    let failed_gates =
+        receipt.gates.iter().filter(|gate| gate.status == "fail").collect::<Vec<_>>();
+
+    for playbook in playbooks {
+        let mut evidence = BTreeSet::new();
+        let mut matched = false;
+
+        for gate in &failed_gates {
+            for gate_pattern in &playbook.match_gate_names {
+                if gate.gate_name.contains(gate_pattern) {
+                    evidence.insert(format!("gate:{} matched {}", gate.gate_name, gate_pattern));
+                    matched = true;
+                }
+            }
+
+            if let Some(command) = &gate.command {
+                for output_pattern in &playbook.match_output_contains {
+                    if command.contains(output_pattern) {
+                        evidence.insert(format!("command:{} matched {}", command, output_pattern));
+                        matched = true;
+                    }
+                }
+            }
+
+            if let Some(output_summary) = &gate.output_summary {
+                for output_pattern in &playbook.match_output_contains {
+                    if output_summary.contains(output_pattern) {
+                        evidence.insert(format!(
+                            "output_summary in {} matched {}",
+                            gate.gate_name, output_pattern
+                        ));
+                        matched = true;
+                    }
+                }
+            }
+        }
+
+        if matched {
+            return Some((playbook, evidence.into_iter().collect()));
+        }
+    }
+
+    None
+}
+
+fn next_agent(playbook: &Playbook) -> String {
+    if playbook.safe_auto_fix {
+        return "fix-forward-bot".to_string();
+    }
+
+    if let Some(route) = &playbook.route {
+        return route.clone();
+    }
+
+    "human-review".to_string()
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -40,6 +40,7 @@ pub mod e2e_validate;
 pub mod edge_cases;
 pub mod features;
 pub mod finalize_check;
+pub mod fix_forward;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;

--- a/xtask/src/tasks/ux_scorecard.rs
+++ b/xtask/src/tasks/ux_scorecard.rs
@@ -425,8 +425,16 @@ mod tests {
 
     #[test]
     fn computes_percentiles() {
-        let rows =
-            vec![measurement("s1", None, None, None, None, None, None, &[("hover", vec![10, 20, 30, 40])])];
+        let rows = vec![measurement(
+            "s1",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &[("hover", vec![10, 20, 30, 40])],
+        )];
 
         let latency = compute_latency_percentiles(&rows);
         let hover = latency.get("hover").expect("hover present");
@@ -437,7 +445,13 @@ mod tests {
     #[test]
     fn single_sample_latency_p50_equals_p95() {
         let rows = vec![measurement(
-            "single", None, None, None, None, None, None,
+            "single",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
             &[("definition", vec![42])],
         )];
         let latency = compute_latency_percentiles(&rows);
@@ -450,7 +464,13 @@ mod tests {
     fn two_sample_latency_percentiles() {
         // [10, 90]: p50 rank=(2-1)*0.5=0.5→1, samples[1]=90; p95 rank=(2-1)*0.95=0.95→1, samples[1]=90
         let rows = vec![measurement(
-            "two", None, None, None, None, None, None,
+            "two",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
             &[("hover", vec![10, 90])],
         )];
         let latency = compute_latency_percentiles(&rows);

--- a/xtask/tests/fix_forward_cli.rs
+++ b/xtask/tests/fix_forward_cli.rs
@@ -1,0 +1,73 @@
+use assert_cmd::Command;
+use color_eyre::eyre::{Result, eyre};
+use std::path::{Path, PathBuf};
+
+fn fixture_path(name: &str) -> PathBuf {
+    Path::new("tests").join("fixtures").join("fix-forward").join(name)
+}
+
+fn run_classify_and_read(receipt_name: &str, output_name: &str) -> Result<serde_json::Value> {
+    let output_path = Path::new("target").join("tmp").join("fix-forward-tests").join(output_name);
+
+    if output_path.exists() {
+        std::fs::remove_file(&output_path)?;
+    }
+
+    let output = Command::cargo_bin("xtask")?
+        .args([
+            "fix-forward",
+            "classify",
+            "--receipt",
+            &fixture_path(receipt_name).to_string_lossy(),
+            "--output",
+            &output_path.to_string_lossy(),
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(eyre!(
+            "fix-forward classify failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let raw = std::fs::read_to_string(&output_path)?;
+    let parsed = serde_json::from_str(&raw)?;
+    Ok(parsed)
+}
+
+#[test]
+fn classify_fmt_failure_receipt() -> Result<()> {
+    let parsed = run_classify_and_read("fmt-failure-receipt.json", "fmt-output.json")?;
+    assert_eq!(parsed["fix_forward_kind"], "FMT_ONLY");
+    assert_eq!(parsed["safe_auto_fix"], true);
+    Ok(())
+}
+
+#[test]
+fn classify_stale_base_receipt() -> Result<()> {
+    let parsed = run_classify_and_read("stale-base-receipt.json", "stale-output.json")?;
+    assert_eq!(parsed["fix_forward_kind"], "STALE_BASE_CASCADE");
+    assert_eq!(parsed["safe_auto_fix"], false);
+    Ok(())
+}
+
+#[test]
+fn classify_generated_docs_receipt() -> Result<()> {
+    let parsed = run_classify_and_read("generated-docs-receipt.json", "docs-output.json")?;
+    assert_eq!(parsed["fix_forward_kind"], "GENERATED_DOC_REGEN");
+    assert_eq!(parsed["safe_auto_fix"], false);
+    Ok(())
+}
+
+#[test]
+fn list_playbooks_includes_known_kinds() -> Result<()> {
+    let output = Command::cargo_bin("xtask")?.args(["fix-forward", "list-playbooks"]).output()?;
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("FMT_ONLY"));
+    assert!(stdout.contains("STALE_BASE_CASCADE"));
+    assert!(stdout.contains("GENERATED_DOC_REGEN"));
+    Ok(())
+}

--- a/xtask/tests/fixtures/fix-forward/fmt-failure-receipt.json
+++ b/xtask/tests/fixtures/fix-forward/fmt-failure-receipt.json
@@ -1,0 +1,10 @@
+{
+  "gates": [
+    {
+      "gate_name": "fmt",
+      "status": "fail",
+      "command": "cargo fmt --check --all",
+      "output_summary": "cargo fmt --check found formatting drift"
+    }
+  ]
+}

--- a/xtask/tests/fixtures/fix-forward/generated-docs-receipt.json
+++ b/xtask/tests/fixtures/fix-forward/generated-docs-receipt.json
@@ -1,0 +1,10 @@
+{
+  "gates": [
+    {
+      "gate_name": "status-docs",
+      "status": "fail",
+      "command": "cargo xtask status-docs --check",
+      "output_summary": "generated docs are stale; CURRENT_STATUS drift"
+    }
+  ]
+}

--- a/xtask/tests/fixtures/fix-forward/stale-base-receipt.json
+++ b/xtask/tests/fixtures/fix-forward/stale-base-receipt.json
@@ -1,0 +1,10 @@
+{
+  "gates": [
+    {
+      "gate_name": "stale-base-classifier",
+      "status": "fail",
+      "command": "cargo xtask ci-policy stale-base",
+      "output_summary": "stale base detected; rebase required"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- CI failures should route to precise repair lanes (e.g., `FMT_ONLY`, `STALE_BASE_CASCADE`, `TITLE_FIX`) instead of generic builder retries to enable targeted remediation and safe automation.  
- Provide a typed, auditable receipt that records classification, suggested command/route, evidence, and the next agent so downstream automation or humans can act deterministically.  

### Description

- Added an `xtask` task implementation `xtask/src/tasks/fix_forward.rs` that loads `.ci/fix-forward/playbooks.toml`, classifies a failing CI receipt, and emits a typed fix-forward receipt containing `classification`, `fix_forward_kind`, `safe_auto_fix`, `command`, `route`, `evidence`, and `next_agent`.  
- Wired the new `FixForward` CLI into `xtask` with `FixForwardCommand::Classify` and `FixForwardCommand::ListPlaybooks` and registered the module in `xtask/src/tasks/mod.rs`.  
- Added playbook configuration `.ci/fix-forward/playbooks.toml`, JSON schema `.ci/receipts/schemas/fix-forward.schema.json`, documentation `docs/ci/typed-fix-forward.md`, and test fixtures plus an integration test `xtask/tests/fix_forward_cli.rs` for the requested cases.  
- Initial playbooks implemented: `FMT_ONLY`, `TITLE_FIX`, `STALE_BASE_CASCADE`, `GENERATED_DOC_REGEN`, `INFRA_ADVISORY_DEMOTION`, and `PARSER_RATCHET_REGRESSION`, and the classifier emits appropriate `next_agent` values (`fix-forward-bot`, route name, or `human-review`).  

### Testing

- Ran `cargo check -p xtask` which passed after formatting; initial `cargo xtask fmt --check` detected formatting drift in the new code and was resolved by running `cargo fmt --manifest-path xtask/Cargo.toml`.  
- Unit/integration tests: `cargo test -p xtask --test fix_forward_cli` passed (4 tests: classification for fmt/stale-base/generated-docs and `list-playbooks`).  
- Manual CLI validation: `cargo xtask fix-forward classify --receipt <fixture> --output <out>` for the three fixtures produced receipts classified as `FMT_ONLY`, `STALE_BASE_CASCADE`, and `GENERATED_DOC_REGEN`, and `cargo xtask fix-forward list-playbooks` lists the configured playbooks.  

Refs #6853

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0843cd48333ad34d5fb20e53ee1)