### PR TITLE
docs(ci): document GitHub-state lease and receipt orchestration (#0000)

### DIFF
--- a/docs/ci/agent-receipts-and-freshness.md
+++ b/docs/ci/agent-receipts-and-freshness.md
@@ -1,0 +1,117 @@
+# Agent Leases, Receipts, and Freshness Rules
+
+This document defines local validation rules for GitHub-backed maintainership receipts.
+
+## Scope
+
+The goal is to make disconnected workers safe by validating claim and output artifacts before any projection step.
+
+This protocol does **not**:
+
+- merge PRs,
+- mutate labels directly,
+- push branches,
+- coordinate via local worktree directories.
+
+## JSON shapes
+
+### Task (`kind: agent_task`)
+
+Required fields:
+
+- `schema_version`
+- `kind`
+- `task_id`
+- `snapshot_id`
+- `lane`
+- `pr`
+- `head_sha`
+- `base_sha`
+- `allowed_mutations`
+- `forbidden_mutations`
+- `expires_at`
+
+### Lease (`kind: agent_lease`)
+
+Required fields:
+
+- `schema_version`
+- `kind`
+- `task_id`
+- `lease_id`
+- `owner`
+- `pr`
+- `head_sha`
+- `base_sha`
+- `allowed_mutations`
+- `expires_at`
+
+### Receipt (`kind: agent_receipt`)
+
+Required fields:
+
+- `schema_version`
+- `kind`
+- `task_id`
+- `lease_id`
+- `lane`
+- `pr`
+- `head_sha`
+- `base_sha`
+- `verdict`
+- `classification`
+- `evidence`
+
+## Validation and status rules
+
+### Hard rejection
+
+Reject receipt/lease when:
+
+- schema is invalid,
+- prohibited mutation appears in requested mutation set,
+- task and receipt identity fields do not match (`task_id`, `pr`, `lane`).
+
+### Stale/advisory classification
+
+Mark stale or advisory when:
+
+- `head_sha` differs from current PR head in snapshot,
+- lease is expired,
+- `base_sha` differs and lane policy does not allow base drift.
+
+### Supersession
+
+For the same tuple (`task_id`, `lane`, `head_sha`), newer receipts supersede older receipts.
+
+### Duplicate lease resolution
+
+For same (`task_id`, `head_sha`):
+
+1. ignore expired leases,
+2. earliest remaining lease wins,
+3. tie-break with lexicographic `lease_id`.
+
+## Command contract (proposed)
+
+```bash
+cargo xtask agent lease create --task <task.json> --out target/receipts/agent-lease.json
+cargo xtask agent lease verify --lease <lease.json> --snapshot <snapshot.json>
+cargo xtask agent receipt validate --receipt <receipt.json> --task <task.json> --snapshot <snapshot.json>
+cargo xtask agent receipt status --receipt <receipt.json> --snapshot <snapshot.json>
+```
+
+## Queue snapshot prerequisite
+
+All workers should derive freshness from a common queue snapshot shape that contains current PR head/base/status check rollups.
+
+```bash
+cargo xtask queue snapshot --out target/queue/open-prs.json
+cargo xtask queue snapshot --fixture <fixture.json> --out target/queue/open-prs.json
+```
+
+## Safety invariant
+
+Agents emit evidence; reconcilers derive canonical state.
+
+Any stale, duplicate, or late worker output must degrade to no-op state projection rather than unsafe mutation.

--- a/docs/ci/github-state-orchestration.md
+++ b/docs/ci/github-state-orchestration.md
@@ -1,0 +1,117 @@
+# GitHub-State Orchestration for Disconnected Maintainers
+
+## Core model
+
+GitHub is the shared distributed state. Agent local filesystems are not.
+
+```text
+multiple boxes / agents / maintainers
+        ↓
+read GitHub state
+        ↓
+claim or inspect bounded work
+        ↓
+emit GitHub-visible evidence
+        ↓
+reconciler derives canonical state
+        ↓
+labels/checks/comments/routes update
+```
+
+In this model:
+
+- GitHub comments and check artifacts carry **leases** and **receipts**.
+- Receipts are durable evidence, not direct state mutation.
+- Labels are projected UI based on canonical reconciled state.
+- PR head/base SHAs provide freshness boundaries.
+- Rulesets and merge queue become final enforcement once enabled.
+
+## Why this replaces local worktree coordination
+
+A local worktree allocator assumes shared filesystem state and direct box-to-box coordination.
+That does not hold for disconnected maintainership.
+
+The repo control plane should therefore:
+
+- avoid `.claude/worktrees` as the coordination substrate,
+- use GitHub-visible claim/receipt records,
+- make stale/duplicate work harmless by enforcing freshness at reconciliation.
+
+## Protocol primitives
+
+### 1. Queue snapshot
+
+Each worker starts from a GitHub snapshot document (`snapshot_id`, captured PR metadata, status rollups).
+
+Authoritative freshness data should come from:
+
+- current `head_sha`,
+- current `base_sha`,
+- status check rollups.
+
+Comments are evidence, not source of truth for CI status.
+
+### 2. Task
+
+A bounded task includes:
+
+- `task_id`, `lane`, `pr`, `head_sha`, `base_sha`,
+- `allowed_mutations` and `forbidden_mutations`,
+- expiration timestamp.
+
+### 3. Lease
+
+A lease is a GitHub-visible claim over a task/head pair.
+
+Idempotency prefix:
+
+```text
+[agent-lease:<lane>:<task_id>]
+```
+
+Deterministic winner rule:
+
+1. earliest non-expired lease for the same `task_id` + `head_sha` wins,
+2. ties break by lexicographic `lease_id`,
+3. losers do not mutate.
+
+### 4. Receipt
+
+A receipt records lane output and evidence.
+
+Idempotency prefix:
+
+```text
+[agent-receipt:<lane>:<task_id>:terminal]
+```
+
+Reconciler checks:
+
+- receipt head/base freshness,
+- lease validity and expiry,
+- mutation policy compliance,
+- supersession by newer receipt for same task/lane/head.
+
+Only valid, current receipts can project labels/routes.
+
+## Suggested phased rollout
+
+1. **Phase 1**: snapshots + leases + receipts + projected labels by convention.
+2. **Phase 2**: Methodology/Parser/CI gates always report machine-readable state.
+3. **Phase 3**: merge-ready receipts required operationally.
+4. **Phase 4**: required status checks enabled in GitHub rulesets.
+5. **Phase 5**: merge queue becomes final landing truth.
+
+## Operator loop
+
+```text
+1. Pull current GitHub state.
+2. Build local snapshot.
+3. Pick bounded work from canonical state.
+4. Claim task in GitHub state.
+5. Re-read GitHub state and verify claim still wins.
+6. Do bounded work.
+7. Verify head/base/state freshness before mutation.
+8. Emit receipt.
+9. Reconciler projects labels/routes.
+```


### PR DESCRIPTION
### Motivation

- Clarify the coordination model by making GitHub the shared distributed state for disconnected maintainers rather than relying on a local worktree allocator. 
- Define a small protocol (queue snapshot, bounded task, GitHub-backed lease, and receipt) with deterministic duplicate-lease resolution and freshness semantics so late or duplicate work degrades to harmless evidence.

### Description

- Add `docs/ci/github-state-orchestration.md` which describes the overall model, operator loop, protocol primitives, idempotency prefixes, and a phased rollout from conventions to ruleset enforcement. 
- Add `docs/ci/agent-receipts-and-freshness.md` which specifies JSON shapes for `agent_task`/`agent_lease`/`agent_receipt`, hard-rejection and stale/advisory rules, supersession and duplicate-lease tie-break rules, and a proposed `xtask` command contract. 
- Commit is a single focused documentation change and does not modify runtime code or tests, and a PR record was prepared referencing the work (#0000). 

### Testing

- Ran `git diff --check` which passed with no whitespace or diff issues. 
- The change was committed locally and a PR record was created; no crate-level `cargo test` or `xtask` automation was executed for this documentation-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd6e7fd7883338fc2b3f012ac0540)