### PR TITLE
fix: resolve 5 independent test failures in parser and refactoring crates (#7059)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -958,6 +958,12 @@ impl<'a> Parser<'a> {
             }
 
             TokenKind::LeftBracket => {
+                // Extra recursion budget: each `[...]` nesting level must consume two
+                // depth units (this check plus parse_primary's own guard) so that
+                // deep array-ref nesting hits MAX_RECURSION_DEPTH before the OS stack
+                // overflows — symmetric with the double-guard used by hash literals.
+                self.check_recursion()?;
+
                 // Array reference constructor: [ LIST ]
                 //
                 // Inside [...] the content is always list context. Fat arrow (=>)
@@ -1019,6 +1025,7 @@ impl<'a> Parser<'a> {
                 self.expect_closing_delimiter(TokenKind::RightBracket)?;
                 let end = self.previous_position();
 
+                self.exit_recursion();
                 Ok(Node::new(NodeKind::ArrayLiteral { elements }, SourceLocation { start, end }))
             }
 

--- a/crates/perl-parser-core/src/engine/parser/expressions/quotes.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/quotes.rs
@@ -123,7 +123,7 @@ impl<'a> Parser<'a> {
             // tokens (which would incorrectly consume the `}` that closes the
             // enclosing hash subscript).
             let delim_text = delim_token.text.as_ref();
-            if delim_text.len() >= 2
+            if delim_text.len() >= delim_char.len_utf8() + close_delim.len_utf8()
                 && delim_text.starts_with(delim_char)
                 && delim_text.ends_with(close_delim)
             {

--- a/crates/perl-parser/src/refactor/refactoring.rs
+++ b/crates/perl-parser/src/refactor/refactoring.rs
@@ -2843,12 +2843,11 @@ sub complex {
                 thread::sleep(Duration::from_millis(50));
             }
 
-            let temp_dir = must(tempfile::tempdir());
             let config = RefactoringConfig {
                 create_backups: true,
                 max_backup_retention: 2,
                 backup_max_age_seconds: 0, // Disable age-based retention
-                backup_root: Some(temp_dir.path().to_path_buf()),
+                backup_root: Some(backup_root.clone()),
                 ..RefactoringConfig::default()
             };
             let mut engine = RefactoringEngine::with_config(config);

--- a/crates/perl-parser/tests/ast_invariant_property_mutation_hardening.proptest-regressions
+++ b/crates/perl-parser/tests/ast_invariant_property_mutation_hardening.proptest-regressions
@@ -8,3 +8,5 @@ cc b4bd8b69eaaa58012fa53641811a82a317b08ee0577f6e4ae24786da17633e03 # shrinks to
 cc f1492843e9e1efe993e271639f9243f0fbce0239b907449e64c1534bfe240074 # shrinks to statements = ["\"\"\"\"A\"0]\u{a0}\u{1680}", "(\"''q\"aa\u{205f} "]
 cc 2731dc211cac1fd3d856d6a288509f665f43709d5a758dc1cc95da74bd47d6eb # shrinks to statements = ["'\"\"0a\u{1680}\"\t\u{1680}]", "\t\t\t\u{a0}A\u{205f}A]\u{3000}'"]
 cc 03e626626479356bc44521a0bae8d71842441a944e0be3cb034ae20877cb65b6 # shrinks to statements = ["q\u{205f}O\u{1680} \u{a0}\u{1680}A\u{2000}\u{205f}", "\"\"\"AA\u{a0}\t\u{2028}\u{85}(", "''''(((\"\"\"\""]
+cc 2467ed08508089e0132a4498c42940cebe1537bfac1cdbb4f9d9c57c3db69091 # shrinks to valid_code = "\u{85}_A\t\u{85}\u{205f}0\u{1680} \u{3000}\u{3000}\u{85}\u{202f}a0\u{205f}m \u{3000}\u{1680}", corruption = "\u{200b}"
+cc 7c43b83b52b410ea2070e18d5cae7f152b2e93b5627ba45aa513e2c12a28e061 # shrinks to statements = ["''0aAAA{0 ", "=A'}A\u{2000}aaaa"]

--- a/crates/perl-parser/tests/ast_invariant_property_mutation_hardening.rs
+++ b/crates/perl-parser/tests/ast_invariant_property_mutation_hardening.rs
@@ -35,10 +35,12 @@ fn count_parentheses_balance(s: &str) -> i32 {
 
     let mut balance = 0;
     let mut in_double_string = false;
-    let mut in_single_string = false;
     let mut escape_next = false;
     let chars = normalized.chars().peekable();
 
+    // S-expressions in this codebase use double-quoted strings ("...") only.
+    // Single quotes appear in raw identifier text (e.g. Perl's old package separator
+    // Foo'bar) and must not be treated as string delimiters here.
     for ch in chars {
         if escape_next {
             escape_next = false;
@@ -46,17 +48,14 @@ fn count_parentheses_balance(s: &str) -> i32 {
         }
 
         match ch {
-            '\\' if (in_double_string || in_single_string) => {
+            '\\' if in_double_string => {
                 escape_next = true;
             }
-            '"' if !in_single_string => {
+            '"' => {
                 in_double_string = !in_double_string;
             }
-            '\'' if !in_double_string => {
-                in_single_string = !in_single_string;
-            }
-            '(' if !in_double_string && !in_single_string => balance += 1,
-            ')' if !in_double_string && !in_single_string => balance -= 1,
+            '(' if !in_double_string => balance += 1,
+            ')' if !in_double_string => balance -= 1,
             _ => {}
         }
     }

--- a/crates/perl-parser/tests/snapshots/ast_snap__errors_unclosed_hash_subscript_and_followup.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__errors_unclosed_hash_subscript_and_followup.snap
@@ -2,5 +2,4 @@
 source: crates/perl-parser/tests/ast_snap.rs
 expression: "parse_errors(\"my $x = $h{foo;\\nmy $y = 2;\")"
 ---
-expected '}', found ';' at position 14
-expected statement, found 'my' at position 16
+Recovered from InsertedCloser at HashSubscript (position 14)

--- a/crates/perl-parser/tests/snapshots/ast_snap__recovery_unclosed_hash_subscript_then_followup_statement.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__recovery_unclosed_hash_subscript_then_followup_statement.snap
@@ -2,4 +2,4 @@
 source: crates/perl-parser/tests/ast_snap.rs
 expression: "parse_sexp(\"my $x = $h{foo;\\nmy $y = 2;\")"
 ---
-(source_file (ERROR "expected \'}\', found \';\' at position 14") (my_declaration (variable $ y)(number 2)))
+(source_file (my_declaration (variable $ x)(binary_{} (variable $ h) (identifier foo))) (my_declaration (variable $ y)(number 2)))


### PR DESCRIPTION
## Summary

Five independent test failures found by running the full test suite and traced to their root causes. Each fix is minimal and surgical.

---

### Fix 1 — `quotes.rs`: panic on multi-byte Unicode delimiters

**File**: `crates/perl-parser-core/src/engine/parser/expressions/quotes.rs`

**Root cause**: In `parse_quote_operator`, after consuming a non-balanced delimiter token, the guard condition was `delim_text.len() >= 2` before slicing with `[delim_char.len_utf8()..delim_text.len() - close_delim.len_utf8()]`. When the delimiter is a multi-byte Unicode character (e.g. U+2015 HORIZONTAL BAR, 3 UTF-8 bytes) and the token text is just that single character (3 bytes total), the arithmetic produces `begin=3, end=0` — an invalid slice range that panics with `"begin <= end (3 <= 0) when slicing"`.

**Fix**: Changed guard to `delim_text.len() >= delim_char.len_utf8() + close_delim.len_utf8()`. For ASCII delimiters (the common case) this is still `>= 2`; for multi-byte delimiters it correctly requires enough bytes to contain both delimiter characters before slicing.

**Test that was failing**: `property_error_recovery_invariants` (proptest corpus entry with U+2015 delimiter)

---

### Fix 2 — `primary.rs`: array-ref constructor missing recursion depth guard

**File**: `crates/perl-parser-core/src/engine/parser/expressions/primary.rs`

**Root cause**: The `TokenKind::LeftBracket` arm (array reference constructor `[...]`) had no additional recursion-depth budget beyond the one provided by `parse_primary()`'s outer `with_recursion_guard`. Each nesting level of `[[...]]` therefore consumed only 1 depth unit, meaning 70 levels of nesting reached depth ≈ 71 — well below `MAX_RECURSION_DEPTH = 128` — and the parser accepted it successfully.

Hash literals already use a **double guard** (`parse_hash_or_block_with_context` wraps `with_recursion_guard`, then `parse_hash_or_block_inner` calls `check_recursion()` again), so `{ a => { ... } }` at depth 70 costs 140 units and correctly triggers the limit.

**Fix**: Added `self.check_recursion()?` at the start of the LeftBracket arm and `self.exit_recursion()` before the success return, symmetric with the hash literal pattern. Each `[...]` nesting level now costs 2 depth units; 70 levels = 140 > 128, triggering `NestingTooDeep` at ~64 levels.

**Test that was failing**: `parser_hang_risk_nested_array_literals` (expected `is_err()` at depth 70)

---

### Fix 3 — `refactoring.rs`: backup-retention test using wrong tempdir

**File**: `crates/perl-parser/src/refactor/refactoring.rs`

**Root cause**: `test_cleanup_respects_retention_count` created 4 backup directories inside `backup_root` (TD1), then immediately created a brand-new `tempfile::tempdir()` (TD2) and passed TD2 as the engine's `backup_root`. The engine scanned the empty TD2, found nothing to delete, and returned `directories_removed = 0`, failing the `assert_eq!(result.directories_removed, 2)` assertion.

**Fix**: Removed the erroneous second `tempfile::tempdir()` call. Changed `backup_root: Some(temp_dir.path().to_path_buf())` to `backup_root: Some(backup_root.clone())` so the engine scans the directory that actually contains the test fixtures.

**Test that was failing**: `test_cleanup_respects_retention_count`

---

### Fix 4 — `ast_invariant_property_mutation_hardening.rs`: single-quote misidentified as string delimiter in sexp balance checker

**File**: `crates/perl-parser/tests/ast_invariant_property_mutation_hardening.rs`

**Root cause**: The proptest helper `count_parentheses_balance` was tracking both `in_double_string` and `in_single_string` state, toggling on `'`. S-expressions in this codebase use `"..."` (double-quoted strings) only. Single quotes appear inside bare identifier names — specifically Perl's old package-separator syntax (e.g. `Foo'bar`) — and should be counted as ordinary characters. When a sexp like `(identifier A'B)` was encountered, the `'` flipped `in_single_string = true`, causing the closing `)` to be skipped. The balance counter read 1 instead of 0, triggering false "Major parentheses imbalance" failures for any input that produced identifiers with a `'` in the name.

**Fix**: Removed all `in_single_string` tracking. The checker now only escapes within `"..."`. Added a one-line comment explaining why single quotes are intentionally ignored.

**Test that was failing**: `property_sexp_generation_consistency` (proptest corpus entry with `'`-separated identifier)

---

### Fix 5 — Snapshot updates: hash-subscript error-recovery improvements

**Files**:
- `crates/perl-parser/tests/snapshots/ast_snap__recovery_unclosed_hash_subscript_then_followup_statement.snap`
- `crates/perl-parser/tests/snapshots/ast_snap__errors_unclosed_hash_subscript_and_followup.snap`

**Root cause**: These insta snapshots stored the expected output from a less-capable version of the error recovery pass. The parser has since been improved to insert a virtual closing `}` (via the `InsertedCloser` mechanism) when it sees `$h{foo;`, allowing the second statement to be parsed cleanly. The old snapshots expected two hard `ERROR` nodes; the new behaviour produces a single `InsertedCloser` diagnostic and a fully-recovered AST.

**Fix**: Updated both snapshot files to match the current parser output. No parser logic changed.

---

## Test plan

- [x] `cargo test -p perl-parser --test hang_risk_deep_nesting_tests` — all 23 tests pass (previously 1 failure)
- [x] `cargo test -p perl-parser --test ast_snap` — all snapshot tests pass
- [x] `cargo test -p perl-parser --test ast_invariant_property_mutation_hardening` — proptest passes
- [x] `cargo test -p perl-parser cleanup_respects_retention` — retention test passes
- [x] `cargo clippy -p perl-parser-core -p perl-parser` — no errors or new warnings

https://claude.ai/code/session_01HcXKvPTGzLvnn6J8E9NNP3

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcXKvPTGzLvnn6J8E9NNP3)_