### PR TITLE
feat(xtask): add parser-ratchet scaffold producer (#0000)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -986,6 +986,12 @@ enum Commands {
         receipt: Option<PathBuf>,
     },
 
+    /// Parser ratchet receipt producer scaffold.
+    ParserRatchet {
+        #[command(subcommand)]
+        command: ParserRatchetCommand,
+    },
+
     /// Manage feature catalog and LSP compliance
     Features {
         #[command(subcommand)]
@@ -1598,6 +1604,28 @@ enum MetricsCommand {
 }
 
 #[derive(Subcommand)]
+enum ParserRatchetCommand {
+    /// Emit parser ratchet scaffold receipt.
+    Run {
+        /// Execution profile (pr/nightly/release).
+        #[arg(long, value_enum)]
+        profile: parser_ratchet::ParserRatchetProfile,
+        /// Explicit base revision (SHA or revspec).
+        #[arg(long)]
+        base: String,
+        /// Explicit head revision (SHA or revspec).
+        #[arg(long)]
+        head: String,
+        /// Output path for parser-ratchet receipt JSON.
+        #[arg(long)]
+        receipt: PathBuf,
+        /// Force selected=true while still emitting scaffold-only payload.
+        #[arg(long)]
+        force_selected: bool,
+    },
+}
+
+#[derive(Subcommand)]
 enum QueueCommand {
     /// Capture the open PR queue into a stable JSON snapshot document.
     Snapshot {
@@ -1929,6 +1957,17 @@ fn main() -> Result<()> {
                 receipt,
             })
         }
+        Commands::ParserRatchet { command } => match command {
+            ParserRatchetCommand::Run { profile, base, head, receipt, force_selected } => {
+                parser_ratchet::run(parser_ratchet::ParserRatchetRunArgs {
+                    profile,
+                    base,
+                    head,
+                    receipt,
+                    force_selected,
+                })
+            }
+        },
         Commands::CpanCorpus { command } => {
             let mut config = cpan_corpus::CpanCorpusConfig::default();
             match command {

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -62,6 +62,7 @@ pub mod metrics;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;
 pub mod parser_matrix;
+pub mod parser_ratchet;
 pub mod populate_book;
 pub mod prep_crates_io_launch;
 pub mod publication_facts;

--- a/xtask/src/tasks/parser_ratchet.rs
+++ b/xtask/src/tasks/parser_ratchet.rs
@@ -1,0 +1,204 @@
+use color_eyre::eyre::{Context, Result, bail};
+use serde::Serialize;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use super::gate_receipts;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
+pub enum ParserRatchetProfile {
+    Pr,
+    Nightly,
+    Release,
+}
+
+impl ParserRatchetProfile {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Pr => "pr",
+            Self::Nightly => "nightly",
+            Self::Release => "release",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ParserRatchetRunArgs {
+    pub profile: ParserRatchetProfile,
+    pub base: String,
+    pub head: String,
+    pub receipt: PathBuf,
+    pub force_selected: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ParserRatchetReceipt {
+    schema_version: &'static str,
+    check: &'static str,
+    event: &'static str,
+    profile: String,
+    base_sha: String,
+    head_sha: String,
+    selected: bool,
+    selection_reason: Vec<String>,
+    verdict: &'static str,
+    repro: Repro,
+}
+
+#[derive(Debug, Serialize)]
+struct Repro {
+    command: String,
+}
+
+pub fn run(args: ParserRatchetRunArgs) -> Result<()> {
+    let base_sha = resolve_commit(&args.base)?;
+    let head_sha = resolve_commit(&args.head)?;
+
+    let selected = args.force_selected;
+    let selection_reason = if args.force_selected {
+        vec!["force-selected (scaffold only)".to_string()]
+    } else {
+        vec!["not selected by ci-scope".to_string()]
+    };
+
+    let receipt = ParserRatchetReceipt {
+        schema_version: "1",
+        check: "parser-ratchet",
+        event: "local",
+        profile: args.profile.as_str().to_string(),
+        base_sha,
+        head_sha,
+        selected,
+        selection_reason,
+        verdict: "pass",
+        repro: Repro {
+            command: format!(
+                "cargo xtask parser-ratchet run --profile {} --base {} --head {} --receipt {}{}",
+                args.profile.as_str(),
+                args.base,
+                args.head,
+                args.receipt.display(),
+                if args.force_selected { " --force-selected" } else { "" }
+            ),
+        },
+    };
+
+    if let Some(parent) = args.receipt.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create receipt directory {}", parent.display()))?;
+    }
+
+    let serialized = serde_json::to_string_pretty(&receipt)?;
+    fs::write(&args.receipt, serialized)
+        .with_context(|| format!("failed to write receipt {}", args.receipt.display()))?;
+
+    if std::path::Path::new(".ci/receipts/registry.toml").exists() {
+        gate_receipts::validate(&args.receipt, gate_receipts::OutputFormat::Human).map_err(
+            |err| {
+                color_eyre::eyre::eyre!(
+                    "parser-ratchet receipt failed schema/registry validation: {}: {err}",
+                    args.receipt.display()
+                )
+            },
+        )?;
+    }
+
+    println!("Wrote parser-ratchet scaffold receipt: {}", args.receipt.display());
+    Ok(())
+}
+
+fn resolve_commit(revision: &str) -> Result<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", revision])
+        .output()
+        .with_context(|| format!("failed to run git rev-parse for '{revision}'"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("unable to resolve revision '{revision}': {}", stderr.trim());
+    }
+
+    let sha = String::from_utf8(output.stdout)
+        .with_context(|| format!("git rev-parse output was not valid UTF-8 for '{revision}'"))?;
+
+    Ok(sha.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn write_file(path: &Path, contents: &str) -> Result<()> {
+        fs::write(path, contents)
+            .with_context(|| format!("failed to write fixture file {}", path.display()))
+    }
+
+    fn git_in(repo: &Path, args: &[&str]) -> Result<()> {
+        let status = Command::new("git").args(args).current_dir(repo).status()?;
+        if status.success() {
+            Ok(())
+        } else {
+            bail!("git command failed in {}: git {:?}", repo.display(), args)
+        }
+    }
+
+    struct CwdGuard {
+        original: PathBuf,
+    }
+
+    impl CwdGuard {
+        fn enter(path: &Path) -> Result<Self> {
+            let original = std::env::current_dir()?;
+            std::env::set_current_dir(path)
+                .with_context(|| format!("failed to enter {}", path.display()))?;
+            Ok(Self { original })
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original);
+        }
+    }
+
+    #[test]
+    fn run_supports_detached_head_with_explicit_base_and_head() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let repo = temp.path();
+
+        git_in(repo, &["init"])?;
+        git_in(repo, &["config", "user.email", "parser-ratchet@example.com"])?;
+        git_in(repo, &["config", "user.name", "Parser Ratchet Test"])?;
+
+        write_file(&repo.join("fixture.txt"), "one\n")?;
+        git_in(repo, &["add", "fixture.txt"])?;
+        git_in(repo, &["commit", "-m", "first"])?;
+
+        write_file(&repo.join("fixture.txt"), "two\n")?;
+        git_in(repo, &["add", "fixture.txt"])?;
+        git_in(repo, &["commit", "-m", "second"])?;
+
+        git_in(repo, &["checkout", "--detach", "HEAD"])?;
+        let _cwd_guard = CwdGuard::enter(repo)?;
+
+        let receipt_path = repo.join("target/receipts/parser-ratchet.json");
+        run(ParserRatchetRunArgs {
+            profile: ParserRatchetProfile::Pr,
+            base: "HEAD~1".to_string(),
+            head: "HEAD".to_string(),
+            receipt: receipt_path.clone(),
+            force_selected: false,
+        })?;
+
+        let content = fs::read_to_string(&receipt_path)?;
+        let receipt: serde_json::Value = serde_json::from_str(&content)?;
+
+        assert_eq!(receipt.get("selected"), Some(&serde_json::Value::Bool(false)));
+        assert_eq!(receipt.get("verdict").and_then(serde_json::Value::as_str), Some("pass"));
+        assert_eq!(receipt.get("profile").and_then(serde_json::Value::as_str), Some("pr"));
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a dedicated, safe `parser-ratchet` producer command to emit a stable scaffold receipt from explicit `--base`/`--head` revisions without running CPAN installs, measurements, or enforcement.
- Ensure the command can run from a detached HEAD (no branch inference) and establish the receipt shape and surface for later measurement/enforcement work.

### Description

- Added a new xtask subcommand `cargo xtask parser-ratchet run` with flags `--profile` (enum: `pr|nightly|release`), `--base`, `--head`, `--receipt`, and `--force-selected`, wired into command dispatch in `xtask/src/main.rs`.
- Implemented the scaffold producer in a new module `xtask/src/tasks/parser_ratchet.rs` which resolves `--base`/`--head` to SHAs via `git rev-parse --verify`, builds a scaffold JSON receipt containing `schema_version`, `check`, `event`, `profile`, `base_sha`, `head_sha`, `selected`, `selection_reason`, `verdict`, and `repro.command`, and writes it to the requested `--receipt` path.
- Receipt emission defaults to `selected:false` and `verdict:pass`, and honors `--force-selected` to set `selected:true` while still emitting a scaffold-only payload (no measurements or CPAN paths are executed).
- When `.ci/receipts/registry.toml` exists, the producer validates the written receipt against the registry/schema using the existing `gate_receipts::validate` helper; otherwise validation is skipped.
- Registered the module in `xtask/src/tasks/mod.rs` and added a unit test `run_supports_detached_head_with_explicit_base_and_head` verifying operation from a detached HEAD using explicit `HEAD~1`/`HEAD` revisions.

### Testing

- Ran `cargo test -p xtask parser_ratchet`, which passed including the detached-HEAD unit test.
- Executed the scaffold end-to-end: `cargo xtask parser-ratchet run --profile pr --base HEAD~1 --head HEAD --receipt target/receipts/parser-ratchet.json` and observed a valid JSON receipt written and (when available) validated via the registry.
- Verified build and tooling: `cargo check --all-targets -p xtask`, `cargo xtask fmt`, and `cargo clippy -p xtask -- -D warnings` completed successfully in this environment.
- `just pr-fast` was not executed because the `just` tool is not installed in the runner environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a6810e2883339b1ef9dbbda79ba0)