### PR TITLE
feat(ci): add scope meta-gate for gate-selection changes (#6847)

### DIFF
--- a/.ci/receipts/schemas/scope-meta-gate.schema.json
+++ b/.ci/receipts/schemas/scope-meta-gate.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/scope-meta-gate.schema.json",
+  "title": "Scope Meta Gate Receipt",
+  "type": "object",
+  "required": ["schema_version", "mode", "old_decision", "new_decision", "changed_lanes", "verdict"],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "mode": { "type": "string", "enum": ["fixture", "git"] },
+    "old_decision": { "type": "object" },
+    "new_decision": { "type": "object" },
+    "changed_lanes": {
+      "type": "object",
+      "required": ["dropped", "added", "unchanged"],
+      "properties": {
+        "dropped": { "type": "array", "items": { "type": "string" } },
+        "added": { "type": "array", "items": { "type": "string" } },
+        "unchanged": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "verdict": {
+      "type": "object",
+      "required": ["status", "reason", "required_lanes"],
+      "properties": {
+        "status": { "type": "string", "enum": ["pass", "warn", "fail"] },
+        "reason": { "type": "string" },
+        "required_lanes": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -86,7 +86,7 @@ impl SafeEvaluator {
         }
 
         // Check for assignment operators while avoiding comparison false positives
-        if let Some(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref().ok() {
+        if let Ok(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref() {
             for mat in re.find_iter(expression) {
                 let op = mat.as_str();
                 if ASSIGNMENT_OPERATORS.contains(&op) {

--- a/docs/ci/scope-meta-gate.md
+++ b/docs/ci/scope-meta-gate.md
@@ -1,0 +1,30 @@
+# Scope Meta Gate
+
+`scope-meta-gate` checks whether lane-selection logic changes accidentally drop lanes.
+
+## Command
+
+- `cargo xtask scope-meta-gate --base <sha> --head <sha> --receipt target/receipts/scope-meta-gate.json`
+- `cargo xtask scope-meta-gate --fixture xtask/tests/fixtures/scope-meta-gate/parser-lane-dropped.json`
+
+## Trigger files
+
+This gate is intended for changes under:
+
+- `xtask/src/tasks/ci_scope.rs`
+- `xtask/src/tasks/gates.rs`
+- `.ci/scope.d/**`
+- `.ci/gates.d/**`
+- `.github/workflows/**`
+- `.ci/parser-ratchet/**`
+
+## Receipt
+
+Receipt fields:
+
+- `old_decision`
+- `new_decision`
+- `changed_lanes`
+- `verdict`
+
+Schema: `.ci/receipts/schemas/scope-meta-gate.schema.json`.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -400,6 +400,25 @@ enum Commands {
         format: String,
     },
 
+    /// Verify scope-selection changes cannot silently disable required lanes.
+    ScopeMetaGate {
+        /// Base SHA/reference for old decision computation.
+        #[arg(long)]
+        base: Option<String>,
+
+        /// Head SHA/reference for new decision computation.
+        #[arg(long)]
+        head: Option<String>,
+
+        /// Write receipt JSON to this path.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+
+        /// Load old/new decisions from a fixture JSON file.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+    },
+
     /// Run version-sync checks from `perl-ci-hygiene`.
     CheckVersionSync,
 
@@ -1461,6 +1480,14 @@ fn main() -> Result<()> {
         }
         Commands::CiScope { base, format } => {
             ci_scope::run(ci_scope::CiScopeConfig { base, format })
+        }
+        Commands::ScopeMetaGate { base, head, receipt, fixture } => {
+            scope_meta_gate::run(scope_meta_gate::ScopeMetaGateConfig {
+                base,
+                head,
+                receipt,
+                fixture,
+            })
         }
         Commands::CheckVersionSync => check_version_sync::run(),
         Commands::CheckFromRaw => ci_policy::check_from_raw(),

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -63,6 +63,7 @@ pub mod receipts;
 pub mod release;
 pub mod release_notes;
 pub mod release_turnkey;
+pub mod scope_meta_gate;
 pub mod srp_microcrates;
 pub mod swarm_summary;
 pub mod targeted_checks;

--- a/xtask/src/tasks/scope_meta_gate.rs
+++ b/xtask/src/tasks/scope_meta_gate.rs
@@ -1,0 +1,309 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Context, Result, bail};
+use duct::cmd;
+use serde::{Deserialize, Serialize};
+
+use crate::tasks::ci_scope::{self, ScopeOutput};
+use crate::utils::project_root;
+
+const TRIGGER_PATH_PREFIXES: &[&str] = &[
+    "xtask/src/tasks/ci_scope.rs",
+    "xtask/src/tasks/gates.rs",
+    ".ci/scope.d/",
+    ".ci/gates.d/",
+    ".github/workflows/",
+    ".ci/parser-ratchet/",
+];
+
+#[derive(Debug)]
+pub struct ScopeMetaGateConfig {
+    pub base: Option<String>,
+    pub head: Option<String>,
+    pub receipt: Option<PathBuf>,
+    pub fixture: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScopeMetaGateReceipt {
+    pub schema_version: u32,
+    pub mode: String,
+    pub old_decision: ScopeOutput,
+    pub new_decision: ScopeOutput,
+    pub changed_lanes: ChangedLanes,
+    pub verdict: Verdict,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChangedLanes {
+    pub dropped: Vec<String>,
+    pub added: Vec<String>,
+    pub unchanged: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Verdict {
+    pub status: String,
+    pub reason: String,
+    pub required_lanes: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureDoc {
+    old_decision: ScopeOutput,
+    new_decision: ScopeOutput,
+}
+
+pub fn run(config: ScopeMetaGateConfig) -> Result<()> {
+    let root = project_root()?;
+
+    let (old_decision, new_decision, mode) = if let Some(fixture_path) = config.fixture.as_ref() {
+        let fixture = load_fixture(fixture_path)?;
+        (fixture.old_decision, fixture.new_decision, "fixture".to_string())
+    } else {
+        let base = config.base.clone().ok_or_else(|| {
+            color_eyre::eyre::eyre!("--base is required when --fixture is not provided")
+        })?;
+        let head = config.head.clone().ok_or_else(|| {
+            color_eyre::eyre::eyre!("--head is required when --fixture is not provided")
+        })?;
+        let old = compute_decision_for_sha(&root, &base, &head)?;
+        let new = compute_decision_for_sha(&root, &head, &head)?;
+        (old, new, "git".to_string())
+    };
+
+    let changed_lanes = compare_lanes(&old_decision, &new_decision);
+    let verdict = evaluate_verdict(&old_decision, &new_decision, &changed_lanes);
+
+    let receipt = ScopeMetaGateReceipt {
+        schema_version: 1,
+        mode,
+        old_decision,
+        new_decision,
+        changed_lanes,
+        verdict,
+    };
+
+    let receipt_json = serde_json::to_string_pretty(&receipt)
+        .context("Failed to serialize scope-meta-gate receipt")?;
+    validate_receipt_registry_if_present(&root, &receipt)?;
+
+    if let Some(path) = config.receipt.as_ref() {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed creating receipt dir {}", parent.display()))?;
+        }
+        fs::write(path, &receipt_json)
+            .with_context(|| format!("Failed writing receipt {}", path.display()))?;
+    }
+
+    println!("{receipt_json}");
+
+    if receipt.verdict.status == "fail" {
+        bail!("scope-meta-gate failed: {}", receipt.verdict.reason);
+    }
+
+    Ok(())
+}
+
+fn load_fixture(path: &Path) -> Result<FixtureDoc> {
+    let payload = fs::read_to_string(path)
+        .with_context(|| format!("Failed reading fixture {}", path.display()))?;
+    serde_json::from_str(&payload)
+        .with_context(|| format!("Failed parsing fixture {}", path.display()))
+}
+
+fn compute_decision_for_sha(root: &Path, base: &str, head: &str) -> Result<ScopeOutput> {
+    let changed_files = changed_files_between(root, base, head)?;
+    let metadata = cmd("cargo", ["metadata", "--format-version", "1"])
+        .dir(root)
+        .stdout_capture()
+        .stderr_capture()
+        .run()
+        .context("Failed to run cargo metadata")?;
+    let metadata_json: serde_json::Value =
+        serde_json::from_slice(&metadata.stdout).context("Failed to parse cargo metadata JSON")?;
+    let workspace_root = root.to_string_lossy().replace('\\', "/");
+    let mut decision = ci_scope::classify_files(&changed_files, &metadata_json, &workspace_root)?;
+    decision.base = base.to_string();
+    decision.head_sha = head.to_string();
+    decision.changed_files = changed_files;
+    Ok(decision)
+}
+
+fn changed_files_between(root: &Path, base: &str, head: &str) -> Result<Vec<String>> {
+    let diff_spec = format!("{base}...{head}");
+    let output = cmd("git", ["diff", "--name-only", &diff_spec])
+        .dir(root)
+        .stdout_capture()
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .context("Failed running git diff for scope-meta-gate")?;
+
+    let stdout_bytes = if output.status.success() {
+        output.stdout
+    } else {
+        let fallback_spec = format!("{base}..{head}");
+        cmd("git", ["diff", "--name-only", &fallback_spec])
+            .dir(root)
+            .stdout_capture()
+            .run()
+            .context("Failed running git diff fallback for scope-meta-gate")?
+            .stdout
+    };
+
+    let stdout = String::from_utf8(stdout_bytes).context("git diff output was not UTF-8")?;
+    Ok(stdout.lines().map(|line| line.to_string()).collect())
+}
+
+fn validate_receipt_registry_if_present(root: &Path, receipt: &ScopeMetaGateReceipt) -> Result<()> {
+    let schema_path = root.join(".ci/receipts/schemas/scope-meta-gate.schema.json");
+    if !schema_path.exists() {
+        return Ok(());
+    }
+
+    let schema_doc = fs::read_to_string(&schema_path)
+        .with_context(|| format!("Failed reading schema {}", schema_path.display()))?;
+    let schema_json: serde_json::Value = serde_json::from_str(&schema_doc)
+        .with_context(|| format!("Failed parsing schema {}", schema_path.display()))?;
+
+    let required = schema_json
+        .get("required")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let receipt_json =
+        serde_json::to_value(receipt).context("Failed converting receipt to JSON")?;
+
+    for field in required {
+        if let Some(field_name) = field.as_str()
+            && receipt_json.get(field_name).is_none()
+        {
+            bail!("scope-meta-gate receipt missing required field `{field_name}`");
+        }
+    }
+
+    Ok(())
+}
+
+fn compare_lanes(old_decision: &ScopeOutput, new_decision: &ScopeOutput) -> ChangedLanes {
+    let old: BTreeSet<String> = lane_set(old_decision);
+    let new: BTreeSet<String> = lane_set(new_decision);
+
+    let dropped = old.difference(&new).cloned().collect();
+    let added = new.difference(&old).cloned().collect();
+    let unchanged = old.intersection(&new).cloned().collect();
+
+    ChangedLanes { dropped, added, unchanged }
+}
+
+fn lane_set(decision: &ScopeOutput) -> BTreeSet<String> {
+    decision
+        .selected_lanes
+        .iter()
+        .map(|lane| lane.lane.clone())
+        .chain(decision.selected_heavy_lanes.iter().map(|lane| lane.lane.clone()))
+        .collect()
+}
+
+fn evaluate_verdict(
+    old_decision: &ScopeOutput,
+    new_decision: &ScopeOutput,
+    changed_lanes: &ChangedLanes,
+) -> Verdict {
+    let meta_sensitive_change =
+        old_decision.changed_files.iter().chain(new_decision.changed_files.iter()).any(|path| {
+            TRIGGER_PATH_PREFIXES.iter().any(|prefix| path == *prefix || path.starts_with(prefix))
+        });
+
+    if !changed_lanes.dropped.is_empty() && meta_sensitive_change {
+        return Verdict {
+            status: "fail".to_string(),
+            reason: "lane selection shrank after scope/gate policy changes".to_string(),
+            required_lanes: changed_lanes.dropped.clone(),
+        };
+    }
+
+    if !changed_lanes.dropped.is_empty() {
+        return Verdict {
+            status: "warn".to_string(),
+            reason: "lane selection shrank, but no scope-meta trigger files changed".to_string(),
+            required_lanes: changed_lanes.dropped.clone(),
+        };
+    }
+
+    if !changed_lanes.added.is_empty() {
+        return Verdict {
+            status: "warn".to_string(),
+            reason: "lane selection expanded safely".to_string(),
+            required_lanes: vec![],
+        };
+    }
+
+    Verdict {
+        status: "pass".to_string(),
+        reason: "lane selection unchanged".to_string(),
+        required_lanes: vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use color_eyre::eyre::Result;
+
+    fn scope_output(files: &[&str], lanes: &[&str]) -> ScopeOutput {
+        ScopeOutput {
+            schema_version: 2,
+            base: "base".to_string(),
+            head_sha: "head".to_string(),
+            changed_files: files.iter().map(|f| (*f).to_string()).collect(),
+            diff_class: "code".to_string(),
+            direct_crates: vec![],
+            reverse_dep_closure: vec![],
+            architecture_wideners: vec![],
+            risk_tags: vec![],
+            platform_overrides: Default::default(),
+            selected_lanes: lanes
+                .iter()
+                .map(|lane| ci_scope::LaneEntry {
+                    lane: (*lane).to_string(),
+                    scope: vec![],
+                    reason: "fixture".to_string(),
+                })
+                .collect(),
+            selected_heavy_lanes: vec![],
+            explanations: Default::default(),
+        }
+    }
+
+    #[test]
+    fn fixture_drop_with_scope_logic_change_fails() -> Result<()> {
+        let old_decision =
+            scope_output(&["xtask/src/tasks/ci_scope.rs"], &["parser_ratchet", "clippy_scoped"]);
+        let new_decision = scope_output(&["xtask/src/tasks/ci_scope.rs"], &["clippy_scoped"]);
+
+        let changed = compare_lanes(&old_decision, &new_decision);
+        let verdict = evaluate_verdict(&old_decision, &new_decision, &changed);
+
+        assert_eq!(verdict.status, "fail");
+        assert!(verdict.required_lanes.contains(&"parser_ratchet".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_docs_expansion_warns() -> Result<()> {
+        let old_decision = scope_output(&["docs/ci/LOCAL_CI_PROTOCOL.md"], &["clippy_scoped"]);
+        let new_decision =
+            scope_output(&["docs/ci/LOCAL_CI_PROTOCOL.md"], &["clippy_scoped", "docs"]);
+
+        let changed = compare_lanes(&old_decision, &new_decision);
+        let verdict = evaluate_verdict(&old_decision, &new_decision, &changed);
+
+        assert!(verdict.status == "warn" || verdict.status == "pass");
+        Ok(())
+    }
+}

--- a/xtask/tests/fixtures/scope-meta-gate/docs-scope-expands.json
+++ b/xtask/tests/fixtures/scope-meta-gate/docs-scope-expands.json
@@ -1,0 +1,37 @@
+{
+  "old_decision": {
+    "schema_version": 2,
+    "base": "old",
+    "head_sha": "old",
+    "changed_files": ["docs/ci/LOCAL_CI_PROTOCOL.md"],
+    "diff_class": "prose_only",
+    "direct_crates": [],
+    "reverse_dep_closure": [],
+    "architecture_wideners": [],
+    "risk_tags": [],
+    "platform_overrides": {"windows_runner": false},
+    "selected_lanes": [
+      {"lane": "clippy_scoped", "scope": ["xtask"], "reason": "direct"}
+    ],
+    "selected_heavy_lanes": [],
+    "explanations": {}
+  },
+  "new_decision": {
+    "schema_version": 2,
+    "base": "new",
+    "head_sha": "new",
+    "changed_files": ["docs/ci/LOCAL_CI_PROTOCOL.md"],
+    "diff_class": "prose_only",
+    "direct_crates": [],
+    "reverse_dep_closure": [],
+    "architecture_wideners": [],
+    "risk_tags": [],
+    "platform_overrides": {"windows_runner": false},
+    "selected_lanes": [
+      {"lane": "clippy_scoped", "scope": ["xtask"], "reason": "direct"},
+      {"lane": "docs", "scope": [], "reason": "docs"}
+    ],
+    "selected_heavy_lanes": [],
+    "explanations": {}
+  }
+}

--- a/xtask/tests/fixtures/scope-meta-gate/parser-lane-dropped.json
+++ b/xtask/tests/fixtures/scope-meta-gate/parser-lane-dropped.json
@@ -1,0 +1,37 @@
+{
+  "old_decision": {
+    "schema_version": 2,
+    "base": "old",
+    "head_sha": "old",
+    "changed_files": ["xtask/src/tasks/ci_scope.rs"],
+    "diff_class": "ci_config",
+    "direct_crates": [],
+    "reverse_dep_closure": [],
+    "architecture_wideners": [],
+    "risk_tags": [],
+    "platform_overrides": {"windows_runner": false},
+    "selected_lanes": [
+      {"lane": "clippy_scoped", "scope": ["xtask"], "reason": "direct"},
+      {"lane": "parser_ratchet", "scope": [], "reason": "policy"}
+    ],
+    "selected_heavy_lanes": [],
+    "explanations": {}
+  },
+  "new_decision": {
+    "schema_version": 2,
+    "base": "new",
+    "head_sha": "new",
+    "changed_files": ["xtask/src/tasks/ci_scope.rs"],
+    "diff_class": "ci_config",
+    "direct_crates": [],
+    "reverse_dep_closure": [],
+    "architecture_wideners": [],
+    "risk_tags": [],
+    "platform_overrides": {"windows_runner": false},
+    "selected_lanes": [
+      {"lane": "clippy_scoped", "scope": ["xtask"], "reason": "direct"}
+    ],
+    "selected_heavy_lanes": [],
+    "explanations": {}
+  }
+}

--- a/xtask/tests/scope_meta_gate_tests.rs
+++ b/xtask/tests/scope_meta_gate_tests.rs
@@ -1,0 +1,61 @@
+use assert_cmd::Command;
+use color_eyre::eyre::Result;
+
+fn fixture_path(name: &str) -> String {
+    format!("{}/tests/fixtures/scope-meta-gate/{name}", env!("CARGO_MANIFEST_DIR"))
+}
+
+#[test]
+fn fixture_parser_lane_removed_fails() -> Result<()> {
+    let fixture = fixture_path("parser-lane-dropped.json");
+    let output = Command::cargo_bin("xtask")?
+        .args(["scope-meta-gate", "--fixture", fixture.as_str()])
+        .output()?;
+
+    assert!(
+        !output.status.success(),
+        "expected failure when parser lane is dropped; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}
+
+#[test]
+fn fixture_docs_scope_expands_passes_or_warns() -> Result<()> {
+    let fixture = fixture_path("docs-scope-expands.json");
+    let output = Command::cargo_bin("xtask")?
+        .args(["scope-meta-gate", "--fixture", fixture.as_str()])
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "docs expansion should pass/warn without failing; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout)?;
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)?;
+    let status =
+        parsed.get("verdict").and_then(|v| v.get("status")).and_then(|v| v.as_str()).unwrap_or("");
+    assert!(status == "warn" || status == "pass", "expected pass/warn, got {status}");
+    Ok(())
+}
+
+#[test]
+fn receipt_contains_required_top_level_fields() -> Result<()> {
+    let fixture = fixture_path("docs-scope-expands.json");
+    let output = Command::cargo_bin("xtask")?
+        .args(["scope-meta-gate", "--fixture", fixture.as_str()])
+        .output()?;
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)?;
+
+    for field in ["old_decision", "new_decision", "changed_lanes", "verdict"] {
+        assert!(parsed.get(field).is_some(), "missing required field: {field}");
+    }
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Prevent scope/gate-selection logic changes from silently disabling critical CI lanes (e.g., Parser Ratchet) by making the gate-selection decision itself testable and enforceable.
- Provide a reproducible, fixture-driven way to compare old/new scope decisions so policy/workflow changes are surfaced during review.

### Description

- Add a new xtask command and task implementation in `xtask/src/tasks/scope_meta_gate.rs` that supports both git SHA mode and fixture mode and emits a structured receipt (schema v1).
- Wire the new command into the CLI and task registry via `xtask/src/main.rs` and `xtask/src/tasks/mod.rs` so it can be invoked as `cargo xtask scope-meta-gate`.
- Implement comparison logic that computes `old_decision` and `new_decision` (via `ci_scope::classify_files`), derives `changed_lanes` (`dropped`, `added`, `unchanged`), and produces a `verdict` of `pass`/`warn`/`fail` that fails when lane selection shrinks and a scope-sensitive file was changed.
- Add artifacts: receipt JSON schema `.ci/receipts/schemas/scope-meta-gate.schema.json`, documentation `docs/ci/scope-meta-gate.md`, fixture inputs `xtask/tests/fixtures/scope-meta-gate/*.json`, and integration tests `xtask/tests/scope_meta_gate_tests.rs` that exercise the fail/warn/pass scenarios.

### Testing

- Ran unit/integration tests with `cargo test -p xtask --test scope_meta_gate_tests` and they passed.
- Performed type/check and lints with `cargo check --all-targets -p xtask` and `cargo clippy -p xtask -- -D warnings`, both of which succeeded.
- Formatted via `cargo xtask fmt` and validated the new task by running fixture-driven commands `cargo xtask scope-meta-gate --fixture xtask/tests/fixtures/scope-meta-gate/parser-lane-dropped.json --receipt target/receipts/scope-meta-gate.json` (produces a failing verdict as expected) and `cargo xtask scope-meta-gate --fixture xtask/tests/fixtures/scope-meta-gate/docs-scope-expands.json --receipt target/receipts/scope-meta-gate.json` (produces pass/warn as expected).

Refs #6847
Refs #6853

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0978c4483338a98cf25ef7a6255)