### PR TITLE
feat(queue): add GREEN/PENDING/RED health modes (#6853)

### DIFF
--- a/.ci/receipts/schemas/queue-health.schema.json
+++ b/.ci/receipts/schemas/queue-health.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/queue-health.schema.json",
+  "title": "Queue Health Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "master_sha",
+    "mode",
+    "allowed_lanes",
+    "blocked_lanes",
+    "reasons",
+    "verdict"
+  ],
+  "properties": {
+    "master_sha": {
+      "type": "string",
+      "minLength": 7
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["GREEN", "PENDING", "RED"]
+    },
+    "allowed_lanes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "blocked_lanes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "reasons": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "verdict": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -464,9 +464,9 @@ impl SymbolExtractor {
                 FrameworkKind::Moo | FrameworkKind::Moose | FrameworkKind::RoleTinyWith => {
                     SymbolKind::Class
                 }
-                FrameworkKind::MooRole
-                | FrameworkKind::MooseRole
-                | FrameworkKind::RoleTiny => SymbolKind::Role,
+                FrameworkKind::MooRole | FrameworkKind::MooseRole | FrameworkKind::RoleTiny => {
+                    SymbolKind::Role
+                }
             };
             if let Some(symbols) = self.table.symbols.get_mut(pkg_name) {
                 for symbol in symbols.iter_mut() {

--- a/docs/ci/queue-health-modes.md
+++ b/docs/ci/queue-health-modes.md
@@ -1,0 +1,52 @@
+# Queue Health Modes
+
+`cargo xtask queue health` classifies master queue safety for orchestrator actions without mutating labels, merging PRs, cancelling workflows, or dispatching agents.
+
+## Commands
+
+```bash
+cargo xtask queue health --receipt target/receipts/queue-health.json --fixture xtask/tests/fixtures/queue-health/master-green.json
+cargo xtask queue health --fixture xtask/tests/fixtures/queue-health/master-pending.json
+cargo xtask queue health --fixture xtask/tests/fixtures/queue-health/master-red.json
+```
+
+## Modes
+
+- **GREEN**
+  - Merge drain allowed
+  - Cascade update allowed
+  - Green-CI promotion allowed
+- **PENDING**
+  - Read-only review/design allowed
+  - No merge-ready promotion unless candidate is current
+  - No broad cascade final labels
+- **RED**
+  - Freeze merge drain
+  - Classify shared blocker
+  - Allow master-fix and read-only review only
+
+## Receipt fields
+
+Written JSON includes:
+
+- `master_sha`
+- `mode`
+- `allowed_lanes`
+- `blocked_lanes`
+- `reasons`
+- `verdict`
+
+Schema: `.ci/receipts/schemas/queue-health.schema.json`.
+
+## Input fixture shape
+
+The fixture JSON accepts:
+
+- `master_sha`
+- `ci_state` (`green`, `pending`, `red`)
+- `pending_checks` (array)
+- `running_checks` (array)
+- `failed_checks` (array)
+- `failure_classifier.shared_blocker` (optional)
+- `failure_classifier.summary` (optional)
+- `gate_policy.pending_allows_merge_ready_if_candidate_current` (optional)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1600,7 +1600,6 @@ enum AgentReceiptCommand {
     },
 }
 
-
 #[derive(ValueEnum, Clone)]
 enum PrepCratesMode {
     Core,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1536,6 +1536,17 @@ enum QueueCommand {
         #[arg(long)]
         fixture: Option<PathBuf>,
     },
+
+    /// Classify master queue health into GREEN/PENDING/RED modes.
+    Health {
+        /// Output path for queue-health receipt JSON.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+
+        /// Fixture JSON input for deterministic health classification.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1589,6 +1600,7 @@ enum AgentReceiptCommand {
     },
 }
 
+
 #[derive(ValueEnum, Clone)]
 enum PrepCratesMode {
     Core,
@@ -1616,6 +1628,9 @@ fn main() -> Result<()> {
         Commands::CheckToolchain { doctor } => check_toolchain::run(doctor),
         Commands::Queue { command } => match command {
             QueueCommand::Snapshot { out, fixture } => queue_snapshot::run_snapshot(out, fixture),
+            QueueCommand::Health { receipt, fixture } => {
+                queue_health::run(queue_health::QueueHealthArgs { receipt, fixture })
+            }
         },
         Commands::Build { release, features, c_scanner, rust_scanner } => {
             build::run(release, features, c_scanner, rust_scanner)

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -67,6 +67,7 @@ pub mod publish;
 pub mod publish_closure;
 pub mod publish_manifest_check;
 pub mod publish_receipts;
+pub mod queue_health;
 pub mod queue_snapshot;
 pub mod receipts;
 pub mod release;

--- a/xtask/src/tasks/queue_health.rs
+++ b/xtask/src/tasks/queue_health.rs
@@ -1,0 +1,276 @@
+//! Queue health classifier for orchestrator merge safety.
+//!
+//! Computes one of three queue health modes:
+//! - GREEN: merge/cascade/promotion lanes are open.
+//! - PENDING: read-only review/design lanes only while master checks settle.
+//! - RED: merge drain frozen; only master-fix and read-only review lanes remain.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_RECEIPT_PATH: &str = "target/receipts/queue-health.json";
+const DEFAULT_INPUT_PATH: &str = "target/receipts/master-ci-state.json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum QueueMode {
+    Green,
+    Pending,
+    Red,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueueHealthReceipt {
+    pub master_sha: String,
+    pub mode: QueueMode,
+    pub allowed_lanes: Vec<String>,
+    pub blocked_lanes: Vec<String>,
+    pub reasons: Vec<String>,
+    pub verdict: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct QueueHealthInput {
+    pub master_sha: String,
+    #[serde(default)]
+    pub ci_state: Option<String>,
+    #[serde(default)]
+    pub pending_checks: Vec<String>,
+    #[serde(default)]
+    pub running_checks: Vec<String>,
+    #[serde(default)]
+    pub failed_checks: Vec<String>,
+    #[serde(default)]
+    pub failure_classifier: Option<FailureClassifier>,
+    #[serde(default)]
+    pub gate_policy: Option<GatePolicy>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FailureClassifier {
+    #[serde(default)]
+    pub shared_blocker: bool,
+    #[serde(default)]
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GatePolicy {
+    #[serde(default)]
+    pub pending_allows_merge_ready_if_candidate_current: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueueHealthArgs {
+    pub receipt: Option<PathBuf>,
+    pub fixture: Option<PathBuf>,
+}
+
+pub fn run(args: QueueHealthArgs) -> Result<()> {
+    let input = load_input(args.fixture.as_deref())?;
+    let receipt = classify(&input);
+
+    let out = serde_json::to_string_pretty(&receipt)?;
+    let receipt_path = args.receipt.unwrap_or_else(|| PathBuf::from(DEFAULT_RECEIPT_PATH));
+
+    if let Some(parent) = receipt_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create parent dir: {}", parent.display()))?;
+    }
+    fs::write(&receipt_path, format!("{out}\n"))
+        .with_context(|| format!("failed writing receipt to {}", receipt_path.display()))?;
+
+    println!("{}", receipt.mode_as_str());
+    println!("wrote {}", receipt_path.display());
+
+    Ok(())
+}
+
+fn load_input(fixture: Option<&Path>) -> Result<QueueHealthInput> {
+    let input_path =
+        fixture.map(PathBuf::from).unwrap_or_else(|| PathBuf::from(DEFAULT_INPUT_PATH));
+    if fixture.is_none() && !input_path.exists() {
+        bail!(
+            "missing default input {} (pass --fixture <json> to classify from a fixture)",
+            input_path.display()
+        );
+    }
+
+    let raw = fs::read_to_string(&input_path)
+        .with_context(|| format!("failed to read input {}", input_path.display()))?;
+    let input: QueueHealthInput = serde_json::from_str(&raw)
+        .with_context(|| format!("invalid queue-health input {}", input_path.display()))?;
+    Ok(input)
+}
+
+pub fn classify(input: &QueueHealthInput) -> QueueHealthReceipt {
+    let mut reasons = Vec::new();
+
+    let state = input
+        .ci_state
+        .as_deref()
+        .map(|value| value.to_ascii_lowercase())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    if !input.pending_checks.is_empty() {
+        reasons.push(format!("{} pending check(s)", input.pending_checks.len()));
+    }
+    if !input.running_checks.is_empty() {
+        reasons.push(format!("{} running check(s)", input.running_checks.len()));
+    }
+    if !input.failed_checks.is_empty() {
+        reasons.push(format!("{} failed check(s)", input.failed_checks.len()));
+    }
+
+    if let Some(classifier) = &input.failure_classifier {
+        if classifier.shared_blocker {
+            reasons.push("failure classifier marked shared blocker".to_string());
+        }
+        if let Some(summary) = &classifier.summary {
+            reasons.push(format!("failure summary: {summary}"));
+        }
+    }
+
+    let has_pending = !input.pending_checks.is_empty() || !input.running_checks.is_empty();
+    let has_failures = !input.failed_checks.is_empty();
+    let shared_blocker = input.failure_classifier.as_ref().is_some_and(|c| c.shared_blocker);
+
+    let mode = if state == "red" || has_failures || shared_blocker {
+        QueueMode::Red
+    } else if state == "pending" || has_pending {
+        QueueMode::Pending
+    } else {
+        QueueMode::Green
+    };
+
+    if reasons.is_empty() {
+        reasons.push("master CI reported fully settled".to_string());
+    }
+
+    let (allowed_lanes, blocked_lanes, verdict) = build_policy(mode, input.gate_policy.as_ref());
+
+    QueueHealthReceipt {
+        master_sha: input.master_sha.clone(),
+        mode,
+        allowed_lanes,
+        blocked_lanes,
+        reasons,
+        verdict,
+    }
+}
+
+fn build_policy(
+    mode: QueueMode,
+    gate_policy: Option<&GatePolicy>,
+) -> (Vec<String>, Vec<String>, String) {
+    match mode {
+        QueueMode::Green => (
+            vec![
+                "merge-drain".to_string(),
+                "cascade-update".to_string(),
+                "green-ci-promotion".to_string(),
+            ],
+            Vec::new(),
+            "master healthy: merge drain/cascade/promotions allowed".to_string(),
+        ),
+        QueueMode::Pending => {
+            let mut allowed = vec!["read-only-review".to_string(), "read-only-design".to_string()];
+            if gate_policy
+                .is_some_and(|policy| policy.pending_allows_merge_ready_if_candidate_current)
+            {
+                allowed.push("merge-ready-promotion-if-candidate-current".to_string());
+            }
+
+            (
+                allowed,
+                vec![
+                    "merge-drain".to_string(),
+                    "green-ci-promotion".to_string(),
+                    "broad-cascade-final-labels".to_string(),
+                ],
+                "master unsettled: review/design only; defer broad promotion lanes".to_string(),
+            )
+        }
+        QueueMode::Red => (
+            vec!["master-fix".to_string(), "read-only-review".to_string()],
+            vec![
+                "merge-drain".to_string(),
+                "cascade-update".to_string(),
+                "green-ci-promotion".to_string(),
+                "merge-ready-promotion".to_string(),
+                "broad-cascade-final-labels".to_string(),
+            ],
+            "master failing: freeze merge drain and classify shared blocker before reopening lanes"
+                .to_string(),
+        ),
+    }
+}
+
+impl QueueHealthReceipt {
+    fn mode_as_str(&self) -> &'static str {
+        match self.mode {
+            QueueMode::Green => "GREEN",
+            QueueMode::Pending => "PENDING",
+            QueueMode::Red => "RED",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn green_mode_when_master_is_settled() {
+        let input = QueueHealthInput {
+            master_sha: "abc123".to_string(),
+            ci_state: Some("green".to_string()),
+            pending_checks: Vec::new(),
+            running_checks: Vec::new(),
+            failed_checks: Vec::new(),
+            failure_classifier: None,
+            gate_policy: None,
+        };
+
+        let receipt = classify(&input);
+        assert_eq!(receipt.mode, QueueMode::Green);
+    }
+
+    #[test]
+    fn pending_mode_when_checks_are_still_running() {
+        let input = QueueHealthInput {
+            master_sha: "def456".to_string(),
+            ci_state: Some("green".to_string()),
+            pending_checks: vec!["merge-gate".to_string()],
+            running_checks: Vec::new(),
+            failed_checks: Vec::new(),
+            failure_classifier: None,
+            gate_policy: None,
+        };
+
+        let receipt = classify(&input);
+        assert_eq!(receipt.mode, QueueMode::Pending);
+    }
+
+    #[test]
+    fn red_mode_when_failures_exist() {
+        let input = QueueHealthInput {
+            master_sha: "ghi789".to_string(),
+            ci_state: Some("green".to_string()),
+            pending_checks: Vec::new(),
+            running_checks: Vec::new(),
+            failed_checks: vec!["clippy".to_string()],
+            failure_classifier: Some(FailureClassifier {
+                shared_blocker: true,
+                summary: Some("clippy broken".to_string()),
+            }),
+            gate_policy: None,
+        };
+
+        let receipt = classify(&input);
+        assert_eq!(receipt.mode, QueueMode::Red);
+    }
+}

--- a/xtask/tests/fixtures/queue-health/master-green.json
+++ b/xtask/tests/fixtures/queue-health/master-green.json
@@ -1,0 +1,10 @@
+{
+  "master_sha": "1111111aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "ci_state": "green",
+  "pending_checks": [],
+  "running_checks": [],
+  "failed_checks": [],
+  "gate_policy": {
+    "pending_allows_merge_ready_if_candidate_current": true
+  }
+}

--- a/xtask/tests/fixtures/queue-health/master-pending.json
+++ b/xtask/tests/fixtures/queue-health/master-pending.json
@@ -1,0 +1,10 @@
+{
+  "master_sha": "2222222bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "ci_state": "pending",
+  "pending_checks": ["merge-gate"],
+  "running_checks": ["clippy"],
+  "failed_checks": [],
+  "gate_policy": {
+    "pending_allows_merge_ready_if_candidate_current": true
+  }
+}

--- a/xtask/tests/fixtures/queue-health/master-red.json
+++ b/xtask/tests/fixtures/queue-health/master-red.json
@@ -1,0 +1,14 @@
+{
+  "master_sha": "3333333cccccccccccccccccccccccccccccccc",
+  "ci_state": "red",
+  "pending_checks": [],
+  "running_checks": [],
+  "failed_checks": ["merge-gate"],
+  "failure_classifier": {
+    "shared_blocker": true,
+    "summary": "master merge-gate is failing"
+  },
+  "gate_policy": {
+    "pending_allows_merge_ready_if_candidate_current": true
+  }
+}

--- a/xtask/tests/queue_health_cli.rs
+++ b/xtask/tests/queue_health_cli.rs
@@ -1,0 +1,34 @@
+use anyhow::{Result, bail};
+use assert_cmd::cargo::cargo_bin_cmd;
+
+#[test]
+fn fixture_master_green_maps_to_green() -> Result<()> {
+    assert_mode("tests/fixtures/queue-health/master-green.json", "GREEN")
+}
+
+#[test]
+fn fixture_master_pending_maps_to_pending() -> Result<()> {
+    assert_mode("tests/fixtures/queue-health/master-pending.json", "PENDING")
+}
+
+#[test]
+fn fixture_master_red_maps_to_red() -> Result<()> {
+    assert_mode("tests/fixtures/queue-health/master-red.json", "RED")
+}
+
+fn assert_mode(fixture: &str, expected: &str) -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd.args(["queue", "health", "--fixture", fixture]).output()?;
+
+    if !output.status.success() {
+        bail!("xtask queue health failed for fixture {fixture}");
+    }
+
+    let stdout = String::from_utf8(output.stdout)?;
+    let first_line = stdout.lines().next().unwrap_or_default();
+    if first_line != expected {
+        bail!("expected mode {expected}, got {first_line}");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Provide the orchestrator with a deterministic, read-only queue-health signal so it can safely decide whether to allow merges, restrict to review-only activity, or freeze merge drain during master instability.
- Prevent stale-state mutations and cascade-update mistakes by classifying master as `GREEN`, `PENDING`, or `RED` and exposing allowed/blocked lanes for downstream agents.
- Make the classification auditable and machine-readable via a receipt schema so external tooling can consume the decision without performing mutative actions.

### Description

- Added a new `queue health` xtask command and CLI wiring in `xtask/src/main.rs` and `xtask/src/tasks/mod.rs` so operators can run `cargo xtask queue health` with `--receipt`/`--fixture` inputs.
- Implemented `xtask/src/tasks/queue_health.rs` which loads fixture or default input, classifies master state into `QueueMode::{Green,Pending,Red}`, assembles `allowed_lanes`/`blocked_lanes`/`reasons`/`verdict`, and writes a JSON receipt (`target/receipts/queue-health.json` by default).
- Added JSON schema `.ci/receipts/schemas/queue-health.schema.json` describing the receipt shape and allowed `mode` enum (`GREEN`,`PENDING`,`RED`).
- Added docs `docs/ci/queue-health-modes.md`, validation fixtures under `xtask/tests/fixtures/queue-health/` (green/pending/red), and an integration test `xtask/tests/queue_health_cli.rs` that asserts fixture→mode mappings. Refs #6853.

### Testing

- Ran `cargo test -p xtask --test queue_health_cli` which passed and verified the three fixtures map to `GREEN`/`PENDING`/`RED` respectively.
- Executed the CLI against fixtures: `cargo xtask queue health --fixture xtask/tests/fixtures/queue-health/master-green.json` (emitted `GREEN` and wrote receipt), and likewise for the `master-pending.json` and `master-red.json` fixtures, all producing the expected modes.
- Ran formatting and compile checks with `cargo xtask fmt` and `cargo check --all-targets -p xtask`, both of which completed successfully.
- Verified `cargo xtask queue health --receipt target/receipts/queue-health.json --fixture <fixture>` writes the receipt and prints the mode as the first line (used by the integration test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0c712e08333b6b5e41a776d080f)