### PR TITLE
docs(agents): mention Claude Code in onboarding docs (#6850)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — Implementation Agent Operating Manual
 
-You are an **implementation agent** (Codex, Jules, or similar). Your job is to make a
+You are an **implementation agent** (Codex, Claude Code, Jules, or similar). Your job is to make a
 scoped change, test it, and open a PR. You are not the orchestrator. You will not be
 routing work or reading CI pipelines — just implement the thing you were asked to implement.
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ See [docs/README.md](docs/README.md) for the full crate map and design notes.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow. AI implementation agents (Codex, Jules, Roo Code) should read [AGENTS.md](AGENTS.md) first.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow. AI implementation agents (Codex, Claude Code, Jules, Roo Code, Gemini CLI) should read [AGENTS.md](AGENTS.md) first. Gemini CLI users should also read [GEMINI.md](GEMINI.md).
 
 ```bash
 cargo test --workspace --lib


### PR DESCRIPTION
Cherry-pick recovery of #6850 onto fresh master.

Original PR #6850 was stranded with no merge-base after master became a fresh root commit. This recovers the topical commits via cherry-pick.

## Changes
- AGENTS.md: adds "Claude Code" to the list of implementation agents on first line
- README.md: expands contributor blurb to include Claude Code and Gemini CLI alongside Codex, Jules, Roo Code

## Original PR
#6850 (cherry-5563-rebased → superseded by this recovery)

Closes #5563