### PR TITLE
docs(opencode): tighten OpenCode setup and verification guidance (#0000)

### DIFF
--- a/docs/EDITORS/OPENCODE_SETUP.md
+++ b/docs/EDITORS/OPENCODE_SETUP.md
@@ -2,23 +2,28 @@
 
 This guide shows how to run `perllsp` as a custom LSP server in OpenCode.
 
+OpenCode uses LSP diagnostics to give the agent feedback about your code.
+Direct hover, go-to-definition, references, and symbol operations are available
+through OpenCode's experimental LSP tool.
+
 ## Prerequisites
 
 - `perllsp` installed and available on your `PATH`
 - OpenCode installed
-- a Perl project opened in OpenCode
+- a Perl project opened from the project root
 
 Verify the server first:
 
 ```bash
 perllsp --version
 perllsp --health
+perllsp --info
 ```
 
 ## Configure OpenCode
 
-Add a project-local `opencode.json` in your repository root (or update an existing
-one) and register `perllsp` as a custom LSP.
+Add a project-local `opencode.json` or `opencode.jsonc` in your repository root
+(or update an existing one) and register `perllsp` as a custom LSP.
 
 ```json
 {
@@ -26,11 +31,34 @@ one) and register `perllsp` as a custom LSP.
   "lsp": {
     "perl-lsp": {
       "command": ["perllsp", "--stdio"],
-      "extensions": [".pl", ".pm", ".t", ".pod", ".psgi"],
+      "extensions": [".pl", ".PL", ".pm", ".t", ".pod", ".psgi", ".cgi", ".fcgi", ".xs", ".xsi"]
+    }
+  }
+}
+```
+
+If your project uses Perl-bearing template files, add their extensions as
+needed, for example `.mason`, `.mas`, `.tt`, `.tt2`, or `.ep`.
+
+Review project-local `opencode.json` before trusting it. Custom LSP commands run
+local executables when matching files are opened.
+
+## Optional: Pass perl-lsp Initialization Options
+
+Prefer `.perl-lsp.toml` for settings that should apply across all editors. Use
+OpenCode `initialization` only for OpenCode-specific startup options.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "perl-lsp": {
+      "command": ["perllsp", "--stdio"],
+      "extensions": [".pl", ".PL", ".pm", ".t", ".pod", ".psgi", ".cgi", ".fcgi", ".xs", ".xsi"],
       "initialization": {
         "perl": {
           "workspace": {
-            "includePaths": ["lib", "local/lib/perl5"]
+            "includePaths": ["lib", ".", "local/lib/perl5"]
           }
         }
       }
@@ -41,18 +69,79 @@ one) and register `perllsp` as a custom LSP.
 
 ## Verify It Is Running
 
-1. Open any Perl file (`.pl`, `.pm`, `.t`) in OpenCode.
-2. Trigger a definition lookup or hover on a known symbol.
-3. Confirm diagnostics appear for an intentional syntax error.
+1. Start OpenCode from the project root.
+2. Open or reference a Perl file such as `lib/My/Module.pm`, `script/app.pl`, or
+   `t/basic.t`.
+3. Introduce a temporary syntax error.
+4. Confirm diagnostics appear.
+5. Remove the syntax error after verification.
 
-If OpenCode does not start the server, confirm `perllsp` is on your shell `PATH`
-and restart OpenCode.
+You can also check a file outside OpenCode:
+
+```bash
+perllsp --check path/to/file.pl
+```
+
+## Optional: Enable Hover, Definition, and References
+
+OpenCode's direct LSP tool is experimental. To let the agent call operations
+such as hover, go-to-definition, references, document symbols, workspace symbols,
+and call hierarchy, start OpenCode with:
+
+```bash
+OPENCODE_EXPERIMENTAL_LSP_TOOL=true opencode
+```
+
+Then allow the LSP tool in `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "lsp": "allow"
+  }
+}
+```
+
+You can combine this `permission` block with the `lsp` block above.
 
 ## Troubleshooting
 
-- If no Perl files activate the server, verify your configured file extensions.
-- If the command fails, run `perllsp --stdio` directly in a terminal to confirm
-  the binary is launchable.
-- For server-side behavior and config details, see
-  [docs/reference/CONFIG.md](../reference/CONFIG.md) and
-  [docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).
+- If no Perl files activate the server, verify the file extension is listed in
+  `opencode.json`.
+- If OpenCode cannot start the server, run `command -v perllsp`,
+  `perllsp --health`, and `perllsp --info` from the same shell environment used
+  to launch OpenCode.
+- On Windows PowerShell, use `where perllsp`.
+- If `perllsp --stdio` appears to hang when run manually, that is expected. It is
+  waiting for framed LSP input from the editor or agent.
+- If module resolution fails, configure shared include paths in `.perl-lsp.toml`
+  or pass `perl.workspace.includePaths` through OpenCode `initialization`.
+- For OpenCode logs, start with debug logging:
+
+  ```bash
+  opencode --log-level DEBUG
+  ```
+
+- OpenCode logs are stored under `~/.local/share/opencode/log/` on macOS/Linux
+  and `%USERPROFILE%\.local\share\opencode\log` on Windows.
+- For server-side logging, temporarily add `--log` to the command or set
+  `PERL_LSP_LOG=1` in the LSP `env` block.
+
+Example server logging config:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "perl-lsp": {
+      "command": ["perllsp", "--stdio", "--log"],
+      "extensions": [".pl", ".PL", ".pm", ".t", ".pod", ".psgi"]
+    }
+  }
+}
+```
+
+For server-side behavior and config details, see
+[docs/reference/CONFIG.md](../reference/CONFIG.md) and
+[docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -17,6 +17,7 @@ Verify the install before debugging editor settings:
 ```bash
 perllsp --version
 perllsp --health
+perllsp --info
 ```
 
 ## Pick Your Editor
@@ -35,7 +36,7 @@ perllsp --health
 | Claude Code | provide a plugin `.lsp.json` pointing to `perllsp --stdio` | [docs/EDITORS/CLAUDE_CODE_SETUP.md](../EDITORS/CLAUDE_CODE_SETUP.md) |
 | Codex CLI | connect an MCP LSP bridge to `perllsp --stdio` | [docs/EDITORS/CODEX_CLI_SETUP.md](../EDITORS/CODEX_CLI_SETUP.md) |
 | Codex Desktop | add a custom Perl server command `perllsp --stdio` | [docs/EDITORS/CODEX_DESKTOP_SETUP.md](../EDITORS/CODEX_DESKTOP_SETUP.md) |
-| OpenCode | configure a custom `perl-lsp` server in `opencode.json` | [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) |
+| OpenCode | configure `perllsp --stdio` as a custom LSP in `opencode.json`; diagnostics work by default, direct LSP operations are experimental | [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -136,9 +137,27 @@ example config and troubleshooting flow.
 
 ### OpenCode
 
-Create or update `opencode.json` and register a custom LSP server with
-`"command": ["perllsp", "--stdio"]` and Perl extensions like `.pl`, `.pm`,
-and `.t`. See [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) for a full example.
+Create or update `opencode.json` or `opencode.jsonc` and register a custom LSP
+server:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "perl-lsp": {
+      "command": ["perllsp", "--stdio"],
+      "extensions": [".pl", ".PL", ".pm", ".t", ".pod", ".psgi", ".cgi", ".fcgi", ".xs", ".xsi"]
+    }
+  }
+}
+```
+
+OpenCode uses LSP diagnostics by default. For direct hover, definition,
+references, and symbol operations, enable OpenCode's experimental LSP tool with
+`OPENCODE_EXPERIMENTAL_LSP_TOOL=true` and allow the `lsp` permission.
+
+See [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) for a full
+example.
 
 ## When Setup Fails
 

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -17,13 +17,14 @@ problem is usually in editor integration, workspace roots, or a stale cache.
 
 ## The Server Will Not Start
 
-1. Run the server in the foreground:
+1. Run server diagnostics first:
 
    ```bash
-   perllsp --stdio
+   perllsp --health
+   perllsp --info
    ```
 
-2. Turn on logging and read stderr:
+2. If needed, turn on logging and read stderr:
 
    ```bash
    RUST_LOG=perl_lsp=debug perllsp --stdio
@@ -70,6 +71,55 @@ If the editor is using a helper extension or plugin, check its own logs too.
 
 If you are debugging with `perl-dap`, check the DAP guide:
 [DAP_USER_GUIDE.md](../tutorials/DAP_USER_GUIDE.md).
+
+## OpenCode Does Not Start `perllsp`
+
+1. Confirm `perllsp` works outside OpenCode:
+
+   ```bash
+   perllsp --version
+   perllsp --health
+   perllsp --info
+   ```
+
+2. Confirm the active file extension is listed in `opencode.json` under
+   `lsp.perl-lsp.extensions`.
+
+3. If OpenCode cannot find the binary, start OpenCode from the same shell where
+   `command -v perllsp` succeeds, or use an absolute path in the `command`
+   array.
+
+4. If `perllsp --stdio` appears to hang when run manually, that is expected. Use
+   `perllsp --health`, `perllsp --info`, or `perllsp --check path/to/file.pl`
+   for manual checks.
+
+5. Start OpenCode with debug logs:
+
+   ```bash
+   opencode --log-level DEBUG
+   ```
+
+6. Check OpenCode logs:
+
+   - macOS/Linux: `~/.local/share/opencode/log/`
+   - Windows: `%USERPROFILE%\.local\share\opencode\log`
+
+7. For direct hover, definition, references, and symbol operations, enable the
+   experimental LSP tool:
+
+   ```bash
+   OPENCODE_EXPERIMENTAL_LSP_TOOL=true opencode
+   ```
+
+   and set:
+
+   ```json
+   {
+     "permission": {
+       "lsp": "allow"
+     }
+   }
+   ```
 
 ## When To Escalate
 

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -512,7 +512,7 @@ decrease them for resource-constrained environments.
 
 ## CLI Flags
 
-Flags passed when launching the `perl-lsp` binary. Source:
+Flags passed when launching the `perllsp` executable. Source:
 `crates/perl-lsp-launcher/src/lib.rs`.
 
 ### Server mode
@@ -559,7 +559,7 @@ perllsp --completion bash >> ~/.bashrc  # install bash completions
 
 ## Environment Variables
 
-Environment variables read at startup by the `perl-lsp` binary. Source:
+Environment variables read at startup by the `perllsp` executable. Source:
 `crates/perl-lsp-launcher/src/lib.rs`.
 
 ### `PERL_LSP_LOG`
@@ -906,6 +906,33 @@ inlayHints.enabled = true
   }
 }
 ```
+
+#### OpenCode (`opencode.json`)
+
+OpenCode configures custom LSP servers through the `lsp` block. The `command`
+array launches the server, `extensions` controls activation, and
+`initialization` is sent as LSP initialization options.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "perl-lsp": {
+      "command": ["perllsp", "--stdio"],
+      "extensions": [".pl", ".PL", ".pm", ".t", ".pod", ".psgi", ".cgi", ".fcgi", ".xs", ".xsi"],
+      "initialization": {
+        "perl": {
+          "workspace": {
+            "includePaths": ["lib", ".", "local/lib/perl5"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+For settings shared across editors, prefer `.perl-lsp.toml`.
 
 ---
 


### PR DESCRIPTION
### Motivation

- The existing OpenCode docs mixed diagnostics-first behavior with experimental direct-LSP tooling and missed practical verification steps and safety notes.  
- Users need an explicit, reliable verification flow (`--health`/`--info`/`--check`) rather than instructing them to run `--stdio` interactively.  
- The guide should document `opencode.jsonc`, preserve the built-in `.` include path, and avoid implying initialization is required by default.

### Description

- Rewrote `docs/EDITORS/OPENCODE_SETUP.md` to show a minimal `opencode.json`/`opencode.jsonc` example, add `perllsp --info`, expand recommended extensions, preserve `"."` in `includePaths`, add a short trust warning, and move hover/definition usage into an optional experimental section.  
- Updated `docs/how-to/EDITOR_SETUP.md` to include `perllsp --info` in verification, document `opencode.jsonc` and the broader extension list, and mark direct LSP operations as experimental.  
- Extended `docs/reference/CONFIG.md` with an OpenCode (`opencode.json`) snippet and changed references from “`perl-lsp` binary” wording to the canonical `perllsp` executable wording.  
- Improved `docs/how-to/TROUBLESHOOTING.md` to prefer `perllsp --health`/`perllsp --info` and `perllsp --check` for manual checks and added an OpenCode-specific troubleshooting section; applied formatting fixes and ran project formatter.

### Testing

- Ran `git diff --check` which passed with no whitespace or diff-check errors.  
- Ran `cargo xtask fmt` which completed successfully and formatted the repo.  
- Ran `cargo check --all-targets -p xtask` which completed successfully.  
- `just pr-fast` was not available in this environment (`just: command not found`), noted in verification output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efef5679e883338c550a17f9be9dbe)