### PR TITLE
fix(ci): replace nonexistent status-docs command with update-status (#6990)

### DIFF
--- a/.ci/fix-forward/playbooks.toml
+++ b/.ci/fix-forward/playbooks.toml
@@ -23,7 +23,7 @@ match_output_contains = ["stale base", "base branch moved", "rebase required"]
 [[playbooks]]
 kind = "GENERATED_DOC_REGEN"
 safe_auto_fix = false
-command = "cargo xtask status-docs"
+command = "cargo xtask update-status --write"
 match_gate_names = ["status-docs", "generated-docs", "docs-regen"]
 match_output_contains = ["generated docs", "status docs", "CURRENT_STATUS"]
 

--- a/.ci/generated-files.toml
+++ b/.ci/generated-files.toml
@@ -1,5 +1,5 @@
 [[generated]]
 path = "docs/project/status/**"
-command = "cargo xtask status-docs"
+command = "cargo xtask update-status --write"
 owner = "status-docs"
 allow_manual_edits = false

--- a/crates/perl-lsp-rs/src/features/workspace_rename.rs
+++ b/crates/perl-lsp-rs/src/features/workspace_rename.rs
@@ -559,8 +559,7 @@ $var;
     /// `main`-package symbols fall through gracefully (empty edits) rather than
     /// returning a hard error, allowing the LSP handler to do same-file rename.
     #[test]
-    fn rename_main_package_sub_returns_empty_not_error()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn rename_main_package_sub_returns_empty_not_error() -> Result<(), Box<dyn std::error::Error>> {
         let idx = WorkspaceIndex::new();
 
         // No package declaration → everything is in `main`.

--- a/crates/perl-lsp-rs/src/runtime/language/rename.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/rename.rs
@@ -296,13 +296,18 @@ impl LspServer {
                                 // Use coordinator.index() directly instead of workspace_index()
                                 // to ensure we go through routing policy
                                 let idx = coordinator.index();
-                                let edits =
-                                    crate::workspace_rename::build_rename_edit(idx, key, normalized_bare)
-                                        .map_err(|refusal| JsonRpcError {
-                                            code: -32602,
-                                            message: refusal.to_string(),
-                                            data: None,
-                                        })?;
+                                let edits = crate::workspace_rename::build_rename_edit(
+                                    idx,
+                                    key,
+                                    normalized_bare,
+                                )
+                                .map_err(|refusal| {
+                                    JsonRpcError {
+                                        code: -32602,
+                                        message: refusal.to_string(),
+                                        data: None,
+                                    }
+                                })?;
                                 if edits.is_empty() {
                                     // Fall through to same-file rename
                                 } else {

--- a/docs/ci/generated-file-policy.md
+++ b/docs/ci/generated-file-policy.md
@@ -24,7 +24,7 @@ Generated status/docs files can drift when hand-edited without the corresponding
 ```toml
 [[generated]]
 path = "docs/project/status/**"
-command = "cargo xtask status-docs"
+command = "cargo xtask update-status --write"
 owner = "status-docs"
 allow_manual_edits = false
 ```

--- a/xtask/tests/fixtures/fix-forward/generated-docs-receipt.json
+++ b/xtask/tests/fixtures/fix-forward/generated-docs-receipt.json
@@ -3,7 +3,7 @@
     {
       "gate_name": "status-docs",
       "status": "fail",
-      "command": "cargo xtask status-docs --check",
+      "command": "cargo xtask update-status --check",
       "output_summary": "generated docs are stale; CURRENT_STATUS drift"
     }
   ]

--- a/xtask/tests/fixtures/generated-files/changed-with-receipt.json
+++ b/xtask/tests/fixtures/generated-files/changed-with-receipt.json
@@ -5,7 +5,7 @@
   "receipts": [
     {
       "owner": "status-docs",
-      "command": "cargo xtask status-docs"
+      "command": "cargo xtask update-status --write"
     }
   ]
 }


### PR DESCRIPTION
## Summary

`cargo xtask status-docs` was referenced in CI configuration and fixture files, but this subcommand has never existed. The correct command is `cargo xtask update-status`. This PR replaces every invocation with the real command.

### What breaks with the wrong command name

- **GENERATED_DOC_REGEN playbook** fires when status docs are stale, prescribes `cargo xtask status-docs` as the fix — developer runs it and gets `error: unrecognized subcommand 'status-docs'`. The remediation loop is dead.
- **`cargo xtask generated-files check`** reports the wrong expected generator command in its error output, making failure messages misleading.
- **Fixture-based integration tests** encode the wrong command string; any future receipt-command lint would fail against the manifest.

### Files changed

| File | Change |
|------|--------|
| `.ci/generated-files.toml` | `command` → `cargo xtask update-status --write` |
| `.ci/fix-forward/playbooks.toml` | playbook `command` → `cargo xtask update-status --write` |
| `docs/ci/generated-file-policy.md` | example snippet corrected |
| `xtask/tests/fixtures/generated-files/changed-with-receipt.json` | receipt `command` corrected |
| `xtask/tests/fixtures/fix-forward/generated-docs-receipt.json` | gate receipt `command` corrected |
| `crates/perl-lsp-rs/src/features/workspace_rename.rs` | rustfmt normalization (long chain) |
| `crates/perl-lsp-rs/src/runtime/language/rename.rs` | rustfmt normalization (long chain) |

The `owner = "status-docs"` and `gate_name = "status-docs"` string labels are intentionally left unchanged — they are receipt-matching identifiers, not command invocations.

### Verification

```
cargo test -p xtask --test generated_files_cli     # 2/2 pass
cargo test -p xtask --test post_merge_status_regen_tests  # 10/10 pass
cargo clippy -p xtask --tests                      # no new warnings
cargo fmt --all                                    # clean
```

Fixes #6990.

## Test plan

- [x] `cargo test -p xtask --test generated_files_cli` — both fixture paths pass
- [x] `cargo test -p xtask --test post_merge_status_regen_tests` — all 10 tests pass
- [x] `cargo clippy -p xtask --tests` — clean (pre-existing warnings only, unrelated to this change)
- [x] `cargo fmt --all` — no diff
- [x] `grep -rn "cargo xtask status-docs"` — zero results after fix

https://claude.ai/code/session_01T4JRb9YwLGVJJoNXGErLrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4JRb9YwLGVJJoNXGErLrR)_