### PR TITLE
fix(ci): add lib.rs to perl-ci-hygiene for cargo test --lib (#6850)

### DIFF
--- a/crates/perl-ci-hygiene/src/lib.rs
+++ b/crates/perl-ci-hygiene/src/lib.rs
@@ -1,0 +1,6 @@
+//! Re-export binary functionality for testing.
+//!
+//! This module is primarily used to enable `cargo test --lib` CI runs.
+//! The primary entry point is the binary in `main.rs`.
+
+pub mod version_sync;

--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -1,4 +1,4 @@
-mod version_sync;
+use perl_ci_hygiene::version_sync;
 
 use chrono::Utc;
 use clap::{Parser, Subcommand};


### PR DESCRIPTION
## Summary

perl-ci-hygiene is a binary crate with library code (version_sync module).
CI's scoped test step runs `cargo test --lib` on touched crates, which fails
if there's no src/lib.rs. This fix adds a minimal lib.rs that re-exports the
public module and updates main.rs to use the library import pattern.

## Fixes

- Unblocks PR #5555 and #5564 which touch perl-ci-hygiene
- Resolves "no library targets" error in PR Smoke test

## Verification

- cargo test --lib -p perl-ci-hygiene: 9 tests passed
- cargo build -p perl-ci-hygiene: succeeds
- cargo test -p perl-ci-hygiene: 42 tests passed
- cargo xtask fmt --check: no format issues