### PR TITLE
docs(ci): document receipt-driven control-plane rollout (#6853)

### DIFF
--- a/docs/ci/codex-agent-implementation-guide.md
+++ b/docs/ci/codex-agent-implementation-guide.md
@@ -1,0 +1,65 @@
+# Codex Agent Implementation Guide for CI/Control-Plane Modernization
+
+This guide describes how implementation agents should execute scoped work for the receipt-driven CI/control-plane model.
+
+## Operating model
+
+Agents are executors, not state authorities.
+
+- Do not mutate shared control-plane state as a source of truth.
+- Emit receipts for work performed.
+- Treat receipt generation as required evidence for routing-critical gates.
+- Expect a reconciler/state builder to derive canonical state and later project labels.
+
+## Codex agent guardrails
+
+Before and during implementation:
+
+1. **Inspect current `master` first.**
+   - Confirm whether targeted functionality already exists before writing new changes.
+2. **If already implemented, do minimal follow-up or no-op.**
+   - Prefer gap-fix PRs or report no-op with evidence over duplicate implementation.
+3. **Keep PRs scoped.**
+   - One concern per PR; avoid opportunistic cleanup.
+4. **Avoid unrelated high-churn global files.**
+   - Do not edit broad/global files outside scope unless strictly required.
+5. **Do not claim enforcement changes that were not made.**
+   - In particular, do not claim ruleset/branch enforcement updates unless they are actually changed.
+
+## Receipt-first execution pattern
+
+For routing-critical jobs:
+
+1. Run job logic.
+2. Emit runtime receipt to `target/receipts/*.json`.
+3. Validate receipt against committed schema.
+4. Let the final aggregator consume evidence.
+5. Let reconciler derive canonical state and downstream projections.
+
+## Workflow expectations for agent-authored changes
+
+- Required-style workflows must not use path filters.
+- Required-style workflows should run on:
+  - `pull_request`
+  - `merge_group`
+  - `push` on `master`
+- Workflows may no-op internally based on context, but they should still execute.
+- Concurrency should be event-aware.
+- Aggregation should happen in explicit final aggregator jobs.
+
+## Partial-closeout language
+
+Use issue verbs precisely:
+
+- Use `Refs #6853` or `Part of #6853` for incremental/scaffold PRs.
+- Reserve `Closes/Fixes/Resolves #6853` for full acceptance-criteria completion.
+
+## Current P0 focus map
+
+- #6855 Methodology Gate
+- #6856 Receipt schema registry
+- #6857 Final aggregator
+- #6858 `merge_group` triggers
+- #6859 Merge-ready SHA binding
+
+These P0 items collectively implement the baseline where impossible states are rejected and final pre-merge truth comes from `merge_group` evidence.

--- a/docs/ci/control-plane-modernization.md
+++ b/docs/ci/control-plane-modernization.md
@@ -1,0 +1,95 @@
+# CI/Control-Plane Modernization (Issue #6853)
+
+This guide defines the repository-internal rollout for the receipt-driven control plane.
+
+## Target architecture
+
+The modernization target is:
+
+- Agents do **not** own canonical state.
+- Agents emit **receipts**.
+- Receipts are the evidence substrate.
+- A **reconciler/state builder** derives canonical state from receipts.
+- Labels are projected UI, not authority.
+- CI enforces invariants.
+- Routes are derived automatically from canonical state.
+- `merge_group` is the final pre-merge truth.
+
+## Repo facts and constraints (current)
+
+- P0 issue set exists and remains active:
+  - #6855 Methodology Gate
+  - #6856 Receipt schema registry
+  - #6857 Final aggregator
+  - #6858 `merge_group` triggers
+  - #6859 Merge-ready SHA binding
+- The repository currently relies on **GitHub Rulesets**, not classic branch protection.
+- Required checks are **not yet configured at the ruleset layer**; references to "required checks" in this guide are target/conventional behavior pending ruleset updates.
+- Runtime receipts live under `target/receipts/`.
+- Committed schemas and registry live under `.ci/receipts/`.
+
+## Staged rollout
+
+### P0 — Make impossible states impossible
+
+Primary objective: prevent contradictory or unverifiable control-plane states.
+
+- Introduce invariant checks that reject impossible transitions.
+- Ensure gates fail closed when evidence is missing or malformed.
+- Establish the Methodology Gate baseline (#6855).
+
+### P1 — Receipts → state → labels
+
+Primary objective: establish unidirectional derivation.
+
+- Routing-critical jobs emit machine-readable receipts.
+- Reconciler derives canonical state from receipts.
+- Label projection becomes a downstream rendering of canonical state.
+- Introduce schema/registry governance (#6856) and final aggregation (#6857).
+
+### P2 — Parser Ratchet scoped gate
+
+Primary objective: isolate parser-ratchet policy in a scoped, auditable gate.
+
+- Keep ratchet policy encoded as evidence-backed gate logic.
+- Avoid broad global coupling; only the scoped gate owns ratchet evaluation.
+- Emit receipts so downstream state derivation remains uniform.
+
+### P3 — Leases/worktree/queue health
+
+Primary objective: operational correctness of orchestration substrate.
+
+- Add health evidence for lease safety, worktree hygiene, and queue consistency.
+- Model health status through receipts and reconciliation, not mutable shared state files.
+- Keep sharded config boundaries to avoid cross-concern drift.
+
+### P4 — Release evidence and scenario gates
+
+Primary objective: release confidence from explicit evidence.
+
+- Add release-oriented evidence receipts.
+- Add scenario gates that validate release-critical paths.
+- Maintain `merge_group` as final pre-merge truth source.
+
+## Workflow rules (implementation policy)
+
+- Required-style workflows must **always run** and no-op internally when not applicable.
+- Do **not** path-filter required-style workflows.
+- Add/keep event coverage on:
+  - `pull_request`
+  - `merge_group`
+  - `push` to `master`
+- Use event-aware concurrency to avoid stale/cross-event cancellation bugs.
+- Use final aggregators so decision status is based on complete evidence.
+
+## Partial-closeout hygiene
+
+- Use `Refs #issue` or `Part of #issue` for scaffolding/partial implementation PRs.
+- Use `Closes/Fixes/Resolves #issue` only when acceptance criteria are complete.
+- For this modernization track, partial infra/doc/mechanics PRs should default to `Refs`/`Part of`.
+
+## Guardrails
+
+- Do not introduce shared mutable state files for control-plane truth.
+- Prefer sharded config and receipt-derived state.
+- Do not claim ruleset-required-check enforcement is active until rulesets are actually updated.

--- a/docs/ci/receipt-contract.md
+++ b/docs/ci/receipt-contract.md
@@ -1,0 +1,35 @@
+# Receipt Contract for CI/Control-Plane Modernization
+
+This document defines the receipt locations, schema contract, and governance rules for routing-critical CI evidence.
+
+## Normative paths
+
+- **Generated runtime receipts:** `target/receipts/*.json`
+- **Committed schemas:** `.ci/receipts/schemas/*.schema.json`
+- **Schema registry:** `.ci/receipts/registry.toml`
+
+## Core contract
+
+1. All routing-critical gates MUST emit receipts.
+2. Receipts MUST be JSON documents written under `target/receipts/`.
+3. Each receipt type MUST have a committed JSON schema under `.ci/receipts/schemas/`.
+4. Schema identifiers and metadata MUST be listed in `.ci/receipts/registry.toml`.
+5. Receipt validation MUST happen before reconciliation/final aggregation consumes evidence.
+
+## Ownership and derivation
+
+- Agents own receipt emission only.
+- Canonical state ownership belongs to reconciler/state builder components.
+- Labels are a projection/UI surface and are not canonical state.
+
+## Evolution policy
+
+- Additive schema changes are preferred.
+- Breaking schema changes require coordinated registry updates and consumer rollout.
+- Runtime receipt payloads should be deterministic and auditable.
+
+## Anti-patterns to avoid
+
+- Using mutable shared state files as an authority instead of receipts.
+- Allowing routing-critical gates to pass without emitting evidence.
+- Treating labels as a decision authority.

--- a/docs/ci/ruleset-rollout.md
+++ b/docs/ci/ruleset-rollout.md
@@ -1,0 +1,41 @@
+# Ruleset Rollout Notes for Receipt-Driven CI
+
+This document describes how to align repository rulesets and workflow behavior with the receipt-driven control plane.
+
+## Current state
+
+- Repository enforcement is managed with **GitHub Rulesets**.
+- Classic branch protection assumptions should not be treated as active.
+- Required status checks are not currently configured at the ruleset layer.
+
+Until rulesets are updated, references to "required checks" are forward-looking/conventional.
+
+## Workflow behavior standards
+
+For required-style workflows in the modernization path:
+
+- Do not use path filters.
+- Always run on:
+  - `pull_request`
+  - `merge_group`
+  - `push` to `master`
+- No-op internally when a gate is non-applicable, rather than skipping trigger coverage.
+- Use event-aware concurrency policies.
+- Feed a final aggregator that computes completion/truth from all required evidence.
+
+## Label and state interpretation
+
+- Labels are projected UI only.
+- Agents should emit receipts.
+- State builder/reconciler should derive canonical state and then project labels.
+
+## `merge_group` as final pre-merge truth
+
+- `merge_group` must run the final pre-merge evaluation path.
+- Final aggregator output under `merge_group` is the canonical pre-merge verdict.
+- Merge-ready decisions should bind to the evaluated SHA evidence chain.
+
+## Issue-closeout hygiene during rollout
+
+- Use `Refs #6853` / `Part of #6853` for incremental rollout PRs.
+- Use `Closes/Fixes/Resolves #6853` only when acceptance criteria are complete end-to-end.


### PR DESCRIPTION
### Motivation

- Provide an internal implementation guide for the receipt-driven CI/control-plane modernization tracked in #6853.
- Capture current repo realities (GitHub Rulesets in use, P0 issue set, receipt/schema paths, partial-PR language, and avoidance of shared mutable state). 
- Give implementers (Codex agents) clear, scoped guardrails and rollout staging (P0–P4) to prevent divergent state or accidental enforcement claims.

### Description

- Add four new docs under `docs/ci/`: `control-plane-modernization.md`, `codex-agent-implementation-guide.md`, `receipt-contract.md`, and `ruleset-rollout.md` that together describe architecture, staged rollout, receipt contract, label projection, workflow rules, and agent guardrails. 
- Document normative receipt and schema locations as `target/receipts/*.json`, `.ci/receipts/schemas/*.schema.json`, and `.ci/receipts/registry.toml` and mandate that routing-critical gates emit receipts. 
- Prescribe workflow and ruleset behavior (no path filters for required-style workflows, triggers on `pull_request`, `merge_group`, and `push` to `master`, event-aware concurrency, and final aggregators) and partial-closeout language (`Refs`/`Part of` vs `Closes`).
- Commit made on branch `ci-modernization/docs-control-plane-guide` and the PR is prepared using `Refs #6853` (not `Closes`).

### Testing

- Verified the four new markdown files were staged and committed via `git show --name-only --stat HEAD` and `git status --short`, which confirmed only the intended docs were added. 
- Ran a whitespace sanity script (`python - <<'PY' ...`) to ensure no tab characters or trailing spaces in the new files, and the checks passed. 
- Attempted to check upstream with `git log origin/master --oneline -20` which failed due to a missing `origin/master` remote in this clone, and the local `git log --oneline -20` fallback was used instead as part of repository inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd0476da08333b0801b27d5d611f7)