### PR TITLE
feat(reviews): add material-observation review receipts (#6853)

### DIFF
--- a/.ci/receipts/registry.toml
+++ b/.ci/receipts/registry.toml
@@ -31,3 +31,9 @@ description = "Rustfmt gate receipt for explicit formatting outcomes."
 check = "failure-classifier"
 schema = ".ci/receipts/schemas/failure-classifier.schema.json"
 description = "Classifies failures into code/infra/staleness classes."
+
+[[receipt]]
+check = "review"
+schema = ".ci/receipts/schemas/review.schema.json"
+description = "Agent sign-off receipt with material observations and negative checks."
+required_fields = ["material_observations", "negative_checks", "verdict"]

--- a/.ci/receipts/schemas/review.schema.json
+++ b/.ci/receipts/schemas/review.schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/review.schema.json",
+  "title": "Review Receipt",
+  "description": "Evidence-only receipt emitted by review agents for PR routing and sign-off decisions.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "producer",
+    "pr",
+    "head_sha",
+    "base_sha",
+    "verdict",
+    "material_observations",
+    "negative_checks",
+    "blockers",
+    "next_routes",
+    "supersedes"
+  ],
+  "properties": {
+    "kind": {
+      "const": "review"
+    },
+    "producer": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Agent, workflow, or reviewer identity that produced this receipt."
+    },
+    "pr": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "head_sha": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "base_sha": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "clean",
+        "needs_builder_fix",
+        "needs_diff_fix",
+        "needs_human",
+        "blocked_unknown"
+      ]
+    },
+    "material_observations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "negative_checks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "next_routes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "signoff_clean",
+          "builder_fix",
+          "diff_fix",
+          "human_review",
+          "blocked"
+        ]
+      }
+    },
+    "supersedes": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Prior review receipt id or null when this is the first receipt."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "verdict": {
+            "const": "clean"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "material_observations": {
+            "minItems": 1
+          },
+          "negative_checks": {
+            "minItems": 1
+          },
+          "next_routes": {
+            "contains": {
+              "const": "signoff_clean"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "verdict": {
+            "enum": [
+              "needs_builder_fix",
+              "needs_diff_fix",
+              "needs_human",
+              "blocked_unknown"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "next_routes": {
+            "not": {
+              "contains": {
+                "const": "signoff_clean"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/ci/review-receipts.md
+++ b/docs/ci/review-receipts.md
@@ -1,0 +1,81 @@
+# Review receipts: material observations required for clean sign-off
+
+Review receipts are **evidence-only** JSON artifacts emitted by review agents. They document what was checked, what was not observed, and what route should happen next. They do not mutate labels and they do not implement state-building logic.
+
+Schema: `.ci/receipts/schemas/review.schema.json`.
+
+## Required fields
+
+Every review receipt includes:
+
+- `kind` (must be `review`)
+- `producer`
+- `pr`
+- `head_sha`
+- `base_sha`
+- `verdict` (`clean` | `needs_builder_fix` | `needs_diff_fix` | `needs_human` | `blocked_unknown`)
+- `material_observations[]`
+- `negative_checks[]`
+- `blockers[]`
+- `next_routes[]`
+- `supersedes`
+
+## Doctrine encoded by the schema
+
+1. **Clean sign-off requires material observations.**
+   - A `clean` verdict must include at least one item in `material_observations`.
+2. **Clean sign-off requires negative checks.**
+   - A `clean` verdict must include at least one item in `negative_checks`.
+3. **Needs-fix verdicts cannot emit clean sign-off intent.**
+   - `needs_builder_fix`, `needs_diff_fix`, `needs_human`, and `blocked_unknown` receipts must not contain `signoff_clean` in `next_routes`.
+4. **Receipts are evidence, not mutation instructions.**
+   - The receipt states review evidence and suggested route only.
+   - Label mutation is intentionally out of scope.
+
+## Minimal examples
+
+### Clean review
+
+```json
+{
+  "kind": "review",
+  "producer": "reviewer@ci",
+  "pr": 6853,
+  "head_sha": "1111111111111111111111111111111111111111",
+  "base_sha": "2222222222222222222222222222222222222222",
+  "verdict": "clean",
+  "material_observations": [
+    "Compared branch diff to base and observed only schema/docs/test additions for review receipts"
+  ],
+  "negative_checks": [
+    "No label mutation code paths introduced"
+  ],
+  "blockers": [],
+  "next_routes": ["signoff_clean"],
+  "supersedes": null
+}
+```
+
+### Needs builder fix
+
+```json
+{
+  "kind": "review",
+  "producer": "reviewer@ci",
+  "pr": 6853,
+  "head_sha": "3333333333333333333333333333333333333333",
+  "base_sha": "4444444444444444444444444444444444444444",
+  "verdict": "needs_builder_fix",
+  "material_observations": [
+    "State builder contract for review receipts is missing routing consumption"
+  ],
+  "negative_checks": [
+    "No signoff label intent should be emitted while builder fix is required"
+  ],
+  "blockers": [
+    "Builder does not parse review receipt verdict taxonomy yet"
+  ],
+  "next_routes": ["builder_fix"],
+  "supersedes": null
+}
+```

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -73,6 +73,7 @@ pub mod release;
 pub mod release_evidence;
 pub mod release_notes;
 pub mod release_turnkey;
+pub mod review_receipts;
 pub mod srp_microcrates;
 pub mod swarm_summary;
 pub mod targeted_checks;

--- a/xtask/src/tasks/review_receipts.rs
+++ b/xtask/src/tasks/review_receipts.rs
@@ -1,0 +1,156 @@
+// Allow dead_code because this helper is currently exercised by tests and schema fixtures before CLI wiring lands.
+#![allow(dead_code)]
+
+use color_eyre::eyre::{Result, bail};
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ReviewVerdict {
+    Clean,
+    NeedsBuilderFix,
+    NeedsDiffFix,
+    NeedsHuman,
+    BlockedUnknown,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReviewReceipt {
+    kind: String,
+    producer: String,
+    pr: u64,
+    head_sha: String,
+    base_sha: String,
+    verdict: ReviewVerdict,
+    material_observations: Vec<String>,
+    negative_checks: Vec<String>,
+    blockers: Vec<String>,
+    next_routes: Vec<String>,
+    supersedes: Option<String>,
+}
+
+/// Validate review receipt invariants that are easy to keep in sync with tests.
+pub fn validate_review_receipt(value: &Value) -> Result<()> {
+    let receipt: ReviewReceipt = serde_json::from_value(value.clone())?;
+
+    if receipt.kind != "review" {
+        bail!("kind must be 'review'");
+    }
+
+    if receipt.producer.is_empty() {
+        bail!("producer must be non-empty");
+    }
+
+    if receipt.pr == 0 {
+        bail!("pr must be >= 1");
+    }
+
+    if !is_sha1_hex(&receipt.head_sha) {
+        bail!("head_sha must be a 40-char lowercase hex commit sha");
+    }
+
+    if !is_sha1_hex(&receipt.base_sha) {
+        bail!("base_sha must be a 40-char lowercase hex commit sha");
+    }
+
+    if receipt.next_routes.is_empty() {
+        bail!("next_routes must not be empty");
+    }
+
+    let has_signoff_intent = receipt.next_routes.iter().any(|route| route == "signoff_clean");
+
+    if matches!(receipt.verdict, ReviewVerdict::Clean) {
+        if receipt.material_observations.is_empty() {
+            bail!("clean verdict requires at least one material observation");
+        }
+        if receipt.negative_checks.is_empty() {
+            bail!("clean verdict requires at least one negative check");
+        }
+        if !has_signoff_intent {
+            bail!("clean verdict must include signoff_clean in next_routes");
+        }
+    }
+
+    if matches!(
+        receipt.verdict,
+        ReviewVerdict::NeedsBuilderFix
+            | ReviewVerdict::NeedsDiffFix
+            | ReviewVerdict::NeedsHuman
+            | ReviewVerdict::BlockedUnknown
+    ) && has_signoff_intent
+    {
+        bail!("needs-fix/human/blocked verdicts must not emit clean sign-off intent");
+    }
+
+    // Evidence-only receipt: route hints are allowed, mutation commands are not.
+    if receipt.next_routes.iter().any(|route| route.starts_with("label:")) {
+        bail!("review receipts are evidence-only and may not include label mutations");
+    }
+
+    let _ = receipt.blockers;
+    let _ = receipt.supersedes;
+
+    Ok(())
+}
+
+fn is_sha1_hex(value: &str) -> bool {
+    value.len() == 40 && value.chars().all(|ch| ch.is_ascii_hexdigit() && !ch.is_ascii_uppercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_review_receipt;
+    use color_eyre::eyre::{Result, eyre};
+    use serde_json::Value;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn fixture_path(name: &str) -> Result<PathBuf> {
+        let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let path = base.join("tests").join("fixtures").join("review-receipts").join(name);
+        if !path.exists() {
+            return Err(eyre!("missing fixture: {}", path.display()));
+        }
+        Ok(path)
+    }
+
+    fn load_fixture(name: &str) -> Result<Value> {
+        let raw = fs::read_to_string(fixture_path(name)?)?;
+        let parsed: Value = serde_json::from_str(&raw)?;
+        Ok(parsed)
+    }
+
+    #[test]
+    fn clean_receipt_with_observations_passes() -> Result<()> {
+        let value = load_fixture("clean-with-observations.json")?;
+        validate_review_receipt(&value)
+    }
+
+    #[test]
+    fn clean_receipt_without_observations_fails() -> Result<()> {
+        let value = load_fixture("clean-without-observations.json")?;
+        let err = validate_review_receipt(&value)
+            .err()
+            .ok_or_else(|| eyre!("fixture should fail validation"))?;
+        let message = err.to_string();
+        if !message.contains("material observation") {
+            return Err(eyre!("expected material observation failure, got: {message}"));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn needs_builder_fix_with_clean_signoff_intent_fails() -> Result<()> {
+        let value = load_fixture("needs-builder-fix-with-clean-signoff-intent.json")?;
+        let err = validate_review_receipt(&value)
+            .err()
+            .ok_or_else(|| eyre!("fixture should fail validation"))?;
+        let message = err.to_string();
+        if !message.contains("must not emit clean sign-off intent") {
+            return Err(eyre!("expected signoff intent failure, got: {message}"));
+        }
+        Ok(())
+    }
+}

--- a/xtask/tests/fixtures/review-receipts/clean-with-observations.json
+++ b/xtask/tests/fixtures/review-receipts/clean-with-observations.json
@@ -1,0 +1,19 @@
+{
+  "kind": "review",
+  "producer": "review-bot",
+  "pr": 6853,
+  "head_sha": "1111111111111111111111111111111111111111",
+  "base_sha": "2222222222222222222222222222222222222222",
+  "verdict": "clean",
+  "material_observations": [
+    "Observed only review-receipt schema/docs/tests changes in this diff"
+  ],
+  "negative_checks": [
+    "Did not observe label mutation instructions"
+  ],
+  "blockers": [],
+  "next_routes": [
+    "signoff_clean"
+  ],
+  "supersedes": null
+}

--- a/xtask/tests/fixtures/review-receipts/clean-without-observations.json
+++ b/xtask/tests/fixtures/review-receipts/clean-without-observations.json
@@ -1,0 +1,17 @@
+{
+  "kind": "review",
+  "producer": "review-bot",
+  "pr": 6853,
+  "head_sha": "3333333333333333333333333333333333333333",
+  "base_sha": "4444444444444444444444444444444444444444",
+  "verdict": "clean",
+  "material_observations": [],
+  "negative_checks": [
+    "No unauthorized file rewrites detected"
+  ],
+  "blockers": [],
+  "next_routes": [
+    "signoff_clean"
+  ],
+  "supersedes": null
+}

--- a/xtask/tests/fixtures/review-receipts/needs-builder-fix-with-clean-signoff-intent.json
+++ b/xtask/tests/fixtures/review-receipts/needs-builder-fix-with-clean-signoff-intent.json
@@ -1,0 +1,22 @@
+{
+  "kind": "review",
+  "producer": "review-bot",
+  "pr": 6853,
+  "head_sha": "5555555555555555555555555555555555555555",
+  "base_sha": "6666666666666666666666666666666666666666",
+  "verdict": "needs_builder_fix",
+  "material_observations": [
+    "Builder route parser does not consume review verdicts"
+  ],
+  "negative_checks": [
+    "No fallback inference route available"
+  ],
+  "blockers": [
+    "State builder cannot apply needs_builder_fix"
+  ],
+  "next_routes": [
+    "builder_fix",
+    "signoff_clean"
+  ],
+  "supersedes": null
+}


### PR DESCRIPTION
### Motivation

- Problem: non-trivial `clean` sign-offs can claim “nothing to flag” without concrete evidence, making sign-off untrustworthy. 
- Goal: require material observations and negative checks for `clean` verdicts and prevent conflicting signoff intent on needs-fix verdicts. 
- Approach: add a machine-readable schema, documentation, and a small validation helper with fixtures so CI and reviewers have verifiable evidence-only receipts.

### Description

- Add JSON Schema at `.ci/receipts/schemas/review.schema.json` that defines the `review` receipt shape and encodes doctrine rules (required fields and conditional constraints for `clean` vs needs-fix verdicts). 
- Add documentation at `docs/ci/review-receipts.md` describing the schema, required fields, doctrine, and minimal examples. 
- Add a lightweight xtask helper `xtask/src/tasks/review_receipts.rs` containing `validate_review_receipt` and unit tests that assert the schema-backed invariants; register the module via `pub mod review_receipts;` in `xtask/src/tasks/mod.rs`. 
- Add fixtures under `xtask/tests/fixtures/review-receipts/` for the three validation scenarios (clean with observations, clean without observations, needs-builder-fix with illicit `signoff_clean`).

### Testing

- Ran `cargo test -p xtask review_receipts::tests` which executes the three focused unit tests and they passed (valid clean passes; missing observations fails; needs-fix with signoff intent fails). 
- Ran formatting and checks: `cargo xtask fmt`, `cargo fmt --all`, and `cargo check --all-targets -p xtask`, all completed successfully.
- Verification summary: `clean` receipt with observations passes validation; `clean` without observations fails validation; `needs_builder_fix` with `signoff_clean` fails validation.

Refs #6853

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0d7a6fc8333a0a53252a91e267b)