### PR TITLE
feat(ci): add Methodology Gate for contradictory PR labels (#6855)

### DIFF
--- a/.ci/policies/label-contradictions.toml
+++ b/.ci/policies/label-contradictions.toml
@@ -1,0 +1,29 @@
+[[forbidden]]
+labels = ["review-reviewed", "needs-builder-fix"]
+reason = "sign-off and builder route are mutually exclusive"
+
+[[forbidden]]
+labels = ["diff-audited", "needs-diff-fix"]
+reason = "diff sign-off and diff fix routing are mutually exclusive"
+
+[[forbidden]]
+labels = ["maintainer-pr-reviewed", "needs-maintainer-fix"]
+reason = "maintainer review approval and maintainer fix routing are mutually exclusive"
+
+[[forbidden]]
+labels = ["ci-green", "needs-ci-fix"]
+reason = "ci-green cannot coexist with active CI fix routing"
+
+[[forbidden]]
+labels = ["deep-reviewed", "needs-deep-review"]
+reason = "deep-reviewed and needs-deep-review are mutually exclusive"
+
+[[forbidden_pattern]]
+required = "merge-ready"
+forbidden_glob = "needs-*"
+reason = "merge-ready cannot coexist with any active blocker"
+
+[[forbidden_pattern]]
+required = "auto-merge"
+forbidden_glob = "needs-*"
+reason = "auto-merge cannot coexist with any active blocker"

--- a/.github/workflows/methodology-gate.yml
+++ b/.github/workflows/methodology-gate.yml
@@ -1,0 +1,48 @@
+name: Methodology Gate
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  methodology-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run Methodology Gate (pull_request)
+        if: github.event_name == 'pull_request'
+        run: |
+          cargo xtask methodology-gate \
+            --pr "${{ github.event.pull_request.number }}" \
+            --receipt target/receipts/methodology-gate.json
+
+      - name: Run Methodology Gate (merge_group/push advisory)
+        if: github.event_name != 'pull_request'
+        run: |
+          cargo xtask methodology-gate \
+            --fixture "$GITHUB_EVENT_PATH" \
+            --receipt target/receipts/methodology-gate.json
+
+      - name: Upload methodology receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: methodology-gate-receipt
+          path: target/receipts/methodology-gate.json
+          if-no-files-found: ignore

--- a/docs/ci/methodology-gate.md
+++ b/docs/ci/methodology-gate.md
@@ -1,0 +1,50 @@
+# Methodology Gate
+
+The Methodology Gate is a cheap deterministic policy check for contradictory PR label states.
+
+## Purpose
+
+This gate detects impossible combinations such as sign-off and fix-routing labels coexisting on the same pull request (for example, `review-reviewed` + `needs-builder-fix`). It does **not** mutate labels, assign labels, or reconcile state.
+
+## Policy source
+
+Rules are defined in:
+
+- `.ci/policies/label-contradictions.toml`
+
+Supported rule shapes:
+
+- `[[forbidden]]` exact label sets
+- `[[forbidden_pattern]]` one required label plus a forbidden glob (currently prefix-style like `needs-*`)
+
+## Commands
+
+Fixture mode:
+
+```bash
+cargo xtask methodology-gate --fixture <json> --receipt target/receipts/methodology-gate.json
+```
+
+PR mode:
+
+```bash
+cargo xtask methodology-gate --pr <number> --receipt target/receipts/methodology-gate.json
+```
+
+Optional flags:
+
+- `--enforce`: treat contradictions as failures (non-zero exit)
+- `--dry-run`: calculate output without writing receipt files
+- `--format json`: print machine-readable output to stdout
+
+Default mode is advisory (warnings).
+
+## Merge queue nuance (`merge_group`)
+
+When merge-queue payloads do not reliably expose PR labels, the gate emits `classification=unknown` and does not fail for label lookup unavailability. Label enforcement remains on `pull_request` runs until merge-ready receipts/state builder work lands.
+
+## Closeout hygiene (conservative)
+
+In advisory mode, the gate warns when a PR body appears partial/scaffold/umbrella while using closeout verbs (`Closes`, `Fixes`, `Resolves`).
+
+Use `Refs` or `Part of` for partial implementations.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,6 +13,7 @@ mod utils;
 use tasks::check_test_wiring;
 use tasks::dead_code::{DeadCodeConfig, DeadCodeMode};
 use tasks::gates::{GateTier, OutputFormat};
+use tasks::methodology_gate::MethodologyGateFormat;
 use tasks::metrics;
 use tasks::targeted_checks::CheckMode;
 use tasks::unwired_scan::UnwiredScanConfig;
@@ -1059,6 +1060,33 @@ enum Commands {
         verbose: bool,
     },
 
+    /// Validate contradictory PR label states and emit a methodology receipt.
+    MethodologyGate {
+        /// Read PR metadata from a fixture JSON payload.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+
+        /// Read PR metadata directly from GitHub for this PR number.
+        #[arg(long)]
+        pr: Option<u64>,
+
+        /// Path to write methodology receipt JSON.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+
+        /// Enforce mode: contradictions fail the task.
+        #[arg(long)]
+        enforce: bool,
+
+        /// Dry-run mode: compute output without writing receipt files.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Output format (default: human).
+        #[arg(long, value_enum, default_value = "human")]
+        format: MethodologyGateFormat,
+    },
+
     /// Verify hook scripts are executable.
     HookCheck,
 
@@ -1663,6 +1691,9 @@ fn main() -> Result<()> {
             parallel,
             verbose,
         }),
+        Commands::MethodologyGate { fixture, pr, receipt, enforce, dry_run, format } => {
+            methodology_gate::run(fixture, pr, receipt, enforce, dry_run, format)
+        }
         Commands::TargetedChecks { base, mode } => targeted_checks::run(base, mode),
         Commands::ResolvePackageName { crate_dir } => {
             // Use the current working directory as workspace root so this subcommand

--- a/xtask/src/tasks/ci_audit_workflows.rs
+++ b/xtask/src/tasks/ci_audit_workflows.rs
@@ -23,6 +23,8 @@ const ALLOWED_WORKFLOWS: &[&str] = &[
     // ci-gate-self-tests.yml is path-filtered to gate scripts only.
     // Runs only when the gate scripts or self-test scripts change.
     "ci-gate-self-tests.yml",
+    // Methodology gate is intentionally lightweight and runs unconditionally.
+    "methodology-gate.yml",
 ];
 
 const ALLOWED_UNGATED_JOBS: &[&str] = &["tautology-check", "test-metrics", "fmt", "clippy"];

--- a/xtask/src/tasks/methodology_gate.rs
+++ b/xtask/src/tasks/methodology_gate.rs
@@ -1,0 +1,348 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use clap::ValueEnum;
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::utils::project_root;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum MethodologyGateFormat {
+    Human,
+    Json,
+}
+
+#[derive(Debug, Deserialize)]
+struct Policy {
+    #[serde(default)]
+    forbidden: Vec<ForbiddenRule>,
+    #[serde(default)]
+    forbidden_pattern: Vec<ForbiddenPatternRule>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForbiddenRule {
+    labels: Vec<String>,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForbiddenPatternRule {
+    required: String,
+    forbidden_glob: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PullRequestApiResponse {
+    number: u64,
+    #[serde(default)]
+    labels: Vec<LabelObject>,
+    body: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LabelObject {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureInput {
+    number: Option<u64>,
+    event_name: Option<String>,
+    body: Option<String>,
+    labels: Option<Vec<FixtureLabel>>,
+    pull_request: Option<FixturePullRequest>,
+    merge_group: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixturePullRequest {
+    number: Option<u64>,
+    body: Option<String>,
+    labels: Option<Vec<FixtureLabel>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum FixtureLabel {
+    NameOnly(String),
+    NamedObject { name: String },
+}
+
+impl FixtureLabel {
+    fn name(&self) -> &str {
+        match self {
+            FixtureLabel::NameOnly(name) => name.as_str(),
+            FixtureLabel::NamedObject { name } => name.as_str(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct InputState {
+    pr_number: Option<u64>,
+    body: String,
+    labels: BTreeSet<String>,
+    source_kind: String,
+    merge_group_label_unavailable: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct Receipt {
+    gate: &'static str,
+    classification: Classification,
+    mode: &'static str,
+    source: String,
+    pr_number: Option<u64>,
+    labels: Vec<String>,
+    violations: Vec<Violation>,
+    closeout_warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct Violation {
+    labels: Vec<String>,
+    reason: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum Classification {
+    Pass,
+    Warn,
+    Fail,
+    Unknown,
+}
+
+pub fn run(
+    fixture: Option<PathBuf>,
+    pr: Option<u64>,
+    receipt: Option<PathBuf>,
+    enforce: bool,
+    dry_run: bool,
+    format: MethodologyGateFormat,
+) -> Result<()> {
+    if fixture.is_some() == pr.is_some() {
+        bail!("exactly one of --fixture or --pr must be supplied");
+    }
+
+    let root = project_root()?;
+    let policy_path = root.join(".ci/policies/label-contradictions.toml");
+    let policy = load_policy(&policy_path)?;
+    let state = if let Some(fixture_path) = fixture {
+        load_fixture(&fixture_path)?
+    } else if let Some(pr_number) = pr {
+        load_pr(pr_number)?
+    } else {
+        bail!("internal argument handling failure");
+    };
+
+    let mut violations = find_violations(&policy, &state.labels);
+    let closeout_warnings = find_closeout_warnings(&state.body);
+    let classification = if state.merge_group_label_unavailable {
+        Classification::Unknown
+    } else if !violations.is_empty() {
+        if enforce { Classification::Fail } else { Classification::Warn }
+    } else if !closeout_warnings.is_empty() {
+        Classification::Warn
+    } else {
+        Classification::Pass
+    };
+
+    if state.merge_group_label_unavailable {
+        violations.clear();
+    }
+
+    let receipt_body = Receipt {
+        gate: "methodology-gate",
+        classification,
+        mode: if enforce { "enforce" } else { "advisory" },
+        source: state.source_kind,
+        pr_number: state.pr_number,
+        labels: state.labels.into_iter().collect(),
+        violations,
+        closeout_warnings,
+    };
+
+    if let Some(path) = receipt {
+        write_receipt(&path, &receipt_body, dry_run)?;
+    }
+
+    print_output(&receipt_body, format)?;
+
+    if matches!(receipt_body.classification, Classification::Fail) {
+        bail!("Methodology Gate found contradictory PR labels");
+    }
+
+    Ok(())
+}
+
+fn load_policy(path: &Path) -> Result<Policy> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read policy file {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("failed to parse policy file {}", path.display()))
+}
+
+fn load_fixture(path: &Path) -> Result<InputState> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read fixture {}", path.display()))?;
+    let fixture: FixtureInput = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse fixture {}", path.display()))?;
+
+    let event_name = fixture.event_name.unwrap_or_else(|| {
+        if fixture.merge_group.is_some() {
+            "merge_group".to_string()
+        } else if fixture.pull_request.is_some() {
+            "pull_request".to_string()
+        } else {
+            "push".to_string()
+        }
+    });
+    let pull_request = fixture.pull_request;
+    let merged_labels = pull_request
+        .as_ref()
+        .and_then(|pr| pr.labels.as_ref())
+        .or(fixture.labels.as_ref())
+        .map(|labels| labels.iter().map(|label| label.name().to_string()).collect::<BTreeSet<_>>())
+        .unwrap_or_default();
+    let merge_group_label_unavailable = event_name == "merge_group" && merged_labels.is_empty();
+
+    Ok(InputState {
+        pr_number: pull_request.as_ref().and_then(|pr| pr.number).or(fixture.number),
+        body: pull_request
+            .as_ref()
+            .and_then(|pr| pr.body.clone())
+            .or(fixture.body)
+            .unwrap_or_default(),
+        labels: merged_labels,
+        source_kind: format!("fixture:{event_name}"),
+        merge_group_label_unavailable,
+    })
+}
+
+fn load_pr(pr_number: u64) -> Result<InputState> {
+    let output = std::process::Command::new("gh")
+        .args(["api", &format!("repos/{{owner}}/{{repo}}/pulls/{pr_number}")])
+        .output()
+        .context("failed to execute gh api for PR metadata")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("gh api request failed for PR {pr_number}: {stderr}");
+    }
+
+    let response: PullRequestApiResponse =
+        serde_json::from_slice(&output.stdout).context("failed to parse gh api PR response")?;
+
+    let labels = response.labels.into_iter().map(|label| label.name).collect();
+    Ok(InputState {
+        pr_number: Some(response.number),
+        body: response.body.unwrap_or_default(),
+        labels,
+        source_kind: "github-pr".to_string(),
+        merge_group_label_unavailable: false,
+    })
+}
+
+fn find_violations(policy: &Policy, labels: &BTreeSet<String>) -> Vec<Violation> {
+    let mut violations = Vec::new();
+
+    for rule in &policy.forbidden {
+        if rule.labels.iter().all(|label| labels.contains(label)) {
+            violations.push(Violation { labels: rule.labels.clone(), reason: rule.reason.clone() });
+        }
+    }
+
+    for rule in &policy.forbidden_pattern {
+        if labels.contains(&rule.required) {
+            let wildcard =
+                rule.forbidden_glob.strip_suffix('*').unwrap_or(rule.forbidden_glob.as_str());
+            for label in labels {
+                if label.starts_with(wildcard) {
+                    violations.push(Violation {
+                        labels: vec![rule.required.clone(), label.clone()],
+                        reason: rule.reason.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    violations
+}
+
+fn find_closeout_warnings(body: &str) -> Vec<String> {
+    let lowercase = body.to_lowercase();
+    let has_closeout_verb =
+        ["closes #", "fixes #", "resolves #"].iter().any(|token| lowercase.contains(token));
+    let has_partial_marker = ["partial", "scaffold", "umbrella", "follow-up", "phase", "advisory"]
+        .iter()
+        .any(|token| lowercase.contains(token));
+
+    if has_closeout_verb && has_partial_marker {
+        return vec![
+            "PR body appears partial/scaffold/umbrella but uses Closes/Fixes/Resolves; prefer Refs or Part of until full delivery."
+                .to_string(),
+        ];
+    }
+
+    Vec::new()
+}
+
+fn write_receipt(path: &Path, receipt: &Receipt, dry_run: bool) -> Result<()> {
+    if dry_run {
+        return Ok(());
+    }
+
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create receipt directory {}", parent.display()))?;
+    }
+
+    let output = serde_json::to_string_pretty(receipt).context("failed to serialize receipt")?;
+    fs::write(path, output)
+        .with_context(|| format!("failed to write receipt file {}", path.display()))
+}
+
+fn print_output(receipt: &Receipt, format: MethodologyGateFormat) -> Result<()> {
+    match format {
+        MethodologyGateFormat::Human => {
+            println!(
+                "Methodology Gate [{}] classification={:?} labels={} violations={} warnings={}",
+                receipt.mode,
+                receipt.classification,
+                receipt.labels.len(),
+                receipt.violations.len(),
+                receipt.closeout_warnings.len()
+            );
+
+            for violation in &receipt.violations {
+                println!(
+                    "  contradiction: {} ({})",
+                    violation.labels.join(" + "),
+                    violation.reason
+                );
+            }
+            for warning in &receipt.closeout_warnings {
+                println!("  warning: {warning}");
+            }
+            if matches!(receipt.classification, Classification::Unknown) {
+                println!(
+                    "  note: merge_group label data unavailable; pull_request event remains enforcement source"
+                );
+            }
+            Ok(())
+        }
+        MethodologyGateFormat::Json => {
+            let json =
+                serde_json::to_string_pretty(receipt).context("failed to serialize JSON output")?;
+            println!("{json}");
+            Ok(())
+        }
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -48,6 +48,7 @@ pub mod hook_checks;
 pub mod ignored_tests;
 pub mod inject_sha_assets;
 pub mod layer_check;
+pub mod methodology_gate;
 pub mod metrics;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;

--- a/xtask/tests/fixtures/methodology/clean.json
+++ b/xtask/tests/fixtures/methodology/clean.json
@@ -1,0 +1,10 @@
+{
+  "event_name": "pull_request",
+  "number": 100,
+  "body": "Refs #6855\n\nFully aligned label state.",
+  "labels": [
+    "review-reviewed",
+    "diff-audited",
+    "ci-green"
+  ]
+}

--- a/xtask/tests/fixtures/methodology/merge-ready-plus-needs.json
+++ b/xtask/tests/fixtures/methodology/merge-ready-plus-needs.json
@@ -1,0 +1,9 @@
+{
+  "event_name": "pull_request",
+  "number": 102,
+  "body": "Refs #6855\n\nContradictory state fixture.",
+  "labels": [
+    "merge-ready",
+    "needs-ci-fix"
+  ]
+}

--- a/xtask/tests/fixtures/methodology/review-plus-needs-builder.json
+++ b/xtask/tests/fixtures/methodology/review-plus-needs-builder.json
@@ -1,0 +1,9 @@
+{
+  "event_name": "pull_request",
+  "number": 101,
+  "body": "Refs #6855\n\nPartial implementation, advisory rollout.",
+  "labels": [
+    "review-reviewed",
+    "needs-builder-fix"
+  ]
+}


### PR DESCRIPTION
### Motivation

- PR label states can become contradictory (for example `review-reviewed` + `needs-builder-fix`) and there is no deterministic guardrail to catch impossible combinations before merge.
- Provide a cheap, deterministic CI/policy gate that detects impossible label combinations and emits a machine-readable receipt so higher-level reconciler work can follow. 
- Be conservative for merge-queue payloads: if label data is unavailable (merge_group), the gate should classify as `unknown` rather than fail.

### Description

- Add a policy file `.ci/policies/label-contradictions.toml` that encodes exact `[[forbidden]]` rules and prefix-style `[[forbidden_pattern]]` rules (e.g. `merge-ready` / `auto-merge` vs `needs-*`).
- Implement `cargo xtask methodology-gate` in `xtask/src/tasks/methodology_gate.rs` with `--fixture` / `--pr` modes, `--receipt`, `--enforce`, `--dry-run`, and `--format` support, and wire into the CLI in `xtask/src/main.rs` and `xtask/src/tasks/mod.rs`.
- Add a lightweight GitHub Actions workflow `.github/workflows/methodology-gate.yml` that runs on `pull_request`, `merge_group`, and `push` to `master`, uses event-aware concurrency, and always uploads `target/receipts/methodology-gate.json` if present.
- Add docs `docs/ci/methodology-gate.md`, three fixture payloads under `xtask/tests/fixtures/methodology/`, and include the workflow in the CI audit allowlist.

### Testing

- Ran `cargo check -p xtask` and `cargo check --all-targets -p xtask`, both succeeded. 
- Ran `cargo clippy -p xtask` and `cargo xtask fmt`, both succeeded. 
- Verified advisory pass with `cargo xtask methodology-gate --fixture xtask/tests/fixtures/methodology/clean.json --receipt target/receipts/methodology-gate.json` which produced a `Pass` receipt. 
- Verified enforcement failures with `cargo xtask methodology-gate --fixture xtask/tests/fixtures/methodology/review-plus-needs-builder.json --receipt target/receipts/methodology-gate.json --enforce` (failed as expected) and `cargo xtask methodology-gate --fixture xtask/tests/fixtures/methodology/merge-ready-plus-needs.json --receipt target/receipts/methodology-gate.json --enforce` (failed as expected). 
- Note: `just pr-fast` was not available in this environment so that step was not executed here.

Refs #6855
Refs #6853

Mode: advisory by default; use `--enforce` to make contradictions fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd059d7108333a30d4e542fe53726)