### PR TITLE
feat(fix-forward): classify failures into typed repair playbooks (#6853)

### DIFF
--- a/.ci/fix-forward/playbooks.toml
+++ b/.ci/fix-forward/playbooks.toml
@@ -1,0 +1,24 @@
+[FMT_ONLY]
+safe_auto_fix = true
+command = "cargo xtask fmt"
+branch_prefix = "fix-forward/fmt"
+
+[TITLE_FIX]
+safe_auto_fix = true
+mutation = "github_pr_title_only"
+
+[STALE_BASE_CASCADE]
+safe_auto_fix = false
+route = "cascade-update"
+
+[GENERATED_DOC_REGEN]
+safe_auto_fix = false
+command = "cargo xtask status-docs"
+
+[INFRA_ADVISORY_DEMOTION]
+safe_auto_fix = false
+route = "infra"
+
+[PARSER_RATCHET_REGRESSION]
+safe_auto_fix = false
+route = "parser-builder"

--- a/.ci/receipts/schemas/fix-forward.schema.json
+++ b/.ci/receipts/schemas/fix-forward.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/fix-forward.schema.json",
+  "title": "FixForwardReceipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "classification",
+    "fix_forward_kind",
+    "safe_auto_fix",
+    "evidence",
+    "next_agent"
+  ],
+  "properties": {
+    "classification": { "type": "string" },
+    "fix_forward_kind": { "type": "string" },
+    "safe_auto_fix": { "type": "boolean" },
+    "command": { "type": ["string", "null"] },
+    "route": { "type": ["string", "null"] },
+    "evidence": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "next_agent": { "type": "string" }
+  }
+}

--- a/docs/ci/typed-fix-forward.md
+++ b/docs/ci/typed-fix-forward.md
@@ -1,0 +1,31 @@
+# Typed fix-forward classification
+
+`cargo xtask fix-forward` maps failing receipts to typed repair lanes so follow-up can route to a specific playbook instead of generic retries.
+
+## Commands
+
+- `cargo xtask fix-forward classify --receipt <receipt.json> --output target/receipts/fix-forward.json`
+- `cargo xtask fix-forward list-playbooks`
+
+## Initial playbooks
+
+Playbooks are defined in `.ci/fix-forward/playbooks.toml`.
+
+- `FMT_ONLY` — safe auto-fix using `cargo xtask fmt`
+- `TITLE_FIX` — safe title mutation only
+- `STALE_BASE_CASCADE` — route to `cascade-update`
+- `GENERATED_DOC_REGEN` — docs regeneration lane (`cargo xtask status-docs`), manual for now
+- `INFRA_ADVISORY_DEMOTION` — route to infra
+- `PARSER_RATCHET_REGRESSION` — route to parser-builder
+
+## Receipt fields
+
+The classifier writes:
+
+- `classification`
+- `fix_forward_kind`
+- `safe_auto_fix`
+- `command`
+- `route`
+- `evidence`
+- `next_agent`

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1152,6 +1152,27 @@ enum Commands {
         /// Current receipt JSON path.
         current: PathBuf,
     },
+
+    /// Typed fix-forward classification and playbook lookup.
+    FixForward {
+        #[command(subcommand)]
+        command: FixForwardCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum FixForwardCommand {
+    /// Classify a failure receipt into a typed fix-forward playbook.
+    Classify {
+        /// Path to source receipt JSON.
+        #[arg(long)]
+        receipt: PathBuf,
+        /// Path to output fix-forward receipt JSON.
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// List configured typed fix-forward playbooks.
+    ListPlaybooks,
 }
 
 #[derive(Subcommand)]
@@ -1686,6 +1707,12 @@ fn main() -> Result<()> {
         Commands::CompareBuildTiming { baseline, current } => {
             build_timing::run_compare(baseline, current)
         }
+        Commands::FixForward { command } => match command {
+            FixForwardCommand::Classify { receipt, output } => {
+                fix_forward::classify(receipt, output)
+            }
+            FixForwardCommand::ListPlaybooks => fix_forward::list_playbooks(),
+        },
     }
 }
 

--- a/xtask/src/tasks/fix_forward.rs
+++ b/xtask/src/tasks/fix_forward.rs
@@ -1,0 +1,215 @@
+use color_eyre::eyre::{Context, Result, eyre};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const PLAYBOOKS_PATH: &str = ".ci/fix-forward/playbooks.toml";
+
+#[derive(Debug, Deserialize)]
+struct PlaybookCatalog {
+    #[serde(flatten)]
+    playbooks: BTreeMap<String, Playbook>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Playbook {
+    pub safe_auto_fix: bool,
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub route: Option<String>,
+    #[serde(default)]
+    pub mutation: Option<String>,
+    #[serde(default)]
+    pub branch_prefix: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FixForwardReceipt {
+    pub classification: String,
+    pub fix_forward_kind: String,
+    pub safe_auto_fix: bool,
+    pub command: Option<String>,
+    pub route: Option<String>,
+    pub evidence: Vec<String>,
+    pub next_agent: String,
+}
+
+pub fn classify(receipt: PathBuf, output: PathBuf) -> Result<()> {
+    let raw = fs::read_to_string(&receipt)
+        .with_context(|| format!("Failed to read receipt {}", receipt.display()))?;
+    let receipt_json: Value = serde_json::from_str(&raw)
+        .with_context(|| format!("Failed to parse receipt JSON {}", receipt.display()))?;
+
+    let catalog = load_playbooks()?;
+    let (classification, evidence) = classify_kind(&receipt_json);
+    let playbook = catalog.playbooks.get(&classification).ok_or_else(|| {
+        eyre!("No playbook found for classification `{classification}` in {}", PLAYBOOKS_PATH)
+    })?;
+
+    let next_agent = if playbook.safe_auto_fix {
+        "builder".to_string()
+    } else {
+        playbook.route.clone().unwrap_or_else(|| "triage".to_string())
+    };
+
+    let fix_forward_receipt = FixForwardReceipt {
+        classification: classification.clone(),
+        fix_forward_kind: classification,
+        safe_auto_fix: playbook.safe_auto_fix,
+        command: playbook.command.clone(),
+        route: playbook.route.clone(),
+        evidence,
+        next_agent,
+    };
+
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create output directory {}", parent.display()))?;
+    }
+    let rendered = serde_json::to_string_pretty(&fix_forward_receipt)
+        .context("Failed to render fix-forward receipt JSON")?;
+    fs::write(&output, format!("{rendered}\n"))
+        .with_context(|| format!("Failed to write {}", output.display()))?;
+
+    Ok(())
+}
+
+pub fn list_playbooks() -> Result<()> {
+    let catalog = load_playbooks()?;
+    for (kind, playbook) in catalog.playbooks {
+        let action = playbook
+            .command
+            .clone()
+            .or(playbook.route.clone())
+            .or(playbook.mutation.clone())
+            .unwrap_or_else(|| "manual".to_string());
+        println!("{kind}\tsafe_auto_fix={}\taction={action}", playbook.safe_auto_fix);
+    }
+    Ok(())
+}
+
+fn load_playbooks() -> Result<PlaybookCatalog> {
+    let root = crate::utils::project_root()?;
+    let path = root.join(PLAYBOOKS_PATH);
+    load_playbooks_from_path(&path)
+}
+
+fn load_playbooks_from_path(path: &Path) -> Result<PlaybookCatalog> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read playbooks from {}", path.display()))?;
+    toml::from_str(&raw)
+        .with_context(|| format!("Failed to parse playbooks TOML {}", path.display()))
+}
+
+fn classify_kind(receipt: &Value) -> (String, Vec<String>) {
+    if let Some(classification) = receipt.get("classification").and_then(Value::as_str) {
+        return (classification.to_string(), vec!["input.classification".to_string()]);
+    }
+
+    let mut evidence = Vec::new();
+
+    let blocking_failures = receipt
+        .get("summary")
+        .and_then(|summary| summary.get("blocking_failures"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    if blocking_failures
+        .iter()
+        .any(|gate| gate.as_str().is_some_and(|name| name == "stale-base-classifier"))
+    {
+        evidence.push("summary.blocking_failures contains stale-base-classifier".to_string());
+        return ("STALE_BASE_CASCADE".to_string(), evidence);
+    }
+
+    let failing_gates = receipt
+        .get("gates")
+        .and_then(Value::as_array)
+        .map(|gates| {
+            gates
+                .iter()
+                .filter(|gate| {
+                    gate.get("status").and_then(Value::as_str).is_some_and(|status| {
+                        status == "fail" || status == "error" || status == "timeout"
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    for gate in &failing_gates {
+        let gate_name = gate.get("gate_name").and_then(Value::as_str).unwrap_or_default();
+        let output_summary = gate
+            .get("output_summary")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+
+        if gate_name == "fmt" || output_summary.contains("cargo fmt") {
+            evidence.push(format!("failing gate `{gate_name}` indicates formatting drift"));
+            return ("FMT_ONLY".to_string(), evidence);
+        }
+
+        if gate_name.contains("title") {
+            evidence.push(format!("failing gate `{gate_name}` validates title"));
+            return ("TITLE_FIX".to_string(), evidence);
+        }
+
+        if gate_name.contains("doc") || output_summary.contains("generated docs") {
+            evidence.push(format!("failing gate `{gate_name}` requires generated docs refresh"));
+            return ("GENERATED_DOC_REGEN".to_string(), evidence);
+        }
+
+        if gate_name.contains("infra") {
+            evidence.push(format!("failing gate `{gate_name}` marked infrastructure advisory"));
+            return ("INFRA_ADVISORY_DEMOTION".to_string(), evidence);
+        }
+
+        if gate_name.contains("parser") && gate_name.contains("ratchet") {
+            evidence.push(format!("failing gate `{gate_name}` is parser ratchet"));
+            return ("PARSER_RATCHET_REGRESSION".to_string(), evidence);
+        }
+    }
+
+    evidence.push("no typed classifier matched; defaulting to STALE_BASE_CASCADE".to_string());
+    ("STALE_BASE_CASCADE".to_string(), evidence)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::classify_kind;
+
+    #[test]
+    fn classify_prefers_explicit_classification() {
+        let receipt = serde_json::json!({"classification": "STALE_BASE_CASCADE"});
+        let (kind, evidence) = classify_kind(&receipt);
+        assert_eq!(kind, "STALE_BASE_CASCADE");
+        assert_eq!(evidence.first().map(String::as_str), Some("input.classification"));
+    }
+
+    #[test]
+    fn classify_fmt_gate() {
+        let receipt = serde_json::json!({
+            "gates": [
+                {"gate_name": "fmt", "status": "fail", "output_summary": ""}
+            ]
+        });
+        let (kind, _) = classify_kind(&receipt);
+        assert_eq!(kind, "FMT_ONLY");
+    }
+
+    #[test]
+    fn classify_generated_doc_gate() {
+        let receipt = serde_json::json!({
+            "gates": [
+                {"gate_name": "status-docs", "status": "fail", "output_summary": "generated docs changed"}
+            ]
+        });
+        let (kind, _) = classify_kind(&receipt);
+        assert_eq!(kind, "GENERATED_DOC_REGEN");
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -36,6 +36,7 @@ pub mod doc_claims;
 pub mod e2e_validate;
 pub mod edge_cases;
 pub mod features;
+pub mod fix_forward;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;

--- a/xtask/tests/fix_forward_cli.rs
+++ b/xtask/tests/fix_forward_cli.rs
@@ -1,0 +1,60 @@
+use anyhow::Result;
+use assert_cmd::Command;
+use serde_json::Value;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn repo_root() -> PathBuf {
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    root.pop();
+    root
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("fix-forward")
+        .join(name)
+}
+
+fn classify_fixture(name: &str) -> Result<Value> {
+    let output_dir = TempDir::new()?;
+    let output_path = output_dir.path().join("fix-forward.json");
+
+    let mut cmd = Command::cargo_bin("xtask")?;
+    cmd.current_dir(repo_root()).args([
+        "fix-forward",
+        "classify",
+        "--receipt",
+        &fixture_path(name).to_string_lossy(),
+        "--output",
+        &output_path.to_string_lossy(),
+    ]);
+    cmd.assert().success();
+
+    let raw = fs::read_to_string(output_path)?;
+    Ok(serde_json::from_str(&raw)?)
+}
+
+#[test]
+fn fmt_receipt_classifies_to_fmt_only() -> Result<()> {
+    let json = classify_fixture("fmt-failure.json")?;
+    assert_eq!(json.get("classification").and_then(Value::as_str), Some("FMT_ONLY"));
+    Ok(())
+}
+
+#[test]
+fn stale_base_receipt_classifies_to_stale_base_cascade() -> Result<()> {
+    let json = classify_fixture("stale-base-failure.json")?;
+    assert_eq!(json.get("classification").and_then(Value::as_str), Some("STALE_BASE_CASCADE"));
+    Ok(())
+}
+
+#[test]
+fn generated_docs_receipt_classifies_to_generated_doc_regen() -> Result<()> {
+    let json = classify_fixture("generated-docs-failure.json")?;
+    assert_eq!(json.get("classification").and_then(Value::as_str), Some("GENERATED_DOC_REGEN"));
+    Ok(())
+}

--- a/xtask/tests/fixtures/fix-forward/fmt-failure.json
+++ b/xtask/tests/fixtures/fix-forward/fmt-failure.json
@@ -1,0 +1,12 @@
+{
+  "gates": [
+    {
+      "gate_name": "fmt",
+      "status": "fail",
+      "output_summary": "cargo fmt --check reported drift"
+    }
+  ],
+  "summary": {
+    "blocking_failures": ["fmt"]
+  }
+}

--- a/xtask/tests/fixtures/fix-forward/generated-docs-failure.json
+++ b/xtask/tests/fixtures/fix-forward/generated-docs-failure.json
@@ -1,0 +1,12 @@
+{
+  "gates": [
+    {
+      "gate_name": "status-docs",
+      "status": "fail",
+      "output_summary": "generated docs are stale"
+    }
+  ],
+  "summary": {
+    "blocking_failures": ["status-docs"]
+  }
+}

--- a/xtask/tests/fixtures/fix-forward/stale-base-failure.json
+++ b/xtask/tests/fixtures/fix-forward/stale-base-failure.json
@@ -1,0 +1,6 @@
+{
+  "classification": "STALE_BASE_CASCADE",
+  "summary": {
+    "blocking_failures": ["stale-base-classifier"]
+  }
+}


### PR DESCRIPTION
### Motivation

- Failures should route to precise repair lanes (FMT_ONLY, STALE_BASE_CASCADE, TITLE_FIX, etc.) instead of generic builder retries.
- Capture a machine-readable classification and playbook so follow-up agents can decide safe auto-fixes, commands, or routing.
- Refs #6853.

### Description

- Added a new `xtask` task module `xtask/src/tasks/fix_forward.rs` implementing receipt classification and playbook lookup from `.ci/fix-forward/playbooks.toml` and emitting a typed fix-forward receipt with `classification`, `fix_forward_kind`, `safe_auto_fix`, `command`, `route`, `evidence`, and `next_agent`.
- Wire new CLI commands `cargo xtask fix-forward classify --receipt <receipt> --output <out>` and `cargo xtask fix-forward list-playbooks` in `xtask/src/main.rs` and registered the module in `xtask/src/tasks/mod.rs`.
- Added initial playbooks file `.ci/fix-forward/playbooks.toml`, JSON schema `.ci/receipts/schemas/fix-forward.schema.json`, documentation `docs/ci/typed-fix-forward.md`, and fixture-backed CLI tests plus fixtures under `xtask/tests/fixtures/fix-forward/`.

### Testing

- Ran `cargo check -p xtask` which completed successfully.
- Exercised formatter path with `cargo xtask fix-forward classify --receipt xtask/tests/fixtures/fix-forward/fmt-failure.json --output target/receipts/fix-forward.json` which produced `FMT_ONLY` (success).
- Exercised stale-base and docs paths with `cargo xtask fix-forward classify` against fixtures which produced `STALE_BASE_CASCADE` and `GENERATED_DOC_REGEN` respectively (success), and `cargo xtask fix-forward list-playbooks` printed configured playbooks.
- Ran `cargo test -p xtask --test fix_forward_cli` and all fixture-backed tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0843cd48333ad34d5fb20e53ee1)