### PR TITLE
feat(ci): add intent/diff closeout evidence gate (#6853)

### DIFF
--- a/.ci/policies/intent-diff-rules.toml
+++ b/.ci/policies/intent-diff-rules.toml
@@ -1,0 +1,20 @@
+[severity]
+docs_only_code_claim = "fail"
+docs_title_code_change = "warn"
+scaffold_closeout = "fail"
+
+override_markers = ["intent-diff-override", "intent-diff: override"]
+test_path_markers = ["/tests/", "_test", "/spec/"]
+behavior_receipt_markers = ["target/receipts/", ".ci/receipts/", "review/receipts/"]
+
+[issue_targets]
+"6747" = [
+  "vscode-extension/package.json",
+  "crates/perl-lsp-rs/tests/",
+  "crates/perl-lsp-ux-tests/"
+]
+
+[component_expectations.vscode_activation]
+keywords = ["vs code activation", "vscode activation"]
+expected_paths = ["vscode-extension/package.json", "crates/perl-lsp-rs/tests/"]
+level = "fail"

--- a/.ci/receipts/schemas/intent-diff-gate.schema.json
+++ b/.ci/receipts/schemas/intent-diff-gate.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.github.io/perl-lsp/schemas/intent-diff-gate.schema.json",
+  "title": "intent-diff-gate receipt",
+  "type": "object",
+  "required": [
+    "claimed_component",
+    "claimed_closeout_issues",
+    "expected_paths",
+    "actual_paths",
+    "evidence",
+    "verdict",
+    "violations"
+  ],
+  "properties": {
+    "claimed_component": { "type": "array", "items": { "type": "string" } },
+    "claimed_closeout_issues": { "type": "array", "items": { "type": "integer", "minimum": 1 } },
+    "expected_paths": { "type": "array", "items": { "type": "string" } },
+    "actual_paths": { "type": "array", "items": { "type": "string" } },
+    "evidence": {
+      "type": "object",
+      "required": ["target_path_touched", "test_updated", "behavior_receipt", "explicit_override"],
+      "properties": {
+        "target_path_touched": { "type": "boolean" },
+        "test_updated": { "type": "boolean" },
+        "behavior_receipt": { "type": "boolean" },
+        "explicit_override": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "verdict": { "type": "string", "enum": ["pass", "warn", "fail"] },
+    "violations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["rule", "level", "message"],
+        "properties": {
+          "rule": { "type": "string" },
+          "level": { "type": "string", "enum": ["warn", "fail"] },
+          "message": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/ci/intent-diff-closeout-gate.md
+++ b/docs/ci/intent-diff-closeout-gate.md
@@ -1,0 +1,37 @@
+# Intent/diff closeout evidence gate
+
+`cargo xtask intent-diff-gate` validates that PR claims (title/body) match the changed paths and closeout evidence.
+
+## Commands
+
+- `cargo xtask intent-diff-gate --pr <N> --receipt target/receipts/intent-diff-gate.json`
+- `cargo xtask intent-diff-gate --fixture <json>`
+
+## What it enforces
+
+1. A fix-style claim with docs-only diff is flagged (policy decides fail/warn).
+2. `Closes/Fixes/Resolves #NNNN` claims for issues with known target paths require evidence:
+   - target path touched, or
+   - test updated, or
+   - behavior receipt path touched, or
+   - explicit override marker in title/body.
+3. Scaffold/partial/WIP PRs must not use closing keywords.
+4. Docs-scoped titles with production code changes are flagged.
+5. VS Code activation claims require `vscode-extension/package.json` or relevant tests, unless overridden.
+
+## Policy and receipt files
+
+- Policy: `.ci/policies/intent-diff-rules.toml`
+- Receipt schema: `.ci/receipts/schemas/intent-diff-gate.schema.json`
+- Receipt output fields:
+  - `claimed_component`
+  - `claimed_closeout_issues`
+  - `expected_paths`
+  - `actual_paths`
+  - `evidence`
+  - `verdict`
+  - `violations`
+
+## Motivation
+
+This gate is intended to prevent intent/diff mismatches like the #6780-style case where a PR claimed a VS Code activation fix and closeout but only changed documentation.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -895,6 +895,21 @@ enum Commands {
     /// Check invariants in features.toml
     DocClaims,
 
+    /// Validate PR intent/title/body against changed paths and closeout evidence.
+    IntentDiffGate {
+        /// Pull request number to inspect using `gh pr view`.
+        #[arg(long)]
+        pr: Option<u64>,
+
+        /// Local JSON fixture for deterministic checks and tests.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+
+        /// Optional receipt output path.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+    },
+
     /// Manage feature catalog and LSP compliance
     Features {
         #[command(subcommand)]
@@ -1592,6 +1607,9 @@ fn main() -> Result<()> {
             })
         }
         Commands::DocClaims => doc_claims::run(),
+        Commands::IntentDiffGate { pr, fixture, receipt } => {
+            intent_diff_gate::run(pr, fixture, receipt)
+        }
         Commands::Features { command } => match command {
             FeaturesCommand::SyncDocs => features::sync_docs(),
             FeaturesCommand::Verify => features::verify(),

--- a/xtask/src/tasks/intent_diff_gate.rs
+++ b/xtask/src/tasks/intent_diff_gate.rs
@@ -1,0 +1,395 @@
+use crate::utils::project_root;
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const POLICY_PATH: &str = ".ci/policies/intent-diff-rules.toml";
+
+#[derive(Debug, Deserialize)]
+struct Policy {
+    severity: SeverityPolicy,
+    #[serde(default)]
+    issue_targets: HashMap<String, Vec<String>>,
+    #[serde(default)]
+    component_expectations: HashMap<String, ComponentPolicy>,
+    #[serde(default = "default_override_markers")]
+    override_markers: Vec<String>,
+    #[serde(default = "default_test_path_markers")]
+    test_path_markers: Vec<String>,
+    #[serde(default = "default_behavior_receipt_markers")]
+    behavior_receipt_markers: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SeverityPolicy {
+    docs_only_code_claim: RuleLevel,
+    docs_title_code_change: RuleLevel,
+    scaffold_closeout: RuleLevel,
+}
+
+#[derive(Debug, Deserialize)]
+struct ComponentPolicy {
+    keywords: Vec<String>,
+    expected_paths: Vec<String>,
+    #[serde(default)]
+    level: Option<RuleLevel>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum RuleLevel {
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureInput {
+    title: String,
+    body: String,
+    actual_paths: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Receipt {
+    claimed_component: Vec<String>,
+    claimed_closeout_issues: Vec<u64>,
+    expected_paths: Vec<String>,
+    actual_paths: Vec<String>,
+    evidence: Evidence,
+    verdict: String,
+    violations: Vec<Violation>,
+}
+
+#[derive(Debug, Serialize)]
+struct Evidence {
+    target_path_touched: bool,
+    test_updated: bool,
+    behavior_receipt: bool,
+    explicit_override: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct Violation {
+    rule: String,
+    level: String,
+    message: String,
+}
+
+#[derive(Debug)]
+struct PrData {
+    title: String,
+    body: String,
+    actual_paths: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhPrResponse {
+    title: String,
+    body: String,
+    files: Vec<GhFile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhFile {
+    path: String,
+}
+
+pub fn run(pr: Option<u64>, fixture: Option<PathBuf>, receipt: Option<PathBuf>) -> Result<()> {
+    if pr.is_some() && fixture.is_some() {
+        bail!("pass only one input source: --pr or --fixture");
+    }
+    if pr.is_none() && fixture.is_none() {
+        bail!("one input source is required: --pr or --fixture");
+    }
+
+    let root = project_root()?;
+    let policy_path = root.join(POLICY_PATH);
+    let policy = load_policy(&policy_path)?;
+
+    let pr_data = match (pr, fixture) {
+        (Some(number), None) => fetch_pr(number)?,
+        (None, Some(path)) => load_fixture(&path)?,
+        _ => bail!("invalid input arguments"),
+    };
+
+    let report = evaluate(&policy, pr_data);
+
+    if let Some(path) = receipt {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create receipt dir {}", parent.display()))?;
+        }
+        let json = serde_json::to_string_pretty(&report)?;
+        fs::write(&path, json)
+            .with_context(|| format!("failed to write receipt {}", path.display()))?;
+    }
+
+    if report.verdict == "fail" {
+        bail!("intent-diff-gate failed");
+    }
+
+    Ok(())
+}
+
+fn load_policy(path: &Path) -> Result<Policy> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read policy file {}", path.display()))?;
+    let parsed: Policy =
+        toml::from_str(&raw).with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(parsed)
+}
+
+fn load_fixture(path: &Path) -> Result<PrData> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read fixture {}", path.display()))?;
+    let input: FixtureInput = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse fixture {}", path.display()))?;
+    Ok(PrData { title: input.title, body: input.body, actual_paths: input.actual_paths })
+}
+
+fn fetch_pr(pr_number: u64) -> Result<PrData> {
+    let output = Command::new("gh")
+        .arg("pr")
+        .arg("view")
+        .arg(pr_number.to_string())
+        .arg("--json")
+        .arg("title,body,files")
+        .output()
+        .context("failed to execute gh; install gh cli or use --fixture")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("gh pr view failed for #{}: {}", pr_number, stderr.trim());
+    }
+
+    let parsed: GhPrResponse = serde_json::from_slice(&output.stdout)
+        .context("failed to parse gh pr view json response")?;
+
+    Ok(PrData {
+        title: parsed.title,
+        body: parsed.body,
+        actual_paths: parsed.files.into_iter().map(|f| f.path).collect(),
+    })
+}
+
+fn evaluate(policy: &Policy, pr: PrData) -> Receipt {
+    let normalized_paths: Vec<String> = pr.actual_paths.iter().map(|p| p.to_lowercase()).collect();
+    let title_lc = pr.title.to_lowercase();
+    let body_lc = pr.body.to_lowercase();
+    let merged_text = format!("{}\n{}", title_lc, body_lc);
+
+    let closeout_issues = parse_closing_issues(&merged_text);
+    let docs_only = is_docs_only(&pr.actual_paths);
+    let docs_claim = is_docs_claim(&title_lc);
+    let code_fix_claim = is_code_fix_claim(&merged_text);
+    let partial_claim = is_partial_or_scaffold(&merged_text);
+
+    let mut expected_paths: BTreeSet<String> = BTreeSet::new();
+    for issue in &closeout_issues {
+        if let Some(paths) = policy.issue_targets.get(&issue.to_string()) {
+            for path in paths {
+                expected_paths.insert(path.clone());
+            }
+        }
+    }
+
+    let mut claimed_components = Vec::new();
+    for (name, rule) in &policy.component_expectations {
+        let claimed =
+            rule.keywords.iter().any(|keyword| merged_text.contains(&keyword.to_lowercase()));
+        if claimed {
+            claimed_components.push(name.clone());
+            for path in &rule.expected_paths {
+                expected_paths.insert(path.clone());
+            }
+        }
+    }
+
+    let target_path_touched = expected_paths
+        .iter()
+        .any(|expected| matches_any_path(&normalized_paths, &expected.to_lowercase()));
+    let test_updated = normalized_paths.iter().any(|path| {
+        policy.test_path_markers.iter().any(|marker| path.contains(&marker.to_lowercase()))
+    });
+    let behavior_receipt = normalized_paths.iter().any(|path| {
+        policy.behavior_receipt_markers.iter().any(|marker| path.contains(&marker.to_lowercase()))
+    });
+    let explicit_override =
+        policy.override_markers.iter().any(|marker| merged_text.contains(&marker.to_lowercase()));
+
+    let evidence =
+        Evidence { target_path_touched, test_updated, behavior_receipt, explicit_override };
+
+    let mut violations: Vec<Violation> = Vec::new();
+
+    if code_fix_claim && docs_only {
+        violations.push(Violation {
+            rule: "docs_only_code_claim".to_string(),
+            level: level_str(policy.severity.docs_only_code_claim).to_string(),
+            message: "PR claims a fix but only docs changed".to_string(),
+        });
+    }
+
+    if docs_claim && !docs_only {
+        violations.push(Violation {
+            rule: "docs_title_code_change".to_string(),
+            level: level_str(policy.severity.docs_title_code_change).to_string(),
+            message: "PR title claims docs scope but production code changed".to_string(),
+        });
+    }
+
+    if (!closeout_issues.is_empty() || !claimed_components.is_empty())
+        && !evidence.target_path_touched
+        && !evidence.test_updated
+        && !evidence.behavior_receipt
+        && !evidence.explicit_override
+    {
+        violations.push(Violation {
+            rule: "closeout_requires_evidence".to_string(),
+            level: "fail".to_string(),
+            message:
+                "Closeout claim requires target path, tests, behavior receipt, or explicit override"
+                    .to_string(),
+        });
+    }
+
+    if partial_claim && !closeout_issues.is_empty() {
+        violations.push(Violation {
+            rule: "scaffold_closeout".to_string(),
+            level: level_str(policy.severity.scaffold_closeout).to_string(),
+            message: "Scaffold/partial PR must not use closing keywords".to_string(),
+        });
+    }
+
+    for (name, rule) in &policy.component_expectations {
+        let claimed =
+            rule.keywords.iter().any(|keyword| merged_text.contains(&keyword.to_lowercase()));
+        if claimed
+            && !rule.expected_paths.is_empty()
+            && !rule
+                .expected_paths
+                .iter()
+                .any(|expected| matches_any_path(&normalized_paths, &expected.to_lowercase()))
+            && !evidence.explicit_override
+        {
+            let level = rule.level.unwrap_or(RuleLevel::Fail);
+            violations.push(Violation {
+                rule: format!("component_path_expectation:{name}"),
+                level: level_str(level).to_string(),
+                message: format!("Component '{name}' claim missing expected path evidence"),
+            });
+        }
+    }
+
+    let fail = violations.iter().any(|v| v.level == "fail");
+    let warn = !fail && !violations.is_empty();
+
+    Receipt {
+        claimed_component: claimed_components,
+        claimed_closeout_issues: closeout_issues,
+        expected_paths: expected_paths.into_iter().collect(),
+        actual_paths: pr.actual_paths,
+        evidence,
+        verdict: if fail {
+            "fail".to_string()
+        } else if warn {
+            "warn".to_string()
+        } else {
+            "pass".to_string()
+        },
+        violations,
+    }
+}
+
+fn parse_closing_issues(text: &str) -> Vec<u64> {
+    let mut issues = BTreeSet::new();
+    let tokens: Vec<&str> = text.split_whitespace().collect();
+    for pair in tokens.windows(2) {
+        let keyword = sanitize_token(pair[0]);
+        let issue_token = sanitize_token(pair[1]);
+        if is_closeout_keyword(&keyword)
+            && let Some(stripped) = issue_token.strip_prefix('#')
+            && let Ok(issue) = stripped.parse::<u64>()
+        {
+            issues.insert(issue);
+        }
+    }
+    issues.into_iter().collect()
+}
+
+fn is_closeout_keyword(token: &str) -> bool {
+    matches!(
+        token,
+        "close"
+            | "closes"
+            | "closed"
+            | "fix"
+            | "fixes"
+            | "fixed"
+            | "resolve"
+            | "resolves"
+            | "resolved"
+    )
+}
+
+fn sanitize_token(token: &str) -> String {
+    token
+        .trim_matches(|c: char| {
+            c == ':' || c == ',' || c == ';' || c == '.' || c == ')' || c == '('
+        })
+        .to_lowercase()
+}
+
+fn is_docs_only(paths: &[String]) -> bool {
+    !paths.is_empty()
+        && paths.iter().all(|path| {
+            let lc = path.to_lowercase();
+            lc.starts_with("docs/")
+                || lc.ends_with(".md")
+                || lc.ends_with(".mdx")
+                || lc.ends_with(".rst")
+                || lc.starts_with(".github/")
+        })
+}
+
+fn is_docs_claim(title_lc: &str) -> bool {
+    title_lc.starts_with("docs") || title_lc.contains("documentation")
+}
+
+fn is_code_fix_claim(text: &str) -> bool {
+    text.contains("fix") || text.contains("bug") || text.contains("regression")
+}
+
+fn is_partial_or_scaffold(text: &str) -> bool {
+    text.contains("scaffold") || text.contains("partial") || text.contains("wip")
+}
+
+fn matches_any_path(actual_paths: &[String], expected: &str) -> bool {
+    actual_paths.iter().any(|path| path == expected || path.contains(expected))
+}
+
+fn level_str(level: RuleLevel) -> &'static str {
+    match level {
+        RuleLevel::Warn => "warn",
+        RuleLevel::Fail => "fail",
+    }
+}
+
+fn default_override_markers() -> Vec<String> {
+    vec!["intent-diff-override".to_string(), "intent-diff: override".to_string()]
+}
+
+fn default_test_path_markers() -> Vec<String> {
+    vec!["/tests/".to_string(), "_test".to_string(), "/spec/".to_string()]
+}
+
+fn default_behavior_receipt_markers() -> Vec<String> {
+    vec![
+        "target/receipts/".to_string(),
+        ".ci/receipts/".to_string(),
+        "review/receipts/".to_string(),
+    ]
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -47,6 +47,7 @@ pub mod highlight;
 pub mod hook_checks;
 pub mod ignored_tests;
 pub mod inject_sha_assets;
+pub mod intent_diff_gate;
 pub mod layer_check;
 pub mod metrics;
 pub mod parse_rust;

--- a/xtask/tests/fixtures/intent-diff/doc_only_code_fix_claim.json
+++ b/xtask/tests/fixtures/intent-diff/doc_only_code_fix_claim.json
@@ -1,0 +1,8 @@
+{
+  "title": "fix(vscode): activation regression",
+  "body": "Fixes #6747. This updates only docs.",
+  "actual_paths": [
+    "docs/project/CURRENT_STATUS.md",
+    "docs/ci/intent-diff-closeout-gate.md"
+  ]
+}

--- a/xtask/tests/fixtures/intent-diff/partial_refs_pass.json
+++ b/xtask/tests/fixtures/intent-diff/partial_refs_pass.json
@@ -1,0 +1,8 @@
+{
+  "title": "chore(ci): scaffold intent gate",
+  "body": "Partial implementation. Refs #6853.",
+  "actual_paths": [
+    "xtask/src/tasks/intent_diff_gate.rs",
+    "docs/ci/intent-diff-closeout-gate.md"
+  ]
+}

--- a/xtask/tests/fixtures/intent-diff/valid_closeout_target_path.json
+++ b/xtask/tests/fixtures/intent-diff/valid_closeout_target_path.json
@@ -1,0 +1,8 @@
+{
+  "title": "fix(vscode): activation failure at startup",
+  "body": "Resolves #6747 by updating activation events.",
+  "actual_paths": [
+    "vscode-extension/package.json",
+    "crates/perl-lsp-rs/tests/vscode_activation_smoke.rs"
+  ]
+}

--- a/xtask/tests/intent_diff_gate_cli.rs
+++ b/xtask/tests/intent_diff_gate_cli.rs
@@ -1,0 +1,46 @@
+use anyhow::Result;
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::path::PathBuf;
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from("tests/fixtures/intent-diff").join(name)
+}
+
+#[test]
+fn doc_only_code_fix_claim_fails() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd
+        .arg("intent-diff-gate")
+        .arg("--fixture")
+        .arg(fixture("doc_only_code_fix_claim.json"))
+        .output()?;
+
+    assert!(!output.status.success(), "doc-only fix claim fixture should fail");
+    Ok(())
+}
+
+#[test]
+fn partial_pr_using_refs_passes() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd
+        .arg("intent-diff-gate")
+        .arg("--fixture")
+        .arg(fixture("partial_refs_pass.json"))
+        .output()?;
+
+    assert!(output.status.success(), "partial refs fixture should pass");
+    Ok(())
+}
+
+#[test]
+fn valid_closeout_with_target_path_passes() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd
+        .arg("intent-diff-gate")
+        .arg("--fixture")
+        .arg(fixture("valid_closeout_target_path.json"))
+        .output()?;
+
+    assert!(output.status.success(), "valid closeout fixture should pass");
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Prevent PR intent vs. diff mismatches where a PR claims a code fix/closeout but only changes documentation, motivated by the #6780-style case. 
- Provide a policy-driven, auditable gate that requires concrete evidence (target paths, test changes, behavior receipts, or explicit override) before accepting closeout/closing-keyword claims.

### Description

- Add a new xtask command implementation at `xtask/src/tasks/intent_diff_gate.rs` and wire it into the CLI as `intent-diff-gate` supporting `--pr <N>` (via `gh pr view`) and `--fixture <json>` inputs. 
- Add policy, schema, docs, fixtures, and tests: policy file ` .ci/policies/intent-diff-rules.toml`, receipt schema `.ci/receipts/schemas/intent-diff-gate.schema.json`, documentation `docs/ci/intent-diff-closeout-gate.md`, fixtures under `xtask/tests/fixtures/intent-diff/`, and test `xtask/tests/intent_diff_gate_cli.rs`.
- Enforce rules: docs-only fix claims, closing-keyword closeouts require evidence (target path touched OR test updated OR behavior receipt OR explicit override), scaffold/partial/WIP PRs must not use closing keywords, docs-title vs production-code diffs flagged, and component-specific expectations (e.g. VS Code activation expected paths) configurable via policy.
- Emit machine-readable receipt with fields `claimed_component`, `claimed_closeout_issues`, `expected_paths`, `actual_paths`, `evidence`, `verdict`, and `violations` (schema added).

### Testing

- Ran `cargo test -p xtask --test intent_diff_gate_cli` and the three fixture-based tests passed (`3 passed`).
- Ran `cargo check --all-targets -p xtask` which completed successfully.
- Ran `cargo xtask fmt` which completed successfully.
- Ran `cargo clippy -p xtask --all-targets -- -D warnings` which failed due to pre-existing, unrelated clippy warnings elsewhere in `xtask` (not introduced by this change).
- Verified runtime behavior with fixtures via `cargo run -p xtask -- intent-diff-gate --fixture xtask/tests/fixtures/intent-diff/valid_closeout_target_path.json --receipt target/receipts/intent-diff-gate.json` (succeeds) and `cargo run -p xtask -- intent-diff-gate --fixture xtask/tests/fixtures/intent-diff/doc_only_code_fix_claim.json` (exits non-zero as expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0dc9dc483338167ebf7f799a4e2)