### PR TITLE
feat(xtask): add control-plane command stubs (#6853)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1152,6 +1152,39 @@ enum Commands {
         /// Current receipt JSON path.
         current: PathBuf,
     },
+
+    /// Manage control-plane gate receipts.
+    GateReceipts {
+        #[command(subcommand)]
+        command: GateReceiptsCommand,
+    },
+
+    /// Run methodology gate checks.
+    MethodologyGate,
+
+    /// Aggregate control-plane receipts.
+    AggregateReceipts,
+
+    /// Finalize gate check state from receipts.
+    FinalizeCheck,
+
+    /// Lint workflow trigger discipline.
+    WorkflowTriggerLint,
+
+    /// Check merge-ready state and receipt bindings.
+    MergeReady,
+
+    /// Classify CI failures for queue/fix-forward flow.
+    FailureClassifier,
+
+    /// Queue control-plane utilities.
+    Queue {
+        #[command(subcommand)]
+        command: QueueCommand,
+    },
+
+    /// Follow up fix-forward actions from queue state.
+    FixForward,
 }
 
 #[derive(Subcommand)]
@@ -1301,6 +1334,25 @@ enum MetricsCommand {
         #[arg(long)]
         input: Option<PathBuf>,
     },
+}
+
+#[derive(Subcommand)]
+enum GateReceiptsCommand {
+    /// List known gate receipts (stub).
+    List,
+    /// Validate a gate receipt path (stub).
+    Validate {
+        /// Path to the receipt file or directory to validate.
+        path: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
+enum QueueCommand {
+    /// Show queue state summary (stub).
+    State,
+    /// Project queue labels from receipts (stub).
+    ProjectLabels,
 }
 
 #[derive(ValueEnum, Clone)]
@@ -1686,6 +1738,21 @@ fn main() -> Result<()> {
         Commands::CompareBuildTiming { baseline, current } => {
             build_timing::run_compare(baseline, current)
         }
+        Commands::GateReceipts { command } => match command {
+            GateReceiptsCommand::List => gate_receipts::list(),
+            GateReceiptsCommand::Validate { path } => gate_receipts::validate(path),
+        },
+        Commands::MethodologyGate => methodology_gate::run(),
+        Commands::AggregateReceipts => aggregate_receipts::run(),
+        Commands::FinalizeCheck => finalize_check::run(),
+        Commands::WorkflowTriggerLint => workflow_trigger_lint::run(),
+        Commands::MergeReady => merge_ready::run(),
+        Commands::FailureClassifier => failure_classifier::run(),
+        Commands::Queue { command } => match command {
+            QueueCommand::State => queue_state::run(),
+            QueueCommand::ProjectLabels => label_projector::run(),
+        },
+        Commands::FixForward => fix_forward::run(),
     }
 }
 

--- a/xtask/src/tasks/aggregate_receipts.rs
+++ b/xtask/src/tasks/aggregate_receipts.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("aggregate-receipts is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/failure_classifier.rs
+++ b/xtask/src/tasks/failure_classifier.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("failure-classifier is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/finalize_check.rs
+++ b/xtask/src/tasks/finalize_check.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("finalize-check is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/fix_forward.rs
+++ b/xtask/src/tasks/fix_forward.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("fix-forward is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/gate_receipts.rs
+++ b/xtask/src/tasks/gate_receipts.rs
@@ -1,0 +1,12 @@
+use color_eyre::eyre::Result;
+use std::path::PathBuf;
+
+pub fn list() -> Result<()> {
+    println!("gate-receipts list is not implemented yet");
+    Ok(())
+}
+
+pub fn validate(path: PathBuf) -> Result<()> {
+    println!("gate-receipts validate is not implemented yet (path: {})", path.display());
+    Ok(())
+}

--- a/xtask/src/tasks/label_projector.rs
+++ b/xtask/src/tasks/label_projector.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("queue project-labels is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/merge_ready.rs
+++ b/xtask/src/tasks/merge_ready.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("merge-ready is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/methodology_gate.rs
+++ b/xtask/src/tasks/methodology_gate.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("methodology-gate is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -1,5 +1,6 @@
 //! Task implementations for xtask automation
 
+pub mod aggregate_receipts;
 pub mod bench;
 pub mod benchmarks;
 #[cfg(feature = "parser-tasks")]
@@ -35,10 +36,14 @@ pub mod doc;
 pub mod doc_claims;
 pub mod e2e_validate;
 pub mod edge_cases;
+pub mod failure_classifier;
 pub mod features;
+pub mod finalize_check;
+pub mod fix_forward;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;
+pub mod gate_receipts;
 pub mod gates;
 pub mod github;
 pub mod hardening;
@@ -47,7 +52,10 @@ pub mod highlight;
 pub mod hook_checks;
 pub mod ignored_tests;
 pub mod inject_sha_assets;
+pub mod label_projector;
 pub mod layer_check;
+pub mod merge_ready;
+pub mod methodology_gate;
 pub mod metrics;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;
@@ -59,6 +67,7 @@ pub mod publish;
 pub mod publish_closure;
 pub mod publish_manifest_check;
 pub mod publish_receipts;
+pub mod queue_state;
 pub mod receipts;
 pub mod release;
 pub mod release_notes;
@@ -73,4 +82,5 @@ pub mod update_homebrew;
 pub mod update_status;
 pub mod ux_scorecard;
 pub mod validate_workspace_exclusions;
+pub mod workflow_trigger_lint;
 pub mod worktrees;

--- a/xtask/src/tasks/queue_state.rs
+++ b/xtask/src/tasks/queue_state.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("queue state is not implemented yet");
+    Ok(())
+}

--- a/xtask/src/tasks/workflow_trigger_lint.rs
+++ b/xtask/src/tasks/workflow_trigger_lint.rs
@@ -1,0 +1,6 @@
+use color_eyre::eyre::Result;
+
+pub fn run() -> Result<()> {
+    println!("workflow-trigger-lint is not implemented yet");
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Refs #6853: upcoming P0/P1 CI modernization needs several new `xtask` entrypoints and adding them piecemeal would cause repeated merge conflicts in `xtask/src/main.rs` and `xtask/src/tasks/mod.rs`.

### Description
- Add top-level `xtask` command plumbing for control-plane work, including `GateReceipts` (with `list`/`validate`), `MethodologyGate`, `AggregateReceipts`, `FinalizeCheck`, `WorkflowTriggerLint`, `MergeReady`, `FailureClassifier`, `Queue` (with `state`/`project-labels`), and `FixForward` in `xtask/src/main.rs`.
- Introduce `GateReceiptsCommand` and `QueueCommand` enums to enable safe extension without repeated edits to the main command shape.
- Wire new modules into `xtask/src/tasks/mod.rs` and add minimal task stubs under `xtask/src/tasks/` that print clear “not implemented yet” messages and return `Ok(())` (no panics, no GitHub calls, no label mutations).
- Files added/modified: `xtask/src/main.rs`, `xtask/src/tasks/mod.rs`, and new stubs `xtask/src/tasks/{gate_receipts,methodology_gate,aggregate_receipts,finalize_check,workflow_trigger_lint,merge_ready,failure_classifier,queue_state,label_projector,fix_forward}.rs`.

### Testing
- Ran `cargo check -p xtask` and it completed successfully.
- Ran `cargo xtask gate-receipts list` and it printed the expected "not implemented yet" stub message.
- Ran `cargo xtask gate-receipts validate sample.json` and it printed the expected stub message including the provided path.
- Ran `cargo xtask methodology-gate --help`, `cargo xtask merge-ready --help`, `cargo xtask queue state --help`, and `cargo xtask queue project-labels --help` and each printed usage/help as expected.
- Ran `cargo xtask fmt` to format xtask and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd04cc93c8333ae58b4845159502f)