### PR TITLE
feat(vscode): detect common Perl project files (#5586)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -59,10 +59,10 @@
   "main": "./out/extension.js",
   "activationEvents": [
     "onLanguage:perl",
+    "onLanguage:perl5",
     "onLanguage:gherkin",
     "onWalkthrough:perl-lsp.gettingStarted",
-    "onDebugResolve:perl",
-    "onDebugInitialConfigurations"
+    "onStartupFinished"
   ],
   "contributes": {
     "languages": [
@@ -75,6 +75,7 @@
         ],
         "extensions": [
           ".pl",
+          ".PL",
           ".cgi",
           ".fcgi",
           ".pm",
@@ -91,7 +92,14 @@
           ".i"
         ],
         "firstLine": "^#!.*\\bperl\\b",
-        "configuration": "./language-configuration.json"
+        "configuration": "./language-configuration.json",
+        "filenames": [
+          "Makefile.PL",
+          "Build.PL",
+          "cpanfile",
+          "cpanfile.snapshot",
+          "dist.ini"
+        ]
       },
       {
         "id": "gherkin",

--- a/vscode-extension/src/test/packageManifest.test.ts
+++ b/vscode-extension/src/test/packageManifest.test.ts
@@ -1,0 +1,28 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('package manifest Perl language registration', () => {
+    test('registers common Perl project files by filename', () => {
+        const manifestPath = path.resolve(__dirname, '../../package.json');
+        const packageJson = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+            contributes?: {
+                languages?: Array<{
+                    id?: string;
+                    filenames?: string[];
+                }>;
+            };
+        };
+
+        const perlLanguage = packageJson.contributes?.languages?.find(language => language.id === 'perl');
+        expect(perlLanguage).toBeDefined();
+
+        const filenames = perlLanguage?.filenames ?? [];
+        expect(filenames).toEqual(expect.arrayContaining([
+            'Makefile.PL',
+            'Build.PL',
+            'cpanfile',
+            'cpanfile.snapshot',
+            'dist.ini',
+        ]));
+    });
+});


### PR DESCRIPTION
Cherry-pick recovery of #5586 onto fresh master.

Original PR #5586 was stranded with no merge-base after master became a fresh root commit (4669 commits diverged — classic fresh-root pattern). The topical changes were extracted via tip-to-tip diff and manually applied.

## Changes
- `vscode-extension/package.json`: Add `filenames` entries for `Makefile.PL`, `Build.PL`, `cpanfile`, `cpanfile.snapshot`, `dist.ini`
- `vscode-extension/package.json`: Add `.PL` extension to Perl language registration
- `vscode-extension/package.json`: Add `onLanguage:perl5` activation event, replace debug activation events with `onStartupFinished`
- `vscode-extension/src/test/packageManifest.test.ts`: New test asserting the filename registrations are present

## Original PR
#5586 (codex/improve-visual-studio-support → superseded by this recovery)