### PR TITLE
fix(ci): clarify parser/corpus PR gate enforcement (#0000)

### DIFF
--- a/.ci/GATE_REGISTRY.toml
+++ b/.ci/GATE_REGISTRY.toml
@@ -1,5 +1,10 @@
 # Gate Registry for perl-lsp
 # Defines all merge-blocking gates with thresholds and enforcement
+#
+# NOTE (2026-04-28):
+#   CI merge-gate execution uses `.ci/gate-policy.yaml` via `cargo xtask gates`.
+#   This registry remains for legacy scripts/receipt tooling and mirrors policy
+#   intent where applicable; gate-policy is authoritative when they differ.
 
 [metadata]
 version = "1.0"
@@ -110,49 +115,49 @@ failure_impact = "medium"  # Cost control
 id = "parser-corpus-ratchet"
 name = "Parser Corpus Ratchet (System)"
 type = "correctness"
-blocking = true
+blocking = false
 timeout_seconds = 180
 command = "cargo run -p xtask -- parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt"
 evidence_pattern = "Ratchet: all checks passed"
 threshold = { type = "exit_code", pass = 0 }
 
 [gate.metadata]
-description = "Prevents parser clean-rate, error-node, and bucket regressions on the system corpus"
+description = "Advisory-only: tracks parser clean-rate, error-node, and bucket drift on system corpus (baseline is environment-sensitive)"
 docs_url = "justfile#corpus-sweep-check"
 cost_tier = "medium"
-failure_impact = "high"
+failure_impact = "informational"
 
 [[gate]]
 id = "cpan-corpus-ratchet"
 name = "Parser Corpus Ratchet (CPAN)"
 type = "correctness"
-blocking = true
+blocking = false
 timeout_seconds = 300
 command = "cargo run -p xtask -- cpan-corpus sweep --enforce"
 evidence_pattern = "Ratchet: all checks passed"
 threshold = { type = "exit_code", pass = 0 }
 
 [gate.metadata]
-description = "Prevents parser regressions on the CPAN corpus and known-clean manifest"
+description = "Advisory-only for PRs: CPAN corpus ratchet is owned by release/nightly/post-merge corpus workflows"
 docs_url = "justfile#cpan-corpus-check"
 cost_tier = "high"
-failure_impact = "high"
+failure_impact = "informational"
 
 [[gate]]
 id = "parser-audit-closeout"
 name = "Parser Closeout Audit Ratchet"
 type = "correctness"
-blocking = true
+blocking = false
 timeout_seconds = 180
 command = "cargo run -p xtask -- corpus-audit --fresh --corpus-path . --check"
 evidence_pattern = "CI gate passed"
 threshold = { type = "exit_code", pass = 0 }
 
 [gate.metadata]
-description = "Defends parser closeout floors for valid-gap count, NodeKind coverage, and recovery salvage"
+description = "Advisory until deterministic/scoped replacement lands; tracks parser closeout floors for gap, NodeKind, and recovery metrics"
 docs_url = "justfile#parser-audit"
 cost_tier = "medium"
-failure_impact = "high"
+failure_impact = "informational"
 
 [[gate]]
 id = "todo-compliance"

--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -331,10 +331,13 @@ gates:
       - cpan
       - ratchet
 
+  # NOTE (2026-04-28): advisory (required: false) until the parser audit
+  # producer is replaced with deterministic/scoped inputs suitable for hard
+  # merge blocking. This still runs in merge_gate for signal collection.
   - name: parser_audit_closeout
     tier: merge_gate
-    description: "Project corpus parser closeout metrics (gaps, NodeKinds, recovery) must not regress"
-    required: true
+    description: "Project corpus parser closeout metrics (gaps, NodeKinds, recovery) ratchet (advisory until deterministic replacement lands)"
+    required: false
     command: >-
       cargo run --locked -p xtask
       -- corpus-audit --fresh --corpus-path . --check

--- a/docs/reference/CI_ARCHITECTURE.md
+++ b/docs/reference/CI_ARCHITECTURE.md
@@ -162,8 +162,10 @@ merge, and every subsequent PR compares regression-to-regression. This is the
 
 ## Section 2 — Gate Definitions and Policy
 
-All gate definitions live in `.ci/gate-policy.yaml`. The schema version is 1. The
+All merge-gate enforcement definitions live in `.ci/gate-policy.yaml`. The schema version is 1. The
 `xtask/src/tasks/gates.rs` runner reads this policy and executes gates, emitting receipts.
+`.ci/GATE_REGISTRY.toml` is legacy metadata for older scripts/receipts and is not the merge-gate
+source of truth.
 
 ### Tier Mapping
 
@@ -188,7 +190,6 @@ these blocks merge (via the `ci/merge-gate` commit status check):
 | `lsp_tier_a` | CLI smoke + capabilities snapshot + protocol tests | LSP capability correctness |
 | `lsp_tier_b` | Definitions, completion, color, code lens, security, behavioral | LSP core behavior |
 | `common_corpus_clean` | `xtask parser-corpus-sweep --manifest --enforce` | Common Perl modules parse with zero errors |
-| `parser_audit_closeout` | `xtask corpus-audit --fresh --check` | Corpus parser metrics do not regress |
 | `security_audit` | `cargo audit --deny warnings` | Known CVEs in dependencies |
 | `policy_checks` | Version sync + docs baseline + features invariants | Project policy invariants |
 | `docs_build` | `cargo doc -p perl-parser -p perl-lsp-rs` | Documentation builds without errors |
@@ -207,6 +208,7 @@ These gates have `required: false`. Failures produce signal and are tracked in
 |------|-------------|
 | `parser_corpus_ratchet` | Baseline drifts with runner Perl version (Ubuntu Perl updates produce environmental false positives) |
 | `cpan_corpus_ratchet` | CPAN corpus not installed on PR runners; owned by post-merge cron |
+| `parser_audit_closeout` | Advisory until deterministic/scoped parser-audit producer replacement lands |
 | `security_audit` | Currently quarantined: `cargo-audit` ecosystem breakage as of 2026-04-26 |
 | `published_crate_count` | Quarantined until collapse completes (~30–31 target crates) |
 | All `nightly` gates | Informational by tier definition |

--- a/xtask/tests/gate_policy_parser_corpus_tests.rs
+++ b/xtask/tests/gate_policy_parser_corpus_tests.rs
@@ -1,0 +1,88 @@
+//! Guardrails for parser/corpus gate policy wiring.
+//!
+//! Ensures merge-blocking behavior follows `.ci/gate-policy.yaml` (the CI gate
+//! source of truth) and that legacy registry metadata cannot accidentally make
+//! CPAN/parser ratchets block ordinary PRs.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn project_root() -> PathBuf {
+    let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    dir.pop();
+    dir
+}
+
+fn gate_section<'a>(content: &'a str, gate_name: &str) -> Result<&'a str, Box<dyn std::error::Error>> {
+    let marker = format!("name: {gate_name}");
+    let start = content
+        .find(&marker)
+        .ok_or_else(|| format!("missing gate in policy: {gate_name}"))?;
+    let section = &content[start..];
+    let end = section[1..].find("\n  - name:").map(|i| i + 1).unwrap_or(section.len());
+    Ok(&section[..end])
+}
+
+fn registry_gate_section<'a>(content: &'a str, gate_id: &str) -> Result<&'a str, Box<dyn std::error::Error>> {
+    let marker = format!("id = \"{gate_id}\"");
+    let start = content
+        .find(&marker)
+        .ok_or_else(|| format!("missing gate in registry: {gate_id}"))?;
+    let section = &content[start..];
+    let end = section[1..].find("\n[[gate]]").map(|i| i + 1).unwrap_or(section.len());
+    Ok(&section[..end])
+}
+
+#[test]
+fn pr_policy_keeps_common_corpus_required_and_cpan_non_blocking() -> Result<(), Box<dyn std::error::Error>> {
+    let root = project_root();
+    let content = fs::read_to_string(root.join(".ci/gate-policy.yaml"))?;
+
+    let common = gate_section(&content, "common_corpus_clean")?;
+    assert!(common.contains("tier: merge_gate"));
+    assert!(common.contains("required: true"));
+
+    let parser_ratchet = gate_section(&content, "parser_corpus_ratchet")?;
+    assert!(parser_ratchet.contains("tier: merge_gate"));
+    assert!(parser_ratchet.contains("required: false"));
+
+    let cpan_ratchet = gate_section(&content, "cpan_corpus_ratchet")?;
+    assert!(cpan_ratchet.contains("required: false"));
+    assert!(
+        !cpan_ratchet.contains("tier: pr_fast"),
+        "cpan_corpus_ratchet must never be a pr_fast gate"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn legacy_registry_cannot_reintroduce_pr_blocking_for_corpus_ratchets() -> Result<(), Box<dyn std::error::Error>> {
+    let root = project_root();
+    let content = fs::read_to_string(root.join(".ci/GATE_REGISTRY.toml"))?;
+
+    for gate_id in ["parser-corpus-ratchet", "cpan-corpus-ratchet", "parser-audit-closeout"] {
+        let section = registry_gate_section(&content, gate_id)?;
+        assert!(
+            section.contains("blocking = false"),
+            "legacy registry gate must stay non-blocking: {gate_id}\n{section}"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn merge_gate_workflow_uses_xtask_gate_policy_runner() -> Result<(), Box<dyn std::error::Error>> {
+    let root = project_root();
+    let content = fs::read_to_string(root.join(".github/workflows/ci.yml"))?;
+
+    assert!(content.contains("Run full ci-gate with receipts"));
+    assert!(content.contains("run: just gates"));
+    assert!(
+        !content.contains("GATE_REGISTRY.toml"),
+        "merge-gate workflow should not read legacy GATE_REGISTRY.toml directly"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- The parser/corpus ratchet gates were ambiguous between the authoritative `.ci/gate-policy.yaml` and the legacy `.ci/GATE_REGISTRY.toml`, which allowed environment-sensitive corpus checks (CPAN/system ratchets and a parser audit closeout) to appear PR-blocking and block unrelated changes.
- Make the PR-effective policy unambiguous so only deterministic, scoped checks can block merges while noisy/environmental ratchets remain advisory or release/nightly-owned.

### Description
- Demoted `parser_audit_closeout` to advisory in `.ci/gate-policy.yaml` by setting `required: false` and added an explanatory note that it is advisory until a deterministic producer replaces it.
- Aligned legacy registry semantics in `.ci/GATE_REGISTRY.toml` by marking `parser-corpus-ratchet`, `cpan-corpus-ratchet`, and `parser-audit-closeout` as non-blocking and adding a header note that `.ci/gate-policy.yaml` (via `cargo xtask gates`) is authoritative for merge-gate execution.
- Updated `docs/reference/CI_ARCHITECTURE.md` to state that `.ci/gate-policy.yaml` is the merge-gate source of truth and documented the advisory status of the parser/corpus ratchets.
- Added focused xtask tests at `xtask/tests/gate_policy_parser_corpus_tests.rs` that assert `common_corpus_clean` remains required, that CPAN/system parser ratchets are non-blocking, and that the merge-gate workflow invokes the `xtask` gate runner rather than reading the legacy registry directly.

### Testing
- Ran `cargo test -p xtask --test gate_policy_parser_corpus_tests` and it passed (`3 passed; 0 failed`).
- Ran `cargo xtask gates --tier merge-gate --list` to verify the effective gate listing and observed `common_corpus_clean` as required and the parser/corpus ratchets listed as advisory.
- Verified CI/workflow wiring by inspecting `.github/workflows/ci.yml` to ensure the merge-gate uses `just gates` (xtask runner) rather than reading the legacy registry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a651fa6c83339ed04efe659442f8)