### PR TITLE
feat(parser-ratchet): add perl-corpus concept floors (#6847)

### DIFF
--- a/.ci/receipts/schemas/parser-concept-floor.schema.json
+++ b/.ci/receipts/schemas/parser-concept-floor.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/parser-concept-floor.schema.json",
+  "title": "Parser concept floor receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "concepts_required",
+    "concepts_hit",
+    "missing_concepts",
+    "violations"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "concepts_required": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "concepts_hit": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "missing_concepts": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "violations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["fixture", "expected", "details"],
+        "properties": {
+          "fixture": { "type": "string" },
+          "expected": {
+            "type": "string",
+            "enum": [
+              "parse_clean",
+              "recover_without_panic",
+              "allow_errors",
+              "ast_shape"
+            ]
+          },
+          "details": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/docs/ci/perl-corpus-concepts.md
+++ b/docs/ci/perl-corpus-concepts.md
@@ -1,0 +1,52 @@
+# Perl corpus concept floors
+
+`parser-ratchet concept-floors` enforces repo-owned fixture floors for `tests/perl-corpus`.
+
+## Metadata sidecars
+
+Each fixture has a `.meta.toml` sidecar:
+
+```toml
+concepts = ["regex", "interpolation", "capture"]
+profile = ["pr"]
+expected = "parse_clean"
+```
+
+Supported `expected` values:
+
+- `parse_clean`
+- `recover_without_panic`
+- `allow_errors`
+- `ast_shape` (parse must succeed; shape assertions can be layered later)
+
+## Required concept buckets
+
+PR profile currently requires all of these buckets to be represented:
+
+- regex
+- interpolation
+- heredoc
+- package
+- subroutine
+- lexical
+- references
+- hash_array_deref
+- pod
+- data_section
+- recovery
+
+## Command
+
+```bash
+cargo xtask parser-ratchet concept-floors \
+  --manifest target/parser-ratchet/corpus-manifest.json \
+  --receipt target/receipts/parser-concept-floor.json
+```
+
+Harness behavior:
+
+- missing required concept bucket => failure
+- `parse_clean` fixture with parser errors or catastrophic parse => failure
+- `recover_without_panic` fixture panic => failure
+- `allow_errors` may include parser errors, but panic => failure
+- receipt captures `concepts_required`, `concepts_hit`, `missing_concepts`, and `violations`

--- a/tests/perl-corpus/core/heredoc_package_subroutine.meta.toml
+++ b/tests/perl-corpus/core/heredoc_package_subroutine.meta.toml
@@ -1,0 +1,3 @@
+concepts = ["heredoc", "package", "subroutine", "lexical"]
+profile = ["pr"]
+expected = "parse_clean"

--- a/tests/perl-corpus/core/heredoc_package_subroutine.pl
+++ b/tests/perl-corpus/core/heredoc_package_subroutine.pl
@@ -1,0 +1,8 @@
+package Demo::Heredoc;
+sub message {
+    my $text = <<'TXT';
+hello
+TXT
+    return $text;
+}
+1;

--- a/tests/perl-corpus/core/pod_data_section.meta.toml
+++ b/tests/perl-corpus/core/pod_data_section.meta.toml
@@ -1,0 +1,3 @@
+concepts = ["pod", "data_section"]
+profile = ["pr"]
+expected = "allow_errors"

--- a/tests/perl-corpus/core/pod_data_section.pl
+++ b/tests/perl-corpus/core/pod_data_section.pl
@@ -1,0 +1,8 @@
+=pod
+Simple POD block
+=cut
+
+my $name = 'demo';
+
+__DATA__
+line from data section

--- a/tests/perl-corpus/core/references_hash_array_deref.meta.toml
+++ b/tests/perl-corpus/core/references_hash_array_deref.meta.toml
@@ -1,0 +1,3 @@
+concepts = ["references", "hash_array_deref", "lexical"]
+profile = ["pr"]
+expected = "parse_clean"

--- a/tests/perl-corpus/core/references_hash_array_deref.pl
+++ b/tests/perl-corpus/core/references_hash_array_deref.pl
@@ -1,0 +1,3 @@
+my $hash = { list => [10, 20, 30] };
+my $ref = $hash;
+my $first = $ref->{list}->[0];

--- a/tests/perl-corpus/core/regex_interpolation_capture.meta.toml
+++ b/tests/perl-corpus/core/regex_interpolation_capture.meta.toml
@@ -1,0 +1,3 @@
+concepts = ["regex", "interpolation", "lexical"]
+profile = ["pr"]
+expected = "parse_clean"

--- a/tests/perl-corpus/core/regex_interpolation_capture.pl
+++ b/tests/perl-corpus/core/regex_interpolation_capture.pl
@@ -1,0 +1,5 @@
+my $value = "abc";
+if ($value =~ /(a)(b)c/) {
+    my $joined = "$1-$2";
+    print $joined;
+}

--- a/tests/perl-corpus/recovery/recover_without_panic.meta.toml
+++ b/tests/perl-corpus/recovery/recover_without_panic.meta.toml
@@ -1,0 +1,3 @@
+concepts = ["recovery"]
+profile = ["pr"]
+expected = "recover_without_panic"

--- a/tests/perl-corpus/recovery/recover_without_panic.pl
+++ b/tests/perl-corpus/recovery/recover_without_panic.pl
@@ -1,0 +1,4 @@
+my $x = ;
+sub broken {
+    return 1;
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -831,6 +831,12 @@ enum Commands {
         command: CpanCorpusCommand,
     },
 
+    /// Parser ratchet tooling for corpus quality floors
+    ParserRatchet {
+        #[command(subcommand)]
+        command: ParserRatchetCommand,
+    },
+
     /// Generate canonical receipts (test summary, doc metrics, consolidated state)
     ///
     /// Runs workspace tests and doc builds, parses output, and produces
@@ -1220,6 +1226,20 @@ enum CpanCorpusCommand {
 }
 
 #[derive(Subcommand)]
+enum ParserRatchetCommand {
+    /// Enforce repository-owned concept floors for perl-corpus fixtures.
+    ConceptFloors {
+        /// Fixture manifest JSON.
+        #[arg(long)]
+        manifest: PathBuf,
+
+        /// Output receipt path.
+        #[arg(long)]
+        receipt: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
 enum FeaturesCommand {
     /// Sync documentation from features.toml
     SyncDocs,
@@ -1571,6 +1591,15 @@ fn main() -> Result<()> {
                 }
             }
         }
+        Commands::ParserRatchet { command } => match command {
+            ParserRatchetCommand::ConceptFloors { manifest, receipt } => {
+                parser_concept_floor::run(parser_concept_floor::ConceptFloorConfig {
+                    manifest,
+                    receipt,
+                    profile: "pr".to_string(),
+                })
+            }
+        },
         Commands::Receipts { tests_only, docs_only, output_dir, test_threads } => {
             receipts::run(receipts::ReceiptsConfig {
                 tests_only,

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -50,6 +50,7 @@ pub mod inject_sha_assets;
 pub mod layer_check;
 pub mod metrics;
 pub mod parse_rust;
+pub mod parser_concept_floor;
 pub mod parser_corpus_sweep;
 pub mod parser_matrix;
 pub mod populate_book;

--- a/xtask/src/tasks/parser_concept_floor.rs
+++ b/xtask/src/tasks/parser_concept_floor.rs
@@ -1,0 +1,275 @@
+use color_eyre::eyre::{Context, Result, bail};
+use perl_parser::Parser;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::{Path, PathBuf};
+
+const REQUIRED_CONCEPTS: &[&str] = &[
+    "regex",
+    "interpolation",
+    "heredoc",
+    "package",
+    "subroutine",
+    "lexical",
+    "references",
+    "hash_array_deref",
+    "pod",
+    "data_section",
+    "recovery",
+];
+
+#[derive(Debug, Clone)]
+pub struct ConceptFloorConfig {
+    pub manifest: PathBuf,
+    pub receipt: PathBuf,
+    pub profile: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConceptFloorReceipt {
+    pub schema_version: String,
+    pub concepts_required: Vec<String>,
+    pub concepts_hit: Vec<String>,
+    pub missing_concepts: Vec<String>,
+    pub violations: Vec<ConceptViolation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConceptViolation {
+    pub fixture: String,
+    pub expected: String,
+    pub details: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureMeta {
+    concepts: Vec<String>,
+    profile: Vec<String>,
+    expected: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum CorpusManifest {
+    Paths(Vec<String>),
+    Fixtures { fixtures: Vec<ManifestFixture> },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ManifestFixture {
+    Path(String),
+    Record { path: String },
+}
+
+pub fn run(config: ConceptFloorConfig) -> Result<()> {
+    let manifest_text = fs::read_to_string(&config.manifest)
+        .with_context(|| format!("failed to read manifest: {}", config.manifest.display()))?;
+    let manifest: CorpusManifest = serde_json::from_str(&manifest_text)
+        .with_context(|| format!("failed to parse manifest JSON: {}", config.manifest.display()))?;
+
+    let fixtures = manifest_paths(&manifest).into_iter().map(PathBuf::from).collect::<Vec<_>>();
+
+    let mut concepts_hit = BTreeSet::new();
+    let mut violations = Vec::new();
+
+    for fixture in fixtures {
+        let meta_path = sidecar_path(&fixture);
+        if !meta_path.exists() {
+            continue;
+        }
+
+        let meta_text = fs::read_to_string(&meta_path)
+            .with_context(|| format!("failed to read metadata: {}", meta_path.display()))?;
+        let meta: FixtureMeta = toml::from_str(&meta_text)
+            .with_context(|| format!("failed to parse metadata TOML: {}", meta_path.display()))?;
+
+        if !meta.profile.iter().any(|bucket| bucket == &config.profile) {
+            continue;
+        }
+
+        for concept in &meta.concepts {
+            concepts_hit.insert(concept.clone());
+        }
+
+        let source = fs::read_to_string(&fixture)
+            .with_context(|| format!("failed to read fixture: {}", fixture.display()))?;
+        if let Some(violation) = evaluate_fixture(&fixture, &source, &meta.expected) {
+            violations.push(violation);
+        }
+    }
+
+    let concepts_required =
+        REQUIRED_CONCEPTS.iter().map(|item| (*item).to_string()).collect::<BTreeSet<_>>();
+
+    let missing_concepts = concepts_required.difference(&concepts_hit).cloned().collect::<Vec<_>>();
+
+    let receipt = ConceptFloorReceipt {
+        schema_version: "1.0.0".to_string(),
+        concepts_required: concepts_required.into_iter().collect(),
+        concepts_hit: concepts_hit.into_iter().collect(),
+        missing_concepts: missing_concepts.clone(),
+        violations,
+    };
+
+    if let Some(parent) = config.receipt.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create receipt directory: {}", parent.display()))?;
+    }
+
+    let receipt_text = serde_json::to_string_pretty(&receipt)?;
+    fs::write(&config.receipt, receipt_text)
+        .with_context(|| format!("failed to write receipt: {}", config.receipt.display()))?;
+
+    if !missing_concepts.is_empty() {
+        bail!("missing required concept buckets: {}", missing_concepts.join(", "));
+    }
+
+    if !receipt.violations.is_empty() {
+        bail!("concept floor violations: {}", receipt.violations.len());
+    }
+
+    println!(
+        "Concept floors passed: {} required concepts hit, {} fixtures violated.",
+        receipt.concepts_hit.len(),
+        receipt.violations.len()
+    );
+
+    Ok(())
+}
+
+fn evaluate_fixture(fixture: &Path, source: &str, expected: &str) -> Option<ConceptViolation> {
+    let parse_attempt = catch_unwind(AssertUnwindSafe(|| {
+        let mut parser = Parser::new(source);
+        let parse_result = parser.parse();
+        let has_errors = !parser.errors().is_empty();
+        (parse_result.is_ok(), has_errors)
+    }));
+
+    match expected {
+        "parse_clean" => match parse_attempt {
+            Ok((true, false)) => None,
+            Ok((false, _)) => {
+                Some(violation(fixture, expected, "parser returned catastrophic error"))
+            }
+            Ok((true, true)) => {
+                Some(violation(fixture, expected, "parse completed with parser errors"))
+            }
+            Err(_) => Some(violation(fixture, expected, "parser panicked")),
+        },
+        "recover_without_panic" => match parse_attempt {
+            Ok(_) => None,
+            Err(_) => Some(violation(fixture, expected, "parser panicked")),
+        },
+        "allow_errors" => match parse_attempt {
+            Ok(_) => None,
+            Err(_) => Some(violation(fixture, expected, "parser panicked")),
+        },
+        "ast_shape" => match parse_attempt {
+            Ok((true, _)) => None,
+            Ok((false, _)) => {
+                Some(violation(fixture, expected, "parser returned catastrophic error"))
+            }
+            Err(_) => Some(violation(fixture, expected, "parser panicked")),
+        },
+        other => Some(violation(fixture, expected, &format!("unknown expected value: {other}"))),
+    }
+}
+
+fn violation(fixture: &Path, expected: &str, details: &str) -> ConceptViolation {
+    ConceptViolation {
+        fixture: fixture.display().to_string(),
+        expected: expected.to_string(),
+        details: details.to_string(),
+    }
+}
+
+fn sidecar_path(fixture_path: &Path) -> PathBuf {
+    fixture_path.with_extension("meta.toml")
+}
+
+fn manifest_paths(manifest: &CorpusManifest) -> Vec<String> {
+    match manifest {
+        CorpusManifest::Paths(items) => items.clone(),
+        CorpusManifest::Fixtures { fixtures } => fixtures
+            .iter()
+            .map(|fixture| match fixture {
+                ManifestFixture::Path(path) => path.clone(),
+                ManifestFixture::Record { path } => path.clone(),
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture(prefix: &Path, rel: &str, source: &str, meta: &str) -> Result<()> {
+        let fixture_path = prefix.join(rel);
+        if let Some(parent) = fixture_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&fixture_path, source)?;
+        fs::write(fixture_path.with_extension("meta.toml"), meta)?;
+        Ok(())
+    }
+
+    #[test]
+    fn concept_floors_detect_missing_concepts() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        fixture(
+            root,
+            "tests/perl-corpus/minimal.pl",
+            "my $x = 1;",
+            "concepts=[\"regex\"]\nprofile=[\"pr\"]\nexpected=\"parse_clean\"\n",
+        )?;
+        let manifest_payload = serde_json::to_string(&vec![
+            root.join("tests/perl-corpus/minimal.pl").display().to_string(),
+        ])?;
+        fs::write(root.join("manifest.json"), manifest_payload)?;
+
+        let outcome = run(ConceptFloorConfig {
+            manifest: root.join("manifest.json"),
+            receipt: root.join("receipt.json"),
+            profile: "pr".to_string(),
+        });
+
+        assert!(outcome.is_err());
+        let receipt: ConceptFloorReceipt =
+            serde_json::from_str(&fs::read_to_string(root.join("receipt.json"))?)?;
+        assert!(receipt.missing_concepts.contains(&"heredoc".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn concept_floors_pass_with_all_required_concepts() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+        fixture(
+            root,
+            "tests/perl-corpus/all-concepts.pl",
+            "package Demo; sub run { my $s = q{abc}; my $h = {a => [1]}; my $r = $h; return $r->{a}->[0]; }\n1;\n__DATA__\n",
+            "concepts=[\"regex\",\"interpolation\",\"heredoc\",\"package\",\"subroutine\",\"lexical\",\"references\",\"hash_array_deref\",\"pod\",\"data_section\",\"recovery\"]\nprofile=[\"pr\"]\nexpected=\"allow_errors\"\n",
+        )?;
+        let manifest_payload = serde_json::to_string(&vec![
+            root.join("tests/perl-corpus/all-concepts.pl").display().to_string(),
+        ])?;
+        fs::write(root.join("manifest.json"), manifest_payload)?;
+
+        run(ConceptFloorConfig {
+            manifest: root.join("manifest.json"),
+            receipt: root.join("receipt.json"),
+            profile: "pr".to_string(),
+        })?;
+
+        let receipt: ConceptFloorReceipt =
+            serde_json::from_str(&fs::read_to_string(root.join("receipt.json"))?)?;
+        assert!(receipt.missing_concepts.is_empty());
+        assert!(receipt.violations.is_empty());
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Motivation
- Refs #6847: base-vs-candidate ratchets can hide quality drift when the baseline is already poor, so repo-owned `tests/perl-corpus` fixtures need absolute concept-floor checks to guarantee minimum parser behaviour.

### Description
- Add a new xtask subcommand `parser-ratchet concept-floors` and CLI wiring to run it with `--manifest` and `--receipt` (see `xtask/src/main.rs`).
- Implement `xtask/src/tasks/parser_concept_floor.rs` to read a manifest, parse `.meta.toml` sidecars, enforce required concept buckets, evaluate expected outcomes (`parse_clean`, `recover_without_panic`, `allow_errors`, `ast_shape`), and emit a JSON receipt with `concepts_required`, `concepts_hit`, `missing_concepts`, and `violations`.
- Register the task module in `xtask/src/tasks/mod.rs` and add a JSON schema at `.ci/receipts/schemas/parser-concept-floor.schema.json` plus docs at `docs/ci/perl-corpus-concepts.md` describing metadata shape, required buckets, command usage, and harness rules.
- Seed a small set of repo-owned fixtures and sidecars under `tests/perl-corpus/` covering initial concept buckets (regex, interpolation, heredoc, package, subroutine, lexical, references, hash_array_deref, pod, data_section, recovery) to avoid a giant manifest and to provide minimal initial coverage.

### Testing
- `cargo check -p xtask` completed successfully.
- Unit tests for the feature `cargo test -p xtask parser_concept_floor -- --nocapture` passed (both tests OK).
- Ran the new command `cargo xtask parser-ratchet concept-floors --manifest target/parser-ratchet/corpus-manifest.json --receipt target/receipts/parser-concept-floor.json` and it passed and produced a receipt.
- Verified failure semantics by running the command with a manifest missing required concept buckets, which exited non-zero as expected (harness failure reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd09fc4e88333a851e2af7b6b1321)