### PR TITLE
feat(parser-ratchet): add canary rollout controls (#6847)

### DIFF
--- a/.ci/parser-ratchet/profiles/pr.toml
+++ b/.ci/parser-ratchet/profiles/pr.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+profile = "pr"
+
+# Rollout starts in scaffold mode: gate metadata is emitted but parser ratchet is
+# not selected. Flip `selected = true` only when canary/enforce evidence is ready.
+selected = false
+mode = "scaffold"
+
+# PR profile intentionally uses the strict-clean common corpus subset. Do not use
+# CPAN top-N here; that belongs to dedicated corpus workflows.
+manifest = ".ci/common-corpus-manifest.txt"
+baseline = ".ci/parser-corpus-baseline.json"
+
+# Enforce only when `mode = "enforce"` and selected=true.
+enforce = false

--- a/.github/workflows/parser-ratchet.yml
+++ b/.github/workflows/parser-ratchet.yml
@@ -1,0 +1,177 @@
+name: Parser Ratchet
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+  push:
+    branches: [master]
+
+concurrency:
+  group: parser-ratchet-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  parser-ratchet:
+    name: Parser Ratchet
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable (master)
+        with:
+          toolchain: 1.92.0
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          shared-key: parser-ratchet-${{ hashFiles('Cargo.lock') }}
+
+      - name: Load rollout profile
+        id: profile
+        run: |
+          python3 - <<'PY'
+          import pathlib
+          import tomllib
+
+          profile = pathlib.Path('.ci/parser-ratchet/profiles/pr.toml')
+          data = tomllib.loads(profile.read_text(encoding='utf-8'))
+
+          selected = bool(data.get('selected', False))
+          mode = str(data.get('mode', 'scaffold')).strip().lower()
+          manifest = str(data.get('manifest', '.ci/common-corpus-manifest.txt'))
+          baseline = str(data.get('baseline', '.ci/parser-corpus-baseline.json'))
+
+          if mode not in {'scaffold', 'canary', 'enforce'}:
+              raise SystemExit(f'Unsupported parser-ratchet mode: {mode}')
+
+          out = pathlib.Path(__import__('os').environ['GITHUB_OUTPUT'])
+          with out.open('a', encoding='utf-8') as fh:
+              fh.write(f'selected={str(selected).lower()}\n')
+              fh.write(f'mode={mode}\n')
+              fh.write(f'manifest={manifest}\n')
+              fh.write(f'baseline={baseline}\n')
+          PY
+
+      - name: Run parser ratchet according to rollout mode
+        id: run
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/receipts
+
+          SELECTED='${{ steps.profile.outputs.selected }}'
+          MODE='${{ steps.profile.outputs.mode }}'
+          MANIFEST='${{ steps.profile.outputs.manifest }}'
+          BASELINE='${{ steps.profile.outputs.baseline }}'
+
+          COMMAND=(cargo xtask parser-corpus-sweep --manifest "$MANIFEST" --baseline "$BASELINE" --enforce --receipt)
+
+          verdict="pass"
+          exit_code=0
+          status_note=""
+
+          if [[ "$SELECTED" != "true" ]]; then
+            verdict="pass"
+            status_note="selected=false (scaffold/no-op)"
+          elif [[ "$MODE" == "canary" ]]; then
+            set +e
+            "${COMMAND[@]}"
+            exit_code=$?
+            set -e
+            if [[ $exit_code -ne 0 ]]; then
+              verdict="would_fail"
+              status_note="selected=true canary captured hard regression"
+            else
+              verdict="pass"
+              status_note="selected=true canary clean"
+            fi
+          elif [[ "$MODE" == "enforce" ]]; then
+            set +e
+            "${COMMAND[@]}"
+            exit_code=$?
+            set -e
+            if [[ $exit_code -ne 0 ]]; then
+              verdict="fail"
+              status_note="selected=true enforce hard regression"
+            else
+              verdict="pass"
+              status_note="selected=true enforce clean"
+            fi
+          else
+            verdict="warn"
+            status_note="unknown rollout mode"
+          fi
+
+          export verdict exit_code status_note
+          python3 - <<'PY'
+          import json
+          import pathlib
+          import os
+
+          payload = {
+              'schema_version': 1,
+              'check': 'parser-ratchet',
+              'profile': 'pr',
+              'event': os.environ.get('GITHUB_EVENT_NAME', ''),
+              'ref': os.environ.get('GITHUB_REF', ''),
+              'sha': os.environ.get('GITHUB_SHA', ''),
+              'selected': os.environ['SELECTED'] == 'true',
+              'mode': os.environ['MODE'],
+              'manifest': os.environ['MANIFEST'],
+              'baseline': os.environ['BASELINE'],
+              'verdict': os.environ['verdict'],
+              'command': os.environ['COMMAND_STR'],
+              'command_exit_code': int(os.environ['exit_code']),
+              'status_note': os.environ['status_note'],
+          }
+
+          target = pathlib.Path('target/receipts/parser-ratchet.json')
+          target.write_text(json.dumps(payload, indent=2) + '\n', encoding='utf-8')
+          print(target)
+          PY
+
+          {
+            echo "selected=$SELECTED"
+            echo "mode=$MODE"
+            echo "verdict=$verdict"
+            echo "exit_code=$exit_code"
+          } >> "$GITHUB_OUTPUT"
+
+          if [[ "$MODE" == "enforce" && "$SELECTED" == "true" && "$exit_code" -ne 0 ]]; then
+            echo "::error::Parser Ratchet enforcement failed (see receipt artifact)."
+            exit 1
+          fi
+        env:
+          SELECTED: ${{ steps.profile.outputs.selected }}
+          MODE: ${{ steps.profile.outputs.mode }}
+          MANIFEST: ${{ steps.profile.outputs.manifest }}
+          BASELINE: ${{ steps.profile.outputs.baseline }}
+          COMMAND_STR: cargo xtask parser-corpus-sweep --manifest ${{ steps.profile.outputs.manifest }} --baseline ${{ steps.profile.outputs.baseline }} --enforce --receipt
+
+      - name: Upload parser ratchet receipt
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: parser-ratchet-receipt-${{ github.sha }}
+          path: |
+            target/receipts/parser-ratchet.json
+            target/receipts/*-corpus-sweep.json
+          if-no-files-found: warn
+          retention-days: 7

--- a/docs/ci/parser-ratchet-rollout.md
+++ b/docs/ci/parser-ratchet-rollout.md
@@ -1,0 +1,75 @@
+# Parser Ratchet rollout (scaffold → canary → enforce)
+
+This document defines the safe rollout for the `Parser Ratchet` workflow and
+its PR profile.
+
+## Scope
+
+- Workflow: `.github/workflows/parser-ratchet.yml`
+- PR profile: `.ci/parser-ratchet/profiles/pr.toml`
+- Final check/job name: **Parser Ratchet**
+
+The workflow runs on:
+
+- `pull_request`
+- `merge_group`
+- `push` to `master`
+
+No path filters are used. Receipt upload is `if: always()`.
+
+## Modes
+
+### 1) `scaffold` (default)
+
+Use when wiring and validating the plumbing.
+
+Expected behavior:
+
+- `selected = false`
+- workflow is a no-op with `verdict = "pass"`
+- exit code = 0
+- receipt is still emitted
+
+This is the default in `.ci/parser-ratchet/profiles/pr.toml`.
+
+### 2) `canary`
+
+Use after scaffold is proven stable.
+
+Expected behavior:
+
+- `selected = true`
+- runs PR profile (`manifest = .ci/common-corpus-manifest.txt`)
+- hard regressions are recorded as `verdict = "would_fail"` (or `warn` for non-regression execution anomalies)
+- workflow still exits 0
+
+### 3) `enforce`
+
+Enable only after canary evidence is consistently clean.
+
+Expected behavior:
+
+- `selected = true` + hard regression => exit 1 (`verdict = "fail"`)
+- `selected = false` => exit 0 (safe no-op)
+
+### 4) `ruleset`
+
+After multiple clean runs across PR, merge queue, and post-merge (`master`),
+update branch protection/ruleset configuration explicitly in a dedicated change.
+
+Do **not** silently change required-check settings from this workflow change.
+
+## Guardrails
+
+- Do not enable hard enforcement immediately without canary evidence.
+- Do not include CPAN top-N in the PR profile.
+- Do not add path filters to this workflow.
+- Do not auto-edit GitHub ruleset settings in CI.
+
+## Validation matrix
+
+Use fixture regression scenarios before promotion:
+
+1. `selected=false` path passes.
+2. `canary` + `selected=true` + fixture regression exits 0 and records `would_fail`/`warn`.
+3. `enforce` + `selected=true` + fixture regression exits 1.


### PR DESCRIPTION
### Motivation

- Provide a safe, observable rollout path for the Parser Ratchet gate so it can prove reporting, no-op behavior, useful receipts, and correct failure classification before becoming merge-blocking (Refs #6847). 
- Default to a non-blocking scaffold mode to avoid enabling hard enforcement until canary evidence is collected. 

### Description

- Add a new GitHub Actions workflow `.github/workflows/parser-ratchet.yml` that runs on `pull_request`, `merge_group`, and `push` to `master`, uses event-aware concurrency, always emits/upload receipts, and implements `scaffold`/`canary`/`enforce` rollout handling with a final job name `Parser Ratchet`. 
- Add a PR rollout profile `.ci/parser-ratchet/profiles/pr.toml` with safe defaults (`selected = false`, `mode = "scaffold"`) and PR-specific corpus settings (strict-clean manifest + baseline) while explicitly avoiding CPAN top-N in the PR profile. 
- Add rollout documentation `docs/ci/parser-ratchet-rollout.md` covering modes, guardrails, validation matrix, and the requirement that branch protection/ruleset changes are made explicitly and not automatically. 
- Do not modify branch protection or required-checks configuration because no conventional `.ci/policies/required-checks.toml` was present to update. 

### Testing

- Parsed the profile file with `python3 + tomllib` and ran assertions against the workflow file shape (presence of `merge_group`, `push: branches: [master]`, absence of path filters, and `if: always()` for receipts), and those checks passed. 
- Ran a local decision simulation that models the workflow logic for three cases (scaffold selected=false, canary selected=true with regression, enforce selected=true with regression) and it produced the expected outcomes (`pass`, `would_fail` with workflow exit 0, and `fail` with workflow exit 1 respectively). 
- Attempted a direct `cargo xtask parser-corpus-sweep` against a tiny fixture to exercise the real sweep, but the run stalled/was terminated in this environment; verification therefore relied on the simulation plus workflow/profile shape checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0a901e083338426650cbbba4e52)