### PR TITLE
docs(ci): plan ruleset required-check rollout (#6858)

### DIFF
--- a/.ci/policies/required-checks.toml
+++ b/.ci/policies/required-checks.toml
@@ -1,0 +1,34 @@
+# Canonical policy placeholders for future GitHub Ruleset required checks.
+# This file is intentionally documentation/config only and does not apply settings.
+
+[rollout]
+enabled = false
+mode = "observe"
+
+[preconditions]
+final_aggregator_checks_exist = true
+methodology_gate_reports_reliably = true
+parser_ratchet_reports_reliably = true
+ci_supports_merge_group = true
+workflow_trigger_lint_passing = true
+no_required_workflow_path_filters = true
+
+[observation_targets]
+minimum_clean_days = 3
+minimum_prs = 10
+minimum_master_pushes = 1
+minimum_merge_group_events = 1
+
+[enforcement]
+# Populate with final/stable check names only after observation targets are met.
+required_check_names = []
+
+[merge_queue]
+enable = false
+initial_batch_size_min = 1
+initial_batch_size_max = 2
+
+[rollback]
+remove_required_status_checks = true
+disable_merge_queue = true
+keep_conventional_ci = true

--- a/docs/ci/ruleset-required-checks-rollout.md
+++ b/docs/ci/ruleset-required-checks-rollout.md
@@ -1,0 +1,64 @@
+# GitHub Ruleset required-status-checks rollout plan
+
+This document defines how to move from convention/ops-enforced CI requirements to a GitHub Ruleset `required_status_checks` rule.
+
+> Scope: planning and operational verification only. This plan does **not** auto-apply repository settings.
+
+## Preconditions (must all be true)
+
+Before any enforcement update is proposed, verify all of the following:
+
+1. Final aggregator check names exist and are stable.
+2. **Methodology Gate** reports reliably.
+3. **Parser Ratchet** reports reliably.
+4. `ci.yml` supports `merge_group` events.
+5. `workflow-trigger-lint` passes.
+6. No workflow that is expected to be required (including style/policy workflows) uses path filters that could skip reporting.
+
+## Observation period (evidence gate)
+
+Collect evidence before enabling required checks:
+
+- At least **3 consecutive days** of clean reporting.
+- At least **10 PRs** where final check names are reported consistently.
+- At least **1 push to `master`** where final check names report consistently.
+- If merge queue is enabled (or planned), at least **1 `merge_group` event** with consistent reporting before enforcement.
+
+### Suggested observation log fields
+
+- Date (UTC)
+- Event type (`pull_request`, `push`, `merge_group`)
+- PR number / commit SHA
+- Observed final check names
+- Missing checks (if any)
+- Notes / remediation
+
+## Ruleset update plan (manual, staged)
+
+After preconditions and observation targets are met:
+
+1. Add a GitHub Ruleset `required_status_checks` rule for **final check names only**.
+   - Do not require intermediate job names.
+   - Keep required list minimal and stable.
+2. If merge queue is used, enable conservatively.
+   - Start with merge queue batch size **1-2**.
+3. Operate for **2-3 additional clean days**, then tune queue settings and required-check list only if needed.
+
+## Rollback plan
+
+If required-check enforcement causes merge blocking or noisy false negatives:
+
+1. Remove the `required_status_checks` rule from the Ruleset.
+2. Disable merge queue (if it was enabled during rollout).
+3. Keep workflows running conventionally while investigating trigger/reporting gaps.
+
+## Non-goals / safety constraints
+
+- Do **not** mutate Rulesets automatically from repo scripts.
+- Do **not** use `gh api` write operations (`PATCH`, `PUT`, `POST`, `DELETE`) in rollout helpers.
+- Do **not** enable merge queue from automation in this repository.
+
+## Read-only inspection helper
+
+Use `scripts/github-ruleset-preview.sh` to inspect current Ruleset state in a read-only way.
+

--- a/scripts/github-ruleset-preview.sh
+++ b/scripts/github-ruleset-preview.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read-only preview of GitHub rulesets for the current repository.
+# This script intentionally performs GET requests only.
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+infer_repo() {
+  local origin_url owner_repo
+  origin_url="$(git remote get-url origin 2>/dev/null || true)"
+  if [[ -z "${origin_url}" ]]; then
+    return 1
+  fi
+
+  # Supports:
+  # - git@github.com:owner/repo.git
+  # - https://github.com/owner/repo.git
+  # - https://github.com/owner/repo
+  if [[ "${origin_url}" =~ github\.com[:/]([^/]+/[^/.]+)(\.git)?$ ]]; then
+    owner_repo="${BASH_REMATCH[1]}"
+    printf '%s\n' "${owner_repo}"
+    return 0
+  fi
+
+  return 1
+}
+
+require_cmd git
+require_cmd gh
+require_cmd jq
+
+repo="${1:-}"
+if [[ -z "${repo}" ]]; then
+  if ! repo="$(infer_repo)"; then
+    echo "error: unable to infer owner/repo from git remote; pass it explicitly:"
+    echo "  scripts/github-ruleset-preview.sh owner/repo"
+    exit 1
+  fi
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "warning: gh is not authenticated. Run 'gh auth login' or export GITHUB_TOKEN."
+  echo "read-only preview could not proceed."
+  exit 0
+fi
+
+echo "Repository: ${repo}"
+echo
+
+echo "=== Repository rulesets (read-only GET) ==="
+if ! gh api "repos/${repo}/rulesets" >/tmp/rulesets_repo.json 2>/tmp/rulesets_repo.err; then
+  echo "warning: failed to read repository rulesets."
+  cat /tmp/rulesets_repo.err
+  exit 0
+fi
+
+jq -r '
+  if length == 0 then
+    "(none)"
+  else
+    .[]
+    | [
+        "- id=" + (.id|tostring),
+        "name=" + .name,
+        "target=" + .target,
+        "enforcement=" + .enforcement
+      ]
+    | join(" ")
+  end
+' /tmp/rulesets_repo.json
+
+echo
+echo "=== required_status_checks details (if present) ==="
+jq -r '
+  .[]
+  | . as $rs
+  | ($rs.rules // [])[]?
+  | select(.type == "required_status_checks")
+  | "Ruleset: " + $rs.name,
+    (
+      (.parameters.required_status_checks // [])
+      | if length == 0 then "  checks: (none configured)"
+        else .[] | "  - " + (.context // "<missing-context>")
+        end
+    )
+' /tmp/rulesets_repo.json
+
+echo
+echo "=== Branch protection summary (legacy endpoint, read-only GET) ==="
+if gh api "repos/${repo}/branches/master/protection" >/tmp/master_protection.json 2>/tmp/master_protection.err; then
+  jq -r '
+    [
+      "master.protected=true",
+      "required_status_checks.strict=" + ((.required_status_checks.strict // false)|tostring),
+      "required_status_checks.count=" + (((.required_status_checks.contexts // [])|length)|tostring)
+    ]
+    | join(" ")
+  ' /tmp/master_protection.json
+else
+  echo "warning: unable to read master branch protection (branch may be absent or caller lacks permission)."
+fi
+
+echo
+echo "Done. No settings were changed."


### PR DESCRIPTION
### Motivation
- The repository uses GitHub Rulesets but lacks a codified `required_status_checks` rollout plan and a safe inspection helper.
- Enforcement must only be enabled after final aggregator check names and merge-related events are proven stable, and automation must not mutate repository settings.

### Description
- Add `docs/ci/ruleset-required-checks-rollout.md` documenting preconditions, observation windows, staged enforcement, rollback, and explicit non-goals.
- Add `scripts/github-ruleset-preview.sh`, a read-only helper that infers `owner/repo`, performs `GET` requests with `gh api`, formats results with `jq`, and exits safely when unauthenticated. 
- Add `.ci/policies/required-checks.toml` as a non-enforcing policy scaffold for rollout gating and defaults. 
- The preview script is executable and intentionally avoids any `gh api` write operations or automatic Ruleset mutations.

### Testing
- Ran `bash -n scripts/github-ruleset-preview.sh` to validate shell syntax, which passed. 
- Executed the preview script in this environment and observed a controlled failure due to the missing `gh` CLI (`error: required command not found: gh`), demonstrating safe read-only behavior when credentials/commands are unavailable. 
- No automated CI settings were changed and the script performs only read operations in normal usage. 
- References: Refs #6858 and Refs #6853.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0ad68f88333931b233ab73820a9)