### PR TITLE
fix(docs): align VS Code docs with perllsp naming (#0000)

### DIFF
--- a/docs/EDITORS/VS_CODE_SETUP.md
+++ b/docs/EDITORS/VS_CODE_SETUP.md
@@ -20,25 +20,38 @@ This guide helps you set up and configure the Perl Language Server in Visual Stu
 ### Required
 
 - **VS Code** version 1.88 or later
-- **perl-lsp** server installed (see [Installation](#installation))
+- **EffortlessMetrics.perl-lsp-rs** extension installed
+
+The extension can auto-download the matching `perllsp` binary. Install
+`perllsp` manually only for offline environments, pinned deployments, or when
+`perl-lsp.autoDownload` is disabled.
 
 ### Optional but Recommended
 
-- **Perl** 5.10 or later (for syntax validation)
+- **Perl** 5.10 or later (for external syntax checks, tests, and debugging)
 - **perltidy** (for code formatting)
+- **perlcritic** (for Perl::Critic diagnostics, if enabled)
 
 ---
 
 ## Installation
 
-### Install the Server
+### Install the VS Code Extension (Recommended)
 
-Choose one of the following methods:
+```bash
+code --install-extension EffortlessMetrics.perl-lsp-rs
+```
+
+Or search for `perl-lsp` in the VS Code Extensions view.
+
+### Optional: Install `perllsp` Manually
+
+Choose one of the following methods when auto-download is unavailable:
 
 #### Option 1: Install from crates.io (Recommended)
 
 ```bash
-cargo install perllsp
+cargo install perllsp --locked
 ```
 
 #### Option 2: Download Pre-built Binary
@@ -46,18 +59,12 @@ cargo install perllsp
 Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases):
 
 ```bash
-# Linux (x86_64)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-linux-x86_64.tar.gz
-tar xzf perl-lsp-linux-x86_64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
+VERSION=0.12.4
+TARGET=x86_64-unknown-linux-gnu
 
-# macOS (Apple Silicon)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-darwin-aarch64.tar.gz
-tar xzf perl-lsp-darwin-aarch64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
-
-# Windows (x86_64)
-# Download and extract to a directory in your PATH
+curl -LO "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v${VERSION}/perllsp-${VERSION}-${TARGET}.tar.gz"
+tar xzf "perllsp-${VERSION}-${TARGET}.tar.gz"
+sudo install -m 0755 "perllsp-${VERSION}-${TARGET}/perllsp" /usr/local/bin/perllsp
 ```
 
 #### Option 3: Build from Source
@@ -65,17 +72,15 @@ sudo mv perl-lsp /usr/local/bin/
 ```bash
 git clone https://github.com/EffortlessMetrics/perl-lsp.git
 cd perl-lsp
-cargo install perllsp
+cargo install --path crates/perllsp --locked
 ```
 
 ### Verify Installation
 
 ```bash
-# Check version
 perllsp --version
-
-# Quick health check
 perllsp --health
+perllsp --info
 ```
 
 ---
@@ -107,7 +112,9 @@ If you prefer using a generic LSP client extension:
 
 ## Configuration
 
-The extension exposes settings in the `perl-lsp.*` namespace. A separate `perl.*` namespace is used for server-side initialization options (see [Advanced Configuration](#advanced-configuration)).
+The extension exposes settings in the `perl-lsp.*` namespace. For server-wide
+options such as workspace limits, prefer `.perl-lsp.toml` or the client
+configuration mechanisms documented in [CONFIG.md](../reference/CONFIG.md).
 
 ### Basic Configuration
 
@@ -122,9 +129,7 @@ Add to your workspace `.vscode/settings.json`:
   "perl-lsp.enableSemanticTokens": true,
   "perl-lsp.enableFormatting": true,
   "perl-lsp.formatOnSave": false,
-  "perl-lsp.enableRefactoring": true,
-  "perl-lsp.includePaths": ["lib", "local/lib/perl5"],
-  "perl-lsp.enableTestIntegration": true
+  "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5"]
 }
 ```
 
@@ -160,13 +165,16 @@ Or edit `settings.json` directly:
 2. Type "Preferences: Open Settings (JSON)"
 3. Add your configuration
 
-### All Extension Settings
+### Common Extension Settings
+
+For the authoritative list, use VS Code's Settings UI or the extension
+manifest. This guide lists the settings most users need.
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `perl-lsp.serverPath` | string | `""` | Absolute path to `perl-lsp` binary. Leave empty to auto-download. |
-| `perl-lsp.autoDownload` | boolean | `true` | Auto-download `perl-lsp` binary if not found locally. |
-| `perl-lsp.includePaths` | array | `["lib", "local/lib/perl5"]` | Additional library paths to search for Perl modules. |
+| `perl-lsp.serverPath` | string | `""` | Absolute path to the `perllsp` binary. Leave empty to auto-download. |
+| `perl-lsp.autoDownload` | boolean | `true` | Auto-download `perllsp` if not found locally. |
+| `perl-lsp.includePaths` | array | `["lib", ".", "local/lib/perl5"]` | Additional library paths to search for Perl modules. |
 | `perl-lsp.enableDiagnostics` | boolean | `true` | Enable real-time syntax diagnostics. |
 | `perl-lsp.enableSemanticTokens` | boolean | `true` | Enable semantic syntax highlighting. |
 | `perl-lsp.perltidyConfig` | string | `""` | Path to `.perltidyrc` configuration file. |
@@ -174,11 +182,17 @@ Or edit `settings.json` directly:
 | `perl-lsp.formatOnSave` | boolean | `false` | Format document on save. |
 | `perl-lsp.enableRefactoring` | boolean | `true` | Enable refactoring-related code actions. |
 | `perl-lsp.enableTestIntegration` | boolean | `true` | Enable `Test::More` and `Test2` integration. |
+| `perl-lsp.perlcritic.enabled` | boolean | `false` | Enable Perl::Critic diagnostics. |
+| `perl-lsp.perlcritic.severity` | number | `3` | Minimum Perl::Critic severity to report. |
+| `perl-lsp.perlcritic.profile` | string | `""` | Path to a `.perlcriticrc` profile file. |
 | `perl-lsp.autoPopulateNewFiles` | boolean | `true` | Auto-populate new `.pm` and `.t` files with boilerplate. |
 | `perl-lsp.featureProfile` | string | `"auto"` | Runtime feature profile: `auto`, `ga`, `ga-lock`, `prod`, `all`. |
 | `perl-lsp.trace.server` | string | `"off"` | LSP traffic logging: `off`, `messages`, `verbose`. |
 | `perl-lsp.channel` | string | `"latest"` | Release channel: `latest`, `stable`, or `tag`. |
 | `perl-lsp.versionTag` | string | `""` | Specific release tag when channel is `tag`. |
+| `perl-lsp.autoUpdate` | boolean | `true` | Auto-update managed server binaries. |
+| `perl-lsp.updateCheckInterval` | number | `24` | Hours between update checks. |
+| `perl-lsp.disabledFeatures` | array | `[]` | Feature flags disabled at extension startup. |
 | `perl-lsp.downloadBaseUrl` | string | `""` | Internal base URL for hosting perl-lsp archives (bypasses GitHub). |
 
 ---
@@ -311,17 +325,17 @@ Reference counts and quick actions inline in the editor.
 
 ### Default LSP Keybindings
 
-| Action | Windows/Linux | macOS |
-|--------|---------------|-------|
-| Go to Definition | `F12` | `F12` |
-| Peek Definition | `Ctrl+Shift+F10` | `Ctrl+Shift+F10` |
-| Find References | `Shift+F12` | `Shift+F12` |
-| Rename Symbol | `F2` | `F2` |
-| Format Document | `Shift+Alt+F` | `Shift+Option+F` |
-| Quick Fix | `Ctrl+.` | `Cmd+.` |
-| Show Hover | `Ctrl+K Ctrl+I` | `Ctrl+K Ctrl+I` |
-| Open Symbol by Name | `Ctrl+T` | `Cmd+T` |
-| Show All Symbols | `Ctrl+Shift+O` | `Cmd+Shift+O` |
+| Action | Windows | Linux | macOS |
+|--------|---------|-------|-------|
+| Go to Definition | `F12` | `F12` | `F12` |
+| Peek Definition | `Alt+F12` | `Ctrl+Shift+F10` | `Option+F12` |
+| Find References | `Shift+F12` | `Shift+F12` | `Shift+F12` |
+| Rename Symbol | `F2` | `F2` | `F2` |
+| Format Document | `Shift+Alt+F` | `Ctrl+Shift+I` | `Shift+Option+F` |
+| Quick Fix | `Ctrl+.` | `Ctrl+.` | `Cmd+.` |
+| Show Hover | `Ctrl+K Ctrl+I` | `Ctrl+K Ctrl+I` | `Cmd+K Cmd+I` |
+| Open Symbol by Name | `Ctrl+T` | `Ctrl+T` | `Cmd+T` |
+| Show All Symbols | `Ctrl+Shift+O` | `Ctrl+Shift+O` | `Cmd+Shift+O` |
 
 ### Extension-Specific Keybindings
 
@@ -370,8 +384,16 @@ Example:
 
 1. **Verify binary is in PATH**:
    ```bash
-   which perl-lsp
-   # Should output: /usr/local/bin/perl-lsp or similar
+   command -v perllsp
+   perllsp --version
+   perllsp --health
+   ```
+
+   On Windows:
+   ```powershell
+   where perllsp
+   perllsp --version
+   perllsp --health
    ```
 
 2. **Check extension logs**:
@@ -386,13 +408,15 @@ Example:
    }
    ```
 
-4. **Run health check**:
-   - Press `Ctrl+Shift+P` → "Perl: Run Health Check"
-
-5. **Test server manually**:
-   ```bash
-   echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perllsp --stdio
+4. **Confirm auto-download setting when relying on managed binaries**:
+   ```json
+   {
+     "perl-lsp.autoDownload": true
+   }
    ```
+
+5. **If `perllsp --stdio` appears to hang**, that is expected: it waits for
+   framed LSP JSON-RPC input.
 
 ### No Diagnostics
 
@@ -421,18 +445,9 @@ Example:
 
 **Solutions**:
 
-1. **Reduce result caps** (server-side limits via `initializationOptions`):
-   ```json
-   {
-     "perl": {
-       "limits": {
-         "workspaceSymbolCap": 100,
-         "referencesCap": 200,
-         "completionCap": 50
-       }
-     }
-   }
-   ```
+1. **Tune project-wide limits via server configuration**:
+   - Use `.perl-lsp.toml` and the server configuration channels documented in
+     [CONFIG.md](../reference/CONFIG.md) for workspace-size tuning.
 
 2. **Disable semantic tokens** (if not needed):
    ```json
@@ -572,7 +587,7 @@ For teams hosting their own perl-lsp binaries:
 
 ```json
 {
-  "perl-lsp.serverPath": "/opt/perl-lsp/bin/perl-lsp",
+  "perl-lsp.serverPath": "/opt/perl-lsp/bin/perllsp",
   "perl-lsp.autoDownload": false
 }
 ```
@@ -612,24 +627,10 @@ See [DAP User Guide](../tutorials/DAP_USER_GUIDE.md) for more details.
 
 ### Server-Side Performance Limits
 
-The `perl.*` namespace passes server-side initialization options. These control internal server caps and are separate from the extension's `perl-lsp.*` settings:
-
-```json
-{
-  "perl": {
-    "limits": {
-      "workspaceSymbolCap": 200,
-      "referencesCap": 500,
-      "completionCap": 100,
-      "astCacheMaxEntries": 50,
-      "maxIndexedFiles": 5000,
-      "maxTotalSymbols": 250000,
-      "workspaceScanDeadlineMs": 20000,
-      "referenceSearchDeadlineMs": 1500
-    }
-  }
-}
-```
+Use `.perl-lsp.toml` for server-side limits and project-wide defaults, then
+keep VS Code-specific behavior in the `perl-lsp.*` namespace. See the
+[Configuration Reference](../reference/CONFIG.md) for supported keys and
+precedence details.
 
 ### Logging and Tracing
 

--- a/docs/how-to/INSTALLATION.md
+++ b/docs/how-to/INSTALLATION.md
@@ -61,7 +61,7 @@ cargo build --release --bin perllsp -p perllsp
 If you want the binary installed into Cargo's bin directory instead:
 
 ```bash
-cargo install perllsp
+cargo install --path crates/perllsp --locked
 ```
 
 ## Prebuilt Releases

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -15,6 +15,22 @@ perllsp --info
 If those fail, fix the binary installation and `PATH` first. If they pass, the
 problem is usually in editor integration, workspace roots, or a stale cache.
 
+## VS Code Quick Checks
+
+1. Confirm the extension can locate the binary:
+
+   ```bash
+   command -v perllsp
+   perllsp --version
+   perllsp --health
+   perllsp --info
+   ```
+
+2. Open **Output** → **Perl Language Server** in VS Code and review startup logs.
+3. If you rely on managed binaries, verify `"perl-lsp.autoDownload": true`.
+4. If `perllsp --stdio` appears to hang in a terminal, that is expected; it is
+   waiting for framed LSP JSON-RPC input.
+
 ## The Server Will Not Start
 
 1. Run the server in the foreground:

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -611,11 +611,15 @@ Settings specific to the VS Code extension (`vscode-extension/package.json`).
 These are separate from the LSP workspace settings above and control extension
 behaviour such as binary management and feature toggles.
 
+The extension uses the `perl-lsp.*` namespace. Server-side LSP workspace
+settings use the `perl.*` namespace, and not every LSP client forwards
+`perl.*` settings in the same way.
+
 ### Binary management
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
-| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perl-lsp` binary. Empty = auto-download. |
+| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perllsp` binary. Empty = auto-download. |
 | `perl-lsp.autoDownload` | `boolean` | `true` | Download the binary automatically if not found locally. |
 | `perl-lsp.downloadBaseUrl` | `string` | `""` | Override the GitHub releases base URL for internal mirrors. |
 | `perl-lsp.channel` | `"latest"\|"stable"\|"tag"` | `"latest"` | Release channel to track. |
@@ -643,7 +647,7 @@ behaviour such as binary management and feature toggles.
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
-| `perl-lsp.includePaths` | `string[]` | `["lib", "local/lib/perl5"]` | Additional module search paths (merged with server-side `perl.workspace.includePaths`). |
+| `perl-lsp.includePaths` | `string[]` | `["lib", ".", "local/lib/perl5"]` | Additional module search paths (merged with server-side `perl.workspace.includePaths`). |
 | `perl-lsp.perltidyConfig` | `string` | `""` | Path to a `.perltidyrc` configuration file. Empty = use Perl::Tidy defaults. |
 | `perl-lsp.featureProfile` | `string` | `"auto"` | Feature profile passed to the server at startup (see [Feature Profiles](#feature-profiles)). |
 

--- a/docs/tutorials/DAP_USER_GUIDE.md
+++ b/docs/tutorials/DAP_USER_GUIDE.md
@@ -7,9 +7,9 @@
 > - **Reference sections**: Configuration specifications and options
 > - **Explanation sections**: Understanding DAP architecture and design
 
-**Status**: Native adapter CLI (launch + attach + stepping + evaluate) + BridgeAdapter guide (Perl::LanguageServer)
-**Version**: 0.9.x
-**Date**: 2025-10-04
+**Status**: Native adapter CLI (launch + attach + stepping + evaluate) + BridgeAdapter guide (Perl::LanguageServer for legacy bridge mode)
+**Version**: 0.12.x
+**Date**: 2026-04-27
 
 **Note**: The `perl-dap` CLI runs the native adapter (launch + attach) and does not require Perl::LanguageServer. The bridge adapter steps below apply only if you are running the BridgeAdapter library or Perl::LanguageServer DAP directly.
 
@@ -50,7 +50,7 @@ Before you begin debugging Perl code with VS Code, ensure you have:
    perl --version  # Should output Perl version
    ```
 
-2. **VS Code**: Visual Studio Code 1.70 or higher with Perl LSP extension installed
+2. **VS Code**: Visual Studio Code 1.88 or higher with the `EffortlessMetrics.perl-lsp-rs` extension installed
 
 3. **Operating System**: Windows, macOS, Linux, or WSL
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Perl LSP installer for Linux and macOS
+# perllsp installer for Linux and macOS
 # Usage: curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
 
 set -euo pipefail
@@ -21,7 +21,7 @@ else
     INSTALL_DIR="$HOME/.local/bin"
 fi
 REPO="EffortlessMetrics/perl-lsp"
-NAME="perl-lsp"
+NAME="perllsp"
 
 # Functions
 write_info() {

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -7,7 +7,7 @@
 
 A fast, native Perl 5 language server extension. Written in Rust for speed and reliability. No runtime dependencies -- just install and code.
 
-> **0.12.3 Public Alpha** -- This extension is under active development. Every feature listed below is wired up and exercised by tests, but as an alpha you will find edge cases where behavior is incomplete or wrong. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose) if you encounter problems. For what the project's headline numbers mean (and do not mean), see the [status overview](https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/project/status/index.md).
+> **Public Alpha** -- This extension is under active development. Every feature listed below is wired up and exercised by tests, but as an alpha you will find edge cases where behavior is incomplete or wrong. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose) if you encounter problems. For what the project's headline numbers mean (and do not mean), see the [status overview](https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/project/status/index.md).
 
 ## Features
 


### PR DESCRIPTION
### Motivation

- The VS Code docs and installer contained naming drift and stale examples referencing `perl-lsp` instead of the canonical `perllsp` binary and Cargo package. 
- Several install/troubleshooting examples used outdated archive names, unframed LSP stdio checks, and misleading source-install instructions which risk user confusion.

### Description

- Standardized user-facing docs to recommend the `EffortlessMetrics.perl-lsp-rs` extension and the `perllsp` binary, and clarified that the extension auto-downloads the server (docs edited: `docs/EDITORS/VS_CODE_SETUP.md`, `docs/reference/CONFIG.md`, `docs/how-to/TROUBLESHOOTING.md`).
- Replaced unsafe/outdated prebuilt archive examples and tightened manual install/source instructions to use `perllsp` and `cargo install --path crates/perllsp --locked` or locked `cargo install perllsp`; updated `docs/how-to/INSTALLATION.md` and `docs/EDITORS/VS_CODE_SETUP.md` accordingly.
- Removed an invalid unframed stdio troubleshooting command and added guidance on framed LSP input and recommended quick checks (`--version`, `--health`, `--info`) in `docs/how-to/TROUBLESHOOTING.md` and the VS Code guide.
- Updated ancillary docs and tooling to match naming and versions: `install.sh` (`NAME="perllsp"`), `docs/tutorials/DAP_USER_GUIDE.md` (version/VS Code baseline and extension name), and `vscode-extension/README.md` (remove stale versioned prose).

### Testing

- Ran `git diff --check` to ensure no trailing-diff issues, which reported clean; result: success.
- Verified build metadata with `cargo check --all-targets -p perllsp`, which completed successfully.
- Committed the changes as `fix(docs): align VS Code docs with perllsp naming (#0000)` and prepared the PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdd01037883338b7f0b91b73ee754)