### PR TITLE
feat(ci): align Parser Ratchet scaffold receipt with schema (#6847)

### DIFF
--- a/.ci/receipts/schemas/parser-ratchet.schema.json
+++ b/.ci/receipts/schemas/parser-ratchet.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/parser-ratchet.schema.json",
+  "title": "Parser Ratchet Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "check",
+    "schema_version",
+    "event",
+    "selected",
+    "selection_reason",
+    "profile",
+    "verdict",
+    "classification",
+    "repro"
+  ],
+  "properties": {
+    "check": {
+      "const": "parser-ratchet"
+    },
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "event": {
+      "type": "string",
+      "minLength": 1
+    },
+    "run_id": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "base_sha": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{7,40}$"
+    },
+    "head_sha": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{7,40}$"
+    },
+    "candidate_sha": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{7,40}$"
+    },
+    "selected": {
+      "type": "boolean",
+      "const": false
+    },
+    "selection_reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "profile": {
+      "type": "string",
+      "enum": ["pr"]
+    },
+    "verdict": {
+      "type": "string",
+      "const": "pass"
+    },
+    "classification": {
+      "type": "string",
+      "enum": ["skipped", "not_selected"]
+    },
+    "repro": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/parser-ratchet.yml
+++ b/.github/workflows/parser-ratchet.yml
@@ -1,0 +1,74 @@
+name: Parser Ratchet
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [master]
+
+concurrency:
+  group: parser-ratchet-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  parser-ratchet:
+    name: Parser Ratchet Scaffold
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: 1.92.0
+
+      - name: Run parser ratchet scaffold
+        env:
+          PARSER_RATCHET_EVENT: ${{ github.event_name }}
+          PARSER_RATCHET_RUN_ID: ${{ github.run_id }}
+          PARSER_RATCHET_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || '' }}
+          PARSER_RATCHET_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          PARSER_RATCHET_CANDIDATE_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
+        run: cargo xtask parser-ratchet --profile pr --receipt target/receipts/parser-ratchet.json
+
+      - name: Validate parser-ratchet receipt schema (if present)
+        run: |
+          if [ -f .ci/receipts/schemas/parser-ratchet.schema.json ]; then
+            python3 - <<'PY'
+import json
+from pathlib import Path
+
+try:
+    import jsonschema
+except ImportError:
+    print("::warning::python jsonschema is unavailable; skipping parser-ratchet receipt validation")
+    raise SystemExit(0)
+
+schema = json.loads(Path('.ci/receipts/schemas/parser-ratchet.schema.json').read_text(encoding='utf-8'))
+receipt = json.loads(Path('target/receipts/parser-ratchet.json').read_text(encoding='utf-8'))
+jsonschema.validate(receipt, schema)
+print('parser-ratchet receipt schema validation passed')
+PY
+          else
+            echo "Schema not present; skipping parser-ratchet receipt schema validation"
+          fi
+
+      - name: Validate receipts gate (if available)
+        run: |
+          if just --list 2>/dev/null | grep -q '^gate-receipts'; then
+            just gate-receipts
+          else
+            echo "gate-receipts recipe not present; skipping"
+          fi
+
+      - name: Upload parser-ratchet receipt
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: parser-ratchet-receipt
+          path: target/receipts/parser-ratchet.json

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -825,6 +825,17 @@ enum Commands {
         receipt: bool,
     },
 
+    /// Emit the parser ratchet scaffold receipt.
+    ParserRatchet {
+        /// Execution profile label for the receipt (defaults to `pr`).
+        #[arg(long, default_value = "pr")]
+        profile: String,
+
+        /// Output path for parser-ratchet receipt JSON.
+        #[arg(long, default_value = "target/receipts/parser-ratchet.json")]
+        receipt: PathBuf,
+    },
+
     /// Manage CPAN top-1000 corpus acquisition, sweep, and ratchet
     CpanCorpus {
         #[command(subcommand)]
@@ -1533,6 +1544,9 @@ fn main() -> Result<()> {
                 verbose,
                 receipt,
             })
+        }
+        Commands::ParserRatchet { profile, receipt } => {
+            parser_ratchet::run(parser_ratchet::ParserRatchetConfig { profile, receipt })
         }
         Commands::CpanCorpus { command } => {
             let mut config = cpan_corpus::CpanCorpusConfig::default();

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -52,6 +52,7 @@ pub mod metrics;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;
 pub mod parser_matrix;
+pub mod parser_ratchet;
 pub mod populate_book;
 pub mod prep_crates_io_launch;
 pub mod publication_facts;

--- a/xtask/src/tasks/parser_ratchet.rs
+++ b/xtask/src/tasks/parser_ratchet.rs
@@ -1,0 +1,90 @@
+use color_eyre::eyre::{Context, Result};
+use serde::Serialize;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct ParserRatchetConfig {
+    pub profile: String,
+    pub receipt: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+struct ParserRatchetReceipt {
+    check: &'static str,
+    schema_version: u32,
+    event: String,
+    run_id: Option<String>,
+    base_sha: Option<String>,
+    head_sha: Option<String>,
+    candidate_sha: Option<String>,
+    selected: bool,
+    selection_reason: String,
+    profile: String,
+    verdict: &'static str,
+    classification: &'static str,
+    repro: Repro,
+}
+
+#[derive(Debug, Serialize)]
+struct Repro {
+    command: String,
+}
+
+pub fn run(config: ParserRatchetConfig) -> Result<()> {
+    let event = env_or_default("PARSER_RATCHET_EVENT", "unknown");
+    let run_id = env_nonempty("PARSER_RATCHET_RUN_ID").or_else(|| env_nonempty("GITHUB_RUN_ID"));
+    let base_sha = env_nonempty("PARSER_RATCHET_BASE_SHA");
+    let head_sha = env_nonempty("PARSER_RATCHET_HEAD_SHA").or_else(|| env_nonempty("GITHUB_SHA"));
+    let candidate_sha = env_nonempty("PARSER_RATCHET_CANDIDATE_SHA");
+
+    let receipt = ParserRatchetReceipt {
+        check: "parser-ratchet",
+        schema_version: 1,
+        event,
+        run_id,
+        base_sha,
+        head_sha,
+        candidate_sha,
+        selected: false,
+        selection_reason: "no-op scaffold: parser scope selection not implemented".to_string(),
+        profile: config.profile.clone(),
+        verdict: "pass",
+        classification: "skipped",
+        repro: Repro {
+            command: format!(
+                "cargo xtask parser-ratchet --profile {} --receipt {}",
+                config.profile,
+                config.receipt.display()
+            ),
+        },
+    };
+
+    if let Some(parent) = config.receipt.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!("failed to create receipt directory {}", parent.display())
+        })?;
+    }
+
+    let raw = serde_json::to_string_pretty(&receipt).context("failed to serialize parser receipt")?;
+    fs::write(&config.receipt, raw)
+        .with_context(|| format!("failed to write receipt {}", config.receipt.display()))?;
+
+    println!(
+        "parser-ratchet: selected=false verdict=pass receipt={} ",
+        config.receipt.display()
+    );
+
+    Ok(())
+}
+
+fn env_nonempty(name: &str) -> Option<String> {
+    std::env::var(name).ok().and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+    })
+}
+
+fn env_or_default(name: &str, default: &str) -> String {
+    env_nonempty(name).unwrap_or_else(|| default.to_string())
+}


### PR DESCRIPTION
### Motivation
- Provide a stable, no-op Parser Ratchet scaffold that always emits a receipt compatible with the common receipt contract while the full ratchet selection/comparison logic is postponed (Refs #6847, Refs #6856).
- Ensure the scaffold runs on CI for PRs and merges (no path filtering), produces a machine-readable artifact, and can be validated against a schema when available.

### Description
- Added an xtask subcommand `parser-ratchet` implemented in `xtask/src/tasks/parser_ratchet.rs` that writes a scaffold JSON receipt to the requested path and prints a short status message.
- Wired the command into the xtask CLI in `xtask/src/main.rs` and registered the module in `xtask/src/tasks/mod.rs` so `cargo xtask parser-ratchet --profile pr --receipt target/receipts/parser-ratchet.json` is supported.
- Added a GitHub Actions workflow `​.github/workflows/parser-ratchet.yml` that triggers on `pull_request`, `merge_group`, and `push` to `master`, uses event-aware `concurrency`, runs the xtask command, conditionally validates the receipt against `.ci/receipts/schemas/parser-ratchet.schema.json`, conditionally runs the `gate-receipts` recipe if present, and uploads `target/receipts/parser-ratchet.json` as an artifact.
- Added the receipt schema at `.ci/receipts/schemas/parser-ratchet.schema.json` and aligned the scaffold to emit the fields required by the schema (including `check`, `schema_version`, `event`, optional SHA/run metadata, `selected=false`, `selection_reason`, `profile=pr`, `verdict=pass`, `classification`, and `repro.command`).
- Intentionally avoided implementing parser scope selection, corpus parsing, CPAN dependencies, or any gate hard-fail behavior in this change.

### Testing
- Ran `cargo check -p xtask` which completed successfully.
- Executed `cargo xtask parser-ratchet --profile pr --receipt target/receipts/parser-ratchet.json` and confirmed the produced receipt contains `selected=false`, `profile=pr`, `verdict=pass`, `classification=skipped`, and the expected metadata fields; the command printed a short status line and wrote `target/receipts/parser-ratchet.json`.
- Attempted schema validation via a local Python `jsonschema` check; validation logic runs in CI when `jsonschema` is available, but the local environment lacked `jsonschema` so validation was skipped (non-blocking).
- Ran the conditional `gate-receipts` invocation path and observed it is invoked only when the `just` recipe exists; on this workspace the recipe was absent so the step was skipped.

Problem: Parser Ratchet scaffold receipts were not aligned to a common receipt contract while the ratchet remains intentionally no-op.
Fix: Emit a no-op, schema-aligned scaffold receipt and add a CI workflow that always runs and uploads `target/receipts/parser-ratchet.json` without path filtering.
Verification: `cargo check -p xtask` passes and `cargo xtask parser-ratchet --profile pr --receipt target/receipts/parser-ratchet.json` produces `selected=false` / `verdict=pass`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd08f121883339c34d2dbe0f86f4f)