### PR TITLE
test(perl-lexer): add hash-subscript guard regression tests (#5361)

### DIFF
--- a/crates/perl-lexer/tests/tokenizer_edge_case_tests.rs
+++ b/crates/perl-lexer/tests/tokenizer_edge_case_tests.rs
@@ -185,6 +185,29 @@ fn ts_transliteration_y_alias() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn ts_fat_arrow_autoquote_not_substitution() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("s=>1");
+    assert_eq!(kind, TokenKind::Identifier, "s=> should remain fat-arrow autoquote identifier");
+    Ok(())
+}
+
+#[test]
+fn ts_substitution_inside_hash_subscript_not_triggered() -> Result<(), Box<dyn std::error::Error>> {
+    // Inside a hash subscript brace ($h{s}), the bareword `s` must not be
+    // interpreted as the substitution operator.  hash_brace_depth is > 0, so
+    // the s/tr/y detection must be suppressed.
+    let kinds = collect_kinds("$h{s}");
+    // Expected: Scalar variable, opening `{`, bareword key `s`, closing `}`.
+    // There must be NO Substitution token in the stream.
+    assert!(
+        !kinds.contains(&TokenKind::Substitution),
+        "`s` inside {{...}} must remain a bareword, not a substitution operator; got {:?}",
+        kinds
+    );
+    Ok(())
+}
+
+#[test]
 fn ts_qr_angle() -> Result<(), Box<dyn std::error::Error>> {
     let kind = first_kind("qr<pattern>i");
     assert_eq!(kind, TokenKind::Regex, "qr<...> should be Regex");


### PR DESCRIPTION
Cherry-pick recovery of #5361 onto fresh master.

Original PR #5361 was stranded with no merge-base after master became a fresh root commit. The fix logic (broaden s/tr/y delimiter detection) was already absorbed into master's more complete implementation — this PR recovers only the regression test commits.

## Changes
- Add `ts_fat_arrow_autoquote_not_substitution` test: `s=>1` must remain a fat-arrow autoquote identifier
- Add `ts_substitution_inside_hash_subscript_not_triggered` test: `s` inside `$h{s}` must remain a bareword, not a substitution operator

## Note on fix commit
The original fix commit (broaden s/tr/y delimiter detection) conflicts with and is superseded by master's more complete implementation that includes whitespace-aware delimiter detection. The regression tests remain valuable independent of which implementation handles them.

## Original PR
#5361 (codex/improve-perl-lexer → superseded by this recovery for tests)