### PR TITLE
feat(release): add release evidence bundle scaffolding (#6853)

### DIFF
--- a/.ci/receipts/schemas/release-evidence.schema.json
+++ b/.ci/receipts/schemas/release-evidence.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/schemas/release-evidence.schema.json",
+  "title": "Release Evidence Summary Receipt",
+  "type": "object",
+  "required": [
+    "version",
+    "bundle_path",
+    "generated_at_utc",
+    "status",
+    "checks"
+  ],
+  "properties": {
+    "version": { "type": "string", "minLength": 1 },
+    "bundle_path": { "type": "string", "minLength": 1 },
+    "generated_at_utc": { "type": "string", "format": "date-time" },
+    "status": {
+      "type": "string",
+      "enum": ["pass", "warning", "fail"]
+    },
+    "checks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "path", "required", "status", "detail"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "path": { "type": "string", "minLength": 1 },
+          "required": { "type": "boolean" },
+          "status": {
+            "type": "string",
+            "enum": ["pass", "warning", "fail"]
+          },
+          "detail": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/.ci/release/evidence.toml
+++ b/.ci/release/evidence.toml
@@ -1,0 +1,15 @@
+[release_evidence]
+required = [
+  "ci-gate.json",
+  "parser-ratchet-release.json",
+  "vscode-extension-smoke.json",
+  "lsp-scenario.json",
+  "real-workspace-baseline.json",
+  "ai-completion-e2e.json",
+  "unresolved-risk-register.json",
+]
+summary_receipt = "target/receipts/release-evidence.json"
+
+[advisory]
+receipt = "advisory-status.json"
+release_blocking = false

--- a/docs/ci/release-evidence.md
+++ b/docs/ci/release-evidence.md
@@ -1,0 +1,36 @@
+# Release Evidence Bundle
+
+Release readiness is proven with a receipt bundle under:
+
+- `target/release-evidence/v<version>/...`
+
+The `xtask release evidence` flow verifies that required receipts exist, required receipts are passing, and advisory failures are classified by policy (warning by default, release-blocking only when policy says so).
+
+## Policy
+
+Policy lives at `.ci/release/evidence.toml`:
+
+- `release_evidence.required`: required receipt filenames.
+- `release_evidence.summary_receipt`: emitted summary receipt path.
+- `advisory.receipt`: advisory receipt filename.
+- `advisory.release_blocking`: whether advisory failures are release-blocking.
+
+## Commands
+
+```bash
+cargo xtask release evidence --version 0.13.0 --out target/release-evidence/v0.13.0
+cargo xtask release verify-evidence --version 0.13.0 --receipt target/receipts/release-evidence.json
+```
+
+## Required evidence paths
+
+- `ci-gate.json`
+- `parser-ratchet-release.json`
+- `vscode-extension-smoke.json`
+- `lsp-scenario.json`
+- `real-workspace-baseline.json`
+- `ai-completion-e2e.json`
+- `advisory-status.json`
+- `unresolved-risk-register.json`
+
+Summary receipts conform to `.ci/receipts/schemas/release-evidence.schema.json`.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -520,14 +520,10 @@ enum Commands {
         bench: bool,
     },
 
-    /// Prepare release
+    /// Release operations.
     Release {
-        /// Version to release
-        version: String,
-
-        /// Skip confirmation
-        #[arg(long)]
-        yes: bool,
+        #[command(subcommand)]
+        command: ReleaseCommand,
     },
 
     /// Extract the curated release body from `docs/releases/<tag>.md`.
@@ -1155,6 +1151,38 @@ enum Commands {
 }
 
 #[derive(Subcommand)]
+enum ReleaseCommand {
+    /// Prepare release artifacts.
+    Prepare {
+        /// Version to release
+        version: String,
+
+        /// Skip confirmation
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Evaluate a release evidence bundle and emit a summary receipt.
+    Evidence {
+        /// Release version (for example `0.13.0`).
+        #[arg(long)]
+        version: String,
+        /// Directory containing release-evidence receipts.
+        #[arg(long)]
+        out: PathBuf,
+    },
+    /// Verify a previously generated release-evidence summary receipt.
+    #[command(name = "verify-evidence")]
+    VerifyEvidence {
+        /// Release version (for example `0.13.0`).
+        #[arg(long)]
+        version: String,
+        /// Path to `release-evidence.json` summary receipt.
+        #[arg(long)]
+        receipt: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
 enum CpanCorpusCommand {
     /// Fetch top N distributions from MetaCPAN by reverse dependency count
     FetchList {
@@ -1410,7 +1438,15 @@ fn main() -> Result<()> {
         Commands::ParseRust { source, sexp, ast, bench } => {
             parse_rust::run(source, sexp, ast, bench)
         }
-        Commands::Release { version, yes } => release::run(version, yes),
+        Commands::Release { command } => match command {
+            ReleaseCommand::Prepare { version, yes } => release::run(version, yes),
+            ReleaseCommand::Evidence { version, out } => {
+                release_evidence::run_evidence(version, out)
+            }
+            ReleaseCommand::VerifyEvidence { version, receipt } => {
+                release_evidence::run_verify_evidence(version, receipt)
+            }
+        },
         Commands::ReleaseNotes { tag, output, root } => release_notes::run(tag, output, root),
         Commands::ReleaseTurnkey {
             version,

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -61,6 +61,7 @@ pub mod publish_manifest_check;
 pub mod publish_receipts;
 pub mod receipts;
 pub mod release;
+pub mod release_evidence;
 pub mod release_notes;
 pub mod release_turnkey;
 pub mod srp_microcrates;

--- a/xtask/src/tasks/release_evidence.rs
+++ b/xtask/src/tasks/release_evidence.rs
@@ -1,0 +1,359 @@
+use color_eyre::eyre::{Context, ContextCompat, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::utils::project_root;
+
+const POLICY_PATH: &str = ".ci/release/evidence.toml";
+const DEFAULT_SUMMARY_RECEIPT: &str = "target/receipts/release-evidence.json";
+
+#[derive(Debug, Deserialize)]
+struct EvidencePolicyFile {
+    release_evidence: Option<ReleaseEvidencePolicy>,
+    advisory: Option<AdvisoryPolicy>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseEvidencePolicy {
+    required: Vec<String>,
+    summary_receipt: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdvisoryPolicy {
+    receipt: Option<String>,
+    release_blocking: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ReleaseEvidenceSummary {
+    version: String,
+    bundle_path: String,
+    generated_at_utc: String,
+    status: EvidenceStatus,
+    checks: Vec<EvidenceCheck>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum EvidenceStatus {
+    Pass,
+    Warning,
+    Fail,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct EvidenceCheck {
+    name: String,
+    path: String,
+    required: bool,
+    status: EvidenceStatus,
+    detail: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericReceipt {
+    status: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdvisoryReceipt {
+    status: Option<String>,
+    release_blocking: Option<bool>,
+}
+
+pub fn run_evidence(version: String, out: PathBuf) -> Result<()> {
+    let root = project_root()?;
+    let policy = load_policy(&root)?;
+    let summary = evaluate_bundle(&version, &out, &policy)?;
+
+    let summary_receipt = root.join(policy.summary_receipt);
+    write_summary(&summary_receipt, &summary)?;
+    println!("Release evidence summary written to {}", summary_receipt.display());
+
+    match summary.status {
+        EvidenceStatus::Pass | EvidenceStatus::Warning => Ok(()),
+        EvidenceStatus::Fail => bail!("release evidence check failed"),
+    }
+}
+
+pub fn run_verify_evidence(version: String, receipt: PathBuf) -> Result<()> {
+    let root = project_root()?;
+    let summary_path = if receipt.is_absolute() { receipt } else { root.join(receipt) };
+
+    let raw = fs::read_to_string(&summary_path)
+        .with_context(|| format!("failed to read summary receipt {}", summary_path.display()))?;
+    let summary: ReleaseEvidenceSummary =
+        serde_json::from_str(&raw).context("failed to parse release evidence summary JSON")?;
+
+    if summary.version != version {
+        bail!("release evidence version mismatch: expected {}, got {}", version, summary.version);
+    }
+
+    match summary.status {
+        EvidenceStatus::Pass => Ok(()),
+        EvidenceStatus::Warning => {
+            println!("release evidence verified with advisory warnings");
+            Ok(())
+        }
+        EvidenceStatus::Fail => bail!("release evidence receipt reports failure"),
+    }
+}
+
+fn evaluate_bundle(
+    version: &str,
+    out: &Path,
+    policy: &ResolvedPolicy,
+) -> Result<ReleaseEvidenceSummary> {
+    let mut checks = Vec::new();
+    let mut has_fail = false;
+    let mut has_warning = false;
+
+    for required in &policy.required_receipts {
+        let receipt_path = out.join(required);
+        if !receipt_path.exists() {
+            has_fail = true;
+            checks.push(EvidenceCheck {
+                name: required.clone(),
+                path: receipt_path.display().to_string(),
+                required: true,
+                status: EvidenceStatus::Fail,
+                detail: "missing required receipt".to_string(),
+            });
+            continue;
+        }
+
+        let status = read_receipt_status(&receipt_path)?;
+        let mapped = map_status(&status);
+        if mapped == EvidenceStatus::Fail {
+            has_fail = true;
+        }
+
+        checks.push(EvidenceCheck {
+            name: required.clone(),
+            path: receipt_path.display().to_string(),
+            required: true,
+            status: mapped,
+            detail: format!("receipt status={status}"),
+        });
+    }
+
+    let advisory_file = out.join(&policy.advisory_receipt);
+    if advisory_file.exists() {
+        let advisory_raw = fs::read_to_string(&advisory_file).with_context(|| {
+            format!("failed to read advisory receipt {}", advisory_file.display())
+        })?;
+        let advisory: AdvisoryReceipt =
+            serde_json::from_str(&advisory_raw).context("failed to parse advisory receipt")?;
+        let status_text = advisory.status.unwrap_or_else(|| "unknown".to_string());
+        let mapped = map_status(&status_text);
+        let is_release_blocking =
+            advisory.release_blocking.unwrap_or(policy.advisory_release_blocking);
+
+        let (status, detail) = if mapped == EvidenceStatus::Fail && !is_release_blocking {
+            has_warning = true;
+            (
+                EvidenceStatus::Warning,
+                "advisory failure classified as warning (non-release-blocking policy)".to_string(),
+            )
+        } else {
+            if mapped == EvidenceStatus::Fail {
+                has_fail = true;
+            }
+            (
+                mapped,
+                format!("advisory status={status_text}, release_blocking={is_release_blocking}"),
+            )
+        };
+
+        checks.push(EvidenceCheck {
+            name: policy.advisory_receipt.clone(),
+            path: advisory_file.display().to_string(),
+            required: true,
+            status,
+            detail,
+        });
+    } else {
+        has_fail = true;
+        checks.push(EvidenceCheck {
+            name: policy.advisory_receipt.clone(),
+            path: advisory_file.display().to_string(),
+            required: true,
+            status: EvidenceStatus::Fail,
+            detail: "missing advisory receipt".to_string(),
+        });
+    }
+
+    let status = if has_fail {
+        EvidenceStatus::Fail
+    } else if has_warning {
+        EvidenceStatus::Warning
+    } else {
+        EvidenceStatus::Pass
+    };
+
+    Ok(ReleaseEvidenceSummary {
+        version: version.to_string(),
+        bundle_path: out.display().to_string(),
+        generated_at_utc: chrono::Utc::now().to_rfc3339(),
+        status,
+        checks,
+    })
+}
+
+fn map_status(status: &str) -> EvidenceStatus {
+    match status.to_ascii_lowercase().as_str() {
+        "pass" | "ok" | "success" => EvidenceStatus::Pass,
+        "warning" | "warn" => EvidenceStatus::Warning,
+        _ => EvidenceStatus::Fail,
+    }
+}
+
+fn read_receipt_status(path: &Path) -> Result<String> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read receipt {}", path.display()))?;
+    let receipt: GenericReceipt = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse JSON receipt {}", path.display()))?;
+    Ok(receipt.status.unwrap_or_else(|| "fail".to_string()))
+}
+
+fn write_summary(path: &Path, summary: &ReleaseEvidenceSummary) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create summary dir {}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(summary).context("failed to serialize summary")?;
+    fs::write(path, json)
+        .with_context(|| format!("failed to write summary receipt {}", path.display()))
+}
+
+struct ResolvedPolicy {
+    required_receipts: Vec<String>,
+    advisory_receipt: String,
+    advisory_release_blocking: bool,
+    summary_receipt: String,
+}
+
+fn load_policy(root: &Path) -> Result<ResolvedPolicy> {
+    let policy_path = root.join(POLICY_PATH);
+    let raw = fs::read_to_string(&policy_path)
+        .with_context(|| format!("failed to read policy file {}", policy_path.display()))?;
+    let file: EvidencePolicyFile =
+        toml::from_str(&raw).context("failed to parse evidence policy")?;
+
+    let release = file.release_evidence.context("missing [release_evidence] table in policy")?;
+
+    let advisory = file.advisory.unwrap_or(AdvisoryPolicy {
+        receipt: Some("advisory-status.json".to_string()),
+        release_blocking: Some(false),
+    });
+
+    let mut dedup = BTreeMap::<String, ()>::new();
+    for name in release.required {
+        dedup.insert(name, ());
+    }
+
+    Ok(ResolvedPolicy {
+        required_receipts: dedup.into_keys().collect(),
+        advisory_receipt: advisory.receipt.unwrap_or_else(|| "advisory-status.json".to_string()),
+        advisory_release_blocking: advisory.release_blocking.unwrap_or(false),
+        summary_receipt: release
+            .summary_receipt
+            .unwrap_or_else(|| DEFAULT_SUMMARY_RECEIPT.to_string()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use color_eyre::eyre::Result;
+    use std::collections::BTreeMap;
+
+    #[derive(Debug, Deserialize)]
+    struct Fixture {
+        receipts: BTreeMap<String, serde_json::Value>,
+    }
+
+    fn load_fixture(path: &Path) -> Result<Fixture> {
+        let raw = fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&raw)?)
+    }
+
+    fn materialize_bundle(bundle_dir: &Path, fixture: &Fixture) -> Result<()> {
+        fs::create_dir_all(bundle_dir)?;
+        for (name, json) in &fixture.receipts {
+            let path = bundle_dir.join(name);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(path, serde_json::to_string_pretty(json)?)?;
+        }
+        Ok(())
+    }
+
+    fn test_policy() -> ResolvedPolicy {
+        ResolvedPolicy {
+            required_receipts: vec![
+                "ci-gate.json".to_string(),
+                "parser-ratchet-release.json".to_string(),
+                "vscode-extension-smoke.json".to_string(),
+                "lsp-scenario.json".to_string(),
+                "real-workspace-baseline.json".to_string(),
+                "ai-completion-e2e.json".to_string(),
+                "unresolved-risk-register.json".to_string(),
+            ],
+            advisory_receipt: "advisory-status.json".to_string(),
+            advisory_release_blocking: false,
+            summary_receipt: DEFAULT_SUMMARY_RECEIPT.to_string(),
+        }
+    }
+
+    #[test]
+    fn fixture_complete_bundle_passes() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let bundle = tmp.path().join("bundle");
+        let fixture =
+            load_fixture(Path::new("tests/fixtures/release-evidence/complete-bundle.json"))?;
+        materialize_bundle(&bundle, &fixture)?;
+
+        let summary = evaluate_bundle("0.13.0", &bundle, &test_policy())?;
+        assert_eq!(summary.status, EvidenceStatus::Pass);
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_missing_parser_ratchet_release_fails() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let bundle = tmp.path().join("bundle");
+        let fixture = load_fixture(Path::new(
+            "tests/fixtures/release-evidence/missing-parser-ratchet-release.json",
+        ))?;
+        materialize_bundle(&bundle, &fixture)?;
+
+        let summary = evaluate_bundle("0.13.0", &bundle, &test_policy())?;
+        assert_eq!(summary.status, EvidenceStatus::Fail);
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_advisory_failure_produces_classified_warning() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let bundle = tmp.path().join("bundle");
+        let fixture = load_fixture(Path::new(
+            "tests/fixtures/release-evidence/advisory-failure-warning.json",
+        ))?;
+        materialize_bundle(&bundle, &fixture)?;
+
+        let summary = evaluate_bundle("0.13.0", &bundle, &test_policy())?;
+        assert_eq!(summary.status, EvidenceStatus::Warning);
+        let advisory = summary
+            .checks
+            .iter()
+            .find(|check| check.name == "advisory-status.json")
+            .context("missing advisory check")?;
+        assert_eq!(advisory.status, EvidenceStatus::Warning);
+        Ok(())
+    }
+}

--- a/xtask/tests/fixtures/release-evidence/advisory-failure-warning.json
+++ b/xtask/tests/fixtures/release-evidence/advisory-failure-warning.json
@@ -1,0 +1,12 @@
+{
+  "receipts": {
+    "ci-gate.json": { "status": "pass" },
+    "parser-ratchet-release.json": { "status": "pass" },
+    "vscode-extension-smoke.json": { "status": "pass" },
+    "lsp-scenario.json": { "status": "pass" },
+    "real-workspace-baseline.json": { "status": "pass" },
+    "ai-completion-e2e.json": { "status": "pass" },
+    "advisory-status.json": { "status": "fail", "release_blocking": false },
+    "unresolved-risk-register.json": { "status": "pass" }
+  }
+}

--- a/xtask/tests/fixtures/release-evidence/complete-bundle.json
+++ b/xtask/tests/fixtures/release-evidence/complete-bundle.json
@@ -1,0 +1,12 @@
+{
+  "receipts": {
+    "ci-gate.json": { "status": "pass" },
+    "parser-ratchet-release.json": { "status": "pass" },
+    "vscode-extension-smoke.json": { "status": "pass" },
+    "lsp-scenario.json": { "status": "pass" },
+    "real-workspace-baseline.json": { "status": "pass" },
+    "ai-completion-e2e.json": { "status": "pass" },
+    "advisory-status.json": { "status": "pass", "release_blocking": false },
+    "unresolved-risk-register.json": { "status": "pass" }
+  }
+}

--- a/xtask/tests/fixtures/release-evidence/missing-parser-ratchet-release.json
+++ b/xtask/tests/fixtures/release-evidence/missing-parser-ratchet-release.json
@@ -1,0 +1,11 @@
+{
+  "receipts": {
+    "ci-gate.json": { "status": "pass" },
+    "vscode-extension-smoke.json": { "status": "pass" },
+    "lsp-scenario.json": { "status": "pass" },
+    "real-workspace-baseline.json": { "status": "pass" },
+    "ai-completion-e2e.json": { "status": "pass" },
+    "advisory-status.json": { "status": "pass", "release_blocking": false },
+    "unresolved-risk-register.json": { "status": "pass" }
+  }
+}


### PR DESCRIPTION
### Motivation
- Reify release readiness as a verifiable evidence bundle for v0.13.0 instead of a label or ad-hoc memory, so CI and release workflows have concrete receipts to inspect (Refs #6853). 
- The bundle must cover CI gate, Parser Ratchet release profile, VS Code smoke, LSP scenario, real-workspace baseline, AI completion E2E, advisories, and an unresolved risk register.

### Description
- Add a new xtask task implementing evidence evaluation at `xtask/src/tasks/release_evidence.rs` plus `release` subcommands `evidence` and `verify-evidence` wired in `xtask/src/main.rs` and registered in `xtask/src/tasks/mod.rs`.
- Add a policy file at `.ci/release/evidence.toml`, a JSON schema at `.ci/receipts/schemas/release-evidence.schema.json`, and docs at `docs/ci/release-evidence.md` that list the required receipt filenames and CLI usage.
- Add fixture inputs under `xtask/tests/fixtures/release-evidence/` and unit tests that validate a complete bundle passes, a missing `parser-ratchet-release.json` fails, and an advisory failure is classified as a warning.
- Implement rules to verify required receipts exist and are passing, classify advisory failures (warning by default unless policy marks them release-blocking), and emit a consolidated summary receipt (default `target/receipts/release-evidence.json`).

### Testing
- Unit tests: `cargo test -p xtask release_evidence` ran the three fixture-backed tests and all passed.
- End-to-end CLI: `cargo xtask release evidence --version 0.13.0 --out target/release-evidence/v0.13.0` produced the summary receipt and `cargo xtask release verify-evidence --version 0.13.0 --receipt target/receipts/release-evidence.json` verified it successfully.
- Formatting/lint seam: `cargo xtask fmt --package xtask` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0e0832c8333a63f682bd3a487b4)