### PR TITLE
feat(perl-corpus): add durable parser concept registry seed (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
  "color-eyre",
  "regex",
  "serde_json",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "walkdir",
 ]
 
@@ -1521,6 +1521,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
 ]
 
@@ -1547,7 +1548,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "winapi",
 ]
@@ -1691,7 +1692,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2998,6 +2999,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
@@ -3005,10 +3021,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -3027,9 +3052,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -3038,7 +3063,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -3730,6 +3755,12 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
@@ -3878,7 +3909,7 @@ dependencies = [
  "similar 3.1.0",
  "tar",
  "tempfile",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tree-sitter",
  "tree-sitter-perl-c",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
  "color-eyre",
  "regex",
  "serde_json",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "walkdir",
 ]
 
@@ -1521,7 +1521,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
 ]
 
@@ -1548,7 +1548,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
  "winapi",
 ]
@@ -1692,7 +1692,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2999,21 +2999,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
@@ -3021,19 +3006,10 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.1",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
+ "winnow",
 ]
 
 [[package]]
@@ -3052,9 +3028,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -3063,7 +3039,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -3755,12 +3731,6 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-
-[[package]]
-name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
@@ -3909,7 +3879,7 @@ dependencies = [
  "similar 3.1.0",
  "tar",
  "tempfile",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tree-sitter",
  "tree-sitter-perl-c",
  "walkdir",

--- a/crates/perl-corpus/Cargo.toml
+++ b/crates/perl-corpus/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/perl-corpus"
 homepage.workspace = true
 keywords = ["perl", "corpus", "proptest", "testing", "parser"]
 categories = ["development-tools", "development-tools::testing"]
-include = ["src/**", "README.md", "LICENSE*", "Cargo.toml"]
+include = ["src/**", "concepts/**", "README.md", "LICENSE*", "Cargo.toml"]
 
 [lib]
 name = "perl_corpus"
@@ -34,6 +34,7 @@ chrono = "0.4.42"
 proptest.workspace = true
 rand = "0.10.1"
 tracing.workspace = true
+toml = "0.9.8"
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/perl-corpus/Cargo.toml
+++ b/crates/perl-corpus/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/bin/main.rs"
 [dependencies]
 anyhow.workspace = true
 serde = { workspace = true }
-serde_json.workspace = true
+serde_json.workspace 4 = true
 regex.workspace = true
 glob = "0.3.3"
 clap = { workspace = true }
@@ -34,9 +34,9 @@ chrono = "0.4.42"
 proptest.workspace = true
 rand = "0.10.1"
 tracing.workspace = true
-toml = "0.9.8"
+toml = "1.1.2"
 
-[dev-dependencies]
+[Dev-dependencies]
 proptest.workspace = true
 perl-tdd-support = { workspace = true }
 

--- a/crates/perl-corpus/Cargo.toml
+++ b/crates/perl-corpus/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/bin/main.rs"
 [dependencies]
 anyhow.workspace = true
 serde = { workspace = true }
-serde_json.workspace 4 = true
+serde_json.workspace = true
 regex.workspace = true
 glob = "0.3.3"
 clap = { workspace = true }
@@ -36,7 +36,7 @@ rand = "0.10.1"
 tracing.workspace = true
 toml = "1.1.2"
 
-[Dev-dependencies]
+[dev-dependencies]
 proptest.workspace = true
 perl-tdd-support = { workspace = true }
 

--- a/crates/perl-corpus/concepts/incremental.toml
+++ b/crates/perl-corpus/concepts/incremental.toml
@@ -1,0 +1,71 @@
+[[concept]]
+id = "incremental.edit_inside_expression"
+status = "seed"
+scope = { crates = ["perl-incremental-parsing", "perl-parser"], risk_tags = ["incremental", "expression"] }
+fixtures = { floors = ["test_corpus/expressions_and_refs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "incremental" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "incremental.edit_shifts_following_nodes"
+status = "seed"
+scope = { crates = ["perl-incremental-parsing", "perl-parser"], risk_tags = ["incremental", "position-shift"] }
+fixtures = { floors = ["test_corpus/parser_stress_cases.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "incremental" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "incremental.edit_package_header"
+status = "seed"
+scope = { crates = ["perl-incremental-parsing", "perl-parser"], risk_tags = ["incremental", "declaration"] }
+fixtures = { floors = ["test_corpus/package_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "incremental" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = false, release = false }
+
+[[concept]]
+id = "incremental.edit_signature_list"
+status = "seed"
+scope = { crates = ["perl-incremental-parsing", "perl-parser"], risk_tags = ["incremental", "signature"] }
+fixtures = { floors = ["test_corpus/signatures_prototypes.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "incremental" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "incremental.edit_regex_literal"
+status = "seed"
+scope = { crates = ["perl-incremental-parsing", "perl-lexer"], risk_tags = ["incremental", "regex"] }
+fixtures = { floors = ["test_corpus/advanced_regex.pl"], variants = [] }
+expect = { panic = false, timeout = true, mode = "incremental" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = false, nightly = true, release = false }
+
+[[concept]]
+id = "incremental.edit_heredoc_marker"
+status = "seed"
+scope = { crates = ["perl-incremental-parsing", "perl-lexer"], risk_tags = ["incremental", "heredoc"] }
+fixtures = { floors = ["test_corpus/heredoc_depth.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "incremental" }
+snapshots = { tokens = true, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "incremental.edit_method_chain"
+status = "seed"
+scope = { crates = ["perl-incremental-parsing", "perl-parser"], risk_tags = ["incremental", "method-call"] }
+fixtures = { floors = ["test_corpus/method_class.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "incremental" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = false, release = false }
+
+[[concept]]
+id = "incremental.edit_error_recovery"
+status = "seed"
+scope = { crates = ["perl-incremental-parsing", "perl-parser"], risk_tags = ["incremental", "error-recovery"] }
+fixtures = { floors = ["test_corpus/error_recovery.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "incremental" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }

--- a/crates/perl-corpus/concepts/lexer.toml
+++ b/crates/perl-corpus/concepts/lexer.toml
@@ -1,0 +1,89 @@
+[[concept]]
+id = "lexer.regex.literal_vs_division"
+status = "seed"
+scope = { crates = ["perl-lexer", "perl-parser"], risk_tags = ["regex", "ambiguous-token"] }
+fixtures = { floors = ["test_corpus/advanced_regex.pl", "test_corpus/clean_regex_substitution.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "tokenize" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = true, nightly = true, release = true }
+
+[[concept]]
+id = "lexer.regex.substitution_delimiters"
+status = "seed"
+scope = { crates = ["perl-lexer"], risk_tags = ["regex", "delimiter"] }
+fixtures = { floors = ["test_corpus/clean_regex_substitution.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "tokenize" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "lexer.quote_like.q_braces"
+status = "seed"
+scope = { crates = ["perl-lexer", "perl-parser"], risk_tags = ["quote-like"] }
+fixtures = { floors = ["test_corpus/string_ops_edge_cases.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "tokenize" }
+snapshots = { tokens = true, ast = false, spans = false }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "lexer.quote_like.qq_parens"
+status = "seed"
+scope = { crates = ["perl-lexer"], risk_tags = ["quote-like"] }
+fixtures = { floors = ["test_corpus/string_ops_edge_cases.pl", "test_corpus/basic_constructs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "tokenize" }
+snapshots = { tokens = true, ast = false, spans = false }
+run = { pr = true, nightly = false, release = false }
+
+[[concept]]
+id = "lexer.heredoc.basic"
+status = "seed"
+scope = { crates = ["perl-lexer", "perl-parser"], risk_tags = ["heredoc"] }
+fixtures = { floors = ["test_corpus/heredoc_depth.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "tokenize" }
+snapshots = { tokens = true, ast = true, spans = true }
+run = { pr = true, nightly = true, release = true }
+
+[[concept]]
+id = "lexer.heredoc.indented"
+status = "seed"
+scope = { crates = ["perl-lexer"], risk_tags = ["heredoc", "layout"] }
+fixtures = { floors = ["test_corpus/heredoc_depth.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "tokenize" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "lexer.data_section.double_underscore_data"
+status = "seed"
+scope = { crates = ["perl-lexer", "perl-parser"], risk_tags = ["data-section"] }
+fixtures = { floors = ["test_corpus/data_end_sections.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "tokenize" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = true, nightly = false, release = true }
+
+[[concept]]
+id = "lexer.data_section.double_underscore_end"
+status = "seed"
+scope = { crates = ["perl-lexer"], risk_tags = ["data-section"] }
+fixtures = { floors = ["test_corpus/end_section.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "tokenize" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = true, nightly = false, release = false }
+
+[[concept]]
+id = "lexer.readline.diamond_operator"
+status = "seed"
+scope = { crates = ["perl-lexer", "perl-parser"], risk_tags = ["readline", "ambiguous-token"] }
+fixtures = { floors = ["test_corpus/readline_diamond_operator_comprehensive.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "tokenize" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "lexer.special_vars.contextual"
+status = "seed"
+scope = { crates = ["perl-lexer"], risk_tags = ["sigil", "special-var"] }
+fixtures = { floors = ["test_corpus/builtins_context_sensitive.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "tokenize" }
+snapshots = { tokens = true, ast = false, spans = false }
+run = { pr = true, nightly = true, release = false }

--- a/crates/perl-corpus/concepts/parser.toml
+++ b/crates/perl-corpus/concepts/parser.toml
@@ -1,0 +1,134 @@
+[[concept]]
+id = "parser.package.declaration"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["declaration"] }
+fixtures = { floors = ["test_corpus/package_production_enhanced.pl", "test_corpus/packages_versions.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = true }
+
+[[concept]]
+id = "parser.sub.named"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["subroutine"] }
+fixtures = { floors = ["test_corpus/basic_constructs.pl", "test_corpus/clean_misc_kinds.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = true }
+
+[[concept]]
+id = "parser.sub.anonymous"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["subroutine", "expression"] }
+fixtures = { floors = ["test_corpus/expressions_and_refs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "parser.sub.signature"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["signature", "prototype"] }
+fixtures = { floors = ["test_corpus/signatures_parameters_production_enhanced.pl", "test_corpus/clean_signatures.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = true }
+
+[[concept]]
+id = "parser.variable.my_our_local_state"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["variable-decl"] }
+fixtures = { floors = ["test_corpus/variable_list_declaration_comprehensive.pl", "test_corpus/variable_list_declaration_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "parser.expression.fat_arrow"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["expression", "operator"] }
+fixtures = { floors = ["test_corpus/expressions_and_refs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "parser.expression.range"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["expression", "operator"] }
+fixtures = { floors = ["test_corpus/parser_stress_cases.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = false, release = false }
+
+[[concept]]
+id = "parser.expression.word_operators"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["expression", "keyword-op"] }
+fixtures = { floors = ["test_corpus/builtins_context_sensitive.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "parser.hash.array_literals"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["literal", "container"] }
+fixtures = { floors = ["test_corpus/expressions_and_refs.pl", "test_corpus/basic_constructs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "parser.method_call.arrow"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["method-call", "oo"] }
+fixtures = { floors = ["test_corpus/method_class.pl", "test_corpus/class_method_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = true }
+
+[[concept]]
+id = "parser.indirect_object_call"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["call-ambiguity"] }
+fixtures = { floors = ["test_corpus/indirect_call_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "parser.statement_modifier.if_unless"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["modifier", "control-flow"] }
+fixtures = { floors = ["test_corpus/statement_modifier_comprehensive.pl", "test_corpus/statement_modifier_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "parser.loop_control.next_last_redo"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["control-flow"] }
+fixtures = { floors = ["test_corpus/loop_control_comprehensive.pl", "test_corpus/continue_redo_statements.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "parser.goto.labeled"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["control-flow", "label"] }
+fixtures = { floors = ["test_corpus/goto_statements_comprehensive.pl", "test_corpus/labeled_statement_comprehensive.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "parser.try_catch.syntax"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["exceptions"] }
+fixtures = { floors = ["test_corpus/try_catch.pl", "test_corpus/try_catch_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }

--- a/crates/perl-corpus/concepts/positions.toml
+++ b/crates/perl-corpus/concepts/positions.toml
@@ -1,0 +1,71 @@
+[[concept]]
+id = "position.byte_span.basic"
+status = "seed"
+scope = { crates = ["perl-position-tracking", "perl-parser"], risk_tags = ["span"] }
+fixtures = { floors = ["test_corpus/basic_constructs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "spans" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = true, nightly = true, release = true }
+
+[[concept]]
+id = "position.utf16.non_ascii"
+status = "seed"
+scope = { crates = ["perl-position-tracking", "perl-line-index"], risk_tags = ["utf16", "unicode"] }
+fixtures = { floors = ["test_corpus/edge_cases/unicode_encoding_edge_cases.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "spans" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "position.crlf.line_index"
+status = "seed"
+scope = { crates = ["perl-line-index", "perl-position-tracking"], risk_tags = ["crlf", "line-index"] }
+fixtures = { floors = ["test_corpus/parser_stress_cases.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "spans" }
+snapshots = { tokens = false, ast = false, spans = true }
+run = { pr = true, nightly = false, release = true }
+
+[[concept]]
+id = "position.multiline.heredoc"
+status = "seed"
+scope = { crates = ["perl-position-tracking", "perl-parser"], risk_tags = ["span", "heredoc"] }
+fixtures = { floors = ["test_corpus/heredoc_depth.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "spans" }
+snapshots = { tokens = true, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "position.method_chain.arrow"
+status = "seed"
+scope = { crates = ["perl-position-tracking", "perl-parser"], risk_tags = ["span", "method-call"] }
+fixtures = { floors = ["test_corpus/method_class.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "spans" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = false, release = false }
+
+[[concept]]
+id = "position.regex.capture_offsets"
+status = "seed"
+scope = { crates = ["perl-position-tracking", "perl-lexer"], risk_tags = ["span", "regex"] }
+fixtures = { floors = ["test_corpus/advanced_regex.pl", "test_corpus/regex_timeout_hardening.pl"], variants = [] }
+expect = { panic = false, timeout = true, mode = "spans" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = false, nightly = true, release = false }
+
+[[concept]]
+id = "position.data_end_boundaries"
+status = "seed"
+scope = { crates = ["perl-position-tracking", "perl-lexer"], risk_tags = ["span", "data-section"] }
+fixtures = { floors = ["test_corpus/data_end_sections.pl", "test_corpus/end_section.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "spans" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = true, nightly = false, release = true }
+
+[[concept]]
+id = "position.signature.parameter_offsets"
+status = "seed"
+scope = { crates = ["perl-position-tracking", "perl-parser"], risk_tags = ["span", "signature"] }
+fixtures = { floors = ["test_corpus/signatures_parameters_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "spans" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }

--- a/crates/perl-corpus/concepts/recovery.toml
+++ b/crates/perl-corpus/concepts/recovery.toml
@@ -1,0 +1,71 @@
+[[concept]]
+id = "parser.recovery.missing_closing_brace"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["error-recovery"] }
+fixtures = { floors = ["test_corpus/error_recovery.pl", "test_corpus/edge_cases/error_recovery_edge_cases.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "recover" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "parser.recovery.missing_paren"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["error-recovery"] }
+fixtures = { floors = ["test_corpus/error_recovery.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "recover" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "parser.recovery.unclosed_quote"
+status = "seed"
+scope = { crates = ["perl-parser", "perl-lexer"], risk_tags = ["error-recovery", "quote-like"] }
+fixtures = { floors = ["test_corpus/error_recovery.pl", "test_corpus/string_ops_edge_cases.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "recover" }
+snapshots = { tokens = true, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "parser.recovery.malformed_signature"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["error-recovery", "signature"] }
+fixtures = { floors = ["test_corpus/signatures_prototypes.pl", "test_corpus/signatures_parameters_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "recover" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "parser.recovery.bad_ternary_colon"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["error-recovery", "expression"] }
+fixtures = { floors = ["test_corpus/ternary_expressions_comprehensive.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "recover" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = false, release = false }
+
+[[concept]]
+id = "parser.recovery.unterminated_heredoc"
+status = "seed"
+scope = { crates = ["perl-parser", "perl-lexer"], risk_tags = ["error-recovery", "heredoc"] }
+fixtures = { floors = ["test_corpus/heredoc_depth.pl", "test_corpus/edge_cases/error_recovery_edge_cases.pl"], variants = [] }
+expect = { panic = false, timeout = true, mode = "recover" }
+snapshots = { tokens = true, ast = true, spans = true }
+run = { pr = false, nightly = true, release = false }
+
+[[concept]]
+id = "parser.recovery.missing_format_dot"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["error-recovery", "format"] }
+fixtures = { floors = ["test_corpus/format_statements.pl", "test_corpus/format_comprehensive.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "recover" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "parser.recovery.invalid_goto_target"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["error-recovery", "control-flow"] }
+fixtures = { floors = ["test_corpus/goto_statements_comprehensive.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "recover" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = true, release = false }

--- a/crates/perl-corpus/concepts/tree_sitter.toml
+++ b/crates/perl-corpus/concepts/tree_sitter.toml
@@ -1,0 +1,71 @@
+[[concept]]
+id = "tree_sitter.parity.package_decl"
+status = "seed"
+scope = { crates = ["tree-sitter-perl-c", "tree-sitter-perl-rs", "perl-parser"], risk_tags = ["tree-sitter", "parity"] }
+fixtures = { floors = [], variants = [] }
+expect = { panic = false, timeout = false, mode = "parity" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = true, release = true }
+
+[[concept]]
+id = "tree_sitter.parity.sub_decl"
+status = "seed"
+scope = { crates = ["tree-sitter-perl-c", "tree-sitter-perl-rs", "perl-parser"], risk_tags = ["tree-sitter", "parity"] }
+fixtures = { floors = [], variants = [] }
+expect = { panic = false, timeout = false, mode = "parity" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = true, release = true }
+
+[[concept]]
+id = "tree_sitter.parity.method_call"
+status = "seed"
+scope = { crates = ["tree-sitter-perl-rs", "perl-parser"], risk_tags = ["tree-sitter", "parity", "oo"] }
+fixtures = { floors = ["test_corpus/method_class.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parity" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "tree_sitter.parity.signature"
+status = "seed"
+scope = { crates = ["tree-sitter-perl-rs", "perl-parser"], risk_tags = ["tree-sitter", "parity", "signature"] }
+fixtures = { floors = ["test_corpus/signatures_parameters_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parity" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "tree_sitter.parity.heredoc"
+status = "seed"
+scope = { crates = ["tree-sitter-perl-rs", "perl-parser", "perl-lexer"], risk_tags = ["tree-sitter", "parity", "heredoc"] }
+fixtures = { floors = ["test_corpus/heredoc_depth.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parity" }
+snapshots = { tokens = true, ast = true, spans = false }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "tree_sitter.parity.regex"
+status = "seed"
+scope = { crates = ["tree-sitter-perl-rs", "perl-parser", "perl-lexer"], risk_tags = ["tree-sitter", "parity", "regex"] }
+fixtures = { floors = ["test_corpus/advanced_regex.pl"], variants = [] }
+expect = { panic = false, timeout = true, mode = "parity" }
+snapshots = { tokens = true, ast = true, spans = false }
+run = { pr = false, nightly = true, release = false }
+
+[[concept]]
+id = "tree_sitter.parity.given_when"
+status = "seed"
+scope = { crates = ["tree-sitter-perl-rs", "perl-parser"], risk_tags = ["tree-sitter", "parity", "control-flow"] }
+fixtures = { floors = ["test_corpus/given_when.pl", "test_corpus/clean_given_when.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parity" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "tree_sitter.parity.format"
+status = "seed"
+scope = { crates = ["tree-sitter-perl-rs", "perl-parser"], risk_tags = ["tree-sitter", "parity", "format"] }
+fixtures = { floors = ["test_corpus/format_comprehensive.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parity" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = true, nightly = false, release = false }

--- a/crates/perl-corpus/src/concepts.rs
+++ b/crates/perl-corpus/src/concepts.rs
@@ -1,0 +1,299 @@
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CONCEPT_FILES: &[&str] = &[
+    "lexer.toml",
+    "parser.toml",
+    "recovery.toml",
+    "positions.toml",
+    "incremental.toml",
+    "tree_sitter.toml",
+];
+
+const KNOWN_STATUS: &[&str] = &["seed", "active", "planned", "deprecated"];
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptRegistryFile {
+    #[serde(default)]
+    pub concept: Vec<ConceptRow>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptRow {
+    pub id: String,
+    pub status: String,
+    pub scope: ConceptScope,
+    pub fixtures: ConceptFixtures,
+    pub expect: ConceptExpect,
+    pub snapshots: ConceptSnapshots,
+    pub run: ConceptRun,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptScope {
+    pub crates: Vec<String>,
+    pub risk_tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptFixtures {
+    #[serde(default)]
+    pub floors: Vec<String>,
+    #[serde(default)]
+    pub variants: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptExpect {
+    pub panic: bool,
+    pub timeout: bool,
+    pub mode: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptSnapshots {
+    pub tokens: bool,
+    pub ast: bool,
+    pub spans: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptRun {
+    pub pr: bool,
+    pub nightly: bool,
+    pub release: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct LoadedConcept {
+    pub source_file: String,
+    pub row: ConceptRow,
+}
+
+pub fn load_concept_registry() -> Result<Vec<LoadedConcept>> {
+    let root = super::files::CorpusPaths::discover().root;
+    let concept_dir = root.join("crates/perl-corpus/concepts");
+    load_concept_registry_from(&concept_dir, &root)
+}
+
+fn load_concept_registry_from(
+    concept_dir: &Path,
+    workspace_root: &Path,
+) -> Result<Vec<LoadedConcept>> {
+    let mut concepts = Vec::new();
+
+    for file_name in CONCEPT_FILES {
+        let path = concept_dir.join(file_name);
+        let content = fs::read_to_string(&path)
+            .with_context(|| format!("reading concept registry file {}", path.display()))?;
+
+        let parsed: ConceptRegistryFile =
+            toml::from_str(&content).with_context(|| format!("parsing {}", path.display()))?;
+
+        for row in parsed.concept {
+            validate_row(&row, workspace_root, &path)?;
+            concepts.push(LoadedConcept { source_file: (*file_name).to_string(), row });
+        }
+    }
+
+    concepts
+        .sort_by(|a, b| a.row.id.cmp(&b.row.id).then_with(|| a.source_file.cmp(&b.source_file)));
+
+    let mut seen = BTreeSet::new();
+    for concept in &concepts {
+        if !seen.insert(concept.row.id.clone()) {
+            bail!("duplicate concept id: {}", concept.row.id);
+        }
+    }
+
+    Ok(concepts)
+}
+
+fn validate_row(row: &ConceptRow, workspace_root: &Path, source_file: &Path) -> Result<()> {
+    if !KNOWN_STATUS.contains(&row.status.as_str()) {
+        bail!(
+            "unknown status '{}' for concept '{}' in {}",
+            row.status,
+            row.id,
+            source_file.display()
+        );
+    }
+
+    for fixture in row.fixtures.floors.iter().chain(row.fixtures.variants.iter()) {
+        let fixture_path = fixture_path(workspace_root, fixture);
+        if !fixture_path.exists() {
+            bail!(
+                "fixture path '{}' for concept '{}' does not exist (resolved to {})",
+                fixture,
+                row.id,
+                fixture_path.display()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn fixture_path(workspace_root: &Path, fixture: &str) -> PathBuf {
+    let path = Path::new(fixture);
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+
+    workspace_root.join(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_tdd_support::must;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let mut dir = std::env::temp_dir();
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
+        dir.push(format!("{}_{}_{}", prefix, std::process::id(), nanos));
+        must(fs::create_dir_all(&dir));
+        dir
+    }
+
+    fn write_registry(path: &Path, body: &str) {
+        let concept_dir = path.join("concepts");
+        must(fs::create_dir_all(&concept_dir));
+
+        for file in CONCEPT_FILES {
+            let content = if *file == "lexer.toml" { body } else { "" };
+            must(fs::write(concept_dir.join(file), content));
+        }
+    }
+
+    #[test]
+    fn registry_loads_deterministically() {
+        let root = temp_dir("concept_registry_deterministic");
+        must(fs::create_dir_all(root.join("fixtures")));
+        must(fs::write(root.join("fixtures/ok.pl"), "my $x = 1;\n"));
+
+        write_registry(
+            &root,
+            r#"
+[[concept]]
+id = "z.last"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["parser"] }
+fixtures = { floors = ["fixtures/ok.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = true, ast = true, spans = false }
+run = { pr = true, nightly = false, release = false }
+
+[[concept]]
+id = "a.first"
+status = "seed"
+scope = { crates = ["perl-lexer"], risk_tags = ["lexer"] }
+fixtures = { floors = ["fixtures/ok.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "lex" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = true, nightly = true, release = false }
+"#,
+        );
+
+        let loaded = must(load_concept_registry_from(&root.join("concepts"), &root));
+        let ids: Vec<_> = loaded.iter().map(|c| c.row.id.as_str()).collect();
+        assert_eq!(ids, vec!["a.first", "z.last"]);
+    }
+
+    #[test]
+    fn duplicate_ids_are_rejected() {
+        let root = temp_dir("concept_registry_dupe");
+        must(fs::create_dir_all(root.join("fixtures")));
+        must(fs::write(root.join("fixtures/ok.pl"), "my $x = 1;\n"));
+
+        write_registry(
+            &root,
+            r#"
+[[concept]]
+id = "dup.id"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["parser"] }
+fixtures = { floors = ["fixtures/ok.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = true, ast = true, spans = false }
+run = { pr = true, nightly = true, release = false }
+
+[[concept]]
+id = "dup.id"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["parser"] }
+fixtures = { floors = ["fixtures/ok.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = true, ast = true, spans = false }
+run = { pr = true, nightly = true, release = false }
+"#,
+        );
+
+        let err = load_concept_registry_from(&root.join("concepts"), &root)
+            .expect_err("expected duplicate id failure");
+        assert!(err.to_string().contains("duplicate concept id"));
+    }
+
+    #[test]
+    fn missing_fixture_path_is_rejected() {
+        let root = temp_dir("concept_registry_fixture");
+
+        write_registry(
+            &root,
+            r#"
+[[concept]]
+id = "bad.fixture"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["parser"] }
+fixtures = { floors = ["fixtures/does-not-exist.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = true, ast = false, spans = false }
+run = { pr = true, nightly = false, release = false }
+"#,
+        );
+
+        let err = load_concept_registry_from(&root.join("concepts"), &root)
+            .expect_err("expected fixture existence failure");
+        assert!(err.to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn unknown_top_level_sections_are_rejected() {
+        let root = temp_dir("concept_registry_unknown");
+        must(fs::create_dir_all(root.join("fixtures")));
+        must(fs::write(root.join("fixtures/ok.pl"), "my $x = 1;\n"));
+
+        write_registry(
+            &root,
+            r#"
+[[concept]]
+id = "good.one"
+status = "seed"
+scope = { crates = ["perl-parser"], risk_tags = ["parser"] }
+fixtures = { floors = ["fixtures/ok.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse" }
+snapshots = { tokens = true, ast = true, spans = false }
+run = { pr = true, nightly = true, release = false }
+
+[extra]
+hello = "world"
+"#,
+        );
+
+        let err = load_concept_registry_from(&root.join("concepts"), &root)
+            .expect_err("expected unknown section failure");
+        let message = err.to_string();
+        assert!(message.contains("unknown") || message.contains("extra"));
+    }
+}

--- a/crates/perl-corpus/src/lib.rs
+++ b/crates/perl-corpus/src/lib.rs
@@ -221,6 +221,7 @@
 
 pub mod cases;
 pub mod codegen;
+pub mod concepts;
 pub mod continue_redo;
 pub mod files;
 pub mod format_statements;
@@ -241,6 +242,7 @@ pub use codegen::{
     CodegenOptions, StatementKind, generate_perl_code, generate_perl_code_with_options,
     generate_perl_code_with_seed, generate_perl_code_with_statements,
 };
+pub use concepts::{ConceptRow, LoadedConcept, load_concept_registry};
 pub use continue_redo::{
     ContinueRedoCase, cases_by_tag as continue_redo_cases_by_tag, continue_redo_cases,
     find_case as find_continue_redo_case, invalid_cases as invalid_continue_redo_cases,


### PR DESCRIPTION
### Motivation
- Provide a durable, concept-indexed registry for perl-corpus so coverage planning can be expressed as named concepts rather than ad-hoc file lists.
- Define the lattice shape for lexer/parser/recovery/positions/incremental/tree-sitter concepts and seed high-value rows without changing parser behavior.

### Description
- Add a deterministic loader/validator `crates/perl-corpus/src/concepts.rs` that reads a stable set of files and enforces schema (`deny_unknown_fields`), known status values, duplicate-id detection, and fixture path resolution.
- Add six registry files under `crates/perl-corpus/concepts/` (`lexer.toml`, `parser.toml`, `recovery.toml`, `positions.toml`, `incremental.toml`, `tree_sitter.toml`) and seed 57 concept rows focused on high-value lexer/parser/recovery/position/incremental/tree-sitter scenarios.
- Expose the registry API from the crate root via `pub use concepts::{ConceptRow, LoadedConcept, load_concept_registry};` and include the concept files in crate packaging via `crates/perl-corpus/Cargo.toml` and add a `toml` dependency for parsing.
- The registry intentionally does not enforce any parser behavior or introduce a parser-ratchet command; it only defines and validates concept metadata and fixture existence.

### Testing
- Automated checks performed: `cargo test -p perl-corpus` (all tests passed), `cargo check --all-targets -p perl-corpus` (passed), `cargo clippy -p perl-corpus` (passed), and formatting via `cargo fmt`/`cargo xtask fmt` (ran).
- Added unit tests exercising deterministic load order, duplicate ID rejection, missing fixture path rejection, and unknown top-level TOML section rejection, and these tests passed as part of the suite.
- The concept registry loader validates fixture paths by resolving them against the discovered workspace root and fails early if a listed fixture does not exist.
- No CI policy changes or parser behavior changes were made as part of this work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a65cf7748333bbaab0259e506039)