### PR TITLE
feat(generated): add generated-file ownership check (#6853)

### DIFF
--- a/.ci/generated-files.toml
+++ b/.ci/generated-files.toml
@@ -1,0 +1,5 @@
+[[generated]]
+path = "docs/project/status/**"
+command = "cargo xtask status-docs"
+owner = "status-docs"
+allow_manual_edits = false

--- a/.ci/receipts/schemas/generated-files.schema.json
+++ b/.ci/receipts/schemas/generated-files.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/generated-files.schema.json",
+  "title": "Generated File Ownership Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "verdict",
+    "changed_files",
+    "expected_command",
+    "missing_receipts"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "fail", "override"]
+    },
+    "changed_files": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "expected_command": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "missing_receipts": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3860,6 +3860,7 @@ dependencies = [
  "console",
  "duct",
  "flate2",
+ "glob",
  "indicatif",
  "notify",
  "peak_alloc",

--- a/crates/perl-lsp-rs/src/features/implementation_provider.rs
+++ b/crates/perl-lsp-rs/src/features/implementation_provider.rs
@@ -317,7 +317,8 @@ impl ImplementationProvider {
         match &node.kind {
             NodeKind::Subroutine { name: Some(name), .. } => {
                 let (_, name_bare) = perl_parser::qualified_name::split_qualified_name(name);
-                let (_, method_bare) = perl_parser::qualified_name::split_qualified_name(method_name);
+                let (_, method_bare) =
+                    perl_parser::qualified_name::split_qualified_name(method_name);
                 if name_bare == method_bare {
                     let target_uri = parse_uri(uri);
                     results.push(LocationLink {

--- a/crates/perl-lsp-rs/src/runtime/language/hover.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover.rs
@@ -1725,7 +1725,8 @@ impl LspServer {
                 }
             }
             NodeKind::Method { name: method_name, .. } => {
-                let (_, method_bare) = perl_parser::qualified_name::split_qualified_name(method_name);
+                let (_, method_bare) =
+                    perl_parser::qualified_name::split_qualified_name(method_name);
                 let (_, name_bare) = perl_parser::qualified_name::split_qualified_name(name);
                 if method_bare == name_bare {
                     return Some(node);

--- a/crates/perl-lsp-rs/src/runtime/symbol_extraction.rs
+++ b/crates/perl-lsp-rs/src/runtime/symbol_extraction.rs
@@ -314,7 +314,10 @@ impl LspServer {
             }
 
             NodeKind::FunctionCall { name, args } => {
-                if symbol_kind == "subroutine" && perl_parser::qualified_name::split_qualified_name(name).1 == perl_parser::qualified_name::split_qualified_name(symbol_name).1 {
+                if symbol_kind == "subroutine"
+                    && perl_parser::qualified_name::split_qualified_name(name).1
+                        == perl_parser::qualified_name::split_qualified_name(symbol_name).1
+                {
                     count += 1;
                 }
                 for arg in args {
@@ -323,7 +326,10 @@ impl LspServer {
             }
 
             NodeKind::MethodCall { object, method, args } => {
-                if symbol_kind == "subroutine" && perl_parser::qualified_name::split_qualified_name(method).1 == perl_parser::qualified_name::split_qualified_name(symbol_name).1 {
+                if symbol_kind == "subroutine"
+                    && perl_parser::qualified_name::split_qualified_name(method).1
+                        == perl_parser::qualified_name::split_qualified_name(symbol_name).1
+                {
                     count += 1;
                 }
                 count += self.count_references(object, symbol_name, symbol_kind);
@@ -385,7 +391,9 @@ impl LspServer {
                 // Check if this is a reference to a subroutine (\&function)
                 if op == "\\" && symbol_kind == "subroutine" {
                     if let NodeKind::Identifier { name } = &operand.kind {
-                        if perl_parser::qualified_name::split_qualified_name(name).1 == perl_parser::qualified_name::split_qualified_name(symbol_name).1 {
+                        if perl_parser::qualified_name::split_qualified_name(name).1
+                            == perl_parser::qualified_name::split_qualified_name(symbol_name).1
+                        {
                             count += 1;
                         }
                     }

--- a/crates/perl-lsp-ux-tests/src/scorecard.rs
+++ b/crates/perl-lsp-ux-tests/src/scorecard.rs
@@ -155,10 +155,7 @@ mod tests {
             definition_exact_hit: def,
             symbol_correct: sym,
             cross_file_success: cross,
-            mean_latency_ms: latency
-                .iter()
-                .map(|(k, v)| ((*k).to_string(), *v))
-                .collect(),
+            mean_latency_ms: latency.iter().map(|(k, v)| ((*k).to_string(), *v)).collect(),
             ..Default::default()
         }
     }
@@ -167,12 +164,22 @@ mod tests {
     fn aggregate_editor_ux_scorecard_computes_expected_rows() -> Result<()> {
         let s1 = make_score(
             "hover-and-def",
-            Some(true), Some(false), Some(true), Some(true), Some(true), Some(true),
+            Some(true),
+            Some(false),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
             &[("hover", 12.0), ("completion", 20.0), ("definition", 30.0)],
         );
         let s2 = make_score(
             "completion-and-cross-file",
-            Some(false), Some(true), Some(true), Some(false), Some(false), Some(true),
+            Some(false),
+            Some(true),
+            Some(true),
+            Some(false),
+            Some(false),
+            Some(true),
             &[("hover", 8.0), ("completion", 40.0), ("workspace_symbols", 50.0)],
         );
 
@@ -203,7 +210,12 @@ mod tests {
     fn aggregate_editor_ux_scorecard_uses_none_when_metric_not_measured() -> Result<()> {
         let s = make_score(
             "symbols-only",
-            None, None, None, None, None, None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
             &[("document_symbols", 18.0)],
         );
 
@@ -275,7 +287,12 @@ mod tests {
     fn all_false_correctness_produces_zero_pct() -> Result<()> {
         let s = make_score(
             "all-fail",
-            Some(false), Some(false), Some(false), Some(false), Some(false), Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(false),
             &[],
         );
 
@@ -295,7 +312,12 @@ mod tests {
     fn single_scenario_all_true_produces_100_pct() -> Result<()> {
         let s = make_score(
             "all-pass",
-            Some(true), Some(true), Some(true), Some(true), Some(true), Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true),
             &[("hover", 15.0), ("completion", 25.0)],
         );
 
@@ -326,7 +348,10 @@ mod tests {
         let scorecard = aggregate_editor_ux_scorecard(&scenarios);
 
         let pct = scorecard.symbol_correctness_pct;
-        assert!(pct.is_some_and(|v| (v - 66.666_666).abs() < 0.01), "expected ~66.67%, got {pct:?}");
+        assert!(
+            pct.is_some_and(|v| (v - 66.666_666).abs() < 0.01),
+            "expected ~66.67%, got {pct:?}"
+        );
 
         Ok(())
     }

--- a/docs/ci/generated-file-policy.md
+++ b/docs/ci/generated-file-policy.md
@@ -1,0 +1,30 @@
+# Generated File Ownership Policy
+
+`cargo xtask generated-files` enforces ownership for generated paths declared in `.ci/generated-files.toml`.
+
+## Why this exists
+
+Generated status/docs files can drift when hand-edited without the corresponding generator run receipt. This command keeps ownership checks narrow to declared generated paths and avoids blocking hand-authored forensics docs.
+
+## Commands
+
+- `cargo xtask generated-files list`
+- `cargo xtask generated-files check --receipt target/receipts/generated-files.json`
+
+## Check behavior
+
+- Detects changed files from git by default.
+- Supports `--fixture <path>` for deterministic tests.
+- Fails when changed generated files are missing a matching generator receipt, unless `--allow-manual-edits` is provided.
+- Writes a receipt with `verdict`, `changed_files`, `expected_command`, and `missing_receipts`.
+- Does not run generators automatically.
+
+## Manifest format
+
+```toml
+[[generated]]
+path = "docs/project/status/**"
+command = "cargo xtask status-docs"
+owner = "status-docs"
+allow_manual_edits = false
+```

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -42,6 +42,7 @@ notify = "8.2.0"
 flate2 = "1.1.5"
 tar = "0.4.44"
 tempfile.workspace = true
+glob = "0.3.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.18.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1276,6 +1276,37 @@ enum Commands {
         /// Current receipt JSON path.
         current: PathBuf,
     },
+
+    /// Validate generated-file ownership and associated receipts.
+    GeneratedFiles {
+        #[command(subcommand)]
+        command: GeneratedFilesCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum GeneratedFilesCommand {
+    /// List generated-file ownership rules.
+    List {
+        /// Optional fixture JSON for deterministic tests.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+    },
+    /// Check changed generated files for matching generator receipts.
+    Check {
+        /// Path where generated-file receipt JSON is written.
+        #[arg(long, default_value = "target/receipts/generated-files.json")]
+        receipt: PathBuf,
+        /// Optional fixture JSON for deterministic tests.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+        /// Path(s) to generator receipt JSON artifacts.
+        #[arg(long = "generator-receipt")]
+        generator_receipt: Vec<PathBuf>,
+        /// Explicit override for manual edits in this run.
+        #[arg(long)]
+        allow_manual_edits: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2070,6 +2101,15 @@ fn main() -> Result<()> {
         Commands::CompareBuildTiming { baseline, current } => {
             build_timing::run_compare(baseline, current)
         }
+        Commands::GeneratedFiles { command } => match command {
+            GeneratedFilesCommand::List { fixture } => generated_files::list(fixture),
+            GeneratedFilesCommand::Check {
+                receipt,
+                fixture,
+                generator_receipt,
+                allow_manual_edits,
+            } => generated_files::check(receipt, fixture, generator_receipt, allow_manual_edits),
+        },
     }
 }
 

--- a/xtask/src/tasks/generated_files.rs
+++ b/xtask/src/tasks/generated_files.rs
@@ -1,0 +1,268 @@
+//! Generated-file ownership checks.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Result, bail, eyre};
+use glob::Pattern;
+use serde::{Deserialize, Serialize};
+
+use crate::utils::project_root;
+
+const MANIFEST_PATH: &str = ".ci/generated-files.toml";
+
+#[derive(Debug, Deserialize)]
+struct GeneratedManifest {
+    generated: Vec<GeneratedEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GeneratedEntry {
+    path: String,
+    command: String,
+    owner: String,
+    #[serde(default)]
+    allow_manual_edits: bool,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct FixtureInput {
+    #[serde(default)]
+    changed_files: Vec<String>,
+    #[serde(default)]
+    receipts: Vec<GeneratorReceipt>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GeneratorReceipt {
+    owner: String,
+    command: String,
+}
+
+#[derive(Debug, Serialize)]
+struct GeneratedFilesReceipt {
+    schema_version: u8,
+    verdict: String,
+    changed_files: Vec<String>,
+    expected_command: Vec<String>,
+    missing_receipts: Vec<String>,
+}
+
+pub fn list(fixture: Option<PathBuf>) -> Result<()> {
+    let manifest = load_manifest()?;
+    let changed_files = load_changed_files(fixture)?;
+
+    for entry in &manifest.generated {
+        println!("{} => {} ({})", entry.path, entry.command, entry.owner);
+    }
+
+    if !changed_files.is_empty() {
+        println!("\nchanged files:");
+        for file in changed_files {
+            println!("- {file}");
+        }
+    }
+
+    Ok(())
+}
+
+pub fn check(
+    receipt_path: PathBuf,
+    fixture: Option<PathBuf>,
+    generator_receipt: Vec<PathBuf>,
+    allow_manual_edits: bool,
+) -> Result<()> {
+    let manifest = load_manifest()?;
+    let fixture_input = load_fixture_input(fixture)?;
+    let mut available_receipts = fixture_input.receipts;
+    available_receipts.extend(load_generator_receipts(&generator_receipt)?);
+
+    let changed_files = if fixture_input.changed_files.is_empty() {
+        detect_changed_files_from_git()?
+    } else {
+        fixture_input.changed_files
+    };
+
+    let mut expected_commands = BTreeSet::new();
+    let mut missing_receipts = BTreeSet::new();
+    let mut override_used = false;
+
+    for changed_file in &changed_files {
+        for entry in &manifest.generated {
+            if !matches_pattern(&entry.path, changed_file)? {
+                continue;
+            }
+
+            expected_commands.insert(entry.command.clone());
+
+            if entry.allow_manual_edits {
+                continue;
+            }
+            if allow_manual_edits {
+                override_used = true;
+                continue;
+            }
+
+            let has_receipt = available_receipts
+                .iter()
+                .any(|receipt| receipt.owner == entry.owner || receipt.command == entry.command);
+
+            if !has_receipt {
+                missing_receipts.insert(entry.owner.clone());
+            }
+        }
+    }
+
+    let verdict = if !missing_receipts.is_empty() {
+        "fail"
+    } else if override_used {
+        "override"
+    } else {
+        "pass"
+    };
+
+    let receipt = GeneratedFilesReceipt {
+        schema_version: 1,
+        verdict: verdict.to_string(),
+        changed_files,
+        expected_command: expected_commands.into_iter().collect(),
+        missing_receipts: missing_receipts.into_iter().collect(),
+    };
+
+    write_receipt(&receipt_path, &receipt)?;
+
+    if receipt.verdict == "fail" {
+        bail!(
+            "generated-files ownership check failed: missing receipts for {:?}",
+            receipt.missing_receipts
+        );
+    }
+
+    println!("generated-files verdict: {}", receipt.verdict);
+    Ok(())
+}
+
+fn load_manifest() -> Result<GeneratedManifest> {
+    let root = project_root()?;
+    let manifest_path = root.join(MANIFEST_PATH);
+    let raw = fs::read_to_string(&manifest_path)?;
+    let parsed: GeneratedManifest = toml::from_str(&raw)
+        .map_err(|err| eyre!("failed to parse {}: {err}", manifest_path.to_string_lossy()))?;
+    Ok(parsed)
+}
+
+fn load_changed_files(fixture: Option<PathBuf>) -> Result<Vec<String>> {
+    let fixture_input = load_fixture_input(fixture)?;
+    if fixture_input.changed_files.is_empty() {
+        detect_changed_files_from_git()
+    } else {
+        Ok(fixture_input.changed_files)
+    }
+}
+
+fn load_fixture_input(fixture: Option<PathBuf>) -> Result<FixtureInput> {
+    match fixture {
+        Some(path) => {
+            let raw = fs::read_to_string(path)?;
+            let parsed = serde_json::from_str::<FixtureInput>(&raw)?;
+            Ok(parsed)
+        }
+        None => Ok(FixtureInput::default()),
+    }
+}
+
+fn load_generator_receipts(paths: &[PathBuf]) -> Result<Vec<GeneratorReceipt>> {
+    let mut receipts = Vec::new();
+    for path in paths {
+        let raw = fs::read_to_string(path)?;
+        let value: serde_json::Value = serde_json::from_str(&raw)?;
+        receipts.extend(parse_receipt_value(&value)?);
+    }
+    Ok(receipts)
+}
+
+fn parse_receipt_value(value: &serde_json::Value) -> Result<Vec<GeneratorReceipt>> {
+    if let Ok(single) = serde_json::from_value::<GeneratorReceipt>(value.clone()) {
+        return Ok(vec![single]);
+    }
+
+    if let Ok(list) = serde_json::from_value::<Vec<GeneratorReceipt>>(value.clone()) {
+        return Ok(list);
+    }
+
+    if let Some(array) = value.get("receipts") {
+        let list: Vec<GeneratorReceipt> = serde_json::from_value(array.clone())?;
+        return Ok(list);
+    }
+
+    bail!("unsupported generator receipt JSON format")
+}
+
+fn detect_changed_files_from_git() -> Result<Vec<String>> {
+    let root = project_root()?;
+    let diff = std::process::Command::new("git")
+        .arg("diff")
+        .arg("--name-only")
+        .current_dir(&root)
+        .output()?;
+
+    if !diff.status.success() {
+        bail!("git diff --name-only failed")
+    }
+
+    let mut files = parse_lines_to_set(&String::from_utf8(diff.stdout)?);
+
+    let staged = std::process::Command::new("git")
+        .arg("diff")
+        .arg("--name-only")
+        .arg("--cached")
+        .current_dir(&root)
+        .output()?;
+
+    if staged.status.success() {
+        files.extend(parse_lines_to_set(&String::from_utf8(staged.stdout)?));
+    }
+
+    let untracked = std::process::Command::new("git")
+        .arg("ls-files")
+        .arg("--others")
+        .arg("--exclude-standard")
+        .current_dir(&root)
+        .output()?;
+
+    if untracked.status.success() {
+        files.extend(parse_lines_to_set(&String::from_utf8(untracked.stdout)?));
+    }
+
+    let mut sorted: Vec<String> = files.into_iter().collect();
+    sorted.sort();
+    Ok(sorted)
+}
+
+fn parse_lines_to_set(raw: &str) -> BTreeSet<String> {
+    raw.lines().map(str::trim).filter(|line| !line.is_empty()).map(ToString::to_string).collect()
+}
+
+fn matches_pattern(pattern: &str, candidate: &str) -> Result<bool> {
+    let compiled = Pattern::new(pattern)?;
+    Ok(compiled.matches(candidate))
+}
+
+fn write_receipt(path: &Path, receipt: &GeneratedFilesReceipt) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let payload = serde_json::json!({
+        "$schema": ".ci/receipts/schemas/generated-files.schema.json",
+        "schema_version": receipt.schema_version,
+        "verdict": receipt.verdict,
+        "changed_files": receipt.changed_files,
+        "expected_command": receipt.expected_command,
+        "missing_receipts": receipt.missing_receipts,
+    });
+
+    fs::write(path, serde_json::to_string_pretty(&payload)?)?;
+    Ok(())
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -45,6 +45,7 @@ pub mod forbid_fatal_constructs;
 pub mod forensics;
 pub mod gate_receipts;
 pub mod gates;
+pub mod generated_files;
 pub mod github;
 pub mod hardening;
 #[cfg(feature = "parser-tasks")]

--- a/xtask/src/tasks/ux_scorecard.rs
+++ b/xtask/src/tasks/ux_scorecard.rs
@@ -425,8 +425,16 @@ mod tests {
 
     #[test]
     fn computes_percentiles() {
-        let rows =
-            vec![measurement("s1", None, None, None, None, None, None, &[("hover", vec![10, 20, 30, 40])])];
+        let rows = vec![measurement(
+            "s1",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &[("hover", vec![10, 20, 30, 40])],
+        )];
 
         let latency = compute_latency_percentiles(&rows);
         let hover = latency.get("hover").expect("hover present");
@@ -437,7 +445,13 @@ mod tests {
     #[test]
     fn single_sample_latency_p50_equals_p95() {
         let rows = vec![measurement(
-            "single", None, None, None, None, None, None,
+            "single",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
             &[("definition", vec![42])],
         )];
         let latency = compute_latency_percentiles(&rows);
@@ -450,7 +464,13 @@ mod tests {
     fn two_sample_latency_percentiles() {
         // [10, 90]: p50 rank=(2-1)*0.5=0.5→1, samples[1]=90; p95 rank=(2-1)*0.95=0.95→1, samples[1]=90
         let rows = vec![measurement(
-            "two", None, None, None, None, None, None,
+            "two",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
             &[("hover", vec![10, 90])],
         )];
         let latency = compute_latency_percentiles(&rows);

--- a/xtask/tests/fixtures/generated-files/changed-with-receipt.json
+++ b/xtask/tests/fixtures/generated-files/changed-with-receipt.json
@@ -1,0 +1,11 @@
+{
+  "changed_files": [
+    "docs/project/status/sample-status.md"
+  ],
+  "receipts": [
+    {
+      "owner": "status-docs",
+      "command": "cargo xtask status-docs"
+    }
+  ]
+}

--- a/xtask/tests/fixtures/generated-files/changed-without-receipt.json
+++ b/xtask/tests/fixtures/generated-files/changed-without-receipt.json
@@ -1,0 +1,6 @@
+{
+  "changed_files": [
+    "docs/project/status/sample-status.md"
+  ],
+  "receipts": []
+}

--- a/xtask/tests/fixtures/generated-files/no-generated-changes.json
+++ b/xtask/tests/fixtures/generated-files/no-generated-changes.json
@@ -1,0 +1,6 @@
+{
+  "changed_files": [
+    "docs/ci/generated-file-policy.md"
+  ],
+  "receipts": []
+}

--- a/xtask/tests/generated_files_cli.rs
+++ b/xtask/tests/generated_files_cli.rs
@@ -1,0 +1,51 @@
+//! Integration tests for `cargo xtask generated-files`.
+
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use color_eyre::eyre::Result;
+
+fn fixture_path(name: &str) -> Result<PathBuf> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    Ok(manifest_dir.join("tests/fixtures/generated-files").join(name))
+}
+
+#[test]
+fn generated_file_changed_without_receipt_fails() -> Result<()> {
+    let fixture = fixture_path("changed-without-receipt.json")?;
+    let receipt = tempfile::NamedTempFile::new()?;
+
+    Command::cargo_bin("xtask")?
+        .args([
+            "generated-files",
+            "check",
+            "--fixture",
+            fixture.to_string_lossy().as_ref(),
+            "--receipt",
+            receipt.path().to_string_lossy().as_ref(),
+        ])
+        .assert()
+        .failure();
+
+    Ok(())
+}
+
+#[test]
+fn generated_file_changed_with_receipt_passes() -> Result<()> {
+    let fixture = fixture_path("changed-with-receipt.json")?;
+    let receipt = tempfile::NamedTempFile::new()?;
+
+    Command::cargo_bin("xtask")?
+        .args([
+            "generated-files",
+            "check",
+            "--fixture",
+            fixture.to_string_lossy().as_ref(),
+            "--receipt",
+            receipt.path().to_string_lossy().as_ref(),
+        ])
+        .assert()
+        .success();
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Prevent hand-edits of generated docs/status files from bypassing the generating tool by requiring a matching generator receipt for declared generated paths.
- Keep checks narrow to explicitly-declared paths so hand-authored forensics/docs are not blocked and generators are not run automatically.

### Description

- Add a manifest `.ci/generated-files.toml` and a JSON Schema `.ci/receipts/schemas/generated-files.schema.json` to declare owned generated paths and the expected generator command/owner. 
- Implement `cargo xtask generated-files` with `list` and `check` flows in `xtask/src/tasks/generated_files.rs`, including git-based changed-file detection, fixture-support (`--fixture`), generator-receipt ingestion (`--generator-receipt`), explicit override (`--allow-manual-edits`), and receipt emission (`verdict`, `changed_files`, `expected_command`, `missing_receipts`).
- Wire the command into the xtask CLI (`xtask/src/main.rs`, `xtask/src/tasks/mod.rs`) and add the `glob` dependency to `xtask/Cargo.toml` for pattern matching.
- Add policy documentation at `docs/ci/generated-file-policy.md` and fixture-backed integration tests plus fixtures at `xtask/tests/generated_files_cli.rs` and `xtask/tests/fixtures/generated-files/*.json`.

### Testing

- Ran `cargo check -p xtask` which completed successfully. 
- Ran the integration tests `cargo test -p xtask --test generated_files_cli` and both fixture cases (changed-without-receipt fails, changed-with-receipt passes) passed. 
- Exercised the CLI manually: `cargo xtask generated-files list` and `cargo xtask generated-files check --receipt target/receipts/generated-files.json` both succeeded and produced a receipt with `verdict: pass`. 
- Formatting and lint gates passed: `cargo xtask fmt` and `cargo clippy -p xtask -- -D warnings` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd088a28083339e22afb3d2e8fec9)