### PR TITLE
feat(parser-ratchet): compare live base vs candidate metrics (#6847)

### DIFF
--- a/.ci/parser-ratchet/profiles/pr.toml
+++ b/.ci/parser-ratchet/profiles/pr.toml
@@ -1,0 +1,5 @@
+profile = "pr"
+selected = ["perl-corpus", "system-perl"]
+clean_parse_rate_epsilon = 0.001
+error_node_material_increase = 10
+node_kind_unexpected_drop = 5

--- a/.ci/receipts/schemas/parser-ratchet.schema.json
+++ b/.ci/receipts/schemas/parser-ratchet.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/parser-ratchet.schema.json",
+  "title": "Parser Ratchet Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "check",
+    "profile",
+    "selected",
+    "selection_reason",
+    "manifest_fingerprint",
+    "base_sha",
+    "candidate_sha",
+    "metrics",
+    "violations",
+    "ratchet_opportunity",
+    "verdict",
+    "repro"
+  ],
+  "properties": {
+    "check": {"type": "string", "const": "Parser Ratchet"},
+    "profile": {"type": "string"},
+    "selected": {"type": "string"},
+    "selection_reason": {"type": "string"},
+    "manifest_fingerprint": {"type": "string"},
+    "base_sha": {"type": "string"},
+    "candidate_sha": {"type": "string"},
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["base", "head"],
+      "properties": {
+        "base": {"$ref": "#/$defs/metrics"},
+        "head": {"$ref": "#/$defs/metrics"}
+      }
+    },
+    "violations": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/violation"}
+    },
+    "ratchet_opportunity": {"type": "boolean"},
+    "verdict": {"type": "string", "enum": ["pass", "fail"]},
+    "repro": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "command": {"type": "string"}
+      }
+    }
+  },
+  "$defs": {
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "panic_count",
+        "timeout_count",
+        "concept_floors_pass",
+        "clean_parse_rate",
+        "error_node_count",
+        "node_kind_seen_count",
+        "corpus_runtime_ms"
+      ],
+      "properties": {
+        "panic_count": {"type": "integer", "minimum": 0},
+        "timeout_count": {"type": "integer", "minimum": 0},
+        "concept_floors_pass": {"type": "boolean"},
+        "clean_parse_rate": {"type": "number", "minimum": 0, "maximum": 1},
+        "error_node_count": {"type": "integer", "minimum": 0},
+        "node_kind_seen_count": {"type": "integer", "minimum": 0},
+        "corpus_runtime_ms": {"type": "integer", "minimum": 0}
+      }
+    },
+    "violation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["selected", "metric", "detail"],
+      "properties": {
+        "selected": {"type": "string"},
+        "metric": {"type": "string"},
+        "detail": {"type": "string"}
+      }
+    }
+  }
+}

--- a/docs/ci/parser-ratchet-comparator.md
+++ b/docs/ci/parser-ratchet-comparator.md
@@ -1,0 +1,33 @@
+# Parser Ratchet Comparator (PR mode)
+
+`cargo xtask parser-ratchet` in PR/merge-group mode compares **live base-vs-candidate** metrics using the **same manifest fingerprint**.
+
+## Commands
+
+```bash
+cargo xtask parser-ratchet --profile pr --base <sha> --head <sha> --manifest target/parser-ratchet/corpus-manifest.json --receipt target/receipts/parser-ratchet.json
+cargo xtask parser-ratchet compare --profile pr --selected perl-corpus --base-metrics <json> --head-metrics <json> --receipt <json>
+```
+
+## Rules
+
+- `perl-corpus`
+  - `panic_count == 0`
+  - `timeout_count == 0`
+  - concept floors pass
+  - `clean_parse_rate` must not regress beyond epsilon
+  - `error_node_count` must not materially increase
+  - `node_kind_seen_count` must not drop unexpectedly
+- `system-perl` (differential only)
+  - fail on new/worsened `panic_count`
+  - fail on new/worsened `timeout_count`
+  - fail on `clean_parse_rate` regression beyond epsilon
+  - unchanged existing base failures do **not** block unrelated PRs
+- `corpus_runtime_ms` is advisory (warn/pass)
+
+## Notes
+
+- No committed PR baseline file is used.
+- No automatic baseline updates are performed.
+- Base and candidate must use the same manifest.
+- Current implementation includes explicit integration hooks for live base/head metric acquisition.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -825,6 +825,32 @@ enum Commands {
         receipt: bool,
     },
 
+    /// Compare parser ratchet metrics for base vs candidate in PR/merge-group mode.
+    ParserRatchet {
+        /// Ratchet profile (for example: pr).
+        #[arg(long, default_value = "pr")]
+        profile: String,
+
+        /// Base git SHA (required for live PR mode).
+        #[arg(long)]
+        base: Option<String>,
+
+        /// Candidate git SHA (required for live PR mode).
+        #[arg(long)]
+        head: Option<String>,
+
+        /// Canonical manifest path used by both base and candidate.
+        #[arg(long)]
+        manifest: Option<PathBuf>,
+
+        /// Output receipt path.
+        #[arg(long, default_value = "target/receipts/parser-ratchet.json")]
+        receipt: PathBuf,
+
+        #[command(subcommand)]
+        command: Option<ParserRatchetCommand>,
+    },
+
     /// Manage CPAN top-1000 corpus acquisition, sweep, and ratchet
     CpanCorpus {
         #[command(subcommand)]
@@ -1220,6 +1246,32 @@ enum CpanCorpusCommand {
 }
 
 #[derive(Subcommand)]
+enum ParserRatchetCommand {
+    /// Compare two metric JSONs and emit a parser-ratchet receipt.
+    Compare {
+        /// Ratchet profile (for example: pr).
+        #[arg(long, default_value = "pr")]
+        profile: String,
+
+        /// Scope selector (perl-corpus or system-perl).
+        #[arg(long, default_value = "perl-corpus")]
+        selected: String,
+
+        /// Base metrics JSON.
+        #[arg(long)]
+        base_metrics: PathBuf,
+
+        /// Candidate metrics JSON.
+        #[arg(long)]
+        head_metrics: PathBuf,
+
+        /// Output receipt path.
+        #[arg(long, default_value = "target/receipts/parser-ratchet.json")]
+        receipt: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
 enum FeaturesCommand {
     /// Sync documentation from features.toml
     SyncDocs,
@@ -1533,6 +1585,51 @@ fn main() -> Result<()> {
                 verbose,
                 receipt,
             })
+        }
+        Commands::ParserRatchet { profile, base, head, manifest, receipt, command } => {
+            match command {
+                Some(ParserRatchetCommand::Compare {
+                    profile,
+                    selected,
+                    base_metrics,
+                    head_metrics,
+                    receipt,
+                }) => parser_ratchet::run_compare(parser_ratchet::ParserRatchetCompareConfig {
+                    profile,
+                    selected,
+                    base_metrics,
+                    head_metrics,
+                    receipt,
+                    base_sha: None,
+                    head_sha: None,
+                    manifest: None,
+                    selection_reason: Some(
+                        "explicit compare mode with supplied metric receipts".to_string(),
+                    ),
+                }),
+                None => {
+                    let base_sha = match base {
+                        Some(value) => value,
+                        None => return Err(eyre!("--base is required for live PR mode")),
+                    };
+                    let head_sha = match head {
+                        Some(value) => value,
+                        None => return Err(eyre!("--head is required for live PR mode")),
+                    };
+                    let manifest = match manifest {
+                        Some(value) => value,
+                        None => return Err(eyre!("--manifest is required for live PR mode")),
+                    };
+
+                    parser_ratchet::run(parser_ratchet::ParserRatchetRunConfig {
+                        profile,
+                        base_sha,
+                        head_sha,
+                        manifest,
+                        receipt,
+                    })
+                }
+            }
         }
         Commands::CpanCorpus { command } => {
             let mut config = cpan_corpus::CpanCorpusConfig::default();

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -52,6 +52,8 @@ pub mod metrics;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;
 pub mod parser_matrix;
+pub mod parser_ratchet;
+pub mod parser_ratchet_compare;
 pub mod populate_book;
 pub mod prep_crates_io_launch;
 pub mod publication_facts;

--- a/xtask/src/tasks/parser_ratchet.rs
+++ b/xtask/src/tasks/parser_ratchet.rs
@@ -1,0 +1,171 @@
+use crate::tasks::parser_ratchet_compare::{
+    ParsedMetrics, ParserRatchetCompareResult, compare_metrics, load_profile, read_metrics,
+};
+use color_eyre::eyre::{Result, bail};
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct ParserRatchetRunConfig {
+    pub profile: String,
+    pub base_sha: String,
+    pub head_sha: String,
+    pub manifest: PathBuf,
+    pub receipt: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParserRatchetCompareConfig {
+    pub profile: String,
+    pub selected: String,
+    pub base_metrics: PathBuf,
+    pub head_metrics: PathBuf,
+    pub receipt: PathBuf,
+    pub base_sha: Option<String>,
+    pub head_sha: Option<String>,
+    pub manifest: Option<PathBuf>,
+    pub selection_reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ParserRatchetReceipt {
+    check: String,
+    profile: String,
+    selected: String,
+    selection_reason: String,
+    manifest_fingerprint: String,
+    base_sha: String,
+    candidate_sha: String,
+    metrics: ReceiptMetrics,
+    violations: Vec<crate::tasks::parser_ratchet_compare::ParserRatchetViolation>,
+    ratchet_opportunity: bool,
+    verdict: String,
+    repro: Repro,
+}
+
+#[derive(Debug, Serialize)]
+struct ReceiptMetrics {
+    base: crate::tasks::parser_ratchet_compare::ParserRatchetMetrics,
+    head: crate::tasks::parser_ratchet_compare::ParserRatchetMetrics,
+}
+
+#[derive(Debug, Serialize)]
+struct Repro {
+    command: String,
+}
+
+pub fn run(config: ParserRatchetRunConfig) -> Result<()> {
+    let profile_path = profile_path(&config.profile);
+    let profile = load_profile(&profile_path)?;
+    if profile.profile != config.profile {
+        bail!("profile file mismatch: expected {}, found {}", config.profile, profile.profile);
+    }
+    let selected = profile.selected.first().cloned().unwrap_or_else(|| "perl-corpus".to_string());
+
+    let base_metrics = PathBuf::from("target/parser-ratchet/base-metrics.json");
+    let head_metrics = PathBuf::from("target/parser-ratchet/head-metrics.json");
+
+    if !(base_metrics.exists() && head_metrics.exists()) {
+        bail!(
+            "live metric acquisition hook not wired yet. expected {} and {}. \
+             Generate metric JSON for base/head with the same manifest, then run `cargo xtask parser-ratchet compare ...`",
+            base_metrics.display(),
+            head_metrics.display()
+        );
+    }
+
+    run_compare(ParserRatchetCompareConfig {
+        profile: config.profile,
+        selected,
+        base_metrics,
+        head_metrics,
+        receipt: config.receipt,
+        base_sha: Some(config.base_sha),
+        head_sha: Some(config.head_sha),
+        manifest: Some(config.manifest),
+        selection_reason: Some("PR mode selected live base-vs-candidate comparison".to_string()),
+    })
+}
+
+pub fn run_compare(config: ParserRatchetCompareConfig) -> Result<()> {
+    let profile_path = profile_path(&config.profile);
+    let profile = load_profile(&profile_path)?;
+    if profile.profile != config.profile {
+        bail!("profile file mismatch: expected {}, found {}", config.profile, profile.profile);
+    }
+    let base = read_metrics(&config.base_metrics, &config.selected)?;
+    let head = read_metrics(&config.head_metrics, &config.selected)?;
+    let comparison = compare_metrics(&profile, &base, &head)?;
+
+    write_receipt(config, base, head, comparison)
+}
+
+fn write_receipt(
+    config: ParserRatchetCompareConfig,
+    base: ParsedMetrics,
+    head: ParsedMetrics,
+    comparison: ParserRatchetCompareResult,
+) -> Result<()> {
+    let manifest_fingerprint = match &config.manifest {
+        Some(path) => fingerprint(path)?,
+        None => "unknown".to_string(),
+    };
+
+    let base_sha = config.base_sha.unwrap_or_else(|| "base-unknown".to_string());
+    let candidate_sha = config.head_sha.unwrap_or_else(|| "candidate-unknown".to_string());
+
+    let repro = format!(
+        "cargo xtask parser-ratchet compare --profile {} --selected {} --base-metrics {} --head-metrics {} --receipt {}",
+        config.profile,
+        config.selected,
+        config.base_metrics.display(),
+        config.head_metrics.display(),
+        config.receipt.display()
+    );
+
+    let selection_reason =
+        config.selection_reason.unwrap_or_else(|| "profile default selection".to_string());
+
+    let receipt = ParserRatchetReceipt {
+        check: "Parser Ratchet".to_string(),
+        profile: config.profile,
+        selected: config.selected,
+        selection_reason,
+        manifest_fingerprint,
+        base_sha,
+        candidate_sha,
+        metrics: ReceiptMetrics { base: base.metrics, head: head.metrics },
+        violations: comparison.violations,
+        ratchet_opportunity: comparison.ratchet_opportunity,
+        verdict: comparison.verdict,
+        repro: Repro { command: repro },
+    };
+
+    if let Some(parent) = config.receipt.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let pretty = serde_json::to_string_pretty(&receipt)?;
+    fs::write(&config.receipt, format!("{pretty}\n"))?;
+
+    if receipt.verdict == "fail" {
+        bail!("Parser Ratchet failed; see {}", config.receipt.display());
+    }
+
+    Ok(())
+}
+
+fn profile_path(profile: &str) -> PathBuf {
+    PathBuf::from(format!(".ci/parser-ratchet/profiles/{profile}.toml"))
+}
+
+fn fingerprint(path: &Path) -> Result<String> {
+    let bytes = fs::read(path)?;
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in bytes {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    Ok(format!("fnv64:{hash:016x}"))
+}

--- a/xtask/src/tasks/parser_ratchet_compare.rs
+++ b/xtask/src/tasks/parser_ratchet_compare.rs
@@ -1,0 +1,369 @@
+use color_eyre::eyre::{Result, bail};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+const DEFAULT_EPSILON: f64 = 0.001;
+const DEFAULT_ERROR_NODE_INCREASE: u64 = 10;
+const DEFAULT_NODE_KIND_DROP: u64 = 5;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ParserRatchetProfile {
+    pub profile: String,
+    #[serde(default)]
+    pub selected: Vec<String>,
+    #[serde(default = "default_epsilon")]
+    pub clean_parse_rate_epsilon: f64,
+    #[serde(default = "default_error_node_increase")]
+    pub error_node_material_increase: u64,
+    #[serde(default = "default_node_kind_drop")]
+    pub node_kind_unexpected_drop: u64,
+}
+
+fn default_epsilon() -> f64 {
+    DEFAULT_EPSILON
+}
+
+fn default_error_node_increase() -> u64 {
+    DEFAULT_ERROR_NODE_INCREASE
+}
+
+fn default_node_kind_drop() -> u64 {
+    DEFAULT_NODE_KIND_DROP
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParserRatchetMetrics {
+    #[serde(default)]
+    pub panic_count: u64,
+    #[serde(default)]
+    pub timeout_count: u64,
+    #[serde(default = "default_concept_floors")]
+    pub concept_floors_pass: bool,
+    #[serde(default)]
+    pub clean_parse_rate: f64,
+    #[serde(default)]
+    pub error_node_count: u64,
+    #[serde(default)]
+    pub node_kind_seen_count: u64,
+    #[serde(default)]
+    pub corpus_runtime_ms: u64,
+}
+
+fn default_concept_floors() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParsedMetrics {
+    pub selected: String,
+    pub metrics: ParserRatchetMetrics,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParserRatchetViolation {
+    pub selected: String,
+    pub metric: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParserRatchetCompareResult {
+    pub violations: Vec<ParserRatchetViolation>,
+    pub ratchet_opportunity: bool,
+    pub runtime_regression: bool,
+    pub verdict: String,
+}
+
+pub fn load_profile(path: &Path) -> Result<ParserRatchetProfile> {
+    let raw = fs::read_to_string(path)?;
+    let profile: ParserRatchetProfile = toml::from_str(&raw)?;
+    Ok(profile)
+}
+
+pub fn read_metrics(path: &Path, selected: &str) -> Result<ParsedMetrics> {
+    let raw = fs::read_to_string(path)?;
+    let value: serde_json::Value = serde_json::from_str(&raw)?;
+
+    let metrics = ParserRatchetMetrics {
+        panic_count: extract_u64(&value, &["panic_count", "files_with_catastrophic_parse_failure"]),
+        timeout_count: extract_u64(&value, &["timeout_count", "timed_out_files"]),
+        concept_floors_pass: extract_bool(&value, &["concept_floors_pass"]).unwrap_or(true),
+        clean_parse_rate: extract_rate(&value),
+        error_node_count: extract_u64(&value, &["error_node_count", "total_error_nodes"]),
+        node_kind_seen_count: extract_u64(&value, &["node_kind_seen_count"]),
+        corpus_runtime_ms: extract_u64(&value, &["corpus_runtime_ms"]),
+    };
+
+    Ok(ParsedMetrics { selected: selected.to_string(), metrics })
+}
+
+pub fn compare_metrics(
+    profile: &ParserRatchetProfile,
+    base: &ParsedMetrics,
+    head: &ParsedMetrics,
+) -> Result<ParserRatchetCompareResult> {
+    if base.selected != head.selected {
+        bail!("selected scope mismatch: {} vs {}", base.selected, head.selected);
+    }
+
+    let selected = base.selected.as_str();
+    let mut violations = Vec::new();
+    let mut improved = false;
+    let mut runtime_regression = false;
+
+    match selected {
+        "perl-corpus" => {
+            if head.metrics.panic_count != 0 {
+                violations.push(violation(
+                    selected,
+                    "panic_count",
+                    "panic_count must be zero in head",
+                ));
+            }
+            if head.metrics.timeout_count != 0 {
+                violations.push(violation(
+                    selected,
+                    "timeout_count",
+                    "timeout_count must be zero in head",
+                ));
+            }
+            if !head.metrics.concept_floors_pass {
+                violations.push(violation(
+                    selected,
+                    "concept_floors_pass",
+                    "concept floors must pass",
+                ));
+            }
+
+            rate_check(
+                profile,
+                selected,
+                &base.metrics,
+                &head.metrics,
+                &mut violations,
+                &mut improved,
+            );
+            error_node_check(
+                profile,
+                selected,
+                &base.metrics,
+                &head.metrics,
+                &mut violations,
+                &mut improved,
+            );
+            node_kind_check(
+                profile,
+                selected,
+                &base.metrics,
+                &head.metrics,
+                &mut violations,
+                &mut improved,
+            );
+        }
+        "system-perl" => {
+            if head.metrics.panic_count > base.metrics.panic_count {
+                violations.push(violation(selected, "panic_count", "new/worsened panic_count"));
+            }
+            if head.metrics.timeout_count > base.metrics.timeout_count {
+                violations.push(violation(selected, "timeout_count", "new/worsened timeout_count"));
+            }
+            rate_check(
+                profile,
+                selected,
+                &base.metrics,
+                &head.metrics,
+                &mut violations,
+                &mut improved,
+            );
+        }
+        other => {
+            bail!("unsupported selected scope: {other}");
+        }
+    }
+
+    if head.metrics.corpus_runtime_ms > base.metrics.corpus_runtime_ms {
+        runtime_regression = true;
+    }
+
+    let verdict = if violations.is_empty() { "pass" } else { "fail" }.to_string();
+
+    Ok(ParserRatchetCompareResult {
+        violations,
+        ratchet_opportunity: improved,
+        runtime_regression,
+        verdict,
+    })
+}
+
+fn rate_check(
+    profile: &ParserRatchetProfile,
+    selected: &str,
+    base: &ParserRatchetMetrics,
+    head: &ParserRatchetMetrics,
+    violations: &mut Vec<ParserRatchetViolation>,
+    improved: &mut bool,
+) {
+    if head.clean_parse_rate + profile.clean_parse_rate_epsilon < base.clean_parse_rate {
+        violations.push(violation(
+            selected,
+            "clean_parse_rate",
+            "clean_parse_rate regressed beyond epsilon",
+        ));
+    } else if head.clean_parse_rate > base.clean_parse_rate {
+        *improved = true;
+    }
+}
+
+fn error_node_check(
+    profile: &ParserRatchetProfile,
+    selected: &str,
+    base: &ParserRatchetMetrics,
+    head: &ParserRatchetMetrics,
+    violations: &mut Vec<ParserRatchetViolation>,
+    improved: &mut bool,
+) {
+    let allowed = base.error_node_count.saturating_add(profile.error_node_material_increase);
+    if head.error_node_count > allowed {
+        violations.push(violation(
+            selected,
+            "error_node_count",
+            "error_node_count materially increased",
+        ));
+    } else if head.error_node_count < base.error_node_count {
+        *improved = true;
+    }
+}
+
+fn node_kind_check(
+    profile: &ParserRatchetProfile,
+    selected: &str,
+    base: &ParserRatchetMetrics,
+    head: &ParserRatchetMetrics,
+    violations: &mut Vec<ParserRatchetViolation>,
+    improved: &mut bool,
+) {
+    let floor = base.node_kind_seen_count.saturating_sub(profile.node_kind_unexpected_drop);
+    if head.node_kind_seen_count < floor {
+        violations.push(violation(
+            selected,
+            "node_kind_seen_count",
+            "node_kind_seen_count dropped unexpectedly",
+        ));
+    } else if head.node_kind_seen_count > base.node_kind_seen_count {
+        *improved = true;
+    }
+}
+
+fn violation(selected: &str, metric: &str, detail: &str) -> ParserRatchetViolation {
+    ParserRatchetViolation {
+        selected: selected.to_string(),
+        metric: metric.to_string(),
+        detail: detail.to_string(),
+    }
+}
+
+fn extract_u64(value: &serde_json::Value, keys: &[&str]) -> u64 {
+    keys.iter().find_map(|key| value.get(*key).and_then(serde_json::Value::as_u64)).unwrap_or(0)
+}
+
+fn extract_bool(value: &serde_json::Value, keys: &[&str]) -> Option<bool> {
+    keys.iter().find_map(|key| value.get(*key).and_then(serde_json::Value::as_bool))
+}
+
+fn extract_rate(value: &serde_json::Value) -> f64 {
+    if let Some(rate) = value.get("clean_parse_rate").and_then(serde_json::Value::as_f64) {
+        return rate;
+    }
+
+    let total = value.get("total_files").and_then(serde_json::Value::as_f64);
+    let clean = value.get("clean_files").and_then(serde_json::Value::as_f64);
+    match (total, clean) {
+        (Some(total), Some(clean)) if total > 0.0 => clean / total,
+        _ => 0.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use color_eyre::eyre::Result;
+    use std::path::{Path, PathBuf};
+
+    fn fixture(name: &str) -> PathBuf {
+        Path::new("tests/fixtures/parser-ratchet").join(name)
+    }
+
+    fn profile() -> ParserRatchetProfile {
+        ParserRatchetProfile {
+            profile: "pr".to_string(),
+            selected: vec!["perl-corpus".to_string(), "system-perl".to_string()],
+            clean_parse_rate_epsilon: 0.001,
+            error_node_material_increase: 10,
+            node_kind_unexpected_drop: 5,
+        }
+    }
+
+    #[test]
+    fn equal_metrics_pass() -> Result<()> {
+        let p = profile();
+        let base = read_metrics(&fixture("equal-base.json"), "perl-corpus")?;
+        let head = read_metrics(&fixture("equal-head.json"), "perl-corpus")?;
+        let result = compare_metrics(&p, &base, &head)?;
+        assert_eq!(result.verdict, "pass");
+        assert!(!result.ratchet_opportunity);
+        Ok(())
+    }
+
+    #[test]
+    fn improvement_sets_ratchet_opportunity() -> Result<()> {
+        let p = profile();
+        let base = read_metrics(&fixture("equal-base.json"), "perl-corpus")?;
+        let head = read_metrics(&fixture("improvement-head.json"), "perl-corpus")?;
+        let result = compare_metrics(&p, &base, &head)?;
+        assert_eq!(result.verdict, "pass");
+        assert!(result.ratchet_opportunity);
+        Ok(())
+    }
+
+    #[test]
+    fn perl_corpus_panic_in_head_fails() -> Result<()> {
+        let p = profile();
+        let base = read_metrics(&fixture("equal-base.json"), "perl-corpus")?;
+        let head = read_metrics(&fixture("perl-corpus-panic-head.json"), "perl-corpus")?;
+        let result = compare_metrics(&p, &base, &head)?;
+        assert_eq!(result.verdict, "fail");
+        Ok(())
+    }
+
+    #[test]
+    fn system_perl_existing_failure_unchanged_passes() -> Result<()> {
+        let p = profile();
+        let base = read_metrics(&fixture("system-base-failure.json"), "system-perl")?;
+        let head = read_metrics(&fixture("system-unchanged-head.json"), "system-perl")?;
+        let result = compare_metrics(&p, &base, &head)?;
+        assert_eq!(result.verdict, "pass");
+        Ok(())
+    }
+
+    #[test]
+    fn system_perl_worsened_failure_fails() -> Result<()> {
+        let p = profile();
+        let base = read_metrics(&fixture("system-base-failure.json"), "system-perl")?;
+        let head = read_metrics(&fixture("system-worsened-head.json"), "system-perl")?;
+        let result = compare_metrics(&p, &base, &head)?;
+        assert_eq!(result.verdict, "fail");
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_only_regression_warns_but_passes() -> Result<()> {
+        let p = profile();
+        let base = read_metrics(&fixture("equal-base.json"), "perl-corpus")?;
+        let head = read_metrics(&fixture("runtime-only-head.json"), "perl-corpus")?;
+        let result = compare_metrics(&p, &base, &head)?;
+        assert_eq!(result.verdict, "pass");
+        assert!(result.runtime_regression);
+        Ok(())
+    }
+}

--- a/xtask/tests/fixtures/parser-ratchet/equal-base.json
+++ b/xtask/tests/fixtures/parser-ratchet/equal-base.json
@@ -1,0 +1,1 @@
+{"panic_count":0,"timeout_count":0,"concept_floors_pass":true,"clean_parse_rate":0.95,"error_node_count":120,"node_kind_seen_count":400,"corpus_runtime_ms":1000}

--- a/xtask/tests/fixtures/parser-ratchet/equal-head.json
+++ b/xtask/tests/fixtures/parser-ratchet/equal-head.json
@@ -1,0 +1,1 @@
+{"panic_count":0,"timeout_count":0,"concept_floors_pass":true,"clean_parse_rate":0.95,"error_node_count":120,"node_kind_seen_count":400,"corpus_runtime_ms":1000}

--- a/xtask/tests/fixtures/parser-ratchet/improvement-head.json
+++ b/xtask/tests/fixtures/parser-ratchet/improvement-head.json
@@ -1,0 +1,1 @@
+{"panic_count":0,"timeout_count":0,"concept_floors_pass":true,"clean_parse_rate":0.97,"error_node_count":110,"node_kind_seen_count":410,"corpus_runtime_ms":900}

--- a/xtask/tests/fixtures/parser-ratchet/perl-corpus-panic-head.json
+++ b/xtask/tests/fixtures/parser-ratchet/perl-corpus-panic-head.json
@@ -1,0 +1,1 @@
+{"panic_count":1,"timeout_count":0,"concept_floors_pass":true,"clean_parse_rate":0.95,"error_node_count":120,"node_kind_seen_count":400,"corpus_runtime_ms":1000}

--- a/xtask/tests/fixtures/parser-ratchet/runtime-only-head.json
+++ b/xtask/tests/fixtures/parser-ratchet/runtime-only-head.json
@@ -1,0 +1,1 @@
+{"panic_count":0,"timeout_count":0,"concept_floors_pass":true,"clean_parse_rate":0.95,"error_node_count":120,"node_kind_seen_count":400,"corpus_runtime_ms":1400}

--- a/xtask/tests/fixtures/parser-ratchet/system-base-failure.json
+++ b/xtask/tests/fixtures/parser-ratchet/system-base-failure.json
@@ -1,0 +1,1 @@
+{"panic_count":2,"timeout_count":1,"concept_floors_pass":true,"clean_parse_rate":0.90,"error_node_count":300,"node_kind_seen_count":300,"corpus_runtime_ms":1200}

--- a/xtask/tests/fixtures/parser-ratchet/system-unchanged-head.json
+++ b/xtask/tests/fixtures/parser-ratchet/system-unchanged-head.json
@@ -1,0 +1,1 @@
+{"panic_count":2,"timeout_count":1,"concept_floors_pass":true,"clean_parse_rate":0.90,"error_node_count":305,"node_kind_seen_count":299,"corpus_runtime_ms":1250}

--- a/xtask/tests/fixtures/parser-ratchet/system-worsened-head.json
+++ b/xtask/tests/fixtures/parser-ratchet/system-worsened-head.json
@@ -1,0 +1,1 @@
+{"panic_count":3,"timeout_count":1,"concept_floors_pass":true,"clean_parse_rate":0.90,"error_node_count":300,"node_kind_seen_count":300,"corpus_runtime_ms":1200}


### PR DESCRIPTION
### Motivation

- Provide a PR/merge-group comparator that measures base and candidate against the same manifest instead of relying on a committed PR baseline file.
- Ship an integration-friendly comparator with fixture-driven checks so live metric acquisition can be wired later without changing comparison semantics.

### Description

- Add a comparator implementation in `xtask/src/tasks/parser_ratchet_compare.rs` that loads a TOML profile, normalizes JSON metric receipts, and enforces scope-specific rules for `perl-corpus` and `system-perl` including clean-parse rate epsilon, error-node material increase, node-kind floor, panic/timeout handling, and advisory runtime regressions.
- Implement the `parser_ratchet` task in `xtask/src/tasks/parser_ratchet.rs` with a PR-mode entrypoint that expects live `base`/`head` metric files and a `compare` subcommand for explicit metric JSON comparison, and emit structured receipts with `check`, `profile`, `selected`, `selection_reason`, `manifest_fingerprint`, SHAs, `metrics.base`/`metrics.head`, `violations`, `ratchet_opportunity`, `verdict`, and `repro.command`.
- Wire CLI and task registration in `xtask/src/main.rs` and `xtask/src/tasks/mod.rs` and add a `pr` profile, JSON schema, documentation, and JSON fixtures at `.ci/parser-ratchet/profiles/pr.toml`, `.ci/receipts/schemas/parser-ratchet.schema.json`, `docs/ci/parser-ratchet-comparator.md`, and `xtask/tests/fixtures/parser-ratchet/*.json` respectively.

### Testing

- Ran `cargo test -p xtask parser_ratchet_compare -- --nocapture` and all unit tests passed (6 passed, 0 failed). 
- Ran `cargo check --all-targets -p xtask` and `cargo clippy -p xtask -- -D warnings` with no errors reported. 
- Ran `cargo xtask parser-ratchet compare --profile pr --selected perl-corpus --base-metrics xtask/tests/fixtures/parser-ratchet/equal-base.json --head-metrics xtask/tests/fixtures/parser-ratchet/improvement-head.json --receipt target/receipts/parser-ratchet.json` which produced a receipt and exited with `pass` as expected. 
- Ran `cargo xtask fmt` as part of verification (completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0a3ca588333816b837e062871a5)