### PR TITLE
docs(orchestration): doctrine + live-signals reference docs (#7084)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@
 
 ## Orchestration Model
 
+> For the design rationale and direction behind this orchestration model, see [docs/reference/ORCHESTRATION_DOCTRINE.md](docs/reference/ORCHESTRATION_DOCTRINE.md).
+
 The orchestrator routes work to agents, never writes code directly.
 
 ### Pipeline: Scout → Accuracy-Scout → Plan-Review → Build → Review → Green → Merge → Wisdom
@@ -53,7 +55,7 @@ Every change flows through this pipeline. Each stage is a cheap pass that catche
 
 ### Pipeline State Labels
 
-Labels are the authoritative state for every issue and PR. The orchestrator reads them; agents write them.
+Labels are the authoritative state for every issue and PR. The orchestrator reads them; agents write them. For the principle distinguishing live-truth labels (CI, mergeability) from authoritative-only labels (signoffs, routing), see [docs/reference/LIVE_SIGNALS_VS_LABELS.md](docs/reference/LIVE_SIGNALS_VS_LABELS.md).
 
 **Sign-off labels** (`<agent>-reviewed` = agent completed its pass):
 

--- a/docs/reference/LIVE_SIGNALS_VS_LABELS.md
+++ b/docs/reference/LIVE_SIGNALS_VS_LABELS.md
@@ -1,0 +1,171 @@
+# Live Signals vs Label Signals
+
+## Principle
+
+Where ground truth exists as a queryable live signal, the live signal is authoritative. Labels are bookkeeping for agent activity, not state machines that compete with live truth.
+
+This means: when the GitHub API can answer "is CI green right now for this HEAD SHA?", that answer supersedes any label's claim about CI state. Labels record what an agent did ("green-ci ran a pass"). They do not record what is currently true when a live source can tell us directly.
+
+---
+
+## The Audit Table
+
+Every label in the repo, classified by whether live ground truth exists for it:
+
+| Label | Has live ground truth? | Live source | Use of label |
+|-------|----------------------|-------------|--------------|
+| `ci-green` | Yes | `statusCheckRollup` for current HEAD SHA | Informational: "green-ci agent ran a pass and it was green at that time" |
+| `needs-ci-fix` | Yes | Same | Informational: "green-ci flagged this needs follow-up at time of check" |
+| `mergeable` | Yes | `mergeStateStatus` on the PR | Not a label — queried directly from the API |
+| `needs-plan-review` | No | — | Authoritative: routing entry to verification pipeline |
+| `accuracy-reviewed` | No | — | Authoritative: signoff that accuracy-scout completed its pass |
+| `research-reviewed` | No | — | Authoritative: signoff that research-verifier completed its pass |
+| `oppositional-reviewed` | No | — | Authoritative: signoff that oppositional-planner completed its pass |
+| `diaboli-reviewed` | No | — | Authoritative: signoff that advocatus-diaboli completed its pass |
+| `architecture-reviewed` | No | — | Authoritative: signoff that architecture-reviewer completed its pass |
+| `maintainer-issue-reviewed` | No | — | Authoritative: signoff that maintainer-issue completed its pass |
+| `plan-reviewed` | No | — | Authoritative: signoff that plan-reviewer completed its pass |
+| `spec-reviewed` | No | — | Authoritative: spec-planner created impl branch with `.spec/` files |
+| `red-tdd-reviewed` | No | — | Authoritative: red-tdd committed failing tests to impl branch |
+| `green-tdd-reviewed` | No | — | Authoritative: green-tdd added edge case and regression tests |
+| `review-reviewed` | No | — | Authoritative: standards reviewer completed its pass |
+| `maintainer-pr-reviewed` | No | — | Authoritative: maintainer-pr completed project-fit check |
+| `pr-responded` | No | — | Authoritative: pr-responder addressed bot comments and CI failures |
+| `refactor-planner-reviewed` | No | — | Authoritative: refactor-planner posted simplification plan |
+| `green-refactor-reviewed` | No | — | Authoritative: green-refactor simplified implementation |
+| `deep-reviewed` | No | — | Authoritative: reviewer-deep correctness check passed |
+| `needs-deep-review` | No | — | Authoritative: routing flag for deep review pass |
+| `diff-audited` | No | — | Authoritative: diff-auditor signoff on coherence and cleanliness |
+| `needs-diff-fix` | No | — | Authoritative: diff-auditor bounce — diff has artifacts or drift |
+| `needs-builder-fix` | No | — | Authoritative: routing flag back to builder (typed split planned) |
+| `builder-ready` | No | — | Authoritative: spec finalized, build pipeline may start |
+| `in-build` | No | — | Authoritative: builder actively working |
+| `in-review` | No | — | Authoritative: PR in review process |
+| `merge-ready` | No | — | Authoritative: composite signoff, all gates passed |
+| `already-fixed` | No | — | Authoritative: close without build |
+| `structural-blocker` | No | — | Authoritative: blocks parallel work |
+| `follow-up-recommended` | No | — | Authoritative: needs follow-up issue |
+
+**The key split:** `ci-green` and `needs-ci-fix` are the only labels with live ground truth. Every other label is the only signal that the corresponding agent activity occurred.
+
+---
+
+## Implications for Tooling
+
+### Reconciler grounds CI-pair decisions in live state
+
+For labels with live ground truth (`ci-green`, `needs-ci-fix`), the reconciler does not use timeline-based "later applied wins" logic. It queries live CI:
+
+- Live CI green and `needs-ci-fix` exists: flag is stale — strip `needs-ci-fix`
+- Live CI red: leave `needs-ci-fix`; `ci-green` is stale but harmless — the live red blocks merge
+- Live CI green and neither label exists: PR may still be mergeable; absence of `ci-green` means "green-ci hasn't formally signed off" — not that CI is red
+
+For no-live-signal labels (every other label), the reconciler uses GitHub timeline: if both `deep-reviewed` and `needs-deep-review` exist, the later-applied label wins.
+
+The reconciler implementation: `xtask/src/tasks/queue_reconciler.rs`
+
+### Anti-patterns
+
+**Wrong: merge gate based on `ci-green` label**
+
+```
+# Do not do this
+if has_label("ci-green") { allow_merge() }
+```
+
+Gate based on live `statusCheckRollup` for the current HEAD SHA. The label is informational about when the agent ran, not whether CI is currently green.
+
+**Wrong: treat `ci-green` and `needs-ci-fix` as a contradiction to resolve**
+
+These labels are not contradictory. They record agent activity at different points in time. The live CI state is what resolves them — not arithmetic over which label was applied later.
+
+**Wrong: strip `merge-ready` whenever `needs-ci-fix` exists**
+
+Only strip `merge-ready` if live CI is actually red. If `needs-ci-fix` is stale (live CI is green), the correct action is to strip `needs-ci-fix`, not `merge-ready`.
+
+---
+
+## Implications for Agents
+
+**Skills that apply `ci-green` may simultaneously apply `needs-ci-fix`** when CI is red. These are not contradictory from the skill's perspective — the skill records "I ran a pass (ci-green) and flagged a problem (needs-ci-fix)." The reconciler resolves the apparent tension on the next pass by querying live CI.
+
+**Skills that bounce should not withhold their signoff label.** A bounce and a signoff coexisting briefly is fine; the reconciler resolves on the next pass. Do not withhold `review-reviewed` because you also set `needs-builder-fix` — that creates a gap in the audit trail.
+
+**Exception: one-decision-per-pass still applies.** Agents should not intentionally apply contradictory no-live-signal labels. The above "brief coexistence is fine" applies only to the transition period before the reconciler runs, not to deliberately conflicting outputs. An agent that sets both `deep-reviewed` and `needs-deep-review` in the same pass has made no decision — that is a bug, not a feature.
+
+The one-decision-per-pass rule from CLAUDE.md applies to authoritative (no-live-signal) labels. For informational (live-signal) labels, the live state is the decision, and agent labels are audit trail entries.
+
+---
+
+## Implications for Operators
+
+**Reading a PR's state?**
+
+Query live CI first; trust live > labels for the CI dimension. Labels tell you what agents have done; live CI tells you what is true now.
+
+```bash
+# Live CI state for a PR
+gh pr view <number> --json statusCheckRollup --jq '.statusCheckRollup[]'
+
+# Latest-per-check (filter stale entries)
+gh pr view <number> --json statusCheckRollup \
+  --jq '[.statusCheckRollup | group_by(.name) | .[] | sort_by(.completedAt) | last]'
+```
+
+**Debugging "why didn't this PR merge"?**
+
+Check in this order:
+1. Live `mergeStateStatus` — is the PR actually mergeable (no conflicts, no branch protection failures)?
+2. Live `statusCheckRollup` — is CI actually green on the current HEAD SHA?
+3. Labels — are required signoff labels present? Are routing labels blocking?
+
+Live state comes first. Labels come second. A PR blocked by live CI failure cannot be unblocked by any label manipulation.
+
+**Emergency override?**
+
+Live state still wins. Labels cannot override a real CI failure. The correct path is to fix the CI failure, not to manipulate labels.
+
+---
+
+## Worked Examples
+
+### Example 1: `ci-green + needs-ci-fix`, live CI green
+
+**Situation:** A PR has both `ci-green` and `needs-ci-fix`. The green-ci agent ran, found a problem, flagged it (`needs-ci-fix`), then a pr-responder fixed the CI failure and pushed. CI re-ran and is now green. No one stripped `needs-ci-fix`.
+
+**What's true:** Live CI is green. `needs-ci-fix` is stale — it recorded a problem that has since been resolved.
+
+**Reconciler action:** Query live CI → green. Strip `needs-ci-fix`. The `ci-green` label stands. `merge-ready` can stand if other gates are complete.
+
+**Do not:** Strip `merge-ready` because `needs-ci-fix` exists. That would block a valid merge on stale label state.
+
+---
+
+### Example 2: `ci-green + needs-ci-fix`, live CI red
+
+**Situation:** Same label state. But this time a new commit was pushed after green-ci ran, and the new commit broke a test. Live CI is red.
+
+**What's true:** Live CI is red. `ci-green` is stale — it recorded a green state that no longer applies to the current HEAD SHA.
+
+**Reconciler action:** Query live CI → red. Leave `needs-ci-fix`. Do not strip it (the problem is real). `ci-green` is stale but stripping it is not urgent — the live red blocks merge regardless.
+
+**Operator action:** Dispatch green-ci agent to address the failure. Do not merge.
+
+---
+
+### Example 3: No `ci-green` label, live CI green
+
+**Situation:** A PR has passed all review gates (`deep-reviewed`, `diff-audited`, `merge-ready`) but the green-ci agent has never formally run — possibly because the gate order was compressed or the agent was skipped for a docs-only PR.
+
+**What's true:** Live CI is green. `merge-ready` is present. No signoff label from green-ci.
+
+**Reconciler/operator action:** Live CI is green. The absence of `ci-green` means "green-ci agent hasn't formally signed off." For the merge gate, live CI is what actually gates the merge. If ops policy requires a formal green-ci pass, dispatch green-ci to do a quick confirmation. If the PR is docs-only and the gate was intentionally skipped, the live green is sufficient.
+
+**Do not:** Block the merge solely because `ci-green` is absent when live CI is green. The label is informational; the live signal is authoritative.
+
+---
+
+## See Also
+
+- [ORCHESTRATION_DOCTRINE.md](ORCHESTRATION_DOCTRINE.md) — the broader design philosophy behind why live signals take priority over labels
+- Reconciler implementation: `xtask/src/tasks/queue_reconciler.rs` — where this principle is encoded as automated logic

--- a/docs/reference/ORCHESTRATION_DOCTRINE.md
+++ b/docs/reference/ORCHESTRATION_DOCTRINE.md
@@ -1,0 +1,205 @@
+# Orchestration Doctrine
+
+> **This doc is the north star for orchestration design decisions. When an implementation pass hits ambiguous decisions, resolve by reading this doc.**
+
+This document captures the mentality, direction, why, and design behind the perl-lsp orchestration model. The tactical roadmap issues are implementation phases; this doc captures the principles those tactics serve. It is a reference doc, not a how-to.
+
+---
+
+## Mentality
+
+> The conveyor is a variance-tolerant, self-improving loop, not a processor.
+
+Three implications:
+
+1. **Variance-tolerant**: PRs vary widely in nature — trivial fmt-fix to architecture-shifting feature. The conveyor adapts; it does not impose one-size-fits-all process. A 1-line cleanup does not pay the same gate cost as a 3000-line feature.
+
+2. **Self-improving**: every cycle leaves the system smarter. Throughput matters; so does learning. The system that only produces output without producing learning degrades over time.
+
+3. **Loop, not processor**: feedback flows back into doctrine, agents, skills, and tooling — not just into the next PR. Learning captured in Gate 7 shapes the next Gate 1.
+
+The opposite of this mentality:
+- Rigid pipeline that runs every gate on every PR regardless of nature
+- Process that produces output without producing learning
+- Tooling that requires constant manual care to stay accurate
+
+If a proposed change reinforces the opposite, it is the wrong change.
+
+---
+
+## Direction
+
+We are moving toward:
+
+### 1. Live truth where it exists, labels for the rest
+
+CI status, mergeability, conflict state, and diff content are all queryable as live signals. Labels are bookkeeping for agent activity, not state machines that compete with live truth. Where live ground truth exists, query it — do not duplicate it into labels.
+
+See [LIVE_SIGNALS_VS_LABELS.md](LIVE_SIGNALS_VS_LABELS.md) for the full classification and implications.
+
+### 2. Gates are coarse stages; agents work within them
+
+The pipeline is gates (coarse stages) with multiple agents working within each gate. Sequencing within a gate is preferred because each agent reads the prior, but sequencing is not strict. Some gates may be skipped when not relevant to a given PR's nature.
+
+The six gates:
+
+| Gate | Purpose | Agents (within-gate) |
+|------|---------|----------------------|
+| **1. Identify** | Get the issue right — file an accurate, builder-ready problem statement | scout, accuracy-scout, research-verifier |
+| **2. Spec** | Accurate, scoped, project-aligned proposed approach | plan-reviewer, oppositional-planner, advocatus-diaboli, architecture-reviewer, maintainer-issue, spec-planner |
+| **3. Build** | Well-tested and implemented PR | red-tdd, builder, green-tdd |
+| **4. Review/improve** | Right thing × what codebase needs × right way | reviewer, maintainer-pr, refactor-planner, green-refactor, reviewer-deep, diff-auditor |
+| **5. CI green** | Live CI actually green (not just the label) | green-ci, pr-responder (iterations) |
+| **6. Merge** | Land it | ops |
+
+A seventh layer (Gate 7 — learning consolidation) is cross-cutting: learning happens throughout all gates, and Gate 7 consolidates captured artifacts into durable memory, doctrine, and follow-up work.
+
+### 3. The reconciler is the authoritative label-state engine
+
+Agents stop manually managing label contradictions. The reconciler:
+- Grounds CI-pair decisions in live state (where live truth exists)
+- Uses GitHub timeline for no-live-signal labels ("later applied wins")
+- Is the only thing that authoritatively strips labels
+
+Agents propose; the reconciler disposes.
+
+### 4. Learning happens continuously throughout all gates
+
+Gate 7 is the dedicated consolidation layer — it shapes captured artifacts into durable memory, doctrine, and follow-up work. It is not where learning starts. Every gate captures learning; Gate 7 makes it durable.
+
+Skipping Gate 7 "because we're busy" degrades the system. It is not optional.
+
+### 5. Three-axis triangulation in Gate 4 review
+
+Multiple agents within Gate 4 cross-check three axes:
+
+- **Building the right *thing*** — matches user/issue intent (reviewer, maintainer-pr)
+- **Building what the *codebase needs*** — matches project direction and architecture (architecture-reviewer if Gate 2 was thin, refactor-planner)
+- **Building it *right*** — correctness, idiomatic, regression-safe (reviewer-deep, diff-auditor, green-tdd)
+
+A PR that clears one axis but fails another is not trustworthy and does not merge. The triangulation is what makes the conveyor produce trustworthy output.
+
+### 6. Automation over manual care
+
+If agents have to remember to do X, eventually X will be forgotten. Automate the bookkeeping; reserve agent attention for novel decisions. Crons, reconcilers, and CI gates encode the invariants so human attention can focus on judgment.
+
+---
+
+## Why Each Direction Came From a Specific Failure
+
+Each direction is the converse of an observed failure, not a speculative improvement:
+
+| Direction | Failure that motivated it |
+|-----------|---------------------------|
+| Live truth over labels | #5365/#5353 sat 4 days on stale `needs-deep-review` while CI was actually green — label drift blocked a valid merge |
+| Gates over strict sequencing | Trivial fmt-fix PRs paid the full 6-agent verification ladder cost because the linear framing made "skip the irrelevant pass" feel like rule-breaking |
+| Reconciler as authoritative | Agents reporting label changes that didn't land (~80% silent-failure on one cluster); contradictions accumulating with no cleanup path |
+| Learning throughout | A 24h master blocker (test panic from PR #5985) wasn't surfaced because no agent had a structured way to flag "this test is broken" between sessions |
+| Three-axis triangulation | PR #5543 reached full 4-signoff with title `docs:` and 24 files / 3082 additions across UX/async/code-actions because each agent checked only one axis |
+| Automation over manual care | Multiple sessions losing time to label drift that a 15-min cron reconciler eliminates |
+
+Each failure is documented as a memory entry or a closed/active issue. The directions are not speculative.
+
+---
+
+## Design
+
+### Shape: gates with agents, three axes, two layers of state
+
+```
+                  ┌─── Live truth (CI, mergeable, diff) ───────┐
+                  │                                              │
+Issue → Gate 1 → Gate 2 → Gate 3 → Gate 4 → Gate 5 → Gate 6 → Gate 7
+        Identify  Spec    Build    Review   CI      Merge    Learn
+                                   ↓↓↓
+                                 Three axes:
+                                 - right thing
+                                 - what codebase needs
+                                 - right way
+                  │                                              │
+                  └─── Bookkeeping (sign-off labels) ───────────┘
+                       ↓
+                  Reconciler (authoritative, grounds in live truth)
+```
+
+### Principles embedded in the shape
+
+- **Gates** are coarse stages, not atomic steps. Skip when not relevant to the PR's nature.
+- **Agents within gates** triangulate. Multiple agents per gate, each covering different ground.
+- **Live truth** is queried, not duplicated into labels.
+- **Labels** record agent activity. They are informational; the reconciler keeps them clean.
+- **Reconciler** is the only thing that authoritatively strips labels. Agents propose; reconciler disposes.
+- **Gate 7** consolidates captured learning. Learning itself is continuous throughout all gates.
+
+### Anti-patterns this design forbids
+
+- Agents using labels as a state machine when live truth exists
+- One agent's signoff being treated as gate-complete (triangulation requires multiple agents within the gate)
+- Skipping Gate 7 under throughput pressure (it is where the conveyor improves)
+- Treating sequencing within a gate as strict (it is a preferred default, not a rule)
+- Adding more agents to compensate for gaps (often the right answer is to remove a noisy agent, not add another)
+- Agents manually managing label contradictions instead of delegating to the reconciler
+
+---
+
+## Tactical Work
+
+The tactical issues that implement this doctrine, grouped by theme:
+
+**Gate model documentation and implementation:**
+- Gate-model docs: introduce the 6-gate structure in `docs/reference/` and update CLAUDE.md
+- Gate-model implementation: make routing logic gate-aware (skip irrelevant gates by PR nature)
+
+**Reconciler maturity:**
+- Reconciler PR1: queue-wide contradiction reconciler with live-signal grounding
+- Reconciler roadmap: subsequent phases (cron frequency, observability, typed contradiction rules)
+
+**Label hygiene:**
+- Deprecate `needs-*` family after reconciler is stable
+- Split `needs-builder-fix` into typed labels (reconciler-derived, per known failure patterns)
+
+**Three-axis review:**
+- Diff-audit title-vs-diff-size scope rule (closes a 3-axis gap where a docs-titled PR carries code)
+- CI receipt fidelity improvements
+
+**Infrastructure:**
+- Add `merge_group` trigger (closes the "merge into red master" hole)
+- Salvage-classify skill (typed routing for stale/dirty PRs)
+
+**Continuous learning:**
+- Continuous-learning-capture roadmap (how Gate 7 consolidation works at scale)
+- Conveyor metrics and observability (measuring learning throughput, not just code throughput)
+
+---
+
+## What This Doctrine Is NOT
+
+- Not a unit of implementation work — it is the design rationale behind implementation work
+- Not a vague aspiration — every direction is grounded in an observed failure
+- Not immutable — see the "How to Update" section below
+
+---
+
+## How to Update This Doctrine
+
+Doctrine evolves as the system encounters new failure modes and resolves old ones. The process:
+
+1. **File an issue** describing the proposed change to a direction or design principle. The issue must link to the specific failure mode that motivates the change — doctrine changes without a concrete failure story are speculative and should be rejected.
+
+2. **Get sign-off from the maintainer.** Doctrine changes affect every downstream agent's behavior. A maintainer sign-off ensures the change is intentional and scoped.
+
+3. **Update both this doc AND issue #7084**, which stays open as the design conversation log. Issue #7084 is where the rationale accumulates; this doc is where the current state lives. Both must be updated together — the issue is not a substitute for the doc, and the doc is not a substitute for the issue trail.
+
+Additions are preferred over removals. If a direction's failure mode disappears, the direction may be marked "superseded by X" rather than deleted — the history of why it existed remains useful.
+
+---
+
+## Memory References
+
+This doctrine consolidates and elevates:
+
+- `project_conveyor_doctrine` — the six conveyor principles (variance-tolerant, self-improving, loop-not-processor, bad-fail-cheaply, good-merge-safely, system-learns)
+- `feedback_labels_as_state_machine` — labels as resumable state machine (refined here: labels record agent activity; live truth takes priority)
+- `feedback_live_signals_vs_label_signals` — live truth over labels (expanded in [LIVE_SIGNALS_VS_LABELS.md](LIVE_SIGNALS_VS_LABELS.md))
+- `feedback_take_judgment_on_verdicts` — synthesis over voting (verification agents are lenses, not votes)
+- `feedback_orchestrator_follows_pipeline` — never bypass the gates, but skip gates when not relevant to a PR's nature


### PR DESCRIPTION
## Summary

- Promotes issue #7084 (DOCTRINE) content to a permanent reference doc at `docs/reference/ORCHESTRATION_DOCTRINE.md` — the north-star doc for orchestration design decisions
- Adds a focused reference doc at `docs/reference/LIVE_SIGNALS_VS_LABELS.md` capturing the live-signals-vs-labels principle embedded in the reconciler and gate model design
- Adds two cross-reference lines in `CLAUDE.md` pointing to each new doc

Closes the acceptance criteria on #7084 (content promoted to permanent doc). Follow-up to #7079 (gate model docs, in flight).

## Changes

- `docs/reference/ORCHESTRATION_DOCTRINE.md` (new, 205 lines): north-star reference doc. Covers: mentality (variance-tolerant, self-improving, loop-not-processor), six design directions each grounded in a specific observed failure, design shape (gates + three-axis triangulation + two state layers), anti-patterns the design forbids, tactical work themes, and an update process. Issue #7084 stays open as the design conversation log; this doc is the current-state snapshot.

- `docs/reference/LIVE_SIGNALS_VS_LABELS.md` (new, 171 lines): focused reference for the principle that live signals (`statusCheckRollup`, `mergeStateStatus`) are authoritative over labels for CI/mergeability dimensions. Load-bearing artifact: a complete audit table of all repo labels classified by whether live ground truth exists. Three worked examples. Implications for tooling, agents, and operators. Points to `xtask/src/tasks/queue_reconciler.rs` as the implementation location (in-flight via #7071).

- `CLAUDE.md` (3 insertions): adds `> For the design rationale...` callout at the top of the Orchestration Model section, and a sentence in the Pipeline State Labels section pointing to the live-signals doc.

## Evidence

- **Commits**: 1
- **Tests**: doc-only, no tests applicable
- **Lint**: `cargo xtask fmt --check` fails on pre-existing Rust files in `crates/perl-lsp-rs/src/` (from commit `8bcf926bfd` on the branch, not from this PR's changes). My diff touches only the three doc/CLAUDE.md files.
- **Files**: 3 changed, +379/-1 lines

## What This Doc Set Provides

The orchestration design now has a reference doc suite:
1. `docs/reference/ORCHESTRATION_DOCTRINE.md` — **why** the design is what it is (this PR)
2. `docs/reference/LIVE_SIGNALS_VS_LABELS.md` — **what** the live-signals principle means in practice (this PR)
3. `docs/reference/PIPELINE_GATES.md` — **how** the gate model works (pending, #7079)

Together they make the architectural model discoverable to future agents and humans without depending on memory entries or issue trails.

## Test Plan

- Read `docs/reference/ORCHESTRATION_DOCTRINE.md` as a fresh agent: can the design philosophy be reconstructed from this doc alone without reading the issue? Yes — all six directions, their failure motivations, and anti-patterns are present.
- Read `docs/reference/LIVE_SIGNALS_VS_LABELS.md` as a fresh agent: is the `ci-green` vs `needs-ci-fix` reconciliation logic clear? Yes — three worked examples cover the key scenarios.
- Verify all internal links: CLAUDE.md → both new docs (checked), ORCHESTRATION_DOCTRINE → LIVE_SIGNALS (checked), LIVE_SIGNALS → ORCHESTRATION_DOCTRINE (checked).

## Unknowns

- `xtask/src/tasks/queue_reconciler.rs` does not exist yet (created by #7071); the LIVE_SIGNALS doc references it as the planned implementation path. When #7071 lands, the link will resolve.
- `docs/reference/PIPELINE_GATES.md` is pending (#7079); not referenced from either new doc per spec instructions.