### PR TITLE
feat(parser-ratchet): add canary rollout controls (#6847)

### DIFF
--- a/.ci/parser-ratchet/profiles/pr.toml
+++ b/.ci/parser-ratchet/profiles/pr.toml
@@ -1,0 +1,18 @@
+# Parser Ratchet PR profile
+# Default rollout is scaffold (non-blocking, no-op selected=false).
+
+[rollout]
+# Valid modes: scaffold | canary | enforce
+mode = "scaffold"
+
+# Selection toggle for whether the parser ratchet command runs on this profile.
+selected = false
+
+# Expected verdict while scaffolded. Workflow computes final verdict at runtime.
+verdict = "pass"
+
+[inputs]
+# Keep PR profile lightweight: strict-clean manifest only.
+# Do NOT use CPAN top-N in this PR profile.
+manifest = ".ci/common-corpus-manifest.txt"
+baseline = ".ci/parser-corpus-baseline.json"

--- a/.github/workflows/parser-ratchet.yml
+++ b/.github/workflows/parser-ratchet.yml
@@ -1,0 +1,203 @@
+name: Parser Ratchet
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: parser-ratchet-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  PARSER_RATCHET_PROFILE: .ci/parser-ratchet/profiles/pr.toml
+
+jobs:
+  parser-ratchet:
+    name: Parser Ratchet
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable (master)
+        with:
+          toolchain: 1.92.0
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-on-failure: true
+          shared-key: parser-ratchet-${{ hashFiles('Cargo.lock') }}
+
+      - name: Resolve rollout profile
+        id: profile
+        run: |
+          python3 - <<'PY'
+          import os
+          import pathlib
+          import tomllib
+
+          profile_path = pathlib.Path(os.environ["PARSER_RATCHET_PROFILE"])
+          data = tomllib.loads(profile_path.read_text(encoding="utf-8"))
+
+          rollout = data.get("rollout", {})
+          inputs = data.get("inputs", {})
+
+          mode = str(rollout.get("mode", "scaffold")).strip()
+          selected = bool(rollout.get("selected", False))
+          default_verdict = str(rollout.get("verdict", "pass")).strip()
+          manifest = str(inputs.get("manifest", ".ci/common-corpus-manifest.txt")).strip()
+          baseline = str(inputs.get("baseline", ".ci/parser-corpus-baseline.json")).strip()
+
+          allowed = {"scaffold", "canary", "enforce"}
+          if mode not in allowed:
+            raise SystemExit(f"invalid rollout.mode={mode!r}; expected one of {sorted(allowed)}")
+
+          out = pathlib.Path(os.environ["GITHUB_OUTPUT"])
+          with out.open("a", encoding="utf-8") as f:
+            f.write(f"mode={mode}\n")
+            f.write(f"selected={'true' if selected else 'false'}\n")
+            f.write(f"default_verdict={default_verdict}\n")
+            f.write(f"manifest={manifest}\n")
+            f.write(f"baseline={baseline}\n")
+
+          print(f"mode={mode} selected={selected} manifest={manifest} baseline={baseline}")
+          PY
+
+      - name: Run parser ratchet
+        id: ratchet
+        run: |
+          mkdir -p target/receipts
+
+          mode="${{ steps.profile.outputs.mode }}"
+          selected="${{ steps.profile.outputs.selected }}"
+          manifest="${{ steps.profile.outputs.manifest }}"
+          baseline="${{ steps.profile.outputs.baseline }}"
+
+          cmd=(cargo run -p xtask -- parser-corpus-sweep --manifest "$manifest" --baseline "$baseline" --enforce --receipt --output target/receipts/parser-ratchet-sweep.json)
+
+          execution_exit=0
+          hard_regression=false
+          verdict="pass"
+          should_fail=false
+
+          if [ "$selected" = "true" ]; then
+            set +e
+            "${cmd[@]}" 2>&1 | tee target/receipts/parser-ratchet.log
+            execution_exit=${PIPESTATUS[0]}
+            set -e
+
+            if [ "$execution_exit" -ne 0 ]; then
+              hard_regression=true
+            fi
+          else
+            echo "Rollout selection disabled (selected=false). No-op path." | tee target/receipts/parser-ratchet.log
+          fi
+
+          case "$mode" in
+            scaffold)
+              verdict="pass"
+              ;;
+            canary)
+              if [ "$selected" = "true" ] && [ "$hard_regression" = "true" ]; then
+                verdict="would_fail"
+              else
+                verdict="pass"
+              fi
+              ;;
+            enforce)
+              if [ "$selected" = "true" ] && [ "$hard_regression" = "true" ]; then
+                verdict="fail"
+                should_fail=true
+              else
+                verdict="pass"
+              fi
+              ;;
+          esac
+
+          {
+            echo "execution_exit=$execution_exit"
+            echo "hard_regression=$hard_regression"
+            echo "verdict=$verdict"
+            echo "should_fail=$should_fail"
+            echo "selected=$selected"
+            printf 'command='"%q " "${cmd[@]}"
+            echo
+          } >> "$GITHUB_OUTPUT"
+
+          echo "mode=$mode selected=$selected hard_regression=$hard_regression verdict=$verdict"
+
+          if [ "$should_fail" = "true" ]; then
+            echo "Enforcement active and hard regression detected; failing job."
+            exit 1
+          fi
+
+      - name: Emit parser ratchet receipt
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import subprocess
+          from datetime import datetime, timezone
+
+          def gh_env(name: str, default: str = "") -> str:
+              return os.environ.get(name, default)
+
+          receipt_path = pathlib.Path("target/receipts/parser-ratchet-receipt.json")
+          receipt_path.parent.mkdir(parents=True, exist_ok=True)
+
+          commit = subprocess.run(
+              ["git", "rev-parse", "HEAD"],
+              check=False,
+              capture_output=True,
+              text=True,
+          ).stdout.strip()
+
+          payload = {
+              "schema_version": 1,
+              "receipt_kind": "parser_ratchet",
+              "generated_at": datetime.now(timezone.utc).isoformat(),
+              "workflow": gh_env("GITHUB_WORKFLOW"),
+              "event_name": gh_env("GITHUB_EVENT_NAME"),
+              "ref": gh_env("GITHUB_REF"),
+              "commit": commit,
+              "profile": gh_env("PARSER_RATCHET_PROFILE"),
+              "mode": "${{ steps.profile.outputs.mode }}",
+              "selected": "${{ steps.ratchet.outputs.selected }}" == "true",
+              "default_verdict": "${{ steps.profile.outputs.default_verdict }}",
+              "verdict": "${{ steps.ratchet.outputs.verdict }}",
+              "hard_regression": "${{ steps.ratchet.outputs.hard_regression }}" == "true",
+              "enforcement_exit": int("${{ steps.ratchet.outputs.execution_exit || '0' }}"),
+              "command": "${{ steps.ratchet.outputs.command }}".strip(),
+              "inputs": {
+                  "manifest": "${{ steps.profile.outputs.manifest }}",
+                  "baseline": "${{ steps.profile.outputs.baseline }}",
+              },
+          }
+
+          receipt_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+          print(f"Wrote receipt: {receipt_path}")
+          PY
+
+      - name: Upload parser ratchet receipt
+        if: always()
+        uses: ./.github/actions/upload-receipt
+        with:
+          receipt-path: target/receipts/parser-ratchet-receipt.json
+          logs-path: target/receipts
+          artifacts-path: target/receipts
+          artifact-name: parser-ratchet-receipt
+          retention-days: 14

--- a/docs/ci/parser-ratchet-rollout.md
+++ b/docs/ci/parser-ratchet-rollout.md
@@ -1,0 +1,68 @@
+# Parser Ratchet rollout
+
+This workflow introduces the `Parser Ratchet` check with an explicit three-stage rollout so it can prove behavior before it becomes blocking.
+
+## Scope
+
+- Workflow: `.github/workflows/parser-ratchet.yml`
+- Profile: `.ci/parser-ratchet/profiles/pr.toml`
+- Triggers: `pull_request`, `merge_group`, and `push` on `master`
+- No path filters
+- Receipt artifact uploaded on every run
+
+The PR profile intentionally uses the strict-clean manifest only and **does not** include CPAN top-N sweeps.
+
+## Modes
+
+The profile controls two things:
+
+- `rollout.mode`: `scaffold`, `canary`, or `enforce`
+- `rollout.selected`: whether the ratchet command executes
+
+### 1) `scaffold`
+
+- `selected=false` (default)
+- No-op execution path
+- `verdict=pass`
+- Workflow exits `0`
+
+Use this to wire job names, triggers, receipts, and artifacts safely.
+
+### 2) `canary`
+
+- `selected=true`
+- Runs parser ratchet command against PR profile
+- Hard regression classifies as `verdict=would_fail`
+- Workflow still exits `0`
+
+Use this to gather evidence that classification and receipts are correct before turning on enforcement.
+
+### 3) `enforce`
+
+- `selected=true`
+- Hard regression classifies as `verdict=fail` and exits `1`
+- `selected=false` still exits `0`
+
+Only switch to this mode after clean canary evidence across PR, merge queue, and post-merge runs.
+
+### 4) `ruleset`
+
+After several clean runs in enforce mode, update repository protection/rulesets manually to require `Parser Ratchet`.
+
+Do **not** auto-edit GitHub rulesets from CI.
+
+## Validation matrix
+
+Use these checks locally (or via CI fixture branches) before moving stages:
+
+1. `selected:false` path passes.
+2. Canary `selected:true` + fixture regression exits `0`, records `would_fail` (or warning classification).
+3. Enforce `selected:true` + fixture regression exits `1`.
+
+## Suggested promotion checklist
+
+1. Merge scaffold wiring.
+2. Flip profile to `mode="canary"`, `selected=true`.
+3. Collect clean evidence over multiple `pull_request`, `merge_group`, and `push master` runs.
+4. Flip to `mode="enforce"`, `selected=true`.
+5. After additional clean evidence, make `Parser Ratchet` a required check in repository settings/rulesets.


### PR DESCRIPTION
### Motivation

- Introduce a safe, evidence-first rollout for the Parser Ratchet gate so it does not become blocking until it proves selection, no-op, receipt emission, and correct failure classification. Refs #6847.
- Provide an explicit PR profile and workflow wiring to gather receipts and telemetry across `pull_request`, `merge_group`, and `push` runs without path filters.

### Description

- Add `.github/workflows/parser-ratchet.yml` which runs on `pull_request`, `merge_group`, and `push` to `master`, uses event-aware concurrency, always uploads a receipt artifact, and exposes a single job named `Parser Ratchet`.
- Add a PR rollout profile at `.ci/parser-ratchet/profiles/pr.toml` with safe defaults `mode="scaffold"` and `selected=false` and inputs limited to the repo-owned strict-clean manifest and parser baseline (no CPAN top-N in PR profile).
- Implement three-mode rollout logic in the workflow: `scaffold` (no-op, verdict=pass), `canary` (selected=true classifies hard regressions as `would_fail` but exits 0), and `enforce` (selected=true makes hard regressions `fail` and exit 1); the workflow emits a machine-readable receipt describing mode, selected, verdict, and enforcement outcome.
- Add `docs/ci/parser-ratchet-rollout.md` documenting scope, modes, validation matrix, and a suggested promotion checklist (explicit warning not to auto-edit repository rulesets).

### Testing

- Ran a TOML sanity check that reads the new profile: `python3 -c 'tomllib.loads(Path(".ci/parser-ratchet/profiles/pr.toml").read_text())'` which verified the `rollout` fields (passed).
- Executed the rollout fixture validation script `bash /tmp/validate-parser-ratchet-rollout.sh` which simulates scaffold/canary/enforce semantics and confirmed expected verdicts and exit behavior (passed).
- Attempted a live `cargo run -p xtask -- parser-corpus-sweep` against a forced-regression baseline to exercise the real ratchet command, but the long-running sweep did not complete in the sandbox and was terminated (manual `validate-parser-ratchet-rollout.sh` covers behavior without a full sweep).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0a901e083338426650cbbba4e52)