### PR TITLE
feat(ci): add receipt finalizer and aggregator framework (#6857)

### DIFF
--- a/.ci/receipts/schemas/aggregator-receipt.schema.json
+++ b/.ci/receipts/schemas/aggregator-receipt.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.github.io/perl-lsp/schemas/aggregator-receipt.schema.json",
+  "title": "CI Aggregator Receipt",
+  "type": "object",
+  "required": ["check", "schema_version", "event", "verdict", "classification", "subreceipts", "missing_receipts", "repro"],
+  "properties": {
+    "check": { "type": "string" },
+    "schema_version": { "type": "integer", "minimum": 1 },
+    "event": { "type": "string" },
+    "verdict": { "type": "string", "enum": ["pass", "fail", "warn", "skipped", "unknown"] },
+    "classification": { "type": "string", "enum": ["code_regression", "infra_failure", "stale_base", "skipped", "unknown"] },
+    "subreceipts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "required", "selected", "verdict"],
+        "properties": {
+          "name": { "type": "string" },
+          "required": { "type": "boolean" },
+          "selected": { "type": "boolean" },
+          "missing": { "type": "boolean" },
+          "verdict": { "type": "string", "enum": ["pass", "fail", "warn", "skipped", "unknown"] },
+          "classification": { "type": ["string", "null"] },
+          "repro": {
+            "type": ["object", "null"],
+            "properties": { "command": { "type": "string" } }
+          }
+        }
+      }
+    },
+    "missing_receipts": { "type": "array", "items": { "type": "string" } },
+    "repro": {
+      "type": "object",
+      "required": ["command"],
+      "properties": { "command": { "type": "string" } }
+    }
+  }
+}

--- a/docs/contributing/required-workflow-template.md
+++ b/docs/contributing/required-workflow-template.md
@@ -1,0 +1,57 @@
+# Required Workflow Template (Stable Final Check Pattern)
+
+Use this template when converting a CI workflow to stable required checks.
+
+## Principles
+
+1. The workflow itself should always trigger.
+2. Internal jobs may be skipped based on scope/routing.
+3. The final job must use `if: always()`.
+4. The final job aggregates sub-job receipts into one final receipt.
+5. The final job owns the stable check name used for required checks.
+6. Branch/ruleset enforcement should point to the final job **only after** an observation window.
+
+## Template
+
+```yaml
+name: ci-example
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  internal-a:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo '{"name":"internal-a","required":true,"selected":true,"verdict":"pass"}' > .ci/receipts/incoming/internal-a.json
+
+  internal-b:
+    runs-on: ubuntu-latest
+    if: ${{ false }}
+    steps:
+      - run: echo "skipped"
+
+  final-check:
+    name: Stable Final Check Name
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [internal-a, internal-b]
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          cargo xtask aggregate-receipts \
+            --check "Stable Final Check Name" \
+            --inputs .ci/receipts/incoming \
+            --output target/receipts/stable-final-check.json
+      - run: cargo xtask finalize-check --receipt target/receipts/stable-final-check.json
+```
+
+## Rollout guidance
+
+- Do not refactor every workflow/job name in one PR.
+- Convert one workflow lane at a time.
+- Keep legacy internal job names until the final-check pattern is proven in production.
+- After observation confirms stability, point branch/ruleset enforcement to the final check name only.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1122,6 +1122,40 @@ enum Commands {
     /// Validate workspace exclusion strategy and dependency invariants.
     ValidateWorkspaceExclusions,
 
+    /// Aggregate subreceipts into a stable final check receipt.
+    AggregateReceipts {
+        /// Stable check name emitted by the final job.
+        #[arg(long)]
+        check: String,
+
+        /// Directory containing subreceipt JSON files.
+        #[arg(long)]
+        inputs: PathBuf,
+
+        /// Output path for the aggregated receipt JSON.
+        #[arg(long)]
+        output: PathBuf,
+
+        /// Event name recorded in the receipt.
+        #[arg(long, default_value = "pull_request")]
+        event: String,
+
+        /// Allow selected=false required jobs to be treated as no-op success.
+        #[arg(long, default_value_t = true)]
+        allow_noop: bool,
+
+        /// Advisory subreceipt handling mode (pass/warn/fail).
+        #[arg(long, value_enum, default_value = "warn")]
+        advisory_mode: aggregate_receipts::AdvisoryMode,
+    },
+
+    /// Finalize a stable check result from an aggregated receipt.
+    FinalizeCheck {
+        /// Path to an aggregated receipt JSON.
+        #[arg(long)]
+        receipt: PathBuf,
+    },
+
     /// Generate a build-timing receipt JSON with workspace duration metrics.
     BuildTimingReceipt {
         /// Measure clean build with `cargo build --workspace --locked`.
@@ -1680,6 +1714,17 @@ fn main() -> Result<()> {
         Commands::PopulateBook => populate_book::run(),
         Commands::LayerCheck => layer_check::run(),
         Commands::ValidateWorkspaceExclusions => validate_workspace_exclusions::run(),
+        Commands::AggregateReceipts { check, inputs, output, event, allow_noop, advisory_mode } => {
+            aggregate_receipts::run(aggregate_receipts::AggregateReceiptsConfig {
+                check,
+                inputs,
+                output,
+                event,
+                allow_noop,
+                advisory_mode,
+            })
+        }
+        Commands::FinalizeCheck { receipt } => finalize_check::run(receipt),
         Commands::BuildTimingReceipt { clean, incremental, tests, output, baseline } => {
             build_timing::run_receipt(clean, incremental, tests, output, baseline)
         }

--- a/xtask/src/tasks/aggregate_receipts.rs
+++ b/xtask/src/tasks/aggregate_receipts.rs
@@ -1,0 +1,211 @@
+use clap::ValueEnum;
+use color_eyre::eyre::{Result, WrapErr, bail};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum AdvisoryMode {
+    Pass,
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Clone)]
+pub struct AggregateReceiptsConfig {
+    pub check: String,
+    pub inputs: PathBuf,
+    pub output: PathBuf,
+    pub event: String,
+    pub allow_noop: bool,
+    pub advisory_mode: AdvisoryMode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Repro {
+    pub command: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Subreceipt {
+    pub name: String,
+    #[serde(default = "default_required")]
+    pub required: bool,
+    #[serde(default = "default_selected")]
+    pub selected: bool,
+    #[serde(default = "default_verdict")]
+    pub verdict: String,
+    #[serde(default)]
+    pub classification: Option<String>,
+    #[serde(default)]
+    pub missing: bool,
+    #[serde(default)]
+    pub repro: Option<Repro>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AggregatorReceipt {
+    pub check: String,
+    pub schema_version: u32,
+    pub event: String,
+    pub verdict: String,
+    pub classification: String,
+    pub subreceipts: Vec<Subreceipt>,
+    pub missing_receipts: Vec<String>,
+    pub repro: Repro,
+}
+
+fn default_required() -> bool {
+    true
+}
+
+fn default_selected() -> bool {
+    true
+}
+
+fn default_verdict() -> String {
+    "unknown".to_string()
+}
+
+pub fn run(config: AggregateReceiptsConfig) -> Result<()> {
+    if config.check.trim().is_empty() {
+        bail!("--check cannot be empty");
+    }
+
+    let subreceipts = load_subreceipts(&config.inputs)?;
+    let (verdict, classification, missing_receipts) =
+        finalize_gate_state(&subreceipts, config.allow_noop, config.advisory_mode);
+
+    let receipt = AggregatorReceipt {
+        check: config.check.clone(),
+        schema_version: 1,
+        event: config.event,
+        verdict,
+        classification,
+        subreceipts,
+        missing_receipts,
+        repro: Repro {
+            command: format!(
+                "cargo xtask aggregate-receipts --check \"{}\" --inputs {} --output {}",
+                config.check,
+                config.inputs.display(),
+                config.output.display()
+            ),
+        },
+    };
+
+    if let Some(parent) = config.output.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating output directory {}", parent.display()))?;
+    }
+
+    let payload =
+        serde_json::to_string_pretty(&receipt).context("serializing aggregator receipt")?;
+    fs::write(&config.output, format!("{payload}\n"))
+        .with_context(|| format!("writing {}", config.output.display()))?;
+
+    println!(
+        "aggregated {} subreceipts -> {} ({})",
+        receipt.subreceipts.len(),
+        receipt.verdict,
+        receipt.classification
+    );
+
+    Ok(())
+}
+
+fn load_subreceipts(inputs_dir: &Path) -> Result<Vec<Subreceipt>> {
+    if !inputs_dir.exists() {
+        bail!("inputs directory does not exist: {}", inputs_dir.display());
+    }
+
+    let mut entries: Vec<PathBuf> = fs::read_dir(inputs_dir)
+        .with_context(|| format!("reading {}", inputs_dir.display()))?
+        .collect::<std::io::Result<Vec<_>>>()?
+        .into_iter()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .collect();
+
+    entries.sort();
+
+    if entries.is_empty() {
+        bail!("no .json subreceipts found in {}", inputs_dir.display());
+    }
+
+    entries
+        .into_iter()
+        .map(|path| {
+            let raw = fs::read_to_string(&path)
+                .with_context(|| format!("reading subreceipt {}", path.display()))?;
+            serde_json::from_str(&raw)
+                .with_context(|| format!("parsing subreceipt {}", path.display()))
+        })
+        .collect()
+}
+
+pub fn finalize_gate_state(
+    subreceipts: &[Subreceipt],
+    allow_noop: bool,
+    advisory_mode: AdvisoryMode,
+) -> (String, String, Vec<String>) {
+    let mut missing_required = Vec::new();
+    let mut required_failed = false;
+    let mut advisory_problem = false;
+
+    for receipt in subreceipts {
+        if receipt.required {
+            if receipt.missing {
+                missing_required.push(receipt.name.clone());
+                continue;
+            }
+
+            if !receipt.selected {
+                if !allow_noop {
+                    missing_required.push(receipt.name.clone());
+                }
+                continue;
+            }
+
+            if receipt.verdict == "fail" {
+                required_failed = true;
+            }
+        } else if matches!(receipt.verdict.as_str(), "fail" | "warn") {
+            advisory_problem = true;
+        }
+    }
+
+    if !missing_required.is_empty() {
+        return ("fail".to_string(), "unknown".to_string(), missing_required);
+    }
+
+    if required_failed {
+        let classification = first_required_failure_classification(subreceipts)
+            .unwrap_or_else(|| "code_regression".to_string());
+        return ("fail".to_string(), classification, Vec::new());
+    }
+
+    if advisory_problem {
+        return match advisory_mode {
+            AdvisoryMode::Pass => ("pass".to_string(), "unknown".to_string(), Vec::new()),
+            AdvisoryMode::Warn => ("warn".to_string(), "infra_failure".to_string(), Vec::new()),
+            AdvisoryMode::Fail => ("fail".to_string(), "infra_failure".to_string(), Vec::new()),
+        };
+    }
+
+    let any_selected_required =
+        subreceipts.iter().any(|receipt| receipt.required && receipt.selected);
+    if !any_selected_required {
+        return ("pass".to_string(), "skipped".to_string(), Vec::new());
+    }
+
+    ("pass".to_string(), "unknown".to_string(), Vec::new())
+}
+
+fn first_required_failure_classification(subreceipts: &[Subreceipt]) -> Option<String> {
+    subreceipts
+        .iter()
+        .find(|receipt| receipt.required && receipt.verdict == "fail")
+        .and_then(|receipt| receipt.classification.clone())
+}

--- a/xtask/src/tasks/finalize_check.rs
+++ b/xtask/src/tasks/finalize_check.rs
@@ -1,0 +1,26 @@
+use color_eyre::eyre::{Result, WrapErr, bail};
+use std::fs;
+use std::path::PathBuf;
+
+use super::aggregate_receipts::AggregatorReceipt;
+
+pub fn run(receipt: PathBuf) -> Result<()> {
+    let raw = fs::read_to_string(&receipt)
+        .with_context(|| format!("reading aggregator receipt {}", receipt.display()))?;
+    let parsed: AggregatorReceipt =
+        serde_json::from_str(&raw).context("parsing aggregator receipt JSON")?;
+
+    match parsed.verdict.as_str() {
+        "pass" | "warn" => {
+            println!("{}: {} ({})", parsed.check, parsed.verdict, parsed.classification);
+            Ok(())
+        }
+        "fail" => bail!(
+            "{} failed: classification={}, missing={:?}",
+            parsed.check,
+            parsed.classification,
+            parsed.missing_receipts
+        ),
+        other => bail!("unsupported verdict in receipt: {other}"),
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -1,5 +1,6 @@
 //! Task implementations for xtask automation
 
+pub mod aggregate_receipts;
 pub mod bench;
 pub mod benchmarks;
 #[cfg(feature = "parser-tasks")]
@@ -36,6 +37,7 @@ pub mod doc_claims;
 pub mod e2e_validate;
 pub mod edge_cases;
 pub mod features;
+pub mod finalize_check;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;

--- a/xtask/tests/aggregate_receipts_cli.rs
+++ b/xtask/tests/aggregate_receipts_cli.rs
@@ -1,0 +1,73 @@
+use anyhow::Result;
+use assert_cmd::Command;
+
+#[test]
+fn aggregate_and_finalize_pass_fixture() -> Result<()> {
+    let output = Command::cargo_bin("xtask")?
+        .args([
+            "aggregate-receipts",
+            "--check",
+            "Test Gate",
+            "--inputs",
+            "tests/fixtures/aggregator/pass",
+            "--output",
+            "target/receipts/test-gate.json",
+            "--advisory-mode",
+            "pass",
+        ])
+        .output()?;
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+    let output = Command::cargo_bin("xtask")?
+        .args(["finalize-check", "--receipt", "target/receipts/test-gate.json"])
+        .output()?;
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+    Ok(())
+}
+
+#[test]
+fn finalize_fails_on_required_failure_fixture() -> Result<()> {
+    let output = Command::cargo_bin("xtask")?
+        .args([
+            "aggregate-receipts",
+            "--check",
+            "Test Gate",
+            "--inputs",
+            "tests/fixtures/aggregator/fail",
+            "--output",
+            "target/receipts/test-gate-fail.json",
+        ])
+        .output()?;
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+    let output = Command::cargo_bin("xtask")?
+        .args(["finalize-check", "--receipt", "target/receipts/test-gate-fail.json"])
+        .output()?;
+    assert!(!output.status.success(), "stdout: {}", String::from_utf8_lossy(&output.stdout));
+
+    Ok(())
+}
+
+#[test]
+fn finalize_fails_on_missing_required_fixture() -> Result<()> {
+    let output = Command::cargo_bin("xtask")?
+        .args([
+            "aggregate-receipts",
+            "--check",
+            "Test Gate",
+            "--inputs",
+            "tests/fixtures/aggregator/missing-required",
+            "--output",
+            "target/receipts/test-gate-missing.json",
+        ])
+        .output()?;
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+    let output = Command::cargo_bin("xtask")?
+        .args(["finalize-check", "--receipt", "target/receipts/test-gate-missing.json"])
+        .output()?;
+    assert!(!output.status.success(), "stdout: {}", String::from_utf8_lossy(&output.stdout));
+
+    Ok(())
+}

--- a/xtask/tests/fixtures/aggregator/fail/other.json
+++ b/xtask/tests/fixtures/aggregator/fail/other.json
@@ -1,0 +1,1 @@
+{"name":"ux-tests","required":true,"selected":true,"verdict":"pass","classification":"unknown"}

--- a/xtask/tests/fixtures/aggregator/fail/required-fail.json
+++ b/xtask/tests/fixtures/aggregator/fail/required-fail.json
@@ -1,0 +1,1 @@
+{"name":"merge-gate","required":true,"selected":true,"verdict":"fail","classification":"code_regression"}

--- a/xtask/tests/fixtures/aggregator/missing-required/missing.json
+++ b/xtask/tests/fixtures/aggregator/missing-required/missing.json
@@ -1,0 +1,1 @@
+{"name":"preflight-latest-check","required":true,"selected":true,"missing":true,"verdict":"unknown","classification":"stale_base"}

--- a/xtask/tests/fixtures/aggregator/missing-required/other.json
+++ b/xtask/tests/fixtures/aggregator/missing-required/other.json
@@ -1,0 +1,1 @@
+{"name":"draft-pr-check","required":true,"selected":false,"verdict":"skipped","classification":"skipped"}

--- a/xtask/tests/fixtures/aggregator/pass/advisory.json
+++ b/xtask/tests/fixtures/aggregator/pass/advisory.json
@@ -1,0 +1,1 @@
+{"name":"windows-guardrails","required":false,"selected":true,"verdict":"warn","classification":"infra_failure"}

--- a/xtask/tests/fixtures/aggregator/pass/required.json
+++ b/xtask/tests/fixtures/aggregator/pass/required.json
@@ -1,0 +1,1 @@
+{"name":"pr-smoke","required":true,"selected":true,"verdict":"pass","classification":"unknown"}


### PR DESCRIPTION
### Motivation

- Provide a stable final-check receipt that aggregates per-job subreceipts so branch/ruleset enforcement and operators can rely on a single, stable check name instead of fragile internal/matrix job names.
- Do not convert existing workflows or branch rules in this PR; ship the aggregator/finalizer framework and guidance first.

### Description

- Add an `xtask` aggregator task (`xtask/src/tasks/aggregate_receipts.rs`) that reads JSON subreceipts, computes final `verdict`/`classification`/`missing_receipts`, and emits a canonical aggregator receipt with `repro.command`.
- Add a finalizer task (`xtask/src/tasks/finalize_check.rs`) that consumes the aggregator receipt and exits nonzero on `fail` while allowing `pass`/`warn` to succeed.
- Add JSON schema for the aggregator receipt at `.ci/receipts/schemas/aggregator-receipt.schema.json`, contributor docs template at `docs/contributing/required-workflow-template.md`, and fixtures under `xtask/tests/fixtures/aggregator/` (pass/fail/missing-required).
- Wire CLI commands and modules (`AggregateReceipts` / `FinalizeCheck`) into `xtask` by updating `xtask/src/main.rs` and `xtask/src/tasks/mod.rs` and add integration tests at `xtask/tests/aggregate_receipts_cli.rs`.

### Testing

- `cargo check -p xtask` completed successfully.
- `cargo xtask aggregate-receipts --check "Test Gate" --inputs xtask/tests/fixtures/aggregator/pass --output target/receipts/test-gate.json` ran and produced an aggregator receipt successfully.
- `cargo xtask finalize-check --receipt target/receipts/test-gate.json` ran and exited zero for the passing fixture.
- Aggregating the failing fixture then running `finalize-check` produced a nonzero exit as expected, verifying the failure path.
- `cargo test -p xtask --test aggregate_receipts_cli` passed (all aggregator CLI integration tests succeeded).

Refs #6857
Refs #6853

Workflow conversion is intentionally deferred to a follow-up PR; this change only adds the aggregator/finalizer framework, schema, fixtures, docs, and tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd06873488333859f69e6c782cc2d)