### PR TITLE
feat(ci): add scope meta-gate for gate-selection changes (#6847)

### DIFF
--- a/.ci/receipts/schemas/scope-meta-gate.schema.json
+++ b/.ci/receipts/schemas/scope-meta-gate.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/ci/receipts/scope-meta-gate.schema.json",
+  "title": "Scope Meta Gate Receipt",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "old_decision",
+    "new_decision",
+    "changed_lanes",
+    "verdict",
+    "advisory"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "old_decision": { "$ref": "#/$defs/decision" },
+    "new_decision": { "$ref": "#/$defs/decision" },
+    "changed_lanes": {
+      "type": "object",
+      "required": ["removed", "added", "unchanged"],
+      "properties": {
+        "removed": { "$ref": "#/$defs/lane_list" },
+        "added": { "$ref": "#/$defs/lane_list" },
+        "unchanged": { "$ref": "#/$defs/lane_list" }
+      },
+      "additionalProperties": false
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "warn", "fail"]
+    },
+    "advisory": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "$defs": {
+    "lane_list": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "decision": {
+      "type": "object",
+      "required": ["selected_lanes"],
+      "properties": {
+        "selected_lanes": { "$ref": "#/$defs/lane_list" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/ci/scope-meta-gate.md
+++ b/docs/ci/scope-meta-gate.md
@@ -1,0 +1,45 @@
+# scope-meta-gate
+
+`scope-meta-gate` protects CI gate selection logic from silent regressions.
+
+## Purpose
+
+When a PR modifies scope/gate policy inputs, we compare **old** and **new** lane decisions.
+If a lane (for example `parser_ratchet`) becomes unselected, the meta-gate fails.
+
+Sensitive paths:
+
+- `xtask/src/tasks/ci_scope.rs`
+- `xtask/src/tasks/gates.rs`
+- `.ci/scope.d/**`
+- `.ci/gates.d/**`
+- `.github/workflows/**`
+- `.ci/parser-ratchet/**`
+
+## Commands
+
+```bash
+cargo xtask scope-meta-gate --base <sha> --head <sha> --receipt target/receipts/scope-meta-gate.json
+cargo xtask scope-meta-gate --fixture xtask/tests/fixtures/scope-meta-gate/parser-lane-removed.json
+```
+
+## Fixture format
+
+```json
+{
+  "old_decision": { "selected_lanes": ["parser_ratchet", "test_scoped"] },
+  "new_decision": { "selected_lanes": ["test_scoped"] }
+}
+```
+
+## Receipt shape
+
+The receipt contains:
+
+- `old_decision`
+- `new_decision`
+- `changed_lanes` (`removed`, `added`, `unchanged`)
+- `verdict` (`pass`, `warn`, `fail`)
+- `advisory`
+
+Use `.ci/receipts/schemas/scope-meta-gate.schema.json` for validation.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -400,6 +400,25 @@ enum Commands {
         format: String,
     },
 
+    /// Detect lane-selection regressions when CI scope logic changes.
+    ScopeMetaGate {
+        /// Base git SHA/reference used for the old decision.
+        #[arg(long)]
+        base: Option<String>,
+
+        /// Head git SHA/reference used for the new decision.
+        #[arg(long)]
+        head: Option<String>,
+
+        /// Optional path to write a receipt JSON.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+
+        /// Optional fixture JSON with `old_decision` and `new_decision`.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+    },
+
     /// Run version-sync checks from `perl-ci-hygiene`.
     CheckVersionSync,
 
@@ -1461,6 +1480,14 @@ fn main() -> Result<()> {
         }
         Commands::CiScope { base, format } => {
             ci_scope::run(ci_scope::CiScopeConfig { base, format })
+        }
+        Commands::ScopeMetaGate { base, head, receipt, fixture } => {
+            scope_meta_gate::run(scope_meta_gate::ScopeMetaGateConfig {
+                base,
+                head,
+                receipt,
+                fixture,
+            })
         }
         Commands::CheckVersionSync => check_version_sync::run(),
         Commands::CheckFromRaw => ci_policy::check_from_raw(),

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -63,6 +63,7 @@ pub mod receipts;
 pub mod release;
 pub mod release_notes;
 pub mod release_turnkey;
+pub mod scope_meta_gate;
 pub mod srp_microcrates;
 pub mod swarm_summary;
 pub mod targeted_checks;

--- a/xtask/src/tasks/scope_meta_gate.rs
+++ b/xtask/src/tasks/scope_meta_gate.rs
@@ -1,0 +1,262 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::tasks::ci_scope::{self, ScopeOutput};
+
+const SENSITIVE_PATH_PREFIXES: &[&str] = &[
+    "xtask/src/tasks/ci_scope.rs",
+    "xtask/src/tasks/gates.rs",
+    ".ci/scope.d/",
+    ".ci/gates.d/",
+    ".github/workflows/",
+    ".ci/parser-ratchet/",
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScopeMetaGateConfig {
+    pub base: Option<String>,
+    pub head: Option<String>,
+    pub receipt: Option<PathBuf>,
+    pub fixture: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScopeMetaGateReceipt {
+    pub schema_version: u32,
+    pub old_decision: LaneDecision,
+    pub new_decision: LaneDecision,
+    pub changed_lanes: ChangedLanes,
+    pub verdict: String,
+    pub advisory: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaneDecision {
+    pub selected_lanes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChangedLanes {
+    pub removed: Vec<String>,
+    pub added: Vec<String>,
+    pub unchanged: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FixtureInput {
+    old_decision: LaneDecision,
+    new_decision: LaneDecision,
+}
+
+pub fn run(config: ScopeMetaGateConfig) -> Result<()> {
+    let receipt = if let Some(fixture) = &config.fixture {
+        run_fixture(fixture)?
+    } else {
+        run_from_git(&config)?
+    };
+
+    if let Some(path) = &config.receipt {
+        write_receipt(path, &receipt)?;
+    }
+
+    println!("{}", serde_json::to_string_pretty(&receipt)?);
+
+    if receipt.verdict == "fail" {
+        bail!("scope-meta-gate failed: one or more lanes became unselected");
+    }
+
+    Ok(())
+}
+
+fn run_fixture(path: &Path) -> Result<ScopeMetaGateReceipt> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read fixture {}", path.display()))?;
+    let fixture: FixtureInput = serde_json::from_str(&raw)
+        .with_context(|| format!("Failed to parse fixture {}", path.display()))?;
+    Ok(build_receipt(fixture.old_decision, fixture.new_decision))
+}
+
+fn run_from_git(config: &ScopeMetaGateConfig) -> Result<ScopeMetaGateReceipt> {
+    let root = crate::utils::project_root()?;
+    let base = config.base.as_deref().unwrap_or("HEAD~1");
+    let head = config.head.as_deref().unwrap_or("HEAD");
+
+    let touched_paths = changed_files_between(base, head, &root)?;
+    if !select_scope_meta_gate(&touched_paths) {
+        return Ok(ScopeMetaGateReceipt {
+            schema_version: 1,
+            old_decision: LaneDecision { selected_lanes: vec![] },
+            new_decision: LaneDecision { selected_lanes: vec![] },
+            changed_lanes: ChangedLanes { removed: vec![], added: vec![], unchanged: vec![] },
+            verdict: "pass".to_string(),
+            advisory: vec!["scope-meta-gate not selected for this diff".to_string()],
+        });
+    }
+
+    let metadata = load_metadata(&root)?;
+    let workspace_root = root.to_string_lossy().replace('\\', "/");
+
+    let old_files = changed_files_between(&format!("{base}^"), base, &root)?;
+    let new_files = changed_files_between(base, head, &root)?;
+
+    let old_scope = ci_scope::classify_files(&old_files, &metadata, &workspace_root)?;
+    let new_scope = ci_scope::classify_files(&new_files, &metadata, &workspace_root)?;
+
+    let old_decision = LaneDecision { selected_lanes: lanes_from_scope(&old_scope) };
+    let new_decision = LaneDecision { selected_lanes: lanes_from_scope(&new_scope) };
+
+    Ok(build_receipt(old_decision, new_decision))
+}
+
+fn lanes_from_scope(scope: &ScopeOutput) -> Vec<String> {
+    let mut lanes: BTreeSet<String> = BTreeSet::new();
+    for lane in &scope.selected_lanes {
+        lanes.insert(lane.lane.clone());
+    }
+    for lane in &scope.selected_heavy_lanes {
+        lanes.insert(lane.lane.clone());
+    }
+    lanes.into_iter().collect()
+}
+
+fn build_receipt(old_decision: LaneDecision, new_decision: LaneDecision) -> ScopeMetaGateReceipt {
+    let old: BTreeSet<String> = old_decision.selected_lanes.iter().cloned().collect();
+    let new: BTreeSet<String> = new_decision.selected_lanes.iter().cloned().collect();
+
+    let removed = old.difference(&new).cloned().collect::<Vec<_>>();
+    let added = new.difference(&old).cloned().collect::<Vec<_>>();
+    let unchanged = new.intersection(&old).cloned().collect::<Vec<_>>();
+
+    let (verdict, advisory) = if !removed.is_empty() {
+        (
+            "fail".to_string(),
+            vec![format!(
+                "Lane selection regressed; affected lanes must run explicitly: {}",
+                removed.join(", ")
+            )],
+        )
+    } else if !added.is_empty() {
+        (
+            "warn".to_string(),
+            vec!["Scope expanded safely; additional lanes are selected".to_string()],
+        )
+    } else {
+        ("pass".to_string(), vec!["No lane-selection regression detected".to_string()])
+    };
+
+    ScopeMetaGateReceipt {
+        schema_version: 1,
+        old_decision,
+        new_decision,
+        changed_lanes: ChangedLanes { removed, added, unchanged },
+        verdict,
+        advisory,
+    }
+}
+
+fn select_scope_meta_gate(changed_files: &[String]) -> bool {
+    changed_files.iter().any(|path| {
+        SENSITIVE_PATH_PREFIXES.iter().any(|prefix| path == *prefix || path.starts_with(prefix))
+    })
+}
+
+fn changed_files_between(base: &str, head: &str, root: &Path) -> Result<Vec<String>> {
+    let diff_spec = format!("{base}...{head}");
+    let output = duct::cmd("git", ["diff", "--name-only", &diff_spec])
+        .dir(root)
+        .stdout_capture()
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .context("Failed to run git diff for scope-meta-gate")?;
+
+    let stdout = if output.status.success() {
+        String::from_utf8(output.stdout).context("git diff output was not valid UTF-8")?
+    } else {
+        let diff_spec_two = format!("{base}..{head}");
+        let output2 = duct::cmd("git", ["diff", "--name-only", &diff_spec_two])
+            .dir(root)
+            .stdout_capture()
+            .stderr_capture()
+            .run()
+            .context("Failed to run git diff two-dot fallback for scope-meta-gate")?;
+        String::from_utf8(output2.stdout).context("git diff output was not valid UTF-8")?
+    };
+
+    Ok(stdout.lines().map(ToOwned::to_owned).collect())
+}
+
+fn load_metadata(root: &Path) -> Result<serde_json::Value> {
+    let output = duct::cmd("cargo", ["metadata", "--format-version", "1"])
+        .dir(root)
+        .stdout_capture()
+        .stderr_capture()
+        .run()
+        .context("Failed to run cargo metadata")?;
+
+    let stdout =
+        String::from_utf8(output.stdout).context("cargo metadata output was not valid UTF-8")?;
+    serde_json::from_str(&stdout).context("Failed to parse cargo metadata JSON")
+}
+
+fn write_receipt(path: &Path, receipt: &ScopeMetaGateReceipt) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create receipt directory {}", parent.display()))?;
+    }
+    let payload = serde_json::to_string_pretty(receipt).context("Failed to serialize receipt")?;
+    fs::write(path, format!("{payload}\n"))
+        .with_context(|| format!("Failed to write receipt {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn removed_lane_fails() {
+        let old = LaneDecision {
+            selected_lanes: vec!["parser_ratchet".to_string(), "test_scoped".to_string()],
+        };
+        let new = LaneDecision { selected_lanes: vec!["test_scoped".to_string()] };
+        let receipt = build_receipt(old, new);
+        assert_eq!(receipt.verdict, "fail");
+        assert_eq!(receipt.changed_lanes.removed, vec!["parser_ratchet".to_string()]);
+    }
+
+    #[test]
+    fn added_lane_warns() {
+        let old = LaneDecision { selected_lanes: vec!["test_scoped".to_string()] };
+        let new =
+            LaneDecision { selected_lanes: vec!["test_scoped".to_string(), "docs".to_string()] };
+        let receipt = build_receipt(old, new);
+        assert_eq!(receipt.verdict, "warn");
+        assert_eq!(receipt.changed_lanes.added, vec!["docs".to_string()]);
+    }
+
+    #[test]
+    fn fixture_parser_rule_removed_fails() -> Result<()> {
+        let receipt =
+            run_fixture(Path::new("tests/fixtures/scope-meta-gate/parser-lane-removed.json"))?;
+        assert_eq!(receipt.verdict, "fail");
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_docs_expands_warns_or_passes() -> Result<()> {
+        let receipt =
+            run_fixture(Path::new("tests/fixtures/scope-meta-gate/docs-scope-expanded.json"))?;
+        assert!(receipt.verdict == "warn" || receipt.verdict == "pass");
+        Ok(())
+    }
+
+    #[test]
+    fn selector_matches_sensitive_paths() {
+        let files = vec![".github/workflows/ci.yml".to_string()];
+        assert!(select_scope_meta_gate(&files));
+    }
+}

--- a/xtask/tests/fixtures/scope-meta-gate/docs-scope-expanded.json
+++ b/xtask/tests/fixtures/scope-meta-gate/docs-scope-expanded.json
@@ -1,0 +1,8 @@
+{
+  "old_decision": {
+    "selected_lanes": ["docs"]
+  },
+  "new_decision": {
+    "selected_lanes": ["docs", "doc_build"]
+  }
+}

--- a/xtask/tests/fixtures/scope-meta-gate/parser-lane-removed.json
+++ b/xtask/tests/fixtures/scope-meta-gate/parser-lane-removed.json
@@ -1,0 +1,8 @@
+{
+  "old_decision": {
+    "selected_lanes": ["parser_ratchet", "test_scoped", "clippy_scoped"]
+  },
+  "new_decision": {
+    "selected_lanes": ["test_scoped", "clippy_scoped"]
+  }
+}


### PR DESCRIPTION
### Motivation

- Prevent silent regressions where changes to scope/gate selection logic can unselect critical lanes (e.g. `parser_ratchet`) without detection.
- Provide a deterministic, testable comparator that verifies that a PR which mutates scope inputs does not remove previously-selected lanes.

### Description

- Add `xtask` task `scope-meta-gate` implemented in `xtask/src/tasks/scope_meta_gate.rs` that supports `--base/--head` live mode and `--fixture` mode and emits a JSON receipt describing `old_decision`, `new_decision`, `changed_lanes`, `verdict`, and `advisory`.
- Wire the new command into the CLI and module exports (`xtask/src/main.rs`, `xtask/src/tasks/mod.rs`).
- Add JSON Schema at `.ci/receipts/schemas/scope-meta-gate.schema.json` and user documentation at `docs/ci/scope-meta-gate.md` describing fixtures, commands, and receipt shape.
- Add fixtures under `xtask/tests/fixtures/scope-meta-gate/` and unit tests in the task for regression (`parser-lane-removed`) and expansion (`docs-scope-expanded`) scenarios.

### Testing

- Ran unit tests: `cargo test -p xtask scope_meta_gate` — all scope-meta-gate unit tests passed.
- Exercise fixtures with the CLI: `cargo xtask scope-meta-gate --fixture xtask/tests/fixtures/scope-meta-gate/parser-lane-removed.json --receipt target/receipts/scope-meta-gate.json` — produced a `fail` verdict (expected) and non-zero exit; `cargo xtask scope-meta-gate --fixture xtask/tests/fixtures/scope-meta-gate/docs-scope-expanded.json --receipt target/receipts/scope-meta-gate.json` — produced a `warn` verdict (expected).
- Build/lint/format checks: `cargo xtask fmt --package xtask`, `cargo check --all-targets -p xtask`, and `cargo clippy -p xtask -- -D warnings` completed successfully in this environment.
- Attempted schema validation using a local script but JSON schema validation step was skipped due to missing `jsonschema` Python module in the run environment (receipt file and schema were produced).

Refs #6847
Refs #6853

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0978c4483338a98cf25ef7a6255)