### PR TITLE
feat(agent): add lease and idempotent receipt primitives (#6853)

### DIFF
--- a/.ci/receipts/schemas/agent-receipt.schema.json
+++ b/.ci/receipts/schemas/agent-receipt.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/schemas/agent-receipt.schema.json",
+  "title": "Agent Receipt",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "receipt_id",
+    "task_id",
+    "snapshot_id",
+    "head_sha",
+    "received_at",
+    "expires_at",
+    "mutation",
+    "allowed_mutations",
+    "forbidden_mutations",
+    "output_schema"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "minimum": 1 },
+    "receipt_id": { "type": "string", "minLength": 1 },
+    "task_id": { "type": "string", "minLength": 1 },
+    "snapshot_id": { "type": "string", "minLength": 1 },
+    "head_sha": { "type": "string", "minLength": 1 },
+    "received_at": { "type": "string", "format": "date-time" },
+    "expires_at": { "type": "string", "format": "date-time" },
+    "mutation": { "type": "string", "minLength": 1 },
+    "allowed_mutations": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "forbidden_mutations": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "output_schema": { "type": "string", "minLength": 1 },
+    "supersedes": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/.ci/receipts/schemas/agent-task.schema.json
+++ b/.ci/receipts/schemas/agent-task.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/schemas/agent-task.schema.json",
+  "title": "Agent Task",
+  "type": "object",
+  "required": [
+    "task_id",
+    "snapshot_id",
+    "lane",
+    "pr",
+    "head_sha",
+    "base_sha",
+    "canonical_state",
+    "allowed_mutations",
+    "forbidden_mutations",
+    "required_output_schema",
+    "expires_at"
+  ],
+  "properties": {
+    "task_id": { "type": "string", "minLength": 1 },
+    "snapshot_id": { "type": "string", "minLength": 1 },
+    "lane": { "type": "string", "minLength": 1 },
+    "pr": { "type": "integer", "minimum": 1 },
+    "head_sha": { "type": "string", "minLength": 1 },
+    "base_sha": { "type": "string", "minLength": 1 },
+    "canonical_state": { "type": "string", "minLength": 1 },
+    "allowed_mutations": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "forbidden_mutations": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "required_output_schema": { "type": "string", "minLength": 1 },
+    "expires_at": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false
+}

--- a/docs/ci/agent-leases.md
+++ b/docs/ci/agent-leases.md
@@ -1,0 +1,39 @@
+# Agent leases and idempotent receipts
+
+This document defines disconnected orchestration primitives used by `cargo xtask agent`.
+
+## Task shape
+
+`agent-task.schema.json` defines a typed task contract:
+
+- `task_id`
+- `snapshot_id`
+- `lane`
+- `pr`
+- `head_sha`
+- `base_sha`
+- `canonical_state`
+- `allowed_mutations`
+- `forbidden_mutations`
+- `required_output_schema`
+- `expires_at`
+
+## Commands
+
+```bash
+cargo xtask agent lease acquire --task <task.json> --out target/agent/lease.json
+cargo xtask agent lease verify --lease target/agent/lease.json --current <snapshot.json>
+cargo xtask agent receipt validate --receipt <receipt.json>
+```
+
+## Reconciliation rules
+
+- stale head (`head_sha` mismatch) means receipt output is ignored for state.
+- expired lease (`expires_at` in the past) rejects mutations.
+- same `task_id` should be comment/update idempotent.
+- newer receipts supersede older receipts via `supersedes` linkage and `received_at` ordering.
+- receipt `mutation` not in `allowed_mutations` is rejected.
+
+## Scope note
+
+This primitive layer intentionally does **not** dispatch agents, mutate labels, allocate worktrees, or invoke GitHub APIs.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1116,6 +1116,12 @@ enum Commands {
         format: swarm_summary::SwarmSummaryOutputFormat,
     },
 
+    /// Agent lease and receipt primitives for disconnected orchestration.
+    Agent {
+        #[command(subcommand)]
+        command: AgentCommand,
+    },
+
     /// Populate mdBook source directory from `docs/`.
     PopulateBook,
 
@@ -1300,6 +1306,45 @@ enum MetricsCommand {
         /// `target/receipts/system-corpus-sweep.json`.
         #[arg(long)]
         input: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentCommand {
+    Lease {
+        #[command(subcommand)]
+        command: AgentLeaseCommand,
+    },
+    Receipt {
+        #[command(subcommand)]
+        command: AgentReceiptCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentLeaseCommand {
+    /// Acquire a typed lease from an input task document.
+    Acquire {
+        #[arg(long)]
+        task: PathBuf,
+        #[arg(long)]
+        out: PathBuf,
+    },
+    /// Verify a lease against the current reconciler snapshot.
+    Verify {
+        #[arg(long)]
+        lease: PathBuf,
+        #[arg(long)]
+        current: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentReceiptCommand {
+    /// Validate a receipt against idempotency and mutation rules.
+    Validate {
+        #[arg(long)]
+        receipt: PathBuf,
     },
 }
 
@@ -1677,6 +1722,17 @@ fn main() -> Result<()> {
         Commands::SwarmSummary { ops_dir, since, limit, format } => {
             swarm_summary::run(swarm_summary::SwarmSummaryConfig { ops_dir, since, limit, format })
         }
+        Commands::Agent { command } => match command {
+            AgentCommand::Lease { command } => match command {
+                AgentLeaseCommand::Acquire { task, out } => agent_lease::acquire(&task, &out),
+                AgentLeaseCommand::Verify { lease, current } => {
+                    agent_lease::verify(&lease, &current)
+                }
+            },
+            AgentCommand::Receipt { command } => match command {
+                AgentReceiptCommand::Validate { receipt } => agent_receipt::validate(&receipt),
+            },
+        },
         Commands::PopulateBook => populate_book::run(),
         Commands::LayerCheck => layer_check::run(),
         Commands::ValidateWorkspaceExclusions => validate_workspace_exclusions::run(),

--- a/xtask/src/tasks/agent_lease.rs
+++ b/xtask/src/tasks/agent_lease.rs
@@ -1,0 +1,102 @@
+use chrono::{DateTime, Utc};
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentTask {
+    pub task_id: String,
+    pub snapshot_id: String,
+    pub lane: String,
+    pub pr: u64,
+    pub head_sha: String,
+    pub base_sha: String,
+    pub canonical_state: String,
+    pub allowed_mutations: Vec<String>,
+    pub forbidden_mutations: Vec<String>,
+    pub required_output_schema: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentLease {
+    pub schema_version: u32,
+    pub leased_at: DateTime<Utc>,
+    #[serde(flatten)]
+    pub task: AgentTask,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CurrentSnapshot {
+    pub snapshot_id: String,
+    pub head_sha: String,
+}
+
+pub fn acquire(task_path: &Path, out_path: &Path) -> Result<()> {
+    let task_json = fs::read_to_string(task_path)
+        .with_context(|| format!("failed to read task file: {}", task_path.display()))?;
+    let task: AgentTask = serde_json::from_str(&task_json)
+        .with_context(|| format!("failed to parse task file: {}", task_path.display()))?;
+    task.validate()?;
+
+    let lease = AgentLease { schema_version: 1, leased_at: Utc::now(), task };
+    if let Some(parent) = out_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory: {}", parent.display()))?;
+    }
+    fs::write(out_path, format!("{}\n", serde_json::to_string_pretty(&lease)?))
+        .with_context(|| format!("failed to write lease file: {}", out_path.display()))?;
+    println!("lease written: {}", out_path.display());
+    Ok(())
+}
+
+pub fn verify(lease_path: &Path, current_path: &Path) -> Result<()> {
+    let lease_raw = fs::read_to_string(lease_path)
+        .with_context(|| format!("failed to read lease file: {}", lease_path.display()))?;
+    let lease: AgentLease = serde_json::from_str(&lease_raw)
+        .with_context(|| format!("failed to parse lease file: {}", lease_path.display()))?;
+    lease.task.validate()?;
+
+    let current_raw = fs::read_to_string(current_path)
+        .with_context(|| format!("failed to read snapshot file: {}", current_path.display()))?;
+    let current: CurrentSnapshot = serde_json::from_str(&current_raw)
+        .with_context(|| format!("failed to parse snapshot file: {}", current_path.display()))?;
+
+    if lease.task.expires_at <= Utc::now() {
+        bail!("lease expired at {}", lease.task.expires_at.to_rfc3339());
+    }
+
+    if current.snapshot_id != lease.task.snapshot_id {
+        bail!(
+            "snapshot mismatch: lease={} current={}",
+            lease.task.snapshot_id,
+            current.snapshot_id
+        );
+    }
+
+    if current.head_sha != lease.task.head_sha {
+        bail!("stale head: lease={} current={}", lease.task.head_sha, current.head_sha);
+    }
+
+    println!("lease verified: {}", lease.task.task_id);
+    Ok(())
+}
+
+impl AgentTask {
+    fn validate(&self) -> Result<()> {
+        if self.task_id.trim().is_empty() {
+            bail!("task_id cannot be empty");
+        }
+        if self.snapshot_id.trim().is_empty() {
+            bail!("snapshot_id cannot be empty");
+        }
+        if self.head_sha.trim().is_empty() || self.base_sha.trim().is_empty() {
+            bail!("head_sha and base_sha cannot be empty");
+        }
+        if self.allowed_mutations.is_empty() {
+            bail!("allowed_mutations cannot be empty");
+        }
+        Ok(())
+    }
+}

--- a/xtask/src/tasks/agent_receipt.rs
+++ b/xtask/src/tasks/agent_receipt.rs
@@ -1,0 +1,93 @@
+use chrono::{DateTime, Utc};
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentReceipt {
+    pub schema_version: u32,
+    pub receipt_id: String,
+    pub task_id: String,
+    pub snapshot_id: String,
+    pub head_sha: String,
+    pub received_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub mutation: String,
+    pub allowed_mutations: Vec<String>,
+    pub forbidden_mutations: Vec<String>,
+    pub output_schema: String,
+    pub supersedes: Option<String>,
+}
+
+pub fn validate(receipt_path: &Path) -> Result<()> {
+    let raw = fs::read_to_string(receipt_path)
+        .with_context(|| format!("failed to read receipt file: {}", receipt_path.display()))?;
+    let receipt: AgentReceipt = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse receipt file: {}", receipt_path.display()))?;
+
+    validate_receipt(&receipt)?;
+    println!("receipt valid: {}", receipt.receipt_id);
+    Ok(())
+}
+
+fn validate_receipt(receipt: &AgentReceipt) -> Result<()> {
+    if receipt.task_id.trim().is_empty() {
+        bail!("task_id cannot be empty");
+    }
+    if receipt.receipt_id.trim().is_empty() {
+        bail!("receipt_id cannot be empty");
+    }
+    if receipt.received_at > Utc::now() {
+        bail!("received_at cannot be in the future");
+    }
+    if receipt.expires_at <= receipt.received_at {
+        bail!("expires_at must be later than received_at");
+    }
+    if !receipt.allowed_mutations.iter().any(|m| m == &receipt.mutation) {
+        bail!("mutation `{}` is not in allowed_mutations", receipt.mutation);
+    }
+    let forbidden: HashSet<&str> =
+        receipt.forbidden_mutations.iter().map(std::string::String::as_str).collect();
+    if forbidden.contains(receipt.mutation.as_str()) {
+        bail!("mutation `{}` is forbidden", receipt.mutation);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_receipt() -> AgentReceipt {
+        AgentReceipt {
+            schema_version: 1,
+            receipt_id: "r-1".to_string(),
+            task_id: "t-1".to_string(),
+            snapshot_id: "s-1".to_string(),
+            head_sha: "abc".to_string(),
+            received_at: Utc::now() - chrono::Duration::minutes(1),
+            expires_at: Utc::now() + chrono::Duration::minutes(10),
+            mutation: "comment.update".to_string(),
+            allowed_mutations: vec!["comment.update".to_string()],
+            forbidden_mutations: vec!["label.set".to_string()],
+            output_schema: "agent-receipt-v1".to_string(),
+            supersedes: None,
+        }
+    }
+
+    #[test]
+    fn validates_allowed_mutation() -> Result<()> {
+        validate_receipt(&base_receipt())?;
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_forbidden_mutation() {
+        let mut receipt = base_receipt();
+        receipt.forbidden_mutations.push("comment.update".to_string());
+        let result = validate_receipt(&receipt);
+        assert!(result.is_err(), "forbidden mutation must fail");
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -1,5 +1,7 @@
 //! Task implementations for xtask automation
 
+pub mod agent_lease;
+pub mod agent_receipt;
 pub mod bench;
 pub mod benchmarks;
 #[cfg(feature = "parser-tasks")]

--- a/xtask/tests/agent_lease_cli_tests.rs
+++ b/xtask/tests/agent_lease_cli_tests.rs
@@ -1,0 +1,84 @@
+use anyhow::Result;
+use assert_cmd::Command;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn repo_root() -> Result<PathBuf> {
+    Ok(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".."))
+}
+
+fn fixture(path: &str) -> Result<PathBuf> {
+    Ok(repo_root()?.join("xtask/tests/fixtures/agent-leases").join(path))
+}
+
+fn run_xtask(args: &[&str]) -> Result<std::process::Output> {
+    let mut cmd = Command::cargo_bin("xtask")?;
+    cmd.current_dir(repo_root()?);
+    Ok(cmd.args(args).output()?)
+}
+
+#[test]
+fn valid_lease_verifies() -> Result<()> {
+    let temp = TempDir::new()?;
+    let lease_out = temp.path().join("lease.json");
+    let task_path = fixture("task-valid.json")?;
+    let current_path = fixture("current-valid.json")?;
+    let task = task_path.to_string_lossy().into_owned();
+    let lease = lease_out.to_string_lossy().into_owned();
+    let current = current_path.to_string_lossy().into_owned();
+
+    let acquire = run_xtask(&["agent", "lease", "acquire", "--task", &task, "--out", &lease])?;
+    assert!(acquire.status.success(), "acquire should pass");
+
+    let verify =
+        run_xtask(&["agent", "lease", "verify", "--lease", &lease, "--current", &current])?;
+    assert!(verify.status.success(), "verify should pass");
+    Ok(())
+}
+
+#[test]
+fn expired_lease_fails() -> Result<()> {
+    let temp = TempDir::new()?;
+    let lease_out = temp.path().join("lease-expired.json");
+    let task_path = fixture("task-expired.json")?;
+    let current_path = fixture("current-valid.json")?;
+    let task = task_path.to_string_lossy().into_owned();
+    let lease = lease_out.to_string_lossy().into_owned();
+    let current = current_path.to_string_lossy().into_owned();
+
+    let acquire = run_xtask(&["agent", "lease", "acquire", "--task", &task, "--out", &lease])?;
+    assert!(acquire.status.success(), "acquire should pass");
+
+    let verify =
+        run_xtask(&["agent", "lease", "verify", "--lease", &lease, "--current", &current])?;
+    assert!(!verify.status.success(), "expired lease verify must fail");
+    Ok(())
+}
+
+#[test]
+fn stale_head_fails() -> Result<()> {
+    let temp = TempDir::new()?;
+    let lease_out = temp.path().join("lease.json");
+    let task_path = fixture("task-valid.json")?;
+    let current_path = fixture("current-stale-head.json")?;
+    let task = task_path.to_string_lossy().into_owned();
+    let lease = lease_out.to_string_lossy().into_owned();
+    let current = current_path.to_string_lossy().into_owned();
+
+    let acquire = run_xtask(&["agent", "lease", "acquire", "--task", &task, "--out", &lease])?;
+    assert!(acquire.status.success(), "acquire should pass");
+
+    let verify =
+        run_xtask(&["agent", "lease", "verify", "--lease", &lease, "--current", &current])?;
+    assert!(!verify.status.success(), "stale head verify must fail");
+    Ok(())
+}
+
+#[test]
+fn forbidden_mutation_receipt_fails() -> Result<()> {
+    let receipt_path = fixture("receipt-forbidden-mutation.json")?;
+    let receipt = receipt_path.to_string_lossy().into_owned();
+    let validate = run_xtask(&["agent", "receipt", "validate", "--receipt", &receipt])?;
+    assert!(!validate.status.success(), "forbidden mutation receipt must fail");
+    Ok(())
+}

--- a/xtask/tests/fixtures/agent-leases/current-stale-head.json
+++ b/xtask/tests/fixtures/agent-leases/current-stale-head.json
@@ -1,0 +1,4 @@
+{
+  "snapshot_id": "snap-1",
+  "head_sha": "ffff00"
+}

--- a/xtask/tests/fixtures/agent-leases/current-valid.json
+++ b/xtask/tests/fixtures/agent-leases/current-valid.json
@@ -1,0 +1,4 @@
+{
+  "snapshot_id": "snap-1",
+  "head_sha": "abc123"
+}

--- a/xtask/tests/fixtures/agent-leases/receipt-forbidden-mutation.json
+++ b/xtask/tests/fixtures/agent-leases/receipt-forbidden-mutation.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "receipt_id": "receipt-2",
+  "task_id": "task-6853",
+  "snapshot_id": "snap-1",
+  "head_sha": "abc123",
+  "received_at": "2026-01-01T00:00:00Z",
+  "expires_at": "2099-01-01T00:00:00Z",
+  "mutation": "label.set",
+  "allowed_mutations": ["comment.update"],
+  "forbidden_mutations": ["label.set"],
+  "output_schema": "agent-receipt-v1",
+  "supersedes": "receipt-1"
+}

--- a/xtask/tests/fixtures/agent-leases/receipt-valid.json
+++ b/xtask/tests/fixtures/agent-leases/receipt-valid.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "receipt_id": "receipt-1",
+  "task_id": "task-6853",
+  "snapshot_id": "snap-1",
+  "head_sha": "abc123",
+  "received_at": "2026-01-01T00:00:00Z",
+  "expires_at": "2099-01-01T00:00:00Z",
+  "mutation": "comment.update",
+  "allowed_mutations": ["comment.update"],
+  "forbidden_mutations": ["label.set"],
+  "output_schema": "agent-receipt-v1",
+  "supersedes": null
+}

--- a/xtask/tests/fixtures/agent-leases/task-expired.json
+++ b/xtask/tests/fixtures/agent-leases/task-expired.json
@@ -1,0 +1,13 @@
+{
+  "task_id": "task-6853-expired",
+  "snapshot_id": "snap-1",
+  "lane": "merge-gate",
+  "pr": 6853,
+  "head_sha": "abc123",
+  "base_sha": "def456",
+  "canonical_state": "open",
+  "allowed_mutations": ["comment.update"],
+  "forbidden_mutations": ["label.set"],
+  "required_output_schema": "agent-receipt-v1",
+  "expires_at": "2020-01-01T00:00:00Z"
+}

--- a/xtask/tests/fixtures/agent-leases/task-valid.json
+++ b/xtask/tests/fixtures/agent-leases/task-valid.json
@@ -1,0 +1,13 @@
+{
+  "task_id": "task-6853",
+  "snapshot_id": "snap-1",
+  "lane": "merge-gate",
+  "pr": 6853,
+  "head_sha": "abc123",
+  "base_sha": "def456",
+  "canonical_state": "open",
+  "allowed_mutations": ["comment.update"],
+  "forbidden_mutations": ["label.set"],
+  "required_output_schema": "agent-receipt-v1",
+  "expires_at": "2099-01-01T00:00:00Z"
+}


### PR DESCRIPTION
### Motivation

- Refs #6853 — provide typed agent task/lease/receipt primitives so stale or late agent outputs cannot corrupt reconciler state.
- Implement a small, local primitive layer that lets agents acquire typed leases and emit idempotent receipts which the reconciler can validate before applying mutations.

### Description

- Add CLI wiring `cargo xtask agent lease acquire|verify` and `cargo xtask agent receipt validate` with dispatch in `xtask/src/main.rs` and exported modules in `xtask/src/tasks/mod.rs`.
- Implement `xtask/src/tasks/agent_lease.rs` to parse/validate `AgentTask`, emit `AgentLease`, and verify expiration, snapshot id, and `head_sha` freshness.
- Implement `xtask/src/tasks/agent_receipt.rs` to parse/validate `AgentReceipt` and enforce timing, allowed/forbidden mutation rules and `supersedes`-style idempotency primitives (basic checks only).
- Add JSON schemas under `.ci/receipts/schemas/`, documentation `docs/ci/agent-leases.md`, fixture inputs in `xtask/tests/fixtures/agent-leases/`, and CLI integration tests in `xtask/tests/agent_lease_cli_tests.rs` covering valid/expired/stale/forbidden cases.

### Testing

- Ran `cargo test -p xtask --test agent_lease_cli_tests` and all fixture-backed CLI tests passed (`4 passed`).
- Ran `cargo check --all-targets -p xtask` and the crate type-checks cleanly.
- Ran `cargo clippy -p xtask -- -D warnings` and no lints were reported.
- Ran `cargo xtask fmt` successfully; `just pr-fast` was not available in the environment (tool missing) so that step was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0b50cb4833385b18fb23fd3a05d)