### PR TITLE
feat(generated): add generated-file ownership check (#6853)

### DIFF
--- a/.ci/generated-files.toml
+++ b/.ci/generated-files.toml
@@ -1,0 +1,5 @@
+[[generated]]
+path = "docs/project/status/**"
+command = "cargo xtask status-docs"
+owner = "status-docs"
+allow_manual_edits = false

--- a/.ci/receipts/schemas/generated-files.schema.json
+++ b/.ci/receipts/schemas/generated-files.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.github.io/perl-lsp/schemas/generated-files.schema.json",
+  "title": "Generated File Ownership Receipt",
+  "type": "object",
+  "required": [
+    "verdict",
+    "changed_files",
+    "expected_command",
+    "missing_receipts"
+  ],
+  "properties": {
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "fail"]
+    },
+    "changed_files": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "expected_command": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "missing_receipts": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3856,6 +3856,7 @@ dependencies = [
  "console",
  "duct",
  "flate2",
+ "glob",
  "indicatif",
  "notify",
  "peak_alloc",

--- a/docs/ci/generated-file-policy.md
+++ b/docs/ci/generated-file-policy.md
@@ -1,0 +1,23 @@
+# Generated File Ownership Policy
+
+Generated status/docs outputs are declared in `.ci/generated-files.toml` and are protected by ownership checks.
+
+## Commands
+
+- `cargo xtask generated-files list`
+- `cargo xtask generated-files check --receipt target/receipts/generated-files.json`
+
+## Behavior
+
+- Detects changed files that match protected generated patterns.
+- Requires a matching generator receipt (`owner` + `command`) unless `--allow-missing-receipt` is explicitly used.
+- Emits a receipt with: `verdict`, `changed_files`, `expected_command`, and `missing_receipts`.
+- Does **not** run generators automatically.
+
+## Scope
+
+Current protected scope:
+
+- `docs/project/status/**` (owner: `status-docs`, command: `cargo xtask status-docs`)
+
+This policy intentionally targets generated outputs and does not block hand-authored forensic documentation.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -42,6 +42,7 @@ notify = "8.2.0"
 flate2 = "1.1.5"
 tar = "0.4.44"
 tempfile.workspace = true
+glob = "0.3.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.18.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -923,6 +923,12 @@ enum Commands {
         only: Option<update_status::StatusSubsystem>,
     },
 
+    /// Generated-file ownership policy checks.
+    GeneratedFiles {
+        #[command(subcommand)]
+        command: GeneratedFilesCommand,
+    },
+
     /// Generate SRP microcrate inventory and split-candidate report
     SrpMicrocrates {
         /// Optional output path (default: docs/SRP_MICROCRATES.md)
@@ -1303,6 +1309,24 @@ enum MetricsCommand {
     },
 }
 
+#[derive(Subcommand)]
+enum GeneratedFilesCommand {
+    /// Check changed generated files for required generator receipts.
+    Check {
+        /// Path to write check receipt JSON.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+        /// Optional fixture JSON for tests.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+        /// Explicit override to allow missing receipts.
+        #[arg(long)]
+        allow_missing_receipt: bool,
+    },
+    /// List generated-file ownership rules from the manifest.
+    List,
+}
+
 #[derive(ValueEnum, Clone)]
 enum PrepCratesMode {
     Core,
@@ -1599,6 +1623,12 @@ fn main() -> Result<()> {
             FeaturesCommand::Report => features::report(),
         },
         Commands::UpdateStatus { write, check, only } => update_status::run(write, check, only),
+        Commands::GeneratedFiles { command } => match command {
+            GeneratedFilesCommand::Check { receipt, fixture, allow_missing_receipt } => {
+                generated_files::check(receipt, fixture, allow_missing_receipt)
+            }
+            GeneratedFilesCommand::List => generated_files::list(),
+        },
         Commands::SrpMicrocrates { output } => srp_microcrates::run(output),
         Commands::UnwiredScan { json, check, lsp_crate } => {
             unwired_scan::run(UnwiredScanConfig { lsp_crate, json, check })

--- a/xtask/src/tasks/generated_files.rs
+++ b/xtask/src/tasks/generated_files.rs
@@ -1,0 +1,233 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Context, Result, bail};
+use glob::Pattern;
+use serde::{Deserialize, Serialize};
+
+use crate::utils::project_root;
+
+const GENERATED_MANIFEST: &str = ".ci/generated-files.toml";
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GeneratedManifest {
+    #[serde(default)]
+    generated: Vec<GeneratedRule>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GeneratedRule {
+    path: String,
+    command: String,
+    owner: String,
+    #[serde(default)]
+    allow_manual_edits: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct GeneratorReceipt {
+    owner: String,
+    command: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FixtureData {
+    #[serde(default)]
+    changed_files: Vec<String>,
+    #[serde(default)]
+    generator_receipts: Vec<GeneratorReceipt>,
+}
+
+#[derive(Debug, Serialize)]
+struct CheckReceipt {
+    verdict: String,
+    changed_files: Vec<String>,
+    expected_command: Vec<String>,
+    missing_receipts: Vec<String>,
+}
+
+pub fn list() -> Result<()> {
+    let root = project_root()?;
+    let manifest = read_manifest(&root)?;
+
+    for rule in manifest.generated {
+        println!(
+            "path={} owner={} command=\"{}\" allow_manual_edits={}",
+            rule.path, rule.owner, rule.command, rule.allow_manual_edits
+        );
+    }
+
+    Ok(())
+}
+
+pub fn check(
+    receipt: Option<PathBuf>,
+    fixture: Option<PathBuf>,
+    allow_missing_receipt: bool,
+) -> Result<()> {
+    let root = project_root()?;
+    let manifest = read_manifest(&root)?;
+    let receipt_path = receipt.unwrap_or_else(|| root.join("target/receipts/generated-files.json"));
+
+    let (changed_files, generator_receipts) = load_inputs(&root, fixture)?;
+
+    let changed_generated = collect_changed_generated_files(&manifest.generated, &changed_files)?;
+    let receipt_lookup: BTreeSet<(String, String)> = generator_receipts
+        .into_iter()
+        .map(|item| (item.owner, item.command))
+        .collect();
+
+    let mut missing_receipts = Vec::new();
+    let mut expected_commands = BTreeSet::new();
+
+    for (owner, command) in changed_generated.values() {
+        expected_commands.insert(command.clone());
+        if !receipt_lookup.contains(&(owner.clone(), command.clone())) {
+            missing_receipts.push(format!("{owner}:{command}"));
+        }
+    }
+
+    let verdict = if missing_receipts.is_empty() || allow_missing_receipt {
+        "pass"
+    } else {
+        "fail"
+    };
+
+    let receipt_payload = CheckReceipt {
+        verdict: verdict.to_string(),
+        changed_files: changed_generated.keys().cloned().collect(),
+        expected_command: expected_commands.into_iter().collect(),
+        missing_receipts: missing_receipts.clone(),
+    };
+
+    if let Some(parent) = receipt_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating receipt directory {}", parent.display()))?;
+    }
+
+    let receipt_json =
+        serde_json::to_string_pretty(&receipt_payload).context("serialize generated-file receipt")?;
+    fs::write(&receipt_path, receipt_json)
+        .with_context(|| format!("writing receipt {}", receipt_path.display()))?;
+
+    if verdict == "fail" {
+        bail!(
+            "generated file ownership check failed: missing receipts for {}",
+            missing_receipts.join(", ")
+        );
+    }
+
+    println!("generated-file ownership check passed");
+    Ok(())
+}
+
+fn collect_changed_generated_files(
+    rules: &[GeneratedRule],
+    changed_files: &[String],
+) -> Result<BTreeMap<String, (String, String)>> {
+    let mut matches = BTreeMap::new();
+
+    for file in changed_files {
+        for rule in rules {
+            if rule.allow_manual_edits {
+                continue;
+            }
+            let pattern = Pattern::new(&rule.path)
+                .with_context(|| format!("invalid generated file glob pattern: {}", rule.path))?;
+            if pattern.matches(file) {
+                matches.insert(file.clone(), (rule.owner.clone(), rule.command.clone()));
+            }
+        }
+    }
+
+    Ok(matches)
+}
+
+fn load_inputs(root: &Path, fixture: Option<PathBuf>) -> Result<(Vec<String>, Vec<GeneratorReceipt>)> {
+    if let Some(path) = fixture {
+        let fixture_path = resolve_path(root, &path);
+        let bytes = fs::read(&fixture_path)
+            .with_context(|| format!("reading fixture {}", fixture_path.display()))?;
+        let fixture_data: FixtureData = serde_json::from_slice(&bytes)
+            .with_context(|| format!("parsing fixture {}", fixture_path.display()))?;
+        return Ok((fixture_data.changed_files, fixture_data.generator_receipts));
+    }
+
+    let output = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(root)
+        .output()
+        .context("running git status --porcelain")?;
+
+    if !output.status.success() {
+        bail!("git status --porcelain exited with non-zero status");
+    }
+
+    let stdout = String::from_utf8(output.stdout).context("git output was not utf8")?;
+    let mut changed_files = Vec::new();
+
+    for line in stdout.lines() {
+        if line.len() < 4 {
+            continue;
+        }
+        let raw_path = &line[3..];
+        if let Some((_, renamed_to)) = raw_path.split_once(" -> ") {
+            changed_files.push(renamed_to.to_string());
+        } else {
+            changed_files.push(raw_path.to_string());
+        }
+    }
+
+    let generator_receipts = collect_generator_receipts_from_changed_files(root, &changed_files)?;
+
+    Ok((changed_files, generator_receipts))
+}
+
+fn resolve_path(root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    root.join(path)
+}
+
+fn read_manifest(root: &Path) -> Result<GeneratedManifest> {
+    let manifest_path = root.join(GENERATED_MANIFEST);
+    let content = fs::read_to_string(&manifest_path)
+        .with_context(|| format!("reading {}", manifest_path.display()))?;
+    let manifest: GeneratedManifest = toml::from_str(&content)
+        .with_context(|| format!("parsing {}", manifest_path.display()))?;
+    Ok(manifest)
+}
+
+fn collect_generator_receipts_from_changed_files(
+    root: &Path,
+    changed_files: &[String],
+) -> Result<Vec<GeneratorReceipt>> {
+    let mut receipts = Vec::new();
+    for path in changed_files {
+        if !path.ends_with(".json") {
+            continue;
+        }
+        let file_path = root.join(path);
+        if !file_path.exists() {
+            continue;
+        }
+        let bytes = fs::read(&file_path)
+            .with_context(|| format!("reading potential generator receipt {}", file_path.display()))?;
+        let parsed: serde_json::Value = match serde_json::from_slice(&bytes) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        if let Some(receipt) = parse_generator_receipt_value(&parsed) {
+            receipts.push(receipt);
+        }
+    }
+    Ok(receipts)
+}
+
+fn parse_generator_receipt_value(value: &serde_json::Value) -> Option<GeneratorReceipt> {
+    let owner = value.get("owner")?.as_str()?.to_string();
+    let command = value.get("command")?.as_str()?.to_string();
+    Some(GeneratorReceipt { owner, command })
+}

--- a/xtask/src/tasks/generated_files.rs
+++ b/xtask/src/tasks/generated_files.rs
@@ -73,10 +73,8 @@ pub fn check(
     let (changed_files, generator_receipts) = load_inputs(&root, fixture)?;
 
     let changed_generated = collect_changed_generated_files(&manifest.generated, &changed_files)?;
-    let receipt_lookup: BTreeSet<(String, String)> = generator_receipts
-        .into_iter()
-        .map(|item| (item.owner, item.command))
-        .collect();
+    let receipt_lookup: BTreeSet<(String, String)> =
+        generator_receipts.into_iter().map(|item| (item.owner, item.command)).collect();
 
     let mut missing_receipts = Vec::new();
     let mut expected_commands = BTreeSet::new();
@@ -88,11 +86,8 @@ pub fn check(
         }
     }
 
-    let verdict = if missing_receipts.is_empty() || allow_missing_receipt {
-        "pass"
-    } else {
-        "fail"
-    };
+    let verdict =
+        if missing_receipts.is_empty() || allow_missing_receipt { "pass" } else { "fail" };
 
     let receipt_payload = CheckReceipt {
         verdict: verdict.to_string(),
@@ -106,8 +101,8 @@ pub fn check(
             .with_context(|| format!("creating receipt directory {}", parent.display()))?;
     }
 
-    let receipt_json =
-        serde_json::to_string_pretty(&receipt_payload).context("serialize generated-file receipt")?;
+    let receipt_json = serde_json::to_string_pretty(&receipt_payload)
+        .context("serialize generated-file receipt")?;
     fs::write(&receipt_path, receipt_json)
         .with_context(|| format!("writing receipt {}", receipt_path.display()))?;
 
@@ -144,7 +139,10 @@ fn collect_changed_generated_files(
     Ok(matches)
 }
 
-fn load_inputs(root: &Path, fixture: Option<PathBuf>) -> Result<(Vec<String>, Vec<GeneratorReceipt>)> {
+fn load_inputs(
+    root: &Path,
+    fixture: Option<PathBuf>,
+) -> Result<(Vec<String>, Vec<GeneratorReceipt>)> {
     if let Some(path) = fixture {
         let fixture_path = resolve_path(root, &path);
         let bytes = fs::read(&fixture_path)
@@ -195,8 +193,8 @@ fn read_manifest(root: &Path) -> Result<GeneratedManifest> {
     let manifest_path = root.join(GENERATED_MANIFEST);
     let content = fs::read_to_string(&manifest_path)
         .with_context(|| format!("reading {}", manifest_path.display()))?;
-    let manifest: GeneratedManifest = toml::from_str(&content)
-        .with_context(|| format!("parsing {}", manifest_path.display()))?;
+    let manifest: GeneratedManifest =
+        toml::from_str(&content).with_context(|| format!("parsing {}", manifest_path.display()))?;
     Ok(manifest)
 }
 
@@ -213,8 +211,9 @@ fn collect_generator_receipts_from_changed_files(
         if !file_path.exists() {
             continue;
         }
-        let bytes = fs::read(&file_path)
-            .with_context(|| format!("reading potential generator receipt {}", file_path.display()))?;
+        let bytes = fs::read(&file_path).with_context(|| {
+            format!("reading potential generator receipt {}", file_path.display())
+        })?;
         let parsed: serde_json::Value = match serde_json::from_slice(&bytes) {
             Ok(value) => value,
             Err(_) => continue,

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -40,6 +40,7 @@ pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;
 pub mod gates;
+pub mod generated_files;
 pub mod github;
 pub mod hardening;
 #[cfg(feature = "parser-tasks")]

--- a/xtask/tests/fixtures/generated-files/missing-receipt.json
+++ b/xtask/tests/fixtures/generated-files/missing-receipt.json
@@ -1,0 +1,6 @@
+{
+  "changed_files": [
+    "docs/project/status/tests.md"
+  ],
+  "generator_receipts": []
+}

--- a/xtask/tests/fixtures/generated-files/with-receipt.json
+++ b/xtask/tests/fixtures/generated-files/with-receipt.json
@@ -1,0 +1,11 @@
+{
+  "changed_files": [
+    "docs/project/status/tests.md"
+  ],
+  "generator_receipts": [
+    {
+      "owner": "status-docs",
+      "command": "cargo xtask status-docs"
+    }
+  ]
+}

--- a/xtask/tests/generated_files_cli.rs
+++ b/xtask/tests/generated_files_cli.rs
@@ -1,0 +1,49 @@
+use std::path::Path;
+
+use anyhow::Result;
+use assert_cmd::cargo::cargo_bin_cmd;
+
+#[test]
+fn generated_file_check_fails_without_receipt_fixture() -> Result<()> {
+    let fixture = fixture_path("missing-receipt.json");
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd
+        .arg("generated-files")
+        .arg("check")
+        .arg("--fixture")
+        .arg(&fixture)
+        .arg("--receipt")
+        .arg("target/receipts/generated-files-test-fail.json")
+        .output()?;
+
+    assert!(!output.status.success());
+    Ok(())
+}
+
+#[test]
+fn generated_file_check_passes_with_receipt_fixture() -> Result<()> {
+    let fixture = fixture_path("with-receipt.json");
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd
+        .arg("generated-files")
+        .arg("check")
+        .arg("--fixture")
+        .arg(&fixture)
+        .arg("--receipt")
+        .arg("target/receipts/generated-files-test-pass.json")
+        .output()?;
+
+    assert!(output.status.success());
+    Ok(())
+}
+
+fn fixture_path(name: &str) -> String {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap_or_else(|| Path::new("."));
+    root.join("xtask")
+        .join("tests")
+        .join("fixtures")
+        .join("generated-files")
+        .join(name)
+        .display()
+        .to_string()
+}


### PR DESCRIPTION
### Motivation

- Refs #6853: prevent hand-edits of generated status/docs without an accompanying generator receipt to improve ownership and diff-audit routing.
- Protects generated artifacts (initial scope: `docs/project/status/**`) from accidental/manual edits unless the generator provides proof of intent.

### Description

- Added a generated-file manifest at `.ci/generated-files.toml` declaring protected patterns and owners. 
- Implemented `xtask` support in `xtask/src/tasks/generated_files.rs` with `list` and `check` commands, fixture support, receipt discovery, and emitted check receipt (`verdict`, `changed_files`, `expected_command`, `missing_receipts`).
- Wired CLI commands as `cargo xtask generated-files {list,check}` and registered the task in `xtask/src/tasks/mod.rs` and `xtask/src/main.rs`.
- Added JSON Schema for emitted receipts at `.ci/receipts/schemas/generated-files.schema.json`, documentation at `docs/ci/generated-file-policy.md`, test fixtures under `xtask/tests/fixtures/generated-files/`, and integration tests `xtask/tests/generated_files_cli.rs`.
- Added `glob = "0.3.3"` dependency to `xtask/Cargo.toml` for manifest glob matching.

### Testing

- Ran `cargo check -p xtask` which completed successfully. 
- Verified CLI behavior using fixtures: `cargo xtask generated-files check --fixture xtask/tests/fixtures/generated-files/missing-receipt.json --receipt target/receipts/generated-files.json` produced the expected failure for missing generator receipt. 
- Verified receipt acceptance using fixture: `cargo xtask generated-files check --fixture xtask/tests/fixtures/generated-files/with-receipt.json --receipt target/receipts/generated-files.json` passed. 
- Verified listing with `cargo xtask generated-files list` and ran `cargo test -p xtask generated_file_check -- --nocapture`, with the new generated-file CLI tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd088a28083339e22afb3d2e8fec9)