### PR TITLE
feat(queue): add GREEN/PENDING/RED health modes (#6853)

### DIFF
--- a/.ci/receipts/schemas/queue-health.schema.json
+++ b/.ci/receipts/schemas/queue-health.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/schemas/queue-health.schema.json",
+  "title": "Queue health receipt",
+  "type": "object",
+  "required": [
+    "master_sha",
+    "mode",
+    "allowed_lanes",
+    "blocked_lanes",
+    "reasons",
+    "verdict"
+  ],
+  "properties": {
+    "master_sha": {
+      "type": "string",
+      "minLength": 7
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["GREEN", "PENDING", "RED"]
+    },
+    "allowed_lanes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "blocked_lanes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "reasons": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "verdict": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/ci/queue-health-modes.md
+++ b/docs/ci/queue-health-modes.md
@@ -1,0 +1,61 @@
+# Queue health modes
+
+`cargo xtask queue health` computes a queue-health receipt so orchestration can gate merge behavior without mutating labels or workflows.
+
+## Commands
+
+```bash
+cargo xtask queue health --receipt target/receipts/queue-health.json
+cargo xtask queue health --fixture xtask/tests/fixtures/queue-health/master-green.json
+```
+
+## Mode definitions
+
+### GREEN
+
+- merge drain allowed
+- cascade update allowed
+- green-ci promotion allowed
+
+### PENDING
+
+- read-only review/design allowed
+- no merge-ready promotion unless candidate current
+- no broad cascade final labels
+
+### RED
+
+- freeze merge drain
+- classify shared blocker
+- allow master-fix and read-only review only
+
+## Input model
+
+The task accepts these inputs through a fixture JSON (`--fixture`) and falls back to conservative local defaults when no fixture is supplied:
+
+- latest master CI state (`master_ci_state`: `green|pending|red`)
+- pending/running checks (`pending_checks`, `running_checks`)
+- failure classifier (`failure_classifier`) when available
+- ruleset/gate policy (`gate_policy`) when available
+
+## Receipt fields
+
+Output receipt shape:
+
+- `master_sha`
+- `mode`
+- `allowed_lanes`
+- `blocked_lanes`
+- `reasons`
+- `verdict`
+
+Schema: `.ci/receipts/schemas/queue-health.schema.json`.
+
+## Non-goals
+
+This command is intentionally read-only. It does **not**:
+
+- mutate labels
+- merge PRs
+- cancel workflows
+- dispatch agents directly

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1152,6 +1152,12 @@ enum Commands {
         /// Current receipt JSON path.
         current: PathBuf,
     },
+
+    /// Queue orchestration and health gates.
+    Queue {
+        #[command(subcommand)]
+        command: QueueCommand,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1300,6 +1306,20 @@ enum MetricsCommand {
         /// `target/receipts/system-corpus-sweep.json`.
         #[arg(long)]
         input: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
+enum QueueCommand {
+    /// Evaluate queue health and emit a GREEN/PENDING/RED receipt.
+    Health {
+        /// Optional path to write queue health receipt JSON.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+
+        /// Optional JSON fixture path used as queue input.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
     },
 }
 
@@ -1686,6 +1706,11 @@ fn main() -> Result<()> {
         Commands::CompareBuildTiming { baseline, current } => {
             build_timing::run_compare(baseline, current)
         }
+        Commands::Queue { command } => match command {
+            QueueCommand::Health { receipt, fixture } => {
+                queue_health::run(queue_health::QueueHealthConfig { receipt, fixture })
+            }
+        },
     }
 }
 

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -59,6 +59,7 @@ pub mod publish;
 pub mod publish_closure;
 pub mod publish_manifest_check;
 pub mod publish_receipts;
+pub mod queue_health;
 pub mod receipts;
 pub mod release;
 pub mod release_notes;

--- a/xtask/src/tasks/queue_health.rs
+++ b/xtask/src/tasks/queue_health.rs
@@ -1,0 +1,207 @@
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::utils::project_root;
+
+#[derive(Debug, Clone)]
+pub struct QueueHealthConfig {
+    pub receipt: Option<PathBuf>,
+    pub fixture: Option<PathBuf>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum MasterCiState {
+    Green,
+    Pending,
+    Red,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct FailureClassifier {
+    #[serde(default)]
+    shared_blocker: bool,
+    #[serde(default)]
+    category: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct GatePolicy {
+    #[serde(default)]
+    candidate_current: bool,
+    #[serde(default)]
+    policy_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct QueueHealthInput {
+    master_sha: Option<String>,
+    master_ci_state: Option<MasterCiState>,
+    #[serde(default)]
+    pending_checks: usize,
+    #[serde(default)]
+    running_checks: usize,
+    #[serde(default)]
+    failure_classifier: Option<FailureClassifier>,
+    #[serde(default)]
+    gate_policy: Option<GatePolicy>,
+    #[serde(default)]
+    expected_mode: Option<QueueMode>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum QueueMode {
+    Green,
+    Pending,
+    Red,
+}
+
+#[derive(Debug, Serialize)]
+struct QueueHealthReceipt {
+    master_sha: String,
+    mode: QueueMode,
+    allowed_lanes: Vec<String>,
+    blocked_lanes: Vec<String>,
+    reasons: Vec<String>,
+    verdict: String,
+}
+
+pub fn run(config: QueueHealthConfig) -> Result<()> {
+    let input = load_input(config.fixture.as_deref())?;
+    let receipt = evaluate(&input)?;
+
+    if let Some(expected_mode) = input.expected_mode
+        && expected_mode != receipt.mode
+    {
+        bail!("fixture expected mode {:?}, got {:?}", expected_mode, receipt.mode);
+    }
+
+    let json = serde_json::to_string_pretty(&receipt).context("serialize queue health receipt")?;
+
+    if let Some(receipt_path) = config.receipt {
+        if let Some(parent) = receipt_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create receipt dir {}", parent.display()))?;
+        }
+        fs::write(&receipt_path, format!("{json}\n"))
+            .with_context(|| format!("write receipt {}", receipt_path.display()))?;
+        println!("queue-health receipt: {}", receipt_path.display());
+    }
+
+    println!("{json}");
+    Ok(())
+}
+
+fn load_input(fixture: Option<&Path>) -> Result<QueueHealthInput> {
+    if let Some(path) = fixture {
+        let body = fs::read_to_string(path)
+            .with_context(|| format!("read queue health fixture {}", path.display()))?;
+        let input: QueueHealthInput = serde_json::from_str(&body)
+            .with_context(|| format!("parse fixture {}", path.display()))?;
+        return Ok(input);
+    }
+
+    let root = project_root()?;
+    let master_sha = resolve_head_sha(&root)?;
+
+    Ok(QueueHealthInput {
+        master_sha: Some(master_sha),
+        master_ci_state: Some(MasterCiState::Pending),
+        pending_checks: 0,
+        running_checks: 0,
+        failure_classifier: None,
+        gate_policy: None,
+        expected_mode: None,
+    })
+}
+
+fn resolve_head_sha(root: &Path) -> Result<String> {
+    let output = std::process::Command::new("git")
+        .arg("rev-parse")
+        .arg("HEAD")
+        .current_dir(root)
+        .output()
+        .context("run git rev-parse HEAD")?;
+
+    if !output.status.success() {
+        bail!("git rev-parse HEAD failed with status {}", output.status);
+    }
+
+    let sha = String::from_utf8(output.stdout).context("decode git rev-parse output")?;
+    Ok(sha.trim().to_string())
+}
+
+fn evaluate(input: &QueueHealthInput) -> Result<QueueHealthReceipt> {
+    let mode = determine_mode(input);
+    let master_sha = input
+        .master_sha
+        .clone()
+        .ok_or_else(|| color_eyre::eyre::eyre!("master_sha is required"))?;
+
+    let mut reasons = Vec::new();
+    reasons.push(format!("master_sha={master_sha}"));
+    reasons.push(format!("pending_checks={}", input.pending_checks));
+    reasons.push(format!("running_checks={}", input.running_checks));
+
+    if let Some(policy) = &input.gate_policy {
+        if let Some(policy_name) = &policy.policy_name {
+            reasons.push(format!("gate_policy={policy_name}"));
+        }
+        reasons.push(format!("candidate_current={}", policy.candidate_current));
+    }
+
+    if let Some(classifier) = &input.failure_classifier {
+        reasons.push(format!("shared_blocker={}", classifier.shared_blocker));
+        if let Some(category) = &classifier.category {
+            reasons.push(format!("failure_category={category}"));
+        }
+    }
+
+    let (allowed_lanes, blocked_lanes, verdict) = match mode {
+        QueueMode::Green => (
+            vec![
+                "merge-drain".to_string(),
+                "cascade-update".to_string(),
+                "green-ci-promotion".to_string(),
+                "review-only".to_string(),
+            ],
+            Vec::new(),
+            "safe-to-merge".to_string(),
+        ),
+        QueueMode::Pending => (
+            vec!["review-only".to_string(), "design".to_string()],
+            vec![
+                "merge-drain".to_string(),
+                "broad-cascade-final-labels".to_string(),
+                "merge-ready-promotion-when-candidate-stale".to_string(),
+            ],
+            "review-only-until-master-current".to_string(),
+        ),
+        QueueMode::Red => (
+            vec!["master-fix".to_string(), "review-only".to_string()],
+            vec![
+                "merge-drain".to_string(),
+                "cascade-update".to_string(),
+                "green-ci-promotion".to_string(),
+            ],
+            "freeze-merge-drain-classify-shared-blocker".to_string(),
+        ),
+    };
+
+    Ok(QueueHealthReceipt { master_sha, mode, allowed_lanes, blocked_lanes, reasons, verdict })
+}
+
+fn determine_mode(input: &QueueHealthInput) -> QueueMode {
+    if input.pending_checks > 0 || input.running_checks > 0 {
+        return QueueMode::Pending;
+    }
+
+    match input.master_ci_state {
+        Some(MasterCiState::Green) => QueueMode::Green,
+        Some(MasterCiState::Pending) | None => QueueMode::Pending,
+        Some(MasterCiState::Red) => QueueMode::Red,
+    }
+}

--- a/xtask/tests/fixtures/queue-health/master-green.json
+++ b/xtask/tests/fixtures/queue-health/master-green.json
@@ -1,0 +1,11 @@
+{
+  "master_sha": "1111111green",
+  "master_ci_state": "green",
+  "pending_checks": 0,
+  "running_checks": 0,
+  "gate_policy": {
+    "candidate_current": true,
+    "policy_name": "default"
+  },
+  "expected_mode": "GREEN"
+}

--- a/xtask/tests/fixtures/queue-health/master-pending.json
+++ b/xtask/tests/fixtures/queue-health/master-pending.json
@@ -1,0 +1,11 @@
+{
+  "master_sha": "2222222pending",
+  "master_ci_state": "pending",
+  "pending_checks": 2,
+  "running_checks": 1,
+  "gate_policy": {
+    "candidate_current": false,
+    "policy_name": "default"
+  },
+  "expected_mode": "PENDING"
+}

--- a/xtask/tests/fixtures/queue-health/master-red.json
+++ b/xtask/tests/fixtures/queue-health/master-red.json
@@ -1,0 +1,15 @@
+{
+  "master_sha": "3333333red",
+  "master_ci_state": "red",
+  "pending_checks": 0,
+  "running_checks": 0,
+  "failure_classifier": {
+    "shared_blocker": true,
+    "category": "master-regression"
+  },
+  "gate_policy": {
+    "candidate_current": false,
+    "policy_name": "default"
+  },
+  "expected_mode": "RED"
+}


### PR DESCRIPTION
### Motivation

- Provide an explicit queue-health model (GREEN / PENDING / RED) so orchestration can decide whether merge-drain, promotions, and cascade updates are safe without mutating labels or workflows.
- Prevent stale-state mutations during master pending/red states by surfacing a read-only receipt that downstream systems can consume.

### Description

- Added a new xtask command `cargo xtask queue health` implemented in `xtask/src/tasks/queue_health.rs` that evaluates inputs into `GREEN`, `PENDING`, or `RED` and emits a JSON receipt with `master_sha`, `mode`, `allowed_lanes`, `blocked_lanes`, `reasons`, and `verdict`.
- Wired CLI support and dispatch for the nested `queue health` command in `xtask/src/main.rs`, and exported the task module in `xtask/src/tasks/mod.rs`.
- Added a JSON Schema for the receipt at `.ci/receipts/schemas/queue-health.schema.json` and written docs describing modes, inputs, receipt shape, and non-goals at `docs/ci/queue-health-modes.md`.
- Added fixtures under `xtask/tests/fixtures/queue-health/` covering `master-green.json`, `master-pending.json`, and `master-red.json`; the task accepts `--fixture <json>` or `--receipt <path>` and validates `expected_mode` in fixtures.

### Testing

- Ran `cargo xtask queue health --fixture xtask/tests/fixtures/queue-health/master-green.json` and it produced a `GREEN` receipt (success).
- Ran `cargo xtask queue health --fixture xtask/tests/fixtures/queue-health/master-pending.json` and it produced a `PENDING` receipt (success).
- Ran `cargo xtask queue health --fixture xtask/tests/fixtures/queue-health/master-red.json` and it produced a `RED` receipt (success).
- Ran `cargo xtask queue health --receipt target/receipts/queue-health.json` which wrote the receipt to `target/receipts/queue-health.json` (success).
- Ran `cargo check --all-targets -p xtask`, `cargo clippy -p xtask`, and `cargo xtask fmt` and they completed successfully; `just pr-fast` was not available in the environment so it was not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0c712e08333b6b5e41a776d080f)