### PR TITLE
feat(reviews): add material-observation review receipts (#6853)

### DIFF
--- a/.ci/receipts/schemas/review.schema.json
+++ b/.ci/receipts/schemas/review.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/review.schema.json",
+  "title": "Review Receipt",
+  "description": "Evidence-only review receipt used by automation to understand reviewer outcomes without mutating labels.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "producer",
+    "pr",
+    "head_sha",
+    "base_sha",
+    "verdict",
+    "material_observations",
+    "negative_checks",
+    "blockers",
+    "next_routes"
+  ],
+  "properties": {
+    "kind": {
+      "const": "review"
+    },
+    "producer": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pr": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "head_sha": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "base_sha": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "clean",
+        "needs_builder_fix",
+        "needs_diff_fix",
+        "needs_human",
+        "blocked_unknown"
+      ]
+    },
+    "material_observations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "negative_checks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "next_routes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "supersedes": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "verdict": {
+            "const": "clean"
+          }
+        },
+        "required": [
+          "verdict"
+        ]
+      },
+      "then": {
+        "properties": {
+          "material_observations": {
+            "minItems": 1
+          },
+          "negative_checks": {
+            "minItems": 1
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/ci/review-receipts.md
+++ b/docs/ci/review-receipts.md
@@ -1,0 +1,36 @@
+# Review Receipts
+
+Review receipts are **evidence artifacts**. They describe what the reviewer observed and
+what they explicitly ruled out. They do **not** mutate labels, and they are not a state
+builder implementation.
+
+Schema: `.ci/receipts/schemas/review.schema.json`
+
+## Required fields
+
+Every review receipt carries:
+
+- `kind` (`review`)
+- `producer`
+- `pr`
+- `head_sha`
+- `base_sha`
+- `verdict` (`clean | needs_builder_fix | needs_diff_fix | needs_human | blocked_unknown`)
+- `material_observations[]`
+- `negative_checks[]`
+- `blockers[]`
+- `next_routes[]`
+- `supersedes` (optional)
+
+## Policy constraints
+
+- Clean sign-off on a non-trivial diff must include **at least one** material observation.
+  - Current validation treats clean receipts as requiring concrete observations.
+- Clean sign-off must include **negative checks** (`negative_checks[]` cannot be empty).
+- Needs-fix verdicts must **not** emit clean sign-off intent (`signoff_clean`) in `next_routes`.
+- Receipts are evidence only; no label mutation is permitted in this contract.
+
+## Why this exists
+
+`"CLEAN, nothing to flag"` on a non-trivial diff is suspicious by doctrine. These receipts
+force specific, auditable evidence so downstream automation can trust review conclusions.

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -63,6 +63,7 @@ pub mod receipts;
 pub mod release;
 pub mod release_notes;
 pub mod release_turnkey;
+pub mod review_receipts;
 pub mod srp_microcrates;
 pub mod swarm_summary;
 pub mod targeted_checks;

--- a/xtask/src/tasks/review_receipts.rs
+++ b/xtask/src/tasks/review_receipts.rs
@@ -1,0 +1,113 @@
+use anyhow::{bail, Context, Result};
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+const CLEAN_VERDICT: &str = "clean";
+const SIGNOFF_CLEAN_ROUTE: &str = "signoff_clean";
+
+/// Validate review receipt policy constraints that cannot be expressed
+/// (or are intentionally duplicated) from JSON Schema alone.
+pub fn validate_review_receipt_value(receipt: &Value) -> Result<()> {
+    let verdict = receipt
+        .get("verdict")
+        .and_then(Value::as_str)
+        .context("review receipt is missing verdict")?;
+
+    let material_observations = receipt
+        .get("material_observations")
+        .and_then(Value::as_array)
+        .context("review receipt is missing material_observations array")?;
+
+    let negative_checks = receipt
+        .get("negative_checks")
+        .and_then(Value::as_array)
+        .context("review receipt is missing negative_checks array")?;
+
+    let next_routes = receipt
+        .get("next_routes")
+        .and_then(Value::as_array)
+        .context("review receipt is missing next_routes array")?;
+
+    if verdict == CLEAN_VERDICT && material_observations.is_empty() {
+        bail!(
+            "clean review receipts must include at least one material observation for non-trivial diffs"
+        );
+    }
+
+    if verdict == CLEAN_VERDICT && negative_checks.is_empty() {
+        bail!("clean review receipts must include negative checks");
+    }
+
+    if verdict.starts_with("needs_")
+        && next_routes.iter().any(|route| route.as_str() == Some(SIGNOFF_CLEAN_ROUTE))
+    {
+        bail!("needs-fix verdicts must not emit clean sign-off intent routes");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_review_receipt_value;
+    use anyhow::{Context, Result};
+    use std::path::PathBuf;
+
+    fn fixture_path(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("review-receipts")
+            .join(name)
+    }
+
+    fn load_fixture(name: &str) -> Result<serde_json::Value> {
+        let path = fixture_path(name);
+        let raw = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read fixture {}", path.display()))?;
+        let value = serde_json::from_str(&raw)
+            .with_context(|| format!("failed to parse fixture {}", path.display()))?;
+        Ok(value)
+    }
+
+    #[test]
+    fn clean_receipt_with_observations_passes() -> Result<()> {
+        let fixture = load_fixture("clean-with-observations.json")?;
+        validate_review_receipt_value(&fixture)
+    }
+
+    #[test]
+    fn clean_receipt_without_observations_fails() -> Result<()> {
+        let fixture = load_fixture("clean-without-observations.json")?;
+        let error = validate_review_receipt_value(&fixture)
+            .expect_err("fixture should fail without material observations");
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("material observation"),
+            "error should mention missing material observations: {message}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn needs_builder_fix_with_clean_signoff_intent_fails() -> Result<()> {
+        let fixture = load_fixture("needs-builder-fix-with-clean-signoff-intent.json")?;
+        let error = validate_review_receipt_value(&fixture)
+            .expect_err("fixture should fail when needs-fix includes clean sign-off intent");
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("must not emit clean sign-off intent"),
+            "error should mention forbidden clean sign-off intent: {message}"
+        );
+        Ok(())
+    }
+}
+
+pub fn validate_review_receipt_file(path: &Path) -> Result<()> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read review receipt {}", path.display()))?;
+    let receipt: Value = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse review receipt {}", path.display()))?;
+    validate_review_receipt_value(&receipt)
+}

--- a/xtask/tests/fixtures/review-receipts/clean-with-observations.json
+++ b/xtask/tests/fixtures/review-receipts/clean-with-observations.json
@@ -1,0 +1,19 @@
+{
+  "kind": "review",
+  "producer": "plan-reviewer",
+  "pr": 6853,
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "verdict": "clean",
+  "material_observations": [
+    "Verified updated review receipt docs now require concrete findings for clean sign-off."
+  ],
+  "negative_checks": [
+    "No missing schema fields in the clean receipt example."
+  ],
+  "blockers": [],
+  "next_routes": [
+    "state_builder"
+  ],
+  "supersedes": null
+}

--- a/xtask/tests/fixtures/review-receipts/clean-without-observations.json
+++ b/xtask/tests/fixtures/review-receipts/clean-without-observations.json
@@ -1,0 +1,17 @@
+{
+  "kind": "review",
+  "producer": "plan-reviewer",
+  "pr": 6853,
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "verdict": "clean",
+  "material_observations": [],
+  "negative_checks": [
+    "No regression found in local review gate handling."
+  ],
+  "blockers": [],
+  "next_routes": [
+    "state_builder"
+  ],
+  "supersedes": null
+}

--- a/xtask/tests/fixtures/review-receipts/needs-builder-fix-with-clean-signoff-intent.json
+++ b/xtask/tests/fixtures/review-receipts/needs-builder-fix-with-clean-signoff-intent.json
@@ -1,0 +1,21 @@
+{
+  "kind": "review",
+  "producer": "plan-reviewer",
+  "pr": 6853,
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "verdict": "needs_builder_fix",
+  "material_observations": [
+    "Builder emitted a stale route table for this diff."
+  ],
+  "negative_checks": [
+    "No parser/lsp behavior change detected in touched crates."
+  ],
+  "blockers": [
+    "Builder must regenerate route table with current schema."
+  ],
+  "next_routes": [
+    "signoff_clean"
+  ],
+  "supersedes": null
+}


### PR DESCRIPTION
Refs #6853

### Motivation

- Prevent weak "CLEAN, nothing to flag" sign-offs by requiring concrete observations and explicit negative checks so downstream state builders can trust review evidence.  
- Provide a machine-checked schema, documentation, and small validation harness to encode the review-doctrine rules as evidence-only receipts (no label mutation).

### Description

- Add JSON Schema for review receipts at `.ci/receipts/schemas/review.schema.json` with required fields (`kind`, `producer`, `pr`, `head_sha`, `base_sha`, `verdict`, `material_observations`, `negative_checks`, `blockers`, `next_routes`, optional `supersedes`) and an `allOf` rule requiring observations and negative checks for `verdict: clean`.  
- Add documentation `docs/ci/review-receipts.md` describing the evidence-only contract and policy constraints (including prohibition of clean sign-off intent on needs-fix verdicts).  
- Add a small helper `xtask/src/tasks/review_receipts.rs` that enforces policy checks not expressible (or intentionally duplicated) in JSON Schema and includes unit tests for the requested scenarios.  
- Add fixtures under `xtask/tests/fixtures/review-receipts/` covering: a passing `clean` receipt with observations, a failing `clean` receipt missing observations, and a failing `needs_builder_fix` receipt that (incorrectly) contains a clean sign-off intent; and register the module in `xtask/src/tasks/mod.rs`.

### Testing

- Ran `cargo test -p xtask review_receipts` and the three unit tests passed (`clean_receipt_with_observations_passes`, `clean_receipt_without_observations_fails`, `needs_builder_fix_with_clean_signoff_intent_fails`).  
- Ran `cargo check --all-targets -p xtask` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0d7a6fc8333a0a53252a91e267b)