### PR TITLE
feat(diagnostics): extend PL303 role conflict detection to Role::Tiny (#4381)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/role_conflicts.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/role_conflicts.rs
@@ -1,8 +1,8 @@
-//! Same-file Moo/Moose role conflict diagnostics.
+//! Same-file Moo/Moose/Role::Tiny role conflict diagnostics.
 //!
 //! This lint checks for roles consumed by a class in the same file that
 //! provide overlapping method names. It intentionally ignores workspace-wide
-//! indexing, Role::Tiny, and transitive role composition.
+//! indexing and transitive role composition.
 
 use std::collections::{HashMap, HashSet};
 
@@ -15,7 +15,7 @@ use perl_semantic_analyzer::{
     symbol::{SymbolKind, SymbolTable},
 };
 
-/// Check for same-file Moo/Moose role method conflicts.
+/// Check for same-file Moo/Moose/Role::Tiny role method conflicts.
 pub fn check_role_conflicts(
     node: &Node,
     symbol_table: &SymbolTable,

--- a/crates/perl-lsp-rs-core/tests/role_tiny_conflict_tests.rs
+++ b/crates/perl-lsp-rs-core/tests/role_tiny_conflict_tests.rs
@@ -1,0 +1,124 @@
+//! Integration tests for PL303 — same-file role method conflicts with Role::Tiny.
+//!
+//! Verifies that the PL303 diagnostic fires for Role::Tiny role conflicts the
+//! same way it already does for Moo/Moose role conflicts.
+
+use std::sync::Arc;
+
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticsProvider};
+use perl_parser::Parser;
+
+fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
+    let output = Parser::new(source).parse_with_recovery();
+    let ast = Arc::new(output.ast);
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    provider.get_diagnostics(&ast, &output.diagnostics, source, None)
+}
+
+fn pl303_diags(source: &str) -> Vec<Diagnostic> {
+    diagnostics_for(source).into_iter().filter(|d| d.code.as_deref() == Some("PL303")).collect()
+}
+
+#[test]
+fn role_tiny_conflict_emits_pl303() {
+    let source = r#"
+package MyApp::Consumer;
+use strict;
+use warnings;
+use Role::Tiny::With;
+with 'MyApp::RoleA', 'MyApp::RoleB';
+
+package MyApp::RoleA;
+use strict;
+use warnings;
+use Role::Tiny;
+sub shared_method { 'A' }
+
+package MyApp::RoleB;
+use strict;
+use warnings;
+use Role::Tiny;
+sub shared_method { 'B' }
+"#;
+
+    let diags = pl303_diags(source);
+    assert_eq!(diags.len(), 1, "Role::Tiny should detect method conflicts: {diags:?}");
+    let diag = &diags[0];
+    assert!(
+        diag.message.contains("shared_method"),
+        "conflict message should name the conflicting method: {}",
+        diag.message
+    );
+    assert!(
+        diag.message.contains("MyApp::Consumer"),
+        "conflict message should name the consuming class: {}",
+        diag.message
+    );
+}
+
+#[test]
+fn role_tiny_three_way_conflict_emits_pl303() {
+    let source = r#"
+package MyApp::Consumer;
+use strict;
+use warnings;
+use Role::Tiny::With;
+with 'RoleX', 'RoleY', 'RoleZ';
+
+package RoleX;
+use strict;
+use warnings;
+use Role::Tiny;
+sub method { 'X' }
+
+package RoleY;
+use strict;
+use warnings;
+use Role::Tiny;
+sub method { 'Y' }
+
+package RoleZ;
+use strict;
+use warnings;
+use Role::Tiny;
+sub method { 'Z' }
+"#;
+
+    let diags = pl303_diags(source);
+    assert_eq!(diags.len(), 1, "three-way Role::Tiny conflict should emit one PL303: {diags:?}");
+    assert!(
+        diags[0].message.contains("method"),
+        "conflict message should name the conflicting method: {}",
+        diags[0].message
+    );
+}
+
+#[test]
+fn role_tiny_class_method_suppresses_conflict() {
+    let source = r#"
+package MyApp::Consumer;
+use strict;
+use warnings;
+use Role::Tiny::With;
+with 'MyApp::RoleA', 'MyApp::RoleB';
+sub shared_method { 42 }
+
+package MyApp::RoleA;
+use strict;
+use warnings;
+use Role::Tiny;
+sub shared_method { 'A' }
+
+package MyApp::RoleB;
+use strict;
+use warnings;
+use Role::Tiny;
+sub shared_method { 'B' }
+"#;
+
+    let diags = pl303_diags(source);
+    assert!(
+        diags.is_empty(),
+        "class-defined method should suppress Role::Tiny conflict, got: {diags:?}"
+    );
+}

--- a/crates/perl-semantic-analyzer/src/analysis/class_model.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/class_model.rs
@@ -27,6 +27,8 @@ pub enum Framework {
     NativeClass,
     /// Plain OO via `use parent`, `use base`, or `@ISA` (no framework)
     PlainOO,
+    /// `use Role::Tiny;` (package is a role) or `use Role::Tiny::With;` (package consumes roles)
+    RoleTiny,
     /// No OO framework detected
     None,
 }
@@ -527,6 +529,7 @@ impl ClassModelBuilder {
             "Moose" | "Moose::Role" => Framework::Moose,
             "Moo" | "Moo::Role" => Framework::Moo,
             "Mouse" | "Mouse::Role" => Framework::Mouse,
+            "Role::Tiny" | "Role::Tiny::With" => Framework::RoleTiny,
             "Class::Accessor" => Framework::ClassAccessor,
             "Object::Pad" => Framework::ObjectPad,
             "base" | "parent" => {

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -339,6 +339,10 @@ pub enum FrameworkKind {
     Moose,
     /// `use Moose::Role;`
     MooseRole,
+    /// `use Role::Tiny;` — the package is a role
+    RoleTiny,
+    /// `use Role::Tiny::With;` — the package consumes roles
+    RoleTinyWith,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -457,8 +461,12 @@ impl SymbolExtractor {
                 continue;
             };
             let new_kind = match kind {
-                FrameworkKind::Moo | FrameworkKind::Moose => SymbolKind::Class,
-                FrameworkKind::MooRole | FrameworkKind::MooseRole => SymbolKind::Role,
+                FrameworkKind::Moo | FrameworkKind::Moose | FrameworkKind::RoleTinyWith => {
+                    SymbolKind::Class
+                }
+                FrameworkKind::MooRole
+                | FrameworkKind::MooseRole
+                | FrameworkKind::RoleTiny => SymbolKind::Role,
             };
             if let Some(symbols) = self.table.symbols.get_mut(pkg_name) {
                 for symbol in symbols.iter_mut() {
@@ -2146,6 +2154,8 @@ impl SymbolExtractor {
             "Moo::Role" | "Mouse::Role" => Some(FrameworkKind::MooRole),
             "Moose" => Some(FrameworkKind::Moose),
             "Moose::Role" => Some(FrameworkKind::MooseRole),
+            "Role::Tiny" => Some(FrameworkKind::RoleTiny),
+            "Role::Tiny::With" => Some(FrameworkKind::RoleTinyWith),
             _ => None,
         };
 


### PR DESCRIPTION
## Problem

The PL303 "role method conflict" diagnostic fired correctly for Moo and Moose roles but was silent for `Role::Tiny`. A class consuming two Role::Tiny roles that both define the same method name produced no warning.

Role::Tiny is in wide use — it is Moo's own role layer, and many CPAN modules (Dancer2, HTTP::Tiny wrappers, etc.) use it standalone — so users of these codebases got no conflict detection at all.

Closes #4381.

## Root cause

The lint path (`check_role_conflicts`) depends on **two separate classification systems** that both needed to know about Role::Tiny:

### 1. `ClassModelBuilder` (class_model.rs)

`ClassModelBuilder::build()` only generates a `ClassModel` for packages where `framework != Framework::None`. Without a `Framework::RoleTiny` variant, packages using `use Role::Tiny` or `use Role::Tiny::With` produced no model, so the lint had nothing to iterate over.

### 2. `SymbolExtractor` (symbol.rs)

`check_role_conflicts` calls `package_kind(symbol_table, name)` to determine whether each model is a *role* (to collect methods from) or a *class* (to check for conflicts). The symbol table is built by `SymbolExtractor`. Without `FrameworkKind::RoleTiny` / `FrameworkKind::RoleTinyWith` entries, Role::Tiny packages got `SymbolKind::None` and fell into the `_ => {}` arm — silently discarded.

Both layers had to be updated together for the end-to-end path to work. The original issue spec only described the `class_model.rs` change; the `symbol.rs` change was identified through code-path tracing.

## Changes

| File | What changed |
|------|-------------|
| `crates/perl-semantic-analyzer/src/analysis/class_model.rs` | Added `Framework::RoleTiny` variant; `detect_framework()` now maps `"Role::Tiny"` and `"Role::Tiny::With"` to it |
| `crates/perl-semantic-analyzer/src/analysis/symbol.rs` | Added `FrameworkKind::RoleTiny` (→ `SymbolKind::Role`) and `FrameworkKind::RoleTinyWith` (→ `SymbolKind::Class`); wired both into `update_framework_context()` |
| `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/role_conflicts.rs` | Updated module/function doc comments to reflect Role::Tiny support |
| `crates/perl-lsp-rs-core/tests/role_tiny_conflict_tests.rs` (**new**) | Three BDD integration tests (see below) |

## Tests

Three new integration tests in `crates/perl-lsp-rs-core/tests/role_tiny_conflict_tests.rs`:

| Test | Scenario | Expected |
|------|----------|----------|
| `role_tiny_conflict_emits_pl303` | Consumer uses `Role::Tiny::With`; two roles each define `shared_method` | One PL303 with method name and class name in message |
| `role_tiny_three_way_conflict_emits_pl303` | Three roles all define `method` | One PL303 (deduplicated to one conflict per method name) |
| `role_tiny_class_method_suppresses_conflict` | Consumer defines `shared_method` itself | Zero PL303 (class-defined method resolves the conflict) |

All three pass. No regressions in `perl-semantic-analyzer` lib tests (132 pass) or `perl-lsp-rs-core` tests.

## Reviewer notes

- The pre-existing `workspace_index_duplicate_uri_update` failure in `perl-semantic-analyzer/tests/extended_unit_tests.rs` is unrelated to these changes (it tests `WorkspaceIndex`, which was not modified). That file has one commit touching it and the test exercises `find_defs` behaviour that predates this branch.
- The pre-existing `test_perl_lsp_cargo_toml_removed_g1b_imports` failure in `perl-lsp-rs-core` references a missing `crates/perl-lsp/Cargo.toml` path that does not exist in this environment — also unrelated.
- Clippy passes clean for both `perl-semantic-analyzer` and `perl-lsp-rs-core` with `-D warnings`.


---
_Generated by [Claude Code](https://claude.ai/code/session_011oFNCrGSvUcQH2aJDWNnze)_