### PR TITLE
docs(kiro): clarify IDE vs CLI setup paths (#0000)

### DIFF
--- a/docs/EDITORS/KIRO_SETUP.md
+++ b/docs/EDITORS/KIRO_SETUP.md
@@ -1,73 +1,219 @@
 # Amazon Kiro Setup Guide for perl-lsp
 
-This guide gives you a reliable setup path for using `perllsp` in Amazon Kiro.
+This guide covers using `perl-lsp` with Amazon Kiro.
+
+Kiro has two setup paths:
+
+- **Kiro IDE** — install the OpenVSX extension `EffortlessMetrics.perl-lsp-rs`
+- **Kiro CLI** — configure a workspace custom language server that launches `perllsp --stdio`
 
 ## Prerequisites
 
-- Amazon Kiro installed
-- `perllsp` installed and available on `PATH`
-- A Perl workspace opened in Kiro
+### Kiro IDE
 
-Verify the server first:
+- Kiro IDE installed
+- A Perl project opened in Kiro
+- `EffortlessMetrics.perl-lsp-rs` installed from OpenVSX
+
+The extension can auto-download `perllsp`. Manual binary installation is mainly
+for offline, pinned, or policy-restricted environments.
+
+### Kiro CLI
+
+- Kiro CLI installed
+- `perllsp` installed and available to the shell that launches Kiro CLI
+- A Perl project opened from project root
+
+Verify manual binary install:
 
 ```bash
 perllsp --version
 perllsp --health
+perllsp --info
 ```
 
-## Kiro IDE (Desktop)
+## Kiro IDE Setup
 
-Kiro IDE is built on VS Code's open-source foundation and uses the OpenVSX
-extension registry. Install the Perl LSP extension from the Extensions panel:
+Kiro uses OpenVSX-compatible extensions. Install:
 
-- Search for `perl-lsp` in Kiro's Extensions panel
-- Extension ID: `EffortlessMetrics.perl-lsp-rs`
+```text
+EffortlessMetrics.perl-lsp-rs
+```
 
-If the extension is not available in OpenVSX, download the `.vsix` from
-[GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases) and
-install it via "Install from VSIX..." in the Extensions panel menu.
+From Kiro:
 
-## Kiro CLI
+1. Open Extensions.
+2. Search for `perl-lsp` or `EffortlessMetrics.perl-lsp-rs`.
+3. Install the extension.
+4. Open a `.pm`, `.pl`, or `.t` file.
 
-If you use the Kiro command-line interface, add a custom language server entry
-in `.kiro/settings/lsp.json` at your project root:
+## Optional: Manual Binary Path (Kiro IDE)
+
+Use this only when extension-managed download is disabled or blocked:
+
+```json
+{
+  "perl-lsp.serverPath": "/absolute/path/to/perllsp",
+  "perl-lsp.autoDownload": false
+}
+```
+
+## Recommended Kiro IDE Settings
+
+```json
+{
+  "perl-lsp.autoDownload": true,
+  "perl-lsp.trace.server": "off",
+  "perl-lsp.enableDiagnostics": true,
+  "perl-lsp.enableSemanticTokens": true,
+  "perl-lsp.enableFormatting": true,
+  "perl-lsp.formatOnSave": false,
+  "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5"]
+}
+```
+
+Use protocol tracing only for debugging:
+
+```json
+{
+  "perl-lsp.trace.server": "messages"
+}
+```
+
+## Kiro CLI Setup
+
+Kiro CLI supports workspace-scoped custom LSP entries.
+
+Run in project root:
+
+```text
+/code init
+```
+
+Then edit the `lsp.json` file that Kiro creates.
+
+Current Kiro docs describe this as project-root `lsp.json`; some Kiro CLI
+examples/builds refer to `.kiro/settings/lsp.json`. Use the file path created
+by your installed Kiro CLI.
+
+Add or merge:
 
 ```json
 {
   "languages": {
     "perl": {
-      "name": "perllsp",
+      "name": "perl-lsp",
       "command": "perllsp",
       "args": ["--stdio"],
-      "file_extensions": ["pl", "pm", "t", "psgi"],
-      "project_patterns": [".perl-lsp.toml", "Makefile.PL", "Build.PL"],
-      "multi_workspace": false
+      "file_extensions": ["pl", "PL", "pm", "t", "psgi", "cgi", "fcgi", "xs", "xsi"],
+      "project_patterns": [".perl-lsp.toml", "Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"],
+      "exclude_patterns": ["**/.git/**", "**/local/**", "**/blib/**", "**/node_modules/**"],
+      "multi_workspace": false,
+      "request_timeout_secs": 60,
+      "initialization_options": {
+        "perl": {
+          "workspace": {
+            "includePaths": ["lib", ".", "local/lib/perl5"],
+            "useSystemInc": false,
+            "resolutionTimeout": 50
+          }
+        }
+      }
     }
   }
 }
 ```
 
-Run `/code init` in the project root first if the `.kiro/settings/` directory
-does not exist, then restart the Kiro CLI to load the new configuration.
+Restart servers:
 
-## Recommended Workspace Settings
+```text
+/code init -f
+```
 
-- Keep your project root open as the workspace root.
-- Add include/library paths in project settings when your code uses nonstandard
-  module locations.
-- Restart the language server after changing server path or arguments.
+Check status and logs:
+
+```text
+/code status
+/code logs
+/code logs -l DEBUG -n 100
+```
+
+## Kiro CLI Caveat
+
+Perl is not currently listed in Kiro CLI's built-in tree-sitter language set.
+Treat custom Perl LSP support as version-dependent and verify locally.
+
+If diagnostics work but hover/references/definition/completion/rename do not,
+that can be a Kiro CLI custom-LSP limitation rather than a `perllsp` issue.
+
+## Verify It Is Running
+
+### Kiro IDE
+
+1. Open the project root.
+2. Open a Perl file.
+3. Introduce a temporary syntax error.
+4. Confirm diagnostics appear.
+5. Remove the temporary error.
+
+### Kiro CLI
+
+After `/code init`, try LSP-backed queries and confirm responses are populated.
+Also validate server behavior directly:
+
+```bash
+perllsp --check path/to/file.pl
+```
 
 ## Troubleshooting
 
-1. **Server does not start**
-   - Run `perllsp --health` in an external shell.
-   - Confirm Kiro inherits the same `PATH` as your shell.
-2. **No diagnostics or completions**
-   - Confirm the file is recognized as Perl.
-   - Confirm the LSP client is attached to the current buffer/file.
-3. **Definitions/references incomplete**
-   - Open the repository root, not a nested subfolder.
-   - Ensure local library paths are configured in project settings.
+### Kiro IDE extension does not install
 
-For cross-editor fallback patterns, see [Editor Setup](../how-to/EDITOR_SETUP.md)
-and [Troubleshooting](../how-to/TROUBLESHOOTING.md).
+- Confirm the extension exists on OpenVSX.
+- Update Kiro.
+- If using an internal extension registry, confirm it mirrors `EffortlessMetrics.perl-lsp-rs`.
+
+### Kiro IDE cannot find `perllsp`
+
+If using auto-download, verify:
+
+```json
+{
+  "perl-lsp.autoDownload": true
+}
+```
+
+If using manual binary mode, run:
+
+```bash
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+Use absolute `perl-lsp.serverPath` if GUI launch does not inherit `PATH`.
+
+### Kiro CLI cannot start `perllsp`
+
+Run from the same shell used to launch Kiro CLI:
+
+```bash
+command -v perllsp
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+Then restart and inspect logs:
+
+```text
+/code init -f
+/code logs -l ERROR
+/code logs -l DEBUG -n 100
+```
+
+## See Also
+
+- [Editor Setup](../how-to/EDITOR_SETUP.md)
+- [Configuration](../reference/CONFIG.md)
+- [Troubleshooting](../how-to/TROUBLESHOOTING.md)

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -31,7 +31,7 @@ perllsp --health
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Zed | install a Perl extension, then optionally point at `perllsp` | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
 | Sublime Text | register `perllsp` in the LSP package settings | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
-| Amazon Kiro | register a Perl LSP client using `perllsp --stdio` | [docs/EDITORS/KIRO_SETUP.md](../EDITORS/KIRO_SETUP.md) |
+| Amazon Kiro | use OpenVSX `EffortlessMetrics.perl-lsp-rs` in Kiro IDE; for Kiro CLI, configure a custom LSP entry launching `perllsp --stdio` | [docs/EDITORS/KIRO_SETUP.md](../EDITORS/KIRO_SETUP.md) |
 | Claude Code | provide a plugin `.lsp.json` pointing to `perllsp --stdio` | [docs/EDITORS/CLAUDE_CODE_SETUP.md](../EDITORS/CLAUDE_CODE_SETUP.md) |
 | Codex CLI | connect an MCP LSP bridge to `perllsp --stdio` | [docs/EDITORS/CODEX_CLI_SETUP.md](../EDITORS/CODEX_CLI_SETUP.md) |
 | Codex Desktop | add a custom Perl server command `perllsp --stdio` | [docs/EDITORS/CODEX_DESKTOP_SETUP.md](../EDITORS/CODEX_DESKTOP_SETUP.md) |
@@ -119,8 +119,28 @@ Register a client with `command: ["perllsp", "--stdio"]`, use a selector such as
 
 ### Amazon Kiro
 
-Register a Perl language-server client that launches `perllsp --stdio`, then
-restart the client after changing workspace settings or include paths.
+For Kiro IDE, install the OpenVSX extension:
+
+```text
+EffortlessMetrics.perl-lsp-rs
+```
+
+The extension can auto-download `perllsp`. For offline or pinned deployments,
+set:
+
+```json
+{
+  "perl-lsp.serverPath": "/absolute/path/to/perllsp",
+  "perl-lsp.autoDownload": false
+}
+```
+
+For Kiro CLI, run `/code init` from project root and edit the generated LSP
+config file to launch `perllsp --stdio` for Perl file extensions.
+
+Kiro CLI Perl support uses a custom-LSP path, so verify diagnostics, hover,
+definition, references, completion, and rename in your installed Kiro CLI
+version.
 
 ### Claude Code
 

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -71,6 +71,53 @@ If the editor is using a helper extension or plugin, check its own logs too.
 If you are debugging with `perl-dap`, check the DAP guide:
 [DAP_USER_GUIDE.md](../tutorials/DAP_USER_GUIDE.md).
 
+## Amazon Kiro Does Not Start `perllsp`
+
+### Kiro IDE
+
+1. Confirm `EffortlessMetrics.perl-lsp-rs` is installed and enabled.
+2. Confirm the active file language is Perl.
+3. If using extension-managed downloads, verify:
+
+   ```json
+   {
+     "perl-lsp.autoDownload": true
+   }
+   ```
+
+4. If using a manual binary, run:
+
+   ```bash
+   perllsp --version
+   perllsp --health
+   perllsp --info
+   ```
+
+5. If Kiro cannot find the binary, set an absolute `perl-lsp.serverPath`.
+
+### Kiro CLI
+
+1. Run `/code init` in project root.
+2. Edit the generated LSP config and add a Perl entry that launches
+   `perllsp --stdio`.
+3. Restart LSP servers:
+
+   ```text
+   /code init -f
+   ```
+
+4. Check status and logs:
+
+   ```text
+   /code status
+   /code logs -l ERROR
+   /code logs -l DEBUG -n 100
+   ```
+
+5. If diagnostics work but hover, definition, references, completion, or rename
+   do not, verify whether your Kiro CLI build fully supports client-initiated
+   custom-LSP operations for non-built-in languages.
+
 ## When To Escalate
 
 Report an issue when you can include:

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -615,7 +615,7 @@ behaviour such as binary management and feature toggles.
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
-| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perl-lsp` binary. Empty = auto-download. |
+| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perllsp` binary. Empty = auto-download. |
 | `perl-lsp.autoDownload` | `boolean` | `true` | Download the binary automatically if not found locally. |
 | `perl-lsp.downloadBaseUrl` | `string` | `""` | Override the GitHub releases base URL for internal mirrors. |
 | `perl-lsp.channel` | `"latest"\|"stable"\|"tag"` | `"latest"` | Release channel to track. |
@@ -646,6 +646,45 @@ behaviour such as binary management and feature toggles.
 | `perl-lsp.includePaths` | `string[]` | `["lib", "local/lib/perl5"]` | Additional module search paths (merged with server-side `perl.workspace.includePaths`). |
 | `perl-lsp.perltidyConfig` | `string` | `""` | Path to a `.perltidyrc` configuration file. Empty = use Perl::Tidy defaults. |
 | `perl-lsp.featureProfile` | `string` | `"auto"` | Feature profile passed to the server at startup (see [Feature Profiles](#feature-profiles)). |
+
+### Amazon Kiro
+
+Kiro IDE uses OpenVSX-compatible extensions. Prefer
+`EffortlessMetrics.perl-lsp-rs`. For manual binary management:
+
+```json
+{
+  "perl-lsp.serverPath": "/absolute/path/to/perllsp",
+  "perl-lsp.autoDownload": false
+}
+```
+
+Kiro CLI uses workspace-scoped LSP configuration. Run `/code init`, then edit
+the generated `lsp.json` file and add a Perl entry that launches
+`perllsp --stdio`.
+
+```json
+{
+  "languages": {
+    "perl": {
+      "name": "perl-lsp",
+      "command": "perllsp",
+      "args": ["--stdio"],
+      "file_extensions": ["pl", "PL", "pm", "t", "psgi", "cgi", "fcgi", "xs", "xsi"],
+      "project_patterns": [".perl-lsp.toml", "Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"],
+      "multi_workspace": false,
+      "initialization_options": {
+        "perl": {
+          "workspace": {
+            "includePaths": ["lib", ".", "local/lib/perl5"],
+            "useSystemInc": false
+          }
+        }
+      }
+    }
+  }
+}
+```
 
 ---
 


### PR DESCRIPTION
### Motivation

- The existing Kiro guide mixed IDE and CLI behaviors, incorrectly referenced the VS Code Marketplace instead of OpenVSX, and demanded `perllsp` on `PATH` for IDE users. 
- The CLI config path and behavior for custom LSPs were asserted too rigidly despite upstream variation and known client-initiated-request limitations for non-built-in languages. 

### Description

- Rewrote `docs/EDITORS/KIRO_SETUP.md` to separate Kiro IDE (OpenVSX extension) and Kiro CLI (workspace custom LSP) flows and added explicit IDE settings and optional manual-binary guidance. 
- Updated `docs/how-to/EDITOR_SETUP.md` to prefer OpenVSX `EffortlessMetrics.perl-lsp-rs` for the IDE and to document the CLI custom-LSP verification expectation. 
- Fixed binary naming and added an Amazon Kiro subsection to `docs/reference/CONFIG.md` that shows `perllsp` usage and an example `lsp.json` entry. 
- Added a Kiro-specific troubleshooting block to `docs/how-to/TROUBLESHOOTING.md` that covers IDE auto-download vs manual `perllsp`, `/code init` guidance for the CLI, restart/status/log commands, and a caveat that Perl is a custom language in some Kiro CLI builds. 

### Testing

- Ran `git diff --check` and it passed. 
- Verified repository state with `git status --short` and committed the four modified files. 
- Created PR metadata via the local PR helper (title/body present) for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eff525133883338292193fffa65d8a)