### PR TITLE
feat(fix-forward): classify failures into typed repair playbooks (#6853)

### DIFF
--- a/.ci/fix-forward/playbooks.toml
+++ b/.ci/fix-forward/playbooks.toml
@@ -1,0 +1,36 @@
+[[playbooks]]
+kind = "FMT_ONLY"
+safe_auto_fix = true
+command = "cargo xtask fmt"
+branch_prefix = "fix-forward/fmt"
+next_agent = "fix-forward-agent"
+
+[[playbooks]]
+kind = "TITLE_FIX"
+safe_auto_fix = true
+mutation = "github_pr_title_only"
+next_agent = "fix-forward-agent"
+
+[[playbooks]]
+kind = "STALE_BASE_CASCADE"
+safe_auto_fix = false
+route = "cascade-update"
+next_agent = "cascade-agent"
+
+[[playbooks]]
+kind = "GENERATED_DOC_REGEN"
+safe_auto_fix = false
+command = "cargo xtask status-docs"
+next_agent = "docs-agent"
+
+[[playbooks]]
+kind = "INFRA_ADVISORY_DEMOTION"
+safe_auto_fix = false
+route = "infra"
+next_agent = "infra-agent"
+
+[[playbooks]]
+kind = "PARSER_RATCHET_REGRESSION"
+safe_auto_fix = false
+route = "parser-builder"
+next_agent = "parser-agent"

--- a/.ci/receipts/schemas/fix-forward.schema.json
+++ b/.ci/receipts/schemas/fix-forward.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/schemas/fix-forward.schema.json",
+  "title": "FixForwardReceipt",
+  "type": "object",
+  "required": [
+    "classification",
+    "fix_forward_kind",
+    "safe_auto_fix",
+    "evidence",
+    "next_agent"
+  ],
+  "properties": {
+    "classification": {
+      "type": "string"
+    },
+    "fix_forward_kind": {
+      "type": "string",
+      "enum": [
+        "FMT_ONLY",
+        "TITLE_FIX",
+        "STALE_BASE_CASCADE",
+        "GENERATED_DOC_REGEN",
+        "INFRA_ADVISORY_DEMOTION",
+        "PARSER_RATCHET_REGRESSION"
+      ]
+    },
+    "safe_auto_fix": {
+      "type": "boolean"
+    },
+    "command": {
+      "type": ["string", "null"]
+    },
+    "route": {
+      "type": ["string", "null"]
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "next_agent": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/ci/typed-fix-forward.md
+++ b/docs/ci/typed-fix-forward.md
@@ -1,0 +1,37 @@
+# Typed fix-forward classification
+
+`cargo xtask fix-forward` classifies CI receipts into explicit repair playbooks instead of routing all failures to a generic retry lane.
+
+## Commands
+
+- `cargo xtask fix-forward classify --receipt <receipt.json> --output target/receipts/fix-forward.json`
+- `cargo xtask fix-forward list-playbooks`
+
+## Output contract
+
+The classifier writes a receipt with:
+
+- `classification`
+- `fix_forward_kind`
+- `safe_auto_fix`
+- `command`
+- `route`
+- `evidence`
+- `next_agent`
+
+Schema: `.ci/receipts/schemas/fix-forward.schema.json`.
+
+## Initial kinds
+
+- `FMT_ONLY`
+- `TITLE_FIX`
+- `STALE_BASE_CASCADE`
+- `GENERATED_DOC_REGEN`
+- `INFRA_ADVISORY_DEMOTION`
+- `PARSER_RATCHET_REGRESSION`
+
+Playbook source of truth: `.ci/fix-forward/playbooks.toml`.
+
+## Notes
+
+Current implementation only classifies and emits receipts. It does **not** mutate branches, create PRs, or apply labels.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -964,6 +964,12 @@ enum Commands {
         command: MetricsCommand,
     },
 
+    /// Classify CI failures into typed fix-forward playbooks.
+    FixForward {
+        #[command(subcommand)]
+        command: FixForwardCommand,
+    },
+
     /// Publish structured editor UX scorecard artifact/status from harness fixtures.
     UxScorecard {
         /// Output format for stdout.
@@ -1303,6 +1309,21 @@ enum MetricsCommand {
     },
 }
 
+#[derive(Subcommand)]
+enum FixForwardCommand {
+    /// Classify a receipt into a typed fix-forward playbook.
+    Classify {
+        /// Path to a CI receipt JSON file.
+        #[arg(long)]
+        receipt: PathBuf,
+        /// Output path for the fix-forward receipt.
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// List configured fix-forward playbooks.
+    ListPlaybooks,
+}
+
 #[derive(ValueEnum, Clone)]
 enum PrepCratesMode {
     Core,
@@ -1622,6 +1643,12 @@ fn main() -> Result<()> {
                 metrics::ratchet::run_promote_baseline(&root, &subsystem, delta_pct)
             }
             MetricsCommand::SweepStats { input } => metrics::sweep_stats::run(input),
+        },
+        Commands::FixForward { command } => match command {
+            FixForwardCommand::Classify { receipt, output } => {
+                fix_forward::classify(receipt, output)
+            }
+            FixForwardCommand::ListPlaybooks => fix_forward::list_playbooks(),
         },
         Commands::UxScorecard { format, input, output, status_md, ratchet_check } => {
             let format = match format {

--- a/xtask/src/tasks/fix_forward.rs
+++ b/xtask/src/tasks/fix_forward.rs
@@ -1,0 +1,221 @@
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const PLAYBOOKS_PATH: &str = ".ci/fix-forward/playbooks.toml";
+
+#[derive(Debug, Deserialize)]
+struct PlaybookCatalog {
+    playbooks: Vec<Playbook>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Playbook {
+    kind: String,
+    safe_auto_fix: bool,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    route: Option<String>,
+    #[serde(default)]
+    mutation: Option<String>,
+    #[serde(default)]
+    branch_prefix: Option<String>,
+    #[serde(default)]
+    next_agent: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FixForwardReceipt {
+    classification: String,
+    fix_forward_kind: String,
+    safe_auto_fix: bool,
+    command: Option<String>,
+    route: Option<String>,
+    evidence: Vec<String>,
+    next_agent: String,
+}
+
+pub fn classify(receipt: PathBuf, output: PathBuf) -> Result<()> {
+    let raw = fs::read_to_string(&receipt)
+        .with_context(|| format!("reading receipt {}", receipt.display()))?;
+    let value: Value =
+        serde_json::from_str(&raw).with_context(|| format!("parsing {}", receipt.display()))?;
+
+    let catalog = load_playbooks()?;
+    let (kind, evidence) = classify_kind(&value);
+    let Some(playbook) = catalog.playbooks.iter().find(|entry| entry.kind == kind) else {
+        bail!("no playbook configured for classified kind: {kind}");
+    };
+
+    let classified = FixForwardReceipt {
+        classification: kind.clone(),
+        fix_forward_kind: kind,
+        safe_auto_fix: playbook.safe_auto_fix,
+        command: playbook.command.clone(),
+        route: playbook.route.clone(),
+        evidence,
+        next_agent: resolve_next_agent(playbook),
+    };
+
+    write_json(&output, &classified)
+}
+
+pub fn list_playbooks() -> Result<()> {
+    let catalog = load_playbooks()?;
+    for playbook in catalog.playbooks {
+        println!(
+            "{}\tsafe_auto_fix={}\tcommand={}\troute={}\tmutation={}\tbranch_prefix={}",
+            playbook.kind,
+            playbook.safe_auto_fix,
+            playbook.command.as_deref().unwrap_or("-"),
+            playbook.route.as_deref().unwrap_or("-"),
+            playbook.mutation.as_deref().unwrap_or("-"),
+            playbook.branch_prefix.as_deref().unwrap_or("-"),
+        );
+    }
+    Ok(())
+}
+
+fn resolve_next_agent(playbook: &Playbook) -> String {
+    if let Some(agent) = &playbook.next_agent {
+        return agent.clone();
+    }
+    if playbook.safe_auto_fix {
+        "fix-forward-agent".to_string()
+    } else {
+        "triage-agent".to_string()
+    }
+}
+
+fn write_json(path: &Path, payload: &FixForwardReceipt) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let rendered =
+        serde_json::to_string_pretty(payload).context("serializing fix-forward output")?;
+    fs::write(path, format!("{rendered}\n")).with_context(|| format!("writing {}", path.display()))
+}
+
+fn load_playbooks() -> Result<PlaybookCatalog> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| color_eyre::eyre::eyre!("cannot resolve repository root"))?;
+    let path = root.join(PLAYBOOKS_PATH);
+    let raw = fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn classify_kind(receipt: &Value) -> (String, Vec<String>) {
+    if is_stale_base(receipt) {
+        return (
+            "STALE_BASE_CASCADE".to_string(),
+            vec!["agent_receipt indicates stale base or stale-base lane failure".to_string()],
+        );
+    }
+
+    let failed_gates = failed_gates(receipt);
+    if is_fmt_only_failure(&failed_gates) {
+        return (
+            "FMT_ONLY".to_string(),
+            vec!["only fmt gate failed while all other required gates passed/skipped".to_string()],
+        );
+    }
+
+    if is_title_failure(&failed_gates) {
+        return (
+            "TITLE_FIX".to_string(),
+            vec!["failing gate output references title validation format".to_string()],
+        );
+    }
+
+    if is_generated_docs_regen(&failed_gates) {
+        return (
+            "GENERATED_DOC_REGEN".to_string(),
+            vec!["failure points to generated docs/status doc drift".to_string()],
+        );
+    }
+
+    if is_parser_ratchet_regression(&failed_gates) {
+        return (
+            "PARSER_RATCHET_REGRESSION".to_string(),
+            vec!["parser-related gate output references ratchet regression".to_string()],
+        );
+    }
+
+    (
+        "INFRA_ADVISORY_DEMOTION".to_string(),
+        vec!["defaulted to infra advisory lane after no narrower classifier matched".to_string()],
+    )
+}
+
+fn failed_gates(receipt: &Value) -> Vec<&Value> {
+    receipt
+        .get("gates")
+        .and_then(Value::as_array)
+        .map(|gates| {
+            gates
+                .iter()
+                .filter(|gate| gate.get("status").and_then(Value::as_str) == Some("fail"))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn is_fmt_only_failure(failed_gates: &[&Value]) -> bool {
+    if failed_gates.len() != 1 {
+        return false;
+    }
+    let gate = failed_gates[0];
+    gate.get("gate_name")
+        .and_then(Value::as_str)
+        .map(|name| name == "fmt" || name.contains("fmt"))
+        .unwrap_or(false)
+}
+
+fn is_stale_base(receipt: &Value) -> bool {
+    if receipt.pointer("/agent_receipt/is_latest").and_then(Value::as_bool) == Some(false) {
+        return true;
+    }
+
+    let Some(failures) = receipt.pointer("/agent_receipt/failures").and_then(Value::as_array)
+    else {
+        return false;
+    };
+
+    failures.iter().any(|failure| {
+        let lane = failure.get("lane").and_then(Value::as_str).unwrap_or_default();
+        let summary = failure.get("summary").and_then(Value::as_str).unwrap_or_default();
+        lane.contains("stale-base") || summary.to_lowercase().contains("stale base")
+    })
+}
+
+fn is_title_failure(failed_gates: &[&Value]) -> bool {
+    failed_gates.iter().any(|gate| {
+        let name = gate.get("gate_name").and_then(Value::as_str).unwrap_or_default();
+        let summary = gate.get("output_summary").and_then(Value::as_str).unwrap_or_default();
+        name.contains("title") || summary.to_lowercase().contains("validate-title")
+    })
+}
+
+fn is_generated_docs_regen(failed_gates: &[&Value]) -> bool {
+    failed_gates.iter().any(|gate| {
+        let name = gate.get("gate_name").and_then(Value::as_str).unwrap_or_default();
+        let summary = gate.get("output_summary").and_then(Value::as_str).unwrap_or_default();
+        name.contains("docs")
+            || summary.to_lowercase().contains("generated docs")
+            || summary.to_lowercase().contains("status doc")
+    })
+}
+
+fn is_parser_ratchet_regression(failed_gates: &[&Value]) -> bool {
+    failed_gates.iter().any(|gate| {
+        let name = gate.get("gate_name").and_then(Value::as_str).unwrap_or_default();
+        let summary = gate.get("output_summary").and_then(Value::as_str).unwrap_or_default();
+        (name.contains("parser") || name.contains("ratchet"))
+            && summary.to_lowercase().contains("regression")
+    })
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -36,6 +36,7 @@ pub mod doc_claims;
 pub mod e2e_validate;
 pub mod edge_cases;
 pub mod features;
+pub mod fix_forward;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;

--- a/xtask/tests/fix_forward_cli.rs
+++ b/xtask/tests/fix_forward_cli.rs
@@ -1,0 +1,87 @@
+use anyhow::{Context, Result};
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::fs;
+
+fn fixture_path(name: &str) -> String {
+    format!("tests/fixtures/fix-forward/{name}")
+}
+
+#[test]
+fn classifies_fmt_receipt_as_fmt_only() -> Result<()> {
+    let output = tempfile::NamedTempFile::new().context("creating temp output")?;
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output_status = cmd
+        .args([
+            "fix-forward",
+            "classify",
+            "--receipt",
+            &fixture_path("fmt-failure-receipt.json"),
+            "--output",
+            output.path().to_str().context("temp path is not utf-8")?,
+        ])
+        .output()
+        .context("running xtask fix-forward classify for fmt receipt")?;
+
+    assert!(output_status.status.success(), "classify command failed for fmt fixture");
+
+    let raw = fs::read_to_string(output.path()).context("reading classifier output")?;
+    let value: serde_json::Value =
+        serde_json::from_str(&raw).context("parsing classifier output")?;
+    assert_eq!(value["fix_forward_kind"], "FMT_ONLY");
+    assert_eq!(value["safe_auto_fix"], true);
+
+    Ok(())
+}
+
+#[test]
+fn classifies_stale_base_receipt_as_stale_base_cascade() -> Result<()> {
+    let output = tempfile::NamedTempFile::new().context("creating temp output")?;
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output_status = cmd
+        .args([
+            "fix-forward",
+            "classify",
+            "--receipt",
+            &fixture_path("stale-base-receipt.json"),
+            "--output",
+            output.path().to_str().context("temp path is not utf-8")?,
+        ])
+        .output()
+        .context("running xtask fix-forward classify for stale-base receipt")?;
+
+    assert!(output_status.status.success(), "classify command failed for stale-base fixture");
+
+    let raw = fs::read_to_string(output.path()).context("reading classifier output")?;
+    let value: serde_json::Value =
+        serde_json::from_str(&raw).context("parsing classifier output")?;
+    assert_eq!(value["fix_forward_kind"], "STALE_BASE_CASCADE");
+    assert_eq!(value["route"], "cascade-update");
+
+    Ok(())
+}
+
+#[test]
+fn classifies_generated_docs_receipt_as_generated_doc_regen() -> Result<()> {
+    let output = tempfile::NamedTempFile::new().context("creating temp output")?;
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output_status = cmd
+        .args([
+            "fix-forward",
+            "classify",
+            "--receipt",
+            &fixture_path("generated-docs-receipt.json"),
+            "--output",
+            output.path().to_str().context("temp path is not utf-8")?,
+        ])
+        .output()
+        .context("running xtask fix-forward classify for generated-docs receipt")?;
+
+    assert!(output_status.status.success(), "classify command failed for generated-docs fixture");
+
+    let raw = fs::read_to_string(output.path()).context("reading classifier output")?;
+    let value: serde_json::Value =
+        serde_json::from_str(&raw).context("parsing classifier output")?;
+    assert_eq!(value["fix_forward_kind"], "GENERATED_DOC_REGEN");
+
+    Ok(())
+}

--- a/xtask/tests/fixtures/fix-forward/fmt-failure-receipt.json
+++ b/xtask/tests/fixtures/fix-forward/fmt-failure-receipt.json
@@ -1,0 +1,17 @@
+{
+  "gates": [
+    {
+      "gate_name": "fmt",
+      "status": "fail",
+      "output_summary": "cargo fmt --check reported drift"
+    },
+    {
+      "gate_name": "clippy-lib",
+      "status": "pass"
+    }
+  ],
+  "agent_receipt": {
+    "is_latest": true,
+    "failures": []
+  }
+}

--- a/xtask/tests/fixtures/fix-forward/generated-docs-receipt.json
+++ b/xtask/tests/fixtures/fix-forward/generated-docs-receipt.json
@@ -1,0 +1,13 @@
+{
+  "gates": [
+    {
+      "gate_name": "docs-check",
+      "status": "fail",
+      "output_summary": "generated docs are stale; run status docs regeneration"
+    }
+  ],
+  "agent_receipt": {
+    "is_latest": true,
+    "failures": []
+  }
+}

--- a/xtask/tests/fixtures/fix-forward/stale-base-receipt.json
+++ b/xtask/tests/fixtures/fix-forward/stale-base-receipt.json
@@ -1,0 +1,18 @@
+{
+  "gates": [
+    {
+      "gate_name": "stale-base-classifier",
+      "status": "fail",
+      "output_summary": "base commit is behind target"
+    }
+  ],
+  "agent_receipt": {
+    "is_latest": false,
+    "failures": [
+      {
+        "lane": "stale-base-classifier",
+        "summary": "stale base detected"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Motivation

- Route CI failures to precise repair playbooks and emit typed receipts (Refs #6853). 
- Provide a machine-readable receipt that recommends safe auto-fix actions, commands, or routing lanes without mutating branches or opening PRs yet.

### Description

- Add `xtask/src/tasks/fix_forward.rs` which loads playbooks from `.ci/fix-forward/playbooks.toml`, classifies CI receipts, and emits a fix-forward receipt containing `classification`, `fix_forward_kind`, `safe_auto_fix`, `command`, `route`, `evidence`, and `next_agent`.
- Wire a new CLI `fix-forward` subcommand in `xtask/src/main.rs` and register the task module in `xtask/src/tasks/mod.rs` with `classify` and `list-playbooks` actions.
- Add the playbook source-of-truth `.ci/fix-forward/playbooks.toml`, the output schema `.ci/receipts/schemas/fix-forward.schema.json`, documentation `docs/ci/typed-fix-forward.md`, and test fixtures plus an integration test `xtask/tests/fix_forward_cli.rs` covering initial kinds.
- Initial playbooks added: `FMT_ONLY`, `TITLE_FIX`, `STALE_BASE_CASCADE`, `GENERATED_DOC_REGEN`, `INFRA_ADVISORY_DEMOTION`, and `PARSER_RATCHET_REGRESSION` with configured `safe_auto_fix`, `command`, `route`, `mutation`, `branch_prefix`, and `next_agent` fields.

### Testing

- `cargo check -p xtask` succeeded.
- Executed `cargo xtask fix-forward classify` on fixtures under `xtask/tests/fixtures/fix-forward/` and observed the expected `fix_forward_kind` values: `FMT_ONLY`, `STALE_BASE_CASCADE`, and `GENERATED_DOC_REGEN`.
- `cargo xtask fix-forward list-playbooks` printed the configured playbooks and `cargo test -p xtask --test fix_forward_cli` passed (3 tests).
- Formatting note: `cargo xtask fmt --check` initially reported formatting drift and was resolved by running `cargo xtask fmt` before finalizing the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0843cd48333ad34d5fb20e53ee1)