### PR TITLE
docs(sublime): modernize setup and config guidance (#0000)

### DIFF
--- a/docs/EDITORS/SUBLIME_SETUP.md
+++ b/docs/EDITORS/SUBLIME_SETUP.md
@@ -107,6 +107,10 @@ The key is `initialization_options` in Sublime LSP settings. The server-side LSP
 protocol field is called `initializationOptions`, but Sublime's configuration
 uses snake_case.
 
+If you use a third-party Perl syntax, open a Perl file and run
+`Tools > Developer > Show Scope Name`; update `selector` only if the root scope
+is different.
+
 ## Optional: Project-Specific Settings
 
 Prefer `.perl-lsp.toml` for settings shared across all editors. Use a

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -31,8 +31,8 @@ perllsp --health
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Zed | install a Perl extension, then optionally point at `perllsp` | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
-| Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
-| Amazon Kiro | use OpenVSX `EffortlessMetrics.perl-lsp-rs` in Kiro IDE; for Kiro CLI configure custom LSP `perllsp --stdio` | [docs/EDITORS/KIRO_SETUP.md](../EDITORS/KIRO_SETUP.md) |
+| Sublime Text | install Sublime's `LSP` package and add a custom `perl-lsp` server in `LanguageServers.sublime-settings` using `perllsp --stdio` | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
+| Amazon Kiro | register a Perl LSP client using `perllsp --stdio` | [docs/EDITORS/KIRO_SETUP.md](../EDITORS/KIRO_SETUP.md) |
 | Claude Code | provide a plugin `.lsp.json` pointing to `perllsp --stdio` | [docs/EDITORS/CLAUDE_CODE_SETUP.md](../EDITORS/CLAUDE_CODE_SETUP.md) |
 | Codex CLI | configure an MCP bridge such as `lsp-mcp`; the bridge exposes tools to Codex and launches `perllsp --stdio` internally | [docs/EDITORS/CODEX_CLI_SETUP.md](../EDITORS/CODEX_CLI_SETUP.md) |
 | Codex Desktop | add a custom Perl server command `perllsp --stdio` | [docs/EDITORS/CODEX_DESKTOP_SETUP.md](../EDITORS/CODEX_DESKTOP_SETUP.md) |
@@ -163,9 +163,27 @@ See [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) for full setup details.
 
 ### Sublime Text
 
+<<<<<<< HEAD
 Register a client with `command: ["perllsp", "--stdio"]`, use a selector such as
 `source.perl | text.perl`, and set `syntaxes` to Perl/Pod syntax files so `.pm`,
 `.pl`, `.t`, and Pod buffers consistently attach to the server.
+=======
+Install the `LSP` package, then open `Preferences: LSP Server Configurations`
+and add:
+
+```json
+{
+  "perl-lsp": {
+    "enabled": true,
+    "command": ["perllsp", "--stdio"],
+    "selector": "source.perl"
+  }
+}
+```
+
+For project-specific server settings, use `.perl-lsp.toml` or add Sublime
+`initialization_options` under the `perl-lsp` server configuration.
+>>>>>>> e3c70ae4e (docs(sublime): modernize setup and config guidance (#0000))
 
 ### Amazon Kiro
 

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -31,6 +31,37 @@ problem is usually in editor integration, workspace roots, or a stale cache.
 
 3. Check the editor's LSP log panel or buffer.
 
+## Sublime Text Does Not Start `perllsp`
+
+1. Confirm `perllsp` works outside Sublime:
+
+   ```bash
+   perllsp --version
+   perllsp --health
+   perllsp --info
+   ```
+
+2. Confirm the `LSP` package is installed.
+
+3. Confirm `Preferences: LSP Server Configurations` contains:
+
+   ```json
+   {
+     "perl-lsp": {
+       "enabled": true,
+       "command": ["perllsp", "--stdio"],
+       "selector": "source.perl"
+     }
+   }
+   ```
+
+4. Run `Tools > Developer > Show Scope Name` in a Perl file and confirm the root
+   scope matches the configured selector.
+
+5. Run `LSP: Troubleshoot Server` and `LSP: Toggle Log Panel`.
+
+6. If Sublime cannot find `perllsp`, use an absolute path in `command`.
+
 ## The Editor Connects, But Nothing Happens
 
 - Confirm the file type is Perl.


### PR DESCRIPTION
### Motivation

- Current Sublime guide mixed legacy and modern Sublime LSP shapes, contained stale `perllsp` install/asset examples, and included untested or incorrect sections (Package Control Python installer, unframed stdio test, DAP/custom formatter wiring). 
- The docs should be short, accurate, and use the current `LSP` package custom-server shape (`LanguageServers.sublime-settings`) and Sublime key names (`initialization_options`).

### Description

- Rewrote `docs/EDITORS/SUBLIME_SETUP.md` to a compact, current guide that requires the `LSP` package, shows `perllsp` install/verification (`--version`, `--health`, `--info`), and provides a canonical `LanguageServers.sublime-settings` server config using `enabled`, `command`, `selector`, and `initialization_options`, plus guidance for inlay hints and logging. 
- Removed stale/unsafe content from the Sublime guide: the embedded Package Control Python installer, legacy `clients` / `initializationOptions` examples, prebuilt archive names that referenced the wrong binary, unframed `echo | perllsp --stdio` smoke test, and untested DAP/custom-formatter snippets. 
- Updated `docs/how-to/EDITOR_SETUP.md` to include `perllsp --info`, modernize the Sublime row, and add the short `Preferences: LSP Server Configurations` snippet. 
- Updated `docs/reference/CONFIG.md` to replace the legacy Sublime snippet with the current server configuration shape and added a note about Sublime's `initialization_options` vs the protocol `initializationOptions`. 
- Added a focused Sublime subsection to `docs/how-to/TROUBLESHOOTING.md` covering verification, Server Configurations, scope/selector checks, log commands, and absolute-path fallback for `perllsp`.

### Testing

- Ran a grep-based validation: `rg -n "initializationOptions|\"clients\"|LSP-pyright|custom-formatter|echo '\{\"jsonrpc\"'|lsp_rename|lsp_diagnostics" docs/EDITORS/SUBLIME_SETUP.md docs/reference/CONFIG.md docs/how-to/EDITOR_SETUP.md docs/how-to/TROUBLESHOOTING.md` and confirmed the targeted legacy/stale tokens were removed (no undesired matches remain). 
- Performed a local commit of the documentation changes (documentation-only PR); commit succeeded. 
- No build/test changes required because this is documentation-only; no cargo/test runs were necessary for these edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efec897fac83338c9cc497359cbee6)