### PR TITLE
feat(ci): add required-workflow trigger lint (#6858)

### DIFF
--- a/.ci/policies/required-checks.toml
+++ b/.ci/policies/required-checks.toml
@@ -1,0 +1,14 @@
+[[check]]
+name = "CI Gate"
+workflow = ".github/workflows/ci.yml"
+required = true
+
+[[check]]
+name = "Parser Ratchet"
+workflow = ".github/workflows/parser-ratchet.yml"
+required = false
+
+[[check]]
+name = "Methodology Gate"
+workflow = ".github/workflows/methodology-gate.yml"
+required = false

--- a/.ci/receipts/schemas/workflow-trigger-lint.schema.json
+++ b/.ci/receipts/schemas/workflow-trigger-lint.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/workflow-trigger-lint.schema.json",
+  "title": "workflow-trigger-lint receipt",
+  "type": "object",
+  "required": ["schema_version", "overall_ok", "evaluations"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "policy_path": { "type": ["string", "null"] },
+    "fixture_path": { "type": ["string", "null"] },
+    "overall_ok": { "type": "boolean" },
+    "evaluations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "workflow", "required", "ok", "violations"],
+        "properties": {
+          "name": { "type": "string" },
+          "workflow": { "type": "string" },
+          "required": { "type": "boolean" },
+          "ok": { "type": "boolean" },
+          "violations": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -1,0 +1,63 @@
+name: Workflow Trigger Lint
+
+on:
+  pull_request:
+    branches: [master]
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches: [master]
+
+concurrency:
+  group: workflow-trigger-lint-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Workflow Trigger Lint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+
+      - name: Run workflow trigger lint (advisory)
+        id: lint
+        shell: bash
+        run: |
+          set +e
+          cargo xtask workflow-trigger-lint \
+            --policy .ci/policies/required-checks.toml \
+            --receipt target/receipts/workflow-trigger-lint.json \
+            --format json
+          status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          if [ "$status" -ne 0 ]; then
+            echo "Workflow trigger lint is currently advisory; violations are reported but do not fail this workflow." >&2
+          fi
+          exit 0
+
+      - name: Upload receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: workflow-trigger-lint-receipt
+          path: target/receipts/workflow-trigger-lint.json
+          if-no-files-found: warn
+
+      - name: Summary
+        if: always()
+        run: |
+          if [ "${{ steps.lint.outputs.exit_code }}" = "0" ]; then
+            echo "## Workflow trigger lint passed" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Workflow trigger lint (advisory) found violations" >> "$GITHUB_STEP_SUMMARY"
+            echo "Conventional required-check policy in .ci/policies/required-checks.toml is enforced in advisory mode until ruleset required checks are configured." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/docs/ci/workflow-trigger-policy.md
+++ b/docs/ci/workflow-trigger-policy.md
@@ -1,0 +1,32 @@
+# Workflow trigger policy (conventional required checks)
+
+`cargo xtask workflow-trigger-lint` validates trigger and concurrency requirements for workflows listed in `.ci/policies/required-checks.toml`.
+
+## Why this exists
+
+The repository currently has no GitHub ruleset `required_status_checks` configured. Until ruleset enforcement lands, `.ci/policies/required-checks.toml` is the conventional source of truth for which checks are treated as required.
+
+## Required-workflow lint rules
+
+For each `required = true` check, the workflow must:
+
+- define `pull_request`
+- define `merge_group`
+- define `push` with `branches: [master]`
+- avoid top-level or event-level `paths` / `paths-ignore`
+- define event-aware concurrency:
+  - `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`
+- exist at the configured path
+
+## Commands
+
+- Policy run with receipt:
+  - `cargo xtask workflow-trigger-lint --policy .ci/policies/required-checks.toml --receipt target/receipts/workflow-trigger-lint.json`
+- Fixture validation:
+  - `cargo xtask workflow-trigger-lint --fixture xtask/tests/fixtures/workflows/valid-required.yml`
+- JSON output:
+  - `cargo xtask workflow-trigger-lint --format json`
+
+## CI workflow
+
+`.github/workflows/workflow-trigger-lint.yml` runs this lint on `pull_request`, `merge_group`, and `push` to `master` with no path filters. The job is currently advisory while legacy required workflows are migrated.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -18,6 +18,7 @@ use tasks::metrics;
 use tasks::targeted_checks::CheckMode;
 use tasks::unwired_scan::UnwiredScanConfig;
 use tasks::ux_scorecard::UxScorecardFormat;
+use tasks::workflow_trigger_lint::WorkflowTriggerLintFormat;
 use tasks::worktree_allocator::AgentWorktreeCommand;
 use tasks::*;
 use types::TestSuite;
@@ -411,6 +412,25 @@ enum Commands {
         /// Output format: `json` or `text` (default: json).
         #[arg(long, default_value = "json")]
         format: String,
+    },
+
+    /// Lint required workflow triggers against policy.
+    WorkflowTriggerLint {
+        /// Policy TOML path listing conventional required checks.
+        #[arg(long)]
+        policy: Option<PathBuf>,
+
+        /// Optional receipt output path (JSON).
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+
+        /// Validate a single workflow fixture file instead of policy workflows.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+
+        /// Output format.
+        #[arg(long, value_enum, default_value = "text")]
+        format: WorkflowTriggerLintFormat,
     },
 
     /// Run version-sync checks from `perl-ci-hygiene`.
@@ -1631,6 +1651,10 @@ fn main() -> Result<()> {
         }
         Commands::CiScope { base, format } => {
             ci_scope::run(ci_scope::CiScopeConfig { base, format })
+        }
+
+        Commands::WorkflowTriggerLint { policy, receipt, fixture, format } => {
+            workflow_trigger_lint::run(policy, receipt, fixture, format)
         }
         Commands::CheckVersionSync => check_version_sync::run(),
         Commands::CheckFromRaw => ci_policy::check_from_raw(),

--- a/xtask/src/tasks/ci_audit_workflows.rs
+++ b/xtask/src/tasks/ci_audit_workflows.rs
@@ -33,6 +33,10 @@ const ALLOWED_WORKFLOWS: &[&str] = &[
     // would prevent it from detecting label contradictions on the PRs that
     // most need detection.
     "methodology-gate.yml",
+    // workflow-trigger-lint.yml is a single small advisory lint (no test
+    // execution); the job exits 0 even when violations are found and only
+    // uploads a JSON receipt.
+    "workflow-trigger-lint.yml",
 ];
 
 const ALLOWED_UNGATED_JOBS: &[&str] = &["tautology-check", "test-metrics", "fmt", "clippy"];

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -80,5 +80,6 @@ pub mod update_status;
 pub mod ux_scorecard;
 pub mod validate_workspace_exclusions;
 pub mod workflow_policy_lint;
+pub mod workflow_trigger_lint;
 pub mod worktree_allocator;
 pub mod worktrees;

--- a/xtask/src/tasks/workflow_trigger_lint.rs
+++ b/xtask/src/tasks/workflow_trigger_lint.rs
@@ -1,0 +1,364 @@
+//! Enforce trigger/concurrency policy for required CI workflows.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use clap::ValueEnum;
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use serde_yaml_ng::Value;
+
+use crate::utils::project_root;
+
+const REQUIRED_CANCEL_IN_PROGRESS: &str = "${{ github.event_name == 'pull_request' }}";
+
+#[derive(Debug, Clone, Deserialize)]
+struct RequiredChecksPolicy {
+    check: Vec<PolicyCheck>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PolicyCheck {
+    name: String,
+    workflow: String,
+    required: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct WorkflowEvaluation {
+    name: String,
+    workflow: String,
+    required: bool,
+    ok: bool,
+    violations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct WorkflowTriggerLintReceipt {
+    schema_version: String,
+    policy_path: Option<String>,
+    fixture_path: Option<String>,
+    overall_ok: bool,
+    evaluations: Vec<WorkflowEvaluation>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum WorkflowTriggerLintFormat {
+    Text,
+    Json,
+}
+
+pub fn run(
+    policy_path: Option<PathBuf>,
+    receipt_path: Option<PathBuf>,
+    fixture_path: Option<PathBuf>,
+    format: WorkflowTriggerLintFormat,
+) -> Result<()> {
+    let root = project_root()?;
+
+    let (evaluations, policy_display, fixture_display) = if let Some(fixture) = fixture_path {
+        let evaluation = evaluate_fixture(&fixture)?;
+        (vec![evaluation], None, Some(fixture.display().to_string()))
+    } else {
+        let policy = policy_path.unwrap_or_else(|| root.join(".ci/policies/required-checks.toml"));
+        let evaluations = evaluate_policy(&root, &policy)?;
+        (evaluations, Some(policy.display().to_string()), None)
+    };
+
+    let overall_ok = evaluations.iter().all(|entry| entry.ok);
+    let receipt = WorkflowTriggerLintReceipt {
+        schema_version: "1.0.0".to_string(),
+        policy_path: policy_display,
+        fixture_path: fixture_display,
+        overall_ok,
+        evaluations,
+    };
+
+    if let Some(path) = receipt_path {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("creating receipt directory {}", parent.display()))?;
+        }
+        let payload = serde_json::to_string_pretty(&receipt)?;
+        fs::write(&path, payload).with_context(|| format!("writing receipt {}", path.display()))?;
+    }
+
+    output(&receipt, format)?;
+
+    if receipt.overall_ok { Ok(()) } else { bail!("workflow-trigger-lint found policy violations") }
+}
+
+fn evaluate_policy(root: &Path, policy_path: &Path) -> Result<Vec<WorkflowEvaluation>> {
+    let raw = fs::read_to_string(policy_path)
+        .with_context(|| format!("reading policy file {}", policy_path.display()))?;
+    let policy: RequiredChecksPolicy = toml::from_str(&raw)
+        .with_context(|| format!("parsing policy file {}", policy_path.display()))?;
+
+    policy
+        .check
+        .into_iter()
+        .filter(|entry| entry.required)
+        .map(|entry| evaluate_required_workflow(root, entry))
+        .collect()
+}
+
+fn evaluate_fixture(fixture_path: &Path) -> Result<WorkflowEvaluation> {
+    let workflow = read_workflow_yaml(fixture_path)?;
+    Ok(evaluate_required_entry(
+        "fixture",
+        fixture_path.display().to_string(),
+        true,
+        fixture_path.exists(),
+        Some(&workflow),
+    ))
+}
+
+fn evaluate_required_workflow(root: &Path, check: PolicyCheck) -> Result<WorkflowEvaluation> {
+    let workflow_path = root.join(&check.workflow);
+    let workflow =
+        if workflow_path.exists() { Some(read_workflow_yaml(&workflow_path)?) } else { None };
+
+    Ok(evaluate_required_entry(
+        &check.name,
+        check.workflow,
+        check.required,
+        workflow_path.exists(),
+        workflow.as_ref(),
+    ))
+}
+
+fn evaluate_required_entry(
+    name: &str,
+    workflow: String,
+    required: bool,
+    workflow_exists: bool,
+    workflow_yaml: Option<&Value>,
+) -> WorkflowEvaluation {
+    let mut violations = Vec::new();
+
+    if required {
+        if !workflow_exists {
+            violations.push("workflow file does not exist".to_string());
+        }
+
+        if let Some(yaml) = workflow_yaml {
+            if !has_trigger(yaml, "pull_request") {
+                violations.push("missing pull_request trigger".to_string());
+            }
+            if !has_trigger(yaml, "merge_group") {
+                violations.push("missing merge_group trigger".to_string());
+            }
+            if !push_targets_master(yaml) {
+                violations.push("push trigger must target master branch".to_string());
+            }
+            if has_path_filters(yaml) {
+                violations.push("path filters are not allowed on required workflows".to_string());
+            }
+            if !has_event_aware_concurrency(yaml) {
+                violations.push(format!(
+                    "concurrency.cancel-in-progress must be `{REQUIRED_CANCEL_IN_PROGRESS}`"
+                ));
+            }
+        }
+    }
+
+    WorkflowEvaluation {
+        name: name.to_string(),
+        workflow,
+        required,
+        ok: violations.is_empty(),
+        violations,
+    }
+}
+
+fn read_workflow_yaml(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let parsed = serde_yaml_ng::from_str(&raw)
+        .with_context(|| format!("parsing workflow YAML {}", path.display()))?;
+    Ok(parsed)
+}
+
+fn has_trigger(workflow: &Value, trigger_name: &str) -> bool {
+    let Some(on) = get_on(workflow) else {
+        return false;
+    };
+
+    match on {
+        Value::String(value) => value == trigger_name,
+        Value::Sequence(values) => {
+            values.iter().any(|value| value.as_str().is_some_and(|item| item == trigger_name))
+        }
+        Value::Mapping(mapping) => {
+            mapping.iter().any(|(key, _)| key.as_str().is_some_and(|item| item == trigger_name))
+        }
+        _ => false,
+    }
+}
+
+fn push_targets_master(workflow: &Value) -> bool {
+    let Some(on) = get_on(workflow) else {
+        return false;
+    };
+
+    match on {
+        Value::Mapping(mapping) => {
+            let push = mapping.iter().find_map(|(key, value)| {
+                if key.as_str().is_some_and(|name| name == "push") { Some(value) } else { None }
+            });
+
+            let Some(push) = push else {
+                return false;
+            };
+
+            match push {
+                Value::Mapping(push_mapping) => push_mapping.iter().any(|(key, value)| {
+                    key.as_str().is_some_and(|name| name == "branches")
+                        && branch_targets_master(value)
+                }),
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+fn branch_targets_master(branches: &Value) -> bool {
+    match branches {
+        Value::String(value) => value == "master" || value == "refs/heads/master",
+        Value::Sequence(values) => values.iter().any(|value| {
+            value.as_str().is_some_and(|item| item == "master" || item == "refs/heads/master")
+        }),
+        _ => false,
+    }
+}
+
+fn has_path_filters(workflow: &Value) -> bool {
+    let Some(on) = get_on(workflow) else {
+        return false;
+    };
+
+    let Value::Mapping(mapping) = on else {
+        return false;
+    };
+
+    if mapping
+        .keys()
+        .any(|key| key.as_str().is_some_and(|name| name == "paths" || name == "paths-ignore"))
+    {
+        return true;
+    }
+
+    mapping.iter().any(|(key, value)| {
+        let Some(name) = key.as_str() else {
+            return false;
+        };
+
+        if name != "pull_request" && name != "merge_group" && name != "push" {
+            return false;
+        }
+
+        match value {
+            Value::Mapping(event_map) => event_map.keys().any(|event_key| {
+                event_key
+                    .as_str()
+                    .is_some_and(|event_name| event_name == "paths" || event_name == "paths-ignore")
+            }),
+            _ => false,
+        }
+    })
+}
+
+fn has_event_aware_concurrency(workflow: &Value) -> bool {
+    let Some(concurrency) = get_top_level_field(workflow, "concurrency") else {
+        return false;
+    };
+
+    let Value::Mapping(map) = concurrency else {
+        return false;
+    };
+
+    map.iter().any(|(key, value)| {
+        key.as_str().is_some_and(|field| field == "cancel-in-progress")
+            && value.as_str().is_some_and(|expr| expr.trim() == REQUIRED_CANCEL_IN_PROGRESS)
+    })
+}
+
+fn output(receipt: &WorkflowTriggerLintReceipt, format: WorkflowTriggerLintFormat) -> Result<()> {
+    match format {
+        WorkflowTriggerLintFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(receipt)?);
+        }
+        WorkflowTriggerLintFormat::Text => {
+            if receipt.overall_ok {
+                println!("✓ workflow-trigger-lint passed");
+            } else {
+                println!("❌ workflow-trigger-lint found violations");
+            }
+
+            for evaluation in &receipt.evaluations {
+                if evaluation.ok {
+                    println!("  - {} ({}) ✓", evaluation.name, evaluation.workflow);
+                } else {
+                    println!("  - {} ({})", evaluation.name, evaluation.workflow);
+                    for violation in &evaluation.violations {
+                        println!("      * {}", violation);
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn get_on(workflow: &Value) -> Option<&Value> {
+    get_top_level_field(workflow, "on")
+}
+
+fn get_top_level_field<'a>(workflow: &'a Value, field: &str) -> Option<&'a Value> {
+    let Value::Mapping(mapping) = workflow else {
+        return None;
+    };
+
+    mapping.iter().find_map(|(key, value)| {
+        if key.as_str().is_some_and(|name| name == field) { Some(value) } else { None }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load_fixture(name: &str) -> Result<Value> {
+        let root = project_root()?;
+        read_workflow_yaml(&root.join("xtask/tests/fixtures/workflows").join(name))
+    }
+
+    #[test]
+    fn valid_required_fixture_passes() -> Result<()> {
+        let fixture = load_fixture("valid-required.yml")?;
+        let eval = evaluate_required_entry(
+            "fixture",
+            "fixture.yml".to_string(),
+            true,
+            true,
+            Some(&fixture),
+        );
+        assert!(eval.ok);
+        Ok(())
+    }
+
+    #[test]
+    fn missing_merge_group_fixture_fails() -> Result<()> {
+        let fixture = load_fixture("missing-merge-group.yml")?;
+        let eval = evaluate_required_entry(
+            "fixture",
+            "fixture.yml".to_string(),
+            true,
+            true,
+            Some(&fixture),
+        );
+        assert!(!eval.ok);
+        assert!(eval.violations.iter().any(|item| item.contains("merge_group")));
+        Ok(())
+    }
+}

--- a/xtask/tests/fixtures/workflows/bad-concurrency.yml
+++ b/xtask/tests/fixtures/workflows/bad-concurrency.yml
@@ -1,0 +1,19 @@
+name: Bad Concurrency
+
+on:
+  pull_request:
+    branches: [master]
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches: [master]
+
+concurrency:
+  group: required-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok

--- a/xtask/tests/fixtures/workflows/missing-merge-group.yml
+++ b/xtask/tests/fixtures/workflows/missing-merge-group.yml
@@ -1,0 +1,17 @@
+name: Missing Merge Group
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+concurrency:
+  group: required-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok

--- a/xtask/tests/fixtures/workflows/path-filtered.yml
+++ b/xtask/tests/fixtures/workflows/path-filtered.yml
@@ -1,0 +1,21 @@
+name: Path Filtered Required Workflow
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - crates/**
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches: [master]
+
+concurrency:
+  group: required-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok

--- a/xtask/tests/fixtures/workflows/valid-required.yml
+++ b/xtask/tests/fixtures/workflows/valid-required.yml
@@ -1,0 +1,19 @@
+name: Valid Required Workflow
+
+on:
+  pull_request:
+    branches: [master]
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches: [master]
+
+concurrency:
+  group: required-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok


### PR DESCRIPTION
### Motivation

- Refs #6858 and Refs #6853: introduce a policy/lint to enforce conventional required-workflow trigger and concurrency semantics because the repository currently lacks ruleset `required_status_checks` enforcement. 
- The goal is to ensure future required-style workflows always report status, support `merge_group`, and are not path-filtered away, using a conventional policy file until ruleset enforcement lands.

### Description

- Add `cargo xtask workflow-trigger-lint` task with CLI flags `--policy`, `--receipt`, `--fixture`, and `--format` to validate required workflows and emit a JSON/text receipt. 
- Add `.ci/policies/required-checks.toml` as the conventional source of required checks and a JSON receipt schema at `.ci/receipts/schemas/workflow-trigger-lint.schema.json`. 
- Implement lint logic in `xtask/src/tasks/workflow_trigger_lint.rs` to require `pull_request`, `merge_group`, `push` targeting `master`, no `paths`/`paths-ignore`, and event-aware concurrency `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`; support fixture mode and per-workflow evaluations. 
- Add an advisory GitHub workflow `.github/workflows/workflow-trigger-lint.yml` that runs the lint and uploads the generated receipt, plus docs at `docs/ci/workflow-trigger-policy.md` and working fixtures under `xtask/tests/fixtures/workflows/` for unit-style checks.

### Testing

- Ran `cargo check -p xtask` and it completed successfully. 
- Ran `cargo xtask workflow-trigger-lint --fixture xtask/tests/fixtures/workflows/valid-required.yml` and it passed. 
- Ran `cargo xtask workflow-trigger-lint --fixture xtask/tests/fixtures/workflows/missing-merge-group.yml` and it failed as expected due to the missing `merge_group` trigger. 
- Ran `cargo xtask workflow-trigger-lint --fixture xtask/tests/fixtures/workflows/path-filtered.yml` and it failed as expected due to path filters. 
- Ran `cargo xtask workflow-trigger-lint --policy .ci/policies/required-checks.toml --receipt target/receipts/workflow-trigger-lint.json --format json` which produced a receipt and exited non-zero because the current canonical `ci.yml` does not satisfy the new required-workflow rules. 
- Ran `cargo xtask fmt` and `cargo clippy -p xtask -- -D warnings` and both completed without errors; `just pr-fast` was not executed in this environment because `just` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd05e8bf4833393439acc36ccc945)