### PR TITLE
feat(ci): add Methodology Gate for contradictory PR labels (#6855)

### DIFF
--- a/.ci/policies/label-contradictions.toml
+++ b/.ci/policies/label-contradictions.toml
@@ -1,0 +1,29 @@
+[[forbidden]]
+labels = ["review-reviewed", "needs-builder-fix"]
+reason = "sign-off and builder route are mutually exclusive"
+
+[[forbidden]]
+labels = ["diff-audited", "needs-diff-fix"]
+reason = "diff audit sign-off and diff fix routing are mutually exclusive"
+
+[[forbidden]]
+labels = ["maintainer-pr-reviewed", "needs-maintainer-fix"]
+reason = "maintainer review sign-off and maintainer fix routing are mutually exclusive"
+
+[[forbidden]]
+labels = ["ci-green", "needs-ci-fix"]
+reason = "CI green state cannot coexist with CI fix routing"
+
+[[forbidden]]
+labels = ["deep-reviewed", "needs-deep-review"]
+reason = "deep review completion cannot coexist with pending deep review"
+
+[[forbidden_pattern]]
+required = "merge-ready"
+forbidden_glob = "needs-*"
+reason = "merge-ready cannot coexist with any active blocker"
+
+[[forbidden_pattern]]
+required = "auto-merge"
+forbidden_glob = "needs-*"
+reason = "auto-merge cannot coexist with any active blocker"

--- a/.github/workflows/methodology-gate.yml
+++ b/.github/workflows/methodology-gate.yml
@@ -1,0 +1,40 @@
+name: Methodology Gate
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  methodology-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run methodology gate (advisory)
+        run: |
+          cargo xtask methodology-gate \
+            --fixture "${GITHUB_EVENT_PATH}" \
+            --receipt target/receipts/methodology-gate.json
+
+      - name: Upload methodology receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: methodology-gate-receipt
+          path: target/receipts/methodology-gate.json
+          if-no-files-found: ignore

--- a/docs/ci/methodology-gate.md
+++ b/docs/ci/methodology-gate.md
@@ -1,0 +1,61 @@
+# Methodology Gate
+
+The Methodology Gate is a deterministic policy check for contradictory pull request labels.
+It is the first enforcement layer to catch impossible PR states before merge.
+
+## Scope
+
+Current scope is label contradiction detection plus a conservative closeout hygiene warning.
+The gate **does not** mutate labels or attempt to reconcile state.
+
+## Policy source
+
+Rules are defined in:
+
+- `.ci/policies/label-contradictions.toml`
+
+Supported rule kinds:
+
+```toml
+[[forbidden]]
+labels = ["review-reviewed", "needs-builder-fix"]
+reason = "sign-off and builder route are mutually exclusive"
+
+[[forbidden_pattern]]
+required = "merge-ready"
+forbidden_glob = "needs-*"
+reason = "merge-ready cannot coexist with any active blocker"
+```
+
+## Command usage
+
+```bash
+cargo xtask methodology-gate --fixture <json> --receipt target/receipts/methodology-gate.json
+cargo xtask methodology-gate --pr <number> --receipt target/receipts/methodology-gate.json
+```
+
+Flags:
+
+- `--dry-run` skips writing receipt files.
+- `--enforce` converts contradictions from advisory warnings into a failing exit code.
+- `--format json` prints the gate result as JSON to stdout.
+
+## Workflow mode
+
+`.github/workflows/methodology-gate.yml` runs in **advisory mode** initially.
+Contradictions are reported in receipts, but CI does not fail until enforcement is explicitly enabled.
+
+## merge_group behavior
+
+`merge_group` payloads may not reliably expose label state.
+When labels are unavailable, the gate emits a receipt with `classification=unknown` and does not fail.
+Label contradiction enforcement remains on `pull_request` events until merge-ready state receipts are available.
+
+## Closeout hygiene warning
+
+A conservative warning is emitted if PR body text looks like a partial/scaffold/umbrella implementation while using `Closes`, `Fixes`, or `Resolves` issue-close keywords.
+
+Preferred wording for partial implementations:
+
+- `Refs #<issue>`
+- `Part of #<issue>`

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,6 +13,7 @@ mod utils;
 use tasks::check_test_wiring;
 use tasks::dead_code::{DeadCodeConfig, DeadCodeMode};
 use tasks::gates::{GateTier, OutputFormat as GatesOutputFormat};
+use tasks::methodology_gate::MethodologyOutputFormat;
 use tasks::metrics;
 use tasks::targeted_checks::CheckMode;
 use tasks::unwired_scan::UnwiredScanConfig;
@@ -1105,6 +1106,33 @@ enum Commands {
         verbose: bool,
     },
 
+    /// Detect contradictory PR label states and emit a methodology receipt.
+    MethodologyGate {
+        /// Fixture JSON file (local snapshot or GitHub event payload).
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+
+        /// Pull request number to inspect via gh CLI.
+        #[arg(long)]
+        pr: Option<u64>,
+
+        /// Path to output receipt JSON.
+        #[arg(long, default_value = "target/receipts/methodology-gate.json")]
+        receipt: PathBuf,
+
+        /// Do not write receipt to disk.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Enforce mode: contradictory states fail the command.
+        #[arg(long)]
+        enforce: bool,
+
+        /// Output format.
+        #[arg(long, value_enum, default_value = "human")]
+        format: MethodologyOutputFormat,
+    },
+
     /// Verify hook scripts are executable.
     HookCheck,
 
@@ -1776,6 +1804,16 @@ fn main() -> Result<()> {
                     .map_err(|error| eyre!(error.to_string()))
             }
         },
+        Commands::MethodologyGate { fixture, pr, receipt, dry_run, enforce, format } => {
+            methodology_gate::run(methodology_gate::MethodologyGateConfig {
+                fixture,
+                pr,
+                receipt,
+                dry_run,
+                enforce,
+                format,
+            })
+        }
         Commands::TargetedChecks { base, mode } => targeted_checks::run(base, mode),
         Commands::ResolvePackageName { crate_dir } => {
             // Use the current working directory as workspace root so this subcommand

--- a/xtask/src/tasks/ci_audit_workflows.rs
+++ b/xtask/src/tasks/ci_audit_workflows.rs
@@ -27,6 +27,12 @@ const ALLOWED_WORKFLOWS: &[&str] = &[
     // Runs only when .github/workflows/, the workflow_policy_lint xtask, or its
     // fixtures/schema change.
     "workflow-policy.yml",
+    // methodology-gate.yml is advisory-only (read-only label detector).
+    // The single job runs `cargo xtask methodology-gate` which is cheap
+    // (no tests, no compilation beyond xtask itself). Adding an `if:` gate
+    // would prevent it from detecting label contradictions on the PRs that
+    // most need detection.
+    "methodology-gate.yml",
 ];
 
 const ALLOWED_UNGATED_JOBS: &[&str] = &["tautology-check", "test-metrics", "fmt", "clippy"];

--- a/xtask/src/tasks/methodology_gate.rs
+++ b/xtask/src/tasks/methodology_gate.rs
@@ -1,0 +1,368 @@
+use color_eyre::eyre::{Context, Result, bail};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::LazyLock;
+
+use crate::utils::project_root;
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum MethodologyOutputFormat {
+    Human,
+    Json,
+}
+
+#[derive(Debug, Clone)]
+pub struct MethodologyGateConfig {
+    pub fixture: Option<PathBuf>,
+    pub pr: Option<u64>,
+    pub receipt: PathBuf,
+    pub dry_run: bool,
+    pub enforce: bool,
+    pub format: MethodologyOutputFormat,
+}
+
+#[derive(Debug, Deserialize)]
+struct PolicyFile {
+    #[serde(default)]
+    forbidden: Vec<ForbiddenLabelSet>,
+    #[serde(default)]
+    forbidden_pattern: Vec<ForbiddenPattern>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForbiddenLabelSet {
+    labels: Vec<String>,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForbiddenPattern {
+    required: String,
+    forbidden_glob: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureInput {
+    #[serde(default)]
+    event_name: Option<String>,
+    #[serde(default)]
+    pull_request: Option<FixturePullRequest>,
+    #[serde(default)]
+    labels: Vec<String>,
+    #[serde(default)]
+    body: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixturePullRequest {
+    number: u64,
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    labels: Vec<LabelObject>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LabelObject {
+    name: String,
+}
+
+#[derive(Debug, Serialize)]
+struct MethodologyReceipt {
+    schema_version: String,
+    classification: String,
+    mode: String,
+    summary: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pr_number: Option<u64>,
+    labels: Vec<String>,
+    contradictions: Vec<Violation>,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct Violation {
+    rule_type: String,
+    labels: Vec<String>,
+    reason: String,
+}
+
+#[derive(Debug)]
+struct InputState {
+    pr_number: Option<u64>,
+    labels: Vec<String>,
+    body: Option<String>,
+    event_name: Option<String>,
+}
+
+pub fn run(config: MethodologyGateConfig) -> Result<()> {
+    let root = project_root()?;
+    let policy_path = root.join(".ci/policies/label-contradictions.toml");
+    let policy_contents = fs::read_to_string(&policy_path)
+        .with_context(|| format!("failed to read {}", policy_path.display()))?;
+    let policy: PolicyFile = toml::from_str(&policy_contents)
+        .with_context(|| format!("failed to parse {}", policy_path.display()))?;
+
+    let input = load_input(&config)?;
+    let mut labels_set = BTreeSet::new();
+    for label in input.labels {
+        labels_set.insert(label);
+    }
+    let labels: Vec<String> = labels_set.into_iter().collect();
+
+    let mut warnings = Vec::new();
+    if should_warn_closeout_hygiene(input.body.as_deref()) {
+        warnings.push(
+            "PR body appears partial/scaffold/umbrella while using Closes/Fixes/Resolves; prefer Refs or Part of".to_string(),
+        );
+    }
+
+    let mut contradictions = Vec::new();
+    let labels_lookup: BTreeSet<&str> = labels.iter().map(String::as_str).collect();
+
+    if input.event_name.as_deref() == Some("merge_group") && labels.is_empty() {
+        let receipt = MethodologyReceipt {
+            schema_version: "1".to_string(),
+            classification: "unknown".to_string(),
+            mode: mode_name(config.enforce),
+            summary:
+                "merge_group payload did not expose labels; enforcement deferred to pull_request"
+                    .to_string(),
+            pr_number: input.pr_number,
+            labels,
+            contradictions,
+            warnings,
+        };
+        write_receipt(&config, &receipt)?;
+        print_receipt(&config, &receipt)?;
+        return Ok(());
+    }
+
+    for forbidden in &policy.forbidden {
+        if forbidden.labels.iter().all(|label| labels_lookup.contains(label.as_str())) {
+            contradictions.push(Violation {
+                rule_type: "forbidden".to_string(),
+                labels: forbidden.labels.clone(),
+                reason: forbidden.reason.clone(),
+            });
+        }
+    }
+
+    for pattern in &policy.forbidden_pattern {
+        if labels_lookup.contains(pattern.required.as_str()) {
+            let mut matches = labels
+                .iter()
+                .filter(|label| glob_matches(&pattern.forbidden_glob, label))
+                .cloned()
+                .collect::<Vec<_>>();
+            if !matches.is_empty() {
+                matches.sort();
+                matches.dedup();
+                let mut labels_for_violation = vec![pattern.required.clone()];
+                labels_for_violation.extend(matches);
+                contradictions.push(Violation {
+                    rule_type: "forbidden_pattern".to_string(),
+                    labels: labels_for_violation,
+                    reason: pattern.reason.clone(),
+                });
+            }
+        }
+    }
+
+    let has_contradictions = !contradictions.is_empty();
+    let classification =
+        if has_contradictions { if config.enforce { "failed" } else { "warn" } } else { "pass" };
+    let summary = if has_contradictions {
+        format!("detected {} contradictory label state(s)", contradictions.len())
+    } else {
+        "no contradictory label states detected".to_string()
+    };
+
+    let receipt = MethodologyReceipt {
+        schema_version: "1".to_string(),
+        classification: classification.to_string(),
+        mode: mode_name(config.enforce),
+        summary,
+        pr_number: input.pr_number,
+        labels,
+        contradictions,
+        warnings,
+    };
+
+    write_receipt(&config, &receipt)?;
+    print_receipt(&config, &receipt)?;
+
+    if config.enforce && has_contradictions {
+        bail!("methodology gate failed: contradictory PR state detected");
+    }
+
+    Ok(())
+}
+
+fn mode_name(enforce: bool) -> String {
+    if enforce { "enforced".to_string() } else { "advisory".to_string() }
+}
+
+fn print_receipt(config: &MethodologyGateConfig, receipt: &MethodologyReceipt) -> Result<()> {
+    match config.format {
+        MethodologyOutputFormat::Human => {
+            println!("Methodology Gate [{}]: {}", receipt.mode, receipt.summary);
+            if !receipt.contradictions.is_empty() {
+                for contradiction in &receipt.contradictions {
+                    println!(
+                        " - {}: {} ({})",
+                        contradiction.rule_type,
+                        contradiction.labels.join(", "),
+                        contradiction.reason
+                    );
+                }
+            }
+            for warning in &receipt.warnings {
+                println!(" - warning: {warning}");
+            }
+            Ok(())
+        }
+        MethodologyOutputFormat::Json => {
+            let rendered = serde_json::to_string_pretty(receipt)?;
+            println!("{rendered}");
+            Ok(())
+        }
+    }
+}
+
+fn write_receipt(config: &MethodologyGateConfig, receipt: &MethodologyReceipt) -> Result<()> {
+    if config.dry_run {
+        return Ok(());
+    }
+
+    if let Some(parent) = config.receipt.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+
+    let receipt_json = serde_json::to_string_pretty(receipt)?;
+    fs::write(&config.receipt, receipt_json)
+        .with_context(|| format!("failed to write receipt {}", config.receipt.display()))
+}
+
+fn load_input(config: &MethodologyGateConfig) -> Result<InputState> {
+    match (&config.fixture, config.pr) {
+        (Some(_), Some(_)) => bail!("use either --fixture or --pr, not both"),
+        (None, None) => bail!("one of --fixture or --pr is required"),
+        (Some(path), None) => load_input_from_fixture(path),
+        (None, Some(pr_number)) => load_input_from_pr(pr_number),
+    }
+}
+
+fn load_input_from_fixture(path: &PathBuf) -> Result<InputState> {
+    let contents = fs::read_to_string(path)
+        .with_context(|| format!("failed to read fixture {}", path.display()))?;
+    let fixture: FixtureInput = serde_json::from_str(&contents)
+        .with_context(|| format!("failed to parse fixture {}", path.display()))?;
+
+    if let Some(pr) = fixture.pull_request {
+        let labels = pr.labels.into_iter().map(|label| label.name).collect::<Vec<_>>();
+        Ok(InputState {
+            pr_number: Some(pr.number),
+            labels,
+            body: pr.body,
+            event_name: fixture.event_name,
+        })
+    } else {
+        Ok(InputState {
+            pr_number: None,
+            labels: fixture.labels,
+            body: fixture.body,
+            event_name: fixture.event_name,
+        })
+    }
+}
+
+fn load_input_from_pr(pr_number: u64) -> Result<InputState> {
+    let output = std::process::Command::new("gh")
+        .args(["pr", "view", &pr_number.to_string(), "--json", "number,body,labels"])
+        .output()
+        .context("failed to execute gh for PR lookup")?;
+
+    if !output.status.success() {
+        bail!(
+            "gh PR lookup failed with status {}",
+            output.status.code().map_or_else(|| "signal".to_string(), |code| code.to_string())
+        );
+    }
+
+    let view: GhPrView =
+        serde_json::from_slice(&output.stdout).context("failed to decode gh pr view JSON")?;
+
+    let labels = view.labels.into_iter().map(|label| label.name).collect();
+    Ok(InputState {
+        pr_number: Some(view.number),
+        labels,
+        body: Some(view.body),
+        event_name: Some("pull_request".to_string()),
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct GhPrView {
+    number: u64,
+    body: String,
+    labels: Vec<LabelObject>,
+}
+
+fn should_warn_closeout_hygiene(body: Option<&str>) -> bool {
+    static CLOSEOUT_RE: LazyLock<Option<Regex>> =
+        LazyLock::new(|| Regex::new(r"(?i)\b(closes|fixes|resolves)\s+#\d+\b").ok());
+    static PARTIAL_RE: LazyLock<Option<Regex>> =
+        LazyLock::new(|| Regex::new(r"(?i)\b(partial|scaffold|umbrella)\b").ok());
+
+    let Some(body) = body else {
+        return false;
+    };
+
+    CLOSEOUT_RE.as_ref().is_some_and(|regex| regex.is_match(body))
+        && PARTIAL_RE
+            .as_ref()
+            .is_some_and(|regex| regex.is_match(body))
+}
+
+fn glob_matches(pattern: &str, value: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        return value.starts_with(prefix);
+    }
+
+    if let Some(suffix) = pattern.strip_prefix('*') {
+        return value.ends_with(suffix);
+    }
+
+    value == pattern
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glob_pattern_prefix_match() {
+        assert!(glob_matches("needs-*", "needs-ci-fix"));
+    }
+
+    #[test]
+    fn glob_pattern_exact_match() {
+        assert!(glob_matches("merge-ready", "merge-ready"));
+    }
+
+    #[test]
+    fn closeout_warning_requires_both_signals() {
+        assert!(should_warn_closeout_hygiene(Some("Partial implementation. Fixes #6855")));
+        assert!(!should_warn_closeout_hygiene(Some("Fixes #6855")));
+    }
+}

--- a/xtask/src/tasks/methodology_gate.rs
+++ b/xtask/src/tasks/methodology_gate.rs
@@ -325,9 +325,7 @@ fn should_warn_closeout_hygiene(body: Option<&str>) -> bool {
     };
 
     CLOSEOUT_RE.as_ref().is_some_and(|regex| regex.is_match(body))
-        && PARTIAL_RE
-            .as_ref()
-            .is_some_and(|regex| regex.is_match(body))
+        && PARTIAL_RE.as_ref().is_some_and(|regex| regex.is_match(body))
 }
 
 fn glob_matches(pattern: &str, value: &str) -> bool {

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -51,6 +51,7 @@ pub mod hook_checks;
 pub mod ignored_tests;
 pub mod inject_sha_assets;
 pub mod layer_check;
+pub mod methodology_gate;
 pub mod metrics;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;

--- a/xtask/tests/fixtures/methodology/clean.json
+++ b/xtask/tests/fixtures/methodology/clean.json
@@ -1,0 +1,11 @@
+{
+  "event_name": "pull_request",
+  "pull_request": {
+    "number": 6855,
+    "body": "Refs #6855\n\nMethodology receipt scaffolding only.",
+    "labels": [
+      { "name": "review-reviewed" },
+      { "name": "ci-green" }
+    ]
+  }
+}

--- a/xtask/tests/fixtures/methodology/merge-ready-plus-needs.json
+++ b/xtask/tests/fixtures/methodology/merge-ready-plus-needs.json
@@ -1,0 +1,12 @@
+{
+  "event_name": "pull_request",
+  "pull_request": {
+    "number": 6855,
+    "body": "Refs #6855",
+    "labels": [
+      { "name": "merge-ready" },
+      { "name": "needs-ci-fix" },
+      { "name": "needs-maintainer-fix" }
+    ]
+  }
+}

--- a/xtask/tests/fixtures/methodology/review-plus-needs-builder.json
+++ b/xtask/tests/fixtures/methodology/review-plus-needs-builder.json
@@ -1,0 +1,11 @@
+{
+  "event_name": "pull_request",
+  "pull_request": {
+    "number": 6855,
+    "body": "Refs #6855",
+    "labels": [
+      { "name": "review-reviewed" },
+      { "name": "needs-builder-fix" }
+    ]
+  }
+}


### PR DESCRIPTION
### Motivation

- Prevent impossible PR label combinations (e.g. `review-reviewed` + `needs-builder-fix`) from slipping through by adding a deterministic, early CI/policy detector that emits a receipt. 

### Description

- Add a new `cargo xtask methodology-gate` command with `--fixture`, `--pr`, `--receipt`, `--dry-run`, `--enforce`, and `--format json` support that evaluates label contradictions and writes a methodology receipt (`xtask/src/tasks/methodology_gate.rs`).
- Introduce the contradiction policy file `.ci/policies/label-contradictions.toml` with explicit forbidden label pairs and forbidden-pattern rules (e.g. `merge-ready` + `needs-*`).
- Wire the command into `xtask` CLI and task registry (`xtask/src/main.rs`, `xtask/src/tasks/mod.rs`) and add fixtures for validation (`xtask/tests/fixtures/methodology/*.json`).
- Add an advisory GitHub Actions workflow `.github/workflows/methodology-gate.yml` that runs on `pull_request`, `merge_group`, and `push` to `master`, uploads the receipt, and defaults to advisory mode; document behavior and merge_group nuance in `docs/ci/methodology-gate.md`.
- Gate is read-only: it only detects and emits receipts and warnings (including a conservative closeout-hygiene warning) and does not mutate labels or reconcile state.

### Testing

- Ran `cargo check -p xtask`, which succeeded. 
- Ran `cargo xtask methodology-gate --fixture xtask/tests/fixtures/methodology/clean.json --receipt target/receipts/methodology-gate.json`, which reported no contradictions and succeeded. 
- Ran `cargo xtask methodology-gate --fixture xtask/tests/fixtures/methodology/review-plus-needs-builder.json --receipt target/receipts/methodology-gate.json --enforce`, which failed as expected in enforced mode due to the `review-reviewed` + `needs-builder-fix` contradiction. 
- Ran `cargo xtask methodology-gate --fixture xtask/tests/fixtures/methodology/merge-ready-plus-needs.json --receipt target/receipts/methodology-gate.json --enforce`, which failed as expected in enforced mode due to `merge-ready` coexisting with `needs-*` labels.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd059d7108333a30d4e542fe53726)