### PR TITLE
docs(vscode): align perllsp naming and setup guidance (#0000)

### DIFF
--- a/docs/EDITORS/VS_CODE_SETUP.md
+++ b/docs/EDITORS/VS_CODE_SETUP.md
@@ -20,7 +20,9 @@ This guide helps you set up and configure the Perl Language Server in Visual Stu
 ### Required
 
 - **VS Code** version 1.88 or later
-- **perl-lsp** server installed (see [Installation](#installation))
+- **EffortlessMetrics.perl-lsp-rs** VS Code extension (see [Installation](#installation))
+
+The extension can auto-download the matching `perllsp` server binary. Install `perllsp` manually only for offline environments, pinned deployments, or when `perl-lsp.autoDownload` is disabled.
 
 ### Optional but Recommended
 
@@ -31,14 +33,26 @@ This guide helps you set up and configure the Perl Language Server in Visual Stu
 
 ## Installation
 
-### Install the Server
+### Install the VS Code Extension
+
+The recommended VS Code path is to install the official extension and let it auto-download the matching `perllsp` binary automatically.
+
+```bash
+code --install-extension EffortlessMetrics.perl-lsp-rs
+```
+
+Or install it from the Extensions view by searching for `perl-lsp`.
+
+### Optional: Install `perllsp` Manually
+
+Manual installation is useful for offline environments, pinned deployments, or when `"perl-lsp.autoDownload": false`.
 
 Choose one of the following methods:
 
 #### Option 1: Install from crates.io (Recommended)
 
 ```bash
-cargo install perllsp
+cargo install perllsp --locked
 ```
 
 #### Option 2: Download Pre-built Binary
@@ -46,26 +60,23 @@ cargo install perllsp
 Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases):
 
 ```bash
-# Linux (x86_64)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-linux-x86_64.tar.gz
-tar xzf perl-lsp-linux-x86_64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
+# Example: Linux x86_64 (glibc)
+VERSION=0.12.4
+TARGET=x86_64-unknown-linux-gnu
 
-# macOS (Apple Silicon)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-darwin-aarch64.tar.gz
-tar xzf perl-lsp-darwin-aarch64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
-
-# Windows (x86_64)
-# Download and extract to a directory in your PATH
+curl -LO "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v${VERSION}/perllsp-${VERSION}-${TARGET}.tar.gz"
+tar xzf "perllsp-${VERSION}-${TARGET}.tar.gz"
+sudo install -m 0755 "perllsp-${VERSION}-${TARGET}/perllsp" /usr/local/bin/perllsp
 ```
+
+For other platforms, use the matching `perllsp-<version>-<target>` asset from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
 
 #### Option 3: Build from Source
 
 ```bash
 git clone https://github.com/EffortlessMetrics/perl-lsp.git
 cd perl-lsp
-cargo install perllsp
+cargo install --path crates/perllsp --locked
 ```
 
 ### Verify Installation
@@ -74,8 +85,9 @@ cargo install perllsp
 # Check version
 perllsp --version
 
-# Quick health check
+# Quick health checks
 perllsp --health
+perllsp --info
 ```
 
 ---
@@ -123,7 +135,7 @@ Add to your workspace `.vscode/settings.json`:
   "perl-lsp.enableFormatting": true,
   "perl-lsp.formatOnSave": false,
   "perl-lsp.enableRefactoring": true,
-  "perl-lsp.includePaths": ["lib", "local/lib/perl5"],
+  "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5"],
   "perl-lsp.enableTestIntegration": true
 }
 ```
@@ -136,6 +148,7 @@ For project-specific settings, create `.vscode/settings.json` in your project ro
 {
   "perl-lsp.includePaths": [
     "lib",
+    ".",
     "local/lib/perl5",
     "vendor/lib"
   ],
@@ -160,13 +173,16 @@ Or edit `settings.json` directly:
 2. Type "Preferences: Open Settings (JSON)"
 3. Add your configuration
 
-### All Extension Settings
+### Common Extension Settings
+
+For the authoritative list, see the VS Code Settings UI or the extension manifest (`vscode-extension/package.json`). This guide lists the settings most users need.
+
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `perl-lsp.serverPath` | string | `""` | Absolute path to `perl-lsp` binary. Leave empty to auto-download. |
-| `perl-lsp.autoDownload` | boolean | `true` | Auto-download `perl-lsp` binary if not found locally. |
-| `perl-lsp.includePaths` | array | `["lib", "local/lib/perl5"]` | Additional library paths to search for Perl modules. |
+| `perl-lsp.serverPath` | string | `""` | Absolute path to the `perllsp` binary. Leave empty to auto-download. |
+| `perl-lsp.autoDownload` | boolean | `true` | Auto-download `perllsp` binary if not found locally. |
+| `perl-lsp.includePaths` | array | `["lib", ".", "local/lib/perl5"]` | Additional library paths to search for Perl modules. |
 | `perl-lsp.enableDiagnostics` | boolean | `true` | Enable real-time syntax diagnostics. |
 | `perl-lsp.enableSemanticTokens` | boolean | `true` | Enable semantic syntax highlighting. |
 | `perl-lsp.perltidyConfig` | string | `""` | Path to `.perltidyrc` configuration file. |
@@ -179,7 +195,7 @@ Or edit `settings.json` directly:
 | `perl-lsp.trace.server` | string | `"off"` | LSP traffic logging: `off`, `messages`, `verbose`. |
 | `perl-lsp.channel` | string | `"latest"` | Release channel: `latest`, `stable`, or `tag`. |
 | `perl-lsp.versionTag` | string | `""` | Specific release tag when channel is `tag`. |
-| `perl-lsp.downloadBaseUrl` | string | `""` | Internal base URL for hosting perl-lsp archives (bypasses GitHub). |
+| `perl-lsp.downloadBaseUrl` | string | `""` | Internal base URL for hosting perllsp archives (bypasses GitHub). |
 
 ---
 
@@ -311,17 +327,17 @@ Reference counts and quick actions inline in the editor.
 
 ### Default LSP Keybindings
 
-| Action | Windows/Linux | macOS |
-|--------|---------------|-------|
-| Go to Definition | `F12` | `F12` |
-| Peek Definition | `Ctrl+Shift+F10` | `Ctrl+Shift+F10` |
-| Find References | `Shift+F12` | `Shift+F12` |
-| Rename Symbol | `F2` | `F2` |
-| Format Document | `Shift+Alt+F` | `Shift+Option+F` |
-| Quick Fix | `Ctrl+.` | `Cmd+.` |
-| Show Hover | `Ctrl+K Ctrl+I` | `Ctrl+K Ctrl+I` |
-| Open Symbol by Name | `Ctrl+T` | `Cmd+T` |
-| Show All Symbols | `Ctrl+Shift+O` | `Cmd+Shift+O` |
+| Action | Windows | Linux | macOS |
+|--------|---------|-------|-------|
+| Go to Definition | `F12` | `F12` | `F12` |
+| Peek Definition | `Alt+F12` | `Ctrl+Shift+F10` | `Option+F12` |
+| Find References | `Shift+F12` | `Shift+F12` | `Shift+F12` |
+| Rename Symbol | `F2` | `F2` | `F2` |
+| Format Document | `Shift+Alt+F` | `Ctrl+Shift+I` | `Shift+Option+F` |
+| Quick Fix | `Ctrl+.` | `Ctrl+.` | `Cmd+.` |
+| Show Hover | `Ctrl+K Ctrl+I` | `Ctrl+K Ctrl+I` | `Cmd+K Cmd+I` |
+| Open Symbol by Name | `Ctrl+T` | `Ctrl+T` | `Cmd+T` |
+| Show All Symbols | `Ctrl+Shift+O` | `Ctrl+Shift+O` | `Cmd+Shift+O` |
 
 ### Extension-Specific Keybindings
 
@@ -364,35 +380,43 @@ Example:
 
 ### Server Not Starting
 
-**Symptoms**: No diagnostics, no completion, error in output panel
+**Symptoms**: no diagnostics, no completion, or errors in the Output panel.
 
-**Solutions**:
-
-1. **Verify binary is in PATH**:
+1. **Check whether the extension can find `perllsp`**:
    ```bash
-   which perl-lsp
-   # Should output: /usr/local/bin/perl-lsp or similar
+   command -v perllsp
+   perllsp --version
+   perllsp --health
    ```
 
-2. **Check extension logs**:
+   On Windows:
+   ```powershell
+   where perllsp
+   perllsp --version
+   perllsp --health
+   ```
+
+2. **If you rely on auto-download, confirm**:
+   ```json
+   {
+     "perl-lsp.autoDownload": true
+   }
+   ```
+
+3. **Check extension logs**:
    - Open Output panel: `Ctrl+Shift+U` (Cmd+Shift+U on macOS)
    - Select "Perl Language Server" from dropdown
    - Look for error messages
 
-3. **Enable debug logging**:
+4. **Enable debug logging only while troubleshooting**:
    ```json
    {
      "perl-lsp.trace.server": "verbose"
    }
    ```
 
-4. **Run health check**:
-   - Press `Ctrl+Shift+P` → "Perl: Run Health Check"
-
-5. **Test server manually**:
-   ```bash
-   echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perllsp --stdio
-   ```
+5. **If `perllsp --stdio` appears to hang, that is expected**:
+   it waits for framed LSP JSON-RPC input (`Content-Length` headers).
 
 ### No Diagnostics
 
@@ -421,18 +445,9 @@ Example:
 
 **Solutions**:
 
-1. **Reduce result caps** (server-side limits via `initializationOptions`):
-   ```json
-   {
-     "perl": {
-       "limits": {
-         "workspaceSymbolCap": 100,
-         "referencesCap": 200,
-         "completionCap": 50
-       }
-     }
-   }
-   ```
+1. **Use a project config file for server-side limits**:
+   - Prefer `.perl-lsp.toml` for workspace-wide caps and scan limits.
+   - See [Configuration Reference](../reference/CONFIG.md) for `perl.limits` options.
 
 2. **Disable semantic tokens** (if not needed):
    ```json
@@ -572,7 +587,7 @@ For teams hosting their own perl-lsp binaries:
 
 ```json
 {
-  "perl-lsp.serverPath": "/opt/perl-lsp/bin/perl-lsp",
+  "perl-lsp.serverPath": "/opt/perl-lsp/bin/perllsp",
   "perl-lsp.autoDownload": false
 }
 ```
@@ -612,24 +627,9 @@ See [DAP User Guide](../tutorials/DAP_USER_GUIDE.md) for more details.
 
 ### Server-Side Performance Limits
 
-The `perl.*` namespace passes server-side initialization options. These control internal server caps and are separate from the extension's `perl-lsp.*` settings:
+The VS Code extension settings use the `perl-lsp.*` namespace. Server-side LSP workspace settings use the `perl.*` namespace and are client-dependent.
 
-```json
-{
-  "perl": {
-    "limits": {
-      "workspaceSymbolCap": 200,
-      "referencesCap": 500,
-      "completionCap": 100,
-      "astCacheMaxEntries": 50,
-      "maxIndexedFiles": 5000,
-      "maxTotalSymbols": 250000,
-      "workspaceScanDeadlineMs": 20000,
-      "referenceSearchDeadlineMs": 1500
-    }
-  }
-}
-```
+For VS Code projects, prefer setting server-wide limits in `.perl-lsp.toml` and use [Configuration Reference](../reference/CONFIG.md) for the full `perl.limits` options.
 
 ### Logging and Tracing
 
@@ -662,6 +662,7 @@ Here is a typical `.vscode/settings.json` for a Perl project using only real ext
   "perl-lsp.enableTestIntegration": true,
   "perl-lsp.includePaths": [
     "lib",
+    ".",
     "local/lib/perl5",
     "vendor/lib"
   ],

--- a/docs/how-to/INSTALLATION.md
+++ b/docs/how-to/INSTALLATION.md
@@ -61,7 +61,7 @@ cargo build --release --bin perllsp -p perllsp
 If you want the binary installed into Cargo's bin directory instead:
 
 ```bash
-cargo install perllsp
+cargo install --path crates/perllsp --locked
 ```
 
 ## Prebuilt Releases

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -15,6 +15,22 @@ perllsp --info
 If those fail, fix the binary installation and `PATH` first. If they pass, the
 problem is usually in editor integration, workspace roots, or a stale cache.
 
+## VS Code-Specific Checks
+
+When using the `EffortlessMetrics.perl-lsp-rs` extension:
+
+1. Open **Output** and select **Perl Language Server**.
+2. Confirm extension settings use the `perl-lsp.*` namespace.
+3. Verify the server binary from a terminal:
+
+```bash
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+Avoid raw `perllsp --stdio` pipe tests unless you send framed LSP messages with `Content-Length` headers.
+
 ## The Server Will Not Start
 
 1. Run the server in the foreground:

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -609,13 +609,13 @@ NO_COLOR=1 perllsp --stdio
 
 Settings specific to the VS Code extension (`vscode-extension/package.json`).
 These are separate from the LSP workspace settings above and control extension
-behaviour such as binary management and feature toggles.
+behaviour such as binary management and feature toggles. The extension uses `perl-lsp.*`; server-side LSP workspace settings remain under `perl.*` and are forwarded according to client behavior.
 
 ### Binary management
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
-| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perl-lsp` binary. Empty = auto-download. |
+| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perllsp` binary. Empty = auto-download. |
 | `perl-lsp.autoDownload` | `boolean` | `true` | Download the binary automatically if not found locally. |
 | `perl-lsp.downloadBaseUrl` | `string` | `""` | Override the GitHub releases base URL for internal mirrors. |
 | `perl-lsp.channel` | `"latest"\|"stable"\|"tag"` | `"latest"` | Release channel to track. |

--- a/docs/tutorials/DAP_USER_GUIDE.md
+++ b/docs/tutorials/DAP_USER_GUIDE.md
@@ -8,7 +8,7 @@
 > - **Explanation sections**: Understanding DAP architecture and design
 
 **Status**: Native adapter CLI (launch + attach + stepping + evaluate) + BridgeAdapter guide (Perl::LanguageServer)
-**Version**: 0.9.x
+**Version**: 0.12.x
 **Date**: 2025-10-04
 
 **Note**: The `perl-dap` CLI runs the native adapter (launch + attach) and does not require Perl::LanguageServer. The bridge adapter steps below apply only if you are running the BridgeAdapter library or Perl::LanguageServer DAP directly.
@@ -50,7 +50,7 @@ Before you begin debugging Perl code with VS Code, ensure you have:
    perl --version  # Should output Perl version
    ```
 
-2. **VS Code**: Visual Studio Code 1.70 or higher with Perl LSP extension installed
+2. **VS Code**: Visual Studio Code 1.88 or higher with Perl LSP extension installed
 
 3. **Operating System**: Windows, macOS, Linux, or WSL
 
@@ -630,4 +630,4 @@ The CLI already uses the native adapter with launch + attach + evaluation suppor
 ---
 
 **Version History**:
-- **0.9.x** (2025-10-04): Phase 1 bridge implementation with Perl::LanguageServer DAP support
+- **0.12.x** (2026-04-27): Native `perl-dap` adapter guidance with BridgeAdapter legacy path documented

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ else
     INSTALL_DIR="$HOME/.local/bin"
 fi
 REPO="EffortlessMetrics/perl-lsp"
-NAME="perl-lsp"
+NAME="perllsp"
 
 # Functions
 write_info() {

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -7,7 +7,7 @@
 
 A fast, native Perl 5 language server extension. Written in Rust for speed and reliability. No runtime dependencies -- just install and code.
 
-> **0.12.3 Public Alpha** -- This extension is under active development. Every feature listed below is wired up and exercised by tests, but as an alpha you will find edge cases where behavior is incomplete or wrong. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose) if you encounter problems. For what the project's headline numbers mean (and do not mean), see the [status overview](https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/project/status/index.md).
+> **Public Alpha** -- This extension is under active development. Every feature listed below is wired up and exercised by tests, but as an alpha you will find edge cases where behavior is incomplete or wrong. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose) if you encounter problems. For what the project's headline numbers mean (and do not mean), see the [status overview](https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/project/status/index.md).
 
 ## Features
 


### PR DESCRIPTION
### Motivation

- The VS Code setup and adjacent docs used legacy `perl-lsp` binary naming and fragile install/troubleshooting examples that no longer match the release assets and extension behaviour. 
- The extension auto-downloads a server binary named `perllsp`, so docs and the installer should use `perllsp` as the canonical CLI/package name. 
- Several VS Code examples implied server-side initialization through `perl.*` settings or used unframed stdio tests which are misleading for users. 
- The DAP guide and extension README contained stale version/compatibility text and platform/keybinding inaccuracies.

### Description

- Standardized binary/package text to `perllsp` across the VS Code guide and configuration reference by editing `docs/EDITORS/VS_CODE_SETUP.md`, `docs/reference/CONFIG.md`, `docs/how-to/INSTALLATION.md`, and `docs/how-to/TROUBLESHOOTING.md`. 
- Rewrote the Installation section to recommend installing the `EffortlessMetrics.perl-lsp-rs` extension first (auto-downloads `perllsp`), added a safe `perllsp` prebuilt archive example, and fixed source-install instructions to use `cargo install --path crates/perllsp --locked` in `docs/EDITORS/VS_CODE_SETUP.md` and `docs/how-to/INSTALLATION.md`. 
- Replaced unsafe stdio troubleshooting with proper verification commands and an explicit note that `perllsp --stdio` requires framed LSP JSON-RPC, and added a VS Code–specific checks section to `docs/how-to/TROUBLESHOOTING.md`. 
- Clarified the difference between extension settings (`perl-lsp.*`) and server LSP workspace settings (`perl.*`) in `docs/reference/CONFIG.md` and moved server-limit guidance to prefer `.perl-lsp.toml`. 
- Improved keybindings mapping and renamed “All Extension Settings” to “Common Extension Settings” in `docs/EDITORS/VS_CODE_SETUP.md`. 
- Updated the DAP guide to current branch/versioning and VS Code engine guidance in `docs/tutorials/DAP_USER_GUIDE.md`. 
- Updated the installer script `install.sh` to use `NAME="perllsp"` so archive and installed binary names match the release runbook. 
- Removed stale hardcoded version text from `vscode-extension/README.md` to avoid misleading marketing copy.

Files changed: `docs/EDITORS/VS_CODE_SETUP.md`, `docs/reference/CONFIG.md`, `docs/how-to/INSTALLATION.md`, `docs/how-to/TROUBLESHOOTING.md`, `docs/tutorials/DAP_USER_GUIDE.md`, `install.sh`, `vscode-extension/README.md`.

### Testing

- Ran a shell syntax/parse check on the installer with `bash -n install.sh`, which completed successfully. 
- Verified there are no remaining legacy or unsafe examples with ripgrep checks: `rg -n 'perl-lsp-linux-x86_64|which perl-lsp|### All Extension Settings|0.12.3 Public Alpha|VS Code 1.70|\*\*Version\*\*: 0.9|NAME="perl-lsp"'` and `rg -n 'echo \{\"jsonrpc\"|Absolute path to the \`perl-lsp\` binary'`, both of which returned no matches. 
- Confirmed edits compile to expected text by inspecting diffs and smoke-checking key examples (manual review of `perllsp --version/--health` guidance replacements).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdd01037883338b7f0b91b73ee754)