### PR TITLE
docs(trae): prioritize extension-first Trae setup and clarify manual perllsp fallbacks (#0000)

### DIFF
--- a/docs/EDITORS/TRAE_SETUP.md
+++ b/docs/EDITORS/TRAE_SETUP.md
@@ -1,57 +1,173 @@
-# Trae (ByteDance) Setup Guide for perl-lsp
+# Trae Setup Guide for perl-lsp
 
-Trae is compatible with the VS Code extension ecosystem, so perl-lsp setup is
-nearly identical to VS Code.
+Trae can use VS Code-compatible extensions, so the recommended setup is the
+same extension-based path used for VS Code.
 
 ## Prerequisites
 
-- `perllsp` available on your `PATH`
 - Trae installed
+- A Perl project opened in Trae
+- The `EffortlessMetrics.perl-lsp-rs` extension installed
 
-Verify the server before configuring the editor:
+The extension can auto-download the matching `perllsp` server binary on first
+activation. Install `perllsp` manually only for offline environments, pinned
+deployments, or when `perl-lsp.autoDownload` is disabled.
+
+## Option 1: Install the perl-lsp extension
+
+Install the official Perl LSP extension:
+
+```text
+EffortlessMetrics.perl-lsp-rs
+```
+
+Try Trae's Extensions panel first. Search for `perl-lsp` or
+`EffortlessMetrics.perl-lsp-rs`.
+
+If it is not available in Trae's Extension Store, download the VSIX from the VS
+Code Marketplace or Open VSX and install it through Trae's Extensions panel.
+
+Trae is VS Code-extension compatible, but some extensions can require VS Code
+APIs newer than the Trae build supports. If installation fails with an engine
+or API compatibility error, try a newer Trae build or an earlier extension
+version.
+
+After installation, open a Perl file such as `lib/My/Module.pm`, `script/app.pl`,
+or `t/basic.t`. The extension should activate for Perl files automatically.
+
+## Optional: Manual `perllsp` installation
+
+Manual installation is useful when:
+
+- extension-managed binary download is blocked by network/proxy policy
+- your team pins a specific `perllsp` binary
+- you use a generic LSP client extension instead of the official extension
+
+Verify the binary:
 
 ```bash
 perllsp --version
 perllsp --health
+perllsp --info
 ```
 
-## Option 1: Install the perl-lsp extension (recommended)
+Then point the extension at it:
 
-Trae supports extensions from its built-in Extension Store and the VS Code
-Marketplace. Install the Perl LSP extension:
+```json
+{
+  "perl-lsp.serverPath": "/absolute/path/to/perllsp",
+  "perl-lsp.autoDownload": false
+}
+```
 
-- Extension ID: `EffortlessMetrics.perl-lsp-rs`
+On macOS/Linux, find the path with:
 
-Search for `perl-lsp` in Trae's Extensions panel, or install via the command
-palette. Then open Trae settings and confirm the extension is enabled for Perl
-files.
+```bash
+command -v perllsp
+```
 
-## Option 2: Generic LSP client configuration
+On Windows PowerShell:
 
-If extension marketplace access is unavailable, configure a generic language
-server entry:
+```powershell
+where perllsp
+```
 
-- **Command**: `perllsp`
-- **Arguments**: `--stdio`
-- **Filetypes / language IDs**: `perl`, `pl`, `pm`, `t`
+## Option 2: Generic LSP client extension
 
-## Recommended settings
+Use this only if the official `EffortlessMetrics.perl-lsp-rs` extension is not
+available.
 
-- Open the project root as your workspace folder (not a nested subdirectory)
-- Keep `perl-lsp.trace.server` at `messages` while debugging setup
-- Put team-shared behavior in `.perl-lsp.toml` at repo root
+Trae does not provide a documented bare settings-only way to register arbitrary
+language servers. Install a generic LSP client extension first, then configure
+that extension to launch `perllsp --stdio`.
+
+For example, with a generic client that uses `lsp_generic_client` settings:
+
+```json
+{
+  "lsp_generic_client": {
+    "servers": {
+      "perl-lsp": {
+        "name": "Perl LSP",
+        "path": "perllsp",
+        "args": ["--stdio"],
+        "documentSelector": ["perl"]
+      }
+    }
+  }
+}
+```
+
+The exact setting names depend on the generic LSP client extension. Use the
+language ID `perl`; file extensions such as `.pl`, `.pm`, and `.t` are handled
+by Trae's language/file association layer or by the installed Perl extension.
+
+## Verify it is running
+
+1. Open the project root as the Trae workspace.
+2. Open a Perl file such as `.pl`, `.pm`, or `.t`.
+3. Confirm the active document language is Perl.
+4. Introduce a temporary syntax error.
+5. Confirm diagnostics appear.
+6. Remove the syntax error after testing.
+
+Try standard editor actions:
+
+- Go to Definition
+- Find References
+- Hover
+- Rename Symbol
+- Format Document
 
 ## Troubleshooting
 
-1. If Trae reports "server not found", run `perllsp --version` in a shell
-   started the same way you launch Trae.
-2. If diagnostics/completion do not appear, verify the active document language
-   is Perl and check the LSP output/log panel.
-3. If modules are unresolved, add include paths in `.perl-lsp.toml` (`include_paths`)
-   or extension settings (`perl-lsp.includePaths`).
+### Server not found
 
-See also:
+If using the official extension, first check whether auto-download is enabled:
+
+```json
+{
+  "perl-lsp.autoDownload": true
+}
+```
+
+If using a manual binary:
+
+```bash
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+If Trae was launched from a GUI, it may not inherit the same `PATH` as your
+terminal. Use an absolute `perl-lsp.serverPath` when needed.
+
+### No diagnostics or completion
+
+- Confirm the active document language is Perl.
+- Confirm the workspace root is the project root, not a nested subdirectory.
+- Check the Perl LSP output/log panel.
+- Temporarily enable protocol tracing:
+
+  ```json
+  {
+    "perl-lsp.trace.server": "messages"
+  }
+  ```
+
+### `perllsp --stdio` appears to hang
+
+That is expected. In stdio mode, `perllsp` waits for framed LSP JSON-RPC input
+from the editor. Use these commands for manual checks instead:
+
+```bash
+perllsp --health
+perllsp --info
+perllsp --check path/to/file.pl
+```
+
+## See also
 
 - [Editor Setup](../how-to/EDITOR_SETUP.md)
-- [Configuration](../reference/CONFIGURATION.md)
+- [Configuration](../reference/CONFIG.md)
 - [Troubleshooting](../how-to/TROUBLESHOOTING.md)

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -24,7 +24,7 @@ perllsp --health
 | Editor | Fast path | Detailed guide |
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
-| Trae (ByteDance) | install the VS Code-compatible extension or set command to `perllsp --stdio` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
+| Trae (ByteDance) | install the VS Code-compatible `EffortlessMetrics.perl-lsp-rs` extension; use `perl-lsp.serverPath` only for manual or offline `perllsp` deployments | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Vim | use `vim-lsp` or `coc.nvim` with `perllsp --stdio` | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
@@ -47,9 +47,25 @@ root pointed at the project root.
 
 ### Trae (ByteDance)
 
-Trae is VS Code-compatible, so the same extension and settings model applies.
-Install the `EffortlessMetrics.perl-lsp-rs` extension from Trae's Extensions
-panel, or configure a generic language server command as `perllsp --stdio`.
+Trae can install VS Code-compatible extensions, so use the official extension
+path first:
+
+```text
+EffortlessMetrics.perl-lsp-rs
+```
+
+The extension can auto-download `perllsp`. For offline or pinned deployments,
+install `perllsp` manually and set:
+
+```json
+{
+  "perl-lsp.serverPath": "/absolute/path/to/perllsp",
+  "perl-lsp.autoDownload": false
+}
+```
+
+If the official extension is unavailable, install a generic LSP client
+extension first, then configure that extension to launch `perllsp --stdio`.
 
 ### Neovim
 

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -66,6 +66,25 @@ If the editor is using a helper extension or plugin, check its own logs too.
 - Check whether the current file actually has a Perl mode or file type.
 - Inspect the LSP log for capability negotiation or request errors.
 
+## Trae does not start `perllsp`
+
+1. Confirm the `EffortlessMetrics.perl-lsp-rs` extension is installed and
+   enabled.
+2. Confirm the active document language is Perl.
+3. If using extension-managed downloads, confirm `perl-lsp.autoDownload` is
+   `true`.
+4. If using a manual binary, run:
+
+   ```bash
+   perllsp --version
+   perllsp --health
+   perllsp --info
+   ```
+
+5. If Trae cannot find the binary, use an absolute `perl-lsp.serverPath`.
+6. Check the Perl LSP output/log panel and temporarily set
+   `perl-lsp.trace.server` to `messages`.
+
 ## DAP Or Debugging Issues
 
 If you are debugging with `perl-dap`, check the DAP guide:

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -615,7 +615,7 @@ behaviour such as binary management and feature toggles.
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
-| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perl-lsp` binary. Empty = auto-download. |
+| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perllsp` binary. Empty = auto-download. |
 | `perl-lsp.autoDownload` | `boolean` | `true` | Download the binary automatically if not found locally. |
 | `perl-lsp.downloadBaseUrl` | `string` | `""` | Override the GitHub releases base URL for internal mirrors. |
 | `perl-lsp.channel` | `"latest"\|"stable"\|"tag"` | `"latest"` | Release channel to track. |
@@ -646,6 +646,21 @@ behaviour such as binary management and feature toggles.
 | `perl-lsp.includePaths` | `string[]` | `["lib", "local/lib/perl5"]` | Additional module search paths (merged with server-side `perl.workspace.includePaths`). |
 | `perl-lsp.perltidyConfig` | `string` | `""` | Path to a `.perltidyrc` configuration file. Empty = use Perl::Tidy defaults. |
 | `perl-lsp.featureProfile` | `string` | `"auto"` | Feature profile passed to the server at startup (see [Feature Profiles](#feature-profiles)). |
+
+### Trae
+
+Trae can use VS Code-compatible extensions. Prefer the official
+`EffortlessMetrics.perl-lsp-rs` extension. For manual binary management, set:
+
+```json
+{
+  "perl-lsp.serverPath": "/absolute/path/to/perllsp",
+  "perl-lsp.autoDownload": false
+}
+```
+
+If using a generic LSP client extension instead, configure that extension to
+launch `perllsp --stdio`.
 
 ---
 


### PR DESCRIPTION
### Motivation

- The Trae editor guide incorrectly made manual `perllsp` installation a default prerequisite instead of an offline/fallback path and used a broken config link.  
- The generic-LSP guidance was ambiguous for Trae because Trae requires a generic LSP client extension to register arbitrary language servers.  
- The docs should document the extension auto-download behavior, VSIX fallback, and add `--info` to the recommended verification commands.

### Description

- Rewrote `docs/EDITORS/TRAE_SETUP.md` to prioritize the `EffortlessMetrics.perl-lsp-rs` extension, document auto-download of `perllsp`, VSIX fallback, add compatibility caveats, provide an explicit generic-LSP-client example, and add `perllsp --info`.  
- Updated `docs/how-to/EDITOR_SETUP.md` to change the Trae row to an extension-first recommendation and expanded the Trae minimal-setup section to show `perl-lsp.serverPath` as a manual/offline fallback.  
- Added a Trae-specific troubleshooting subsection to `docs/how-to/TROUBLESHOOTING.md` that lists extension checks, auto-download verification, `perllsp --version|--health|--info`, and absolute `perl-lsp.serverPath` guidance.  
- Fixed wording in `docs/reference/CONFIG.md` to refer to the `perllsp` binary (not `perl-lsp`) and added a Trae note under VS Code-compatible extension settings explaining the extension-first and generic-client fallback options.

### Testing

- Ran `cargo xtask fmt` and the formatter completed successfully.  
- Ran `git diff --check` and `git status --short` to verify no whitespace/merge issues and to confirm the intended files were staged for commit.  
- Changes were committed as `docs(trae): clarify extension-first setup and fallbacks (#0000)` and a PR body was generated; no crate unit tests were modified or run as part of this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe7cc9df48333860761b158315179)