### PR TITLE
refactor(xtask): expose parser corpus sweep primitives (#0000)

### DIFF
--- a/xtask/src/tasks/parser_corpus_sweep.rs
+++ b/xtask/src/tasks/parser_corpus_sweep.rs
@@ -140,6 +140,42 @@ pub struct SweepConfig {
     pub receipt: bool,
 }
 
+/// Manifest-backed corpus discovery configuration.
+#[derive(Debug, Clone)]
+pub struct CorpusManifest {
+    /// Manifest file listing module names.
+    pub path: PathBuf,
+    /// Extra lookup roots used during module resolution.
+    pub perl5lib: Vec<PathBuf>,
+    /// Minimum number of modules that must resolve.
+    pub min_resolved: usize,
+}
+
+/// Corpus source variants reused by sweep orchestration.
+#[derive(Debug, Clone)]
+pub enum CorpusSource {
+    RepoOwned,
+    CiBoxSystemPerl,
+    CpanTopN,
+}
+
+/// Infer corpus source kind from sweep configuration.
+pub fn infer_corpus_source(config: &SweepConfig) -> CorpusSource {
+    if config.manifest_path.is_some() {
+        CorpusSource::RepoOwned
+    } else if config.corpus_profile.as_deref().is_some_and(|profile| profile.contains("cpan")) {
+        CorpusSource::CpanTopN
+    } else {
+        CorpusSource::CiBoxSystemPerl
+    }
+}
+
+/// Parser measurement controls reused by higher-level orchestration.
+#[derive(Debug, Clone)]
+pub struct MeasureOptions {
+    pub verbose: bool,
+}
+
 /// Overall sweep report (serialized to JSON)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SweepReport {
@@ -241,6 +277,17 @@ fn default_corpus_profile() -> String {
 
 fn receipt_path_for_profile(profile: &str) -> PathBuf {
     PathBuf::from(format!("target/receipts/{profile}-corpus-sweep.json"))
+}
+
+/// Serialize and write a corpus sweep receipt for the provided profile.
+pub fn write_sweep_receipt(report: &SweepReport, profile: &str) -> Result<PathBuf> {
+    let receipt_path = receipt_path_for_profile(profile);
+    if let Some(parent) = receipt_path.parent() {
+        fs::create_dir_all(parent).context("Failed to create receipt directory")?;
+    }
+    let json = serde_json::to_string_pretty(report).context("Failed to serialize receipt")?;
+    fs::write(&receipt_path, json).context("Failed to write receipt file")?;
+    Ok(receipt_path)
 }
 
 fn default_perl_version() -> String {
@@ -469,6 +516,21 @@ pub fn resolve_manifest_modules(
     Ok(resolved)
 }
 
+/// Discover corpus files from a manifest configuration.
+pub fn discover_manifest(manifest: &CorpusManifest) -> Result<Vec<PathBuf>> {
+    resolve_manifest_modules(&manifest.path, &manifest.perl5lib, manifest.min_resolved)
+}
+
+/// Discover parser corpus files from repo-owned roots.
+pub fn discover_repo_corpus(roots: &[PathBuf]) -> Vec<PathBuf> {
+    discover_pm_files(roots)
+}
+
+/// Discover parser corpus files from system Perl roots.
+pub fn discover_system_perl(roots: &[PathBuf]) -> Vec<PathBuf> {
+    discover_pm_files(roots)
+}
+
 fn resolve_module_in_roots(module: &str, roots: &[PathBuf]) -> Option<PathBuf> {
     let relative = PathBuf::from(format!("{}.pm", module.replace("::", "/")));
     roots.iter().map(|root| root.join(&relative)).find(|candidate| candidate.exists())
@@ -653,41 +715,16 @@ fn compute_median_error_density(measurements: &[FileMeasurement]) -> Option<f64>
     Some(median)
 }
 
-/// Run the corpus sweep with the given configuration
-pub fn run(config: SweepConfig) -> Result<()> {
+/// Measure parser behavior across a fixed set of `.pm` files and produce a report.
+pub fn measure_manifest(
+    pm_files: &[PathBuf],
+    corpus_profile: &str,
+    corpus_roots: Vec<String>,
+    resolved_roots_count: usize,
+    options: &MeasureOptions,
+) -> SweepReport {
     let start_time = Instant::now();
 
-    // Determine corpus profile and file list
-    let default_profile =
-        if config.manifest_path.is_some() { "common".to_string() } else { "system".to_string() };
-    let corpus_profile = config.corpus_profile.clone().unwrap_or(default_profile);
-
-    let discovery_start = Instant::now();
-    let pm_files = if let Some(ref manifest) = config.manifest_path {
-        resolve_manifest_modules(manifest, &config.manifest_perl5lib, 6)?
-    } else {
-        discover_pm_files(&config.corpus_roots)
-    };
-    let discovery_ms = discovery_start.elapsed().as_millis() as u64;
-
-    let use_manifest = config.manifest_path.is_some();
-    if pm_files.is_empty() {
-        if use_manifest {
-            println!("No modules resolved from manifest.");
-        } else {
-            println!("No .pm files found in specified roots.");
-            println!("Searched: {:?}", config.corpus_roots);
-        }
-        return Ok(());
-    }
-
-    if use_manifest {
-        println!("Resolved {} modules from manifest", pm_files.len());
-    } else {
-        println!("Found {} .pm files across {} roots", pm_files.len(), config.corpus_roots.len());
-    }
-
-    // Parse each file
     let progress = ProgressBar::new(pm_files.len() as u64);
     progress.set_style(
         ProgressStyle::default_bar()
@@ -710,19 +747,11 @@ pub fn run(config: SweepConfig) -> Result<()> {
     let mut first_error_buckets: BTreeMap<String, usize> = BTreeMap::new();
     let mut files_by_bucket: BTreeMap<String, Vec<String>> = BTreeMap::new();
     let mut file_results: Vec<FileResult> = Vec::new();
-
-    // Phase-timing accumulators (nanoseconds to avoid rounding when summing
-    // many small per-file durations; converted to ms once at the end).
     let mut file_io_ns: u128 = 0;
     let mut parse_ns: u128 = 0;
-
-    // Per-file measurements used to build the slowest-file report and to
-    // compute median error density per 1k LOC. Kept in memory always (not
-    // gated by verbose) so receipts can include the derived aggregates
-    // without paying the verbose-serialization cost.
     let mut measurements: Vec<FileMeasurement> = Vec::with_capacity(pm_files.len());
 
-    for path in &pm_files {
+    for path in pm_files {
         total_files += 1;
         let portable_path = portable_report_path(path);
         progress.set_message(
@@ -737,7 +766,7 @@ pub fn run(config: SweepConfig) -> Result<()> {
             Ok(s) => s,
             Err(_) => {
                 files_unreadable += 1;
-                if config.verbose {
+                if options.verbose {
                     file_results.push(FileResult {
                         path: portable_path.clone(),
                         status: "unreadable".to_string(),
@@ -754,8 +783,6 @@ pub fn run(config: SweepConfig) -> Result<()> {
         };
 
         let line_count = source.lines().count();
-
-        // Parse — wall-time the parse call itself (post-read).
         let parse_start = Instant::now();
         let mut parser = Parser::new(&source);
         let parse_result = parser.parse();
@@ -766,7 +793,6 @@ pub fn run(config: SweepConfig) -> Result<()> {
         let ast = match parse_result {
             Ok(ast) => ast,
             Err(_) => {
-                // Catastrophic failure (recursion limit etc.) — separate from AST ERROR nodes.
                 files_with_errors += 1;
                 total_dirty_files += 1;
                 files_with_catastrophic_parse_failure += 1;
@@ -776,7 +802,7 @@ pub fn run(config: SweepConfig) -> Result<()> {
                     line_count,
                     error_node_count: 0,
                 });
-                if config.verbose {
+                if options.verbose {
                     file_results.push(FileResult {
                         path: portable_path.clone(),
                         status: "catastrophic".to_string(),
@@ -794,7 +820,6 @@ pub fn run(config: SweepConfig) -> Result<()> {
 
         let errors: Vec<ParseError> = parser.errors().to_vec();
         let salvage = RecoverySalvageProfile::from_parse(&ast, &errors, false);
-
         measurements.push(FileMeasurement {
             path: portable_path.clone(),
             parse_duration_ms,
@@ -806,7 +831,7 @@ pub fn run(config: SweepConfig) -> Result<()> {
         match salvage.class {
             RecoverySalvageClass::Clean => {
                 clean_files += 1;
-                if config.verbose {
+                if options.verbose {
                     file_results.push(FileResult {
                         path: portable_path.clone(),
                         status: "clean".to_string(),
@@ -822,7 +847,7 @@ pub fn run(config: SweepConfig) -> Result<()> {
                 files_with_errors += 1;
                 total_dirty_files += 1;
                 files_with_structured_recovery_only += 1;
-                if config.verbose {
+                if options.verbose {
                     file_results.push(FileResult {
                         path: portable_path.clone(),
                         status: "recovered".to_string(),
@@ -844,7 +869,7 @@ pub fn run(config: SweepConfig) -> Result<()> {
                 *first_unrecovered_error_node_buckets.entry(bucket.clone()).or_default() += 1;
                 *first_error_buckets.entry(bucket.clone()).or_default() += 1;
                 files_by_bucket.entry(bucket.clone()).or_default().push(portable_path.clone());
-                if config.verbose {
+                if options.verbose {
                     file_results.push(FileResult {
                         path: portable_path.clone(),
                         status: "errors".to_string(),
@@ -857,11 +882,6 @@ pub fn run(config: SweepConfig) -> Result<()> {
                 }
             }
             RecoverySalvageClass::CatastrophicFailure => {
-                // This arm is unreachable in this branch: `from_parse` is always
-                // called with `catastrophic=false` here.  True catastrophic failures
-                // are handled above via the `Err(_)` arm which calls `continue`.
-                // Keeping the arm to satisfy the exhaustive match; clippy will flag
-                // it as unreachable if the enum ever gains a structural invariant.
                 files_with_errors += 1;
                 total_dirty_files += 1;
                 files_with_catastrophic_parse_failure += 1;
@@ -870,14 +890,11 @@ pub fn run(config: SweepConfig) -> Result<()> {
 
         progress.inc(1);
     }
-
     progress.finish_and_clear();
 
     let elapsed = start_time.elapsed();
-    let commit = get_git_commit();
-
     let phase_timings = PhaseTimings {
-        discovery_ms,
+        discovery_ms: 0,
         file_io_ms: (file_io_ns / 1_000_000) as u64,
         parse_ms: (parse_ns / 1_000_000) as u64,
         total_ms: elapsed.as_millis() as u64,
@@ -890,17 +907,13 @@ pub fn run(config: SweepConfig) -> Result<()> {
     };
     let slowest_files = top_n_slowest(&measurements, SLOWEST_FILES_LIMIT);
 
-    let report = SweepReport {
+    SweepReport {
         schema_version: "1.3.0".to_string(),
-        commit,
+        commit: get_git_commit(),
         timestamp: chrono::Utc::now().to_rfc3339(),
-        corpus_profile: corpus_profile.clone(),
-        corpus_roots: if use_manifest {
-            vec![config.manifest_path.as_ref().map(|p| portable_report_path(p)).unwrap_or_default()]
-        } else {
-            config.base_roots.iter().map(|p| portable_report_path(p)).collect()
-        },
-        resolved_roots_count: if use_manifest { pm_files.len() } else { config.corpus_roots.len() },
+        corpus_profile: corpus_profile.to_string(),
+        corpus_roots,
+        resolved_roots_count,
         perl_version: get_perl_version(),
         total_files,
         files_unreadable,
@@ -915,13 +928,74 @@ pub fn run(config: SweepConfig) -> Result<()> {
         first_unrecovered_error_node_buckets,
         first_error_buckets,
         files_by_bucket,
-        file_results: if config.verbose { file_results } else { Vec::new() },
+        file_results: if options.verbose { file_results } else { Vec::new() },
         elapsed_secs: elapsed.as_secs_f64(),
         phase_timings: Some(phase_timings),
         median_error_density_per_1k_loc,
         recovery_salvage_rate,
         slowest_files,
+    }
+}
+
+/// Run the corpus sweep with the given configuration
+pub fn run(config: SweepConfig) -> Result<()> {
+    let start_time = Instant::now();
+    let source = infer_corpus_source(&config);
+
+    // Determine corpus profile and file list
+    let default_profile =
+        if config.manifest_path.is_some() { "common".to_string() } else { "system".to_string() };
+    let corpus_profile = config.corpus_profile.clone().unwrap_or(default_profile);
+
+    let discovery_start = Instant::now();
+    let pm_files = if let Some(ref manifest) = config.manifest_path {
+        discover_manifest(&CorpusManifest {
+            path: manifest.clone(),
+            perl5lib: config.manifest_perl5lib.clone(),
+            min_resolved: 6,
+        })?
+    } else {
+        match source {
+            CorpusSource::CiBoxSystemPerl => discover_system_perl(&config.corpus_roots),
+            CorpusSource::RepoOwned | CorpusSource::CpanTopN => {
+                discover_repo_corpus(&config.corpus_roots)
+            }
+        }
     };
+    let discovery_ms = discovery_start.elapsed().as_millis() as u64;
+
+    let use_manifest = config.manifest_path.is_some();
+    if pm_files.is_empty() {
+        if use_manifest {
+            println!("No modules resolved from manifest.");
+        } else {
+            println!("No .pm files found in specified roots.");
+            println!("Searched: {:?}", config.corpus_roots);
+        }
+        return Ok(());
+    }
+
+    if use_manifest {
+        println!("Resolved {} modules from manifest", pm_files.len());
+    } else {
+        println!("Found {} .pm files across {} roots", pm_files.len(), config.corpus_roots.len());
+    }
+
+    let mut report = measure_manifest(
+        &pm_files,
+        &corpus_profile,
+        if use_manifest {
+            vec![config.manifest_path.as_ref().map(|p| portable_report_path(p)).unwrap_or_default()]
+        } else {
+            config.base_roots.iter().map(|p| portable_report_path(p)).collect()
+        },
+        if use_manifest { pm_files.len() } else { config.corpus_roots.len() },
+        &MeasureOptions { verbose: config.verbose },
+    );
+    if let Some(ref mut timings) = report.phase_timings {
+        timings.discovery_ms = discovery_ms;
+    }
+    report.elapsed_secs = start_time.elapsed().as_secs_f64();
 
     // Print summary
     print_summary(&report);
@@ -938,12 +1012,7 @@ pub fn run(config: SweepConfig) -> Result<()> {
 
     // Write receipt if requested
     if config.receipt {
-        let receipt_path = receipt_path_for_profile(&corpus_profile);
-        if let Some(parent) = receipt_path.parent() {
-            fs::create_dir_all(parent).context("Failed to create receipt directory")?;
-        }
-        let json = serde_json::to_string_pretty(&report).context("Failed to serialize receipt")?;
-        fs::write(&receipt_path, json).context("Failed to write receipt file")?;
+        let receipt_path = write_sweep_receipt(&report, &corpus_profile)?;
         eprintln!("Receipt written to: {}", receipt_path.display());
     }
 
@@ -997,7 +1066,7 @@ pub fn run(config: SweepConfig) -> Result<()> {
         }
 
         if config.enforce {
-            let violations = enforce_ratchet(&report, &baseline);
+            let violations = compare_reports(&report, &baseline);
             if !violations.is_empty() {
                 println!("\n--- Ratchet violations ---");
                 for v in &violations {
@@ -1084,6 +1153,11 @@ pub fn enforce_ratchet(report: &SweepReport, baseline: &SweepReport) -> Vec<Ratc
     }
 
     violations
+}
+
+/// Compare two reports with ratchet semantics.
+pub fn compare_reports(current: &SweepReport, baseline: &SweepReport) -> Vec<RatchetViolation> {
+    enforce_ratchet(current, baseline)
 }
 
 fn clean_rate(report: &SweepReport) -> f64 {
@@ -2187,6 +2261,26 @@ mod tests {
         assert_eq!(slowest[0].path, "alpha.pm");
         assert_eq!(slowest[1].path, "mu.pm");
         assert_eq!(slowest[2].path, "zeta.pm");
+    }
+
+    #[test]
+    fn test_measure_manifest_produces_report_in_memory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let file = tmp.path().join("example.pm");
+        fs::write(&file, "package Example;\n1;\n").expect("write fixture");
+
+        let report = measure_manifest(
+            &[file],
+            "repo-owned",
+            vec!["fixtures/corpus".to_string()],
+            1,
+            &MeasureOptions { verbose: false },
+        );
+
+        assert_eq!(report.corpus_profile, "repo-owned");
+        assert_eq!(report.total_files, 1);
+        assert_eq!(report.clean_files, 1);
+        assert_eq!(report.files_with_errors, 0);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Parser Ratchet should orchestrate existing corpus-sweep primitives instead of reimplementing discovery/measurement logic, so the sweep engine must be reusable as an API. 
- The existing `parser_corpus_sweep` implementation contained measurement and discovery logic tightly coupled to the CLI; extracting small primitives enables reuse without changing behavior or receipts.

### Description

- Added lightweight types `CorpusManifest`, `CorpusSource`, and `MeasureOptions` and an `infer_corpus_source` helper to encode corpus origin and measurement options. 
- Introduced discovery helpers `discover_manifest`, `discover_repo_corpus`, and `discover_system_perl` so callers can obtain file lists using the existing resolution logic. 
- Extracted the core in-memory measurement engine into `measure_manifest(...) -> SweepReport` and rewired `run(...)` to orchestrate discovery, measurement, and enforcement via the new primitives while preserving existing CLI semantics. 
- Added helpers `write_sweep_receipt(...)` and `compare_reports(...)` (thin wrappers around existing behavior) and a unit test proving `measure_manifest` can produce a `SweepReport` in memory without writing files.

### Testing

- Ran unit tests for the sweep module with `cargo test -p xtask parser_corpus_sweep` and the module tests passed (all tests OK). 
- Performed a full crate check with `cargo check --all-targets -p xtask` which succeeded. 
- Ran lints with `cargo clippy -p xtask -- -D warnings` which succeeded. 
- Ran formatter with `cargo xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a67b84808333bc5b336097ba67c4)