### PR TITLE
docs(zed): clarify extension contract and setup guidance (#0000)

### DIFF
--- a/docs/EDITORS/ZED_SETUP.md
+++ b/docs/EDITORS/ZED_SETUP.md
@@ -1,27 +1,51 @@
 # Zed Setup Guide for perl-lsp
 
-Use this guide to wire `perllsp` into Zed via the built-in LSP client.
+Use this guide to run `perllsp` in Zed through Zed's built-in LSP client.
+
+> **Current status:** Zed requires a language extension to register a language
+> server for each language. The public Zed Perl extension currently registers
+> `perlnavigator-server`, not `perllsp`. The configuration below works only with
+> a Perl extension that registers a `perl-lsp` language server and launches
+> `perllsp --stdio`.
 
 ## Prerequisites
 
-- `perllsp` installed and available on your `PATH`
-- Zed updated to a recent stable release (0.150+)
+- A current stable Zed release
+- `perllsp` installed and available on your `PATH`, unless your Zed extension
+  downloads or bundles it
+- A Perl project opened in Zed
+- A Zed Perl extension that registers `perl-lsp` as a language server
 
-Quick verification before changing editor settings:
+If you rely on shell `PATH` lookup, start Zed from the same shell:
+
+```bash
+zed .
+```
+
+Verify `perllsp` before changing editor settings:
 
 ```bash
 perllsp --version
 perllsp --health
+perllsp --info
 ```
 
 ## How Zed Loads Language Servers
 
-Zed discovers language servers through extensions. A Perl extension that
-registers `perllsp` is the supported path for first-class Perl IDE features in
-Zed (syntax highlighting, diagnostics, completions, go-to-definition, etc.).
+Zed discovers language servers through language extensions. The `lsp` block in
+`settings.json` configures language servers that Zed already knows about; it does
+not register a new language server by itself.
 
-If you already have a Zed Perl extension installed that launches `perllsp`, you
-can override the binary path via `settings.json` using the `binary` key:
+For `perl-lsp`, the installed Zed extension must register a language server ID
+such as `perl-lsp` for the `Perl` language.
+
+If Zed logs `no language server found matching 'perl-lsp'`, the extension is
+missing or registered the server under a different ID.
+
+## Configure the `perllsp` Binary
+
+Once a Zed extension has registered `perl-lsp`, you can override the executable
+path in `settings.json`:
 
 ```json
 {
@@ -36,20 +60,38 @@ can override the binary path via `settings.json` using the `binary` key:
 }
 ```
 
-The `binary` key tells Zed where to find the executable and which arguments to
-pass instead of using whatever the extension resolves automatically. The key
-name (`"perl-lsp"` above) must match the name your installed Perl extension
-registers for the language server.
+On macOS or Linux, find the path with:
 
-> **Note:** Without a Perl extension, Zed has no built-in mechanism to
-> associate Perl files with `perllsp`. The `lsp` settings block only configures
-> *known* language servers. For a fully generic LSP client approach, see
-> [docs/how-to/EDITOR_SETUP.md](../how-to/EDITOR_SETUP.md).
+```bash
+command -v perllsp
+```
 
-## Optional Server Settings
+On Windows PowerShell:
 
-Once Zed is launching `perllsp`, you can pass `perl.*` workspace configuration
-through `initialization_options`:
+```powershell
+where perllsp
+```
+
+The key name, `perl-lsp`, must match the language server ID registered by the
+installed Zed extension.
+
+## Optional: Perl File Associations
+
+If your project uses Perl-bearing files beyond `.pl`, `.pm`, and `.t`, add file
+associations:
+
+```json
+{
+  "file_types": {
+    "Perl": ["pl", "PL", "pm", "t", "pod", "psgi", "cgi", "fcgi"]
+  }
+}
+```
+
+## Optional: Server Initialization Options
+
+Prefer `.perl-lsp.toml` for settings that should apply across all editors. Use
+Zed `initialization_options` for Zed-specific startup settings.
 
 ```json
 {
@@ -58,7 +100,7 @@ through `initialization_options`:
       "initialization_options": {
         "perl": {
           "workspace": {
-            "includePaths": ["lib", "."]
+            "includePaths": ["lib", ".", "local/lib/perl5"]
           },
           "inlayHints": {
             "enabled": true
@@ -70,10 +112,57 @@ through `initialization_options`:
 }
 ```
 
+## Optional: Semantic Tokens
+
+Zed does not enable LSP semantic tokens by default. If your `perllsp` build and
+extension support semantic tokens, enable them globally or for Perl:
+
+```json
+{
+  "languages": {
+    "Perl": {
+      "semantic_tokens": "combined"
+    }
+  }
+}
+```
+
+## Verify It Is Running
+
+1. Open a Perl file such as `lib/My/Module.pm` or `t/basic.t`.
+2. Confirm Zed shows the file language as `Perl`.
+3. Introduce a temporary syntax error.
+4. Confirm diagnostics appear.
+5. Remove the syntax error after testing.
+
+You can also try LSP-backed navigation:
+
+- `editor: Go to Definition`
+- `editor: Find All References`
+- `editor: Hover`
+
+These features depend on what `perllsp` advertises and what the Zed extension
+wires through.
+
 ## Troubleshooting
 
-- If Perl files do not show diagnostics/completions, confirm that a Zed Perl
-  extension is installed and active (`Extensions` panel -> search "Perl").
-- If the server fails to launch, run `perllsp --health` in a terminal first and
-  fix installation issues before adjusting Zed settings.
-- If behavior is still off, use [docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).
+- If Perl files do not activate the server, confirm that a Zed Perl extension is
+  installed and that it registers the `perl-lsp` server ID.
+- If Zed reports `no language server found matching 'perl-lsp'`, the `lsp` key
+  does not match any registered server.
+- If the server fails to launch, run `perllsp --health` and `perllsp --info` in a
+  terminal first.
+- If Zed cannot find `perllsp`, start Zed from a shell with `zed .`, or set an
+  absolute `binary.path`.
+- If `perllsp --stdio` appears to hang when run manually, that is expected: it is
+  waiting for framed LSP JSON-RPC input.
+- Check Zed logs with `zed: open log`.
+- For more verbose startup logs, close Zed and relaunch it from a terminal with:
+
+  ```bash
+  zed --foreground .
+  ```
+
+For server-side behavior and configuration details, see
+[docs/reference/CONFIG.md](../reference/CONFIG.md) and
+[docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -17,6 +17,7 @@ Verify the install before debugging editor settings:
 ```bash
 perllsp --version
 perllsp --health
+perllsp --info
 ```
 
 ## Pick Your Editor
@@ -29,7 +30,7 @@ perllsp --health
 | Vim | use `vim-lsp` or `coc.nvim` with `perllsp --stdio` | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
-| Zed | install a Perl extension, then optionally point at `perllsp` | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
+| Zed | requires a Zed Perl extension that registers `perllsp`; `settings.json` can override the binary and initialization options for that registered server | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
 | Amazon Kiro | register a Perl LSP client using `perllsp --stdio` | [docs/EDITORS/KIRO_SETUP.md](../EDITORS/KIRO_SETUP.md) |
 | Claude Code | provide a plugin `.lsp.json` pointing to `perllsp --stdio` | [docs/EDITORS/CLAUDE_CODE_SETUP.md](../EDITORS/CLAUDE_CODE_SETUP.md) |
@@ -92,8 +93,11 @@ args = ["--stdio"]
 
 ### Zed
 
-Zed requires a Perl extension that registers `perllsp`. Once installed, you
-can override the binary path via `settings.json`:
+Zed does not create arbitrary language servers from `settings.json` alone. A
+Zed language extension must first register a Perl language server ID, for
+example `perl-lsp`.
+
+Once that extension exists, configure the server in Zed settings:
 
 ```json
 {
@@ -108,8 +112,10 @@ can override the binary path via `settings.json`:
 }
 ```
 
-See [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) for full setup details.
-
+The public Zed Perl extension currently registers `perlnavigator-server`, not
+`perllsp`, so use a perllsp-capable extension or development extension before
+applying the `perl-lsp` settings. See
+[docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) for full setup details.
 
 ### Sublime Text
 

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -66,6 +66,37 @@ If the editor is using a helper extension or plugin, check its own logs too.
 - Check whether the current file actually has a Perl mode or file type.
 - Inspect the LSP log for capability negotiation or request errors.
 
+## Zed Does Not Start `perllsp`
+
+1. Confirm `perllsp` works outside Zed:
+
+   ```bash
+   perllsp --version
+   perllsp --health
+   perllsp --info
+   ```
+
+2. Confirm the installed Zed extension registers the same server ID used in
+   `settings.json`, for example `perl-lsp`.
+
+3. If Zed logs `no language server found matching 'perl-lsp'`, the server is
+   not registered. Installing `perllsp` alone is not enough.
+
+4. If Zed cannot find the binary, start Zed from the project shell:
+
+   ```bash
+   zed .
+   ```
+
+   or use an absolute `lsp.perl-lsp.binary.path`.
+
+5. Check Zed logs with `zed: open log`. For more startup detail, relaunch Zed
+   from a terminal:
+
+   ```bash
+   zed --foreground .
+   ```
+
 ## DAP Or Debugging Issues
 
 If you are debugging with `perl-dap`, check the DAP guide:

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -615,7 +615,7 @@ behaviour such as binary management and feature toggles.
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
-| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perl-lsp` binary. Empty = auto-download. |
+| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perllsp` binary. Empty = auto-download. |
 | `perl-lsp.autoDownload` | `boolean` | `true` | Download the binary automatically if not found locally. |
 | `perl-lsp.downloadBaseUrl` | `string` | `""` | Override the GitHub releases base URL for internal mirrors. |
 | `perl-lsp.channel` | `"latest"\|"stable"\|"tag"` | `"latest"` | Release channel to track. |
@@ -646,6 +646,35 @@ behaviour such as binary management and feature toggles.
 | `perl-lsp.includePaths` | `string[]` | `["lib", "local/lib/perl5"]` | Additional module search paths (merged with server-side `perl.workspace.includePaths`). |
 | `perl-lsp.perltidyConfig` | `string` | `""` | Path to a `.perltidyrc` configuration file. Empty = use Perl::Tidy defaults. |
 | `perl-lsp.featureProfile` | `string` | `"auto"` | Feature profile passed to the server at startup (see [Feature Profiles](#feature-profiles)). |
+
+### Zed (`settings.json`)
+
+Zed requires a language extension that registers the language server ID used
+below. The `lsp` block configures known servers; it does not register a new
+language server by itself.
+
+```json
+{
+  "lsp": {
+    "perl-lsp": {
+      "binary": {
+        "path": "/usr/local/bin/perllsp",
+        "arguments": ["--stdio"]
+      },
+      "initialization_options": {
+        "perl": {
+          "workspace": {
+            "includePaths": ["lib", ".", "local/lib/perl5"]
+          },
+          "inlayHints": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  }
+}
+```
 
 ---
 


### PR DESCRIPTION
### Motivation

- Make the Zed editor documentation explicit that Zed only configures language servers that are registered by an extension and that the public Zed Perl extension currently registers `perlnavigator-server`, not `perllsp`.
- Prevent user confusion where adding `lsp` entries to `settings.json` without a matching registered server ID causes no activation.
- Improve verification and troubleshooting guidance (add `perllsp --info`, explain `--stdio` behavior, recommend starting Zed from the shell when relying on `PATH`).

### Description

- Rewrote `docs/EDITORS/ZED_SETUP.md` to state the current extension contract, require a perllsp-capable Zed extension, preserve default `includePaths`, add file-type association guidance, and extend troubleshooting and verification steps.
- Updated `docs/how-to/EDITOR_SETUP.md` to include `perllsp --info` in baseline checks, change the Zed table row to require a perllsp-capable extension, and replace the Zed minimal section with the registered-server guidance and caveat about `perlnavigator-server`.
- Added a dedicated Zed troubleshooting subsection to `docs/how-to/TROUBLESHOOTING.md` with server-ID mismatch diagnostics and Zed log/launch tips.
- Adjusted `docs/reference/CONFIG.md` to reference the `perllsp` executable name for the extension `serverPath` and added a Zed `settings.json` snippet showing `binary` + `initialization_options` (including `includePaths` with `local/lib/perl5`).

### Testing

- Ran `git diff --check` and it completed with no issues.
- Attempted `markdownlint` on the modified files, but `markdownlint` is not installed in this environment so that check could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdf4da2788333bb3cac746cf5ea42)