### PR TITLE
docs(coc.nvim): modernize perllsp setup guidance (#0000)

### DIFF
--- a/docs/EDITORS/COC_NEOVIM_SETUP.md
+++ b/docs/EDITORS/COC_NEOVIM_SETUP.md
@@ -1,160 +1,104 @@
 # coc.nvim Setup Guide for perl-lsp
 
-This comprehensive guide helps you set up and configure the Perl Language Server in Vim/Neovim using coc.nvim.
+This guide shows how to run `perllsp` from coc.nvim in Neovim.
 
-## Table of Contents
-
-- [Prerequisites](#prerequisites)
-- [Installation](#installation)
-- [Basic Setup](#basic-setup)
-- [Configuration](#configuration)
-- [Features](#features)
-- [Keybindings](#keybindings)
-- [Plugins](#plugins)
-- [Troubleshooting](#troubleshooting)
-- [Advanced Configuration](#advanced-configuration)
-
----
+For Neovim's built-in LSP client, see [NEOVIM_SETUP.md](NEOVIM_SETUP.md).
+Use this guide only if you prefer the coc.nvim client.
 
 ## Prerequisites
 
-### Required
+- Neovim 0.8.0 or later
+- Node.js 16.18.0 or later
+- coc.nvim installed
+- `perllsp` installed and available on your `PATH`
+- A Perl project opened from the project root
 
-- **Vim** 8.0+ or **Neovim** 0.3+
-- **Node.js** 14+ (for coc.nvim)
-- **perl-lsp** server installed (see [Installation](#installation))
+If you use classic Vim with coc.nvim, use Vim 9.0.0438 or later.
 
-### Optional but Recommended
+Verify `perllsp` before changing coc.nvim settings:
 
-- **vim-plug** or **packer.nvim** (plugin manager)
-- **coc.nvim** (LSP client)
-- **coc-snippets** (snippet support)
-- **Perl** 5.10 or later (for syntax validation)
-- **perltidy** (for code formatting)
-- **perlcritic** (for linting)
+```bash
+perllsp --version
+perllsp --health
+perllsp --info
+```
 
----
+## Install `perllsp`
 
-## Installation
-
-### Install the Server
-
-Choose one of the following methods:
-
-#### Option 1: Install from crates.io (Recommended)
+### Cargo
 
 ```bash
 cargo install perllsp
 ```
 
-#### Option 2: Download Pre-built Binary
-
-Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases):
+### Homebrew
 
 ```bash
-# Linux (x86_64)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-linux-x86_64.tar.gz
-tar xzf perl-lsp-linux-x86_64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
-
-# macOS (Apple Silicon)
-curl -LO https://github.com/EffortlessMetrics/perl-lsp/releases/latest/download/perl-lsp-darwin-aarch64.tar.gz
-tar xzf perl-lsp-darwin-aarch64.tar.gz
-sudo mv perl-lsp /usr/local/bin/
+brew install perl-lsp
 ```
 
-#### Option 3: Build from Source
+### From Source
 
 ```bash
 git clone https://github.com/EffortlessMetrics/perl-lsp.git
 cd perl-lsp
-cargo install perllsp
+cargo install --path crates/perllsp --locked
 ```
 
-### Verify Installation
+### Prebuilt Binary
 
-```bash
-# Check version
-perllsp --version
+Download the archive for your platform from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases),
+extract it, and put the `perllsp` binary on your `PATH`.
 
-# Quick health check
-perllsp --health
-# Should output: ok 0.10.0
-```
+Release assets use the `perllsp-<version>-<target>` naming pattern.
 
-### Install coc.nvim
+## Install coc.nvim
 
-#### Using vim-plug
-
-Add to your `.vimrc` or `init.vim`:
+Install coc.nvim with your preferred plugin manager. With vim-plug:
 
 ```vim
-" Use release branch (recommended)
 Plug 'neoclide/coc.nvim', {'branch': 'release'}
 ```
 
-Then run:
+Then restart Neovim and run:
 
 ```vim
 :PlugInstall
 ```
 
-#### Using packer.nvim (Neovim)
+coc.nvim does not install Perl LSP support automatically. You must either install
+an extension that provides Perl support or configure a language server in
+`coc-settings.json`. This guide uses manual language-server configuration.
 
-Add to your `init.lua`:
+## Configure coc.nvim
 
-```lua
-use {
-  'neoclide/coc.nvim',
-  branch = 'release',
-  run = ':CocInstall'
-}
+Open your coc.nvim config:
+
+```vim
+:CocConfig
 ```
 
-#### Manual Installation
-
-```bash
-# Release branch
-cd ~/.vim/bundle
-git clone --branch release https://github.com/neoclide/coc.nvim.git
-
-# Or for Neovim
-cd ~/.local/share/nvim/site/pack/coc/start
-git clone --branch release https://github.com/neoclide/coc.nvim.git
-```
-
----
-
-## Basic Setup
-
-### Create coc.nvim Configuration
-
-Create `~/.vim/coc-settings.json` (or `~/.config/nvim/coc-settings.json` for Neovim):
+Add:
 
 ```json
 {
   "languageserver": {
-    "perl": {
-      "command": "perl-lsp",
+    "perl-lsp": {
+      "command": "perllsp",
       "args": ["--stdio"],
       "filetypes": ["perl"],
-      "rootPatterns": ["Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"],
+      "rootPatterns": [
+        ".perl-lsp.toml",
+        "Makefile.PL",
+        "Build.PL",
+        "cpanfile",
+        "dist.ini",
+        ".git"
+      ],
       "settings": {
         "perl": {
           "workspace": {
-            "includePaths": ["lib", ".", "local/lib/perl5"],
-            "useSystemInc": false,
-            "resolutionTimeout": 50
-          },
-          "inlayHints": {
-            "enabled": true,
-            "parameterHints": true,
-            "typeHints": true
-          },
-          "limits": {
-            "workspaceSymbolCap": 200,
-            "referencesCap": 500,
-            "completionCap": 100
+            "includePaths": ["lib", ".", "local/lib/perl5"]
           }
         }
       }
@@ -163,890 +107,377 @@ Create `~/.vim/coc-settings.json` (or `~/.config/nvim/coc-settings.json` for Neo
 }
 ```
 
-### Verify Setup
+coc.nvim uses Vim/Neovim filetypes. The server starts only when the active
+buffer has `filetype=perl`.
 
-1. Restart Vim/Neovim
-2. Open a `.pl` or `.pm` file
-3. Check if coc.nvim is loaded:
-   ```vim
-   :CocInfo
-   ```
-4. Check if perl-lsp is running:
-   ```vim
-   :CocCommand workspace.showOutput
-   ```
+## Optional: Project-Local coc.nvim Config
 
----
-
-## Configuration
-
-### Full Configuration
-
-Add to `~/.vim/coc-settings.json`:
-
-```json
-{
-  "languageserver": {
-    "perl": {
-      "command": "perl-lsp",
-      "args": ["--stdio"],
-      "filetypes": ["perl"],
-      "rootPatterns": ["Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"],
-      "settings": {
-        "perl": {
-          "workspace": {
-            "includePaths": ["lib", ".", "local/lib/perl5", "vendor/lib"],
-            "useSystemInc": false,
-            "resolutionTimeout": 50
-          },
-          "inlayHints": {
-            "enabled": true,
-            "parameterHints": true,
-            "typeHints": true,
-            "chainedHints": false,
-            "maxLength": 30
-          },
-          "testRunner": {
-            "enabled": true,
-            "command": "perl",
-            "args": [],
-            "timeout": 60000
-          },
-          "limits": {
-            "workspaceSymbolCap": 200,
-            "referencesCap": 500,
-            "completionCap": 100,
-            "astCacheMaxEntries": 100,
-            "maxIndexedFiles": 10000,
-            "maxTotalSymbols": 500000,
-            "workspaceScanDeadlineMs": 30000,
-            "referenceSearchDeadlineMs": 2000
-          }
-        }
-      },
-      "env": {
-        "PERL5LIB": "${workspaceFolder}/lib",
-        "PERL_MB_OPT": "--install_base ${workspaceFolder}/local"
-      }
-    }
-  },
-  "diagnostic.enable": true,
-  "diagnostic.displayByAle": false,
-  "diagnostic.errorSign": "✗",
-  "diagnostic.warningSign": "⚠",
-  "diagnostic.infoSign": "ℹ",
-  "diagnostic.hintSign": "➤",
-  "diagnostic.virtualText": true,
-  "diagnostic.virtualTextPrefix": "■",
-  "suggest.enablePreselect": true,
-  "suggest.minTriggerInputLength": 1,
-  "suggest.noselect": false,
-  "suggest.enablePreview": true,
-  "suggest.floatEnable": true,
-  "signature.enable": true,
-  "signature.target": "float",
-  "signature.triggerSignatureWait": 50,
-  "codeLens.enable": true,
-  "codeLens.position": "eol",
-  "inlayHint.enable": true,
-  "inlayHint.display": true,
-  "inlayHint.enableParameter": true,
-  "inlayHint.enableType": true
-}
-```
-
-### Project-Specific Configuration
-
-Create `.vim/coc-settings.json` in your project root:
-
-```json
-{
-  "languageserver": {
-    "perl": {
-      "settings": {
-        "perl": {
-          "workspace": {
-            "includePaths": ["lib", "local/lib/perl5", "vendor/lib"]
-          }
-        }
-      }
-    }
-  }
-}
-```
-
----
-
-## Features
-
-### Syntax Diagnostics
-
-Real-time syntax error detection and reporting:
-
-```perl
-# Errors are highlighted as you type
-my $x = 1
-# Missing semicolon - error shown immediately
-```
-
-View diagnostics:
-- Errors are shown in the gutter
-- Hover over error markers for details
-- View all diagnostics: `:CocDiagnostics`
-
-### Go to Definition
-
-Navigate to symbol definitions:
+For one project, run:
 
 ```vim
-:CocAction('jumpDefinition')
+:CocLocalConfig
 ```
 
-Or use keybinding: `gd`
+This creates or edits `.vim/coc-settings.json` in the current workspace.
 
-```perl
-use MyModule;
+Prefer `.perl-lsp.toml` for settings shared across editors. Use local coc config
+for coc.nvim-specific behavior only.
 
-MyModule::some_function();
-# ^ gd here jumps to the definition
+Example `.perl-lsp.toml`:
+
+```toml
+[perl]
+include_paths = ["lib", ".", "local/lib/perl5", "vendor/lib"]
+
+[features]
+inlay_hints = true
+
+[diagnostics]
+perlcritic = false
+perlcritic_severity = 3
 ```
 
-### Find References
+## Optional: Filetype Detection
 
-Find all usages of a symbol:
+Check a Perl buffer:
 
 ```vim
-:CocAction('jumpReferences')
+:set filetype?
+:CocCommand document.echoFiletype
 ```
 
-Or use keybinding: `gr`
+Expected result: `perl`.
 
-```perl
-sub my_function {
-    return 42;
-}
-
-# ^ Find references here shows all calls to my_function
-```
-
-### Hover Information
-
-View documentation and type information:
+If `.t`, `.psgi`, `.cgi`, or `.fcgi` files are not detected as Perl, add
+filetype rules before coc.nvim starts the language server:
 
 ```vim
-:CocAction('doHover')
-```
-
-Or use keybinding: `K`
-
-### Code Completion
-
-Intelligent code completion:
-
-```vim
-:CocAction('suggest')
-```
-
-Or use keybinding: `Ctrl+Space`
-
-```perl
-use MyModule;
-
-MyModule::  # Press Ctrl+Space for completion
-```
-
-### Document Symbols
-
-Navigate symbols in the current file:
-
-```vim
-:CocList symbols
-```
-
-### Workspace Symbols
-
-Search symbols across the entire workspace:
-
-```vim
-:CocList workspaceSymbols
-```
-
-### Rename Symbol
-
-Rename symbols across the workspace:
-
-```vim
-:CocRename
-```
-
-Or use keybinding: `<leader>rn`
-
-### Formatting
-
-Format Perl code using perltidy:
-
-```vim
-:CocAction('format')
-```
-
-Or use keybinding: `<leader>f`
-
-### Code Actions
-
-Quick fixes and refactorings:
-
-```vim
-:CocAction('codeAction')
-```
-
-Or use keybinding: `<leader>ca`
-
-Available actions:
-- Extract variable
-- Extract subroutine
-- Optimize imports
-- Add missing pragmas
-
-### Inlay Hints
-
-Inline type and parameter hints:
-
-```perl
-sub my_function($name, $count) {
-    return "Hello, $name x$count";
-}
-
-my_function("World", 5);
-# ^ Shows: my_function(/* name: */ "World", /* count: */ 5)
-```
-
-Enable inlay hints:
-```vim
-:CocCommand inlayHints.toggle
-```
-
----
-
-## Keybindings
-
-### Recommended Keybindings
-
-Add to your `.vimrc` or `init.vim`:
-
-```vim
-" Use Tab for trigger completion with characters ahead and navigate
-inoremap <silent><expr> <TAB>
-      \ pumvisible() ? "\<C-n>" :
-      \ <SID>check_back_space() ? "\<TAB>" :
-      \ coc#refresh()
-inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"
-
-function! s:check_back_space() abort
-  let col = col('.') - 1
-  return !col || getline('.')[col - 1]  =~# '\s'
-endfunction
-
-" Use <c-space> to trigger completion
-if has('nvim')
-  inoremap <silent><expr> <c-space> coc#refresh()
-else
-  inoremap <silent><expr> <c-@> coc#refresh()
-endif
-
-" Make <CR> auto-select the first completion item and notify coc.nvim to
-" format on enter
-inoremap <silent><expr> <cr> pumvisible() ? coc#_select_confirm()
-                              \: "\<C-g>u\<CR>\<c-r>=coc#on_enter()\<CR>"
-
-" Use `[g` and `]g` to navigate diagnostics
-nmap <silent> [g <Plug>(coc-diagnostic-prev)
-nmap <silent> ]g <Plug>(coc-diagnostic-next)
-
-" GoTo code navigation
-nmap <silent> gd <Plug>(coc-definition)
-nmap <silent> gy <Plug>(coc-type-definition)
-nmap <silent> gi <Plug>(coc-implementation)
-nmap <silent> gr <Plug>(coc-references)
-
-" Use K to show documentation in preview window
-nnoremap <silent> K :call <SID>show_documentation()<CR>
-
-function! s:show_documentation()
-  if (index(['vim','help'], &filetype) >= 0)
-    execute 'h '.expand('<cword>')
-  elseif (coc#rpc#ready())
-    call CocActionAsync('doHover')
-  else
-    execute '!' . &keywordprg . " " . expand('<cword>')
-  endif
-endfunction
-
-" Highlight the symbol and its references when holding the cursor
-autocmd CursorHold * silent call CocActionAsync('highlight')
-
-" Symbol renaming
-nmap <leader>rn <Plug>(coc-rename)
-
-" Formatting
-nmap <leader>f <Plug>(coc-format-selected)
-xmap <leader>f <Plug>(coc-format-selected)
-
-" Apply AutoFix to problem on the current line
-nmap <leader>qf  <Plug>(coc-fix-current)
-
-" Map function and class text objects
-xmap if <Plug>(coc-funcobj-i)
-omap if <Plug>(coc-funcobj-i)
-xmap af <Plug>(coc-funcobj-a)
-omap af <Plug>(coc-funcobj-a)
-xmap ic <Plug>(coc-classobj-i)
-omap ic <Plug>(coc-classobj-i)
-xmap ac <Plug>(coc-classobj-a)
-omap ac <Plug>(coc-classobj-a)
-
-" Remap <C-f> to scroll float windows
-nnoremap <silent><nowait><expr> <C-f> coc#float#has_scroll() ? coc#float#scroll(1) : "\<C-f>"
-nnoremap <silent><nowait><expr> <C-b> coc#float#has_scroll() ? coc#float#scroll(0) : "\<C-b>"
-
-" Add status line support
-set statusline^=%{coc#status()}%{get(b:,'coc_current_function','')}
-
-" Show all diagnostics
-nnoremap <silent><nowait> <space>a  :<C-u>CocList diagnostics<cr>
-
-" Manage extensions
-nnoremap <silent><nowait> <space>e  :<C-u>CocList extensions<cr>
-
-" Show commands
-nnoremap <silent><nowait> <space>c  :<C-u>CocList commands<cr>
-
-" Find symbol of current document
-nnoremap <silent><nowait> <space>o  :<C-u>CocList outline<cr>
-
-" Search workspace symbols
-nnoremap <silent><nowait> <space>s  :<C-u>CocList -I symbols<cr>
-
-" Resume latest coc list
-nnoremap <silent><nowait> <space>p  :<C-u>CocListResume<CR>
-```
-
----
-
-## Plugins
-
-### coc-snippets
-
-For snippet support:
-
-```vim
-" Install coc-snippets
-:CocInstall coc-snippets
-
-" Add to .vimrc or init.vim
-let g:coc_snippet_next = '<tab>'
-let g:coc_snippet_prev = '<s-tab>'
-```
-
-### coc-pairs
-
-For auto-closing brackets:
-
-```vim
-:CocInstall coc-pairs
-```
-
-### coc-lists
-
-For fuzzy finding:
-
-```vim
-:CocInstall coc-lists
-```
-
-### coc-explorer
-
-For file explorer:
-
-```vim
-:CocInstall coc-explorer
-
-" Add keybinding
-nnoremap <space>e :CocCommand explorer<CR>
-```
-
-### coc-git
-
-For Git integration:
-
-```vim
-:CocInstall coc-git
-```
-
-### coc-yank
-
-For yank history:
-
-```vim
-:CocInstall coc-yank
-
-" Add keybindings
-nnoremap <silent> <space>y  :<C-u>CocList -A --normal yank<cr>
-```
-
----
-
-## Troubleshooting
-
-### Server Not Starting
-
-**Symptoms**: No diagnostics, no completion, error in output
-
-**Solutions**:
-
-1. **Verify binary is in PATH**:
-   ```vim
-   :!which perl-lsp
-   ```
-
-2. **Check coc.nvim info**:
-   ```vim
-   :CocInfo
-   ```
-
-3. **Check coc.nvim logs**:
-   ```vim
-   :CocCommand workspace.showOutput
-   ```
-
-4. **Test server manually**:
-   ```bash
-   echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perllsp --stdio
-   ```
-
-### No Diagnostics
-
-**Symptoms**: No errors shown for invalid code
-
-**Solutions**:
-
-1. **Check file type**:
-   ```vim
-   :set filetype?
-   ```
-   Should output: `filetype=perl`
-
-2. **Set file type manually**:
-   ```vim
-   :set filetype=perl
-   ```
-
-3. **Verify diagnostics enabled**:
-   ```vim
-   :CocCommand workspace.toggleDiagnostics
-   ```
-
-### Slow Performance
-
-**Symptoms**: Lag when typing, slow completions
-
-**Solutions**:
-
-1. **Reduce result caps**:
-   ```json
-   {
-     "languageserver": {
-       "perl": {
-         "settings": {
-           "perl": {
-             "limits": {
-               "workspaceSymbolCap": 100,
-               "referencesCap": 200,
-               "completionCap": 50
-             }
-           }
-         }
-       }
-     }
-   }
-   ```
-
-2. **Disable system @INC**:
-   ```json
-   {
-     "languageserver": {
-       "perl": {
-         "settings": {
-           "perl": {
-             "workspace": {
-               "useSystemInc": false
-             }
-           }
-         }
-       }
-     }
-   }
-   ```
-
-3. **Reduce resolution timeout**:
-   ```json
-   {
-     "languageserver": {
-       "perl": {
-         "settings": {
-           "perl": {
-             "workspace": {
-               "resolutionTimeout": 25
-             }
-           }
-         }
-       }
-     }
-   }
-   ```
-
-### Module Resolution Issues
-
-**Symptoms**: Can't find modules, go-to-definition fails
-
-**Solutions**:
-
-1. **Check include paths**:
-   ```json
-   {
-     "languageserver": {
-       "perl": {
-         "settings": {
-           "perl": {
-             "workspace": {
-               "includePaths": ["lib", ".", "local/lib/perl5", "vendor/lib"]
-             }
-           }
-         }
-       }
-     }
-   }
-   ```
-
-2. **Verify module exists**:
-   ```bash
-   perl -e 'use Module::Name;'
-   ```
-
-3. **Check workspace root**:
-   ```vim
-   :CocCommand workspace.workspaceFolders
-   ```
-
-### Formatting Not Working
-
-**Symptoms**: Format command does nothing or errors
-
-**Solutions**:
-
-1. **Install perltidy**:
-   ```bash
-   # macOS
-   brew install perltidy
-
-   # Ubuntu/Debian
-   sudo apt-get install perltidy
-
-   # CentOS/RHEL
-   sudo yum install perl-Perl-Tidy
-   ```
-
-2. **Check perltidy works**:
-   ```bash
-   perltidy --version
-   ```
-
-3. **Verify formatting enabled**:
-   ```vim
-   :CocAction('format')
-   ```
-
----
-
-## Advanced Configuration
-
-### Multi-Root Workspace
-
-For workspaces with multiple folders:
-
-```vim
-" Add to .vimrc or init.vim
-function! s:workspace_folders() abort
-  let folders = []
-  let root = finddir('.git/..', expand('%:p:h').';')
-  if !empty(root)
-    call add(folders, { 'uri': 'file://' . fnamemodify(root, ':p'), 'name': fnamemodify(root, ':t') })
-  endif
-  return folders
-endfunction
-
-augroup coc_workspace
+augroup perl_filetypes
   autocmd!
-  autocmd BufEnter * call coc#rpc#notify('workspace/didChangeWorkspaceFolders', {'added': s:workspace_folders()})
+  autocmd BufRead,BufNewFile *.t setfiletype perl
+  autocmd BufRead,BufNewFile *.psgi setfiletype perl
+  autocmd BufRead,BufNewFile *.cgi,*.fcgi setfiletype perl
 augroup END
 ```
 
-### Custom Handlers
+For Lua-based Neovim config:
 
-Override default LSP handlers:
-
-```vim
-" Custom hover handler
-function! s:custom_hover() abort
-  call CocActionAsync('doHover')
-  " Add custom logic here
-endfunction
-
-nnoremap <silent> K :call <SID>custom_hover()<CR>
-```
-
-### Diagnostic Configuration
-
-Customize diagnostic display:
-
-```json
-{
-  "diagnostic.errorSign": "✗",
-  "diagnostic.warningSign": "⚠",
-  "diagnostic.infoSign": "ℹ",
-  "diagnostic.hintSign": "➤",
-  "diagnostic.virtualText": true,
-  "diagnostic.virtualTextPrefix": "■",
-  "diagnostic.virtualTextLineSeparator": " └ ",
-  "diagnostic.virtualTextCurrentLineOnly": false
-}
-```
-
-### Auto-Commands
-
-Set up auto-commands for automatic actions:
-
-```vim
-" Format on save
-autocmd BufWritePre *.pl :call CocAction('format')
-
-" Auto-start coc.nvim for Perl files
-autocmd FileType perl :CocCommand workspace.toggleDiagnostics
-```
-
-### Performance Tuning
-
-For large workspaces, adjust performance settings:
-
-```json
-{
-  "suggest.maxCompleteItemCount": 50,
-  "suggest.minTriggerInputLength": 1,
-  "suggest.triggerCompletionWait": 50,
-  "suggest.noselect": false,
-  "suggest.enablePreselect": true,
-  "suggest.completionItemKindLabels": {
-    "function": "ƒ",
-    "method": "m",
-    "variable": "v",
-    "constant": "c",
-    "class": "C",
-    "interface": "I",
-    "module": "M"
-  }
-}
-```
-
-### Debug Logging
-
-Enable detailed logging for troubleshooting:
-
-```vim
-" Enable debug logging
-:CocCommand workspace.toggleDebug
-
-" View logs
-:CocCommand workspace.showOutput
-```
-
----
-
-## Complete Example Configuration
-
-### .vimrc or init.vim
-
-```vim
-" Plugin setup (using vim-plug)
-call plug#begin('~/.vim/plugged')
-Plug 'neoclide/coc.nvim', {'branch': 'release'}
-call plug#end()
-
-" coc.nvim configuration
-let g:coc_global_extensions = [
-      \ 'coc-snippets',
-      \ 'coc-pairs',
-      \ 'coc-lists',
-      \ 'coc-explorer',
-      \ 'coc-git',
-      \ 'coc-yank'
-      \]
-
-" Use Tab for trigger completion
-inoremap <silent><expr> <TAB>
-      \ pumvisible() ? "\<C-n>" :
-      \ <SID>check_back_space() ? "\<TAB>" :
-      \ coc#refresh()
-
-function! s:check_back_space() abort
-  let col = col('.') - 1
-  return !col || getline('.')[col - 1]  =~# '\s'
-endfunction
-
-" Use <c-space> to trigger completion
-if has('nvim')
-  inoremap <silent><expr> <c-space> coc#refresh()
-else
-  inoremap <silent><expr> <c-@> coc#refresh()
-endif
-
-" Make <CR> auto-select the first completion item
-inoremap <silent><expr> <cr> pumvisible() ? coc#_select_confirm()
-                              \: "\<C-g>u\<CR>\<c-r>=coc#on_enter()\<CR>"
-
-" Navigate diagnostics
-nmap <silent> [g <Plug>(coc-diagnostic-prev)
-nmap <silent> ]g <Plug>(coc-diagnostic-next)
-
-" GoTo code navigation
-nmap <silent> gd <Plug>(coc-definition)
-nmap <silent> gy <Plug>(coc-type-definition)
-nmap <silent> gi <Plug>(coc-implementation)
-nmap <silent> gr <Plug>(coc-references)
-
-" Show documentation
-nnoremap <silent> K :call <SID>show_documentation()<CR>
-
-function! s:show_documentation()
-  if (index(['vim','help'], &filetype) >= 0)
-    execute 'h '.expand('<cword>')
-  elseif (coc#rpc#ready())
-    call CocActionAsync('doHover')
-  else
-    execute '!' . &keywordprg . " " . expand('<cword>')
-  endif
-endfunction
-
-" Highlight symbol under cursor
-autocmd CursorHold * silent call CocActionAsync('highlight')
-
-" Symbol renaming
-nmap <leader>rn <Plug>(coc-rename)
-
-" Formatting
-nmap <leader>f <Plug>(coc-format-selected)
-xmap <leader>f <Plug>(coc-format-selected)
-
-" Apply AutoFix
-nmap <leader>qf  <Plug>(coc-fix-current)
-
-" Symbol text objects
-xmap if <Plug>(coc-funcobj-i)
-omap if <Plug>(coc-funcobj-i)
-xmap af <Plug>(coc-funcobj-a)
-omap af <Plug>(coc-funcobj-a)
-xmap ic <Plug>(coc-classobj-i)
-omap ic <Plug>(coc-classobj-i)
-xmap ac <Plug>(coc-classobj-a)
-omap ac <Plug>(coc-classobj-a)
-
-" Scroll float windows
-nnoremap <silent><nowait><expr> <C-f> coc#float#has_scroll() ? coc#float#scroll(1) : "\<C-f>"
-nnoremap <silent><nowait><expr> <C-b> coc#float#has_scroll() ? coc#float#scroll(0) : "\<C-b>"
-
-" Status line
-set statusline^=%{coc#status()}%{get(b:,'coc_current_function','')}
-
-" CocList commands
-nnoremap <silent><nowait> <space>a  :<C-u>CocList diagnostics<cr>
-nnoremap <silent><nowait> <space>e  :<C-u>CocList extensions<cr>
-nnoremap <silent><nowait> <space>c  :<C-u>CocList commands<cr>
-nnoremap <silent><nowait> <space>o  :<C-u>CocList outline<cr>
-nnoremap <silent><nowait> <space>s  :<C-u>CocList -I symbols<cr>
-nnoremap <silent><nowait> <space>p  :<C-u>CocListResume<CR>
-
-" Format on save
-autocmd BufWritePre *.pl :call CocAction('format')
-
-" Auto-start for Perl files
-autocmd FileType perl :CocCommand workspace.toggleDiagnostics
-```
-
-### coc-settings.json
-
-```json
-{
-  "languageserver": {
-    "perl": {
-      "command": "perl-lsp",
-      "args": ["--stdio"],
-      "filetypes": ["perl"],
-      "rootPatterns": ["Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"],
-      "settings": {
-        "perl": {
-          "workspace": {
-            "includePaths": ["lib", ".", "local/lib/perl5", "vendor/lib"],
-            "useSystemInc": false,
-            "resolutionTimeout": 50
-          },
-          "inlayHints": {
-            "enabled": true,
-            "parameterHints": true,
-            "typeHints": true,
-            "maxLength": 30
-          },
-          "limits": {
-            "workspaceSymbolCap": 200,
-            "referencesCap": 500,
-            "completionCap": 100
-          }
-        }
-      },
-      "env": {
-        "PERL5LIB": "${workspaceFolder}/lib",
-        "PERL_MB_OPT": "--install_base ${workspaceFolder}/local"
-      }
-    }
+```lua
+vim.filetype.add({
+  extension = {
+    t = 'perl',
+    psgi = 'perl',
+    cgi = 'perl',
+    fcgi = 'perl',
+    PL = 'perl',
   },
+})
+```
+
+## Optional UI Settings
+
+Keep first-run config small, then add UI settings after the server attaches:
+
+```json
+{
   "diagnostic.enable": true,
-  "diagnostic.errorSign": "✗",
-  "diagnostic.warningSign": "⚠",
-  "diagnostic.infoSign": "ℹ",
-  "diagnostic.hintSign": "➤",
   "diagnostic.virtualText": true,
   "diagnostic.virtualTextPrefix": "■",
   "suggest.enablePreselect": true,
   "suggest.minTriggerInputLength": 1,
   "suggest.noselect": false,
   "suggest.enablePreview": true,
-  "suggest.floatEnable": true,
+  "suggest.enableFloat": true,
   "signature.enable": true,
   "signature.target": "float",
-  "signature.triggerSignatureWait": 50,
   "codeLens.enable": true,
-  "codeLens.position": "eol",
   "inlayHint.enable": true,
   "inlayHint.display": true,
-  "inlayHint.enableParameter": true,
-  "inlayHint.enableType": true
+  "inlayHint.enableParameter": true
 }
 ```
 
----
+## Recommended Keybindings
+
+```vim
+" Trigger completion.
+if has('nvim')
+  inoremap <silent><expr> <c-space> coc#refresh()
+else
+  inoremap <silent><expr> <c-@> coc#refresh()
+endif
+
+" Diagnostics.
+nmap <silent> [g <Plug>(coc-diagnostic-prev)
+nmap <silent> ]g <Plug>(coc-diagnostic-next)
+
+" Navigation.
+nmap <silent> gd <Plug>(coc-definition)
+nmap <silent> gy <Plug>(coc-type-definition)
+nmap <silent> gi <Plug>(coc-implementation)
+nmap <silent> gr <Plug>(coc-references)
+
+" Hover.
+nnoremap <silent> K :call CocActionAsync('doHover')<CR>
+
+" Rename and code actions.
+nmap <leader>rn <Plug>(coc-rename)
+nmap <leader>ca <Plug>(coc-codeaction-cursor)
+nmap <leader>qf <Plug>(coc-fix-current)
+
+" Formatting.
+nmap <leader>f <Plug>(coc-format-selected)
+xmap <leader>f <Plug>(coc-format-selected)
+
+" Lists.
+nnoremap <silent><nowait> <space>a :<C-u>CocList diagnostics<CR>
+nnoremap <silent><nowait> <space>o :<C-u>CocList outline<CR>
+nnoremap <silent><nowait> <space>s :<C-u>CocList -I symbols<CR>
+```
+
+Optional format command:
+
+```vim
+command! -nargs=0 Format :call CocActionAsync('format')
+```
+
+Optional format on save:
+
+```vim
+augroup perl_lsp_format
+  autocmd!
+  autocmd BufWritePre *.pl,*.pm,*.t,*.psgi call CocAction('format')
+augroup END
+```
+
+## Verify It Is Running
+
+1. Restart Neovim.
+2. Open a Perl file such as `lib/My/Module.pm`, `script/app.pl`, or `t/basic.t`.
+3. Confirm filetype:
+
+   ```vim
+   :set filetype?
+   ```
+
+4. Check coc.nvim status:
+
+   ```vim
+   :CocInfo
+   ```
+
+5. Check the active filetype as coc.nvim sees it:
+
+   ```vim
+   :CocCommand document.echoFiletype
+   ```
+
+6. Open the output channel:
+
+   ```vim
+   :CocCommand workspace.showOutput
+   ```
+
+7. Introduce a temporary syntax error and confirm diagnostics appear.
+8. Remove the syntax error after testing.
+
+You can also test a file outside Neovim:
+
+```bash
+perllsp --check path/to/file.pl
+```
+
+## Troubleshooting
+
+### coc.nvim does not start `perllsp`
+
+Check from a shell:
+
+```bash
+command -v perllsp
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+On Windows PowerShell:
+
+```powershell
+where perllsp
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+Check from Neovim:
+
+```vim
+:!command -v perllsp
+:CocInfo
+:CocOpenLog
+:CocCommand workspace.showOutput
+```
+
+If Neovim was launched from a GUI, it may not inherit the same `PATH` as your
+terminal. Use an absolute path if needed:
+
+```json
+{
+  "languageserver": {
+    "perl-lsp": {
+      "command": "/absolute/path/to/perllsp",
+      "args": ["--stdio"],
+      "filetypes": ["perl"]
+    }
+  }
+}
+```
+
+### No diagnostics or completion
+
+Check the active filetype:
+
+```vim
+:set filetype?
+:CocCommand document.echoFiletype
+```
+
+It must be `perl`.
+
+Then check diagnostics:
+
+```vim
+:CocDiagnostics
+```
+
+Also test outside Neovim:
+
+```bash
+perllsp --check path/to/file.pl
+```
+
+### Module resolution issues
+
+Prefer `.perl-lsp.toml` for shared include paths:
+
+```toml
+[perl]
+include_paths = ["lib", ".", "local/lib/perl5", "vendor/lib"]
+```
+
+Or use coc.nvim settings:
+
+```json
+{
+  "languageserver": {
+    "perl-lsp": {
+      "settings": {
+        "perl": {
+          "workspace": {
+            "includePaths": ["lib", ".", "local/lib/perl5", "vendor/lib"],
+            "useSystemInc": false
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Slow performance
+
+Reduce result caps:
+
+```json
+{
+  "languageserver": {
+    "perl-lsp": {
+      "settings": {
+        "perl": {
+          "limits": {
+            "workspaceSymbolCap": 100,
+            "referencesCap": 200,
+            "completionCap": 50,
+            "astCacheMaxEntries": 50,
+            "maxIndexedFiles": 5000,
+            "maxTotalSymbols": 250000,
+            "workspaceScanDeadlineMs": 20000,
+            "referenceSearchDeadlineMs": 1500
+          },
+          "workspace": {
+            "resolutionTimeout": 25
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Formatting does not work
+
+Confirm `perltidy` is installed:
+
+```bash
+perltidy --version
+```
+
+Then run:
+
+```vim
+:call CocActionAsync('format')
+```
+
+### Debug logging
+
+Open coc.nvim logs:
+
+```vim
+:CocOpenLog
+:CocCommand workspace.showOutput
+```
+
+For protocol tracing, set:
+
+```json
+{
+  "languageserver": {
+    "perl-lsp": {
+      "trace.server": "verbose"
+    }
+  }
+}
+```
+
+For server-side logs, temporarily add `--log`:
+
+```json
+{
+  "languageserver": {
+    "perl-lsp": {
+      "command": "perllsp",
+      "args": ["--stdio", "--log"],
+      "filetypes": ["perl"]
+    }
+  }
+}
+```
+
+### `perllsp --stdio` appears to hang
+
+That is expected. In stdio mode, `perllsp` waits for framed LSP input from
+coc.nvim. Use these commands for manual checks instead:
+
+```bash
+perllsp --health
+perllsp --info
+perllsp --check path/to/file.pl
+```
 
 ## See Also
 
-- [Getting Started](../tutorials/GETTING_STARTED.md) - Quick start guide
-- [Configuration Reference](../reference/CONFIG.md) - Complete configuration options
-- [Troubleshooting Guide](../how-to/TROUBLESHOOTING.md) - Common issues and solutions
-- [Performance Tuning](../how-to/PERFORMANCE_TUNING.md) - Performance optimization guide
-- [Editor Setup](../how-to/EDITOR_SETUP.md) - Other editor configurations
-- [coc.nvim Documentation](https://github.com/neoclide/coc.nvim)
+- [docs/EDITORS/NEOVIM_SETUP.md](NEOVIM_SETUP.md)
+- [docs/EDITORS/VIM_SETUP.md](VIM_SETUP.md)
+- [docs/reference/CONFIG.md](../reference/CONFIG.md)
+- [docs/how-to/TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md)
+- [docs/how-to/EDITOR_SETUP.md](../how-to/EDITOR_SETUP.md)

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -27,6 +27,7 @@ perllsp --health
 | Trae (ByteDance) | install the VS Code-compatible extension or set command to `perllsp --stdio` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
 | Neovim | define a custom `perllsp` config with `vim.lsp.config()` and enable via `vim.lsp.enable()` (legacy `nvim-lspconfig` supported for older Neovim) | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Vim | use `vim-lsp` or `coc.nvim` with `perllsp --stdio` | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
+| coc.nvim | configure `languageserver.perl-lsp` in `coc-settings.json` to launch `perllsp --stdio`; works in Neovim and Vim when buffer filetype is `perl` | [docs/EDITORS/COC_NEOVIM_SETUP.md](../EDITORS/COC_NEOVIM_SETUP.md) |
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | add a `perllsp` language server entry | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Zed | install a Perl extension, then optionally point at `perllsp` | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |
@@ -89,6 +90,44 @@ editor-specific guide has the full snippets for both.
 Use either `vim-lsp` (native LSP in Vim) or `coc.nvim` (Node-based client),
 both configured to launch `perllsp --stdio`. See
 [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) for complete examples.
+
+### coc.nvim
+
+Open coc.nvim settings:
+
+```vim
+:CocConfig
+```
+
+Add:
+
+```json
+{
+  "languageserver": {
+    "perl-lsp": {
+      "command": "perllsp",
+      "args": ["--stdio"],
+      "filetypes": ["perl"],
+      "rootPatterns": [".perl-lsp.toml", "Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"],
+      "settings": {
+        "perl": {
+          "workspace": {
+            "includePaths": ["lib", ".", "local/lib/perl5"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Check the active filetype with:
+
+```vim
+:CocCommand document.echoFiletype
+```
+
+It must be `perl`.
 
 ### Helix
 

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -100,6 +100,45 @@ If the editor is using a helper extension or plugin, check its own logs too.
 5. Use `perllsp --check path/to/file.pl` for manual diagnostics.
    Do not test stdio mode by piping unframed JSON.
 
+## coc.nvim Does Not Start `perllsp`
+
+1. Confirm coc.nvim is running:
+
+   ```vim
+   :CocInfo
+   ```
+
+2. Confirm the filetype:
+
+   ```vim
+   :set filetype?
+   :CocCommand document.echoFiletype
+   ```
+
+   It must be `perl`.
+
+3. Confirm `perllsp` works outside Neovim:
+
+   ```bash
+   perllsp --version
+   perllsp --health
+   perllsp --info
+   perllsp --check path/to/file.pl
+   ```
+
+4. Inspect coc.nvim logs:
+
+   ```vim
+   :CocOpenLog
+   :CocCommand workspace.showOutput
+   ```
+
+5. If `perllsp` is not found, set an absolute `languageserver.perl-lsp.command`
+   path in `coc-settings.json`.
+
+6. Do not test stdio mode with raw JSON. LSP stdio traffic requires
+   `Content-Length` framing.
+
 ## DAP Or Debugging Issues
 
 If you are debugging with `perl-dap`, check the DAP guide:

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -598,6 +598,9 @@ autocmd User lsp_setup call lsp#register_server({
 }
 ```
 
+coc.nvim uses Vim/Neovim filetypes, so Perl buffers must report `filetype=perl`
+before this language server starts.
+
 ## Environment Variables
 
 Environment variables read at startup by the `perllsp` executable. Source:


### PR DESCRIPTION
### Motivation

- Update the coc.nvim documentation to reflect current tooling and server naming, fixing stale prerequisites and incorrect examples. 
- Replace broken manual stdio smoke-test guidance and stale release/archive examples that could mislead users. 
- Provide a small, focused coc.nvim config snippet and aligned troubleshooting steps so users can reliably start `perllsp` from Vim/Neovim.

### Description

- Rewrote the coc.nvim guide at `docs/EDITORS/COC_NEOVIM_SETUP.md` to use the `perllsp` executable, modern coc.nvim/Node/Neovim version guidance, `languageserver.perl-lsp` shape, and recommended minimal settings (including `includePaths`).
- Added a coc.nvim entry and minimal `perllsp --stdio` snippet to `docs/how-to/EDITOR_SETUP.md` so the editor matrix points to the canonical configuration.
- Added a `coc.nvim Does Not Start perllsp` troubleshooting section to `docs/how-to/TROUBLESHOOTING.md` with concrete checks and commands like `:CocInfo`, `:CocOpenLog`, `:CocCommand workspace.showOutput`, and replaced invalid raw-JSON stdio tests with `perllsp --health`, `perllsp --info`, and `perllsp --check` examples.
- Touched `docs/reference/CONFIG.md` to align the coc.nvim example and add an explicit note that coc.nvim attaches by Vim/Neovim `filetype=perl` so the server only starts when that filetype is reported.

### Testing

- Attempted to run the project gate with `just pr-fast`, but it could not run in this environment (`just: command not found`).
- Ran an automated stale-pattern check (`rg`/conditional grep) for removed bad patterns (e.g. `perl-lsp-linux`, `command": "perl-lsp"`, `suggest.floatEnable`, `inlayHint.enableType`, `workspace.toggleDiagnostics`) and it passed (`stale pattern check passed`).
- All modified documentation files were committed successfully and are ready for the repository CI to run full validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a64de43c833399474b94e238e9ad)