### PR TITLE
feat(work-2097a449): first-run error classification and messaging (#4178)

### DIFF
--- a/.hermes/conveyor/work-2097a449/adr.md
+++ b/.hermes/conveyor/work-2097a449/adr.md
@@ -1,0 +1,137 @@
+# ADR-0017: First-Run Error Classification and Messaging
+
+## Status
+Proposed
+
+## Context
+
+Issue #4178 identifies 7 first-run error scenarios in perl-lsp where users see nothing, generic messages, or log-only errors instead of actionable messaging. After investigation:
+
+- **4 of 7 are already addressed** in the current codebase (parse error hints, missing module @INC context, workspace building notification, permission denied)
+- **2 genuinely remain unaddressed**:
+  1. **Gap 1 (HIGH)**: Perl not installed — `WARN_ONCE_ROOT_UNDETECTED.call_once(|| { tracing::warn!(...) })` writes to server log only; user sees nothing
+  2. **Gap 5 (MEDIUM)**: DAP launch — `Err(e.to_string())` returns raw I/O error `"No such file or directory: 'perl'"` instead of actionable guidance
+
+### Gap 1: Why the Initial Fix Was Infeasible
+
+The initial plan proposed replacing `tracing::warn!()` with `self.show_message(...)` inside the `call_once` closure. This fails because:
+
+```rust
+// Current code — module-level static
+static WARN_ONCE_ROOT_UNDETECTED: Once = Once::new();
+WARN_ONCE_ROOT_UNDETECTED.call_once(|| {
+    tracing::warn!("perl-lsp: workspace root not detected — ...");
+});
+```
+
+The `call_once` closure is `'static` and captures nothing from the environment — it cannot access `self`. The `LspServer` methods `resolve_module_path` and `resolve_module_path_with_uri` have access to `self`, but the closure does not.
+
+### Gap 5: Raw I/O Error Instead of Actionable Message
+
+```rust
+// process.rs:365 — current code
+Err(e) => Err(e.to_string())  // produces "No such file or directory: 'perl'"
+```
+
+When `perl -d` fails to spawn, the raw I/O error string is returned. The user receives `"No such file or directory: 'perl'"` with no remediation guidance.
+
+## Decision
+
+### Gap 1: Use Instance-Level AtomicFlag for One-Time Warning
+
+Add `root_undetected_shown: Arc<AtomicBool>` to the `LspServer` struct. Replace the `WARN_ONCE_ROOT_UNDETECTED.call_once(|| { tracing::warn!(...) })` pattern with:
+
+```rust
+if self.root_undetected_shown.fetch_or(true, Ordering::SeqCst) == false {
+    let _ = self.show_message(MessageType::Warning, 
+        "perl-lsp: workspace root not detected — module resolution disabled. \
+        To enable: open the project folder in your editor (File > Open Folder) \
+        rather than individual files. This warning appears once per server session.");
+}
+```
+
+**Rationale**: This approach:
+- Allows `self.show_message(...)` to be called (closure captures `self` via the method)
+- Uses atomic check-and-set to ensure exactly-once semantics
+- Changes semantics from "once per process" to "once per server session", which is more correct for the stated use case
+- Follows existing patterns in `LspServer` (which already has many `Arc<AtomicBool>` fields like `client_supports_pull_diagns`)
+- Is purely additive — no existing APIs or protocols are modified
+
+### Gap 5: Detect ErrorKind::NotFound for Actionable DAP Error
+
+In `process.rs:365`, replace `Err(e) => Err(e.to_string())` with:
+
+```rust
+Err(e) => {
+    if e.kind() == std::io::ErrorKind::NotFound {
+        Err("Perl interpreter not found on PATH. Ensure 'perl' is installed and on your system PATH.".to_string())
+    } else {
+        Err(e.to_string())
+    }
+}
+```
+
+**Rationale**: 
+- Directly addresses the user-facing gap: raw I/O error vs. actionable guidance
+- Localized change with no architectural impact
+- `ErrorKind::NotFound` is the correct kind to check when a command cannot be found on PATH
+- Easy to test by temporarily renaming `perl`
+
+## Consequences
+
+### Benefits
+
+1. **First-run users get actionable guidance**: Instead of silent failure or cryptic errors, users see clear messages explaining the problem and how to fix it
+2. **Reduces support burden**: Actionable error messages reduce "it doesn't work" issues filed without understanding why
+3. **No API changes**: Both changes use existing methods (`show_message()`, error matching) — purely additive
+4. **No protocol changes**: All changes are internal to the server implementation
+5. **Follows existing patterns**: `LspServer` already uses `Arc<AtomicBool>` for instance-level flags
+
+### Tradeoffs
+
+1. **Semantic shift (Gap 1)**: Changes from "once per process" to "once per server session". If multiple `LspServer` instances run in one process, each shows the message once. This is arguably more correct for the use case (each server session should warn once).
+
+2. **Minor latency (Gap 1)**: `fetch_or` on `AtomicBool` adds a small atomic operation to each module resolution call. The `tracing::warn!` was already fire-and-forget; the atomic check is similarly cheap.
+
+3. **Channel timing (Gap 1)**: If `show_message` fails because the LSP channel isn't initialized, the message is silently dropped. This is acceptable — the previous `tracing::warn!` was also fire-and-forget.
+
+4. **DAP permission denied (Gap 5)**: The fix only handles `NotFound`. If `perl` is on PATH but not executable, the error remains a raw I/O error. This is a separate edge case deferred to future work.
+
+## Alternatives Considered
+
+### Alternative 1: Keep Module-Level static Once, Deferred Flag Pattern
+
+Keep `WARN_ONCE_ROOT_UNDETECTED` as-is, but add a deferred notification:
+```rust
+WARN_ONCE_ROOT_UNDETECTED.call_once(|| {
+    set_deferred_warning("perl-lsp: workspace root not detected — ...");
+});
+```
+
+**Rejected**: More complex — requires adding deferred warning infrastructure. The `Arc<AtomicBool>` approach is simpler and directly callable.
+
+### Alternative 2: Centralized Error Message Service (Option A from Issue #4178)
+
+Create a centralized `ErrorMessageService` that aggregates and deduplicates all error messages.
+
+**Rejected**: Too high-cost. The issue explicitly considered this and recommended Option B (per-subsystem approach). The current changes are localized and sufficient.
+
+### Alternative 3: Only Fix Gap 5, Defer Gap 1
+
+Focus on the DAP fix only and defer the `LspServer` refactoring.
+
+**Rejected**: Gap 1 is the higher-priority issue — it affects the most fundamental onboarding scenario (users opening a single file without a workspace). The architectural refactoring is straightforward once the correct approach is specified.
+
+### Alternative 4: Use tokio::sync::OnceCell Instead of Arc<AtomicBool>
+
+Use `tokio::sync::OnceCell` for the instance-level flag.
+
+**Rejected**: `Arc<AtomicBool>` is simpler for this use case (just check-and-set, no async). The existing codebase uses `Arc<AtomicBool>` for similar patterns. No benefit to introducing `OnceCell`.
+
+## Deferred Decisions
+
+1. **Missing module diagnostic severity (Gap 3)**: Whether `Warning` vs `Error` severity is appropriate for missing required modules. Deferred to team/product decision.
+
+2. **Editor-agnostic messaging**: The Gap 1 message mentions "File > Open Folder" which is VS Code-specific. Whether the message should be editor-agnostic is deferred.
+
+3. **DAP PermissionDenied handling**: Whether to also detect `ErrorKind::PermissionDenied` for the case where `perl` is found but not executable is deferred to future work.

--- a/.hermes/conveyor/work-2097a449/initial_plan.md
+++ b/.hermes/conveyor/work-2097a449/initial_plan.md
@@ -1,0 +1,69 @@
+# Initial Plan — work-2097a449
+
+## Issue
+[UX] first-run error classification and messaging — https://github.com/EffortlessMetrics/perl-lsp/issues/4178
+
+## Approach
+
+This umbrella issue describes 7 error scenarios. My research found that **4 of the 7 are already addressed** in the current codebase (likely fixed since the issue was filed), because I examined the actual code at each cited location and found that the issue descriptions did not match the current state. The genuinely remaining gaps are:
+
+1. **Gap 1 (HIGH): Perl not installed — use window/showMessage instead of tracing::warn!()**
+   - Site: `crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs:181-226`
+   - Currently: `WARN_ONCE_ROOT_UNDETECTED.call_once(|| { tracing::warn!(...) })` — goes to server log only
+   - Fix: Replace `tracing::warn!()` with `self.show_message(MessageType::Warning, ...)` using the same `LspServer` receiver pattern
+   - Why: `tracing::warn!()` writes to the server's debug log which users never see unless they explicitly enable verbose logging. Using `window/showMessage` ensures the user sees the message directly in VS Code. The `WARN_ONCE_ROOT_UNDETECTED` static is kept to avoid duplicate notifications because we want to show the message exactly once per session, not on every module resolution attempt.
+
+2. **Gap 2 (MEDIUM): DAP — explicit "perl not on PATH" remediation in check_syntax skip path**
+   - Site: `crates/perl-dap/src/debug_adapter/process.rs:393-398`
+   - Currently: When `perl -c` can't be spawned, silently returns `Ok(())` and lets the subsequent `perl -d` launch produce whatever error comes out
+   - Fix: When `perl` cannot be found (not on PATH), detect this specifically and return a targeted error like `"Perl interpreter not found on PATH. Ensure 'perl' is installed and on your system PATH."`
+   - Why: The current approach technically works — `perl -d` will fail and produce an error — but that error message is less actionable because it surfaces as an I/O error rather than a clear "perl not found" message. Detecting `io::ErrorKind::NotFound` explicitly allows us to provide a targeted remediation message upfront. This matters because the DAP launch flow is a key onboarding scenario for new users.
+
+3. **Gap 3 (LOW): Missing module diagnostic severity**
+   - Site: `crates/perl-lsp-diagnostics/src/lints/missing_module.rs:245-256`
+   - Currently: `DiagnosticSeverity::Warning`
+   - Consider: Whether a missing required module should be `Error` severity instead of `Warning`
+   - Why: A Warning severity lets the file open and show other diagnostics, but a required module that's truly missing might be a critical import that will cause runtime failures. This is a design decision — the current Warning is conservative (non-blocking), but Error would be more consistent with how other languages handle missing imports. We defer this decision to the team.
+
+## What NOT To Do
+
+The issue recommends filing 7 follow-up issues, but my research shows only **2-3 genuine gaps** remain in the current codebase. The following were found to already be addressed:
+- Parse errors with hints (already have `build_parse_error_hint`)
+- Missing module @INC context (already shows searched paths)
+- Workspace building notification (already sends `logMessage`)
+- Permission denied (already sends `showMessage`; wrong file cited in issue)
+- LSP crash classification (already wired in `startupDiagnosis.ts`)
+
+## Task Breakdown
+
+### Phase 1: Fix Perl Not Installed (Highest Priority)
+1. In `module_resolution.rs`, refactor `WARN_ONCE_ROOT_UNDETECTED` to also call `self.show_message(...)` instead of only `tracing::warn!(...)`
+   - The `LspServer` has access to `show_message()` — need to verify it's callable from this context (the module resolution functions are methods on `LspServer`)
+   - If not directly callable, may need to pass a messenger/shell handle
+2. Add a test that verifies the window/showMessage is sent (not just traced)
+3. Verify with manual testing that the message appears in VSCode
+
+### Phase 2: Fix DAP Perl Not On PATH
+1. In `process.rs`, modify the `check_syntax` error path at line 393-398
+2. Detect specifically when `e.kind() == ErrorKind::NotFound` (io::Error)
+3. Return explicit "Perl interpreter not found on PATH" message with remediation hint
+4. Add test for this specific error path
+
+### Phase 3: Validate/Review Missing Module Severity
+1. Check with team/product on whether `Warning` vs `Error` severity is the right default
+2. If Error is desired, change `DiagnosticSeverity::Warning` to `DiagnosticSeverity::Error` in `missing_module.rs`
+
+## Risks
+
+1. **Risk: show_message requires LspServer context** — The `resolve_module_path` and `resolve_module_path_with_uri` functions ARE methods on `LspServer` (line: `impl LspServer`), so `self.show_message(...)` should be callable. However, need to verify the channel is initialized at the point these warnings fire (they fire during early module resolution).
+
+2. **Risk: Testability** — Adding tests for window/showMessage may require mocking the LspServer's message channel. Need to verify existing test infrastructure can handle this.
+
+3. **Risk: Stale issue description** — The issue was filed based on a scan of the codebase at a point in time. Some gaps may have already been fixed by other work. The plan above reflects the current (not historical) state.
+
+4. **Risk: Umbrella issue scope creep** — If we file only 3 follow-up issues instead of 7, we may need to update the umbrella issue to reflect what's actually left.
+
+## Scope
+
+- **In scope**: Fix the 2-3 genuine gaps identified in research; file updated follow-up issues; link them to the umbrella
+- **Out of scope**: Centralized error message service (Option A from issue — rejected as too high-cost); re-filing already-addressed gaps as new issues

--- a/.hermes/conveyor/work-2097a449/specs.md
+++ b/.hermes/conveyor/work-2097a449/specs.md
@@ -1,0 +1,128 @@
+# Specs: First-Run Error Classification and Messaging
+
+## Feature Description
+
+Improve user-facing error messaging for two first-run failure scenarios:
+
+1. **Gap 1 (Perl Not Installed/Workspace Root Undetected)**: When perl-lsp cannot detect a workspace root, it currently logs a warning to the server log only. Users opening a single file without a workspace see nothing. The fix surfaces a `window/showMessage` notification to the user with actionable guidance.
+
+2. **Gap 5 (DAP Perl Not on PATH)**: When the debugger cannot find the `perl` interpreter, it currently returns a raw I/O error `"No such file or directory: 'perl'"`. The fix detects this specific failure and returns an actionable error message: `"Perl interpreter not found on PATH. Ensure 'perl' is installed and on your system PATH."`
+
+## Non-Goals
+
+- This spec does NOT address the missing module diagnostic severity question (Warning vs Error) — deferred to team decision
+- This spec does NOT implement a centralized error message service
+- This spec does NOT add editor-specific messaging beyond what is already in the codebase
+- This spec does NOT address DAP PermissionDenied errors (when perl is found but not executable)
+- This spec does NOT re-file already-addressed error scenarios (parse error hints, missing module @INC context, workspace building notification, permission denied, LSP crash classification)
+
+## Gap 1: Workspace Root Undetected Messaging
+
+### Changes
+
+1. **Add `root_undetected_shown` field to `LspServer`**:
+   - Type: `Arc<AtomicBool>`
+   - Location: In the `LspServer` struct definition alongside other `Arc<AtomicBool>` fields
+   - Initialization: `root_undetected_shown: Arc::new(AtomicBool::new(false))`
+
+2. **Update `resolve_module_path` call site** (3 locations in `module_resolution.rs`):
+   - Lines 181-186, 218-224, 349-355
+   - Replace `WARN_ONCE_ROOT_UNDETECTED.call_once(|| { tracing::warn!(...) })` with:
+     ```rust
+     if self.root_undetected_shown.fetch_or(true, Ordering::SeqCst) == false {
+         let _ = self.show_message(MessageType::Warning, 
+             "perl-lsp: workspace root not detected — module resolution disabled. \
+              To enable: open the project folder in your editor (File > Open Folder) \
+              rather than individual files. This warning appears once per server session.");
+     }
+     ```
+
+3. **Remove `WARN_ONCE_ROOT_UNDETECTED` static** after migration is complete
+
+### Message Text
+> "perl-lsp: workspace root not detected — module resolution disabled. To enable: open the project folder in your editor (File > Open Folder) rather than individual files. This warning appears once per server session."
+
+### Behavior
+- Message appears once per `LspServer` instance (not once per process)
+- Subsequent module resolution calls within the same session do not re-display the message
+- Message is non-blocking (uses `let _ =` to ignore result)
+- If `show_message` fails (channel not initialized), the error is silently dropped
+
+## Gap 5: DAP Perl Not Found Error Message
+
+### Changes
+
+1. **In `perl-dap/src/debug_adapter/process.rs:365`**:
+   - Before:
+     ```rust
+     Err(e) => Err(e.to_string())
+     ```
+   - After:
+     ```rust
+     Err(e) => {
+         if e.kind() == std::io::ErrorKind::NotFound {
+             Err("Perl interpreter not found on PATH. Ensure 'perl' is installed and on your system PATH.".to_string())
+         } else {
+             Err(e.to_string())
+         }
+     }
+     ```
+
+### Message Text
+> "Perl interpreter not found on PATH. Ensure 'perl' is installed and on your system PATH."
+
+### Behavior
+- Only triggers when `perl` is not found (`ErrorKind::NotFound`)
+- Other spawn errors return the original I/O error string (unchanged behavior)
+- Error is returned to the DAP client as a structured error message
+
+## Acceptance Criteria
+
+### Gap 1: Workspace Root Undetected
+
+1. **AC1**: When a user opens a single Perl file (no workspace root) and triggers module resolution, a `window/showMessage` notification with `MessageType::Warning` is sent exactly once for that server session.
+
+2. **AC2**: The warning message text includes: (a) the problem description ("workspace root not detected"), (b) remediation guidance ("open the project folder in your editor"), and (c) a note that it appears once per session.
+
+3. **AC3**: Multiple rapid module resolution calls before the first call completes do not result in multiple user-visible notifications.
+
+4. **AC4**: The `LspServer` struct has a `root_undetected_shown: Arc<AtomicBool>` field.
+
+5. **AC5**: Existing tests pass; a new test verifies that `show_message` is called once when root is undetected.
+
+### Gap 5: DAP Perl Not Found
+
+6. **AC6**: When `perl` is not on PATH and the user launches the debugger, the error message displayed is: "Perl interpreter not found on PATH. Ensure 'perl' is installed and on your system PATH." — NOT "No such file or directory: 'perl'".
+
+7. **AC7**: Other spawn errors (e.g., permission denied when perl exists but is not executable) continue to return their original I/O error string.
+
+8. **AC8**: A test exists for the `ErrorKind::NotFound` detection path in `process.rs`.
+
+## Dependencies
+
+- **Rust crates**: `perl-lsp`, `perl-dap`
+- **LSP infrastructure**: `LspServer::show_message()` method (already exists)
+- **Testing infrastructure**: Existing Rust test patterns in `perl-dap`
+
+## Testing Strategy
+
+### Gap 1
+- Unit test: Verify `show_message` is called exactly once when `root_undetected_shown` is initially `false` and module resolution is triggered
+- Unit test: Verify `show_message` is not called again when `root_undetected_shown` is already `true`
+
+### Gap 5
+- Unit test: Verify `ErrorKind::NotFound` returns the actionable error message
+- Unit test: Verify other error kinds return the original error string
+
+## Files to Modify
+
+1. `crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs` — Replace `WARN_ONCE_ROOT_UNDETECTED` pattern with `Arc<AtomicBool>` check
+2. `crates/perl-lsp/src/runtime/lsp_server.rs` — Add `root_undetected_shown: Arc<AtomicBool>` field to `LspServer` struct
+3. `crates/perl-dap/src/debug_adapter/process.rs:365` — Add `ErrorKind::NotFound` detection
+4. Test files: Add tests for both behaviors
+
+## Open Questions (Deferred)
+
+1. Should the missing module diagnostic be `Warning` or `Error` severity? (Deferred to team)
+2. Is the VS Code-specific "File > Open Folder" message appropriate for all editor contexts? (Deferred)
+3. Should DAP also handle `PermissionDenied` when perl is found but not executable? (Future work)

--- a/.hermes/conveyor/work-2097a449/task_list.md
+++ b/.hermes/conveyor/work-2097a449/task_list.md
@@ -1,0 +1,33 @@
+# Task List — work-2097a449
+
+## Gap 1: Workspace Root Undetected Messaging
+
+- [ ] 1.1 Add `root_undetected_shown: Arc<AtomicBool>` field to `LspServer` struct in `perl-lsp/src/runtime/lsp_server.rs`
+- [ ] 1.2 Initialize field in `LspServer::new()` as `root_undetected_shown: Arc::new(AtomicBool::new(false))`
+- [ ] 1.3 Replace first `WARN_ONCE_ROOT_UNDETECTED.call_once()` at `module_resolution.rs:181-186` with atomic check-and-set pattern
+- [ ] 1.4 Replace second call site at `module_resolution.rs:218-224` with same pattern
+- [ ] 1.5 Replace third call site at `module_resolution.rs:349-355` with same pattern
+- [ ] 1.6 Remove `WARN_ONCE_ROOT_UNDETECTED` static declaration from module level
+- [ ] 1.7 Add unit test verifying `show_message` is called exactly once when root is undetected
+- [ ] 1.8 Add unit test verifying `show_message` is not called again when flag is already set
+- [ ] 1.9 Verify existing tests pass
+
+## Gap 5: DAP Perl Not Found Error Message
+
+- [ ] 2.1 In `perl-dap/src/debug_adapter/process.rs:365`, replace `Err(e) => Err(e.to_string())` with `ErrorKind::NotFound` detection
+- [ ] 2.2 Return actionable message: "Perl interpreter not found on PATH. Ensure 'perl' is installed and on your system PATH."
+- [ ] 2.3 Add unit test for `ErrorKind::NotFound` path returning actionable message
+- [ ] 2.4 Add unit test verifying other error kinds return original error string
+- [ ] 2.5 Verify existing tests pass
+
+## Integration
+
+- [ ] 3.1 Create GitHub follow-up issues for Gap 1 and Gap 5, linking to umbrella issue #4178
+- [ ] 3.2 Close or update umbrella issue #4178 to reflect remaining work
+- [ ] 3.3 Update CHANGELOG or docs if error message text is user-facing
+
+## Deferred Decisions (No Implementation)
+
+- [ ] 4.1 Missing module diagnostic severity (Warning vs Error) — deferred to team decision
+- [ ] 4.2 Editor-agnostic messaging — deferred to future discussion
+- [ ] 4.3 DAP PermissionDenied handling — deferred to future work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "perl-lsp: workspace root not detected — module resolution disabled. To enable: open
   the project folder in your editor (File > Open Folder) rather than individual files.
   This warning appears once per server session." Previously this was logged to the server
-  log only and users saw nothing. (#4178)
-
-- **DAP debugger now shows actionable error when Perl is not on PATH** — When launching
-  the debugger and `perl` cannot be found, the error message is now: "Perl interpreter
-  not found on PATH. Ensure 'perl' is installed and on your system PATH." Previously
-  users saw the raw I/O error "No such file or directory: 'perl'" with no remediation
-  guidance. (#4178)
+  log only and users saw nothing. The warning flag is stored as an `Arc<AtomicBool>` on
+  `LspServer`, so each server session shows the warning independently — in multi-root or
+  multi-server workspace configurations, each `LspServer` instance tracks its own shown
+  state rather than sharing a process-level `Once`. (#4178)
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **First-run error messaging now surfaces to users instead of silent logging** — When
+  workspace root is not detected (e.g., opening a single file without opening a folder),
+  perl-lsp now sends a `window/showMessage` notification with actionable guidance:
+  "perl-lsp: workspace root not detected — module resolution disabled. To enable: open
+  the project folder in your editor (File > Open Folder) rather than individual files.
+  This warning appears once per server session." Previously this was logged to the server
+  log only and users saw nothing. (#4178)
+
+- **DAP debugger now shows actionable error when Perl is not on PATH** — When launching
+  the debugger and `perl` cannot be found, the error message is now: "Perl interpreter
+  not found on PATH. Ensure 'perl' is installed and on your system PATH." Previously
+  users saw the raw I/O error "No such file or directory: 'perl'" with no remediation
+  guidance. (#4178)
+
 ### Internal
 
 - **`cargo xtask published-crate-count`** — new ratchet gate that monitors the

--- a/crates/perl-lsp-rs/src/runtime/constructors.rs
+++ b/crates/perl-lsp-rs/src/runtime/constructors.rs
@@ -61,6 +61,7 @@ impl LspServer {
             indexing_in_progress: Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "workspace")]
             permission_denied_shown: Arc::new(AtomicBool::new(false)),
+            root_undetected_shown: Arc::new(AtomicBool::new(false)),
             #[cfg(not(target_arch = "wasm32"))]
             critic_analyzer: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
@@ -170,6 +171,7 @@ impl LspServer {
             indexing_in_progress: Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "workspace")]
             permission_denied_shown: Arc::new(AtomicBool::new(false)),
+            root_undetected_shown: Arc::new(AtomicBool::new(false)),
             #[cfg(not(target_arch = "wasm32"))]
             critic_analyzer: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
@@ -242,6 +244,7 @@ impl LspServer {
             indexing_in_progress: Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "workspace")]
             permission_denied_shown: Arc::new(AtomicBool::new(false)),
+            root_undetected_shown: Arc::new(AtomicBool::new(false)),
             #[cfg(not(target_arch = "wasm32"))]
             critic_analyzer: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]

--- a/crates/perl-lsp-rs/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/module_resolution.rs
@@ -12,7 +12,7 @@ use perl_module::resolution::{
 };
 use std::collections::HashSet;
 use std::path::PathBuf;
-use std::sync::Once;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 /// A single resolution scope representing a workspace folder's search context.
@@ -40,13 +40,6 @@ pub struct ResolutionContext {
     /// Ordered search scopes (current folder first, then others)
     pub search_scopes: Vec<ResolutionScope>,
 }
-
-/// Fires a `tracing::warn!` the first time workspace root is found to be undetected.
-///
-/// Both `resolve_module_path` and `resolve_module_path_with_uri` share this sentinel
-/// because both sites indicate the same underlying problem: no workspace root was
-/// provided by the LSP client (single-file mode with no open folder).
-static WARN_ONCE_ROOT_UNDETECTED: Once = Once::new();
 
 /// Prepend `use lib` paths extracted from `doc_text` to `include_paths`.
 ///
@@ -210,13 +203,14 @@ impl LspServer {
         let root = match resolution_root(self, None) {
             Some(r) => r,
             None => {
-                WARN_ONCE_ROOT_UNDETECTED.call_once(|| {
-                    tracing::warn!(
+                if !self.root_undetected_shown.fetch_or(true, Ordering::SeqCst) {
+                    let _ = self.show_message(
+                        MessageType::Warning,
                         "perl-lsp: workspace root not detected — module resolution disabled. \
                          To enable: open the project folder in your editor (File > Open Folder) \
-                         rather than individual files. This warning appears once per server session."
+                         rather than individual files. This warning appears once per server session.",
                     );
-                });
+                }
                 return None;
             }
         };
@@ -248,13 +242,14 @@ impl LspServer {
         let root = match resolution_root(self, doc_uri) {
             Some(r) => r,
             None => {
-                WARN_ONCE_ROOT_UNDETECTED.call_once(|| {
-                    tracing::warn!(
+                if !self.root_undetected_shown.fetch_or(true, Ordering::SeqCst) {
+                    let _ = self.show_message(
+                        MessageType::Warning,
                         "perl-lsp: workspace root not detected — module resolution disabled. \
                          To enable: open the project folder in your editor (File > Open Folder) \
-                         rather than individual files. This warning appears once per server session."
+                         rather than individual files. This warning appears once per server session.",
                     );
-                });
+                }
                 return None;
             }
         };
@@ -380,13 +375,14 @@ impl LspServer {
         let root = match resolution_root(self, doc_uri) {
             Some(r) => r,
             None => {
-                WARN_ONCE_ROOT_UNDETECTED.call_once(|| {
-                    tracing::warn!(
+                if !self.root_undetected_shown.fetch_or(true, Ordering::SeqCst) {
+                    let _ = self.show_message(
+                        MessageType::Warning,
                         "perl-lsp: workspace root not detected — module resolution disabled. \
                          To enable: open the project folder in your editor (File > Open Folder) \
-                         rather than individual files. This warning appears once per server session."
+                         rather than individual files. This warning appears once per server session.",
                     );
-                });
+                }
                 return None;
             }
         };

--- a/crates/perl-lsp-rs/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/module_resolution.rs
@@ -1259,6 +1259,146 @@ use Overlay::Live;
         Ok(())
     }
 
+    // --- AC5: warns only once per LspServer instance ---
+
+    /// AC5: The first call to resolve_module_path when no workspace root is configured
+    /// must set root_undetected_shown to true. Subsequent calls must NOT reset it —
+    /// confirming that the warning fires exactly once per LspServer instance.
+    #[test]
+    fn root_undetected_shown_flag_is_set_on_first_failed_resolution() {
+        let server = LspServer::new();
+
+        // Flag must start false so the first warning can fire.
+        assert!(
+            !server.root_undetected_shown.load(std::sync::atomic::Ordering::SeqCst),
+            "root_undetected_shown must be false at server creation"
+        );
+
+        // First resolution attempt (no root set) → flag flips to true.
+        let _ = server.resolve_module_path("First::Module", None);
+        assert!(
+            server.root_undetected_shown.load(std::sync::atomic::Ordering::SeqCst),
+            "root_undetected_shown must be true after first failed resolution"
+        );
+    }
+
+    /// AC5 continued: a second resolution attempt with no root must see the flag already
+    /// set (suppressing a second warning). Verifies the atomic once-per-session contract.
+    #[test]
+    fn root_undetected_shown_flag_stays_set_on_subsequent_failed_resolutions() {
+        let server = LspServer::new();
+
+        // First call flips the flag.
+        let _ = server.resolve_module_path("First::Module", None);
+
+        // Manually snapshot old value to confirm the next call will suppress.
+        // fetch_or(true) returns the *previous* value: false on first, true on second.
+        // Here we test the cumulative: after two calls the flag is still true (not reset).
+        let _ = server.resolve_module_path("Second::Module", None);
+        assert!(
+            server.root_undetected_shown.load(std::sync::atomic::Ordering::SeqCst),
+            "root_undetected_shown must remain true after subsequent failed resolutions"
+        );
+    }
+
+    /// AC5: The Arc<AtomicBool> fetch_or semantics ensure the first call returns false
+    /// (enabling the warning) and subsequent calls return true (suppressing it).
+    /// This test validates the raw atomic protocol in isolation, independent of I/O.
+    #[test]
+    fn arc_atomic_fetch_or_warns_only_once_per_session() {
+        use std::sync::atomic::Ordering;
+
+        let flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        // First fetch_or: previous value is false → warning fires.
+        let first_was_false = !flag.fetch_or(true, Ordering::SeqCst);
+        assert!(first_was_false, "first fetch_or must return false (warning fires)");
+
+        // Second fetch_or: previous value is true → warning suppressed.
+        let second_was_true = flag.fetch_or(true, Ordering::SeqCst);
+        assert!(second_was_true, "second fetch_or must return true (warning suppressed)");
+
+        // Flag is still true regardless of subsequent calls.
+        assert!(
+            flag.load(Ordering::SeqCst),
+            "flag must remain true after multiple fetch_or(true) calls"
+        );
+    }
+
+    // --- AC8: window/showMessage payload uses MessageType::Warning ---
+
+    /// AC8: MessageType::Warning must have discriminant value 2 per the LSP specification.
+    /// The show_message call serializes `typ as i32` into the JSON payload —
+    /// this test verifies that the enum value the production code uses is correct.
+    #[test]
+    fn message_type_warning_has_lsp_discriminant_two() {
+        // LSP spec §3.16.1: MessageType.Warning = 2.
+        // Production code: `json!({ "type": typ as i32, ... })`.
+        assert_eq!(
+            MessageType::Warning as i32,
+            2,
+            "MessageType::Warning must serialize to 2 per LSP spec §3.16.1"
+        );
+    }
+
+    /// AC8: When workspace root is not detected, the outbound window/showMessage notification
+    /// must carry "type": 2 (Warning) and include actionable guidance text.
+    ///
+    /// Uses with_io() to capture the outbound stream and verifies the JSON payload
+    /// after the server is dropped (which joins the writer thread for a clean flush).
+    #[test]
+    fn show_message_on_root_undetected_uses_warning_type() -> TestResult {
+        use std::io::Cursor;
+
+        let output = std::sync::Arc::new(parking_lot::Mutex::new(Vec::<u8>::new()));
+
+        struct CaptureWriter(std::sync::Arc<parking_lot::Mutex<Vec<u8>>>);
+
+        impl std::io::Write for CaptureWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let captured = std::sync::Arc::clone(&output);
+        let server = LspServer::with_io(
+            Box::new(Cursor::new(Vec::<u8>::new())),
+            Box::new(CaptureWriter(captured)),
+        );
+
+        // Trigger the first-run warning by calling resolve with no workspace root.
+        let _ = server.resolve_module_path("Warn::Me", None);
+
+        // Drop the server to flush and join the writer thread.
+        drop(server);
+
+        let bytes = output.lock().clone();
+        let text = String::from_utf8(bytes).map_err(|e| format!("output not valid UTF-8: {e}"))?;
+
+        assert!(
+            text.contains("window/showMessage"),
+            "expected window/showMessage notification in outbound stream, got: {text}"
+        );
+        assert!(
+            text.contains("\"type\":2"),
+            "expected MessageType::Warning (type:2) in window/showMessage payload, got: {text}"
+        );
+        assert!(
+            text.contains("workspace root not detected"),
+            "expected actionable guidance text in warning message, got: {text}"
+        );
+        assert!(
+            text.contains("Open Folder"),
+            "expected 'Open Folder' actionable text in warning message, got: {text}"
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn test_resolve_module_path_with_uri_honors_system_inc_opt_in() -> TestResult {
         // This test shells out to `perl -I <path> -e 'print join("\n", @INC)'`.

--- a/crates/perl-lsp-rs/src/runtime/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/mod.rs
@@ -295,6 +295,14 @@ pub struct LspServer {
     /// by this flag — it repeats for every affected file.
     #[cfg(feature = "workspace")]
     permission_denied_shown: Arc<AtomicBool>,
+    /// One-time guard for the `window/showMessage` workspace-root-undetected warning.
+    ///
+    /// Set to `true` after the first module resolution attempt when no workspace
+    /// root is configured, so the user is warned once per server session rather
+    /// than on every resolution call.  Uses an instance-level flag (not a
+    /// process-level `Once`) so that each `LspServer` instance tracks its own
+    /// session independently.
+    pub(crate) root_undetected_shown: Arc<AtomicBool>,
     /// Shared Perl::Critic analyzer for the diagnostic pipeline.
     ///
     /// Lazily initialized on first use and reused across diagnostic cycles so


### PR DESCRIPTION
Closes #4178

## Summary
Implements first-run error messaging improvement from issue #4178:

**Gap 1 (HIGH)**: When workspace root is not detected, replaces `tracing::warn!()` (server log only) with `window/showMessage` user-facing notification. Uses instance-level `Arc<AtomicBool>` instead of module-level `Once` for exactly-once semantics per server session.

**Semantic note**: The `Arc<AtomicBool>` approach means each `LspServer` instance shows the warning independently. In multi-root or multi-server workspace configurations, each instance tracks its own shown state — not a shared process-level `Once`. Users in single-server setups see no change; users who restart their LSP server will see the warning again (as expected for a new session).

## What Was Done
- Added `root_undetected_shown: Arc<AtomicBool>` field to `LspServer` struct
- Replaced `WARN_ONCE_ROOT_UNDETECTED.call_once` pattern with `fetch_or + show_message` at 3 locations in `module_resolution.rs`
- Added tests for the behavior

## Out of Scope
- Gap 5 (DAP `format_perl_spawn_error` actionable error message) was already shipped to master in a prior PR; it is not implemented here.

## Test Status
- All workspace tests passing (cargo test --workspace)
- CI: green (PR Title Check, UX Regression Gate, CI all passing)