### PR TITLE
fix(vscode-extension): improve Termux binary handling (#0000)

### DIFF
--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -117,11 +117,10 @@ export class BinaryDownloader {
                 // Architecture or OS not supported by the release
                 const platformMatch = /platform:\s*([^\s.]+)/.exec(errorMsg);
                 const platformStr = platformMatch ? platformMatch[1] : 'your platform';
-                if (this.isAndroidEnvironment()) {
+                if (this.isTermuxEnvironment() || platformStr.includes('linux-android')) {
                     message =
-                        `perl-lsp: Android environment detected (${platformStr}). ` +
-                        'Pre-built Android binaries are not published yet. ' +
-                        'Use Termux package tooling or build from source, then point perl-lsp.serverPath to the binary. ' +
+                        `perl-lsp: No pre-built binary for ${platformStr} (Termux/Android). ` +
+                        'Install from source in Termux (for example: pkg install rust && cargo install --locked --path crates/perllsp), then configure perl-lsp.serverPath. ' +
                         manualInstallNote;
                 } else {
                     message =
@@ -597,6 +596,9 @@ export class BinaryDownloader {
                 return androidArchMap[arch] ?? `${arch}-linux-android`;
             }
             const archPrefix = arch === 'arm64' ? 'aarch64' : 'x86_64';
+            if (this.isTermuxEnvironment()) {
+                return `${archPrefix}-linux-android`;
+            }
             const libc = this.detectMusl() ? 'musl' : 'gnu';
             return `${archPrefix}-unknown-linux-${libc}`;
         } else if (platform === 'win32') {
@@ -649,6 +651,14 @@ export class BinaryDownloader {
         ];
         
         return muslLibs.some(lib => fs.existsSync(lib));
+    }
+
+    private isTermuxEnvironment(): boolean {
+        return Boolean(
+            process.env.TERMUX_VERSION ||
+            process.env.PREFIX?.includes('/com.termux/') ||
+            fs.existsSync('/data/data/com.termux/files/usr')
+        );
     }
     
     private getLocalBinaryPath(): string {

--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -586,6 +586,14 @@ export class BinaryDownloader {
         if (platform === 'darwin') {
             return arch === 'arm64' ? 'aarch64-apple-darwin' : 'x86_64-apple-darwin';
         } else if (platform === 'linux') {
+            // Check Termux first: isTermuxEnvironment() is the authoritative Termux
+            // detector.  isAndroidEnvironment() also matches TERMUX_VERSION and would
+            // shadow this branch if checked first, routing to the old arch-map path
+            // instead of the uniform `${archPrefix}-linux-android` form.
+            const archPrefix = arch === 'arm64' ? 'aarch64' : 'x86_64';
+            if (this.isTermuxEnvironment()) {
+                return `${archPrefix}-linux-android`;
+            }
             if (this.isAndroidEnvironment()) {
                 const androidArchMap: Record<string, string> = {
                     arm64: 'aarch64-linux-android',
@@ -594,10 +602,6 @@ export class BinaryDownloader {
                     arm: 'armv7-linux-androideabi'
                 };
                 return androidArchMap[arch] ?? `${arch}-linux-android`;
-            }
-            const archPrefix = arch === 'arm64' ? 'aarch64' : 'x86_64';
-            if (this.isTermuxEnvironment()) {
-                return `${archPrefix}-linux-android`;
             }
             const libc = this.detectMusl() ? 'musl' : 'gnu';
             return `${archPrefix}-unknown-linux-${libc}`;

--- a/vscode-extension/src/test/downloader.test.ts
+++ b/vscode-extension/src/test/downloader.test.ts
@@ -74,10 +74,14 @@ describe('BinaryDownloader.getPlatformTarget', () => {
     expect(target).toMatch(/(apple-darwin|unknown-linux|pc-windows)/);
   });
 
-  test('detects Android/Termux and returns android target triple', () => {
-    process.env.TERMUX_VERSION = '0.118.0';
+  test('uses linux-android target in Termux environments', () => {
+    if (process.platform !== 'linux') {
+      return;
+    }
+
+    jest.spyOn(downloader as any, 'isTermuxEnvironment').mockReturnValue(true);
     const target = getPlatformTarget(downloader);
-    expect(target).toMatch(/linux-android/);
+    expect(target).toMatch(/-linux-android$/);
   });
 });
 
@@ -879,22 +883,18 @@ describe('ensureBinary error classification', () => {
     expect(call[0]).toMatch(/perl-lsp\.serverPath/);
   });
 
-  test('android/termux no-binary error includes android guidance', async () => {
-    const termuxVersionBackup = process.env.TERMUX_VERSION;
-    try {
-      process.env.TERMUX_VERSION = '0.118.0';
-      setupDownloadError('No binary found for platform: aarch64-linux-android. Available assets: perllsp-x86_64-unknown-linux-gnu.tar.gz');
-      const vscode = require('vscode');
-      vscode.window.showErrorMessage.mockResolvedValue(undefined);
+  test('termux platform mismatch shows Termux-specific source-build guidance', async () => {
+    setupDownloadError('No binary found for platform: aarch64-linux-android. Available assets: perllsp-x86_64-unknown-linux-gnu.tar.gz');
+    jest.spyOn(downloader as any, 'isTermuxEnvironment').mockReturnValue(true);
+    const vscode = require('vscode');
+    vscode.window.showErrorMessage.mockResolvedValue(undefined);
 
-      await downloader.ensureBinary();
+    await downloader.ensureBinary();
 
-      const call = vscode.window.showErrorMessage.mock.calls[0];
-      expect(call[0]).toMatch(/android environment detected/i);
-      expect(call[0]).toMatch(/termux|build from source|serverPath/i);
-    } finally {
-      process.env.TERMUX_VERSION = termuxVersionBackup;
-    }
+    const call = vscode.window.showErrorMessage.mock.calls[0];
+    expect(call[0]).toMatch(/Termux|Android/i);
+    expect(call[0]).toMatch(/pkg install rust/i);
+    expect(call[0]).toMatch(/perl-lsp\.serverPath/);
   });
 
   test('HTTP 403 rate limit shows GitHub rate limit guidance', async () => {


### PR DESCRIPTION
Cherry-pick of #5676 onto fresh master. Original PR had no common ancestor with current master (fresh-root rebuild 2026-04-24).

Original: #5676

### Motivation
Termux users were being classified as generic Linux and received unhelpful guidance instead of actionable Termux/Android instructions.

### Description
- Update error message for "No binary found for platform" to use `isTermuxEnvironment()` instead of `isAndroidEnvironment()` for the condition check.
- Show Termux-specific source-build guidance including `pkg install rust && cargo install --locked --path crates/perllsp` example.
- Update tests to use `jest.spyOn` mocking of `isTermuxEnvironment` rather than env variable manipulation.

### Cherry-pick notes
Resolved conflicts in `downloader.ts` (kept `isTermuxEnvironment()` condition from cherry-pick since both methods exist on master) and `downloader.test.ts` (kept improved mock-based test approach from cherry-pick, removed env-variable-based test).