### PR TITLE
fix(ci): make parser corpus gating policy unambiguous (#0000)

### DIFF
--- a/.ci/GATE_REGISTRY.toml
+++ b/.ci/GATE_REGISTRY.toml
@@ -1,10 +1,12 @@
 # Gate Registry for perl-lsp
-# Defines all merge-blocking gates with thresholds and enforcement
+# Legacy gate metadata used by helper scripts under scripts/.
+# CI merge-gate enforcement is driven by `.ci/gate-policy.yaml` via
+# `cargo xtask gates` (see docs/reference/CI_ARCHITECTURE.md).
 
 [metadata]
 version = "1.0"
-last_updated = "2026-01-29"
-blocking_policy = "all-gates-must-pass"
+last_updated = "2026-04-28"
+blocking_policy = "legacy-script-registry"
 
 # ============================================================================
 # Merge-Blocking Gates (REQUIRED for all PRs)
@@ -110,7 +112,7 @@ failure_impact = "medium"  # Cost control
 id = "parser-corpus-ratchet"
 name = "Parser Corpus Ratchet (System)"
 type = "correctness"
-blocking = true
+blocking = false
 timeout_seconds = 180
 command = "cargo run -p xtask -- parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt"
 evidence_pattern = "Ratchet: all checks passed"
@@ -126,7 +128,7 @@ failure_impact = "high"
 id = "cpan-corpus-ratchet"
 name = "Parser Corpus Ratchet (CPAN)"
 type = "correctness"
-blocking = true
+blocking = false
 timeout_seconds = 300
 command = "cargo run -p xtask -- cpan-corpus sweep --enforce"
 evidence_pattern = "Ratchet: all checks passed"
@@ -142,7 +144,7 @@ failure_impact = "high"
 id = "parser-audit-closeout"
 name = "Parser Closeout Audit Ratchet"
 type = "correctness"
-blocking = true
+blocking = false
 timeout_seconds = 180
 command = "cargo run -p xtask -- corpus-audit --fresh --corpus-path . --check"
 evidence_pattern = "CI gate passed"

--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -333,8 +333,8 @@ gates:
 
   - name: parser_audit_closeout
     tier: merge_gate
-    description: "Project corpus parser closeout metrics (gaps, NodeKinds, recovery) must not regress"
-    required: true
+    description: "Project corpus parser closeout metrics (gaps, NodeKinds, recovery) are advisory until deterministic parser-ratchet v2 lands"
+    required: false
     command: >-
       cargo run --locked -p xtask
       -- corpus-audit --fresh --corpus-path . --check
@@ -348,6 +348,7 @@ gates:
       - parser
       - audit
       - ratchet
+      - advisory
 
   - name: security_audit
     tier: merge_gate

--- a/docs/reference/CI_ARCHITECTURE.md
+++ b/docs/reference/CI_ARCHITECTURE.md
@@ -24,6 +24,7 @@ Cluster. It answers:
 
 **Sources of truth:**
 - Gate definitions: `.ci/gate-policy.yaml`
+- Legacy script metadata: `.ci/GATE_REGISTRY.toml` (non-authoritative for merge blocking)
 - Workflow runner: `.github/workflows/ci.yml`
 - Scope classifier: `xtask/src/tasks/ci_scope.rs`
 - Gate runner: `xtask/src/tasks/gates.rs`
@@ -188,7 +189,6 @@ these blocks merge (via the `ci/merge-gate` commit status check):
 | `lsp_tier_a` | CLI smoke + capabilities snapshot + protocol tests | LSP capability correctness |
 | `lsp_tier_b` | Definitions, completion, color, code lens, security, behavioral | LSP core behavior |
 | `common_corpus_clean` | `xtask parser-corpus-sweep --manifest --enforce` | Common Perl modules parse with zero errors |
-| `parser_audit_closeout` | `xtask corpus-audit --fresh --check` | Corpus parser metrics do not regress |
 | `security_audit` | `cargo audit --deny warnings` | Known CVEs in dependencies |
 | `policy_checks` | Version sync + docs baseline + features invariants | Project policy invariants |
 | `docs_build` | `cargo doc -p perl-parser -p perl-lsp-rs` | Documentation builds without errors |
@@ -207,6 +207,7 @@ These gates have `required: false`. Failures produce signal and are tracked in
 |------|-------------|
 | `parser_corpus_ratchet` | Baseline drifts with runner Perl version (Ubuntu Perl updates produce environmental false positives) |
 | `cpan_corpus_ratchet` | CPAN corpus not installed on PR runners; owned by post-merge cron |
+| `parser_audit_closeout` | Historical corpus/environment coupling; advisory until deterministic parser-ratchet producer replaces closeout gate |
 | `security_audit` | Currently quarantined: `cargo-audit` ecosystem breakage as of 2026-04-26 |
 | `published_crate_count` | Quarantined until collapse completes (~30–31 target crates) |
 | All `nightly` gates | Informational by tier definition |

--- a/justfile
+++ b/justfile
@@ -971,6 +971,14 @@ gates-json tier='merge-gate':
 gates-list:
     @cargo xtask gates --list
 
+# Validate effective policy invariants (authoritative gate-policy + legacy registry parity).
+gate-policy-check:
+    @cargo xtask gate-policy check
+
+# Show effective policy for a profile (default: pr).
+gate-policy-effective profile='pr':
+    @cargo xtask gate-policy effective --profile {{profile}}
+
 # Run old shell-based gate runner (deprecated, kept for compatibility)
 gates-legacy:
     @echo "🧾 Running legacy gate runner..."

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,6 +12,7 @@ mod types;
 mod utils;
 use tasks::check_test_wiring;
 use tasks::dead_code::{DeadCodeConfig, DeadCodeMode};
+use tasks::gate_policy::GatePolicyCommand;
 use tasks::gates::{GateTier, OutputFormat as GatesOutputFormat};
 use tasks::methodology_gate::MethodologyOutputFormat;
 use tasks::metrics;
@@ -1162,6 +1163,12 @@ enum Commands {
         verbose: bool,
     },
 
+    /// Inspect and validate effective gate policy profiles.
+    GatePolicy {
+        #[command(subcommand)]
+        command: GatePolicyCommand,
+    },
+
     /// Detect contradictory PR label states and emit a methodology receipt.
     MethodologyGate {
         /// Fixture JSON file (local snapshot or GitHub event payload).
@@ -2107,6 +2114,7 @@ fn main() -> Result<()> {
             parallel,
             verbose,
         }),
+        Commands::GatePolicy { command } => gate_policy::run(command),
         Commands::GateReceipts { command } => match command {
             GateReceiptsCommand::List { format } => {
                 gate_receipts::list(convert_gate_receipts_format(format))

--- a/xtask/src/tasks/gate_policy.rs
+++ b/xtask/src/tasks/gate_policy.rs
@@ -1,0 +1,227 @@
+use color_eyre::eyre::{Context, ContextCompat, Result, bail};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use crate::utils::project_root;
+
+#[derive(Clone, Debug, clap::Subcommand)]
+pub enum GatePolicyCommand {
+    /// Validate that authoritative gate-policy and legacy registry do not disagree on parser corpus blocking.
+    Check,
+    /// Print effective gate policy for a profile.
+    Effective {
+        /// Policy profile to render.
+        #[arg(long, value_enum, default_value = "pr")]
+        profile: GatePolicyProfile,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum GatePolicyProfile {
+    /// Pull-request effective gates (pr_fast + merge_gate).
+    Pr,
+    /// Nightly effective gates.
+    Nightly,
+    /// Release effective gates.
+    Release,
+}
+
+#[derive(Debug, Deserialize)]
+struct GatePolicyDoc {
+    gates: Vec<GatePolicyGate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GatePolicyGate {
+    name: String,
+    tier: String,
+    required: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryDoc {
+    gate: Vec<RegistryGate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryGate {
+    id: String,
+    blocking: bool,
+}
+
+#[derive(Debug, Clone)]
+struct EffectiveGate {
+    name: String,
+    tier: String,
+    required: bool,
+}
+
+pub fn run(command: GatePolicyCommand) -> Result<()> {
+    match command {
+        GatePolicyCommand::Check => check(),
+        GatePolicyCommand::Effective { profile } => effective(profile),
+    }
+}
+
+fn check() -> Result<()> {
+    let root = project_root()?;
+    let policy = load_policy(&root.join(".ci/gate-policy.yaml"))?;
+    let registry = load_registry(&root.join(".ci/GATE_REGISTRY.toml"))?;
+
+    let effective = effective_gates_for_profile(&policy, &GatePolicyProfile::Pr);
+    let effective_map: HashMap<&str, bool> =
+        effective.iter().map(|gate| (gate.name.as_str(), gate.required)).collect();
+
+    // Canonical PR corpus policy expectations.
+    assert_gate_required(&effective_map, "common_corpus_clean", true)?;
+    assert_gate_required(&effective_map, "cpan_corpus_ratchet", false)?;
+    assert_gate_required(&effective_map, "parser_corpus_ratchet", false)?;
+
+    let registry_expectations = [
+        ("cpan-corpus-ratchet", false),
+        ("parser-corpus-ratchet", false),
+        ("parser-audit-closeout", false),
+    ];
+
+    for (id, expected_blocking) in registry_expectations {
+        let gate = registry
+            .gate
+            .iter()
+            .find(|gate| gate.id == id)
+            .with_context(|| format!("missing '{id}' in .ci/GATE_REGISTRY.toml"))?;
+        if gate.blocking != expected_blocking {
+            bail!(
+                "registry mismatch for '{id}': blocking={} expected={}",
+                gate.blocking,
+                expected_blocking
+            );
+        }
+    }
+
+    println!("✅ gate-policy check passed");
+    println!("   source of truth: .ci/gate-policy.yaml (consumed by cargo xtask gates)");
+    println!("   legacy registry parity: parser/corpus blocking flags aligned");
+    Ok(())
+}
+
+fn effective(profile: GatePolicyProfile) -> Result<()> {
+    let root = project_root()?;
+    let policy = load_policy(&root.join(".ci/gate-policy.yaml"))?;
+    let gates = effective_gates_for_profile(&policy, &profile);
+
+    println!("profile: {}", profile_label(&profile));
+    println!("source_of_truth: .ci/gate-policy.yaml");
+    for gate in gates {
+        let status = if gate.required { "required" } else { "advisory" };
+        println!("- {} [{}] ({})", gate.name, gate.tier, status);
+    }
+
+    Ok(())
+}
+
+fn assert_gate_required(
+    effective_map: &HashMap<&str, bool>,
+    gate_name: &str,
+    expected_required: bool,
+) -> Result<()> {
+    let required = effective_map
+        .get(gate_name)
+        .copied()
+        .with_context(|| format!("missing '{gate_name}' in effective PR profile"))?;
+    if required != expected_required {
+        bail!(
+            "effective policy mismatch for '{gate_name}': required={} expected={}",
+            required,
+            expected_required
+        );
+    }
+    Ok(())
+}
+
+fn effective_gates_for_profile(
+    policy: &GatePolicyDoc,
+    profile: &GatePolicyProfile,
+) -> Vec<EffectiveGate> {
+    policy
+        .gates
+        .iter()
+        .filter(|gate| match profile {
+            GatePolicyProfile::Pr => gate.tier == "pr_fast" || gate.tier == "merge_gate",
+            GatePolicyProfile::Nightly => gate.tier == "nightly",
+            GatePolicyProfile::Release => gate.tier == "release",
+        })
+        .map(|gate| EffectiveGate {
+            name: gate.name.clone(),
+            tier: gate.tier.clone(),
+            required: gate.required,
+        })
+        .collect()
+}
+
+fn profile_label(profile: &GatePolicyProfile) -> &'static str {
+    match profile {
+        GatePolicyProfile::Pr => "pr",
+        GatePolicyProfile::Nightly => "nightly",
+        GatePolicyProfile::Release => "release",
+    }
+}
+
+fn load_policy(path: &Path) -> Result<GatePolicyDoc> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed to read policy file {}", path.display()))?;
+    let policy = serde_yaml_ng::from_str::<GatePolicyDoc>(&content)
+        .with_context(|| format!("failed to parse policy file {}", path.display()))?;
+    Ok(policy)
+}
+
+fn load_registry(path: &Path) -> Result<RegistryDoc> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed to read registry file {}", path.display()))?;
+    let registry = toml::from_str::<RegistryDoc>(&content)
+        .with_context(|| format!("failed to parse registry file {}", path.display()))?;
+    Ok(registry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pr_profile_keeps_common_required_and_cpan_advisory() {
+        let policy = GatePolicyDoc {
+            gates: vec![
+                GatePolicyGate {
+                    name: "common_corpus_clean".to_string(),
+                    tier: "merge_gate".to_string(),
+                    required: true,
+                },
+                GatePolicyGate {
+                    name: "cpan_corpus_ratchet".to_string(),
+                    tier: "merge_gate".to_string(),
+                    required: false,
+                },
+                GatePolicyGate {
+                    name: "fmt".to_string(),
+                    tier: "pr_fast".to_string(),
+                    required: true,
+                },
+                GatePolicyGate {
+                    name: "nightly_only".to_string(),
+                    tier: "nightly".to_string(),
+                    required: false,
+                },
+            ],
+        };
+
+        let effective = effective_gates_for_profile(&policy, &GatePolicyProfile::Pr);
+        let by_name: HashMap<&str, bool> =
+            effective.iter().map(|gate| (gate.name.as_str(), gate.required)).collect();
+
+        assert_eq!(by_name.get("common_corpus_clean"), Some(&true));
+        assert_eq!(by_name.get("cpan_corpus_ratchet"), Some(&false));
+        assert_eq!(by_name.get("fmt"), Some(&true));
+        assert_eq!(by_name.get("nightly_only"), None);
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -44,6 +44,7 @@ pub mod fix_forward;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;
+pub mod gate_policy;
 pub mod gate_receipts;
 pub mod gates;
 pub mod generated_files;


### PR DESCRIPTION
### Motivation
- Make the effective PR gating policy unambiguous for parser/corpus checks so CPAN/system ratchets cannot accidentally block ordinary PRs.
- Keep `common_corpus_clean` as the strict PR/merge blocker while demoting environment-sensitive corpus checks to advisory until a deterministic ratchet producer exists.
- Ensure legacy helper scripts that read `.ci/GATE_REGISTRY.toml` cannot be relied on as the authoritative merge-blocking source.
- Provide an automated check and an "effective" view so the authoritative policy and the legacy registry remain aligned.

### Description
- Demote parser closeout ratchet to advisory in the authoritative policy by setting `parser_audit_closeout` to `required: false` and updating its description in `.ci/gate-policy.yaml`.
- Document that `.ci/GATE_REGISTRY.toml` is legacy/non-authoritative and set `blocking = false` for `parser-corpus-ratchet`, `cpan-corpus-ratchet`, and `parser-audit-closeout` to avoid stale registry wiring interpreting them as PR-blocking.
- Add a new xtask command `gate-policy` implemented in `xtask/src/tasks/gate_policy.rs` that provides `check` and `effective` subcommands to validate invariants and print the effective profile view.
- Wire the new command into `xtask` (`xtask/src/main.rs`, `xtask/src/tasks/mod.rs`) and add `just` helpers (`gate-policy-check`, `gate-policy-effective`) and doc updates to `docs/reference/CI_ARCHITECTURE.md` explaining that `.ci/gate-policy.yaml` is authoritative.
- Include a focused unit test in the new module to assert PR-profile expectations (keeps `common_corpus_clean` required and `cpan_corpus_ratchet` advisory).

### Testing
- Ran `cargo xtask gate-policy check` and it succeeded (verifies authoritative policy + legacy registry parity).
- Ran `cargo xtask gate-policy effective --profile pr` and it printed the expected effective PR profile showing `common_corpus_clean` required and CPAN/system ratchets advisory.
- Ran `cargo test -p xtask gate_policy` and the unit test passed.
- Ran `cargo xtask fmt` and `cargo check -p xtask` as part of verification; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a651fa6c83339ed04efe659442f8)