### PR TITLE
feat(agent): add GitHub-state lease and receipt freshness primitives (#6853)

### DIFF
--- a/.ci/receipts/schemas/agent-lease.schema.json
+++ b/.ci/receipts/schemas/agent-lease.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/schemas/agent-lease.schema.json",
+  "type": "object",
+  "required": ["schema_version", "kind", "task_id", "lease_id", "owner", "lane", "pr", "head_sha", "base_sha", "issued_at", "expires_at"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "kind": { "const": "agent_lease" },
+    "task_id": { "type": "string" },
+    "lease_id": { "type": "string" },
+    "owner": { "type": "string" },
+    "lane": { "type": "string" },
+    "pr": { "type": "integer", "minimum": 1 },
+    "head_sha": { "type": "string" },
+    "base_sha": { "type": "string" },
+    "allowed_mutations": { "type": "array", "items": { "type": "string" } },
+    "issued_at": { "type": "string", "format": "date-time" },
+    "expires_at": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": true
+}

--- a/.ci/receipts/schemas/agent-receipt.schema.json
+++ b/.ci/receipts/schemas/agent-receipt.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/schemas/agent-receipt.schema.json",
+  "type": "object",
+  "required": ["schema_version", "kind", "task_id", "lease_id", "lane", "pr", "head_sha", "base_sha", "verdict", "created_at"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "kind": { "const": "agent_receipt" },
+    "task_id": { "type": "string" },
+    "lease_id": { "type": "string" },
+    "lane": { "type": "string" },
+    "pr": { "type": "integer", "minimum": 1 },
+    "head_sha": { "type": "string" },
+    "base_sha": { "type": "string" },
+    "verdict": { "type": "string" },
+    "requested_mutations": { "type": "array", "items": { "type": "string" } },
+    "created_at": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": true
+}

--- a/.ci/receipts/schemas/agent-task.schema.json
+++ b/.ci/receipts/schemas/agent-task.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/schemas/agent-task.schema.json",
+  "type": "object",
+  "required": ["schema_version", "kind", "task_id", "snapshot_id", "lane", "pr", "head_sha", "base_sha", "expires_at"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "kind": { "const": "agent_task" },
+    "task_id": { "type": "string", "minLength": 1 },
+    "snapshot_id": { "type": "string", "minLength": 1 },
+    "lane": { "type": "string", "minLength": 1 },
+    "pr": { "type": "integer", "minimum": 1 },
+    "head_sha": { "type": "string", "minLength": 3 },
+    "base_sha": { "type": "string", "minLength": 3 },
+    "allowed_mutations": { "type": "array", "items": { "type": "string" } },
+    "forbidden_mutations": { "type": "array", "items": { "type": "string" } },
+    "expires_at": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": true
+}

--- a/docs/ci/agent-receipts-and-freshness.md
+++ b/docs/ci/agent-receipts-and-freshness.md
@@ -1,0 +1,24 @@
+# Agent Receipts and Freshness
+
+`agent_receipt` is durable evidence. It is not a direct state mutation.
+
+## Freshness checks
+
+Receipt validation enforces:
+
+- `head_sha` mismatch => `stale`
+- `base_sha` mismatch => `advisory`
+- forbidden requested mutation => `rejected`
+- newer receipt for same `task/lane/head` => `superseded`
+
+## Idempotency markers
+
+Recommended GitHub-visible prefixes for comments/check payloads:
+
+- `[agent-lease:<lane>:<task_id>]`
+- `[agent-receipt:<lane>:<task_id>:terminal]`
+
+## Relationship to labels
+
+Labels are UI projections from reconciled canonical state.
+Agents should emit receipts and let reconciler logic project labels/routes.

--- a/docs/ci/github-state-orchestration.md
+++ b/docs/ci/github-state-orchestration.md
@@ -1,0 +1,36 @@
+# GitHub-State Orchestration (Leases + Receipts)
+
+This repository treats **GitHub state as the coordination substrate** for disconnected maintainership boxes.
+
+## Protocol summary
+
+1. Build a queue snapshot.
+2. Create a bounded `agent_task`.
+3. Emit a GitHub-visible `agent_lease` claim.
+4. Re-verify lease winner deterministically.
+5. Perform bounded work.
+6. Emit `agent_receipt` evidence.
+7. Reconciler derives canonical state and projects labels/routes.
+
+## Command surface
+
+```bash
+cargo xtask agent lease create --task <task.json> --out <lease.json>
+cargo xtask agent lease verify --lease <lease.json> --snapshot <snapshot.json>
+cargo xtask agent receipt validate --receipt <receipt.json> --task <task.json> --snapshot <snapshot.json>
+cargo xtask agent receipt status --receipt <receipt.json> --snapshot <snapshot.json>
+```
+
+## Deterministic duplicate lease winner
+
+When multiple leases exist for the same `task_id + head_sha`, winner selection is deterministic:
+
+- earliest non-expired lease wins
+- tie-break by lexicographic `lease_id`
+
+Losers are stale and MUST NOT mutate shared state.
+
+## Scope boundaries
+
+These primitives only validate local JSON protocol invariants and freshness against a snapshot.
+They do not mutate labels, merge PRs, or push branches.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -36,6 +36,12 @@ enum Commands {
     #[command(name = "list-commands")]
     List,
 
+    /// Manage GitHub-state coordination primitives for disconnected maintainership.
+    Agent {
+        #[command(subcommand)]
+        command: AgentCommand,
+    },
+
     /// Run lean CI suite (format, clippy, tests) for constrained environments
     Ci,
 
@@ -1155,6 +1161,60 @@ enum Commands {
 }
 
 #[derive(Subcommand)]
+enum AgentCommand {
+    /// Lease operations for bounded agent tasks.
+    Lease {
+        #[command(subcommand)]
+        command: AgentLeaseCommand,
+    },
+    /// Receipt validation and freshness status checks.
+    Receipt {
+        #[command(subcommand)]
+        command: AgentReceiptCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentLeaseCommand {
+    /// Create a lease JSON from an agent task JSON.
+    Create {
+        #[arg(long)]
+        task: PathBuf,
+        #[arg(long)]
+        out: PathBuf,
+        #[arg(long, default_value = "local/codex")]
+        owner: String,
+    },
+    /// Verify lease freshness and deterministic winner selection against a snapshot.
+    Verify {
+        #[arg(long)]
+        lease: PathBuf,
+        #[arg(long)]
+        snapshot: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
+enum AgentReceiptCommand {
+    /// Validate receipt freshness and policy constraints.
+    Validate {
+        #[arg(long)]
+        receipt: PathBuf,
+        #[arg(long)]
+        task: PathBuf,
+        #[arg(long)]
+        snapshot: PathBuf,
+    },
+    /// Compute receipt freshness status against snapshot state.
+    Status {
+        #[arg(long)]
+        receipt: PathBuf,
+        #[arg(long)]
+        snapshot: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
 enum CpanCorpusCommand {
     /// Fetch top N distributions from MetaCPAN by reverse dependency count
     FetchList {
@@ -1325,6 +1385,30 @@ fn main() -> Result<()> {
             print_top_level_commands();
             Ok(())
         }
+        Commands::Agent { command } => match command {
+            AgentCommand::Lease { command } => match command {
+                AgentLeaseCommand::Create { task, out, owner } => {
+                    agent_lease::create(&task, &out, &owner)
+                }
+                AgentLeaseCommand::Verify { lease, snapshot } => {
+                    let result = agent_lease::verify(&lease, &snapshot)?;
+                    println!("{}", serde_json::to_string_pretty(&result)?);
+                    Ok(())
+                }
+            },
+            AgentCommand::Receipt { command } => match command {
+                AgentReceiptCommand::Validate { receipt, task, snapshot } => {
+                    let result = agent_receipt::validate(&receipt, &task, &snapshot)?;
+                    println!("{}", serde_json::to_string_pretty(&result)?);
+                    Ok(())
+                }
+                AgentReceiptCommand::Status { receipt, snapshot } => {
+                    let result = agent_receipt::status(&receipt, &snapshot)?;
+                    println!("{}", serde_json::to_string_pretty(&result)?);
+                    Ok(())
+                }
+            },
+        },
         Commands::Ci => ci::run(),
         Commands::CheckOnly => ci::check_only(),
         Commands::CheckToolchain { doctor } => check_toolchain::run(doctor),

--- a/xtask/src/tasks/agent_lease.rs
+++ b/xtask/src/tasks/agent_lease.rs
@@ -1,0 +1,163 @@
+use color_eyre::eyre::{Context, Result, eyre};
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use std::fs;
+use std::path::Path;
+
+use super::agent_receipt::QueueSnapshot;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentTask {
+    pub schema_version: u32,
+    pub kind: String,
+    pub task_id: String,
+    pub snapshot_id: String,
+    pub lane: String,
+    pub pr: u64,
+    pub head_sha: String,
+    pub base_sha: String,
+    #[serde(default)]
+    pub allowed_mutations: Vec<String>,
+    #[serde(default)]
+    pub forbidden_mutations: Vec<String>,
+    pub expires_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentLease {
+    pub schema_version: u32,
+    pub kind: String,
+    pub task_id: String,
+    pub lease_id: String,
+    pub owner: String,
+    pub lane: String,
+    pub pr: u64,
+    pub head_sha: String,
+    pub base_sha: String,
+    #[serde(default)]
+    pub allowed_mutations: Vec<String>,
+    pub issued_at: String,
+    pub expires_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LeaseVerification {
+    pub status: String,
+    pub reason: String,
+    pub winning_lease_id: Option<String>,
+}
+
+pub fn create(task_path: &Path, output_path: &Path, owner: &str) -> Result<()> {
+    let task: AgentTask = read_json(task_path)?;
+    let now = chrono::Utc::now();
+    let lease = AgentLease {
+        schema_version: 1,
+        kind: "agent_lease".to_string(),
+        task_id: task.task_id.clone(),
+        lease_id: format!("lease-{}-{}", task.pr, now.timestamp()),
+        owner: owner.to_string(),
+        lane: task.lane,
+        pr: task.pr,
+        head_sha: task.head_sha,
+        base_sha: task.base_sha,
+        allowed_mutations: task.allowed_mutations,
+        issued_at: now.to_rfc3339(),
+        expires_at: task.expires_at,
+    };
+
+    write_json(output_path, &lease)
+}
+
+pub fn verify(lease_path: &Path, snapshot_path: &Path) -> Result<LeaseVerification> {
+    let lease: AgentLease = read_json(lease_path)?;
+    let snapshot: QueueSnapshot = read_json(snapshot_path)?;
+    let captured = chrono::DateTime::parse_from_rfc3339(&snapshot.captured_at)
+        .context("snapshot.captured_at must be RFC3339")?;
+    let expires = chrono::DateTime::parse_from_rfc3339(&lease.expires_at)
+        .context("lease.expires_at must be RFC3339")?;
+    if expires <= captured {
+        return Ok(LeaseVerification {
+            status: "stale".to_string(),
+            reason: "lease expired at snapshot time".to_string(),
+            winning_lease_id: None,
+        });
+    }
+
+    let Some(pr) = snapshot.prs.iter().find(|p| p.number == lease.pr) else {
+        return Ok(LeaseVerification {
+            status: "stale".to_string(),
+            reason: "PR missing from snapshot".to_string(),
+            winning_lease_id: None,
+        });
+    };
+
+    if pr.head_sha != lease.head_sha {
+        return Ok(LeaseVerification {
+            status: "stale".to_string(),
+            reason: "head sha mismatch".to_string(),
+            winning_lease_id: None,
+        });
+    }
+
+    let winner =
+        select_winner(&lease, snapshot.active_leases.as_deref().unwrap_or(&[]), &captured)?;
+    if winner.lease_id != lease.lease_id {
+        return Ok(LeaseVerification {
+            status: "stale".to_string(),
+            reason: "lost deterministic lease tie-break".to_string(),
+            winning_lease_id: Some(winner.lease_id),
+        });
+    }
+
+    Ok(LeaseVerification {
+        status: "valid".to_string(),
+        reason: "lease matches current snapshot".to_string(),
+        winning_lease_id: Some(lease.lease_id),
+    })
+}
+
+fn select_winner(
+    current: &AgentLease,
+    candidates: &[AgentLease],
+    captured: &chrono::DateTime<chrono::FixedOffset>,
+) -> Result<AgentLease> {
+    let mut all = candidates
+        .iter()
+        .filter(|lease| lease.task_id == current.task_id && lease.head_sha == current.head_sha)
+        .filter_map(|lease| {
+            let expires = chrono::DateTime::parse_from_rfc3339(&lease.expires_at).ok()?;
+            if expires <= *captured {
+                return None;
+            }
+            Some(lease.clone())
+        })
+        .collect::<Vec<_>>();
+    all.push(current.clone());
+
+    all.sort_by(|left, right| compare_lease_priority(left, right).unwrap_or(Ordering::Equal));
+    all.into_iter().next().ok_or_else(|| eyre!("no non-expired leases available"))
+}
+
+fn compare_lease_priority(left: &AgentLease, right: &AgentLease) -> Result<Ordering> {
+    let left_issued = chrono::DateTime::parse_from_rfc3339(&left.issued_at)
+        .context("left lease issued_at must be RFC3339")?;
+    let right_issued = chrono::DateTime::parse_from_rfc3339(&right.issued_at)
+        .context("right lease issued_at must be RFC3339")?;
+    Ok(left_issued.cmp(&right_issued).then_with(|| left.lease_id.cmp(&right.lease_id)))
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T> {
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("failed to read JSON file {}", path.display()))?;
+    serde_json::from_str(&text)
+        .with_context(|| format!("failed to parse JSON file {}", path.display()))
+}
+
+fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create output dir {}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(value).context("failed to serialize json")?;
+    fs::write(path, json).with_context(|| format!("failed to write {}", path.display()))
+}

--- a/xtask/src/tasks/agent_receipt.rs
+++ b/xtask/src/tasks/agent_receipt.rs
@@ -1,0 +1,170 @@
+use color_eyre::eyre::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+use super::agent_lease::{AgentLease, AgentTask};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueueSnapshot {
+    pub snapshot_id: String,
+    pub captured_at: String,
+    pub prs: Vec<SnapshotPr>,
+    #[serde(default)]
+    pub active_leases: Option<Vec<AgentLease>>,
+    #[serde(default)]
+    pub receipts: Option<Vec<AgentReceipt>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotPr {
+    pub number: u64,
+    pub head_sha: String,
+    pub base_sha: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentReceipt {
+    pub schema_version: u32,
+    pub kind: String,
+    pub task_id: String,
+    pub lease_id: String,
+    pub lane: String,
+    pub pr: u64,
+    pub head_sha: String,
+    pub base_sha: String,
+    pub verdict: String,
+    #[serde(default)]
+    pub requested_mutations: Vec<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ReceiptStatus {
+    pub status: String,
+    pub reason: String,
+}
+
+pub fn validate(
+    receipt_path: &Path,
+    task_path: &Path,
+    snapshot_path: &Path,
+) -> Result<ReceiptStatus> {
+    let receipt: AgentReceipt = read_json(receipt_path)?;
+    let task: AgentTask = read_json(task_path)?;
+    let snapshot: QueueSnapshot = read_json(snapshot_path)?;
+
+    if receipt.task_id != task.task_id || receipt.pr != task.pr {
+        return Ok(ReceiptStatus {
+            status: "rejected".to_string(),
+            reason: "task mismatch".to_string(),
+        });
+    }
+
+    if task.allowed_mutations.iter().any(|mutation| task.forbidden_mutations.contains(mutation)) {
+        return Ok(ReceiptStatus {
+            status: "rejected".to_string(),
+            reason: "task mutation policy is self-contradictory".to_string(),
+        });
+    }
+
+    if receipt
+        .requested_mutations
+        .iter()
+        .any(|mutation| task.forbidden_mutations.contains(mutation))
+    {
+        return Ok(ReceiptStatus {
+            status: "rejected".to_string(),
+            reason: "receipt requested forbidden mutation".to_string(),
+        });
+    }
+
+    let Some(pr) = snapshot.prs.iter().find(|pr| pr.number == receipt.pr) else {
+        return Ok(ReceiptStatus {
+            status: "stale".to_string(),
+            reason: "pr not present in snapshot".to_string(),
+        });
+    };
+
+    if pr.head_sha != receipt.head_sha {
+        return Ok(ReceiptStatus {
+            status: "stale".to_string(),
+            reason: "head sha mismatch".to_string(),
+        });
+    }
+
+    if pr.base_sha != receipt.base_sha {
+        return Ok(ReceiptStatus {
+            status: "advisory".to_string(),
+            reason: "base sha mismatch".to_string(),
+        });
+    }
+
+    if has_newer_receipt(&snapshot, &receipt)? {
+        return Ok(ReceiptStatus {
+            status: "superseded".to_string(),
+            reason: "newer receipt exists for same task/lane/head".to_string(),
+        });
+    }
+
+    Ok(ReceiptStatus {
+        status: "valid".to_string(),
+        reason: "receipt is current for snapshot head/base".to_string(),
+    })
+}
+
+pub fn status(receipt_path: &Path, snapshot_path: &Path) -> Result<ReceiptStatus> {
+    let receipt: AgentReceipt = read_json(receipt_path)?;
+    let snapshot: QueueSnapshot = read_json(snapshot_path)?;
+    let Some(pr) = snapshot.prs.iter().find(|pr| pr.number == receipt.pr) else {
+        return Ok(ReceiptStatus {
+            status: "stale".to_string(),
+            reason: "pr not present".to_string(),
+        });
+    };
+    if pr.head_sha != receipt.head_sha {
+        return Ok(ReceiptStatus {
+            status: "stale".to_string(),
+            reason: "head sha mismatch".to_string(),
+        });
+    }
+    if has_newer_receipt(&snapshot, &receipt)? {
+        return Ok(ReceiptStatus {
+            status: "superseded".to_string(),
+            reason: "newer receipt exists".to_string(),
+        });
+    }
+    Ok(ReceiptStatus {
+        status: "current".to_string(),
+        reason: "receipt tracks latest head".to_string(),
+    })
+}
+
+fn has_newer_receipt(snapshot: &QueueSnapshot, receipt: &AgentReceipt) -> Result<bool> {
+    let Some(receipts) = snapshot.receipts.as_ref() else {
+        return Ok(false);
+    };
+    let created = chrono::DateTime::parse_from_rfc3339(&receipt.created_at)
+        .context("receipt.created_at must be RFC3339")?;
+    for candidate in receipts {
+        if candidate.task_id != receipt.task_id
+            || candidate.lane != receipt.lane
+            || candidate.head_sha != receipt.head_sha
+        {
+            continue;
+        }
+        let candidate_created = chrono::DateTime::parse_from_rfc3339(&candidate.created_at)
+            .context("snapshot receipt created_at must be RFC3339")?;
+        if candidate_created > created {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T> {
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("failed to read JSON file {}", path.display()))?;
+    serde_json::from_str(&text)
+        .with_context(|| format!("failed to parse JSON file {}", path.display()))
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -1,5 +1,7 @@
 //! Task implementations for xtask automation
 
+pub mod agent_lease;
+pub mod agent_receipt;
 pub mod bench;
 pub mod benchmarks;
 #[cfg(feature = "parser-tasks")]

--- a/xtask/tests/fixtures/agent-leases/receipt-stale-head.json
+++ b/xtask/tests/fixtures/agent-leases/receipt-stale-head.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kind": "agent_receipt",
+  "task_id": "task-6854-green-ci-abc123",
+  "lease_id": "lease-6854-early",
+  "lane": "green_ci",
+  "pr": 6854,
+  "head_sha": "old999",
+  "base_sha": "def456",
+  "verdict": "ci_green",
+  "requested_mutations": ["emit_receipt"],
+  "created_at": "2026-04-26T18:49:00Z"
+}

--- a/xtask/tests/fixtures/agent-leases/snapshot.json
+++ b/xtask/tests/fixtures/agent-leases/snapshot.json
@@ -1,0 +1,24 @@
+{
+  "snapshot_id": "gh-snapshot-2026-04-26T18:50:00Z",
+  "captured_at": "2026-04-26T18:50:00Z",
+  "prs": [
+    { "number": 6854, "head_sha": "abc123", "base_sha": "def456" }
+  ],
+  "active_leases": [
+    {
+      "schema_version": 1,
+      "kind": "agent_lease",
+      "task_id": "task-6854-green-ci-abc123",
+      "lease_id": "lease-6854-early",
+      "owner": "box-a/codex-17",
+      "lane": "green_ci",
+      "pr": 6854,
+      "head_sha": "abc123",
+      "base_sha": "def456",
+      "allowed_mutations": ["emit_receipt", "comment"],
+      "issued_at": "2026-04-26T18:41:00Z",
+      "expires_at": "2026-04-26T19:10:00Z"
+    }
+  ],
+  "receipts": []
+}

--- a/xtask/tests/fixtures/agent-leases/task.json
+++ b/xtask/tests/fixtures/agent-leases/task.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kind": "agent_task",
+  "task_id": "task-6854-green-ci-abc123",
+  "snapshot_id": "gh-snapshot-2026-04-26T18:40:00Z",
+  "lane": "green_ci",
+  "pr": 6854,
+  "head_sha": "abc123",
+  "base_sha": "def456",
+  "allowed_mutations": ["emit_receipt", "comment"],
+  "forbidden_mutations": ["apply_labels", "merge", "push_branch"],
+  "expires_at": "2026-04-26T19:10:00Z"
+}


### PR DESCRIPTION
### Motivation

- Disconnected maintainer boxes need a GitHub-backed coordination protocol (leases + receipts) so multiple boxes can safely claim work and emit durable evidence without relying on local worktree leases.
- Deterministic winner selection and receipt freshness checks are required to make late/duplicate agent work harmless and to keep labels/routes projection declarative.
- This change scopes the implementation to validation and evidence primitives and explicitly avoids mutating labels, merging PRs, or managing local worktrees.

### Description

- Added a new `xtask agent` command family and subcommands wired into `xtask/src/main.rs` (`agent lease create`, `agent lease verify`, `agent receipt validate`, `agent receipt status`).
- Implemented lease primitives in `xtask/src/tasks/agent_lease.rs` providing `AgentTask`/`AgentLease` models, `create` and `verify` operations, and deterministic winner selection (earliest non-expired `issued_at`, tie-break by `lease_id`).
- Implemented receipt primitives in `xtask/src/tasks/agent_receipt.rs` providing `AgentReceipt`/`QueueSnapshot` models, `validate`/`status` checks (task mismatch, forbidden mutations, head/base freshness, supersession detection).
- Added JSON schemas under `.ci/receipts/schemas/` (`agent-task`, `agent-lease`, `agent-receipt`), example fixtures under `xtask/tests/fixtures/agent-leases/`, and documentation describing the protocol and freshness rules in `docs/ci/`.

### Testing

- Ran `cargo check -p xtask` which completed successfully. 
- Ran `cargo fmt --all` to ensure formatting compliance which succeeded. 
- Attempted `cargo check --all-targets -p xtask` but it was blocked by a transient build-directory file lock in the execution environment. 
- Exercised the new CLI wiring during development (created lease JSON and exercised validation against the snapshot fixtures) with the xtask commands listed in the docs and fixtures present for deterministic unit-style validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd6e7fd7883338fc2b3f012ac0540)