### PR TITLE
feat(release): add release evidence bundle scaffolding (#6853)

### DIFF
--- a/.ci/receipts/schemas/release-evidence.schema.json
+++ b/.ci/receipts/schemas/release-evidence.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/release-evidence.schema.json",
+  "title": "release-evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "subsystem",
+    "version",
+    "bundle_root",
+    "required_receipts",
+    "missing_receipts",
+    "failed_receipts",
+    "advisory_warnings",
+    "status"
+  ],
+  "properties": {
+    "subsystem": { "const": "release_evidence" },
+    "version": { "type": "string" },
+    "bundle_root": { "type": "string" },
+    "required_receipts": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 8
+    },
+    "missing_receipts": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "failed_receipts": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "advisory_warnings": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "status": { "enum": ["pass", "fail"] }
+  }
+}

--- a/.ci/release/evidence.toml
+++ b/.ci/release/evidence.toml
@@ -1,0 +1,3 @@
+# Release evidence verification policy.
+# Severity values are matched case-insensitively.
+release_blocking_advisory_severities = ["critical"]

--- a/docs/ci/release-evidence.md
+++ b/docs/ci/release-evidence.md
@@ -1,0 +1,38 @@
+# Release Evidence Bundle
+
+`cargo xtask release evidence` scaffolds a release evidence bundle directory and
+records the required receipt filenames for a versioned release candidate.
+
+`cargo xtask release verify-evidence` validates an existing bundle and writes a
+summary receipt (`target/receipts/release-evidence.json` by default in CI jobs).
+
+## Required receipt files
+
+For `--version 0.13.0`, the verifier expects:
+
+- `target/release-evidence/v0.13.0/ci-gate.json`
+- `target/release-evidence/v0.13.0/parser-ratchet-release.json`
+- `target/release-evidence/v0.13.0/vscode-extension-smoke.json`
+- `target/release-evidence/v0.13.0/lsp-scenario.json`
+- `target/release-evidence/v0.13.0/real-workspace-baseline.json`
+- `target/release-evidence/v0.13.0/ai-completion-e2e.json`
+- `target/release-evidence/v0.13.0/advisory-status.json`
+- `target/release-evidence/v0.13.0/unresolved-risk-register.json`
+
+## Policy
+
+Policy lives in `.ci/release/evidence.toml`.
+
+- Missing required receipts fail verification.
+- Non-advisory required receipts with `status != "pass"` fail verification.
+- Advisory failures are classified against
+  `release_blocking_advisory_severities`.
+- Advisory failures do **not** fail verification unless an advisory matches a
+  release-blocking severity.
+
+## Commands
+
+```bash
+cargo xtask release evidence --version 0.13.0 --out target/release-evidence/v0.13.0
+cargo xtask release verify-evidence --version 0.13.0 --receipt target/receipts/release-evidence.json
+```

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -520,14 +520,10 @@ enum Commands {
         bench: bool,
     },
 
-    /// Prepare release
+    /// Release workflows and evidence validation.
     Release {
-        /// Version to release
-        version: String,
-
-        /// Skip confirmation
-        #[arg(long)]
-        yes: bool,
+        #[command(subcommand)]
+        command: ReleaseCommand,
     },
 
     /// Extract the curated release body from `docs/releases/<tag>.md`.
@@ -1303,6 +1299,37 @@ enum MetricsCommand {
     },
 }
 
+#[derive(Subcommand)]
+enum ReleaseCommand {
+    /// Prepare release artifacts.
+    Prepare {
+        /// Version to release.
+        version: String,
+
+        /// Skip confirmation.
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Scaffold the release evidence bundle for a target version.
+    Evidence {
+        /// Release version (for example `0.13.0`).
+        #[arg(long)]
+        version: String,
+        /// Output bundle directory.
+        #[arg(long)]
+        out: PathBuf,
+    },
+    /// Verify release evidence receipts and emit a summary receipt.
+    VerifyEvidence {
+        /// Release version (for example `0.13.0`).
+        #[arg(long)]
+        version: String,
+        /// Output path for the summary verification receipt.
+        #[arg(long)]
+        receipt: PathBuf,
+    },
+}
+
 #[derive(ValueEnum, Clone)]
 enum PrepCratesMode {
     Core,
@@ -1410,7 +1437,13 @@ fn main() -> Result<()> {
         Commands::ParseRust { source, sexp, ast, bench } => {
             parse_rust::run(source, sexp, ast, bench)
         }
-        Commands::Release { version, yes } => release::run(version, yes),
+        Commands::Release { command } => match command {
+            ReleaseCommand::Prepare { version, yes } => release::run(version, yes),
+            ReleaseCommand::Evidence { version, out } => release_evidence::scaffold(version, out),
+            ReleaseCommand::VerifyEvidence { version, receipt } => {
+                release_evidence::verify(version, receipt)
+            }
+        },
         Commands::ReleaseNotes { tag, output, root } => release_notes::run(tag, output, root),
         Commands::ReleaseTurnkey {
             version,

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -61,6 +61,7 @@ pub mod publish_manifest_check;
 pub mod publish_receipts;
 pub mod receipts;
 pub mod release;
+pub mod release_evidence;
 pub mod release_notes;
 pub mod release_turnkey;
 pub mod srp_microcrates;

--- a/xtask/src/tasks/release_evidence.rs
+++ b/xtask/src/tasks/release_evidence.rs
@@ -1,0 +1,194 @@
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::utils::project_root;
+
+const POLICY_PATH: &str = ".ci/release/evidence.toml";
+const REQUIRED_RECEIPTS: [&str; 8] = [
+    "ci-gate.json",
+    "parser-ratchet-release.json",
+    "vscode-extension-smoke.json",
+    "lsp-scenario.json",
+    "real-workspace-baseline.json",
+    "ai-completion-e2e.json",
+    "advisory-status.json",
+    "unresolved-risk-register.json",
+];
+
+#[derive(Debug, Deserialize)]
+struct EvidencePolicy {
+    #[serde(default)]
+    release_blocking_advisory_severities: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ScaffoldReceipt<'a> {
+    version: &'a str,
+    out: String,
+    required_receipts: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericReceipt {
+    status: String,
+    #[serde(default)]
+    advisories: Vec<AdvisoryFinding>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdvisoryFinding {
+    id: Option<String>,
+    severity: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct VerifyReceipt {
+    subsystem: &'static str,
+    version: String,
+    bundle_root: String,
+    required_receipts: Vec<String>,
+    missing_receipts: Vec<String>,
+    failed_receipts: Vec<String>,
+    advisory_warnings: Vec<String>,
+    status: String,
+}
+
+pub fn scaffold(version: String, out: PathBuf) -> Result<()> {
+    fs::create_dir_all(&out)
+        .with_context(|| format!("creating evidence bundle directory {}", out.display()))?;
+
+    let receipt = ScaffoldReceipt {
+        version: &version,
+        out: out.display().to_string(),
+        required_receipts: REQUIRED_RECEIPTS.iter().map(|name| (*name).to_string()).collect(),
+    };
+
+    let manifest = out.join("bundle-scaffold.json");
+    fs::write(&manifest, serde_json::to_string_pretty(&receipt)?).with_context(|| {
+        format!("writing release evidence scaffold manifest to {}", manifest.display())
+    })?;
+
+    println!("Scaffolded release evidence bundle at {}", out.display());
+    Ok(())
+}
+
+pub fn verify(version: String, receipt_out: PathBuf) -> Result<()> {
+    let root = project_root()?;
+    let bundle_root = root.join("target").join("release-evidence").join(format!("v{version}"));
+    let policy = load_policy(&root)?;
+
+    let mut missing = Vec::new();
+    let mut failed = Vec::new();
+    let mut advisory_warnings = Vec::new();
+
+    for name in REQUIRED_RECEIPTS {
+        let path = bundle_root.join(name);
+        if !path.exists() {
+            missing.push(name.to_string());
+            continue;
+        }
+
+        let parsed = parse_receipt(&path)?;
+        let passed = parsed.status.eq_ignore_ascii_case("pass");
+
+        if name == "advisory-status.json" {
+            if !passed {
+                let blocking = classify_advisory_failure(&parsed.advisories, &policy);
+                if blocking.is_empty() {
+                    advisory_warnings.push(
+                        "advisory-status.json failed but no release-blocking policy match"
+                            .to_string(),
+                    );
+                } else {
+                    failed.push(name.to_string());
+                    advisory_warnings.extend(blocking);
+                }
+            }
+            continue;
+        }
+
+        if !passed {
+            failed.push(name.to_string());
+        }
+    }
+
+    let status = if missing.is_empty() && failed.is_empty() { "pass" } else { "fail" };
+
+    let summary = VerifyReceipt {
+        subsystem: "release_evidence",
+        version,
+        bundle_root: bundle_root.display().to_string(),
+        required_receipts: REQUIRED_RECEIPTS.iter().map(|value| (*value).to_string()).collect(),
+        missing_receipts: missing.clone(),
+        failed_receipts: failed.clone(),
+        advisory_warnings,
+        status: status.to_string(),
+    };
+
+    if let Some(parent) = receipt_out.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating receipt directory {}", parent.display()))?;
+    }
+    fs::write(&receipt_out, serde_json::to_string_pretty(&summary)?).with_context(|| {
+        format!("writing release-evidence summary receipt {}", receipt_out.display())
+    })?;
+
+    if !missing.is_empty() {
+        bail!("release evidence verification failed: missing receipts: {}", missing.join(", "));
+    }
+    if !failed.is_empty() {
+        bail!("release evidence verification failed: failing receipts: {}", failed.join(", "));
+    }
+
+    println!("Release evidence verified: {}", receipt_out.display());
+    Ok(())
+}
+
+fn load_policy(root: &Path) -> Result<EvidencePolicy> {
+    let path = root.join(POLICY_PATH);
+    let contents = fs::read_to_string(&path)
+        .with_context(|| format!("reading release evidence policy {}", path.display()))?;
+    let policy = toml::from_str::<EvidencePolicy>(&contents)
+        .with_context(|| format!("parsing release evidence policy {}", path.display()))?;
+    Ok(policy)
+}
+
+fn parse_receipt(path: &Path) -> Result<GenericReceipt> {
+    let contents = fs::read_to_string(path)
+        .with_context(|| format!("reading evidence receipt {}", path.display()))?;
+    let parsed = serde_json::from_str::<GenericReceipt>(&contents)
+        .with_context(|| format!("parsing evidence receipt {}", path.display()))?;
+    Ok(parsed)
+}
+
+fn classify_advisory_failure(
+    advisories: &[AdvisoryFinding],
+    policy: &EvidencePolicy,
+) -> Vec<String> {
+    let blocking: BTreeSet<String> = policy
+        .release_blocking_advisory_severities
+        .iter()
+        .map(|value| value.to_ascii_lowercase())
+        .collect();
+
+    advisories
+        .iter()
+        .filter_map(|advisory| {
+            let severity = advisory
+                .severity
+                .as_ref()
+                .map(|value| value.to_ascii_lowercase())
+                .unwrap_or_else(|| "unknown".to_string());
+
+            if blocking.contains(&severity) {
+                let id = advisory.id.as_deref().unwrap_or("unknown-advisory");
+                Some(format!("release-blocking advisory: id={id}, severity={severity}"))
+            } else {
+                None
+            }
+        })
+        .collect()
+}

--- a/xtask/tests/fixtures/release-evidence/advisory-fail-nonblocking.json
+++ b/xtask/tests/fixtures/release-evidence/advisory-fail-nonblocking.json
@@ -1,0 +1,9 @@
+{
+  "status": "fail",
+  "advisories": [
+    {
+      "id": "RUSTSEC-2026-0001",
+      "severity": "high"
+    }
+  ]
+}

--- a/xtask/tests/fixtures/release-evidence/fail.json
+++ b/xtask/tests/fixtures/release-evidence/fail.json
@@ -1,0 +1,3 @@
+{
+  "status": "fail"
+}

--- a/xtask/tests/fixtures/release-evidence/pass.json
+++ b/xtask/tests/fixtures/release-evidence/pass.json
@@ -1,0 +1,3 @@
+{
+  "status": "pass"
+}

--- a/xtask/tests/release_evidence_cli.rs
+++ b/xtask/tests/release_evidence_cli.rs
@@ -1,0 +1,108 @@
+use anyhow::{Context, Result};
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const REQUIRED: [&str; 8] = [
+    "ci-gate.json",
+    "parser-ratchet-release.json",
+    "vscode-extension-smoke.json",
+    "lsp-scenario.json",
+    "real-workspace-baseline.json",
+    "ai-completion-e2e.json",
+    "advisory-status.json",
+    "unresolved-risk-register.json",
+];
+
+fn fixture_path(name: &str) -> PathBuf {
+    Path::new("tests").join("fixtures").join("release-evidence").join(name)
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn write_bundle(version: &str, advisory_fixture: &str) -> Result<PathBuf> {
+    let bundle =
+        workspace_root().join("target").join("release-evidence").join(format!("v{version}"));
+    if bundle.exists() {
+        fs::remove_dir_all(&bundle)?;
+    }
+    fs::create_dir_all(&bundle)?;
+
+    let pass = fs::read_to_string(fixture_path("pass.json"))?;
+    for receipt in REQUIRED {
+        let path = bundle.join(receipt);
+        if receipt == "advisory-status.json" {
+            fs::write(path, fs::read_to_string(fixture_path(advisory_fixture))?)?;
+        } else {
+            fs::write(path, &pass)?;
+        }
+    }
+
+    Ok(bundle)
+}
+
+fn run_verify(version: &str, receipt: &Path) -> assert_cmd::assert::Assert {
+    cargo_bin_cmd!("xtask")
+        .args([
+            "release",
+            "verify-evidence",
+            "--version",
+            version,
+            "--receipt",
+            receipt.to_str().unwrap_or("target/receipts/release-evidence.json"),
+        ])
+        .assert()
+}
+
+#[test]
+fn fixture_complete_bundle_passes() -> Result<()> {
+    let version = "0.13.0-fixture-complete";
+    write_bundle(version, "pass.json")?;
+    let receipt =
+        workspace_root().join("target").join("receipts").join("release-evidence-complete.json");
+
+    run_verify(version, &receipt).success();
+
+    let summary: Value =
+        serde_json::from_str(&fs::read_to_string(&receipt).context("reading summary receipt")?)?;
+    assert_eq!(summary["status"], "pass");
+    Ok(())
+}
+
+#[test]
+fn fixture_missing_parser_ratchet_release_fails() -> Result<()> {
+    let version = "0.13.0-fixture-missing-parser";
+    let bundle = write_bundle(version, "pass.json")?;
+    fs::remove_file(bundle.join("parser-ratchet-release.json"))?;
+    let receipt =
+        workspace_root().join("target").join("receipts").join("release-evidence-missing.json");
+
+    run_verify(version, &receipt).failure();
+
+    let summary: Value = serde_json::from_str(&fs::read_to_string(&receipt)?)?;
+    assert_eq!(summary["status"], "fail");
+    assert!(summary["missing_receipts"].to_string().contains("parser-ratchet-release.json"));
+    Ok(())
+}
+
+#[test]
+fn fixture_advisory_failure_produces_classified_warning() -> Result<()> {
+    let version = "0.13.0-fixture-advisory-warning";
+    write_bundle(version, "advisory-fail-nonblocking.json")?;
+    let receipt =
+        workspace_root().join("target").join("receipts").join("release-evidence-advisory.json");
+
+    run_verify(version, &receipt).success();
+
+    let summary: Value = serde_json::from_str(&fs::read_to_string(&receipt)?)?;
+    assert_eq!(summary["status"], "pass");
+    let warnings = summary["advisory_warnings"].to_string();
+    assert!(warnings.contains("failed"));
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Release readiness should be an evidence bundle rather than a label or memory, so add scaffolding to produce and verify a versioned release-evidence bundle that records CI, parser ratchet, VS Code smoke, LSP scenario, real-workspace baseline, AI E2E, advisory status, and risk-register receipts (Refs #6853).

### Description

- Add a new xtask module `xtask/src/tasks/release_evidence.rs` that scaffolds a bundle manifest and verifies required receipts, classifies advisory failures against policy, and emits a summary receipt without hard-failing non-blocking advisories.
- Wire CLI entrypoints via a new `ReleaseCommand` subcommand so the following commands are available: `cargo xtask release evidence --version ... --out ...` and `cargo xtask release verify-evidence --version ... --receipt ...`.
- Add a JSON schema and policy scaffolding at `.ci/receipts/schemas/release-evidence.schema.json` and `.ci/release/evidence.toml`, and document behavior and expected bundle files in `docs/ci/release-evidence.md`.
- Add fixtures and an integration test (`xtask/tests/release_evidence_cli.rs` + fixtures in `xtask/tests/fixtures/release-evidence/`) that exercise: complete bundle passing, missing `parser-ratchet-release.json` failing, and advisory failure producing a classified warning.

### Testing

- `cargo xtask release evidence --version 0.13.0 --out target/release-evidence/v0.13.0` succeeded and created the scaffolded bundle manifest.
- `cargo xtask release verify-evidence --version 0.13.0 --receipt target/receipts/release-evidence.json` failed as expected when required receipts were not present (verifier correctly reports missing receipts).
- `cargo test -p xtask --test release_evidence_cli -- --nocapture` passed and confirmed the three fixture scenarios: complete bundle passes, missing parser-ratchet receipt fails, and advisory failure produced a classified (non-blocking) warning.
- `cargo xtask fmt`, `cargo check --all-targets -p xtask`, and `cargo clippy -p xtask -- -D warnings` completed successfully; `just pr-fast` was not run due to missing `just` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0e0832c8333a63f682bd3a487b4)