### PR TITLE
feat(parser-ratchet): select parser gate from scope and risk tags (#6847)

### DIFF
--- a/.ci/scope.d/parser-ratchet.toml
+++ b/.ci/scope.d/parser-ratchet.toml
@@ -1,0 +1,60 @@
+schema_version = 1
+id = "parser-ratchet"
+name = "Parser Ratchet scope selection"
+always_report = true
+
+[selection]
+# Parser Ratchet reports on every run, but only executes parser-expensive
+# corpus work when parser behavior is plausibly affected.
+#
+# Selection is an OR across path and risk conditions.
+mode = "any"
+
+# Path rules that should select parser scope work.
+path_globs = [
+  "crates/perl-parser/**",
+  "crates/perl-parser-core/**",
+  "crates/perl-lexer/**",
+  "crates/perl-token/**",
+  "crates/tree-sitter-perl-rs/**",
+  "crates/tree-sitter-perl-c/**",
+  "xtask/src/tasks/*parser*",
+  "xtask/src/tasks/*corpus*",
+  "xtask/src/tasks/ci_scope.rs",
+  "xtask/src/tasks/gates.rs",
+  "xtask/src/tasks/ratchet*.rs",
+  ".ci/scope.d/**",
+  ".ci/gates.d/**",
+  ".ci/parser-ratchet/**",
+  ".github/workflows/**",
+  "tests/parser/**",
+  "tests/perl-corpus/**",
+  "Cargo.lock",
+]
+
+# Risk tags that should also select parser scope work, even when path matches
+# are not present in the changed-file set.
+risk_tags_any = [
+  "parser",
+  "lexer",
+  "token",
+  "corpus",
+  "incremental",
+  "tree-sitter",
+  "parser-recovery",
+  "parser-accuracy",
+]
+
+[receipt]
+selected_key = "selected"
+selected_reason_key = "selection_reason"
+not_selected_reason_key = "reason"
+
+[non_parser_noop]
+examples = [
+  "docs-only non-parser docs",
+  "VS Code extension-only unless workflow/scope affects parser gate",
+  "DAP-only",
+  "editor docs",
+  "forensics docs",
+]

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -86,7 +86,7 @@ impl SafeEvaluator {
         }
 
         // Check for assignment operators while avoiding comparison false positives
-        if let Some(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref().ok() {
+        if let Ok(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref() {
             for mat in re.find_iter(expression) {
                 let op = mat.as_str();
                 if ASSIGNMENT_OPERATORS.contains(&op) {

--- a/docs/ci/parser-ratchet-scope.md
+++ b/docs/ci/parser-ratchet-scope.md
@@ -1,0 +1,75 @@
+# Parser Ratchet scope selection
+
+Parser Ratchet is **always reported**, but parser-expensive work should run only when
+parser behavior is plausibly affected.
+
+This policy is configured in:
+
+- `.ci/scope.d/parser-ratchet.toml`
+
+## Selection inputs
+
+Parser Ratchet is selected when **any** parser-relevant signal matches:
+
+1. Changed file path matches a parser-relevant glob.
+2. Scope/risk classification includes any parser-relevant risk tag.
+
+### Parser-relevant path families
+
+- `crates/perl-parser/**`
+- `crates/perl-parser-core/**`
+- `crates/perl-lexer/**`
+- `crates/perl-token/**`
+- `crates/tree-sitter-perl-rs/**`
+- `crates/tree-sitter-perl-c/**`
+- `xtask/src/tasks/*parser*`
+- `xtask/src/tasks/*corpus*`
+- `xtask/src/tasks/ci_scope.rs`
+- `xtask/src/tasks/gates.rs`
+- `xtask/src/tasks/ratchet*.rs`
+- `.ci/scope.d/**`
+- `.ci/gates.d/**`
+- `.ci/parser-ratchet/**`
+- `.github/workflows/**`
+- `tests/parser/**`
+- `tests/perl-corpus/**`
+- `Cargo.lock` (when parser-relevant dependency movement is present)
+
+### Parser-relevant risk tags
+
+- `parser`
+- `lexer`
+- `token`
+- `corpus`
+- `incremental`
+- `tree-sitter`
+- `parser-recovery`
+- `parser-accuracy`
+
+## Receipt contract
+
+Selection is reported in receipt-style output with explicit reason fields:
+
+- selected case: `selected=true` with `selection_reason`
+- non-selected case: `selected=false` with `reason`
+
+This PR intentionally adds **scope-selection only**:
+
+- no workflow-level path filtering
+- no parser corpus execution wiring yet
+- no comparator implementation yet
+- no CPAN additions
+
+## Fixtures
+
+Scope fixtures for policy examples and regression coverage are in:
+
+- `xtask/tests/fixtures/ci-scope/parser-ratchet/`
+
+Included examples:
+
+- docs-only fixture -> `selected:false`
+- parser crate change -> `selected:true`
+- lexer/token change -> `selected:true`
+- `ci_scope.rs` change -> `selected:true`
+- workflow change -> `selected:true`

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/ci-scope-task-change.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/ci-scope-task-change.json
@@ -1,0 +1,11 @@
+{
+  "name": "ci scope task change",
+  "changed_files": [
+    "xtask/src/tasks/ci_scope.rs"
+  ],
+  "risk_tags": [],
+  "expected": {
+    "selected": true,
+    "selection_reason": "matched path: xtask/src/tasks/ci_scope.rs"
+  }
+}

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/docs-only-non-parser.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/docs-only-non-parser.json
@@ -1,0 +1,11 @@
+{
+  "name": "docs-only non-parser docs",
+  "changed_files": [
+    "docs/reference/FAQ.md"
+  ],
+  "risk_tags": [],
+  "expected": {
+    "selected": false,
+    "reason": "no parser-relevant paths or risk tags matched"
+  }
+}

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/lexer-token-change.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/lexer-token-change.json
@@ -1,0 +1,15 @@
+{
+  "name": "lexer token change",
+  "changed_files": [
+    "crates/perl-lexer/src/lexer.rs",
+    "crates/perl-token/src/token.rs"
+  ],
+  "risk_tags": [
+    "lexer",
+    "token"
+  ],
+  "expected": {
+    "selected": true,
+    "selection_reason": "matched path: crates/perl-lexer/**"
+  }
+}

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/parser-crate-change.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/parser-crate-change.json
@@ -1,0 +1,13 @@
+{
+  "name": "parser crate change",
+  "changed_files": [
+    "crates/perl-parser/src/parser.rs"
+  ],
+  "risk_tags": [
+    "parser"
+  ],
+  "expected": {
+    "selected": true,
+    "selection_reason": "matched path: crates/perl-parser/**"
+  }
+}

--- a/xtask/tests/fixtures/ci-scope/parser-ratchet/workflow-change.json
+++ b/xtask/tests/fixtures/ci-scope/parser-ratchet/workflow-change.json
@@ -1,0 +1,11 @@
+{
+  "name": "workflow change",
+  "changed_files": [
+    ".github/workflows/ci.yml"
+  ],
+  "risk_tags": [],
+  "expected": {
+    "selected": true,
+    "selection_reason": "matched path: .github/workflows/**"
+  }
+}


### PR DESCRIPTION
### Motivation

- Parser Ratchet should always report, but only run parser-expensive corpus work when parser behavior is plausibly affected, so a dedicated scope policy is needed to drive that selection decision.

### Description

- Add a scope policy file `.ci/scope.d/parser-ratchet.toml` that sets `always_report = true`, path globs for parser-relevant families, parser-related `risk_tags_any`, and receipt key names (`selected`, `selection_reason`, `reason`).
- Add documentation at `docs/ci/parser-ratchet-scope.md` describing selection inputs, parser-relevant paths and risk tags, the receipt contract, and explicit non-goals (scope-selection only).
- Add fixtures under `xtask/tests/fixtures/ci-scope/parser-ratchet/` covering docs-only no-op, parser crate change, lexer/token change, `ci_scope.rs` change, and workflow change with explicit expected `selected`/reason fields.
- No runtime gate wiring or comparator/corpus execution changes were made; this PR is scope-selection only and does not modify `xtask/src/tasks/*` behavior.

### Testing

- Loaded and parsed the new TOML policy with `tomllib` successfully, confirming validity of `.ci/scope.d/parser-ratchet.toml`.
- Verified all JSON fixture files under `xtask/tests/fixtures/ci-scope/parser-ratchet/` parse successfully with `python json` parsing.
- Attempted `cargo test -p xtask ci_scope_tests` locally (test run started and compiled dependencies), but the local test session was interrupted before completion; full test execution should be validated by CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0935b8c833390b358794836183f)