### PR TITLE
docs(trae): prioritize extension-first setup guidance (#0000)

### DIFF
--- a/docs/EDITORS/TRAE_SETUP.md
+++ b/docs/EDITORS/TRAE_SETUP.md
@@ -1,57 +1,228 @@
-# Trae (ByteDance) Setup Guide for perl-lsp
+# Trae Setup Guide for perl-lsp
 
-Trae is compatible with the VS Code extension ecosystem, so perl-lsp setup is
-nearly identical to VS Code.
+Trae can use VS Code-compatible extensions, so the recommended setup mirrors the
+VS Code extension flow.
 
 ## Prerequisites
 
-- `perllsp` available on your `PATH`
 - Trae installed
+- A Perl project opened in Trae
+- The `EffortlessMetrics.perl-lsp-rs` extension installed
 
-Verify the server before configuring the editor:
+The extension can auto-download a matching `perllsp` binary on first
+activation. Install `perllsp` manually only for offline environments, pinned
+binary deployments, or when `perl-lsp.autoDownload` is disabled.
+
+## Option 1: Install the perl-lsp extension (recommended)
+
+Install the official extension:
+
+```text
+EffortlessMetrics.perl-lsp-rs
+```
+
+Try Trae's Extensions panel first. Search for `perl-lsp` or
+`EffortlessMetrics.perl-lsp-rs`.
+
+If the extension is not available in Trae's Extension Store, download the VSIX
+from the VS Code Marketplace or Open VSX, then install it through Trae's
+Extensions panel.
+
+After installation, open a Perl file such as `lib/My/Module.pm`,
+`script/app.pl`, or `t/basic.t`. The extension should auto-activate for Perl
+files.
+
+## Optional: Manual `perllsp` installation
+
+Manual installation is useful when:
+
+- extension-managed downloads are blocked by network or proxy policy
+- your team pins a specific `perllsp` binary
+- you use a generic LSP client extension instead of the official extension
+
+Verify the binary:
 
 ```bash
 perllsp --version
 perllsp --health
+perllsp --info
 ```
 
-## Option 1: Install the perl-lsp extension (recommended)
+Then point the extension at it:
 
-Trae supports extensions from its built-in Extension Store and the VS Code
-Marketplace. Install the Perl LSP extension:
+```json
+{
+  "perl-lsp.serverPath": "/absolute/path/to/perllsp",
+  "perl-lsp.autoDownload": false
+}
+```
 
-- Extension ID: `EffortlessMetrics.perl-lsp-rs`
+On macOS/Linux, find the path with:
 
-Search for `perl-lsp` in Trae's Extensions panel, or install via the command
-palette. Then open Trae settings and confirm the extension is enabled for Perl
-files.
+```bash
+command -v perllsp
+```
 
-## Option 2: Generic LSP client configuration
+On Windows PowerShell:
 
-If extension marketplace access is unavailable, configure a generic language
-server entry:
-
-- **Command**: `perllsp`
-- **Arguments**: `--stdio`
-- **Filetypes / language IDs**: `perl`, `pl`, `pm`, `t`
+```powershell
+where perllsp
+```
 
 ## Recommended settings
 
-- Open the project root as your workspace folder (not a nested subdirectory)
-- Keep `perl-lsp.trace.server` at `messages` while debugging setup
-- Put team-shared behavior in `.perl-lsp.toml` at repo root
+For most users:
+
+```json
+{
+  "perl-lsp.autoDownload": true,
+  "perl-lsp.trace.server": "off",
+  "perl-lsp.enableDiagnostics": true,
+  "perl-lsp.enableSemanticTokens": true,
+  "perl-lsp.enableFormatting": true,
+  "perl-lsp.formatOnSave": false,
+  "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5"]
+}
+```
+
+Use trace logging only while debugging:
+
+```json
+{
+  "perl-lsp.trace.server": "messages"
+}
+```
+
+For team-shared project behavior, prefer `.perl-lsp.toml` at repo root:
+
+```toml
+[perl]
+include_paths = ["lib", "local/lib/perl5", "vendor/lib"]
+
+[features]
+inlay_hints = true
+```
+
+## Option 2: Generic LSP client extension
+
+Use this only if the official `EffortlessMetrics.perl-lsp-rs` extension is
+unavailable.
+
+Trae does not document a bare settings-only method to register arbitrary
+language servers. Install a generic LSP client extension first, then configure
+that extension to launch:
+
+```text
+perllsp --stdio
+```
+
+Example for a generic client extension that uses `lsp_generic_client` settings:
+
+```json
+{
+  "lsp_generic_client": {
+    "servers": {
+      "perl-lsp": {
+        "name": "Perl LSP",
+        "path": "perllsp",
+        "args": ["--stdio"],
+        "documentSelector": ["perl"]
+      }
+    }
+  }
+}
+```
+
+Exact setting keys depend on the generic client extension you choose. Use the
+language ID `perl`; file extensions like `.pl`, `.pm`, and `.t` are handled by
+file associations and language detection.
+
+## Verify it is running
+
+1. Open the project root as the Trae workspace.
+2. Open a Perl file such as `.pl`, `.pm`, or `.t`.
+3. Confirm the active document language is Perl.
+4. Introduce a temporary syntax error.
+5. Confirm diagnostics appear.
+6. Remove the syntax error after testing.
+
+Try editor actions such as Go to Definition, Find References, Hover, Rename
+Symbol, and Format Document.
 
 ## Troubleshooting
 
-1. If Trae reports "server not found", run `perllsp --version` in a shell
-   started the same way you launch Trae.
-2. If diagnostics/completion do not appear, verify the active document language
-   is Perl and check the LSP output/log panel.
-3. If modules are unresolved, add include paths in `.perl-lsp.toml` (`include_paths`)
-   or extension settings (`perl-lsp.includePaths`).
+### Extension does not install
 
-See also:
+- Update Trae to a current build.
+- If Trae reports an engine or API compatibility error, use a newer Trae build
+  or an earlier extension version.
+- If Marketplace search does not show the extension, install from a downloaded
+  `.vsix`.
+
+### Server not found
+
+If using the official extension, check auto-download first:
+
+```json
+{
+  "perl-lsp.autoDownload": true
+}
+```
+
+If using a manual binary:
+
+```bash
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+If Trae was launched from a GUI, it may not inherit the same `PATH` as your
+terminal. Use an absolute `perl-lsp.serverPath` when needed.
+
+### No diagnostics or completion
+
+- Confirm the active document language is Perl.
+- Confirm the workspace root is the project root, not a nested subdirectory.
+- Check the Perl LSP output/log panel.
+- Temporarily enable protocol tracing:
+
+  ```json
+  {
+    "perl-lsp.trace.server": "messages"
+  }
+  ```
+
+### Module resolution issues
+
+Prefer `.perl-lsp.toml` for shared include paths:
+
+```toml
+[perl]
+include_paths = ["lib", "local/lib/perl5", "vendor/lib"]
+```
+
+Or use editor settings for personal overrides:
+
+```json
+{
+  "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5", "vendor/lib"]
+}
+```
+
+### `perllsp --stdio` appears to hang
+
+That is expected. In stdio mode, `perllsp` waits for framed LSP JSON-RPC input
+from the editor. Use these commands for manual checks instead:
+
+```bash
+perllsp --health
+perllsp --info
+perllsp --check path/to/file.pl
+```
+
+## See also
 
 - [Editor Setup](../how-to/EDITOR_SETUP.md)
-- [Configuration](../reference/CONFIGURATION.md)
+- [Configuration](../reference/CONFIG.md)
 - [Troubleshooting](../how-to/TROUBLESHOOTING.md)

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -24,7 +24,7 @@ perllsp --health
 | Editor | Fast path | Detailed guide |
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
-| Trae (ByteDance) | install the VS Code-compatible extension or set command to `perllsp --stdio` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
+| Trae (ByteDance) | install `EffortlessMetrics.perl-lsp-rs`; use `perl-lsp.serverPath` for manual or offline `perllsp` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Vim | use `vim-lsp` or `coc.nvim` with `perllsp --stdio` | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
@@ -47,9 +47,19 @@ root pointed at the project root.
 
 ### Trae (ByteDance)
 
-Trae is VS Code-compatible, so the same extension and settings model applies.
-Install the `EffortlessMetrics.perl-lsp-rs` extension from Trae's Extensions
-panel, or configure a generic language server command as `perllsp --stdio`.
+Trae can install VS Code-compatible extensions, so use the official extension
+path first:
+
+```text
+EffortlessMetrics.perl-lsp-rs
+```
+
+The extension can auto-download `perllsp`. For offline or pinned deployments,
+install `perllsp` manually and set `perl-lsp.serverPath` with
+`perl-lsp.autoDownload` set to `false`.
+
+If the official extension is unavailable, install a generic LSP client
+extension first, then configure that extension to launch `perllsp --stdio`.
 
 ### Neovim
 

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -71,6 +71,25 @@ If the editor is using a helper extension or plugin, check its own logs too.
 If you are debugging with `perl-dap`, check the DAP guide:
 [DAP_USER_GUIDE.md](../tutorials/DAP_USER_GUIDE.md).
 
+## Trae Does Not Start `perllsp`
+
+1. Confirm the `EffortlessMetrics.perl-lsp-rs` extension is installed and
+   enabled.
+2. Confirm the active document language is Perl.
+3. If using extension-managed downloads, confirm `perl-lsp.autoDownload` is
+   `true`.
+4. If using a manual binary, run:
+
+   ```bash
+   perllsp --version
+   perllsp --health
+   perllsp --info
+   ```
+
+5. If Trae cannot find the binary, set an absolute `perl-lsp.serverPath`.
+6. Check the Perl LSP output/log panel and temporarily set
+   `perl-lsp.trace.server` to `messages`.
+
 ## When To Escalate
 
 Report an issue when you can include:

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -615,7 +615,7 @@ behaviour such as binary management and feature toggles.
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
-| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perl-lsp` binary. Empty = auto-download. |
+| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perllsp` binary. Empty = auto-download. |
 | `perl-lsp.autoDownload` | `boolean` | `true` | Download the binary automatically if not found locally. |
 | `perl-lsp.downloadBaseUrl` | `string` | `""` | Override the GitHub releases base URL for internal mirrors. |
 | `perl-lsp.channel` | `"latest"\|"stable"\|"tag"` | `"latest"` | Release channel to track. |
@@ -646,6 +646,25 @@ behaviour such as binary management and feature toggles.
 | `perl-lsp.includePaths` | `string[]` | `["lib", "local/lib/perl5"]` | Additional module search paths (merged with server-side `perl.workspace.includePaths`). |
 | `perl-lsp.perltidyConfig` | `string` | `""` | Path to a `.perltidyrc` configuration file. Empty = use Perl::Tidy defaults. |
 | `perl-lsp.featureProfile` | `string` | `"auto"` | Feature profile passed to the server at startup (see [Feature Profiles](#feature-profiles)). |
+
+---
+
+
+#### Trae
+
+Trae is VS Code-extension compatible. Prefer the official
+`EffortlessMetrics.perl-lsp-rs` extension in Trae, then use these settings as
+needed:
+
+```json
+{
+  "perl-lsp.serverPath": "/absolute/path/to/perllsp",
+  "perl-lsp.autoDownload": false
+}
+```
+
+If using a generic LSP client extension instead, configure that extension to
+launch `perllsp --stdio`.
 
 ---
 


### PR DESCRIPTION
### Motivation

- The Trae setup guide implied `perllsp` must be preinstalled and provided an imprecise generic-LSP path, which is misleading for Trae/VS Code extension usage.  
- Make the official extension auto-download flow the primary path and document manual binary installation as an offline/pinned/fallback option.  
- Clarify that generic LSP registration requires a generic LSP client extension and that language IDs (e.g. `perl`) should be used instead of file extensions.  
- Fix a broken config link and correct wording that referenced the executable as `perl-lsp` instead of `perllsp`.

### Description

- Rewrote `docs/EDITORS/TRAE_SETUP.md` to prefer the `EffortlessMetrics.perl-lsp-rs` extension, document VSIX fallback, move manual `perllsp` install to an Optional section, add `perllsp --info`, and note `--stdio` will wait for LSP input.  
- Updated `docs/how-to/EDITOR_SETUP.md` to reflect the extension-first flow for Trae and to show `perl-lsp.serverPath` as the manual/offline override.  
- Updated `docs/reference/CONFIG.md` to correct the binary name to `perllsp` and to add a Trae note showing the manual `perl-lsp.serverPath`/`perl-lsp.autoDownload` settings and generic-client guidance.  
- Added a Trae-specific troubleshooting subsection in `docs/how-to/TROUBLESHOOTING.md` covering extension state, auto-download checks, manual binary verification (`--version`, `--health`, `--info`), `serverPath`, and trace logging.

### Testing

- Ran `cargo xtask fmt` to format docs and xtask outputs, and it completed successfully.  
- No code changes or unit tests were modified; this PR only updates documentation files.  
- Commit created and PR opened with title `docs(trae): prioritize extension-first setup guidance (#0000)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe7cc9df48333860761b158315179)