### PR TITLE
feat(ci): add merge_group trigger to main CI workflow (#6858)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches: [ main, master ]
     types: [opened, synchronize, reopened, labeled, ready_for_review, converted_to_draft]
+  merge_group: {}
   push:
     branches: [ main, master ]
   workflow_dispatch: {}
@@ -16,8 +17,8 @@ on:
 # Coalesce-queue-tail: let the running CI complete; skip superseded SHAs at a
 # preflight gate instead of cancelling in-flight work mid-run.
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: write


### PR DESCRIPTION
### Motivation
- Allow future merge-queue / exact-candidate CI to target this workflow by adding `merge_group` while preserving the existing `pull_request` and `push` triggers and semantics.

### Description
- Added `merge_group: {}` to `on` and replaced the workflow-level concurrency with the event-aware form `group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}` and `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`, while keeping `pull_request`, `push` (branches: `[ main, master ]`), and all jobs/commands unchanged; Refs #6858 and Refs #6853, and no test semantics changed, no ruleset settings changed, and merge queue is not enabled here.

### Testing
- Verified the edited YAML parses via `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml')"` and validated presence of `pull_request`, `merge_group`, `push` (main/master), and the event-aware `concurrency` using `rg`/manual inspection, and no `workflow-trigger-lint` hook was found so trigger/concurrency presence was validated directly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd064319c83339d63ecea5c918767)