### PR TITLE
docs(codex): align MCP bridge setup guidance (#0000)

### DIFF
--- a/docs/EDITORS/CODEX_CLI_SETUP.md
+++ b/docs/EDITORS/CODEX_CLI_SETUP.md
@@ -1,81 +1,275 @@
 # Codex CLI + perl-lsp Setup
 
-This guide shows how to wire `perllsp` into Codex CLI so Codex can call real LSP
-operations (`definition`, `hover`, `references`, `rename`, diagnostics) while it
-is editing your Perl workspace.
+This guide shows how to make OpenAI Codex CLI use `perllsp` through an MCP
+bridge.
+
+Codex CLI does not register LSP servers directly. Instead, Codex calls tools
+exposed by Model Context Protocol (MCP) servers. For Perl LSP features, run an
+MCP bridge that launches `perllsp --stdio` behind the scenes.
 
 ## Prerequisites
 
-- `perllsp` installed and on `PATH`
 - Codex CLI installed and authenticated
-- A project folder opened as your Codex working directory
+- `perllsp` installed and available on `PATH`
+- an LSP-to-MCP bridge installed, for example `lsp-mcp`
+- a Perl project opened as your Codex working directory
 
 Quick sanity checks:
 
 ```bash
 perllsp --version
 perllsp --health
+perllsp --info
 codex --version
 ```
 
-## 1) Add an LSP bridge MCP server
+## 1. Install the LSP MCP bridge
 
-Codex CLI does not speak LSP directly; it calls tools via MCP. Configure an MCP
-server that bridges MCP requests to your local language server.
+One available bridge is `lsp-mcp`:
 
-Add/update `~/.codex/config.toml`:
+```bash
+cargo install lsp-mcp
+```
+
+Verify it is available:
+
+```bash
+lsp-mcp --help
+```
+
+## 2. Configure lsp-mcp for Perl
+
+Create `lsp-mcp.toml` in your project root:
+
+```toml
+[[servers]]
+name = "perl"
+command = ["perllsp", "--stdio"]
+extensions = [".pl", ".PL", ".pm", ".t", ".pod", ".psgi", ".cgi", ".fcgi", ".xs", ".xsi"]
+root_markers = [".perl-lsp.toml", "Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"]
+language_id = "perl"
+```
+
+Validate the bridge config:
+
+```bash
+lsp-mcp check --config ./lsp-mcp.toml
+```
+
+You can also start the bridge manually for smoke testing:
+
+```bash
+lsp-mcp --config ./lsp-mcp.toml --workspace "$PWD"
+```
+
+It is normal for this command to keep running; it is waiting for MCP JSON-RPC
+input from a client.
+
+## 3. Add the bridge to Codex MCP config
+
+Use either user-level config:
+
+```text
+~/.codex/config.toml
+```
+
+or trusted project-local config:
+
+```text
+.codex/config.toml
+```
+
+For a project-specific setup, create or update `.codex/config.toml`:
 
 ```toml
 [mcp_servers.perl_lsp]
-command = "uvx"
-args = ["lsp-mcp", "--workspace", "/absolute/path/to/project"]
+command = "lsp-mcp"
+args = [
+  "--config",
+  "/absolute/path/to/project/lsp-mcp.toml",
+  "--workspace",
+  "/absolute/path/to/project"
+]
+cwd = "/absolute/path/to/project"
+startup_timeout_sec = 20
+tool_timeout_sec = 120
 ```
 
-If you do not use `uvx`, replace `command`/`args` with your preferred launcher
-for the bridge server.
+Replace `/absolute/path/to/project` with your repository root.
 
-## 2) Register perl-lsp with the bridge
+You can also add the server through the Codex CLI:
 
-Most LSP bridge servers accept a per-language mapping. Add Perl so `.pl`, `.pm`,
-`.t`, and `.pod` files resolve to `perllsp --stdio`.
+```bash
+codex mcp add perl_lsp -- lsp-mcp --config /absolute/path/to/project/lsp-mcp.toml --workspace /absolute/path/to/project
+```
 
-Example `~/.config/lsp-mcp/config.toml`:
+## 4. Recommended perl-lsp project config
+
+Prefer `.perl-lsp.toml` for settings shared across editors and agents:
 
 ```toml
-[language_servers.perl]
-command = "perllsp"
-args = ["--stdio"]
-filetypes = ["perl"]
+[perl]
+include_paths = ["lib", ".", "local/lib/perl5", "vendor/lib"]
+
+[features]
+inlay_hints = true
+
+[diagnostics]
+perlcritic = false
+perlcritic_severity = 3
 ```
 
-If your bridge uses JSON/YAML instead of TOML, keep the same values.
+If your project only needs the built-in include paths, omit `include_paths`. The
+built-in defaults are `lib`, `.`, and `local/lib/perl5`.
 
-## 3) Validate from Codex
+## 5. Validate from Codex
 
-From inside your Perl repo:
+Start Codex from the project root:
+
+```bash
+codex
+```
+
+Inside Codex, run:
 
 ```text
 /mcp
 ```
 
-Confirm the Perl LSP bridge is connected, then try prompts like:
+Confirm the `perl_lsp` MCP server is listed and that LSP tools are available.
 
-- "Find all references to `My::Package::run`."
-- "Rename `build_index` to `build_workspace_index` and update call sites."
-- "Show diagnostics for this file and apply the safe fixes."
+Good test prompts:
+
+```text
+Use the Perl LSP MCP tools to show diagnostics for lib/My/Module.pm.
+```
+
+```text
+Use the Perl LSP MCP tools to show hover information for the symbol at
+lib/My/Module.pm line 42 column 7.
+```
+
+```text
+Use the Perl LSP MCP tools to find references for the symbol at
+lib/My/Module.pm line 42 column 7.
+```
+
+```text
+Use the Perl LSP MCP tools to preview renaming the symbol at
+lib/My/Module.pm line 42 column 7 to build_workspace_index. Show me the edits
+before applying them.
+```
+
+For diagnostics without MCP, you can always run:
+
+```bash
+perllsp --check path/to/file.pl
+perllsp --check-project .
+```
+
+## Do Not Register perllsp Directly as MCP
+
+Do not configure Codex like this:
+
+```toml
+[mcp_servers.perl_lsp]
+command = "perllsp"
+args = ["--stdio"]
+```
+
+`perllsp --stdio` speaks the Language Server Protocol. Codex MCP configuration
+expects a Model Context Protocol server. Use an MCP bridge such as `lsp-mcp`;
+the bridge launches `perllsp --stdio` internally.
 
 ## Troubleshooting
 
-- **No LSP tools appear in `/mcp`:** verify the bridge process starts outside
-  Codex first, then restart Codex.
-- **Server starts but returns empty results:** ensure Codex is running at the
-  project root so workspace indexing can discover files.
-- **`perllsp` not found:** run `which perllsp` and use an absolute path in the
-  bridge config if needed.
-- **Slow first queries:** this is usually initial indexing; retry after the
-  first warmup pass.
+### No LSP tools appear in `/mcp`
+
+Check the bridge outside Codex:
+
+```bash
+lsp-mcp check --config ./lsp-mcp.toml
+lsp-mcp --config ./lsp-mcp.toml --workspace "$PWD"
+```
+
+Then restart Codex and run:
+
+```text
+/mcp
+```
+
+### `perllsp` not found
+
+Check from the same shell used to launch Codex:
+
+```bash
+command -v perllsp
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+On Windows PowerShell:
+
+```powershell
+where perllsp
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+If needed, use an absolute path in `lsp-mcp.toml`:
+
+```toml
+[[servers]]
+name = "perl"
+command = ["/absolute/path/to/perllsp", "--stdio"]
+extensions = [".pl", ".PL", ".pm", ".t", ".psgi"]
+root_markers = [".perl-lsp.toml", "Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"]
+language_id = "perl"
+```
+
+### Bridge starts but returns empty results
+
+- Start Codex from the project root.
+- Confirm `--workspace` points at the repository root.
+- Confirm the target file extension is listed in `extensions`.
+- Confirm the project has a root marker such as `.perl-lsp.toml`, `Makefile.PL`,
+  `Build.PL`, `cpanfile`, `dist.ini`, or `.git`.
+- Try a file-specific diagnostic first:
+
+  ```text
+  Use the Perl LSP MCP tools to show diagnostics for path/to/file.pl.
+  ```
+
+### Rename does not apply changes automatically
+
+Depending on the bridge, `rename` may preview a workspace edit rather than write
+files directly. Ask Codex to inspect the preview and then apply the returned
+edits.
+
+### Slow first query
+
+The bridge and `perllsp` may need to initialize and index the workspace. Retry
+after the first request finishes. If the project is large, tune `.perl-lsp.toml`
+or LSP initialization options rather than raising timeouts indefinitely.
+
+### `perllsp --stdio` appears to hang
+
+That is expected. In stdio mode, `perllsp` waits for framed LSP input from a
+client. For manual checks, use:
+
+```bash
+perllsp --health
+perllsp --info
+perllsp --check path/to/file.pl
+perllsp --check-project .
+```
 
 ## Notes
 
 - Keep one Codex session per project root for best workspace accuracy.
-- `perllsp --stdio` is the supported transport for editor and bridge clients.
+- Keep `lsp-mcp.toml` project-specific unless every project uses the same server
+  mappings.
+- Use project-local `.codex/config.toml` only in trusted repositories.
+- Use `.perl-lsp.toml` for editor-agnostic `perl-lsp` settings.

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -34,7 +34,7 @@ perllsp --info
 | Sublime Text | install Sublime's `LSP` package and add `perllsp --stdio` in `LanguageServers.sublime-settings` | [docs/EDITORS/SUBLIME_SETUP.md](../EDITORS/SUBLIME_SETUP.md) |
 | Amazon Kiro | register a Perl LSP client using `perllsp --stdio` | [docs/EDITORS/KIRO_SETUP.md](../EDITORS/KIRO_SETUP.md) |
 | Claude Code | provide a plugin `.lsp.json` pointing to `perllsp --stdio` | [docs/EDITORS/CLAUDE_CODE_SETUP.md](../EDITORS/CLAUDE_CODE_SETUP.md) |
-| Codex CLI | connect an MCP LSP bridge to `perllsp --stdio` | [docs/EDITORS/CODEX_CLI_SETUP.md](../EDITORS/CODEX_CLI_SETUP.md) |
+| Codex CLI | configure an MCP bridge such as `lsp-mcp`; the bridge exposes tools to Codex and launches `perllsp --stdio` internally | [docs/EDITORS/CODEX_CLI_SETUP.md](../EDITORS/CODEX_CLI_SETUP.md) |
 | Codex Desktop | add a custom Perl server command `perllsp --stdio` | [docs/EDITORS/CODEX_DESKTOP_SETUP.md](../EDITORS/CODEX_DESKTOP_SETUP.md) |
 | OpenCode | configure `perllsp --stdio` as a custom LSP in `opencode.json`; diagnostics work by default, direct LSP operations are experimental | [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) |
 
@@ -143,10 +143,30 @@ using `command: "perllsp"` and `args: ["--stdio"]`.
 
 ### Codex CLI
 
-Configure an MCP LSP bridge that launches `perllsp --stdio`, then verify the
-bridge appears in Codex via `/mcp`. See
-[docs/EDITORS/CODEX_CLI_SETUP.md](../EDITORS/CODEX_CLI_SETUP.md) for a full
-example config and troubleshooting flow.
+Codex CLI uses MCP tools rather than direct LSP server registration. Configure
+an LSP-to-MCP bridge such as `lsp-mcp`, then point Codex at the bridge:
+
+```toml
+[mcp_servers.perl_lsp]
+command = "lsp-mcp"
+args = ["--config", "/absolute/path/to/project/lsp-mcp.toml", "--workspace", "/absolute/path/to/project"]
+cwd = "/absolute/path/to/project"
+```
+
+Example `lsp-mcp.toml`:
+
+```toml
+[[servers]]
+name = "perl"
+command = ["perllsp", "--stdio"]
+extensions = [".pl", ".PL", ".pm", ".t", ".pod", ".psgi", ".cgi", ".fcgi", ".xs", ".xsi"]
+root_markers = [".perl-lsp.toml", "Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"]
+language_id = "perl"
+```
+
+Do not register `perllsp --stdio` directly as an MCP server; it speaks LSP, not
+MCP. See [docs/EDITORS/CODEX_CLI_SETUP.md](../EDITORS/CODEX_CLI_SETUP.md) for
+full setup and troubleshooting.
 
 ### OpenCode
 

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -970,6 +970,35 @@ For settings shared across editors, prefer `.perl-lsp.toml`.
 }
 ```
 
+#### Codex CLI via MCP bridge
+
+Codex CLI does not configure LSP servers directly. Use an MCP bridge that
+launches `perllsp --stdio`.
+
+Codex config:
+
+```toml
+[mcp_servers.perl_lsp]
+command = "lsp-mcp"
+args = ["--config", "/absolute/path/to/project/lsp-mcp.toml", "--workspace", "/absolute/path/to/project"]
+cwd = "/absolute/path/to/project"
+startup_timeout_sec = 20
+tool_timeout_sec = 120
+```
+
+Bridge config:
+
+```toml
+[[servers]]
+name = "perl"
+command = ["perllsp", "--stdio"]
+extensions = [".pl", ".PL", ".pm", ".t", ".pod", ".psgi", ".cgi", ".fcgi", ".xs", ".xsi"]
+root_markers = [".perl-lsp.toml", "Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"]
+language_id = "perl"
+```
+
+Do not register `perllsp --stdio` directly as an MCP server; it speaks LSP, not MCP.
+
 ---
 
 ## See Also


### PR DESCRIPTION
### Motivation

- The existing Codex CLI docs described the correct MCP-bridge architecture but used outdated bridge examples and omitted key validation and config-location details.
- The goal is to steer users to a bridge-based setup (e.g. `lsp-mcp`) that launches `perllsp --stdio` and to avoid the common mistake of registering `perllsp --stdio` directly as an MCP server.

### Description

- Rewrote `docs/EDITORS/CODEX_CLI_SETUP.md` to present a bridge-first flow with an `lsp-mcp` installation example, a `[[servers]]`-style `lsp-mcp.toml` example, `lsp-mcp check`/start guidance, and an explicit warning that `perllsp --stdio` is LSP (not MCP).
- Updated `docs/how-to/EDITOR_SETUP.md` to change the Codex CLI table row and the Codex CLI mini-section to reference an MCP bridge such as `lsp-mcp`, include a concrete `.codex` example, and show the `lsp-mcp.toml` snippet.
- Added a `Codex CLI via MCP bridge` subsection to `docs/reference/CONFIG.md` with concrete `~/.codex`/`.codex` configuration examples, `lsp-mcp` bridge config, and the same LSP-vs-MCP warning.
- Kept the changes limited to documentation files: `docs/EDITORS/CODEX_CLI_SETUP.md`, `docs/how-to/EDITOR_SETUP.md`, and `docs/reference/CONFIG.md`.

### Testing

- Ran `cargo xtask fmt` to format docs and repo files, and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f015290f64833394a6405f8af0b831)