### PR TITLE
feat(perl-corpus): seed durable concept registry (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "toml",
  "tracing",
 ]
 

--- a/crates/perl-corpus/Cargo.toml
+++ b/crates/perl-corpus/Cargo.toml
@@ -34,6 +34,7 @@ chrono = "0.4.42"
 proptest.workspace = true
 rand = "0.10.1"
 tracing.workspace = true
+toml = "1.1.2"
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/perl-corpus/concepts/incremental.toml
+++ b/crates/perl-corpus/concepts/incremental.toml
@@ -1,0 +1,71 @@
+[[concepts]]
+id = "incremental.edit_inside_expression"
+status = "seeded"
+scope = { crates = ["perl-incremental-parsing", "perl-parser"], risk_tags = ["incremental", "expression"] }
+fixtures = { floors = ["test_corpus/expressions_and_refs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = true, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "incremental.edit_shifts_following_nodes"
+status = "seeded"
+scope = { crates = ["perl-incremental-parsing", "perl-position-tracking"], risk_tags = ["incremental", "positions"] }
+fixtures = { floors = ["test_corpus/low_frequency_nodekinds_expression_positions.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "incremental.edit_inside_signature"
+status = "proposed"
+scope = { crates = ["perl-incremental-parsing", "perl-parser"], risk_tags = ["incremental", "signature"] }
+fixtures = { floors = ["test_corpus/signatures_parameters_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "skip", nightly = "smoke", release = "full" }
+
+[[concepts]]
+id = "incremental.edit_package_header"
+status = "proposed"
+scope = { crates = ["perl-incremental-parsing", "perl-parser"], risk_tags = ["incremental", "declaration"] }
+fixtures = { floors = ["test_corpus/package_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "skip", nightly = "smoke", release = "full" }
+
+[[concepts]]
+id = "incremental.edit_heredoc_delimiter"
+status = "proposed"
+scope = { crates = ["perl-incremental-parsing", "perl-lexer"], risk_tags = ["incremental", "heredoc"] }
+fixtures = { floors = ["test_corpus/heredoc_depth.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = true, ast = true, spans = true }
+run = { pr = "skip", nightly = "smoke", release = "full" }
+
+[[concepts]]
+id = "incremental.comment_toggle"
+status = "active"
+scope = { crates = ["perl-incremental-parsing", "perl-lexer"], risk_tags = ["incremental", "comments"] }
+fixtures = { floors = ["test_corpus/clean_misc_kinds.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "incremental.indirect_call_disambiguation"
+status = "proposed"
+scope = { crates = ["perl-incremental-parsing", "perl-parser"], risk_tags = ["incremental", "ambiguity"] }
+fixtures = { floors = ["test_corpus/indirect_call_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "skip", nightly = "smoke", release = "full" }
+
+[[concepts]]
+id = "incremental.range_operator_flip"
+status = "proposed"
+scope = { crates = ["perl-incremental-parsing", "perl-parser"], risk_tags = ["incremental", "operator"] }
+fixtures = { floors = ["test_corpus/expressions_and_refs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "skip", nightly = "smoke", release = "full" }

--- a/crates/perl-corpus/concepts/lexer.toml
+++ b/crates/perl-corpus/concepts/lexer.toml
@@ -1,0 +1,71 @@
+[[concepts]]
+id = "lexer.regex.literal_vs_division"
+status = "seeded"
+scope = { crates = ["perl-lexer", "perl-parser"], risk_tags = ["ambiguity", "regex"] }
+fixtures = { floors = ["test_corpus/clean_regex_substitution.pl"], variants = ["test_corpus/advanced_regex.pl"] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "lexer.regex.substitution_delimiters"
+status = "seeded"
+scope = { crates = ["perl-lexer"], risk_tags = ["regex", "delimiters"] }
+fixtures = { floors = ["test_corpus/clean_regex_substitution.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "lexer.quote_like.q_braces"
+status = "seeded"
+scope = { crates = ["perl-lexer"], risk_tags = ["quote_like"] }
+fixtures = { floors = ["test_corpus/expressions_and_refs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = true, ast = false, spans = false }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "lexer.quote_like.qq_parens"
+status = "seeded"
+scope = { crates = ["perl-lexer"], risk_tags = ["quote_like"] }
+fixtures = { floors = ["test_corpus/expressions_and_refs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = true, ast = false, spans = false }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "lexer.heredoc.basic"
+status = "seeded"
+scope = { crates = ["perl-lexer", "perl-parser"], risk_tags = ["heredoc"] }
+fixtures = { floors = ["test_corpus/heredoc_depth.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = true, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "lexer.heredoc.indented"
+status = "seeded"
+scope = { crates = ["perl-lexer"], risk_tags = ["heredoc", "perl_5_26"] }
+fixtures = { floors = ["test_corpus/heredoc_depth.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "lexer.data_section.double_underscore_data"
+status = "seeded"
+scope = { crates = ["perl-lexer", "perl-parser"], risk_tags = ["data_section"] }
+fixtures = { floors = ["test_corpus/data_end_sections.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "lexer.filetest.chained_operators"
+status = "proposed"
+scope = { crates = ["perl-lexer", "perl-parser"], risk_tags = ["operator"] }
+fixtures = { floors = ["test_corpus/io_operations_comprehensive.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = true, ast = false, spans = false }
+run = { pr = "skip", nightly = "smoke", release = "full" }

--- a/crates/perl-corpus/concepts/parser.toml
+++ b/crates/perl-corpus/concepts/parser.toml
@@ -1,0 +1,107 @@
+[[concepts]]
+id = "parser.package.declaration"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["declaration"] }
+fixtures = { floors = ["test_corpus/package_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.sub.named"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["declaration"] }
+fixtures = { floors = ["test_corpus/basic_constructs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.sub.anonymous"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["closure"] }
+fixtures = { floors = ["test_corpus/expressions_and_refs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.sub.signature"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["signature", "perl_5_36"] }
+fixtures = { floors = ["test_corpus/signatures_parameters_production_enhanced.pl"], variants = ["test_corpus/clean_signatures.pl"] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.variable.my_our_local_state"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["declaration", "scope"] }
+fixtures = { floors = ["test_corpus/variable_list_declaration_comprehensive.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.expression.fat_arrow"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["operator"] }
+fixtures = { floors = ["test_corpus/expressions_and_refs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.expression.range"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["operator"] }
+fixtures = { floors = ["test_corpus/expressions_and_refs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.expression.word_operators"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["operator", "precedence"] }
+fixtures = { floors = ["test_corpus/basic_constructs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.hash.array_literals"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["literal"] }
+fixtures = { floors = ["test_corpus/expressions_and_refs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.method_call.arrow"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["method_call"] }
+fixtures = { floors = ["test_corpus/method_class.pl"], variants = ["test_corpus/class_method_production_enhanced.pl"] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.indirect_object_call"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["ambiguity", "method_call"] }
+fixtures = { floors = ["test_corpus/indirect_call_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.statement_modifier.if_unless"
+status = "proposed"
+scope = { crates = ["perl-parser"], risk_tags = ["statement_modifier"] }
+fixtures = { floors = ["test_corpus/statement_modifier_comprehensive.pl"], variants = ["test_corpus/statement_modifier_production_enhanced.pl"] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = "skip", nightly = "smoke", release = "full" }

--- a/crates/perl-corpus/concepts/positions.toml
+++ b/crates/perl-corpus/concepts/positions.toml
@@ -1,0 +1,71 @@
+[[concepts]]
+id = "position.byte_span.basic"
+status = "seeded"
+scope = { crates = ["perl-position-tracking", "perl-parser"], risk_tags = ["positions"] }
+fixtures = { floors = ["test_corpus/basic_constructs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = false, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "position.utf16.non_ascii"
+status = "seeded"
+scope = { crates = ["perl-line-index", "perl-position-tracking"], risk_tags = ["unicode", "positions"] }
+fixtures = { floors = ["test_corpus/edge_cases/unicode_encoding_edge_cases.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = false, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "position.crlf.line_index"
+status = "seeded"
+scope = { crates = ["perl-line-index", "perl-position-tracking"], risk_tags = ["line_endings", "positions"] }
+fixtures = { floors = ["test_corpus/edge_cases/unicode_encoding_edge_cases.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = false, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "position.multibyte.heredoc_body"
+status = "proposed"
+scope = { crates = ["perl-position-tracking", "perl-parser"], risk_tags = ["unicode", "heredoc"] }
+fixtures = { floors = ["test_corpus/heredoc_depth.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = false, spans = true }
+run = { pr = "skip", nightly = "smoke", release = "full" }
+
+[[concepts]]
+id = "position.range.operator"
+status = "seeded"
+scope = { crates = ["perl-position-tracking", "perl-parser"], risk_tags = ["operator", "positions"] }
+fixtures = { floors = ["test_corpus/expressions_and_refs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = false, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "position.comments.trailing"
+status = "proposed"
+scope = { crates = ["perl-position-tracking", "perl-lexer"], risk_tags = ["comments", "positions"] }
+fixtures = { floors = ["test_corpus/clean_misc_kinds.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = true, ast = false, spans = true }
+run = { pr = "skip", nightly = "smoke", release = "full" }
+
+[[concepts]]
+id = "position.special_vars.offsets"
+status = "proposed"
+scope = { crates = ["perl-position-tracking", "perl-parser"], risk_tags = ["special_vars", "positions"] }
+fixtures = { floors = ["test_corpus/caller_context_comprehensive.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = false, spans = true }
+run = { pr = "skip", nightly = "smoke", release = "full" }
+
+[[concepts]]
+id = "position.statement_modifier.boundaries"
+status = "active"
+scope = { crates = ["perl-position-tracking", "perl-parser"], risk_tags = ["statement_modifier", "positions"] }
+fixtures = { floors = ["test_corpus/statement_modifier_comprehensive.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = false, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }

--- a/crates/perl-corpus/concepts/recovery.toml
+++ b/crates/perl-corpus/concepts/recovery.toml
@@ -1,0 +1,71 @@
+[[concepts]]
+id = "parser.recovery.missing_closing_brace"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["recovery"] }
+fixtures = { floors = ["test_corpus/edge_cases/error_recovery_edge_cases.pl"], variants = ["test_corpus/parser_stress_cases.pl"] }
+expect = { panic = false, timeout = false, mode = "parse_and_recover" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.recovery.missing_paren"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["recovery"] }
+fixtures = { floors = ["test_corpus/edge_cases/error_recovery_edge_cases.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_and_recover" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.recovery.unclosed_quote"
+status = "seeded"
+scope = { crates = ["perl-parser", "perl-lexer"], risk_tags = ["recovery", "quote_like"] }
+fixtures = { floors = ["test_corpus/edge_cases/error_recovery_edge_cases.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_and_recover" }
+snapshots = { tokens = true, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.recovery.malformed_signature"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["recovery", "signature"] }
+fixtures = { floors = ["test_corpus/signatures_parameters_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_and_recover" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.recovery.unterminated_heredoc"
+status = "proposed"
+scope = { crates = ["perl-parser", "perl-lexer"], risk_tags = ["recovery", "heredoc"] }
+fixtures = { floors = ["test_corpus/heredoc_depth.pl"], variants = [] }
+expect = { panic = false, timeout = true, mode = "parse_and_recover" }
+snapshots = { tokens = true, ast = true, spans = true }
+run = { pr = "skip", nightly = "smoke", release = "full" }
+
+[[concepts]]
+id = "parser.recovery.double_else"
+status = "proposed"
+scope = { crates = ["perl-parser"], risk_tags = ["recovery", "control_flow"] }
+fixtures = { floors = ["test_corpus/edge_cases/error_recovery_edge_cases.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_and_recover" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "skip", nightly = "smoke", release = "full" }
+
+[[concepts]]
+id = "parser.recovery.missing_semicolon"
+status = "seeded"
+scope = { crates = ["perl-parser"], risk_tags = ["recovery"] }
+fixtures = { floors = ["test_corpus/parser_stress_cases.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_and_recover" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "parser.recovery.nested_block_boundary"
+status = "active"
+scope = { crates = ["perl-parser"], risk_tags = ["recovery", "nesting"] }
+fixtures = { floors = ["test_corpus/edge_cases/deeply_nested_constructs.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_and_recover" }
+snapshots = { tokens = false, ast = true, spans = true }
+run = { pr = "smoke", nightly = "full", release = "full" }

--- a/crates/perl-corpus/concepts/tree_sitter.toml
+++ b/crates/perl-corpus/concepts/tree_sitter.toml
@@ -1,0 +1,71 @@
+[[concepts]]
+id = "tree_sitter.parity.package_decl"
+status = "seeded"
+scope = { crates = ["perl-parser", "tree-sitter-perl"], risk_tags = ["parity", "declaration"] }
+fixtures = { floors = ["tree-sitter-perl/test/corpus/simple"], variants = ["test_corpus/package_production_enhanced.pl"] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "tree_sitter.parity.sub_decl"
+status = "seeded"
+scope = { crates = ["perl-parser", "tree-sitter-perl"], risk_tags = ["parity", "declaration"] }
+fixtures = { floors = ["tree-sitter-perl/test/corpus/subroutines"], variants = ["test_corpus/basic_constructs.pl"] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "tree_sitter.parity.regex_literals"
+status = "proposed"
+scope = { crates = ["perl-parser", "tree-sitter-perl"], risk_tags = ["parity", "regex"] }
+fixtures = { floors = ["tree-sitter-perl/test/corpus/regexp"], variants = ["test_corpus/advanced_regex.pl"] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = "skip", nightly = "smoke", release = "full" }
+
+[[concepts]]
+id = "tree_sitter.parity.method_calls"
+status = "proposed"
+scope = { crates = ["perl-parser", "tree-sitter-perl"], risk_tags = ["parity", "method_call"] }
+fixtures = { floors = ["tree-sitter-perl/test/corpus/expressions"], variants = ["test_corpus/method_class.pl"] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = "skip", nightly = "smoke", release = "full" }
+
+[[concepts]]
+id = "tree_sitter.parity.heredoc"
+status = "proposed"
+scope = { crates = ["perl-parser", "tree-sitter-perl"], risk_tags = ["parity", "heredoc"] }
+fixtures = { floors = ["tree-sitter-perl/test/corpus/heredocs"], variants = ["test_corpus/heredoc_depth.pl"] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = "skip", nightly = "smoke", release = "full" }
+
+[[concepts]]
+id = "tree_sitter.parity.signatures"
+status = "proposed"
+scope = { crates = ["perl-parser", "tree-sitter-perl"], risk_tags = ["parity", "signature"] }
+fixtures = { floors = ["test_corpus/signatures_parameters_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = "skip", nightly = "smoke", release = "full" }
+
+[[concepts]]
+id = "tree_sitter.parity.indirect_call"
+status = "proposed"
+scope = { crates = ["perl-parser", "tree-sitter-perl"], risk_tags = ["parity", "ambiguity"] }
+fixtures = { floors = ["test_corpus/indirect_call_production_enhanced.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = "skip", nightly = "smoke", release = "full" }
+
+[[concepts]]
+id = "tree_sitter.parity.statement_modifiers"
+status = "active"
+scope = { crates = ["perl-parser", "tree-sitter-perl"], risk_tags = ["parity", "statement_modifier"] }
+fixtures = { floors = ["test_corpus/statement_modifier_comprehensive.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "snapshot_only" }
+snapshots = { tokens = false, ast = true, spans = false }
+run = { pr = "smoke", nightly = "full", release = "full" }

--- a/crates/perl-corpus/src/concepts.rs
+++ b/crates/perl-corpus/src/concepts.rs
@@ -1,0 +1,276 @@
+//! Durable concept registry for corpus-driven parser coverage planning.
+
+use crate::files::CorpusPaths;
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+const CONCEPT_FILES: &[&str] = &[
+    "lexer.toml",
+    "parser.toml",
+    "recovery.toml",
+    "positions.toml",
+    "incremental.toml",
+    "tree_sitter.toml",
+];
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptRegistryFile {
+    #[serde(default)]
+    pub concepts: Vec<ConceptRow>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptRow {
+    pub id: String,
+    pub status: ConceptStatus,
+    pub scope: ConceptScope,
+    pub fixtures: ConceptFixtures,
+    pub expect: ConceptExpect,
+    pub snapshots: ConceptSnapshots,
+    pub run: ConceptRun,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConceptStatus {
+    Proposed,
+    Seeded,
+    Active,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptScope {
+    #[serde(default)]
+    pub crates: Vec<String>,
+    #[serde(default)]
+    pub risk_tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptFixtures {
+    #[serde(default)]
+    pub floors: Vec<String>,
+    #[serde(default)]
+    pub variants: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptExpect {
+    pub panic: bool,
+    pub timeout: bool,
+    pub mode: ConceptExpectMode,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConceptExpectMode {
+    ParseOnly,
+    ParseAndRecover,
+    SnapshotOnly,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptSnapshots {
+    pub tokens: bool,
+    pub ast: bool,
+    pub spans: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptRun {
+    pub pr: RunTier,
+    pub nightly: RunTier,
+    pub release: RunTier,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunTier {
+    Skip,
+    Smoke,
+    Full,
+}
+
+/// Load registry rows from `crates/perl-corpus/concepts/*.toml`.
+pub fn load_concept_registry() -> Result<Vec<ConceptRow>> {
+    let root = CorpusPaths::discover().root;
+    load_concept_registry_from_root(&root)
+}
+
+/// Load registry rows from a provided workspace root.
+pub fn load_concept_registry_from_root(root: &Path) -> Result<Vec<ConceptRow>> {
+    let concepts_dir = root.join("crates/perl-corpus/concepts");
+    let mut rows = Vec::new();
+
+    for file_name in CONCEPT_FILES {
+        let path = concepts_dir.join(file_name);
+        let source = fs::read_to_string(&path)
+            .with_context(|| format!("reading concept file {}", path.display()))?;
+        let parsed: ConceptRegistryFile = toml::from_str(&source)
+            .with_context(|| format!("parsing concept file {}", path.display()))?;
+        rows.extend(parsed.concepts);
+    }
+
+    validate_registry(&rows, root)?;
+
+    rows.sort_by(|left, right| left.id.cmp(&right.id));
+    Ok(rows)
+}
+
+fn validate_registry(rows: &[ConceptRow], root: &Path) -> Result<()> {
+    let mut seen = HashSet::new();
+    for row in rows {
+        if !seen.insert(row.id.as_str()) {
+            bail!("duplicate concept id: {}", row.id);
+        }
+
+        validate_fixture_paths(&row.fixtures.floors, root, &row.id, "floors")?;
+        validate_fixture_paths(&row.fixtures.variants, root, &row.id, "variants")?;
+    }
+
+    Ok(())
+}
+
+fn validate_fixture_paths(paths: &[String], root: &Path, id: &str, bucket: &str) -> Result<()> {
+    for fixture in paths {
+        let fixture_path = root.join(fixture);
+        if !fixture_path.exists() {
+            bail!("concept '{}' {} fixture does not exist: {}", id, bucket, fixture);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_root(prefix: &str) -> std::io::Result<PathBuf> {
+        let mut root = std::env::temp_dir();
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
+        root.push(format!("{}_{}_{}", prefix, std::process::id(), nanos));
+        fs::create_dir_all(root.join("crates/perl-corpus/concepts"))?;
+        Ok(root)
+    }
+
+    fn write_concept_file(root: &Path, file_name: &str, body: &str) -> std::io::Result<()> {
+        fs::write(root.join("crates/perl-corpus/concepts").join(file_name), body)
+    }
+
+    fn write_minimal_files(root: &Path, body_fn: impl Fn(usize) -> String) -> std::io::Result<()> {
+        for (index, file_name) in CONCEPT_FILES.iter().enumerate() {
+            write_concept_file(root, file_name, &body_fn(index))?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn registry_load_is_deterministic() -> Result<()> {
+        let root = temp_root("perl_corpus_concepts_det")?;
+        fs::write(root.join("exists.pl"), "print 1;\n")?;
+
+        write_minimal_files(&root, |index| {
+            format!(
+                r#"
+[[concepts]]
+id = "z.id.{index}"
+status = "seeded"
+scope = {{ crates = ["perl-parser"], risk_tags = [] }}
+fixtures = {{ floors = ["exists.pl"], variants = [] }}
+expect = {{ panic = false, timeout = false, mode = "parse_only" }}
+snapshots = {{ tokens = true, ast = false, spans = true }}
+run = {{ pr = "smoke", nightly = "full", release = "full" }}
+
+[[concepts]]
+id = "a.id.{index}"
+status = "seeded"
+scope = {{ crates = ["perl-parser"], risk_tags = [] }}
+fixtures = {{ floors = [], variants = [] }}
+expect = {{ panic = false, timeout = false, mode = "parse_only" }}
+snapshots = {{ tokens = true, ast = true, spans = true }}
+run = {{ pr = "smoke", nightly = "full", release = "full" }}
+"#
+            )
+        })?;
+
+        let rows = load_concept_registry_from_root(&root)?;
+        assert_eq!(rows.first().map(|row| row.id.as_str()), Some("a.id.0"));
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn registry_rejects_duplicate_ids() -> Result<()> {
+        let root = temp_root("perl_corpus_concepts_dup")?;
+
+        write_minimal_files(&root, |_| {
+            r#"
+[[concepts]]
+id = "dup.id"
+status = "seeded"
+scope = { crates = [], risk_tags = [] }
+fixtures = { floors = [], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = true, ast = false, spans = false }
+run = { pr = "smoke", nightly = "full", release = "full" }
+
+[[concepts]]
+id = "dup.id"
+status = "seeded"
+scope = { crates = [], risk_tags = [] }
+fixtures = { floors = [], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = true, ast = false, spans = false }
+run = { pr = "smoke", nightly = "full", release = "full" }
+"#
+            .to_string()
+        })?;
+
+        let error = load_concept_registry_from_root(&root)
+            .expect_err("duplicate concept ids should fail validation");
+        assert!(error.to_string().contains("duplicate concept id"));
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn registry_rejects_missing_fixture_paths() -> Result<()> {
+        let root = temp_root("perl_corpus_concepts_fixture")?;
+
+        write_minimal_files(&root, |_| {
+            r#"
+[[concepts]]
+id = "fixture.bad"
+status = "seeded"
+scope = { crates = [], risk_tags = [] }
+fixtures = { floors = ["does/not/exist.pl"], variants = [] }
+expect = { panic = false, timeout = false, mode = "parse_only" }
+snapshots = { tokens = true, ast = true, spans = false }
+run = { pr = "smoke", nightly = "full", release = "full" }
+"#
+            .to_string()
+        })?;
+
+        let error = load_concept_registry_from_root(&root)
+            .expect_err("missing fixture paths should fail validation");
+        assert!(error.to_string().contains("fixture does not exist"));
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+}

--- a/crates/perl-corpus/src/lib.rs
+++ b/crates/perl-corpus/src/lib.rs
@@ -221,6 +221,7 @@
 
 pub mod cases;
 pub mod codegen;
+pub mod concepts;
 pub mod continue_redo;
 pub mod files;
 pub mod format_statements;
@@ -240,6 +241,11 @@ pub use cases::{
 pub use codegen::{
     CodegenOptions, StatementKind, generate_perl_code, generate_perl_code_with_options,
     generate_perl_code_with_seed, generate_perl_code_with_statements,
+};
+pub use concepts::{
+    ConceptExpect, ConceptExpectMode, ConceptFixtures, ConceptRegistryFile, ConceptRow, ConceptRun,
+    ConceptScope, ConceptSnapshots, ConceptStatus, RunTier, load_concept_registry,
+    load_concept_registry_from_root,
 };
 pub use continue_redo::{
     ContinueRedoCase, cases_by_tag as continue_redo_cases_by_tag, continue_redo_cases,


### PR DESCRIPTION
### Motivation
- The corpus needed a durable, typed concept registry to drive concept-indexed parser/lexer/recovery/position/incremental/tree-sitter coverage without enforcing parser behavior.
- Provide a single canonical shape for concept rows, surface early high-value concepts, and enable deterministic loading and validation before downstream tooling consumes the registry.

### Description
- Added a typed loader/validator `crates/perl-corpus/src/concepts.rs` that reads a fixed file ordering from `crates/perl-corpus/concepts/`, parses TOML into strongly-typed rows, enforces `deny_unknown_fields`, and returns rows sorted by `id`.
- Seeded six TOML catalogs (`lexer.toml`, `parser.toml`, `recovery.toml`, `positions.toml`, `incremental.toml`, `tree_sitter.toml`) containing 52 concept rows including the requested starter IDs and sensible `fixtures`, `scope`, `expect`, `snapshots`, and `run` fields.
- Added validation logic to reject duplicate concept IDs and to verify that any listed fixture paths exist relative to the workspace root, and exported the new API from `lib.rs`.
- Added `toml` crate dependency to `crates/perl-corpus/Cargo.toml` and included unit tests that cover deterministic loading, duplicate-id rejection, and missing-fixture rejection.

### Testing
- Ran `cargo test -p perl-corpus` and all tests passed, including the new concept validator tests.
- Ran `cargo check --all-targets -p perl-corpus` which completed successfully.
- Ran `cargo clippy -p perl-corpus -- -D warnings` which completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a65cf7748333bbaab0259e506039)