### PR TITLE
feat(agent): add lease and idempotent receipt primitives (#6853)

### DIFF
--- a/.ci/receipts/schemas/agent-receipt.schema.json
+++ b/.ci/receipts/schemas/agent-receipt.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/agent-receipt.schema.json",
+  "title": "AgentReceipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_id",
+    "snapshot_id",
+    "head_sha",
+    "lease_path",
+    "required_output_schema",
+    "received_at",
+    "idempotency_key",
+    "mutation",
+    "status"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "minimum": 1 },
+    "task_id": { "type": "string", "minLength": 1 },
+    "snapshot_id": { "type": "string", "minLength": 1 },
+    "head_sha": { "type": "string", "minLength": 1 },
+    "lease_path": { "type": "string", "minLength": 1 },
+    "required_output_schema": { "type": "string", "minLength": 1 },
+    "received_at": { "type": "string", "format": "date-time" },
+    "idempotency_key": { "type": "string", "minLength": 1 },
+    "mutation": { "type": "string", "minLength": 1 },
+    "status": { "type": "string", "minLength": 1 }
+  }
+}

--- a/.ci/receipts/schemas/agent-task.schema.json
+++ b/.ci/receipts/schemas/agent-task.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/agent-task.schema.json",
+  "title": "AgentTask",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "task_id",
+    "snapshot_id",
+    "lane",
+    "pr",
+    "head_sha",
+    "base_sha",
+    "canonical_state",
+    "allowed_mutations",
+    "forbidden_mutations",
+    "required_output_schema",
+    "expires_at"
+  ],
+  "properties": {
+    "task_id": { "type": "string", "minLength": 1 },
+    "snapshot_id": { "type": "string", "minLength": 1 },
+    "lane": { "type": "string", "minLength": 1 },
+    "pr": { "type": "integer", "minimum": 1 },
+    "head_sha": { "type": "string", "minLength": 1 },
+    "base_sha": { "type": "string", "minLength": 1 },
+    "canonical_state": { "type": "string", "minLength": 1 },
+    "allowed_mutations": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "forbidden_mutations": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "required_output_schema": { "type": "string", "minLength": 1 },
+    "expires_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/.ci/receipts/schemas/worktree-lease.schema.json
+++ b/.ci/receipts/schemas/worktree-lease.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/schemas/worktree-lease.schema.json",
+  "title": "Worktree Lease Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "worktree_id",
+    "path",
+    "pr",
+    "branch",
+    "base_sha",
+    "owner",
+    "task_id",
+    "lease_expiry"
+  ],
+  "properties": {
+    "worktree_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pr": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "branch": {
+      "type": "string",
+      "minLength": 1
+    },
+    "base_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,40}$"
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lease_expiry": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/docs/ci/agent-leases.md
+++ b/docs/ci/agent-leases.md
@@ -1,0 +1,43 @@
+# Agent leases and idempotent receipts
+
+This document defines the `cargo xtask agent ...` primitives used by disconnected
+orchestration. It does **not** dispatch agents or apply reconciler mutations.
+
+## Commands
+
+```bash
+cargo xtask agent lease acquire --task <task.json> --out target/agent/lease.json
+cargo xtask agent lease verify --lease target/agent/lease.json --current <snapshot.json>
+cargo xtask agent receipt validate --receipt <receipt.json>
+```
+
+## Task schema
+
+Task JSON must follow `.ci/receipts/schemas/agent-task.schema.json`.
+
+Required fields:
+
+- `task_id`
+- `snapshot_id`
+- `lane`
+- `pr`
+- `head_sha`
+- `base_sha`
+- `canonical_state`
+- `allowed_mutations`
+- `forbidden_mutations`
+- `required_output_schema`
+- `expires_at`
+
+## Behavioral rules encoded in these primitives
+
+- **stale head**: receipt/lease verification fails when `head_sha` differs from current.
+- **expired lease**: lease verification and receipt validation reject mutations.
+- **idempotency key**: receipt carries `idempotency_key`; reconciler can upsert by `task_id`.
+- **newer wins**: receipt carries `received_at`; reconciler can supersede older receipts.
+- **allowed mutations only**: receipt validation rejects any mutation not in `allowed_mutations`.
+
+## Scope
+
+These commands intentionally stop at typed validation and invariants so that a
+separate reconciler can decide whether to apply or ignore late/stale receipts.

--- a/docs/ci/worktree-allocator.md
+++ b/docs/ci/worktree-allocator.md
@@ -1,0 +1,53 @@
+# Worktree allocator (local agent orchestration)
+
+The worktree allocator introduces an explicit lease model for locally-created agent worktrees.
+It prevents writeable-branch collisions and gives operators a safe way to list, release, and
+garbage-collect stale worktrees.
+
+## Commands
+
+```bash
+cargo xtask agent worktree acquire --pr <N> --base <ref>
+cargo xtask agent worktree release --id <worktree_id>
+cargo xtask agent worktree list
+cargo xtask agent worktree gc --stale
+```
+
+## Lease state
+
+Allocator state is written to `.claude/worktrees/lease-state.json` with:
+
+- `worktree_id`
+- `path`
+- `task_id`
+- `pr`
+- `branch`
+- `base_sha`
+- `owner`
+- `lease_expiry`
+- `last_heartbeat`
+
+Acquire also writes a receipt at `target/receipts/worktree-lease.json`.
+
+## Safety rules
+
+- No writable branch can be leased twice.
+- No nested agent worktree paths (for `.claude/worktrees` descendants below one level).
+- Release is explicit (`release --id ...`).
+- GC is dry-run by default.
+- GC prints exact candidate paths before removal.
+- GC will not remove worktrees with uncommitted changes unless `--force` is provided.
+
+## Destructive cleanup
+
+Use `--apply` to execute removals:
+
+```bash
+cargo xtask agent worktree gc --stale --apply
+```
+
+Use `--force` only when you intend to drop dirty worktrees:
+
+```bash
+cargo xtask agent worktree gc --stale --apply --force
+```

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,6 +17,7 @@ use tasks::metrics;
 use tasks::targeted_checks::CheckMode;
 use tasks::unwired_scan::UnwiredScanConfig;
 use tasks::ux_scorecard::UxScorecardFormat;
+use tasks::worktree_allocator::AgentWorktreeCommand;
 use tasks::*;
 use types::TestSuite;
 #[cfg(any(feature = "legacy", feature = "parser-tasks"))]
@@ -1361,6 +1362,11 @@ enum AgentCommand {
         #[command(subcommand)]
         command: AgentReceiptCommand,
     },
+    /// Manage leased local worktrees for agent orchestration.
+    Worktree {
+        #[command(subcommand)]
+        command: AgentWorktreeCommand,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1721,6 +1727,7 @@ fn main() -> Result<()> {
             AgentCommand::Receipt { command } => match command {
                 AgentReceiptCommand::Validate { receipt } => agent_receipt::validate(&receipt),
             },
+            AgentCommand::Worktree { command } => worktree_allocator::run(command),
         },
         Commands::UpdateStatus { write, check, only } => update_status::run(write, check, only),
         Commands::SrpMicrocrates { output } => srp_microcrates::run(output),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -941,6 +941,12 @@ enum Commands {
         command: FeaturesCommand,
     },
 
+    /// Agent lease + receipt primitives for disconnected orchestration.
+    Agent {
+        #[command(subcommand)]
+        command: AgentCommand,
+    },
+
     /// Update derived metrics in docs/project/status/ subsystem files.
     ///
     /// Computes workspace test counts, ignored test counts, feature catalog
@@ -1343,6 +1349,52 @@ enum MetricsCommand {
     },
 }
 
+#[derive(Subcommand)]
+enum AgentCommand {
+    /// Lease lifecycle commands.
+    Lease {
+        #[command(subcommand)]
+        command: AgentLeaseCommand,
+    },
+    /// Receipt commands.
+    Receipt {
+        #[command(subcommand)]
+        command: AgentReceiptCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentLeaseCommand {
+    /// Acquire a lease from a typed task JSON.
+    Acquire {
+        /// Path to task JSON.
+        #[arg(long)]
+        task: PathBuf,
+        /// Path to write lease JSON.
+        #[arg(long)]
+        out: PathBuf,
+    },
+    /// Verify lease against current snapshot state.
+    Verify {
+        /// Path to lease JSON.
+        #[arg(long)]
+        lease: PathBuf,
+        /// Path to current snapshot JSON.
+        #[arg(long)]
+        current: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentReceiptCommand {
+    /// Validate a receipt against its lease and mutation rules.
+    Validate {
+        /// Path to receipt JSON.
+        #[arg(long)]
+        receipt: PathBuf,
+    },
+}
+
 #[derive(ValueEnum, Clone)]
 enum PrepCratesMode {
     Core,
@@ -1658,6 +1710,17 @@ fn main() -> Result<()> {
             FeaturesCommand::Verify => features::verify(),
             FeaturesCommand::Invariants => features::invariants(),
             FeaturesCommand::Report => features::report(),
+        },
+        Commands::Agent { command } => match command {
+            AgentCommand::Lease { command } => match command {
+                AgentLeaseCommand::Acquire { task, out } => agent_lease::acquire(&task, &out),
+                AgentLeaseCommand::Verify { lease, current } => {
+                    agent_lease::verify(&lease, &current)
+                }
+            },
+            AgentCommand::Receipt { command } => match command {
+                AgentReceiptCommand::Validate { receipt } => agent_receipt::validate(&receipt),
+            },
         },
         Commands::UpdateStatus { write, check, only } => update_status::run(write, check, only),
         Commands::SrpMicrocrates { output } => srp_microcrates::run(output),

--- a/xtask/src/tasks/agent_lease.rs
+++ b/xtask/src/tasks/agent_lease.rs
@@ -1,0 +1,134 @@
+use chrono::{DateTime, Utc};
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AgentTask {
+    pub task_id: String,
+    pub snapshot_id: String,
+    pub lane: String,
+    pub pr: u64,
+    pub head_sha: String,
+    pub base_sha: String,
+    pub canonical_state: String,
+    pub allowed_mutations: Vec<String>,
+    pub forbidden_mutations: Vec<String>,
+    pub required_output_schema: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AgentLease {
+    pub schema_version: u32,
+    pub issued_at: DateTime<Utc>,
+    #[serde(flatten)]
+    pub task: AgentTask,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CurrentSnapshot {
+    pub snapshot_id: String,
+    pub head_sha: String,
+}
+
+pub fn acquire(task_path: &Path, out_path: &Path) -> Result<()> {
+    let task = read_task(task_path)?;
+    validate_task(&task)?;
+
+    let lease = AgentLease { schema_version: 1, issued_at: Utc::now(), task };
+
+    write_json(out_path, &lease)?;
+    println!("Lease written to {}", out_path.display());
+    Ok(())
+}
+
+pub fn verify(lease_path: &Path, current_path: &Path) -> Result<()> {
+    let lease = read_lease(lease_path)?;
+    validate_task(&lease.task)?;
+
+    let now = Utc::now();
+    if now > lease.task.expires_at {
+        bail!("Lease expired at {} (now {})", lease.task.expires_at.to_rfc3339(), now.to_rfc3339());
+    }
+
+    let current = read_snapshot(current_path)?;
+    if current.snapshot_id != lease.task.snapshot_id {
+        bail!(
+            "snapshot mismatch: lease={}, current={}",
+            lease.task.snapshot_id,
+            current.snapshot_id
+        );
+    }
+
+    if current.head_sha != lease.task.head_sha {
+        bail!("stale head: lease={}, current={}", lease.task.head_sha, current.head_sha);
+    }
+
+    println!("Lease verification succeeded for task {}", lease.task.task_id);
+    Ok(())
+}
+
+pub fn read_lease(path: &Path) -> Result<AgentLease> {
+    read_json(path, "lease")
+}
+
+fn read_task(path: &Path) -> Result<AgentTask> {
+    read_json(path, "task")
+}
+
+fn read_snapshot(path: &Path) -> Result<CurrentSnapshot> {
+    read_json(path, "snapshot")
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path, label: &str) -> Result<T> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("reading {label} JSON from {}", path.display()))?;
+    serde_json::from_str(&content)
+        .with_context(|| format!("parsing {label} JSON from {}", path.display()))
+}
+
+fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating parent directory {}", parent.display()))?;
+    }
+
+    let raw = serde_json::to_string_pretty(value).context("serializing lease JSON")?;
+    fs::write(path, format!("{raw}\n"))
+        .with_context(|| format!("writing JSON output to {}", path.display()))
+}
+
+fn validate_task(task: &AgentTask) -> Result<()> {
+    if task.task_id.trim().is_empty() {
+        bail!("task_id must not be empty");
+    }
+    if task.snapshot_id.trim().is_empty() {
+        bail!("snapshot_id must not be empty");
+    }
+    if task.head_sha.trim().is_empty() {
+        bail!("head_sha must not be empty");
+    }
+    if task.required_output_schema.trim().is_empty() {
+        bail!("required_output_schema must not be empty");
+    }
+    if task.allowed_mutations.is_empty() {
+        bail!("allowed_mutations must not be empty");
+    }
+
+    let duplicates = task
+        .allowed_mutations
+        .iter()
+        .filter(|mutation| task.forbidden_mutations.contains(*mutation))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !duplicates.is_empty() {
+        bail!("allowed_mutations and forbidden_mutations overlap: {}", duplicates.join(", "));
+    }
+
+    Ok(())
+}

--- a/xtask/src/tasks/agent_receipt.rs
+++ b/xtask/src/tasks/agent_receipt.rs
@@ -1,0 +1,101 @@
+use crate::tasks::agent_lease::{AgentLease, read_lease};
+use chrono::{DateTime, Utc};
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AgentReceipt {
+    pub schema_version: u32,
+    pub task_id: String,
+    pub snapshot_id: String,
+    pub head_sha: String,
+    pub lease_path: String,
+    pub required_output_schema: String,
+    pub received_at: DateTime<Utc>,
+    pub idempotency_key: String,
+    pub mutation: String,
+    pub status: String,
+}
+
+pub fn validate(receipt_path: &Path) -> Result<()> {
+    let receipt = read_receipt(receipt_path)?;
+    validate_core_fields(&receipt)?;
+
+    let lease = read_lease(Path::new(&receipt.lease_path))?;
+    validate_against_lease(&receipt, &lease)?;
+
+    println!("Receipt validation succeeded for task {}", receipt.task_id);
+    Ok(())
+}
+
+fn read_receipt(path: &Path) -> Result<AgentReceipt> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("reading receipt JSON from {}", path.display()))?;
+    serde_json::from_str(&content)
+        .with_context(|| format!("parsing receipt JSON from {}", path.display()))
+}
+
+fn validate_core_fields(receipt: &AgentReceipt) -> Result<()> {
+    if receipt.task_id.trim().is_empty() {
+        bail!("task_id must not be empty");
+    }
+    if receipt.idempotency_key.trim().is_empty() {
+        bail!("idempotency_key must not be empty");
+    }
+    if receipt.mutation.trim().is_empty() {
+        bail!("mutation must not be empty");
+    }
+    Ok(())
+}
+
+fn validate_against_lease(receipt: &AgentReceipt, lease: &AgentLease) -> Result<()> {
+    if receipt.task_id != lease.task.task_id {
+        bail!("task_id mismatch: receipt={}, lease={}", receipt.task_id, lease.task.task_id);
+    }
+    if receipt.snapshot_id != lease.task.snapshot_id {
+        bail!(
+            "snapshot_id mismatch: receipt={}, lease={}",
+            receipt.snapshot_id,
+            lease.task.snapshot_id
+        );
+    }
+    if receipt.head_sha != lease.task.head_sha {
+        bail!("stale head: receipt={}, lease={}", receipt.head_sha, lease.task.head_sha);
+    }
+    if receipt.required_output_schema != lease.task.required_output_schema {
+        bail!(
+            "required_output_schema mismatch: receipt={}, lease={}",
+            receipt.required_output_schema,
+            lease.task.required_output_schema
+        );
+    }
+
+    let allowed = lease.task.allowed_mutations.iter().collect::<HashSet<_>>();
+    if !allowed.contains(&receipt.mutation) {
+        bail!(
+            "mutation '{}' is not in allowed_mutations [{}]",
+            receipt.mutation,
+            lease.task.allowed_mutations.join(", ")
+        );
+    }
+
+    let forbidden = lease.task.forbidden_mutations.iter().collect::<HashSet<_>>();
+    if forbidden.contains(&receipt.mutation) {
+        bail!("mutation '{}' is forbidden", receipt.mutation);
+    }
+
+    let now = Utc::now();
+    if now > lease.task.expires_at {
+        bail!(
+            "lease expired at {}; mutation '{}' rejected",
+            lease.task.expires_at.to_rfc3339(),
+            receipt.mutation
+        );
+    }
+
+    Ok(())
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -78,4 +78,5 @@ pub mod update_status;
 pub mod ux_scorecard;
 pub mod validate_workspace_exclusions;
 pub mod workflow_policy_lint;
+pub mod worktree_allocator;
 pub mod worktrees;

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -1,8 +1,8 @@
 //! Task implementations for xtask automation
 
-pub mod aggregate_receipts;
 pub mod agent_lease;
 pub mod agent_receipt;
+pub mod aggregate_receipts;
 pub mod bench;
 pub mod benchmarks;
 #[cfg(feature = "parser-tasks")]

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -1,6 +1,8 @@
 //! Task implementations for xtask automation
 
 pub mod aggregate_receipts;
+pub mod agent_lease;
+pub mod agent_receipt;
 pub mod bench;
 pub mod benchmarks;
 #[cfg(feature = "parser-tasks")]

--- a/xtask/src/tasks/worktree_allocator.rs
+++ b/xtask/src/tasks/worktree_allocator.rs
@@ -191,6 +191,11 @@ fn gc(stale_only: bool, apply: bool, force: bool, ttl_hours: i64) -> Result<()> 
         return Ok(());
     }
 
+    // Track which worktrees were *actually* removed so the lease-state update only drops
+    // leases whose worktrees were successfully removed. Dirty-skipped worktrees must remain
+    // in the state file because their git metadata and working directory are still live.
+    let mut removed_ids = BTreeSet::new();
+
     for lease in &state.leases {
         if !stale_ids.contains(&lease.worktree_id) {
             continue;
@@ -213,9 +218,11 @@ fn gc(stale_only: bool, apply: bool, force: bool, ttl_hours: i64) -> Result<()> 
         if !status.success() {
             bail!("failed to remove worktree {}", lease.path);
         }
+        removed_ids.insert(lease.worktree_id.clone());
     }
 
-    state.leases.retain(|lease| !stale_ids.contains(&lease.worktree_id) || !apply);
+    // Only evict leases whose worktrees were actually removed (not merely dirty-skipped).
+    state.leases.retain(|lease| !removed_ids.contains(&lease.worktree_id));
     save_state(&root, &state)?;
     Ok(())
 }

--- a/xtask/src/tasks/worktree_allocator.rs
+++ b/xtask/src/tasks/worktree_allocator.rs
@@ -1,0 +1,374 @@
+//! Local agent worktree lease allocator.
+
+use crate::utils::project_root;
+use chrono::{DateTime, Duration, Utc};
+use clap::Subcommand;
+use color_eyre::eyre::{Result, bail, eyre};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const DEFAULT_LEASE_MINUTES: i64 = 120;
+const DEFAULT_STALE_TTL_HOURS: i64 = 24;
+const STATE_FILE: &str = ".claude/worktrees/lease-state.json";
+const RECEIPT_FILE: &str = "target/receipts/worktree-lease.json";
+
+#[derive(Subcommand)]
+pub enum AgentWorktreeCommand {
+    /// Acquire a lease for an agent worktree.
+    Acquire {
+        /// Pull request number associated with this lease.
+        #[arg(long)]
+        pr: u64,
+        /// Base reference used to derive base SHA.
+        #[arg(long)]
+        base: String,
+        /// Agent task identifier.
+        #[arg(long)]
+        task_id: Option<String>,
+        /// Owner identity for this lease.
+        #[arg(long)]
+        owner: Option<String>,
+        /// Desired branch name.
+        #[arg(long)]
+        branch: Option<String>,
+        /// Proposed worktree path.
+        #[arg(long)]
+        path: Option<PathBuf>,
+        /// Lease TTL in minutes.
+        #[arg(long, default_value_t = DEFAULT_LEASE_MINUTES)]
+        ttl_minutes: i64,
+    },
+    /// Release a lease by worktree id.
+    Release {
+        #[arg(long)]
+        id: String,
+    },
+    /// List active leases.
+    List,
+    /// Garbage-collect stale leases and optionally remove worktrees.
+    Gc {
+        /// GC stale leases/worktrees only.
+        #[arg(long)]
+        stale: bool,
+        /// Actually remove stale worktrees (default is dry-run).
+        #[arg(long)]
+        apply: bool,
+        /// Remove even with uncommitted changes.
+        #[arg(long)]
+        force: bool,
+        /// Treat leases older than this many hours as stale.
+        #[arg(long, default_value_t = DEFAULT_STALE_TTL_HOURS)]
+        ttl_hours: i64,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LeaseState {
+    pub leases: Vec<WorktreeLease>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorktreeLease {
+    pub worktree_id: String,
+    pub path: String,
+    pub task_id: String,
+    pub pr: u64,
+    pub branch: String,
+    pub base_sha: String,
+    pub owner: String,
+    pub lease_expiry: DateTime<Utc>,
+    pub last_heartbeat: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WorktreeLeaseReceipt {
+    worktree_id: String,
+    path: String,
+    pr: u64,
+    branch: String,
+    base_sha: String,
+    owner: String,
+    task_id: String,
+    lease_expiry: DateTime<Utc>,
+}
+
+pub fn run(command: AgentWorktreeCommand) -> Result<()> {
+    match command {
+        AgentWorktreeCommand::Acquire { pr, base, task_id, owner, branch, path, ttl_minutes } => {
+            acquire(pr, &base, task_id, owner, branch, path, ttl_minutes)
+        }
+        AgentWorktreeCommand::Release { id } => release(&id),
+        AgentWorktreeCommand::List => list(),
+        AgentWorktreeCommand::Gc { stale, apply, force, ttl_hours } => {
+            gc(stale, apply, force, ttl_hours)
+        }
+    }
+}
+
+fn acquire(
+    pr: u64,
+    base: &str,
+    task_id: Option<String>,
+    owner: Option<String>,
+    branch: Option<String>,
+    path: Option<PathBuf>,
+    ttl_minutes: i64,
+) -> Result<()> {
+    let root = project_root()?;
+    let mut state = load_state(&root)?;
+    let branch = branch.unwrap_or_else(|| format!("agent/pr-{pr}"));
+    let task_id = task_id.unwrap_or_else(|| format!("pr-{pr}"));
+    let owner = owner.unwrap_or_else(default_owner);
+    let worktree_id = format!("wt-pr-{pr}-{}", short_timestamp());
+    let path =
+        path.unwrap_or_else(|| root.join(".claude/worktrees").join(format!("agent-{worktree_id}")));
+    reject_nested_agent_path(&root, &path)?;
+    reject_duplicate_branch(&state, &branch)?;
+    reject_existing_git_branch_checkout(&root, &branch)?;
+
+    let now = Utc::now();
+    let lease = WorktreeLease {
+        worktree_id: worktree_id.clone(),
+        path: path.to_string_lossy().to_string(),
+        task_id,
+        pr,
+        branch: branch.clone(),
+        base_sha: resolve_base_sha(&root, base)?,
+        owner: owner.clone(),
+        lease_expiry: now + Duration::minutes(ttl_minutes),
+        last_heartbeat: now,
+    };
+    state.leases.push(lease.clone());
+    save_state(&root, &state)?;
+    save_receipt(&root, &lease)?;
+
+    println!("acquired {}", lease.worktree_id);
+    println!("path: {}", lease.path);
+    println!("branch: {}", lease.branch);
+    Ok(())
+}
+
+fn release(id: &str) -> Result<()> {
+    let root = project_root()?;
+    let mut state = load_state(&root)?;
+    let before = state.leases.len();
+    state.leases.retain(|lease| lease.worktree_id != id);
+    if before == state.leases.len() {
+        bail!("no lease found for id '{id}'");
+    }
+    save_state(&root, &state)?;
+    println!("released {id}");
+    Ok(())
+}
+
+fn list() -> Result<()> {
+    let root = project_root()?;
+    let state = load_state(&root)?;
+    if state.leases.is_empty() {
+        println!("no active leases");
+        return Ok(());
+    }
+    for lease in state.leases {
+        println!(
+            "{} | pr={} | branch={} | {} | expires={}",
+            lease.worktree_id, lease.pr, lease.branch, lease.path, lease.lease_expiry
+        );
+    }
+    Ok(())
+}
+
+fn gc(stale_only: bool, apply: bool, force: bool, ttl_hours: i64) -> Result<()> {
+    let root = project_root()?;
+    let mut state = load_state(&root)?;
+    let cutoff = Utc::now() - Duration::hours(ttl_hours);
+    let stale_ids = gc_candidates(&state, stale_only, cutoff);
+
+    if stale_ids.is_empty() {
+        println!("no leases eligible for gc");
+        return Ok(());
+    }
+
+    for lease in &state.leases {
+        if !stale_ids.contains(&lease.worktree_id) {
+            continue;
+        }
+        println!("candidate: {} -> {}", lease.worktree_id, lease.path);
+        if !apply {
+            continue;
+        }
+        if has_uncommitted_changes(&root, &lease.path)? && !force {
+            println!("skipping {} (uncommitted changes, use --force)", lease.path);
+            continue;
+        }
+        println!("removing {}", lease.path);
+        let status = Command::new("git")
+            .current_dir(&root)
+            .args(["worktree", "remove"])
+            .args(if force { vec!["--force"] } else { Vec::new() })
+            .arg(&lease.path)
+            .status()?;
+        if !status.success() {
+            bail!("failed to remove worktree {}", lease.path);
+        }
+    }
+
+    state.leases.retain(|lease| !stale_ids.contains(&lease.worktree_id) || !apply);
+    save_state(&root, &state)?;
+    Ok(())
+}
+
+fn gc_candidates(state: &LeaseState, stale_only: bool, cutoff: DateTime<Utc>) -> BTreeSet<String> {
+    state
+        .leases
+        .iter()
+        .filter(|lease| {
+            if stale_only {
+                lease.last_heartbeat < cutoff || lease.lease_expiry < Utc::now()
+            } else {
+                true
+            }
+        })
+        .map(|lease| lease.worktree_id.clone())
+        .collect()
+}
+
+fn reject_nested_agent_path(root: &Path, candidate: &Path) -> Result<()> {
+    let agent_root = root.join(".claude/worktrees");
+    if !candidate.starts_with(&agent_root) {
+        return Ok(());
+    }
+
+    let candidate_norm = candidate.components().collect::<Vec<_>>();
+    let agent_norm = agent_root.components().collect::<Vec<_>>();
+    if candidate_norm.len() > agent_norm.len() + 1 {
+        bail!("nested agent worktrees are not allowed: {}", candidate.display());
+    }
+    Ok(())
+}
+
+fn reject_duplicate_branch(state: &LeaseState, branch: &str) -> Result<()> {
+    if state.leases.iter().any(|lease| lease.branch == branch) {
+        bail!("branch '{branch}' is already leased");
+    }
+    Ok(())
+}
+
+fn reject_existing_git_branch_checkout(root: &Path, branch: &str) -> Result<()> {
+    let output =
+        Command::new("git").current_dir(root).args(["worktree", "list", "--porcelain"]).output()?;
+    if !output.status.success() {
+        return Err(eyre!("failed to query git worktree list"));
+    }
+    let stdout = String::from_utf8(output.stdout)?;
+    for line in stdout.lines() {
+        if line.trim_start().starts_with("branch refs/heads/") && line.ends_with(branch) {
+            bail!("branch '{branch}' is already checked out in another worktree");
+        }
+    }
+    Ok(())
+}
+
+fn has_uncommitted_changes(root: &Path, worktree_path: &str) -> Result<bool> {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args(["-C", worktree_path, "status", "--porcelain"])
+        .output()?;
+    if !output.status.success() {
+        return Ok(false);
+    }
+    Ok(!String::from_utf8(output.stdout)?.trim().is_empty())
+}
+
+fn resolve_base_sha(root: &Path, base: &str) -> Result<String> {
+    let output = Command::new("git").current_dir(root).args(["rev-parse", base]).output()?;
+    if !output.status.success() {
+        bail!("unable to resolve base ref '{base}'");
+    }
+    Ok(String::from_utf8(output.stdout)?.trim().to_string())
+}
+
+fn load_state(root: &Path) -> Result<LeaseState> {
+    let path = root.join(STATE_FILE);
+    if !path.exists() {
+        return Ok(LeaseState { leases: Vec::new() });
+    }
+    let data = fs::read_to_string(path)?;
+    let parsed = serde_json::from_str::<LeaseState>(&data)?;
+    Ok(parsed)
+}
+
+fn save_state(root: &Path, state: &LeaseState) -> Result<()> {
+    let path = root.join(STATE_FILE);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_string_pretty(state)?)?;
+    Ok(())
+}
+
+fn save_receipt(root: &Path, lease: &WorktreeLease) -> Result<()> {
+    let receipt = WorktreeLeaseReceipt {
+        worktree_id: lease.worktree_id.clone(),
+        path: lease.path.clone(),
+        pr: lease.pr,
+        branch: lease.branch.clone(),
+        base_sha: lease.base_sha.clone(),
+        owner: lease.owner.clone(),
+        task_id: lease.task_id.clone(),
+        lease_expiry: lease.lease_expiry,
+    };
+    let path = root.join(RECEIPT_FILE);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_string_pretty(&receipt)?)?;
+    Ok(())
+}
+
+fn default_owner() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn short_timestamp() -> i64 {
+    Utc::now().timestamp()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use color_eyre::eyre::Result;
+
+    #[test]
+    fn fixture_duplicate_branch_detected() -> Result<()> {
+        let fixture = include_str!("../../tests/fixtures/worktree-allocator/duplicate-branch.json");
+        let state: LeaseState = serde_json::from_str(fixture)?;
+        let err = reject_duplicate_branch(&state, "agent/pr-101")
+            .expect_err("duplicate branch should fail");
+        assert!(err.to_string().contains("already leased"));
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_unique_branch_allowed() -> Result<()> {
+        let fixture = include_str!("../../tests/fixtures/worktree-allocator/unique-branch.json");
+        let state: LeaseState = serde_json::from_str(fixture)?;
+        reject_duplicate_branch(&state, "agent/pr-999")?;
+        Ok(())
+    }
+
+    #[test]
+    fn stale_gc_candidates_are_identified_without_deleting() -> Result<()> {
+        let fixture = include_str!("../../tests/fixtures/worktree-allocator/gc-stale.json");
+        let state: LeaseState = serde_json::from_str(fixture)?;
+        let cutoff = DateTime::parse_from_rfc3339("2026-04-30T00:00:00Z")?.with_timezone(&Utc);
+        let candidates = gc_candidates(&state, true, cutoff);
+        assert!(candidates.contains("wt-stale-1"));
+        assert!(!candidates.contains("wt-fresh-1"));
+        Ok(())
+    }
+}

--- a/xtask/tests/agent_leases_cli.rs
+++ b/xtask/tests/agent_leases_cli.rs
@@ -1,0 +1,139 @@
+use anyhow::Result;
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::fs;
+
+fn fixture(path: &str) -> String {
+    format!("{}/tests/fixtures/agent-leases/{path}", env!("CARGO_MANIFEST_DIR"))
+}
+
+#[test]
+fn valid_lease_verifies() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let lease = tmp.path().join("lease.json");
+
+    let mut acquire = cargo_bin_cmd!("xtask");
+    let output = acquire
+        .args([
+            "agent",
+            "lease",
+            "acquire",
+            "--task",
+            &fixture("task-valid.json"),
+            "--out",
+            lease.to_string_lossy().as_ref(),
+        ])
+        .output()?;
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+
+    let mut verify = cargo_bin_cmd!("xtask");
+    let output = verify
+        .args([
+            "agent",
+            "lease",
+            "verify",
+            "--lease",
+            lease.to_string_lossy().as_ref(),
+            "--current",
+            &fixture("current-valid.json"),
+        ])
+        .output()?;
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+
+    Ok(())
+}
+
+#[test]
+fn expired_lease_fails() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd
+        .args([
+            "agent",
+            "lease",
+            "verify",
+            "--lease",
+            &fixture("lease-expired.json"),
+            "--current",
+            &fixture("current-valid.json"),
+        ])
+        .output()?;
+
+    assert!(!output.status.success(), "expired lease must fail verification");
+    Ok(())
+}
+
+#[test]
+fn stale_head_fails() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let lease = tmp.path().join("lease.json");
+
+    let mut acquire = cargo_bin_cmd!("xtask");
+    let output = acquire
+        .args([
+            "agent",
+            "lease",
+            "acquire",
+            "--task",
+            &fixture("task-valid.json"),
+            "--out",
+            lease.to_string_lossy().as_ref(),
+        ])
+        .output()?;
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+
+    let mut verify = cargo_bin_cmd!("xtask");
+    let output = verify
+        .args([
+            "agent",
+            "lease",
+            "verify",
+            "--lease",
+            lease.to_string_lossy().as_ref(),
+            "--current",
+            &fixture("current-stale-head.json"),
+        ])
+        .output()?;
+
+    assert!(!output.status.success(), "stale head must fail verification");
+    Ok(())
+}
+
+#[test]
+fn forbidden_mutation_receipt_fails() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let lease_path = tmp.path().join("lease.json");
+    let receipt_path = tmp.path().join("receipt.json");
+
+    let mut acquire = cargo_bin_cmd!("xtask");
+    let output = acquire
+        .args([
+            "agent",
+            "lease",
+            "acquire",
+            "--task",
+            &fixture("task-valid.json"),
+            "--out",
+            lease_path.to_string_lossy().as_ref(),
+        ])
+        .output()?;
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+
+    let raw = fs::read_to_string(fixture("receipt-forbidden-mutation.json"))?;
+    let mut receipt_json: serde_json::Value = serde_json::from_str(&raw)?;
+    receipt_json["lease_path"] =
+        serde_json::Value::String(lease_path.to_string_lossy().to_string());
+    fs::write(&receipt_path, format!("{}\n", serde_json::to_string_pretty(&receipt_json)?))?;
+
+    let mut validate = cargo_bin_cmd!("xtask");
+    let output = validate
+        .args([
+            "agent",
+            "receipt",
+            "validate",
+            "--receipt",
+            receipt_path.to_string_lossy().as_ref(),
+        ])
+        .output()?;
+
+    assert!(!output.status.success(), "forbidden mutation receipt must fail validation");
+    Ok(())
+}

--- a/xtask/tests/fixtures/agent-leases/current-stale-head.json
+++ b/xtask/tests/fixtures/agent-leases/current-stale-head.json
@@ -1,0 +1,4 @@
+{
+  "snapshot_id": "snap-001",
+  "head_sha": "999999"
+}

--- a/xtask/tests/fixtures/agent-leases/current-valid.json
+++ b/xtask/tests/fixtures/agent-leases/current-valid.json
@@ -1,0 +1,4 @@
+{
+  "snapshot_id": "snap-001",
+  "head_sha": "abc123"
+}

--- a/xtask/tests/fixtures/agent-leases/lease-expired.json
+++ b/xtask/tests/fixtures/agent-leases/lease-expired.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "issued_at": "2024-01-01T00:00:00Z",
+  "task_id": "task-6853",
+  "snapshot_id": "snap-001",
+  "lane": "ci-modernization",
+  "pr": 6853,
+  "head_sha": "abc123",
+  "base_sha": "def456",
+  "canonical_state": "open",
+  "allowed_mutations": ["comment_upsert"],
+  "forbidden_mutations": ["label_mutation"],
+  "required_output_schema": ".ci/receipts/schemas/agent-receipt.schema.json",
+  "expires_at": "2020-01-01T00:00:00Z"
+}

--- a/xtask/tests/fixtures/agent-leases/receipt-forbidden-mutation.json
+++ b/xtask/tests/fixtures/agent-leases/receipt-forbidden-mutation.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "task_id": "task-6853",
+  "snapshot_id": "snap-001",
+  "head_sha": "abc123",
+  "lease_path": "",
+  "required_output_schema": ".ci/receipts/schemas/agent-receipt.schema.json",
+  "received_at": "2026-01-01T00:00:00Z",
+  "idempotency_key": "task-6853-comment-upsert",
+  "mutation": "label_mutation",
+  "status": "ok"
+}

--- a/xtask/tests/fixtures/agent-leases/task-valid.json
+++ b/xtask/tests/fixtures/agent-leases/task-valid.json
@@ -1,0 +1,13 @@
+{
+  "task_id": "task-6853",
+  "snapshot_id": "snap-001",
+  "lane": "ci-modernization",
+  "pr": 6853,
+  "head_sha": "abc123",
+  "base_sha": "def456",
+  "canonical_state": "open",
+  "allowed_mutations": ["comment_upsert"],
+  "forbidden_mutations": ["label_mutation"],
+  "required_output_schema": ".ci/receipts/schemas/agent-receipt.schema.json",
+  "expires_at": "2030-01-01T00:00:00Z"
+}

--- a/xtask/tests/fixtures/worktree-allocator/duplicate-branch.json
+++ b/xtask/tests/fixtures/worktree-allocator/duplicate-branch.json
@@ -1,0 +1,15 @@
+{
+  "leases": [
+    {
+      "worktree_id": "wt-pr-101-1700000000",
+      "path": "/tmp/.claude/worktrees/agent-wt-pr-101-1700000000",
+      "task_id": "task-101",
+      "pr": 101,
+      "branch": "agent/pr-101",
+      "base_sha": "0123456789abcdef0123456789abcdef01234567",
+      "owner": "agent-a",
+      "lease_expiry": "2026-04-30T00:00:00Z",
+      "last_heartbeat": "2026-04-29T23:55:00Z"
+    }
+  ]
+}

--- a/xtask/tests/fixtures/worktree-allocator/gc-stale.json
+++ b/xtask/tests/fixtures/worktree-allocator/gc-stale.json
@@ -1,0 +1,26 @@
+{
+  "leases": [
+    {
+      "worktree_id": "wt-stale-1",
+      "path": "/tmp/.claude/worktrees/agent-wt-stale-1",
+      "task_id": "task-stale",
+      "pr": 201,
+      "branch": "agent/pr-201",
+      "base_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "owner": "agent-gc",
+      "lease_expiry": "2026-04-29T00:00:00Z",
+      "last_heartbeat": "2026-04-29T00:00:00Z"
+    },
+    {
+      "worktree_id": "wt-fresh-1",
+      "path": "/tmp/.claude/worktrees/agent-wt-fresh-1",
+      "task_id": "task-fresh",
+      "pr": 202,
+      "branch": "agent/pr-202",
+      "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "owner": "agent-gc",
+      "lease_expiry": "2026-05-01T00:00:00Z",
+      "last_heartbeat": "2026-04-30T12:00:00Z"
+    }
+  ]
+}

--- a/xtask/tests/fixtures/worktree-allocator/unique-branch.json
+++ b/xtask/tests/fixtures/worktree-allocator/unique-branch.json
@@ -1,0 +1,15 @@
+{
+  "leases": [
+    {
+      "worktree_id": "wt-pr-102-1700000200",
+      "path": "/tmp/.claude/worktrees/agent-wt-pr-102-1700000200",
+      "task_id": "task-102",
+      "pr": 102,
+      "branch": "agent/pr-102",
+      "base_sha": "89abcdef0123456789abcdef0123456789abcdef",
+      "owner": "agent-b",
+      "lease_expiry": "2026-04-30T00:10:00Z",
+      "last_heartbeat": "2026-04-30T00:05:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Prevent stale or late agents from corrupting reconciled state by providing typed task/lease/receipt primitives that encode snapshot/head/allowed mutations and enforce idempotency rules.

### Description

- Add `cargo xtask agent ...` CLI with `agent lease acquire|verify` and `agent receipt validate` command handlers wired into `xtask` CLI dispatch.
- Implement lease/task/snapshot models and logic in `xtask/src/tasks/agent_lease.rs` and receipt validation in `xtask/src/tasks/agent_receipt.rs`, enforcing expiry, snapshot/head consistency, allowed/forbidden mutation rules, and idempotency metadata.
- Add JSON schemas under `.ci/receipts/schemas/` for `agent-task` and `agent-receipt`, a short usage doc `docs/ci/agent-leases.md`, and fixtures under `xtask/tests/fixtures/agent-leases/` plus an integration test `xtask/tests/agent_leases_cli.rs` that covers the main validation scenarios.

### Testing

- Ran `cargo test -p xtask --test agent_leases_cli`, which passed (covers valid lease, expired lease, stale head, and forbidden-mutation receipt cases).
- Ran `cargo check --all-targets -p xtask`, which passed.
- Ran formatting and lints: `cargo xtask fmt` completed and `cargo clippy -p xtask -- -D warnings` passed.

Refs #6853

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0b50cb4833385b18fb23fd3a05d)