### PR TITLE
feat(perl-corpus): add corpus fixture expectation sidecars (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "toml",
  "tracing",
 ]
 

--- a/crates/perl-corpus/Cargo.toml
+++ b/crates/perl-corpus/Cargo.toml
@@ -34,6 +34,7 @@ chrono = "0.4.42"
 proptest.workspace = true
 rand = "0.10.1"
 tracing.workspace = true
+toml = "1.1.2"
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/perl-corpus/src/fixture_expectations.rs
+++ b/crates/perl-corpus/src/fixture_expectations.rs
@@ -1,0 +1,314 @@
+use anyhow::{Context, Result, anyhow, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const META_TOML_SUFFIX: &str = ".meta.toml";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FixtureExpectation {
+    pub concept: ConceptSpec,
+    pub expect: ExpectSpec,
+    #[serde(default)]
+    pub metrics: MetricsSpec,
+    #[serde(default)]
+    pub snapshots: SnapshotSpec,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConceptSpec {
+    pub id: String,
+    pub tier: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExpectSpec {
+    pub panic: bool,
+    pub timeout: bool,
+    pub mode: ExpectationMode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExpectationMode {
+    ParseClean,
+    RecoverWithoutPanic,
+    ExpectedError,
+    TokenOnly,
+    SpanOnly,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct MetricsSpec {
+    pub max_error_nodes: Option<u32>,
+    #[serde(default)]
+    pub must_emit_node_kinds: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct SnapshotSpec {
+    #[serde(default)]
+    pub tokens: bool,
+    #[serde(default)]
+    pub ast: bool,
+    #[serde(default)]
+    pub spans: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SidecarFixture {
+    pub sidecar_path: PathBuf,
+    pub fixture_path: PathBuf,
+    pub expectation: FixtureExpectation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConceptRegistry {
+    ids: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationNote {
+    ConceptResolutionPending { concept_id: String },
+}
+
+impl ConceptRegistry {
+    pub fn from_ids<I>(ids: I) -> Self
+    where
+        I: IntoIterator<Item = String>,
+    {
+        Self { ids: ids.into_iter().collect() }
+    }
+
+    pub fn load_if_present(path: &Path) -> Result<Option<Self>> {
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let raw = fs::read_to_string(path)
+            .with_context(|| format!("reading concept registry {}", path.display()))?;
+        let parsed: ConceptRegistryFile = toml::from_str(&raw)
+            .with_context(|| format!("parsing concept registry {}", path.display()))?;
+
+        let ids: Vec<String> =
+            parsed.concept.into_iter().map(|item| item.id).chain(parsed.concepts).collect();
+
+        Ok(Some(Self::from_ids(ids)))
+    }
+
+    pub fn contains(&self, concept_id: &str) -> bool {
+        self.ids.contains(concept_id)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ConceptRegistryFile {
+    #[serde(default)]
+    concept: Vec<ConceptRegistryItem>,
+    #[serde(default)]
+    concepts: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConceptRegistryItem {
+    id: String,
+}
+
+pub fn parse_sidecar_file(path: &Path) -> Result<FixtureExpectation> {
+    let raw =
+        fs::read_to_string(path).with_context(|| format!("reading sidecar {}", path.display()))?;
+    let parsed =
+        toml::from_str(&raw).with_context(|| format!("parsing sidecar {}", path.display()))?;
+    Ok(parsed)
+}
+
+pub fn discover_sidecars(root: &Path) -> Vec<PathBuf> {
+    let mut sidecars = Vec::new();
+    if !root.exists() {
+        return sidecars;
+    }
+
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+
+        for entry in entries.flatten() {
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(_) => continue,
+            };
+            let path = entry.path();
+
+            if file_type.is_dir() {
+                stack.push(path);
+                continue;
+            }
+
+            if file_type.is_file()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with(META_TOML_SUFFIX))
+            {
+                sidecars.push(path);
+            }
+        }
+    }
+
+    sidecars.sort();
+    sidecars.dedup();
+    sidecars
+}
+
+pub fn validate_sidecar(
+    sidecar_path: &Path,
+    concept_registry: Option<&ConceptRegistry>,
+) -> Result<(SidecarFixture, Vec<ValidationNote>)> {
+    let expectation = parse_sidecar_file(sidecar_path)?;
+
+    let fixture_path = fixture_path_for_sidecar(sidecar_path)?;
+    if !fixture_path.exists() {
+        bail!("fixture {} missing for sidecar {}", fixture_path.display(), sidecar_path.display());
+    }
+
+    let mut notes = Vec::new();
+    if let Some(registry) = concept_registry {
+        if !registry.contains(&expectation.concept.id) {
+            bail!(
+                "concept id '{}' from {} not present in concept registry",
+                expectation.concept.id,
+                sidecar_path.display()
+            );
+        }
+    } else {
+        notes.push(ValidationNote::ConceptResolutionPending {
+            concept_id: expectation.concept.id.clone(),
+        });
+    }
+
+    Ok((
+        SidecarFixture { sidecar_path: sidecar_path.to_path_buf(), fixture_path, expectation },
+        notes,
+    ))
+}
+
+pub fn validate_sidecars_under(
+    sidecar_root: &Path,
+    concept_registry: Option<&ConceptRegistry>,
+) -> Result<(Vec<SidecarFixture>, Vec<ValidationNote>)> {
+    let sidecar_paths = discover_sidecars(sidecar_root);
+    if sidecar_paths.is_empty() {
+        return Err(anyhow!("no sidecars found under {}", sidecar_root.display()));
+    }
+
+    let mut fixtures = Vec::new();
+    let mut notes = Vec::new();
+    for sidecar_path in sidecar_paths {
+        let (fixture, mut sidecar_notes) = validate_sidecar(&sidecar_path, concept_registry)?;
+        fixtures.push(fixture);
+        notes.append(&mut sidecar_notes);
+    }
+
+    Ok((fixtures, notes))
+}
+
+fn fixture_path_for_sidecar(sidecar_path: &Path) -> Result<PathBuf> {
+    let Some(file_name) = sidecar_path.file_name().and_then(|name| name.to_str()) else {
+        bail!("sidecar {} missing filename", sidecar_path.display());
+    };
+
+    let Some(fixture_name) = file_name.strip_suffix(META_TOML_SUFFIX) else {
+        bail!("sidecar {} does not end with {}", sidecar_path.display(), META_TOML_SUFFIX);
+    };
+
+    Ok(sidecar_path.with_file_name(format!("{fixture_name}.pl")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_root(prefix: &str) -> std::io::Result<PathBuf> {
+        let mut root = std::env::temp_dir();
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
+        root.push(format!("{}_{}_{}", prefix, std::process::id(), nanos));
+        fs::create_dir_all(&root)?;
+        Ok(root)
+    }
+
+    fn write_sidecar(path: &Path, mode: &str, concept_id: &str) -> Result<()> {
+        fs::write(
+            path,
+            format!(
+                r#"[concept]
+id = "{concept_id}"
+tier = "pr"
+
+[expect]
+panic = false
+timeout = false
+mode = "{mode}"
+
+[snapshots]
+tokens = false
+ast = true
+spans = true
+"#
+            ),
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn validate_sidecar_accepts_known_mode_and_fixture_pair() -> Result<()> {
+        let root = temp_root("perl_corpus_sidecar")?;
+        let sidecar_path = root.join("missing_brace.meta.toml");
+        let fixture_path = root.join("missing_brace.pl");
+        fs::write(&fixture_path, "sub broken {\n")?;
+        write_sidecar(&sidecar_path, "recover_without_panic", "parser.recovery.missing_brace")?;
+
+        let registry = ConceptRegistry::from_ids(["parser.recovery.missing_brace".to_string()]);
+        let (_, notes) = validate_sidecar(&sidecar_path, Some(&registry))?;
+        assert!(notes.is_empty());
+
+        fs::remove_dir_all(&root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn validate_sidecar_reports_pending_concepts_without_registry() -> Result<()> {
+        let root = temp_root("perl_corpus_sidecar_pending")?;
+        let sidecar_path = root.join("regex.meta.toml");
+        let fixture_path = root.join("regex.pl");
+        fs::write(&fixture_path, "my $ratio = 6 / 3;\n")?;
+        write_sidecar(&sidecar_path, "parse_clean", "parser.ambiguity.regex_vs_division")?;
+
+        let (_, notes) = validate_sidecar(&sidecar_path, None)?;
+        assert_eq!(notes.len(), 1);
+        assert!(matches!(notes[0], ValidationNote::ConceptResolutionPending { .. }));
+
+        fs::remove_dir_all(&root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn validate_sidecar_rejects_unknown_mode() -> Result<()> {
+        let root = temp_root("perl_corpus_sidecar_invalid_mode")?;
+        let sidecar_path = root.join("invalid.meta.toml");
+        let fixture_path = root.join("invalid.pl");
+        fs::write(&fixture_path, "print \"ok\\n\";\n")?;
+        write_sidecar(&sidecar_path, "unknown_mode", "parser.test.invalid_mode")?;
+
+        let err =
+            validate_sidecar(&sidecar_path, None).expect_err("unknown mode must fail parsing");
+        assert!(err.to_string().contains("parsing sidecar"));
+
+        fs::remove_dir_all(&root)?;
+        Ok(())
+    }
+}

--- a/crates/perl-corpus/src/lib.rs
+++ b/crates/perl-corpus/src/lib.rs
@@ -223,6 +223,7 @@ pub mod cases;
 pub mod codegen;
 pub mod continue_redo;
 pub mod files;
+pub mod fixture_expectations;
 pub mod format_statements;
 pub mod r#gen;
 pub mod glob_expressions;
@@ -249,6 +250,10 @@ pub use continue_redo::{
 pub use files::{
     CORPUS_ROOT_ENV, CorpusFile, CorpusLayer, CorpusPaths, get_all_test_files, get_corpus_files,
     get_corpus_files_from, get_fuzz_files, get_test_files,
+};
+pub use fixture_expectations::{
+    ConceptRegistry, ExpectationMode, FixtureExpectation, SidecarFixture, ValidationNote,
+    discover_sidecars, parse_sidecar_file, validate_sidecar, validate_sidecars_under,
 };
 pub use format_statements::{
     FormatStatementCase, FormatStatementGenerator, find_format_case, format_statement_cases,

--- a/crates/perl-corpus/tests/fixture_sidecar_validation.rs
+++ b/crates/perl-corpus/tests/fixture_sidecar_validation.rs
@@ -1,0 +1,42 @@
+use perl_corpus::{ConceptRegistry, ValidationNote, validate_sidecars_under};
+use std::path::PathBuf;
+
+fn workspace_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for ancestor in manifest_dir.ancestors() {
+        let cargo_toml = ancestor.join("Cargo.toml");
+        if !cargo_toml.exists() {
+            continue;
+        }
+
+        if let Ok(contents) = std::fs::read_to_string(&cargo_toml)
+            && contents.contains("[workspace]")
+        {
+            return ancestor.to_path_buf();
+        }
+    }
+
+    manifest_dir
+}
+
+#[test]
+fn validates_seed_sidecars_without_hard_failing_when_registry_is_absent()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = workspace_root();
+    let sidecar_root = root.join("tests/perl-corpus");
+    let concept_registry_path = root.join("tests/perl-corpus/concepts.toml");
+
+    let concept_registry = ConceptRegistry::load_if_present(&concept_registry_path)?;
+    let (_fixtures, notes) = validate_sidecars_under(&sidecar_root, concept_registry.as_ref())?;
+
+    if concept_registry.is_none() {
+        assert!(!notes.is_empty(), "Expected concept resolution pending notes without registry");
+        assert!(
+            notes
+                .iter()
+                .all(|note| matches!(note, ValidationNote::ConceptResolutionPending { .. }))
+        );
+    }
+
+    Ok(())
+}

--- a/tests/perl-corpus/ambiguity/regex_vs_division.meta.toml
+++ b/tests/perl-corpus/ambiguity/regex_vs_division.meta.toml
@@ -1,0 +1,17 @@
+[concept]
+id = "parser.ambiguity.regex_vs_division"
+tier = "pr"
+
+[expect]
+panic = false
+timeout = false
+mode = "parse_clean"
+
+[metrics]
+max_error_nodes = 0
+must_emit_node_kinds = ["RegexMatch", "BinaryExpression"]
+
+[snapshots]
+tokens = true
+ast = true
+spans = false

--- a/tests/perl-corpus/ambiguity/regex_vs_division.pl
+++ b/tests/perl-corpus/ambiguity/regex_vs_division.pl
@@ -1,0 +1,5 @@
+my $ratio = 12 / 3;
+my $subject = "abc";
+if ($subject =~ /a.c/) {
+    print $ratio;
+}

--- a/tests/perl-corpus/heredoc/heredoc_and_data_section.meta.toml
+++ b/tests/perl-corpus/heredoc/heredoc_and_data_section.meta.toml
@@ -1,0 +1,17 @@
+[concept]
+id = "parser.heredoc.data_section"
+tier = "pr"
+
+[expect]
+panic = false
+timeout = false
+mode = "parse_clean"
+
+[metrics]
+max_error_nodes = 0
+must_emit_node_kinds = ["Heredoc", "DataSection"]
+
+[snapshots]
+tokens = false
+ast = true
+spans = true

--- a/tests/perl-corpus/heredoc/heredoc_and_data_section.pl
+++ b/tests/perl-corpus/heredoc/heredoc_and_data_section.pl
@@ -1,0 +1,9 @@
+my $doc = <<'END_TEXT';
+line one
+line two
+END_TEXT
+
+print $doc;
+
+__DATA__
+trailing data payload

--- a/tests/perl-corpus/quote_like/custom_delimiter.meta.toml
+++ b/tests/perl-corpus/quote_like/custom_delimiter.meta.toml
@@ -1,0 +1,17 @@
+[concept]
+id = "parser.quote_like.custom_delimiter"
+tier = "pr"
+
+[expect]
+panic = false
+timeout = false
+mode = "parse_clean"
+
+[metrics]
+max_error_nodes = 0
+must_emit_node_kinds = ["QuoteLike", "QwList"]
+
+[snapshots]
+tokens = true
+ast = true
+spans = true

--- a/tests/perl-corpus/quote_like/custom_delimiter.pl
+++ b/tests/perl-corpus/quote_like/custom_delimiter.pl
@@ -1,0 +1,3 @@
+my $single = q{alpha};
+my $double = qq!beta!;
+my @words = qw(one two three);

--- a/tests/perl-corpus/recovery/missing_closing_brace.meta.toml
+++ b/tests/perl-corpus/recovery/missing_closing_brace.meta.toml
@@ -1,0 +1,17 @@
+[concept]
+id = "parser.recovery.missing_closing_brace"
+tier = "pr"
+
+[expect]
+panic = false
+timeout = false
+mode = "recover_without_panic"
+
+[metrics]
+max_error_nodes = 2
+must_emit_node_kinds = ["SubDecl", "Block"]
+
+[snapshots]
+tokens = false
+ast = true
+spans = true

--- a/tests/perl-corpus/recovery/missing_closing_brace.pl
+++ b/tests/perl-corpus/recovery/missing_closing_brace.pl
@@ -1,0 +1,5 @@
+sub broken_recovery {
+    my $x = 1;
+    if ($x > 0) {
+        print "ok\n";
+# missing closing braces on purpose

--- a/tests/perl-corpus/spans/utf16_crlf_positions.meta.toml
+++ b/tests/perl-corpus/spans/utf16_crlf_positions.meta.toml
@@ -1,0 +1,17 @@
+[concept]
+id = "parser.spans.utf16_crlf_positions"
+tier = "pr"
+
+[expect]
+panic = false
+timeout = false
+mode = "span_only"
+
+[metrics]
+max_error_nodes = 0
+must_emit_node_kinds = ["String"]
+
+[snapshots]
+tokens = false
+ast = false
+spans = true

--- a/tests/perl-corpus/spans/utf16_crlf_positions.pl
+++ b/tests/perl-corpus/spans/utf16_crlf_positions.pl
@@ -1,0 +1,3 @@
+my $emoji = "🙂";
+my $snowman = "☃";
+print $emoji, $snowman;


### PR DESCRIPTION
### Motivation

- Provide a repo-owned sidecar model to declare parser-corpus concept expectations before introducing any parser-ratchet enforcement. 
- Seed a small, focused set of high-value fixtures (recovery, ambiguity, quote-like, heredoc/data, span/encoding) with adjacent `.meta.toml` expectations so validation and tooling can reason about intent. 

### Description

- Added a typed sidecar model and validator in `crates/perl-corpus/src/fixture_expectations.rs` implementing `FixtureExpectation`, `ConceptSpec`, `ExpectSpec`, `MetricsSpec`, `SnapshotSpec`, discovery (`discover_sidecars`), pairing (`fixture_path_for_sidecar`), parsing (`parse_sidecar_file`) and validation (`validate_sidecar`, `validate_sidecars_under`), plus a lightweight `ConceptRegistry` loader that is optional. 
- Introduced a strict set of known expectation modes via `ExpectationMode` (supported: `parse_clean`, `recover_without_panic`, `expected_error`, `token_only`, `span_only`) and made TOML parsing the canonical sidecar format. 
- Seeded focused fixtures and sidecars under `tests/perl-corpus/` for the requested areas: `recovery/missing_closing_brace`, `ambiguity/regex_vs_division`, `quote_like/custom_delimiter`, `heredoc/heredoc_and_data_section`, and `spans/utf16_crlf_positions` (each with an adjacent `.meta.toml`). 
- Exposed the new API from the crate root (`pub use fixture_expectations::{...}`) and added a crate dependency on `toml` to enable TOML sidecar parsing.

### Testing

- Added unit tests in `crates/perl-corpus/src/fixture_expectations.rs` to validate sidecar parsing, known/unknown modes, fixture pairing, and pending concept resolution behavior. 
- Added an integration test `crates/perl-corpus/tests/fixture_sidecar_validation.rs` that runs validation over the seeded `tests/perl-corpus` sidecars and accepts pending concept resolution when the registry file is absent. 
- Verification performed: `cargo test -p perl-corpus` passed, `cargo check --all-targets -p perl-corpus` passed, `cargo clippy -p perl-corpus` passed, and `cargo xtask fmt` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a6750b848333bc172017462455a0)