### PR TITLE
docs(helix): modernize perllsp setup guidance (#0000)

### DIFF
--- a/docs/EDITORS/HELIX_SETUP.md
+++ b/docs/EDITORS/HELIX_SETUP.md
@@ -1,721 +1,319 @@
 # Helix Setup Guide for perl-lsp
 
-This comprehensive guide helps you set up and configure the Perl Language Server in Helix editor.
+Use this guide to run `perllsp` in Helix through Helix's built-in LSP client.
 
-## Table of Contents
-
-- [Prerequisites](#prerequisites)
-- [Installation](#installation)
-- [Basic Setup](#basic-setup)
-- [Configuration](#configuration)
-- [Features](#features)
-- [Keybindings](#keybindings)
-- [Troubleshooting](#troubleshooting)
-- [Advanced Configuration](#advanced-configuration)
-
----
+Helix already has built-in Perl language support. Its default Perl language
+server is currently `perlnavigator`, so this guide shows how to override the
+Perl language server to `perllsp`.
 
 ## Prerequisites
 
-### Required
+- Helix 23.10 or later; a current stable release is recommended
+- `perllsp` installed and available on your `PATH`
+- A Perl project opened from the project root
 
-- **Helix** version 23.03 or later
-- **perl-lsp** server installed (see [Installation](#installation))
-
-### Optional but Recommended
-
-- **Perl** 5.10 or later (for syntax validation)
-- **perltidy** (for code formatting)
-- **perlcritic** (for linting)
-
----
-
-## Installation
-
-### Install the Server
-
-Choose one of the following methods:
-
-#### Option 1: Install from crates.io (Recommended)
+Verify both Helix and `perllsp` before editing configuration:
 
 ```bash
-cargo install perllsp
+hx --health perl
+
+perllsp --version
+perllsp --health
+perllsp --info
 ```
 
-#### Option 2: Download Pre-built Binary
+## Install `perllsp`
 
-Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases):
+### Cargo
 
 ```bash
-# Linux (x86_64)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-linux-x86_64.tar.gz
-tar xzf perl-lsp-linux-x86_64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
-
-# macOS (Apple Silicon)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-darwin-aarch64.tar.gz
-tar xzf perl-lsp-darwin-aarch64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
+cargo install perllsp --locked
 ```
 
-#### Option 3: Build from Source
+### From Source
 
 ```bash
 git clone https://github.com/EffortlessMetrics/perl-lsp.git
 cd perl-lsp
-cargo install perllsp
+cargo install --path crates/perllsp --locked
 ```
 
-### Verify Installation
+### Prebuilt Binary
+
+Download the archive for your platform from GitHub Releases, extract it, and put
+the `perllsp` binary on your `PATH`.
+
+Check the release page before copying a version number. Release assets use the
+`perllsp-<version>-<target>` naming pattern.
+
+## Configure Helix
+
+Create or update your Helix language configuration:
+
+- Linux/macOS: `~/.config/helix/languages.toml`
+- Windows: `%AppData%\\helix\\languages.toml`
+- Project-local override: `.helix/languages.toml`
+
+Add:
+
+```toml
+[language-server.perl-lsp]
+command = "perllsp"
+args = ["--stdio"]
+
+[[language]]
+name = "perl"
+language-servers = ["perl-lsp"]
+```
+
+Restart Helix after changing `languages.toml`.
+
+## Optional: Project-Specific Configuration
+
+For one project, create `.helix/languages.toml` in the repository root:
+
+```toml
+[language-server.perl-lsp]
+command = "perllsp"
+args = ["--stdio"]
+
+[[language]]
+name = "perl"
+language-servers = ["perl-lsp"]
+```
+
+Prefer `.perl-lsp.toml` for settings that should apply across all editors. Use
+Helix `languages.toml` for Helix-specific wiring.
+
+## Optional: Perl File Types
+
+Helix file types are extensions without leading dots. If your project uses Perl
+files beyond `.pl`, `.pm`, and `.t`, add them explicitly:
+
+```toml
+[[language]]
+name = "perl"
+file-types = ["pl", "PL", "pm", "t", "psgi", "cgi", "fcgi", "xs", "xsi"]
+language-servers = ["perl-lsp"]
+```
+
+Avoid assigning `.pod` to Perl unless you intentionally want POD files handled as
+Perl source; Helix has separate POD language support.
+
+## Optional: Server Initialization Options
+
+Helix sends `language-server.<name>.config` as LSP initialization options.
+
+```toml
+[language-server.perl-lsp.config.perl.workspace]
+includePaths = ["lib", ".", "local/lib/perl5"]
+useSystemInc = false
+resolutionTimeout = 50
+
+[language-server.perl-lsp.config.perl.inlayHints]
+enabled = true
+parameterHints = true
+typeHints = true
+maxLength = 30
+
+[language-server.perl-lsp.config.perl.limits]
+workspaceSymbolCap = 200
+referencesCap = 500
+completionCap = 100
+```
+
+For large workspaces, tune limits conservatively:
+
+```toml
+[language-server.perl-lsp.config.perl.limits]
+workspaceSymbolCap = 100
+referencesCap = 200
+completionCap = 50
+astCacheMaxEntries = 50
+maxIndexedFiles = 5000
+maxTotalSymbols = 250000
+workspaceScanDeadlineMs = 20000
+referenceSearchDeadlineMs = 1500
+```
+
+## Optional: Inlay Hints in Helix
+
+`perllsp` can provide inlay hints, but Helix does not display them by default.
+Enable them in `config.toml`:
+
+```toml
+[editor.lsp]
+display-inlay-hints = true
+```
+
+You can also toggle them at runtime:
+
+```text
+:toggle lsp.display-inlay-hints
+```
+
+## Optional: Environment Variables
+
+Use Helix's `environment` table instead of wrapping the command with `env`:
+
+```toml
+[language-server.perl-lsp]
+command = "perllsp"
+args = ["--stdio"]
+environment = { PERL5LIB = "lib" }
+```
+
+## Verify It Is Running
+
+1. Open a Perl file such as `lib/My/Module.pm`, `script/app.pl`, or `t/basic.t`.
+2. Confirm the Helix statusline shows the language as `perl`.
+3. Introduce a temporary syntax error.
+4. Confirm diagnostics appear.
+5. Remove the syntax error.
+
+Useful checks:
 
 ```bash
-# Check version
-perllsp --version
-
-# Quick health check
+hx --health perl
 perllsp --health
-# Should output: ok 0.10.0
+perllsp --info
+perllsp --check path/to/file.pl
 ```
 
----
+Inside Helix:
 
-## Basic Setup
-
-### Configuration File
-
-Helix uses TOML configuration files located at:
-
-- **Linux/macOS**: `~/.config/helix/languages.toml`
-- **Windows**: `%APPDATA%\helix\languages.toml`
-
-### Basic Configuration
-
-Add the following to your `languages.toml`:
-
-```toml
-[[language]]
-name = "perl"
-scope = "source.perl"
-injection-regex = "perl"
-file-types = ["pl", "pm", "t", "psgi"]
-roots = ["Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"]
-comment-token = "#"
-indent = { tab-width = 4, unit = "    " }
-language-servers = ["perl-lsp"]
-
-[language-server.perl-lsp]
-command = "perllsp"
-args = ["--stdio"]
+```text
+:log-open
+:lsp-restart
+:lsp-stop
+:set-language perl
 ```
 
-### Verify Setup
-
-1. Restart Helix
-2. Open a `.pl` or `.pm` file
-3. Check if LSP is attached:
-   - Press `:`
-   - Type `lsp`
-   - Look for perl-lsp in the list
-
----
-
-## Configuration
-
-### Full Configuration
-
-Add to your `languages.toml`:
-
-```toml
-[[language]]
-name = "perl"
-scope = "source.perl"
-injection-regex = "perl"
-file-types = ["pl", "pm", "t", "psgi"]
-roots = ["Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"]
-comment-token = "#"
-indent = { tab-width = 4, unit = "    " }
-language-servers = ["perl-lsp"]
-
-[language-server.perl-lsp]
-command = "perllsp"
-args = ["--stdio"]
-
-[language-server.perl-lsp.config.perl]
-workspace.includePaths = ["lib", ".", "local/lib/perl5"]
-workspace.useSystemInc = false
-workspace.resolutionTimeout = 50
-inlayHints.enabled = true
-inlayHints.parameterHints = true
-inlayHints.typeHints = true
-inlayHints.maxLength = 30
-testRunner.enabled = true
-testRunner.command = "perl"
-testRunner.args = []
-testRunner.timeout = 60000
-limits.workspaceSymbolCap = 200
-limits.referencesCap = 500
-limits.completionCap = 100
-limits.astCacheMaxEntries = 100
-limits.maxIndexedFiles = 10000
-limits.maxTotalSymbols = 500000
-limits.workspaceScanDeadlineMs = 30000
-limits.referenceSearchDeadlineMs = 2000
-```
-
-### Project-Specific Configuration
-
-Create `.helix/languages.toml` in your project root:
-
-```toml
-[[language]]
-name = "perl"
-language-servers = ["perl-lsp"]
-
-[language-server.perl-lsp.config.perl]
-workspace.includePaths = ["lib", "local/lib/perl5", "vendor/lib"]
-workspace.useSystemInc = false
-```
-
----
-
-## Features
-
-### Syntax Diagnostics
-
-Real-time syntax error detection and reporting:
-
-```perl
-# Errors are highlighted as you type
-my $x = 1
-# Missing semicolon - error shown immediately
-```
-
-View diagnostics:
-- Press `:`
-- Type `diagnostics`
-
-### Go to Definition
-
-Navigate to symbol definitions:
-
-- **Keybinding**: `gd`
-- **Command**: `:goto_definition`
-
-```perl
-use MyModule;
-
-MyModule::some_function();
-# ^ gd here jumps to the definition
-```
-
-### Find References
-
-Find all usages of a symbol:
-
-- **Keybinding**: `gr`
-- **Command**: `:references`
-
-```perl
-sub my_function {
-    return 42;
-}
-
-# ^ Find references here shows all calls to my_function
-```
-
-### Hover Information
-
-View documentation and type information:
-
-- **Keybinding**: `K`
-- **Command**: `:hover`
-
-### Code Completion
-
-Intelligent code completion:
-
-- **Keybinding**: `Ctrl+x Ctrl+o` or type to trigger
-- **Command**: `:completion`
-
-```perl
-use MyModule;
-
-MyModule::  # Type here for completion
-```
-
-### Document Symbols
-
-Navigate symbols in the current file:
-
-- **Keybinding**: `g a`
-- **Command**: `:symbol-picker`
-
-### Workspace Symbols
-
-Search symbols across the entire workspace:
-
-- **Keybinding**: `Space s s`
-- **Command**: `:workspace_symbol`
-
-### Rename Symbol
-
-Rename symbols across the workspace:
-
-- **Keybinding**: `Space r n`
-- **Command**: `:rename`
-
-### Formatting
-
-Format Perl code using perltidy:
-
-- **Keybinding**: `Space f`
-- **Command**: `:format`
-
-### Code Actions
-
-Quick fixes and refactorings:
-
-- **Keybinding**: `Space a a`
-- **Command**: `:code_action`
-
-Available actions:
-- Extract variable
-- Extract subroutine
-- Optimize imports
-- Add missing pragmas
-
-### Inlay Hints
-
-Inline type and parameter hints:
-
-```perl
-sub my_function($name, $count) {
-    return "Hello, $name x$count";
-}
-
-my_function("World", 5);
-# ^ Shows: my_function(/* name: */ "World", /* count: */ 5)
-```
-
-Enable inlay hints:
-- **Keybinding**: `Space h i`
-- **Command**: `:inlay_hints`
-
----
-
-## Keybindings
-
-### Default LSP Keybindings
+## Common Helix LSP Keybindings
 
 | Action | Keybinding | Command |
-|--------|------------|---------|
-| Go to Definition | `gd` | `:goto_definition` |
-| Find References | `gr` | `:references` |
-| Hover | `K` | `:hover` |
-| Completion | `Ctrl+x Ctrl+o` | `:completion` |
-| Document Symbols | `g a` | `:symbol-picker` |
-| Workspace Symbols | `Space s s` | `:workspace_symbol` |
-| Rename | `Space r n` | `:rename` |
-| Format | `Space f` | `:format` |
-| Code Actions | `Space a a` | `:code_action` |
-| Inlay Hints | `Space h i` | `:inlay_hints` |
-| Diagnostics | `Space d d` | `:diagnostics` |
-| Next Diagnostic | `] d` | - |
-| Previous Diagnostic | `[ d` | - |
+| --- | --- | --- |
+| Go to definition | `gd` | `goto_definition` |
+| Find references | `gr` | `goto_reference` |
+| Hover | `<space>k` | `hover` |
+| Completion | `<C-x>` in insert mode | `completion` |
+| Document symbols | `<space>s` | `symbol_picker` |
+| Workspace symbols | `<space>S` | `workspace_symbol_picker` |
+| Rename symbol | `<space>r` | `rename_symbol` |
+| Code action | `<space>a` | `code_action` |
+| Diagnostics picker | `<space>d` | `diagnostics_picker` |
+| Workspace diagnostics | `<space>D` | `workspace_diagnostics_picker` |
+| Next diagnostic | `]d` | `goto_next_diag` |
+| Previous diagnostic | `[d` | `goto_prev_diag` |
+| Format file | `:format` or `:fmt` | `format` |
+| Format selection | `=` | `format_selections` |
 
-### Custom Keybindings
+## Formatting
 
-Add to your `config.toml`:
+Helix uses the language server for `:format` unless you configure an external
+formatter. If formatting fails, confirm `perltidy` is installed:
 
-```toml
-[keys.normal]
-# LSP keybindings
-gd = ":goto_definition"
-gr = ":references"
-K = ":hover"
-
-# Space keybindings
-[keys.normal.space]
-f = ":format"
-a = { a = ":code_action" }
-r = { n = ":rename" }
-s = { s = ":workspace_symbol" }
-d = { d = ":diagnostics" }
-h = { i = ":inlay_hints" }
+```bash
+perltidy --version
 ```
 
----
+To use an external formatter instead of LSP formatting:
+
+```toml
+[[language]]
+name = "perl"
+formatter = { command = "perltidy", args = ["-q"] }
+```
 
 ## Troubleshooting
 
-### Server Not Starting
+### Server not starting
 
-**Symptoms**: No diagnostics, no completion, error in status bar
+1. Confirm `perllsp` is launchable:
 
-**Solutions**:
-
-1. **Verify binary is in PATH**:
    ```bash
-   which perllsp
-   # Should output: /usr/local/bin/perllsp or similar
+   command -v perllsp
+   perllsp --version
+   perllsp --health
+   perllsp --info
    ```
 
-2. **Check LSP status**:
-   - Press `:`
-   - Type `lsp`
-   - Look for perl-lsp in the list
+   On Windows PowerShell:
 
-3. **Check logs**:
+   ```powershell
+   where perllsp
+   perllsp --version
+   perllsp --health
+   perllsp --info
+   ```
+
+2. Confirm Helix sees the Perl language configuration:
+
    ```bash
-   # Helix logs are in:
-   # Linux: ~/.cache/helix/helix.log
-   # macOS: ~/Library/Caches/helix/helix.log
-   # Windows: %APPDATA%\helix\helix.log
+   hx --health perl
    ```
 
-4. **Test server manually**:
-   ```bash
-   echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perllsp --stdio
+3. Open the Helix log:
+
+   ```text
+   :log-open
    ```
 
-### No Diagnostics
+4. Restart the server from Helix:
 
-**Symptoms**: No errors shown for invalid code
-
-**Solutions**:
-
-1. **Check file type**:
-   - Look at the status bar
-   - Should show "perl" as the language
-
-2. **Set file type manually**:
-   - Press `:`
-   - Type `set-language perl`
-
-3. **Verify diagnostics enabled**:
-   - Press `:`
-   - Type `diagnostics`
-
-### Slow Performance
-
-**Symptoms**: Lag when typing, slow completions
-
-**Solutions**:
-
-1. **Reduce result caps**:
-   ```toml
-   [language-server.perl-lsp.config.perl]
-   limits.workspaceSymbolCap = 100
-   limits.referencesCap = 200
-   limits.completionCap = 50
+   ```text
+   :lsp-restart
    ```
 
-2. **Disable system @INC**:
-   ```toml
-   [language-server.perl-lsp.config.perl]
-   workspace.useSystemInc = false
-   ```
+5. If `perllsp --stdio` appears to hang when run manually, that is expected. It
+   is waiting for framed LSP input from the editor.
 
-3. **Reduce resolution timeout**:
-   ```toml
-   [language-server.perl-lsp.config.perl]
-   workspace.resolutionTimeout = 25
-   ```
+### No diagnostics
 
-### Module Resolution Issues
+- Confirm the file language is `perl` in the statusline.
+- Run `:set-language perl` if Helix detected the wrong language.
+- Confirm `language-servers = ["perl-lsp"]` is attached to the `perl` language.
+- Run `perllsp --check path/to/file.pl` outside Helix.
 
-**Symptoms**: Can't find modules, go-to-definition fails
+### Module resolution issues
 
-**Solutions**:
-
-1. **Check include paths**:
-   ```toml
-   [language-server.perl-lsp.config.perl]
-   workspace.includePaths = ["lib", ".", "local/lib/perl5", "vendor/lib"]
-   ```
-
-2. **Verify module exists**:
-   ```bash
-   perl -e 'use Module::Name;'
-   ```
-
-3. **Check workspace root**:
-   - Press `:`
-   - Type `pwd`
-
-### Formatting Not Working
-
-**Symptoms**: Format command does nothing or errors
-
-**Solutions**:
-
-1. **Install perltidy**:
-   ```bash
-   # macOS
-   brew install perltidy
-
-   # Ubuntu/Debian
-   sudo apt-get install perltidy
-
-   # CentOS/RHEL
-   sudo yum install perl-Perl-Tidy
-   ```
-
-2. **Check perltidy works**:
-   ```bash
-   perltidy --version
-   ```
-
-3. **Verify formatting enabled**:
-   - Press `:`
-   - Type `format`
-
-### Tree-sitter Grammar Issues
-
-**Symptoms**: Incorrect highlighting, parsing errors
-
-**Solutions**:
-
-1. **Install tree-sitter CLI**:
-   ```bash
-   cargo install tree-sitter-cli
-   ```
-
-2. **Fetch and build grammar**:
-   ```bash
-   cd ~/.local/share/helix/runtime
-   hx --grammar fetch
-   hx --grammar build
-   ```
-
-3. **Restart Helix**
-
----
-
-## Advanced Configuration
-
-### Multi-Root Workspace
-
-For workspaces with multiple folders:
+Configure include paths in `.perl-lsp.toml` for shared project defaults, or pass
+Helix-specific initialization options:
 
 ```toml
-[[language]]
-name = "perl"
-roots = ["Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git", "Cargo.toml"]
+[language-server.perl-lsp.config.perl.workspace]
+includePaths = ["lib", ".", "local/lib/perl5", "vendor/lib"]
+useSystemInc = false
 ```
 
-### Environment Variables
+### Slow performance
 
-Set environment variables for the LSP server:
+Reduce result caps and indexing limits:
 
 ```toml
-[language-server.perl-lsp]
-command = "env"
-args = ["PERL5LIB=lib", "PERL_MB_OPT=--install_base local", "perllsp", "--stdio"]
+[language-server.perl-lsp.config.perl.limits]
+workspaceSymbolCap = 100
+referencesCap = 200
+completionCap = 50
+maxIndexedFiles = 5000
+maxTotalSymbols = 250000
 ```
 
-### Custom Formatter
+### Tree-sitter or highlighting issues
 
-Use a custom formatter instead of perltidy:
+Run:
 
-```toml
-[[language]]
-name = "perl"
-formatter = { command = "my-formatter", args = ["--style", "perl"] }
+```bash
+hx --health perl
 ```
 
-### Debug Adapter Protocol (DAP)
+If you build Helix from source or maintain a custom runtime, refresh grammars:
 
-Enable debugging support:
-
-```toml
-[language.debugger]
-name = "perl-debug"
-command = "perl-debug-adapter"
-args = []
-transport = "tcp"
-port-arg = "--port {}"
+```bash
+hx --grammar fetch
+hx --grammar build
 ```
 
-See [DAP User Guide](../tutorials/DAP_USER_GUIDE.md) for more details.
-
-### Performance Tuning
-
-For large workspaces, adjust performance settings:
-
-```toml
-[language-server.perl-lsp.config.perl]
-limits.workspaceSymbolCap = 100
-limits.referencesCap = 200
-limits.completionCap = 50
-limits.astCacheMaxEntries = 50
-limits.maxIndexedFiles = 5000
-limits.maxTotalSymbols = 250000
-limits.workspaceScanDeadlineMs = 20000
-limits.referenceSearchDeadlineMs = 1500
-workspace.resolutionTimeout = 25
-```
-
-### Auto-Save Configuration
-
-Configure auto-save behavior:
-
-```toml
-[editor]
-auto-save = true
-auto-save-timeout = 1000
-```
-
-### Indentation Configuration
-
-Customize indentation for Perl:
-
-```toml
-[[language]]
-name = "perl"
-indent = { tab-width = 4, unit = "    " }
-```
-
-### Comment Configuration
-
-Customize comment behavior:
-
-```toml
-[[language]]
-name = "perl"
-comment-token = "#"
-```
-
----
-
-## Complete Example Configuration
-
-Here's a comprehensive example configuration:
-
-### languages.toml
-
-```toml
-[[language]]
-name = "perl"
-scope = "source.perl"
-injection-regex = "perl"
-file-types = ["pl", "pm", "t", "psgi"]
-roots = ["Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"]
-comment-token = "#"
-indent = { tab-width = 4, unit = "    " }
-language-servers = ["perl-lsp"]
-
-[language-server.perl-lsp]
-command = "perllsp"
-args = ["--stdio"]
-
-[language-server.perl-lsp.config.perl]
-# Workspace configuration
-workspace.includePaths = ["lib", ".", "local/lib/perl5", "vendor/lib"]
-workspace.useSystemInc = false
-workspace.resolutionTimeout = 50
-
-# Inlay hints
-inlayHints.enabled = true
-inlayHints.parameterHints = true
-inlayHints.typeHints = true
-inlayHints.maxLength = 30
-
-# Test runner
-testRunner.enabled = true
-testRunner.command = "perl"
-testRunner.args = []
-testRunner.timeout = 60000
-
-# Performance limits
-limits.workspaceSymbolCap = 200
-limits.referencesCap = 500
-limits.completionCap = 100
-limits.astCacheMaxEntries = 100
-limits.maxIndexedFiles = 10000
-limits.maxTotalSymbols = 500000
-limits.workspaceScanDeadlineMs = 30000
-limits.referenceSearchDeadlineMs = 2000
-```
-
-### config.toml
-
-```toml
-[editor]
-line-number = "relative"
-mouse = true
-auto-save = true
-auto-save-timeout = 1000
-completion-timeout = 250
-idle-timeout = 250
-preview-completion-insert = true
-
-[editor.cursor-shape]
-insert = "bar"
-normal = "block"
-select = "underline"
-
-[editor.file-picker]
-hidden = false
-git-ignore = true
-git-global = true
-parents = true
-
-[editor.soft-wrap]
-enable = true
-max-wrap = 25
-
-[editor.whitespace]
-render = "all"
-
-[editor.indent-guides]
-render = true
-
-[keys.normal]
-# LSP keybindings
-gd = ":goto_definition"
-gr = ":references"
-K = ":hover"
-
-# Space keybindings
-[keys.normal.space]
-f = ":format"
-a = { a = ":code_action" }
-r = { n = ":rename" }
-s = { s = ":workspace_symbol" }
-d = { d = ":diagnostics" }
-h = { i = ":inlay_hints" }
-
-# File operations
-[keys.normal.space.f]
-f = ":format"
-s = ":write"
-
-# Window management
-[keys.normal.space.w]
-h = ":hsplit"
-v = ":vsplit"
-c = ":buffer-close"
-
-# Search
-[keys.normal.space.s]
-s = ":workspace_symbol"
-f = ":global_search"
-
-# Git
-[keys.normal.space.g]
-c = ":git-commit"
-p = ":git-push"
-l = ":git-log"
-```
-
----
-
-## See Also
-
-- [Getting Started](../tutorials/GETTING_STARTED.md) - Quick start guide
-- [Configuration Reference](../reference/CONFIG.md) - Complete configuration options
-- [Troubleshooting Guide](../how-to/TROUBLESHOOTING.md) - Common issues and solutions
-- [Performance Tuning](../how-to/PERFORMANCE_TUNING.md) - Performance optimization guide
-- [Editor Setup](../how-to/EDITOR_SETUP.md) - Other editor configurations
-- [Helix Documentation](https://docs.helix-editor.com/)
+For server-side behaviour and configuration details, see
+[docs/reference/CONFIG.md](../reference/CONFIG.md) and
+[docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,7 +28,7 @@ perllsp --health
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Vim | use `vim-lsp` or `coc.nvim` with `perllsp --stdio` | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
-| Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
+| Helix | override the built-in Perl language server from `perlnavigator` to `perllsp --stdio` in `languages.toml` | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Zed | install a Perl extension, then optionally point at `perllsp` | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
 | Amazon Kiro | register a Perl LSP client using `perllsp --stdio` | [docs/EDITORS/KIRO_SETUP.md](../EDITORS/KIRO_SETUP.md) |
@@ -80,15 +80,29 @@ both configured to launch `perllsp --stdio`. See
 
 ### Helix
 
-```toml
-[[language]]
-name = "perl"
-language-servers = ["perllsp"]
+Helix already has a Perl language entry, but its default server is
+`perlnavigator`. To use `perllsp`, define a new language server and attach it to
+the `perl` language:
 
-[language-server.perllsp]
+```toml
+[language-server.perl-lsp]
 command = "perllsp"
 args = ["--stdio"]
+
+[[language]]
+name = "perl"
+language-servers = ["perl-lsp"]
 ```
+
+Check setup with:
+
+```bash
+hx --health perl
+perllsp --health
+perllsp --info
+```
+
+See [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) for a full example.
 
 ### Zed
 

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -512,7 +512,7 @@ decrease them for resource-constrained environments.
 
 ## CLI Flags
 
-Flags passed when launching the `perl-lsp` binary. Source:
+Flags passed when launching the `perllsp` binary. Source:
 `crates/perl-lsp-launcher/src/lib.rs`.
 
 ### Server mode
@@ -559,7 +559,7 @@ perllsp --completion bash >> ~/.bashrc  # install bash completions
 
 ## Environment Variables
 
-Environment variables read at startup by the `perl-lsp` binary. Source:
+Environment variables read at startup by the `perllsp` binary. Source:
 `crates/perl-lsp-launcher/src/lib.rs`.
 
 ### `PERL_LSP_LOG`
@@ -615,7 +615,7 @@ behaviour such as binary management and feature toggles.
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
-| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perl-lsp` binary. Empty = auto-download. |
+| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perllsp` binary. Empty = auto-download. |
 | `perl-lsp.autoDownload` | `boolean` | `true` | Download the binary automatically if not found locally. |
 | `perl-lsp.downloadBaseUrl` | `string` | `""` | Override the GitHub releases base URL for internal mirrors. |
 | `perl-lsp.channel` | `"latest"\|"stable"\|"tag"` | `"latest"` | Release channel to track. |
@@ -847,11 +847,25 @@ require("lspconfig").perl_ls.setup({
 
 #### Helix (`languages.toml`)
 
+Helix has built-in Perl language support, but its default Perl language server is
+`perlnavigator`. To use `perllsp`, define the server and attach it to the `perl`
+language:
+
 ```toml
-[language-server.perl-lsp.config.perl]
-workspace.includePaths = ["lib", ".", "local/lib/perl5"]
-workspace.useSystemInc = false
-inlayHints.enabled = true
+[language-server.perl-lsp]
+command = "perllsp"
+args = ["--stdio"]
+
+[[language]]
+name = "perl"
+language-servers = ["perl-lsp"]
+
+[language-server.perl-lsp.config.perl.workspace]
+includePaths = ["lib", ".", "local/lib/perl5"]
+useSystemInc = false
+
+[language-server.perl-lsp.config.perl.inlayHints]
+enabled = true
 ```
 
 #### Emacs (eglot)

--- a/docs/reference/LSP_FEATURES.md
+++ b/docs/reference/LSP_FEATURES.md
@@ -463,9 +463,9 @@ Intelligent code folding:
 ```json
 {
   "perl.testRunner.enabled": true,
-  "perl.testRunner.testCommand": "perl",
-  "perl.testRunner.testArgs": [],
-  "perl.testRunner.testTimeout": 60000
+  "perl.testRunner.command": "perl",
+  "perl.testRunner.args": [],
+  "perl.testRunner.timeout": 60000
 }
 ```
 
@@ -591,8 +591,11 @@ With lsp-mode or eglot:
 # Check if perllsp is in PATH
 which perllsp
 
-# Test standalone
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | perllsp --stdio
+# Run server diagnostics and info commands
+perllsp --version
+perllsp --health
+perllsp --info
+perllsp --check path/to/file.pl
 ```
 
 **Slow performance:**


### PR DESCRIPTION
### Motivation

- The existing Helix guide contained stale Helix version guidance, incorrect binary/release examples, Vim-style commands/keybindings, an invalid unframed stdio smoke test, and an unverified DAP example that could mislead users. 
- The intent is to provide a minimal, correct Helix wiring that explicitly overrides Helix's default Perl server (`perlnavigator`) to run `perllsp --stdio` and to align related docs with current Helix behaviour and `perllsp` CLI flags.

### Description

- Rewrote `docs/EDITORS/HELIX_SETUP.md` into a concise, current Helix guide that documents a minimal `languages.toml` override for `perllsp`, corrects verification steps, clarifies inlay-hints and environment usage, and removes the unsupported DAP example. 
- Updated `docs/how-to/EDITOR_SETUP.md` to replace the Helix row and minimal Helix snippet with the override model (attach `perl-lsp` server running `perllsp --stdio`) and added `hx --health`/`perllsp --info` checks. 
- Updated `docs/reference/CONFIG.md` to refer to the actual `perllsp` executable, add the full minimal Helix wiring example, and prefer using `environment` over `env`-wrapped commands. 
- Updated `docs/reference/LSP_FEATURES.md` to align test-runner keys to current naming (`command`, `args`, `timeout`) and replace the invalid `echo | perllsp --stdio` smoke test with supported CLI checks (`--version`, `--health`, `--info`, `--check`).

### Testing

- Ran `cargo xtask fmt` and the formatter completed successfully. 
- Ran `cargo check --all-targets -p perl-lsp-rs` and the crate type-checked without errors. 
- `just pr-fast` was not available in this environment (`just: command not found`), so that gate was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe1f8c8dc83339ab7b0f072fc1017)