### PR TITLE
feat(perl-corpus): add durable concept registry seed (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "toml",
  "tracing",
 ]
 

--- a/crates/perl-corpus/Cargo.toml
+++ b/crates/perl-corpus/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/perl-corpus"
 homepage.workspace = true
 keywords = ["perl", "corpus", "proptest", "testing", "parser"]
 categories = ["development-tools", "development-tools::testing"]
-include = ["src/**", "README.md", "LICENSE*", "Cargo.toml"]
+include = ["src/**", "concepts/**", "README.md", "LICENSE*", "Cargo.toml"]
 
 [lib]
 name = "perl_corpus"
@@ -34,6 +34,7 @@ chrono = "0.4.42"
 proptest.workspace = true
 rand = "0.10.1"
 tracing.workspace = true
+toml = "1.1.2"
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/perl-corpus/concepts/incremental.toml
+++ b/crates/perl-corpus/concepts/incremental.toml
@@ -1,0 +1,135 @@
+[[concepts]]
+id = "incremental.edit_inside_expression"
+status = "seed"
+scope.crates = ["perl-lsp-rs-core", "perl-parser"]
+scope.risk_tags = ["incremental", "expression"]
+fixtures.floors = ["test_corpus/ternary_expressions_comprehensive.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "index"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "incremental.edit_shifts_following_nodes"
+status = "seed"
+scope.crates = ["perl-lsp-rs-core", "perl-parser-core"]
+scope.risk_tags = ["incremental", "positions"]
+fixtures.floors = ["test_corpus/basic_constructs.pl"]
+fixtures.variants = ["test_corpus/parser_stress_cases.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "index"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "incremental.rename.local_shadow"
+status = "seed"
+scope.crates = ["perl-lsp-rs-core", "perl-workspace-index"]
+scope.risk_tags = ["incremental", "rename"]
+fixtures.floors = ["test_corpus/workspace_rename/scoping/lexical_scope_shadowing.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "index"
+snapshots.tokens = false
+snapshots.ast = false
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "incremental.rename.package_conflict"
+status = "seed"
+scope.crates = ["perl-lsp-rs-core", "perl-workspace-index"]
+scope.risk_tags = ["incremental", "rename", "workspace"]
+fixtures.floors = ["test_corpus/workspace_rename/scoping/package_scope_conflict.pm"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "index"
+snapshots.tokens = false
+snapshots.ast = false
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "incremental.workspace.multi_file_reference"
+status = "seed"
+scope.crates = ["perl-lsp-rs-core", "perl-workspace-index"]
+scope.risk_tags = ["incremental", "workspace"]
+fixtures.floors = ["test_corpus/workspace_rename/basic/multi_file_main.pl", "test_corpus/workspace_rename/basic/multi_file_utils.pm"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "index"
+snapshots.tokens = false
+snapshots.ast = false
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "incremental.circular_dependencies"
+status = "seed"
+scope.crates = ["perl-workspace-index", "perl-lsp-rs-core"]
+scope.risk_tags = ["incremental", "workspace", "cycle"]
+fixtures.floors = ["test_corpus/workspace_rename/edge_cases/circular_deps_a.pm", "test_corpus/workspace_rename/edge_cases/circular_deps_b.pm"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "index"
+snapshots.tokens = false
+snapshots.ast = false
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "incremental.trivia_only_edit"
+status = "planned"
+scope.crates = ["perl-lsp-rs-core", "perl-parser-core"]
+scope.risk_tags = ["incremental", "trivia"]
+fixtures.floors = []
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "index"
+snapshots.tokens = false
+snapshots.ast = false
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "incremental.edit_near_data_section"
+status = "seed"
+scope.crates = ["perl-lsp-rs-core", "perl-parser"]
+scope.risk_tags = ["incremental", "data-section"]
+fixtures.floors = ["test_corpus/end_section.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "index"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false

--- a/crates/perl-corpus/concepts/lexer.toml
+++ b/crates/perl-corpus/concepts/lexer.toml
@@ -1,0 +1,135 @@
+[[concepts]]
+id = "lexer.regex.literal_vs_division"
+status = "seed"
+scope.crates = ["perl-lexer", "perl-parser"]
+scope.risk_tags = ["token-boundary", "regex"]
+fixtures.floors = ["test_corpus/clean_regex_substitution.pl"]
+fixtures.variants = ["test_corpus/parser_stress_cases.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = true
+snapshots.ast = false
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "lexer.regex.substitution_delimiters"
+status = "seed"
+scope.crates = ["perl-lexer"]
+scope.risk_tags = ["regex", "delimiter"]
+fixtures.floors = ["test_corpus/clean_regex_substitution.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = true
+snapshots.ast = false
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "lexer.quote_like.q_braces"
+status = "seed"
+scope.crates = ["perl-lexer", "perl-parser"]
+scope.risk_tags = ["quote-like"]
+fixtures.floors = ["test_corpus/string_ops_edge_cases.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = true
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "lexer.quote_like.qq_parens"
+status = "seed"
+scope.crates = ["perl-lexer", "perl-parser"]
+scope.risk_tags = ["quote-like", "nesting"]
+fixtures.floors = ["test_corpus/string_ops_edge_cases.pl"]
+fixtures.variants = ["test_corpus/basic_constructs.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = true
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "lexer.heredoc.basic"
+status = "seed"
+scope.crates = ["perl-lexer", "perl-parser"]
+scope.risk_tags = ["heredoc"]
+fixtures.floors = ["test_corpus/heredoc_depth.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = true
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "lexer.heredoc.indented"
+status = "planned"
+scope.crates = ["perl-lexer", "perl-parser"]
+scope.risk_tags = ["heredoc", "indentation"]
+fixtures.floors = []
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = true
+snapshots.ast = false
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "lexer.data_section.double_underscore_data"
+status = "seed"
+scope.crates = ["perl-lexer", "perl-parser"]
+scope.risk_tags = ["data-section", "eof"]
+fixtures.floors = ["test_corpus/end_section.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = true
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "lexer.source_filter.boundary_tokens"
+status = "seed"
+scope.crates = ["perl-lexer"]
+scope.risk_tags = ["source-filter", "token-boundary"]
+fixtures.floors = ["test_corpus/source_filters.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = true
+snapshots.ast = false
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false

--- a/crates/perl-corpus/concepts/parser.toml
+++ b/crates/perl-corpus/concepts/parser.toml
@@ -1,0 +1,186 @@
+[[concepts]]
+id = "parser.package.declaration"
+status = "seed"
+scope.crates = ["perl-parser", "perl-parser-core"]
+scope.risk_tags = ["declaration"]
+fixtures.floors = ["test_corpus/package_production_enhanced.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "parser.sub.named"
+status = "seed"
+scope.crates = ["perl-parser"]
+scope.risk_tags = ["declaration", "subroutine"]
+fixtures.floors = ["test_corpus/basic_constructs.pl"]
+fixtures.variants = ["test_corpus/prototypes_only.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "parser.sub.anonymous"
+status = "seed"
+scope.crates = ["perl-parser"]
+scope.risk_tags = ["subroutine", "expression"]
+fixtures.floors = ["test_corpus/basic_constructs.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "parser.sub.signature"
+status = "seed"
+scope.crates = ["perl-parser", "perl-semantic-analyzer"]
+scope.risk_tags = ["signature", "perl-5.20+"]
+fixtures.floors = ["test_corpus/variable_with_attributes_comprehensive.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "parser.variable.my_our_local_state"
+status = "seed"
+scope.crates = ["perl-parser", "perl-semantic-analyzer"]
+scope.risk_tags = ["scope", "declaration"]
+fixtures.floors = ["test_corpus/variable_list_declaration_comprehensive.pl"]
+fixtures.variants = ["test_corpus/basic_constructs.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "parser.expression.fat_arrow"
+status = "seed"
+scope.crates = ["perl-parser", "perl-lexer"]
+scope.risk_tags = ["operator", "associativity"]
+fixtures.floors = ["test_corpus/string_ops_edge_cases.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = true
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "parser.expression.range"
+status = "seed"
+scope.crates = ["perl-parser"]
+scope.risk_tags = ["operator", "precedence"]
+fixtures.floors = ["test_corpus/basic_constructs.pl"]
+fixtures.variants = ["test_corpus/parser_stress_cases.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "parser.expression.word_operators"
+status = "seed"
+scope.crates = ["perl-parser"]
+scope.risk_tags = ["operator", "keyword-operator"]
+fixtures.floors = ["test_corpus/string_ops_edge_cases.pl"]
+fixtures.variants = ["test_corpus/basic_constructs.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "parser.hash.array_literals"
+status = "seed"
+scope.crates = ["perl-parser", "perl-semantic-analyzer"]
+scope.risk_tags = ["literal", "data-structure"]
+fixtures.floors = ["test_corpus/basic_constructs.pl"]
+fixtures.variants = ["test_corpus/glob_assignments.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "parser.method_call.arrow"
+status = "seed"
+scope.crates = ["perl-parser", "perl-semantic-analyzer"]
+scope.risk_tags = ["method-call", "dispatch"]
+fixtures.floors = ["test_corpus/method_class.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "parser.indirect_object_call"
+status = "planned"
+scope.crates = ["perl-parser", "perl-semantic-analyzer"]
+scope.risk_tags = ["ambiguity", "dispatch"]
+fixtures.floors = []
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false

--- a/crates/perl-corpus/concepts/positions.toml
+++ b/crates/perl-corpus/concepts/positions.toml
@@ -1,0 +1,135 @@
+[[concepts]]
+id = "position.byte_span.basic"
+status = "seed"
+scope.crates = ["perl-parser-core", "perl-parser"]
+scope.risk_tags = ["positions", "byte-offset"]
+fixtures.floors = ["test_corpus/basic_constructs.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "position.utf16.non_ascii"
+status = "planned"
+scope.crates = ["perl-parser-core", "perl-lsp-rs-core"]
+scope.risk_tags = ["positions", "utf16"]
+fixtures.floors = ["test_corpus/workspace_rename/edge_cases/unicode_identifiers.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "index"
+snapshots.tokens = false
+snapshots.ast = false
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "position.crlf.line_index"
+status = "planned"
+scope.crates = ["perl-parser-core", "perl-lsp-rs-core"]
+scope.risk_tags = ["positions", "crlf"]
+fixtures.floors = []
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "index"
+snapshots.tokens = false
+snapshots.ast = false
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "position.multiline.heredoc_spans"
+status = "seed"
+scope.crates = ["perl-parser-core", "perl-parser"]
+scope.risk_tags = ["positions", "heredoc"]
+fixtures.floors = ["test_corpus/heredoc_depth.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = false
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "position.regex.capture_boundaries"
+status = "seed"
+scope.crates = ["perl-parser-core", "perl-lexer"]
+scope.risk_tags = ["positions", "regex"]
+fixtures.floors = ["test_corpus/clean_regex_substitution.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = true
+snapshots.ast = false
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "position.package_decl.leading_comments"
+status = "seed"
+scope.crates = ["perl-parser-core", "perl-parser"]
+scope.risk_tags = ["positions", "comments"]
+fixtures.floors = ["test_corpus/package_production_enhanced.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "position.statement_modifier_tail"
+status = "seed"
+scope.crates = ["perl-parser-core", "perl-parser"]
+scope.risk_tags = ["positions", "statement-modifier"]
+fixtures.floors = ["test_corpus/statement_modifier_comprehensive.pl"]
+fixtures.variants = ["test_corpus/statement_modifier_production_enhanced.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "position.loop_labels.boundaries"
+status = "seed"
+scope.crates = ["perl-parser-core", "perl-parser"]
+scope.risk_tags = ["positions", "labels"]
+fixtures.floors = ["test_corpus/clean_for_labeled.pl"]
+fixtures.variants = ["test_corpus/loop_control_comprehensive.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false

--- a/crates/perl-corpus/concepts/recovery.toml
+++ b/crates/perl-corpus/concepts/recovery.toml
@@ -1,0 +1,135 @@
+[[concepts]]
+id = "parser.recovery.missing_closing_brace"
+status = "seed"
+scope.crates = ["perl-parser", "perl-parser-core"]
+scope.risk_tags = ["recovery", "brace"]
+fixtures.floors = ["test_corpus/error_recovery.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "recover"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "parser.recovery.missing_paren"
+status = "seed"
+scope.crates = ["perl-parser", "perl-parser-core"]
+scope.risk_tags = ["recovery", "paren"]
+fixtures.floors = ["test_corpus/error_recovery.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "recover"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "parser.recovery.unclosed_quote"
+status = "seed"
+scope.crates = ["perl-parser", "perl-lexer"]
+scope.risk_tags = ["recovery", "quote"]
+fixtures.floors = ["test_corpus/error_recovery.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "recover"
+snapshots.tokens = true
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "parser.recovery.malformed_signature"
+status = "seed"
+scope.crates = ["perl-parser", "perl-parser-core"]
+scope.risk_tags = ["recovery", "signature"]
+fixtures.floors = ["test_corpus/error_recovery.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "recover"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "parser.recovery.bad_format_block"
+status = "seed"
+scope.crates = ["perl-parser"]
+scope.risk_tags = ["recovery", "format"]
+fixtures.floors = ["test_corpus/format_statements.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "recover"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "parser.recovery.given_when_fallback"
+status = "seed"
+scope.crates = ["perl-parser"]
+scope.risk_tags = ["recovery", "switch"]
+fixtures.floors = ["test_corpus/given_when.pl"]
+fixtures.variants = ["test_corpus/clean_given_when.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "recover"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "parser.recovery.loop_control"
+status = "seed"
+scope.crates = ["perl-parser"]
+scope.risk_tags = ["recovery", "loop-control"]
+fixtures.floors = ["test_corpus/loop_control_comprehensive.pl"]
+fixtures.variants = ["test_corpus/clean_for_labeled.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "recover"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "parser.recovery.ternary_colon_missing"
+status = "planned"
+scope.crates = ["perl-parser", "perl-parser-core"]
+scope.risk_tags = ["recovery", "ternary"]
+fixtures.floors = []
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "recover"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false

--- a/crates/perl-corpus/concepts/tree_sitter.toml
+++ b/crates/perl-corpus/concepts/tree_sitter.toml
@@ -1,0 +1,135 @@
+[[concepts]]
+id = "tree_sitter.parity.package_decl"
+status = "seed"
+scope.crates = ["perl-parser", "perl-corpus"]
+scope.risk_tags = ["parity", "tree-sitter"]
+fixtures.floors = ["test_corpus/package_production_enhanced.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parity"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "tree_sitter.parity.sub_decl"
+status = "seed"
+scope.crates = ["perl-parser", "perl-corpus"]
+scope.risk_tags = ["parity", "tree-sitter"]
+fixtures.floors = ["test_corpus/basic_constructs.pl"]
+fixtures.variants = ["test_corpus/prototypes_only.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "parity"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = true
+
+[[concepts]]
+id = "tree_sitter.parity.method_call"
+status = "seed"
+scope.crates = ["perl-parser", "perl-corpus"]
+scope.risk_tags = ["parity", "tree-sitter", "dispatch"]
+fixtures.floors = ["test_corpus/method_class.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parity"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "tree_sitter.parity.given_when"
+status = "seed"
+scope.crates = ["perl-parser", "perl-corpus"]
+scope.risk_tags = ["parity", "tree-sitter", "switch"]
+fixtures.floors = ["test_corpus/given_when.pl"]
+fixtures.variants = ["test_corpus/clean_given_when.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "parity"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "tree_sitter.parity.regex_substitution"
+status = "seed"
+scope.crates = ["perl-lexer", "perl-corpus"]
+scope.risk_tags = ["parity", "tree-sitter", "regex"]
+fixtures.floors = ["test_corpus/clean_regex_substitution.pl"]
+fixtures.variants = ["test_corpus/regex_timeout_hardening.pl"]
+expect.panic = false
+expect.timeout = true
+expect.mode = "parity"
+snapshots.tokens = true
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "tree_sitter.parity.statement_modifiers"
+status = "seed"
+scope.crates = ["perl-parser", "perl-corpus"]
+scope.risk_tags = ["parity", "tree-sitter", "statement-modifier"]
+fixtures.floors = ["test_corpus/statement_modifier_comprehensive.pl"]
+fixtures.variants = ["test_corpus/statement_modifier_production_enhanced.pl"]
+expect.panic = false
+expect.timeout = false
+expect.mode = "parity"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "tree_sitter.parity.glob_assignments"
+status = "seed"
+scope.crates = ["perl-parser", "perl-corpus"]
+scope.risk_tags = ["parity", "tree-sitter", "glob"]
+fixtures.floors = ["test_corpus/glob_assignments.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parity"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false
+
+[[concepts]]
+id = "tree_sitter.parity.deferred_blocks"
+status = "seed"
+scope.crates = ["perl-parser", "perl-corpus"]
+scope.risk_tags = ["parity", "tree-sitter", "phaser"]
+fixtures.floors = ["test_corpus/defer_blocks.pl"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parity"
+snapshots.tokens = false
+snapshots.ast = true
+snapshots.spans = true
+run.pr = false
+run.nightly = true
+run.release = false

--- a/crates/perl-corpus/src/concepts.rs
+++ b/crates/perl-corpus/src/concepts.rs
@@ -1,0 +1,269 @@
+//! Durable concept registry for parser-focused corpus coverage.
+
+use crate::files::CorpusPaths;
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+use toml::Value;
+
+const CONCEPT_FILES: [&str; 6] = [
+    "lexer.toml",
+    "parser.toml",
+    "recovery.toml",
+    "positions.toml",
+    "incremental.toml",
+    "tree_sitter.toml",
+];
+
+const KNOWN_STATUS: [&str; 4] = ["seed", "active", "planned", "deprecated"];
+const KNOWN_TOP_LEVEL_KEYS: [&str; 1] = ["concepts"];
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptRegistry {
+    pub concepts: Vec<ConceptRow>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptRow {
+    pub id: String,
+    pub status: String,
+    pub scope: ConceptScope,
+    pub fixtures: ConceptFixtures,
+    pub expect: ConceptExpect,
+    pub snapshots: ConceptSnapshots,
+    pub run: ConceptRun,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptScope {
+    pub crates: Vec<String>,
+    pub risk_tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptFixtures {
+    pub floors: Vec<String>,
+    pub variants: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptExpect {
+    pub panic: bool,
+    pub timeout: bool,
+    pub mode: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptSnapshots {
+    pub tokens: bool,
+    pub ast: bool,
+    pub spans: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptRun {
+    pub pr: bool,
+    pub nightly: bool,
+    pub release: bool,
+}
+
+pub fn load_concept_registry() -> Result<ConceptRegistry> {
+    load_concept_registry_from(&CorpusPaths::discover().root)
+}
+
+pub fn load_concept_registry_from(workspace_root: &Path) -> Result<ConceptRegistry> {
+    let concepts_dir = workspace_root.join("crates/perl-corpus/concepts");
+    let mut concepts = Vec::new();
+
+    for file_name in CONCEPT_FILES {
+        let path = concepts_dir.join(file_name);
+        let mut file_concepts = load_concepts_file(&path)?;
+        concepts.append(&mut file_concepts);
+    }
+
+    concepts.sort_by(|a, b| a.id.cmp(&b.id));
+    validate_registry(workspace_root, &concepts)?;
+
+    Ok(ConceptRegistry { concepts })
+}
+
+fn load_concepts_file(path: &Path) -> Result<Vec<ConceptRow>> {
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("reading concepts file {}", path.display()))?;
+
+    let raw_value: Value =
+        toml::from_str::<Value>(&text).with_context(|| format!("parsing TOML {}", path.display()))?;
+    validate_top_level_keys(path, &raw_value)?;
+
+    #[derive(Deserialize)]
+    struct ConceptsFile {
+        concepts: Vec<ConceptRow>,
+    }
+
+    let parsed: ConceptsFile = raw_value
+        .try_into()
+        .with_context(|| format!("deserializing concepts file {}", path.display()))?;
+
+    Ok(parsed.concepts)
+}
+
+fn validate_top_level_keys(path: &Path, value: &Value) -> Result<()> {
+    let table = value
+        .as_table()
+        .with_context(|| format!("concept file {} must be a TOML table", path.display()))?;
+
+    for key in table.keys() {
+        if !KNOWN_TOP_LEVEL_KEYS.contains(&key.as_str()) {
+            bail!("unknown top-level TOML section '{}' in {}", key, path.display());
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_registry(workspace_root: &Path, concepts: &[ConceptRow]) -> Result<()> {
+    let mut ids = BTreeSet::new();
+    for concept in concepts {
+        if !ids.insert(concept.id.clone()) {
+            bail!("duplicate concept id '{}'", concept.id);
+        }
+
+        if !KNOWN_STATUS.contains(&concept.status.as_str()) {
+            bail!("unknown status '{}' for concept '{}'", concept.status, concept.id);
+        }
+
+        validate_fixture_paths(workspace_root, concept)?;
+    }
+
+    Ok(())
+}
+
+fn validate_fixture_paths(workspace_root: &Path, concept: &ConceptRow) -> Result<()> {
+    for fixture_path in concept.fixtures.floors.iter().chain(concept.fixtures.variants.iter()) {
+        let full_path = workspace_root.join(fixture_path);
+        if !full_path.exists() {
+            bail!("fixture path '{}' for concept '{}' does not exist", fixture_path, concept.id);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_root(prefix: &str) -> Result<PathBuf> {
+        let mut root = std::env::temp_dir();
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        root.push(format!("{}_{}_{}", prefix, std::process::id(), nanos));
+        fs::create_dir_all(&root)?;
+        Ok(root)
+    }
+
+    fn write_file(root: &Path, relative: &str, content: &str) -> Result<()> {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, content)?;
+        Ok(())
+    }
+
+    fn minimal_concepts_doc(id: &str, fixture: &str) -> String {
+        format!(
+            r#"[[concepts]]
+id = "{id}"
+status = "seed"
+scope.crates = ["perl-lexer"]
+scope.risk_tags = ["lexing"]
+fixtures.floors = ["{fixture}"]
+fixtures.variants = []
+expect.panic = false
+expect.timeout = false
+expect.mode = "parse"
+snapshots.tokens = true
+snapshots.ast = false
+snapshots.spans = true
+run.pr = true
+run.nightly = true
+run.release = false
+"#
+        )
+    }
+
+    fn write_all_concept_files(root: &Path, shared_content: &str) -> Result<()> {
+        for file_name in CONCEPT_FILES {
+            write_file(root, &format!("crates/perl-corpus/concepts/{file_name}"), shared_content)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn registry_rejects_duplicate_concept_ids() -> Result<()> {
+        let root = temp_root("perl_corpus_duplicate_concepts")?;
+        write_file(&root, "test_corpus/sample.pl", "print 1;\n")?;
+        write_all_concept_files(&root, &minimal_concepts_doc("dup.id", "test_corpus/sample.pl"))?;
+
+        let message = match load_concept_registry_from(&root) {
+            Ok(_) => bail!("expected duplicate id validation failure"),
+            Err(err) => err.to_string(),
+        };
+        assert!(message.contains("duplicate concept id 'dup.id'"));
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn registry_rejects_missing_fixture_path() -> Result<()> {
+        let root = temp_root("perl_corpus_missing_fixture")?;
+        write_all_concept_files(
+            &root,
+            &minimal_concepts_doc("unique.id", "test_corpus/does_not_exist.pl"),
+        )?;
+
+        let message = match load_concept_registry_from(&root) {
+            Ok(_) => bail!("expected missing fixture path validation failure"),
+            Err(err) => err.to_string(),
+        };
+        assert!(message.contains("does not exist"));
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn registry_load_is_deterministic() -> Result<()> {
+        let root = temp_root("perl_corpus_deterministic_concepts")?;
+        write_file(&root, "test_corpus/sample.pl", "print 1;\n")?;
+
+        let mut index = 0usize;
+        for file_name in CONCEPT_FILES {
+            let id = format!("zeta.{index}");
+            write_file(
+                &root,
+                &format!("crates/perl-corpus/concepts/{file_name}"),
+                &minimal_concepts_doc(&id, "test_corpus/sample.pl"),
+            )?;
+            index += 1;
+        }
+
+        let first = load_concept_registry_from(&root)?;
+        let second = load_concept_registry_from(&root)?;
+        assert_eq!(first, second);
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+}

--- a/crates/perl-corpus/src/lib.rs
+++ b/crates/perl-corpus/src/lib.rs
@@ -221,6 +221,7 @@
 
 pub mod cases;
 pub mod codegen;
+pub mod concepts;
 pub mod continue_redo;
 pub mod files;
 pub mod format_statements;
@@ -240,6 +241,9 @@ pub use cases::{
 pub use codegen::{
     CodegenOptions, StatementKind, generate_perl_code, generate_perl_code_with_options,
     generate_perl_code_with_seed, generate_perl_code_with_statements,
+};
+pub use concepts::{
+    ConceptRegistry, ConceptRow, load_concept_registry, load_concept_registry_from,
 };
 pub use continue_redo::{
     ContinueRedoCase, cases_by_tag as continue_redo_cases_by_tag, continue_redo_cases,


### PR DESCRIPTION
### Motivation
- Provide a durable, concept-indexed registry so perl-corpus can be treated as a concept lattice (lexer / parser / recovery / positions / incremental / tree-sitter) rather than just a list of files.
- Seed high-value concept rows to bootstrap coverage planning without imposing parser behavior or CI policy changes.

### Description
- Add a new `crates/perl-corpus/src/concepts.rs` loader/validator that deterministically loads six TOML concept files, sorts concepts by ID, and validates for duplicate IDs, known status values, fixture path existence, and unknown top-level TOML sections via strict deserialization (`serde(deny_unknown_fields)`).
- Seed six concept files under `crates/perl-corpus/concepts/` (`lexer.toml`, `parser.toml`, `recovery.toml`, `positions.toml`, `incremental.toml`, `tree_sitter.toml`) with 51 concept rows covering the starter IDs and related high-value concepts. 
- Export the registry API from `crates/perl-corpus/src/lib.rs` and include the `concepts/` directory in the crate `include` list, and add `toml = "1.1.2"` dependency to support TOML parsing.
- Add unit tests in `concepts.rs` to cover duplicate-ID rejection, missing fixture path rejection, and deterministic load behavior.

### Testing
- Ran `cargo test -p perl-corpus` and the full crate test suite for `perl-corpus`; all tests passed (new concept tests included). 
- Ran `cargo check --all-targets -p perl-corpus` and `cargo clippy -p perl-corpus`; both completed successfully. 
- Ran formatting with `cargo fmt` as part of the changes; formatting completed without issues. 
- The new validator tests specifically exercise duplicate-ID detection, missing fixture path detection, and deterministic reload behavior and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a65cf7748333bbaab0259e506039)