### PR TITLE
feat(ci): add Methodology Gate for contradictory PR labels (#6855)

### DIFF
--- a/.ci/policies/label-contradictions.toml
+++ b/.ci/policies/label-contradictions.toml
@@ -1,0 +1,29 @@
+[[forbidden]]
+labels = ["review-reviewed", "needs-builder-fix"]
+reason = "sign-off and builder route are mutually exclusive"
+
+[[forbidden]]
+labels = ["diff-audited", "needs-diff-fix"]
+reason = "diff audit sign-off cannot coexist with diff remediation routing"
+
+[[forbidden]]
+labels = ["maintainer-pr-reviewed", "needs-maintainer-fix"]
+reason = "maintainer-reviewed and maintainer-fix-needed are mutually exclusive"
+
+[[forbidden]]
+labels = ["ci-green", "needs-ci-fix"]
+reason = "ci-green and ci remediation routing are mutually exclusive"
+
+[[forbidden]]
+labels = ["deep-reviewed", "needs-deep-review"]
+reason = "deep review completion cannot coexist with pending deep review"
+
+[[forbidden_pattern]]
+required = "merge-ready"
+forbidden_glob = "needs-*"
+reason = "merge-ready cannot coexist with any active blocker"
+
+[[forbidden_pattern]]
+required = "auto-merge"
+forbidden_glob = "needs-*"
+reason = "auto-merge cannot coexist with any active blocker"

--- a/.github/workflows/methodology-gate.yml
+++ b/.github/workflows/methodology-gate.yml
@@ -1,0 +1,61 @@
+name: Methodology Gate
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  methodology-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run methodology gate (advisory)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/receipts
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            cargo xtask methodology-gate \
+              --pr "${{ github.event.pull_request.number }}" \
+              --receipt target/receipts/methodology-gate.json
+          elif [[ "${GITHUB_EVENT_NAME}" == "merge_group" ]]; then
+            cat > target/receipts/methodology-merge-group.json <<'JSON'
+          {
+            "event_name": "merge_group",
+            "labels_available": false,
+            "body": "",
+            "labels": []
+          }
+          JSON
+            cargo xtask methodology-gate \
+              --fixture target/receipts/methodology-merge-group.json \
+              --receipt target/receipts/methodology-gate.json
+          else
+            cargo xtask methodology-gate \
+              --fixture xtask/tests/fixtures/methodology/clean.json \
+              --receipt target/receipts/methodology-gate.json
+          fi
+
+      - name: Upload methodology receipt
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: methodology-gate-receipt
+          path: target/receipts/methodology-gate.json
+          if-no-files-found: ignore

--- a/docs/ci/methodology-gate.md
+++ b/docs/ci/methodology-gate.md
@@ -1,0 +1,66 @@
+# Methodology Gate
+
+The Methodology Gate catches contradictory PR methodology label states and writes a deterministic receipt.
+
+## Scope
+
+The gate is intentionally narrow:
+
+- It does **not** mutate labels.
+- It does **not** implement a full reconciler/state builder.
+- It only detects impossible combinations and reports them.
+
+## Policy Source
+
+Contradiction rules are declared in:
+
+- `.ci/policies/label-contradictions.toml`
+
+Supported policy sections:
+
+- `[[forbidden]]` for exact forbidden label combinations.
+- `[[forbidden_pattern]]` for required-label + forbidden-glob combinations.
+
+Example:
+
+```toml
+[[forbidden]]
+labels = ["review-reviewed", "needs-builder-fix"]
+reason = "sign-off and builder route are mutually exclusive"
+```
+
+## Command Usage
+
+Fixture mode:
+
+```bash
+cargo xtask methodology-gate --fixture <json> --receipt target/receipts/methodology-gate.json
+```
+
+Live PR mode (GitHub CLI required):
+
+```bash
+cargo xtask methodology-gate --pr <number> --receipt target/receipts/methodology-gate.json
+```
+
+Optional flags:
+
+- `--dry-run` — always succeeds and only emits findings.
+- `--enforce` — contradictory states become command failure.
+- `--format json` — print machine-readable output to stdout.
+
+## Advisory Rollout
+
+Current default behavior is advisory. Contradictions are surfaced in the receipt but do not fail unless `--enforce` is supplied.
+
+## Merge Group Nuance
+
+`merge_group` payloads may not expose reliable PR labels. In that case the workflow passes a fixture with `labels_available=false`; the receipt classification becomes `unknown` and the gate does not fail.
+
+Label contradiction enforcement currently happens on `pull_request` runs, with `merge_group` kept informative until merge-ready receipt/state-builder plumbing exists.
+
+## Closeout Hygiene Warning
+
+As conservative guidance, the gate emits a warning when the PR body appears partial/scaffold/umbrella and still uses closeout keywords (`Closes/Fixes/Resolves`).
+
+Partial implementations should prefer `Refs` or `Part of`.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -406,6 +406,33 @@ enum Commands {
     /// Check for disallowed direct `ExitStatus::from_raw()` usage.
     CheckFromRaw,
 
+    /// Evaluate PR methodology contradictions from labels and emit a receipt.
+    MethodologyGate {
+        /// Path to fixture JSON payload (offline mode).
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+
+        /// PR number to inspect via `gh pr view`.
+        #[arg(long)]
+        pr: Option<u64>,
+
+        /// Optional output path for methodology receipt JSON.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+
+        /// Dry-run mode: never fail, only emit findings.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Enforce mode: contradictory labels fail the command.
+        #[arg(long)]
+        enforce: bool,
+
+        /// Output format: `human` (default) or `json`.
+        #[arg(long, default_value = "human")]
+        format: String,
+    },
+
     /// Run production security hardening checks.
     SecurityHardening,
 
@@ -1464,6 +1491,20 @@ fn main() -> Result<()> {
         }
         Commands::CheckVersionSync => check_version_sync::run(),
         Commands::CheckFromRaw => ci_policy::check_from_raw(),
+        Commands::MethodologyGate { fixture, pr, receipt, dry_run, enforce, format } => {
+            let format_json = format.eq_ignore_ascii_case("json");
+            if !format_json && !format.eq_ignore_ascii_case("human") {
+                return Err(eyre!("unsupported methodology-gate --format: {format}"));
+            }
+            methodology_gate::run(methodology_gate::MethodologyGateConfig {
+                fixture,
+                pr,
+                receipt,
+                dry_run,
+                enforce,
+                format_json,
+            })
+        }
         Commands::SecurityHardening => hardening::security_hardening(),
         Commands::PerformanceHardening => hardening::performance_hardening(),
         Commands::ProductionGatesValidation => hardening::production_gates_validation(),

--- a/xtask/src/tasks/methodology_gate.rs
+++ b/xtask/src/tasks/methodology_gate.rs
@@ -1,0 +1,366 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_POLICY_PATH: &str = ".ci/policies/label-contradictions.toml";
+
+#[derive(Debug, Clone)]
+pub struct MethodologyGateConfig {
+    pub fixture: Option<PathBuf>,
+    pub pr: Option<u64>,
+    pub receipt: Option<PathBuf>,
+    pub dry_run: bool,
+    pub enforce: bool,
+    pub format_json: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct Policy {
+    #[serde(default)]
+    forbidden: Vec<ForbiddenRule>,
+    #[serde(default)]
+    forbidden_pattern: Vec<ForbiddenPatternRule>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForbiddenRule {
+    labels: Vec<String>,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForbiddenPatternRule {
+    required: String,
+    forbidden_glob: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixturePayload {
+    #[serde(default)]
+    pr_number: Option<u64>,
+    #[serde(default)]
+    event_name: Option<String>,
+    #[serde(default)]
+    body: String,
+    #[serde(default)]
+    labels: Vec<String>,
+    #[serde(default)]
+    labels_available: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct MethodologyGateReceipt {
+    schema_version: u32,
+    classification: String,
+    mode: String,
+    source: String,
+    pr_number: Option<u64>,
+    event_name: Option<String>,
+    labels_available: bool,
+    labels: Vec<String>,
+    violations: Vec<Violation>,
+    closeout_hygiene_warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Violation {
+    kind: String,
+    labels: Vec<String>,
+    reason: String,
+}
+
+pub fn run(config: MethodologyGateConfig) -> Result<()> {
+    if config.fixture.is_some() == config.pr.is_some() {
+        bail!("pass exactly one of --fixture <json> or --pr <number>");
+    }
+
+    let root = crate::utils::project_root()?;
+    let policy = load_policy(&root.join(DEFAULT_POLICY_PATH))?;
+    let context = load_context(&root, &config)?;
+
+    let unknown = is_unknown_context(&context);
+    let violations = if unknown { vec![] } else { find_violations(&policy, &context.labels) };
+    let closeout_hygiene_warnings = find_closeout_hygiene_warnings(&context.body);
+
+    let classification = if unknown {
+        "unknown"
+    } else if violations.is_empty() {
+        "clean"
+    } else {
+        "contradiction"
+    };
+
+    let receipt = MethodologyGateReceipt {
+        schema_version: 1,
+        classification: classification.to_string(),
+        mode: if config.enforce { "enforce" } else { "advisory" }.to_string(),
+        source: context.source,
+        pr_number: context.pr_number,
+        event_name: context.event_name,
+        labels_available: context.labels_available,
+        labels: sorted_labels(context.labels),
+        violations,
+        closeout_hygiene_warnings,
+    };
+
+    if let Some(path) = config.receipt.as_ref() {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("creating receipt directory {}", parent.display()))?;
+        }
+        let payload = serde_json::to_string_pretty(&receipt)?;
+        fs::write(path, format!("{payload}\n"))
+            .with_context(|| format!("writing receipt {}", path.display()))?;
+    }
+
+    emit_output(&receipt, config.format_json)?;
+
+    if config.dry_run {
+        return Ok(());
+    }
+
+    if config.enforce && !unknown && !receipt.violations.is_empty() {
+        bail!("methodology gate failed: contradictory labels detected");
+    }
+
+    Ok(())
+}
+
+fn emit_output(receipt: &MethodologyGateReceipt, format_json: bool) -> Result<()> {
+    if format_json {
+        println!("{}", serde_json::to_string_pretty(receipt)?);
+        return Ok(());
+    }
+
+    println!("Methodology Gate");
+    println!("  classification: {}", receipt.classification);
+    println!("  mode: {}", receipt.mode);
+    println!("  source: {}", receipt.source);
+    if let Some(pr_number) = receipt.pr_number {
+        println!("  pr: #{}", pr_number);
+    }
+    if let Some(event_name) = receipt.event_name.as_ref() {
+        println!("  event: {}", event_name);
+    }
+
+    if receipt.violations.is_empty() {
+        println!("  contradictions: none");
+    } else {
+        println!("  contradictions: {}", receipt.violations.len());
+        for violation in &receipt.violations {
+            println!("    - {} ({})", violation.labels.join(" + "), violation.reason);
+        }
+    }
+
+    if !receipt.closeout_hygiene_warnings.is_empty() {
+        println!("  closeout hygiene warnings:");
+        for warning in &receipt.closeout_hygiene_warnings {
+            println!("    - {warning}");
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct GateContext {
+    source: String,
+    pr_number: Option<u64>,
+    event_name: Option<String>,
+    body: String,
+    labels: Vec<String>,
+    labels_available: bool,
+}
+
+fn is_unknown_context(context: &GateContext) -> bool {
+    matches!(context.event_name.as_deref(), Some("merge_group")) && !context.labels_available
+}
+
+fn load_context(root: &Path, config: &MethodologyGateConfig) -> Result<GateContext> {
+    if let Some(fixture_path) = config.fixture.as_ref() {
+        return load_fixture_context(fixture_path);
+    }
+
+    if let Some(pr_number) = config.pr {
+        return load_pr_context(root, pr_number);
+    }
+
+    bail!("either --fixture or --pr is required")
+}
+
+fn load_fixture_context(path: &Path) -> Result<GateContext> {
+    let raw =
+        fs::read_to_string(path).with_context(|| format!("reading fixture {}", path.display()))?;
+    let payload: FixturePayload = serde_json::from_str(&raw)
+        .with_context(|| format!("parsing fixture {}", path.display()))?;
+
+    Ok(GateContext {
+        source: format!("fixture:{}", path.display()),
+        pr_number: payload.pr_number,
+        event_name: payload.event_name,
+        body: payload.body,
+        labels: payload.labels,
+        labels_available: payload.labels_available,
+    })
+}
+
+fn load_pr_context(root: &Path, pr_number: u64) -> Result<GateContext> {
+    let output = Command::new("gh")
+        .args(["pr", "view", &pr_number.to_string(), "--json", "number,body,labels"])
+        .current_dir(root)
+        .output()
+        .context("failed to run `gh pr view`")?;
+
+    if !output.status.success() {
+        bail!(
+            "failed to query PR #{pr_number}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    #[derive(Deserialize)]
+    struct GhResponse {
+        number: u64,
+        #[serde(default)]
+        body: String,
+        #[serde(default)]
+        labels: Vec<GhLabel>,
+    }
+
+    #[derive(Deserialize)]
+    struct GhLabel {
+        name: String,
+    }
+
+    let parsed: GhResponse =
+        serde_json::from_slice(&output.stdout).context("parsing gh pr view output")?;
+    let labels = parsed.labels.into_iter().map(|entry| entry.name).collect();
+
+    Ok(GateContext {
+        source: format!("pr:{pr_number}"),
+        pr_number: Some(parsed.number),
+        event_name: std::env::var("GITHUB_EVENT_NAME").ok(),
+        body: parsed.body,
+        labels,
+        labels_available: true,
+    })
+}
+
+fn load_policy(path: &Path) -> Result<Policy> {
+    let raw =
+        fs::read_to_string(path).with_context(|| format!("reading policy {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("parsing policy {}", path.display()))
+}
+
+fn find_violations(policy: &Policy, labels: &[String]) -> Vec<Violation> {
+    let mut violations = Vec::new();
+
+    for rule in &policy.forbidden {
+        if rule.labels.iter().all(|needle| labels.iter().any(|label| label == needle)) {
+            violations.push(Violation {
+                kind: "forbidden".to_string(),
+                labels: rule.labels.clone(),
+                reason: rule.reason.clone(),
+            });
+        }
+    }
+
+    for rule in &policy.forbidden_pattern {
+        if !labels.iter().any(|label| label == &rule.required) {
+            continue;
+        }
+
+        let forbidden_labels: Vec<String> = labels
+            .iter()
+            .filter(|label| label_matches_glob(label, &rule.forbidden_glob))
+            .cloned()
+            .collect();
+
+        if !forbidden_labels.is_empty() {
+            let mut labels_with_required = vec![rule.required.clone()];
+            labels_with_required.extend(forbidden_labels);
+            violations.push(Violation {
+                kind: "forbidden_pattern".to_string(),
+                labels: labels_with_required,
+                reason: rule.reason.clone(),
+            });
+        }
+    }
+
+    violations
+}
+
+fn find_closeout_hygiene_warnings(body: &str) -> Vec<String> {
+    let body_lower = body.to_ascii_lowercase();
+    if !body_lower.contains("partial")
+        && !body_lower.contains("scaffold")
+        && !body_lower.contains("umbrella")
+    {
+        return vec![];
+    }
+
+    if body_lower.contains("closes #")
+        || body_lower.contains("fixes #")
+        || body_lower.contains("resolves #")
+    {
+        return vec![
+            "PR body appears partial/scaffold/umbrella but uses Closes/Fixes/Resolves; prefer Refs/Part of until fully complete"
+                .to_string(),
+        ];
+    }
+
+    vec![]
+}
+
+fn label_matches_glob(label: &str, glob: &str) -> bool {
+    if let Some(prefix) = glob.strip_suffix('*') {
+        return label.starts_with(prefix);
+    }
+    label == glob
+}
+
+fn sorted_labels(mut labels: Vec<String>) -> Vec<String> {
+    labels.sort();
+    labels
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use color_eyre::eyre::Result;
+
+    #[test]
+    fn detects_fixture_contradiction() -> Result<()> {
+        let root = crate::utils::project_root()?;
+        let policy = load_policy(&root.join(DEFAULT_POLICY_PATH))?;
+        let fixture_path =
+            root.join("xtask/tests/fixtures/methodology/review-plus-needs-builder.json");
+        let context = load_fixture_context(&fixture_path)?;
+        let violations = find_violations(&policy, &context.labels);
+        assert!(!violations.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn clean_fixture_has_no_violations() -> Result<()> {
+        let root = crate::utils::project_root()?;
+        let policy = load_policy(&root.join(DEFAULT_POLICY_PATH))?;
+        let fixture_path = root.join("xtask/tests/fixtures/methodology/clean.json");
+        let context = load_fixture_context(&fixture_path)?;
+        let violations = find_violations(&policy, &context.labels);
+        assert!(violations.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn partial_closeout_warns_on_fixes() {
+        let warnings = find_closeout_hygiene_warnings(
+            "This is a partial implementation. Fixes #6855 because reasons.",
+        );
+        assert_eq!(warnings.len(), 1);
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -48,6 +48,7 @@ pub mod hook_checks;
 pub mod ignored_tests;
 pub mod inject_sha_assets;
 pub mod layer_check;
+pub mod methodology_gate;
 pub mod metrics;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;

--- a/xtask/tests/fixtures/methodology/clean.json
+++ b/xtask/tests/fixtures/methodology/clean.json
@@ -1,0 +1,11 @@
+{
+  "pr_number": 6855,
+  "event_name": "pull_request",
+  "body": "Refs #6855\n\nMethodology gate scaffold.",
+  "labels_available": true,
+  "labels": [
+    "in-review",
+    "review-reviewed",
+    "diff-audited"
+  ]
+}

--- a/xtask/tests/fixtures/methodology/merge-ready-plus-needs.json
+++ b/xtask/tests/fixtures/methodology/merge-ready-plus-needs.json
@@ -1,0 +1,11 @@
+{
+  "pr_number": 6780,
+  "event_name": "pull_request",
+  "body": "Refs #6855\n\npartial implementation umbrella",
+  "labels_available": true,
+  "labels": [
+    "merge-ready",
+    "needs-ci-fix",
+    "deep-reviewed"
+  ]
+}

--- a/xtask/tests/fixtures/methodology/review-plus-needs-builder.json
+++ b/xtask/tests/fixtures/methodology/review-plus-needs-builder.json
@@ -1,0 +1,11 @@
+{
+  "pr_number": 6780,
+  "event_name": "pull_request",
+  "body": "Refs #6855\n\npartial implementation for methodology gate",
+  "labels_available": true,
+  "labels": [
+    "review-reviewed",
+    "needs-builder-fix",
+    "in-review"
+  ]
+}


### PR DESCRIPTION
### Motivation

- PRs can enter impossible methodology states (for example `review-reviewed` coexisting with `needs-builder-fix`) which agents may apply and which can inadvertently merge.
- A deterministic, cheap CI/policy layer is needed to catch these contradictions before merge while ownership and reconciliation remain out of scope. 
- The initial rollout should be advisory by default and provide an explicit `--enforce` flag to turn contradictions into failures when desired.

### Description

- Add a new `cargo xtask methodology-gate` task implemented in `xtask/src/tasks/methodology_gate.rs` that supports `--fixture` and `--pr` input modes, emits a deterministic receipt, and classifies runs as `unknown`/`clean`/`contradiction`.
- Introduce a TOML policy file `.ci/policies/label-contradictions.toml` that declares exact forbidden combinations (`[[forbidden]]`) and pattern rules (`[[forbidden_pattern]]`) including the requested rules (e.g. `review-reviewed` + `needs-builder-fix`, `merge-ready` + `needs-*`, `auto-merge` + `needs-*`).
- Wire the command into the `xtask` CLI (`xtask/src/main.rs`, `xtask/src/tasks/mod.rs`) and add fixtures under `xtask/tests/fixtures/methodology/` plus a closeout hygiene warning that flags partial/scaffold/umbrella PR bodies using `Closes`/`Fixes`/`Resolves`.
- Add a GitHub Actions workflow `.github/workflows/methodology-gate.yml` that runs on `pull_request`, `merge_group`, and `push: master`, handles `merge_group` payloads that lack label visibility by emitting an `unknown` receipt, and always uploads `target/receipts/methodology-gate.json`; also add docs in `docs/ci/methodology-gate.md` describing scope and rollout.

### Testing

- Ran `cargo check -p xtask`, which completed successfully.
- Ran `cargo xtask methodology-gate --fixture xtask/tests/fixtures/methodology/clean.json --receipt target/receipts/methodology-gate.json` and it reported `classification: clean` and emitted the receipt.
- Ran `cargo xtask methodology-gate --fixture xtask/tests/fixtures/methodology/review-plus-needs-builder.json --receipt target/receipts/methodology-gate.json --enforce`, which produced a `contradiction` classification and failed as expected.
- Ran `cargo xtask methodology-gate --fixture xtask/tests/fixtures/methodology/merge-ready-plus-needs.json --receipt target/receipts/methodology-gate.json --enforce`, which produced a `contradiction` classification and failed as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd059d7108333a30d4e542fe53726)