### PR TITLE
feat(ci): add required-workflow trigger lint (#6858)

### DIFF
--- a/.ci/policies/required-checks.toml
+++ b/.ci/policies/required-checks.toml
@@ -1,0 +1,14 @@
+[[check]]
+name = "CI Gate"
+workflow = ".github/workflows/ci.yml"
+required = true
+
+[[check]]
+name = "Parser Ratchet"
+workflow = ".github/workflows/parser-ratchet.yml"
+required = false
+
+[[check]]
+name = "Methodology Gate"
+workflow = ".github/workflows/methodology-gate.yml"
+required = false

--- a/.ci/receipts/schemas/workflow-trigger-lint.schema.json
+++ b/.ci/receipts/schemas/workflow-trigger-lint.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.github.io/perl-lsp/schemas/workflow-trigger-lint.schema.json",
+  "title": "Workflow Trigger Lint Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "ok", "checked", "violations"],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "workflow-trigger-lint@1"
+    },
+    "ok": {
+      "type": "boolean"
+    },
+    "checked": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "violations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["check_name", "workflow", "violations"],
+        "properties": {
+          "check_name": { "type": "string" },
+          "workflow": { "type": "string" },
+          "violations": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -1,0 +1,36 @@
+name: Workflow Trigger Lint
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [master]
+
+concurrency:
+  group: workflow-trigger-lint-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  workflow-trigger-lint:
+    name: Workflow Trigger Lint
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run workflow trigger lint (advisory)
+        run: |
+          cargo xtask workflow-trigger-lint \
+            --policy .ci/policies/required-checks.toml \
+            --receipt target/receipts/workflow-trigger-lint.json
+
+      - name: Upload lint receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: workflow-trigger-lint-receipt
+          path: target/receipts/workflow-trigger-lint.json

--- a/docs/ci/workflow-trigger-policy.md
+++ b/docs/ci/workflow-trigger-policy.md
@@ -1,0 +1,34 @@
+# Workflow trigger policy lint
+
+`cargo xtask workflow-trigger-lint` validates required GitHub workflows against a
+conventional policy list in `.ci/policies/required-checks.toml`.
+
+Until repository rulesets enforce `required_status_checks`, this policy file is the
+source of truth for which workflows must satisfy trigger guarantees.
+
+## Rules for `required = true` workflows
+
+- `on.pull_request` must exist.
+- `on.merge_group` must exist.
+- `on.push.branches` must include `master`.
+- No `paths` or `paths-ignore` filters may be present on the top-level `on` block or
+  required event triggers.
+- Top-level concurrency must be event-aware:
+  - `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`
+- The workflow file referenced by policy must exist.
+
+## Commands
+
+```bash
+cargo xtask workflow-trigger-lint \
+  --policy .ci/policies/required-checks.toml \
+  --receipt target/receipts/workflow-trigger-lint.json
+
+cargo xtask workflow-trigger-lint \
+  --fixture xtask/tests/fixtures/workflows/missing-merge-group.yml
+
+cargo xtask workflow-trigger-lint --format json
+```
+
+The JSON receipt schema is defined at
+`.ci/receipts/schemas/workflow-trigger-lint.schema.json`.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,6 +17,7 @@ use tasks::metrics;
 use tasks::targeted_checks::CheckMode;
 use tasks::unwired_scan::UnwiredScanConfig;
 use tasks::ux_scorecard::UxScorecardFormat;
+use tasks::workflow_trigger_lint::WorkflowTriggerLintConfig;
 use tasks::*;
 use types::TestSuite;
 #[cfg(any(feature = "legacy", feature = "parser-tasks"))]
@@ -348,6 +349,25 @@ enum Commands {
 
     /// Audit CI workflows for PR-safety and spend-risk controls.
     CiAuditWorkflows,
+
+    /// Lint required workflows for stable trigger and concurrency policy.
+    WorkflowTriggerLint {
+        /// Path to required checks policy TOML.
+        #[arg(long)]
+        policy: Option<PathBuf>,
+
+        /// Path to write a JSON receipt artifact.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+
+        /// Lint a single workflow fixture file directly.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+
+        /// Output format.
+        #[arg(long, value_enum, default_value = "human")]
+        format: WorkflowTriggerLintOutputFormat,
+    },
 
     /// Measure CI lane runtimes and emit timing artifacts.
     CiMeasure,
@@ -1315,6 +1335,12 @@ enum UxScorecardOutputFormat {
     Json,
 }
 
+#[derive(ValueEnum, Clone)]
+enum WorkflowTriggerLintOutputFormat {
+    Human,
+    Json,
+}
+
 fn main() -> Result<()> {
     color_eyre::install()?;
 
@@ -1454,6 +1480,21 @@ fn main() -> Result<()> {
         }
         Commands::TestEdgeCases { bench, coverage, test } => edge_cases::run(bench, coverage, test),
         Commands::CiAuditWorkflows => ci_audit_workflows::run(),
+        Commands::WorkflowTriggerLint { policy, receipt, fixture, format } => {
+            workflow_trigger_lint::run(WorkflowTriggerLintConfig {
+                policy,
+                receipt,
+                fixture,
+                format: match format {
+                    WorkflowTriggerLintOutputFormat::Human => {
+                        workflow_trigger_lint::WorkflowTriggerLintFormat::Human
+                    }
+                    WorkflowTriggerLintOutputFormat::Json => {
+                        workflow_trigger_lint::WorkflowTriggerLintFormat::Json
+                    }
+                },
+            })
+        }
         Commands::CiMeasure => ci_measure::run(),
         Commands::CiCostMonitor { days, json } => ci_metrics::run_cost_monitor(days, json),
         Commands::CiBaseline { branch, days, limit, output } => {

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -73,4 +73,5 @@ pub mod update_homebrew;
 pub mod update_status;
 pub mod ux_scorecard;
 pub mod validate_workspace_exclusions;
+pub mod workflow_trigger_lint;
 pub mod worktrees;

--- a/xtask/src/tasks/workflow_trigger_lint.rs
+++ b/xtask/src/tasks/workflow_trigger_lint.rs
@@ -1,0 +1,310 @@
+use color_eyre::eyre::{Context, Result, bail};
+use serde::Deserialize;
+use serde::Serialize;
+use serde_yaml_ng::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::utils::project_root;
+
+const DEFAULT_POLICY_PATH: &str = ".ci/policies/required-checks.toml";
+const EXPECTED_CANCEL_IN_PROGRESS: &str = "${{ github.event_name == 'pull_request' }}";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkflowTriggerLintFormat {
+    Human,
+    Json,
+}
+
+#[derive(Debug)]
+pub struct WorkflowTriggerLintConfig {
+    pub policy: Option<PathBuf>,
+    pub receipt: Option<PathBuf>,
+    pub fixture: Option<PathBuf>,
+    pub format: WorkflowTriggerLintFormat,
+}
+
+#[derive(Debug, Deserialize)]
+struct RequiredChecksPolicy {
+    check: Vec<PolicyCheck>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PolicyCheck {
+    name: String,
+    workflow: String,
+    required: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct WorkflowTriggerLintReceipt {
+    schema: String,
+    ok: bool,
+    checked: usize,
+    violations: Vec<ViolationReceipt>,
+}
+
+#[derive(Debug, Serialize)]
+struct ViolationReceipt {
+    check_name: String,
+    workflow: String,
+    violations: Vec<String>,
+}
+
+pub fn run(config: WorkflowTriggerLintConfig) -> Result<()> {
+    let root = project_root()?;
+    let findings = if let Some(fixture) = config.fixture.as_ref() {
+        let fixture_path = resolve_path(&root, fixture);
+        let violations = lint_required_workflow_file(&fixture_path)?;
+        vec![ViolationReceipt {
+            check_name: fixture_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("fixture")
+                .to_string(),
+            workflow: fixture_path.display().to_string(),
+            violations,
+        }]
+    } else {
+        let policy_path = resolve_path(
+            &root,
+            config.policy.as_ref().unwrap_or(&PathBuf::from(DEFAULT_POLICY_PATH)),
+        );
+        lint_policy(&root, &policy_path)?
+    };
+
+    let ok = findings.iter().all(|entry| entry.violations.is_empty());
+    let checked = findings.len();
+    let violations: Vec<ViolationReceipt> =
+        findings.into_iter().filter(|entry| !entry.violations.is_empty()).collect();
+
+    let receipt = WorkflowTriggerLintReceipt {
+        schema: "workflow-trigger-lint@1".to_string(),
+        ok,
+        checked,
+        violations,
+    };
+
+    if let Some(receipt_path) = config.receipt.as_ref() {
+        write_receipt(&root, receipt_path, &receipt)?;
+    }
+
+    output_receipt(&receipt, config.format)?;
+
+    if receipt.ok { Ok(()) } else { bail!("workflow-trigger-lint found policy violations") }
+}
+
+fn resolve_path(root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() { path.to_path_buf() } else { root.join(path) }
+}
+
+fn lint_policy(root: &Path, policy_path: &Path) -> Result<Vec<ViolationReceipt>> {
+    let policy_raw = fs::read_to_string(policy_path)
+        .with_context(|| format!("reading policy {}", policy_path.display()))?;
+    let policy: RequiredChecksPolicy = toml::from_str(&policy_raw)
+        .with_context(|| format!("parsing policy {}", policy_path.display()))?;
+
+    let mut findings = Vec::new();
+    for check in &policy.check {
+        if !check.required {
+            continue;
+        }
+
+        let workflow_path = root.join(&check.workflow);
+        let violations = lint_required_workflow_file(&workflow_path)?;
+        findings.push(ViolationReceipt {
+            check_name: check.name.clone(),
+            workflow: check.workflow.clone(),
+            violations,
+        });
+    }
+
+    Ok(findings)
+}
+
+fn lint_required_workflow_file(workflow_path: &Path) -> Result<Vec<String>> {
+    if !workflow_path.exists() {
+        return Ok(vec![format!("workflow file does not exist: {}", workflow_path.display())]);
+    }
+
+    let raw = fs::read_to_string(workflow_path)
+        .with_context(|| format!("reading workflow {}", workflow_path.display()))?;
+    let workflow: Value = serde_yaml_ng::from_str(&raw)
+        .with_context(|| format!("parsing workflow YAML {}", workflow_path.display()))?;
+
+    let mut violations = Vec::new();
+
+    let on = workflow.get("on");
+    if !has_trigger(on, "pull_request") {
+        violations.push("missing on.pull_request trigger".to_string());
+    }
+    if !has_trigger(on, "merge_group") {
+        violations.push("missing on.merge_group trigger".to_string());
+    }
+    if !has_push_master(on) {
+        violations.push("missing on.push trigger for master branch".to_string());
+    }
+    if has_path_filter(on) {
+        violations.push("workflow trigger must not use paths or paths-ignore filters".to_string());
+    }
+    if !has_event_aware_concurrency(&workflow) {
+        violations.push(format!(
+            "top-level concurrency.cancel-in-progress must equal {EXPECTED_CANCEL_IN_PROGRESS}"
+        ));
+    }
+
+    Ok(violations)
+}
+
+fn has_trigger(on: Option<&Value>, trigger_name: &str) -> bool {
+    match on {
+        Some(Value::String(single)) => single == trigger_name,
+        Some(Value::Sequence(seq)) => seq.iter().any(|item| item.as_str() == Some(trigger_name)),
+        Some(Value::Mapping(map)) => map.contains_key(Value::String(trigger_name.to_string())),
+        _ => false,
+    }
+}
+
+fn has_push_master(on: Option<&Value>) -> bool {
+    let Some(on_value) = on else {
+        return false;
+    };
+
+    match on_value {
+        Value::String(single) => single == "push",
+        Value::Sequence(seq) => seq.iter().any(|item| item.as_str() == Some("push")),
+        Value::Mapping(map) => {
+            let Some(push) = map.get(Value::String("push".to_string())) else {
+                return false;
+            };
+
+            match push {
+                Value::Null => true,
+                Value::Mapping(push_map) => {
+                    if let Some(branches) = push_map.get(Value::String("branches".to_string())) {
+                        value_contains_string(branches, "master")
+                    } else {
+                        false
+                    }
+                }
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+fn value_contains_string(value: &Value, expected: &str) -> bool {
+    match value {
+        Value::String(single) => single == expected,
+        Value::Sequence(seq) => seq.iter().any(|item| item.as_str() == Some(expected)),
+        _ => false,
+    }
+}
+
+fn has_path_filter(on: Option<&Value>) -> bool {
+    let Some(Value::Mapping(on_map)) = on else {
+        return false;
+    };
+
+    if on_map.contains_key(Value::String("paths".to_string()))
+        || on_map.contains_key(Value::String("paths-ignore".to_string()))
+    {
+        return true;
+    }
+
+    for event in ["pull_request", "merge_group", "push"] {
+        if let Some(Value::Mapping(event_map)) = on_map.get(Value::String(event.to_string()))
+            && (event_map.contains_key(Value::String("paths".to_string()))
+                || event_map.contains_key(Value::String("paths-ignore".to_string())))
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn has_event_aware_concurrency(workflow: &Value) -> bool {
+    let Some(concurrency) = workflow.get("concurrency") else {
+        return false;
+    };
+    let Some(concurrency_map) = concurrency.as_mapping() else {
+        return false;
+    };
+
+    concurrency_map
+        .get(Value::String("cancel-in-progress".to_string()))
+        .and_then(Value::as_str)
+        .is_some_and(|value| value == EXPECTED_CANCEL_IN_PROGRESS)
+}
+
+fn write_receipt(
+    root: &Path,
+    relative_path: &Path,
+    receipt: &WorkflowTriggerLintReceipt,
+) -> Result<()> {
+    let receipt_path = resolve_path(root, relative_path);
+    if let Some(parent) = receipt_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating receipt directory {}", parent.display()))?;
+    }
+
+    let json = serde_json::to_string_pretty(receipt).context("serializing receipt json")?;
+    fs::write(&receipt_path, format!("{json}\n"))
+        .with_context(|| format!("writing receipt {}", receipt_path.display()))?;
+
+    Ok(())
+}
+
+fn output_receipt(
+    receipt: &WorkflowTriggerLintReceipt,
+    format: WorkflowTriggerLintFormat,
+) -> Result<()> {
+    match format {
+        WorkflowTriggerLintFormat::Human => {
+            if receipt.ok {
+                println!("workflow-trigger-lint passed (checked {} workflow(s))", receipt.checked);
+            } else {
+                println!("workflow-trigger-lint failed:");
+                for entry in &receipt.violations {
+                    println!("- {} ({})", entry.check_name, entry.workflow);
+                    for violation in &entry.violations {
+                        println!("  - {violation}");
+                    }
+                }
+            }
+            Ok(())
+        }
+        WorkflowTriggerLintFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(receipt).context("serializing json output")?
+            );
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_fixture_passes() -> Result<()> {
+        let root = project_root()?;
+        let fixture = root.join("xtask/tests/fixtures/workflows/valid-required.yml");
+        let violations = lint_required_workflow_file(&fixture)?;
+        assert!(violations.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn merge_group_fixture_fails() -> Result<()> {
+        let root = project_root()?;
+        let fixture = root.join("xtask/tests/fixtures/workflows/missing-merge-group.yml");
+        let violations = lint_required_workflow_file(&fixture)?;
+        assert!(violations.iter().any(|item| item.contains("merge_group")));
+        Ok(())
+    }
+}

--- a/xtask/tests/fixtures/workflows/bad-concurrency.yml
+++ b/xtask/tests/fixtures/workflows/bad-concurrency.yml
@@ -1,0 +1,17 @@
+name: CI Gate
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [master]
+
+concurrency:
+  group: ci-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo bad concurrency

--- a/xtask/tests/fixtures/workflows/missing-merge-group.yml
+++ b/xtask/tests/fixtures/workflows/missing-merge-group.yml
@@ -1,0 +1,16 @@
+name: CI Gate
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+concurrency:
+  group: ci-gate-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo missing merge_group

--- a/xtask/tests/fixtures/workflows/path-filtered.yml
+++ b/xtask/tests/fixtures/workflows/path-filtered.yml
@@ -1,0 +1,19 @@
+name: CI Gate
+
+on:
+  pull_request:
+    paths:
+      - 'crates/**'
+  merge_group:
+  push:
+    branches: [master]
+
+concurrency:
+  group: ci-gate-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo filtered

--- a/xtask/tests/fixtures/workflows/valid-required.yml
+++ b/xtask/tests/fixtures/workflows/valid-required.yml
@@ -1,0 +1,17 @@
+name: CI Gate
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [master]
+
+concurrency:
+  group: ci-gate-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok


### PR DESCRIPTION
### Motivation

- Ensure required-style workflows always report, support `merge_group`, and are not path-filtered by providing a repo-local policy/lint until ruleset `required_status_checks` enforcement lands (Refs #6858, Refs #6853).

### Description

- Add a new xtask command `workflow-trigger-lint` implemented in `xtask/src/tasks/workflow_trigger_lint.rs` that lints required workflows from a conventional policy or a single fixture and emits an advisory JSON/human receipt.
- Introduce the conventional policy file `.ci/policies/required-checks.toml` listing required workflow checks and wire the lint to validate each `required = true` entry exists and follows trigger/concurrency rules.
- Add an advisory GitHub Actions workflow `.github/workflows/workflow-trigger-lint.yml` that runs the lint on `pull_request`, `merge_group`, and `push: master` and uploads the JSON receipt; the job is `continue-on-error: true` for advisory rollout.
- Add receipt schema, docs, and fixtures: `.ci/receipts/schemas/workflow-trigger-lint.schema.json`, `docs/ci/workflow-trigger-policy.md`, and fixtures under `xtask/tests/fixtures/workflows/` (valid, missing-merge-group, path-filtered, bad-concurrency).

### Testing

- Ran `cargo check -p xtask`, which completed successfully.
- Ran `cargo xtask workflow-trigger-lint --fixture xtask/tests/fixtures/workflows/valid-required.yml`, which passed (no violations).
- Ran `cargo xtask workflow-trigger-lint --fixture xtask/tests/fixtures/workflows/missing-merge-group.yml`, which failed as expected reporting a missing `merge_group` trigger.
- Ran `cargo xtask workflow-trigger-lint --fixture xtask/tests/fixtures/workflows/path-filtered.yml`, which failed as expected reporting path-filter usage, and ran `cargo xtask workflow-trigger-lint --policy .ci/policies/required-checks.toml --receipt target/receipts/workflow-trigger-lint.json --format json` which emitted a JSON receipt with the detected violations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd05e8bf4833393439acc36ccc945)