### PR TITLE
docs(ci): document receipt-driven control-plane rollout (#6853)

### DIFF
--- a/docs/ci/codex-agent-implementation-guide.md
+++ b/docs/ci/codex-agent-implementation-guide.md
@@ -1,0 +1,45 @@
+# Codex Agent Implementation Guide for Control-Plane Modernization
+
+This guide defines how Codex-driven implementation work should be performed for the receipt-driven control-plane architecture in `#6853` and linked issues.
+
+## Core operating model
+
+- Agents produce evidence (receipts), not canonical control-plane state.
+- Reconciler/state-builder logic derives canonical state from receipts.
+- Labels are projected UI and can lag or be recomputed.
+- CI gates enforce invariant checks using event-complete execution (`pull_request`, `merge_group`, `push` to `master`).
+
+## Workflow contract
+
+For required-style workflows:
+
+- Include triggers for:
+  - `pull_request`
+  - `merge_group`
+  - `push` on `master`
+- Use event-aware concurrency so runs cancel safely by event/ref semantics.
+- Use final aggregators to compute authoritative pass/fail from upstream jobs.
+- Do **not** path-filter required-style workflows.
+- If a workflow is not relevant for a change, it should still start and no-op internally.
+
+## Receipt-first implementation expectations
+
+- Runtime-generated receipts: `target/receipts/*.json`
+- Committed schemas: `.ci/receipts/schemas/*.schema.json`
+- Committed registry: `.ci/receipts/registry.toml`
+- All routing-critical gates must emit receipts.
+
+## Partial-closeout hygiene
+
+When a PR is a scaffold or partial implementation:
+
+- Use `Refs #issue` or `Part of #issue`.
+- Do **not** use `Closes #issue`, `Fixes #issue`, or `Resolves #issue` unless acceptance criteria are fully complete.
+
+## Codex agent guardrails
+
+1. Inspect current `master` (or latest local equivalent) before implementing to avoid duplicating already-merged work.
+2. If target behavior already exists, create only a minimal follow-up (docs/test hardening) or report a no-op.
+3. Keep PRs tightly scoped to one concern.
+4. Do not edit unrelated high-churn global files.
+5. Do not claim branch/ruleset enforcement has been changed unless it was actually changed.

--- a/docs/ci/control-plane-modernization.md
+++ b/docs/ci/control-plane-modernization.md
@@ -1,0 +1,85 @@
+# Control-Plane Modernization (Issue #6853)
+
+This document describes the repository-internal rollout plan for the CI/control-plane modernization effort tracked by `#6853`.
+
+## Architecture target
+
+The target operating model is:
+
+1. Agents do **not** own canonical state.
+2. Agents emit receipts.
+3. Receipts are evidence.
+4. A reconciler derives canonical state.
+5. Labels are projected UI.
+6. CI enforces invariants.
+7. Routes are derived automatically.
+8. `merge_group` becomes final pre-merge truth.
+
+## Ground rules
+
+- Runtime receipts are generated under `target/receipts/`.
+- Committed receipt schemas/registry live under `.ci/receipts/`.
+- Avoid shared mutable state files; prefer sharded config and deterministic recompute.
+- Required-style workflows must always run and internally no-op when not applicable.
+- Do not use path filters for required-style workflows.
+- The repository currently uses **GitHub Rulesets** (not classic branch protection).
+- Treat “required check” wording as a future/conventional target until rulesets are updated to enforce those checks.
+
+## Staged rollout
+
+### P0 — Impossible states impossible
+
+P0 hardens invariants so contradictory or unverifiable control-plane state cannot be accepted.
+
+Tracked P0 items:
+
+- `#6855` Methodology Gate
+- `#6856` Receipt schema registry
+- `#6857` Final aggregator
+- `#6858` `merge_group` triggers
+- `#6859` merge-ready SHA binding
+
+Primary objective: make invalid state transitions unrepresentable and force evidence-backed outcomes.
+
+### P1 — Receipts -> state -> labels
+
+P1 codifies receipt-first processing:
+
+- CI/runtime tasks emit receipts.
+- A state builder/reconciler consumes receipts.
+- Labels are projected from canonical state (never treated as authority).
+
+Primary objective: labels become a view, not control-plane source-of-truth.
+
+### P2 — Parser Ratchet scoped gate
+
+P2 introduces a scoped Parser Ratchet gate as a receipt-producing invariant check.
+
+Primary objective: tighten quality ratchets incrementally without introducing global fragility.
+
+### P3 — Leases/worktree/queue health
+
+P3 extends receipt coverage and reconciliation to coordination health:
+
+- lease integrity
+- worktree hygiene
+- queue-level readiness
+
+Primary objective: make operational health measurable and enforceable via evidence.
+
+### P4 — Release evidence and scenario gates
+
+P4 applies the same evidence model to release readiness and scenario-based gates.
+
+Primary objective: release/merge decisions are backed by auditable receipt trails and final aggregations.
+
+## Relationship to enforcement
+
+Ruleset and check enforcement should be rolled out in lockstep with receipt confidence:
+
+1. Generate and validate receipts.
+2. Reconcile into canonical state.
+3. Project labels/UI.
+4. Elevate checks into enforcement once signal quality is stable.
+
+Until ruleset-level required checks are fully configured, this doc should not be read as claiming completed enforcement changes.

--- a/docs/ci/receipt-contract.md
+++ b/docs/ci/receipt-contract.md
@@ -1,0 +1,44 @@
+# Receipt Contract
+
+This document defines the contract for evidence receipts used by the CI/control-plane model.
+
+## Purpose
+
+Receipts are durable evidence artifacts. They are emitted by routing-critical and gate-critical automation, then consumed by a reconciler/state builder to derive canonical control-plane state.
+
+## Locations
+
+### Runtime receipts
+
+- Path: `target/receipts/*.json`
+- Producer: CI/runtime jobs and gate steps
+- Lifecycle: ephemeral build artifacts per run
+
+### Committed schemas
+
+- Path: `.ci/receipts/schemas/*.schema.json`
+- Producer: repository-maintained contract definitions
+- Lifecycle: versioned in git; reviewed like code
+
+### Registry
+
+- Path: `.ci/receipts/registry.toml`
+- Purpose: authoritative mapping of receipt kinds to schema and validation metadata
+
+## Required behaviors
+
+1. All routing-critical gates emit receipts.
+2. Receipts are validated against committed schemas.
+3. Registry entries are the control point for receipt discoverability and validation wiring.
+4. Reconciliation uses receipts as source evidence; labels are projection-only output.
+
+## Non-goals
+
+- Receipts are not a mutable shared state store.
+- Labels are not a canonical state backend.
+
+## Evolution rules
+
+- Additive schema evolution is preferred.
+- Breaking schema changes require coordinated registry updates and reconciler updates.
+- Partial implementation PRs should reference parent issues with `Refs`/`Part of`, not closeout keywords.

--- a/docs/ci/ruleset-rollout.md
+++ b/docs/ci/ruleset-rollout.md
@@ -1,0 +1,48 @@
+# Ruleset Rollout Plan for Receipt-Driven CI
+
+This plan documents how to align GitHub Rulesets with the receipt-driven control-plane architecture.
+
+## Current repository reality
+
+- The repository uses GitHub **Rulesets**, not classic branch protection.
+- Required status checks are not currently configured at the ruleset layer.
+- Therefore, references to “required checks” in this plan are a target/convention until rulesets are explicitly updated.
+
+## Rollout principles
+
+1. Required-style workflows must always run.
+2. Required-style workflows must not rely on path filters.
+3. Workflows should no-op internally when conditions do not apply.
+4. Event coverage must include `pull_request`, `merge_group`, and `push` to `master`.
+5. Final aggregators should provide the merge-facing truth signal.
+6. `merge_group` is the final pre-merge validation truth.
+
+## Event and concurrency guidance
+
+- Trigger on:
+  - `pull_request`
+  - `merge_group`
+  - `push` branches: `master`
+- Use event-aware concurrency keys so:
+  - PR updates supersede stale PR runs,
+  - merge queue runs remain isolated,
+  - push-to-master validation is preserved.
+
+## Aggregation guidance
+
+- Upstream jobs emit receipts and local statuses.
+- A final aggregator evaluates all required invariants and emits a decisive result.
+- Aggregator output is the principal merge-facing check signal.
+
+## Label projection boundary
+
+- Labels are UI-only projection.
+- Labels must not be used as merge authority.
+- State reconciliation from receipts is authoritative; labels mirror that state.
+
+## Issue closeout hygiene
+
+For rollout/scaffold PRs that only prepare infrastructure:
+
+- Use `Refs #issue` or `Part of #issue`.
+- Reserve `Closes`/`Fixes`/`Resolves` for PRs that fully satisfy acceptance criteria.


### PR DESCRIPTION
### Motivation

- Create a repo-internal implementation guide for the CI/control-plane modernization tracked by `#6853` that captures the target architecture, staged rollout, and operational rules.
- Reflect current repository realities including use of GitHub Rulesets (not classic branch protection), planned P0 items (`#6855`–`#6859`), receipt and schema locations, and partial-PR hygiene.
- Provide concrete guidance for agents, workflows, receipt contracts, label projection, and ruleset rollout so implementation PRs remain scoped and safe.

### Description

- Added four focused docs under `docs/ci/`: `control-plane-modernization.md`, `codex-agent-implementation-guide.md`, `receipt-contract.md`, and `ruleset-rollout.md` describing architecture, staged P0→P4 rollout, Codex guardrails, receipt contract locations (`target/receipts/` and `.ci/receipts/`), and ruleset/workflow guidance.
- Each file documents required behavior: receipts-as-evidence, reconciler-derived canonical state, labels-as-UI-only, required-style workflow triggers (`pull_request`, `merge_group`, `push`->`master`), no path filters for required workflows, and final aggregator guidance.
- Emphasizes partial-closeout hygiene: use `Refs #issue` / `Part of #issue` for scaffold PRs and reserve `Closes`/`Fixes`/`Resolves` for full acceptance; notes committed schemas location `.ci/receipts/schemas/*.schema.json` and registry `.ci/receipts/registry.toml`.
- No code changes were made and the restricted files (`.github/workflows/ci.yml`, `xtask/src/main.rs`, `xtask/src/tasks/mod.rs`) were not touched.

### Testing

- Verified repository history visibility with `git log origin/master --oneline -20 || git log --oneline -20`, which completed successfully.
- Ran `git status --short` to confirm changes were docs-only and `git diff --check` to validate no trailing whitespace or diff issues, both of which passed.
- Created the PR record with the requested title and used `Refs #6853` in PR metadata; no additional automated crate tests were required because only documentation was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0476da08333b0801b27d5d611f7)