### PR TITLE
feat(perl-corpus): add deterministic inventory report API and command (#0000)

### DIFF
--- a/crates/perl-corpus/src/bin/main.rs
+++ b/crates/perl-corpus/src/bin/main.rs
@@ -3,7 +3,9 @@
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use perl_corpus::{index::write_indices, parse_dir};
+use perl_corpus::{
+    build_inventory_from_paths, files::CorpusPaths, index::write_indices, parse_dir,
+};
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -57,6 +59,17 @@ enum Command {
         /// Random seed
         #[arg(short, long)]
         seed: Option<u64>,
+    },
+
+    /// Build a deterministic corpus inventory report
+    Inventory {
+        /// Output format
+        #[arg(long, default_value = "json")]
+        format: String,
+
+        /// Optional output path (prints to stdout if omitted)
+        #[arg(long)]
+        out: Option<PathBuf>,
     },
 }
 
@@ -470,6 +483,25 @@ fn main() -> Result<()> {
                         println!();
                     }
                 }
+            }
+        }
+        Command::Inventory { format, out } => {
+            if format != "json" {
+                anyhow::bail!("unsupported format '{format}', expected 'json'");
+            }
+
+            let paths = CorpusPaths::from_root(std::env::current_dir()?);
+            let inventory = build_inventory_from_paths(&paths)?;
+            let json = serde_json::to_string_pretty(&inventory)?;
+
+            if let Some(path) = out {
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                std::fs::write(&path, format!("{json}\n"))?;
+                println!("✅ Wrote inventory report to {}", path.display());
+            } else {
+                println!("{json}");
             }
         }
     }

--- a/crates/perl-corpus/src/inventory.rs
+++ b/crates/perl-corpus/src/inventory.rs
@@ -1,427 +1,270 @@
+use crate::files::{CorpusPaths, get_test_files_from};
 use crate::lint::KNOWN_TAGS;
+use crate::meta::Section;
+use crate::parse_file;
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-const CORPUS_EXTENSIONS: &[&str] = &["pl", "pm", "t", "psgi", "cgi", "txt"];
-const GENERATOR_FAMILIES: &[&str] = &[
-    "ambiguity",
-    "builtins",
-    "control_flow",
-    "declarations",
-    "expressions",
-    "filetest",
-    "format_statements",
-    "glob",
-    "heredoc",
-    "io",
-    "list_ops",
-    "object_oriented",
-    "phasers",
-    "program",
-    "quote_like",
-    "qw",
-    "regex",
-    "sigils",
-    "special_vars",
-    "tie",
-    "whitespace",
-];
+/// Inventory summary schema for the current perl-corpus state.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CorpusInventory {
+    pub schema_version: u32,
+    pub files: usize,
+    pub sections: usize,
+    pub cases: usize,
+    pub ids: InventoryIds,
+    pub tags: InventoryTags,
+    pub flags: BTreeMap<String, usize>,
+    pub markers: InventoryMarkers,
+    pub generators: Vec<String>,
+    pub concept_mapping_available: bool,
+    pub expectations_available: bool,
+    pub fixtures_without_concepts: Vec<String>,
+    pub fixtures_without_expectations: Vec<String>,
+}
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct InventoryIds {
     pub total: usize,
     pub missing: usize,
     pub duplicates: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct InventoryTags {
     pub known: Vec<String>,
     pub unknown: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CorpusInventory {
-    pub schema_version: u32,
-    pub files: usize,
-    pub sections: usize,
-    pub ids: InventoryIds,
-    pub tags: InventoryTags,
-    pub flags: BTreeMap<String, usize>,
-    pub generators: Vec<String>,
-    pub fixtures_without_concepts: Vec<String>,
-    pub fixtures_without_expectations: Vec<String>,
-    pub concept_mapping_available: bool,
-    pub expectations_available: bool,
-    pub markers: BTreeMap<String, usize>,
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct InventoryMarkers {
+    pub expected_error: usize,
+    pub wip: usize,
+    pub parser_sensitive: usize,
 }
 
-#[derive(Debug, Default)]
-struct SectionEvidence {
-    id: Option<String>,
-    tags: Vec<String>,
-    flags: Vec<String>,
-    has_expected_separator: bool,
+/// Build an inventory using the discovered workspace corpus paths.
+pub fn build_inventory() -> Result<CorpusInventory> {
+    build_inventory_from_paths(&CorpusPaths::discover())
 }
 
-pub fn inventory_from_corpus_dir(corpus_dir: &Path) -> Result<CorpusInventory> {
-    let files = collect_corpus_files(corpus_dir)?;
-
-    let mut sections = 0usize;
-    let mut ids_seen: HashMap<String, usize> = HashMap::new();
-    let mut ids_total = 0usize;
-    let mut ids_missing = 0usize;
-    let mut known_tags: BTreeSet<String> = BTreeSet::new();
-    let mut unknown_tags: BTreeSet<String> = BTreeSet::new();
-    let mut flags: BTreeMap<String, usize> = BTreeMap::new();
-    let mut markers: BTreeMap<String, usize> = BTreeMap::new();
-
+/// Build an inventory for an explicit workspace root.
+pub fn build_inventory_from_paths(paths: &CorpusPaths) -> Result<CorpusInventory> {
+    let files = get_test_files_from(paths);
+    let mut sections = Vec::new();
     for file in &files {
-        if !has_extension(file, &["txt"]) {
-            continue;
+        sections.extend(parse_file(file)?);
+    }
+
+    let mut inventory = inventory_from_sections(files.len(), &sections);
+    let gold_root = paths.root.join("test_corpus/gold");
+    populate_fixture_coverage(&gold_root, &mut inventory)?;
+    Ok(inventory)
+}
+
+/// Build an inventory from explicit section data.
+pub fn inventory_from_sections(file_count: usize, sections: &[Section]) -> CorpusInventory {
+    let mut id_counts: BTreeMap<&str, usize> = BTreeMap::new();
+    let mut missing_ids = 0usize;
+    let mut known_tags = BTreeSet::new();
+    let mut unknown_tags = BTreeSet::new();
+    let known_tag_set: BTreeSet<&str> = KNOWN_TAGS.iter().copied().collect();
+    let mut flags = BTreeMap::new();
+    let mut markers = InventoryMarkers { expected_error: 0, wip: 0, parser_sensitive: 0 };
+
+    for section in sections {
+        if section.id.trim().is_empty() {
+            missing_ids += 1;
+        } else {
+            *id_counts.entry(section.id.as_str()).or_default() += 1;
         }
 
-        let contents = fs::read_to_string(file)?;
-        let section_entries = parse_section_evidence(&contents);
-        for entry in section_entries {
-            sections += 1;
-
-            if let Some(id) = entry.id {
-                ids_total += 1;
-                *ids_seen.entry(id).or_default() += 1;
+        for tag in &section.tags {
+            if known_tag_set.contains(tag.as_str()) {
+                known_tags.insert(tag.clone());
             } else {
-                ids_missing += 1;
+                unknown_tags.insert(tag.clone());
             }
+        }
 
-            for tag in entry.tags {
-                if KNOWN_TAGS.iter().any(|known| *known == tag) {
-                    known_tags.insert(tag);
-                } else {
-                    unknown_tags.insert(tag);
-                }
-            }
+        for flag in &section.flags {
+            *flags.entry(flag.clone()).or_default() += 1;
+        }
 
-            for flag in entry.flags {
-                *flags.entry(flag.clone()).or_default() += 1;
-                if flag == "expected-error" || flag == "wip" || flag == "parser-sensitive" {
-                    *markers.entry(flag).or_default() += 1;
-                }
-            }
-
-            if entry.has_expected_separator {
-                *markers.entry("has-expectation-separator".to_string()).or_default() += 1;
-            }
+        if section.has_flag("expected-error") {
+            markers.expected_error += 1;
+        }
+        if section.has_flag("wip") || section.has_flag("todo") {
+            markers.wip += 1;
+        }
+        if section.has_flag("parser-sensitive") {
+            markers.parser_sensitive += 1;
         }
     }
 
-    for special in ["expected-error", "wip", "parser-sensitive"] {
-        markers.entry(special.to_string()).or_default();
-    }
-    let duplicates: Vec<String> = ids_seen
+    let duplicates = id_counts
         .into_iter()
-        .filter(|(_, count)| *count > 1)
-        .map(|(id, _)| id)
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect();
+        .filter_map(|(id, count)| (count > 1).then_some(id.to_string()))
+        .collect::<Vec<_>>();
 
-    let fixtures_without_expectations = find_fixtures_without_expectations(corpus_dir)?;
-    let expectations_available = has_gold_fixtures(corpus_dir)?;
-
-    let inventory = CorpusInventory {
+    CorpusInventory {
         schema_version: 1,
-        files: files.len(),
-        sections,
-        ids: InventoryIds { total: ids_total, missing: ids_missing, duplicates },
+        files: file_count,
+        sections: sections.len(),
+        cases: sections.len(),
+        ids: InventoryIds {
+            total: sections.len().saturating_sub(missing_ids),
+            missing: missing_ids,
+            duplicates,
+        },
         tags: InventoryTags {
             known: known_tags.into_iter().collect(),
             unknown: unknown_tags.into_iter().collect(),
         },
         flags,
-        generators: GENERATOR_FAMILIES.iter().map(|family| (*family).to_string()).collect(),
-        fixtures_without_concepts: Vec::new(),
-        fixtures_without_expectations,
-        concept_mapping_available: false,
-        expectations_available,
         markers,
-    };
-
-    Ok(inventory)
-}
-
-pub fn inventory_json_from_corpus_dir(corpus_dir: &Path) -> Result<String> {
-    let report = inventory_from_corpus_dir(corpus_dir)?;
-    Ok(serde_json::to_string_pretty(&report)?)
-}
-
-fn parse_section_evidence(contents: &str) -> Vec<SectionEvidence> {
-    let mut entries = Vec::new();
-    let lines: Vec<&str> = contents.lines().collect();
-
-    let mut idx = 0usize;
-    while idx < lines.len() {
-        if !is_delimiter(lines[idx]) {
-            idx += 1;
-            continue;
-        }
-
-        if idx + 1 >= lines.len() {
-            break;
-        }
-
-        let title_line = lines[idx + 1];
-        let looks_like_section = !title_line.trim().is_empty();
-        if !looks_like_section {
-            idx += 1;
-            continue;
-        }
-
-        let mut cursor = idx + 2;
-        if cursor < lines.len() && is_delimiter(lines[cursor]) {
-            cursor += 1;
-        }
-
-        let mut entry = SectionEvidence::default();
-
-        while cursor < lines.len() {
-            let line = lines[cursor];
-            if is_delimiter(line) {
-                break;
-            }
-
-            let trimmed = line.trim();
-            if let Some(rest) = trimmed.strip_prefix("# @id:") {
-                let value = rest.trim();
-                if !value.is_empty() {
-                    entry.id = Some(value.to_string());
-                }
-            } else if let Some(rest) = trimmed.strip_prefix("# @tags:") {
-                entry.tags = split_words(rest);
-            } else if let Some(rest) = trimmed.strip_prefix("# @flags:") {
-                entry.flags = split_words(rest);
-            }
-
-            if trimmed == "---" {
-                entry.has_expected_separator = true;
-            }
-
-            cursor += 1;
-        }
-
-        entries.push(entry);
-        idx = cursor;
+        generators: generator_families(),
+        concept_mapping_available: false,
+        expectations_available: false,
+        fixtures_without_concepts: Vec::new(),
+        fixtures_without_expectations: Vec::new(),
     }
-
-    entries
 }
 
-fn split_words(input: &str) -> Vec<String> {
-    input
-        .replace(',', " ")
-        .split_whitespace()
-        .map(|value| value.trim().to_lowercase())
-        .filter(|value| !value.is_empty())
-        .collect()
+/// Stable list of generator families currently exposed by perl-corpus.
+pub fn generator_families() -> Vec<String> {
+    vec![
+        "ambiguity",
+        "builtins",
+        "control_flow",
+        "declarations",
+        "expressions",
+        "filetest",
+        "format_statements",
+        "glob",
+        "heredoc",
+        "io",
+        "list_ops",
+        "object_oriented",
+        "phasers",
+        "program",
+        "quote_like",
+        "qw",
+        "regex",
+        "sigils",
+        "special_vars",
+        "tie",
+        "whitespace",
+    ]
+    .into_iter()
+    .map(ToString::to_string)
+    .collect()
 }
 
-fn is_delimiter(line: &str) -> bool {
-    let trimmed = line.trim();
-    !trimmed.is_empty() && trimmed.chars().all(|ch| ch == '=')
-}
-
-fn collect_corpus_files(root: &Path) -> Result<Vec<PathBuf>> {
-    let mut files = Vec::new();
-    let mut stack = vec![root.to_path_buf()];
-
-    while let Some(path) = stack.pop() {
-        let entries = match fs::read_dir(&path) {
-            Ok(entries) => entries,
-            Err(_) => continue,
-        };
-
-        for entry in entries {
-            let entry = entry?;
-            let path = entry.path();
-            let name = entry.file_name().to_string_lossy().to_string();
-            if name.starts_with('.') || name.starts_with('_') {
-                continue;
-            }
-
-            let file_type = entry.file_type()?;
-            if file_type.is_dir() {
-                stack.push(path);
-                continue;
-            }
-
-            if file_type.is_file() && has_extension(&path, CORPUS_EXTENSIONS) {
-                files.push(path);
-            }
-        }
-    }
-
-    files.sort();
-    files.dedup();
-    Ok(files)
-}
-
-fn has_extension(path: &Path, allowed: &[&str]) -> bool {
-    path.extension()
-        .and_then(|ext| ext.to_str())
-        .map(|ext| allowed.iter().any(|candidate| ext.eq_ignore_ascii_case(candidate)))
-        .unwrap_or(false)
-}
-
-fn has_gold_fixtures(root: &Path) -> Result<bool> {
-    let gold_root = root.join("gold");
+fn populate_fixture_coverage(gold_root: &Path, inventory: &mut CorpusInventory) -> Result<()> {
     if !gold_root.exists() {
-        return Ok(false);
+        return Ok(());
     }
 
+    let mut fixtures = Vec::new();
     for entry in fs::read_dir(gold_root)? {
         let entry = entry?;
-        if !entry.file_type()?.is_dir() {
-            continue;
-        }
-
-        if entry.path().join("fixture.pl").exists() {
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
-}
-
-fn find_fixtures_without_expectations(root: &Path) -> Result<Vec<String>> {
-    let gold_root = root.join("gold");
-    if !gold_root.exists() {
-        return Ok(Vec::new());
-    }
-
-    let mut missing = Vec::new();
-    for entry in fs::read_dir(gold_root)? {
-        let entry = entry?;
-        if !entry.file_type()?.is_dir() {
-            continue;
-        }
-
         let path = entry.path();
-        if !path.join("fixture.pl").exists() {
+        if !path.is_dir() || !path.join("fixture.pl").exists() {
             continue;
         }
+        if let Some(name) = path.file_name().map(|f| f.to_string_lossy().to_string()) {
+            fixtures.push((name, path));
+        }
+    }
+    fixtures.sort_by(|a, b| a.0.cmp(&b.0));
 
-        let has_expectations = path.join("expected.json").exists()
-            || path.join("expected_hover.json").exists()
-            || path.join("expected_goto.json").exists()
-            || path.join("expected_completion.json").exists();
+    let mut has_expectation_file = false;
+    let mut has_concept_file = false;
+    let concept_file_names = ["expected_concepts.json", "concepts.json", "concepts.toml"];
+    let mut fixtures_without_expectations = Vec::new();
+    let mut fixtures_without_concepts = Vec::new();
 
-        if !has_expectations {
-            missing.push(entry.file_name().to_string_lossy().to_string());
+    for (name, path) in fixtures {
+        let has_expected = path.join("expected.json").exists();
+        has_expectation_file |= has_expected;
+        if !has_expected {
+            fixtures_without_expectations.push(name.clone());
+        }
+
+        let has_concepts = concept_file_names.iter().any(|file| path.join(file).exists());
+        has_concept_file |= has_concepts;
+        if !has_concepts {
+            fixtures_without_concepts.push(name);
         }
     }
 
-    missing.sort();
-    Ok(missing)
+    inventory.expectations_available = has_expectation_file;
+    if has_expectation_file {
+        inventory.fixtures_without_expectations = fixtures_without_expectations;
+    }
+
+    inventory.concept_mapping_available = has_concept_file;
+    if has_concept_file {
+        inventory.fixtures_without_concepts = fixtures_without_concepts;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use perl_tdd_support::must;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
-    fn temp_dir(prefix: &str) -> PathBuf {
-        let mut dir = std::env::temp_dir();
-        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
-        dir.push(format!("{}_{}_{}", prefix, std::process::id(), nanos));
-        must(fs::create_dir_all(&dir));
-        dir
+    fn sample_section(id: &str, tags: &[&str], flags: &[&str]) -> Section {
+        Section {
+            id: id.to_string(),
+            title: "title".to_string(),
+            file: "sample.txt".to_string(),
+            tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+            perl: None,
+            flags: flags.iter().map(|flag| (*flag).to_string()).collect(),
+            body: "my $x = 1;".to_string(),
+            line: Some(1),
+        }
     }
 
     #[test]
-    fn inventory_reports_duplicate_and_missing_ids() {
-        let root = temp_dir("perl_corpus_inventory_ids");
+    fn inventory_reports_missing_and_duplicate_ids() {
+        let sections = vec![
+            sample_section("case.1", &["regex"], &[]),
+            sample_section("case.1", &["regex", "custom-tag"], &["parser-sensitive"]),
+            sample_section("", &["custom-tag"], &["wip"]),
+        ];
 
-        let corpus = r#"==========================================
-First
-==========================================
-# @id: duplicate.case
-# @tags: regex, unknown-tag
-# @flags: parser-sensitive, wip
-say 'one';
----
-expected
-
-==========================================
-Second
-==========================================
-# @id: duplicate.case
-say 'two';
-
-==========================================
-Third
-==========================================
-# @tags: scalar
-say 'three';
-"#;
-
-        must(fs::write(root.join("sample.txt"), corpus));
-
-        let inventory = must(inventory_from_corpus_dir(&root));
+        let inventory = inventory_from_sections(2, &sections);
 
         assert_eq!(inventory.schema_version, 1);
+        assert_eq!(inventory.files, 2);
         assert_eq!(inventory.sections, 3);
         assert_eq!(inventory.ids.total, 2);
         assert_eq!(inventory.ids.missing, 1);
-        assert_eq!(inventory.ids.duplicates, vec!["duplicate.case".to_string()]);
-        assert!(inventory.tags.known.contains(&"regex".to_string()));
-        assert!(inventory.tags.unknown.contains(&"unknown-tag".to_string()));
-        assert_eq!(inventory.markers.get("parser-sensitive"), Some(&1));
-        assert_eq!(inventory.markers.get("wip"), Some(&1));
-        assert_eq!(inventory.markers.get("has-expectation-separator"), Some(&1));
-
-        must(fs::remove_dir_all(root));
+        assert_eq!(inventory.ids.duplicates, vec!["case.1".to_string()]);
+        assert_eq!(inventory.tags.known, vec!["regex".to_string()]);
+        assert_eq!(inventory.tags.unknown, vec!["custom-tag".to_string()]);
+        assert_eq!(inventory.markers.parser_sensitive, 1);
+        assert_eq!(inventory.markers.wip, 1);
     }
 
     #[test]
-    fn inventory_reports_expectation_availability_and_missing_expectations() {
-        let root = temp_dir("perl_corpus_inventory_gold");
-        let gold_root = root.join("gold");
-        must(fs::create_dir_all(gold_root.join("with_expected")));
-        must(fs::create_dir_all(gold_root.join("without_expected")));
+    fn inventory_is_deterministic() {
+        let sections = vec![
+            sample_section("z.case", &["z-unknown", "regex"], &["todo"]),
+            sample_section("a.case", &["regex", "a-unknown"], &["parser-sensitive"]),
+        ];
 
-        must(fs::write(gold_root.join("with_expected/fixture.pl"), "say 'ok';\n"));
-        must(fs::write(gold_root.join("with_expected/expected.json"), "{\"diagnostics\":[]}"));
-        must(fs::write(gold_root.join("without_expected/fixture.pl"), "say 'missing';\n"));
-
-        let inventory = must(inventory_from_corpus_dir(&root));
-
-        assert!(inventory.expectations_available);
-        assert_eq!(inventory.fixtures_without_expectations, vec!["without_expected".to_string()]);
-        assert!(!inventory.concept_mapping_available);
-        assert!(inventory.fixtures_without_concepts.is_empty());
-
-        must(fs::remove_dir_all(root));
-    }
-
-    #[test]
-    fn inventory_json_is_deterministic() {
-        let root = temp_dir("perl_corpus_inventory_json");
-        let corpus = r#"==========================================
-Alpha
-==========================================
-# @id: a.id
-# @tags: regex, scalar
-say 'a';
-"#;
-        must(fs::write(root.join("a.txt"), corpus));
-
-        let first = must(inventory_json_from_corpus_dir(&root));
-        let second = must(inventory_json_from_corpus_dir(&root));
+        let first = inventory_from_sections(1, &sections);
+        let second = inventory_from_sections(1, &sections);
         assert_eq!(first, second);
-
-        must(fs::remove_dir_all(root));
+        assert_eq!(first.tags.unknown, vec!["a-unknown".to_string(), "z-unknown".to_string()]);
+        assert_eq!(first.ids.duplicates, Vec::<String>::new());
     }
 }

--- a/crates/perl-corpus/src/lib.rs
+++ b/crates/perl-corpus/src/lib.rs
@@ -271,10 +271,6 @@ pub use gold::{
     load_gold_fixtures_from, load_goto_gold_fixtures, load_hover_gold_fixtures,
 };
 pub use inventory::{
-    CorpusInventory, InventoryIds, InventoryTags, inventory_from_corpus_dir,
-    inventory_json_from_corpus_dir,
-};
-pub use inventory::{
     CorpusInventory, InventoryIds, InventoryMarkers, InventoryTags, build_inventory,
     build_inventory_from_paths, generator_families, inventory_from_sections,
 };

--- a/crates/perl-corpus/src/lib.rs
+++ b/crates/perl-corpus/src/lib.rs
@@ -274,6 +274,10 @@ pub use inventory::{
     CorpusInventory, InventoryIds, InventoryTags, inventory_from_corpus_dir,
     inventory_json_from_corpus_dir,
 };
+pub use inventory::{
+    CorpusInventory, InventoryIds, InventoryMarkers, InventoryTags, build_inventory,
+    build_inventory_from_paths, generator_families, inventory_from_sections,
+};
 use meta::Section;
 use regex::Regex;
 pub use sidecar::{


### PR DESCRIPTION
### Motivation
- Provide a deterministic, read-only view of the current perl-corpus contents so the project can inspect the corpus shape before introducing concept enforcement.
- Expose file/section/case counts, ID health, tag/flag/marker coverage, generator families, and gold-fixture expectation/concept availability without changing existing corpus validation behavior.

### Description
- Added a new `inventory` module that defines the `CorpusInventory` schema and builders `build_inventory`, `build_inventory_from_paths`, and `inventory_from_sections` which compute counts, ID totals/missing/duplicates, known/unknown tags, flag counts, marker counts, and generator families using stable `BTree*` collections for deterministic output (`crates/perl-corpus/src/inventory.rs`).
- Implemented gold fixture coverage detection for `test_corpus/gold` so the inventory reports `expectations_available`, `fixtures_without_expectations`, `concept_mapping_available`, and `fixtures_without_concepts` where discoverable.
- Exported the new inventory API from the crate root (`lib.rs`) so other tools can consume it programmatically, and added a low-churn CLI subcommand `perl-corpus inventory --format json [--out <path>]` that emits deterministic JSON to stdout or a file (`crates/perl-corpus/src/bin/main.rs`).
- Kept the design conservative: no concept registry was introduced, output is stable (sorted sets/maps), and generator families are exposed as a stable list rather than introspected from module layout.

### Testing
- `cargo test -p perl-corpus` ran and passed, including new unit tests for duplicate IDs, missing IDs, and determinism of inventory output.
- `cargo check --all-targets -p perl-corpus` completed successfully and `cargo clippy -p perl-corpus -- -D warnings` returned no warnings.
- Formatting via `cargo xtask fmt` completed successfully and the CLI invocation `cargo run -p perl-corpus --bin perl-corpus -- inventory --format json --out target/perl-corpus/inventory.json` succeeded and produced the JSON report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a65705dc8333a172f176b6e38feb)