### PR TITLE
feat(installer): add ARM source-build fallback (#0000)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,7 @@
 # Or with options via environment variables:
 #   VERSION=v0.12.0 INSTALL_DIR=/usr/local/bin bash scripts/install.sh
 #   PREFER_GNU=1 bash scripts/install.sh   # prefer glibc over musl on Linux
+#   BUILD_FROM_SOURCE=1 bash scripts/install.sh   # force cargo build/install
 #
 # Supported platforms:
 #   Linux x86_64 (musl/gnu), Linux aarch64 (musl/gnu), macOS x86_64, macOS aarch64
@@ -17,6 +18,7 @@ BIN_NAME="perllsp"
 DAP_BIN_NAME="perl-dap"
 VERSION="${VERSION:-latest}"
 PREFER_GNU="${PREFER_GNU:-0}"
+BUILD_FROM_SOURCE="${BUILD_FROM_SOURCE:-0}"
 
 # Determine install directory: user-local by default, system-wide if explicitly set
 if [ -z "${INSTALL_DIR:-}" ]; then
@@ -55,6 +57,8 @@ detect_platform() {
     _os="$(uname -s)"
     _arch="$(uname -m)"
     _termux=0
+    SOURCE_TARGET=""
+    INSTALL_MODE="release"
 
     if [ -n "${TERMUX_VERSION:-}" ] || [ -d "/data/data/com.termux/files/usr/bin" ]; then
         _termux=1
@@ -89,25 +93,48 @@ detect_platform() {
     case "$_arch" in
         x86_64|amd64|x64) _arch="x86_64" ;;
         aarch64|arm64)    _arch="aarch64" ;;
-        armv7l|armv7|armv6l|armhf)
-            err "detected 32-bit ARM architecture (${_arch}); prebuilt releases currently support ARM64 only.
-
-Try one of:
-  cargo install perllsp --locked --target armv7-unknown-linux-gnueabihf
-or run this installer from an ARM64 (aarch64) OS/device."
+        armv8l|armv7l|armv7*|armhf)
+            if [ "$_os" = "linux" ]; then
+                _arch="armv7"
+                SOURCE_TARGET="armv7-unknown-linux-gnueabihf"
+                INSTALL_MODE="source"
+            else
+                err "unsupported architecture: $_arch"
+            fi
+            ;;
+        armv6l|armv6*|arm)
+            if [ "$_os" = "linux" ]; then
+                _arch="armv6"
+                SOURCE_TARGET="arm-unknown-linux-gnueabihf"
+                INSTALL_MODE="source"
+            else
+                err "unsupported architecture: $_arch"
+            fi
             ;;
         *) err "unsupported architecture: $_arch" ;;
     esac
 
-    if [ "$_os" = "linux" ]; then
-        TARGET="${_arch}-unknown-linux-${_libc}"
-    else
-        TARGET="${_arch}-apple-darwin"
+    if [ "$BUILD_FROM_SOURCE" = "1" ]; then
+        INSTALL_MODE="source"
     fi
 
-    info "platform: $_os $_arch (target: $TARGET)"
-    if [ "$_termux" = "1" ]; then
-        info "termux environment detected; using musl release artifacts for compatibility"
+    if [ "$INSTALL_MODE" = "release" ]; then
+        if [ "$_os" = "linux" ]; then
+            TARGET="${_arch}-unknown-linux-${_libc}"
+        else
+            TARGET="${_arch}-apple-darwin"
+        fi
+        info "platform: $_os $_arch (target: $TARGET)"
+        if [ "$_termux" = "1" ]; then
+            info "termux environment detected; using musl release artifacts for compatibility"
+        fi
+    else
+        TARGET="${SOURCE_TARGET:-}"
+        if [ -n "$TARGET" ]; then
+            info "platform: $_os $_arch (source build target: $TARGET)"
+        else
+            info "platform: $_os $_arch (source build mode)"
+        fi
     fi
 }
 
@@ -149,10 +176,6 @@ download_and_verify() {
 
     ASSET_URL="${_base_url}/${_asset}"
     CHECKSUM_URL="${_base_url}/SHA256SUMS"
-
-    TMPDIR="$(mktemp -d)"
-    # shellcheck disable=SC2064
-    trap "rm -rf '$TMPDIR'" EXIT
 
     local _archive="${TMPDIR}/${_asset}"
 
@@ -213,6 +236,22 @@ extract_archive() {
         err "expected directory not found after extraction: $EXTRACT_DIR
 The release archive may have an unexpected layout."
     fi
+}
+
+# ── Source build ───────────────────────────────────────────────────────────────
+
+build_from_source() {
+    need_cmd cargo
+    need_cmd rustup
+
+    local _cargo_target
+    _cargo_target="${TARGET:-$(rustc -vV | awk -F': ' '/host:/ {print $2}')}"
+
+    info "building from source for target: $_cargo_target"
+    rustup target add "$_cargo_target"
+    cargo install perllsp --locked --target "$_cargo_target" --root "$TMPDIR/install-root"
+
+    EXTRACT_DIR="${TMPDIR}/install-root/bin"
 }
 
 # ── Install ────────────────────────────────────────────────────────────────────
@@ -295,8 +334,16 @@ main() {
 
     detect_platform
     resolve_version
-    download_and_verify
-    extract_archive
+    TMPDIR="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '$TMPDIR'" EXIT
+
+    if [ "$INSTALL_MODE" = "release" ]; then
+        download_and_verify
+        extract_archive
+    else
+        build_from_source
+    fi
     install_binaries
     verify_install
     check_path


### PR DESCRIPTION
Cherry-pick of #5674 onto fresh master. Original PR had no common ancestor with current master (fresh-root rebuild 2026-04-24).

Original: #5674

### Motivation
The installer previously only supported downloading prebuilt release assets for x86_64 and aarch64, which caused installs to fail on many 32-bit ARM Linux devices.

### Description
- Add a `BUILD_FROM_SOURCE` environment toggle that forces source-build install mode.
- Extend architecture detection to recognize common 32-bit Linux ARM variants (`armv7*`, `armhf`, `armv6*`) and auto-select a source-build mode with appropriate Rust target triples.
- Add `build_from_source()` which runs `rustup target add` and `cargo install perllsp --target ... --root ...`.
- Wire `main()` to choose release-download vs source-build based on `INSTALL_MODE`.
- Preserve existing Termux detection and release-download behavior.

### Cherry-pick notes
Resolved three conflict regions in `scripts/install.sh`: merged ARM source-build detection with existing Termux handling from master. Both coexist cleanly — release mode retains Termux message, source mode uses `SOURCE_TARGET`.