### PR TITLE
docs(editors): add OpenCode setup guide (#5643)

### DIFF
--- a/docs/EDITORS/OPENCODE_SETUP.md
+++ b/docs/EDITORS/OPENCODE_SETUP.md
@@ -1,0 +1,58 @@
+# OpenCode Setup Guide for perl-lsp
+
+This guide shows how to run `perllsp` as a custom LSP server in OpenCode.
+
+## Prerequisites
+
+- `perllsp` installed and available on your `PATH`
+- OpenCode installed
+- a Perl project opened in OpenCode
+
+Verify the server first:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+## Configure OpenCode
+
+Add a project-local `opencode.json` in your repository root (or update an existing
+one) and register `perllsp` as a custom LSP.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "perl-lsp": {
+      "command": ["perllsp", "--stdio"],
+      "extensions": [".pl", ".pm", ".t", ".pod", ".psgi"],
+      "initialization": {
+        "perl": {
+          "workspace": {
+            "includePaths": ["lib", "local/lib/perl5"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Verify It Is Running
+
+1. Open any Perl file (`.pl`, `.pm`, `.t`) in OpenCode.
+2. Trigger a definition lookup or hover on a known symbol.
+3. Confirm diagnostics appear for an intentional syntax error.
+
+If OpenCode does not start the server, confirm `perllsp` is on your shell `PATH`
+and restart OpenCode.
+
+## Troubleshooting
+
+- If no Perl files activate the server, verify your configured file extensions.
+- If the command fails, run `perllsp --stdio` directly in a terminal to confirm
+  the binary is launchable.
+- For server-side behavior and config details, see
+  [docs/reference/CONFIG.md](../reference/CONFIG.md) and
+  [docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -35,6 +35,7 @@ perllsp --health
 | Claude Code | provide a plugin `.lsp.json` pointing to `perllsp --stdio` | [docs/EDITORS/CLAUDE_CODE_SETUP.md](../EDITORS/CLAUDE_CODE_SETUP.md) |
 | Codex CLI | connect an MCP LSP bridge to `perllsp --stdio` | [docs/EDITORS/CODEX_CLI_SETUP.md](../EDITORS/CODEX_CLI_SETUP.md) |
 | Codex Desktop | add a custom Perl server command `perllsp --stdio` | [docs/EDITORS/CODEX_DESKTOP_SETUP.md](../EDITORS/CODEX_DESKTOP_SETUP.md) |
+| OpenCode | configure a custom `perl-lsp` server in `opencode.json` | [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -132,6 +133,12 @@ Configure an MCP LSP bridge that launches `perllsp --stdio`, then verify the
 bridge appears in Codex via `/mcp`. See
 [docs/EDITORS/CODEX_CLI_SETUP.md](../EDITORS/CODEX_CLI_SETUP.md) for a full
 example config and troubleshooting flow.
+
+### OpenCode
+
+Create or update `opencode.json` and register a custom LSP server with
+`"command": ["perllsp", "--stdio"]` and Perl extensions like `.pl`, `.pm`,
+and `.t`. See [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) for a full example.
 
 ## When Setup Fails
 


### PR DESCRIPTION
Cherry-pick recovery of #5643 onto fresh master.

Original PR #5643 was stranded with no merge-base after master became a fresh root commit. This recovers the topical commits via cherry-pick.

## Changes
- Add `docs/EDITORS/OPENCODE_SETUP.md` with OpenCode configuration guide
- Add OpenCode row to `docs/how-to/EDITOR_SETUP.md` editor table

## Original PR
#5643 (codex/improve-opencode-support → superseded by this recovery)