### PR TITLE
feat(agent): add lease and idempotent receipt primitives (#6853)

### DIFF
--- a/.ci/receipts/schemas/agent-receipt.schema.json
+++ b/.ci/receipts/schemas/agent-receipt.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/schemas/agent-receipt.schema.json",
+  "title": "Agent Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "receipt_id",
+    "task_id",
+    "snapshot_id",
+    "canonical_head_sha",
+    "observed_head_sha",
+    "created_at",
+    "lease_expires_at",
+    "allowed_mutations",
+    "forbidden_mutations",
+    "idempotency_key",
+    "required_output_schema",
+    "applied_mutations"
+  ],
+  "properties": {
+    "receipt_id": { "type": "string", "minLength": 1 },
+    "task_id": { "type": "string", "minLength": 1 },
+    "snapshot_id": { "type": "string", "minLength": 1 },
+    "canonical_head_sha": { "type": "string", "minLength": 7 },
+    "observed_head_sha": { "type": "string", "minLength": 7 },
+    "created_at": { "type": "string", "format": "date-time" },
+    "lease_expires_at": { "type": "string", "format": "date-time" },
+    "allowed_mutations": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "forbidden_mutations": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "idempotency_key": { "type": "string", "minLength": 1 },
+    "supersedes_receipt_id": { "type": ["string", "null"] },
+    "required_output_schema": { "type": "string", "minLength": 1 },
+    "applied_mutations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["action", "target"],
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "comment",
+              "comment_update",
+              "state_transition",
+              "artifact_upload"
+            ]
+          },
+          "target": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/.ci/receipts/schemas/agent-task.schema.json
+++ b/.ci/receipts/schemas/agent-task.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/schemas/agent-task.schema.json",
+  "title": "Agent Task",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "task_id",
+    "snapshot_id",
+    "lane",
+    "pr",
+    "head_sha",
+    "base_sha",
+    "canonical_state",
+    "allowed_mutations",
+    "forbidden_mutations",
+    "required_output_schema",
+    "expires_at"
+  ],
+  "properties": {
+    "task_id": { "type": "string", "minLength": 1 },
+    "snapshot_id": { "type": "string", "minLength": 1 },
+    "lane": { "type": "string", "minLength": 1 },
+    "pr": { "type": "integer", "minimum": 1 },
+    "head_sha": { "type": "string", "minLength": 7 },
+    "base_sha": { "type": "string", "minLength": 7 },
+    "canonical_state": { "type": "object" },
+    "allowed_mutations": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "forbidden_mutations": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "required_output_schema": { "type": "string", "minLength": 1 },
+    "expires_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/docs/ci/agent-leases.md
+++ b/docs/ci/agent-leases.md
@@ -1,0 +1,49 @@
+# Agent leases and idempotent receipts
+
+This document defines xtask primitives for disconnected agent execution where stale
+or late workers must not mutate canonical state.
+
+## Commands
+
+```bash
+cargo xtask agent lease acquire --task <task.json> --out target/agent/lease.json
+cargo xtask agent lease verify --lease target/agent/lease.json --current <snapshot.json>
+cargo xtask agent receipt validate --receipt <receipt.json>
+```
+
+## Task contract
+
+`agent-task.schema.json` requires:
+
+- `task_id`
+- `snapshot_id`
+- `lane`
+- `pr`
+- `head_sha`
+- `base_sha`
+- `canonical_state`
+- `allowed_mutations`
+- `forbidden_mutations`
+- `required_output_schema`
+- `expires_at`
+
+## Enforcement rules
+
+- **Stale head:** receipt and lease state transitions are ignored when `head_sha` does
+  not match current snapshot head.
+- **Expired lease:** any post-expiry mutation is rejected.
+- **Idempotency:** `idempotency_key` must equal `task_id`; same task updates comment
+  state idempotently.
+- **Supersedence:** newer receipts may supersede older receipts via
+  `supersedes_receipt_id`.
+- **Mutation allowlist:** each applied mutation must appear in `allowed_mutations` and
+  must not appear in `forbidden_mutations`.
+
+## Fixtures
+
+Reference fixtures live in `xtask/tests/fixtures/agent-leases/` and cover:
+
+- valid lease + snapshot verification
+- expired lease rejection
+- stale head rejection
+- forbidden mutation receipt rejection

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1097,6 +1097,12 @@ enum Commands {
     /// Remove stale `.claude/worktrees` entries and prune Git metadata.
     WorktreeCleanup,
 
+    /// Agent lease/receipt primitives for disconnected orchestration safety.
+    Agent {
+        #[command(subcommand)]
+        command: AgentCommand,
+    },
+
     /// Show summary statistics from swarm-metrics.jsonl.
     SwarmSummary {
         /// Path to operations directory (defaults to `.ops-perl-lsp`).
@@ -1216,6 +1222,52 @@ enum CpanCorpusCommand {
         /// Local install directory containing CPAN modules
         #[arg(long)]
         install_dir: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentCommand {
+    /// Acquire and verify task leases.
+    Lease {
+        #[command(subcommand)]
+        command: AgentLeaseCommand,
+    },
+    /// Validate agent receipts against lease constraints.
+    Receipt {
+        #[command(subcommand)]
+        command: AgentReceiptCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentLeaseCommand {
+    /// Acquire a lease from a typed task payload.
+    Acquire {
+        /// Path to an agent task JSON.
+        #[arg(long)]
+        task: PathBuf,
+        /// Output path for the generated lease JSON.
+        #[arg(long)]
+        out: PathBuf,
+    },
+    /// Verify that a lease is still valid for the current snapshot.
+    Verify {
+        /// Path to a lease JSON created by `agent lease acquire`.
+        #[arg(long)]
+        lease: PathBuf,
+        /// Path to current snapshot JSON used by the reconciler.
+        #[arg(long)]
+        current: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentReceiptCommand {
+    /// Validate a receipt's idempotency and mutation constraints.
+    Validate {
+        /// Path to an agent receipt JSON.
+        #[arg(long)]
+        receipt: PathBuf,
     },
 }
 
@@ -1674,6 +1726,21 @@ fn main() -> Result<()> {
             Ok(())
         }
         Commands::WorktreeCleanup => worktrees::cleanup(),
+        Commands::Agent { command } => match command {
+            AgentCommand::Lease { command } => match command {
+                AgentLeaseCommand::Acquire { task, out } => {
+                    agent_lease::acquire(task.as_path(), out.as_path())
+                }
+                AgentLeaseCommand::Verify { lease, current } => {
+                    agent_lease::verify(lease.as_path(), current.as_path())
+                }
+            },
+            AgentCommand::Receipt { command } => match command {
+                AgentReceiptCommand::Validate { receipt } => {
+                    agent_receipt::validate(receipt.as_path())
+                }
+            },
+        },
         Commands::SwarmSummary { ops_dir, since, limit, format } => {
             swarm_summary::run(swarm_summary::SwarmSummaryConfig { ops_dir, since, limit, format })
         }

--- a/xtask/src/tasks/agent_lease.rs
+++ b/xtask/src/tasks/agent_lease.rs
@@ -1,0 +1,111 @@
+use chrono::{DateTime, Utc};
+use color_eyre::eyre::{Context, Result, bail, ensure};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentTask {
+    pub task_id: String,
+    pub snapshot_id: String,
+    pub lane: String,
+    pub pr: u64,
+    pub head_sha: String,
+    pub base_sha: String,
+    pub canonical_state: serde_json::Value,
+    pub allowed_mutations: Vec<String>,
+    pub forbidden_mutations: Vec<String>,
+    pub required_output_schema: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentLease {
+    pub lease_version: String,
+    pub lease_id: String,
+    pub acquired_at: DateTime<Utc>,
+    pub task: AgentTask,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SnapshotState {
+    pub snapshot_id: String,
+    pub head_sha: String,
+}
+
+pub fn acquire(task_path: &Path, out_path: &Path) -> Result<()> {
+    let task = read_json::<AgentTask>(task_path)?;
+    validate_task_shape(&task)?;
+
+    let lease = AgentLease {
+        lease_version: "1".to_string(),
+        lease_id: format!("{}:{}", task.task_id, task.snapshot_id),
+        acquired_at: Utc::now(),
+        task,
+    };
+
+    write_json(out_path, &lease)?;
+    println!("Lease acquired: {}", lease.lease_id);
+    Ok(())
+}
+
+pub fn verify(lease_path: &Path, current_path: &Path) -> Result<()> {
+    let lease = read_json::<AgentLease>(lease_path)?;
+    let current = read_json::<SnapshotState>(current_path)?;
+
+    validate_task_shape(&lease.task)?;
+
+    if Utc::now() > lease.task.expires_at {
+        bail!("Lease expired at {} (current UTC time {})", lease.task.expires_at, Utc::now());
+    }
+
+    ensure!(
+        lease.task.snapshot_id == current.snapshot_id,
+        "Snapshot mismatch: lease={} current={}",
+        lease.task.snapshot_id,
+        current.snapshot_id
+    );
+
+    ensure!(
+        lease.task.head_sha == current.head_sha,
+        "Stale head: lease={} current={}",
+        lease.task.head_sha,
+        current.head_sha
+    );
+
+    println!("Lease is valid for task {}", lease.task.task_id);
+    Ok(())
+}
+
+fn validate_task_shape(task: &AgentTask) -> Result<()> {
+    ensure!(!task.task_id.trim().is_empty(), "task_id must not be empty");
+    ensure!(!task.snapshot_id.trim().is_empty(), "snapshot_id must not be empty");
+    ensure!(!task.head_sha.trim().is_empty(), "head_sha must not be empty");
+    ensure!(!task.base_sha.trim().is_empty(), "base_sha must not be empty");
+    ensure!(
+        !task.allowed_mutations.is_empty(),
+        "allowed_mutations must include at least one mutation"
+    );
+    Ok(())
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read JSON file at {}", path.display()))?;
+    serde_json::from_str::<T>(&raw)
+        .with_context(|| format!("Failed to parse JSON file at {}", path.display()))
+}
+
+fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create output directory {}", parent.display()))?;
+    }
+
+    let json = serde_json::to_string_pretty(value).context("Failed to serialize JSON")?;
+    fs::write(path, json)
+        .with_context(|| format!("Failed to write JSON file at {}", path.display()))
+}

--- a/xtask/src/tasks/agent_receipt.rs
+++ b/xtask/src/tasks/agent_receipt.rs
@@ -1,0 +1,97 @@
+use chrono::{DateTime, Utc};
+use color_eyre::eyre::{Context, Result, ensure};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationAction {
+    Comment,
+    CommentUpdate,
+    StateTransition,
+    ArtifactUpload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppliedMutation {
+    pub action: MutationAction,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentReceipt {
+    pub receipt_id: String,
+    pub task_id: String,
+    pub snapshot_id: String,
+    pub canonical_head_sha: String,
+    pub observed_head_sha: String,
+    pub created_at: DateTime<Utc>,
+    pub lease_expires_at: DateTime<Utc>,
+    pub allowed_mutations: Vec<String>,
+    pub forbidden_mutations: Vec<String>,
+    pub idempotency_key: String,
+    pub supersedes_receipt_id: Option<String>,
+    pub required_output_schema: String,
+    pub applied_mutations: Vec<AppliedMutation>,
+}
+
+pub fn validate(receipt_path: &Path) -> Result<()> {
+    let receipt = read_json::<AgentReceipt>(receipt_path)?;
+
+    ensure!(!receipt.task_id.trim().is_empty(), "task_id must not be empty");
+    ensure!(receipt.idempotency_key == receipt.task_id, "idempotency_key must match task_id");
+    ensure!(
+        receipt.created_at <= receipt.lease_expires_at,
+        "receipt created_at is later than lease_expires_at"
+    );
+    ensure!(
+        receipt.canonical_head_sha == receipt.observed_head_sha,
+        "stale head: canonical_head_sha ({}) != observed_head_sha ({})",
+        receipt.canonical_head_sha,
+        receipt.observed_head_sha
+    );
+
+    for mutation in &receipt.applied_mutations {
+        let action = mutation_name(&mutation.action);
+        ensure!(
+            receipt.allowed_mutations.iter().any(|allowed| allowed == action),
+            "mutation '{}' is not present in allowed_mutations",
+            action
+        );
+
+        ensure!(
+            receipt.forbidden_mutations.iter().all(|forbidden| forbidden != action),
+            "mutation '{}' is present in forbidden_mutations",
+            action
+        );
+    }
+
+    if let Some(supersedes_receipt_id) = &receipt.supersedes_receipt_id {
+        ensure!(
+            !supersedes_receipt_id.trim().is_empty(),
+            "supersedes_receipt_id, when provided, must not be empty"
+        );
+    }
+
+    println!("Receipt is valid for task {}", receipt.task_id);
+    Ok(())
+}
+
+fn mutation_name(action: &MutationAction) -> &'static str {
+    match action {
+        MutationAction::Comment => "comment",
+        MutationAction::CommentUpdate => "comment_update",
+        MutationAction::StateTransition => "state_transition",
+        MutationAction::ArtifactUpload => "artifact_upload",
+    }
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read JSON file at {}", path.display()))?;
+    serde_json::from_str::<T>(&raw)
+        .with_context(|| format!("Failed to parse JSON file at {}", path.display()))
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -1,5 +1,7 @@
 //! Task implementations for xtask automation
 
+pub mod agent_lease;
+pub mod agent_receipt;
 pub mod bench;
 pub mod benchmarks;
 #[cfg(feature = "parser-tasks")]

--- a/xtask/tests/agent_leases_cli.rs
+++ b/xtask/tests/agent_leases_cli.rs
@@ -1,0 +1,95 @@
+use anyhow::Result;
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::path::{Path, PathBuf};
+
+fn fixture(path: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/agent-leases").join(path)
+}
+
+#[test]
+fn valid_lease_verifies() -> Result<()> {
+    let out = Path::new(env!("CARGO_MANIFEST_DIR")).join("../target/agent/test-lease-valid.json");
+
+    let mut acquire = cargo_bin_cmd!("xtask");
+    let acquire_out = acquire
+        .args(["agent", "lease", "acquire", "--task"])
+        .arg(fixture("task-valid.json"))
+        .args(["--out"])
+        .arg(&out)
+        .output()?;
+    assert!(acquire_out.status.success(), "acquire failed: {:?}", acquire_out);
+
+    let mut verify = cargo_bin_cmd!("xtask");
+    let verify_out = verify
+        .args(["agent", "lease", "verify", "--lease"])
+        .arg(&out)
+        .args(["--current"])
+        .arg(fixture("snapshot-valid.json"))
+        .output()?;
+
+    assert!(verify_out.status.success(), "verify failed: {:?}", verify_out);
+    Ok(())
+}
+
+#[test]
+fn expired_lease_fails() -> Result<()> {
+    let out = Path::new(env!("CARGO_MANIFEST_DIR")).join("../target/agent/test-lease-expired.json");
+
+    let mut acquire = cargo_bin_cmd!("xtask");
+    let acquire_out = acquire
+        .args(["agent", "lease", "acquire", "--task"])
+        .arg(fixture("task-expired.json"))
+        .args(["--out"])
+        .arg(&out)
+        .output()?;
+    assert!(acquire_out.status.success(), "acquire failed: {:?}", acquire_out);
+
+    let mut verify = cargo_bin_cmd!("xtask");
+    let verify_out = verify
+        .args(["agent", "lease", "verify", "--lease"])
+        .arg(&out)
+        .args(["--current"])
+        .arg(fixture("snapshot-valid.json"))
+        .output()?;
+
+    assert!(!verify_out.status.success(), "expired lease unexpectedly verified");
+    Ok(())
+}
+
+#[test]
+fn stale_head_fails() -> Result<()> {
+    let out =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../target/agent/test-lease-stale-head.json");
+
+    let mut acquire = cargo_bin_cmd!("xtask");
+    let acquire_out = acquire
+        .args(["agent", "lease", "acquire", "--task"])
+        .arg(fixture("task-valid.json"))
+        .args(["--out"])
+        .arg(&out)
+        .output()?;
+    assert!(acquire_out.status.success(), "acquire failed: {:?}", acquire_out);
+
+    let mut verify = cargo_bin_cmd!("xtask");
+    let verify_out = verify
+        .args(["agent", "lease", "verify", "--lease"])
+        .arg(&out)
+        .args(["--current"])
+        .arg(fixture("snapshot-stale-head.json"))
+        .output()?;
+
+    assert!(!verify_out.status.success(), "stale head unexpectedly verified");
+    Ok(())
+}
+
+#[test]
+fn forbidden_mutation_receipt_fails() -> Result<()> {
+    let mut validate = cargo_bin_cmd!("xtask");
+    let validate_out = validate
+        .args(["agent", "receipt", "validate", "--receipt"])
+        .arg(fixture("receipt-forbidden-mutation.json"))
+        .output()?;
+
+    assert!(!validate_out.status.success(), "forbidden mutation unexpectedly validated");
+    Ok(())
+}

--- a/xtask/tests/fixtures/agent-leases/receipt-forbidden-mutation.json
+++ b/xtask/tests/fixtures/agent-leases/receipt-forbidden-mutation.json
@@ -1,0 +1,20 @@
+{
+  "receipt_id": "receipt-6853-2",
+  "task_id": "task-6853-a",
+  "snapshot_id": "snap-2026-04-26-001",
+  "canonical_head_sha": "abc1234def5678",
+  "observed_head_sha": "abc1234def5678",
+  "created_at": "2026-04-26T00:00:00Z",
+  "lease_expires_at": "2099-01-01T00:00:00Z",
+  "allowed_mutations": ["comment", "comment_update"],
+  "forbidden_mutations": ["state_transition"],
+  "idempotency_key": "task-6853-a",
+  "supersedes_receipt_id": "receipt-6853-1",
+  "required_output_schema": ".ci/receipts/schemas/agent-receipt.schema.json",
+  "applied_mutations": [
+    {
+      "action": "state_transition",
+      "target": "pr:6853"
+    }
+  ]
+}

--- a/xtask/tests/fixtures/agent-leases/receipt-valid.json
+++ b/xtask/tests/fixtures/agent-leases/receipt-valid.json
@@ -1,0 +1,20 @@
+{
+  "receipt_id": "receipt-6853-1",
+  "task_id": "task-6853-a",
+  "snapshot_id": "snap-2026-04-26-001",
+  "canonical_head_sha": "abc1234def5678",
+  "observed_head_sha": "abc1234def5678",
+  "created_at": "2026-04-26T00:00:00Z",
+  "lease_expires_at": "2099-01-01T00:00:00Z",
+  "allowed_mutations": ["comment", "comment_update"],
+  "forbidden_mutations": ["label_mutation", "worktree_allocate"],
+  "idempotency_key": "task-6853-a",
+  "supersedes_receipt_id": null,
+  "required_output_schema": ".ci/receipts/schemas/agent-receipt.schema.json",
+  "applied_mutations": [
+    {
+      "action": "comment",
+      "target": "pr:6853"
+    }
+  ]
+}

--- a/xtask/tests/fixtures/agent-leases/snapshot-stale-head.json
+++ b/xtask/tests/fixtures/agent-leases/snapshot-stale-head.json
@@ -1,0 +1,4 @@
+{
+  "snapshot_id": "snap-2026-04-26-001",
+  "head_sha": "fffffff99999999"
+}

--- a/xtask/tests/fixtures/agent-leases/snapshot-valid.json
+++ b/xtask/tests/fixtures/agent-leases/snapshot-valid.json
@@ -1,0 +1,4 @@
+{
+  "snapshot_id": "snap-2026-04-26-001",
+  "head_sha": "abc1234def5678"
+}

--- a/xtask/tests/fixtures/agent-leases/task-expired.json
+++ b/xtask/tests/fixtures/agent-leases/task-expired.json
@@ -1,0 +1,16 @@
+{
+  "task_id": "task-6853-expired",
+  "snapshot_id": "snap-2026-04-26-expired",
+  "lane": "ci-modernization",
+  "pr": 6853,
+  "head_sha": "abc1234def5678",
+  "base_sha": "00112233445566",
+  "canonical_state": {
+    "phase": "review",
+    "status": "open"
+  },
+  "allowed_mutations": ["comment"],
+  "forbidden_mutations": ["label_mutation"],
+  "required_output_schema": ".ci/receipts/schemas/agent-receipt.schema.json",
+  "expires_at": "2020-01-01T00:00:00Z"
+}

--- a/xtask/tests/fixtures/agent-leases/task-valid.json
+++ b/xtask/tests/fixtures/agent-leases/task-valid.json
@@ -1,0 +1,16 @@
+{
+  "task_id": "task-6853-a",
+  "snapshot_id": "snap-2026-04-26-001",
+  "lane": "ci-modernization",
+  "pr": 6853,
+  "head_sha": "abc1234def5678",
+  "base_sha": "00112233445566",
+  "canonical_state": {
+    "phase": "review",
+    "status": "open"
+  },
+  "allowed_mutations": ["comment", "comment_update"],
+  "forbidden_mutations": ["label_mutation", "worktree_allocate"],
+  "required_output_schema": ".ci/receipts/schemas/agent-receipt.schema.json",
+  "expires_at": "2099-01-01T00:00:00Z"
+}


### PR DESCRIPTION
### Motivation

- Disconnected orchestration can be corrupted by stale or late agents that mutate canonical state, so agents must carry typed leases and produce idempotent receipts to avoid unsafe mutations (Refs #6853).
- Provide a minimal, fixture-backed set of CLI primitives so the reconciler can decide whether an agent's result still applies.

### Description

- Added typed lease primitives in `xtask/src/tasks/agent_lease.rs` with `acquire` and `verify` for producing and validating `AgentLease` objects and `AgentTask` payloads.
- Added receipt validation in `xtask/src/tasks/agent_receipt.rs` with `validate` for `AgentReceipt` enforcement of idempotency, `allowed_mutations`/`forbidden_mutations`, stale-head detection, and expiry checks.
- Wired CLI commands in `xtask/src/main.rs` for `cargo xtask agent lease acquire|verify` and `cargo xtask agent receipt validate` and registered modules in `xtask/src/tasks/mod.rs`.
- Added JSON schema contracts under `.ci/receipts/schemas/` and documentation `docs/ci/agent-leases.md`, plus fixture inputs in `xtask/tests/fixtures/agent-leases/` and the integration tests `xtask/tests/agent_leases_cli.rs`.

### Testing

- Ran `cargo test -p xtask --test agent_leases_cli -- --nocapture` and the fixture-backed tests passed (`4` tests passed).
- Ran `cargo check --all-targets -p xtask` which completed successfully.
- Ran `cargo clippy -p xtask` which completed successfully.
- Ran `cargo xtask fmt` to format new files successfully.
- Note: `just pr-fast` was not executed in this environment because the `just` binary was not available, but the crate-level tests/lints/checks above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0b50cb4833385b18fb23fd3a05d)