### PR TITLE
feat(ci): align Parser Ratchet scaffold receipt with schema (#6847)

### DIFF
--- a/.ci/receipts/schemas/parser-ratchet.schema.json
+++ b/.ci/receipts/schemas/parser-ratchet.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/parser-ratchet.schema.json",
+  "title": "Parser Ratchet receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "check",
+    "schema_version",
+    "selected",
+    "selection_reason",
+    "profile",
+    "verdict",
+    "classification",
+    "repro"
+  ],
+  "properties": {
+    "check": {
+      "type": "string",
+      "const": "parser-ratchet"
+    },
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "event": {
+      "type": ["string", "null"]
+    },
+    "run_id": {
+      "type": ["string", "null"]
+    },
+    "base_sha": {
+      "type": ["string", "null"]
+    },
+    "head_sha": {
+      "type": ["string", "null"]
+    },
+    "candidate_sha": {
+      "type": ["string", "null"]
+    },
+    "selected": {
+      "type": "boolean",
+      "const": false
+    },
+    "selection_reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "profile": {
+      "type": "string"
+    },
+    "verdict": {
+      "type": "string",
+      "const": "pass"
+    },
+    "classification": {
+      "type": "string",
+      "enum": ["skipped", "not_selected"]
+    },
+    "repro": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/parser-ratchet.yml
+++ b/.github/workflows/parser-ratchet.yml
@@ -1,0 +1,46 @@
+name: Parser Ratchet (Scaffold)
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: parser-ratchet-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  parser-ratchet:
+    name: Parser Ratchet Receipt
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+
+      - name: Emit parser-ratchet receipt scaffold
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          GITHUB_CANDIDATE_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
+        run: cargo xtask parser-ratchet --profile pr --receipt target/receipts/parser-ratchet.json
+
+      - name: Upload parser-ratchet receipt
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: parser-ratchet-receipt
+          path: target/receipts/parser-ratchet.json
+          if-no-files-found: error

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -86,7 +86,7 @@ impl SafeEvaluator {
         }
 
         // Check for assignment operators while avoiding comparison false positives
-        if let Some(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref().ok() {
+        if let Ok(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref() {
             for mat in re.find_iter(expression) {
                 let op = mat.as_str();
                 if ASSIGNMENT_OPERATORS.contains(&op) {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -794,6 +794,17 @@ enum Commands {
     /// is wired into `just pr-fast` and `just ci-gate`.
     PublishManifestCheck,
 
+    /// Emit a no-op parser-ratchet receipt scaffold for CI integration.
+    ParserRatchet {
+        /// Check profile to include in the receipt (default: pr).
+        #[arg(long, default_value = "pr")]
+        profile: String,
+
+        /// Path to write receipt JSON (default: target/receipts/parser-ratchet.json).
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+    },
+
     /// Sweep system Perl corpus for parser error rates
     ParserCorpusSweep {
         /// Comma-separated corpus root directories
@@ -1510,6 +1521,7 @@ fn main() -> Result<()> {
         Commands::PublishManifestCheck => publish_manifest_check::run(),
         Commands::SmokeTestRelease { version } => publish::smoke_test_release(version),
         Commands::PublishReceipts { date } => publish_receipts::run(date),
+        Commands::ParserRatchet { profile, receipt } => parser_ratchet::run(profile, receipt),
         Commands::ParserCorpusSweep {
             roots,
             manifest,

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -52,6 +52,7 @@ pub mod metrics;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;
 pub mod parser_matrix;
+pub mod parser_ratchet;
 pub mod populate_book;
 pub mod prep_crates_io_launch;
 pub mod publication_facts;

--- a/xtask/src/tasks/parser_ratchet.rs
+++ b/xtask/src/tasks/parser_ratchet.rs
@@ -1,0 +1,105 @@
+use color_eyre::eyre::{Result, eyre};
+use serde::Serialize;
+use std::fs;
+use std::path::PathBuf;
+
+const DEFAULT_RECEIPT_PATH: &str = "target/receipts/parser-ratchet.json";
+const CHECK_NAME: &str = "parser-ratchet";
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone)]
+pub struct ParserRatchetConfig {
+    pub profile: String,
+    pub receipt: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+struct ParserRatchetReceipt {
+    check: &'static str,
+    schema_version: u32,
+    event: Option<String>,
+    run_id: Option<String>,
+    base_sha: Option<String>,
+    head_sha: Option<String>,
+    candidate_sha: Option<String>,
+    selected: bool,
+    selection_reason: String,
+    profile: String,
+    verdict: &'static str,
+    classification: &'static str,
+    repro: Repro,
+}
+
+#[derive(Debug, Serialize)]
+struct Repro {
+    command: String,
+}
+
+pub fn run(profile: String, receipt: Option<PathBuf>) -> Result<()> {
+    let config = ParserRatchetConfig {
+        profile,
+        receipt: receipt.unwrap_or_else(|| PathBuf::from(DEFAULT_RECEIPT_PATH)),
+    };
+    run_with_config(config)
+}
+
+fn run_with_config(config: ParserRatchetConfig) -> Result<()> {
+    let receipt = build_receipt(&config);
+    write_receipt(&config.receipt, &receipt)?;
+
+    println!(
+        "{CHECK_NAME}: profile={} selected=false verdict=pass classification=skipped receipt={}",
+        config.profile,
+        config.receipt.display()
+    );
+
+    Ok(())
+}
+
+fn build_receipt(config: &ParserRatchetConfig) -> ParserRatchetReceipt {
+    let event = env_var("GITHUB_EVENT_NAME");
+    let run_id = env_var("GITHUB_RUN_ID");
+    let base_sha = env_var("GITHUB_BASE_SHA");
+    let head_sha = env_var("GITHUB_HEAD_SHA");
+    let candidate_sha = env_var("GITHUB_CANDIDATE_SHA");
+
+    let selection_reason =
+        "Parser Ratchet scaffold: selection scope/comparison not implemented yet".to_string();
+
+    ParserRatchetReceipt {
+        check: CHECK_NAME,
+        schema_version: SCHEMA_VERSION,
+        event,
+        run_id,
+        base_sha,
+        head_sha,
+        candidate_sha,
+        selected: false,
+        selection_reason,
+        profile: config.profile.clone(),
+        verdict: "pass",
+        classification: "skipped",
+        repro: Repro {
+            command: format!(
+                "cargo xtask parser-ratchet --profile {} --receipt {}",
+                config.profile,
+                config.receipt.display()
+            ),
+        },
+    }
+}
+
+fn env_var(name: &str) -> Option<String> {
+    std::env::var(name).ok().and_then(|value| (!value.trim().is_empty()).then_some(value))
+}
+
+fn write_receipt(path: &PathBuf, receipt: &ParserRatchetReceipt) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| eyre!("failed to create {}: {error}", parent.display()))?;
+    }
+
+    let payload = serde_json::to_string_pretty(receipt)?;
+    fs::write(path, format!("{payload}\n"))
+        .map_err(|error| eyre!("failed to write {}: {error}", path.display()))
+}


### PR DESCRIPTION
### Motivation

- Provide a stable no-op Parser Ratchet scaffold that conforms to the repository's common receipt contract so CI and downstream tooling can consume a consistent receipt before the full ratchet logic lands. 
- The scaffold must always run (no path filtering), be event-aware for concurrency, and emit `selected=false` / `verdict=pass` while exposing common provenance fields. 
- This change tracks the work described in Refs #6847 and Refs #6856.

### Description

- Add a new xtask subcommand `parser-ratchet` implemented in `xtask/src/tasks/parser_ratchet.rs` that writes a JSON receipt (default `target/receipts/parser-ratchet.json`) with fields: `check`, `schema_version`, `event`, `run_id`, `base_sha`, `head_sha`, `candidate_sha`, `selected=false`, `selection_reason`, `profile`, `verdict=pass`, `classification=skipped`, and `repro.command`.
- Wire the subcommand into the xtask CLI by updating `xtask/src/tasks/mod.rs` and `xtask/src/main.rs` so CI can invoke `cargo xtask parser-ratchet`.
- Add a dedicated GitHub workflow `.github/workflows/parser-ratchet.yml` that runs on `pull_request`, `merge_group`, and `push` to `master`, uses an event-aware `concurrency` group, invokes the xtask command, writes `target/receipts/parser-ratchet.json`, and uploads the receipt artifact.
- Add the receipt JSON Schema at `.ci/receipts/schemas/parser-ratchet.schema.json` that enforces `selected=false` and `verdict=pass` and validates the common fields required by downstream consumers.

### Testing

- Ran `cargo check -p xtask` which completed successfully. 
- Ran `cargo xtask parser-ratchet --profile pr --receipt target/receipts/parser-ratchet.json` which produced a receipt showing `selected=false` and `verdict=pass` and wrote `target/receipts/parser-ratchet.json` successfully. 
- Ran formatter via `cargo xtask fmt` with no actionable failures. 
- Attempted schema validation with `python -m jsonschema -i target/receipts/parser-ratchet.json .ci/receipts/schemas/parser-ratchet.schema.json` but the `jsonschema` Python package was not available in this environment, so automated schema validation was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd08f121883339c34d2dbe0f86f4f)