### PR TITLE
feat(xtask): add control-plane command stubs (#6853)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -853,6 +853,39 @@ enum Commands {
         test_threads: u32,
     },
 
+    /// Manage control-plane CI gate receipts.
+    GateReceipts {
+        #[command(subcommand)]
+        command: GateReceiptsCommand,
+    },
+
+    /// Run methodology gate checks.
+    MethodologyGate,
+
+    /// Aggregate receipt data for downstream checks.
+    AggregateReceipts,
+
+    /// Run finalize-check verification.
+    FinalizeCheck,
+
+    /// Lint workflow triggers used by CI orchestration.
+    WorkflowTriggerLint,
+
+    /// Evaluate merge-ready control-plane signals.
+    MergeReady,
+
+    /// Classify CI failures for queue follow-ups.
+    FailureClassifier,
+
+    /// Queue management control-plane commands.
+    Queue {
+        #[command(subcommand)]
+        command: QueueCommand,
+    },
+
+    /// Apply fix-forward follow-up workflow.
+    FixForward,
+
     /// Track ignored tests and enforce gate policy
     IgnoredTests {
         /// Write current counts back to baseline
@@ -1220,6 +1253,22 @@ enum CpanCorpusCommand {
 }
 
 #[derive(Subcommand)]
+enum GateReceiptsCommand {
+    /// List known gate receipt entries.
+    List,
+    /// Validate one gate receipt payload file.
+    Validate { path: PathBuf },
+}
+
+#[derive(Subcommand)]
+enum QueueCommand {
+    /// Show queue state summary.
+    State,
+    /// Project labels for queue work items (stub, non-mutating).
+    ProjectLabels,
+}
+
+#[derive(Subcommand)]
 enum FeaturesCommand {
     /// Sync documentation from features.toml
     SyncDocs,
@@ -1579,6 +1628,21 @@ fn main() -> Result<()> {
                 test_threads,
             })
         }
+        Commands::GateReceipts { command } => match command {
+            GateReceiptsCommand::List => gate_receipts::list(),
+            GateReceiptsCommand::Validate { path } => gate_receipts::validate(&path),
+        },
+        Commands::MethodologyGate => methodology_gate::run(),
+        Commands::AggregateReceipts => aggregate_receipts::run(),
+        Commands::FinalizeCheck => finalize_check::run(),
+        Commands::WorkflowTriggerLint => workflow_trigger_lint::run(),
+        Commands::MergeReady => merge_ready::run(),
+        Commands::FailureClassifier => failure_classifier::run(),
+        Commands::Queue { command } => match command {
+            QueueCommand::State => queue_state::run(),
+            QueueCommand::ProjectLabels => label_projector::run(),
+        },
+        Commands::FixForward => fix_forward::run(),
         Commands::IgnoredTests { update, check, verbose } => {
             ignored_tests::run(update, check, verbose)
         }

--- a/xtask/src/tasks/aggregate_receipts.rs
+++ b/xtask/src/tasks/aggregate_receipts.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("aggregate-receipts: not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/failure_classifier.rs
+++ b/xtask/src/tasks/failure_classifier.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("failure-classifier: not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/finalize_check.rs
+++ b/xtask/src/tasks/finalize_check.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("finalize-check: not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/fix_forward.rs
+++ b/xtask/src/tasks/fix_forward.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("fix-forward: not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/gate_receipts.rs
+++ b/xtask/src/tasks/gate_receipts.rs
@@ -1,0 +1,12 @@
+use color_eyre::eyre::Result;
+use std::path::Path;
+
+pub fn list() -> Result<()> {
+    println!("gate-receipts list: not implemented yet");
+    Ok(())
+}
+
+pub fn validate(path: &Path) -> Result<()> {
+    println!("gate-receipts validate {}: not implemented yet", path.display());
+    Ok(())
+}

--- a/xtask/src/tasks/label_projector.rs
+++ b/xtask/src/tasks/label_projector.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("queue project-labels: not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/merge_ready.rs
+++ b/xtask/src/tasks/merge_ready.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("merge-ready: not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/methodology_gate.rs
+++ b/xtask/src/tasks/methodology_gate.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("methodology-gate: not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -1,5 +1,6 @@
 //! Task implementations for xtask automation
 
+pub mod aggregate_receipts;
 pub mod bench;
 pub mod benchmarks;
 #[cfg(feature = "parser-tasks")]
@@ -35,10 +36,14 @@ pub mod doc;
 pub mod doc_claims;
 pub mod e2e_validate;
 pub mod edge_cases;
+pub mod failure_classifier;
 pub mod features;
+pub mod finalize_check;
+pub mod fix_forward;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;
+pub mod gate_receipts;
 pub mod gates;
 pub mod github;
 pub mod hardening;
@@ -47,7 +52,10 @@ pub mod highlight;
 pub mod hook_checks;
 pub mod ignored_tests;
 pub mod inject_sha_assets;
+pub mod label_projector;
 pub mod layer_check;
+pub mod merge_ready;
+pub mod methodology_gate;
 pub mod metrics;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;
@@ -59,6 +67,7 @@ pub mod publish;
 pub mod publish_closure;
 pub mod publish_manifest_check;
 pub mod publish_receipts;
+pub mod queue_state;
 pub mod receipts;
 pub mod release;
 pub mod release_notes;
@@ -73,4 +82,5 @@ pub mod update_homebrew;
 pub mod update_status;
 pub mod ux_scorecard;
 pub mod validate_workspace_exclusions;
+pub mod workflow_trigger_lint;
 pub mod worktrees;

--- a/xtask/src/tasks/queue_state.rs
+++ b/xtask/src/tasks/queue_state.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("queue state: not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/workflow_trigger_lint.rs
+++ b/xtask/src/tasks/workflow_trigger_lint.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("workflow-trigger-lint: not implemented yet");
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Several CI-modernization tasks require new `xtask` subcommands and without shared plumbing multiple follow-ups would conflict on `xtask/src/main.rs` and `xtask/src/tasks/mod.rs`.
- Provide minimal, compile-safe CLI scaffolding so subsequent PRs can implement logic without mass merge conflicts.

### Description
- Added new top-level `xtask` commands and subcommands: `gate-receipts` (with `list` and `validate <path>`), `methodology-gate`, `aggregate-receipts`, `finalize-check`, `workflow-trigger-lint`, `merge-ready`, `failure-classifier`, `queue` (with `state` and `project-labels`), and `fix-forward`.
- Wired new task modules into `xtask/src/tasks/mod.rs` and added minimal stub modules under `xtask/src/tasks/` that print a clear "not implemented yet" message and return `Ok(())` (no panics, no network/GitHub calls, no label mutations).
- Implemented `gate-receipts::list()` and `gate-receipts::validate(path)` stubs and connected CLI dispatch in `xtask/src/main.rs` so the new commands are discoverable and runnable.

### Testing
- `cargo check -p xtask` completed successfully.
- Ran representative `xtask` invocations and help commands which all returned expected stubs/help: `cargo xtask gate-receipts list`, `cargo xtask gate-receipts validate xtask/src/main.rs`, `cargo xtask methodology-gate --help`, `cargo xtask aggregate-receipts --help`, `cargo xtask finalize-check --help`, `cargo xtask workflow-trigger-lint --help`, `cargo xtask merge-ready --help`, `cargo xtask failure-classifier --help`, `cargo xtask queue state --help`, `cargo xtask queue project-labels --help`, and `cargo xtask fix-forward --help`, all succeeded.

Refs #6853

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd04cc93c8333ae58b4845159502f)