### PR TITLE
docs(neovim): modernize setup and troubleshooting guidance (#0000)

### DIFF
--- a/docs/EDITORS/NEOVIM_SETUP.md
+++ b/docs/EDITORS/NEOVIM_SETUP.md
@@ -1,816 +1,446 @@
 # Neovim Setup Guide for perl-lsp
 
-This comprehensive guide helps you set up and configure the Perl Language Server in Neovim.
-
-## Table of Contents
-
-- [Prerequisites](#prerequisites)
-- [Installation](#installation)
-- [Basic Setup](#basic-setup)
-- [Configuration](#configuration)
-- [Features](#features)
-- [Keybindings](#keybindings)
-- [Plugins](#plugins)
-- [Troubleshooting](#troubleshooting)
-- [Advanced Configuration](#advanced-configuration)
-
----
+Use this guide to run `perllsp` in Neovim through Neovim's built-in LSP client.
 
 ## Prerequisites
 
-### Required
+- Neovim 0.11.3 or later; a current stable release is recommended
+- `perllsp` installed and available on your `PATH`
+- a Perl project opened from the project root
 
-- **Neovim** version 0.8 or later
-- **perl-lsp** server installed (see [Installation](#installation))
-- **nvim-lspconfig** plugin
-- **nvim-cmp** (optional, for enhanced completion)
+Optional:
 
-### Optional but Recommended
+- `nvim-lspconfig`, if you already use it for other language-server configs
+- `nvim-cmp`, if you prefer cmp-based completion
+- `telescope.nvim`, if you want Telescope-backed symbol/reference pickers
+- `perltidy`, for formatting
+- `perlcritic`, only if Perl::Critic diagnostics are enabled
 
-- **LuaSnip** - for snippet support
-- **plenary.nvim** - for async utilities
-- **telescope.nvim** - for fuzzy finding
-- **Perl** 5.10 or later (for syntax validation)
-- **perltidy** (for code formatting)
-- **perlcritic** (for linting)
+Verify `perllsp` before changing Neovim configuration:
 
----
+```bash
+perllsp --version
+perllsp --health
+perllsp --info
+```
 
-## Installation
+## Install `perllsp`
 
-### Install the Server
-
-Choose one of the following methods:
-
-#### Option 1: Install from crates.io (Recommended)
+### Cargo
 
 ```bash
 cargo install perllsp
 ```
 
-#### Option 2: Download Pre-built Binary
-
-Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases):
+### Homebrew
 
 ```bash
-# Linux (x86_64)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-linux-x86_64.tar.gz
-tar xzf perl-lsp-linux-x86_64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
-
-# macOS (Apple Silicon)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-darwin-aarch64.tar.gz
-tar xzf perl-lsp-darwin-aarch64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
+brew install perl-lsp
 ```
 
-#### Option 3: Build from Source
+### From Source
 
 ```bash
 git clone https://github.com/EffortlessMetrics/perl-lsp.git
 cd perl-lsp
-cargo install perllsp
+cargo install --path crates/perllsp --locked
 ```
 
-### Verify Installation
+### Prebuilt Binary
 
-```bash
-# Check version
-perllsp --version
+Download the archive for your platform from GitHub Releases, extract it, and put
+`perllsp` on your `PATH`.
 
-# Quick health check
-perllsp --health
-# Should output: ok 0.10.0
+Release assets use the `perllsp-<version>-<target>` naming pattern. Check the
+release page before copying a version number.
+
+## Basic Setup: Neovim 0.11+
+
+Create a custom LSP config file:
+
+```vim
+:exe 'edit' stdpath('config') .. '/lsp/perllsp.lua'
 ```
 
-### Install Required Plugins
-
-Using [packer.nvim](https://github.com/wbthomason/packer.nvim):
+Add:
 
 ```lua
-use {
-  'neovim/nvim-lspconfig',
-  config = function()
-    -- LSP configuration will go here
-  end
-}
-```
-
-Using [lazy.nvim](https://github.com/folke/lazy.nvim):
-
-```lua
-{
-  'neovim/nvim-lspconfig',
-  config = function()
-    -- LSP configuration will go here
-  end
-}
-```
-
----
-
-## Basic Setup
-
-### Minimal Configuration
-
-Add to your `init.lua`:
-
-```lua
-local lspconfig = require('lspconfig')
-local configs = require('lspconfig.configs')
-
--- Define perl-lsp server
-if not configs.perl_lsp then
-  configs.perl_lsp = {
-    default_config = {
-      cmd = { 'perl-lsp', '--stdio' },
-      filetypes = { 'perl' },
-      root_dir = lspconfig.util.root_pattern('.git'),
-      single_file_support = true,
-    },
-  }
-end
-
--- Enable the server
-lspconfig.perl_lsp.setup({})
-```
-
-### Verify Setup
-
-1. Restart Neovim
-2. Open a `.pl` or `.pm` file
-3. Check if LSP is attached:
-   ```vim
-   :LspInfo
-   ```
-4. You should see perl-lsp listed under "Client: perl_lsp"
-
----
-
-## Configuration
-
-### Full Configuration
-
-Add to your `init.lua`:
-
-```lua
-local lspconfig = require('lspconfig')
-local configs = require('lspconfig.configs')
-
--- Define perl-lsp server
-if not configs.perl_lsp then
-  configs.perl_lsp = {
-    default_config = {
-      cmd = { 'perl-lsp', '--stdio' },
-      filetypes = { 'perl' },
-      root_dir = lspconfig.util.root_pattern(
-        'Makefile.PL',
-        'Build.PL',
-        'cpanfile',
-        'dist.ini',
-        '.git'
-      ),
-      single_file_support = true,
-      settings = {
-        perl = {
-          workspace = {
-            includePaths = { 'lib', '.', 'local/lib/perl5' },
-            useSystemInc = false,
-            resolutionTimeout = 50,
-          },
-          inlayHints = {
-            enabled = true,
-            parameterHints = true,
-            typeHints = true,
-            chainedHints = false,
-            maxLength = 30,
-          },
-          testRunner = {
-            enabled = true,
-            command = 'perl',
-            args = {},
-            timeout = 60000,
-          },
-          limits = {
-            workspaceSymbolCap = 200,
-            referencesCap = 500,
-            completionCap = 100,
-            astCacheMaxEntries = 100,
-            maxIndexedFiles = 10000,
-            maxTotalSymbols = 500000,
-            workspaceScanDeadlineMs = 30000,
-            referenceSearchDeadlineMs = 2000,
-          },
-        },
-      },
-    },
-  }
-end
-
--- Enable the server with custom on_attach
-lspconfig.perl_lsp.setup({
-  on_attach = function(client, bufnr)
-    -- Enable completion triggered by <c-x><c-o>
-    vim.bo[bufnr].omnifunc = 'v:lua.vim.lsp.omnifunc'
-
-    -- Buffer local keymaps
-    local opts = { buffer = bufnr, noremap = true, silent = true }
-    vim.keymap.set('n', 'gd', vim.lsp.buf.definition, opts)
-    vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, opts)
-    vim.keymap.set('n', 'gr', vim.lsp.buf.references, opts)
-    vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, opts)
-    vim.keymap.set('n', 'K', vim.lsp.buf.hover, opts)
-    vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, opts)
-    vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, opts)
-    vim.keymap.set('n', '<leader>ca', vim.lsp.buf.code_action, opts)
-    vim.keymap.set('n', '<leader>f', function()
-      vim.lsp.buf.format { async = true }
-    end, opts)
-    vim.keymap.set('n', '[d', vim.diagnostic.goto_prev, opts)
-    vim.keymap.set('n', ']d', vim.diagnostic.goto_next, opts)
-    vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, opts)
-  end,
-  capabilities = vim.lsp.protocol.make_client_capabilities(),
-})
-```
-
-### Project-Specific Configuration
-
-Create `.nvimrc` or `init.lua` in your project root:
-
-```lua
--- .nvimrc or lua/init.lua
-vim.lsp.start {
-  name = 'perl-lsp',
-  cmd = { 'perl-lsp', '--stdio' },
-  root_dir = vim.fn.getcwd(),
-  settings = {
+return {
+  cmd = { 'perllsp', '--stdio' },
+  filetypes = { 'perl' },
+  root_markers = {
+    '.perl-lsp.toml',
+    'Makefile.PL',
+    'Build.PL',
+    'cpanfile',
+    'dist.ini',
+    '.git',
+  },
+  init_options = {
     perl = {
       workspace = {
-        includePaths = { 'lib', 'local/lib/perl5', 'vendor/lib' },
+        includePaths = { 'lib', '.', 'local/lib/perl5' },
+        useSystemInc = false,
+        resolutionTimeout = 50,
       },
     },
   },
 }
 ```
 
----
-
-## Features
-
-### Syntax Diagnostics
-
-Real-time syntax error detection and reporting:
-
-```perl
-# Errors are highlighted as you type
-my $x = 1
-# Missing semicolon - error shown immediately
-```
-
-View diagnostics:
-```vim
-:lua vim.diagnostic.open_float()
-```
-
-### Go to Definition
-
-Navigate to symbol definitions:
-
-```vim
-:lua vim.lsp.buf.definition()
-```
-
-Or use keybinding: `gd`
-
-```perl
-use MyModule;
-
-MyModule::some_function();
-# ^ gd here jumps to the definition
-```
-
-### Find References
-
-Find all usages of a symbol:
-
-```vim
-:lua vim.lsp.buf.references()
-```
-
-Or use keybinding: `gr`
-
-```perl
-sub my_function {
-    return 42;
-}
-
-# ^ Find references here shows all calls to my_function
-```
-
-### Hover Information
-
-View documentation and type information:
-
-```vim
-:lua vim.lsp.buf.hover()
-```
-
-Or use keybinding: `K`
-
-### Code Completion
-
-Intelligent code completion:
-
-```vim
-:lua vim.lsp.buf.completion()
-```
-
-Or use keybinding: `Ctrl+x Ctrl+o`
-
-```perl
-use MyModule;
-
-MyModule::  # Press Ctrl+x Ctrl+o for completion
-```
-
-### Document Symbols
-
-Navigate symbols in the current file:
-
-```vim
-:lua vim.lsp.buf.document_symbol()
-```
-
-### Workspace Symbols
-
-Search symbols across the entire workspace:
-
-```vim
-:lua vim.lsp.buf.workspace_symbol()
-```
-
-### Rename Symbol
-
-Rename symbols across the workspace:
-
-```vim
-:lua vim.lsp.buf.rename()
-```
-
-Or use keybinding: `<leader>rn`
-
-### Formatting
-
-Format Perl code using perltidy:
-
-```vim
-:lua vim.lsp.buf.format { async = true }
-```
-
-Or use keybinding: `<leader>f`
-
-### Code Actions
-
-Quick fixes and refactorings:
-
-```vim
-:lua vim.lsp.buf.code_action()
-```
-
-Or use keybinding: `<leader>ca`
-
-Available actions:
-- Extract variable
-- Extract subroutine
-- Optimize imports
-- Add missing pragmas
-
-### Inlay Hints
-
-Inline type and parameter hints:
-
-```perl
-sub my_function($name, $count) {
-    return "Hello, $name x$count";
-}
-
-my_function("World", 5);
-# ^ Shows: my_function(/* name: */ "World", /* count: */ 5)
-```
-
-Enable inlay hints:
+Then enable it from `init.lua`:
 
 ```lua
-vim.lsp.inlay_hint.enable(bufnr, true)
+vim.lsp.enable('perllsp')
 ```
 
-Or use keybinding:
-```lua
-vim.keymap.set('n', '<leader>ih', function()
-  vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled())
-end, opts)
+Restart Neovim, open a Perl file, and run:
+
+```vim
+:checkhealth vim.lsp
 ```
 
----
+## Optional: Define the Config Inline
 
-## Keybindings
-
-### Default LSP Keybindings
-
-Add these to your `init.lua`:
+Instead of creating `lsp/perllsp.lua`, you can define the config directly in
+`init.lua`:
 
 ```lua
-local opts = { buffer = bufnr, noremap = true, silent = true }
-
--- Navigation
-vim.keymap.set('n', 'gd', vim.lsp.buf.definition, opts)
-vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, opts)
-vim.keymap.set('n', 'gr', vim.lsp.buf.references, opts)
-vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, opts)
-
--- Documentation
-vim.keymap.set('n', 'K', vim.lsp.buf.hover, opts)
-vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, opts)
-
--- Refactoring
-vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, opts)
-vim.keymap.set('n', '<leader>ca', vim.lsp.buf.code_action, opts)
-
--- Formatting
-vim.keymap.set('n', '<leader>f', function()
-  vim.lsp.buf.format { async = true }
-end, opts)
-
--- Diagnostics
-vim.keymap.set('n', '[d', vim.diagnostic.goto_prev, opts)
-vim.keymap.set('n', ']d', vim.diagnostic.goto_next, opts)
-vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, opts)
-vim.keymap.set('n', '<leader>e', vim.diagnostic.open_float, opts)
-```
-
-### Telescope Integration
-
-If using [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim):
-
-```lua
-local telescope = require('telescope.builtin')
-
-vim.keymap.set('n', '<leader>ss', telescope.lsp_document_symbols, opts)
-vim.keymap.set('n', '<leader>sw', telescope.lsp_workspace_symbols, opts)
-vim.keymap.set('n', '<leader>sr', telescope.lsp_references, opts)
-vim.keymap.set('n', '<leader>sd', telescope.lsp_definitions, opts)
-vim.keymap.set('n', '<leader>si', telescope.lsp_implementations, opts)
-```
-
----
-
-## Plugins
-
-### nvim-cmp Integration
-
-For enhanced autocompletion with [nvim-cmp](https://github.com/hrsh7th/nvim-cmp):
-
-```lua
-local cmp = require('cmp')
-local cmp_lsp = require('cmp_nvim_lsp')
-
-cmp.setup {
-  sources = {
-    { name = 'nvim_lsp' },
-    { name = 'buffer' },
-    { name = 'path' },
+vim.lsp.config('perllsp', {
+  cmd = { 'perllsp', '--stdio' },
+  filetypes = { 'perl' },
+  root_markers = {
+    '.perl-lsp.toml',
+    'Makefile.PL',
+    'Build.PL',
+    'cpanfile',
+    'dist.ini',
+    '.git',
   },
-  mapping = cmp.mapping.preset.insert({
-    ['<C-b>'] = cmp.mapping.scroll_docs(-4),
-    ['<C-f>'] = cmp.mapping.scroll_docs(4),
-    ['<C-Space>'] = cmp.mapping.complete(),
-    ['<C-e>'] = cmp.mapping.abort(),
-    ['<CR>'] = cmp.mapping.confirm({ select = true }),
-  }),
-}
+  init_options = {
+    perl = {
+      workspace = {
+        includePaths = { 'lib', '.', 'local/lib/perl5' },
+        useSystemInc = false,
+        resolutionTimeout = 50,
+      },
+      inlayHints = {
+        enabled = true,
+        parameterHints = true,
+        typeHints = true,
+        chainedHints = false,
+        maxLength = 30,
+      },
+      limits = {
+        workspaceSymbolCap = 200,
+        referencesCap = 500,
+        completionCap = 100,
+      },
+    },
+  },
+})
 
-lspconfig.perl_lsp.setup({
-  capabilities = cmp_lsp.default_capabilities(),
+vim.lsp.enable('perllsp')
+```
+
+## Optional: Filetype Detection
+
+Neovim starts the server only when the buffer filetype is `perl`.
+
+Check a buffer with:
+
+```vim
+:set filetype?
+```
+
+If `.t`, `.psgi`, `.cgi`, or other Perl-bearing files are not detected as Perl
+in your environment, add filetype rules before enabling the server:
+
+```lua
+vim.filetype.add({
+  extension = {
+    t = 'perl',
+    psgi = 'perl',
+    cgi = 'perl',
+    fcgi = 'perl',
+    PL = 'perl',
+  },
 })
 ```
 
-### LuaSnip Integration
+## Optional: Project-Wide perl-lsp Settings
 
-For snippet support with [LuaSnip](https://github.com/L3MON4D3/LuaSnip):
+Prefer `.perl-lsp.toml` for settings shared across editors:
 
-```lua
-local luasnip = require('luasnip')
+```toml
+# .perl-lsp.toml
+[perl]
+include_paths = ["lib", "local/lib/perl5", "vendor/lib"]
 
-cmp.setup {
-  snippet = {
-    expand = function(args)
-      luasnip.lsp_expand(args.body)
-    end,
-  },
-  mapping = cmp.mapping.preset.insert({
-    ['<Tab>'] = cmp.mapping(function(fallback)
-      if cmp.visible() then
-        cmp.select_next_item()
-      elseif luasnip.expand_or_jumpable() then
-        luasnip.expand_or_jump()
-      else
-        fallback()
-      end
-    end, { 'i', 's' }),
-    ['<S-Tab>'] = cmp.mapping(function(fallback)
-      if cmp.visible() then
-        cmp.select_prev_item()
-      elseif luasnip.jumpable(-1) then
-        luasnip.jump(-1)
-      else
-        fallback()
-      end
-    end, { 'i', 's' }),
-  }),
-}
+[features]
+inlay_hints = true
 ```
 
-### null-ls Integration
+Use Neovim `init_options` only for Neovim-specific startup behavior.
 
-For additional linting and formatting with [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim):
+## Useful LSP Keymaps
 
-```lua
-local null_ls = require('null-ls')
+Neovim provides several LSP defaults when LSP is active, including `K` for
+hover, `CTRL-X CTRL-O` for omnifunc completion, `gO` for document symbols, `grr`
+for references, `grn` for rename, and `gra` for code actions.
 
-null_ls.setup {
-  sources = {
-    null_ls.builtins.diagnostics.perlcritic.with({
-      extra_args = { '--severity', '3' },
-    }),
-    null_ls.builtins.formatting.perltidy,
-  },
-}
-```
-
-### nvim-lightbulb Integration
-
-For code action hints with [nvim-lightbulb](https://github.com/kosayoda/nvim-lightbulb):
+If you prefer traditional mappings such as `gd`, add them with `LspAttach`:
 
 ```lua
-require('nvim-lightbulb').setup({
-  autocmd = { enabled = true },
-  sign = { enabled = true },
-  virtual_text = { enabled = true },
+vim.api.nvim_create_autocmd('LspAttach', {
+  callback = function(ev)
+    local client = vim.lsp.get_client_by_id(ev.data.client_id)
+    if not client or client.name ~= 'perllsp' then
+      return
+    end
+
+    local opts = { buffer = ev.buf, silent = true }
+
+    vim.keymap.set('n', 'gd', vim.lsp.buf.definition, opts)
+    vim.keymap.set('n', 'gr', vim.lsp.buf.references, opts)
+    vim.keymap.set('n', 'K', vim.lsp.buf.hover, opts)
+    vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, opts)
+    vim.keymap.set({ 'n', 'v' }, '<leader>ca', vim.lsp.buf.code_action, opts)
+    vim.keymap.set('n', '<leader>f', function()
+      vim.lsp.buf.format({ async = true })
+    end, opts)
+
+    vim.keymap.set('n', '[d', function()
+      vim.diagnostic.jump({ count = -1 })
+    end, opts)
+
+    vim.keymap.set('n', ']d', function()
+      vim.diagnostic.jump({ count = 1 })
+    end, opts)
+
+    vim.keymap.set('n', '<leader>e', vim.diagnostic.open_float, opts)
+    vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, opts)
+  end,
 })
 ```
 
----
+## Optional: Built-in LSP Completion
 
-## Troubleshooting
-
-### Server Not Starting
-
-**Symptoms**: No diagnostics, no completion, error in `:LspInfo`
-
-**Solutions**:
-
-1. **Verify binary is in PATH**:
-   ```vim
-   :!which perl-lsp
-   ```
-
-2. **Check LSP info**:
-   ```vim
-   :LspInfo
-   ```
-   Look for error messages
-
-3. **Check LSP logs**:
-   ```vim
-   :lua vim.cmd('e' .. vim.lsp.get_log_path())
-   ```
-
-4. **Test server manually**:
-   ```vim
-   :!echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perllsp --stdio
-   ```
-
-### No Diagnostics
-
-**Symptoms**: No errors shown for invalid code
-
-**Solutions**:
-
-1. **Check file type**:
-   ```vim
-   :set filetype?
-   ```
-   Should output: `filetype=perl`
-
-2. **Set file type manually**:
-   ```vim
-   :set filetype=perl
-   ```
-
-3. **Verify diagnostics enabled**:
-   ```vim
-   :lua print(vim.inspect(vim.diagnostic.config()))
-   ```
-
-### Slow Performance
-
-**Symptoms**: Lag when typing, slow completions
-
-**Solutions**:
-
-1. **Reduce result caps**:
-   ```lua
-   settings = {
-     perl = {
-       limits = {
-         workspaceSymbolCap = 100,
-         referencesCap = 200,
-         completionCap = 50,
-       },
-     },
-   }
-   ```
-
-2. **Disable system @INC**:
-   ```lua
-   settings = {
-     perl = {
-       workspace = {
-         useSystemInc = false,
-       },
-     },
-   }
-   ```
-
-3. **Reduce resolution timeout**:
-   ```lua
-   settings = {
-     perl = {
-       workspace = {
-         resolutionTimeout = 25,
-       },
-     },
-   }
-   ```
-
-### Module Resolution Issues
-
-**Symptoms**: Can't find modules, go-to-definition fails
-
-**Solutions**:
-
-1. **Check include paths**:
-   ```lua
-   settings = {
-     perl = {
-       workspace = {
-         includePaths = { 'lib', '.', 'local/lib/perl5', 'vendor/lib' },
-       },
-     },
-   }
-   ```
-
-2. **Verify module exists**:
-   ```vim
-   :!perl -e 'use Module::Name;'
-   ```
-
-3. **Check workspace root**:
-   ```vim
-   :lua print(vim.lsp.buf.list_workspace_folders()[1])
-   ```
-
-### Formatting Not Working
-
-**Symptoms**: Format command does nothing or errors
-
-**Solutions**:
-
-1. **Install perltidy**:
-   ```bash
-   # macOS
-   brew install perltidy
-
-   # Ubuntu/Debian
-   sudo apt-get install perltidy
-
-   # CentOS/RHEL
-   sudo yum install perl-Perl-Tidy
-   ```
-
-2. **Check perltidy works**:
-   ```vim
-   :!perltidy --version
-   ```
-
-3. **Verify formatting enabled**:
-   ```lua
-   :lua vim.lsp.buf.format { async = true }
-   ```
-
----
-
-## Advanced Configuration
-
-### Multi-Root Workspace
-
-For workspaces with multiple folders:
+For Neovim's built-in LSP completion:
 
 ```lua
-lspconfig.perl_lsp.setup({
-  on_attach = function(client, bufnr)
-    local workspace_folders = vim.lsp.buf.list_workspace_folders()
-    for _, folder in ipairs(workspace_folders) do
-      print('Workspace folder:', folder)
+vim.api.nvim_create_autocmd('LspAttach', {
+  callback = function(ev)
+    local client = vim.lsp.get_client_by_id(ev.data.client_id)
+    if not client or client.name ~= 'perllsp' then
+      return
+    end
+
+    vim.lsp.completion.enable(true, client.id, ev.buf, {
+      autotrigger = true,
+    })
+
+    vim.keymap.set('i', '<C-Space>', function()
+      vim.lsp.completion.get()
+    end, { buffer = ev.buf, desc = 'Trigger LSP completion' })
+  end,
+})
+```
+
+If you use `nvim-cmp`, configure cmp capabilities before enabling the server:
+
+```lua
+local capabilities = require('cmp_nvim_lsp').default_capabilities()
+
+vim.lsp.config('perllsp', {
+  capabilities = capabilities,
+  cmd = { 'perllsp', '--stdio' },
+  filetypes = { 'perl' },
+  root_markers = {
+    '.perl-lsp.toml',
+    'Makefile.PL',
+    'Build.PL',
+    'cpanfile',
+    'dist.ini',
+    '.git',
+  },
+})
+vim.lsp.enable('perllsp')
+```
+
+## Optional: Inlay Hints
+
+`perllsp` can provide inlay hints. Enable display on attach:
+
+```lua
+vim.api.nvim_create_autocmd('LspAttach', {
+  callback = function(ev)
+    local client = vim.lsp.get_client_by_id(ev.data.client_id)
+    if not client or client.name ~= 'perllsp' then
+      return
+    end
+
+    if client:supports_method('textDocument/inlayHint') then
+      vim.lsp.inlay_hint.enable(true, { bufnr = ev.buf })
     end
   end,
 })
 ```
 
-### Environment Variables
-
-Set environment variables for the LSP server:
+Toggle inlay hints for the current buffer:
 
 ```lua
-lspconfig.perl_lsp.setup({
-  cmd_env = {
-    PERL5LIB = vim.fn.getcwd() .. '/lib',
-    PERL_MB_OPT = '--install_base ' .. vim.fn.getcwd() .. '/local',
-  },
+vim.keymap.set('n', '<leader>ih', function()
+  vim.lsp.inlay_hint.enable(
+    not vim.lsp.inlay_hint.is_enabled({ bufnr = 0 }),
+    { bufnr = 0 }
+  )
+end, { desc = 'Toggle inlay hints' })
+```
+
+## Optional: Telescope Integration
+
+If using `telescope.nvim`:
+
+```lua
+local telescope = require('telescope.builtin')
+
+vim.keymap.set('n', '<leader>ss', telescope.lsp_document_symbols)
+vim.keymap.set('n', '<leader>sw', telescope.lsp_workspace_symbols)
+vim.keymap.set('n', '<leader>sr', telescope.lsp_references)
+vim.keymap.set('n', '<leader>sd', telescope.lsp_definitions)
+```
+
+## Optional: External Formatting and Linting
+
+`perllsp` can provide LSP formatting through `perltidy`. If you also want
+non-LSP formatter/linter orchestration, prefer maintained plugins such as
+`conform.nvim`, `nvim-lint`, or `none-ls.nvim`.
+
+## Verify It Is Running
+
+1. Restart Neovim.
+2. Open a Perl file such as `lib/My/Module.pm`, `script/app.pl`, or `t/basic.t`.
+3. Confirm filetype:
+
+   ```vim
+   :set filetype?
+   ```
+
+4. Check LSP state:
+
+   ```vim
+   :checkhealth vim.lsp
+   ```
+
+5. Introduce a temporary syntax error and confirm diagnostics appear.
+6. Remove the syntax error after testing.
+
+You can also check a file outside Neovim:
+
+```bash
+perllsp --check path/to/file.pl
+```
+
+## Troubleshooting
+
+### Neovim cannot find `perllsp`
+
+From a shell:
+
+```bash
+command -v perllsp
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+On Windows PowerShell:
+
+```powershell
+where perllsp
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+From Neovim:
+
+```vim
+:!command -v perllsp
+```
+
+If Neovim was launched from a GUI, it may not inherit the same `PATH` as your
+terminal. Use an absolute command path if needed:
+
+```lua
+vim.lsp.config('perllsp', {
+  cmd = { '/absolute/path/to/perllsp', '--stdio' },
 })
 ```
 
-### Custom Handlers
+### Server does not attach
 
-Override default LSP handlers:
+Check:
 
-```lua
-lspconfig.perl_lsp.setup({
-  handlers = {
-    ['textDocument/hover'] = vim.lsp.with(vim.lsp.handlers.hover, {
-      border = 'rounded',
-    }),
-    ['textDocument/signatureHelp'] = vim.lsp.with(vim.lsp.handlers.signature_help, {
-      border = 'rounded',
-    }),
-  },
-})
+```vim
+:set filetype?
+:checkhealth vim.lsp
 ```
 
-### Diagnostic Configuration
+Common causes:
 
-Customize diagnostic display:
+- the buffer filetype is not `perl`
+- the workspace has no root marker
+- `perllsp` is not on `PATH`
+- the config name was not enabled with `vim.lsp.enable('perllsp')`
+
+### No diagnostics
+
+Run outside Neovim:
+
+```bash
+perllsp --check path/to/file.pl
+```
+
+Inside Neovim:
+
+```vim
+:lua vim.diagnostic.open_float()
+:lua vim.diagnostic.setloclist()
+```
+
+### Module resolution issues
+
+Prefer `.perl-lsp.toml` for project-wide include paths:
+
+```toml
+[perl]
+include_paths = ["lib", "local/lib/perl5", "vendor/lib"]
+```
+
+Or pass Neovim-specific startup options:
 
 ```lua
-vim.diagnostic.config({
-  virtual_text = {
-    prefix = '■',
-    spacing = 4,
-  },
-  signs = {
-    text = {
-      [vim.diagnostic.severity.ERROR] = '✗',
-      [vim.diagnostic.severity.WARN] = '⚠',
-      [vim.diagnostic.severity.INFO] = 'ℹ',
-      [vim.diagnostic.severity.HINT] = '➤',
+vim.lsp.config('perllsp', {
+  init_options = {
+    perl = {
+      workspace = {
+        includePaths = { 'lib', '.', 'local/lib/perl5', 'vendor/lib' },
+        useSystemInc = false,
+      },
     },
   },
-  float = {
-    border = 'rounded',
-  },
 })
 ```
 
-### Auto-Commands
+### Slow performance
 
-Set up auto-commands for automatic actions:
-
-```lua
-vim.api.nvim_create_autocmd('BufWritePre', {
-  pattern = '*.pl',
-  callback = function()
-    vim.lsp.buf.format { async = false }
-  end,
-})
-
-vim.api.nvim_create_autocmd('LspAttach', {
-  group = vim.api.nvim_create_augroup('UserLspConfig', {}),
-  callback = function(ev)
-    local opts = { buffer = ev.buf }
-    vim.keymap.set('n', 'gd', vim.lsp.buf.definition, opts)
-    -- ... more keymaps
-  end,
-})
-```
-
-### Performance Tuning
-
-For large workspaces, adjust performance settings:
+For large workspaces, reduce caps:
 
 ```lua
-lspconfig.perl_lsp.setup({
-  settings = {
+vim.lsp.config('perllsp', {
+  init_options = {
     perl = {
       limits = {
         workspaceSymbolCap = 100,
@@ -830,129 +460,98 @@ lspconfig.perl_lsp.setup({
 })
 ```
 
-### Debug Logging
+### Formatting does not work
 
-Enable detailed logging for troubleshooting:
+Confirm `perltidy` is available:
 
-```lua
-vim.lsp.set_log_level('debug')
-
--- View logs
-vim.cmd('e ' .. vim.lsp.get_log_path())
+```bash
+perltidy --version
 ```
 
----
+Then run:
 
-## Complete Example Configuration
+```vim
+:lua vim.lsp.buf.format({ async = true })
+```
 
-Here's a comprehensive example configuration:
+### Debug logs
+
+Enable Neovim LSP logs temporarily:
 
 ```lua
--- init.lua
+vim.lsp.log.set_level('debug')
+```
 
--- Plugin setup (using lazy.nvim)
-return {
-  {
-    'neovim/nvim-lspconfig',
-    config = function()
-      local lspconfig = require('lspconfig')
-      local configs = require('lspconfig.configs')
+Open the LSP log:
 
-      -- Define perl-lsp server
-      if not configs.perl_lsp then
-        configs.perl_lsp = {
-          default_config = {
-            cmd = { 'perl-lsp', '--stdio' },
-            filetypes = { 'perl' },
-            root_dir = lspconfig.util.root_pattern(
-              'Makefile.PL',
-              'Build.PL',
-              'cpanfile',
-              'dist.ini',
-              '.git'
-            ),
-            single_file_support = true,
-            settings = {
-              perl = {
-                workspace = {
-                  includePaths = { 'lib', '.', 'local/lib/perl5' },
-                  useSystemInc = false,
-                  resolutionTimeout = 50,
-                },
-                inlayHints = {
-                  enabled = true,
-                  parameterHints = true,
-                  typeHints = true,
-                  maxLength = 30,
-                },
-                limits = {
-                  workspaceSymbolCap = 200,
-                  referencesCap = 500,
-                  completionCap = 100,
-                },
-              },
-            },
+```vim
+:log lsp
+```
+
+For server-side logs, start `perllsp` with `--log`:
+
+```lua
+vim.lsp.config('perllsp', {
+  cmd = { 'perllsp', '--stdio', '--log' },
+})
+```
+
+or set:
+
+```bash
+PERL_LSP_LOG=1
+```
+
+### `perllsp --stdio` appears to hang
+
+That is expected. In stdio mode, `perllsp` waits for framed LSP JSON-RPC input
+from Neovim. Use these commands for manual checks instead:
+
+```bash
+perllsp --health
+perllsp --info
+perllsp --check path/to/file.pl
+```
+
+## Legacy Setup: Neovim 0.8–0.10 with nvim-lspconfig
+
+Use this only if you cannot upgrade to Neovim 0.11+.
+
+```lua
+local lspconfig = require('lspconfig')
+local configs = require('lspconfig.configs')
+
+if not configs.perllsp then
+  configs.perllsp = {
+    default_config = {
+      cmd = { 'perllsp', '--stdio' },
+      filetypes = { 'perl' },
+      root_dir = lspconfig.util.root_pattern(
+        '.perl-lsp.toml',
+        'Makefile.PL',
+        'Build.PL',
+        'cpanfile',
+        'dist.ini',
+        '.git'
+      ),
+      single_file_support = true,
+      init_options = {
+        perl = {
+          workspace = {
+            includePaths = { 'lib', '.', 'local/lib/perl5' },
+            useSystemInc = false,
           },
-        }
-      end
-
-      -- Common on_attach function
-      local on_attach = function(client, bufnr)
-        vim.bo[bufnr].omnifunc = 'v:lua.vim.lsp.omnifunc'
-
-        local opts = { buffer = bufnr, noremap = true, silent = true }
-
-        -- Navigation
-        vim.keymap.set('n', 'gd', vim.lsp.buf.definition, opts)
-        vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, opts)
-        vim.keymap.set('n', 'gr', vim.lsp.buf.references, opts)
-        vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, opts)
-
-        -- Documentation
-        vim.keymap.set('n', 'K', vim.lsp.buf.hover, opts)
-        vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, opts)
-
-        -- Refactoring
-        vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, opts)
-        vim.keymap.set('n', '<leader>ca', vim.lsp.buf.code_action, opts)
-
-        -- Formatting
-        vim.keymap.set('n', '<leader>f', function()
-          vim.lsp.buf.format { async = true }
-        end, opts)
-
-        -- Diagnostics
-        vim.keymap.set('n', '[d', vim.diagnostic.goto_prev, opts)
-        vim.keymap.set('n', ']d', vim.diagnostic.goto_next, opts)
-        vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, opts)
-        vim.keymap.set('n', '<leader>e', vim.diagnostic.open_float, opts)
-
-        -- Inlay hints
-        vim.lsp.inlay_hint.enable(bufnr, true)
-      end
-
-      -- Enable perl-lsp
-      lspconfig.perl_lsp.setup({
-        on_attach = on_attach,
-        capabilities = vim.lsp.protocol.make_client_capabilities(),
-        handlers = {
-          ['textDocument/hover'] = vim.lsp.with(vim.lsp.handlers.hover, {
-            border = 'rounded',
-          }),
         },
-      })
-    end,
-  },
-}
+      },
+    },
+  }
+end
+
+lspconfig.perllsp.setup({})
 ```
 
----
+For server-side behavior and configuration details, see:
 
-## See Also
-
-- [Getting Started](../tutorials/GETTING_STARTED.md) - Quick start guide
-- [Configuration Reference](../reference/CONFIG.md) - Complete configuration options
-- [Troubleshooting Guide](../how-to/TROUBLESHOOTING.md) - Common issues and solutions
-- [Performance Tuning](../how-to/PERFORMANCE_TUNING.md) - Performance optimization guide
-- [Editor Setup](../how-to/EDITOR_SETUP.md) - Other editor configurations
-- [nvim-lspconfig Documentation](https://github.com/neovim/nvim-lspconfig)
+- [Configuration Reference](../reference/CONFIG.md)
+- [Troubleshooting Guide](../how-to/TROUBLESHOOTING.md)
+- [Editor Setup](../how-to/EDITOR_SETUP.md)

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -25,7 +25,7 @@ perllsp --health
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
 | Trae (ByteDance) | install the VS Code-compatible extension or set command to `perllsp --stdio` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
-| Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
+| Neovim | define a custom `perllsp` LSP config with `vim.lsp.config()` and enable it with `vim.lsp.enable()`; legacy `nvim-lspconfig` setup is available for older Neovim | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Vim | use `vim-lsp` or `coc.nvim` with `perllsp --stdio` | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
@@ -54,18 +54,37 @@ panel, or configure a generic language server command as `perllsp --stdio`.
 ### Neovim
 
 ```lua
-local capabilities = vim.lsp.protocol.make_client_capabilities()
-local ok_cmp, cmp_lsp = pcall(require, "cmp_nvim_lsp")
-if ok_cmp then
-  capabilities = cmp_lsp.default_capabilities(capabilities)
-end
-
-require("lspconfig").perl_lsp.setup({
-  cmd = { "perllsp", "--stdio" },
-  filetypes = { "perl" },
-  capabilities = capabilities,
+vim.lsp.config('perllsp', {
+  cmd = { 'perllsp', '--stdio' },
+  filetypes = { 'perl' },
+  root_markers = {
+    '.perl-lsp.toml',
+    'Makefile.PL',
+    'Build.PL',
+    'cpanfile',
+    'dist.ini',
+    '.git',
+  },
+  init_options = {
+    perl = {
+      workspace = {
+        includePaths = { 'lib', '.', 'local/lib/perl5' },
+      },
+    },
+  },
 })
+
+vim.lsp.enable('perllsp')
 ```
+
+Check setup with:
+
+```vim
+:checkhealth vim.lsp
+```
+
+See [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) for filetype
+rules, keymaps, completion, inlay hints, and troubleshooting.
 
 ### Emacs
 

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -39,6 +39,40 @@ problem is usually in editor integration, workspace roots, or a stale cache.
 
 If the editor is using a helper extension or plugin, check its own logs too.
 
+### Neovim does not start `perllsp`
+
+1. Confirm the binary works outside Neovim:
+
+   ```bash
+   perllsp --version
+   perllsp --health
+   perllsp --info
+   ```
+
+2. Confirm the buffer filetype:
+
+   ```vim
+   :set filetype?
+   ```
+
+   It must be `perl`.
+
+3. Confirm the LSP config is enabled:
+
+   ```vim
+   :checkhealth vim.lsp
+   ```
+
+4. If using Neovim 0.11+, confirm the config is named and enabled consistently:
+
+   ```lua
+   vim.lsp.config('perllsp', { cmd = { 'perllsp', '--stdio' } })
+   vim.lsp.enable('perllsp')
+   ```
+
+5. Use `perllsp --check path/to/file.pl` for manual diagnostics. Do not test
+   stdio mode with unframed raw JSON.
+
 ## Diagnostics Or Completions Are Missing
 
 - Re-check the install with `perllsp --health`.

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -829,20 +829,35 @@ perllsp --features-json --feature-profile production
 
 ### Editor-specific snippets
 
-#### Neovim (lua)
+#### Neovim 0.11+
 
 ```lua
-require("lspconfig").perl_ls.setup({
-  settings = {
+vim.lsp.config('perllsp', {
+  cmd = { 'perllsp', '--stdio' },
+  filetypes = { 'perl' },
+  root_markers = {
+    '.perl-lsp.toml',
+    'Makefile.PL',
+    'Build.PL',
+    'cpanfile',
+    'dist.ini',
+    '.git',
+  },
+  init_options = {
     perl = {
       workspace = {
-        includePaths = { "lib", ".", "local/lib/perl5" },
+        includePaths = { 'lib', '.', 'local/lib/perl5' },
         useSystemInc = false,
       },
-      inlayHints = { enabled = true, parameterHints = true },
+      inlayHints = {
+        enabled = true,
+        parameterHints = true,
+      },
     },
   },
 })
+
+vim.lsp.enable('perllsp')
 ```
 
 #### Helix (`languages.toml`)

--- a/docs/reference/LSP_FEATURES.md
+++ b/docs/reference/LSP_FEATURES.md
@@ -463,9 +463,9 @@ Intelligent code folding:
 ```json
 {
   "perl.testRunner.enabled": true,
-  "perl.testRunner.testCommand": "perl",
-  "perl.testRunner.testArgs": [],
-  "perl.testRunner.testTimeout": 60000
+  "perl.testRunner.command": "perl",
+  "perl.testRunner.args": [],
+  "perl.testRunner.timeout": 60000
 }
 ```
 
@@ -504,20 +504,35 @@ Install the Perl LSP extension or configure the `perllsp` binary manually:
 
 ### Neovim
 
-Using nvim-lspconfig:
+For Neovim 0.11+:
 
 ```lua
-require('lspconfig').perl_lsp.setup{
-  cmd = {'perllsp', '--stdio'},
-  settings = {
+vim.lsp.config('perllsp', {
+  cmd = { 'perllsp', '--stdio' },
+  filetypes = { 'perl' },
+  root_markers = {
+    '.perl-lsp.toml',
+    'Makefile.PL',
+    'Build.PL',
+    'cpanfile',
+    'dist.ini',
+    '.git',
+  },
+  init_options = {
     perl = {
-      lsp = {
-        diagnostics = true,
-        completion = { enableSnippets = true }
-      }
-    }
-  }
-}
+      workspace = {
+        includePaths = { 'lib', '.', 'local/lib/perl5' },
+        useSystemInc = false,
+      },
+      inlayHints = {
+        enabled = true,
+        parameterHints = true,
+      },
+    },
+  },
+})
+
+vim.lsp.enable('perllsp')
 ```
 
 ### Emacs
@@ -589,10 +604,13 @@ With lsp-mode or eglot:
 **LSP not starting:**
 ```bash
 # Check if perllsp is in PATH
-which perllsp
+command -v perllsp
 
-# Test standalone
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | perllsp --stdio
+# Run supported health checks
+perllsp --version
+perllsp --health
+perllsp --info
+perllsp --check path/to/file.pl
 ```
 
 **Slow performance:**


### PR DESCRIPTION
### Motivation

- The Neovim guide used legacy patterns (`perl-lsp`, `lspconfig.setup{}`, unframed stdio tests) that are stale and can mislead users. 
- Modern Neovim (0.11+) prefers `vim.lsp.config()` / `vim.lsp.enable()` and the executable is `perllsp --stdio`, so the docs must reflect that to ensure correct startup and settings delivery. 
- Installation and manual-test snippets referenced outdated release asset names and unsafe raw-stdio checks that should be replaced with supported CLI checks.

### Description

- Rewrote `docs/EDITORS/NEOVIM_SETUP.md` to target Neovim 0.11+ using `vim.lsp.config('perllsp', ...)` and `vim.lsp.enable('perllsp')`, moved server startup options into `init_options`, and standardized use of the `perllsp --stdio` command. 
- Updated `docs/how-to/EDITOR_SETUP.md` to reference the modern Neovim config flow and to link to the new detailed Neovim guide. 
- Replaced legacy snippets in `docs/reference/CONFIG.md` and `docs/reference/LSP_FEATURES.md` with `vim.lsp.config()`/`vim.lsp.enable()` examples, adjusted test-runner keys to `perl.testRunner.command/args/timeout`, and removed the unframed `echo ... | perllsp --stdio` smoke test in favor of `perllsp --version`, `--health`, `--info`, and `--check`. 
- Added a Neovim-specific troubleshooting subsection in `docs/how-to/TROUBLESHOOTING.md` (binary validation, filetype checks, config enablement, and advice not to test stdio mode with unframed raw JSON). 

### Testing

- Ran `cargo check --all-targets -p perl-lsp-rs`, which completed successfully. 
- Ran formatting via `cargo xtask fmt`, which completed successfully. 
- Attempted `just pr-fast` but it was not available in the environment, so that check could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eff11cb11083339b8ddf2de83304bd)