### PR TITLE
feat(parser-ratchet): add canary rollout controls (#6847)

### DIFF
--- a/.ci/parser-ratchet/profiles/pr.toml
+++ b/.ci/parser-ratchet/profiles/pr.toml
@@ -1,0 +1,7 @@
+# Parser Ratchet PR profile (system/common corpus only).
+# Intentionally excludes CPAN top-N corpus to keep PR runs bounded.
+name = "pr"
+command = "cargo xtask parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt --output target/receipts/parser-ratchet-sweep.json"
+hard_regression_exit_codes = [1]
+warn_exit_codes = []
+receipt = "target/receipts/parser-ratchet.json"

--- a/.github/workflows/parser-ratchet.yml
+++ b/.github/workflows/parser-ratchet.yml
@@ -1,0 +1,160 @@
+name: Parser Ratchet
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: parser-ratchet-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  parser-ratchet:
+    name: Parser Ratchet
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      PARSER_RATCHET_MODE: ${{ vars.PARSER_RATCHET_MODE || 'canary' }}
+      PARSER_RATCHET_PROFILE: .ci/parser-ratchet/profiles/pr.toml
+      # Optional simulation knob for rollout validation drills.
+      # Values: hard_regression, warn_regression, pass
+      PARSER_RATCHET_SIMULATE: ${{ vars.PARSER_RATCHET_SIMULATE || '' }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: 1.92.0
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        with:
+          cache-on-failure: true
+          shared-key: parser-ratchet-${{ hashFiles('Cargo.lock') }}
+
+      - name: Run parser ratchet (mode-aware)
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import subprocess
+          import sys
+          import tomllib
+          from datetime import datetime, timezone
+
+          mode = os.environ.get("PARSER_RATCHET_MODE", "canary").strip()
+          profile_path = pathlib.Path(os.environ["PARSER_RATCHET_PROFILE"])
+          simulate = os.environ.get("PARSER_RATCHET_SIMULATE", "").strip()
+
+          if mode not in {"scaffold", "canary", "enforce"}:
+              raise SystemExit(f"Unsupported PARSER_RATCHET_MODE={mode!r}")
+
+          with profile_path.open("rb") as f:
+              profile = tomllib.load(f)
+
+          receipt_path = pathlib.Path(profile.get("receipt", "target/receipts/parser-ratchet.json"))
+          receipt_path.parent.mkdir(parents=True, exist_ok=True)
+          log_path = pathlib.Path("target/receipts/parser-ratchet.log")
+
+          selected = mode in {"canary", "enforce"}
+          verdict = "pass"
+          classification = "none"
+          command = profile.get("command", "")
+          command_exit = 0
+          final_exit = 0
+
+          hard_codes = set(profile.get("hard_regression_exit_codes", [1]))
+          warn_codes = set(profile.get("warn_exit_codes", []))
+
+          stdout = ""
+          stderr = ""
+
+          if selected:
+              if simulate == "hard_regression":
+                  command_exit = 1
+                  stderr = "simulated hard regression"
+              elif simulate == "warn_regression":
+                  command_exit = 2
+                  stderr = "simulated warn regression"
+              elif simulate in {"", "pass"}:
+                  proc = subprocess.run(command, shell=True, text=True, capture_output=True)
+                  command_exit = proc.returncode
+                  stdout = proc.stdout
+                  stderr = proc.stderr
+              else:
+                  raise SystemExit(f"Unsupported PARSER_RATCHET_SIMULATE={simulate!r}")
+
+              if command_exit == 0:
+                  verdict = "pass"
+              else:
+                  if command_exit in hard_codes:
+                      classification = "hard_regression"
+                      if mode == "canary":
+                          verdict = "would_fail"
+                          final_exit = 0
+                      else:
+                          verdict = "fail"
+                          final_exit = 1
+                  elif command_exit in warn_codes:
+                      classification = "warn"
+                      verdict = "warn"
+                      final_exit = 0
+                  else:
+                      classification = "warn"
+                      verdict = "warn"
+                      final_exit = 0
+          else:
+              verdict = "pass"
+
+          log_path.write_text(
+              "=== parser-ratchet stdout ===\n"
+              + stdout
+              + "\n=== parser-ratchet stderr ===\n"
+              + stderr,
+              encoding="utf-8",
+          )
+
+          receipt = {
+              "schema_version": 1,
+              "gate": "parser-ratchet",
+              "generated_at": datetime.now(timezone.utc).isoformat(),
+              "event": os.environ.get("GITHUB_EVENT_NAME", ""),
+              "ref": os.environ.get("GITHUB_REF", ""),
+              "sha": os.environ.get("GITHUB_SHA", ""),
+              "mode": mode,
+              "selected": selected,
+              "profile": str(profile_path),
+              "verdict": verdict,
+              "classification": classification,
+              "command": command,
+              "command_exit_code": command_exit,
+              "final_exit_code": final_exit,
+              "simulate": simulate,
+          }
+          receipt_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+
+          print(json.dumps(receipt, indent=2))
+          if final_exit != 0:
+              sys.exit(final_exit)
+          PY
+
+      - name: Upload parser-ratchet receipt
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: parser-ratchet-${{ github.sha }}
+          path: |
+            target/receipts/parser-ratchet.json
+            target/receipts/parser-ratchet.log
+            target/receipts/parser-ratchet-sweep.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/ci/parser-ratchet-rollout.md
+++ b/docs/ci/parser-ratchet-rollout.md
@@ -1,0 +1,59 @@
+# Parser Ratchet rollout
+
+Issue: Refs #6847
+
+## Rollout modes
+
+Parser Ratchet is wired for a three-stage rollout controlled by the repository
+variable `PARSER_RATCHET_MODE`.
+
+- `scaffold`
+  - `selected=false`
+  - always records a receipt
+  - `verdict=pass`
+  - exits 0
+- `canary` (**current rollout mode**)
+  - `selected=true`
+  - runs `.ci/parser-ratchet/profiles/pr.toml`
+  - hard regressions are classified as `hard_regression` and reported as `would_fail`
+  - non-hard failures are reported as `warn`
+  - exits 0 (advisory)
+- `enforce`
+  - `selected=true` runs profile and classifies outcomes
+  - hard regressions exit 1 with `verdict=fail`
+  - `selected=false` (only scaffold mode) exits 0
+
+`ruleset` is intentionally not automatic. After several clean `pull_request`,
+`merge_group`, and `push` (`master`) runs in canary/enforce, update branch
+protection/rulesets manually in a follow-up change.
+
+## Workflow scope
+
+`.github/workflows/parser-ratchet.yml` runs on:
+
+- `pull_request`
+- `merge_group`
+- `push` to `master`
+
+There are no path filters. Concurrency is event-aware to avoid stale duplicate
+runs. Receipts are uploaded on every run (`if: always()`).
+
+## PR profile
+
+PR profile is intentionally constrained to the common/system corpus path and does
+not run CPAN top-N workloads.
+
+## Validation matrix
+
+The workflow supports a simulation variable (`PARSER_RATCHET_SIMULATE`) to test
+rollout behavior without introducing real regressions:
+
+- `hard_regression`: simulates a hard regression (exit code 1)
+- `warn_regression`: simulates a warning-grade failure
+- `pass` (or unset): runs the real profile command
+
+Expected outcomes:
+
+1. `scaffold` + any simulation => `selected:false`, exit 0, `verdict:pass`
+2. `canary` + `hard_regression` => exit 0, `verdict:would_fail`
+3. `enforce` + `hard_regression` => exit 1, `verdict:fail`


### PR DESCRIPTION
### Motivation

- Introduce a staged, non-blocking rollout for the Parser Ratchet gate so the new gate can prove it always emits receipts, no-ops correctly, classifies failures, and reports useful evidence before becoming merge-blocking.

### Description

- Add a mode-aware GitHub Actions workflow at `.github/workflows/parser-ratchet.yml` that runs on `pull_request`, `merge_group`, and `push` to `master`, uses event-aware `concurrency`, and always uploads receipts as artifacts.
- Add a PR profile at `.ci/parser-ratchet/profiles/pr.toml` which runs `cargo xtask parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt` and intentionally excludes CPAN top-N workloads to keep PR runs bounded.
- Implement three rollout modes via the repository variable `PARSER_RATCHET_MODE`: `scaffold` (`selected=false`, always `verdict=pass`), `canary` (advisory, `selected=true`, hard regressions classified as `would_fail` but exit 0), and `enforce` (hard regressions exit 1); add a simulation knob `PARSER_RATCHET_SIMULATE` for `hard_regression`/`warn_regression`/`pass` to validate behavior without real regressions.
- Add documentation `docs/ci/parser-ratchet-rollout.md` describing modes, scope, validation matrix, and the deliberate choice not to automatically update GitHub rulesets.

### Testing

- Verified the PR profile does not include CPAN by loading `.ci/parser-ratchet/profiles/pr.toml` with `tomllib` and asserting the command string contains no `cpan` (passed).
- Validated `scaffold` semantics with a local assertion that `selected=false`, `verdict=pass`, and exit 0 under simulation (passed).
- Validated `canary` behavior by simulating a hard regression and asserting the generated receipt is `verdict: would_fail` with final exit 0 (passed).
- Validated `enforce` behavior by simulating a hard regression and asserting the workflow would exit 1 with `verdict: fail` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0a901e083338426650cbbba4e52)