### PR TITLE
feat(agent): add worktree allocator for orchestration (#6853)

### DIFF
--- a/.ci/receipts/schemas/worktree-lease.schema.json
+++ b/.ci/receipts/schemas/worktree-lease.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/schemas/worktree-lease.schema.json",
+  "title": "Worktree Lease Receipt",
+  "type": "object",
+  "required": [
+    "worktree_id",
+    "path",
+    "agent_task_id",
+    "pr",
+    "branch",
+    "base_sha",
+    "owner",
+    "lease_expiry_epoch_secs",
+    "last_heartbeat_epoch_secs"
+  ],
+  "properties": {
+    "worktree_id": { "type": "string", "minLength": 1 },
+    "path": { "type": "string", "minLength": 1 },
+    "agent_task_id": { "type": "string", "minLength": 1 },
+    "pr": { "type": "integer", "minimum": 1 },
+    "branch": { "type": "string", "minLength": 1 },
+    "base_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,40}$"
+    },
+    "owner": { "type": "string", "minLength": 1 },
+    "lease_expiry_epoch_secs": { "type": "integer", "minimum": 0 },
+    "last_heartbeat_epoch_secs": { "type": "integer", "minimum": 0 }
+  },
+  "additionalProperties": false
+}

--- a/docs/ci/worktree-allocator.md
+++ b/docs/ci/worktree-allocator.md
@@ -1,0 +1,45 @@
+# Worktree allocator (local agent orchestration)
+
+The worktree allocator introduces an explicit lease model for local agent worktree creation and cleanup.
+
+## Commands
+
+- `cargo xtask agent worktree acquire --pr <N> --base origin/master`
+- `cargo xtask agent worktree release --id <id>`
+- `cargo xtask agent worktree list`
+- `cargo xtask agent worktree gc --stale`
+
+## State model
+
+Each lease tracks:
+
+- `worktree_id`
+- `path`
+- `agent_task_id`
+- `pr`
+- `branch`
+- `base_sha`
+- `owner`
+- `lease_expiry_epoch_secs`
+- `last_heartbeat_epoch_secs`
+
+State is persisted under `.claude/worktrees/allocator-state.json`.
+
+## Safety rules
+
+- The allocator will not lease the same writable branch twice.
+- Nested agent worktree paths are rejected.
+- `release` is explicit and lease-driven.
+- `gc` is dry-run by default; pass `--apply` to remove stale worktrees.
+- GC and release both print exact paths before deletion.
+- Worktrees with uncommitted changes are never deleted unless `--force` is set.
+
+## Receipts
+
+On successful acquisition, a receipt is written to:
+
+- `target/receipts/worktree-leases/<worktree_id>.json`
+
+The receipt schema is defined at:
+
+- `.ci/receipts/schemas/worktree-lease.schema.json`

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1097,6 +1097,12 @@ enum Commands {
     /// Remove stale `.claude/worktrees` entries and prune Git metadata.
     WorktreeCleanup,
 
+    /// Local agent orchestration helpers.
+    Agent {
+        #[command(subcommand)]
+        command: AgentCommand,
+    },
+
     /// Show summary statistics from swarm-metrics.jsonl.
     SwarmSummary {
         /// Path to operations directory (defaults to `.ops-perl-lsp`).
@@ -1216,6 +1222,48 @@ enum CpanCorpusCommand {
         /// Local install directory containing CPAN modules
         #[arg(long)]
         install_dir: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentCommand {
+    /// Manage leased agent worktrees.
+    Worktree {
+        #[command(subcommand)]
+        command: AgentWorktreeCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentWorktreeCommand {
+    /// Acquire a leased agent worktree.
+    Acquire {
+        #[arg(long)]
+        pr: u64,
+        #[arg(long, default_value = "origin/master")]
+        base: String,
+        #[arg(long, default_value = "local-agent")]
+        owner: String,
+        #[arg(long, default_value = "task-unknown")]
+        task: String,
+    },
+    /// Release a leased agent worktree by id.
+    Release {
+        #[arg(long)]
+        id: String,
+        #[arg(long)]
+        force: bool,
+    },
+    /// List active worktree leases.
+    List,
+    /// Garbage-collect stale leases.
+    Gc {
+        #[arg(long)]
+        stale: bool,
+        #[arg(long)]
+        apply: bool,
+        #[arg(long)]
+        force: bool,
     },
 }
 
@@ -1674,6 +1722,20 @@ fn main() -> Result<()> {
             Ok(())
         }
         Commands::WorktreeCleanup => worktrees::cleanup(),
+        Commands::Agent { command } => match command {
+            AgentCommand::Worktree { command } => match command {
+                AgentWorktreeCommand::Acquire { pr, base, owner, task } => {
+                    worktree_allocator::acquire(pr, base, owner, task)
+                }
+                AgentWorktreeCommand::Release { id, force } => {
+                    worktree_allocator::release(id, force)
+                }
+                AgentWorktreeCommand::List => worktree_allocator::list(),
+                AgentWorktreeCommand::Gc { stale, apply, force } => {
+                    worktree_allocator::gc(stale, apply, force)
+                }
+            },
+        },
         Commands::SwarmSummary { ops_dir, since, limit, format } => {
             swarm_summary::run(swarm_summary::SwarmSummaryConfig { ops_dir, since, limit, format })
         }

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -73,4 +73,5 @@ pub mod update_homebrew;
 pub mod update_status;
 pub mod ux_scorecard;
 pub mod validate_workspace_exclusions;
+pub mod worktree_allocator;
 pub mod worktrees;

--- a/xtask/src/tasks/worktree_allocator.rs
+++ b/xtask/src/tasks/worktree_allocator.rs
@@ -1,0 +1,308 @@
+//! Agent worktree allocator with lease tracking.
+
+use crate::utils::project_root;
+use color_eyre::eyre::{Context, Result, bail, eyre};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const DEFAULT_TTL_SECS: u64 = 4 * 60 * 60;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorktreeLease {
+    pub worktree_id: String,
+    pub path: PathBuf,
+    pub agent_task_id: String,
+    pub pr: u64,
+    pub branch: String,
+    pub base_sha: String,
+    pub owner: String,
+    pub lease_expiry_epoch_secs: u64,
+    pub last_heartbeat_epoch_secs: u64,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct AllocatorState {
+    leases: Vec<WorktreeLease>,
+}
+
+pub fn acquire(pr: u64, base: String, owner: String, agent_task_id: String) -> Result<()> {
+    let root = project_root()?;
+    let mut state = load_state(&root)?;
+    let worktrees_dir = root.join(".claude").join("worktrees");
+    fs::create_dir_all(&worktrees_dir)
+        .with_context(|| format!("creating {}", worktrees_dir.display()))?;
+
+    let now = now_secs()?;
+    let worktree_id = format!("wt-{}-{}", pr, now);
+    let branch = format!("agent/pr-{pr}-{now}");
+    ensure_branch_is_not_leased(&state, &branch)?;
+
+    let path = worktrees_dir.join(format!("agent-pr-{pr}-{now}"));
+    ensure_not_nested_with_existing(&state, &path)?;
+
+    let base_sha = git_output(&root, ["rev-parse", &base])?;
+
+    let status = Command::new("git")
+        .current_dir(&root)
+        .args(["worktree", "add", "-b", &branch, &path.display().to_string(), &base])
+        .status()
+        .context("running git worktree add")?;
+    if !status.success() {
+        bail!("failed to create worktree at {}", path.display());
+    }
+
+    let lease = WorktreeLease {
+        worktree_id: worktree_id.clone(),
+        path: path.clone(),
+        agent_task_id,
+        pr,
+        branch,
+        base_sha,
+        owner,
+        lease_expiry_epoch_secs: now + DEFAULT_TTL_SECS,
+        last_heartbeat_epoch_secs: now,
+    };
+
+    state.leases.push(lease.clone());
+    save_state(&root, &state)?;
+    write_receipt(&root, &lease)?;
+
+    println!("acquired worktree lease {}", lease.worktree_id);
+    println!("path: {}", path.display());
+    println!("branch: {}", lease.branch);
+    println!("base_sha: {}", lease.base_sha);
+    Ok(())
+}
+
+pub fn release(worktree_id: String, force: bool) -> Result<()> {
+    let root = project_root()?;
+    let mut state = load_state(&root)?;
+    let Some(index) = state.leases.iter().position(|lease| lease.worktree_id == worktree_id) else {
+        bail!("unknown worktree lease id");
+    };
+    let lease = state.leases[index].clone();
+
+    if !force && has_uncommitted_changes(&lease.path)? {
+        bail!(
+            "refusing to remove {} with uncommitted changes (pass --force to override)",
+            lease.path.display()
+        );
+    }
+
+    println!("removing worktree path: {}", lease.path.display());
+    let mut args = vec!["worktree".to_string(), "remove".to_string()];
+    if force {
+        args.push("--force".to_string());
+    }
+    args.push(lease.path.to_string_lossy().into_owned());
+
+    let status = Command::new("git").current_dir(&root).args(&args).status()?;
+    if !status.success() {
+        bail!("git worktree remove failed for {}", lease.path.display());
+    }
+
+    state.leases.remove(index);
+    save_state(&root, &state)?;
+    println!("released worktree lease {}", lease.worktree_id);
+    Ok(())
+}
+
+pub fn list() -> Result<()> {
+    let root = project_root()?;
+    let state = load_state(&root)?;
+    if state.leases.is_empty() {
+        println!("no active worktree leases");
+        return Ok(());
+    }
+
+    for lease in &state.leases {
+        println!(
+            "{}\t{}\t{}\t{}\t{}",
+            lease.worktree_id,
+            lease.pr,
+            lease.branch,
+            lease.owner,
+            lease.path.display()
+        );
+    }
+    Ok(())
+}
+
+pub fn gc(stale_only: bool, apply: bool, force: bool) -> Result<()> {
+    let root = project_root()?;
+    let mut state = load_state(&root)?;
+    let now = now_secs()?;
+
+    let stale = state
+        .leases
+        .iter()
+        .filter(|lease| !stale_only || lease.lease_expiry_epoch_secs <= now)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    if stale.is_empty() {
+        println!("no stale leased worktrees found");
+        return Ok(());
+    }
+
+    println!("stale lease candidates:");
+    for lease in &stale {
+        println!("- {} ({})", lease.worktree_id, lease.path.display());
+    }
+
+    if !apply {
+        println!("dry-run mode (no deletion performed). pass --apply to remove.");
+        return Ok(());
+    }
+
+    let ids: HashSet<&str> = stale.iter().map(|lease| lease.worktree_id.as_str()).collect();
+    for lease in &stale {
+        if !force && has_uncommitted_changes(&lease.path)? {
+            println!("skipping {} due to uncommitted changes (use --force)", lease.path.display());
+            continue;
+        }
+        println!("removing stale worktree path: {}", lease.path.display());
+        let mut args = vec!["worktree".to_string(), "remove".to_string()];
+        if force {
+            args.push("--force".to_string());
+        }
+        args.push(lease.path.to_string_lossy().into_owned());
+        let status = Command::new("git").current_dir(&root).args(&args).status()?;
+        if !status.success() {
+            bail!("git worktree remove failed for {}", lease.path.display());
+        }
+    }
+
+    state.leases.retain(|lease| !ids.contains(lease.worktree_id.as_str()));
+    save_state(&root, &state)?;
+    Ok(())
+}
+
+fn write_receipt(root: &Path, lease: &WorktreeLease) -> Result<()> {
+    let dir = root.join("target").join("receipts").join("worktree-leases");
+    fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+    let receipt = serde_json::to_string_pretty(lease)?;
+    fs::write(dir.join(format!("{}.json", lease.worktree_id)), receipt)?;
+    Ok(())
+}
+
+fn ensure_branch_is_not_leased(state: &AllocatorState, branch: &str) -> Result<()> {
+    if state.leases.iter().any(|lease| lease.branch == branch) {
+        bail!("branch {branch} is already leased as writable");
+    }
+    Ok(())
+}
+
+fn ensure_not_nested_with_existing(state: &AllocatorState, candidate: &Path) -> Result<()> {
+    let candidate = normalize(candidate);
+    for lease in &state.leases {
+        let existing = normalize(&lease.path);
+        if candidate.starts_with(&existing) || existing.starts_with(&candidate) {
+            bail!(
+                "nested worktree paths are not allowed: candidate={} existing={}",
+                candidate.display(),
+                existing.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn has_uncommitted_changes(path: &Path) -> Result<bool> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["status", "--porcelain"])
+        .output()
+        .with_context(|| format!("checking git status in {}", path.display()))?;
+    if !output.status.success() {
+        bail!("git status failed in {}", path.display());
+    }
+    Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
+}
+
+fn git_output<const N: usize>(root: &Path, args: [&str; N]) -> Result<String> {
+    let output = Command::new("git").current_dir(root).args(args).output()?;
+    if !output.status.success() {
+        return Err(eyre!("git command failed"));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn state_path(root: &Path) -> PathBuf {
+    root.join(".claude").join("worktrees").join("allocator-state.json")
+}
+
+fn load_state(root: &Path) -> Result<AllocatorState> {
+    let path = state_path(root);
+    if !path.exists() {
+        return Ok(AllocatorState::default());
+    }
+    let text = fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    Ok(serde_json::from_str(&text).with_context(|| format!("parsing {}", path.display()))?)
+}
+
+fn save_state(root: &Path, state: &AllocatorState) -> Result<()> {
+    let path = state_path(root);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let text = serde_json::to_string_pretty(state)?;
+    fs::write(&path, text).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+fn normalize(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        normalized.push(component);
+    }
+    normalized
+}
+
+fn now_secs() -> Result<u64> {
+    Ok(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duplicate_branch_is_rejected() -> Result<()> {
+        let fixture = include_str!("../../tests/fixtures/worktree-allocator/duplicate-branch.json");
+        let state: AllocatorState = serde_json::from_str(fixture)?;
+        let err = ensure_branch_is_not_leased(&state, "agent/pr-6853-123").expect_err("must fail");
+        assert!(err.to_string().contains("already leased"));
+        Ok(())
+    }
+
+    #[test]
+    fn nested_path_is_rejected() -> Result<()> {
+        let fixture = include_str!("../../tests/fixtures/worktree-allocator/nested-worktree.json");
+        let state: AllocatorState = serde_json::from_str(fixture)?;
+        let candidate = PathBuf::from("/repo/.claude/worktrees/agent-pr-6853-200/subdir");
+        let err = ensure_not_nested_with_existing(&state, &candidate).expect_err("must fail");
+        assert!(err.to_string().contains("nested worktree"));
+        Ok(())
+    }
+
+    #[test]
+    fn stale_filter_selects_expired_entries() -> Result<()> {
+        let fixture = include_str!("../../tests/fixtures/worktree-allocator/stale-leases.json");
+        let state: AllocatorState = serde_json::from_str(fixture)?;
+        let now = 1_700_000_000_u64;
+        let stale = state
+            .leases
+            .iter()
+            .filter(|lease| lease.lease_expiry_epoch_secs <= now)
+            .collect::<Vec<_>>();
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].worktree_id, "wt-stale");
+        Ok(())
+    }
+}

--- a/xtask/tests/fixtures/worktree-allocator/duplicate-branch.json
+++ b/xtask/tests/fixtures/worktree-allocator/duplicate-branch.json
@@ -1,0 +1,15 @@
+{
+  "leases": [
+    {
+      "worktree_id": "wt-existing",
+      "path": "/repo/.claude/worktrees/agent-pr-6853-123",
+      "agent_task_id": "task-a",
+      "pr": 6853,
+      "branch": "agent/pr-6853-123",
+      "base_sha": "1234567890abcdef1234567890abcdef12345678",
+      "owner": "agent-a",
+      "lease_expiry_epoch_secs": 1700001000,
+      "last_heartbeat_epoch_secs": 1700000000
+    }
+  ]
+}

--- a/xtask/tests/fixtures/worktree-allocator/nested-worktree.json
+++ b/xtask/tests/fixtures/worktree-allocator/nested-worktree.json
@@ -1,0 +1,15 @@
+{
+  "leases": [
+    {
+      "worktree_id": "wt-parent",
+      "path": "/repo/.claude/worktrees/agent-pr-6853-200",
+      "agent_task_id": "task-b",
+      "pr": 6853,
+      "branch": "agent/pr-6853-200",
+      "base_sha": "abcdefabcdefabcdefabcdefabcdefabcdefabcd",
+      "owner": "agent-b",
+      "lease_expiry_epoch_secs": 1700001000,
+      "last_heartbeat_epoch_secs": 1700000000
+    }
+  ]
+}

--- a/xtask/tests/fixtures/worktree-allocator/stale-leases.json
+++ b/xtask/tests/fixtures/worktree-allocator/stale-leases.json
@@ -1,0 +1,26 @@
+{
+  "leases": [
+    {
+      "worktree_id": "wt-stale",
+      "path": "/repo/.claude/worktrees/agent-pr-6853-300",
+      "agent_task_id": "task-c",
+      "pr": 6853,
+      "branch": "agent/pr-6853-300",
+      "base_sha": "abcdefabcdefabcdefabcdefabcdefabcdefabcd",
+      "owner": "agent-c",
+      "lease_expiry_epoch_secs": 1699999999,
+      "last_heartbeat_epoch_secs": 1699990000
+    },
+    {
+      "worktree_id": "wt-fresh",
+      "path": "/repo/.claude/worktrees/agent-pr-6853-301",
+      "agent_task_id": "task-d",
+      "pr": 6853,
+      "branch": "agent/pr-6853-301",
+      "base_sha": "1234567890abcdef1234567890abcdef12345678",
+      "owner": "agent-d",
+      "lease_expiry_epoch_secs": 1700009999,
+      "last_heartbeat_epoch_secs": 1700005000
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Local orchestration could create conflicting writable Git worktrees (including nested worktrees) when agents raw-create worktrees, leading to collisions and contamination.

### Description

- Add a lease-backed worktree allocator implemented in `xtask/src/tasks/worktree_allocator.rs` exposing `acquire`, `release`, `list`, and `gc` operations and persisting state to `.claude/worktrees/allocator-state.json` with acquisition receipts written to `target/receipts/worktree-leases/<worktree_id>.json`.
- Wire new CLI commands under `cargo xtask agent worktree ...` by adding `Agent`/`AgentWorktreeCommand` to `xtask/src/main.rs` and register the module in `xtask/src/tasks/mod.rs`.
- Add a JSON schema for receipts at `.ci/receipts/schemas/worktree-lease.schema.json`, operator docs at `docs/ci/worktree-allocator.md`, and fixture inputs at `xtask/tests/fixtures/worktree-allocator/*.json`.
- Enforce safety rules: prevent leasing the same writable branch twice, reject nested agent worktree paths, require explicit `release`, default `gc` to dry-run (use `--apply` to remove), and refuse deletion of worktrees with uncommitted changes unless `--force` is passed.

### Testing

- Ran `cargo check -p xtask` which completed successfully.
- Ran unit/fixture tests with `cargo test -p xtask worktree_allocator::tests -- --nocapture` and all allocator tests passed (duplicate-branch, nested-path, stale-filter).
- Ran `cargo xtask fmt` to format xtask changes successfully.
- Ran a dry-run validation `cargo xtask agent worktree gc --stale` which listed stale lease candidates and did not delete them (dry-run behavior verified).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0b9185c833387864f3f104be9bc)