### PR TITLE
fix(ci-gate): clarify parser corpus gate policy precedence (#0000)

### DIFF
--- a/.ci/GATE_REGISTRY.toml
+++ b/.ci/GATE_REGISTRY.toml
@@ -5,6 +5,8 @@
 version = "1.0"
 last_updated = "2026-01-29"
 blocking_policy = "all-gates-must-pass"
+# NOTE: CI Gate source of truth is .ci/gate-policy.yaml (consumed by `cargo xtask gates`).
+# Keep this registry aligned for legacy scripts and receipt tooling.
 
 # ============================================================================
 # Merge-Blocking Gates (REQUIRED for all PRs)
@@ -110,7 +112,7 @@ failure_impact = "medium"  # Cost control
 id = "parser-corpus-ratchet"
 name = "Parser Corpus Ratchet (System)"
 type = "correctness"
-blocking = true
+blocking = false
 timeout_seconds = 180
 command = "cargo run -p xtask -- parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt"
 evidence_pattern = "Ratchet: all checks passed"
@@ -126,7 +128,7 @@ failure_impact = "high"
 id = "cpan-corpus-ratchet"
 name = "Parser Corpus Ratchet (CPAN)"
 type = "correctness"
-blocking = true
+blocking = false
 timeout_seconds = 300
 command = "cargo run -p xtask -- cpan-corpus sweep --enforce"
 evidence_pattern = "Ratchet: all checks passed"

--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -333,7 +333,10 @@ gates:
 
   - name: parser_audit_closeout
     tier: merge_gate
-    description: "Project corpus parser closeout metrics (gaps, NodeKinds, recovery) must not regress"
+    # Deterministic/scoped rationale for required=true:
+    # - Evaluates repository-local corpus files only (`--corpus-path .`), not host CPAN/system trees.
+    # - Uses a fresh in-process run (`--fresh`) to avoid stale machine-local cache baselines.
+    description: "Project corpus parser closeout metrics (repo-scoped, deterministic run) must not regress"
     required: true
     command: >-
       cargo run --locked -p xtask

--- a/docs/reference/CI_ARCHITECTURE.md
+++ b/docs/reference/CI_ARCHITECTURE.md
@@ -162,8 +162,10 @@ merge, and every subsequent PR compares regression-to-regression. This is the
 
 ## Section 2 — Gate Definitions and Policy
 
-All gate definitions live in `.ci/gate-policy.yaml`. The schema version is 1. The
-`xtask/src/tasks/gates.rs` runner reads this policy and executes gates, emitting receipts.
+All merge-gate decisions use `.ci/gate-policy.yaml` as the source of truth. The schema
+version is 1, and `xtask/src/tasks/gates.rs` reads this policy and executes gates.
+`.ci/GATE_REGISTRY.toml` is legacy/auxiliary metadata for scripts/receipt tooling and must
+remain aligned with gate-policy required/advisory semantics for overlapping gates.
 
 ### Tier Mapping
 

--- a/justfile
+++ b/justfile
@@ -971,6 +971,14 @@ gates-json tier='merge-gate':
 gates-list:
     @cargo xtask gates --list
 
+# Validate gate-policy invariants and registry alignment.
+gate-policy-check:
+    @cargo xtask gate-policy check
+
+# Print effective gates for a policy profile (pr, merge, nightly, release).
+gate-policy-effective profile='pr':
+    @cargo xtask gate-policy effective --profile {{profile}}
+
 # Run old shell-based gate runner (deprecated, kept for compatibility)
 gates-legacy:
     @echo "🧾 Running legacy gate runner..."

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,6 +12,7 @@ mod types;
 mod utils;
 use tasks::check_test_wiring;
 use tasks::dead_code::{DeadCodeConfig, DeadCodeMode};
+use tasks::gate_policy::GatePolicyCommand;
 use tasks::gates::{GateTier, OutputFormat as GatesOutputFormat};
 use tasks::methodology_gate::MethodologyOutputFormat;
 use tasks::metrics;
@@ -940,6 +941,12 @@ enum Commands {
     GateReceipts {
         #[command(subcommand)]
         command: GateReceiptsCommand,
+    },
+
+    /// Inspect and validate effective gate policy profiles.
+    GatePolicy {
+        #[command(subcommand)]
+        command: GatePolicyCommand,
     },
 
     /// Show technical debt report from debt ledger
@@ -2121,6 +2128,7 @@ fn main() -> Result<()> {
                     .map_err(|error| eyre!(error.to_string()))
             }
         },
+        Commands::GatePolicy { command } => gate_policy::run(command),
         Commands::MethodologyGate { fixture, pr, receipt, dry_run, enforce, format } => {
             methodology_gate::run(methodology_gate::MethodologyGateConfig {
                 fixture,

--- a/xtask/src/tasks/gate_policy.rs
+++ b/xtask/src/tasks/gate_policy.rs
@@ -1,0 +1,200 @@
+use color_eyre::eyre::{Context, ContextCompat, Result, bail};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use crate::utils::project_root;
+
+#[derive(clap::Subcommand, Debug)]
+pub enum GatePolicyCommand {
+    /// Validate policy invariants and detect stale gate-registry wiring.
+    Check,
+    /// Show the effective gate policy for a CI profile.
+    Effective {
+        /// CI profile to evaluate.
+        #[arg(long, value_enum, default_value = "pr")]
+        profile: GateProfile,
+    },
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GateProfile {
+    /// Pull-request profile (pr_fast + merge_gate tiers).
+    Pr,
+    /// Full merge-gate profile (same tier set as `pr`).
+    Merge,
+    /// Nightly profile (all tiers, informational depth).
+    Nightly,
+    /// Release profile.
+    Release,
+}
+
+#[derive(Debug, Deserialize)]
+struct GatePolicyDoc {
+    gates: Vec<PolicyGate>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct PolicyGate {
+    name: String,
+    tier: String,
+    #[serde(default = "default_true")]
+    required: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GateRegistryDoc {
+    gate: Vec<RegistryGate>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct RegistryGate {
+    id: String,
+    #[serde(default)]
+    blocking: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+pub fn run(command: GatePolicyCommand) -> Result<()> {
+    match command {
+        GatePolicyCommand::Check => check(),
+        GatePolicyCommand::Effective { profile } => effective(profile),
+    }
+}
+
+fn check() -> Result<()> {
+    let root = project_root()?;
+    let policy = load_policy(&root)?;
+    let registry = load_registry(&root)?;
+
+    let policy_by_name: BTreeMap<_, _> =
+        policy.gates.into_iter().map(|gate| (gate.name.clone(), gate)).collect();
+    let registry_by_id: BTreeMap<_, _> =
+        registry.gate.into_iter().map(|gate| (gate.id.clone(), gate)).collect();
+
+    assert_required_flag(&policy_by_name, "common_corpus_clean", true)?;
+    assert_required_flag(&policy_by_name, "parser_corpus_ratchet", false)?;
+    assert_required_flag(&policy_by_name, "cpan_corpus_ratchet", false)?;
+
+    // Keep YAML policy and legacy TOML registry aligned for corpus gates.
+    assert_registry_alignment(
+        &policy_by_name,
+        &registry_by_id,
+        "parser_corpus_ratchet",
+        "parser-corpus-ratchet",
+    )?;
+    assert_registry_alignment(
+        &policy_by_name,
+        &registry_by_id,
+        "cpan_corpus_ratchet",
+        "cpan-corpus-ratchet",
+    )?;
+    assert_registry_alignment(
+        &policy_by_name,
+        &registry_by_id,
+        "parser_audit_closeout",
+        "parser-audit-closeout",
+    )?;
+
+    println!("gate-policy check passed");
+    println!("- common_corpus_clean: required in PR merge-gate profile");
+    println!("- parser_corpus_ratchet: advisory (non-blocking)");
+    println!("- cpan_corpus_ratchet: advisory (non-blocking)");
+    Ok(())
+}
+
+fn effective(profile: GateProfile) -> Result<()> {
+    let root = project_root()?;
+    let policy = load_policy(&root)?;
+    let selected_tiers = profile_tiers(profile);
+
+    println!("profile={:?}", profile);
+    println!("gate | tier | required | effective_blocking");
+
+    for gate in policy.gates.iter().filter(|gate| selected_tiers.contains(&gate.tier.as_str())) {
+        println!("{} | {} | {} | {}", gate.name, gate.tier, gate.required, gate.required);
+    }
+
+    Ok(())
+}
+
+fn profile_tiers(profile: GateProfile) -> &'static [&'static str] {
+    match profile {
+        GateProfile::Pr | GateProfile::Merge => &["pr_fast", "merge_gate"],
+        GateProfile::Nightly => &["pr_fast", "merge_gate", "nightly"],
+        GateProfile::Release => &["release"],
+    }
+}
+
+fn load_policy(root: &Path) -> Result<GatePolicyDoc> {
+    let path = root.join(".ci/gate-policy.yaml");
+    let content =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    serde_yaml_ng::from_str(&content).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn load_registry(root: &Path) -> Result<GateRegistryDoc> {
+    let path = root.join(".ci/GATE_REGISTRY.toml");
+    let content =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    toml::from_str(&content).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn assert_required_flag(
+    gates: &BTreeMap<String, PolicyGate>,
+    gate: &str,
+    expected_required: bool,
+) -> Result<()> {
+    let policy_gate =
+        gates.get(gate).with_context(|| format!("missing gate-policy entry '{gate}'"))?;
+    if policy_gate.required != expected_required {
+        bail!(
+            "gate-policy mismatch for {gate}: expected required={}, got required={}",
+            expected_required,
+            policy_gate.required
+        );
+    }
+    Ok(())
+}
+
+fn assert_registry_alignment(
+    policy: &BTreeMap<String, PolicyGate>,
+    registry: &BTreeMap<String, RegistryGate>,
+    policy_gate_name: &str,
+    registry_gate_id: &str,
+) -> Result<()> {
+    let policy_gate = policy
+        .get(policy_gate_name)
+        .with_context(|| format!("missing gate-policy entry '{policy_gate_name}'"))?;
+    let registry_gate = registry
+        .get(registry_gate_id)
+        .with_context(|| format!("missing gate-registry entry '{registry_gate_id}'"))?;
+
+    if policy_gate.required != registry_gate.blocking {
+        bail!(
+            "policy mismatch: .ci/gate-policy.yaml gate '{}' required={} but .ci/GATE_REGISTRY.toml gate '{}' blocking={}",
+            policy_gate_name,
+            policy_gate.required,
+            registry_gate_id,
+            registry_gate.blocking
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GateProfile, profile_tiers};
+
+    #[test]
+    fn pr_profile_contains_merge_gate_tiers() {
+        let tiers = profile_tiers(GateProfile::Pr);
+        assert!(tiers.contains(&"pr_fast"));
+        assert!(tiers.contains(&"merge_gate"));
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -44,6 +44,7 @@ pub mod fix_forward;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;
+pub mod gate_policy;
 pub mod gate_receipts;
 pub mod gates;
 pub mod generated_files;

--- a/xtask/tests/gate_policy_profile_tests.rs
+++ b/xtask/tests/gate_policy_profile_tests.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+fn project_root() -> PathBuf {
+    let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    dir.pop();
+    dir
+}
+
+#[derive(Debug, Deserialize)]
+struct GatePolicyDoc {
+    gates: Vec<PolicyGate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PolicyGate {
+    name: String,
+    tier: String,
+    #[serde(default = "default_true")]
+    required: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GateRegistryDoc {
+    gate: Vec<RegistryGate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryGate {
+    id: String,
+    #[serde(default)]
+    blocking: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[test]
+fn parser_corpus_pr_policy_is_unambiguous() -> Result<(), Box<dyn std::error::Error>> {
+    let root = project_root();
+    let policy_path = root.join(".ci/gate-policy.yaml");
+    let content = fs::read_to_string(policy_path)?;
+    let parsed: GatePolicyDoc = serde_yaml_ng::from_str(&content)?;
+
+    let gates: HashMap<_, _> =
+        parsed.gates.into_iter().map(|gate| (gate.name.clone(), gate)).collect();
+
+    let common = gates.get("common_corpus_clean").ok_or("missing common_corpus_clean gate")?;
+    let parser = gates.get("parser_corpus_ratchet").ok_or("missing parser_corpus_ratchet gate")?;
+    let cpan = gates.get("cpan_corpus_ratchet").ok_or("missing cpan_corpus_ratchet gate")?;
+
+    assert_eq!(common.tier, "merge_gate");
+    assert!(common.required, "common_corpus_clean must stay PR-blocking");
+
+    assert_eq!(parser.tier, "merge_gate");
+    assert!(!parser.required, "parser_corpus_ratchet must be advisory in PR merge-gate profile");
+
+    assert_eq!(cpan.tier, "merge_gate");
+    assert!(!cpan.required, "cpan_corpus_ratchet must never be PR-blocking");
+
+    Ok(())
+}
+
+#[test]
+fn gate_registry_alignment_prevents_stale_parser_wiring() -> Result<(), Box<dyn std::error::Error>>
+{
+    let root = project_root();
+
+    let policy: GatePolicyDoc =
+        serde_yaml_ng::from_str(&fs::read_to_string(root.join(".ci/gate-policy.yaml"))?)?;
+    let registry: GateRegistryDoc =
+        toml::from_str(&fs::read_to_string(root.join(".ci/GATE_REGISTRY.toml"))?)?;
+
+    let policy_by_name: HashMap<_, _> =
+        policy.gates.into_iter().map(|gate| (gate.name.clone(), gate.required)).collect();
+    let registry_by_id: HashMap<_, _> =
+        registry.gate.into_iter().map(|gate| (gate.id.clone(), gate.blocking)).collect();
+
+    let pairs = [
+        ("parser_corpus_ratchet", "parser-corpus-ratchet"),
+        ("cpan_corpus_ratchet", "cpan-corpus-ratchet"),
+        ("parser_audit_closeout", "parser-audit-closeout"),
+    ];
+
+    for (policy_name, registry_id) in pairs {
+        let required = policy_by_name
+            .get(policy_name)
+            .ok_or_else(|| format!("missing policy gate: {policy_name}"))?;
+        let blocking = registry_by_id
+            .get(registry_id)
+            .ok_or_else(|| format!("missing registry gate: {registry_id}"))?;
+        assert_eq!(
+            required, blocking,
+            "gate-policy and gate-registry must agree for {policy_name}/{registry_id}"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- CI gate behavior for parser/corpus checks was ambiguous between the active YAML policy and a legacy TOML registry, allowing advisory corpus checks to be treated as blocking in some paths. 
- CPAN/system corpus checks are environment-dependent and must never block ordinary PRs, while `common_corpus_clean` must remain a strict PR blocker. 
- We need a machine-checkable policy view and tests to prevent stale registry wiring from reintroducing blocking CPAN/parser ratchets. 

### Description
- Add a new `xtask gate-policy` command with subcommands `check` and `effective --profile` to make effective PR/merge/release gate semantics explicit and machine-checkable in `xtask/src/tasks/gate_policy.rs`. 
- Wire the command into the CLI and task exports so it is runnable via `cargo xtask gate-policy ...` and expose `just` helpers `gate-policy-check` and `gate-policy-effective`. 
- Align legacy registry entries in `.ci/GATE_REGISTRY.toml` by marking `parser-corpus-ratchet` and `cpan-corpus-ratchet` as non-blocking and add a header noting `.ci/gate-policy.yaml` is the source of truth for merge decisions. 
- Keep `common_corpus_clean` required and retain `parser_audit_closeout` as required, adding a deterministic/scoped rationale to the YAML (`repo-local corpus` + `--fresh`) so its required status is justified. 
- Add integration tests in `xtask/tests/gate_policy_profile_tests.rs` asserting the PR-profile semantics (`common_corpus_clean` required, `parser_corpus_ratchet` advisory, `cpan_corpus_ratchet` advisory) and asserting registry ↔ policy alignment to prevent stale wiring. 
- Update docs (`docs/reference/CI_ARCHITECTURE.md`) and `justfile` with guidance and helper targets for policy inspection. 

### Testing
- Ran `cargo xtask gate-policy check` which printed the expected advisory/required mapping and returned success. (passed) 
- Ran `cargo xtask gate-policy effective --profile pr` to show the effective PR profile and confirmed `common_corpus_clean` required and CPAN/parser ratchets advisory. (passed) 
- Ran the new integration tests via `cargo test -p xtask --test gate_policy_profile_tests` and all tests passed. (2 tests passed) 
- Performed sanity checks: `cargo check --all-targets -p xtask`, `cargo xtask fmt`, and `cargo xtask fmt --check` which completed successfully. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a651fa6c83339ed04efe659442f8)