### PR TITLE
feat(ci): add Methodology Gate for contradictory PR labels (#6855)

### DIFF
--- a/.ci/policies/label-contradictions.toml
+++ b/.ci/policies/label-contradictions.toml
@@ -1,0 +1,29 @@
+[[forbidden]]
+labels = ["review-reviewed", "needs-builder-fix"]
+reason = "sign-off and builder route are mutually exclusive"
+
+[[forbidden]]
+labels = ["diff-audited", "needs-diff-fix"]
+reason = "diff sign-off and diff-fix routing are mutually exclusive"
+
+[[forbidden]]
+labels = ["maintainer-pr-reviewed", "needs-maintainer-fix"]
+reason = "maintainer sign-off and maintainer-fix routing are mutually exclusive"
+
+[[forbidden]]
+labels = ["ci-green", "needs-ci-fix"]
+reason = "ci-green cannot coexist with active CI remediation"
+
+[[forbidden]]
+labels = ["deep-reviewed", "needs-deep-review"]
+reason = "deep-reviewed cannot coexist with needs-deep-review"
+
+[[forbidden_pattern]]
+required = "merge-ready"
+forbidden_glob = "needs-*"
+reason = "merge-ready cannot coexist with any active blocker"
+
+[[forbidden_pattern]]
+required = "auto-merge"
+forbidden_glob = "needs-*"
+reason = "auto-merge cannot coexist with any active blocker"

--- a/.github/workflows/methodology-gate.yml
+++ b/.github/workflows/methodology-gate.yml
@@ -1,0 +1,68 @@
+name: Methodology Gate
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  methodology-gate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run methodology gate (advisory)
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          mkdir -p target/receipts
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            cargo xtask methodology-gate \
+              --pr "${{ github.event.pull_request.number }}" \
+              --receipt target/receipts/methodology-gate.json
+          elif [ "${{ github.event_name }}" = "merge_group" ]; then
+            cat > target/methodology-merge-group.json <<'JSON'
+          {
+            "labels": [],
+            "merge_group_lookup_unavailable": true,
+            "body": ""
+          }
+          JSON
+            cargo xtask methodology-gate \
+              --fixture target/methodology-merge-group.json \
+              --receipt target/receipts/methodology-gate.json
+          else
+            cat > target/methodology-push.json <<'JSON'
+          {
+            "labels": [],
+            "merge_group_lookup_unavailable": true,
+            "body": ""
+          }
+          JSON
+            cargo xtask methodology-gate \
+              --fixture target/methodology-push.json \
+              --receipt target/receipts/methodology-gate.json
+          fi
+
+      - name: Upload methodology gate receipt
+        if: always() && hashFiles('target/receipts/methodology-gate.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: methodology-gate-receipt
+          path: target/receipts/methodology-gate.json

--- a/docs/ci/methodology-gate.md
+++ b/docs/ci/methodology-gate.md
@@ -1,0 +1,58 @@
+# Methodology Gate
+
+The Methodology Gate is a deterministic policy check for contradictory PR state labels.
+
+## What it checks
+
+Policy source: `.ci/policies/label-contradictions.toml`.
+
+Current contradictions:
+
+- `review-reviewed` + `needs-builder-fix`
+- `diff-audited` + `needs-diff-fix`
+- `maintainer-pr-reviewed` + `needs-maintainer-fix`
+- `ci-green` + `needs-ci-fix`
+- `deep-reviewed` + `needs-deep-review`
+- `merge-ready` + any `needs-*`
+- `auto-merge` + any `needs-*`
+
+## Modes
+
+- **Advisory (default):** contradictions produce warnings and a receipt classification of `warn`.
+- **Enforce (`--enforce`):** contradictions fail the command and produce a receipt classification of `fail`.
+
+## Commands
+
+```bash
+cargo xtask methodology-gate --fixture <json> --receipt target/receipts/methodology-gate.json
+cargo xtask methodology-gate --pr <number> --receipt target/receipts/methodology-gate.json
+cargo xtask methodology-gate --fixture <json> --receipt target/receipts/methodology-gate.json --enforce
+```
+
+Optional flags:
+
+- `--dry-run` evaluates policy but skips writing the receipt file.
+- `--format json` prints machine-readable output to stdout.
+
+## Receipt semantics
+
+The gate emits `target/receipts/methodology-gate.json` when requested.
+
+Classification values:
+
+- `pass`: no contradictions detected.
+- `warn`: contradictions detected in advisory mode.
+- `fail`: contradictions detected in enforce mode.
+- `unknown`: lookup not available (for example, merge queue contexts where labels are unavailable).
+
+For `merge_group` events, label lookup may be unavailable. In that case the workflow records
+`classification = "unknown"` and defers strict label enforcement to `pull_request` runs.
+
+## Closeout hygiene
+
+The gate currently emits a conservative warning (not a failure) when PR body text combines:
+
+- closing keywords (`Closes`, `Fixes`, `Resolves`) and
+- partial/scaffold/umbrella language.
+
+Use `Refs` or `Part of` for partial implementations.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,6 +13,7 @@ mod utils;
 use tasks::check_test_wiring;
 use tasks::dead_code::{DeadCodeConfig, DeadCodeMode};
 use tasks::gates::{GateTier, OutputFormat};
+use tasks::methodology_gate::MethodologyGateOutputFormat;
 use tasks::metrics;
 use tasks::targeted_checks::CheckMode;
 use tasks::unwired_scan::UnwiredScanConfig;
@@ -1059,6 +1060,33 @@ enum Commands {
         verbose: bool,
     },
 
+    /// Detect contradictory PR methodology labels and emit a receipt.
+    MethodologyGate {
+        /// Read PR labels/body from a local JSON fixture.
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+
+        /// Read PR labels/body from GitHub for the given PR number.
+        #[arg(long)]
+        pr: Option<u64>,
+
+        /// Receipt output path (for CI artifact upload).
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+
+        /// Enforce mode (fail on contradictions). Default is advisory.
+        #[arg(long)]
+        enforce: bool,
+
+        /// Dry-run mode (evaluate but do not write receipt file).
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Output format.
+        #[arg(long, value_enum, default_value = "human")]
+        format: MethodologyGateOutputFormat,
+    },
+
     /// Verify hook scripts are executable.
     HookCheck,
 
@@ -1663,6 +1691,16 @@ fn main() -> Result<()> {
             parallel,
             verbose,
         }),
+        Commands::MethodologyGate { fixture, pr, receipt, enforce, dry_run, format } => {
+            methodology_gate::run(methodology_gate::MethodologyGateConfig {
+                fixture,
+                pr,
+                receipt,
+                enforce,
+                dry_run,
+                format,
+            })
+        }
         Commands::TargetedChecks { base, mode } => targeted_checks::run(base, mode),
         Commands::ResolvePackageName { crate_dir } => {
             // Use the current working directory as workspace root so this subcommand

--- a/xtask/src/tasks/ci_audit_workflows.rs
+++ b/xtask/src/tasks/ci_audit_workflows.rs
@@ -23,6 +23,8 @@ const ALLOWED_WORKFLOWS: &[&str] = &[
     // ci-gate-self-tests.yml is path-filtered to gate scripts only.
     // Runs only when the gate scripts or self-test scripts change.
     "ci-gate-self-tests.yml",
+    // methodology-gate.yml is a low-cost policy check that runs across PR states.
+    "methodology-gate.yml",
 ];
 
 const ALLOWED_UNGATED_JOBS: &[&str] = &["tautology-check", "test-metrics", "fmt", "clippy"];

--- a/xtask/src/tasks/methodology_gate.rs
+++ b/xtask/src/tasks/methodology_gate.rs
@@ -1,0 +1,392 @@
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const DEFAULT_POLICY_PATH: &str = ".ci/policies/label-contradictions.toml";
+
+#[derive(Debug, Clone)]
+pub struct MethodologyGateConfig {
+    pub fixture: Option<PathBuf>,
+    pub pr: Option<u64>,
+    pub receipt: Option<PathBuf>,
+    pub enforce: bool,
+    pub dry_run: bool,
+    pub format: MethodologyGateOutputFormat,
+}
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum MethodologyGateOutputFormat {
+    Human,
+    Json,
+}
+
+#[derive(Debug, Deserialize)]
+struct LabelPolicy {
+    #[serde(default)]
+    forbidden: Vec<ForbiddenRule>,
+    #[serde(default)]
+    forbidden_pattern: Vec<ForbiddenPatternRule>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForbiddenRule {
+    labels: Vec<String>,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ForbiddenPatternRule {
+    required: String,
+    forbidden_glob: String,
+    reason: String,
+}
+
+#[derive(Debug, Serialize)]
+struct MethodologyReceipt {
+    gate: &'static str,
+    mode: &'static str,
+    classification: &'static str,
+    source: &'static str,
+    enforce: bool,
+    contradictions: Vec<Contradiction>,
+    warnings: Vec<String>,
+    labels: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct Contradiction {
+    rule: String,
+    reason: String,
+    labels: Vec<String>,
+}
+
+#[derive(Debug)]
+struct InputState {
+    labels: BTreeSet<String>,
+    body: Option<String>,
+    merge_group_lookup_unavailable: bool,
+}
+
+pub fn run(config: MethodologyGateConfig) -> Result<()> {
+    if config.fixture.is_some() == config.pr.is_some() {
+        bail!("provide exactly one of --fixture or --pr");
+    }
+
+    let policy_path = crate::utils::project_root()?.join(DEFAULT_POLICY_PATH);
+    let policy = read_policy(&policy_path)?;
+
+    let (source, state) = if let Some(fixture_path) = &config.fixture {
+        ("fixture", read_input_state_from_fixture(fixture_path)?)
+    } else if let Some(pr_number) = config.pr {
+        ("pr", read_input_state_from_pr(pr_number)?)
+    } else {
+        bail!("either --fixture or --pr is required");
+    };
+
+    let receipt = evaluate(&policy, state, source, config.enforce);
+    emit_output(&receipt, config.format)?;
+    write_receipt_if_requested(&receipt, config.receipt.as_deref(), config.dry_run)?;
+
+    if config.enforce && !receipt.contradictions.is_empty() {
+        bail!("methodology-gate found contradictory methodology labels");
+    }
+
+    Ok(())
+}
+
+fn read_policy(path: &Path) -> Result<LabelPolicy> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read policy file {}", path.display()))?;
+    let parsed = toml::from_str::<LabelPolicy>(&raw)
+        .with_context(|| format!("failed to parse policy file {}", path.display()))?;
+    Ok(parsed)
+}
+
+fn read_input_state_from_fixture(path: &Path) -> Result<InputState> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read fixture {}", path.display()))?;
+    let value: Value = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse fixture {}", path.display()))?;
+    input_state_from_value(&value)
+}
+
+fn read_input_state_from_pr(pr_number: u64) -> Result<InputState> {
+    let repo = std::env::var("GITHUB_REPOSITORY")
+        .context("GITHUB_REPOSITORY must be set (example: EffortlessMetrics/perl-lsp)")?;
+    let endpoint = format!("repos/{repo}/pulls/{pr_number}");
+    let output = Command::new("gh")
+        .args(["api", endpoint.as_str()])
+        .output()
+        .context("failed to execute `gh api` to read PR labels")?;
+
+    if !output.status.success() {
+        bail!(
+            "gh api request failed while reading PR {}: {}",
+            pr_number,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let body = String::from_utf8(output.stdout)
+        .context("gh api returned non-UTF8 output while reading PR")?;
+    let value: Value = serde_json::from_str(&body)
+        .context("failed to parse gh api JSON payload for PR")?;
+    input_state_from_value(&value)
+}
+
+fn input_state_from_value(value: &Value) -> Result<InputState> {
+    let labels = extract_labels(value)?;
+    let body = value.get("body").and_then(Value::as_str).map(ToString::to_string);
+    let merge_group_lookup_unavailable = value
+        .get("merge_group_lookup_unavailable")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    Ok(InputState {
+        labels,
+        body,
+        merge_group_lookup_unavailable,
+    })
+}
+
+fn extract_labels(value: &Value) -> Result<BTreeSet<String>> {
+    let labels_value = value
+        .get("labels")
+        .ok_or_else(|| color_eyre::eyre::eyre!("input must include a top-level `labels` array"))?;
+    let labels = labels_value
+        .as_array()
+        .ok_or_else(|| color_eyre::eyre::eyre!("input field `labels` must be an array"))?;
+
+    let mut out = BTreeSet::new();
+    for label in labels {
+        if let Some(name) = label.as_str() {
+            out.insert(name.to_string());
+            continue;
+        }
+        if let Some(name) = label.get("name").and_then(Value::as_str) {
+            out.insert(name.to_string());
+            continue;
+        }
+        bail!("label entries must be strings or objects with a `name` field");
+    }
+    Ok(out)
+}
+
+fn evaluate(
+    policy: &LabelPolicy,
+    state: InputState,
+    source: &'static str,
+    enforce: bool,
+) -> MethodologyReceipt {
+    if state.merge_group_lookup_unavailable {
+        return MethodologyReceipt {
+            gate: "methodology-gate",
+            mode: if enforce { "enforce" } else { "advisory" },
+            classification: "unknown",
+            source,
+            enforce,
+            contradictions: Vec::new(),
+            warnings: vec![
+                "merge_group label lookup unavailable; enforcement is deferred to pull_request runs"
+                    .to_string(),
+            ],
+            labels: state.labels.into_iter().collect(),
+        };
+    }
+
+    let mut contradictions = Vec::new();
+    for rule in &policy.forbidden {
+        let matched: Vec<String> = rule
+            .labels
+            .iter()
+            .filter(|label| state.labels.contains(*label))
+            .cloned()
+            .collect();
+        if matched.len() == rule.labels.len() {
+            contradictions.push(Contradiction {
+                rule: format!("all({})", rule.labels.join(", ")),
+                reason: rule.reason.clone(),
+                labels: matched,
+            });
+        }
+    }
+
+    for rule in &policy.forbidden_pattern {
+        if !state.labels.contains(&rule.required) {
+            continue;
+        }
+        let prefix = rule.forbidden_glob.strip_suffix('*');
+        let matched: Vec<String> = state
+            .labels
+            .iter()
+            .filter(|label| {
+                if let Some(prefix) = prefix {
+                    label.starts_with(prefix)
+                } else {
+                    *label == &rule.forbidden_glob
+                }
+            })
+            .cloned()
+            .collect();
+
+        if !matched.is_empty() {
+            let mut labels = Vec::with_capacity(matched.len() + 1);
+            labels.push(rule.required.clone());
+            labels.extend(matched);
+            contradictions.push(Contradiction {
+                rule: format!("{} + {}", rule.required, rule.forbidden_glob),
+                reason: rule.reason.clone(),
+                labels,
+            });
+        }
+    }
+
+    let mut warnings = Vec::new();
+    if let Some(body) = &state.body
+        && has_closeout_hygiene_risk(body)
+    {
+        warnings.push(
+            "PR body uses closing keywords with partial/scaffold/umbrella language; prefer Refs/Part of for partial work".to_string(),
+        );
+    }
+
+    let classification = if contradictions.is_empty() {
+        "pass"
+    } else if enforce {
+        "fail"
+    } else {
+        "warn"
+    };
+
+    MethodologyReceipt {
+        gate: "methodology-gate",
+        mode: if enforce { "enforce" } else { "advisory" },
+        classification,
+        source,
+        enforce,
+        contradictions,
+        warnings,
+        labels: state.labels.into_iter().collect(),
+    }
+}
+
+fn has_closeout_hygiene_risk(body: &str) -> bool {
+    let lower = body.to_ascii_lowercase();
+    let has_closer = ["closes", "fixes", "resolves"].iter().any(|token| lower.contains(token));
+    let has_partial = ["partial", "scaffold", "umbrella"]
+        .iter()
+        .any(|token| lower.contains(token));
+    has_closer && has_partial
+}
+
+fn emit_output(receipt: &MethodologyReceipt, format: MethodologyGateOutputFormat) -> Result<()> {
+    match format {
+        MethodologyGateOutputFormat::Human => {
+            println!(
+                "Methodology Gate ({}) => {}",
+                receipt.mode,
+                receipt.classification
+            );
+            if receipt.contradictions.is_empty() {
+                println!("No contradictory label states detected.");
+            } else {
+                println!("Contradictions:");
+                for contradiction in &receipt.contradictions {
+                    println!(
+                        "- {} [{}]",
+                        contradiction.reason,
+                        contradiction.labels.join(", ")
+                    );
+                }
+            }
+            for warning in &receipt.warnings {
+                println!("warning: {warning}");
+            }
+        }
+        MethodologyGateOutputFormat::Json => {
+            let json = serde_json::to_string_pretty(receipt)
+                .context("failed to serialize methodology gate output JSON")?;
+            println!("{json}");
+        }
+    }
+
+    Ok(())
+}
+
+fn write_receipt_if_requested(
+    receipt: &MethodologyReceipt,
+    receipt_path: Option<&Path>,
+    dry_run: bool,
+) -> Result<()> {
+    if let Some(path) = receipt_path {
+        if dry_run {
+            println!("dry-run: skipping receipt write to {}", path.display());
+            return Ok(());
+        }
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create receipt directory {}", parent.display()))?;
+        }
+        let json = serde_json::to_string_pretty(receipt)
+            .context("failed to serialize methodology gate receipt")?;
+        fs::write(path, format!("{json}\n"))
+            .with_context(|| format!("failed to write receipt {}", path.display()))?;
+        println!("receipt: {}", path.display());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_pair_and_pattern_contradictions() -> Result<()> {
+        let policy: LabelPolicy = toml::from_str(
+            r#"
+            [[forbidden]]
+            labels = ["review-reviewed", "needs-builder-fix"]
+            reason = "mutually exclusive"
+
+            [[forbidden_pattern]]
+            required = "merge-ready"
+            forbidden_glob = "needs-*"
+            reason = "cannot merge with blockers"
+            "#,
+        )?;
+
+        let state = InputState {
+            labels: BTreeSet::from([
+                "review-reviewed".to_string(),
+                "needs-builder-fix".to_string(),
+                "merge-ready".to_string(),
+                "needs-ci-fix".to_string(),
+            ]),
+            body: None,
+            merge_group_lookup_unavailable: false,
+        };
+
+        let receipt = evaluate(&policy, state, "fixture", true);
+        assert_eq!(receipt.classification, "fail");
+        assert_eq!(receipt.contradictions.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_when_merge_group_lookup_is_unavailable() -> Result<()> {
+        let policy: LabelPolicy = toml::from_str("")?;
+        let state = InputState {
+            labels: BTreeSet::new(),
+            body: None,
+            merge_group_lookup_unavailable: true,
+        };
+
+        let receipt = evaluate(&policy, state, "fixture", false);
+        assert_eq!(receipt.classification, "unknown");
+        Ok(())
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -49,6 +49,7 @@ pub mod ignored_tests;
 pub mod inject_sha_assets;
 pub mod layer_check;
 pub mod metrics;
+pub mod methodology_gate;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;
 pub mod parser_matrix;

--- a/xtask/tests/fixtures/methodology/clean.json
+++ b/xtask/tests/fixtures/methodology/clean.json
@@ -1,0 +1,10 @@
+{
+  "labels": [
+    "review-reviewed",
+    "diff-audited",
+    "maintainer-pr-reviewed",
+    "ci-green",
+    "deep-reviewed"
+  ],
+  "body": "Refs #6855"
+}

--- a/xtask/tests/fixtures/methodology/merge-ready-plus-needs.json
+++ b/xtask/tests/fixtures/methodology/merge-ready-plus-needs.json
@@ -1,0 +1,8 @@
+{
+  "labels": [
+    "merge-ready",
+    "needs-ci-fix",
+    "ci-green"
+  ],
+  "body": "Partial scaffold; closes #6855"
+}

--- a/xtask/tests/fixtures/methodology/review-plus-needs-builder.json
+++ b/xtask/tests/fixtures/methodology/review-plus-needs-builder.json
@@ -1,0 +1,7 @@
+{
+  "labels": [
+    "review-reviewed",
+    "needs-builder-fix"
+  ],
+  "body": "Refs #6855"
+}


### PR DESCRIPTION
### Motivation

- Prevent impossible PR label combinations (e.g. `review-reviewed` + `needs-builder-fix`) from silently merging by adding a deterministic CI-level policy check. 
- Provide an early, conservative advisory layer that detects contradictions and emits a machine-readable receipt while deferring final state reconciliation to a later reconciler. 

### Description

- Add a label contradiction policy at `.ci/policies/label-contradictions.toml` encoding pair and pattern rules (including `merge-ready`/`auto-merge` vs `needs-*`).
- Implement `cargo xtask methodology-gate` in `xtask/src/tasks/methodology_gate.rs` with `--fixture`, `--pr`, `--receipt`, `--dry-run`, `--format json|human`, and `--enforce` modes and conservative closeout-hygiene warnings.
- Wire the command into the xtask CLI and task registry (`xtask/src/main.rs`, `xtask/src/tasks/mod.rs`) and add fixtures under `xtask/tests/fixtures/methodology/` plus docs at `docs/ci/methodology-gate.md`.
- Add a GitHub Actions workflow `.github/workflows/methodology-gate.yml` to run on `pull_request`, `merge_group`, and `push: master`, emit event-aware concurrency, treat merge-group label lookups as `unknown`, and upload `target/receipts/methodology-gate.json` when present.
- Update CI workflow audit allowlist to include `methodology-gate.yml` so the repo audit task recognizes the new workflow.

### Testing

- `cargo check -p xtask` succeeded.
- `cargo xtask methodology-gate --fixture xtask/tests/fixtures/methodology/clean.json --receipt target/receipts/methodology-gate.json` succeeded and wrote a receipt with `classification = "pass"`.
- `cargo xtask methodology-gate --fixture xtask/tests/fixtures/methodology/review-plus-needs-builder.json --receipt target/receipts/methodology-gate.json --enforce` failed as expected and wrote a receipt showing the contradiction.
- `cargo xtask methodology-gate --fixture xtask/tests/fixtures/methodology/merge-ready-plus-needs.json --receipt target/receipts/methodology-gate.json --enforce` failed as expected and produced warnings for closeout hygiene.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd059d7108333a30d4e542fe53726)