### PR TITLE
docs(opencode): clarify OpenCode setup & troubleshooting guidance (#0000)

### DIFF
--- a/docs/EDITORS/OPENCODE_SETUP.md
+++ b/docs/EDITORS/OPENCODE_SETUP.md
@@ -2,23 +2,28 @@
 
 This guide shows how to run `perllsp` as a custom LSP server in OpenCode.
 
+OpenCode uses LSP diagnostics to give the agent feedback about your code.
+Direct hover, go-to-definition, references, and symbol operations are available
+through OpenCode's experimental LSP tool.
+
 ## Prerequisites
 
 - `perllsp` installed and available on your `PATH`
 - OpenCode installed
-- a Perl project opened in OpenCode
+- a Perl project opened from the project root
 
 Verify the server first:
 
 ```bash
 perllsp --version
 perllsp --health
+perllsp --info
 ```
 
 ## Configure OpenCode
 
-Add a project-local `opencode.json` in your repository root (or update an existing
-one) and register `perllsp` as a custom LSP.
+Add a project-local `opencode.json` or `opencode.jsonc` in your repository root
+(or update an existing one) and register `perllsp` as a custom LSP.
 
 ```json
 {
@@ -26,11 +31,34 @@ one) and register `perllsp` as a custom LSP.
   "lsp": {
     "perl-lsp": {
       "command": ["perllsp", "--stdio"],
-      "extensions": [".pl", ".pm", ".t", ".pod", ".psgi"],
+      "extensions": [".pl", ".PL", ".pm", ".t", ".pod", ".psgi", ".cgi", ".fcgi", ".xs", ".xsi"]
+    }
+  }
+}
+```
+
+If your project uses Perl-bearing template files, add their extensions as
+needed, for example `.mason`, `.mas`, `.tt`, `.tt2`, or `.ep`.
+
+Review project-local `opencode.json` before trusting it. Custom LSP commands run
+local executables when matching files are opened.
+
+## Optional: Pass perl-lsp Initialization Options
+
+Prefer `.perl-lsp.toml` for settings that should apply across all editors. Use
+OpenCode `initialization` only for OpenCode-specific startup options.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "perl-lsp": {
+      "command": ["perllsp", "--stdio"],
+      "extensions": [".pl", ".PL", ".pm", ".t", ".pod", ".psgi", ".cgi", ".fcgi", ".xs", ".xsi"],
       "initialization": {
         "perl": {
           "workspace": {
-            "includePaths": ["lib", "local/lib/perl5"]
+            "includePaths": ["lib", ".", "local/lib/perl5"]
           }
         }
       }
@@ -41,18 +69,79 @@ one) and register `perllsp` as a custom LSP.
 
 ## Verify It Is Running
 
-1. Open any Perl file (`.pl`, `.pm`, `.t`) in OpenCode.
-2. Trigger a definition lookup or hover on a known symbol.
-3. Confirm diagnostics appear for an intentional syntax error.
+1. Start OpenCode from the project root.
+2. Open or reference a Perl file such as `lib/My/Module.pm`, `script/app.pl`, or
+   `t/basic.t`.
+3. Introduce a temporary syntax error.
+4. Confirm diagnostics appear.
+5. Remove the syntax error after verification.
 
-If OpenCode does not start the server, confirm `perllsp` is on your shell `PATH`
-and restart OpenCode.
+You can also check a file outside OpenCode:
+
+```bash
+perllsp --check path/to/file.pl
+```
+
+## Optional: Enable Hover, Definition, and References
+
+OpenCode's direct LSP tool is experimental. To let the agent call operations
+such as hover, go-to-definition, references, document symbols, workspace
+symbols, and call hierarchy, start OpenCode with:
+
+```bash
+OPENCODE_EXPERIMENTAL_LSP_TOOL=true opencode
+```
+
+Then allow the LSP tool in `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "lsp": "allow"
+  }
+}
+```
+
+You can combine this `permission` block with the `lsp` block above.
 
 ## Troubleshooting
 
-- If no Perl files activate the server, verify your configured file extensions.
-- If the command fails, run `perllsp --stdio` directly in a terminal to confirm
-  the binary is launchable.
-- For server-side behavior and config details, see
-  [docs/reference/CONFIG.md](../reference/CONFIG.md) and
-  [docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).
+- If no Perl files activate the server, verify the file extension is listed in
+  `opencode.json`.
+- If OpenCode cannot start the server, run `command -v perllsp`,
+  `perllsp --health`, and `perllsp --info` from the same shell environment used
+  to launch OpenCode.
+- On Windows PowerShell, use `where perllsp`.
+- If `perllsp --stdio` appears to hang when run manually, that is expected. It
+  is waiting for framed LSP input from the editor or agent.
+- If module resolution fails, configure shared include paths in `.perl-lsp.toml`
+  or pass `perl.workspace.includePaths` through OpenCode `initialization`.
+- For OpenCode logs, start with debug logging:
+
+  ```bash
+  opencode --log-level DEBUG
+  ```
+
+- OpenCode logs are stored under `~/.local/share/opencode/log/` on macOS/Linux
+  and `%USERPROFILE%\.local\share\opencode\log` on Windows.
+- For server-side logging, temporarily add `--log` to the command or set
+  `PERL_LSP_LOG=1` in the LSP `env` block.
+
+Example server logging config:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "perl-lsp": {
+      "command": ["perllsp", "--stdio", "--log"],
+      "extensions": [".pl", ".PL", ".pm", ".t", ".pod", ".psgi"]
+    }
+  }
+}
+```
+
+For server-side behavior and config details, see
+[docs/reference/CONFIG.md](../reference/CONFIG.md) and
+[docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -36,7 +36,7 @@ perllsp --info
 | Claude Code | provide a plugin `.lsp.json` pointing to `perllsp --stdio` | [docs/EDITORS/CLAUDE_CODE_SETUP.md](../EDITORS/CLAUDE_CODE_SETUP.md) |
 | Codex CLI | connect an MCP LSP bridge to `perllsp --stdio` | [docs/EDITORS/CODEX_CLI_SETUP.md](../EDITORS/CODEX_CLI_SETUP.md) |
 | Codex Desktop | add a custom Perl server command `perllsp --stdio` | [docs/EDITORS/CODEX_DESKTOP_SETUP.md](../EDITORS/CODEX_DESKTOP_SETUP.md) |
-| OpenCode | configure a custom `perl-lsp` server in `opencode.json` | [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) |
+| OpenCode | configure `perllsp --stdio` as a custom LSP in `opencode.json`; diagnostics work by default, direct LSP operations are experimental | [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) |
 
 ## Minimal Configurations
 
@@ -150,9 +150,27 @@ example config and troubleshooting flow.
 
 ### OpenCode
 
-Create or update `opencode.json` and register a custom LSP server with
-`"command": ["perllsp", "--stdio"]` and Perl extensions like `.pl`, `.pm`,
-and `.t`. See [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) for a full example.
+Create or update `opencode.json` or `opencode.jsonc` and register a custom LSP
+server:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "perl-lsp": {
+      "command": ["perllsp", "--stdio"],
+      "extensions": [".pl", ".PL", ".pm", ".t", ".pod", ".psgi", ".cgi", ".fcgi", ".xs", ".xsi"]
+    }
+  }
+}
+```
+
+OpenCode uses LSP diagnostics by default. For direct hover, definition,
+references, and symbol operations, enable OpenCode's experimental LSP tool with
+`OPENCODE_EXPERIMENTAL_LSP_TOOL=true` and allow the `lsp` permission.
+
+See [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) for a full
+example.
 
 ## When Setup Fails
 

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -137,6 +137,55 @@ If the editor is using a helper extension or plugin, check its own logs too.
 - Check whether the current file actually has a Perl mode or file type.
 - Inspect the LSP log for capability negotiation or request errors.
 
+## OpenCode does not start `perllsp`
+
+1. Confirm `perllsp` works outside OpenCode:
+
+   ```bash
+   perllsp --version
+   perllsp --health
+   perllsp --info
+   ```
+
+2. Confirm the active file extension is listed in
+   `opencode.json` under `lsp.perl-lsp.extensions`.
+
+3. If OpenCode cannot find the binary, start OpenCode from the same shell where
+   `command -v perllsp` succeeds, or use an absolute path in the `command`
+   array.
+
+4. If `perllsp --stdio` appears to hang when run manually, that is expected. Use
+   `perllsp --health`, `perllsp --info`, or `perllsp --check path/to/file.pl`
+   for manual checks.
+
+5. Start OpenCode with debug logs:
+
+   ```bash
+   opencode --log-level DEBUG
+   ```
+
+6. Check OpenCode logs:
+
+   - macOS/Linux: `~/.local/share/opencode/log/`
+   - Windows: `%USERPROFILE%\.local\share\opencode\log`
+
+7. For direct hover, definition, references, and symbol operations, enable the
+   experimental LSP tool:
+
+   ```bash
+   OPENCODE_EXPERIMENTAL_LSP_TOOL=true opencode
+   ```
+
+   and set:
+
+   ```json
+   {
+     "permission": {
+       "lsp": "allow"
+     }
+   }
+   ```
+
 ## DAP Or Debugging Issues
 
 If you are debugging with `perl-dap`, check the DAP guide:

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -512,7 +512,7 @@ decrease them for resource-constrained environments.
 
 ## CLI Flags
 
-Flags passed when launching the `perllsp` binary. Source:
+Flags passed when launching the `perllsp` executable. Source:
 `crates/perl-lsp-launcher/src/lib.rs`.
 
 ### Server mode
@@ -559,7 +559,7 @@ perllsp --completion bash >> ~/.bashrc  # install bash completions
 
 ## Environment Variables
 
-Environment variables read at startup by the `perllsp` binary. Source:
+Environment variables read at startup by the `perllsp` executable. Source:
 `crates/perl-lsp-launcher/src/lib.rs`.
 
 ### `PERL_LSP_LOG`
@@ -619,7 +619,7 @@ options or client-specific configuration mechanisms.
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
-| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perllsp` binary. Empty = auto-download. |
+| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perllsp` executable. Empty = auto-download. |
 | `perl-lsp.autoDownload` | `boolean` | `true` | Download the binary automatically if not found locally. |
 | `perl-lsp.downloadBaseUrl` | `string` | `""` | Override the GitHub releases base URL for internal mirrors. |
 | `perl-lsp.channel` | `"latest"\|"stable"\|"tag"` | `"latest"` | Release channel to track. |
@@ -918,8 +918,32 @@ Open `Preferences: LSP Server Configurations` and add:
 }
 ```
 
-Sublime LSP uses `initialization_options`; the LSP protocol field is named
-`initializationOptions`.
+#### OpenCode (`opencode.json`)
+
+OpenCode configures custom LSP servers through the `lsp` block. The `command`
+array launches the server, `extensions` controls activation, and
+`initialization` is sent as LSP initialization options.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "perl-lsp": {
+      "command": ["perllsp", "--stdio"],
+      "extensions": [".pl", ".PL", ".pm", ".t", ".pod", ".psgi", ".cgi", ".fcgi", ".xs", ".xsi"],
+      "initialization": {
+        "perl": {
+          "workspace": {
+            "includePaths": ["lib", ".", "local/lib/perl5"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+For settings shared across editors, prefer `.perl-lsp.toml`.
 
 #### Claude Code (plugin `.lsp.json`)
 


### PR DESCRIPTION
### Motivation

- The OpenCode guide mixed diagnostics-first verification with experimental direct LSP operations and omitted several practical checks and wording inconsistencies.
- Make the onboarding flow clearer and safer by preferring diagnostics verification, documenting experimental gating, and adding helpful troubleshooting commands.

### Description

- Updated `docs/EDITORS/OPENCODE_SETUP.md` to prefer diagnostics-first verification, add `perllsp --info`, document `opencode.json` or `opencode.jsonc`, expand the example `extensions` list, include `"."` in `includePaths` examples, add a short trust warning, and move hover/definition references into an experimental section gated by `OPENCODE_EXPERIMENTAL_LSP_TOOL` and `permission.lsp`.
- Updated `docs/how-to/EDITOR_SETUP.md` to reflect OpenCode changes with a fuller `opencode.json/jsonc` example and an explicit note that diagnostics are default while direct LSP operations are experimental.
- Added an OpenCode editor snippet and corrected wording to refer to the `perllsp` executable in `docs/reference/CONFIG.md`.
- Added a dedicated `OpenCode does not start perllsp` section to `docs/how-to/TROUBLESHOOTING.md` with concrete checks including `perllsp --version`, `--health`, `--info`, `--check`, advice on PATH/absolute paths, logging, and experimental-tool permissions.

### Testing

- Ran `cargo check --all-targets -p perl-lsp-rs`, which completed successfully.
- `just pr-fast` is unavailable in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efef5679e883338c550a17f9be9dbe)