### PR TITLE
feat(xtask): add control-plane command stubs (#6853)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -853,6 +853,39 @@ enum Commands {
         test_threads: u32,
     },
 
+    /// Control-plane receipts for CI methodology and merge gates.
+    GateReceipts {
+        #[command(subcommand)]
+        command: GateReceiptsCommand,
+    },
+
+    /// Methodology gate orchestration entry point.
+    MethodologyGate,
+
+    /// Aggregate gate receipts into a summary artifact.
+    AggregateReceipts,
+
+    /// Final merge-check validation over aggregated receipts.
+    FinalizeCheck,
+
+    /// Lint workflow trigger policies and invariants.
+    WorkflowTriggerLint,
+
+    /// Merge-readiness gate scaffold.
+    MergeReady,
+
+    /// Classify queue failures by fix-forward policy.
+    FailureClassifier,
+
+    /// Queue state and label projection stubs.
+    Queue {
+        #[command(subcommand)]
+        command: QueueCommand,
+    },
+
+    /// Fix-forward orchestration stub.
+    FixForward,
+
     /// Track ignored tests and enforce gate policy
     IgnoredTests {
         /// Write current counts back to baseline
@@ -1220,6 +1253,28 @@ enum CpanCorpusCommand {
 }
 
 #[derive(Subcommand)]
+enum GateReceiptsCommand {
+    /// List known gate receipt entries.
+    List,
+
+    /// Validate a gate receipt file path.
+    Validate {
+        /// Path to the receipt to validate.
+        path: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
+enum QueueCommand {
+    /// Show queue state summary.
+    State,
+
+    /// Project queue labels from queue state.
+    #[command(name = "project-labels")]
+    ProjectLabels,
+}
+
+#[derive(Subcommand)]
 enum FeaturesCommand {
     /// Sync documentation from features.toml
     SyncDocs,
@@ -1579,6 +1634,21 @@ fn main() -> Result<()> {
                 test_threads,
             })
         }
+        Commands::GateReceipts { command } => match command {
+            GateReceiptsCommand::List => gate_receipts::list(),
+            GateReceiptsCommand::Validate { path } => gate_receipts::validate(path),
+        },
+        Commands::MethodologyGate => methodology_gate::run(),
+        Commands::AggregateReceipts => aggregate_receipts::run(),
+        Commands::FinalizeCheck => finalize_check::run(),
+        Commands::WorkflowTriggerLint => workflow_trigger_lint::run(),
+        Commands::MergeReady => merge_ready::run(),
+        Commands::FailureClassifier => failure_classifier::run(),
+        Commands::Queue { command } => match command {
+            QueueCommand::State => queue_state::run(),
+            QueueCommand::ProjectLabels => label_projector::run(),
+        },
+        Commands::FixForward => fix_forward::run(),
         Commands::IgnoredTests { update, check, verbose } => {
             ignored_tests::run(update, check, verbose)
         }

--- a/xtask/src/tasks/aggregate_receipts.rs
+++ b/xtask/src/tasks/aggregate_receipts.rs
@@ -1,0 +1,9 @@
+//! Stub for the aggregate-receipts xtask command.
+
+use color_eyre::eyre::Result;
+
+/// Run `cargo xtask aggregate-receipts`.
+pub fn run() -> Result<()> {
+    println!("[stub] aggregate-receipts is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/failure_classifier.rs
+++ b/xtask/src/tasks/failure_classifier.rs
@@ -1,0 +1,9 @@
+//! Stub for the failure-classifier xtask command.
+
+use color_eyre::eyre::Result;
+
+/// Run `cargo xtask failure-classifier`.
+pub fn run() -> Result<()> {
+    println!("[stub] failure-classifier is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/finalize_check.rs
+++ b/xtask/src/tasks/finalize_check.rs
@@ -1,0 +1,9 @@
+//! Stub for the finalize-check xtask command.
+
+use color_eyre::eyre::Result;
+
+/// Run `cargo xtask finalize-check`.
+pub fn run() -> Result<()> {
+    println!("[stub] finalize-check is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/fix_forward.rs
+++ b/xtask/src/tasks/fix_forward.rs
@@ -1,0 +1,9 @@
+//! Stub for the fix-forward xtask command.
+
+use color_eyre::eyre::Result;
+
+/// Run `cargo xtask fix-forward`.
+pub fn run() -> Result<()> {
+    println!("[stub] fix-forward is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/gate_receipts.rs
+++ b/xtask/src/tasks/gate_receipts.rs
@@ -1,0 +1,19 @@
+//! Stubs for control-plane gate receipt commands.
+
+use color_eyre::eyre::Result;
+use std::path::PathBuf;
+
+/// Run `cargo xtask gate-receipts list`.
+pub fn list() -> Result<()> {
+    println!("[stub] gate-receipts list is not implemented yet");
+    Ok(())
+}
+
+/// Run `cargo xtask gate-receipts validate <path>`.
+pub fn validate(path: PathBuf) -> Result<()> {
+    println!(
+        "[stub] gate-receipts validate is not implemented yet (path: {})",
+        path.display()
+    );
+    Ok(())
+}

--- a/xtask/src/tasks/label_projector.rs
+++ b/xtask/src/tasks/label_projector.rs
@@ -1,0 +1,9 @@
+//! Stub for queue label projection.
+
+use color_eyre::eyre::Result;
+
+/// Run `cargo xtask queue project-labels`.
+pub fn run() -> Result<()> {
+    println!("[stub] queue project-labels is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/merge_ready.rs
+++ b/xtask/src/tasks/merge_ready.rs
@@ -1,0 +1,9 @@
+//! Stub for the merge-ready xtask command.
+
+use color_eyre::eyre::Result;
+
+/// Run `cargo xtask merge-ready`.
+pub fn run() -> Result<()> {
+    println!("[stub] merge-ready is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/methodology_gate.rs
+++ b/xtask/src/tasks/methodology_gate.rs
@@ -1,0 +1,9 @@
+//! Stub for the methodology-gate xtask command.
+
+use color_eyre::eyre::Result;
+
+/// Run `cargo xtask methodology-gate`.
+pub fn run() -> Result<()> {
+    println!("[stub] methodology-gate is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod bench;
 pub mod benchmarks;
+pub mod aggregate_receipts;
 #[cfg(feature = "parser-tasks")]
 pub mod bindings;
 pub mod build;
@@ -36,10 +37,14 @@ pub mod doc_claims;
 pub mod e2e_validate;
 pub mod edge_cases;
 pub mod features;
+pub mod failure_classifier;
+pub mod finalize_check;
+pub mod fix_forward;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;
 pub mod gates;
+pub mod gate_receipts;
 pub mod github;
 pub mod hardening;
 #[cfg(feature = "parser-tasks")]
@@ -48,7 +53,10 @@ pub mod hook_checks;
 pub mod ignored_tests;
 pub mod inject_sha_assets;
 pub mod layer_check;
+pub mod label_projector;
+pub mod merge_ready;
 pub mod metrics;
+pub mod methodology_gate;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;
 pub mod parser_matrix;
@@ -73,4 +81,6 @@ pub mod update_homebrew;
 pub mod update_status;
 pub mod ux_scorecard;
 pub mod validate_workspace_exclusions;
+pub mod workflow_trigger_lint;
 pub mod worktrees;
+pub mod queue_state;

--- a/xtask/src/tasks/queue_state.rs
+++ b/xtask/src/tasks/queue_state.rs
@@ -1,0 +1,9 @@
+//! Stub for queue state reporting.
+
+use color_eyre::eyre::Result;
+
+/// Run `cargo xtask queue state`.
+pub fn run() -> Result<()> {
+    println!("[stub] queue state is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/workflow_trigger_lint.rs
+++ b/xtask/src/tasks/workflow_trigger_lint.rs
@@ -1,0 +1,9 @@
+//! Stub for the workflow-trigger-lint xtask command.
+
+use color_eyre::eyre::Result;
+
+/// Run `cargo xtask workflow-trigger-lint`.
+pub fn run() -> Result<()> {
+    println!("[stub] workflow-trigger-lint is not implemented yet");
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Refs #6853: Several P0/P1 CI-modernization issues need new xtask entry points and adding plumbing reduces repeated merge conflicts when multiple follow-up PRs implement logic.
- Provide minimal, safe CLI entry points so future agents can implement each command in separate PRs without contending over `xtask/src/main.rs` and `xtask/src/tasks/mod.rs`.

### Description
- Added new top-level CLI variants in `xtask/src/main.rs` for `gate-receipts`, `methodology-gate`, `aggregate-receipts`, `finalize-check`, `workflow-trigger-lint`, `merge-ready`, `failure-classifier`, `queue` (with `state` and `project-labels`), and `fix-forward`, plus small enums `GateReceiptsCommand` and `QueueCommand` and dispatch wiring to task modules.
- Registered new modules in `xtask/src/tasks/mod.rs` so the build references compile (`gate_receipts`, `methodology_gate`, `aggregate_receipts`, `finalize_check`, `workflow_trigger_lint`, `merge_ready`, `failure_classifier`, `queue_state`, `label_projector`, `fix_forward`).
- Added minimal stub implementations under `xtask/src/tasks/*.rs` that print clear "not implemented yet" messages and return `Ok(())`; the stubs do not contact GitHub or mutate labels and do not panic.
- This change is limited to plumbing only and does not implement gate logic, receipts schema changes, or any network/API interactions.

### Testing
- Ran `cargo check -p xtask` and it succeeded (xtask compiled).
- Executed the following commands and verified they print stubs or show help without panicking: `cargo xtask gate-receipts list`, `cargo xtask gate-receipts validate some/path.json`, `cargo xtask methodology-gate --help`, `cargo xtask aggregate-receipts --help`, `cargo xtask finalize-check --help`, `cargo xtask workflow-trigger-lint --help`, `cargo xtask merge-ready --help`, `cargo xtask failure-classifier --help`, `cargo xtask queue state --help`, `cargo xtask queue project-labels --help`, and `cargo xtask fix-forward --help`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd04cc93c8333ae58b4845159502f)