### PR TITLE
docs(ci): plan ruleset required-check rollout (#6858)

### DIFF
--- a/.ci/policies/required-checks.toml
+++ b/.ci/policies/required-checks.toml
@@ -1,0 +1,17 @@
+# Candidate final check names for eventual GitHub Ruleset required_status_checks.
+#
+# This file is planning metadata only. Do not treat this as automatic enforcement.
+# Apply ruleset updates manually after the rollout observation criteria are met.
+
+[required_checks]
+# Replace with stable final aggregator check names once confirmed.
+final_aggregators = [
+  "Methodology Gate",
+  "Parser Ratchet",
+]
+
+[rollout]
+min_clean_days = 3
+min_prs = 10
+min_master_pushes = 1
+min_merge_group_events = 1

--- a/docs/ci/ruleset-required-checks-rollout.md
+++ b/docs/ci/ruleset-required-checks-rollout.md
@@ -1,0 +1,65 @@
+# GitHub Ruleset required-status-checks rollout plan
+
+This runbook documents how to move from convention-enforced CI to an explicit GitHub Ruleset `required_status_checks` rule.
+
+> Scope: **planning and verification only**. Do not apply Ruleset mutations from this document.
+
+## Objective
+
+Enable required status checks only after final check names are stable and observed as reliable across pull requests, merge groups (if enabled), and pushes to `master`.
+
+## Preconditions (must all be true)
+
+1. Final aggregator check names exist and are listed in `.ci/policies/required-checks.toml`.
+2. `Methodology Gate` reports reliably.
+3. `Parser Ratchet` reports reliably.
+4. `.github/workflows/ci.yml` includes a `merge_group` trigger.
+5. Workflow trigger linting passes (for example, a `workflow-trigger-lint` check in CI or an equivalent repository lint command).
+6. No workflow that will become required uses path filters (`paths` / `paths-ignore`) that could suppress reporting.
+
+## Observation period before enforcement
+
+Collect evidence before updating Rulesets:
+
+- At least **3 consecutive days** of clean reporting.
+- At least **10 PRs** where all planned required checks report.
+- At least **1 push to `master`** where all planned required checks report.
+- If merge queue is enabled, at least **1 `merge_group` event** where all planned required checks report before enforcement.
+
+Record evidence in the rollout issue (sample):
+
+- Date window observed.
+- Number of PRs sampled.
+- Example PR links with full check reporting.
+- Example `master` push link.
+- Example `merge_group` run link (if applicable).
+
+## Ruleset update plan (manual, conservative)
+
+1. Open repository Rulesets and edit the active branch protection Ruleset manually.
+2. Add `required_status_checks` using only the final aggregator check names from `.ci/policies/required-checks.toml`.
+3. Do **not** include ephemeral or matrix-expanded job names.
+4. If using merge queue, enable conservatively:
+   - start with batch size **1–2**,
+   - monitor queue health,
+   - tune only after **2–3 additional clean days**.
+5. Announce enforcement start time in the infra issue/PR so contributors know required checks are now platform-enforced.
+
+## Rollback plan
+
+If required-check enforcement causes merge blockage due to check non-reporting:
+
+1. Remove the `required_status_checks` rule from the Ruleset.
+2. Disable merge queue (if it was enabled for rollout).
+3. Keep CI workflows running conventionally while fixing trigger/reporting reliability.
+4. Re-enter observation mode and repeat enforcement only after the observation criteria are met again.
+
+## Verification helpers
+
+Use `scripts/github-ruleset-preview.sh` for a read-only snapshot of current Ruleset state and whether `required_status_checks` is configured.
+
+```bash
+bash scripts/github-ruleset-preview.sh
+```
+
+The script is intentionally read-only and must not apply any Ruleset changes.

--- a/scripts/github-ruleset-preview.sh
+++ b/scripts/github-ruleset-preview.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read-only Ruleset preview helper.
+# - Queries current repository rulesets.
+# - Prints whether required_status_checks appears in each ruleset.
+# - Never mutates repository settings.
+
+REPO="${GITHUB_REPOSITORY:-}"
+if [[ -z "${REPO}" ]]; then
+  if git remote get-url origin >/dev/null 2>&1; then
+    ORIGIN_URL="$(git remote get-url origin)"
+    if [[ "${ORIGIN_URL}" =~ github.com[:/]([^/]+/[^/.]+)(\.git)?$ ]]; then
+      REPO="${BASH_REMATCH[1]}"
+    fi
+  fi
+fi
+
+if [[ -z "${REPO}" ]]; then
+  cat <<'MSG'
+Unable to determine repository.
+Set GITHUB_REPOSITORY=owner/repo and re-run.
+MSG
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  cat <<'MSG'
+GitHub CLI (gh) is not installed.
+Install gh, authenticate, and re-run for a read-only preview.
+MSG
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  cat <<'MSG'
+GitHub CLI is not authenticated.
+Run: gh auth login
+Required scope: read access to repository rulesets.
+MSG
+  exit 1
+fi
+
+echo "Repository: ${REPO}"
+echo "Fetching rulesets (read-only)..."
+
+RULESETS_JSON="$(gh api -H 'Accept: application/vnd.github+json' "/repos/${REPO}/rulesets")"
+COUNT="$(jq 'length' <<<"${RULESETS_JSON}")"
+
+echo "Rulesets found: ${COUNT}"
+
+if [[ "${COUNT}" -eq 0 ]]; then
+  echo "No rulesets configured."
+  exit 0
+fi
+
+echo
+jq -r '
+  .[] |
+  . as $r |
+  [
+    "- name: \($r.name)",
+    "  id: \($r.id)",
+    "  target: \($r.target)",
+    "  enforcement: \($r.enforcement)",
+    "  required_status_checks: " +
+      (if any($r.rules[]?; .type == "required_status_checks") then "present" else "absent" end)
+  ] | join("\n")
+' <<<"${RULESETS_JSON}"
+
+echo
+echo "Details (required_status_checks rules only):"
+jq -r '
+  .[] as $r |
+  ($r.rules[]? | select(.type == "required_status_checks")) as $rule |
+  "- \($r.name) [id=\($r.id)]\n" +
+  (if ($rule.parameters.required_status_checks // []) | length == 0
+   then "  checks: (none listed)"
+   else (
+     "  checks:\n" +
+     (($rule.parameters.required_status_checks // [])
+       | map("    - " + (.context // "<missing-context>"))
+       | join("\n"))
+   )
+  )
+' <<<"${RULESETS_JSON}" || true
+
+echo
+echo "Note: this script is read-only. It does not PATCH/PUT or modify rulesets."


### PR DESCRIPTION
### Motivation

- Move from a convention/ops-enforced “required CI” to an explicit, auditable GitHub Ruleset `required_status_checks` rollout plan. 
- Ensure enforcement only happens after final aggregator check names and GitHub reporting are stable across PRs, `merge_group` runs, and pushes to `master`. 
- Provide safe, read-only tooling and guidance so repository settings are not mutated automatically during rollout.

### Description

- Add a rollout runbook at `docs/ci/ruleset-required-checks-rollout.md` that documents preconditions, an observation period, a conservative update plan, and rollback steps. 
- Add a read-only helper script `scripts/github-ruleset-preview.sh` that discovers `owner/repo`, requires `gh` and `jq`, fetches rulesets with `gh api` (GET only), and reports whether `required_status_checks` is present without making any changes. 
- Add planning metadata `.ci/policies/required-checks.toml` that lists candidate final aggregator check names and the observation thresholds used by the runbook. 
- The changes are planning and verification artifacts only and explicitly avoid any automatic PATCH/PUT to rulesets or enabling the merge queue.

### Testing

- Run a static syntax check with `bash -n scripts/github-ruleset-preview.sh`, which passed. 
- Execute `bash scripts/github-ruleset-preview.sh` in a minimal environment, which exits with a clear message when repository context is missing (expected behavior). 
- Execute `GITHUB_REPOSITORY=EffortlessMetrics/perl-lsp bash scripts/github-ruleset-preview.sh` in this environment, which exits with a clear message when `gh` is not installed or authenticated (expected behavior).

Refs #6858
Refs #6853

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0ad68f88333931b233ab73820a9)