### PR TITLE
feat(ci): align Parser Ratchet scaffold receipt with schema (#6847)

### DIFF
--- a/.ci/receipts/schemas/parser-ratchet.schema.json
+++ b/.ci/receipts/schemas/parser-ratchet.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/receipts/parser-ratchet.schema.json",
+  "title": "Parser Ratchet receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "check",
+    "schema_version",
+    "event",
+    "selected",
+    "selection_reason",
+    "profile",
+    "verdict",
+    "classification",
+    "repro"
+  ],
+  "properties": {
+    "check": {
+      "const": "parser-ratchet"
+    },
+    "schema_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "event": {
+      "type": "string",
+      "minLength": 1
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "base_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,40}$"
+    },
+    "head_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,40}$"
+    },
+    "candidate_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,40}$"
+    },
+    "selected": {
+      "type": "boolean",
+      "const": false
+    },
+    "selection_reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "profile": {
+      "type": "string",
+      "const": "pr"
+    },
+    "verdict": {
+      "type": "string",
+      "const": "pass"
+    },
+    "classification": {
+      "type": "string",
+      "enum": ["skipped", "not-selected"]
+    },
+    "repro": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/parser-ratchet.yml
+++ b/.github/workflows/parser-ratchet.yml
@@ -1,0 +1,64 @@
+name: Parser Ratchet
+
+on:
+  pull_request:
+    branches: [main, master]
+  merge_group: {}
+  push:
+    branches: [master]
+
+concurrency:
+  group: parser-ratchet-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  parser-ratchet:
+    name: Parser Ratchet Receipt
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: 1.92.0
+
+      - name: Emit parser-ratchet receipt
+        run: cargo xtask parser-ratchet --profile pr --receipt target/receipts/parser-ratchet.json
+
+      - name: Validate parser-ratchet receipt schema (if present)
+        if: hashFiles('.ci/receipts/schemas/parser-ratchet.schema.json') != ''
+        run: |
+          python3 -m pip install --disable-pip-version-check --quiet jsonschema
+          python3 - <<'PY'
+          import json
+          from jsonschema import Draft202012Validator
+
+          schema_path = '.ci/receipts/schemas/parser-ratchet.schema.json'
+          receipt_path = 'target/receipts/parser-ratchet.json'
+
+          with open(schema_path, 'r', encoding='utf-8') as f:
+              schema = json.load(f)
+          with open(receipt_path, 'r', encoding='utf-8') as f:
+              receipt = json.load(f)
+
+          Draft202012Validator(schema).validate(receipt)
+          print('parser-ratchet receipt schema validation passed')
+          PY
+
+      - name: Upload parser-ratchet receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: parser-ratchet-receipt-${{ github.sha }}
+          path: target/receipts/parser-ratchet.json
+          if-no-files-found: warn

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -86,7 +86,7 @@ impl SafeEvaluator {
         }
 
         // Check for assignment operators while avoiding comparison false positives
-        if let Some(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref().ok() {
+        if let Ok(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref() {
             for mat in re.find_iter(expression) {
                 let op = mat.as_str();
                 if ASSIGNMENT_OPERATORS.contains(&op) {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -794,6 +794,17 @@ enum Commands {
     /// is wired into `just pr-fast` and `just ci-gate`.
     PublishManifestCheck,
 
+    /// Emit Parser Ratchet scaffold receipt (no-op selector).
+    ParserRatchet {
+        /// Execution profile to record in the receipt.
+        #[arg(long, default_value = "pr")]
+        profile: String,
+
+        /// Write receipt JSON to target/receipts/parser-ratchet.json
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+    },
+
     /// Sweep system Perl corpus for parser error rates
     ParserCorpusSweep {
         /// Comma-separated corpus root directories
@@ -1510,6 +1521,7 @@ fn main() -> Result<()> {
         Commands::PublishManifestCheck => publish_manifest_check::run(),
         Commands::SmokeTestRelease { version } => publish::smoke_test_release(version),
         Commands::PublishReceipts { date } => publish_receipts::run(date),
+        Commands::ParserRatchet { profile, receipt } => parser_ratchet::run(profile, receipt),
         Commands::ParserCorpusSweep {
             roots,
             manifest,

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -52,6 +52,7 @@ pub mod metrics;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;
 pub mod parser_matrix;
+pub mod parser_ratchet;
 pub mod populate_book;
 pub mod prep_crates_io_launch;
 pub mod publication_facts;

--- a/xtask/src/tasks/parser_ratchet.rs
+++ b/xtask/src/tasks/parser_ratchet.rs
@@ -1,0 +1,98 @@
+use crate::utils::project_root;
+use color_eyre::eyre::{Context, Result};
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DEFAULT_RECEIPT_PATH: &str = "target/receipts/parser-ratchet.json";
+const CHECK_ID: &str = "parser-ratchet";
+const SCHEMA_VERSION: &str = "1";
+const DEFAULT_CLASSIFICATION: &str = "skipped";
+
+#[derive(Debug, Serialize)]
+struct ParserRatchetReceipt {
+    check: &'static str,
+    schema_version: &'static str,
+    event: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    base_sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    head_sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    candidate_sha: Option<String>,
+    selected: bool,
+    selection_reason: String,
+    profile: String,
+    verdict: &'static str,
+    classification: &'static str,
+    repro: Repro,
+}
+
+#[derive(Debug, Serialize)]
+struct Repro {
+    command: String,
+}
+
+pub fn run(profile: String, receipt_path: Option<PathBuf>) -> Result<()> {
+    let root = project_root()?;
+    let receipt_path = resolve_receipt_path(&root, receipt_path);
+
+    if let Some(parent) = receipt_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create receipt directory {}", parent.display()))?;
+    }
+
+    let repro_command = format!(
+        "cargo xtask parser-ratchet --profile {} --receipt {}",
+        profile,
+        receipt_path.display()
+    );
+
+    let receipt = ParserRatchetReceipt {
+        check: CHECK_ID,
+        schema_version: SCHEMA_VERSION,
+        event: env_or_default("GITHUB_EVENT_NAME", "manual"),
+        run_id: env_optional("GITHUB_RUN_ID"),
+        base_sha: env_optional("GITHUB_BASE_SHA"),
+        head_sha: env_optional("GITHUB_HEAD_SHA"),
+        candidate_sha: env_optional("GITHUB_SHA"),
+        selected: false,
+        selection_reason: "Parser ratchet scaffold is no-op until scope/comparison logic lands"
+            .to_string(),
+        profile,
+        verdict: "pass",
+        classification: DEFAULT_CLASSIFICATION,
+        repro: Repro { command: repro_command },
+    };
+
+    let payload = serde_json::to_string_pretty(&receipt)
+        .context("Failed to serialize parser-ratchet receipt")?;
+    fs::write(&receipt_path, format!("{payload}\n"))
+        .with_context(|| format!("Failed to write receipt to {}", receipt_path.display()))?;
+
+    println!("parser-ratchet scaffold receipt written to {}", receipt_path.display());
+    println!("{payload}");
+
+    Ok(())
+}
+
+fn resolve_receipt_path(root: &Path, receipt_path: Option<PathBuf>) -> PathBuf {
+    match receipt_path {
+        Some(path) if path.is_absolute() => path,
+        Some(path) => root.join(path),
+        None => root.join(DEFAULT_RECEIPT_PATH),
+    }
+}
+
+fn env_optional(key: &str) -> Option<String> {
+    std::env::var(key).ok().and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+    })
+}
+
+fn env_or_default(key: &str, default: &str) -> String {
+    env_optional(key).unwrap_or_else(|| default.to_string())
+}


### PR DESCRIPTION
### Motivation

- Ensure the Parser Ratchet scaffold emits a receipt that matches the common receipt contract so the check always runs (no path filtering) and produces a schema-valid no-op receipt while selector/comparison logic is pending; this work is scoped as the scaffold-only step for the Parser Ratchet story (Refs #6847, Refs #6856).

### Description

- Add `xtask` emitter `parser_ratchet::run(...)` that writes `target/receipts/parser-ratchet.json` with common fields (`check`, `schema_version`, `event`, optional SHAs/run id, `selected=false`, `selection_reason`, `profile`, `verdict=pass`, `classification`, `repro.command`).
- Wire the new `ParserRatchet` command into `xtask` CLI (`xtask/src/main.rs`) and register the module in `xtask/src/tasks/mod.rs` so CI can invoke `cargo xtask parser-ratchet --profile pr --receipt ...`.
- Add a GitHub Actions workflow `.github/workflows/parser-ratchet.yml` that runs on `pull_request`, `merge_group`, and `push: master`, uses event-aware `concurrency`, has no `paths` filter, emits the receipt, validates it against the schema (if present), and uploads the artifact.
- Add the JSON schema `.ci/receipts/schemas/parser-ratchet.schema.json` that enforces the scaffold constraints (`selected:false`, `profile:"pr"`, `verdict:"pass"`) for the no-op phase.

### Testing

- Ran `cargo check -p xtask` and it completed successfully.
- Executed `cargo xtask parser-ratchet --profile pr --receipt target/receipts/parser-ratchet.json` and it produced `target/receipts/parser-ratchet.json` with the expected fields.
- Validated the produced receipt against the new schema using `python3` + `jsonschema` and the receipt validated successfully.
- Ran `cargo xtask fmt` to format changes and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd08f121883339c34d2dbe0f86f4f)