### PR TITLE
fix(fmt): apply cargo xtask fmt to master post-#7019 cascade (#7088)

### DIFF
--- a/crates/perl-lsp-rs/src/features/workspace_rename.rs
+++ b/crates/perl-lsp-rs/src/features/workspace_rename.rs
@@ -559,8 +559,7 @@ $var;
     /// `main`-package symbols fall through gracefully (empty edits) rather than
     /// returning a hard error, allowing the LSP handler to do same-file rename.
     #[test]
-    fn rename_main_package_sub_returns_empty_not_error()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn rename_main_package_sub_returns_empty_not_error() -> Result<(), Box<dyn std::error::Error>> {
         let idx = WorkspaceIndex::new();
 
         // No package declaration → everything is in `main`.

--- a/crates/perl-lsp-rs/src/runtime/language/rename.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/rename.rs
@@ -296,13 +296,18 @@ impl LspServer {
                                 // Use coordinator.index() directly instead of workspace_index()
                                 // to ensure we go through routing policy
                                 let idx = coordinator.index();
-                                let edits =
-                                    crate::workspace_rename::build_rename_edit(idx, key, normalized_bare)
-                                        .map_err(|refusal| JsonRpcError {
-                                            code: -32602,
-                                            message: refusal.to_string(),
-                                            data: None,
-                                        })?;
+                                let edits = crate::workspace_rename::build_rename_edit(
+                                    idx,
+                                    key,
+                                    normalized_bare,
+                                )
+                                .map_err(|refusal| {
+                                    JsonRpcError {
+                                        code: -32602,
+                                        message: refusal.to_string(),
+                                        data: None,
+                                    }
+                                })?;
                                 if edits.is_empty() {
                                     // Fall through to same-file rename
                                 } else {


### PR DESCRIPTION
## Summary

- `crates/perl-lsp-rs/src/features/workspace_rename.rs` and `crates/perl-lsp-rs/src/runtime/language/rename.rs` were merged via #7019 (rename slice) without running `cargo xtask fmt`
- This blocked `cargo xtask fmt --check` on master, cascading into queued PRs failing CI
- Same narrow-scope doctrine as #7031: fmt-only, no logic changes

## Changes

- `workspace_rename.rs:559` — fn signature reformatted to single-line (rustfmt collapsed split-return-position into one line)
- `rename.rs:296` — `build_rename_edit` call chain reformatted into idiomatic rustfmt style

## Verification

- `cargo xtask fmt` applied cleanly (exit 0)
- `cargo xtask fmt --check` passes (exit 0)
- `git diff` shows fmt-only changes — no logic, no behavior, no test changes

## Acceptance

- [x] `cargo xtask fmt --check` passes
- [x] Diff is fmt-only (no logic changes)
- [x] PR opened against master
- [x] No tests run (fmt-only, no behavior to verify)

Closes #7088

**Admin-merge-eligible after local pass** — narrow scope, unblocks cascading queued PRs.