### PR TITLE
feat(ci): add receipt finalizer and aggregator framework (#6857)

### DIFF
--- a/.ci/receipts/schemas/aggregator-receipt.schema.json
+++ b/.ci/receipts/schemas/aggregator-receipt.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/aggregator-receipt.schema.json",
+  "title": "Aggregator Receipt",
+  "type": "object",
+  "required": [
+    "check",
+    "schema_version",
+    "event",
+    "verdict",
+    "classification",
+    "subreceipts",
+    "missing_receipts",
+    "repro"
+  ],
+  "properties": {
+    "check": { "type": "string" },
+    "schema_version": { "type": "string" },
+    "event": { "type": "string" },
+    "verdict": { "type": "string", "enum": ["pass", "fail", "warn", "skipped", "unknown"] },
+    "classification": {
+      "type": "string",
+      "enum": ["code_regression", "infra_failure", "stale_base", "skipped", "unknown"]
+    },
+    "subreceipts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["check", "required", "selected", "verdict"],
+        "properties": {
+          "check": { "type": "string" },
+          "required": { "type": "boolean" },
+          "selected": { "type": "boolean" },
+          "verdict": { "type": "string" },
+          "classification": { "type": ["string", "null"] }
+        },
+        "additionalProperties": true
+      }
+    },
+    "missing_receipts": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "repro": {
+      "type": "object",
+      "required": ["command"],
+      "properties": {
+        "command": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/contributing/required-workflow-template.md
+++ b/docs/contributing/required-workflow-template.md
@@ -1,0 +1,58 @@
+# Required Workflow Template (Final Aggregator Pattern)
+
+Use this template when introducing stable required checks for branch/ruleset enforcement.
+
+## Design goals
+
+- The workflow itself always triggers on the relevant events.
+- Internal matrix/component jobs may be skipped depending on scope.
+- A final aggregator job runs with `if: always()`.
+- The final job collects receipts from internal jobs.
+- The final job publishes the stable check name that policies should enforce.
+- Branch/ruleset enforcement should target only that final job, and only after an observation period.
+
+## Skeleton
+
+```yaml
+name: example-ci
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  internal-job-a:
+    runs-on: ubuntu-latest
+    outputs:
+      receipt_path: ${{ steps.write.outputs.receipt_path }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run scoped checks
+        run: echo "selected=true"
+      - id: write
+        name: Write receipt
+        run: |
+          mkdir -p target/receipts/internal
+          cat > target/receipts/internal/job-a.json <<'JSON'
+          {"check":"job-a","required":true,"selected":true,"verdict":"pass","classification":"unknown"}
+          JSON
+          echo "receipt_path=target/receipts/internal/job-a.json" >> "$GITHUB_OUTPUT"
+
+  final-example-check:
+    if: always()
+    needs: [internal-job-a]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Aggregate receipts
+        run: cargo xtask aggregate-receipts --check "Example Final Check" --inputs target/receipts/internal --output target/receipts/example-final.json
+      - name: Finalize stable check
+        run: cargo xtask finalize-check --receipt target/receipts/example-final.json
+```
+
+## Rollout notes
+
+1. Ship the final aggregator job first and observe results for stability.
+2. Keep existing internal job names unchanged during this framework phase.
+3. Update branch protection/rulesets to require only the final stable check after observation.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -42,6 +42,26 @@ enum Commands {
     /// Run format and clippy checks only (no tests)
     CheckOnly,
 
+    /// Aggregate internal receipt JSON files into one final gate receipt.
+    AggregateReceipts {
+        /// Stable final check name.
+        #[arg(long)]
+        check: String,
+        /// Directory containing subreceipt JSON files.
+        #[arg(long)]
+        inputs: PathBuf,
+        /// Output path for the aggregator receipt.
+        #[arg(long)]
+        output: PathBuf,
+    },
+
+    /// Finalize a gate receipt and return non-zero on failure verdict.
+    FinalizeCheck {
+        /// Path to the aggregated gate receipt JSON.
+        #[arg(long)]
+        receipt: PathBuf,
+    },
+
     /// Verify local Rust toolchain meets the pinned MSRV in rust-toolchain.toml.
     CheckToolchain {
         /// Show a warning when rustc satisfies the minimum MSRV but differs
@@ -1327,6 +1347,10 @@ fn main() -> Result<()> {
         }
         Commands::Ci => ci::run(),
         Commands::CheckOnly => ci::check_only(),
+        Commands::AggregateReceipts { check, inputs, output } => {
+            aggregate_receipts::run(check, inputs, output)
+        }
+        Commands::FinalizeCheck { receipt } => finalize_check::run(receipt),
         Commands::CheckToolchain { doctor } => check_toolchain::run(doctor),
         Commands::Build { release, features, c_scanner, rust_scanner } => {
             build::run(release, features, c_scanner, rust_scanner)

--- a/xtask/src/tasks/aggregate_receipts.rs
+++ b/xtask/src/tasks/aggregate_receipts.rs
@@ -1,0 +1,177 @@
+use color_eyre::eyre::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const SCHEMA_VERSION: &str = "1";
+
+#[derive(Debug, Deserialize)]
+struct InputSubreceipt {
+    check: String,
+    #[serde(default)]
+    required: bool,
+    #[serde(default = "default_selected")]
+    selected: bool,
+    verdict: String,
+    #[serde(default)]
+    classification: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RequiredManifest {
+    required_receipts: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AggregatorReceipt {
+    pub check: String,
+    pub schema_version: String,
+    pub event: String,
+    pub verdict: String,
+    pub classification: String,
+    pub subreceipts: Vec<Subreceipt>,
+    pub missing_receipts: Vec<String>,
+    pub repro: Repro,
+    pub allow_noop: bool,
+    pub advisory_mode: AdvisoryMode,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Subreceipt {
+    pub check: String,
+    pub required: bool,
+    pub selected: bool,
+    pub verdict: String,
+    pub classification: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Repro {
+    pub command: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AdvisoryMode {
+    Warn,
+    Fail,
+}
+
+impl Default for AdvisoryMode {
+    fn default() -> Self {
+        Self::Warn
+    }
+}
+
+pub fn run(check: String, inputs: PathBuf, output: PathBuf) -> Result<()> {
+    let receipt = aggregate_from_dir(&check, &inputs)?;
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(&receipt).context("Failed to serialize receipt")?;
+    fs::write(&output, json).with_context(|| format!("Failed to write {}", output.display()))?;
+    println!("Wrote aggregator receipt: {}", output.display());
+    Ok(())
+}
+
+pub fn aggregate_from_dir(check: &str, inputs: &Path) -> Result<AggregatorReceipt> {
+    let mut subreceipts = Vec::new();
+    let mut required = HashSet::new();
+
+    for entry in
+        fs::read_dir(inputs).with_context(|| format!("Failed to read {}", inputs.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+
+        let data = fs::read_to_string(&path)
+            .with_context(|| format!("Failed to read input receipt {}", path.display()))?;
+        if let Ok(manifest) = serde_json::from_str::<RequiredManifest>(&data) {
+            required.extend(manifest.required_receipts);
+            continue;
+        }
+
+        let input: InputSubreceipt = serde_json::from_str(&data)
+            .with_context(|| format!("Failed to parse subreceipt {}", path.display()))?;
+
+        if input.required {
+            required.insert(input.check.clone());
+        }
+
+        subreceipts.push(Subreceipt {
+            check: input.check,
+            required: input.required,
+            selected: input.selected,
+            verdict: input.verdict,
+            classification: input.classification,
+        });
+    }
+
+    subreceipts.sort_by(|a, b| a.check.cmp(&b.check));
+
+    let present: HashSet<String> = subreceipts.iter().map(|item| item.check.clone()).collect();
+    let mut missing_receipts: Vec<String> =
+        required.into_iter().filter(|name| !present.contains(name)).collect();
+    missing_receipts.sort();
+
+    let receipt = AggregatorReceipt {
+        check: check.to_string(),
+        schema_version: SCHEMA_VERSION.to_string(),
+        event: "pull_request".to_string(),
+        verdict: "unknown".to_string(),
+        classification: "unknown".to_string(),
+        subreceipts,
+        missing_receipts,
+        repro: Repro {
+            command: format!(
+                "cargo xtask aggregate-receipts --check \"{}\" --inputs {} --output <path>",
+                check,
+                inputs.display()
+            ),
+        },
+        allow_noop: true,
+        advisory_mode: AdvisoryMode::Warn,
+    };
+
+    Ok(super::finalize_check::finalize_receipt(receipt))
+}
+
+fn default_selected() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use color_eyre::Result;
+
+    fn fixture_dir(path: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(path)
+    }
+
+    #[test]
+    fn aggregates_passing_fixture() -> Result<()> {
+        let receipt =
+            aggregate_from_dir("Test Gate", &fixture_dir("tests/fixtures/aggregator/pass"))?;
+        assert_eq!(receipt.verdict, "pass");
+        assert!(receipt.missing_receipts.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn aggregates_missing_required_fixture() -> Result<()> {
+        let receipt = aggregate_from_dir(
+            "Test Gate",
+            &fixture_dir("tests/fixtures/aggregator/missing-required"),
+        )?;
+        assert_eq!(receipt.verdict, "fail");
+        assert_eq!(receipt.classification, "stale_base");
+        assert!(!receipt.missing_receipts.is_empty());
+        Ok(())
+    }
+}

--- a/xtask/src/tasks/finalize_check.rs
+++ b/xtask/src/tasks/finalize_check.rs
@@ -1,0 +1,111 @@
+use color_eyre::eyre::{Context, Result, bail};
+use std::fs;
+
+use super::aggregate_receipts::{AdvisoryMode, AggregatorReceipt};
+
+pub fn run(receipt: std::path::PathBuf) -> Result<()> {
+    let content = fs::read_to_string(&receipt)
+        .with_context(|| format!("Failed to read {}", receipt.display()))?;
+    let parsed: AggregatorReceipt =
+        serde_json::from_str(&content).context("Failed to parse aggregator receipt")?;
+    let finalized = finalize_receipt(parsed);
+
+    let json = serde_json::to_string_pretty(&finalized).context("Failed to serialize receipt")?;
+    fs::write(&receipt, json).with_context(|| format!("Failed to write {}", receipt.display()))?;
+
+    if finalized.verdict == "pass" {
+        println!("{}: pass ({})", finalized.check, finalized.classification);
+        Ok(())
+    } else {
+        bail!("{}: fail ({})", finalized.check, finalized.classification)
+    }
+}
+
+pub fn finalize_receipt(mut receipt: AggregatorReceipt) -> AggregatorReceipt {
+    let required: Vec<_> = receipt.subreceipts.iter().filter(|item| item.required).collect();
+
+    if !receipt.missing_receipts.is_empty() {
+        receipt.verdict = "fail".to_string();
+        receipt.classification = "stale_base".to_string();
+        return receipt;
+    }
+
+    if required.is_empty()
+        && receipt.allow_noop
+        && receipt
+            .subreceipts
+            .iter()
+            .all(|item| !item.selected || item.verdict.as_str() == "skipped")
+    {
+        receipt.verdict = "pass".to_string();
+        receipt.classification = "skipped".to_string();
+        return receipt;
+    }
+
+    if let Some(failed_required) = required
+        .into_iter()
+        .find(|item| item.verdict.as_str() != "pass" && item.verdict.as_str() != "skipped")
+    {
+        receipt.verdict = "fail".to_string();
+        receipt.classification = classify_failure(failed_required.classification.as_deref());
+        return receipt;
+    }
+
+    let advisory_failures = receipt.subreceipts.iter().any(|item| {
+        !item.required && item.verdict.as_str() != "pass" && item.verdict.as_str() != "skipped"
+    });
+
+    if advisory_failures && receipt.advisory_mode == AdvisoryMode::Fail {
+        receipt.verdict = "fail".to_string();
+        receipt.classification = "infra_failure".to_string();
+        return receipt;
+    }
+
+    receipt.verdict = "pass".to_string();
+    receipt.classification =
+        if advisory_failures { "infra_failure" } else { "unknown" }.to_string();
+    receipt
+}
+
+fn classify_failure(classification: Option<&str>) -> String {
+    match classification {
+        Some("code_regression") => "code_regression".to_string(),
+        Some("infra_failure") => "infra_failure".to_string(),
+        Some("stale_base") => "stale_base".to_string(),
+        Some("skipped") => "skipped".to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tasks::aggregate_receipts::{Repro, Subreceipt};
+    use color_eyre::Result;
+
+    #[test]
+    fn finalizes_failing_fixture() -> Result<()> {
+        let receipt = AggregatorReceipt {
+            check: "Test Gate".to_string(),
+            schema_version: "1".to_string(),
+            event: "pull_request".to_string(),
+            verdict: "unknown".to_string(),
+            classification: "unknown".to_string(),
+            subreceipts: vec![Subreceipt {
+                check: "unit-tests".to_string(),
+                required: true,
+                selected: true,
+                verdict: "fail".to_string(),
+                classification: Some("code_regression".to_string()),
+            }],
+            missing_receipts: Vec::new(),
+            repro: Repro { command: "cargo xtask aggregate-receipts".to_string() },
+            allow_noop: true,
+            advisory_mode: AdvisoryMode::Warn,
+        };
+
+        let final_receipt = finalize_receipt(receipt);
+        assert_eq!(final_receipt.verdict, "fail");
+        Ok(())
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -1,5 +1,6 @@
 //! Task implementations for xtask automation
 
+pub mod aggregate_receipts;
 pub mod bench;
 pub mod benchmarks;
 #[cfg(feature = "parser-tasks")]
@@ -36,6 +37,7 @@ pub mod doc_claims;
 pub mod e2e_validate;
 pub mod edge_cases;
 pub mod features;
+pub mod finalize_check;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;

--- a/xtask/tests/fixtures/aggregator/fail/unit-tests.json
+++ b/xtask/tests/fixtures/aggregator/fail/unit-tests.json
@@ -1,0 +1,7 @@
+{
+  "check": "unit-tests",
+  "required": true,
+  "selected": true,
+  "verdict": "fail",
+  "classification": "code_regression"
+}

--- a/xtask/tests/fixtures/aggregator/missing-required/required-receipts.json
+++ b/xtask/tests/fixtures/aggregator/missing-required/required-receipts.json
@@ -1,0 +1,6 @@
+{
+  "required_receipts": [
+    "unit-tests",
+    "lint"
+  ]
+}

--- a/xtask/tests/fixtures/aggregator/missing-required/unit-tests.json
+++ b/xtask/tests/fixtures/aggregator/missing-required/unit-tests.json
@@ -1,0 +1,7 @@
+{
+  "check": "unit-tests",
+  "required": true,
+  "selected": true,
+  "verdict": "pass",
+  "classification": "unknown"
+}

--- a/xtask/tests/fixtures/aggregator/pass/advisory-style.json
+++ b/xtask/tests/fixtures/aggregator/pass/advisory-style.json
@@ -1,0 +1,7 @@
+{
+  "check": "advisory-style",
+  "required": false,
+  "selected": true,
+  "verdict": "fail",
+  "classification": "infra_failure"
+}

--- a/xtask/tests/fixtures/aggregator/pass/unit-tests.json
+++ b/xtask/tests/fixtures/aggregator/pass/unit-tests.json
@@ -1,0 +1,7 @@
+{
+  "check": "unit-tests",
+  "required": true,
+  "selected": true,
+  "verdict": "pass",
+  "classification": "unknown"
+}


### PR DESCRIPTION
### Motivation
- CI enforcement currently depends on fragile internal/matrix job names instead of a stable final check receipt contract. 
- Provide a small aggregator/finalizer framework so future branch/ruleset enforcement can point to a stable final check name and operators get clear receipts. 
- Deliver the framework without converting existing workflows in this PR so rollout can be observed first.

### Description
- Add `xtask` commands `aggregate-receipts` and `finalize-check` implemented in `xtask/src/tasks/aggregate_receipts.rs` and `xtask/src/tasks/finalize_check.rs` and wired into `xtask/src/main.rs` and `xtask/src/tasks/mod.rs`. 
- Implement aggregator behavior that reads subreceipt JSON and optional `required_receipts` manifests, computes `missing_receipts`, and emits the normalized aggregator shape (`check`, `schema_version`, `event`, `verdict`, `classification`, `subreceipts`, `missing_receipts`, `repro.command`). 
- Implement finalization rules that allow noop/skipped gates, fail on required failures or missing required receipts, support advisory `Warn`/`Fail` modes, and classify failures as `code_regression`, `infra_failure`, `stale_base`, `skipped`, or `unknown`. 
- Add schema and docs: `.ci/receipts/schemas/aggregator-receipt.schema.json`, `docs/contributing/required-workflow-template.md`, and test fixtures under `xtask/tests/fixtures/aggregator/*`; includes `Refs #6857` and `Refs #6853` and notes that workflow conversion is deferred to a follow-up PR.

### Testing
- Ran `cargo check -p xtask` and it passed. 
- Ran `cargo xtask aggregate-receipts --check "Test Gate" --inputs xtask/tests/fixtures/aggregator/pass --output target/receipts/test-gate.json` which wrote `target/receipts/test-gate.json`. 
- Ran `cargo xtask finalize-check --receipt target/receipts/test-gate.json` which exited zero and printed a pass verdict. 
- Ran aggregate+finalize against the failing fixture and observed finalize exit non-zero as expected. 
- Ran the new unit tests via `cargo test -p xtask` filtered for the new modules and they passed, and ran `cargo xtask fmt` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd06873488333859f69e6c782cc2d)