### PR TITLE
feat(receipts): add gate receipt schema registry (#6856)

### DIFF
--- a/.ci/receipts/registry.toml
+++ b/.ci/receipts/registry.toml
@@ -1,0 +1,41 @@
+[[schemas]]
+name = "common-gate-receipt"
+schema = ".ci/receipts/schemas/common-gate-receipt.schema.json"
+description = "Common minimal receipt contract used by all CI/control-plane receipts"
+checks = ["common-gate-receipt"]
+
+[[schemas]]
+name = "parser-ratchet"
+schema = ".ci/receipts/schemas/parser-ratchet.schema.json"
+description = "Parser ratchet compatibility receipt schema (substrate for #6854 evolution)"
+checks = ["parser-ratchet"]
+
+[[schemas]]
+name = "methodology-gate"
+schema = ".ci/receipts/schemas/methodology-gate.schema.json"
+description = "Methodology gate selection and verdict receipt"
+checks = ["methodology-gate"]
+
+[[schemas]]
+name = "aggregator"
+schema = ".ci/receipts/schemas/aggregator-receipt.schema.json"
+description = "Aggregator roll-up verdict receipt"
+checks = ["aggregator"]
+
+[[schemas]]
+name = "merge-readiness"
+schema = ".ci/receipts/schemas/merge-readiness.schema.json"
+description = "Merge readiness classification receipt"
+checks = ["merge-readiness"]
+
+[[schemas]]
+name = "fmt"
+schema = ".ci/receipts/schemas/fmt.schema.json"
+description = "Formatting gate receipt"
+checks = ["fmt"]
+
+[[schemas]]
+name = "failure-classifier"
+schema = ".ci/receipts/schemas/failure-classifier.schema.json"
+description = "Failure classification receipt"
+checks = ["failure-classifier"]

--- a/.ci/receipts/schemas/aggregator-receipt.schema.json
+++ b/.ci/receipts/schemas/aggregator-receipt.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/aggregator-receipt.schema.json",
+  "title": "Gate aggregator receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check", "schema_version", "event", "verdict"],
+      "properties": {
+        "check": { "const": "aggregator" },
+        "selected": { "type": "array", "items": { "type": "string" } },
+        "metrics": { "type": "object" },
+        "artifacts": { "type": "array", "items": { "type": "object" } }
+      },
+      "additionalProperties": true
+    }
+  ]
+}

--- a/.ci/receipts/schemas/common-gate-receipt.schema.json
+++ b/.ci/receipts/schemas/common-gate-receipt.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/common-gate-receipt.schema.json",
+  "title": "Common CI/control-plane gate receipt",
+  "type": "object",
+  "required": ["check", "schema_version", "event", "verdict"],
+  "additionalProperties": true,
+  "properties": {
+    "check": { "type": "string", "minLength": 1 },
+    "schema_version": { "type": "string", "minLength": 1 },
+    "event": {
+      "type": "string",
+      "enum": ["pull_request", "merge_group", "push", "local"]
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "fail", "warn", "skipped"]
+    },
+    "run_id": { "type": ["string", "integer"] },
+    "pr": { "type": "integer", "minimum": 1 },
+    "base_sha": { "type": "string" },
+    "head_sha": { "type": "string" },
+    "candidate_sha": { "type": "string" },
+    "selected": { "type": "array", "items": { "type": "string" } },
+    "selection_reason": { "type": "string" },
+    "classification": {
+      "type": "string",
+      "enum": [
+        "code_regression",
+        "infra_failure",
+        "stale_base",
+        "master_red",
+        "skipped",
+        "unknown"
+      ]
+    },
+    "violations": { "type": "array", "items": { "type": "object" } },
+    "metrics": { "type": "object" },
+    "artifacts": { "type": "array", "items": { "type": "object" } },
+    "repro": {
+      "type": "object",
+      "properties": {
+        "command": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "runner": { "type": "object" }
+  }
+}

--- a/.ci/receipts/schemas/failure-classifier.schema.json
+++ b/.ci/receipts/schemas/failure-classifier.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/failure-classifier.schema.json",
+  "title": "Failure classifier receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check", "schema_version", "event", "verdict", "classification"],
+      "properties": {
+        "check": { "const": "failure-classifier" },
+        "classification": {
+          "type": "string",
+          "enum": [
+            "code_regression",
+            "infra_failure",
+            "stale_base",
+            "master_red",
+            "skipped",
+            "unknown"
+          ]
+        },
+        "selection_reason": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  ]
+}

--- a/.ci/receipts/schemas/fmt.schema.json
+++ b/.ci/receipts/schemas/fmt.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/fmt.schema.json",
+  "title": "Formatting gate receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check", "schema_version", "event", "verdict"],
+      "properties": {
+        "check": { "const": "fmt" },
+        "violations": { "type": "array", "items": { "type": "object" } },
+        "repro": {
+          "type": "object",
+          "properties": {
+            "command": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  ]
+}

--- a/.ci/receipts/schemas/merge-readiness.schema.json
+++ b/.ci/receipts/schemas/merge-readiness.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/merge-readiness.schema.json",
+  "title": "Merge readiness receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check", "schema_version", "event", "verdict"],
+      "properties": {
+        "check": { "const": "merge-readiness" },
+        "classification": {
+          "type": "string",
+          "enum": [
+            "code_regression",
+            "infra_failure",
+            "stale_base",
+            "master_red",
+            "skipped",
+            "unknown"
+          ]
+        }
+      },
+      "additionalProperties": true
+    }
+  ]
+}

--- a/.ci/receipts/schemas/methodology-gate.schema.json
+++ b/.ci/receipts/schemas/methodology-gate.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/methodology-gate.schema.json",
+  "title": "Methodology gate receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check", "schema_version", "event", "verdict"],
+      "properties": {
+        "check": { "const": "methodology-gate" },
+        "selected": { "type": "array", "items": { "type": "string" } },
+        "selection_reason": { "type": "string" },
+        "violations": { "type": "array", "items": { "type": "object" } }
+      },
+      "additionalProperties": true
+    }
+  ]
+}

--- a/.ci/receipts/schemas/parser-ratchet.schema.json
+++ b/.ci/receipts/schemas/parser-ratchet.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/parser-ratchet.schema.json",
+  "title": "Parser ratchet gate receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check", "schema_version", "event", "verdict"],
+      "properties": {
+        "check": { "const": "parser-ratchet" },
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "baseline_error_rate": { "type": "number", "minimum": 0 },
+            "current_error_rate": { "type": "number", "minimum": 0 },
+            "delta_error_rate": { "type": "number" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  ]
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,6 +12,7 @@ mod types;
 mod utils;
 use tasks::check_test_wiring;
 use tasks::dead_code::{DeadCodeConfig, DeadCodeMode};
+use tasks::gate_receipts::OutputFormat as GateReceiptOutputFormat;
 use tasks::gates::{GateTier, OutputFormat};
 use tasks::metrics;
 use tasks::targeted_checks::CheckMode;
@@ -853,6 +854,16 @@ enum Commands {
         test_threads: u32,
     },
 
+    /// Validate CI/control-plane gate receipt schemas from .ci/receipts/registry.toml.
+    GateReceipts {
+        /// Output format.
+        #[arg(long, value_enum, default_value = "human")]
+        format: GateReceiptsFormat,
+
+        #[command(subcommand)]
+        command: GateReceiptsCommand,
+    },
+
     /// Track ignored tests and enforce gate policy
     IgnoredTests {
         /// Write current counts back to baseline
@@ -1220,6 +1231,24 @@ enum CpanCorpusCommand {
 }
 
 #[derive(Subcommand)]
+enum GateReceiptsCommand {
+    /// List registered receipt schemas.
+    List,
+
+    /// Validate a single receipt JSON against registry-selected schema.
+    Validate {
+        /// Path to receipt JSON.
+        path: PathBuf,
+    },
+
+    /// Validate all receipt JSON files under a directory.
+    ValidateAll {
+        /// Directory to scan recursively for *.json receipt files.
+        dir: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
 enum FeaturesCommand {
     /// Sync documentation from features.toml
     SyncDocs,
@@ -1301,6 +1330,12 @@ enum MetricsCommand {
         #[arg(long)]
         input: Option<PathBuf>,
     },
+}
+
+#[derive(ValueEnum, Clone)]
+enum GateReceiptsFormat {
+    Human,
+    Json,
 }
 
 #[derive(ValueEnum, Clone)]
@@ -1578,6 +1613,19 @@ fn main() -> Result<()> {
                 output_dir,
                 test_threads,
             })
+        }
+        Commands::GateReceipts { format, command } => {
+            let output = match format {
+                GateReceiptsFormat::Human => GateReceiptOutputFormat::Human,
+                GateReceiptsFormat::Json => GateReceiptOutputFormat::Json,
+            };
+            match command {
+                GateReceiptsCommand::List => gate_receipts::list(output),
+                GateReceiptsCommand::Validate { path } => gate_receipts::validate(&path, output),
+                GateReceiptsCommand::ValidateAll { dir } => {
+                    gate_receipts::validate_all(&dir, output)
+                }
+            }
         }
         Commands::IgnoredTests { update, check, verbose } => {
             ignored_tests::run(update, check, verbose)

--- a/xtask/src/tasks/gate_receipts.rs
+++ b/xtask/src/tasks/gate_receipts.rs
@@ -1,0 +1,288 @@
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use std::ffi::OsStr;
+use std::fs;
+use std::path::Path;
+use walkdir::WalkDir;
+
+use crate::utils::project_root;
+
+const REGISTRY_PATH: &str = ".ci/receipts/registry.toml";
+
+const COMMON_REQUIRED_FIELDS: [&str; 4] = ["check", "schema_version", "event", "verdict"];
+const SUPPORTED_VERDICTS: [&str; 4] = ["pass", "fail", "warn", "skipped"];
+const SUPPORTED_EVENTS: [&str; 4] = ["pull_request", "merge_group", "push", "local"];
+const SUPPORTED_CLASSIFICATIONS: [&str; 6] =
+    ["code_regression", "infra_failure", "stale_base", "master_red", "skipped", "unknown"];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OutputFormat {
+    Human,
+    Json,
+}
+
+#[derive(Debug, Deserialize)]
+struct Registry {
+    schemas: Vec<RegistrySchema>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct RegistrySchema {
+    name: String,
+    schema: String,
+    description: String,
+    checks: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TopLevelSchema {
+    required: Option<Vec<String>>,
+    properties: Option<Map<String, Value>>,
+}
+
+#[derive(Debug, Serialize)]
+struct ValidationOutcome {
+    path: String,
+    ok: bool,
+    check: Option<String>,
+    schema: Option<String>,
+    errors: Vec<String>,
+}
+
+pub fn list(format: OutputFormat) -> Result<()> {
+    let registry = load_registry()?;
+    match format {
+        OutputFormat::Human => {
+            for schema in &registry.schemas {
+                println!(
+                    "{}\n  schema: {}\n  checks: {}\n  description: {}",
+                    schema.name,
+                    schema.schema,
+                    schema.checks.join(", "),
+                    schema.description
+                );
+            }
+        }
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&json!({"schemas": registry.schemas}))?);
+        }
+    }
+    Ok(())
+}
+
+pub fn validate(path: &Path, format: OutputFormat) -> Result<()> {
+    let registry = load_registry()?;
+    let outcome = validate_path(path, &registry)?;
+    emit_outcome(&outcome, format)?;
+    if outcome.ok { Ok(()) } else { bail!("gate receipt validation failed: {}", path.display()) }
+}
+
+pub fn validate_all(dir: &Path, format: OutputFormat) -> Result<()> {
+    let registry = load_registry()?;
+    let mut outcomes = Vec::new();
+
+    for entry in WalkDir::new(dir).into_iter().filter_map(Result::ok) {
+        let path = entry.path();
+        if entry.file_type().is_file() && path.extension() == Some(OsStr::new("json")) {
+            outcomes.push(validate_path(path, &registry)?);
+        }
+    }
+
+    let has_failures = outcomes.iter().any(|o| !o.ok);
+    match format {
+        OutputFormat::Human => {
+            for outcome in &outcomes {
+                if outcome.ok {
+                    println!("PASS {}", outcome.path);
+                } else {
+                    println!("FAIL {}", outcome.path);
+                    for error in &outcome.errors {
+                        println!("  - {error}");
+                    }
+                }
+            }
+        }
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json!({
+                    "ok": !has_failures,
+                    "count": outcomes.len(),
+                    "results": outcomes
+                }))?
+            );
+        }
+    }
+
+    if has_failures {
+        bail!("one or more gate receipts failed validation")
+    }
+    Ok(())
+}
+
+fn emit_outcome(outcome: &ValidationOutcome, format: OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Human => {
+            if outcome.ok {
+                println!(
+                    "PASS {} (check: {}, schema: {})",
+                    outcome.path,
+                    outcome.check.as_deref().unwrap_or("unknown"),
+                    outcome.schema.as_deref().unwrap_or("unknown")
+                );
+            } else {
+                println!("FAIL {}", outcome.path);
+                for error in &outcome.errors {
+                    println!("  - {error}");
+                }
+            }
+        }
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(outcome)?),
+    }
+
+    Ok(())
+}
+
+fn validate_path(path: &Path, registry: &Registry) -> Result<ValidationOutcome> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let doc: Value = serde_json::from_str(&raw)
+        .with_context(|| format!("parsing JSON receipt {}", path.display()))?;
+
+    let mut errors = Vec::new();
+    let obj = match doc.as_object() {
+        Some(obj) => obj,
+        None => {
+            return Ok(ValidationOutcome {
+                path: path.display().to_string(),
+                ok: false,
+                check: None,
+                schema: None,
+                errors: vec!["receipt root must be an object".to_string()],
+            });
+        }
+    };
+
+    let check = obj.get("check").and_then(Value::as_str).map(ToOwned::to_owned);
+    let Some(check_name) = check.clone() else {
+        return Ok(ValidationOutcome {
+            path: path.display().to_string(),
+            ok: false,
+            check,
+            schema: None,
+            errors: vec!["missing required field: check".to_string()],
+        });
+    };
+
+    let schema_entry =
+        registry.schemas.iter().find(|entry| entry.checks.iter().any(|c| c == &check_name));
+    let Some(schema_entry) = schema_entry else {
+        return Ok(ValidationOutcome {
+            path: path.display().to_string(),
+            ok: false,
+            check,
+            schema: None,
+            errors: vec![format!("no schema registry entry for check '{check_name}'")],
+        });
+    };
+
+    let schema_path = project_root()?.join(&schema_entry.schema);
+    let schema = read_schema(&schema_path)?;
+
+    validate_common_contract(obj, &mut errors);
+    validate_required_fields(obj, &schema, &mut errors);
+    validate_enum_fields(obj, &schema, &mut errors);
+
+    Ok(ValidationOutcome {
+        path: path.display().to_string(),
+        ok: errors.is_empty(),
+        check,
+        schema: Some(schema_entry.schema.clone()),
+        errors,
+    })
+}
+
+fn validate_common_contract(obj: &Map<String, Value>, errors: &mut Vec<String>) {
+    for field in COMMON_REQUIRED_FIELDS {
+        if !obj.contains_key(field) {
+            errors.push(format!("missing required field: {field}"));
+        }
+    }
+
+    validate_allowed_value(obj, "event", &SUPPORTED_EVENTS, errors);
+    validate_allowed_value(obj, "verdict", &SUPPORTED_VERDICTS, errors);
+
+    if obj.contains_key("classification") {
+        validate_allowed_value(obj, "classification", &SUPPORTED_CLASSIFICATIONS, errors);
+    }
+}
+
+fn validate_allowed_value(
+    obj: &Map<String, Value>,
+    field: &str,
+    allowed_values: &[&str],
+    errors: &mut Vec<String>,
+) {
+    let Some(value) = obj.get(field).and_then(Value::as_str) else {
+        return;
+    };
+
+    if !allowed_values.iter().any(|allowed| allowed == &value) {
+        errors.push(format!(
+            "invalid value for {field}: '{value}' (allowed: {})",
+            allowed_values.join(", ")
+        ));
+    }
+}
+
+fn validate_required_fields(
+    obj: &Map<String, Value>,
+    schema: &TopLevelSchema,
+    errors: &mut Vec<String>,
+) {
+    if let Some(required) = &schema.required {
+        for field in required {
+            if !obj.contains_key(field) {
+                errors.push(format!("missing required field: {field}"));
+            }
+        }
+    }
+}
+
+fn validate_enum_fields(
+    obj: &Map<String, Value>,
+    schema: &TopLevelSchema,
+    errors: &mut Vec<String>,
+) {
+    let Some(properties) = &schema.properties else {
+        return;
+    };
+
+    for (name, prop) in properties {
+        let Some(allowed_values) = prop.get("enum").and_then(Value::as_array) else {
+            continue;
+        };
+        let Some(value) = obj.get(name).and_then(Value::as_str) else {
+            continue;
+        };
+
+        let contains =
+            allowed_values.iter().filter_map(Value::as_str).any(|allowed| allowed == value);
+        if !contains {
+            let allowed =
+                allowed_values.iter().filter_map(Value::as_str).collect::<Vec<_>>().join(", ");
+            errors.push(format!("invalid value for {name}: '{value}' (allowed: {allowed})"));
+        }
+    }
+}
+
+fn load_registry() -> Result<Registry> {
+    let path = project_root()?.join(REGISTRY_PATH);
+    let raw = fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn read_schema(path: &Path) -> Result<TopLevelSchema> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("parsing schema {}", path.display()))
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -39,6 +39,7 @@ pub mod features;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;
+pub mod gate_receipts;
 pub mod gates;
 pub mod github;
 pub mod hardening;

--- a/xtask/tests/fixtures/gate-receipts/invalid-missing-verdict.json
+++ b/xtask/tests/fixtures/gate-receipts/invalid-missing-verdict.json
@@ -1,0 +1,6 @@
+{
+  "check": "methodology-gate",
+  "schema_version": "1.0.0",
+  "event": "pull_request",
+  "run_id": "gha-12345"
+}

--- a/xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json
+++ b/xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json
@@ -1,0 +1,17 @@
+{
+  "check": "methodology-gate",
+  "schema_version": "1.0.0",
+  "event": "pull_request",
+  "verdict": "pass",
+  "run_id": "gha-12345",
+  "pr": 6856,
+  "selection_reason": "baseline satisfied",
+  "selected": ["fmt", "lint", "tests"],
+  "metrics": {
+    "required_checks": 3,
+    "present_checks": 3
+  },
+  "repro": {
+    "command": "cargo xtask gate-receipts validate xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json"
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a committed, discoverable schema registry for CI/control-plane receipts so gate failures are machine-classifiable and less ambiguous across PR vs master runs.
- Establish a substrate for receipts -> state builder -> label projection without changing workflow checks or requiring runtime artifact downloads.
- Place committed schemas under `.ci/receipts/` and keep runtime receipts in `target/receipts/`, and avoid reusing the existing `receipts.rs` generator by adding a focused `gate_receipts.rs` task.
- Define the `parser-ratchet` schema as a future-compatible placeholder (do not assume the narrow no-op from Parser Ratchet #6854 satisfies all fields). 

### Description

- Added a schema registry file at `.ci/receipts/registry.toml` and committed JSON Schema files under `.ci/receipts/schemas/` (`common-gate-receipt`, `parser-ratchet`, `methodology-gate`, `aggregator-receipt`, `merge-readiness`, `fmt`, `failure-classifier`).
- Implemented `xtask/src/tasks/gate_receipts.rs` with `list`, `validate`, and `validate_all` flows that load the registry and perform required-field and enum validation, and emit human or JSON output via an `--format` option.
- Wired the new CLI commands into `xtask/src/main.rs` and exported the module in `xtask/src/tasks/mod.rs` as `cargo xtask gate-receipts { list | validate <path> | validate-all <dir> }` with `--format {human,json}`.
- Added fixture receipts `xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json` and `invalid-missing-verdict.json` to exercise positive and negative validation.
- Note: validator implements registry parsing plus common-contract and schema-required-field / enum checks rather than a full JSON Schema `$ref` resolver; this is intentional to keep the change focused and lightweight — full schema resolution can be layered later. 

### Testing

- Ran `cargo check -p xtask` which succeeded. 
- Ran `cargo xtask gate-receipts list` which printed the registered schemas and succeeded. 
- Ran `cargo xtask gate-receipts validate xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json` which passed validation. 
- Ran `cargo xtask gate-receipts validate xtask/tests/fixtures/gate-receipts/invalid-missing-verdict.json` which failed as expected with `missing required field: verdict`. 
- Exercised `cargo xtask gate-receipts --format json validate <path>` which emits machine-readable JSON output, and ran formatting and lints via `cargo xtask fmt --package xtask` and `cargo clippy -p xtask -- -D warnings` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0535be88333b7d569d9fe97e23c)