### PR TITLE
feat(receipts): add gate receipt schema registry (#6856)

### DIFF
--- a/.ci/receipts/registry.toml
+++ b/.ci/receipts/registry.toml
@@ -1,0 +1,54 @@
+version = 1
+
+[common]
+required = ["check", "schema_version", "event", "verdict"]
+optional = [
+  "run_id",
+  "pr",
+  "base_sha",
+  "head_sha",
+  "candidate_sha",
+  "selected",
+  "selection_reason",
+  "classification",
+  "violations",
+  "metrics",
+  "artifacts",
+  "repro.command",
+  "runner",
+]
+
+[[schemas]]
+name = "common-gate-receipt"
+check = "*"
+path = ".ci/receipts/schemas/common-gate-receipt.schema.json"
+
+[[schemas]]
+name = "methodology-gate"
+check = "methodology-gate"
+path = ".ci/receipts/schemas/methodology-gate.schema.json"
+
+[[schemas]]
+name = "parser-ratchet"
+check = "parser-ratchet"
+path = ".ci/receipts/schemas/parser-ratchet.schema.json"
+
+[[schemas]]
+name = "aggregator"
+check = "aggregator"
+path = ".ci/receipts/schemas/aggregator-receipt.schema.json"
+
+[[schemas]]
+name = "merge-readiness"
+check = "merge-readiness"
+path = ".ci/receipts/schemas/merge-readiness.schema.json"
+
+[[schemas]]
+name = "fmt"
+check = "fmt"
+path = ".ci/receipts/schemas/fmt.schema.json"
+
+[[schemas]]
+name = "failure-classifier"
+check = "failure-classifier"
+path = ".ci/receipts/schemas/failure-classifier.schema.json"

--- a/.ci/receipts/schemas/aggregator-receipt.schema.json
+++ b/.ci/receipts/schemas/aggregator-receipt.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/aggregator-receipt.schema.json",
+  "title": "Aggregator Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check"],
+      "properties": {
+        "check": { "const": "aggregator" },
+        "selected": { "type": "boolean" },
+        "selection_reason": { "type": "string" }
+      }
+    }
+  ]
+}

--- a/.ci/receipts/schemas/common-gate-receipt.schema.json
+++ b/.ci/receipts/schemas/common-gate-receipt.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/common-gate-receipt.schema.json",
+  "title": "Common Gate Receipt",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["check", "schema_version", "event", "verdict"],
+  "properties": {
+    "check": { "type": "string", "minLength": 1 },
+    "schema_version": { "type": "string", "minLength": 1 },
+    "event": {
+      "type": "string",
+      "enum": ["pull_request", "merge_group", "push", "local"]
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "fail", "warn", "skipped"]
+    },
+    "run_id": { "type": ["string", "integer"] },
+    "pr": { "type": "integer", "minimum": 1 },
+    "base_sha": { "type": "string", "minLength": 7 },
+    "head_sha": { "type": "string", "minLength": 7 },
+    "candidate_sha": { "type": "string", "minLength": 7 },
+    "selected": { "type": "boolean" },
+    "selection_reason": { "type": "string" },
+    "classification": {
+      "type": "string",
+      "enum": [
+        "code_regression",
+        "infra_failure",
+        "stale_base",
+        "master_red",
+        "skipped",
+        "unknown"
+      ]
+    },
+    "violations": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "metrics": { "type": "object" },
+    "artifacts": {
+      "type": "array",
+      "items": { "type": ["string", "object"] }
+    },
+    "repro": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": { "type": "string" }
+      }
+    },
+    "runner": { "type": "object" }
+  }
+}

--- a/.ci/receipts/schemas/failure-classifier.schema.json
+++ b/.ci/receipts/schemas/failure-classifier.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/failure-classifier.schema.json",
+  "title": "Failure Classifier Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check"],
+      "properties": {
+        "check": { "const": "failure-classifier" },
+        "classification": {
+          "type": "string",
+          "enum": [
+            "code_regression",
+            "infra_failure",
+            "stale_base",
+            "master_red",
+            "skipped",
+            "unknown"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/.ci/receipts/schemas/fmt.schema.json
+++ b/.ci/receipts/schemas/fmt.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/fmt.schema.json",
+  "title": "Fmt Gate Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check"],
+      "properties": {
+        "check": { "const": "fmt" },
+        "repro": {
+          "type": "object",
+          "properties": {
+            "command": { "type": "string" }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/.ci/receipts/schemas/merge-readiness.schema.json
+++ b/.ci/receipts/schemas/merge-readiness.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/merge-readiness.schema.json",
+  "title": "Merge Readiness Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check"],
+      "properties": {
+        "check": { "const": "merge-readiness" },
+        "classification": {
+          "type": "string",
+          "enum": [
+            "code_regression",
+            "infra_failure",
+            "stale_base",
+            "master_red",
+            "skipped",
+            "unknown"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/.ci/receipts/schemas/methodology-gate.schema.json
+++ b/.ci/receipts/schemas/methodology-gate.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/methodology-gate.schema.json",
+  "title": "Methodology Gate Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check"],
+      "properties": {
+        "check": { "const": "methodology-gate" },
+        "metrics": { "type": "object" }
+      }
+    }
+  ]
+}

--- a/.ci/receipts/schemas/parser-ratchet.schema.json
+++ b/.ci/receipts/schemas/parser-ratchet.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/parser-ratchet.schema.json",
+  "title": "Parser Ratchet Gate Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["check"],
+      "properties": {
+        "check": { "const": "parser-ratchet" },
+        "violations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rule": { "type": "string" },
+              "path": { "type": "string" },
+              "detail": { "type": "string" }
+            },
+            "required": ["rule"]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,6 +12,7 @@ mod types;
 mod utils;
 use tasks::check_test_wiring;
 use tasks::dead_code::{DeadCodeConfig, DeadCodeMode};
+use tasks::gate_receipts::GateReceiptsFormat;
 use tasks::gates::{GateTier, OutputFormat};
 use tasks::metrics;
 use tasks::targeted_checks::CheckMode;
@@ -1059,6 +1060,13 @@ enum Commands {
         verbose: bool,
     },
 
+    /// Manage CI/control-plane gate receipt schema registry and validation.
+    #[command(name = "gate-receipts")]
+    GateReceipts {
+        #[command(subcommand)]
+        command: GateReceiptsCommand,
+    },
+
     /// Verify hook scripts are executable.
     HookCheck,
 
@@ -1152,6 +1160,38 @@ enum Commands {
         /// Current receipt JSON path.
         current: PathBuf,
     },
+}
+
+#[derive(Subcommand)]
+enum GateReceiptsCommand {
+    /// List registered gate receipt schemas.
+    List {
+        /// Output format.
+        #[arg(long, value_enum, default_value = "human")]
+        format: GateReceiptsOutputFormat,
+    },
+    /// Validate a single gate receipt JSON file.
+    Validate {
+        /// Path to receipt JSON.
+        path: PathBuf,
+        /// Output format.
+        #[arg(long, value_enum, default_value = "human")]
+        format: GateReceiptsOutputFormat,
+    },
+    /// Validate all gate receipt JSON files in a directory.
+    ValidateAll {
+        /// Directory containing receipt JSON files.
+        dir: PathBuf,
+        /// Output format.
+        #[arg(long, value_enum, default_value = "human")]
+        format: GateReceiptsOutputFormat,
+    },
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum GateReceiptsOutputFormat {
+    Human,
+    Json,
 }
 
 #[derive(Subcommand)]
@@ -1663,6 +1703,26 @@ fn main() -> Result<()> {
             parallel,
             verbose,
         }),
+        Commands::GateReceipts { command } => match command {
+            GateReceiptsCommand::List { format } => gate_receipts::list(match format {
+                GateReceiptsOutputFormat::Human => GateReceiptsFormat::Human,
+                GateReceiptsOutputFormat::Json => GateReceiptsFormat::Json,
+            }),
+            GateReceiptsCommand::Validate { path, format } => gate_receipts::validate(
+                &path,
+                match format {
+                    GateReceiptsOutputFormat::Human => GateReceiptsFormat::Human,
+                    GateReceiptsOutputFormat::Json => GateReceiptsFormat::Json,
+                },
+            ),
+            GateReceiptsCommand::ValidateAll { dir, format } => gate_receipts::validate_all(
+                &dir,
+                match format {
+                    GateReceiptsOutputFormat::Human => GateReceiptsFormat::Human,
+                    GateReceiptsOutputFormat::Json => GateReceiptsFormat::Json,
+                },
+            ),
+        },
         Commands::TargetedChecks { base, mode } => targeted_checks::run(base, mode),
         Commands::ResolvePackageName { crate_dir } => {
             // Use the current working directory as workspace root so this subcommand

--- a/xtask/src/tasks/gate_receipts.rs
+++ b/xtask/src/tasks/gate_receipts.rs
@@ -1,0 +1,272 @@
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum GateReceiptsFormat {
+    Human,
+    Json,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryCommon {
+    required: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct RegistrySchema {
+    name: String,
+    check: String,
+    path: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Registry {
+    common: RegistryCommon,
+    schemas: Vec<RegistrySchema>,
+}
+
+#[derive(Debug, Serialize)]
+struct ValidationIssue {
+    path: String,
+    code: String,
+    message: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ValidationResult {
+    receipt_path: String,
+    valid: bool,
+    schema: Option<String>,
+    issues: Vec<ValidationIssue>,
+}
+
+const REGISTRY_PATH: &str = ".ci/receipts/registry.toml";
+const SUPPORTED_VERDICTS: &[&str] = &["pass", "fail", "warn", "skipped"];
+const SUPPORTED_EVENTS: &[&str] = &["pull_request", "merge_group", "push", "local"];
+const SUPPORTED_CLASSIFICATIONS: &[&str] =
+    &["code_regression", "infra_failure", "stale_base", "master_red", "skipped", "unknown"];
+
+pub fn list(format: GateReceiptsFormat) -> Result<()> {
+    let root = crate::utils::project_root()?;
+    let registry = load_registry(&root)?;
+
+    match format {
+        GateReceiptsFormat::Human => {
+            println!("Registry: {}", root.join(REGISTRY_PATH).display());
+            for schema in registry.schemas {
+                println!("- {} (check: {}) -> {}", schema.name, schema.check, schema.path);
+            }
+        }
+        GateReceiptsFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&registry.schemas)?);
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate(path: &Path, format: GateReceiptsFormat) -> Result<()> {
+    let root = crate::utils::project_root()?;
+    let registry = load_registry(&root)?;
+    let result = validate_receipt_path(&root, &registry, path)?;
+    emit_validation_result(&result, format)?;
+
+    if !result.valid {
+        bail!("receipt validation failed for {}", path.display());
+    }
+
+    Ok(())
+}
+
+pub fn validate_all(dir: &Path, format: GateReceiptsFormat) -> Result<()> {
+    let root = crate::utils::project_root()?;
+    let registry = load_registry(&root)?;
+    let mut results = Vec::new();
+
+    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
+        let entry = entry.with_context(|| format!("reading entry under {}", dir.display()))?;
+        let path = entry.path();
+        if path.extension() != Some(OsStr::new("json")) {
+            continue;
+        }
+        results.push(validate_receipt_path(&root, &registry, &path)?);
+    }
+
+    match format {
+        GateReceiptsFormat::Human => {
+            for result in &results {
+                emit_validation_result(result, format)?;
+            }
+        }
+        GateReceiptsFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&results)?);
+        }
+    }
+
+    if results.iter().any(|result| !result.valid) {
+        bail!("one or more receipts failed validation");
+    }
+
+    Ok(())
+}
+
+fn emit_validation_result(result: &ValidationResult, format: GateReceiptsFormat) -> Result<()> {
+    match format {
+        GateReceiptsFormat::Human => {
+            if result.valid {
+                println!(
+                    "VALID {} ({})",
+                    result.receipt_path,
+                    result.schema.as_deref().unwrap_or("unknown")
+                );
+            } else {
+                println!(
+                    "INVALID {} ({})",
+                    result.receipt_path,
+                    result.schema.as_deref().unwrap_or("unknown")
+                );
+                for issue in &result.issues {
+                    println!("  - [{}] {}: {}", issue.code, issue.path, issue.message);
+                }
+            }
+        }
+        GateReceiptsFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(result)?);
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_receipt_path(
+    root: &Path,
+    registry: &Registry,
+    path: &Path,
+) -> Result<ValidationResult> {
+    let raw =
+        fs::read_to_string(path).with_context(|| format!("reading receipt {}", path.display()))?;
+    let receipt: Value = serde_json::from_str(&raw)
+        .with_context(|| format!("parsing receipt JSON {}", path.display()))?;
+
+    let mut issues = Vec::new();
+
+    for field in &registry.common.required {
+        if lookup_field(&receipt, field).is_none() {
+            issues.push(ValidationIssue {
+                path: field.clone(),
+                code: "missing_required".to_string(),
+                message: format!("Required field `{field}` is missing"),
+            });
+        }
+    }
+
+    if let Some(event) = receipt.get("event").and_then(Value::as_str)
+        && !SUPPORTED_EVENTS.contains(&event)
+    {
+        issues.push(ValidationIssue {
+            path: "event".to_string(),
+            code: "invalid_enum".to_string(),
+            message: format!("Unsupported event `{event}`"),
+        });
+    }
+
+    if let Some(verdict) = receipt.get("verdict").and_then(Value::as_str)
+        && !SUPPORTED_VERDICTS.contains(&verdict)
+    {
+        issues.push(ValidationIssue {
+            path: "verdict".to_string(),
+            code: "invalid_enum".to_string(),
+            message: format!("Unsupported verdict `{verdict}`"),
+        });
+    }
+
+    if let Some(classification) = receipt.get("classification").and_then(Value::as_str)
+        && !SUPPORTED_CLASSIFICATIONS.contains(&classification)
+    {
+        issues.push(ValidationIssue {
+            path: "classification".to_string(),
+            code: "invalid_enum".to_string(),
+            message: format!("Unsupported classification `{classification}`"),
+        });
+    }
+
+    let check_name =
+        receipt.get("check").and_then(Value::as_str).map(std::borrow::ToOwned::to_owned);
+    let schema = check_name
+        .as_deref()
+        .and_then(|check| registry.schemas.iter().find(|entry| entry.check == check))
+        .or_else(|| registry.schemas.iter().find(|entry| entry.check == "*"));
+
+    if check_name.is_some() && schema.is_none() {
+        issues.push(ValidationIssue {
+            path: "check".to_string(),
+            code: "unknown_check".to_string(),
+            message: "No schema mapped for check in .ci/receipts/registry.toml".to_string(),
+        });
+    }
+
+    if let Some(schema) = schema {
+        let schema_path = root.join(&schema.path);
+        if !schema_path.exists() {
+            issues.push(ValidationIssue {
+                path: "schema".to_string(),
+                code: "missing_schema".to_string(),
+                message: format!("Schema path does not exist: {}", schema_path.display()),
+            });
+        }
+    }
+
+    Ok(ValidationResult {
+        receipt_path: path.display().to_string(),
+        valid: issues.is_empty(),
+        schema: schema.map(|entry| entry.name.clone()),
+        issues,
+    })
+}
+
+fn lookup_field<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    let mut cursor = value;
+    for segment in path.split('.') {
+        cursor = cursor.get(segment)?;
+    }
+    Some(cursor)
+}
+
+fn load_registry(root: &Path) -> Result<Registry> {
+    let path = root.join(REGISTRY_PATH);
+    let raw = fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let registry: Registry =
+        toml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?;
+
+    if registry.schemas.is_empty() {
+        bail!("receipt schema registry is empty: {}", path.display());
+    }
+
+    Ok(registry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SUPPORTED_EVENTS, SUPPORTED_VERDICTS, lookup_field};
+    use serde_json::json;
+
+    #[test]
+    fn lookup_field_resolves_nested_segments() {
+        let value = json!({"repro": {"command": "cargo xtask"}});
+        assert_eq!(
+            lookup_field(&value, "repro.command").and_then(|v| v.as_str()),
+            Some("cargo xtask")
+        );
+        assert!(lookup_field(&value, "repro.missing").is_none());
+    }
+
+    #[test]
+    fn enums_cover_expected_values() {
+        assert!(SUPPORTED_VERDICTS.contains(&"pass"));
+        assert!(SUPPORTED_EVENTS.contains(&"pull_request"));
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -39,6 +39,7 @@ pub mod features;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;
+pub mod gate_receipts;
 pub mod gates;
 pub mod github;
 pub mod hardening;

--- a/xtask/tests/fixtures/gate-receipts/invalid-missing-verdict.json
+++ b/xtask/tests/fixtures/gate-receipts/invalid-missing-verdict.json
@@ -1,0 +1,5 @@
+{
+  "check": "methodology-gate",
+  "schema_version": "1.0.0",
+  "event": "pull_request"
+}

--- a/xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json
+++ b/xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json
@@ -1,0 +1,17 @@
+{
+  "check": "methodology-gate",
+  "schema_version": "1.0.0",
+  "event": "pull_request",
+  "verdict": "pass",
+  "run_id": "12345",
+  "pr": 6856,
+  "base_sha": "aaaaaaaa",
+  "head_sha": "bbbbbbbb",
+  "metrics": {
+    "required_checks": 12,
+    "completed_checks": 12
+  },
+  "repro": {
+    "command": "cargo xtask gates --tier merge-gate"
+  }
+}


### PR DESCRIPTION
### Motivation
- CI/control-plane receipts lacked a shared, committed schema registry which made failures hard to classify and reconcile and blocked the larger receipts -> state-builder work.  
- We need a committed place for schemas (`.ci/receipts/`) and a runtime write target for generated receipts (`target/receipts/`) so tools and workflows can rely on stable contracts.  
- Provide a simple, repo-native validator and CLI so authors can `list` and `validate` receipt JSON before relying on them in automation.  

### Description
- Add a committed registry and schemas under `.ci/receipts/`: `registry.toml` plus `schemas/{common-gate-receipt,parser-ratchet,methodology-gate,aggregator-receipt,merge-readiness,fmt,failure-classifier}.schema.json`.  
- Implement `xtask` task module `gate_receipts` providing `list`, `validate <path>`, and `validate-all <dir>` and wire the CLI as `cargo xtask gate-receipts {list,validate,validate-all}`.  
- Registry parsing verifies required common fields and does enum checks for `event`, `verdict`, and `classification`, maps `check` -> schema entry and ensures referenced schema files exist; full JSON-Schema evaluation was deferred (no jsonschema crate added) and is documented as a limitation.  
- Add fixtures `xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json` and `invalid-missing-verdict.json` to exercise success and failure paths.  
- This change is substrate-only and does not change workflows, branch rules, or runtime receipt locations (runtime receipts should continue to be written to `target/receipts/`).  

### Testing
- Ran formatter: `cargo xtask fmt` (succeeded).  
- Type/check: `cargo check -p xtask` (succeeded).  
- CLI smoke: `cargo xtask gate-receipts list` (succeeded and printed registry).  
- Positive validation: `cargo xtask gate-receipts validate xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json` (succeeded).  
- Negative validation: `cargo xtask gate-receipts validate xtask/tests/fixtures/gate-receipts/invalid-missing-verdict.json` (failed as expected due to missing `verdict`).  
- Directory JSON output: `cargo xtask gate-receipts validate-all xtask/tests/fixtures/gate-receipts --format json` (emits JSON with one invalid entry and exits non-zero as expected).  

Refs #6856
Refs #6853

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0535be88333b7d569d9fe97e23c)