### PR TITLE
feat(queue): add GREEN/PENDING/RED health modes (#6853)

### DIFF
--- a/.ci/receipts/schemas/queue-health.schema.json
+++ b/.ci/receipts/schemas/queue-health.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/schemas/queue-health.schema.json",
+  "title": "QueueHealthReceipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "master_sha",
+    "mode",
+    "allowed_lanes",
+    "blocked_lanes",
+    "reasons",
+    "verdict"
+  ],
+  "properties": {
+    "master_sha": {
+      "type": "string",
+      "minLength": 1
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["GREEN", "PENDING", "RED"]
+    },
+    "allowed_lanes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "blocked_lanes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "reasons": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "verdict": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/docs/ci/queue-health-modes.md
+++ b/docs/ci/queue-health-modes.md
@@ -1,0 +1,46 @@
+# Queue health modes
+
+`cargo xtask queue health` computes a queue health receipt for orchestration safety decisions.
+
+## Commands
+
+```bash
+cargo xtask queue health --fixture xtask/tests/fixtures/queue-health/master-green.json
+cargo xtask queue health --fixture xtask/tests/fixtures/queue-health/master-green.json --receipt target/receipts/queue-health.json
+```
+
+## Mode semantics
+
+### GREEN
+- merge drain allowed
+- cascade update allowed
+- green-ci promotion allowed
+
+### PENDING
+- read-only review/design allowed
+- no merge-ready promotion unless candidate current
+- no broad cascade final labels
+
+### RED
+- freeze merge drain
+- classify shared blocker
+- allow master-fix and read-only review only
+
+## Receipt fields
+
+The receipt JSON follows `.ci/receipts/schemas/queue-health.schema.json` and includes:
+
+- `master_sha`
+- `mode`
+- `allowed_lanes`
+- `blocked_lanes`
+- `reasons`
+- `verdict`
+
+## Safety boundaries
+
+This command is read-only and **must not**:
+- mutate labels
+- merge PRs
+- cancel workflows
+- dispatch agents directly

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -853,6 +853,12 @@ enum Commands {
         test_threads: u32,
     },
 
+    /// Queue orchestration helpers.
+    Queue {
+        #[command(subcommand)]
+        command: QueueCommand,
+    },
+
     /// Track ignored tests and enforce gate policy
     IgnoredTests {
         /// Write current counts back to baseline
@@ -1303,6 +1309,19 @@ enum MetricsCommand {
     },
 }
 
+#[derive(Subcommand)]
+enum QueueCommand {
+    /// Compute queue health mode (GREEN/PENDING/RED) from CI state inputs.
+    Health {
+        /// Optional path to write queue-health receipt JSON.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+        /// Fixture JSON path to supply master CI inputs.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+    },
+}
+
 #[derive(ValueEnum, Clone)]
 enum PrepCratesMode {
     Core,
@@ -1579,6 +1598,9 @@ fn main() -> Result<()> {
                 test_threads,
             })
         }
+        Commands::Queue { command } => match command {
+            QueueCommand::Health { receipt, fixture } => queue_health::run_health(receipt, fixture),
+        },
         Commands::IgnoredTests { update, check, verbose } => {
             ignored_tests::run(update, check, verbose)
         }

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -59,6 +59,7 @@ pub mod publish;
 pub mod publish_closure;
 pub mod publish_manifest_check;
 pub mod publish_receipts;
+pub mod queue_health;
 pub mod receipts;
 pub mod release;
 pub mod release_notes;

--- a/xtask/src/tasks/queue_health.rs
+++ b/xtask/src/tasks/queue_health.rs
@@ -1,0 +1,170 @@
+use color_eyre::eyre::{Result, bail};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum QueueHealthMode {
+    Green,
+    Pending,
+    Red,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueueHealthReceipt {
+    pub master_sha: String,
+    pub mode: QueueHealthMode,
+    pub allowed_lanes: Vec<String>,
+    pub blocked_lanes: Vec<String>,
+    pub reasons: Vec<String>,
+    pub verdict: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct QueueHealthFixture {
+    master_sha: String,
+    master_ci: MasterCiState,
+    #[serde(default)]
+    failure_classifier: Option<FailureClassifier>,
+    #[serde(default)]
+    gate_policy: Option<GatePolicy>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct MasterCiState {
+    status: String,
+    #[serde(default)]
+    pending_checks: usize,
+    #[serde(default)]
+    running_checks: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FailureClassifier {
+    #[serde(default)]
+    summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GatePolicy {
+    #[serde(default)]
+    ruleset_name: Option<String>,
+}
+
+pub fn run_health(receipt: Option<PathBuf>, fixture: Option<PathBuf>) -> Result<()> {
+    let fixture_path = fixture.ok_or_else(|| {
+        color_eyre::eyre::eyre!(
+            "queue health currently requires --fixture <json> to provide CI inputs"
+        )
+    })?;
+
+    let fixture_data = fs::read_to_string(&fixture_path)?;
+    let fixture: QueueHealthFixture = serde_json::from_str(&fixture_data)?;
+    let receipt_payload = build_receipt(&fixture)?;
+
+    if let Some(receipt_path) = receipt {
+        if let Some(parent) = receipt_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let pretty = serde_json::to_string_pretty(&receipt_payload)?;
+        fs::write(receipt_path, pretty)?;
+    }
+
+    println!("{}", serde_json::to_string_pretty(&receipt_payload)?);
+    Ok(())
+}
+
+fn build_receipt(input: &QueueHealthFixture) -> Result<QueueHealthReceipt> {
+    let status = input.master_ci.status.to_ascii_lowercase();
+    let mode = match status.as_str() {
+        "green" | "success" | "passed" => QueueHealthMode::Green,
+        "pending" | "running" => QueueHealthMode::Pending,
+        "red" | "failed" | "failure" => QueueHealthMode::Red,
+        _ => bail!(
+            "unknown master_ci.status '{}'; expected green|pending|red",
+            input.master_ci.status
+        ),
+    };
+
+    let mut reasons = vec![format!("master CI status is {}", input.master_ci.status)];
+    if input.master_ci.pending_checks > 0 {
+        reasons.push(format!("{} check(s) pending", input.master_ci.pending_checks));
+    }
+    if input.master_ci.running_checks > 0 {
+        reasons.push(format!("{} check(s) running", input.master_ci.running_checks));
+    }
+    if let Some(classifier) = &input.failure_classifier
+        && let Some(summary) = &classifier.summary
+    {
+        reasons.push(format!("failure classifier: {summary}"));
+    }
+    if let Some(gate_policy) = &input.gate_policy
+        && let Some(name) = &gate_policy.ruleset_name
+    {
+        reasons.push(format!("gate policy: {name}"));
+    }
+
+    let (allowed_lanes, blocked_lanes, verdict) = match mode {
+        QueueHealthMode::Green => (
+            vec![
+                "merge-drain".to_string(),
+                "cascade-update".to_string(),
+                "green-ci-promotion".to_string(),
+            ],
+            Vec::new(),
+            "safe-to-merge".to_string(),
+        ),
+        QueueHealthMode::Pending => (
+            vec!["review-design-read-only".to_string()],
+            vec![
+                "merge-ready-promotion-non-current-candidate".to_string(),
+                "broad-cascade-final-labels".to_string(),
+            ],
+            "review-only".to_string(),
+        ),
+        QueueHealthMode::Red => (
+            vec!["master-fix".to_string(), "review-design-read-only".to_string()],
+            vec![
+                "merge-drain".to_string(),
+                "cascade-update".to_string(),
+                "green-ci-promotion".to_string(),
+            ],
+            "freeze-merge-drain".to_string(),
+        ),
+    };
+
+    Ok(QueueHealthReceipt {
+        master_sha: input.master_sha.clone(),
+        mode,
+        allowed_lanes,
+        blocked_lanes,
+        reasons,
+        verdict,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use color_eyre::eyre::Result;
+
+    #[test]
+    fn maps_green_mode() -> Result<()> {
+        let fixture = QueueHealthFixture {
+            master_sha: "abc123".to_string(),
+            master_ci: MasterCiState {
+                status: "green".to_string(),
+                pending_checks: 0,
+                running_checks: 0,
+            },
+            failure_classifier: None,
+            gate_policy: None,
+        };
+
+        let receipt = build_receipt(&fixture)?;
+        assert_eq!(receipt.mode, QueueHealthMode::Green);
+        assert!(receipt.blocked_lanes.is_empty());
+        Ok(())
+    }
+}

--- a/xtask/tests/fixtures/queue-health/master-green.json
+++ b/xtask/tests/fixtures/queue-health/master-green.json
@@ -1,0 +1,11 @@
+{
+  "master_sha": "1111111",
+  "master_ci": {
+    "status": "green",
+    "pending_checks": 0,
+    "running_checks": 0
+  },
+  "gate_policy": {
+    "ruleset_name": "merge-gate-v1"
+  }
+}

--- a/xtask/tests/fixtures/queue-health/master-pending.json
+++ b/xtask/tests/fixtures/queue-health/master-pending.json
@@ -1,0 +1,11 @@
+{
+  "master_sha": "2222222",
+  "master_ci": {
+    "status": "pending",
+    "pending_checks": 2,
+    "running_checks": 1
+  },
+  "gate_policy": {
+    "ruleset_name": "merge-gate-v1"
+  }
+}

--- a/xtask/tests/fixtures/queue-health/master-red.json
+++ b/xtask/tests/fixtures/queue-health/master-red.json
@@ -1,0 +1,14 @@
+{
+  "master_sha": "3333333",
+  "master_ci": {
+    "status": "red",
+    "pending_checks": 0,
+    "running_checks": 0
+  },
+  "failure_classifier": {
+    "summary": "shared infrastructure blocker"
+  },
+  "gate_policy": {
+    "ruleset_name": "merge-gate-v1"
+  }
+}

--- a/xtask/tests/queue_health_tests.rs
+++ b/xtask/tests/queue_health_tests.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+
+fn run_fixture(path: &str) -> Result<Value> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd.args(["queue", "health", "--fixture", path]).output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    let receipt: Value = serde_json::from_str(&stdout)?;
+    Ok(receipt)
+}
+
+fn fixture_path(name: &str) -> String {
+    format!("{}/tests/fixtures/queue-health/{name}", env!("CARGO_MANIFEST_DIR"))
+}
+
+#[test]
+fn fixture_master_green_maps_to_green_mode() -> Result<()> {
+    let receipt = run_fixture(&fixture_path("master-green.json"))?;
+    assert_eq!(receipt["mode"], "GREEN");
+    Ok(())
+}
+
+#[test]
+fn fixture_master_pending_maps_to_pending_mode() -> Result<()> {
+    let receipt = run_fixture(&fixture_path("master-pending.json"))?;
+    assert_eq!(receipt["mode"], "PENDING");
+    Ok(())
+}
+
+#[test]
+fn fixture_master_red_maps_to_red_mode() -> Result<()> {
+    let receipt = run_fixture(&fixture_path("master-red.json"))?;
+    assert_eq!(receipt["mode"], "RED");
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Provide an authoritative, machine-readable queue health result so orchestrator decisions (merge-drain, review-only, freeze) can be gated by master CI state.

### Description

- Add `cargo xtask queue health` CLI wiring with `--fixture` and optional `--receipt` arguments and dispatch to `queue_health::run_health`.
- Implement queue health computation in `xtask/src/tasks/queue_health.rs` that maps master CI state to `GREEN`/`PENDING`/`RED`, emits allowed/blocked lanes, reasons, and a `verdict` in a structured receipt.
- Add JSON schema `.ci/receipts/schemas/queue-health.schema.json`, docs `docs/ci/queue-health-modes.md`, and three fixture inputs under `xtask/tests/fixtures/queue-health/` to represent green/pending/red master scenarios.
- Add integration tests `xtask/tests/queue_health_tests.rs` and register the new module in `xtask/src/tasks/mod.rs`.

### Testing

- Ran `cargo test -p xtask --test queue_health_tests` and all tests passed (`3 passed`).
- Ran `cargo run -p xtask -- queue health --fixture xtask/tests/fixtures/queue-health/master-green.json` and `--fixture` runs for pending and red fixtures; each produced the expected receipts.
- Emitted receipt file successfully with `cargo run -p xtask -- queue health --receipt target/receipts/queue-health.json --fixture xtask/tests/fixtures/queue-health/master-green.json`.
- Ran formatting and checks: `cargo xtask fmt --check` and `cargo check --all-targets -p xtask` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0c712e08333b6b5e41a776d080f)