### PR TITLE
feat(ci): add intent/diff closeout evidence gate (#6853)

### DIFF
--- a/.ci/policies/intent-diff-rules.toml
+++ b/.ci/policies/intent-diff-rules.toml
@@ -1,0 +1,18 @@
+[severity]
+docs_only_code_fix = "fail"
+closeout_missing_evidence = "fail"
+scaffold_with_close_keyword = "fail"
+docs_claim_but_code_changed = "warn"
+vscode_activation_missing_path = "fail"
+
+[issues."6747"]
+expected_paths = [
+  "vscode-extension/package.json",
+  "crates/perl-lsp-rs/tests",
+]
+
+[component_expected_paths]
+vscode_activation_fix = [
+  "vscode-extension/package.json",
+  "crates/perl-lsp-rs/tests",
+]

--- a/.ci/receipts/schemas/intent-diff-gate.schema.json
+++ b/.ci/receipts/schemas/intent-diff-gate.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/ci/intent-diff-gate.schema.json",
+  "title": "Intent Diff Gate Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "claimed_component",
+    "claimed_closeout_issues",
+    "expected_paths",
+    "actual_paths",
+    "evidence",
+    "verdict",
+    "violations"
+  ],
+  "properties": {
+    "claimed_component": { "type": "string" },
+    "claimed_closeout_issues": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "expected_paths": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    },
+    "actual_paths": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "touched_expected_path",
+        "test_updated",
+        "behavior_receipt",
+        "explicit_override"
+      ],
+      "properties": {
+        "touched_expected_path": { "type": "boolean" },
+        "test_updated": { "type": "boolean" },
+        "behavior_receipt": { "type": "boolean" },
+        "explicit_override": { "type": "boolean" }
+      }
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "warn", "fail"]
+    },
+    "violations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["code", "severity", "message"],
+        "properties": {
+          "code": { "type": "string" },
+          "severity": { "type": "string", "enum": ["warn", "fail"] },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/docs/ci/intent-diff-closeout-gate.md
+++ b/docs/ci/intent-diff-closeout-gate.md
@@ -1,0 +1,24 @@
+# Intent/Diff Closeout Evidence Gate
+
+`cargo xtask intent-diff-gate` validates whether PR intent claims (title/body) match the diff and whether closeout keywords have supporting evidence.
+
+## Commands
+
+```bash
+cargo xtask intent-diff-gate --pr <N> --receipt target/receipts/intent-diff-gate.json
+cargo xtask intent-diff-gate --fixture xtask/tests/fixtures/intent-diff/<fixture>.json
+```
+
+## Rules
+
+1. Code-fix intent with docs-only diffs is a policy violation (`warn`/`fail` by policy).
+2. `Closes/Fixes/Resolves #<issue>` requires one of:
+   - expected target path changed,
+   - tests updated,
+   - behavior receipt present,
+   - explicit override reason.
+3. Scaffold/partial PRs must not use closing keywords.
+4. Docs-scoped titles that modify production code are flagged.
+5. VS Code activation fix claims require `vscode-extension/package.json` (or relevant tests) unless explicitly overridden.
+
+Motivation: we want to prevent intent/diff/closeout drift like the #6780-style mismatch while keeping `Refs #...` usable for partial work.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -895,6 +895,19 @@ enum Commands {
     /// Check invariants in features.toml
     DocClaims,
 
+    /// Validate PR intent/body claims against changed-file evidence.
+    IntentDiffGate {
+        /// Pull request number to inspect via gh CLI.
+        #[arg(long)]
+        pr: Option<u64>,
+        /// Fixture JSON input for deterministic local validation.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+        /// Optional output path for gate receipt JSON.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+    },
+
     /// Manage feature catalog and LSP compliance
     Features {
         #[command(subcommand)]
@@ -1592,6 +1605,9 @@ fn main() -> Result<()> {
             })
         }
         Commands::DocClaims => doc_claims::run(),
+        Commands::IntentDiffGate { pr, fixture, receipt } => {
+            intent_diff_gate::run(pr, fixture, receipt)
+        }
         Commands::Features { command } => match command {
             FeaturesCommand::SyncDocs => features::sync_docs(),
             FeaturesCommand::Verify => features::verify(),

--- a/xtask/src/tasks/intent_diff_gate.rs
+++ b/xtask/src/tasks/intent_diff_gate.rs
@@ -1,0 +1,359 @@
+use crate::utils::project_root;
+use color_eyre::eyre::{Context, Result, bail, eyre};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug, Deserialize)]
+pub struct IntentDiffPolicy {
+    #[serde(default)]
+    pub severity: SeverityPolicy,
+    #[serde(default)]
+    pub issues: BTreeMap<String, IssueRule>,
+    #[serde(default)]
+    pub component_expected_paths: BTreeMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct IssueRule {
+    #[serde(default)]
+    pub expected_paths: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SeverityPolicy {
+    #[serde(default = "default_fail")]
+    pub docs_only_code_fix: String,
+    #[serde(default = "default_fail")]
+    pub closeout_missing_evidence: String,
+    #[serde(default = "default_fail")]
+    pub scaffold_with_close_keyword: String,
+    #[serde(default = "default_warn")]
+    pub docs_claim_but_code_changed: String,
+    #[serde(default = "default_fail")]
+    pub vscode_activation_missing_path: String,
+}
+
+impl Default for SeverityPolicy {
+    fn default() -> Self {
+        Self {
+            docs_only_code_fix: default_fail(),
+            closeout_missing_evidence: default_fail(),
+            scaffold_with_close_keyword: default_fail(),
+            docs_claim_but_code_changed: default_warn(),
+            vscode_activation_missing_path: default_fail(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GateInput {
+    pub title: String,
+    #[serde(default)]
+    pub body: String,
+    #[serde(default)]
+    pub actual_paths: Vec<String>,
+    #[serde(default)]
+    pub behavior_receipt: bool,
+    #[serde(default)]
+    pub override_reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GateReceipt {
+    pub claimed_component: String,
+    pub claimed_closeout_issues: Vec<String>,
+    pub expected_paths: BTreeMap<String, Vec<String>>,
+    pub actual_paths: Vec<String>,
+    pub evidence: Evidence,
+    pub verdict: String,
+    pub violations: Vec<Violation>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Evidence {
+    pub touched_expected_path: bool,
+    pub test_updated: bool,
+    pub behavior_receipt: bool,
+    pub explicit_override: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Violation {
+    pub code: String,
+    pub severity: String,
+    pub message: String,
+}
+
+fn default_fail() -> String {
+    "fail".to_string()
+}
+
+fn default_warn() -> String {
+    "warn".to_string()
+}
+
+pub fn run(pr: Option<u64>, fixture: Option<PathBuf>, receipt: Option<PathBuf>) -> Result<()> {
+    if pr.is_some() == fixture.is_some() {
+        bail!("Provide exactly one of --pr <N> or --fixture <json>");
+    }
+
+    let root = project_root()?;
+    let policy = load_policy(&root.join(".ci/policies/intent-diff-rules.toml"))?;
+    let input = if let Some(path) = fixture {
+        load_fixture(&path)?
+    } else if let Some(pr_number) = pr {
+        load_pr_input(pr_number)?
+    } else {
+        bail!("Provide exactly one of --pr <N> or --fixture <json>");
+    };
+
+    let gate_receipt = evaluate(&input, &policy);
+    let serialized = serde_json::to_string_pretty(&gate_receipt)?;
+
+    if let Some(path) = receipt {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create receipt directory {}", parent.display())
+            })?;
+        }
+        fs::write(&path, &serialized)
+            .with_context(|| format!("Failed to write receipt to {}", path.display()))?;
+    }
+
+    println!("{serialized}");
+
+    if gate_receipt.verdict == "fail" {
+        bail!("intent-diff gate failed");
+    }
+
+    Ok(())
+}
+
+fn load_policy(path: &Path) -> Result<IntentDiffPolicy> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read policy file {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("Failed to parse policy file {}", path.display()))
+}
+
+fn load_fixture(path: &Path) -> Result<GateInput> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read fixture {}", path.display()))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("Failed to parse fixture {}", path.display()))
+}
+
+fn load_pr_input(pr: u64) -> Result<GateInput> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &pr.to_string(),
+            "--json",
+            "title,body,files",
+            "--repo",
+            "EffortlessMetrics/perl-lsp",
+        ])
+        .output()
+        .context("Failed to execute gh CLI")?;
+
+    if !output.status.success() {
+        return Err(eyre!("gh pr view failed: {}", String::from_utf8_lossy(&output.stderr)));
+    }
+
+    #[derive(Deserialize)]
+    struct GhFile {
+        path: String,
+    }
+    #[derive(Deserialize)]
+    struct GhPr {
+        title: String,
+        #[serde(default)]
+        body: String,
+        #[serde(default)]
+        files: Vec<GhFile>,
+    }
+
+    let parsed: GhPr = serde_json::from_slice(&output.stdout).context("Failed to parse gh JSON")?;
+    let actual_paths = parsed.files.into_iter().map(|file| file.path).collect();
+
+    Ok(GateInput {
+        title: parsed.title,
+        body: parsed.body,
+        actual_paths,
+        behavior_receipt: false,
+        override_reason: None,
+    })
+}
+
+fn evaluate(input: &GateInput, policy: &IntentDiffPolicy) -> GateReceipt {
+    let merged_text = format!("{}\n{}", input.title.to_lowercase(), input.body.to_lowercase());
+    let claimed_component = detect_component(&merged_text);
+    let closeout_issues = parse_closeout_issues(&input.body);
+    let is_docs_only = input.actual_paths.iter().all(|path| is_docs_path(path));
+    let test_updated = input.actual_paths.iter().any(|path| is_test_path(path));
+    let explicit_override = input.override_reason.is_some();
+
+    let mut expected_paths = BTreeMap::new();
+    let mut all_expected_paths = BTreeSet::new();
+
+    for issue in &closeout_issues {
+        if let Some(rule) = policy.issues.get(issue) {
+            expected_paths.insert(issue.clone(), rule.expected_paths.clone());
+            for path in &rule.expected_paths {
+                all_expected_paths.insert(path.clone());
+            }
+        }
+    }
+
+    if let Some(paths) = policy.component_expected_paths.get(&claimed_component) {
+        expected_paths.insert(claimed_component.clone(), paths.clone());
+        for path in paths {
+            all_expected_paths.insert(path.clone());
+        }
+    }
+
+    let touched_expected_path = input
+        .actual_paths
+        .iter()
+        .any(|actual| all_expected_paths.iter().any(|expected| actual.starts_with(expected)));
+
+    let evidence = Evidence {
+        touched_expected_path,
+        test_updated,
+        behavior_receipt: input.behavior_receipt,
+        explicit_override,
+    };
+
+    let mut violations = Vec::new();
+    let claims_fix = merged_text.contains("fix") || merged_text.contains("bug");
+    let claims_docs = input.title.to_lowercase().contains("docs");
+    let production_changed =
+        input.actual_paths.iter().any(|path| !is_docs_path(path) && !is_test_path(path));
+    let claims_scaffold_partial =
+        merged_text.contains("scaffold") || merged_text.contains("partial");
+
+    if claims_fix && is_docs_only {
+        violations.push(Violation {
+            code: "docs-only-code-fix-claim".to_string(),
+            severity: policy.severity.docs_only_code_fix.clone(),
+            message: "PR claims a fix but only docs files changed".to_string(),
+        });
+    }
+
+    if claims_docs && production_changed {
+        violations.push(Violation {
+            code: "docs-title-with-code-change".to_string(),
+            severity: policy.severity.docs_claim_but_code_changed.clone(),
+            message: "PR title claims docs-only scope but production code changed".to_string(),
+        });
+    }
+
+    if claims_scaffold_partial && !closeout_issues.is_empty() {
+        violations.push(Violation {
+            code: "partial-pr-uses-close-keyword".to_string(),
+            severity: policy.severity.scaffold_with_close_keyword.clone(),
+            message: "Scaffold/partial PR should not use closing keywords".to_string(),
+        });
+    }
+
+    if !(closeout_issues.is_empty()
+        || touched_expected_path
+        || test_updated
+        || input.behavior_receipt
+        || explicit_override)
+    {
+        violations.push(Violation {
+            code: "closeout-missing-evidence".to_string(),
+            severity: policy.severity.closeout_missing_evidence.clone(),
+            message: "Closeout keyword used without target-path touch, tests, receipt, or override"
+                .to_string(),
+        });
+    }
+
+    if claimed_component == "vscode_activation_fix"
+        && !(touched_expected_path || test_updated || explicit_override)
+    {
+        violations.push(Violation {
+            code: "vscode-activation-missing-evidence".to_string(),
+            severity: policy.severity.vscode_activation_missing_path.clone(),
+            message:
+                "VS Code activation fix claims must touch expected extension paths or tests (or override)"
+                    .to_string(),
+        });
+    }
+
+    let verdict = if violations.iter().any(|violation| violation.severity == "fail") {
+        "fail"
+    } else if violations.iter().any(|violation| violation.severity == "warn") {
+        "warn"
+    } else {
+        "pass"
+    }
+    .to_string();
+
+    GateReceipt {
+        claimed_component,
+        claimed_closeout_issues: closeout_issues,
+        expected_paths,
+        actual_paths: input.actual_paths.clone(),
+        evidence,
+        verdict,
+        violations,
+    }
+}
+
+fn detect_component(merged_text: &str) -> String {
+    if merged_text.contains("vs code")
+        && merged_text.contains("activation")
+        && merged_text.contains("fix")
+    {
+        return "vscode_activation_fix".to_string();
+    }
+    if merged_text.contains("docs") {
+        return "docs".to_string();
+    }
+    if merged_text.contains("fix") {
+        return "code_fix".to_string();
+    }
+    "unspecified".to_string()
+}
+
+fn parse_closeout_issues(body: &str) -> Vec<String> {
+    let mut issues = BTreeSet::new();
+    let normalized = body.replace('\n', " ");
+    let tokens: Vec<&str> = normalized.split_whitespace().collect();
+
+    for window in tokens.windows(2) {
+        if let [keyword, issue_ref] = window {
+            let key = keyword.to_ascii_lowercase();
+            if (key == "closes" || key == "fixes" || key == "resolves")
+                && let Some(stripped) = issue_ref.strip_prefix('#')
+            {
+                let digits: String =
+                    stripped.chars().take_while(|ch| ch.is_ascii_digit()).collect();
+                if !digits.is_empty() {
+                    issues.insert(digits);
+                }
+            }
+        }
+    }
+
+    issues.into_iter().collect()
+}
+
+fn is_docs_path(path: &str) -> bool {
+    path.starts_with("docs/")
+        || path.ends_with(".md")
+        || path.ends_with(".txt")
+        || path.starts_with(".github/")
+}
+
+fn is_test_path(path: &str) -> bool {
+    path.contains("/tests/")
+        || path.contains("_test")
+        || path.ends_with("_tests.rs")
+        || path.contains("fixtures")
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -47,6 +47,7 @@ pub mod highlight;
 pub mod hook_checks;
 pub mod ignored_tests;
 pub mod inject_sha_assets;
+pub mod intent_diff_gate;
 pub mod layer_check;
 pub mod metrics;
 pub mod parse_rust;

--- a/xtask/tests/fixtures/intent-diff/doc_only_code_fix_claim.json
+++ b/xtask/tests/fixtures/intent-diff/doc_only_code_fix_claim.json
@@ -1,0 +1,7 @@
+{
+  "title": "fix(vscode): fix VS Code activation bug",
+  "body": "Fixes #6747\n\nAdded docs note only.",
+  "actual_paths": [
+    "docs/troubleshooting/vscode-activation.md"
+  ]
+}

--- a/xtask/tests/fixtures/intent-diff/partial_refs_pass.json
+++ b/xtask/tests/fixtures/intent-diff/partial_refs_pass.json
@@ -1,0 +1,8 @@
+{
+  "title": "feat(ci): scaffold intent diff gate",
+  "body": "Refs #6853\n\npartial scaffolding only",
+  "actual_paths": [
+    "xtask/src/tasks/intent_diff_gate.rs",
+    "docs/ci/intent-diff-closeout-gate.md"
+  ]
+}

--- a/xtask/tests/fixtures/intent-diff/valid_closeout_target_path_touched.json
+++ b/xtask/tests/fixtures/intent-diff/valid_closeout_target_path_touched.json
@@ -1,0 +1,8 @@
+{
+  "title": "fix(vscode): fix VS Code activation path",
+  "body": "Resolves #6747",
+  "actual_paths": [
+    "vscode-extension/package.json",
+    "crates/perl-lsp-rs/tests/vscode_activation.rs"
+  ]
+}

--- a/xtask/tests/intent_diff_gate_tests.rs
+++ b/xtask/tests/intent_diff_gate_tests.rs
@@ -1,0 +1,57 @@
+use assert_cmd::Command;
+use color_eyre::eyre::Result;
+use std::path::PathBuf;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/intent-diff").join(name)
+}
+
+fn run_fixture(name: &str) -> Result<std::process::Output> {
+    let fixture = fixture_path(name);
+    let fixture_arg = fixture.to_string_lossy().into_owned();
+    Ok(Command::cargo_bin("xtask")?
+        .args(["intent-diff-gate", "--fixture", fixture_arg.as_str()])
+        .output()?)
+}
+
+#[test]
+fn fixture_doc_only_code_fix_claim_fails() -> Result<()> {
+    let output = run_fixture("doc_only_code_fix_claim.json")?;
+
+    assert!(
+        !output.status.success(),
+        "expected failure, got stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn fixture_partial_pr_with_refs_passes() -> Result<()> {
+    let output = run_fixture("partial_refs_pass.json")?;
+
+    assert!(
+        output.status.success(),
+        "expected success, got stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn fixture_valid_closeout_target_path_touched_passes() -> Result<()> {
+    let output = run_fixture("valid_closeout_target_path_touched.json")?;
+
+    assert!(
+        output.status.success(),
+        "expected success, got stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Prevent PR intent/body claims from drifting from the actual diff and stop premature use of closing keywords (motivation: #6780-style mismatch where a claimed code-fix closed an issue but only a docs file was changed). 
- Provide a lightweight, policy-driven gate that requires concrete evidence (target path touched, tests updated, behavior receipt, or explicit override) before allowing closeout keywords to implicitly close issues.

### Description

- Add a new xtask gate implementation `xtask/src/tasks/intent_diff_gate.rs` implementing the intent/diff/closeout checks and emitting a structured receipt with fields `claimed_component`, `claimed_closeout_issues`, `expected_paths`, `actual_paths`, `evidence`, `verdict`, and `violations`.
- Add policy and schema artifacts: `.ci/policies/intent-diff-rules.toml` to control severities and expected paths, and `.ci/receipts/schemas/intent-diff-gate.schema.json` to document the receipt contract.
- Wire the command into the xtask CLI as `IntentDiffGate` and register the module in `xtask/src/tasks/mod.rs`.
- Add docs `docs/ci/intent-diff-closeout-gate.md` describing usage and rules, and provide fixture inputs under `xtask/tests/fixtures/intent-diff/` plus integration tests `xtask/tests/intent_diff_gate_tests.rs` covering: a #6780-like docs-only code-fix claim (should fail), a partial `Refs` scaffold PR (passes), and a valid closeout where the expected target path is touched (passes).
- Implemented rules (policy-driven): (1) code-fix claims with docs-only diffs are flagged; (2) `Closes/Fixes/Resolves #N` requires evidence (target path, test update, behavior receipt, or override); (3) scaffold/partial PRs must not use closing keywords; (4) docs-titled PRs that change production code are flagged; (5) VS Code activation claims require touching expected extension paths or tests unless overridden.

### Testing

- Ran formatter: `cargo xtask fmt --package xtask` (succeeded).
- Unit/integration tests: `cargo test -p xtask --test intent_diff_gate_tests` (3 tests passed).
- Build checks: `cargo check --all-targets -p xtask` (succeeded) and `cargo clippy -p xtask -- -D warnings` (succeeded).
- Exercised the CLI in fixture mode: `cargo xtask intent-diff-gate --fixture <fixture.json>` for all three fixtures; the docs-only code-fix fixture produced the expected failing verdict while the partial-Refs and valid-closeout fixtures passed.
- Attempted to run `just pr-fast` but it is unavailable in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0dc9dc483338167ebf7f799a4e2)