### PR TITLE
docs(opencode): clarify diagnostics-first setup and LSP tool gating (#0000)

### DIFF
--- a/docs/EDITORS/OPENCODE_SETUP.md
+++ b/docs/EDITORS/OPENCODE_SETUP.md
@@ -2,23 +2,28 @@
 
 This guide shows how to run `perllsp` as a custom LSP server in OpenCode.
 
+OpenCode is an AI coding agent rather than a traditional editor. Its LSP
+integration is most useful for diagnostics by default. Hover, references, and
+go-to-definition are available through OpenCode's experimental LSP tool.
+
 ## Prerequisites
 
 - `perllsp` installed and available on your `PATH`
 - OpenCode installed
-- a Perl project opened in OpenCode
+- a Perl project opened from the project root
 
 Verify the server first:
 
 ```bash
 perllsp --version
 perllsp --health
+perllsp --info
 ```
 
 ## Configure OpenCode
 
-Add a project-local `opencode.json` in your repository root (or update an existing
-one) and register `perllsp` as a custom LSP.
+Add a project-local `opencode.json` or `opencode.jsonc` in your repository root
+(or update an existing one) and register `perllsp` as a custom LSP.
 
 ```json
 {
@@ -26,11 +31,31 @@ one) and register `perllsp` as a custom LSP.
   "lsp": {
     "perl-lsp": {
       "command": ["perllsp", "--stdio"],
-      "extensions": [".pl", ".pm", ".t", ".pod", ".psgi"],
+      "extensions": [".pl", ".PL", ".pm", ".t", ".pod", ".psgi", ".cgi", ".fcgi", ".xs", ".xsi"]
+    }
+  }
+}
+```
+
+If your project uses additional Perl-bearing template files, add their
+extensions to the list, for example `.mason`, `.mas`, `.tt`, `.tt2`, or `.ep`.
+
+## Optional: Pass perl-lsp Initialization Options
+
+Prefer `.perl-lsp.toml` for settings that should apply to all editors. Use
+OpenCode `initialization` only for OpenCode-specific startup options.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "perl-lsp": {
+      "command": ["perllsp", "--stdio"],
+      "extensions": [".pl", ".PL", ".pm", ".t", ".pod", ".psgi", ".cgi", ".fcgi", ".xs", ".xsi"],
       "initialization": {
         "perl": {
           "workspace": {
-            "includePaths": ["lib", "local/lib/perl5"]
+            "includePaths": ["lib", ".", "local/lib/perl5", "vendor/lib"]
           }
         }
       }
@@ -41,18 +66,54 @@ one) and register `perllsp` as a custom LSP.
 
 ## Verify It Is Running
 
-1. Open any Perl file (`.pl`, `.pm`, `.t`) in OpenCode.
-2. Trigger a definition lookup or hover on a known symbol.
-3. Confirm diagnostics appear for an intentional syntax error.
+1. Start OpenCode from the project root.
+2. Open or reference a Perl file such as `lib/My/Module.pm` or `t/basic.t`.
+3. Introduce a temporary syntax error and confirm OpenCode reports diagnostics.
+4. Remove the syntax error after verification.
 
-If OpenCode does not start the server, confirm `perllsp` is on your shell `PATH`
-and restart OpenCode.
+For OpenCode builds with the debug LSP command available, you can also test
+diagnostics directly:
+
+```bash
+opencode debug lsp diagnostics path/to/file.pl
+```
+
+## Optional: Enable Hover, Definition, and References
+
+OpenCode's direct LSP tool is experimental. To let the agent call operations
+such as hover, go-to-definition, references, document symbols, and workspace
+symbols, start OpenCode with:
+
+```bash
+OPENCODE_EXPERIMENTAL_LSP_TOOL=true opencode
+```
+
+Then allow the LSP tool in `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "lsp": "allow"
+  }
+}
+```
+
+You can combine this `permission` block with the `lsp` block above.
 
 ## Troubleshooting
 
-- If no Perl files activate the server, verify your configured file extensions.
-- If the command fails, run `perllsp --stdio` directly in a terminal to confirm
-  the binary is launchable.
-- For server-side behavior and config details, see
-  [docs/reference/CONFIG.md](../reference/CONFIG.md) and
-  [docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).
+- If no Perl files activate the server, verify the file extension is listed in
+  `opencode.json`.
+- If OpenCode cannot start the server, run `which perllsp` and `perllsp --health`
+  from the same shell environment used to launch OpenCode.
+- If `perllsp --stdio` appears to hang when run manually, that is expected: it is
+  waiting for LSP JSON-RPC input.
+- If module resolution fails, configure shared include paths in `.perl-lsp.toml`
+  or pass `perl.workspace.includePaths` through OpenCode `initialization`.
+- If OpenCode still does not report diagnostics, start it with debug logging and
+  check the OpenCode logs.
+
+For server-side behavior and config details, see
+[docs/reference/CONFIG.md](../reference/CONFIG.md) and
+[docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -35,7 +35,7 @@ perllsp --health
 | Claude Code | provide a plugin `.lsp.json` pointing to `perllsp --stdio` | [docs/EDITORS/CLAUDE_CODE_SETUP.md](../EDITORS/CLAUDE_CODE_SETUP.md) |
 | Codex CLI | connect an MCP LSP bridge to `perllsp --stdio` | [docs/EDITORS/CODEX_CLI_SETUP.md](../EDITORS/CODEX_CLI_SETUP.md) |
 | Codex Desktop | add a custom Perl server command `perllsp --stdio` | [docs/EDITORS/CODEX_DESKTOP_SETUP.md](../EDITORS/CODEX_DESKTOP_SETUP.md) |
-| OpenCode | configure a custom `perl-lsp` server in `opencode.json` | [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) |
+| OpenCode | configure `perllsp --stdio` as a custom LSP in `opencode.json`; diagnostics work by default, direct LSP operations are experimental | [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -136,9 +136,16 @@ example config and troubleshooting flow.
 
 ### OpenCode
 
-Create or update `opencode.json` and register a custom LSP server with
-`"command": ["perllsp", "--stdio"]` and Perl extensions like `.pl`, `.pm`,
-and `.t`. See [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) for a full example.
+Create or update `opencode.json` or `opencode.jsonc` and register a custom LSP
+server with `"command": ["perllsp", "--stdio"]` and Perl extensions like `.pl`,
+`.PL`, `.pm`, `.t`, `.pod`, and `.psgi`.
+
+OpenCode uses LSP diagnostics by default. For direct hover, definition,
+references, and symbol operations, enable OpenCode's experimental LSP tool with
+`OPENCODE_EXPERIMENTAL_LSP_TOOL=true` and allow the `lsp` permission.
+
+See [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) for a full
+example.
 
 ## When Setup Fails
 

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -46,6 +46,41 @@ If the editor is using a helper extension or plugin, check its own logs too.
 - Restart the editor after changing language-server settings.
 - If the project is large, try a smaller workspace root first.
 
+## OpenCode Does Not Show Perl Diagnostics
+
+1. Confirm `perllsp` is launchable:
+
+   ```bash
+   perllsp --health
+   perllsp --info
+   ```
+
+2. Confirm your Perl file extension is listed in the OpenCode `lsp.perl-lsp`
+   `extensions` array.
+
+3. Run OpenCode with debug logs:
+
+   ```bash
+   opencode --print-logs --log-level DEBUG
+   ```
+
+4. If available in your OpenCode build, run:
+
+   ```bash
+   opencode debug lsp diagnostics path/to/file.pl
+   ```
+
+5. If hover or go-to-definition does not work, enable the experimental LSP tool:
+
+   ```bash
+   OPENCODE_EXPERIMENTAL_LSP_TOOL=true opencode
+   ```
+
+   and set `"permission": { "lsp": "allow" }` in `opencode.json`.
+
+OpenCode logs are typically under `~/.local/share/opencode/log/` on macOS/Linux
+and `%USERPROFILE%\.local\share\opencode\log` on Windows.
+
 ## The Server Feels Slow
 
 - Close unrelated files and trim the workspace to the project root.

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -219,6 +219,32 @@ Extra arguments passed to the Perl interpreter when probing startup `@INC`.
 }
 ```
 
+#### OpenCode initialization example
+
+OpenCode passes LSP startup settings through the `initialization` field in
+`opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "perl-lsp": {
+      "command": ["perllsp", "--stdio"],
+      "extensions": [".pl", ".PL", ".pm", ".t", ".pod", ".psgi"],
+      "initialization": {
+        "perl": {
+          "workspace": {
+            "includePaths": ["lib", ".", "local/lib/perl5"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+For settings that should apply across all editors, prefer `.perl-lsp.toml`.
+
 #### `perl.workspace.useSystemInc`
 
 | Property | Value |


### PR DESCRIPTION
### Motivation

- Make OpenCode guidance explicit that LSP diagnostics are available by default while hover/definition/references require the experimental LSP tool, because prior text suggested those operations as a reliable verification step.
- Provide safer, more complete `opencode.json` examples (mention `opencode.jsonc`, include the current-directory `.` in include paths, and broaden sensible file extensions) to avoid users accidentally breaking module resolution.
- Improve troubleshooting and surface an OpenCode-specific initialization example in the configuration reference so users have concrete debug commands and settings locations.
- Ensure updated Markdown does not contain hidden bidi/formatting Unicode characters by scanning the edited files.

### Description

- Expanded `docs/EDITORS/OPENCODE_SETUP.md` to call out that OpenCode is diagnostics-first, added the experimental LSP-tool gating, recommended `opencode.jsonc` as an option, broadened the `extensions` list, added `perllsp --info` to verification tips, and included an `initialization` example that keeps `"."` in `includePaths`.
- Updated `docs/how-to/EDITOR_SETUP.md` to change the OpenCode table row and the minimal OpenCode section to align with the new guidance and to mention enabling `OPENCODE_EXPERIMENTAL_LSP_TOOL` and `"permission": { "lsp": "allow" }` when needed.
- Added an `OpenCode Does Not Show Perl Diagnostics` section to `docs/how-to/TROUBLESHOOTING.md` with concrete debug commands (`opencode --print-logs --log-level DEBUG`, `opencode debug lsp diagnostics`, `perllsp --health`/`--info`) and log location hints.
- Inserted an `OpenCode initialization example` into `docs/reference/CONFIG.md` and reiterated preferring `.perl-lsp.toml` for project-wide settings.

### Testing

- Ran the invisible-Unicode scan via a `python3` script over the modified docs and it reported no `Cf` (format control) characters.
- Ran `cargo xtask fmt --check` and it completed successfully.
- Attempted to run `markdownlint` on the changed files but the tool was not installed in the environment, so that lint could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef06c72ff88333a9eff16d5f990f68)