### PR TITLE
feat(parser-ratchet): discover PR corpus manifest (#6847)

### DIFF
--- a/.ci/receipts/schemas/parser-corpus-manifest.schema.json
+++ b/.ci/receipts/schemas/parser-corpus-manifest.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://perl-lsp.dev/schemas/parser-corpus-manifest.schema.json",
+  "title": "Parser Corpus Manifest",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "profile",
+    "sources",
+    "runner",
+    "files",
+    "fingerprint"
+  ],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "profile": { "type": "string" },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "kind", "status"],
+        "properties": {
+          "id": { "type": "string" },
+          "kind": { "type": "string" },
+          "path": { "type": ["string", "null"] },
+          "status": { "type": "string" },
+          "note": { "type": ["string", "null"] }
+        },
+        "additionalProperties": false
+      }
+    },
+    "runner": {
+      "type": "object",
+      "required": ["os", "perl_version"],
+      "properties": {
+        "os": { "type": "string" },
+        "perl_version": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "source", "bytes", "sha256"],
+        "properties": {
+          "path": { "type": "string" },
+          "source": { "type": "string" },
+          "bytes": { "type": "integer", "minimum": 0 },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          },
+          "concepts": {
+            "type": ["array", "null"],
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "fingerprint": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3870,6 +3870,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha2",
  "similar 3.1.0",
  "tar",
  "tempfile",

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -86,7 +86,7 @@ impl SafeEvaluator {
         }
 
         // Check for assignment operators while avoiding comparison false positives
-        if let Some(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref().ok() {
+        if let Ok(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref() {
             for mat in re.find_iter(expression) {
                 let op = mat.as_str();
                 if ASSIGNMENT_OPERATORS.contains(&op) {

--- a/docs/ci/parser-corpus-manifest.md
+++ b/docs/ci/parser-corpus-manifest.md
@@ -1,0 +1,40 @@
+# Parser corpus manifest (PR profile)
+
+`cargo xtask parser-corpus manifest` discovers the parser-ratchet corpus for PR mode without installing CPAN.
+
+## Command
+
+```bash
+cargo xtask parser-corpus manifest \
+  --profile pr \
+  --out target/parser-ratchet/corpus-manifest.json \
+  --receipt target/receipts/parser-corpus-manifest.json
+```
+
+## Sources included
+
+1. Repo-owned corpus (when present):
+   - `tests/perl-corpus/**/*.pl`
+   - `tests/perl-corpus/**/*.pm`
+   - `tests/parser/**/*.pl`
+   - `tests/parser/**/*.pm`
+2. Ambient system Perl from `perl -MConfig` library roots:
+   - `privlib`
+   - `archlib`
+   - `vendorlib`
+   - `vendorarch`
+
+Only readable `.pm`/`.pl` files are included.
+
+## Determinism and fingerprinting
+
+- Files are ordered stably by path then source.
+- Each file entry includes `bytes` and `sha256`.
+- The manifest `fingerprint` hashes schema/profile/runner info plus ordered file metadata.
+- Base and candidate should run against the same runner image to get the same fingerprint for the same file set.
+
+## Failure posture
+
+- System Perl discovery failures are emitted as advisories for PR profile.
+- Missing/unreadable system paths are handled gracefully and recorded in `sources`.
+- Runtime manifest artifacts stay under `target/parser-ratchet/` and are not committed.

--- a/tests/perl-corpus/README.md
+++ b/tests/perl-corpus/README.md
@@ -1,0 +1,5 @@
+# perl-corpus fixtures
+
+This directory is reserved for repo-owned Perl corpus fixtures used by parser ratchet tooling.
+
+PR corpus manifest discovery includes `*.pl` and `*.pm` files under this tree when present.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -42,6 +42,7 @@ notify = "8.2.0"
 flate2 = "1.1.5"
 tar = "0.4.44"
 tempfile.workspace = true
+sha2 = "0.10.9"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.18.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -825,6 +825,12 @@ enum Commands {
         receipt: bool,
     },
 
+    /// Parser corpus utility commands for ratchet workflows
+    ParserCorpus {
+        #[command(subcommand)]
+        command: ParserCorpusCommand,
+    },
+
     /// Manage CPAN top-1000 corpus acquisition, sweep, and ratchet
     CpanCorpus {
         #[command(subcommand)]
@@ -1151,6 +1157,24 @@ enum Commands {
         baseline: PathBuf,
         /// Current receipt JSON path.
         current: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
+enum ParserCorpusCommand {
+    /// Discover and fingerprint parser ratchet corpus manifest
+    Manifest {
+        /// Corpus profile (for example: pr)
+        #[arg(long, default_value = "pr")]
+        profile: String,
+
+        /// Output manifest file path
+        #[arg(long)]
+        out: PathBuf,
+
+        /// Optional receipt file path
+        #[arg(long)]
+        receipt: Option<PathBuf>,
     },
 }
 
@@ -1534,6 +1558,15 @@ fn main() -> Result<()> {
                 receipt,
             })
         }
+        Commands::ParserCorpus { command } => match command {
+            ParserCorpusCommand::Manifest { profile, out, receipt } => {
+                parser_corpus_manifest::run(parser_corpus_manifest::ManifestConfig {
+                    profile,
+                    out,
+                    receipt,
+                })
+            }
+        },
         Commands::CpanCorpus { command } => {
             let mut config = cpan_corpus::CpanCorpusConfig::default();
             match command {

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -50,6 +50,7 @@ pub mod inject_sha_assets;
 pub mod layer_check;
 pub mod metrics;
 pub mod parse_rust;
+pub mod parser_corpus_manifest;
 pub mod parser_corpus_sweep;
 pub mod parser_matrix;
 pub mod populate_book;

--- a/xtask/src/tasks/parser_corpus_manifest.rs
+++ b/xtask/src/tasks/parser_corpus_manifest.rs
@@ -1,0 +1,357 @@
+use color_eyre::eyre::{Context, Result};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use walkdir::WalkDir;
+
+const SCHEMA_VERSION: &str = "1.0.0";
+
+#[derive(Debug, Clone)]
+pub struct ManifestConfig {
+    pub profile: String,
+    pub out: PathBuf,
+    pub receipt: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CorpusManifest {
+    pub schema_version: String,
+    pub profile: String,
+    pub sources: Vec<ManifestSource>,
+    pub runner: RunnerInfo,
+    pub files: Vec<ManifestFile>,
+    pub fingerprint: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ManifestSource {
+    pub id: String,
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RunnerInfo {
+    pub os: String,
+    pub perl_version: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ManifestFile {
+    pub path: String,
+    pub source: String,
+    pub bytes: u64,
+    pub sha256: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub concepts: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ManifestReceipt {
+    pub schema_version: String,
+    pub profile: String,
+    pub out: String,
+    pub fingerprint: String,
+    pub total_files: usize,
+    pub advisory: bool,
+    pub advisories: Vec<String>,
+}
+
+pub fn run(config: ManifestConfig) -> Result<()> {
+    let mut sources = Vec::new();
+    let mut files = Vec::new();
+    let mut advisories = Vec::new();
+
+    collect_repo_sources(&mut sources, &mut files)?;
+    collect_system_perl_sources(&mut sources, &mut files, &mut advisories)?;
+
+    files.sort_by(|a, b| a.path.cmp(&b.path).then(a.source.cmp(&b.source)));
+
+    let runner =
+        RunnerInfo { os: std::env::consts::OS.to_string(), perl_version: detect_perl_version() };
+
+    let fingerprint = compute_fingerprint(&config.profile, &runner, &files);
+    let manifest = CorpusManifest {
+        schema_version: SCHEMA_VERSION.to_string(),
+        profile: config.profile.clone(),
+        sources,
+        runner,
+        files,
+        fingerprint: fingerprint.clone(),
+    };
+
+    if let Some(parent) = config.out.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create output directory {}", parent.display()))?;
+    }
+    fs::write(&config.out, serde_json::to_string_pretty(&manifest)?)
+        .with_context(|| format!("failed to write manifest to {}", config.out.display()))?;
+
+    if let Some(receipt_path) = config.receipt {
+        if let Some(parent) = receipt_path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create receipt directory {}", parent.display())
+            })?;
+        }
+        let advisory = !advisories.is_empty() && !profile_requires_system_perl(&config.profile);
+        let receipt = ManifestReceipt {
+            schema_version: SCHEMA_VERSION.to_string(),
+            profile: config.profile,
+            out: config.out.display().to_string(),
+            fingerprint,
+            total_files: manifest.files.len(),
+            advisory,
+            advisories,
+        };
+        fs::write(receipt_path, serde_json::to_string_pretty(&receipt)?)
+            .context("failed to write parser corpus manifest receipt")?;
+    }
+
+    Ok(())
+}
+
+fn collect_repo_sources(
+    sources: &mut Vec<ManifestSource>,
+    files: &mut Vec<ManifestFile>,
+) -> Result<()> {
+    let repo_patterns = ["tests/perl-corpus", "tests/parser"];
+    for root in repo_patterns {
+        let path = PathBuf::from(root);
+        if !path.exists() {
+            sources.push(ManifestSource {
+                id: format!("repo:{}", root),
+                kind: "repo".to_string(),
+                path: Some(root.to_string()),
+                status: "missing".to_string(),
+                note: None,
+            });
+            continue;
+        }
+        let mut added = 0usize;
+        for entry in WalkDir::new(&path)
+            .into_iter()
+            .filter_map(std::result::Result::ok)
+            .filter(|entry| entry.file_type().is_file())
+        {
+            let Some(ext) = entry.path().extension().and_then(|ext| ext.to_str()) else {
+                continue;
+            };
+            if ext != "pl" && ext != "pm" {
+                continue;
+            }
+            if let Some(file) = make_file_entry(entry.path(), "repo")? {
+                files.push(file);
+                added += 1;
+            }
+        }
+        sources.push(ManifestSource {
+            id: format!("repo:{}", root),
+            kind: "repo".to_string(),
+            path: Some(root.to_string()),
+            status: "ok".to_string(),
+            note: Some(format!("{added} files")),
+        });
+    }
+    Ok(())
+}
+
+fn collect_system_perl_sources(
+    sources: &mut Vec<ManifestSource>,
+    files: &mut Vec<ManifestFile>,
+    advisories: &mut Vec<String>,
+) -> Result<()> {
+    let output = Command::new("perl")
+        .args([
+            "-MConfig",
+            "-e",
+            "print join(qq{\\n}, map { \"$_=$Config{$_}\" } qw(privlib archlib vendorlib vendorarch));",
+        ])
+        .output();
+
+    let output = match output {
+        Ok(value) if value.status.success() => value,
+        Ok(value) => {
+            advisories
+                .push(format!("system perl config discovery failed with status {}", value.status));
+            sources.push(ManifestSource {
+                id: "system:perl-config".to_string(),
+                kind: "system".to_string(),
+                path: None,
+                status: "error".to_string(),
+                note: Some("unable to query perl config".to_string()),
+            });
+            return Ok(());
+        }
+        Err(error) => {
+            advisories.push(format!("system perl config discovery failed: {error}"));
+            sources.push(ManifestSource {
+                id: "system:perl-config".to_string(),
+                kind: "system".to_string(),
+                path: None,
+                status: "error".to_string(),
+                note: Some("perl executable unavailable".to_string()),
+            });
+            return Ok(());
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut unique_paths = BTreeSet::new();
+    for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
+        let Some((key, raw_path)) = line.split_once('=') else {
+            continue;
+        };
+        let path = PathBuf::from(raw_path);
+        if !unique_paths.insert(path.clone()) {
+            continue;
+        }
+
+        if !path.exists() {
+            sources.push(ManifestSource {
+                id: format!("system:{key}"),
+                kind: "system".to_string(),
+                path: Some(path.display().to_string()),
+                status: "missing".to_string(),
+                note: None,
+            });
+            continue;
+        }
+        if !path.is_dir() {
+            sources.push(ManifestSource {
+                id: format!("system:{key}"),
+                kind: "system".to_string(),
+                path: Some(path.display().to_string()),
+                status: "unreadable".to_string(),
+                note: Some("not a directory".to_string()),
+            });
+            advisories.push(format!("system perl path is not a directory: {}", path.display()));
+            continue;
+        }
+
+        let mut added = 0usize;
+        for entry in WalkDir::new(&path)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(std::result::Result::ok)
+            .filter(|entry| entry.file_type().is_file())
+        {
+            let Some(ext) = entry.path().extension().and_then(|ext| ext.to_str()) else {
+                continue;
+            };
+            if ext != "pm" && ext != "pl" {
+                continue;
+            }
+
+            match make_file_entry(entry.path(), &format!("system:{key}")) {
+                Ok(Some(file)) => {
+                    files.push(file);
+                    added += 1;
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    advisories.push(format!(
+                        "skipped unreadable file {}: {error}",
+                        entry.path().display()
+                    ));
+                }
+            }
+        }
+
+        sources.push(ManifestSource {
+            id: format!("system:{key}"),
+            kind: "system".to_string(),
+            path: Some(path.display().to_string()),
+            status: "ok".to_string(),
+            note: Some(format!("{added} files")),
+        });
+    }
+
+    Ok(())
+}
+
+fn make_file_entry(path: &Path, source: &str) -> Result<Option<ManifestFile>> {
+    let Ok(bytes) = fs::read(path) else {
+        return Ok(None);
+    };
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let sha = format!("{:x}", hasher.finalize());
+
+    Ok(Some(ManifestFile {
+        path: portable_path(path),
+        source: source.to_string(),
+        bytes: bytes.len() as u64,
+        sha256: sha,
+        concepts: None,
+    }))
+}
+
+fn portable_path(path: &Path) -> String {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
+    if let Ok(rel) = path.strip_prefix(&root) {
+        return rel.display().to_string();
+    }
+    path.display().to_string()
+}
+
+fn detect_perl_version() -> String {
+    let output = Command::new("perl").args(["-e", "print $^V"]).output();
+    match output {
+        Ok(value) if value.status.success() => {
+            String::from_utf8_lossy(&value.stdout).trim().to_string()
+        }
+        _ => "unknown".to_string(),
+    }
+}
+
+fn compute_fingerprint(profile: &str, runner: &RunnerInfo, files: &[ManifestFile]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(format!(
+        "schema={SCHEMA_VERSION}\nprofile={profile}\nos={}\nperl={}\n",
+        runner.os, runner.perl_version
+    ));
+    for file in files {
+        hasher.update(format!("{}\t{}\t{}\t{}\n", file.path, file.source, file.bytes, file.sha256));
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+fn profile_requires_system_perl(profile: &str) -> bool {
+    profile == "strict"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_is_stable_for_same_sorted_files() {
+        let runner = RunnerInfo { os: "linux".to_string(), perl_version: "v5.38.2".to_string() };
+        let files = vec![
+            ManifestFile {
+                path: "a.pm".to_string(),
+                source: "repo".to_string(),
+                bytes: 1,
+                sha256: "aa".to_string(),
+                concepts: None,
+            },
+            ManifestFile {
+                path: "b.pm".to_string(),
+                source: "system:privlib".to_string(),
+                bytes: 2,
+                sha256: "bb".to_string(),
+                concepts: None,
+            },
+        ];
+        let one = compute_fingerprint("pr", &runner, &files);
+        let two = compute_fingerprint("pr", &runner, &files);
+        assert_eq!(one, two);
+    }
+}


### PR DESCRIPTION
### Motivation

- PR-mode parser ratchet needs a deterministic, runner-local corpus manifest built from repo-owned fixtures plus the ambient system Perl, without requiring CPAN installs (Refs #6847). 
- The manifest must be identical for base and candidate runs on the same runner image so ratchet comparisons are meaningful. 
- System-Perl discovery can fail on some runners and must be treated as advisory for PR profiles rather than hard failure.

### Description

- Added `cargo xtask parser-corpus manifest` (`xtask/src/main.rs` wiring and `ParserCorpusCommand::Manifest`) to emit a PR-focused corpus manifest. 
- Implemented discovery and deterministic fingerprinting in `xtask/src/tasks/parser_corpus_manifest.rs`, which collects repo files under `tests/perl-corpus` and `tests/parser` and ambient Perl library roots from `perl -MConfig`, includes only readable `.pm`/`.pl` files, and computes per-file `bytes` + `sha256` plus a stable manifest `fingerprint`. 
- Added JSON schema `.ci/receipts/schemas/parser-corpus-manifest.schema.json`, usage docs `docs/ci/parser-corpus-manifest.md`, and a placeholder `tests/perl-corpus/README.md`. 
- Registered the new task module in `xtask/src/tasks/mod.rs` and added the `sha2` dependency to `xtask/Cargo.toml` for hashing; outputs are written under `target/parser-ratchet/` and an optional receipt can be emitted.

### Testing

- `cargo check -p xtask` completed successfully. 
- The manifest command was exercised locally with `cargo xtask parser-corpus manifest --profile pr --out target/parser-ratchet/corpus-manifest.json --receipt target/receipts/parser-corpus-manifest.json` and produced the manifest and receipt. 
- The command was run twice and the manifest `fingerprint` was identical across both runs, demonstrating determinism. 
- `cargo fmt --all` succeeded and the generated receipt reported `advisory: false` with zero advisories in the exercised environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd09c30ac83338550d8d295df5f6a)