### PR TITLE
fix(test): relax file_watcher_debouncer threshold for CI-load tolerance (#6917)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/file_watcher_debounce.rs
+++ b/crates/perl-lsp-rs/src/runtime/file_watcher_debounce.rs
@@ -211,9 +211,15 @@ mod tests {
         debouncer.schedule("file:///c.pl");
         thread::sleep(Duration::from_millis(150));
         let b = batches.lock();
-        // All three URIs should arrive in a single batch
-        assert_eq!(b.len(), 1);
-        assert_eq!(b[0], vec!["file:///a.pl", "file:///b.pl", "file:///c.pl"]);
+        // All three URIs should arrive in 1-2 batches (all arrive before window expires,
+        // but CI scheduler jitter may split into a second batch under load)
+        assert!(b.len() <= 2, "Expected <=2 batches for 3 rapid changes, got {}", b.len());
+        // All three URIs must be delivered exactly once across all batches
+        let all_uris: Vec<String> = b.iter().flat_map(|v| v.iter().cloned()).collect();
+        assert!(all_uris.contains(&"file:///a.pl".to_string()), "Missing file:///a.pl");
+        assert!(all_uris.contains(&"file:///b.pl".to_string()), "Missing file:///b.pl");
+        assert!(all_uris.contains(&"file:///c.pl".to_string()), "Missing file:///c.pl");
+        assert_eq!(all_uris.len(), 3, "Expected exactly 3 URIs total, got {}", all_uris.len());
     }
 
     #[test]
@@ -254,8 +260,10 @@ mod tests {
 
         let calls = call_count.load(Ordering::SeqCst);
         let uris = total_uris.load(Ordering::SeqCst);
-        // Should coalesce into 1-2 batch calls (all 50 URIs arrive before window expires)
-        assert!(calls <= 2, "Expected <=2 batch calls for 50 rapid changes, got {calls}");
+        // Should coalesce into <=4 batch calls — under CI scheduler load the 100ms
+        // window may fire before all 50 events arrive, splitting into a few batches.
+        // The meaningful check is that coalescence occurred (not 50 individual calls).
+        assert!(calls <= 4, "Expected <=4 batch calls for 50 rapid changes, got {calls}");
         assert_eq!(uris, 50, "All 50 URIs should be delivered, got {uris}");
     }
 }


### PR DESCRIPTION
## Summary

- Bumps `file_watcher_debouncer_coalesces_bulk_operations` assertion from `<= 2` to `<= 4` batch calls for 50 rapid events
- Reworks `file_watcher_debouncer_batches_multiple_uris` to allow 1-2 batches (was `assert_eq!(b.len(), 1)`) while still verifying all 3 URIs are delivered exactly once via per-URI presence checks

## Why this fix is correct

During the 2026-04-26 session, 6+ PRs false-failed on this test. The root cause is OS scheduler preemption: the producer thread sending 50 `schedule()` calls can be interrupted mid-loop long enough for the debouncer's 100ms window to expire and fire a batch before all events have arrived. This produces 3-4 batch calls instead of 1-2.

The semantic invariant being tested is **coalescence** — that the debouncer batches events rather than firing one callback per event. A regressed debouncer would produce 50 calls (one per URI), which still fails both `<= 4` and `<= 2`. The exact batch count is a scheduler artifact, not a behavioral contract.

## Test plan

- [x] All 5 debounce tests pass locally: `RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs file_watcher_debounce -- --test-threads=2`
- [x] `cargo fmt --check` passes
- [x] No new clippy issues in the edited file
- [x] Semantics preserved: still verifies coalescence happened, all URIs delivered

Fixes #6917