### PR TITLE
test(perl-parser): update wave4 baseline assertion from 34 → 31 (#4542)

### DIFF
--- a/crates/perl-parser/tests/wave4_completion_absorption_tests.rs
+++ b/crates/perl-parser/tests/wave4_completion_absorption_tests.rs
@@ -188,17 +188,22 @@ fn test_perl_incremental_parsing_not_in_allowlist() -> TestResult {
 // Section 4: Published Count Baseline Tests
 // =============================================================================
 
-/// Test that published-crate-baseline.txt is updated to 34 (down from 37)
+/// Test that published-crate-baseline.txt is updated to 31.
+///
+/// Wave 4-Completion absorbed perl-dead-code, perl-refactoring, and
+/// perl-incremental-parsing (37 → 34). Wave Final PR B subsequently absorbed
+/// perl-lsp-feature-catalog, perl-lsp-config, and perl-content-length-framing
+/// (34 → 31). The current baseline is 31.
 #[test]
-fn test_published_count_baseline_is_34() -> TestResult {
+fn test_published_count_baseline_is_current() -> TestResult {
     let baseline_path = ws("xtask/published-crate-baseline.txt");
     let content = fs::read_to_string(&baseline_path)?;
     let baseline_count = content.trim().parse::<u32>()?;
 
-    if baseline_count == 34 {
+    if baseline_count == 31 {
         Ok(())
     } else {
-        Err(format!("published-crate-baseline.txt must be 34, got {}", baseline_count).into())
+        Err(format!("published-crate-baseline.txt must be 31, got {}", baseline_count).into())
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the one failing test in the wave4 absorption test suite.

- **Root cause:** `test_published_count_baseline_is_34` was written when Wave 4-Completion was expected to lower the published crate count from 37 → 34. Wave Final PR B subsequently absorbed three more crates (`perl-lsp-feature-catalog`, `perl-lsp-config`, `perl-content-length-framing`), moving the count from 34 → 31. The baseline file (`xtask/published-crate-baseline.txt`) correctly reflects 31, but the test expectation was never updated — causing a CI failure on every run.

- **Fix:** Rename the test to `test_published_count_baseline_is_current` (avoids re-staling if future waves embed a count in the function name) and update the expected value from 34 → 31. Add a doc comment summarising the full wave history (Wave 4-Completion: 37→34, Wave Final PR B: 34→31) so future contributors understand how the count reached 31.

- **Scope:** Single test file, zero production code changes.

## Why 31 is correct

The wave absorption history in `g3_publish_baseline_enforcement.rs` (which already asserts `== 31` and passes) documents:

| Wave | Crates absorbed | Count after |
|------|----------------|-------------|
| G3 | perl-lsp-feature-governance, perl-lsp-protocol, perl-lsp-uri, perl-lsp-transport, perl-lsp-performance, perl-lsp-critic-parser, perl-lsp-tooling | 37 |
| Wave 4-Completion | perl-dead-code, perl-refactoring, perl-incremental-parsing | 34 |
| Wave Final PR B | perl-lsp-feature-catalog, perl-lsp-config, perl-content-length-framing | **31** ← current |

`cargo xtask publish-manifest-check` confirms: `OK (31 crates checked, 0 violations)`.

## Verification

```
cargo test -p perl-parser --test wave4_completion_absorption_tests
# Before: 25 passed, 1 FAILED (test_published_count_baseline_is_34)
# After:  26 passed, 0 failed
```

```
cargo test --workspace --lib   # all pass
cargo clippy -p perl-parser -- -D warnings  # clean
cargo xtask fmt  # no diffs
cargo xtask publish-manifest-check  # OK (31 crates checked, 0 violations)
```

## Related

- Issue #4542 (Wave 4-Completion absorption)
- `g3_publish_baseline_enforcement.rs` — already correctly asserts `== 31`
- `wave_final_absorption_tests.rs` — already correctly asserts `== 31`

https://claude.ai/code/session_01THqgoBetmNox2bjAmZHqaP

---
_Generated by [Claude Code](https://claude.ai/code/session_01THqgoBetmNox2bjAmZHqaP)_