### PR TITLE
feat(reviews): add material-observation review receipts (#6853)

### DIFF
--- a/.ci/receipts/schemas/review.schema.json
+++ b/.ci/receipts/schemas/review.schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/review.schema.json",
+  "title": "Review Receipt",
+  "description": "Evidence-only review receipt for sign-off routing.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "producer",
+    "pr",
+    "head_sha",
+    "base_sha",
+    "verdict",
+    "material_observations",
+    "negative_checks",
+    "blockers",
+    "next_routes",
+    "supersedes"
+  ],
+  "properties": {
+    "kind": {
+      "const": "review"
+    },
+    "producer": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pr": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "head_sha": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "base_sha": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "clean",
+        "needs_builder_fix",
+        "needs_diff_fix",
+        "needs_human",
+        "blocked_unknown"
+      ]
+    },
+    "material_observations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "negative_checks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "next_routes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "builder_fix",
+          "diff_fix",
+          "human_review",
+          "await_context",
+          "signoff_clean"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "supersedes": {
+      "type": ["string", "null"],
+      "minLength": 1
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "verdict": {
+            "const": "clean"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "material_observations": {
+            "minItems": 1
+          },
+          "negative_checks": {
+            "minItems": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "verdict": {
+            "enum": ["needs_builder_fix", "needs_diff_fix"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "next_routes": {
+            "not": {
+              "contains": {
+                "const": "signoff_clean"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/ci/review-receipts.md
+++ b/docs/ci/review-receipts.md
@@ -1,0 +1,52 @@
+# Review receipts
+
+Review receipts are **evidence-only** artifacts used by CI/state routing to evaluate sign-off quality.
+They do not mutate labels and they do not perform builder/state transitions directly.
+
+Schema: [`.ci/receipts/schemas/review.schema.json`](../../.ci/receipts/schemas/review.schema.json)
+
+## Required fields
+
+Each receipt must include:
+
+- `kind` (`review`)
+- `producer`
+- `pr`
+- `head_sha`
+- `base_sha`
+- `verdict` (`clean | needs_builder_fix | needs_diff_fix | needs_human | blocked_unknown`)
+- `material_observations[]`
+- `negative_checks[]`
+- `blockers[]`
+- `next_routes[]`
+- `supersedes`
+
+## Policy rules
+
+- `clean` verdicts must include at least one `material_observations` entry.
+- `clean` verdicts must include at least one `negative_checks` entry.
+- `needs_builder_fix` and `needs_diff_fix` verdicts must **not** include `signoff_clean` in `next_routes`.
+- Receipts are evidence records only; label mutation is intentionally out of scope.
+
+## Example (clean)
+
+```json
+{
+  "kind": "review",
+  "producer": "codex",
+  "pr": 6853,
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "verdict": "clean",
+  "material_observations": [
+    "Verified parser changes are mechanical and preserve token boundaries."
+  ],
+  "negative_checks": [
+    "No panic!/unwrap!/expect! introduced in touched code.",
+    "No mutation-side effects observed outside scoped crates."
+  ],
+  "blockers": [],
+  "next_routes": ["signoff_clean"],
+  "supersedes": null
+}
+```

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -757,6 +757,12 @@ enum Commands {
         date: Option<String>,
     },
 
+    /// Validate a review receipt JSON payload against policy rules.
+    ValidateReviewReceipt {
+        /// Path to a review receipt JSON file.
+        path: PathBuf,
+    },
+
     /// Publish VSCode extension to marketplace
     PublishVscode {
         /// Skip confirmation
@@ -1510,6 +1516,7 @@ fn main() -> Result<()> {
         Commands::PublishManifestCheck => publish_manifest_check::run(),
         Commands::SmokeTestRelease { version } => publish::smoke_test_release(version),
         Commands::PublishReceipts { date } => publish_receipts::run(date),
+        Commands::ValidateReviewReceipt { path } => review_receipts::run_validate(path),
         Commands::ParserCorpusSweep {
             roots,
             manifest,

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -63,6 +63,7 @@ pub mod receipts;
 pub mod release;
 pub mod release_notes;
 pub mod release_turnkey;
+pub mod review_receipts;
 pub mod srp_microcrates;
 pub mod swarm_summary;
 pub mod targeted_checks;

--- a/xtask/src/tasks/review_receipts.rs
+++ b/xtask/src/tasks/review_receipts.rs
@@ -1,0 +1,130 @@
+use color_eyre::eyre::{Context, Result, bail};
+use serde::Deserialize;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+pub struct ReviewReceipt {
+    pub kind: String,
+    pub producer: String,
+    pub pr: u64,
+    pub head_sha: String,
+    pub base_sha: String,
+    pub verdict: ReviewVerdict,
+    pub material_observations: Vec<String>,
+    pub negative_checks: Vec<String>,
+    pub blockers: Vec<String>,
+    pub next_routes: Vec<ReviewRoute>,
+    pub supersedes: Option<String>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewVerdict {
+    Clean,
+    NeedsBuilderFix,
+    NeedsDiffFix,
+    NeedsHuman,
+    BlockedUnknown,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewRoute {
+    BuilderFix,
+    DiffFix,
+    HumanReview,
+    AwaitContext,
+    SignoffClean,
+}
+
+pub fn run_validate(path: PathBuf) -> Result<()> {
+    let payload = fs::read_to_string(&path)
+        .with_context(|| format!("failed to read receipt {}", path.display()))?;
+    let receipt: ReviewReceipt = serde_json::from_str(&payload)
+        .with_context(|| format!("failed to parse receipt {}", path.display()))?;
+    validate_review_receipt(&receipt)
+}
+
+pub fn validate_review_receipt(receipt: &ReviewReceipt) -> Result<()> {
+    if receipt.kind != "review" {
+        bail!("review receipt kind must be 'review'");
+    }
+
+    let _evidence_fields_are_present = (
+        &receipt.producer,
+        receipt.pr,
+        &receipt.head_sha,
+        &receipt.base_sha,
+        &receipt.blockers,
+        &receipt.supersedes,
+    );
+
+    if receipt.verdict == ReviewVerdict::Clean {
+        if receipt.material_observations.is_empty() {
+            bail!("clean verdict requires at least one material observation");
+        }
+
+        if receipt.negative_checks.is_empty() {
+            bail!("clean verdict requires at least one negative check");
+        }
+    }
+
+    if matches!(receipt.verdict, ReviewVerdict::NeedsBuilderFix | ReviewVerdict::NeedsDiffFix)
+        && receipt.next_routes.contains(&ReviewRoute::SignoffClean)
+    {
+        bail!("needs-fix verdict cannot include signoff_clean route");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use color_eyre::eyre::{Context, Result};
+
+    fn fixture_path(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("review-receipts")
+            .join(name)
+    }
+
+    fn load_fixture(name: &str) -> Result<ReviewReceipt> {
+        let path = fixture_path(name);
+        let data = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read fixture {}", path.display()))?;
+        serde_json::from_str(&data)
+            .with_context(|| format!("failed to parse fixture {}", path.display()))
+    }
+
+    #[test]
+    fn clean_receipt_with_observations_passes() -> Result<()> {
+        let receipt = load_fixture("clean-with-observations.json")?;
+        validate_review_receipt(&receipt)
+    }
+
+    #[test]
+    fn clean_receipt_without_observations_fails() -> Result<()> {
+        let receipt = load_fixture("clean-without-observations.json")?;
+        let result = validate_review_receipt(&receipt);
+        if result.is_ok() {
+            bail!("expected validation to fail for clean receipt without observations");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn needs_builder_fix_with_signoff_intent_fails() -> Result<()> {
+        let receipt = load_fixture("needs-builder-fix-with-signoff-intent.json")?;
+        let result = validate_review_receipt(&receipt);
+        if result.is_ok() {
+            bail!(
+                "expected validation to fail when needs_builder_fix includes signoff_clean route"
+            );
+        }
+        Ok(())
+    }
+}

--- a/xtask/tests/fixtures/review-receipts/clean-with-observations.json
+++ b/xtask/tests/fixtures/review-receipts/clean-with-observations.json
@@ -1,0 +1,17 @@
+{
+  "kind": "review",
+  "producer": "codex",
+  "pr": 6853,
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "verdict": "clean",
+  "material_observations": [
+    "Confirmed symbol resolution logic is unchanged for non-edited files."
+  ],
+  "negative_checks": [
+    "No new fallback paths silently swallowing parser errors."
+  ],
+  "blockers": [],
+  "next_routes": ["signoff_clean"],
+  "supersedes": null
+}

--- a/xtask/tests/fixtures/review-receipts/clean-without-observations.json
+++ b/xtask/tests/fixtures/review-receipts/clean-without-observations.json
@@ -1,0 +1,15 @@
+{
+  "kind": "review",
+  "producer": "codex",
+  "pr": 6853,
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "verdict": "clean",
+  "material_observations": [],
+  "negative_checks": [
+    "No unsupported feature flags were introduced."
+  ],
+  "blockers": [],
+  "next_routes": ["signoff_clean"],
+  "supersedes": null
+}

--- a/xtask/tests/fixtures/review-receipts/needs-builder-fix-with-signoff-intent.json
+++ b/xtask/tests/fixtures/review-receipts/needs-builder-fix-with-signoff-intent.json
@@ -1,0 +1,17 @@
+{
+  "kind": "review",
+  "producer": "codex",
+  "pr": 6853,
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "verdict": "needs_builder_fix",
+  "material_observations": [
+    "State builder emitted duplicate routes for same evidence input."
+  ],
+  "negative_checks": [
+    "No diff-level correctness issue found in reviewed hunk."
+  ],
+  "blockers": ["state builder route conflict"],
+  "next_routes": ["builder_fix", "signoff_clean"],
+  "supersedes": "review-2026-04-25T10:00:00Z-abc"
+}


### PR DESCRIPTION
### Motivation

- Non-trivial “clean” signoffs lacked concrete evidence and could mislead downstream routing; receipts should capture material observations and explicit negative checks. 
- Policy must prevent contradictory routing (e.g. a `needs_*_fix` verdict that also claims `signoff_clean`).

### Description

- Add a JSON Schema at `.ci/receipts/schemas/review.schema.json` that defines a `review` receipt with required fields (`kind`, `producer`, `pr`, `head_sha`, `base_sha`, `verdict`, `material_observations`, `negative_checks`, `blockers`, `next_routes`, `supersedes`) and `additionalProperties: false`.
- Encode policy constraints in the schema so `clean` verdicts require at least one `material_observations` and one `negative_checks`, and `needs_builder_fix`/`needs_diff_fix` may not include `signoff_clean` in `next_routes`.
- Add documentation `docs/ci/review-receipts.md` describing the schema, required fields, policy rules, and a `clean` example emphasizing receipts are evidence-only and do not mutate labels.
- Add an xtask helper `xtask/src/tasks/review_receipts.rs` with typed structs/enums, `validate_review_receipt` enforcement, `run_validate(path)` file loader, unit tests, and wire the helper into `xtask` CLI via `ValidateReviewReceipt { path }` and `pub mod review_receipts;` in task registry.
- Include test fixtures under `xtask/tests/fixtures/review-receipts/` for the three validation scenarios used by unit tests.
- Refs #6853

### Testing

- Ran `cargo test -p xtask review_receipt` which executed unit tests that verify: `clean` with observations passes, `clean` without observations fails, and `needs_builder_fix` with `signoff_clean` route fails; all tests passed.
- Ran `cargo check --all-targets -p xtask` which completed successfully.
- Ran `cargo clippy -p xtask -- -D warnings` which completed successfully (no warnings remain for `xtask`).
- Ran `cargo xtask fmt` successfully; `just pr-fast` was not available in this environment (command not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0d7a6fc8333a0a53252a91e267b)