### PR TITLE
docs(ci): plan ruleset required-check rollout (#6858)

### DIFF
--- a/.ci/policies/required-checks.toml
+++ b/.ci/policies/required-checks.toml
@@ -1,0 +1,12 @@
+# Required check names policy (planning scaffold).
+#
+# This file is informational unless and until the ruleset rollout is approved.
+
+[metadata]
+status = "draft"
+source_of_truth = "GitHub repository ruleset"
+notes = "Keep this aligned with final aggregator check names before required_status_checks enforcement."
+
+[required_checks]
+# Populate with final aggregator check names after observation criteria are met.
+contexts = []

--- a/docs/ci/ruleset-required-checks-rollout.md
+++ b/docs/ci/ruleset-required-checks-rollout.md
@@ -1,0 +1,52 @@
+# GitHub Ruleset required-status-checks rollout plan
+
+This repository currently enforces required CI checks by convention and operations process. This document defines the **manual** rollout plan for a GitHub Ruleset `required_status_checks` rule once final check names have proven stable.
+
+> Scope: planning + verification only. This document does **not** authorize automatic ruleset mutation.
+
+## Preconditions before enforcement
+
+Do not add `required_status_checks` until all of the following are true:
+
+1. Final aggregator check names are present and stable (same names across PR, `merge_group`, and `master` contexts).
+2. The Methodology Gate reports reliably for all required trigger types.
+3. The Parser Ratchet reports reliably for all required trigger types.
+4. `.github/workflows/ci.yml` includes `merge_group` support when merge queue is intended.
+5. `workflow-trigger-lint` passes and confirms required workflows trigger in all expected contexts.
+6. No workflow that would become required uses path filters that can skip required reporting.
+
+## Observation period (before any ruleset change)
+
+Collect evidence first. Keep convention-based enforcement in place during observation.
+
+Minimum evidence window:
+
+- At least **3 consecutive clean days** of reporting.
+- At least **10 pull requests** observed with clean final checks.
+- At least **1 push to `master`** with clean final checks.
+- If merge queue is enabled or planned, at least **1 `merge_group` event** with clean final checks before enforcement.
+
+Use `scripts/github-ruleset-preview.sh` plus workflow run history to capture and retain evidence snapshots.
+
+## Ruleset update plan (manual, staged)
+
+When preconditions and observation criteria are satisfied:
+
+1. Update the repository ruleset manually in GitHub UI to add a `required_status_checks` rule.
+2. Add only the **final aggregator check names** as required checks (do not require every internal job).
+3. If merge queue is desired, enable it conservatively and start with batch size **1-2**.
+4. Observe for **2-3 additional clean days** and tune queue settings only after stable behavior.
+
+## Rollback plan
+
+If required checks enforcement causes regressions or blocked merges:
+
+1. Remove the `required_status_checks` rule from the ruleset.
+2. Disable merge queue (if it was enabled for this rollout).
+3. Keep CI workflows running under conventional enforcement while issues are triaged.
+
+## Explicit non-goals
+
+- No automatic ruleset mutation from repository scripts.
+- No `gh api PATCH`/`PUT` ruleset writes.
+- No automatic merge queue enablement from repository automation.

--- a/scripts/github-ruleset-preview.sh
+++ b/scripts/github-ruleset-preview.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read-only ruleset preview for repository maintainers.
+#
+# Usage:
+#   scripts/github-ruleset-preview.sh [owner/repo]
+#
+# Behavior:
+# - Queries existing repository rulesets.
+# - Prints whether required_status_checks rules are present.
+# - Never mutates settings.
+
+repo_arg="${1:-}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: GitHub CLI (gh) is not installed." >&2
+  exit 1
+fi
+
+if [[ -n "$repo_arg" ]]; then
+  repo="$repo_arg"
+else
+  repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+fi
+
+if [[ -z "$repo" ]]; then
+  echo "error: unable to determine repository. Pass owner/repo explicitly." >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  cat >&2 <<MSG
+warning: gh is not authenticated.
+Run: gh auth login
+Then rerun: scripts/github-ruleset-preview.sh $repo
+MSG
+  exit 2
+fi
+
+endpoint="repos/$repo/rulesets"
+
+if ! json="$(gh api -H 'Accept: application/vnd.github+json' "$endpoint" 2>/dev/null)"; then
+  cat >&2 <<MSG
+warning: unable to read $endpoint.
+This is read-only and commonly fails when the token lacks repository admin/ruleset read permissions.
+MSG
+  exit 3
+fi
+
+if [[ "$(gh api -H 'Accept: application/vnd.github+json' "$endpoint" --jq 'length')" -eq 0 ]]; then
+  echo "No rulesets found for $repo."
+  exit 0
+fi
+
+echo "Repository: $repo"
+echo "Endpoint: $endpoint"
+echo
+
+gh api -H 'Accept: application/vnd.github+json' "$endpoint" --jq '
+  .[] |
+  {
+    id,
+    name,
+    target,
+    enforcement,
+    required_status_checks: ([.rules[]? | select(.type == "required_status_checks")] | length)
+  } |
+  "ruleset \(.id): \(.name) | target=\(.target) | enforcement=\(.enforcement) | required_status_checks_rules=\(.required_status_checks)"
+'
+
+echo
+echo "Required status check details (if configured):"
+gh api -H 'Accept: application/vnd.github+json' "$endpoint" --jq '
+  .[] as $rs |
+  ($rs.rules[]? | select(.type == "required_status_checks")) as $rule |
+  "- \($rs.name) (id=\($rs.id)): required checks => \(($rule.parameters.required_status_checks // []) | map(.context) | join(", "))"
+' || true
+
+echo
+echo "Read-only preview complete. No repository settings were changed."


### PR DESCRIPTION
### Motivation

- Provide a conservative, manual rollout plan for enabling a GitHub Ruleset `required_status_checks` rule once final aggregator check names and reporting behaviors are stable.
- Offer a read-only tool to inspect existing repository rulesets without mutating settings and a lightweight scaffold to record final required-check contexts.

### Description

- Add `docs/ci/ruleset-required-checks-rollout.md` documenting preconditions, the observation period, staged update plan, rollback steps, and explicit non-goals (no automatic ruleset mutation).
- Add `scripts/github-ruleset-preview.sh`, a read-only script that uses `gh api` to list repository rulesets and report `required_status_checks` details while exiting with clear messages when authentication/permissions are missing.
- Add `.ci/policies/required-checks.toml` as a draft scaffold for final aggregator check contexts (keeps `contexts = []` until observation criteria are met).
- References: `Refs #6858` and `Refs #6853` are recorded for tracking the rollout and related discussions.

### Testing

- Ran a syntax check: `bash -n scripts/github-ruleset-preview.sh` passed successfully.
- Executed `scripts/github-ruleset-preview.sh` in this environment and it exited with a clear diagnostic when `gh` was not available or not authenticated, which is the expected read-only behavior (no settings were mutated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0ad68f88333931b233ab73820a9)