### PR TITLE
feat(ci): add scope meta-gate for gate-selection changes (#6847)

### DIFF
--- a/.ci/receipts/schemas/scope-meta-gate.schema.json
+++ b/.ci/receipts/schemas/scope-meta-gate.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/scope-meta-gate.schema.json",
+  "title": "scope-meta-gate receipt",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "changed_files",
+    "old_decision",
+    "new_decision",
+    "changed_lanes",
+    "verdict",
+    "reason"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "base": {
+      "type": ["string", "null"]
+    },
+    "head": {
+      "type": ["string", "null"]
+    },
+    "changed_files": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "old_decision": {
+      "$ref": "#/$defs/scopeDecision"
+    },
+    "new_decision": {
+      "$ref": "#/$defs/scopeDecision"
+    },
+    "changed_lanes": {
+      "type": "object",
+      "required": ["removed", "added", "unchanged"],
+      "properties": {
+        "removed": { "type": "array", "items": { "type": "string" } },
+        "added": { "type": "array", "items": { "type": "string" } },
+        "unchanged": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "warn", "fail"]
+    },
+    "reason": {
+      "type": "string"
+    }
+  },
+  "$defs": {
+    "scopeDecision": {
+      "type": "object",
+      "required": ["selected_lanes", "selected_heavy_lanes"],
+      "properties": {
+        "selected_lanes": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "selected_heavy_lanes": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -86,7 +86,7 @@ impl SafeEvaluator {
         }
 
         // Check for assignment operators while avoiding comparison false positives
-        if let Some(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref().ok() {
+        if let Ok(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref() {
             for mat in re.find_iter(expression) {
                 let op = mat.as_str();
                 if ASSIGNMENT_OPERATORS.contains(&op) {

--- a/docs/ci/scope-meta-gate.md
+++ b/docs/ci/scope-meta-gate.md
@@ -1,0 +1,39 @@
+# Scope Meta-Gate
+
+`scope-meta-gate` protects lane-selection governance from silent narrowing.
+
+## Command
+
+```bash
+cargo xtask scope-meta-gate --base <sha> --head <sha> --receipt target/receipts/scope-meta-gate.json
+cargo xtask scope-meta-gate --fixture xtask/tests/fixtures/scope-meta-gate/remove-parser-lane-fail.json
+```
+
+## Trigger surface
+
+Run this gate when any of these change:
+
+- `xtask/src/tasks/ci_scope.rs`
+- `xtask/src/tasks/gates.rs`
+- `.ci/scope.d/**`
+- `.ci/gates.d/**`
+- `.github/workflows/**`
+- `.ci/parser-ratchet/**`
+
+## Verdict policy
+
+- **fail**: protected scope files changed and at least one lane was removed.
+- **warn**: protected scope files changed and scope only expanded.
+- **pass**: no protected files changed, or protected files changed with no lane delta.
+
+## Receipt schema
+
+Schema path: `.ci/receipts/schemas/scope-meta-gate.schema.json`.
+
+Receipt includes:
+
+- `old_decision`
+- `new_decision`
+- `changed_lanes` (`removed`, `added`, `unchanged`)
+- `verdict`
+- `reason`

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1059,6 +1059,25 @@ enum Commands {
         verbose: bool,
     },
 
+    /// Compare scope decisions across gate-selection logic changes.
+    ScopeMetaGate {
+        /// Base git reference (required unless --fixture is provided).
+        #[arg(long)]
+        base: Option<String>,
+
+        /// Head git reference (required unless --fixture is provided).
+        #[arg(long)]
+        head: Option<String>,
+
+        /// Fixture JSON path containing old_decision/new_decision.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+
+        /// Receipt output path.
+        #[arg(long, default_value = "target/receipts/scope-meta-gate.json")]
+        receipt: PathBuf,
+    },
+
     /// Verify hook scripts are executable.
     HookCheck,
 
@@ -1461,6 +1480,14 @@ fn main() -> Result<()> {
         }
         Commands::CiScope { base, format } => {
             ci_scope::run(ci_scope::CiScopeConfig { base, format })
+        }
+        Commands::ScopeMetaGate { base, head, fixture, receipt } => {
+            scope_meta_gate::run(scope_meta_gate::ScopeMetaGateConfig {
+                base,
+                head,
+                fixture,
+                receipt,
+            })
         }
         Commands::CheckVersionSync => check_version_sync::run(),
         Commands::CheckFromRaw => ci_policy::check_from_raw(),

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -63,6 +63,7 @@ pub mod receipts;
 pub mod release;
 pub mod release_notes;
 pub mod release_turnkey;
+pub mod scope_meta_gate;
 pub mod srp_microcrates;
 pub mod swarm_summary;
 pub mod targeted_checks;

--- a/xtask/src/tasks/scope_meta_gate.rs
+++ b/xtask/src/tasks/scope_meta_gate.rs
@@ -1,0 +1,290 @@
+//! Scope meta-gate: protects CI gate-selection logic from silent regressions.
+//!
+//! `scope-meta-gate` compares an `old_decision` and `new_decision` and fails
+//! when lanes are dropped by scope-logic changes in protected files.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Context, Result, bail};
+use duct::cmd;
+use serde::{Deserialize, Serialize};
+
+use crate::tasks::ci_scope::{self, ScopeOutput};
+
+const META_SCOPE_PREFIXES: &[&str] = &[
+    "xtask/src/tasks/ci_scope.rs",
+    "xtask/src/tasks/gates.rs",
+    ".ci/scope.d/",
+    ".ci/gates.d/",
+    ".github/workflows/",
+    ".ci/parser-ratchet/",
+];
+
+#[derive(Debug, Clone)]
+pub struct ScopeMetaGateConfig {
+    pub base: Option<String>,
+    pub head: Option<String>,
+    pub fixture: Option<PathBuf>,
+    pub receipt: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScopeDecision {
+    pub selected_lanes: Vec<String>,
+    #[serde(default)]
+    pub selected_heavy_lanes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FixtureInput {
+    #[serde(default)]
+    changed_files: Vec<String>,
+    old_decision: ScopeDecision,
+    new_decision: ScopeDecision,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScopeMetaGateReceipt {
+    pub schema_version: u32,
+    pub base: Option<String>,
+    pub head: Option<String>,
+    pub changed_files: Vec<String>,
+    pub old_decision: ScopeDecision,
+    pub new_decision: ScopeDecision,
+    pub changed_lanes: ChangedLanes,
+    pub verdict: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChangedLanes {
+    pub removed: Vec<String>,
+    pub added: Vec<String>,
+    pub unchanged: Vec<String>,
+}
+
+pub fn run(config: ScopeMetaGateConfig) -> Result<()> {
+    let (base, head, changed_files, old_decision, new_decision) =
+        load_decisions(&config).context("Failed to load scope decisions")?;
+
+    let changed_lanes = diff_lanes(&old_decision, &new_decision);
+    let meta_touched = touches_meta_scope_files(&changed_files);
+
+    let (verdict, reason) = if !meta_touched {
+        ("pass".to_string(), "No protected scope-meta files changed".to_string())
+    } else if !changed_lanes.removed.is_empty() {
+        (
+            "fail".to_string(),
+            format!(
+                "Protected scope logic changed and lane(s) were removed: {}",
+                changed_lanes.removed.join(", ")
+            ),
+        )
+    } else if !changed_lanes.added.is_empty() {
+        (
+            "warn".to_string(),
+            format!(
+                "Protected scope logic changed and lane coverage expanded: {}",
+                changed_lanes.added.join(", ")
+            ),
+        )
+    } else {
+        (
+            "pass".to_string(),
+            "Protected scope logic changed but lane selection is unchanged".to_string(),
+        )
+    };
+
+    let receipt = ScopeMetaGateReceipt {
+        schema_version: 1,
+        base,
+        head,
+        changed_files,
+        old_decision,
+        new_decision,
+        changed_lanes,
+        verdict: verdict.clone(),
+        reason,
+    };
+
+    if let Some(parent) = config.receipt.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed creating receipt dir {}", parent.display()))?;
+    }
+
+    let json = serde_json::to_string_pretty(&receipt)?;
+    fs::write(&config.receipt, json)
+        .with_context(|| format!("Failed writing receipt to {}", config.receipt.display()))?;
+
+    println!("scope-meta-gate verdict: {}", receipt.verdict);
+    println!("receipt: {}", config.receipt.display());
+
+    if verdict == "fail" {
+        bail!("scope-meta-gate failed: lane selection narrowed in protected scope files");
+    }
+
+    Ok(())
+}
+
+fn load_decisions(
+    config: &ScopeMetaGateConfig,
+) -> Result<(Option<String>, Option<String>, Vec<String>, ScopeDecision, ScopeDecision)> {
+    if let Some(fixture) = &config.fixture {
+        let raw = fs::read_to_string(fixture)
+            .with_context(|| format!("Failed reading fixture {}", fixture.display()))?;
+        let parsed: FixtureInput = serde_json::from_str(&raw)
+            .with_context(|| format!("Fixture JSON is invalid: {}", fixture.display()))?;
+
+        return Ok((None, None, parsed.changed_files, parsed.old_decision, parsed.new_decision));
+    }
+
+    let (base, head) = match (&config.base, &config.head) {
+        (Some(base), Some(head)) => (base.clone(), head.clone()),
+        _ => bail!("Provide either --fixture <path> OR both --base <sha> --head <sha>"),
+    };
+
+    let root = crate::utils::project_root()?;
+    let changed_files = changed_files_between(&root, &base, &head)?;
+
+    let metadata = load_metadata(&root)?;
+    let workspace_root = root.to_string_lossy().replace('\\', "/");
+
+    // `old_decision` is evaluated against non-meta paths to represent prior
+    // lane intent. `new_decision` includes all changed files under new logic.
+    let non_meta_files: Vec<String> =
+        changed_files.iter().filter(|f| !is_meta_scope_file(f)).cloned().collect();
+
+    let old_scope = ci_scope::classify_files(&non_meta_files, &metadata, &workspace_root)?;
+    let new_scope = ci_scope::classify_files(&changed_files, &metadata, &workspace_root)?;
+
+    Ok((
+        Some(base),
+        Some(head),
+        changed_files,
+        scope_to_decision(&old_scope),
+        scope_to_decision(&new_scope),
+    ))
+}
+
+fn scope_to_decision(scope: &ScopeOutput) -> ScopeDecision {
+    ScopeDecision {
+        selected_lanes: scope.selected_lanes.iter().map(|lane| lane.lane.clone()).collect(),
+        selected_heavy_lanes: scope
+            .selected_heavy_lanes
+            .iter()
+            .map(|lane| lane.lane.clone())
+            .collect(),
+    }
+}
+
+fn diff_lanes(old_decision: &ScopeDecision, new_decision: &ScopeDecision) -> ChangedLanes {
+    let old: BTreeSet<String> = old_decision
+        .selected_lanes
+        .iter()
+        .chain(old_decision.selected_heavy_lanes.iter())
+        .cloned()
+        .collect();
+    let new: BTreeSet<String> = new_decision
+        .selected_lanes
+        .iter()
+        .chain(new_decision.selected_heavy_lanes.iter())
+        .cloned()
+        .collect();
+
+    let removed: Vec<String> = old.difference(&new).cloned().collect();
+    let added: Vec<String> = new.difference(&old).cloned().collect();
+    let unchanged: Vec<String> = old.intersection(&new).cloned().collect();
+
+    ChangedLanes { removed, added, unchanged }
+}
+
+fn touches_meta_scope_files(files: &[String]) -> bool {
+    files.iter().any(|f| is_meta_scope_file(f))
+}
+
+fn is_meta_scope_file(path: &str) -> bool {
+    META_SCOPE_PREFIXES.iter().any(|prefix| path == *prefix || path.starts_with(prefix))
+}
+
+fn changed_files_between(root: &Path, base: &str, head: &str) -> Result<Vec<String>> {
+    let diff_spec = format!("{base}...{head}");
+    let output = cmd("git", ["diff", "--name-only", &diff_spec])
+        .dir(root)
+        .stdout_capture()
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .context("Failed to run git diff")?;
+
+    let stdout = if output.status.success() {
+        String::from_utf8(output.stdout).context("git diff output was not valid UTF-8")?
+    } else {
+        let fallback_diff = format!("{base}..{head}");
+        let fallback = cmd("git", ["diff", "--name-only", &fallback_diff])
+            .dir(root)
+            .stdout_capture()
+            .stderr_capture()
+            .run()
+            .context("Failed to run fallback git diff")?;
+        String::from_utf8(fallback.stdout)
+            .context("fallback git diff output was not valid UTF-8")?
+    };
+
+    Ok(stdout.lines().map(ToString::to_string).collect())
+}
+
+fn load_metadata(root: &Path) -> Result<serde_json::Value> {
+    let output = cmd("cargo", ["metadata", "--format-version", "1"])
+        .dir(root)
+        .stdout_capture()
+        .stderr_capture()
+        .run()
+        .context("Failed to run cargo metadata")?;
+
+    let stdout =
+        String::from_utf8(output.stdout).context("cargo metadata output was not valid UTF-8")?;
+    serde_json::from_str(&stdout).context("Failed to parse cargo metadata JSON")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use color_eyre::eyre::Result;
+
+    #[test]
+    fn lane_diff_detects_removed_lanes() {
+        let old = ScopeDecision {
+            selected_lanes: vec!["parser_ratchet".to_string(), "test_scoped".to_string()],
+            selected_heavy_lanes: vec![],
+        };
+        let new = ScopeDecision {
+            selected_lanes: vec!["test_scoped".to_string()],
+            selected_heavy_lanes: vec![],
+        };
+
+        let diff = diff_lanes(&old, &new);
+        assert_eq!(diff.removed, vec!["parser_ratchet".to_string()]);
+        assert!(diff.added.is_empty());
+    }
+
+    #[test]
+    fn meta_path_matcher_handles_prefixes() {
+        assert!(is_meta_scope_file("xtask/src/tasks/ci_scope.rs"));
+        assert!(is_meta_scope_file(".ci/scope.d/parser.yaml"));
+        assert!(is_meta_scope_file(".github/workflows/pr-smoke.yml"));
+        assert!(!is_meta_scope_file("crates/perl-parser/src/lib.rs"));
+    }
+
+    #[test]
+    fn fixture_roundtrip_parses() -> Result<()> {
+        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/scope-meta-gate/remove-parser-lane-fail.json");
+        let raw = fs::read_to_string(&fixture_path)?;
+        let fixture: FixtureInput = serde_json::from_str(&raw)?;
+        assert!(fixture.changed_files.iter().any(|f| f == "xtask/src/tasks/ci_scope.rs"));
+        assert!(fixture.old_decision.selected_lanes.iter().any(|l| l == "parser_ratchet"));
+        Ok(())
+    }
+}

--- a/xtask/tests/fixtures/scope-meta-gate/docs-expands-warn.json
+++ b/xtask/tests/fixtures/scope-meta-gate/docs-expands-warn.json
@@ -1,0 +1,19 @@
+{
+  "changed_files": [
+    ".ci/scope.d/docs.yaml",
+    "docs/ci/policy.md"
+  ],
+  "old_decision": {
+    "selected_lanes": [
+      "test_scoped"
+    ],
+    "selected_heavy_lanes": []
+  },
+  "new_decision": {
+    "selected_lanes": [
+      "test_scoped",
+      "doc_check"
+    ],
+    "selected_heavy_lanes": []
+  }
+}

--- a/xtask/tests/fixtures/scope-meta-gate/remove-parser-lane-fail.json
+++ b/xtask/tests/fixtures/scope-meta-gate/remove-parser-lane-fail.json
@@ -1,0 +1,19 @@
+{
+  "changed_files": [
+    "xtask/src/tasks/ci_scope.rs",
+    ".ci/parser-ratchet/rules.yaml"
+  ],
+  "old_decision": {
+    "selected_lanes": [
+      "parser_ratchet",
+      "test_scoped"
+    ],
+    "selected_heavy_lanes": []
+  },
+  "new_decision": {
+    "selected_lanes": [
+      "test_scoped"
+    ],
+    "selected_heavy_lanes": []
+  }
+}

--- a/xtask/tests/scope_meta_gate_tests.rs
+++ b/xtask/tests/scope_meta_gate_tests.rs
@@ -1,0 +1,96 @@
+use assert_cmd::Command;
+use color_eyre::eyre::Result;
+use std::path::PathBuf;
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+#[test]
+fn fixture_that_removes_parser_lane_fails() -> Result<()> {
+    let fixture =
+        manifest_dir().join("tests/fixtures/scope-meta-gate/remove-parser-lane-fail.json");
+    let receipt = manifest_dir().join("target/receipts/scope-meta-gate-fixture-fail.json");
+
+    let output = Command::cargo_bin("xtask")?
+        .current_dir(manifest_dir())
+        .args([
+            "scope-meta-gate",
+            "--fixture",
+            &fixture.to_string_lossy(),
+            "--receipt",
+            &receipt.to_string_lossy(),
+        ])
+        .output()?;
+
+    assert!(!output.status.success(), "fixture removing parser lane must fail");
+    Ok(())
+}
+
+#[test]
+fn fixture_that_expands_docs_scope_warns_and_passes() -> Result<()> {
+    let fixture = manifest_dir().join("tests/fixtures/scope-meta-gate/docs-expands-warn.json");
+    let receipt = manifest_dir().join("target/receipts/scope-meta-gate-fixture-warn.json");
+
+    let output = Command::cargo_bin("xtask")?
+        .current_dir(manifest_dir())
+        .args([
+            "scope-meta-gate",
+            "--fixture",
+            &fixture.to_string_lossy(),
+            "--receipt",
+            &receipt.to_string_lossy(),
+        ])
+        .output()?;
+
+    assert!(output.status.success(), "scope expansion fixture should not fail");
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(
+        stdout.contains("warn") || stdout.contains("pass"),
+        "expected warn/pass verdict in output, got: {stdout}"
+    );
+    Ok(())
+}
+
+#[test]
+fn receipt_validates_against_schema_when_python_jsonschema_is_available() -> Result<()> {
+    let fixture = manifest_dir().join("tests/fixtures/scope-meta-gate/docs-expands-warn.json");
+    let receipt = manifest_dir().join("target/receipts/scope-meta-gate-fixture-schema.json");
+
+    let output = Command::cargo_bin("xtask")?
+        .current_dir(manifest_dir())
+        .args([
+            "scope-meta-gate",
+            "--fixture",
+            &fixture.to_string_lossy(),
+            "--receipt",
+            &receipt.to_string_lossy(),
+        ])
+        .output()?;
+    assert!(output.status.success(), "receipt generation should succeed");
+
+    let py = std::process::Command::new("python3")
+        .args([
+            "-c",
+            "import importlib.util,sys;sys.exit(0 if importlib.util.find_spec('jsonschema') else 1)",
+        ])
+        .status()?;
+
+    if !py.success() {
+        return Ok(());
+    }
+
+    let schema = manifest_dir().join("../.ci/receipts/schemas/scope-meta-gate.schema.json");
+    let validate = std::process::Command::new("python3")
+        .args([
+            "-c",
+            &format!(
+                "import json, jsonschema; s=json.load(open(r'{}')); d=json.load(open(r'{}')); jsonschema.validate(d, s)",
+                schema.display(),
+                receipt.display()
+            ),
+        ])
+        .status()?;
+    assert!(validate.success(), "jsonschema validation should pass when jsonschema is installed");
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Prevent silent regressions in gate-selection logic by making the scope-decision comparator itself testable and auditable. 
- Ensure that changes to `ci-scope`, gate policy, scope fragments, or workflows cannot quietly narrow protected lanes (for example the Parser Ratchet). 
- Provide a deterministic, fixture-driven comparison path so repository changes that affect lane selection produce a structured receipt for downstream validation.

### Description
- Add `xtask/src/tasks/scope_meta_gate.rs` which implements `cargo xtask scope-meta-gate` supporting `--fixture` or `--base/--head`, computes `old_decision` and `new_decision` via `ci_scope::classify_files`, diffs lanes, and emits a `ScopeMetaGateReceipt` JSON. 
- Add a JSON schema at `.ci/receipts/schemas/scope-meta-gate.schema.json` and user docs at `docs/ci/scope-meta-gate.md`. 
- Add fixtures under `xtask/tests/fixtures/scope-meta-gate/` and integration tests `xtask/tests/scope_meta_gate_tests.rs`, and wire the new command into the xtask CLI (`xtask/src/main.rs`) and task registry (`xtask/src/tasks/mod.rs`). 
- Verdict policy implemented: `fail` when protected scope files changed and lanes were removed, `warn` when scope expands, and `pass` otherwise (receipt includes `old_decision`, `new_decision`, `changed_lanes`, `verdict`, and `reason`). Refs `#6847` and `#6853`.

### Testing
- Unit tests for the new module (`cargo test -p xtask scope_meta_gate`) passed. 
- Integration/fixture tests (`cargo test -p xtask --test scope_meta_gate_tests`) passed and verify the failing fixture (parser-lane removal) and the warn/pass fixture (docs expansion). 
- `cargo check --all-targets -p xtask` and `cargo xtask fmt --package xtask` completed successfully. 
- `cargo clippy -p xtask` passed, while `cargo clippy -p xtask --all-targets -- -D warnings` surfaced unrelated pre-existing lints and therefore failed; these lints are not introduced by this change. 
- Manual CLI runs of `cargo xtask scope-meta-gate --fixture <fixture> --receipt <path>` produced the expected `fail` and `warn` verdicts and wrote receipts, and tests include an optional Python `jsonschema` validation that is skipped when the `jsonschema` package is not present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0978c4483338a98cf25ef7a6255)