### PR TITLE
feat(perl-corpus): add durable parser concept registry seeds (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
  "color-eyre",
  "regex",
  "serde_json",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "walkdir",
 ]
 
@@ -1521,6 +1521,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
 ]
 
@@ -1547,7 +1548,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "winapi",
 ]
@@ -1691,7 +1692,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2998,6 +2999,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
@@ -3005,10 +3021,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -3027,9 +3052,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -3038,7 +3063,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -3730,6 +3755,12 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
@@ -3878,7 +3909,7 @@ dependencies = [
  "similar 3.1.0",
  "tar",
  "tempfile",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tree-sitter",
  "tree-sitter-perl-c",
  "walkdir",

--- a/crates/perl-corpus/Cargo.toml
+++ b/crates/perl-corpus/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/perl-corpus"
 homepage.workspace = true
 keywords = ["perl", "corpus", "proptest", "testing", "parser"]
 categories = ["development-tools", "development-tools::testing"]
-include = ["src/**", "README.md", "LICENSE*", "Cargo.toml"]
+include = ["src/**", "concepts/**", "README.md", "LICENSE*", "Cargo.toml"]
 
 [lib]
 name = "perl_corpus"
@@ -34,6 +34,7 @@ chrono = "0.4.42"
 proptest.workspace = true
 rand = "0.10.1"
 tracing.workspace = true
+toml = "0.9.8"
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/perl-corpus/concepts/incremental.toml
+++ b/crates/perl-corpus/concepts/incremental.toml
@@ -1,0 +1,133 @@
+# Durable concept registry seeds for perl-corpus.
+
+[[concepts]]
+id = "incremental.edit_inside_expression"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-incremental-parsing", "perl-parser"]
+risk_tags = ["incremental", "expressions"]
+[concepts.fixtures]
+floors = ["test_corpus/expressions_and_refs.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "incremental.edit_shifts_following_nodes"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-incremental-parsing", "perl-parser"]
+risk_tags = ["incremental", "positions"]
+[concepts.fixtures]
+floors = ["test_corpus/parser_stress_cases.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "incremental.edit_signature_parameter"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-incremental-parsing", "perl-parser"]
+risk_tags = ["incremental", "signatures"]
+[concepts.fixtures]
+floors = ["test_corpus/signatures_parameters_production_enhanced.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "incremental.edit_method_chain"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-incremental-parsing", "perl-parser"]
+risk_tags = ["incremental", "method_call"]
+[concepts.fixtures]
+floors = ["test_corpus/clean_class_method.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "incremental.edit_regex_delimiter"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-incremental-parsing", "perl-lexer"]
+risk_tags = ["incremental", "regex"]
+[concepts.fixtures]
+floors = ["test_corpus/advanced_regex.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = true
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "incremental.edit_heredoc_anchor"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-incremental-parsing", "perl-lexer"]
+risk_tags = ["incremental", "heredoc"]
+[concepts.fixtures]
+floors = ["test_corpus/heredoc_depth.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = true
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true

--- a/crates/perl-corpus/concepts/lexer.toml
+++ b/crates/perl-corpus/concepts/lexer.toml
@@ -1,0 +1,177 @@
+# Durable concept registry seeds for perl-corpus.
+
+[[concepts]]
+id = "lexer.regex.literal_vs_division"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-lexer"]
+risk_tags = ["ambiguity", "regex"]
+[concepts.fixtures]
+floors = ["test_corpus/advanced_regex.pl"]
+variants = ["test_corpus/edge_cases/ambiguous_syntax_scenarios.pl"]
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = true
+ast = false
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "lexer.regex.substitution_delimiters"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-lexer"]
+risk_tags = ["regex", "delimiter"]
+[concepts.fixtures]
+floors = ["test_corpus/advanced_regex.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = true
+ast = false
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "lexer.quote_like.q_braces"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-lexer"]
+risk_tags = ["quote_like"]
+[concepts.fixtures]
+floors = ["test_corpus/string_ops_edge_cases.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = true
+ast = false
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "lexer.quote_like.qq_parens"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-lexer"]
+risk_tags = ["quote_like"]
+[concepts.fixtures]
+floors = ["test_corpus/string_ops_edge_cases.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = true
+ast = false
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "lexer.quote_like.qw_words"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-lexer"]
+risk_tags = ["quote_like", "lists"]
+[concepts.fixtures]
+floors = ["test_corpus/string_ops_edge_cases.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = true
+ast = false
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "lexer.heredoc.basic"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-lexer"]
+risk_tags = ["heredoc"]
+[concepts.fixtures]
+floors = ["test_corpus/heredoc_depth.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = true
+ast = false
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "lexer.heredoc.indented"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-lexer"]
+risk_tags = ["heredoc"]
+[concepts.fixtures]
+floors = ["test_corpus/heredoc_depth.pl"]
+variants = ["test_corpus/edge_cases/unicode_encoding_edge_cases.pl"]
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = true
+ast = false
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "lexer.data_section.double_underscore_data"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-lexer"]
+risk_tags = ["data_section"]
+[concepts.fixtures]
+floors = ["test_corpus/basic_constructs.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = true
+ast = false
+spans = false
+[concepts.run]
+pr = true
+nightly = true
+release = true

--- a/crates/perl-corpus/concepts/parser.toml
+++ b/crates/perl-corpus/concepts/parser.toml
@@ -1,0 +1,309 @@
+# Durable concept registry seeds for perl-corpus.
+
+[[concepts]]
+id = "parser.package.declaration"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["declaration"]
+[concepts.fixtures]
+floors = ["test_corpus/packages_versions.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.sub.named"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["declaration"]
+[concepts.fixtures]
+floors = ["test_corpus/modern_perl_features.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.sub.anonymous"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["closures"]
+[concepts.fixtures]
+floors = ["test_corpus/expressions_and_refs.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.sub.signature"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["signatures"]
+[concepts.fixtures]
+floors = ["test_corpus/signatures_parameters_production_enhanced.pl"]
+variants = ["test_corpus/signatures_prototypes.pl"]
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.variable.my_our_local_state"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["variables"]
+[concepts.fixtures]
+floors = ["test_corpus/basic_constructs.pl"]
+variants = ["test_corpus/variable_list_declaration_comprehensive.pl"]
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.expression.fat_arrow"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["expressions"]
+[concepts.fixtures]
+floors = ["test_corpus/expressions_and_refs.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.expression.range"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["expressions"]
+[concepts.fixtures]
+floors = ["test_corpus/ternary_expressions_comprehensive.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.expression.word_operators"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["expressions"]
+[concepts.fixtures]
+floors = ["test_corpus/basic_constructs.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.hash.array_literals"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["literals"]
+[concepts.fixtures]
+floors = ["test_corpus/expressions_and_refs.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.method_call.arrow"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["method_call"]
+[concepts.fixtures]
+floors = ["test_corpus/clean_class_method.pl"]
+variants = ["test_corpus/gold/completion_method_arrow/fixture.pl"]
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.indirect_object_call"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["ambiguity", "calls"]
+[concepts.fixtures]
+floors = ["test_corpus/edge_cases/ambiguous_syntax_scenarios.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.control_flow.given_when"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["control_flow"]
+[concepts.fixtures]
+floors = ["test_corpus/given_when.pl"]
+variants = ["test_corpus/given_when_default_production_enhanced.pl"]
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.control_flow.try_catch"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["control_flow"]
+[concepts.fixtures]
+floors = ["test_corpus/try_catch.pl"]
+variants = ["test_corpus/try_catch_production_enhanced.pl"]
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.io.open_modes"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["io"]
+[concepts.fixtures]
+floors = ["test_corpus/open_modes_comprehensive.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true

--- a/crates/perl-corpus/concepts/positions.toml
+++ b/crates/perl-corpus/concepts/positions.toml
@@ -1,0 +1,133 @@
+# Durable concept registry seeds for perl-corpus.
+
+[[concepts]]
+id = "position.byte_span.basic"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-position-tracking", "perl-parser"]
+risk_tags = ["positions"]
+[concepts.fixtures]
+floors = ["test_corpus/basic_constructs.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = false
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "position.utf16.non_ascii"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-position-tracking", "perl-parser"]
+risk_tags = ["positions", "unicode"]
+[concepts.fixtures]
+floors = ["test_corpus/edge_cases/unicode_encoding_edge_cases.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = false
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "position.crlf.line_index"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-position-tracking", "perl-line-index"]
+risk_tags = ["positions", "crlf"]
+[concepts.fixtures]
+floors = []
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = false
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "position.heredoc.body_span"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-position-tracking", "perl-parser"]
+risk_tags = ["positions", "heredoc"]
+[concepts.fixtures]
+floors = ["test_corpus/heredoc_depth.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = false
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "position.regex.capture_groups"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-position-tracking", "perl-parser"]
+risk_tags = ["positions", "regex"]
+[concepts.fixtures]
+floors = ["test_corpus/advanced_regex.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = false
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "position.package_block_boundaries"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-position-tracking", "perl-parser"]
+risk_tags = ["positions", "declaration"]
+[concepts.fixtures]
+floors = ["test_corpus/packages_versions.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = false
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true

--- a/crates/perl-corpus/concepts/recovery.toml
+++ b/crates/perl-corpus/concepts/recovery.toml
@@ -1,0 +1,155 @@
+# Durable concept registry seeds for perl-corpus.
+
+[[concepts]]
+id = "parser.recovery.missing_closing_brace"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["recovery"]
+[concepts.fixtures]
+floors = ["test_corpus/edge_cases/error_recovery_edge_cases.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "recover"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.recovery.missing_paren"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["recovery"]
+[concepts.fixtures]
+floors = ["test_corpus/edge_cases/error_recovery_edge_cases.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "recover"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.recovery.unclosed_quote"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["recovery", "quote_like"]
+[concepts.fixtures]
+floors = ["test_corpus/edge_cases/error_recovery_edge_cases.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "recover"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.recovery.malformed_signature"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["recovery", "signatures"]
+[concepts.fixtures]
+floors = ["test_corpus/edge_cases/error_recovery_edge_cases.pl"]
+variants = ["test_corpus/signatures_prototypes.pl"]
+[concepts.expect]
+panic = false
+timeout = false
+mode = "recover"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.recovery.bad_heredoc_terminator"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser", "perl-lexer"]
+risk_tags = ["recovery", "heredoc"]
+[concepts.fixtures]
+floors = ["test_corpus/heredoc_depth.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "recover"
+[concepts.snapshots]
+tokens = true
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.recovery.unexpected_fat_arrow_rhs"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["recovery", "expressions"]
+[concepts.fixtures]
+floors = ["test_corpus/edge_cases/error_recovery_edge_cases.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "recover"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "parser.recovery.missing_statement_terminator"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["recovery"]
+[concepts.fixtures]
+floors = ["test_corpus/edge_cases/error_recovery_edge_cases.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "recover"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true

--- a/crates/perl-corpus/concepts/tree_sitter.toml
+++ b/crates/perl-corpus/concepts/tree_sitter.toml
@@ -1,0 +1,133 @@
+# Durable concept registry seeds for perl-corpus.
+
+[[concepts]]
+id = "tree_sitter.parity.package_decl"
+status = "seeded"
+[concepts.scope]
+crates = ["tree-sitter-perl-rs", "perl-parser"]
+risk_tags = ["tree_sitter", "parity"]
+[concepts.fixtures]
+floors = ["test_corpus/packages_versions.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "compare"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = false
+nightly = true
+release = true
+
+[[concepts]]
+id = "tree_sitter.parity.sub_decl"
+status = "seeded"
+[concepts.scope]
+crates = ["tree-sitter-perl-rs", "perl-parser"]
+risk_tags = ["tree_sitter", "parity"]
+[concepts.fixtures]
+floors = ["test_corpus/modern_perl_features.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "compare"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = false
+nightly = true
+release = true
+
+[[concepts]]
+id = "tree_sitter.parity.method_call_arrow"
+status = "seeded"
+[concepts.scope]
+crates = ["tree-sitter-perl-rs", "perl-parser"]
+risk_tags = ["tree_sitter", "parity"]
+[concepts.fixtures]
+floors = ["test_corpus/clean_class_method.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "compare"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = false
+nightly = true
+release = true
+
+[[concepts]]
+id = "tree_sitter.parity.heredoc"
+status = "seeded"
+[concepts.scope]
+crates = ["tree-sitter-perl-rs", "perl-parser"]
+risk_tags = ["tree_sitter", "parity", "heredoc"]
+[concepts.fixtures]
+floors = ["test_corpus/heredoc_depth.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "compare"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = false
+nightly = true
+release = true
+
+[[concepts]]
+id = "tree_sitter.parity.regex_substitution"
+status = "seeded"
+[concepts.scope]
+crates = ["tree-sitter-perl-rs", "perl-parser"]
+risk_tags = ["tree_sitter", "parity", "regex"]
+[concepts.fixtures]
+floors = ["test_corpus/advanced_regex.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "compare"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = false
+nightly = true
+release = true
+
+[[concepts]]
+id = "tree_sitter.parity.given_when"
+status = "seeded"
+[concepts.scope]
+crates = ["tree-sitter-perl-rs", "perl-parser"]
+risk_tags = ["tree_sitter", "parity"]
+[concepts.fixtures]
+floors = ["test_corpus/given_when.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "compare"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = false
+nightly = true
+release = true

--- a/crates/perl-corpus/src/concepts.rs
+++ b/crates/perl-corpus/src/concepts.rs
@@ -1,0 +1,372 @@
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CONCEPTS_DIR: &str = "concepts";
+const ALLOWED_TOP_LEVEL_SECTIONS: &[&str] = &["concepts"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConceptRegistry {
+    pub concepts: Vec<ConceptRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptRow {
+    pub id: String,
+    pub status: ConceptStatus,
+    pub scope: ConceptScope,
+    pub fixtures: ConceptFixtures,
+    pub expect: ConceptExpect,
+    pub snapshots: ConceptSnapshots,
+    pub run: ConceptRun,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConceptStatus {
+    Seeded,
+    Active,
+    Planned,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptScope {
+    pub crates: Vec<String>,
+    pub risk_tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptFixtures {
+    pub floors: Vec<String>,
+    pub variants: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptExpect {
+    pub panic: bool,
+    pub timeout: bool,
+    pub mode: ConceptMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConceptMode {
+    Parse,
+    Recover,
+    Compare,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptSnapshots {
+    pub tokens: bool,
+    pub ast: bool,
+    pub spans: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConceptRun {
+    pub pr: bool,
+    pub nightly: bool,
+    pub release: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConceptFile {
+    concepts: Vec<ConceptRow>,
+}
+
+pub fn load_concept_registry() -> Result<ConceptRegistry> {
+    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = crate_root
+        .ancestors()
+        .nth(2)
+        .map(Path::to_path_buf)
+        .context("failed to derive workspace root")?;
+    load_concept_registry_from_dir(&crate_root.join(CONCEPTS_DIR), &repo_root)
+}
+
+pub fn load_concept_registry_from_dir(
+    concepts_dir: &Path,
+    fixture_root: &Path,
+) -> Result<ConceptRegistry> {
+    let mut files = collect_toml_files(concepts_dir)?;
+    files.sort();
+
+    let mut concepts = Vec::new();
+    for path in files {
+        concepts.extend(load_concepts_from_file(&path)?);
+    }
+
+    validate_registry(&concepts, fixture_root)?;
+    concepts.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(ConceptRegistry { concepts })
+}
+
+fn collect_toml_files(concepts_dir: &Path) -> Result<Vec<PathBuf>> {
+    let entries = fs::read_dir(concepts_dir).with_context(|| {
+        format!("failed to read concepts directory: {}", concepts_dir.display())
+    })?;
+
+    let mut files = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("toml") {
+            files.push(path);
+        }
+    }
+
+    if files.is_empty() {
+        bail!("no concept TOML files found in {}", concepts_dir.display());
+    }
+
+    Ok(files)
+}
+
+fn load_concepts_from_file(path: &Path) -> Result<Vec<ConceptRow>> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed to read concept file {}", path.display()))?;
+    let value: toml::Value = toml::from_str(&content)
+        .with_context(|| format!("failed to parse TOML in {}", path.display()))?;
+
+    validate_top_level_sections(path, &value)?;
+
+    let file: ConceptFile = value
+        .try_into()
+        .with_context(|| format!("invalid concept registry shape in {}", path.display()))?;
+    Ok(file.concepts)
+}
+
+fn validate_top_level_sections(path: &Path, value: &toml::Value) -> Result<()> {
+    let Some(table) = value.as_table() else {
+        bail!("concept file {} must contain a TOML table", path.display());
+    };
+
+    let allowed: HashSet<&str> = ALLOWED_TOP_LEVEL_SECTIONS.iter().copied().collect();
+    for key in table.keys() {
+        if !allowed.contains(key.as_str()) {
+            bail!(
+                "unknown top-level TOML section '{key}' in {} (allowed: concepts)",
+                path.display()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_registry(concepts: &[ConceptRow], fixture_root: &Path) -> Result<()> {
+    let mut seen: HashMap<&str, usize> = HashMap::new();
+    for (idx, concept) in concepts.iter().enumerate() {
+        if let Some(existing_idx) = seen.insert(&concept.id, idx) {
+            bail!("duplicate concept id '{}' at indexes {} and {}", concept.id, existing_idx, idx);
+        }
+
+        validate_fixture_paths(&concept.fixtures.floors, fixture_root, &concept.id, "floors")?;
+        validate_fixture_paths(&concept.fixtures.variants, fixture_root, &concept.id, "variants")?;
+    }
+
+    Ok(())
+}
+
+fn validate_fixture_paths(
+    paths: &[String],
+    fixture_root: &Path,
+    concept_id: &str,
+    fixture_kind: &str,
+) -> Result<()> {
+    for relative in paths {
+        let candidate = fixture_root.join(relative);
+        if !candidate.exists() {
+            bail!(
+                "fixture path '{}' ({} for concept '{}') does not exist under {}",
+                relative,
+                fixture_kind,
+                concept_id,
+                fixture_root.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_root(prefix: &str) -> Result<PathBuf> {
+        let mut root = std::env::temp_dir();
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
+        root.push(format!("{}_{}_{}", prefix, std::process::id(), nanos));
+        fs::create_dir_all(&root)?;
+        Ok(root)
+    }
+
+    #[test]
+    fn rejects_duplicate_concept_ids() -> Result<()> {
+        let root = temp_root("perl_corpus_concepts_dup")?;
+        let concepts_dir = root.join("concepts");
+        fs::create_dir_all(&concepts_dir)?;
+
+        fs::write(
+            concepts_dir.join("lexer.toml"),
+            r#"
+[[concepts]]
+id = "lexer.regex.duplicate"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-lexer"]
+risk_tags = ["lexing"]
+[concepts.fixtures]
+floors = []
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = true
+ast = false
+spans = false
+[concepts.run]
+pr = true
+nightly = true
+release = true
+
+[[concepts]]
+id = "lexer.regex.duplicate"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-lexer"]
+risk_tags = ["lexing"]
+[concepts.fixtures]
+floors = []
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = true
+ast = false
+spans = false
+[concepts.run]
+pr = true
+nightly = true
+release = true
+"#,
+        )?;
+
+        let err = load_concept_registry_from_dir(&concepts_dir, &root)
+            .expect_err("must fail duplicate ids");
+        assert!(err.to_string().contains("duplicate concept id"));
+
+        fs::remove_dir_all(&root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_missing_fixture_path() -> Result<()> {
+        let root = temp_root("perl_corpus_concepts_fixture")?;
+        let concepts_dir = root.join("concepts");
+        fs::create_dir_all(&concepts_dir)?;
+
+        fs::write(
+            concepts_dir.join("parser.toml"),
+            r#"
+[[concepts]]
+id = "parser.fixture.missing"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["parser"]
+[concepts.fixtures]
+floors = ["test_corpus/does_not_exist.pl"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+"#,
+        )?;
+
+        let err = load_concept_registry_from_dir(&concepts_dir, &root)
+            .expect_err("must fail missing fixture");
+        assert!(err.to_string().contains("does not exist"));
+
+        fs::remove_dir_all(&root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn loads_registry_deterministically() -> Result<()> {
+        let root = temp_root("perl_corpus_concepts_order")?;
+        let concepts_dir = root.join("concepts");
+        fs::create_dir_all(&concepts_dir)?;
+
+        fs::write(
+            concepts_dir.join("zeta.toml"),
+            concept_entry("parser.zeta", "test_corpus/basic_constructs.pl"),
+        )?;
+        fs::write(
+            concepts_dir.join("alpha.toml"),
+            concept_entry("lexer.alpha", "test_corpus/advanced_regex.pl"),
+        )?;
+        fs::create_dir_all(root.join("test_corpus"))?;
+        fs::write(root.join("test_corpus/basic_constructs.pl"), "print 1;\n")?;
+        fs::write(root.join("test_corpus/advanced_regex.pl"), "print 1;\n")?;
+
+        let registry = load_concept_registry_from_dir(&concepts_dir, &root)?;
+        let ids: Vec<&str> = registry.concepts.iter().map(|concept| concept.id.as_str()).collect();
+        assert_eq!(ids, vec!["lexer.alpha", "parser.zeta"]);
+
+        fs::remove_dir_all(&root)?;
+        Ok(())
+    }
+
+    fn concept_entry(id: &str, fixture: &str) -> String {
+        format!(
+            r#"
+[[concepts]]
+id = "{id}"
+status = "seeded"
+[concepts.scope]
+crates = ["perl-parser"]
+risk_tags = ["parser"]
+[concepts.fixtures]
+floors = ["{fixture}"]
+variants = []
+[concepts.expect]
+panic = false
+timeout = false
+mode = "parse"
+[concepts.snapshots]
+tokens = false
+ast = true
+spans = true
+[concepts.run]
+pr = true
+nightly = true
+release = true
+"#
+        )
+    }
+}

--- a/crates/perl-corpus/src/lib.rs
+++ b/crates/perl-corpus/src/lib.rs
@@ -221,6 +221,7 @@
 
 pub mod cases;
 pub mod codegen;
+pub mod concepts;
 pub mod continue_redo;
 pub mod files;
 pub mod format_statements;
@@ -240,6 +241,10 @@ pub use cases::{
 pub use codegen::{
     CodegenOptions, StatementKind, generate_perl_code, generate_perl_code_with_options,
     generate_perl_code_with_seed, generate_perl_code_with_statements,
+};
+pub use concepts::{
+    ConceptMode, ConceptRegistry, ConceptRow, ConceptStatus, load_concept_registry,
+    load_concept_registry_from_dir,
 };
 pub use continue_redo::{
     ContinueRedoCase, cases_by_tag as continue_redo_cases_by_tag, continue_redo_cases,


### PR DESCRIPTION
### Motivation
- Provide a durable concept-index for perl-corpus so corpus items can be classified by lexer/parser/recovery/position/incremental/tree-sitter concepts rather than just by file lists.
- Seed a first high-value lattice of concepts to guide future corpus indexing and test selection without enforcing parser behavior.

### Description
- Add a typed TOML-backed concept loader and validator at `crates/perl-corpus/src/concepts.rs` with public APIs `load_concept_registry` and `load_concept_registry_from_dir` and stable deterministic load ordering.
- Implement strict schema models and validations including no duplicate `id`s, only allowed top-level TOML sections, known enum shapes for `status`/`mode`, and fixture path existence checks.
- Ship six TOML registry files under `crates/perl-corpus/concepts/` (`lexer.toml`, `parser.toml`, `recovery.toml`, `positions.toml`, `incremental.toml`, `tree_sitter.toml`) seeding 47 concept rows (starter IDs from the brief plus additional high-value rows) and do not change parser runtime behavior.
- Wire the module into crate exports and packaging: add `pub mod concepts;`/`pub use concepts::{...}` in `src/lib.rs`, include `concepts/**` in `Cargo.toml`, and add the `toml` dependency required for parsing.

### Testing
- Ran `cargo test -p perl-corpus` and all tests passed, including new validator tests for duplicate IDs, missing fixture paths, and deterministic load ordering.
- Ran `cargo fmt --all` to ensure formatting changes; it completed successfully.
- `just pr-fast` is unavailable in this environment (`just: command not found`) and was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a65cf7748333bbaab0259e506039)