### PR TITLE
docs(trae): align setup with extension-first flow (#0000)

### DIFF
--- a/docs/EDITORS/TRAE_SETUP.md
+++ b/docs/EDITORS/TRAE_SETUP.md
@@ -1,57 +1,234 @@
-# Trae (ByteDance) Setup Guide for perl-lsp
+# Trae Setup Guide for perl-lsp
 
-Trae is compatible with the VS Code extension ecosystem, so perl-lsp setup is
-nearly identical to VS Code.
+Trae can use VS Code-compatible extensions, so the recommended setup is the
+same extension-based path used for VS Code.
 
 ## Prerequisites
 
-- `perllsp` available on your `PATH`
 - Trae installed
+- A Perl project opened in Trae
+- The `EffortlessMetrics.perl-lsp-rs` extension installed
 
-Verify the server before configuring the editor:
+The extension can auto-download the matching `perllsp` server binary on first
+activation. Install `perllsp` manually only for offline environments, pinned
+deployments, or when `perl-lsp.autoDownload` is disabled.
+
+## Option 1: Install the perl-lsp Extension
+
+Install the official Perl LSP extension:
+
+```text
+EffortlessMetrics.perl-lsp-rs
+```
+
+Try Trae's Extensions panel first. Search for `perl-lsp` or
+`EffortlessMetrics.perl-lsp-rs`.
+
+If it is not available in Trae's Extension Store, download the VSIX from the VS
+Code Marketplace or Open VSX and install it through Trae's Extensions panel.
+
+After installation, open a Perl file such as `lib/My/Module.pm`, `script/app.pl`,
+or `t/basic.t`. The extension should activate for Perl files automatically.
+
+## Optional: Manual `perllsp` Installation
+
+Manual installation is useful when:
+
+- extension-managed binary download is blocked by network/proxy policy
+- your team pins a specific `perllsp` binary
+- you use a generic LSP client extension instead of the official extension
+
+Verify the binary:
 
 ```bash
 perllsp --version
 perllsp --health
+perllsp --info
 ```
 
-## Option 1: Install the perl-lsp extension (recommended)
+Then point the extension at it:
 
-Trae supports extensions from its built-in Extension Store and the VS Code
-Marketplace. Install the Perl LSP extension:
+```json
+{
+  "perl-lsp.serverPath": "/absolute/path/to/perllsp",
+  "perl-lsp.autoDownload": false
+}
+```
 
-- Extension ID: `EffortlessMetrics.perl-lsp-rs`
+On macOS/Linux, find the path with:
 
-Search for `perl-lsp` in Trae's Extensions panel, or install via the command
-palette. Then open Trae settings and confirm the extension is enabled for Perl
-files.
+```bash
+command -v perllsp
+```
 
-## Option 2: Generic LSP client configuration
+On Windows PowerShell:
 
-If extension marketplace access is unavailable, configure a generic language
-server entry:
+```powershell
+where perllsp
+```
 
-- **Command**: `perllsp`
-- **Arguments**: `--stdio`
-- **Filetypes / language IDs**: `perl`, `pl`, `pm`, `t`
+## Option 2: Generic LSP Client Extension
 
-## Recommended settings
+Use this only if the official extension is unavailable.
 
-- Open the project root as your workspace folder (not a nested subdirectory)
-- Keep `perl-lsp.trace.server` at `messages` while debugging setup
-- Put team-shared behavior in `.perl-lsp.toml` at repo root
+Trae does not provide a documented bare settings-only way to register arbitrary
+language servers. Install a generic LSP client extension first, then configure
+that extension to launch:
+
+```text
+perllsp --stdio
+```
+
+For example, with a generic client that uses `lsp_generic_client` settings:
+
+```json
+{
+  "lsp_generic_client": {
+    "servers": {
+      "perl-lsp": {
+        "name": "Perl LSP",
+        "path": "perllsp",
+        "args": ["--stdio"],
+        "documentSelector": ["perl"]
+      }
+    }
+  }
+}
+```
+
+The exact setting names depend on the generic LSP client extension. Use the
+language ID `perl`; file extensions such as `.pl`, `.pm`, and `.t` are handled
+by Trae's language/file association layer or by the installed Perl extension.
+
+## Recommended Settings
+
+For most users:
+
+```json
+{
+  "perl-lsp.autoDownload": true,
+  "perl-lsp.trace.server": "off",
+  "perl-lsp.enableDiagnostics": true,
+  "perl-lsp.enableSemanticTokens": true,
+  "perl-lsp.enableFormatting": true,
+  "perl-lsp.formatOnSave": false,
+  "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5"]
+}
+```
+
+Use trace logging only while debugging:
+
+```json
+{
+  "perl-lsp.trace.server": "messages"
+}
+```
+
+For team-shared project behavior, prefer `.perl-lsp.toml` at the repository
+root:
+
+```toml
+[perl]
+include_paths = ["lib", "local/lib/perl5", "vendor/lib"]
+
+[features]
+inlay_hints = true
+```
+
+## Verify It Is Running
+
+1. Open the project root as the Trae workspace.
+2. Open a Perl file such as `.pl`, `.pm`, or `.t`.
+3. Confirm the active document language is Perl.
+4. Introduce a temporary syntax error.
+5. Confirm diagnostics appear.
+6. Remove the syntax error after testing.
+
+Try standard editor actions:
+
+- Go to Definition
+- Find References
+- Hover
+- Rename Symbol
+- Format Document
+
+Available features depend on the installed extension, the active `perllsp`
+binary, and the current file's language mode.
 
 ## Troubleshooting
 
-1. If Trae reports "server not found", run `perllsp --version` in a shell
-   started the same way you launch Trae.
-2. If diagnostics/completion do not appear, verify the active document language
-   is Perl and check the LSP output/log panel.
-3. If modules are unresolved, add include paths in `.perl-lsp.toml` (`include_paths`)
-   or extension settings (`perl-lsp.includePaths`).
+### Extension does not install
 
-See also:
+- Update Trae to a current build.
+- If Trae reports an engine or API compatibility error, try a newer Trae build
+  or an earlier extension version.
+- If Marketplace search does not show the extension, install from a downloaded
+  `.vsix`.
+
+### Server not found
+
+If using the official extension, first check whether auto-download is enabled:
+
+```json
+{
+  "perl-lsp.autoDownload": true
+}
+```
+
+If using a manual binary:
+
+```bash
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+If Trae was launched from a GUI, it may not inherit the same `PATH` as your
+terminal. Use an absolute `perl-lsp.serverPath` when needed.
+
+### No diagnostics or completion
+
+- Confirm the active document language is Perl.
+- Confirm the workspace root is the project root, not a nested subdirectory.
+- Check the Perl LSP output/log panel.
+- Temporarily enable protocol tracing:
+
+  ```json
+  {
+    "perl-lsp.trace.server": "messages"
+  }
+  ```
+
+### Module resolution issues
+
+Prefer `.perl-lsp.toml` for shared include paths:
+
+```toml
+[perl]
+include_paths = ["lib", "local/lib/perl5", "vendor/lib"]
+```
+
+Or use editor settings for a personal/workspace override:
+
+```json
+{
+  "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5", "vendor/lib"]
+}
+```
+
+### `perllsp --stdio` appears to hang
+
+That is expected. In stdio mode, `perllsp` waits for framed LSP JSON-RPC input
+from the editor. Use these commands for manual checks instead:
+
+```bash
+perllsp --health
+perllsp --info
+perllsp --check path/to/file.pl
+```
+
+## See Also
 
 - [Editor Setup](../how-to/EDITOR_SETUP.md)
-- [Configuration](../reference/CONFIGURATION.md)
+- [Configuration](../reference/CONFIG.md)
 - [Troubleshooting](../how-to/TROUBLESHOOTING.md)

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -24,7 +24,7 @@ perllsp --health
 | Editor | Fast path | Detailed guide |
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
-| Trae (ByteDance) | install the VS Code-compatible extension or set command to `perllsp --stdio` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
+| Trae | install the VS Code-compatible `EffortlessMetrics.perl-lsp-rs` extension; use `perl-lsp.serverPath` only for manual or offline `perllsp` deployments | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Vim | use `vim-lsp` or `coc.nvim` with `perllsp --stdio` | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
@@ -45,11 +45,27 @@ The repo-maintained extension is the easiest route. If you prefer a manual
 configuration, set the command to `perllsp --stdio` and keep the workspace
 root pointed at the project root.
 
-### Trae (ByteDance)
+### Trae
 
-Trae is VS Code-compatible, so the same extension and settings model applies.
-Install the `EffortlessMetrics.perl-lsp-rs` extension from Trae's Extensions
-panel, or configure a generic language server command as `perllsp --stdio`.
+Trae can install VS Code-compatible extensions, so use the official extension
+path first:
+
+```text
+EffortlessMetrics.perl-lsp-rs
+```
+
+The extension can auto-download `perllsp`. For offline or pinned deployments,
+install `perllsp` manually and set:
+
+```json
+{
+  "perl-lsp.serverPath": "/absolute/path/to/perllsp",
+  "perl-lsp.autoDownload": false
+}
+```
+
+If the official extension is unavailable, install a generic LSP client extension
+first, then configure that extension to launch `perllsp --stdio`.
 
 ### Neovim
 

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -71,6 +71,25 @@ If the editor is using a helper extension or plugin, check its own logs too.
 If you are debugging with `perl-dap`, check the DAP guide:
 [DAP_USER_GUIDE.md](../tutorials/DAP_USER_GUIDE.md).
 
+## Trae does not start `perllsp`
+
+1. Confirm the `EffortlessMetrics.perl-lsp-rs` extension is installed and
+   enabled.
+2. Confirm the active document language is Perl.
+3. If using extension-managed downloads, confirm `perl-lsp.autoDownload` is
+   `true`.
+4. If using a manual binary, run:
+
+   ```bash
+   perllsp --version
+   perllsp --health
+   perllsp --info
+   ```
+
+5. If Trae cannot find the binary, use an absolute `perl-lsp.serverPath`.
+6. Check the Perl LSP output/log panel and temporarily set
+   `perl-lsp.trace.server` to `messages`.
+
 ## When To Escalate
 
 Report an issue when you can include:

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -615,11 +615,26 @@ behaviour such as binary management and feature toggles.
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
-| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perl-lsp` binary. Empty = auto-download. |
+| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perllsp` binary. Empty = auto-download. |
 | `perl-lsp.autoDownload` | `boolean` | `true` | Download the binary automatically if not found locally. |
 | `perl-lsp.downloadBaseUrl` | `string` | `""` | Override the GitHub releases base URL for internal mirrors. |
 | `perl-lsp.channel` | `"latest"\|"stable"\|"tag"` | `"latest"` | Release channel to track. |
 | `perl-lsp.versionTag` | `string` | `""` | Specific release tag (e.g., `v0.8.3`) when `channel` is `"tag"`. |
+
+### Trae
+
+Trae can use VS Code-compatible extensions. Prefer the official
+`EffortlessMetrics.perl-lsp-rs` extension. For manual binary management, set:
+
+```json
+{
+  "perl-lsp.serverPath": "/absolute/path/to/perllsp",
+  "perl-lsp.autoDownload": false
+}
+```
+
+If using a generic LSP client extension instead, configure that extension to
+launch `perllsp --stdio`.
 
 ### Debugging
 


### PR DESCRIPTION
### Motivation

- The existing Trae setup guide required `perllsp` on `PATH` by default which is incorrect for VS Code-compatible extensions that can auto-download the server. 
- The generic LSP client instructions were too vague for Trae and risked suggesting a bare settings-only registration path that Trae does not document. 
- The docs referenced the wrong configuration document and used inconsistent binary naming, causing potential user confusion.

### Description

- Rewrote `docs/EDITORS/TRAE_SETUP.md` to follow an extension-first flow and made manual `perllsp` installation an explicit optional/pinned/offline fallback while adding `perllsp --info` to the verification steps. 
- Updated `docs/how-to/EDITOR_SETUP.md` to change the editor matrix entry for Trae to recommend `EffortlessMetrics.perl-lsp-rs` as the primary install path and to show `perl-lsp.serverPath` as the manual fallback. 
- Updated `docs/reference/CONFIG.md` to use the correct executable name (`perllsp`), added a Trae-specific note under VS Code-compatible settings, and inserted the Trae manual-binary snippet and generic-client guidance. 
- Added a Trae-specific troubleshooting subsection to `docs/how-to/TROUBLESHOOTING.md` that checks extension state, language ID, auto-download, manual-binary validation, and tracing guidance, and clarified that a generic LSP approach requires installing a generic LSP client extension and using the `perl` language ID.

### Testing

- Ran `cargo check -p perl-lsp-rs --all-targets` which completed successfully. 
- Attempted the repository fast gate `just pr-fast` but it could not run in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe7cc9df48333860761b158315179)