### PR TITLE
docs(ci): document receipt-driven control-plane rollout (#6853)

### DIFF
--- a/docs/ci/codex-agent-implementation-guide.md
+++ b/docs/ci/codex-agent-implementation-guide.md
@@ -1,0 +1,57 @@
+# Codex Agent Implementation Guide (Control-Plane Modernization)
+
+This guide defines how implementation agents contribute to the receipt-driven CI/control-plane model tracked by **#6853**.
+
+## Codex agent guardrails
+
+1. Inspect current `master` first so already-merged work is not reimplemented.
+2. If the target is already implemented, deliver a minimal follow-up (or explicitly report a no-op).
+3. Keep PRs narrowly scoped to one concern.
+4. Do not edit unrelated high-churn global files.
+5. Do not claim branch/ruleset enforcement was changed unless it was actually changed.
+
+## Operating model for agents
+
+- Agents do not own mutable canonical state.
+- Agents emit receipts as evidence.
+- Routing-critical operations must emit receipts.
+- Reconciler/state builder derives canonical state.
+- Labels are projected UI, not authority.
+
+## Receipt locations
+
+- Generated runtime receipts: `target/receipts/*.json`
+- Committed schemas: `.ci/receipts/schemas/*.schema.json`
+- Registry: `.ci/receipts/registry.toml`
+
+When adding new receipt types, update schema + registry in the same scoped PR.
+
+## Workflow rules agents must preserve
+
+- Required-style workflows must always run and no-op internally when not applicable.
+- Do not path-filter required-style workflows.
+- For modernization work, ensure workflows are wired for:
+  - `pull_request`
+  - `merge_group`
+  - `push` to `master`
+- Use event-aware concurrency groups so events do not cancel unrelated truth-building runs.
+- Use final aggregators to publish a single canonical pass/fail signal for the control-plane view.
+
+## Staged rollout expectations
+
+- **P0**: impossible states impossible.
+- **P1**: receipts -> state -> labels.
+- **P2**: Parser Ratchet scoped gate.
+- **P3**: leases/worktree/queue health.
+- **P4**: release evidence and scenario gates.
+
+Agent PRs should state which stage they advance and what invariant/evidence boundary they add.
+
+## Partial-closeout hygiene
+
+Use close keywords intentionally:
+
+- For scaffold/partial work: `Refs #6853` or `Part of #6853`.
+- Use `Closes` / `Fixes` / `Resolves` only when acceptance criteria for the target issue are complete.
+
+This avoids premature issue closure during staged rollout.

--- a/docs/ci/codex-agent-implementation-guide.md
+++ b/docs/ci/codex-agent-implementation-guide.md
@@ -21,8 +21,8 @@ This guide defines how implementation agents contribute to the receipt-driven CI
 ## Receipt locations
 
 - Generated runtime receipts: `target/receipts/*.json`
-- Committed schemas: `.ci/receipts/schemas/*.schema.json`
-- Registry: `.ci/receipts/registry.toml`
+- Committed schemas: `.ci/schemas/*.schema.{json,yaml}`
+- Registry: `.ci/GATE_REGISTRY.toml`
 
 When adding new receipt types, update schema + registry in the same scoped PR.
 

--- a/docs/ci/control-plane-modernization.md
+++ b/docs/ci/control-plane-modernization.md
@@ -1,0 +1,71 @@
+# CI Control-Plane Modernization
+
+This guide documents the receipt-driven CI/control-plane modernization tracked in **#6853** and broken into P0 issues **#6855–#6859**.
+
+## Target architecture
+
+The target model is:
+
+1. Agents do **not** own state.
+2. Agents emit **receipts**.
+3. Receipts are **evidence**.
+4. A reconciler derives **canonical state** from evidence.
+5. Labels are a **projected UI** view of reconciled state.
+6. CI enforces invariants (impossible states become impossible).
+7. Routing is derived automatically from canonical state and receipt evidence.
+8. `merge_group` becomes the final pre-merge truth gate.
+
+## Staged rollout
+
+### P0 — impossible states impossible
+
+P0 establishes control-plane invariants and the baseline constraints:
+
+- **#6855**: Methodology Gate
+- **#6856**: Receipt schema registry
+- **#6857**: Final aggregator
+- **#6858**: `merge_group` triggers
+- **#6859**: merge-ready SHA binding
+
+Practical P0 result: state transitions that violate invariants are rejected by CI aggregation logic.
+
+### P1 — receipts -> state -> labels
+
+P1 formalizes the normal data flow:
+
+- Receipts are emitted by agents and routing-critical workflows.
+- Reconciler/state builder consumes receipt evidence.
+- Labels are projected from reconciled state (never source-of-truth state).
+
+### P2 — Parser Ratchet scoped gate
+
+P2 introduces a scoped ratchet gate for parser quality/control-plane signal quality. It should be integrated as receipt-producing evidence and included in final aggregation logic.
+
+### P3 — leases/worktree/queue health
+
+P3 adds operational health evidence (lease validity, worktree hygiene, queue integrity) into the same receipt+reconciler model.
+
+### P4 — release evidence and scenario gates
+
+P4 extends the same architecture into release readiness and scenario-driven gates so release decisions are evidence-backed and aggregation-enforced.
+
+## Current repository facts and constraints
+
+- The repository uses **GitHub Rulesets**, not classic branch protection.
+- Required status checks are **not yet configured at the GitHub Ruleset layer**.
+- Therefore, references to “required checks” in this document are a **future/conventional target** until rulesets are updated.
+- Runtime receipts belong under `target/receipts/`.
+- Committed schemas and registry belong under `.ci/receipts/`.
+- Partial implementation PRs use `Refs #<issue>` or `Part of #<issue>` (not `Closes #<issue>`).
+- Avoid shared mutable state files; prefer sharded config and evidence-driven reconciliation.
+- Required-style workflows must always run and no-op internally when out-of-scope; do not path-filter them.
+
+## Label projection model
+
+Labels are UI affordances only:
+
+- Agents emit receipts.
+- Reconciler derives canonical state.
+- Label projector updates PR labels from canonical state.
+
+Agents must not directly treat labels as state ownership.

--- a/docs/ci/receipt-contract.md
+++ b/docs/ci/receipt-contract.md
@@ -1,0 +1,57 @@
+# Receipt Contract (CI Control-Plane)
+
+This document defines the receipt contract for the control-plane modernization tracked by **#6853**.
+
+## Contract summary
+
+- Receipts are machine-readable evidence emitted by agents and routing-critical gates.
+- Reconciler/state-builder logic consumes receipts to derive canonical state.
+- Labels are projected from canonical state and are UI only.
+
+## Storage and ownership
+
+### Generated runtime receipts
+
+- Path: `target/receipts/*.json`
+- Characteristics:
+  - ephemeral build/runtime outputs
+  - not source-controlled as canonical policy artifacts
+
+### Committed schemas
+
+- Path: `.ci/receipts/schemas/*.schema.json`
+- Characteristics:
+  - versioned contract for receipt payload validation
+  - code-reviewed alongside producer/consumer changes
+
+### Committed registry
+
+- Path: `.ci/receipts/registry.toml`
+- Characteristics:
+  - catalog of known receipt kinds and schema mappings
+  - single source for schema discovery by validators/reconcilers
+
+## Required behavior
+
+1. All routing-critical gates must emit receipts.
+2. Every receipt kind must map to a committed schema in the registry.
+3. Schema changes and producer changes should land together.
+4. Reconciler must treat receipts as evidence, not inferred label state.
+
+## Design constraints
+
+- Avoid shared mutable state files in control-plane logic.
+- Prefer sharded config/evidence artifacts that aggregate deterministically.
+- Required-style workflows run every time and no-op internally as needed; they are not path-filtered.
+
+## Rollout linkage
+
+- **P0** establishes invariants and baseline machinery (methodology gate, schema registry, aggregator, `merge_group`, merge-ready SHA binding).
+- **P1+** scales the same receipt contract into richer state/label projection and domain-specific gates.
+
+## Partial implementation PR semantics
+
+Use issue keywords carefully during staged rollout:
+
+- Partial/scaffold: `Refs #...` or `Part of #...`
+- Complete acceptance criteria: `Closes #...`, `Fixes #...`, or `Resolves #...`

--- a/docs/ci/receipt-contract.md
+++ b/docs/ci/receipt-contract.md
@@ -19,14 +19,14 @@ This document defines the receipt contract for the control-plane modernization t
 
 ### Committed schemas
 
-- Path: `.ci/receipts/schemas/*.schema.json`
+- Path: `.ci/schemas/*.schema.{json,yaml}`
 - Characteristics:
   - versioned contract for receipt payload validation
   - code-reviewed alongside producer/consumer changes
 
 ### Committed registry
 
-- Path: `.ci/receipts/registry.toml`
+- Path: `.ci/GATE_REGISTRY.toml`
 - Characteristics:
   - catalog of known receipt kinds and schema mappings
   - single source for schema discovery by validators/reconcilers

--- a/docs/ci/ruleset-rollout.md
+++ b/docs/ci/ruleset-rollout.md
@@ -1,0 +1,50 @@
+# Ruleset Rollout Plan for Receipt-Driven CI
+
+This document explains how to align GitHub Rulesets with the control-plane modernization tracked in **#6853**.
+
+## Current state
+
+- The repository uses **GitHub Rulesets** (not classic branch protection).
+- Required checks are **not yet configured at the Ruleset layer**.
+- Treat “required check” language in this guide as the intended end-state until rulesets are updated.
+
+## Workflow invariants to enforce
+
+For control-plane reliability, required-style workflows must be structurally predictable:
+
+1. No path filters for required-style workflows.
+2. Include events:
+   - `pull_request`
+   - `merge_group`
+   - `push` to `master`
+3. Use event-aware concurrency (avoid cross-event cancellation of truth signals).
+4. Use final aggregators to produce canonical pass/fail outputs.
+
+Required-style workflows should always run and no-op internally when work is out-of-scope.
+
+## Why `merge_group` matters
+
+`merge_group` is the final pre-merge truth surface. Any control-plane signal used for merge confidence must execute and aggregate on `merge_group`, not only on `pull_request`.
+
+## Staged rollout alignment
+
+- **P0**: impossible states impossible via methodology gate, schema registry, final aggregator, `merge_group` triggers, and merge-ready SHA binding.
+- **P1**: receipt evidence reconciled into canonical state, then projected to labels.
+- **P2**: Parser Ratchet scoped gate in the same aggregator model.
+- **P3**: leases/worktree/queue health evidence.
+- **P4**: release evidence and scenario gates.
+
+## Label projection and policy boundaries
+
+- Labels are projected UI state, not policy authority.
+- Agents emit receipts only; they do not own canonical state.
+- Reconciler/state-builder is authoritative for derived status and label projection.
+
+## Partial-closeout hygiene during rollout
+
+Use issue closing keywords according to completion level:
+
+- Partial/scaffold PRs: `Refs #...` or `Part of #...`
+- Only fully complete acceptance criteria PRs: `Closes` / `Fixes` / `Resolves`
+
+This prevents premature closure while the rollout is staged across P0–P4.


### PR DESCRIPTION
### Motivation

- Add an internal implementation guide to capture the receipt-driven CI/control-plane modernization tracked in `#6853` and the P0 issues `#6855–#6859`.
- Capture the target architecture where agents emit receipts, a reconciler derives canonical state, labels are a projected UI, and `merge_group` is the final pre-merge truth.
- Record repository constraints and conventions (Rulesets vs branch protection, receipt and schema locations, partial-PR hygiene, and required-style workflow expectations).

### Description

- Added four docs under `docs/ci`: `control-plane-modernization.md`, `codex-agent-implementation-guide.md`, `receipt-contract.md`, and `ruleset-rollout.md`, each describing the staged P0–P4 rollout, receipt contract, label projection, workflow rules, and Codex agent guardrails.
- Specified runtime and committed receipt locations as `target/receipts/*.json`, `.ci/receipts/schemas/*.schema.json`, and `.ci/receipts/registry.toml` and required that routing-critical gates emit receipts.
- Documented workflow invariants (no path filters for required-style workflows, include `pull_request`, `merge_group`, `push` to `master`, event-aware concurrency, and final aggregators) and partial-closeout PR semantics (`Refs`/`Part of` vs `Closes`/`Fixes`).
- Changes committed on branch `ci-modernization/docs-control-plane-guide` and a PR was opened with title `docs(ci): document receipt-driven control-plane rollout (#6853)` and body referencing `Refs #6853`.

### Testing

- Ran `git diff --check` which passed with no whitespace or formatting errors.
- Verified working-tree/docs-only changes via `git status --short` before committing.
- Ran `git log --oneline -20` to inspect recent history and attempted `git log origin/master --oneline -20` which failed because `origin/master` is not present in this worktree; this did not block the docs-only change.
- No crate code was modified so no `cargo test` or other crate-level tests were required for this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0476da08333b0801b27d5d611f7)