### PR TITLE
feat(agent): add worktree allocator for orchestration (#6853)

### DIFF
--- a/.ci/receipts/schemas/worktree-lease.schema.json
+++ b/.ci/receipts/schemas/worktree-lease.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/schemas/worktree-lease.schema.json",
+  "title": "Worktree Lease Receipt",
+  "type": "object",
+  "required": [
+    "action",
+    "worktree_id",
+    "pr",
+    "branch",
+    "path",
+    "base_sha",
+    "lease_expiry"
+  ],
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["acquire", "release", "gc"]
+    },
+    "worktree_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pr": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "branch": {
+      "type": "string",
+      "minLength": 1
+    },
+    "path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "base_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,40}$"
+    },
+    "lease_expiry": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/ci/worktree-allocator.md
+++ b/docs/ci/worktree-allocator.md
@@ -1,0 +1,47 @@
+# Worktree allocator (agent orchestration)
+
+The worktree allocator provides lease-based local worktree management for agent orchestration.
+
+## Commands
+
+```bash
+cargo xtask agent worktree acquire --pr <N> --base origin/master
+cargo xtask agent worktree release --id <id>
+cargo xtask agent worktree list
+cargo xtask agent worktree gc --stale
+```
+
+## Lease state
+
+Leases are persisted at `.claude/worktree-allocator/leases.json`.
+
+Each lease tracks:
+
+- `worktree_id`
+- `path`
+- `agent_task_id`
+- `pr`
+- `branch`
+- `base_sha`
+- `owner`
+- `lease_expiry`
+- `last_heartbeat`
+
+## Invariants
+
+- A writable branch cannot be checked out in two worktrees.
+- Nested worktree paths are rejected.
+- Stale leases (TTL expired) are eligible for garbage collection.
+- Release is explicit (`release --id ...`).
+- Acquire emits a receipt that includes `worktree_id` at `target/receipts/worktree-lease.json`.
+
+## Safety behavior
+
+- `gc --stale` is dry-run by default.
+- Destructive cleanup requires `--apply`.
+- Removal refuses dirty worktrees unless `--force` is provided.
+- Paths are printed before any removal.
+
+## Scope note
+
+This allocator is additive and does not globally change existing agent behavior.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1097,6 +1097,12 @@ enum Commands {
     /// Remove stale `.claude/worktrees` entries and prune Git metadata.
     WorktreeCleanup,
 
+    /// Agent orchestration helpers.
+    Agent {
+        #[command(subcommand)]
+        command: AgentCommand,
+    },
+
     /// Show summary statistics from swarm-metrics.jsonl.
     SwarmSummary {
         /// Path to operations directory (defaults to `.ops-perl-lsp`).
@@ -1300,6 +1306,54 @@ enum MetricsCommand {
         /// `target/receipts/system-corpus-sweep.json`.
         #[arg(long)]
         input: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentCommand {
+    /// Lease-based worktree allocator commands.
+    Worktree {
+        #[command(subcommand)]
+        command: AgentWorktreeCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentWorktreeCommand {
+    /// Acquire a lease and create an agent worktree for a PR.
+    Acquire {
+        /// Pull request number.
+        #[arg(long)]
+        pr: u64,
+        /// Base ref used for branch creation.
+        #[arg(long, default_value = "origin/master")]
+        base: String,
+        /// Optional agent task/session identifier for the lease.
+        #[arg(long)]
+        agent_task_id: Option<String>,
+    },
+    /// Release a lease and remove its worktree.
+    Release {
+        /// Worktree lease ID to release.
+        #[arg(long)]
+        id: String,
+        /// Force removal even with local modifications.
+        #[arg(long)]
+        force: bool,
+    },
+    /// List active worktree leases.
+    List,
+    /// Garbage-collect stale worktrees.
+    Gc {
+        /// Restrict GC to stale leases only.
+        #[arg(long)]
+        stale: bool,
+        /// Apply destructive cleanup (dry-run by default).
+        #[arg(long)]
+        apply: bool,
+        /// Force removal even with local modifications.
+        #[arg(long)]
+        force: bool,
     },
 }
 
@@ -1674,6 +1728,23 @@ fn main() -> Result<()> {
             Ok(())
         }
         Commands::WorktreeCleanup => worktrees::cleanup(),
+        Commands::Agent { command } => match command {
+            AgentCommand::Worktree { command } => match command {
+                AgentWorktreeCommand::Acquire { pr, base, agent_task_id } => {
+                    worktree_allocator::acquire(pr, base, agent_task_id)
+                }
+                AgentWorktreeCommand::Release { id, force } => {
+                    worktree_allocator::release(id, force)
+                }
+                AgentWorktreeCommand::List => worktree_allocator::list(),
+                AgentWorktreeCommand::Gc { stale, apply, force } => {
+                    if !stale {
+                        return Err(eyre!("gc currently requires --stale"));
+                    }
+                    worktree_allocator::gc_stale(apply, force)
+                }
+            },
+        },
         Commands::SwarmSummary { ops_dir, since, limit, format } => {
             swarm_summary::run(swarm_summary::SwarmSummaryConfig { ops_dir, since, limit, format })
         }

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -73,4 +73,5 @@ pub mod update_homebrew;
 pub mod update_status;
 pub mod ux_scorecard;
 pub mod validate_workspace_exclusions;
+pub mod worktree_allocator;
 pub mod worktrees;

--- a/xtask/src/tasks/worktree_allocator.rs
+++ b/xtask/src/tasks/worktree_allocator.rs
@@ -1,0 +1,457 @@
+//! Lease-based worktree allocator for local agent orchestration.
+
+use crate::utils::project_root;
+use chrono::{DateTime, Duration, Utc};
+use color_eyre::eyre::{Result, bail, eyre};
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const LEASES_PATH: &str = ".claude/worktree-allocator/leases.json";
+const RECEIPT_PATH: &str = "target/receipts/worktree-lease.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorktreeLease {
+    pub worktree_id: String,
+    pub path: String,
+    pub agent_task_id: String,
+    pub pr: u64,
+    pub branch: String,
+    pub base_sha: String,
+    pub owner: String,
+    pub lease_expiry: DateTime<Utc>,
+    pub last_heartbeat: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LeaseState {
+    leases: Vec<WorktreeLease>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WorktreeLeaseReceipt {
+    action: String,
+    worktree_id: String,
+    pr: u64,
+    branch: String,
+    path: String,
+    base_sha: String,
+    lease_expiry: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct WorktreeEntry {
+    path: String,
+    branch: Option<String>,
+    bare: bool,
+    detached: bool,
+}
+
+pub fn acquire(pr: u64, base: String, agent_task_id: Option<String>) -> Result<()> {
+    let root = project_root()?;
+    let mut state = load_state(&root)?;
+
+    let base_sha = resolve_ref(&root, &base)?;
+    let worktree_id = generate_worktree_id();
+    let branch = format!("pr-{pr}");
+    let worktree_path = root.join(".claude/worktrees").join(&worktree_id);
+    let worktree_path_str = worktree_path.to_string_lossy().into_owned();
+
+    let entries = list_git_worktrees(&root)?;
+    ensure_branch_available(&entries, &branch)?;
+    ensure_not_nested(&entries, &worktree_path_str)?;
+
+    fs::create_dir_all(worktree_path.parent().ok_or_else(|| eyre!("missing parent path"))?)?;
+
+    let branch_exists = branch_exists(&root, &branch)?;
+    let status = if branch_exists {
+        Command::new("git")
+            .current_dir(&root)
+            .args(["worktree", "add", &worktree_path_str, &branch])
+            .status()?
+    } else {
+        Command::new("git")
+            .current_dir(&root)
+            .args(["worktree", "add", "-b", &branch, &worktree_path_str, &base_sha])
+            .status()?
+    };
+
+    if !status.success() {
+        bail!("failed to create worktree at {worktree_path_str}");
+    }
+
+    let now = Utc::now();
+    let lease = WorktreeLease {
+        worktree_id: worktree_id.clone(),
+        path: worktree_path_str.clone(),
+        agent_task_id: agent_task_id.unwrap_or_else(default_agent_task_id),
+        pr,
+        branch: branch.clone(),
+        base_sha: base_sha.clone(),
+        owner: default_owner(),
+        lease_expiry: now + Duration::hours(8),
+        last_heartbeat: now,
+    };
+    state.leases.push(lease.clone());
+    save_state(&root, &state)?;
+
+    let receipt = WorktreeLeaseReceipt {
+        action: "acquire".to_string(),
+        worktree_id,
+        pr,
+        branch,
+        path: worktree_path_str,
+        base_sha,
+        lease_expiry: lease.lease_expiry,
+    };
+    write_receipt(&root, &receipt)?;
+
+    println!("Acquired worktree {} at {}", receipt.worktree_id, receipt.path);
+    Ok(())
+}
+
+pub fn release(id: String, force: bool) -> Result<()> {
+    let root = project_root()?;
+    let mut state = load_state(&root)?;
+
+    let Some(idx) = state.leases.iter().position(|lease| lease.worktree_id == id) else {
+        bail!("lease id not found");
+    };
+
+    let lease = state.leases[idx].clone();
+    let path = PathBuf::from(&lease.path);
+    println!("Releasing worktree path: {}", lease.path);
+
+    if path.exists() {
+        ensure_clean_or_force(&path, force)?;
+
+        let mut args = vec!["worktree", "remove"];
+        if force {
+            args.push("--force");
+        }
+        args.push(&lease.path);
+
+        let status = Command::new("git").current_dir(&root).args(args).status()?;
+        if !status.success() {
+            bail!("failed to remove worktree {}", lease.path);
+        }
+    }
+
+    state.leases.remove(idx);
+    save_state(&root, &state)?;
+    println!("Released lease {}", lease.worktree_id);
+    Ok(())
+}
+
+pub fn list() -> Result<()> {
+    let root = project_root()?;
+    let state = load_state(&root)?;
+
+    if state.leases.is_empty() {
+        println!("No active worktree leases");
+        return Ok(());
+    }
+
+    for lease in &state.leases {
+        println!(
+            "{} pr={} branch={} expires={} path={}",
+            lease.worktree_id, lease.pr, lease.branch, lease.lease_expiry, lease.path
+        );
+    }
+    Ok(())
+}
+
+pub fn gc_stale(apply: bool, force: bool) -> Result<()> {
+    let root = project_root()?;
+    let mut state = load_state(&root)?;
+    let now = Utc::now();
+
+    let stale_ids = state
+        .leases
+        .iter()
+        .filter(|lease| lease.lease_expiry <= now)
+        .map(|lease| lease.worktree_id.clone())
+        .collect::<Vec<_>>();
+
+    if stale_ids.is_empty() {
+        println!("No stale worktrees found");
+        return Ok(());
+    }
+
+    println!("Stale worktrees ({}):", stale_ids.len());
+    for id in &stale_ids {
+        if let Some(lease) = state.leases.iter().find(|lease| &lease.worktree_id == id) {
+            println!("{} -> {}", lease.worktree_id, lease.path);
+        }
+    }
+
+    if !apply {
+        println!("Dry-run only. Re-run with --apply to remove stale worktrees.");
+        return Ok(());
+    }
+
+    for id in &stale_ids {
+        if let Some(lease) = state.leases.iter().find(|lease| &lease.worktree_id == id) {
+            let path = PathBuf::from(&lease.path);
+            if path.exists() {
+                ensure_clean_or_force(&path, force)?;
+                let mut args = vec!["worktree", "remove"];
+                if force {
+                    args.push("--force");
+                }
+                args.push(&lease.path);
+                let status = Command::new("git").current_dir(&root).args(args).status()?;
+                if !status.success() {
+                    bail!("failed to remove stale worktree {}", lease.path);
+                }
+            }
+        }
+    }
+
+    state.leases.retain(|lease| !stale_ids.contains(&lease.worktree_id));
+    save_state(&root, &state)?;
+    println!("Removed {} stale worktrees", stale_ids.len());
+    Ok(())
+}
+
+fn load_state(root: &Path) -> Result<LeaseState> {
+    let path = root.join(LEASES_PATH);
+    if !path.exists() {
+        return Ok(LeaseState { leases: Vec::new() });
+    }
+
+    let content = fs::read_to_string(path)?;
+    let state: LeaseState = serde_json::from_str(&content)?;
+    Ok(state)
+}
+
+fn save_state(root: &Path, state: &LeaseState) -> Result<()> {
+    let path = root.join(LEASES_PATH);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let body = serde_json::to_string_pretty(state)?;
+    fs::write(path, body)?;
+    Ok(())
+}
+
+fn write_receipt(root: &Path, receipt: &WorktreeLeaseReceipt) -> Result<()> {
+    let path = root.join(RECEIPT_PATH);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let body = serde_json::to_string_pretty(receipt)?;
+    fs::write(path, body)?;
+    Ok(())
+}
+
+fn resolve_ref(root: &Path, git_ref: &str) -> Result<String> {
+    let output = Command::new("git").current_dir(root).args(["rev-parse", git_ref]).output()?;
+    if !output.status.success() {
+        bail!("failed to resolve git ref {git_ref}");
+    }
+    Ok(String::from_utf8(output.stdout)?.trim().to_string())
+}
+
+fn branch_exists(root: &Path, branch: &str) -> Result<bool> {
+    let status = Command::new("git")
+        .current_dir(root)
+        .args(["show-ref", "--verify", "--quiet", &format!("refs/heads/{branch}")])
+        .status()?;
+    Ok(status.success())
+}
+
+fn list_git_worktrees(root: &Path) -> Result<Vec<WorktreeEntry>> {
+    let output =
+        Command::new("git").current_dir(root).args(["worktree", "list", "--porcelain"]).output()?;
+    if !output.status.success() {
+        bail!("failed to list worktrees");
+    }
+
+    let text = String::from_utf8(output.stdout)?;
+    parse_worktree_porcelain(&text)
+}
+
+fn parse_worktree_porcelain(input: &str) -> Result<Vec<WorktreeEntry>> {
+    let mut entries = Vec::new();
+    let mut current_path: Option<String> = None;
+    let mut current_branch: Option<String> = None;
+    let mut current_bare = false;
+    let mut current_detached = false;
+
+    for line in input.lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            if let Some(path_value) = current_path.take() {
+                entries.push(WorktreeEntry {
+                    path: path_value,
+                    branch: current_branch.take(),
+                    bare: current_bare,
+                    detached: current_detached,
+                });
+                current_bare = false;
+                current_detached = false;
+            }
+            current_path = Some(path.to_string());
+            continue;
+        }
+
+        if line == "bare" {
+            current_bare = true;
+            continue;
+        }
+
+        if line == "detached" {
+            current_detached = true;
+            continue;
+        }
+
+        if let Some(head) = line.strip_prefix("branch refs/heads/") {
+            current_branch = Some(head.to_string());
+        }
+    }
+
+    if let Some(path_value) = current_path.take() {
+        entries.push(WorktreeEntry {
+            path: path_value,
+            branch: current_branch,
+            bare: current_bare,
+            detached: current_detached,
+        });
+    }
+
+    Ok(entries)
+}
+
+fn ensure_branch_available(entries: &[WorktreeEntry], branch: &str) -> Result<()> {
+    if entries
+        .iter()
+        .any(|entry| !entry.bare && !entry.detached && entry.branch.as_deref() == Some(branch))
+    {
+        bail!("branch {branch} is already checked out in another writable worktree");
+    }
+    Ok(())
+}
+
+fn ensure_not_nested(entries: &[WorktreeEntry], candidate: &str) -> Result<()> {
+    let candidate_path = Path::new(candidate);
+    for entry in entries {
+        let existing = Path::new(&entry.path);
+        if candidate_path.starts_with(existing) || existing.starts_with(candidate_path) {
+            bail!("nested worktree path detected: candidate={candidate} existing={}", entry.path);
+        }
+    }
+    Ok(())
+}
+
+fn ensure_clean_or_force(worktree_path: &Path, force: bool) -> Result<()> {
+    let output =
+        Command::new("git").current_dir(worktree_path).args(["status", "--porcelain"]).output()?;
+
+    if !output.status.success() {
+        bail!("unable to inspect worktree status at {}", worktree_path.display());
+    }
+
+    let dirty = !String::from_utf8(output.stdout)?.trim().is_empty();
+    if dirty && !force {
+        bail!(
+            "worktree {} has uncommitted changes; rerun with --force to delete",
+            worktree_path.display()
+        );
+    }
+    Ok(())
+}
+
+fn generate_worktree_id() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    format!("wt-{nanos:x}")
+}
+
+fn default_owner() -> String {
+    env::var("USER")
+        .or_else(|_| env::var("USERNAME"))
+        .unwrap_or_else(|_| "unknown-owner".to_string())
+}
+
+fn default_agent_task_id() -> String {
+    env::var("CODEX_SESSION_ID")
+        .or_else(|_| env::var("CLAUDE_SESSION_ID"))
+        .unwrap_or_else(|_| "manual-session".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Deserialize)]
+    struct BranchFixture {
+        worktrees_porcelain: String,
+        target_branch: String,
+        expected_conflict: bool,
+    }
+
+    fn load_fixture(name: &str) -> Result<BranchFixture> {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/worktree-allocator")
+            .join(name);
+        let body = fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&body)?)
+    }
+
+    #[test]
+    fn detects_duplicate_writable_branch_from_fixture() -> Result<()> {
+        let fixture = load_fixture("duplicate-branch.json")?;
+        let entries = parse_worktree_porcelain(&fixture.worktrees_porcelain)?;
+        let conflict = ensure_branch_available(&entries, &fixture.target_branch).is_err();
+        assert_eq!(fixture.expected_conflict, conflict);
+        Ok(())
+    }
+
+    #[test]
+    fn allows_detached_duplicate_branch_from_fixture() -> Result<()> {
+        let fixture = load_fixture("detached-no-conflict.json")?;
+        let entries = parse_worktree_porcelain(&fixture.worktrees_porcelain)?;
+        let conflict = ensure_branch_available(&entries, &fixture.target_branch).is_err();
+        assert_eq!(fixture.expected_conflict, conflict);
+        Ok(())
+    }
+
+    #[test]
+    fn stale_gc_dry_run_lists_without_deleting() -> Result<()> {
+        let now = Utc::now();
+        let stale = WorktreeLease {
+            worktree_id: "wt-old".to_string(),
+            path: "/tmp/wt-old".to_string(),
+            agent_task_id: "agent-1".to_string(),
+            pr: 6853,
+            branch: "pr-6853".to_string(),
+            base_sha: "abc123".to_string(),
+            owner: "tester".to_string(),
+            lease_expiry: now - Duration::minutes(1),
+            last_heartbeat: now - Duration::minutes(1),
+        };
+        let fresh = WorktreeLease {
+            worktree_id: "wt-new".to_string(),
+            path: "/tmp/wt-new".to_string(),
+            agent_task_id: "agent-2".to_string(),
+            pr: 6854,
+            branch: "pr-6854".to_string(),
+            base_sha: "def456".to_string(),
+            owner: "tester".to_string(),
+            lease_expiry: now + Duration::minutes(30),
+            last_heartbeat: now,
+        };
+
+        let stale_ids = vec![stale, fresh]
+            .into_iter()
+            .filter(|lease| lease.lease_expiry <= now)
+            .map(|lease| lease.worktree_id)
+            .collect::<Vec<_>>();
+
+        assert_eq!(stale_ids, vec!["wt-old".to_string()]);
+        Ok(())
+    }
+}

--- a/xtask/tests/fixtures/worktree-allocator/detached-no-conflict.json
+++ b/xtask/tests/fixtures/worktree-allocator/detached-no-conflict.json
@@ -1,0 +1,5 @@
+{
+  "worktrees_porcelain": "worktree /repo\nHEAD aaaaaaa\nbranch refs/heads/master\n\nworktree /repo/.claude/worktrees/wt-1\nHEAD bbbbbbb\ndetached\n\nworktree /repo/.claude/worktrees/wt-2\nHEAD ccccccc\nbranch refs/heads/pr-6854\n",
+  "target_branch": "pr-6853",
+  "expected_conflict": false
+}

--- a/xtask/tests/fixtures/worktree-allocator/duplicate-branch.json
+++ b/xtask/tests/fixtures/worktree-allocator/duplicate-branch.json
@@ -1,0 +1,5 @@
+{
+  "worktrees_porcelain": "worktree /repo\nHEAD aaaaaaa\nbranch refs/heads/master\n\nworktree /repo/.claude/worktrees/wt-1\nHEAD bbbbbbb\nbranch refs/heads/pr-6853\n\nworktree /repo/.claude/worktrees/wt-2\nHEAD ccccccc\nbranch refs/heads/pr-6853\n",
+  "target_branch": "pr-6853",
+  "expected_conflict": true
+}


### PR DESCRIPTION
### Motivation

- Refs #6853: local agent orchestration was creating colliding writable worktrees and lacked lease tracking and safe cleanup behavior.
- Provide a lease-backed allocator so agents only create writeable worktrees with an explicit lease and safe GC semantics.

### Description

- Added a new `xtask` module `worktree_allocator` implementing `acquire`, `release`, `list`, and stale-`gc` flows with persisted lease state at `.claude/worktree-allocator/leases.json` and receipt emission to `target/receipts/worktree-lease.json`.
- Enforced invariants: no writable branch checked out twice (`ensure_branch_available`), no nested agent worktrees (`ensure_not_nested`), and refuse destructive removal of dirty worktrees unless `--force` is used (`ensure_clean_or_force`).
- Exposed CLI surface under `cargo xtask agent worktree ...` with subcommands: `acquire --pr <N> --base <ref>`, `release --id <id> [--force]`, `list`, and `gc --stale [--apply] [--force]` (dry-run by default).
- Added schema and docs: `.ci/receipts/schemas/worktree-lease.schema.json` and `docs/ci/worktree-allocator.md`, plus fixture-backed unit tests under `xtask/tests/fixtures/worktree-allocator/` and wired the module into `xtask/src/tasks/mod.rs` and `xtask/src/main.rs`.

### Testing

- Ran `cargo fmt --all` and `cargo check -p xtask`, which completed successfully.
- Ran unit tests for the allocator via `cargo test -p xtask worktree_allocator::tests::` and all allocator tests passed (`detects_duplicate_writable_branch`, `allows_detached_duplicate_branch`, `stale_gc_dry_run_lists_without_deleting`).
- Executed `cargo xtask agent worktree gc --stale` which ran in dry-run mode and printed "No stale worktrees found" as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0b9185c833387864f3f104be9bc)