### PR TITLE
feat(parser-ratchet): discover PR corpus manifest (#6847)

### DIFF
--- a/.ci/receipts/schemas/parser-corpus-manifest.schema.json
+++ b/.ci/receipts/schemas/parser-corpus-manifest.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/parser-corpus-manifest.schema.json",
+  "title": "Parser Corpus Manifest",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "profile",
+    "sources",
+    "runner",
+    "files",
+    "fingerprint"
+  ],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "profile": { "type": "string" },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["source", "root", "files"],
+        "properties": {
+          "source": { "type": "string" },
+          "root": { "type": "string" },
+          "files": { "type": "integer", "minimum": 0 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "runner": {
+      "type": "object",
+      "required": ["os", "perl_version"],
+      "properties": {
+        "os": { "type": "string" },
+        "perl_version": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "source", "bytes", "sha256"],
+        "properties": {
+          "path": { "type": "string" },
+          "source": { "type": "string" },
+          "bytes": { "type": "integer", "minimum": 0 },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          },
+          "concepts": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "fingerprint": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3870,6 +3870,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha2",
  "similar 3.1.0",
  "tar",
  "tempfile",

--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -86,7 +86,7 @@ impl SafeEvaluator {
         }
 
         // Check for assignment operators while avoiding comparison false positives
-        if let Some(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref().ok() {
+        if let Ok(re) = ASSIGNMENT_OP_TOKENS_RE.as_ref() {
             for mat in re.find_iter(expression) {
                 let op = mat.as_str();
                 if ASSIGNMENT_OPERATORS.contains(&op) {

--- a/docs/ci/parser-corpus-manifest.md
+++ b/docs/ci/parser-corpus-manifest.md
@@ -1,0 +1,38 @@
+# Parser corpus manifest (PR profile)
+
+`cargo xtask parser-corpus manifest` discovers the parser ratchet input set for pull request mode.
+
+## Command
+
+```bash
+cargo xtask parser-corpus manifest \
+  --profile pr \
+  --out target/parser-ratchet/corpus-manifest.json \
+  --receipt target/receipts/parser-corpus-manifest.json
+```
+
+## Discovery policy
+
+PR profile includes:
+
+1. Repo-owned fixtures (if directories exist):
+   - `tests/perl-corpus/**/*.pl`
+   - `tests/perl-corpus/**/*.pm`
+   - `tests/parser/**/*.pl`
+   - `tests/parser/**/*.pm`
+2. Ambient system Perl libraries from `perl -MConfig` paths (`privlib`, `archlib`, `vendorlib`, `vendorarch`).
+
+PR profile does **not** install CPAN and does not require ad-hoc CPAN paths.
+
+## Determinism
+
+- Manifest entries are stably ordered by normalized path then source.
+- Every file records byte size and SHA-256 digest.
+- Manifest fingerprint is deterministic for the same discovered file set.
+- Base and candidate comparisons should run against the same generated manifest fingerprint.
+
+## Failure handling
+
+- Missing/unreadable Perl-configured directories are advisory in PR profile.
+- If system Perl discovery itself fails, PR profile emits advisory receipt data instead of hard-failing.
+- Runtime manifests are generated under `target/parser-ratchet/` and should not be committed.

--- a/tests/perl-corpus/README.md
+++ b/tests/perl-corpus/README.md
@@ -1,0 +1,9 @@
+# perl-corpus fixtures
+
+This directory contains repo-owned Perl corpus files used by parser/corpus CI flows.
+
+Files here are auto-discovered by:
+
+- `cargo xtask parser-corpus manifest --profile pr`
+
+Supported fixture extensions for discovery are `.pl` and `.pm`.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -42,6 +42,7 @@ notify = "8.2.0"
 flate2 = "1.1.5"
 tar = "0.4.44"
 tempfile.workspace = true
+sha2 = "0.10.9"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.18.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -825,6 +825,12 @@ enum Commands {
         receipt: bool,
     },
 
+    /// Parser corpus manifest tasks for parser-ratchet workflows
+    ParserCorpus {
+        #[command(subcommand)]
+        command: ParserCorpusCommand,
+    },
+
     /// Manage CPAN top-1000 corpus acquisition, sweep, and ratchet
     CpanCorpus {
         #[command(subcommand)]
@@ -1220,6 +1226,29 @@ enum CpanCorpusCommand {
 }
 
 #[derive(Subcommand)]
+enum ParserCorpusCommand {
+    /// Discover corpus files and write deterministic parser-ratchet manifest
+    Manifest {
+        /// Discovery profile
+        #[arg(long, value_enum)]
+        profile: ParserCorpusProfile,
+
+        /// Output path for the manifest JSON
+        #[arg(long)]
+        out: PathBuf,
+
+        /// Optional receipt path
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+    },
+}
+
+#[derive(ValueEnum, Clone, Copy)]
+enum ParserCorpusProfile {
+    Pr,
+}
+
+#[derive(Subcommand)]
 enum FeaturesCommand {
     /// Sync documentation from features.toml
     SyncDocs,
@@ -1534,6 +1563,18 @@ fn main() -> Result<()> {
                 receipt,
             })
         }
+        Commands::ParserCorpus { command } => match command {
+            ParserCorpusCommand::Manifest { profile, out, receipt } => {
+                let profile = match profile {
+                    ParserCorpusProfile::Pr => parser_corpus_manifest::Profile::Pr,
+                };
+                parser_corpus_manifest::run(parser_corpus_manifest::ManifestConfig {
+                    profile,
+                    out,
+                    receipt,
+                })
+            }
+        },
         Commands::CpanCorpus { command } => {
             let mut config = cpan_corpus::CpanCorpusConfig::default();
             match command {

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -50,6 +50,7 @@ pub mod inject_sha_assets;
 pub mod layer_check;
 pub mod metrics;
 pub mod parse_rust;
+pub mod parser_corpus_manifest;
 pub mod parser_corpus_sweep;
 pub mod parser_matrix;
 pub mod populate_book;

--- a/xtask/src/tasks/parser_corpus_manifest.rs
+++ b/xtask/src/tasks/parser_corpus_manifest.rs
@@ -92,7 +92,10 @@ pub fn run(config: ManifestConfig) -> Result<()> {
         Ok(found) => found,
         Err(error) => {
             if config.profile.requires_system_perl() {
-                bail!("system Perl discovery required for profile {}: {error}", config.profile.as_str());
+                bail!(
+                    "system Perl discovery required for profile {}: {error}",
+                    config.profile.as_str()
+                );
             }
             advisory.push(format!("system Perl discovery unavailable: {error}"));
             ("unknown".to_string(), BTreeMap::new())
@@ -113,10 +116,7 @@ pub fn run(config: ManifestConfig) -> Result<()> {
         schema_version: SCHEMA_VERSION.to_string(),
         profile: config.profile.as_str().to_string(),
         sources,
-        runner: RunnerInfo {
-            os: std::env::consts::OS.to_string(),
-            perl_version,
-        },
+        runner: RunnerInfo { os: std::env::consts::OS.to_string(), perl_version },
         files,
         fingerprint: fingerprint.clone(),
     };
@@ -152,10 +152,8 @@ fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
 
 fn discover_repo_files(root: &Path) -> Result<Vec<ManifestFile>> {
     let mut files = Vec::new();
-    let patterns = [
-        ("repo:tests/perl-corpus", "tests/perl-corpus"),
-        ("repo:tests/parser", "tests/parser"),
-    ];
+    let patterns =
+        [("repo:tests/perl-corpus", "tests/perl-corpus"), ("repo:tests/parser", "tests/parser")];
 
     for (source, rel) in patterns {
         let dir = root.join(rel);
@@ -234,7 +232,11 @@ fn discover_system_files(
     Ok(files)
 }
 
-fn discover_files_under(path: &Path, source: &str, advisory: &mut Vec<String>) -> Result<Vec<ManifestFile>> {
+fn discover_files_under(
+    path: &Path,
+    source: &str,
+    advisory: &mut Vec<String>,
+) -> Result<Vec<ManifestFile>> {
     let mut files = Vec::new();
 
     for entry in WalkDir::new(path).follow_links(false).into_iter().filter_map(Result::ok) {
@@ -251,7 +253,8 @@ fn discover_files_under(path: &Path, source: &str, advisory: &mut Vec<String>) -
         let record = match build_file_record(entry.path(), source) {
             Ok(value) => value,
             Err(error) => {
-                advisory.push(format!("skipping unreadable file {}: {error}", entry.path().display()));
+                advisory
+                    .push(format!("skipping unreadable file {}: {error}", entry.path().display()));
                 continue;
             }
         };

--- a/xtask/src/tasks/parser_corpus_manifest.rs
+++ b/xtask/src/tasks/parser_corpus_manifest.rs
@@ -197,10 +197,10 @@ fn discover_system_perl_paths() -> Result<(String, BTreeMap<String, PathBuf>)> {
 
     let mut paths = BTreeMap::new();
     for line in stdout.lines() {
-        if let Some((key, value)) = line.split_once('=') {
-            if !value.trim().is_empty() {
-                paths.insert(key.to_string(), PathBuf::from(value.trim()));
-            }
+        if let Some((key, value)) = line.split_once('=')
+            && !value.trim().is_empty()
+        {
+            paths.insert(key.to_string(), PathBuf::from(value.trim()));
         }
     }
 
@@ -296,10 +296,10 @@ fn summarize_sources(files: &[ManifestFile]) -> Vec<ManifestSource> {
 fn source_root(path: &str, source: &str) -> String {
     if source.starts_with("repo:") {
         let maybe = path.split("/tests/").next();
-        if let Some(prefix) = maybe {
-            if !prefix.is_empty() {
-                return prefix.to_string();
-            }
+        if let Some(prefix) = maybe
+            && !prefix.is_empty()
+        {
+            return prefix.to_string();
         }
     }
 

--- a/xtask/src/tasks/parser_corpus_manifest.rs
+++ b/xtask/src/tasks/parser_corpus_manifest.rs
@@ -1,0 +1,381 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use color_eyre::eyre::{Context, Result, bail};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use walkdir::WalkDir;
+
+use crate::utils;
+
+const SCHEMA_VERSION: &str = "1.0.0";
+
+#[derive(Clone, Copy, Debug)]
+pub enum Profile {
+    Pr,
+}
+
+impl Profile {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pr => "pr",
+        }
+    }
+
+    fn requires_system_perl(self) -> bool {
+        match self {
+            Self::Pr => false,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ManifestConfig {
+    pub profile: Profile,
+    pub out: PathBuf,
+    pub receipt: Option<PathBuf>,
+}
+
+#[derive(Serialize)]
+struct Manifest {
+    schema_version: String,
+    profile: String,
+    sources: Vec<ManifestSource>,
+    runner: RunnerInfo,
+    files: Vec<ManifestFile>,
+    fingerprint: String,
+}
+
+#[derive(Serialize)]
+struct ManifestSource {
+    source: String,
+    root: String,
+    files: usize,
+}
+
+#[derive(Serialize)]
+struct RunnerInfo {
+    os: String,
+    perl_version: String,
+}
+
+#[derive(Serialize, Clone)]
+struct ManifestFile {
+    path: String,
+    source: String,
+    bytes: u64,
+    sha256: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    concepts: Option<Vec<String>>,
+}
+
+#[derive(Serialize)]
+struct ManifestReceipt {
+    schema_version: String,
+    profile: String,
+    status: String,
+    manifest_path: String,
+    fingerprint: String,
+    file_count: usize,
+    advisory: Vec<String>,
+}
+
+pub fn run(config: ManifestConfig) -> Result<()> {
+    let root = utils::project_root()?;
+    let mut advisory = Vec::new();
+
+    let repo_files = discover_repo_files(&root)?;
+
+    let (perl_version, system_paths) = match discover_system_perl_paths() {
+        Ok(found) => found,
+        Err(error) => {
+            if config.profile.requires_system_perl() {
+                bail!("system Perl discovery required for profile {}: {error}", config.profile.as_str());
+            }
+            advisory.push(format!("system Perl discovery unavailable: {error}"));
+            ("unknown".to_string(), BTreeMap::new())
+        }
+    };
+
+    let system_files = discover_system_files(&system_paths, &mut advisory)?;
+
+    let mut files = Vec::new();
+    files.extend(repo_files);
+    files.extend(system_files);
+    files.sort_by(|a, b| a.path.cmp(&b.path).then_with(|| a.source.cmp(&b.source)));
+
+    let sources = summarize_sources(&files);
+    let fingerprint = compute_fingerprint(config.profile, &files);
+
+    let manifest = Manifest {
+        schema_version: SCHEMA_VERSION.to_string(),
+        profile: config.profile.as_str().to_string(),
+        sources,
+        runner: RunnerInfo {
+            os: std::env::consts::OS.to_string(),
+            perl_version,
+        },
+        files,
+        fingerprint: fingerprint.clone(),
+    };
+
+    write_json(&config.out, &manifest)?;
+
+    if let Some(receipt_path) = config.receipt {
+        let receipt = ManifestReceipt {
+            schema_version: SCHEMA_VERSION.to_string(),
+            profile: config.profile.as_str().to_string(),
+            status: if advisory.is_empty() { "ok".to_string() } else { "advisory".to_string() },
+            manifest_path: normalize_path(&config.out),
+            fingerprint,
+            file_count: manifest.files.len(),
+            advisory,
+        };
+        write_json(&receipt_path, &receipt)?;
+    }
+
+    Ok(())
+}
+
+fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating parent dir for {}", path.display()))?;
+    }
+    let payload = serde_json::to_string_pretty(value).context("serializing json")?;
+    fs::write(path, format!("{payload}\n"))
+        .with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+fn discover_repo_files(root: &Path) -> Result<Vec<ManifestFile>> {
+    let mut files = Vec::new();
+    let patterns = [
+        ("repo:tests/perl-corpus", "tests/perl-corpus"),
+        ("repo:tests/parser", "tests/parser"),
+    ];
+
+    for (source, rel) in patterns {
+        let dir = root.join(rel);
+        if !dir.exists() {
+            continue;
+        }
+        files.extend(discover_files_under(&dir, source, &mut Vec::new())?);
+    }
+
+    Ok(files)
+}
+
+fn discover_system_perl_paths() -> Result<(String, BTreeMap<String, PathBuf>)> {
+    let output = Command::new("perl")
+        .args([
+            "-MConfig",
+            "-e",
+            "print join(qq{\\n}, map { defined $Config{$_} ? qq{$_=$Config{$_}} : () } qw(privlib archlib vendorlib vendorarch));",
+        ])
+        .output()
+        .context("running perl Config probe")?;
+
+    if !output.status.success() {
+        bail!("perl Config probe failed with status {}", output.status);
+    }
+
+    let stdout = String::from_utf8(output.stdout).context("perl Config probe emitted non-utf8")?;
+
+    let version_output = Command::new("perl")
+        .args(["-e", "print $^V"])
+        .output()
+        .context("running perl version probe")?;
+
+    let perl_version = if version_output.status.success() {
+        String::from_utf8(version_output.stdout)
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|_| "unknown".to_string())
+    } else {
+        "unknown".to_string()
+    };
+
+    let mut paths = BTreeMap::new();
+    for line in stdout.lines() {
+        if let Some((key, value)) = line.split_once('=') {
+            if !value.trim().is_empty() {
+                paths.insert(key.to_string(), PathBuf::from(value.trim()));
+            }
+        }
+    }
+
+    Ok((perl_version, paths))
+}
+
+fn discover_system_files(
+    perl_paths: &BTreeMap<String, PathBuf>,
+    advisory: &mut Vec<String>,
+) -> Result<Vec<ManifestFile>> {
+    let mut files = Vec::new();
+    let mut dedup = BTreeSet::new();
+
+    for (bucket, path) in perl_paths {
+        if !path.exists() {
+            advisory.push(format!("system path missing: {}={}", bucket, path.display()));
+            continue;
+        }
+
+        let source = format!("system:{bucket}");
+        let bucket_files = discover_files_under(path, &source, advisory)?;
+        for item in bucket_files {
+            if dedup.insert(item.path.clone()) {
+                files.push(item);
+            }
+        }
+    }
+
+    Ok(files)
+}
+
+fn discover_files_under(path: &Path, source: &str, advisory: &mut Vec<String>) -> Result<Vec<ManifestFile>> {
+    let mut files = Vec::new();
+
+    for entry in WalkDir::new(path).follow_links(false).into_iter().filter_map(Result::ok) {
+        let file_type = entry.file_type();
+        if !file_type.is_file() {
+            continue;
+        }
+
+        let ext = entry.path().extension().and_then(|e| e.to_str());
+        if !matches!(ext, Some("pm" | "pl")) {
+            continue;
+        }
+
+        let record = match build_file_record(entry.path(), source) {
+            Ok(value) => value,
+            Err(error) => {
+                advisory.push(format!("skipping unreadable file {}: {error}", entry.path().display()));
+                continue;
+            }
+        };
+
+        files.push(record);
+    }
+
+    Ok(files)
+}
+
+fn build_file_record(path: &Path, source: &str) -> Result<ManifestFile> {
+    let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let sha256 = format!("{:x}", hasher.finalize());
+
+    Ok(ManifestFile {
+        path: normalize_path(path),
+        source: source.to_string(),
+        bytes: u64::try_from(bytes.len()).context("file length does not fit u64")?,
+        sha256,
+        concepts: None,
+    })
+}
+
+fn summarize_sources(files: &[ManifestFile]) -> Vec<ManifestSource> {
+    let mut counts: BTreeMap<(String, String), usize> = BTreeMap::new();
+    for file in files {
+        let root = source_root(&file.path, &file.source);
+        *counts.entry((file.source.clone(), root)).or_default() += 1;
+    }
+
+    counts
+        .into_iter()
+        .map(|((source, root), files)| ManifestSource { source, root, files })
+        .collect()
+}
+
+fn source_root(path: &str, source: &str) -> String {
+    if source.starts_with("repo:") {
+        let maybe = path.split("/tests/").next();
+        if let Some(prefix) = maybe {
+            if !prefix.is_empty() {
+                return prefix.to_string();
+            }
+        }
+    }
+
+    let parent = Path::new(path).parent().map(normalize_path);
+    parent.unwrap_or_else(|| ".".to_string())
+}
+
+fn compute_fingerprint(profile: Profile, files: &[ManifestFile]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(profile.as_str().as_bytes());
+    hasher.update([0u8]);
+
+    for file in files {
+        hasher.update(file.path.as_bytes());
+        hasher.update([0u8]);
+        hasher.update(file.source.as_bytes());
+        hasher.update([0u8]);
+        hasher.update(file.bytes.to_string().as_bytes());
+        hasher.update([0u8]);
+        hasher.update(file.sha256.as_bytes());
+        hasher.update([0u8]);
+    }
+
+    format!("{:x}", hasher.finalize())
+}
+
+fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use color_eyre::eyre::Result;
+
+    #[test]
+    fn fingerprint_is_stable_for_identical_inputs() {
+        let files = vec![ManifestFile {
+            path: "a.pm".to_string(),
+            source: "repo:tests/perl-corpus".to_string(),
+            bytes: 1,
+            sha256: "abc".to_string(),
+            concepts: None,
+        }];
+
+        let a = compute_fingerprint(Profile::Pr, &files);
+        let b = compute_fingerprint(Profile::Pr, &files);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn fingerprint_changes_when_file_changes() {
+        let a = vec![ManifestFile {
+            path: "a.pm".to_string(),
+            source: "repo:tests/perl-corpus".to_string(),
+            bytes: 1,
+            sha256: "abc".to_string(),
+            concepts: None,
+        }];
+        let b = vec![ManifestFile {
+            path: "a.pm".to_string(),
+            source: "repo:tests/perl-corpus".to_string(),
+            bytes: 2,
+            sha256: "abc".to_string(),
+            concepts: None,
+        }];
+
+        assert_ne!(compute_fingerprint(Profile::Pr, &a), compute_fingerprint(Profile::Pr, &b));
+    }
+
+    #[test]
+    fn missing_system_path_is_advisory_not_error() -> Result<()> {
+        let mut advisory = Vec::new();
+        let mut paths = BTreeMap::new();
+        paths.insert("vendorlib".to_string(), PathBuf::from("/definitely/missing/path"));
+
+        let files = discover_system_files(&paths, &mut advisory)?;
+        assert!(files.is_empty());
+        assert!(!advisory.is_empty());
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a deterministic PR-mode parser-ratchet manifest so base and candidate runs use the exact same corpus fingerprint.
- PR profile must discover repo-owned corpus fixtures plus ambient system Perl without installing CPAN, and classify missing system discovery as advisory (not blocking) for PRs.
- Avoid committing a runtime manifest and ensure stable ordering and reproducible fingerprints for ratchet comparisons.

### Description

- Add `xtask/src/tasks/parser_corpus_manifest.rs` implementing `cargo xtask parser-corpus manifest` PR-profile discovery, SHA-256 per-file hashing, deterministic sorting, fingerprinting, and optional receipt output.
- Wire a new CLI group `ParserCorpus` with `ParserCorpusCommand::Manifest` into `xtask/src/main.rs` and register the task module in `xtask/src/tasks/mod.rs`.
- Add schema `.ci/receipts/schemas/parser-corpus-manifest.schema.json`, documentation `docs/ci/parser-corpus-manifest.md`, and a placeholder `tests/perl-corpus/README.md` for repo-owned fixtures.
- Add `sha2` dependency to `xtask/Cargo.toml` and include unit tests for fingerprint stability and advisory handling of missing system paths; manifest and receipt writing are implemented under `target/parser-ratchet/`/`target/receipts/`.

### Testing

- Ran `cargo check -p xtask` which completed successfully. 
- Executed the manifest command `cargo xtask parser-corpus manifest --profile pr --out target/parser-ratchet/corpus-manifest.json --receipt target/receipts/parser-corpus-manifest.json` and verified repeated runs produce an identical fingerprint. 
- Ran `cargo test -p xtask parser_corpus_manifest -- --nocapture` and all added unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd09c30ac83338550d8d295df5f6a)