### PR TITLE
docs(editors): align VS Code setup with perllsp naming (#0000)

### DIFF
--- a/docs/EDITORS/VS_CODE_SETUP.md
+++ b/docs/EDITORS/VS_CODE_SETUP.md
@@ -20,7 +20,8 @@ This guide helps you set up and configure the Perl Language Server in Visual Stu
 ### Required
 
 - **VS Code** version 1.88 or later
-- **perl-lsp** server installed (see [Installation](#installation))
+- **EffortlessMetrics.perl-lsp-rs** extension installed
+- `perllsp` server binary (auto-downloaded by the extension by default)
 
 ### Optional but Recommended
 
@@ -31,41 +32,48 @@ This guide helps you set up and configure the Perl Language Server in Visual Stu
 
 ## Installation
 
-### Install the Server
+### Install the VS Code Extension
+
+Recommended for most users (auto-downloads the matching `perllsp` server):
+
+```bash
+code --install-extension EffortlessMetrics.perl-lsp-rs
+```
+
+### Optional: Install the Server Manually
+
+Manual installation is useful for offline environments, pinned deployments, or when `"perl-lsp.autoDownload": false`.
 
 Choose one of the following methods:
 
 #### Option 1: Install from crates.io (Recommended)
 
 ```bash
-cargo install perllsp
+cargo install perllsp --locked
 ```
 
 #### Option 2: Download Pre-built Binary
 
-Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases):
+Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
 
 ```bash
-# Linux (x86_64)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-linux-x86_64.tar.gz
-tar xzf perl-lsp-linux-x86_64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
+# Linux x86_64 (glibc)
+VERSION=0.12.4
+TARGET=x86_64-unknown-linux-gnu
 
-# macOS (Apple Silicon)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-darwin-aarch64.tar.gz
-tar xzf perl-lsp-darwin-aarch64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
-
-# Windows (x86_64)
-# Download and extract to a directory in your PATH
+curl -LO "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v${VERSION}/perllsp-${VERSION}-${TARGET}.tar.gz"
+tar xzf "perllsp-${VERSION}-${TARGET}.tar.gz"
+sudo install -m 0755 "perllsp-${VERSION}-${TARGET}/perllsp" /usr/local/bin/perllsp
 ```
+
+Use the matching `perllsp-<version>-<target>` asset name for other platforms.
 
 #### Option 3: Build from Source
 
 ```bash
 git clone https://github.com/EffortlessMetrics/perl-lsp.git
 cd perl-lsp
-cargo install perllsp
+cargo install --path crates/perllsp --locked
 ```
 
 ### Verify Installation
@@ -107,7 +115,7 @@ If you prefer using a generic LSP client extension:
 
 ## Configuration
 
-The extension exposes settings in the `perl-lsp.*` namespace. A separate `perl.*` namespace is used for server-side initialization options (see [Advanced Configuration](#advanced-configuration)).
+The extension exposes settings in the `perl-lsp.*` namespace. For server-wide limits and configuration, prefer `.perl-lsp.toml` and the mechanisms documented in `docs/reference/CONFIG.md`.
 
 ### Basic Configuration
 
@@ -123,7 +131,7 @@ Add to your workspace `.vscode/settings.json`:
   "perl-lsp.enableFormatting": true,
   "perl-lsp.formatOnSave": false,
   "perl-lsp.enableRefactoring": true,
-  "perl-lsp.includePaths": ["lib", "local/lib/perl5"],
+  "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5"],
   "perl-lsp.enableTestIntegration": true
 }
 ```
@@ -160,13 +168,15 @@ Or edit `settings.json` directly:
 2. Type "Preferences: Open Settings (JSON)"
 3. Add your configuration
 
-### All Extension Settings
+### Common Extension Settings
+
+For the authoritative list, use the VS Code Settings UI or the extension manifest (`vscode-extension/package.json`). This table focuses on commonly used settings.
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `perl-lsp.serverPath` | string | `""` | Absolute path to `perl-lsp` binary. Leave empty to auto-download. |
-| `perl-lsp.autoDownload` | boolean | `true` | Auto-download `perl-lsp` binary if not found locally. |
-| `perl-lsp.includePaths` | array | `["lib", "local/lib/perl5"]` | Additional library paths to search for Perl modules. |
+| `perl-lsp.serverPath` | string | `""` | Absolute path to the `perllsp` binary. Leave empty to auto-download. |
+| `perl-lsp.autoDownload` | boolean | `true` | Auto-download `perllsp` binary if not found locally. |
+| `perl-lsp.includePaths` | array | `["lib", ".", "local/lib/perl5"]` | Additional library paths to search for Perl modules. |
 | `perl-lsp.enableDiagnostics` | boolean | `true` | Enable real-time syntax diagnostics. |
 | `perl-lsp.enableSemanticTokens` | boolean | `true` | Enable semantic syntax highlighting. |
 | `perl-lsp.perltidyConfig` | string | `""` | Path to `.perltidyrc` configuration file. |
@@ -179,7 +189,7 @@ Or edit `settings.json` directly:
 | `perl-lsp.trace.server` | string | `"off"` | LSP traffic logging: `off`, `messages`, `verbose`. |
 | `perl-lsp.channel` | string | `"latest"` | Release channel: `latest`, `stable`, or `tag`. |
 | `perl-lsp.versionTag` | string | `""` | Specific release tag when channel is `tag`. |
-| `perl-lsp.downloadBaseUrl` | string | `""` | Internal base URL for hosting perl-lsp archives (bypasses GitHub). |
+| `perl-lsp.downloadBaseUrl` | string | `""` | Internal base URL for hosting perllsp archives (bypasses GitHub). |
 
 ---
 
@@ -311,17 +321,17 @@ Reference counts and quick actions inline in the editor.
 
 ### Default LSP Keybindings
 
-| Action | Windows/Linux | macOS |
-|--------|---------------|-------|
-| Go to Definition | `F12` | `F12` |
-| Peek Definition | `Ctrl+Shift+F10` | `Ctrl+Shift+F10` |
-| Find References | `Shift+F12` | `Shift+F12` |
-| Rename Symbol | `F2` | `F2` |
-| Format Document | `Shift+Alt+F` | `Shift+Option+F` |
-| Quick Fix | `Ctrl+.` | `Cmd+.` |
-| Show Hover | `Ctrl+K Ctrl+I` | `Ctrl+K Ctrl+I` |
-| Open Symbol by Name | `Ctrl+T` | `Cmd+T` |
-| Show All Symbols | `Ctrl+Shift+O` | `Cmd+Shift+O` |
+| Action | Windows | Linux | macOS |
+|--------|---------|-------|-------|
+| Go to Definition | `F12` | `F12` | `F12` |
+| Peek Definition | `Alt+F12` | `Ctrl+Shift+F10` | `Option+F12` |
+| Find References | `Shift+F12` | `Shift+F12` | `Shift+F12` |
+| Rename Symbol | `F2` | `F2` | `F2` |
+| Format Document | `Shift+Alt+F` | `Ctrl+Shift+I` | `Shift+Option+F` |
+| Quick Fix | `Ctrl+.` | `Ctrl+.` | `Cmd+.` |
+| Show Hover | `Ctrl+K Ctrl+I` | `Ctrl+K Ctrl+I` | `Cmd+K Cmd+I` |
+| Open Symbol by Name | `Ctrl+T` | `Ctrl+T` | `Cmd+T` |
+| Show All Symbols | `Ctrl+Shift+O` | `Ctrl+Shift+O` | `Cmd+Shift+O` |
 
 ### Extension-Specific Keybindings
 
@@ -368,31 +378,45 @@ Example:
 
 **Solutions**:
 
-1. **Verify binary is in PATH**:
+1. **Verify `perllsp` is available**:
    ```bash
-   which perl-lsp
-   # Should output: /usr/local/bin/perl-lsp or similar
+   command -v perllsp
+   perllsp --version
+   perllsp --health
    ```
 
-2. **Check extension logs**:
+   On Windows:
+   ```powershell
+   where perllsp
+   perllsp --version
+   perllsp --health
+   ```
+
+2. **If relying on extension-managed binaries, confirm auto-download is enabled**:
+   ```json
+   {
+     "perl-lsp.autoDownload": true
+   }
+   ```
+
+3. **Check extension logs**:
    - Open Output panel: `Ctrl+Shift+U` (Cmd+Shift+U on macOS)
    - Select "Perl Language Server" from dropdown
    - Look for error messages
 
-3. **Enable debug logging**:
+4. **Enable debug logging**:
    ```json
    {
      "perl-lsp.trace.server": "verbose"
    }
    ```
 
-4. **Run health check**:
+5. **Run health check**:
    - Press `Ctrl+Shift+P` → "Perl: Run Health Check"
 
-5. **Test server manually**:
-   ```bash
-   echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perllsp --stdio
-   ```
+6. **Manual stdio note**:
+   - `perllsp --stdio` waits for framed LSP JSON-RPC input (with `Content-Length` headers).
+   - For quick validation, prefer: `perllsp --info` and `perllsp --check path/to/file.pl`.
 
 ### No Diagnostics
 
@@ -421,18 +445,9 @@ Example:
 
 **Solutions**:
 
-1. **Reduce result caps** (server-side limits via `initializationOptions`):
-   ```json
-   {
-     "perl": {
-       "limits": {
-         "workspaceSymbolCap": 100,
-         "referencesCap": 200,
-         "completionCap": 50
-       }
-     }
-   }
-   ```
+1. **Reduce result caps**:
+   - Configure server-side limits in `.perl-lsp.toml` (recommended for VS Code workflows).
+   - See `docs/reference/CONFIG.md` for precedence and client-specific forwarding behavior.
 
 2. **Disable semantic tokens** (if not needed):
    ```json


### PR DESCRIPTION
### Motivation

- The VS Code guide contained naming drift and outdated install/troubleshooting examples that referenced the legacy `perl-lsp` binary and incorrect release asset names instead of the current `perllsp` package and binary. 
- The extension is designed to auto-download the server binary, so the guide should recommend an extension-first install flow and only require manual `perllsp` installs for offline or pinned deployments. 
- Several configuration, keybinding, and stdio troubleshooting examples were misleading or unsafe and needed alignment with the repo manifests and release asset patterns.

### Description

- Standardized the VS Code guide to recommend installing the `EffortlessMetrics.perl-lsp-rs` extension first and use the `perllsp` binary name throughout `docs/EDITORS/VS_CODE_SETUP.md`. 
- Replaced prebuilt archive examples with the `perllsp-<version>-<target>` pattern and added a safe Linux example using `VERSION`, `TARGET`, and `install`, and changed Cargo installs to use `--locked` and the correct local source path `--path crates/perllsp`. 
- Renamed the settings section from `All Extension Settings` to `Common Extension Settings`, clarified that authoritative settings live in the VS Code Settings UI or `vscode-extension/package.json`, added `"."` to include paths, and updated wording to prefer `.perl-lsp.toml` for server-wide limits. 
- Fixed the keybindings table to split Windows/Linux/macOS platform mappings and corrected platform-specific defaults, and replaced the invalid unframed stdio test with a note about framed LSP JSON-RPC and recommended `perllsp --version`, `--health`, `--info`, and `--check` for quick validation.

### Testing

- Ran `cargo xtask fmt` which completed successfully. 
- Performed targeted searches to confirm old references were removed using ripgrep, e.g. `rg -n "which perl-lsp|perl-lsp-linux-x86_64|echo '.*perllsp --stdio|### All Extension Settings" docs/EDITORS/VS_CODE_SETUP.md`, and verified the updated `docs/EDITORS/VS_CODE_SETUP.md` contents. 
- No other automated gates were run in this change set; formatting/lint gate (`cargo xtask fmt`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdd01037883338b7f0b91b73ee754)