### PR TITLE
docs(emacs): refresh setup and diagnostics guidance (#0000)

### DIFF
--- a/docs/EDITORS/EMACS_SETUP.md
+++ b/docs/EDITORS/EMACS_SETUP.md
@@ -1,13 +1,13 @@
 # Emacs Setup Guide for perl-lsp
 
-This guide gives you a fast, reliable Emacs setup for `perllsp` with a minimal first-run path.
+This guide shows how to use `perllsp` from Emacs.
 
-## Official support posture
+## Recommended Support Posture
 
-- **Primary path (Emacs 29+)**: `eglot`
-- **Alternative path**: `lsp-mode` (for users who prefer that stack)
+- **Primary path:** Eglot, especially on Emacs 29 or later
+- **Alternative path:** `lsp-mode`, for users already using that stack
 
-Both clients are supported with the same server command:
+Both clients launch the same server command:
 
 ```bash
 perllsp --stdio
@@ -15,141 +15,354 @@ perllsp --stdio
 
 ## Prerequisites
 
-- Emacs 29+ recommended
-- `perllsp` installed and available on your `PATH`
+- Emacs 29 or later recommended
+- `perllsp` installed and available to Emacs
+- A Perl project opened from the project root
 
-Install `perllsp` using the same methods described in:
+Emacs 29 includes Eglot. If you use Emacs 28 or older, install Eglot separately
+or use `lsp-mode`.
 
-- [README Quick Start](../../README.md)
-- [Getting Started](../tutorials/GETTING_STARTED.md)
+Do not use:
 
-> Do not use `cargo install perl-lsp` (different crates.io package name).
+```bash
+cargo install perl-lsp
+```
 
-## 1) Minimal setup (recommended)
+That crates.io package name belongs to a different project. Use:
 
-Copy this into your Emacs config:
+```bash
+cargo install perllsp
+```
+
+Verify the server before changing Emacs configuration:
+
+```bash
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+## Perl File Modes
+
+Emacs has built-in `perl-mode` and `cperl-mode`.
+
+`perl-ts-mode` is optional and third-party. Do not include it in your hooks unless
+you have installed a package that provides it.
+
+If files such as `.t`, `.psgi`, `.cgi`, or `.fcgi` are not detected as Perl, add
+file associations:
+
+```elisp
+(add-to-list 'auto-mode-alist '("\\.t\\'" . perl-mode))
+(add-to-list 'auto-mode-alist '("\\.psgi\\'" . perl-mode))
+(add-to-list 'auto-mode-alist '("\\.cgi\\'" . perl-mode))
+(add-to-list 'auto-mode-alist '("\\.fcgi\\'" . perl-mode))
+```
+
+## 1. Minimal Eglot Setup
+
+For Emacs 29+, add this to your Emacs config:
 
 ```elisp
 (use-package eglot
+  :ensure nil
   :hook ((perl-mode . eglot-ensure)
-         (cperl-mode . eglot-ensure)
-         (perl-ts-mode . eglot-ensure))  ; remove if perl-ts-mode is not installed
+         (cperl-mode . eglot-ensure))
   :config
   (add-to-list 'eglot-server-programs
-               '((perl-mode cperl-mode perl-ts-mode) . ("perllsp" "--stdio"))))
+               '(((perl-mode :language-id "perl")
+                  (cperl-mode :language-id "perl"))
+                 . ("perllsp" "--stdio"))))
 ```
 
-> **Note:** `perl-mode` and `cperl-mode` are built into Emacs. `perl-ts-mode` is a
-> third-party package (not included in Emacs core); remove it from the hook and mode list
-> if you have not installed it separately.
+If you have installed `perl-ts-mode`, add it explicitly:
+
+```elisp
+(with-eval-after-load 'eglot
+  (add-to-list 'eglot-server-programs
+               '((perl-ts-mode :language-id "perl")
+                 . ("perllsp" "--stdio"))))
+
+(add-hook 'perl-ts-mode-hook #'eglot-ensure)
+```
 
 Then:
 
 1. Restart Emacs.
-2. Open a `.pl` or `.pm` file.
-3. Confirm `eglot` is attached (`M-x eglot`).
+2. Open a Perl file such as `lib/My/Module.pm`, `script/app.pl`, or `t/basic.t`.
+3. Confirm the mode line shows `[eglot:PROJECT]`.
+4. Introduce a temporary syntax error.
+5. Confirm Flymake diagnostics appear.
+6. Remove the syntax error after testing.
 
-### Minimal key commands
+You can also check attachment with:
 
-- Go to definition: `M-.`
-- Find references: `M-?`
-- Rename symbol: `M-x eglot-rename`
-- Code actions: `M-x eglot-code-actions`
-- Format buffer: `M-x eglot-format-buffer`
+```elisp
+M-: (eglot-managed-p)
+```
 
-With `eglot`, diagnostics are provided through Flymake in standard Emacs UI.
+## Useful Eglot Commands
 
-## 2) Team/project configuration (preferred over large Emacs Lisp)
+| Action                  | Command                                |
+| ----------------------- | -------------------------------------- |
+| Start / reconnect Eglot | `M-x eglot`                            |
+| Restart server          | `M-x eglot-reconnect`                  |
+| Go to definition        | `M-.` / `M-x xref-find-definitions`    |
+| Find references         | `M-?` / `M-x xref-find-references`     |
+| Rename symbol           | `M-x eglot-rename`                     |
+| Code actions            | `M-x eglot-code-actions`               |
+| Format buffer           | `M-x eglot-format-buffer`              |
+| Toggle inlay hints      | `M-x eglot-inlay-hints-mode`           |
+| Buffer diagnostics      | `M-x flymake-show-buffer-diagnostics`  |
+| Project diagnostics     | `M-x flymake-show-project-diagnostics` |
+| Protocol log            | `M-x eglot-events-buffer`              |
+| Server stderr           | `M-x eglot-stderr-buffer`              |
 
-Keep project-wide defaults in `.perl-lsp.toml` at repository root.
+## Optional: Eglot Initialization Options
 
-Example:
+Prefer `.perl-lsp.toml` for settings shared across editors. Use Eglot
+initialization options only for Emacs-specific startup behavior.
+
+```elisp
+(use-package eglot
+  :ensure nil
+  :hook ((perl-mode . eglot-ensure)
+         (cperl-mode . eglot-ensure))
+  :config
+  (add-to-list 'eglot-server-programs
+               '(((perl-mode :language-id "perl")
+                  (cperl-mode :language-id "perl"))
+                 . ("perllsp" "--stdio"
+                    :initializationOptions
+                    (:perl
+                     (:workspace
+                      (:includePaths ["lib" "." "local/lib/perl5"]
+                       :useSystemInc :json-false
+                       :resolutionTimeout 50)
+                      :inlayHints
+                      (:enabled t
+                       :parameterHints t
+                       :typeHints t)))))))
+```
+
+## 2. Project Configuration
+
+For team-shared settings, prefer `.perl-lsp.toml` at the repository root.
 
 ```toml
 [perl]
-include_paths = ["lib", "local/lib/perl5"]
+include_paths = ["lib", ".", "local/lib/perl5", "vendor/lib"]
 
 [diagnostics]
-enabled = true
+perlcritic = true
+perlcritic_severity = 3
 
-[format]
-enabled = true
-
-[perlcritic]
-enabled = true
+[features]
+inlay_hints = true
 ```
 
-This keeps editor startup config thin and makes settings portable across VS Code, Neovim, Emacs, and other clients.
+If your project only needs the built-in defaults, omit `include_paths`. The
+built-in include paths are `lib`, `.`, and `local/lib/perl5`.
 
-For full configuration reference, see [docs/reference/CONFIG.md](../reference/CONFIG.md).
+## 3. lsp-mode Alternative
 
-## 3) lsp-mode alternative
-
-If you prefer `lsp-mode`, use this minimal config:
+Use this path if you already prefer `lsp-mode`.
 
 ```elisp
 (use-package lsp-mode
+  :commands (lsp lsp-deferred)
   :hook ((perl-mode . lsp-deferred)
-         (cperl-mode . lsp-deferred)
-         (perl-ts-mode . lsp-deferred))  ; remove if perl-ts-mode is not installed
-  :commands lsp
+         (cperl-mode . lsp-deferred))
   :config
+  (add-to-list 'lsp-language-id-configuration '(perl-mode . "perl"))
+  (add-to-list 'lsp-language-id-configuration '(cperl-mode . "perl"))
+
   (lsp-register-client
    (make-lsp-client
     :new-connection (lsp-stdio-connection '("perllsp" "--stdio"))
-    :major-modes '(perl-mode cperl-mode perl-ts-mode)
+    :activation-fn (lsp-activate-on "perl")
+    :major-modes '(perl-mode cperl-mode)
+    :priority 1
     :server-id 'perllsp)))
 ```
 
-> **Note:** `perl-ts-mode` is a third-party package (not built into Emacs); remove it
-> from `:hook` and `:major-modes` if you have not installed it separately.
+If using `perl-ts-mode`:
 
-Keep optional packages (`lsp-ui`, custom completion stacks, extra modeline integrations) layered on only after base connectivity works.
+```elisp
+(with-eval-after-load 'lsp-mode
+  (add-to-list 'lsp-language-id-configuration '(perl-ts-mode . "perl")))
 
-## 4) Troubleshooting quick checks
+(add-hook 'perl-ts-mode-hook #'lsp-deferred)
+```
 
-Run these in order:
+Optional initialization options:
 
-1. Binary resolution:
+```elisp
+(use-package lsp-mode
+  :commands (lsp lsp-deferred)
+  :hook ((perl-mode . lsp-deferred)
+         (cperl-mode . lsp-deferred))
+  :config
+  (add-to-list 'lsp-language-id-configuration '(perl-mode . "perl"))
+  (add-to-list 'lsp-language-id-configuration '(cperl-mode . "perl"))
 
-   ```elisp
-   M-: (executable-find "perllsp")
-   ```
+  (lsp-register-client
+   (make-lsp-client
+    :new-connection (lsp-stdio-connection '("perllsp" "--stdio"))
+    :activation-fn (lsp-activate-on "perl")
+    :major-modes '(perl-mode cperl-mode)
+    :priority 1
+    :server-id 'perllsp
+    :initialization-options
+    '(:perl
+      (:workspace
+       (:includePaths ["lib" "." "local/lib/perl5"]
+        :useSystemInc :json-false
+        :resolutionTimeout 50)
+       :inlayHints
+       (:enabled t
+        :parameterHints t
+        :typeHints t))))))
+```
 
-2. Verify server outside Emacs:
+Keep optional packages such as `lsp-ui`, `company`, `corfu`, `cape`,
+`consult`, `vertico`, `orderless`, or modeline integrations layered on only after
+base connectivity works.
 
-   ```bash
-   perllsp --version
-   perllsp --health
-   ```
+## 4. Verify It Is Running
 
-3. Verify active major mode:
+### Eglot
 
-   ```elisp
-   M-: major-mode
-   ```
+1. Open a Perl file.
+2. Confirm `[eglot:PROJECT]` appears in the mode line.
+3. Run `M-: (eglot-managed-p)`.
+4. Check diagnostics with `M-x flymake-show-buffer-diagnostics`.
+5. Check logs if needed:
+   - `M-x eglot-events-buffer`
+   - `M-x eglot-stderr-buffer`
 
-   Expected: `perl-mode`, `cperl-mode`, or `perl-ts-mode`.
+### lsp-mode
 
-4. Check client attachment:
+1. Open a Perl file.
+2. Run `M-x lsp-describe-session`.
+3. Check logs with `M-x lsp-workspace-show-log`.
 
-   - `eglot`: `M-x eglot`
-   - `lsp-mode`: `M-x lsp-describe-session`
+## 5. Troubleshooting
 
-5. Optional low-level server check:
+### Emacs cannot find `perllsp`
 
-   ```bash
-   echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perllsp --stdio
-   ```
+Check inside Emacs:
 
-If the CLI checks pass but Emacs does not attach, see [Troubleshooting](../how-to/TROUBLESHOOTING.md).
+```elisp
+M-: (executable-find "perllsp")
+```
 
-## 5) Scope and expectations
+It should return a path.
 
-This page intentionally focuses on:
+Check from a shell:
 
-- a successful first connection,
-- consistent binary naming (`perllsp`), and
-- consistent mode coverage (`perl-mode` + `cperl-mode` + `perl-ts-mode`).
+```bash
+command -v perllsp
+perllsp --version
+perllsp --health
+perllsp --info
+```
 
-For broader editor guidance, see [Editor Setup](../how-to/EDITOR_SETUP.md).
+On Windows PowerShell:
+
+```powershell
+where perllsp
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+If GUI Emacs does not inherit your shell `PATH`, either fix Emacs `exec-path` or
+use an absolute path:
+
+```elisp
+(add-to-list 'eglot-server-programs
+             '(((perl-mode :language-id "perl")
+                (cperl-mode :language-id "perl"))
+               . ("/absolute/path/to/perllsp" "--stdio")))
+```
+
+### Emacs starts the wrong Perl language server
+
+`lsp-mode` has existing Perl clients for other Perl language servers. If another
+Perl server starts instead of `perllsp`, raise the custom client's priority,
+disable the other Perl clients, or remove the other server binary from `PATH`.
+
+### No diagnostics
+
+Check the active major mode:
+
+```elisp
+M-: major-mode
+```
+
+Expected values include:
+
+```elisp
+perl-mode
+cperl-mode
+perl-ts-mode
+```
+
+If the file is not in a Perl mode, add an `auto-mode-alist` entry for the file
+extension.
+
+Then check the server outside Emacs:
+
+```bash
+perllsp --check path/to/file.pl
+```
+
+### Module resolution issues
+
+Prefer `.perl-lsp.toml` for project-wide include paths:
+
+```toml
+[perl]
+include_paths = ["lib", ".", "local/lib/perl5", "vendor/lib"]
+```
+
+Or pass Emacs-specific startup options through Eglot `:initializationOptions` or
+`lsp-mode` `:initialization-options`.
+
+### Formatting does not work
+
+Install `perltidy` and confirm it is visible to Emacs:
+
+```bash
+perltidy --version
+```
+
+Then try:
+
+```elisp
+M-x eglot-format-buffer
+```
+
+or, in `lsp-mode`:
+
+```elisp
+M-x lsp-format-buffer
+```
+
+### `perllsp --stdio` appears to hang
+
+That is expected. In stdio mode, `perllsp` waits for framed LSP JSON-RPC input
+from Emacs. Use these manual checks instead:
+
+```bash
+perllsp --health
+perllsp --info
+perllsp --check path/to/file.pl
+```
+
+For server-side behavior and configuration details, see:
+
+- [Configuration Reference](../reference/CONFIG.md)
+- [Troubleshooting Guide](../how-to/TROUBLESHOOTING.md)
+- [Editor Setup](../how-to/EDITOR_SETUP.md)

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -28,7 +28,7 @@ perllsp --info
 | Trae (ByteDance) | install the VS Code-compatible extension or set command to `perllsp --stdio` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Vim | use `vim-lsp` or `coc.nvim` with `perllsp --stdio` | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
-| Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
+| Emacs | use Eglot on Emacs 29+ or `lsp-mode`; register `perllsp --stdio` for `perl-mode`, `cperl-mode`, and optionally `perl-ts-mode` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Zed | install a Perl extension, then optionally point at `perllsp` | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
 | Sublime Text | install Sublime's `LSP` package and add `perllsp --stdio` in `LanguageServers.sublime-settings` | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
@@ -70,8 +70,24 @@ require("lspconfig").perl_lsp.setup({
 
 ### Emacs
 
-Use `lsp-mode` or `eglot` with the same `perllsp --stdio` command. The
-editor-specific guide has the full snippets for both.
+For Emacs 29+, prefer Eglot:
+
+```elisp
+(use-package eglot
+  :ensure nil
+  :hook ((perl-mode . eglot-ensure)
+         (cperl-mode . eglot-ensure))
+  :config
+  (add-to-list 'eglot-server-programs
+               '(((perl-mode :language-id "perl")
+                  (cperl-mode :language-id "perl"))
+                 . ("perllsp" "--stdio"))))
+```
+
+For `lsp-mode`, register a custom client that launches `perllsp --stdio`.
+
+See [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) for full Eglot,
+`lsp-mode`, filetype, and troubleshooting examples.
 
 ### Vim
 

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -39,6 +39,50 @@ problem is usually in editor integration, workspace roots, or a stale cache.
 
 If the editor is using a helper extension or plugin, check its own logs too.
 
+
+## Emacs Does Not Start `perllsp`
+
+1. Confirm Emacs can find the binary:
+
+   ```elisp
+   M-: (executable-find "perllsp")
+   ```
+
+2. Confirm the file is in a Perl major mode:
+
+   ```elisp
+   M-: major-mode
+   ```
+
+   Expected: `perl-mode`, `cperl-mode`, or an installed `perl-ts-mode`.
+
+3. Confirm the server works outside Emacs:
+
+   ```bash
+   perllsp --version
+   perllsp --health
+   perllsp --info
+   perllsp --check path/to/file.pl
+   ```
+
+4. For Eglot, inspect:
+
+   ```elisp
+   M-: (eglot-managed-p)
+   M-x eglot-events-buffer
+   M-x eglot-stderr-buffer
+   ```
+
+5. For `lsp-mode`, inspect:
+
+   ```elisp
+   M-x lsp-describe-session
+   M-x lsp-workspace-show-log
+   ```
+
+6. Do not test stdio mode with raw JSON. LSP stdio traffic requires
+   `Content-Length` framing.
+
 ## Sublime Text Does Not Start `perllsp`
 
 1. Confirm `perllsp` works outside Sublime:

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -512,7 +512,7 @@ decrease them for resource-constrained environments.
 
 ## CLI Flags
 
-Flags passed when launching the `perl-lsp` binary. Source:
+Flags passed when launching the `perllsp` binary. Source:
 `crates/perl-lsp-launcher/src/lib.rs`.
 
 ### Server mode
@@ -559,7 +559,7 @@ perllsp --completion bash >> ~/.bashrc  # install bash completions
 
 ## Environment Variables
 
-Environment variables read at startup by the `perl-lsp` binary. Source:
+Environment variables read at startup by the `perllsp` binary. Source:
 `crates/perl-lsp-launcher/src/lib.rs`.
 
 ### `PERL_LSP_LOG`
@@ -615,7 +615,7 @@ behaviour such as binary management and feature toggles.
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
-| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perl-lsp` binary. Empty = auto-download. |
+| `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perllsp` binary. Empty = auto-download. |
 | `perl-lsp.autoDownload` | `boolean` | `true` | Download the binary automatically if not found locally. |
 | `perl-lsp.downloadBaseUrl` | `string` | `""` | Override the GitHub releases base URL for internal mirrors. |
 | `perl-lsp.channel` | `"latest"\|"stable"\|"tag"` | `"latest"` | Release channel to track. |
@@ -854,14 +854,43 @@ workspace.useSystemInc = false
 inlayHints.enabled = true
 ```
 
-#### Emacs (eglot)
+#### Emacs with Eglot
 
 ```elisp
-(setq-default eglot-workspace-configuration
-  '((perl
-     (workspace
-      (includePaths . ["lib" "." "local/lib/perl5"])
-      (useSystemInc . :json-false)))))
+(use-package eglot
+  :ensure nil
+  :hook ((perl-mode . eglot-ensure)
+         (cperl-mode . eglot-ensure))
+  :config
+  (add-to-list 'eglot-server-programs
+               '(((perl-mode :language-id "perl")
+                  (cperl-mode :language-id "perl"))
+                 . ("perllsp" "--stdio"
+                    :initializationOptions
+                    (:perl
+                     (:workspace
+                      (:includePaths ["lib" "." "local/lib/perl5"]
+                       :useSystemInc :json-false)))))))
+```
+
+#### Emacs with lsp-mode
+
+```elisp
+(use-package lsp-mode
+  :commands (lsp lsp-deferred)
+  :hook ((perl-mode . lsp-deferred)
+         (cperl-mode . lsp-deferred))
+  :config
+  (add-to-list 'lsp-language-id-configuration '(perl-mode . "perl"))
+  (add-to-list 'lsp-language-id-configuration '(cperl-mode . "perl"))
+
+  (lsp-register-client
+   (make-lsp-client
+    :new-connection (lsp-stdio-connection '("perllsp" "--stdio"))
+    :activation-fn (lsp-activate-on "perl")
+    :major-modes '(perl-mode cperl-mode)
+    :priority 1
+    :server-id 'perllsp)))
 ```
 
 #### Sublime Text (LSP package)


### PR DESCRIPTION
### Motivation

- The Emacs guide contained an invalid raw stdio smoke test and incomplete verification steps that could mislead users.
- The project config example in `.perl-lsp.toml` did not match the supported schema and omitted `--info` checks that are useful for manual validation.
- Eglot and `lsp-mode` snippets lacked explicit language-id and more robust client registration options for reliable editor attachment.
- Filetype detection and troubleshooting guidance for common Perl extensions were missing, reducing first-run reliability.

### Description

- Rewrote `docs/EDITORS/EMACS_SETUP.md` to add `perllsp --info`, remove the raw `echo | perllsp --stdio` test, correct the `.perl-lsp.toml` example (`[perl]`, `[diagnostics]`, `[features]`), add file-association hints for `.t`, `.psgi`, `.cgi`, and `.fcgi`, and improve Eglot and `lsp-mode` snippets (explicit language-id, `:initializationOptions`, `:activation-fn`, `:priority`, and `:server-id`).
- Updated `docs/how-to/EDITOR_SETUP.md` to recommend Eglot on Emacs 29+, adjust the Emacs row, and include a minimal Eglot snippet pointing at `perllsp --stdio`.
- Added an Emacs-specific troubleshooting section to `docs/how-to/TROUBLESHOOTING.md` covering binary discovery, major-mode checks, Eglot/lsp-mode attachment checks, and the `Content-Length` framing warning.
- Aligned wording and editor snippets in `docs/reference/CONFIG.md` to refer to the `perllsp` binary and added Emacs (Eglot and `lsp-mode`) initialization examples consistent with the other doc updates.

### Testing

- Ran a repository search to verify the new checks and keys are present with `rg -n "perllsp --info|perlcritic_severity|Emacs Does Not Start|perllsp binary"` across the modified docs, which returned expected matches.
- Performed local edits and created a commit (`docs(emacs): refresh setup and diagnostics guidance (#0000)`), and verified the working tree contains the intended changes via `git status` and `git diff`.
- `just pr-fast` could not be executed in this environment (`just: command not found`), so the full local gate was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f004c5c8988333b11e01b0daa2aae8)