### PR TITLE
feat(parser-ratchet): select parser gate from scope and risk tags (#6847)

### DIFF
--- a/.ci/scope.d/parser-ratchet.toml
+++ b/.ci/scope.d/parser-ratchet.toml
@@ -1,0 +1,50 @@
+# Parser Ratchet scope selection policy.
+# Scope-selection only: this policy decides when parser ratchet work is selected.
+
+schema_version = 1
+name = "parser-ratchet"
+always_report = true
+
+[rule]
+mode = "any"
+
+# File changes that should select parser ratchet.
+include_paths = [
+  "crates/perl-parser/**",
+  "crates/perl-parser-core/**",
+  "crates/perl-lexer/**",
+  "crates/perl-token/**",
+  "crates/tree-sitter-perl-rs/**",
+  "crates/tree-sitter-perl-c/**",
+  "xtask/src/tasks/*parser*",
+  "xtask/src/tasks/*corpus*",
+  "xtask/src/tasks/ci_scope.rs",
+  "xtask/src/tasks/gates.rs",
+  "xtask/src/tasks/ratchet*.rs",
+  ".ci/scope.d/**",
+  ".ci/gates.d/**",
+  ".ci/parser-ratchet/**",
+  ".github/workflows/**",
+  "tests/parser/**",
+  "tests/perl-corpus/**",
+]
+
+# Cargo.lock is parser-relevant when paired with parser signals (path or risk tag).
+conditional_paths = ["Cargo.lock"]
+conditional_requires = ["parser", "lexer", "token", "tree-sitter", "dep_change"]
+
+# Risk tags that should force parser-ratchet selection even if path matching is ambiguous.
+include_risk_tags = [
+  "parser",
+  "lexer",
+  "token",
+  "corpus",
+  "incremental",
+  "tree-sitter",
+  "parser-recovery",
+  "parser-accuracy",
+]
+
+# Always provide deterministic receipt reasons.
+selected_reason = "parser-ratchet scope matched parser-related paths or risk tags"
+not_selected_reason = "parser-ratchet scope not matched (non-parser diff)"

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -86,7 +86,7 @@ impl SafeEvaluator {
         }
 
         // Check for assignment operators while avoiding comparison false positives
-        if let Some(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref().ok() {
+        if let Ok(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref() {
             for mat in re.find_iter(expression) {
                 let op = mat.as_str();
                 if ASSIGNMENT_OPERATORS.contains(&op) {

--- a/docs/ci/parser-ratchet-scope.md
+++ b/docs/ci/parser-ratchet-scope.md
@@ -1,0 +1,70 @@
+# Parser Ratchet Scope Selection
+
+This document defines **scope selection only** for Parser Ratchet. It does **not** run parser corpus work and does **not** implement parser comparators.
+
+## Goal
+
+Parser Ratchet should always emit a receipt, while only selecting expensive parser work when parser behavior is plausibly affected.
+
+## Policy file
+
+Policy source: `.ci/scope.d/parser-ratchet.toml`.
+
+Selection is `selected=true` when either of these is true:
+
+1. Any parser-relevant path pattern matches.
+2. Any parser-relevant risk tag is present.
+
+Otherwise, the receipt must report `selected=false` with a non-selection reason.
+
+## Selected paths
+
+- `crates/perl-parser/**`
+- `crates/perl-parser-core/**`
+- `crates/perl-lexer/**`
+- `crates/perl-token/**`
+- `crates/tree-sitter-perl-rs/**`
+- `crates/tree-sitter-perl-c/**`
+- `xtask/src/tasks/*parser*`
+- `xtask/src/tasks/*corpus*`
+- `xtask/src/tasks/ci_scope.rs`
+- `xtask/src/tasks/gates.rs`
+- `xtask/src/tasks/ratchet*.rs`
+- `.ci/scope.d/**`
+- `.ci/gates.d/**`
+- `.ci/parser-ratchet/**`
+- `.github/workflows/**`
+- `tests/parser/**`
+- `tests/perl-corpus/**`
+- `Cargo.lock` (when parser-relevant dep movement is indicated by parser-related tags/signals)
+
+## Selected risk tags
+
+- `parser`
+- `lexer`
+- `token`
+- `corpus`
+- `incremental`
+- `tree-sitter`
+- `parser-recovery`
+- `parser-accuracy`
+
+## Non-parser no-op examples
+
+Expected `selected=false`:
+
+- docs-only updates outside parser docs
+- VS Code extension-only updates (unless workflow/scope policy files change)
+- DAP-only updates
+- editor docs
+- forensics docs
+
+## Fixture coverage
+
+Fixtures under `xtask/tests/fixtures/ci-scope/parser-ratchet/` cover:
+
+- docs-only fixture → `selected:false`
+- parser crate change → `selected:true`
+- lexer/token change → `selected:true`
+- `ci_scope.rs` change → `selected:true` (scope-meta)
+- workflow change → `selected:true` (policy-defined)

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/ci-scope-rs-change.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/ci-scope-rs-change.json
@@ -1,0 +1,11 @@
+{
+  "name": "ci-scope-rs-change",
+  "changed_files": [
+    "xtask/src/tasks/ci_scope.rs"
+  ],
+  "risk_tags": [],
+  "expected": {
+    "selected": true,
+    "selection_reason": "scope-meta change affected parser selection policy"
+  }
+}

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/docs-only.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/docs-only.json
@@ -1,0 +1,11 @@
+{
+  "name": "docs-only-non-parser",
+  "changed_files": [
+    "docs/ci/LOCAL_CI_PROTOCOL.md"
+  ],
+  "risk_tags": [],
+  "expected": {
+    "selected": false,
+    "reason": "non-parser docs-only change"
+  }
+}

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/lexer-token-change.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/lexer-token-change.json
@@ -1,0 +1,15 @@
+{
+  "name": "lexer-token-change",
+  "changed_files": [
+    "crates/perl-lexer/src/lib.rs",
+    "crates/perl-token/src/token.rs"
+  ],
+  "risk_tags": [
+    "lexer",
+    "token"
+  ],
+  "expected": {
+    "selected": true,
+    "selection_reason": "lexer/token path and risk tags matched"
+  }
+}

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/parser-crate-change.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/parser-crate-change.json
@@ -1,0 +1,14 @@
+{
+  "name": "parser-crate-change",
+  "changed_files": [
+    "crates/perl-parser/src/parser.rs"
+  ],
+  "risk_tags": [
+    "parser",
+    "parser-accuracy"
+  ],
+  "expected": {
+    "selected": true,
+    "selection_reason": "parser crate path matched"
+  }
+}

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/workflow-change.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/workflow-change.json
@@ -1,0 +1,11 @@
+{
+  "name": "workflow-change",
+  "changed_files": [
+    ".github/workflows/ci.yml"
+  ],
+  "risk_tags": [],
+  "expected": {
+    "selected": true,
+    "selection_reason": "workflow policy change can affect parser ratchet execution"
+  }
+}


### PR DESCRIPTION
### Motivation

- Refs #6847: Parser Ratchet must always emit a receipt but should only run expensive parser corpus work when parser behavior is plausibly affected.
- Introduce a deterministic, selection-only policy so CI can mark `selected=true` with a `selection_reason` for parser-relevant diffs and `selected=false` otherwise.

### Description

- Add a scope policy at `/.ci/scope.d/parser-ratchet.toml` that is `always_report = true`, matches parser-relevant path globs, promotes selection via parser-related risk tags, and supports `Cargo.lock` as a conditional path paired with parser signals.
- Add validation fixtures under `xtask/tests/fixtures/ci-scope/parser-ratchet/` for the covered cases: docs-only (non-selected), parser crate change, lexer/token change, `ci_scope.rs` change, and workflow change (all selected as appropriate).
- Add documentation `docs/ci/parser-ratchet-scope.md` describing the selection-only policy, selected paths and risk tags, non-parser no-op examples, and fixture coverage.
- No runtime changes to `xtask` scope classifier logic were required; this is scope-selection only and does not implement parser corpus runs or comparator logic.

### Testing

- Validated the TOML policy and fixture JSON files with a small `python` check that parsed `.ci/scope.d/parser-ratchet.toml` and all JSON fixtures, which succeeded.
- Ran `cargo test -p xtask ci_scope_tests -- --nocapture` and the test suite completed successfully (scope classification tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0935b8c833390b358794836183f)