### PR TITLE
feat(ci): add merge_group trigger to main CI workflow (#6858)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches: [ main, master ]
     types: [opened, synchronize, reopened, labeled, ready_for_review, converted_to_draft]
+  merge_group: {}
   push:
     branches: [ main, master ]
   workflow_dispatch: {}
@@ -16,8 +17,8 @@ on:
 # Coalesce-queue-tail: let the running CI complete; skip superseded SHAs at a
 # preflight gate instead of cancelling in-flight work mid-run.
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: write


### PR DESCRIPTION
### Motivation

- Refs #6858 and Refs #6853 — add `merge_group` trigger and make concurrency event-aware so future merge-queue / exact-candidate CI can operate while keeping test semantics unchanged.

### Description

- Added `merge_group: {}` under the `on:` triggers and preserved `pull_request` and `push` (including `main`/`master`).
- Updated `concurrency` to `group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}` and `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` to be event-aware.
- No jobs were renamed or removed, no test commands were altered, no ruleset settings changed, and the merge queue is not enabled by this PR.

### Testing

- Verified the presence of `pull_request`, `merge_group`, `push` to `main/master`, and the updated `concurrency` via `rg`/manual inspection (succeeded).
- Attempted to parse the YAML with `python`/`yaml.safe_load` but `PyYAML` is not installed in this environment so automated YAML validation could not run (skipped).
- Attempted to run the `workflow-trigger-lint` check via `just` but the linter target is unavailable in this environment so that check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd064319c83339d63ecea5c918767)