### PR TITLE
feat(reviews): add material-observation review receipts (#6853)

### DIFF
--- a/.ci/receipts/schemas/review.schema.json
+++ b/.ci/receipts/schemas/review.schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/review.schema.json",
+  "title": "Review Receipt",
+  "description": "Evidence-only reviewer receipt used by CI/state builders.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "producer",
+    "pr",
+    "head_sha",
+    "base_sha",
+    "verdict",
+    "material_observations",
+    "negative_checks",
+    "blockers",
+    "next_routes",
+    "supersedes"
+  ],
+  "properties": {
+    "kind": {
+      "const": "review"
+    },
+    "producer": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pr": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "head_sha": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{7,40}$"
+    },
+    "base_sha": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{7,40}$"
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "clean",
+        "needs_builder_fix",
+        "needs_diff_fix",
+        "needs_human",
+        "blocked_unknown"
+      ]
+    },
+    "material_observations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "negative_checks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "next_routes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "supersedes": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[a-zA-Z0-9._:-]+$"
+    },
+    "diff_classification": {
+      "type": "string",
+      "enum": [
+        "trivial",
+        "non_trivial"
+      ],
+      "description": "Optional hint for validators enforcing clean-signoff observation requirements."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "verdict": {
+            "const": "clean"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "negative_checks": {
+            "minItems": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "verdict": {
+            "const": "clean"
+          },
+          "diff_classification": {
+            "const": "non_trivial"
+          }
+        },
+        "required": [
+          "diff_classification"
+        ]
+      },
+      "then": {
+        "properties": {
+          "material_observations": {
+            "minItems": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "verdict": {
+            "enum": [
+              "needs_builder_fix",
+              "needs_diff_fix",
+              "needs_human",
+              "blocked_unknown"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "next_routes": {
+            "not": {
+              "contains": {
+                "type": "string",
+                "pattern": "(^|:)signoff_clean$|clean-signoff|signoff:clean"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/ci/review-receipts.md
+++ b/docs/ci/review-receipts.md
@@ -1,0 +1,45 @@
+# Review receipts
+
+Review receipts are evidence artifacts. They capture what a reviewer observed and what they explicitly tried to falsify before issuing a verdict.
+
+## Schema
+
+Path: `.ci/receipts/schemas/review.schema.json`
+
+Required fields:
+
+- `kind` (must be `review`)
+- `producer`
+- `pr`
+- `head_sha`
+- `base_sha`
+- `verdict` (`clean | needs_builder_fix | needs_diff_fix | needs_human | blocked_unknown`)
+- `material_observations[]`
+- `negative_checks[]`
+- `blockers[]`
+- `next_routes[]`
+- `supersedes`
+
+Optional helper field:
+
+- `diff_classification` (`trivial | non_trivial`)
+
+## Review doctrine encoded in receipt validation
+
+1. **Clean on non-trivial diff requires material observations.**
+   - A clean verdict is suspicious if it says “nothing to flag” while the diff is non-trivial.
+   - For `diff_classification = non_trivial`, `material_observations` must contain at least one concrete finding.
+2. **Clean verdict requires negative checks.**
+   - Clean sign-off must record what was actively checked and not observed (for example, no label mutation side effects).
+3. **Needs-fix verdicts cannot emit clean sign-off route intent.**
+   - If verdict is `needs_builder_fix`, `needs_diff_fix`, `needs_human`, or `blocked_unknown`, `next_routes` must not include clean sign-off intent (`signoff:clean`, `signoff_clean`, `clean-signoff`).
+4. **Receipts are evidence only.**
+   - Review receipts must not mutate labels. They describe findings and suggested routes; label mutation belongs elsewhere.
+
+## Validation fixtures
+
+Fixtures used by tests live in:
+
+- `xtask/tests/fixtures/review-receipts/clean-with-observations.json` (valid)
+- `xtask/tests/fixtures/review-receipts/clean-without-observations.json` (invalid)
+- `xtask/tests/fixtures/review-receipts/needs-builder-fix-with-clean-signoff-intent.json` (invalid)

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -63,6 +63,7 @@ pub mod receipts;
 pub mod release;
 pub mod release_notes;
 pub mod release_turnkey;
+pub mod review_receipts;
 pub mod srp_microcrates;
 pub mod swarm_summary;
 pub mod targeted_checks;

--- a/xtask/src/tasks/review_receipts.rs
+++ b/xtask/src/tasks/review_receipts.rs
@@ -1,0 +1,141 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReviewReceipt {
+    pub kind: String,
+    pub producer: String,
+    pub pr: u64,
+    pub head_sha: String,
+    pub base_sha: String,
+    pub verdict: ReviewVerdict,
+    pub material_observations: Vec<String>,
+    pub negative_checks: Vec<String>,
+    pub blockers: Vec<String>,
+    pub next_routes: Vec<String>,
+    pub supersedes: Option<String>,
+    pub diff_classification: Option<DiffClassification>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewVerdict {
+    Clean,
+    NeedsBuilderFix,
+    NeedsDiffFix,
+    NeedsHuman,
+    BlockedUnknown,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum DiffClassification {
+    Trivial,
+    NonTrivial,
+}
+
+pub fn validate_review_receipt(value: &Value) -> Result<(), Vec<String>> {
+    let receipt = match serde_json::from_value::<ReviewReceipt>(value.clone()) {
+        Ok(receipt) => receipt,
+        Err(error) => {
+            return Err(vec![format!("schema violation: {error}")]);
+        }
+    };
+
+    let mut errors = Vec::new();
+
+    if receipt.kind != "review" {
+        errors.push("kind must be 'review'".to_string());
+    }
+    if receipt.producer.trim().is_empty() {
+        errors.push("producer must be non-empty".to_string());
+    }
+    if receipt.pr == 0 {
+        errors.push("pr must be >= 1".to_string());
+    }
+    if !is_hex_sha(&receipt.head_sha) {
+        errors.push("head_sha must be a 7-40 char lowercase hex sha".to_string());
+    }
+    if !is_hex_sha(&receipt.base_sha) {
+        errors.push("base_sha must be a 7-40 char lowercase hex sha".to_string());
+    }
+
+    if receipt.verdict == ReviewVerdict::Clean {
+        if receipt.negative_checks.is_empty() {
+            errors.push("clean verdict must include at least one negative_check".to_string());
+        }
+
+        if receipt.diff_classification == Some(DiffClassification::NonTrivial)
+            && receipt.material_observations.is_empty()
+        {
+            errors.push(
+                "clean verdict on a non-trivial diff must include material_observations"
+                    .to_string(),
+            );
+        }
+    }
+
+    if receipt.verdict != ReviewVerdict::Clean
+        && receipt.next_routes.iter().any(|route| is_clean_signoff_route(route))
+    {
+        errors.push("needs-fix verdicts cannot emit clean sign-off route intent".to_string());
+    }
+
+    if errors.is_empty() { Ok(()) } else { Err(errors) }
+}
+
+fn is_hex_sha(value: &str) -> bool {
+    let len = value.len();
+    (7..=40).contains(&len)
+        && value.chars().all(|ch| ch.is_ascii_hexdigit() && !ch.is_ascii_uppercase())
+}
+
+fn is_clean_signoff_route(route: &str) -> bool {
+    let normalized = route.trim().to_ascii_lowercase();
+    normalized == "signoff:clean" || normalized == "signoff_clean" || normalized == "clean-signoff"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_review_receipt;
+    use color_eyre::eyre::Result;
+
+    fn fixture(path: &str) -> Result<serde_json::Value> {
+        let content = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&content)?)
+    }
+
+    #[test]
+    fn clean_receipt_with_observations_passes() -> Result<()> {
+        let receipt = fixture("tests/fixtures/review-receipts/clean-with-observations.json")?;
+        assert!(validate_review_receipt(&receipt).is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn clean_receipt_without_observations_fails() -> Result<()> {
+        let receipt = fixture("tests/fixtures/review-receipts/clean-without-observations.json")?;
+        let errors = validate_review_receipt(&receipt)
+            .expect_err("clean receipt on non-trivial diff must fail without observations");
+        assert!(
+            errors.iter().any(|error| error.contains("material_observations")),
+            "errors must mention missing material observations: {errors:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn needs_builder_fix_with_clean_signoff_intent_fails() -> Result<()> {
+        let receipt = fixture(
+            "tests/fixtures/review-receipts/needs-builder-fix-with-clean-signoff-intent.json",
+        )?;
+        let errors = validate_review_receipt(&receipt)
+            .expect_err("needs_builder_fix must not carry clean signoff route intent");
+        assert!(
+            errors.iter().any(|error| error.contains("sign-off")),
+            "errors must mention clean sign-off intent conflict: {errors:?}"
+        );
+        Ok(())
+    }
+}

--- a/xtask/tests/fixtures/review-receipts/clean-with-observations.json
+++ b/xtask/tests/fixtures/review-receipts/clean-with-observations.json
@@ -1,0 +1,22 @@
+{
+  "kind": "review",
+  "producer": "codex",
+  "pr": 6853,
+  "head_sha": "abcdef1234567890abcdef1234567890abcdef12",
+  "base_sha": "1234567890abcdef1234567890abcdef12345678",
+  "verdict": "clean",
+  "diff_classification": "non_trivial",
+  "material_observations": [
+    "Validated parser fallback behavior still routes through perl-lsp-rs-core feature gates.",
+    "Confirmed no label mutation side effects in review receipt handling."
+  ],
+  "negative_checks": [
+    "No panic/unwrap/todo usage introduced.",
+    "No CI label mutation command emitted by receipt generation."
+  ],
+  "blockers": [],
+  "next_routes": [
+    "builder:apply-clean"
+  ],
+  "supersedes": null
+}

--- a/xtask/tests/fixtures/review-receipts/clean-without-observations.json
+++ b/xtask/tests/fixtures/review-receipts/clean-without-observations.json
@@ -1,0 +1,18 @@
+{
+  "kind": "review",
+  "producer": "codex",
+  "pr": 6853,
+  "head_sha": "abcdef1234567890abcdef1234567890abcdef12",
+  "base_sha": "1234567890abcdef1234567890abcdef12345678",
+  "verdict": "clean",
+  "diff_classification": "non_trivial",
+  "material_observations": [],
+  "negative_checks": [
+    "No CI policy regressions found."
+  ],
+  "blockers": [],
+  "next_routes": [
+    "builder:apply-clean"
+  ],
+  "supersedes": null
+}

--- a/xtask/tests/fixtures/review-receipts/needs-builder-fix-with-clean-signoff-intent.json
+++ b/xtask/tests/fixtures/review-receipts/needs-builder-fix-with-clean-signoff-intent.json
@@ -1,0 +1,23 @@
+{
+  "kind": "review",
+  "producer": "codex",
+  "pr": 6853,
+  "head_sha": "abcdef1234567890abcdef1234567890abcdef12",
+  "base_sha": "1234567890abcdef1234567890abcdef12345678",
+  "verdict": "needs_builder_fix",
+  "diff_classification": "non_trivial",
+  "material_observations": [
+    "Builder route computes incorrect merge-gate state for receipts missing negative checks."
+  ],
+  "negative_checks": [
+    "No parser regressions observed in touched crates."
+  ],
+  "blockers": [
+    "State builder must reject empty evidence payloads before sign-off."
+  ],
+  "next_routes": [
+    "signoff:clean",
+    "builder:repair-review-flow"
+  ],
+  "supersedes": "review:2026-04-25:abc1234"
+}


### PR DESCRIPTION
### Motivation

- Refs #6853: the review doctrine requires concrete evidence for a `clean` sign-off on non-trivial diffs so downstream state builders can trust receipts.
- Encode review rules (material observations, negative checks, and no clean-signoff intent on needs-fix verdicts) in a machine-checkable way rather than leaving them informal.

### Description

- Add a JSON Schema at `.ci/receipts/schemas/review.schema.json` that defines the `review` receipt shape and enforces rule-level constraints for `clean` evidence and `needs_*` signoff intent.
- Add documentation `docs/ci/review-receipts.md` that describes the schema, doctrine, and expected validation behaviour.
- Add a lightweight validation helper and unit tests in `xtask/src/tasks/review_receipts.rs` and register the module in `xtask/src/tasks/mod.rs` to keep validation colocated with other `xtask` checks.
- Add JSON fixtures under `xtask/tests/fixtures/review-receipts/` to exercise the key validation cases (valid clean receipt with observations, invalid clean without observations, invalid needs_builder_fix with clean-signoff intent).

### Testing

- Ran `cargo test -p xtask review_receipts -- --nocapture`, and the three unit tests (clean-with-observations passes, clean-without-observations fails, needs-builder-fix-with-clean-signoff-intent fails) succeeded.
- Ran `cargo check --all-targets -p xtask` and `cargo xtask fmt`, both completed successfully with only benign warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0d7a6fc8333a0a53252a91e267b)