### PR TITLE
feat(receipts): add gate receipt schema registry (#6856)

### DIFF
--- a/.ci/receipts/registry.toml
+++ b/.ci/receipts/registry.toml
@@ -1,0 +1,31 @@
+registry_version = "1"
+
+[[receipt]]
+check = "methodology-gate"
+schema = ".ci/receipts/schemas/methodology-gate.schema.json"
+description = "Records gate methodology interpretation and decisioning substrate."
+
+[[receipt]]
+check = "parser-ratchet"
+schema = ".ci/receipts/schemas/parser-ratchet.schema.json"
+description = "Captures parser ratchet result summaries and violation metadata."
+
+[[receipt]]
+check = "aggregator"
+schema = ".ci/receipts/schemas/aggregator-receipt.schema.json"
+description = "Aggregates multiple gate receipts into a control-plane summary."
+
+[[receipt]]
+check = "merge-readiness"
+schema = ".ci/receipts/schemas/merge-readiness.schema.json"
+description = "Represents merge readiness derivation from upstream receipts."
+
+[[receipt]]
+check = "fmt"
+schema = ".ci/receipts/schemas/fmt.schema.json"
+description = "Rustfmt gate receipt for explicit formatting outcomes."
+
+[[receipt]]
+check = "failure-classifier"
+schema = ".ci/receipts/schemas/failure-classifier.schema.json"
+description = "Classifies failures into code/infra/staleness classes."

--- a/.ci/receipts/schemas/common-gate-receipt.schema.json
+++ b/.ci/receipts/schemas/common-gate-receipt.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/common-gate-receipt.schema.json",
+  "title": "Common Gate Receipt",
+  "type": "object",
+  "required": ["check", "schema_version", "event", "verdict"],
+  "properties": {
+    "check": { "type": "string" },
+    "schema_version": { "type": "string" },
+    "event": {
+      "type": "string",
+      "enum": ["pull_request", "merge_group", "push", "local"]
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "fail", "warn", "skipped"]
+    },
+    "run_id": { "type": ["string", "integer"] },
+    "pr": { "type": "integer", "minimum": 1 },
+    "base_sha": { "type": "string" },
+    "head_sha": { "type": "string" },
+    "candidate_sha": { "type": "string" },
+    "selected": { "type": "boolean" },
+    "selection_reason": { "type": "string" },
+    "classification": {
+      "type": "string",
+      "enum": [
+        "code_regression",
+        "infra_failure",
+        "stale_base",
+        "master_red",
+        "skipped",
+        "unknown"
+      ]
+    },
+    "violations": { "type": "array", "items": { "type": "object" } },
+    "metrics": { "type": "object" },
+    "artifacts": { "type": "array", "items": { "type": "object" } },
+    "repro": {
+      "type": "object",
+      "properties": {
+        "command": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "runner": { "type": "object" }
+  },
+  "additionalProperties": true
+}

--- a/.ci/receipts/schemas/failure-classifier.schema.json
+++ b/.ci/receipts/schemas/failure-classifier.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/failure-classifier.schema.json",
+  "title": "Failure Classifier Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check", "classification"],
+      "properties": {
+        "check": { "const": "failure-classifier" },
+        "classification": {
+          "type": "string",
+          "enum": [
+            "code_regression",
+            "infra_failure",
+            "stale_base",
+            "master_red",
+            "skipped",
+            "unknown"
+          ]
+        }
+      },
+      "additionalProperties": true
+    }
+  ]
+}

--- a/.ci/receipts/schemas/fmt.schema.json
+++ b/.ci/receipts/schemas/fmt.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/fmt.schema.json",
+  "title": "Fmt Gate Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check"],
+      "properties": {
+        "check": { "const": "fmt" },
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "files_checked": { "type": "integer", "minimum": 0 },
+            "files_reformatted": { "type": "integer", "minimum": 0 }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  ]
+}

--- a/.ci/receipts/schemas/merge-readiness.schema.json
+++ b/.ci/receipts/schemas/merge-readiness.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/merge-readiness.schema.json",
+  "title": "Merge Readiness Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check", "selected"],
+      "properties": {
+        "check": { "const": "merge-readiness" },
+        "selected": { "type": "boolean" },
+        "selection_reason": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  ]
+}

--- a/.ci/receipts/schemas/methodology-gate.schema.json
+++ b/.ci/receipts/schemas/methodology-gate.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/methodology-gate.schema.json",
+  "title": "Methodology Gate Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check", "selection_reason"],
+      "properties": {
+        "check": { "const": "methodology-gate" },
+        "selected": { "type": "boolean" },
+        "selection_reason": { "type": "string" },
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "stale_check_count": { "type": "integer", "minimum": 0 },
+            "missing_required_count": { "type": "integer", "minimum": 0 }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  ]
+}

--- a/.ci/receipts/schemas/parser-ratchet.schema.json
+++ b/.ci/receipts/schemas/parser-ratchet.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/parser-ratchet.schema.json",
+  "title": "Parser Ratchet Receipt",
+  "description": "Future-complete parser ratchet schema. Current producers may emit narrower payloads.",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check"],
+      "properties": {
+        "check": { "const": "parser-ratchet" },
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "baseline_clean_rate": { "type": "number" },
+            "current_clean_rate": { "type": "number" },
+            "error_nodes": { "type": "integer", "minimum": 0 }
+          },
+          "additionalProperties": true
+        },
+        "violations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "metric": { "type": "string" },
+              "expected": {},
+              "actual": {}
+            },
+            "required": ["metric"],
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    }
+  ]
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,7 +12,7 @@ mod types;
 mod utils;
 use tasks::check_test_wiring;
 use tasks::dead_code::{DeadCodeConfig, DeadCodeMode};
-use tasks::gates::{GateTier, OutputFormat};
+use tasks::gates::{GateTier, OutputFormat as GatesOutputFormat};
 use tasks::metrics;
 use tasks::targeted_checks::CheckMode;
 use tasks::unwired_scan::UnwiredScanConfig;
@@ -906,6 +906,12 @@ enum Commands {
         verbose: bool,
     },
 
+    /// Manage gate receipt schema registry and validate receipt payloads.
+    GateReceipts {
+        #[command(subcommand)]
+        command: GateReceiptsCommand,
+    },
+
     /// Show technical debt report from debt ledger
     ///
     /// Reads `.ci/debt-ledger.yaml` and reports on quarantined tests,
@@ -1072,7 +1078,7 @@ enum Commands {
 
         /// Output format (default: human)
         #[arg(long, short, value_enum, default_value = "human")]
-        format: OutputFormat,
+        format: GatesOutputFormat,
 
         /// Emit receipt JSON (also writes to target/receipts/receipt.json)
         #[arg(long, short)]
@@ -1257,6 +1263,38 @@ enum CpanCorpusCommand {
         #[arg(long)]
         install_dir: Option<PathBuf>,
     },
+}
+
+#[derive(Subcommand)]
+enum GateReceiptsCommand {
+    /// List registered receipt schemas.
+    List {
+        /// Output format (default: human).
+        #[arg(long, value_enum, default_value = "human")]
+        format: GateReceiptsFormat,
+    },
+    /// Validate a single receipt JSON file.
+    Validate {
+        /// Path to receipt JSON file.
+        path: PathBuf,
+        /// Output format (default: human).
+        #[arg(long, value_enum, default_value = "human")]
+        format: GateReceiptsFormat,
+    },
+    /// Validate all receipt JSON files under a directory.
+    ValidateAll {
+        /// Root directory containing receipt JSON files.
+        dir: PathBuf,
+        /// Output format (default: human).
+        #[arg(long, value_enum, default_value = "human")]
+        format: GateReceiptsFormat,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum GateReceiptsFormat {
+    Human,
+    Json,
 }
 
 #[derive(Subcommand)]
@@ -1724,6 +1762,20 @@ fn main() -> Result<()> {
             parallel,
             verbose,
         }),
+        Commands::GateReceipts { command } => match command {
+            GateReceiptsCommand::List { format } => {
+                gate_receipts::list(convert_gate_receipts_format(format))
+                    .map_err(|error| eyre!(error.to_string()))
+            }
+            GateReceiptsCommand::Validate { path, format } => {
+                gate_receipts::validate(&path, convert_gate_receipts_format(format))
+                    .map_err(|error| eyre!(error.to_string()))
+            }
+            GateReceiptsCommand::ValidateAll { dir, format } => {
+                gate_receipts::validate_all(&dir, convert_gate_receipts_format(format))
+                    .map_err(|error| eyre!(error.to_string()))
+            }
+        },
         Commands::TargetedChecks { base, mode } => targeted_checks::run(base, mode),
         Commands::ResolvePackageName { crate_dir } => {
             // Use the current working directory as workspace root so this subcommand
@@ -1759,5 +1811,12 @@ fn print_top_level_commands() {
 
     for command_name in command_names {
         println!("{command_name}");
+    }
+}
+
+fn convert_gate_receipts_format(format: GateReceiptsFormat) -> gate_receipts::OutputFormat {
+    match format {
+        GateReceiptsFormat::Human => gate_receipts::OutputFormat::Human,
+        GateReceiptsFormat::Json => gate_receipts::OutputFormat::Json,
     }
 }

--- a/xtask/src/tasks/gate_receipts.rs
+++ b/xtask/src/tasks/gate_receipts.rs
@@ -1,0 +1,289 @@
+//! Gate receipt schema registry helpers.
+//!
+//! This task provides a lightweight control-plane registry for CI receipts.
+//! It validates registry membership and required/common fields, with optional
+//! JSON output for machine consumers.
+
+use anyhow::{Context, Result, anyhow};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::{BTreeMap, HashSet};
+use std::fs;
+use std::path::Path;
+use walkdir::WalkDir;
+
+const REGISTRY_PATH: &str = ".ci/receipts/registry.toml";
+
+const REQUIRED_COMMON_FIELDS: &[&str] = &["check", "schema_version", "event", "verdict"];
+
+const SUPPORTED_VERDICTS: &[&str] = &["pass", "fail", "warn", "skipped"];
+const SUPPORTED_EVENTS: &[&str] = &["pull_request", "merge_group", "push", "local"];
+const SUPPORTED_CLASSIFICATIONS: &[&str] =
+    &["code_regression", "infra_failure", "stale_base", "master_red", "skipped", "unknown"];
+
+#[derive(Debug, Clone, Copy)]
+pub enum OutputFormat {
+    Human,
+    Json,
+}
+
+#[derive(Debug, Deserialize)]
+struct Registry {
+    registry_version: String,
+    #[serde(default)]
+    receipt: Vec<RegistryEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryEntry {
+    check: String,
+    schema: String,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ListItem {
+    check: String,
+    schema: String,
+    description: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ValidationResult {
+    path: String,
+    ok: bool,
+    check: Option<String>,
+    schema: Option<String>,
+    errors: Vec<String>,
+}
+
+pub fn list(format: OutputFormat) -> Result<()> {
+    let registry = load_registry()?;
+
+    let items = registry
+        .receipt
+        .iter()
+        .map(|entry| ListItem {
+            check: entry.check.clone(),
+            schema: entry.schema.clone(),
+            description: entry.description.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    match format {
+        OutputFormat::Human => {
+            println!("Gate receipt registry v{}", registry.registry_version);
+            for item in &items {
+                if let Some(description) = &item.description {
+                    println!("- {} => {} ({description})", item.check, item.schema);
+                } else {
+                    println!("- {} => {}", item.check, item.schema);
+                }
+            }
+        }
+        OutputFormat::Json => {
+            let payload = json!({
+                "registry_version": registry.registry_version,
+                "receipts": items,
+            });
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate(path: &Path, format: OutputFormat) -> Result<()> {
+    let registry = load_registry()?;
+    let result = validate_receipt(path, &registry)?;
+    emit_results(vec![result], format)
+}
+
+pub fn validate_all(dir: &Path, format: OutputFormat) -> Result<()> {
+    let registry = load_registry()?;
+
+    let mut results = Vec::new();
+    for entry in WalkDir::new(dir) {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.path().extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+
+        let result = validate_receipt(entry.path(), &registry)?;
+        results.push(result);
+    }
+
+    if results.is_empty() {
+        return Err(anyhow!("no .json files found in {}", dir.display()));
+    }
+
+    emit_results(results, format)
+}
+
+fn emit_results(results: Vec<ValidationResult>, format: OutputFormat) -> Result<()> {
+    let has_errors = results.iter().any(|result| !result.ok);
+
+    match format {
+        OutputFormat::Human => {
+            for result in &results {
+                if result.ok {
+                    println!("PASS {}", result.path);
+                } else {
+                    println!("FAIL {}", result.path);
+                    for error in &result.errors {
+                        println!("  - {error}");
+                    }
+                }
+            }
+        }
+        OutputFormat::Json => {
+            let payload = json!({
+                "ok": !has_errors,
+                "results": results,
+            });
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        }
+    }
+
+    if has_errors { Err(anyhow!("gate receipt validation failed")) } else { Ok(()) }
+}
+
+fn validate_receipt(path: &Path, registry: &Registry) -> Result<ValidationResult> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed to read receipt {}", path.display()))?;
+    let receipt: Value = serde_json::from_str(&content)
+        .with_context(|| format!("invalid JSON in {}", path.display()))?;
+
+    let mut errors = Vec::new();
+    validate_common_fields(&receipt, &mut errors);
+
+    let check = receipt.get("check").and_then(Value::as_str).map(ToOwned::to_owned);
+
+    let registry_map = registry_map(registry)?;
+    let schema = check.as_ref().and_then(|check_name| registry_map.get(check_name)).cloned();
+
+    match &check {
+        Some(check_name) => {
+            if !registry_map.contains_key(check_name) {
+                errors.push(format!("unknown check '{check_name}' (not in registry)"));
+            }
+        }
+        None => {
+            errors.push("missing or non-string field: check".to_string());
+        }
+    }
+
+    if let Some(schema_path) = &schema {
+        validate_schema_required_fields(&receipt, schema_path, &mut errors)?;
+    }
+
+    Ok(ValidationResult {
+        path: path.display().to_string(),
+        ok: errors.is_empty(),
+        check,
+        schema,
+        errors,
+    })
+}
+
+fn validate_common_fields(receipt: &Value, errors: &mut Vec<String>) {
+    for field in REQUIRED_COMMON_FIELDS {
+        let value = receipt.get(field);
+        if value.is_none() {
+            errors.push(format!("missing required field: {field}"));
+            continue;
+        }
+        if value.and_then(Value::as_str).is_none() {
+            errors.push(format!("field '{field}' must be a string"));
+        }
+    }
+
+    if let Some(event) = receipt.get("event").and_then(Value::as_str)
+        && !SUPPORTED_EVENTS.contains(&event)
+    {
+        errors.push(format!(
+            "unsupported event '{event}', expected one of {}",
+            SUPPORTED_EVENTS.join(", ")
+        ));
+    }
+
+    if let Some(verdict) = receipt.get("verdict").and_then(Value::as_str)
+        && !SUPPORTED_VERDICTS.contains(&verdict)
+    {
+        errors.push(format!(
+            "unsupported verdict '{verdict}', expected one of {}",
+            SUPPORTED_VERDICTS.join(", ")
+        ));
+    }
+
+    if let Some(classification) = receipt.get("classification").and_then(Value::as_str)
+        && !SUPPORTED_CLASSIFICATIONS.contains(&classification)
+    {
+        errors.push(format!(
+            "unsupported classification '{classification}', expected one of {}",
+            SUPPORTED_CLASSIFICATIONS.join(", ")
+        ));
+    }
+}
+
+fn validate_schema_required_fields(
+    receipt: &Value,
+    schema_path: &str,
+    errors: &mut Vec<String>,
+) -> Result<()> {
+    let schema_content = fs::read_to_string(schema_path)
+        .with_context(|| format!("failed to read schema {schema_path}"))?;
+    let schema_value: Value = serde_json::from_str(&schema_content)
+        .with_context(|| format!("invalid schema JSON in {schema_path}"))?;
+
+    let mut required = HashSet::new();
+    collect_required_fields(&schema_value, &mut required);
+
+    for field in required {
+        if receipt.get(&field).is_none() {
+            errors.push(format!("missing schema-required field: {field}"));
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_required_fields(schema_value: &Value, required: &mut HashSet<String>) {
+    if let Some(required_fields) = schema_value.get("required").and_then(Value::as_array) {
+        for field in required_fields.iter().filter_map(Value::as_str) {
+            required.insert(field.to_string());
+        }
+    }
+
+    if let Some(all_of) = schema_value.get("allOf").and_then(Value::as_array) {
+        for sub_schema in all_of {
+            collect_required_fields(sub_schema, required);
+        }
+    }
+}
+
+fn load_registry() -> Result<Registry> {
+    let content = fs::read_to_string(REGISTRY_PATH)
+        .with_context(|| format!("failed to read registry at {REGISTRY_PATH}"))?;
+    let registry: Registry = toml::from_str(&content).context("invalid registry TOML")?;
+
+    if registry.receipt.is_empty() {
+        return Err(anyhow!("registry has no receipt entries"));
+    }
+
+    Ok(registry)
+}
+
+fn registry_map(registry: &Registry) -> Result<BTreeMap<String, String>> {
+    let mut map = BTreeMap::new();
+    for entry in &registry.receipt {
+        if map.insert(entry.check.clone(), entry.schema.clone()).is_some() {
+            return Err(anyhow!("duplicate registry check '{}'", entry.check));
+        }
+    }
+    Ok(map)
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -41,6 +41,7 @@ pub mod finalize_check;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;
+pub mod gate_receipts;
 pub mod gates;
 pub mod github;
 pub mod hardening;

--- a/xtask/src/tasks/workflow_policy_lint.rs
+++ b/xtask/src/tasks/workflow_policy_lint.rs
@@ -214,7 +214,7 @@ fn lint_workflow_file(path: &Path, is_fixture: bool, issues: &mut Vec<LintIssue>
 }
 
 fn is_contents_write_allowlisted(workflow_name: &str) -> bool {
-    ALLOWLIST_PR_CONTENTS_WRITE.iter().any(|value| *value == workflow_name)
+    ALLOWLIST_PR_CONTENTS_WRITE.contains(&workflow_name)
 }
 
 fn triggers(workflow: &Value) -> Vec<String> {

--- a/xtask/tests/fixtures/gate-receipts/invalid-missing-verdict.json
+++ b/xtask/tests/fixtures/gate-receipts/invalid-missing-verdict.json
@@ -1,0 +1,6 @@
+{
+  "check": "methodology-gate",
+  "schema_version": "1",
+  "event": "pull_request",
+  "selection_reason": "missing verdict field intentionally"
+}

--- a/xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json
+++ b/xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json
@@ -1,0 +1,21 @@
+{
+  "check": "methodology-gate",
+  "schema_version": "1",
+  "event": "pull_request",
+  "verdict": "pass",
+  "run_id": "run-12345",
+  "pr": 6856,
+  "base_sha": "1111111",
+  "head_sha": "2222222",
+  "candidate_sha": "3333333",
+  "selected": true,
+  "selection_reason": "all required checks are current and green",
+  "classification": "unknown",
+  "metrics": {
+    "stale_check_count": 0,
+    "missing_required_count": 0
+  },
+  "repro": {
+    "command": "cargo xtask gate-receipts validate xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json"
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a committed, machine-readable receipt contract to eliminate ambiguity when gates fail and to act as substrate for receipts → state builder → label projection work.
- Ensure committed schemas live under `.ci/receipts/` while runtime receipts remain in `target/receipts/`, and define a forward-compatible parser-ratchet schema without assuming current producers emit all future fields.

### Description

- Add a registry and schemas under `.ci/receipts/`: `registry.toml` and per-check JSON schemas (common-gate, methodology-gate, parser-ratchet, aggregator, merge-readiness, fmt, failure-classifier).
- Implement a new `xtask` task module `xtask/src/tasks/gate_receipts.rs` providing `list`, `validate <path>`, and `validate_all <dir>` with `Human`/`Json` output and lightweight schema-aware validation (registry membership, required common fields, enum checks, and extraction of `required` fields from schema `required`/`allOf`).
- Wire CLI and task plumbing: register `gate_receipts` in `xtask/src/tasks/mod.rs`, add `GateReceipts` subcommand and format enum in `xtask/src/main.rs`, and dispatch the new commands to the task functions.
- Add fixtures for testing: `xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json` and `invalid-missing-verdict.json`.

Refs #6856
Refs #6853

### Testing

- Ran `cargo fmt --all` successfully.
- Ran `cargo check -p xtask` successfully to verify compilation.
- Executed `cargo xtask gate-receipts list` which printed the registry entries successfully.
- Executed `cargo xtask gate-receipts validate xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json` which passed.
- Executed `cargo xtask gate-receipts validate xtask/tests/fixtures/gate-receipts/invalid-missing-verdict.json` which failed as expected due to the missing `verdict` field, and `cargo xtask gate-receipts validate-all xtask/tests/fixtures/gate-receipts` also failed as expected because the fixture set includes the invalid file.

Notes: validation currently performs registry parsing and required-field checks derived from the committed JSON schemas (collects `required` and `allOf`), rather than full JSON Schema evaluation; this is intentional to keep dependencies small and is documented in the task implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0535be88333b7d569d9fe97e23c)