### PR TITLE
feat(receipts): add gate receipt schema registry (#6856)

### DIFF
--- a/.ci/receipts/registry.toml
+++ b/.ci/receipts/registry.toml
@@ -1,0 +1,42 @@
+[registry]
+version = "1"
+default_schema_version = "1.0.0"
+
+[[schema]]
+check = "common-gate-receipt"
+schema = ".ci/receipts/schemas/common-gate-receipt.schema.json"
+description = "Common gate receipt contract used by CI/control-plane checks"
+
+[[schema]]
+check = "parser-ratchet"
+schema = ".ci/receipts/schemas/parser-ratchet.schema.json"
+description = "Parser ratchet verdict and metrics receipt"
+
+[[schema]]
+check = "methodology-gate"
+schema = ".ci/receipts/schemas/methodology-gate.schema.json"
+description = "Methodology gate decision receipt"
+extra_required = ["selected", "selection_reason"]
+
+[[schema]]
+check = "aggregator-receipt"
+schema = ".ci/receipts/schemas/aggregator-receipt.schema.json"
+description = "Aggregated gate status receipt"
+extra_required = ["metrics"]
+
+[[schema]]
+check = "merge-readiness"
+schema = ".ci/receipts/schemas/merge-readiness.schema.json"
+description = "Merge readiness decision receipt"
+extra_required = ["candidate_sha", "selected"]
+
+[[schema]]
+check = "fmt"
+schema = ".ci/receipts/schemas/fmt.schema.json"
+description = "Formatting check verdict receipt"
+
+[[schema]]
+check = "failure-classifier"
+schema = ".ci/receipts/schemas/failure-classifier.schema.json"
+description = "Failure classification receipt"
+extra_required = ["classification"]

--- a/.ci/receipts/schemas/aggregator-receipt.schema.json
+++ b/.ci/receipts/schemas/aggregator-receipt.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/aggregator-receipt.schema.json",
+  "title": "Aggregator Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["metrics"],
+      "properties": {
+        "check": { "const": "aggregator-receipt" },
+        "metrics": { "type": "object" }
+      }
+    }
+  ]
+}

--- a/.ci/receipts/schemas/common-gate-receipt.schema.json
+++ b/.ci/receipts/schemas/common-gate-receipt.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/common-gate-receipt.schema.json",
+  "title": "Common Gate Receipt",
+  "type": "object",
+  "required": ["check", "schema_version", "event", "verdict"],
+  "properties": {
+    "check": { "type": "string" },
+    "schema_version": { "type": "string" },
+    "event": { "type": "string", "enum": ["pull_request", "merge_group", "push", "local"] },
+    "verdict": { "type": "string", "enum": ["pass", "fail", "warn", "skipped"] },
+    "run_id": { "type": ["string", "integer"] },
+    "pr": { "type": ["integer", "string"] },
+    "base_sha": { "type": "string" },
+    "head_sha": { "type": "string" },
+    "candidate_sha": { "type": "string" },
+    "selected": { "type": ["boolean", "string"] },
+    "selection_reason": { "type": "string" },
+    "classification": {
+      "type": "string",
+      "enum": ["code_regression", "infra_failure", "stale_base", "master_red", "skipped", "unknown"]
+    },
+    "violations": { "type": "array", "items": { "type": "object" } },
+    "metrics": { "type": "object" },
+    "artifacts": { "type": "array", "items": { "type": "object" } },
+    "repro": {
+      "type": "object",
+      "properties": {
+        "command": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "runner": { "type": "object" }
+  },
+  "additionalProperties": true
+}

--- a/.ci/receipts/schemas/failure-classifier.schema.json
+++ b/.ci/receipts/schemas/failure-classifier.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/failure-classifier.schema.json",
+  "title": "Failure Classifier Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["classification"],
+      "properties": {
+        "check": { "const": "failure-classifier" },
+        "classification": {
+          "type": "string",
+          "enum": ["code_regression", "infra_failure", "stale_base", "master_red", "skipped", "unknown"]
+        }
+      }
+    }
+  ]
+}

--- a/.ci/receipts/schemas/fmt.schema.json
+++ b/.ci/receipts/schemas/fmt.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/fmt.schema.json",
+  "title": "Formatting Gate Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "properties": {
+        "check": { "const": "fmt" },
+        "violations": { "type": "array", "items": { "type": "object" } }
+      }
+    }
+  ]
+}

--- a/.ci/receipts/schemas/merge-readiness.schema.json
+++ b/.ci/receipts/schemas/merge-readiness.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/merge-readiness.schema.json",
+  "title": "Merge Readiness Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["candidate_sha", "selected"],
+      "properties": {
+        "check": { "const": "merge-readiness" },
+        "candidate_sha": { "type": "string" },
+        "selected": { "type": ["boolean", "string"] }
+      }
+    }
+  ]
+}

--- a/.ci/receipts/schemas/methodology-gate.schema.json
+++ b/.ci/receipts/schemas/methodology-gate.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/methodology-gate.schema.json",
+  "title": "Methodology Gate Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": ["selected", "selection_reason"],
+      "properties": {
+        "check": { "const": "methodology-gate" },
+        "selected": { "type": ["boolean", "string"] },
+        "selection_reason": { "type": "string" }
+      }
+    }
+  ]
+}

--- a/.ci/receipts/schemas/parser-ratchet.schema.json
+++ b/.ci/receipts/schemas/parser-ratchet.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/receipts/parser-ratchet.schema.json",
+  "title": "Parser Ratchet Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "properties": {
+        "check": { "const": "parser-ratchet" },
+        "metrics": { "type": "object" },
+        "violations": { "type": "array", "items": { "type": "object" } }
+      }
+    }
+  ]
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,6 +12,7 @@ mod types;
 mod utils;
 use tasks::check_test_wiring;
 use tasks::dead_code::{DeadCodeConfig, DeadCodeMode};
+use tasks::gate_receipts::ReceiptOutputFormat;
 use tasks::gates::{GateTier, OutputFormat};
 use tasks::metrics;
 use tasks::targeted_checks::CheckMode;
@@ -1059,6 +1060,13 @@ enum Commands {
         verbose: bool,
     },
 
+    /// Validate and inspect gate receipt schemas from `.ci/receipts/registry.toml`.
+    #[command(name = "gate-receipts")]
+    GateReceipts {
+        #[command(subcommand)]
+        command: GateReceiptsCommands,
+    },
+
     /// Verify hook scripts are executable.
     HookCheck,
 
@@ -1151,6 +1159,32 @@ enum Commands {
         baseline: PathBuf,
         /// Current receipt JSON path.
         current: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
+enum GateReceiptsCommands {
+    /// List registered gate receipt schemas.
+    List {
+        /// Output format (default: human).
+        #[arg(long, value_enum, default_value = "human")]
+        format: ReceiptOutputFormat,
+    },
+    /// Validate one receipt JSON against common + check-specific requirements.
+    Validate {
+        /// Path to receipt JSON file.
+        path: PathBuf,
+        /// Output format (default: human).
+        #[arg(long, value_enum, default_value = "human")]
+        format: ReceiptOutputFormat,
+    },
+    /// Validate every JSON receipt file found under a directory.
+    ValidateAll {
+        /// Directory containing receipt JSON files.
+        dir: PathBuf,
+        /// Output format (default: human).
+        #[arg(long, value_enum, default_value = "human")]
+        format: ReceiptOutputFormat,
     },
 }
 
@@ -1663,6 +1697,15 @@ fn main() -> Result<()> {
             parallel,
             verbose,
         }),
+        Commands::GateReceipts { command } => match command {
+            GateReceiptsCommands::List { format } => gate_receipts::list(format),
+            GateReceiptsCommands::Validate { path, format } => {
+                gate_receipts::validate(path, format)
+            }
+            GateReceiptsCommands::ValidateAll { dir, format } => {
+                gate_receipts::validate_all(dir, format)
+            }
+        },
         Commands::TargetedChecks { base, mode } => targeted_checks::run(base, mode),
         Commands::ResolvePackageName { crate_dir } => {
             // Use the current working directory as workspace root so this subcommand

--- a/xtask/src/tasks/gate_receipts.rs
+++ b/xtask/src/tasks/gate_receipts.rs
@@ -1,0 +1,276 @@
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+use crate::utils::project_root;
+
+const COMMON_REQUIRED_FIELDS: [&str; 4] = ["check", "schema_version", "event", "verdict"];
+const VERDICTS: [&str; 4] = ["pass", "fail", "warn", "skipped"];
+const EVENTS: [&str; 4] = ["pull_request", "merge_group", "push", "local"];
+const CLASSIFICATIONS: [&str; 6] =
+    ["code_regression", "infra_failure", "stale_base", "master_red", "skipped", "unknown"];
+
+#[derive(Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum ReceiptOutputFormat {
+    Human,
+    Json,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReceiptRegistry {
+    pub registry: RegistryMetadata,
+    #[serde(default)]
+    pub schema: Vec<SchemaEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RegistryMetadata {
+    pub version: String,
+    pub default_schema_version: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SchemaEntry {
+    pub check: String,
+    pub schema: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub extra_required: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ValidationReport {
+    path: String,
+    check: Option<String>,
+    schema: Option<String>,
+    valid: bool,
+    errors: Vec<String>,
+}
+
+pub fn list(format: ReceiptOutputFormat) -> Result<()> {
+    let registry = load_registry()?;
+    match format {
+        ReceiptOutputFormat::Human => {
+            println!(
+                "Gate receipt registry v{} (default schema version: {})",
+                registry.registry.version, registry.registry.default_schema_version
+            );
+            for entry in registry.schema {
+                println!("- {} => {}", entry.check, entry.schema);
+            }
+        }
+        ReceiptOutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&registry.schema)?);
+        }
+    }
+    Ok(())
+}
+
+pub fn validate(path: PathBuf, format: ReceiptOutputFormat) -> Result<()> {
+    let registry = load_registry()?;
+    let report = validate_path(&registry, &path)?;
+    print_report(&report, format)?;
+    if !report.valid {
+        bail!("receipt validation failed for {}", path.display());
+    }
+    Ok(())
+}
+
+pub fn validate_all(dir: PathBuf, format: ReceiptOutputFormat) -> Result<()> {
+    let registry = load_registry()?;
+    let mut reports = Vec::new();
+
+    for entry in WalkDir::new(&dir).into_iter().filter_map(|entry| entry.ok()) {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        reports.push(validate_path(&registry, path)?);
+    }
+
+    match format {
+        ReceiptOutputFormat::Human => {
+            for report in &reports {
+                if report.valid {
+                    println!("OK: {}", report.path);
+                } else {
+                    println!("FAIL: {}", report.path);
+                    for error in &report.errors {
+                        println!("  - {error}");
+                    }
+                }
+            }
+        }
+        ReceiptOutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&reports)?);
+        }
+    }
+
+    let failed = reports.iter().filter(|report| !report.valid).count();
+    if failed > 0 {
+        bail!("{failed} receipt(s) failed validation");
+    }
+
+    Ok(())
+}
+
+fn load_registry() -> Result<ReceiptRegistry> {
+    let root = project_root()?;
+    let path = root.join(".ci/receipts/registry.toml");
+    let content = fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read registry file: {}", path.display()))?;
+    toml::from_str(&content).with_context(|| format!("Failed to parse {}", path.display()))
+}
+
+fn validate_path(registry: &ReceiptRegistry, path: &Path) -> Result<ValidationReport> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read receipt file: {}", path.display()))?;
+    let value: Value = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse receipt JSON: {}", path.display()))?;
+
+    let mut errors = Vec::new();
+
+    for field in COMMON_REQUIRED_FIELDS {
+        if value.get(field).is_none() {
+            errors.push(format!("missing required field `{field}`"));
+        }
+    }
+
+    let check = value.get("check").and_then(Value::as_str).map(str::to_owned);
+
+    let schema_entry = if let Some(check_value) = &check {
+        registry.schema.iter().find(|entry| entry.check == *check_value).map(|entry| {
+            for field in &entry.extra_required {
+                if value.get(field).is_none() {
+                    errors.push(format!(
+                        "missing required field `{field}` for check `{}`",
+                        entry.check
+                    ));
+                }
+            }
+            entry
+        })
+    } else {
+        None
+    };
+
+    if check.is_some() && schema_entry.is_none() {
+        errors.push("check is not registered in .ci/receipts/registry.toml".to_string());
+    }
+
+    validate_enum_field(&value, "verdict", &VERDICTS, &mut errors);
+    validate_enum_field(&value, "event", &EVENTS, &mut errors);
+    validate_enum_field(&value, "classification", &CLASSIFICATIONS, &mut errors);
+
+    Ok(ValidationReport {
+        path: path.display().to_string(),
+        check,
+        schema: schema_entry.map(|entry| entry.schema.clone()),
+        valid: errors.is_empty(),
+        errors,
+    })
+}
+
+fn validate_enum_field(
+    value: &Value,
+    field: &str,
+    allowed_values: &[&str],
+    errors: &mut Vec<String>,
+) {
+    if let Some(field_value) = value.get(field) {
+        match field_value.as_str() {
+            Some(raw) if allowed_values.contains(&raw) => {}
+            Some(raw) => errors.push(format!(
+                "field `{field}` has unsupported value `{raw}`; allowed: {}",
+                allowed_values.join(", ")
+            )),
+            None => errors.push(format!("field `{field}` must be a string")),
+        }
+    }
+}
+
+fn print_report(report: &ValidationReport, format: ReceiptOutputFormat) -> Result<()> {
+    match format {
+        ReceiptOutputFormat::Human => {
+            if report.valid {
+                println!("OK: {}", report.path);
+            } else {
+                println!("FAIL: {}", report.path);
+                for error in &report.errors {
+                    println!("  - {error}");
+                }
+            }
+        }
+        ReceiptOutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(report)?);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn validates_common_fields_and_enums() {
+        let receipt = json!({
+            "check": "methodology-gate",
+            "schema_version": "1.0.0",
+            "event": "pull_request",
+            "verdict": "pass",
+            "classification": "unknown"
+        });
+
+        let mut errors = Vec::new();
+        validate_enum_field(&receipt, "verdict", &VERDICTS, &mut errors);
+        validate_enum_field(&receipt, "event", &EVENTS, &mut errors);
+        validate_enum_field(&receipt, "classification", &CLASSIFICATIONS, &mut errors);
+
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn rejects_invalid_enum_values() {
+        let receipt = json!({
+            "verdict": "green",
+            "event": "cron",
+            "classification": "weird"
+        });
+
+        let mut errors = Vec::new();
+        validate_enum_field(&receipt, "verdict", &VERDICTS, &mut errors);
+        validate_enum_field(&receipt, "event", &EVENTS, &mut errors);
+        validate_enum_field(&receipt, "classification", &CLASSIFICATIONS, &mut errors);
+
+        assert_eq!(errors.len(), 3);
+    }
+
+    #[test]
+    fn parses_registry_schema_entries() -> Result<()> {
+        let raw = r#"
+[registry]
+version = "1"
+default_schema_version = "1.0.0"
+
+[[schema]]
+check = "fmt"
+schema = ".ci/receipts/schemas/fmt.schema.json"
+description = "fmt result"
+extra_required = ["violations"]
+"#;
+
+        let registry: ReceiptRegistry = toml::from_str(raw)?;
+        assert_eq!(registry.schema.len(), 1);
+        assert_eq!(registry.schema[0].check, "fmt");
+        Ok(())
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -39,6 +39,7 @@ pub mod features;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;
+pub mod gate_receipts;
 pub mod gates;
 pub mod github;
 pub mod hardening;

--- a/xtask/tests/fixtures/gate-receipts/invalid-missing-verdict.json
+++ b/xtask/tests/fixtures/gate-receipts/invalid-missing-verdict.json
@@ -1,0 +1,9 @@
+{
+  "check": "methodology-gate",
+  "schema_version": "1.0.0",
+  "event": "pull_request",
+  "run_id": "12345",
+  "pr": 6856,
+  "selected": true,
+  "selection_reason": "missing verdict should fail"
+}

--- a/xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json
+++ b/xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json
@@ -1,0 +1,12 @@
+{
+  "check": "methodology-gate",
+  "schema_version": "1.0.0",
+  "event": "pull_request",
+  "verdict": "pass",
+  "run_id": "12345",
+  "pr": 6856,
+  "base_sha": "abc123",
+  "head_sha": "def456",
+  "selected": true,
+  "selection_reason": "all prerequisite gates passed"
+}


### PR DESCRIPTION
### Motivation

- Provide a committed, discoverable registry for CI/control-plane gate receipts to make failures easier to classify and aggregate.
- Create a stable substrate for the larger receipts -> state-builder -> label-projection work while keeping runtime receipts under `target/receipts/` and committed schemas under `.ci/receipts/`.
- Ensure gate code can assert minimum contract (common fields and enums) and allow check-specific required fields to be declared in a registry.

### Description

- Add `.ci/receipts/registry.toml` and committed JSON schema stubs under `.ci/receipts/schemas/` for `common-gate-receipt`, `parser-ratchet`, `methodology-gate`, `aggregator-receipt`, `merge-readiness`, `fmt`, and `failure-classifier`.
- Add a new xtask module `xtask/src/tasks/gate_receipts.rs` and wire CLI subcommand `cargo xtask gate-receipts` with `list`, `validate <path>`, and `validate-all <dir>` actions, plus `--format json` output option.
- Registry-driven validation enforces common required fields (`check`, `schema_version`, `event`, `verdict`), checks enums (`verdict`, `event`, `classification`), and enforces per-check `extra_required` fields listed in `registry.toml`.
- Note: this rollout implements registry parsing and required-field / enum validation (lightweight validation) rather than full JSON Schema validation against the committed schema files, which is intentional to keep the change focused and small.

### Testing

- Ran `cargo check -p xtask` which completed successfully.
- Ran `cargo xtask gate-receipts list` which printed the registry entries successfully.
- Ran `cargo xtask gate-receipts validate xtask/tests/fixtures/gate-receipts/valid-methodology-gate.json` which reported `OK`.
- Ran `cargo xtask gate-receipts validate xtask/tests/fixtures/gate-receipts/invalid-missing-verdict.json` and `cargo xtask gate-receipts validate-all xtask/tests/fixtures/gate-receipts`, both of which failed as expected due to the missing `verdict` field.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0535be88333b7d569d9fe97e23c)