### PR TITLE
feat(generated): add generated-file ownership check (#6853)

### DIFF
--- a/.ci/generated-files.toml
+++ b/.ci/generated-files.toml
@@ -1,0 +1,5 @@
+[[generated]]
+path = "docs/project/status/**"
+command = "cargo xtask status-docs"
+owner = "status-docs"
+allow_manual_edits = false

--- a/.ci/receipts/schemas/generated-files.schema.json
+++ b/.ci/receipts/schemas/generated-files.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/generated-files.schema.json",
+  "title": "Generated File Ownership Receipt",
+  "type": "object",
+  "required": ["verdict", "changed_files", "expected_command", "missing_receipts"],
+  "properties": {
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "fail"]
+    },
+    "changed_files": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "expected_command": {
+      "type": ["string", "null"]
+    },
+    "missing_receipts": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/ci/generated-file-policy.md
+++ b/docs/ci/generated-file-policy.md
@@ -1,0 +1,24 @@
+# Generated file ownership policy
+
+Generated docs/status files are owned by explicit generator commands declared in `.ci/generated-files.toml`.
+
+## Commands
+
+- Check ownership: `cargo xtask generated-files check --receipt target/receipts/generated-files.json`
+- List ownership rules: `cargo xtask generated-files list`
+
+## Enforcement behavior
+
+- The check detects changed files that match generated ownership rules.
+- If `allow_manual_edits = false`, changes require matching generator receipt evidence or `--allow-override`.
+- The command writes an ownership receipt with:
+  - `verdict`
+  - `changed_files`
+  - `expected_command`
+  - `missing_receipts`
+
+## Scope guardrails
+
+- Only paths declared in `.ci/generated-files.toml` are treated as generated ownership paths.
+- Hand-authored forensics documents remain unaffected unless explicitly listed in the manifest.
+- The checker does not run generators automatically.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -400,6 +400,12 @@ enum Commands {
         format: String,
     },
 
+    /// Enforce ownership rules for generated files.
+    GeneratedFiles {
+        #[command(subcommand)]
+        command: GeneratedFilesCommand,
+    },
+
     /// Run version-sync checks from `perl-ci-hygiene`.
     CheckVersionSync,
 
@@ -1303,6 +1309,26 @@ enum MetricsCommand {
     },
 }
 
+#[derive(Subcommand)]
+enum GeneratedFilesCommand {
+    /// Check changed generated files for matching generator receipts.
+    Check {
+        /// Output path for the generated ownership receipt.
+        #[arg(long)]
+        receipt: PathBuf,
+
+        /// Optional fixture JSON for tests.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+
+        /// Explicitly allow manual edits without a generator receipt.
+        #[arg(long)]
+        allow_override: bool,
+    },
+    /// List generated-file ownership rules.
+    List,
+}
+
 #[derive(ValueEnum, Clone)]
 enum PrepCratesMode {
     Core,
@@ -1462,6 +1488,12 @@ fn main() -> Result<()> {
         Commands::CiScope { base, format } => {
             ci_scope::run(ci_scope::CiScopeConfig { base, format })
         }
+        Commands::GeneratedFiles { command } => match command {
+            GeneratedFilesCommand::Check { receipt, fixture, allow_override } => {
+                generated_files::check(receipt, fixture, allow_override)
+            }
+            GeneratedFilesCommand::List => generated_files::list(),
+        },
         Commands::CheckVersionSync => check_version_sync::run(),
         Commands::CheckFromRaw => ci_policy::check_from_raw(),
         Commands::SecurityHardening => hardening::security_hardening(),

--- a/xtask/src/tasks/generated_files.rs
+++ b/xtask/src/tasks/generated_files.rs
@@ -1,0 +1,200 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::utils::project_root;
+
+const MANIFEST_PATH: &str = ".ci/generated-files.toml";
+
+#[derive(Debug, Clone, Deserialize)]
+struct Manifest {
+    generated: Vec<GeneratedRule>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GeneratedRule {
+    path: String,
+    command: String,
+    owner: String,
+    allow_manual_edits: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureInput {
+    changed_files: Vec<String>,
+    #[serde(default)]
+    generator_receipts: Vec<GeneratorReceipt>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GeneratorReceipt {
+    owner: String,
+    #[serde(default)]
+    files: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CheckReceipt {
+    verdict: String,
+    changed_files: Vec<String>,
+    expected_command: Option<String>,
+    missing_receipts: Vec<String>,
+}
+
+pub fn list() -> Result<()> {
+    let root = project_root()?;
+    let manifest = load_manifest(&root)?;
+
+    for entry in manifest.generated {
+        println!(
+            "path={} owner={} allow_manual_edits={} command={}",
+            entry.path, entry.owner, entry.allow_manual_edits, entry.command
+        );
+    }
+
+    Ok(())
+}
+
+pub fn check(receipt_path: PathBuf, fixture: Option<PathBuf>, allow_override: bool) -> Result<()> {
+    let root = project_root()?;
+    let manifest = load_manifest(&root)?;
+
+    let (changed_files, generator_receipts) = if let Some(fixture_path) = fixture {
+        let raw = fs::read_to_string(&fixture_path)
+            .with_context(|| format!("failed to read fixture {}", fixture_path.display()))?;
+        let fixture: FixtureInput = serde_json::from_str(&raw)
+            .with_context(|| format!("invalid fixture JSON {}", fixture_path.display()))?;
+        (fixture.changed_files, fixture.generator_receipts)
+    } else {
+        (collect_changed_files(&root)?, Vec::new())
+    };
+
+    let mut generated_changed = Vec::new();
+    let mut missing_receipts = Vec::new();
+    let mut expected_command = None;
+
+    for file in &changed_files {
+        if let Some(rule) = manifest
+            .generated
+            .iter()
+            .find(|rule| !rule.allow_manual_edits && matches_glob(&rule.path, file))
+        {
+            generated_changed.push(file.clone());
+
+            let has_receipt = generator_receipts.iter().any(|receipt| {
+                receipt.owner == rule.owner && receipt.files.iter().any(|f| f == file)
+            });
+
+            if !has_receipt {
+                missing_receipts.push(file.clone());
+                if expected_command.is_none() {
+                    expected_command = Some(rule.command.clone());
+                }
+            }
+        }
+    }
+
+    generated_changed.sort();
+    generated_changed.dedup();
+    missing_receipts.sort();
+    missing_receipts.dedup();
+
+    let verdict = if missing_receipts.is_empty() || allow_override { "pass" } else { "fail" };
+
+    let receipt = CheckReceipt {
+        verdict: verdict.to_string(),
+        changed_files: generated_changed,
+        expected_command,
+        missing_receipts,
+    };
+
+    write_receipt(&receipt_path, &receipt)?;
+
+    if receipt.verdict == "fail" {
+        bail!(
+            "generated-files check failed: missing generator receipt for {} file(s)",
+            receipt.missing_receipts.len()
+        );
+    }
+
+    Ok(())
+}
+
+fn load_manifest(root: &Path) -> Result<Manifest> {
+    let manifest_path = root.join(MANIFEST_PATH);
+    let raw = fs::read_to_string(&manifest_path)
+        .with_context(|| format!("failed to read {}", manifest_path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("invalid TOML in {}", manifest_path.display()))
+}
+
+fn collect_changed_files(root: &Path) -> Result<Vec<String>> {
+    let diff = std::process::Command::new("git")
+        .args(["diff", "--name-only", "HEAD"])
+        .current_dir(root)
+        .output()
+        .context("failed to run git diff --name-only HEAD")?;
+
+    if !diff.status.success() {
+        bail!("git diff --name-only HEAD failed with status {}", diff.status);
+    }
+
+    let mut files: BTreeSet<String> = String::from_utf8(diff.stdout)
+        .context("git diff output was not valid UTF-8")?
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .collect();
+
+    let untracked = std::process::Command::new("git")
+        .args(["ls-files", "--others", "--exclude-standard"])
+        .current_dir(root)
+        .output()
+        .context("failed to run git ls-files --others --exclude-standard")?;
+
+    if !untracked.status.success() {
+        bail!("git ls-files --others --exclude-standard failed with status {}", untracked.status);
+    }
+
+    for line in String::from_utf8(untracked.stdout)
+        .context("git ls-files output was not valid UTF-8")?
+        .lines()
+    {
+        if !line.trim().is_empty() {
+            files.insert(line.to_string());
+        }
+    }
+
+    Ok(files.into_iter().collect())
+}
+
+fn write_receipt(path: &Path, receipt: &CheckReceipt) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory {}", parent.display()))?;
+    }
+
+    let payload = serde_json::to_string_pretty(receipt).context("failed to serialize receipt")?;
+    fs::write(path, payload).with_context(|| format!("failed to write receipt {}", path.display()))
+}
+
+fn matches_glob(pattern: &str, candidate: &str) -> bool {
+    if let Some(prefix) = pattern.strip_suffix("/**") {
+        return candidate == prefix || candidate.starts_with(&format!("{prefix}/"));
+    }
+
+    pattern == candidate
+}
+
+#[cfg(test)]
+mod tests {
+    use super::matches_glob;
+
+    #[test]
+    fn supports_double_star_directory_pattern() {
+        assert!(matches_glob("docs/project/status/**", "docs/project/status/parser.md"));
+        assert!(!matches_glob("docs/project/status/**", "docs/project/other.md"));
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -40,6 +40,7 @@ pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;
 pub mod gates;
+pub mod generated_files;
 pub mod github;
 pub mod hardening;
 #[cfg(feature = "parser-tasks")]

--- a/xtask/tests/fixtures/generated-files/changed-with-receipt.json
+++ b/xtask/tests/fixtures/generated-files/changed-with-receipt.json
@@ -1,0 +1,13 @@
+{
+  "changed_files": [
+    "docs/project/status/parser.md"
+  ],
+  "generator_receipts": [
+    {
+      "owner": "status-docs",
+      "files": [
+        "docs/project/status/parser.md"
+      ]
+    }
+  ]
+}

--- a/xtask/tests/fixtures/generated-files/changed-without-receipt.json
+++ b/xtask/tests/fixtures/generated-files/changed-without-receipt.json
@@ -1,0 +1,6 @@
+{
+  "changed_files": [
+    "docs/project/status/parser.md"
+  ],
+  "generator_receipts": []
+}

--- a/xtask/tests/generated_files_cli.rs
+++ b/xtask/tests/generated_files_cli.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use assert_cmd::Command;
+use tempfile::tempdir;
+
+#[test]
+fn generated_file_changed_without_receipt_fails() -> Result<()> {
+    let fixture = "tests/fixtures/generated-files/changed-without-receipt.json";
+    let temp = tempdir()?;
+    let receipt = temp.path().join("generated-files.json");
+
+    let output = Command::cargo_bin("xtask")?
+        .args([
+            "generated-files",
+            "check",
+            "--fixture",
+            fixture,
+            "--receipt",
+            receipt.to_str().ok_or_else(|| anyhow::anyhow!("utf8 path expected"))?,
+        ])
+        .output()?;
+
+    assert!(!output.status.success(), "check should fail without matching receipt");
+    Ok(())
+}
+
+#[test]
+fn generator_receipt_present_passes() -> Result<()> {
+    let fixture = "tests/fixtures/generated-files/changed-with-receipt.json";
+    let temp = tempdir()?;
+    let receipt = temp.path().join("generated-files.json");
+
+    let output = Command::cargo_bin("xtask")?
+        .args([
+            "generated-files",
+            "check",
+            "--fixture",
+            fixture,
+            "--receipt",
+            receipt.to_str().ok_or_else(|| anyhow::anyhow!("utf8 path expected"))?,
+        ])
+        .output()?;
+
+    assert!(output.status.success(), "check should pass with matching receipt");
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Generated docs/status files can be hand-edited without proof that the owning generator was run, which makes diff-audit routing noisy and error-prone. 
- The goal is to require generator receipts for changes to declared generated paths and to provide a lightweight check and receipt emission to document verdicts. 
- Refs #6853

### Description

- Add a manifest at ` .ci/generated-files.toml` and a JSON schema at `.ci/receipts/schemas/generated-files.schema.json` to declare and validate generated-file ownership rules. 
- Introduce a new `cargo xtask generated-files` command surface (subcommands `check` and `list`) wired in `xtask/src/main.rs` and exported via `xtask/src/tasks/mod.rs`. 
- Implement core logic in `xtask/src/tasks/generated_files.rs` to load the manifest, detect changed files, match `/**` path globs, require matching generator receipts (or accept `--allow-override`), and emit an ownership receipt with `verdict`, `changed_files`, `expected_command`, and `missing_receipts`. 
- Add documentation and tests: `docs/ci/generated-file-policy.md`, fixture inputs under `xtask/tests/fixtures/generated-files/`, and CLI integration tests in `xtask/tests/generated_files_cli.rs` covering fail/pass scenarios and `--fixture` support.

### Testing

- Ran `cargo check -p xtask`, which completed successfully. 
- Ran `cargo xtask generated-files list` and it printed the declared rule, which succeeded. 
- Ran `cargo xtask fmt --package xtask` to ensure formatting; formatting was applied and the check passed. 
- Executed fixture-backed tests: `generated_file_changed_without_receipt_fails` (failed-as-expected case) and `generator_receipt_present_passes` (receipt-present pass case), both passing when run individually under `cargo test -p xtask`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd088a28083339e22afb3d2e8fec9)