### PR TITLE
feat(generated): add generated-file ownership check (#6853)

### DIFF
--- a/.ci/generated-files.toml
+++ b/.ci/generated-files.toml
@@ -1,0 +1,5 @@
+[[generated]]
+path = "docs/project/status/**"
+command = "cargo xtask status-docs"
+owner = "status-docs"
+allow_manual_edits = false

--- a/.ci/receipts/schemas/generated-files.schema.json
+++ b/.ci/receipts/schemas/generated-files.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/schemas/generated-files.schema.json",
+  "title": "Generated File Ownership Receipt",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "verdict",
+    "changed_files",
+    "expected_command",
+    "missing_receipts"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "fail"]
+    },
+    "changed_files": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "expected_command": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "missing_receipts": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/ci/generated-file-policy.md
+++ b/docs/ci/generated-file-policy.md
@@ -1,0 +1,25 @@
+# Generated-file ownership policy
+
+`cargo xtask generated-files` enforces ownership for generated files declared in `.ci/generated-files.toml`.
+
+## Commands
+
+- `cargo xtask generated-files list`
+- `cargo xtask generated-files check --receipt target/receipts/generated-files.json`
+
+`check` inspects changed files, matches them against configured generated-file globs, and fails when ownership receipts are missing.
+
+## Receipt shape
+
+`check` writes a JSON receipt with:
+
+- `verdict`
+- `changed_files`
+- `expected_command`
+- `missing_receipts`
+
+The command does not run generators automatically. Use explicit generator commands and rerun the check.
+
+## Test fixtures
+
+Integration tests can use `--fixture <path>` to provide deterministic changed-files and receipt-owner inputs.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -901,6 +901,12 @@ enum Commands {
         command: FeaturesCommand,
     },
 
+    /// Enforce generated-file ownership policy.
+    GeneratedFiles {
+        #[command(subcommand)]
+        command: GeneratedFilesCommand,
+    },
+
     /// Update derived metrics in docs/project/status/ subsystem files.
     ///
     /// Computes workspace test counts, ignored test counts, feature catalog
@@ -1232,6 +1238,31 @@ enum FeaturesCommand {
 
     /// Generate compliance report
     Report,
+}
+
+#[derive(Subcommand)]
+enum GeneratedFilesCommand {
+    /// Check whether generated files were changed without matching receipts.
+    Check {
+        /// Optional path to generated-files manifest.
+        #[arg(long)]
+        manifest: Option<PathBuf>,
+        /// Path where the check receipt JSON will be written.
+        #[arg(long)]
+        receipt: PathBuf,
+        /// Explicit override that permits manual edits for this run.
+        #[arg(long)]
+        allow_manual_edits: bool,
+        /// Fixture JSON (tests only): bypass git discovery with canned inputs.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+    },
+    /// Print configured generated-file ownership rules.
+    List {
+        /// Optional path to generated-files manifest.
+        #[arg(long)]
+        manifest: Option<PathBuf>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1597,6 +1628,12 @@ fn main() -> Result<()> {
             FeaturesCommand::Verify => features::verify(),
             FeaturesCommand::Invariants => features::invariants(),
             FeaturesCommand::Report => features::report(),
+        },
+        Commands::GeneratedFiles { command } => match command {
+            GeneratedFilesCommand::Check { manifest, receipt, allow_manual_edits, fixture } => {
+                generated_files::check(manifest, receipt, allow_manual_edits, fixture)
+            }
+            GeneratedFilesCommand::List { manifest } => generated_files::list(manifest),
         },
         Commands::UpdateStatus { write, check, only } => update_status::run(write, check, only),
         Commands::SrpMicrocrates { output } => srp_microcrates::run(output),

--- a/xtask/src/tasks/generated_files.rs
+++ b/xtask/src/tasks/generated_files.rs
@@ -1,0 +1,187 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_MANIFEST: &str = ".ci/generated-files.toml";
+
+#[derive(Debug, Deserialize)]
+struct GeneratedManifest {
+    generated: Vec<GeneratedRule>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct GeneratedRule {
+    path: String,
+    command: String,
+    owner: String,
+    #[serde(default)]
+    allow_manual_edits: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct CheckReceipt {
+    schema_version: u32,
+    verdict: String,
+    changed_files: Vec<String>,
+    expected_command: Vec<String>,
+    missing_receipts: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureInput {
+    changed_files: Vec<String>,
+    #[serde(default)]
+    receipt_owners: Vec<String>,
+}
+
+pub fn check(
+    manifest_path: Option<PathBuf>,
+    receipt_path: PathBuf,
+    allow_manual_edits_override: bool,
+    fixture: Option<PathBuf>,
+) -> Result<()> {
+    let root = crate::utils::project_root()?;
+    let manifest_path = manifest_path.unwrap_or_else(|| root.join(DEFAULT_MANIFEST));
+    let manifest = read_manifest(&manifest_path)?;
+
+    let (changed_files, receipt_owners) = if let Some(fixture_path) = fixture {
+        let fixture = read_fixture(&fixture_path)?;
+        (fixture.changed_files, fixture.receipt_owners.into_iter().collect::<BTreeSet<_>>())
+    } else {
+        (collect_git_changed_files()?, BTreeSet::new())
+    };
+
+    let mut missing_receipts = BTreeSet::new();
+    let mut expected_commands = BTreeSet::new();
+
+    for changed_file in &changed_files {
+        for rule in &manifest.generated {
+            if !path_matches_rule(changed_file, &rule.path) {
+                continue;
+            }
+            if allow_manual_edits_override || rule.allow_manual_edits {
+                continue;
+            }
+            if !receipt_owners.contains(&rule.owner) {
+                missing_receipts.insert(rule.owner.clone());
+                expected_commands.insert(rule.command.clone());
+            }
+        }
+    }
+
+    let verdict = if missing_receipts.is_empty() { "pass" } else { "fail" };
+    let receipt = CheckReceipt {
+        schema_version: 1,
+        verdict: verdict.to_string(),
+        changed_files,
+        expected_command: expected_commands.into_iter().collect(),
+        missing_receipts: missing_receipts.into_iter().collect(),
+    };
+
+    if let Some(parent) = receipt_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating receipt directory {}", parent.display()))?;
+    }
+    let payload =
+        serde_json::to_string_pretty(&receipt).context("serializing generated file receipt")?;
+    fs::write(&receipt_path, format!("{payload}\n"))
+        .with_context(|| format!("writing {}", receipt_path.display()))?;
+
+    if receipt.verdict == "fail" {
+        bail!(
+            "generated-file ownership check failed: missing receipts for owners [{}]",
+            receipt.missing_receipts.join(", ")
+        );
+    }
+
+    Ok(())
+}
+
+pub fn list(manifest_path: Option<PathBuf>) -> Result<()> {
+    let root = crate::utils::project_root()?;
+    let manifest_path = manifest_path.unwrap_or_else(|| root.join(DEFAULT_MANIFEST));
+    let manifest = read_manifest(&manifest_path)?;
+
+    for rule in manifest.generated {
+        println!(
+            "{}\t{}\t{}\tallow_manual_edits={}",
+            rule.owner, rule.path, rule.command, rule.allow_manual_edits
+        );
+    }
+
+    Ok(())
+}
+
+fn read_manifest(path: &Path) -> Result<GeneratedManifest> {
+    let raw =
+        fs::read_to_string(path).with_context(|| format!("reading manifest {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("parsing manifest {}", path.display()))
+}
+
+fn read_fixture(path: &Path) -> Result<FixtureInput> {
+    let raw =
+        fs::read_to_string(path).with_context(|| format!("reading fixture {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("parsing fixture {}", path.display()))
+}
+
+fn collect_git_changed_files() -> Result<Vec<String>> {
+    let mut changed = BTreeSet::new();
+
+    collect_from_command(&["diff", "--name-only"])?.into_iter().for_each(|path| {
+        changed.insert(path);
+    });
+    collect_from_command(&["diff", "--name-only", "--cached"])?.into_iter().for_each(|path| {
+        changed.insert(path);
+    });
+    collect_from_command(&["ls-files", "--others", "--exclude-standard"])?.into_iter().for_each(
+        |path| {
+            changed.insert(path);
+        },
+    );
+
+    Ok(changed.into_iter().collect())
+}
+
+fn collect_from_command(args: &[&str]) -> Result<Vec<String>> {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .output()
+        .with_context(|| format!("running git {}", args.join(" ")))?;
+    if !output.status.success() {
+        bail!("git {} failed: {}", args.join(" "), String::from_utf8_lossy(&output.stderr));
+    }
+
+    let stdout = String::from_utf8(output.stdout).context("git output was not UTF-8")?;
+    Ok(stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect())
+}
+
+fn path_matches_rule(file_path: &str, rule_path: &str) -> bool {
+    if let Some(prefix) = rule_path.strip_suffix("**") {
+        return file_path.starts_with(prefix);
+    }
+
+    file_path == rule_path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::path_matches_rule;
+
+    #[test]
+    fn matches_recursive_prefix_rules() {
+        assert!(path_matches_rule("docs/project/status/parser.md", "docs/project/status/**"));
+    }
+
+    #[test]
+    fn does_not_match_outside_prefix() {
+        assert!(!path_matches_rule("docs/project/ROADMAP.md", "docs/project/status/**"));
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -40,6 +40,7 @@ pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;
 pub mod gates;
+pub mod generated_files;
 pub mod github;
 pub mod hardening;
 #[cfg(feature = "parser-tasks")]

--- a/xtask/tests/fixtures/generated-files/changed-with-receipt.json
+++ b/xtask/tests/fixtures/generated-files/changed-with-receipt.json
@@ -1,0 +1,6 @@
+{
+  "changed_files": [
+    "docs/project/status/parser.md"
+  ],
+  "receipt_owners": ["status-docs"]
+}

--- a/xtask/tests/fixtures/generated-files/changed-without-receipt.json
+++ b/xtask/tests/fixtures/generated-files/changed-without-receipt.json
@@ -1,0 +1,6 @@
+{
+  "changed_files": [
+    "docs/project/status/parser.md"
+  ],
+  "receipt_owners": []
+}

--- a/xtask/tests/generated_files_cli.rs
+++ b/xtask/tests/generated_files_cli.rs
@@ -1,0 +1,69 @@
+use std::fs;
+
+use assert_cmd::Command;
+use color_eyre::eyre::Result;
+use tempfile::tempdir;
+
+#[test]
+fn generated_files_changed_without_receipt_fails() -> Result<()> {
+    let temp = tempdir()?;
+    let receipt_path = temp.path().join("generated-files.json");
+
+    let fixture = "tests/fixtures/generated-files/changed-without-receipt.json";
+    let output = Command::cargo_bin("xtask")?
+        .args([
+            "generated-files",
+            "check",
+            "--fixture",
+            fixture,
+            "--receipt",
+            receipt_path.to_str().ok_or_else(|| color_eyre::eyre::eyre!("non-utf8 path"))?,
+        ])
+        .output()?;
+
+    assert!(
+        !output.status.success(),
+        "check should fail when receipt is missing; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let receipt_raw = fs::read_to_string(&receipt_path)?;
+    let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
+    assert_eq!(receipt["verdict"], "fail");
+    assert_eq!(receipt["missing_receipts"], serde_json::json!(["status-docs"]));
+
+    Ok(())
+}
+
+#[test]
+fn generated_files_with_receipt_passes() -> Result<()> {
+    let temp = tempdir()?;
+    let receipt_path = temp.path().join("generated-files.json");
+
+    let fixture = "tests/fixtures/generated-files/changed-with-receipt.json";
+    let output = Command::cargo_bin("xtask")?
+        .args([
+            "generated-files",
+            "check",
+            "--fixture",
+            fixture,
+            "--receipt",
+            receipt_path.to_str().ok_or_else(|| color_eyre::eyre::eyre!("non-utf8 path"))?,
+        ])
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "check should pass when matching receipt owner exists; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let receipt_raw = fs::read_to_string(&receipt_path)?;
+    let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
+    assert_eq!(receipt["verdict"], "pass");
+    assert_eq!(receipt["missing_receipts"], serde_json::json!([]));
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Prevent hand-edits to generated docs/status files from being merged without evidence that the corresponding generator was run, reducing noisy diffs and mis-routed audits.

### Description

- Add a manifest `.ci/generated-files.toml` declaring generated-file rules (initial rule: `docs/project/status/**` owned by `status-docs`).
- Implement `xtask` task module `xtask/src/tasks/generated_files.rs` providing `generated-files check` and `generated-files list` with git-based changed-file discovery, `--fixture` support, `--allow-manual-edits` override, and JSON receipt emission.
- Wire the new CLI subcommand into `xtask/src/main.rs` and register the module in `xtask/src/tasks/mod.rs` so the commands are available as `cargo xtask generated-files {list|check}`.
- Add receipt JSON schema `.ci/receipts/schemas/generated-files.schema.json`, documentation `docs/ci/generated-file-policy.md`, and fixture-backed integration tests plus fixtures under `xtask/tests/fixtures/generated-files/` and `xtask/tests/generated_files_cli.rs`.

### Testing

- Ran `cargo check -p xtask`, which completed successfully.
- Ran the integration tests `cargo test -p xtask --test generated_files_cli -- --nocapture`, and both fixture tests passed.
- Exercised the CLI manually in CI style: `cargo xtask generated-files list` and `cargo xtask generated-files check --receipt target/receipts/generated-files.json` (both executed without error in the test environment).
- Ran formatting via `cargo xtask fmt --package xtask` as part of verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd088a28083339e22afb3d2e8fec9)