### PR TITLE
fix(fmt): add missing blank line in perl-pragma comprehensive tests (#7017)

### DIFF
--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -1254,6 +1254,7 @@ fn no_warnings_empty_string_category_is_ignored() -> Result<(), Box<dyn std::err
     );
     Ok(())
 }
+
 #[test]
 fn no_warnings_bare_disables_all_warnings() -> Result<(), Box<dyn std::error::Error>> {
     // `no warnings;` (no args) must still disable the global warnings flag.


### PR DESCRIPTION
## Summary

- **Root cause**: `comprehensive_unit_tests.rs` was introduced in the fresh-root master rebuild with formatting inconsistencies. CI's rustfmt 1.92.0 on Linux rejected the stale pre-fresh-root PR branches (#6773, #6742) because those branches had the old version with: (1) a double blank line between two test functions, (2) an inline `vec![...]` that exceeded the `use_small_heuristics = "Max"` line-width budget. These issues were fixed in the fresh-root rebuild but the PRs couldn't be updated via `gh pr update-branch` (no common ancestor after history rewrite).

- **Which option**: Hybrid — the master-side fix (Option A) for the old PR branches was applied via GitHub Contents API (direct push to each PR branch), and this PR fixes the remaining cosmetic inconsistency on master (missing blank line before `#[test]` at line 1257).

- **Stale PRs fixed**: `claude/improve-include-roots-iWL6u` (PR #6773) and `claude/improve-test-coverage-A2qrY` (PR #6742) were updated via API commits `cc3867a20f7b21058f9f` and `e8ca03af2f9a8de40491` respectively, replacing the old file with master's fmt-clean version.

## Test plan

- [x] `cargo fmt --check -p perl-pragma` passes with exit code 0
- [x] `cargo check --tests -p perl-pragma` passes — file still compiles
- [x] `cargo xtask fmt --check` passes for full workspace (exit code 0)
- [ ] CI PR Smoke (Fast Feedback) on both #6773 and #6742 — new CI runs triggered by the API commits