### PR TITLE
feat(perl-symbol): handle signature parameters in SymbolRef extraction (#6395)

### DIFF
--- a/crates/perl-symbol/src/surface/ref.rs
+++ b/crates/perl-symbol/src/surface/ref.rs
@@ -14,6 +14,9 @@
 //! - Method calls (`$obj->method(...)`, `NodeKind::MethodCall`) — method name is not a
 //!   `Node`, so extraction requires a dedicated `MethodCallRef` kind (future phase)
 //! - Indirect-object calls (`new Class @args`, `NodeKind::IndirectCall`) — same reason
+//! - Subroutine signature parameter bindings (`MandatoryParameter`, `SlurpyParameter`,
+//!   `NamedParameter`) — these are declaration sites, not reference sites.  Optional
+//!   parameter *default values* are still walked because they are expressions.
 
 use crate::types::VarKind;
 use perl_ast::{Node, NodeKind};
@@ -63,6 +66,19 @@ fn walk(node: &Node, out: &mut Vec<SymbolRef>) {
             if let Some(init) = initializer {
                 walk(init, out);
             }
+        }
+
+        // Signature parameter nodes bind variables — skip the variable (it is a
+        // declaration site), but walk the default-value expression for optional
+        // parameters because it is evaluated in the caller's scope.
+        NodeKind::MandatoryParameter { .. }
+        | NodeKind::SlurpyParameter { .. }
+        | NodeKind::NamedParameter { .. } => {
+            // Nothing to walk: the bound variable is a declaration, not a ref.
+        }
+        NodeKind::OptionalParameter { default_value, .. } => {
+            // The default expression may reference other variables.
+            walk(default_value, out);
         }
 
         NodeKind::Variable { sigil, name } => {

--- a/crates/perl-symbol/tests/surface_refs.rs
+++ b/crates/perl-symbol/tests/surface_refs.rs
@@ -242,3 +242,68 @@ fn parser_sentinel_names_are_not_emitted_as_refs() -> Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn signature_parameters_are_not_emitted_as_refs() -> Result<()> {
+    // `sub foo($x, $y = $default, @rest)` — $x, $y, @rest are declaration sites;
+    // only $default (the default-value expression) must be emitted as a ref.
+    let param_x =
+        Node::new(NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() }, loc(8, 10));
+    let mandatory =
+        Node::new(NodeKind::MandatoryParameter { variable: Box::new(param_x) }, loc(8, 10));
+
+    let param_y = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "y".to_string() },
+        loc(12, 14),
+    );
+    let default_var = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "default".to_string() },
+        loc(17, 25),
+    );
+    let optional = Node::new(
+        NodeKind::OptionalParameter {
+            variable: Box::new(param_y),
+            default_value: Box::new(default_var),
+        },
+        loc(12, 25),
+    );
+
+    let param_rest = Node::new(
+        NodeKind::Variable { sigil: "@".to_string(), name: "rest".to_string() },
+        loc(27, 32),
+    );
+    let slurpy =
+        Node::new(NodeKind::SlurpyParameter { variable: Box::new(param_rest) }, loc(27, 32));
+
+    let sig = Node::new(
+        NodeKind::Signature { parameters: vec![mandatory, optional, slurpy] },
+        loc(7, 33),
+    );
+    let body = Node::new(NodeKind::Block { statements: vec![] }, loc(34, 36));
+    let sub_node = Node::new(
+        NodeKind::Subroutine {
+            name: Some("foo".to_string()),
+            name_span: None,
+            prototype: None,
+            signature: Some(Box::new(sig)),
+            attributes: vec![],
+            body: Box::new(body),
+        },
+        loc(0, 36),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![sub_node] }, loc(0, 36));
+
+    let refs = extract_symbol_refs(&program);
+
+    // Only $default (the optional-parameter default value) should appear.
+    // $x, $y, @rest are declaration sites and must not be emitted.
+    assert_eq!(
+        refs.len(),
+        1,
+        "only $default should be a ref; got: {:?}",
+        refs.iter().map(|r| &r.name).collect::<Vec<_>>()
+    );
+    assert_eq!(refs[0].kind, SymbolRefKind::Variable(VarKind::Scalar));
+    assert_eq!(refs[0].name, "default");
+    Ok(())
+}


### PR DESCRIPTION
Cherry-pick recovery of #6395 onto fresh master.

Original PR #6395 had 130+ file conflicts spanning CI config and status files because it diverged long ago. The core feature (SymbolRef projection) was already merged in a prior wave. This recovery PR adds only the unique delta from #6395 that was not yet in master.

## Changes
- `crates/perl-symbol/src/surface/ref.rs`: Add `MandatoryParameter`, `SlurpyParameter`, `NamedParameter` walk arms (declaration sites — not refs). Add `OptionalParameter` arm that walks the default-value expression only. Update module-level doc to mention signature parameter exclusions.
- `crates/perl-symbol/tests/surface_refs.rs`: Add `signature_parameters_are_not_emitted_as_refs` test asserting only the optional-parameter default expression becomes a ref.

## What was NOT recovered
- Cargo.toml benchmark removal (master is better — has criterion benchmarks)
- cursor/mod.rs regressions (master's more complete implementation is preferred)
- decl.rs Format/Label removal (master has these handlers; PR's older diverged branch was missing them)
- Status/CI files (auto-generated, not applicable)

## Original PR
#6395 (codex/add-phase-1-symbolref-projection-layer-ltjgje → superseded by this recovery)

Closes #6466