### PR TITLE
fix(vscode-docs): align perllsp naming and install guidance (#0000)

### DIFF
--- a/docs/EDITORS/VS_CODE_SETUP.md
+++ b/docs/EDITORS/VS_CODE_SETUP.md
@@ -20,7 +20,11 @@ This guide helps you set up and configure the Perl Language Server in Visual Stu
 ### Required
 
 - **VS Code** version 1.88 or later
-- **perl-lsp** server installed (see [Installation](#installation))
+- **EffortlessMetrics.perl-lsp-rs** extension installed (see [Installation](#installation))
+
+The extension auto-downloads the matching `perllsp` server by default. Manual
+server installation is only required for offline/pinned deployments or when
+`perl-lsp.autoDownload` is disabled.
 
 ### Optional but Recommended
 
@@ -31,14 +35,24 @@ This guide helps you set up and configure the Perl Language Server in Visual Stu
 
 ## Installation
 
-### Install the Server
-
-Choose one of the following methods:
-
-#### Option 1: Install from crates.io (Recommended)
+### Install the VS Code Extension
 
 ```bash
-cargo install perllsp
+code --install-extension EffortlessMetrics.perl-lsp-rs
+```
+
+Or search for `perl-lsp` in the Extensions view and install
+`EffortlessMetrics.perl-lsp-rs`.
+
+### Optional: Install `perllsp` Manually
+
+Use manual installation for offline/pinned environments, or when
+`"perl-lsp.autoDownload": false`.
+
+#### Option 1: Install from crates.io
+
+```bash
+cargo install perllsp --locked
 ```
 
 #### Option 2: Download Pre-built Binary
@@ -46,18 +60,15 @@ cargo install perllsp
 Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases):
 
 ```bash
-# Linux (x86_64)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-linux-x86_64.tar.gz
-tar xzf perl-lsp-linux-x86_64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
+# Linux x86_64 (glibc)
+VERSION=0.12.4
+TARGET=x86_64-unknown-linux-gnu
 
-# macOS (Apple Silicon)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-darwin-aarch64.tar.gz
-tar xzf perl-lsp-darwin-aarch64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
+curl -LO "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v${VERSION}/perllsp-${VERSION}-${TARGET}.tar.gz"
+tar xzf "perllsp-${VERSION}-${TARGET}.tar.gz"
+sudo install -m 0755 "perllsp-${VERSION}-${TARGET}/perllsp" /usr/local/bin/perllsp
 
-# Windows (x86_64)
-# Download and extract to a directory in your PATH
+# For other targets, download the matching perllsp-<version>-<target> archive.
 ```
 
 #### Option 3: Build from Source
@@ -65,7 +76,7 @@ sudo mv perl-lsp /usr/local/bin/
 ```bash
 git clone https://github.com/EffortlessMetrics/perl-lsp.git
 cd perl-lsp
-cargo install perllsp
+cargo install --path crates/perllsp --locked
 ```
 
 ### Verify Installation
@@ -76,6 +87,9 @@ perllsp --version
 
 # Quick health check
 perllsp --health
+
+# Build/runtime summary
+perllsp --info
 ```
 
 ---
@@ -107,7 +121,7 @@ If you prefer using a generic LSP client extension:
 
 ## Configuration
 
-The extension exposes settings in the `perl-lsp.*` namespace. A separate `perl.*` namespace is used for server-side initialization options (see [Advanced Configuration](#advanced-configuration)).
+The extension exposes settings in the `perl-lsp.*` namespace.
 
 ### Basic Configuration
 
@@ -123,7 +137,7 @@ Add to your workspace `.vscode/settings.json`:
   "perl-lsp.enableFormatting": true,
   "perl-lsp.formatOnSave": false,
   "perl-lsp.enableRefactoring": true,
-  "perl-lsp.includePaths": ["lib", "local/lib/perl5"],
+  "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5"],
   "perl-lsp.enableTestIntegration": true
 }
 ```
@@ -160,13 +174,17 @@ Or edit `settings.json` directly:
 2. Type "Preferences: Open Settings (JSON)"
 3. Add your configuration
 
-### All Extension Settings
+### Common Extension Settings
+
+For the authoritative settings list, use VS Code Settings UI or the extension
+manifest (`vscode-extension/package.json`). This table focuses on common
+production settings.
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `perl-lsp.serverPath` | string | `""` | Absolute path to `perl-lsp` binary. Leave empty to auto-download. |
-| `perl-lsp.autoDownload` | boolean | `true` | Auto-download `perl-lsp` binary if not found locally. |
-| `perl-lsp.includePaths` | array | `["lib", "local/lib/perl5"]` | Additional library paths to search for Perl modules. |
+| `perl-lsp.serverPath` | string | `""` | Absolute path to the `perllsp` binary. Leave empty to auto-download. |
+| `perl-lsp.autoDownload` | boolean | `true` | Auto-download `perllsp` binary if not found locally. |
+| `perl-lsp.includePaths` | array | `["lib", ".", "local/lib/perl5"]` | Additional library paths to search for Perl modules. |
 | `perl-lsp.enableDiagnostics` | boolean | `true` | Enable real-time syntax diagnostics. |
 | `perl-lsp.enableSemanticTokens` | boolean | `true` | Enable semantic syntax highlighting. |
 | `perl-lsp.perltidyConfig` | string | `""` | Path to `.perltidyrc` configuration file. |
@@ -175,7 +193,13 @@ Or edit `settings.json` directly:
 | `perl-lsp.enableRefactoring` | boolean | `true` | Enable refactoring-related code actions. |
 | `perl-lsp.enableTestIntegration` | boolean | `true` | Enable `Test::More` and `Test2` integration. |
 | `perl-lsp.autoPopulateNewFiles` | boolean | `true` | Auto-populate new `.pm` and `.t` files with boilerplate. |
+| `perl-lsp.perlcritic.enabled` | boolean | `false` | Enable external `perlcritic` diagnostics. |
+| `perl-lsp.perlcritic.severity` | string | `"warning"` | Severity level for `perlcritic` diagnostics. |
+| `perl-lsp.perlcritic.profile` | string | `""` | Path to `.perlcriticrc` profile file. |
 | `perl-lsp.featureProfile` | string | `"auto"` | Runtime feature profile: `auto`, `ga`, `ga-lock`, `prod`, `all`. |
+| `perl-lsp.disabledFeatures` | array | `[]` | Disable selected server features at client startup. |
+| `perl-lsp.autoUpdate` | boolean | `true` | Allow extension-managed server auto-updates. |
+| `perl-lsp.updateCheckInterval` | number | `24` | Hours between automatic update checks. |
 | `perl-lsp.trace.server` | string | `"off"` | LSP traffic logging: `off`, `messages`, `verbose`. |
 | `perl-lsp.channel` | string | `"latest"` | Release channel: `latest`, `stable`, or `tag`. |
 | `perl-lsp.versionTag` | string | `""` | Specific release tag when channel is `tag`. |
@@ -311,17 +335,17 @@ Reference counts and quick actions inline in the editor.
 
 ### Default LSP Keybindings
 
-| Action | Windows/Linux | macOS |
-|--------|---------------|-------|
-| Go to Definition | `F12` | `F12` |
-| Peek Definition | `Ctrl+Shift+F10` | `Ctrl+Shift+F10` |
-| Find References | `Shift+F12` | `Shift+F12` |
-| Rename Symbol | `F2` | `F2` |
-| Format Document | `Shift+Alt+F` | `Shift+Option+F` |
-| Quick Fix | `Ctrl+.` | `Cmd+.` |
-| Show Hover | `Ctrl+K Ctrl+I` | `Ctrl+K Ctrl+I` |
-| Open Symbol by Name | `Ctrl+T` | `Cmd+T` |
-| Show All Symbols | `Ctrl+Shift+O` | `Cmd+Shift+O` |
+| Action | Windows | Linux | macOS |
+|--------|---------|-------|-------|
+| Go to Definition | `F12` | `F12` | `F12` |
+| Peek Definition | `Alt+F12` | `Ctrl+Shift+F10` | `Option+F12` |
+| Find References | `Shift+F12` | `Shift+F12` | `Shift+F12` |
+| Rename Symbol | `F2` | `F2` | `F2` |
+| Format Document | `Shift+Alt+F` | `Ctrl+Shift+I` | `Shift+Option+F` |
+| Quick Fix | `Ctrl+.` | `Ctrl+.` | `Cmd+.` |
+| Show Hover | `Ctrl+K Ctrl+I` | `Ctrl+K Ctrl+I` | `Cmd+K Cmd+I` |
+| Open Symbol by Name | `Ctrl+T` | `Ctrl+T` | `Cmd+T` |
+| Show All Symbols | `Ctrl+Shift+O` | `Ctrl+Shift+O` | `Cmd+Shift+O` |
 
 ### Extension-Specific Keybindings
 
@@ -370,8 +394,10 @@ Example:
 
 1. **Verify binary is in PATH**:
    ```bash
-   which perl-lsp
-   # Should output: /usr/local/bin/perl-lsp or similar
+   command -v perllsp
+   perllsp --version
+   perllsp --health
+   perllsp --info
    ```
 
 2. **Check extension logs**:
@@ -389,10 +415,8 @@ Example:
 4. **Run health check**:
    - Press `Ctrl+Shift+P` → "Perl: Run Health Check"
 
-5. **Test server manually**:
-   ```bash
-   echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perllsp --stdio
-   ```
+5. **If `perllsp --stdio` appears to hang, that is expected**:
+   - It is waiting for framed LSP JSON-RPC input (`Content-Length` headers).
 
 ### No Diagnostics
 
@@ -421,18 +445,9 @@ Example:
 
 **Solutions**:
 
-1. **Reduce result caps** (server-side limits via `initializationOptions`):
-   ```json
-   {
-     "perl": {
-       "limits": {
-         "workspaceSymbolCap": 100,
-         "referencesCap": 200,
-         "completionCap": 50
-       }
-     }
-   }
-   ```
+1. **Prefer project config for server-side limits**:
+   - Configure workspace caps in `.perl-lsp.toml` (see [Configuration Reference](../reference/CONFIG.md)).
+   - The VS Code extension settings use `perl-lsp.*`; not all clients forward raw `perl.*` workspace settings consistently.
 
 2. **Disable semantic tokens** (if not needed):
    ```json
@@ -572,7 +587,7 @@ For teams hosting their own perl-lsp binaries:
 
 ```json
 {
-  "perl-lsp.serverPath": "/opt/perl-lsp/bin/perl-lsp",
+  "perl-lsp.serverPath": "/opt/perl-lsp/bin/perllsp",
   "perl-lsp.autoDownload": false
 }
 ```
@@ -612,24 +627,9 @@ See [DAP User Guide](../tutorials/DAP_USER_GUIDE.md) for more details.
 
 ### Server-Side Performance Limits
 
-The `perl.*` namespace passes server-side initialization options. These control internal server caps and are separate from the extension's `perl-lsp.*` settings:
-
-```json
-{
-  "perl": {
-    "limits": {
-      "workspaceSymbolCap": 200,
-      "referencesCap": 500,
-      "completionCap": 100,
-      "astCacheMaxEntries": 50,
-      "maxIndexedFiles": 5000,
-      "maxTotalSymbols": 250000,
-      "workspaceScanDeadlineMs": 20000,
-      "referenceSearchDeadlineMs": 1500
-    }
-  }
-}
-```
+For server-wide caps (workspace symbols, references, completion limits, and
+scan deadlines), prefer `.perl-lsp.toml` and the mechanisms documented in
+[Configuration Reference](../reference/CONFIG.md).
 
 ### Logging and Tracing
 
@@ -662,6 +662,7 @@ Here is a typical `.vscode/settings.json` for a Perl project using only real ext
   "perl-lsp.enableTestIntegration": true,
   "perl-lsp.includePaths": [
     "lib",
+    ".",
     "local/lib/perl5",
     "vendor/lib"
   ],

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -611,11 +611,15 @@ Settings specific to the VS Code extension (`vscode-extension/package.json`).
 These are separate from the LSP workspace settings above and control extension
 behaviour such as binary management and feature toggles.
 
+The VS Code extension uses the `perl-lsp.*` namespace. Server-side workspace
+settings use the `perl.*` namespace and may be forwarded via initialization
+options or client-specific configuration mechanisms.
+
 ### Binary management
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
-| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perl-lsp` binary. Empty = auto-download. |
+| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perllsp` binary. Empty = auto-download. |
 | `perl-lsp.autoDownload` | `boolean` | `true` | Download the binary automatically if not found locally. |
 | `perl-lsp.downloadBaseUrl` | `string` | `""` | Override the GitHub releases base URL for internal mirrors. |
 | `perl-lsp.channel` | `"latest"\|"stable"\|"tag"` | `"latest"` | Release channel to track. |

--- a/docs/tutorials/DAP_USER_GUIDE.md
+++ b/docs/tutorials/DAP_USER_GUIDE.md
@@ -8,8 +8,8 @@
 > - **Explanation sections**: Understanding DAP architecture and design
 
 **Status**: Native adapter CLI (launch + attach + stepping + evaluate) + BridgeAdapter guide (Perl::LanguageServer)
-**Version**: 0.9.x
-**Date**: 2025-10-04
+**Version**: 0.12.x
+**Date**: 2026-04-27
 
 **Note**: The `perl-dap` CLI runs the native adapter (launch + attach) and does not require Perl::LanguageServer. The bridge adapter steps below apply only if you are running the BridgeAdapter library or Perl::LanguageServer DAP directly.
 
@@ -50,7 +50,7 @@ Before you begin debugging Perl code with VS Code, ensure you have:
    perl --version  # Should output Perl version
    ```
 
-2. **VS Code**: Visual Studio Code 1.70 or higher with Perl LSP extension installed
+2. **VS Code**: Visual Studio Code 1.88 or higher with `EffortlessMetrics.perl-lsp-rs` installed
 
 3. **Operating System**: Windows, macOS, Linux, or WSL
 

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ else
     INSTALL_DIR="$HOME/.local/bin"
 fi
 REPO="EffortlessMetrics/perl-lsp"
-NAME="perl-lsp"
+NAME="perllsp"
 
 # Functions
 write_info() {

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -7,7 +7,7 @@
 
 A fast, native Perl 5 language server extension. Written in Rust for speed and reliability. No runtime dependencies -- just install and code.
 
-> **0.12.3 Public Alpha** -- This extension is under active development. Every feature listed below is wired up and exercised by tests, but as an alpha you will find edge cases where behavior is incomplete or wrong. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose) if you encounter problems. For what the project's headline numbers mean (and do not mean), see the [status overview](https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/project/status/index.md).
+> **Public Alpha** -- This extension is under active development. Every feature listed below is wired up and exercised by tests, but as an alpha you will find edge cases where behavior is incomplete or wrong. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose) if you encounter problems. For what the project's headline numbers mean (and do not mean), see the [status overview](https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/project/status/index.md).
 
 ## Features
 


### PR DESCRIPTION
### Motivation

- The VS Code setup guide and installer mixed legacy `perl-lsp` binary naming with the current `perllsp` packaging and contained several stale or misleading installation and troubleshooting snippets.
- The docs exposed ambiguous guidance about when to install the server vs relying on the extension's auto-download and mixed client (`perl-lsp.*`) vs server (`perl.*`) configuration namespaces.
- Keybits such as prebuilt asset names, source-install commands, stdio troubleshooting, DAP prerequisites, and the extension README wording had drifted and needed to match the repository/packaging conventions.

### Description

- Standardized user-facing docs to prefer the `EffortlessMetrics.perl-lsp-rs` extension and the canonical CLI/Cargo package name `perllsp`, and made manual server install optional for VS Code users (`docs/EDITORS/VS_CODE_SETUP.md`).
- Rewrote prebuilt archive and source-install examples to use `perllsp-<version>-<target>` asset names and `cargo install --path crates/perllsp --locked`, and added `perllsp --info` to verification steps (`docs/EDITORS/VS_CODE_SETUP.md`, `install.sh`).
- Renamed “All Extension Settings” to “Common Extension Settings”, added several production-relevant settings (perlcritic, autoUpdate, updateCheckInterval, disabledFeatures), fixed include-path examples, corrected keybinding mappings, and removed the invalid unframed stdio test in troubleshooting (`docs/EDITORS/VS_CODE_SETUP.md`).
- Clarified `perl-lsp.*` (extension settings) vs `perl.*` (server/workspace settings) and updated `serverPath` wording to reference the `perllsp` binary (`docs/reference/CONFIG.md`).
- Updated DAP guide prerequisites to the current baseline (VS Code 1.88+, extension id), and made the extension README's alpha text version-agnostic (`docs/tutorials/DAP_USER_GUIDE.md`, `vscode-extension/README.md`).
- Updated the installer script to use the `perllsp` name for asset discovery and installed binary (`install.sh`).

### Testing

- Ran `bash -n install.sh` to validate the installer script syntax, which passed. 
- Ran `cargo check --all-targets -p perllsp` to verify the workspace compiles against the changes, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdd01037883338b7f0b91b73ee754)