### PR TITLE
feat(parser-ratchet): select parser gate from scope and risk tags (#6847)

### DIFF
--- a/.ci/scope.d/parser-ratchet.toml
+++ b/.ci/scope.d/parser-ratchet.toml
@@ -1,0 +1,58 @@
+# Parser Ratchet scope selection (Issue #6847)
+#
+# Policy intent:
+# - Always produce a receipt for Parser Ratchet.
+# - Only run expensive parser corpus/ratchet work when parser behavior is plausibly affected.
+# - This file defines *selection only* (not execution strategy, comparator logic, or corpus wiring).
+
+[id]
+name = "parser-ratchet"
+kind = "selection-only"
+
+[selection]
+mode = "any"
+
+# Select when any changed path matches one of these patterns.
+path_globs = [
+  "crates/perl-parser/**",
+  "crates/perl-parser-core/**",
+  "crates/perl-lexer/**",
+  "crates/perl-token/**",
+  "crates/tree-sitter-perl-rs/**",
+  "crates/tree-sitter-perl-c/**",
+  "xtask/src/tasks/*parser*",
+  "xtask/src/tasks/*corpus*",
+  "xtask/src/tasks/ci_scope.rs",
+  "xtask/src/tasks/gates.rs",
+  "xtask/src/tasks/ratchet*.rs",
+  ".ci/scope.d/**",
+  ".ci/gates.d/**",
+  ".ci/parser-ratchet/**",
+  ".github/workflows/**",
+  "tests/parser/**",
+  "tests/perl-corpus/**",
+]
+
+# Cargo.lock is selected only when parser-relevant deps change.
+# (This remains a policy marker for now; lockfile package diffing is future work.)
+cargo_lock = "parser_relevant_deps_only"
+
+# Select when any of these risk tags are present.
+risk_tags_any = [
+  "parser",
+  "lexer",
+  "token",
+  "corpus",
+  "incremental",
+  "tree-sitter",
+  "parser-recovery",
+  "parser-accuracy",
+]
+
+# When nothing matches, selection must be false and still emit a receipt.
+default_reason = "no parser-relevant paths or risk tags detected"
+
+[receipt]
+selected_true_field = "selection_reason"
+selected_false_field = "reason"
+always_emit = true

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -86,7 +86,7 @@ impl SafeEvaluator {
         }
 
         // Check for assignment operators while avoiding comparison false positives
-        if let Some(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref().ok() {
+        if let Ok(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref() {
             for mat in re.find_iter(expression) {
                 let op = mat.as_str();
                 if ASSIGNMENT_OPERATORS.contains(&op) {

--- a/docs/ci/parser-ratchet-scope.md
+++ b/docs/ci/parser-ratchet-scope.md
@@ -1,0 +1,57 @@
+# Parser Ratchet scope selection
+
+This document defines **selection-only policy** for Parser Ratchet.
+
+- Parser Ratchet should **always emit a receipt**.
+- Parser Ratchet should run expensive parser work **only when parser behavior is plausibly affected**.
+- This change does **not** implement parser corpus execution, comparator logic, or CPAN behavior.
+
+## Source of truth
+
+Selection rules live in:
+
+- `.ci/scope.d/parser-ratchet.toml`
+
+## Selection criteria
+
+Parser Ratchet is selected when **any** configured parser-relevant path glob matches a changed file, or when any parser-relevant risk tag is present.
+
+Primary path groups:
+
+- Parser/lexer/token and parser-core crates.
+- Tree-sitter parser crates.
+- `xtask` parser/corpus/ratchet task wiring and `ci_scope`/`gates` changes.
+- CI policy and workflow folders that can alter parser gate behavior.
+- Parser/corpus test folders.
+- `Cargo.lock` policy marker for parser-relevant dependency movement.
+
+Risk tags:
+
+- `parser`
+- `lexer`
+- `token`
+- `corpus`
+- `incremental`
+- `tree-sitter`
+- `parser-recovery`
+- `parser-accuracy`
+
+## Receipt behavior
+
+- On selection: `selected: true` with `selection_reason`.
+- On no-op: `selected: false` with `reason`.
+- Receipt emission remains required in both cases.
+
+## Fixtures
+
+Parser-ratchet scope fixtures are stored under:
+
+- `xtask/tests/fixtures/ci-scope/parser-ratchet/`
+
+Included scenarios:
+
+- docs-only fixture → selected false
+- parser crate change → selected true
+- lexer/token change → selected true
+- `ci_scope.rs` change → selected true
+- workflow change → selected true

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/ci-scope-rs-change.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/ci-scope-rs-change.json
@@ -1,0 +1,11 @@
+{
+  "name": "ci_scope.rs change",
+  "changed_files": [
+    "xtask/src/tasks/ci_scope.rs"
+  ],
+  "risk_tags": ["parser"],
+  "expected": {
+    "selected": true,
+    "selection_reason": "matched path: xtask/src/tasks/ci_scope.rs"
+  }
+}

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/docs-only.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/docs-only.json
@@ -1,0 +1,12 @@
+{
+  "name": "docs-only non-parser docs",
+  "changed_files": [
+    "docs/project/CURRENT_STATUS.md",
+    "docs/articles/CONTINUOUS_REVIEW_PATTERNS.md"
+  ],
+  "risk_tags": [],
+  "expected": {
+    "selected": false,
+    "reason": "no parser-relevant paths or risk tags detected"
+  }
+}

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/lexer-token-change.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/lexer-token-change.json
@@ -1,0 +1,12 @@
+{
+  "name": "lexer/token change",
+  "changed_files": [
+    "crates/perl-lexer/src/tokenize.rs",
+    "crates/perl-token/src/kinds.rs"
+  ],
+  "risk_tags": [],
+  "expected": {
+    "selected": true,
+    "selection_reason": "matched path: crates/perl-lexer/**"
+  }
+}

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/parser-crate-change.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/parser-crate-change.json
@@ -1,0 +1,11 @@
+{
+  "name": "parser crate change",
+  "changed_files": [
+    "crates/perl-parser/src/parser.rs"
+  ],
+  "risk_tags": [],
+  "expected": {
+    "selected": true,
+    "selection_reason": "matched path: crates/perl-parser/**"
+  }
+}

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/workflow-change.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/workflow-change.json
@@ -1,0 +1,11 @@
+{
+  "name": "workflow change",
+  "changed_files": [
+    ".github/workflows/ci.yml"
+  ],
+  "risk_tags": [],
+  "expected": {
+    "selected": true,
+    "selection_reason": "matched path: .github/workflows/**"
+  }
+}


### PR DESCRIPTION
### Motivation

- Parser Ratchet must always emit a receipt but should only run expensive parser/corpus ratchet work when parser behavior is plausibly affected.
- Selection logic must capture parser-relevant paths and risk tags so CI can avoid unnecessary heavy work while still reporting.

### Description

- Added a selection-only policy file at `.ci/scope.d/parser-ratchet.toml` containing `path_globs`, `risk_tags_any`, a `cargo_lock` policy marker, and explicit receipt fields (`selected_true_field`, `selected_false_field`, `always_emit`).
- Added validation fixtures under `xtask/tests/fixtures/ci-scope/parser-ratchet/` for the requested scenarios: docs-only, parser crate change, lexer/token change, `ci_scope.rs` change, and workflow change.
- Added documentation at `docs/ci/parser-ratchet-scope.md` describing selection intent, criteria, risk tags, and receipt semantics, and clarified this is scope-selection only (no corpus execution/comparator/CPAN changes).
- This change is scope-selection only and does not modify runtime `ci_scope` logic, implement the parser comparator, or enable corpus runs.

### Testing

- Verified fixture JSONs parse with a Python check: `python3` JSON load of `xtask/tests/fixtures/ci-scope/parser-ratchet/*.json`, which succeeded.
- Ran the xtask test slice with `cargo test -p xtask ci_scope_tests -- --nocapture`, which completed successfully (tests filtered appropriately and returned OK).
- No additional CI gates or parser corpus execution were run as part of this change; the PR only supplies selection metadata and fixtures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0935b8c833390b358794836183f)