### PR TITLE
docs(vim): tighten Vim client setup guidance (#0000)

### DIFF
--- a/docs/EDITORS/VIM_SETUP.md
+++ b/docs/EDITORS/VIM_SETUP.md
@@ -1,53 +1,135 @@
 # Vim Setup Guide for perl-lsp
 
-This guide covers classic Vim setup (not Neovim). Use this when you want
-`perllsp` features such as diagnostics, go-to-definition, references, and
-rename directly in Vim.
+This guide covers classic Vim setup, not Neovim's built-in LSP client. Use this
+when you want `perllsp` features such as diagnostics, go-to-definition,
+references, hover, formatting, and rename directly in Vim.
 
 ## Prerequisites
 
-- Vim 8.2+ (or newer)
+- Vim with Perl filetype detection enabled
 - `perllsp` installed and available on your `PATH`
 - one LSP client plugin:
   - [`vim-lsp`](https://github.com/prabirshrestha/vim-lsp), or
   - [`coc.nvim`](https://github.com/neoclide/coc.nvim)
 
-Quick verification:
+Client-specific notes:
+
+- `vim-lsp` works on Vim 8+, while newer Vim 9 builds provide better support
+  for virtual text and inlay hints.
+- `coc.nvim` requires Vim `>= 9.0.0438` and Node.js `>= 16.18.0`.
+
+Verify `perllsp` before changing Vim configuration:
 
 ```bash
 perllsp --version
 perllsp --health
+perllsp --info
+```
+
+## Perl Filetype Detection
+
+The LSP client starts only when Vim sets the buffer filetype to `perl`.
+
+Check a Perl buffer with:
+
+```vim
+:set filetype?
+```
+
+It should print:
+
+```text
+filetype=perl
+```
+
+If `.t` test files or CGI files are not detected as Perl, add:
+
+```vim
+augroup perl_filetypes
+  autocmd!
+  autocmd BufRead,BufNewFile *.t setfiletype perl
+  autocmd BufRead,BufNewFile *.cgi,*.fcgi setfiletype perl
+augroup END
 ```
 
 ## Option A: vim-lsp
 
-Add this to your `.vimrc` after loading `vim-lsp`:
+Install `vim-lsp` with your preferred plugin manager, then add this to `.vimrc`
+after the plugin is loaded.
 
 ```vim
+function! s:perl_lsp_root_uri(server_info) abort
+  let l:root = lsp#utils#find_nearest_parent_file_directory(
+        \ expand('%:p'),
+        \ ['.perl-lsp.toml', 'Makefile.PL', 'Build.PL', 'cpanfile', 'dist.ini', '.git']
+        \ )
+
+  if empty(l:root)
+    let l:root = getcwd()
+  endif
+
+  return lsp#utils#path_to_uri(l:root)
+endfunction
+
 if executable('perllsp')
-  augroup perllsp_vim
+  augroup perllsp_vim_lsp
     autocmd!
     autocmd User lsp_setup call lsp#register_server({
-          \ 'name': 'perllsp',
-          \ 'cmd': {server_info->['perllsp', '--stdio']},
+          \ 'name': 'perl-lsp',
+          \ 'cmd': {server_info -> ['perllsp', '--stdio']},
           \ 'allowlist': ['perl'],
+          \ 'root_uri': function('s:perl_lsp_root_uri'),
           \ })
   augroup END
 endif
+
+function! s:on_perl_lsp_buffer_enabled() abort
+  setlocal omnifunc=lsp#complete
+  setlocal signcolumn=yes
+
+  nmap <buffer> gd <plug>(lsp-definition)
+  nmap <buffer> gr <plug>(lsp-references)
+  nmap <buffer> K  <plug>(lsp-hover)
+  nmap <buffer> <leader>rn <plug>(lsp-rename)
+  nmap <buffer> <leader>ca <plug>(lsp-code-action)
+endfunction
+
+augroup perllsp_vim_lsp_mappings
+  autocmd!
+  autocmd User lsp_buffer_enabled
+        \ if &filetype ==# 'perl' |
+        \   call s:on_perl_lsp_buffer_enabled() |
+        \ endif
+augroup END
 ```
 
-Useful default mappings (optional):
+### Optional vim-lsp server settings
+
+Prefer `.perl-lsp.toml` for project-wide settings shared across editors. For
+Vim-specific settings, pass workspace configuration through `workspace_config`:
 
 ```vim
-nmap <buffer> gd <plug>(lsp-definition)
-nmap <buffer> gr <plug>(lsp-references)
-nmap <buffer> K  <plug>(lsp-hover)
-nmap <buffer> <leader>rn <plug>(lsp-rename)
+'workspace_config': {
+\   'perl': {
+\     'workspace': {
+\       'includePaths': ['lib', '.', 'local/lib/perl5']
+\     },
+\     'inlayHints': {
+\       'enabled': v:true
+\     }
+\   }
+\ }
 ```
 
 ## Option B: coc.nvim
 
-If you already use coc.nvim, configure `perllsp` in `coc-settings.json`:
+Install `coc.nvim`, then open Coc configuration:
+
+```vim
+:CocConfig
+```
+
+Add:
 
 ```json
 {
@@ -55,21 +137,131 @@ If you already use coc.nvim, configure `perllsp` in `coc-settings.json`:
     "perl-lsp": {
       "command": "perllsp",
       "args": ["--stdio"],
-      "filetypes": ["perl"]
+      "filetypes": ["perl"],
+      "rootPatterns": [
+        ".perl-lsp.toml",
+        "Makefile.PL",
+        "Build.PL",
+        "cpanfile",
+        "dist.ini",
+        ".git"
+      ],
+      "settings": {
+        "perl": {
+          "workspace": {
+            "includePaths": ["lib", ".", "local/lib/perl5"]
+          }
+        }
+      }
     }
   }
 }
 ```
 
+Coc uses Vim filetypes, not filename extensions. If the server does not start,
+check:
+
+```vim
+:CocCommand document.echoFiletype
+```
+
+It should report `perl`.
+
 For a full coc-focused walkthrough, see
-[COC_NEOVIM_SETUP.md](./COC_NEOVIM_SETUP.md).
+[COC_NEOVIM_SETUP.md](./COC_NEOVIM_SETUP.md). The LSP configuration model also
+applies to Vim, but Neovim-specific keybindings or paths may differ.
+
+## Verify It Is Running
+
+1. Open a Perl file such as `lib/My/Module.pm`, `script/app.pl`, or `t/basic.t`.
+2. Run `:set filetype?` and confirm `filetype=perl`.
+3. Introduce a temporary syntax error.
+4. Confirm diagnostics appear.
+5. Try hover, definition lookup, or references lookup.
+6. Remove the syntax error after testing.
+
+Useful commands:
+
+```vim
+" vim-lsp
+:LspStatus
+:LspDocumentDiagnostics
+
+" coc.nvim
+:CocInfo
+:CocOpenLog
+:CocCommand workspace.showOutput
+```
 
 ## Troubleshooting
 
-- If Vim reports the server is not executable, run `:echo executable('perllsp')`
-  and fix your `PATH`.
-- If the server starts but no Perl features appear, confirm filetype detection:
-  `:set filetype?` should return `filetype=perl`.
-- If features are intermittent, check client logs:
-  - vim-lsp: `:LspStatus`
-  - coc.nvim: `:CocInfo`
+### Vim cannot find `perllsp`
+
+Check from Vim:
+
+```vim
+:echo executable('perllsp')
+```
+
+It should print `1`.
+
+Check from a shell:
+
+```bash
+command -v perllsp
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+On Windows PowerShell:
+
+```powershell
+where perllsp
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+If Vim was launched from a GUI, it may not inherit the same `PATH` as your
+terminal. Use an absolute path in the LSP config if needed.
+
+### Server starts but no Perl features appear
+
+Check the filetype:
+
+```vim
+:set filetype?
+```
+
+If it is empty or wrong, set it manually for the current buffer:
+
+```vim
+:setfiletype perl
+```
+
+Then add a persistent ftdetect rule for that file extension.
+
+### Diagnostics do not appear
+
+For `vim-lsp`:
+
+```vim
+:LspStatus
+:LspDocumentDiagnostics
+```
+
+For `coc.nvim`:
+
+```vim
+:CocInfo
+:CocOpenLog
+:CocCommand document.echoFiletype
+:CocCommand workspace.showOutput
+```
+
+Also verify outside Vim:
+
+```bash
+perllsp --check path/to/file.pl
+```

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -17,6 +17,7 @@ Verify the install before debugging editor settings:
 ```bash
 perllsp --version
 perllsp --health
+perllsp --info
 ```
 
 ## Pick Your Editor
@@ -26,7 +27,7 @@ perllsp --health
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
 | Trae (ByteDance) | install the VS Code-compatible extension or set command to `perllsp --stdio` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
-| Vim | use `vim-lsp` or `coc.nvim` with `perllsp --stdio` | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
+| Vim | use `vim-lsp` or `coc.nvim` with `perllsp --stdio`; Coc requires Vim 9 + Node.js | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Zed | install a Perl extension, then optionally point at `perllsp` | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
@@ -74,9 +75,25 @@ editor-specific guide has the full snippets for both.
 
 ### Vim
 
-Use either `vim-lsp` (native LSP in Vim) or `coc.nvim` (Node-based client),
-both configured to launch `perllsp --stdio`. See
-[docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) for complete examples.
+Use either `vim-lsp` or `coc.nvim`.
+
+For `vim-lsp`:
+
+```vim
+if executable('perllsp')
+  autocmd User lsp_setup call lsp#register_server({
+        \ 'name': 'perl-lsp',
+        \ 'cmd': {server_info -> ['perllsp', '--stdio']},
+        \ 'allowlist': ['perl'],
+        \ })
+endif
+```
+
+For `coc.nvim`, configure `languageserver.perl-lsp` in `coc-settings.json` with
+`"command": "perllsp"`, `"args": ["--stdio"]`, and `"filetypes": ["perl"]`.
+
+See [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) for root detection,
+buffer-local mappings, and troubleshooting.
 
 ### Helix
 

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -39,6 +39,48 @@ problem is usually in editor integration, workspace roots, or a stale cache.
 
 If the editor is using a helper extension or plugin, check its own logs too.
 
+
+
+### Vim does not start `perllsp`
+
+1. Confirm Vim can see the binary:
+
+   ```vim
+   :echo executable('perllsp')
+   ```
+
+2. Confirm the buffer filetype:
+
+   ```vim
+   :set filetype?
+   ```
+
+   It must be `perl`.
+
+3. For `vim-lsp`, inspect:
+
+   ```vim
+   :LspStatus
+   :LspDocumentDiagnostics
+   ```
+
+4. For `coc.nvim`, inspect:
+
+   ```vim
+   :CocInfo
+   :CocOpenLog
+   :CocCommand document.echoFiletype
+   :CocCommand workspace.showOutput
+   ```
+
+5. Check the server outside Vim:
+
+   ```bash
+   perllsp --health
+   perllsp --info
+   perllsp --check path/to/file.pl
+   ```
+
 ## Diagnostics Or Completions Are Missing
 
 - Re-check the install with `perllsp --health`.

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -845,6 +845,45 @@ require("lspconfig").perl_ls.setup({
 })
 ```
 
+#### Vim with vim-lsp
+
+```vim
+autocmd User lsp_setup call lsp#register_server({
+      \ 'name': 'perl-lsp',
+      \ 'cmd': {server_info -> ['perllsp', '--stdio']},
+      \ 'allowlist': ['perl'],
+      \ 'workspace_config': {
+      \   'perl': {
+      \     'workspace': {
+      \       'includePaths': ['lib', '.', 'local/lib/perl5']
+      \     }
+      \   }
+      \ },
+      \ })
+```
+
+#### Vim with coc.nvim
+
+```json
+{
+  "languageserver": {
+    "perl-lsp": {
+      "command": "perllsp",
+      "args": ["--stdio"],
+      "filetypes": ["perl"],
+      "rootPatterns": [".perl-lsp.toml", "Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"],
+      "settings": {
+        "perl": {
+          "workspace": {
+            "includePaths": ["lib", ".", "local/lib/perl5"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 #### Helix (`languages.toml`)
 
 ```toml


### PR DESCRIPTION
### Motivation

- Clarify and tighten the Vim editor documentation to avoid a copy/paste hazard that would place buffer-local `vim-lsp` mappings into the wrong buffer and to surface client-specific prerequisites for `vim-lsp` vs `coc.nvim`.
- Add canonical verification and troubleshooting steps so users can confirm `perllsp` and the editor are wired up (`--info`, client logs, filetype checks).
- Ensure project-wide conventions (root detection, `.perl-lsp.toml`, and example workspace settings) are represented consistently across editor docs and the central config reference.

### Description

- Expanded `docs/EDITORS/VIM_SETUP.md` to split client-specific prerequisites, add `perllsp --info`, provide a safe `vim-lsp` registration using `root_uri` detection, and move buffer-local mappings into a `User lsp_buffer_enabled` hook with `omnifunc` and `signcolumn` setup.
- Enhanced the `coc.nvim` example in `docs/EDITORS/VIM_SETUP.md` with `rootPatterns` and optional `settings` demonstrating workspace include paths.
- Updated `docs/how-to/EDITOR_SETUP.md` to add `perllsp --info` to the verify list and to call out `coc.nvim`'s newer requirements in the editor matrix and minimal Vim snippet.
- Added a Vim-specific troubleshooting subsection to `docs/how-to/TROUBLESHOOTING.md` with concrete `vim-lsp` and `coc.nvim` diagnostic commands, and added Vim examples to `docs/reference/CONFIG.md` for both `vim-lsp` and `coc.nvim`.

### Testing

- Ran `cargo check --all-targets -p perl-lsp-rs`, which completed successfully.
- Attempted to run the repository `just` verification (`just pr-fast`) but the `just` tool is not installed in this environment so that step could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe3c56fa88333844e91c6c136ba0a)