### PR TITLE
feat(xtask): add parser-ratchet scaffold command (#0000)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -701,6 +701,12 @@ enum Commands {
         output: PathBuf,
     },
 
+    /// Produce parser-ratchet receipts and scaffolding artifacts.
+    ParserRatchet {
+        #[command(subcommand)]
+        command: ParserRatchetCommand,
+    },
+
     /// Run three-way parser comparison
     #[cfg(feature = "parser-tasks")]
     CompareThree {
@@ -1381,6 +1387,35 @@ enum CpanCorpusCommand {
 }
 
 #[derive(Subcommand)]
+enum ParserRatchetCommand {
+    /// Run parser-ratchet and emit a receipt.
+    Run {
+        /// Execution profile for this run.
+        #[arg(long, value_enum)]
+        profile: ParserRatchetProfileArg,
+        /// Explicit base revision (branch names are not inferred).
+        #[arg(long)]
+        base: String,
+        /// Explicit head revision (supports detached HEAD).
+        #[arg(long)]
+        head: String,
+        /// Output path for parser-ratchet receipt JSON.
+        #[arg(long)]
+        receipt: PathBuf,
+        /// Force selected=true while keeping scaffold-only behavior.
+        #[arg(long)]
+        force_selected: bool,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum ParserRatchetProfileArg {
+    Pr,
+    Nightly,
+    Release,
+}
+
+#[derive(Subcommand)]
 enum GateReceiptsCommand {
     /// List registered receipt schemas.
     List {
@@ -1882,6 +1917,27 @@ fn main() -> Result<()> {
             })
         }
         Commands::ParserMatrix { report, output } => parser_matrix::run_with_paths(report, output),
+        Commands::ParserRatchet { command } => match command {
+            ParserRatchetCommand::Run { profile, base, head, receipt, force_selected } => {
+                let profile = match profile {
+                    ParserRatchetProfileArg::Pr => parser_ratchet::ParserRatchetProfile::Pr,
+                    ParserRatchetProfileArg::Nightly => {
+                        parser_ratchet::ParserRatchetProfile::Nightly
+                    }
+                    ParserRatchetProfileArg::Release => {
+                        parser_ratchet::ParserRatchetProfile::Release
+                    }
+                };
+                parser_ratchet::run(parser_ratchet::ParserRatchetRunConfig {
+                    profile,
+                    base,
+                    head,
+                    receipt,
+                    force_selected,
+                })
+                .map_err(|error| eyre!(error.to_string()))
+            }
+        },
         #[cfg(feature = "parser-tasks")]
         Commands::CompareThree { verbose, format } => {
             compare_parsers::run_three_way(verbose, format.as_str())

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -62,6 +62,7 @@ pub mod metrics;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;
 pub mod parser_matrix;
+pub mod parser_ratchet;
 pub mod populate_book;
 pub mod prep_crates_io_launch;
 pub mod publication_facts;

--- a/xtask/src/tasks/parser_ratchet.rs
+++ b/xtask/src/tasks/parser_ratchet.rs
@@ -1,0 +1,148 @@
+use crate::tasks::gate_receipts;
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const CHECK_NAME: &str = "parser-ratchet";
+const RECEIPT_SCHEMA_VERSION: &str = "1";
+const REGISTRY_PATH: &str = ".ci/receipts/registry.toml";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ParserRatchetProfile {
+    Pr,
+    Nightly,
+    Release,
+}
+
+impl ParserRatchetProfile {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pr => "pr",
+            Self::Nightly => "nightly",
+            Self::Release => "release",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ParserRatchetRunConfig {
+    pub profile: ParserRatchetProfile,
+    pub base: String,
+    pub head: String,
+    pub receipt: PathBuf,
+    pub force_selected: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ParserRatchetReceipt {
+    schema_version: &'static str,
+    check: &'static str,
+    event: &'static str,
+    profile: String,
+    base_sha: String,
+    head_sha: String,
+    selected: bool,
+    selection_reason: String,
+    verdict: &'static str,
+    repro: Repro,
+}
+
+#[derive(Debug, Serialize)]
+struct Repro {
+    command: String,
+}
+
+pub fn run(config: ParserRatchetRunConfig) -> Result<()> {
+    let workspace_root = std::env::current_dir().context("failed to get current directory")?;
+
+    let base_sha = resolve_git_sha(&workspace_root, &config.base)
+        .with_context(|| format!("failed to resolve --base ref '{}'", config.base))?;
+    let head_sha = resolve_git_sha(&workspace_root, &config.head)
+        .with_context(|| format!("failed to resolve --head ref '{}'", config.head))?;
+
+    let (selected, selection_reason) = if config.force_selected {
+        (true, "force-selected (scaffold only; measurement not yet implemented)")
+    } else {
+        (false, "not selected by ci-scope")
+    };
+
+    let receipt = ParserRatchetReceipt {
+        schema_version: RECEIPT_SCHEMA_VERSION,
+        check: CHECK_NAME,
+        event: "local",
+        profile: config.profile.as_str().to_string(),
+        base_sha,
+        head_sha,
+        selected,
+        selection_reason: selection_reason.to_string(),
+        verdict: "pass",
+        repro: Repro {
+            command: format!(
+                "cargo xtask parser-ratchet run --profile {} --base {} --head {} --receipt {}{}",
+                config.profile.as_str(),
+                config.base,
+                config.head,
+                config.receipt.display(),
+                if config.force_selected { " --force-selected" } else { "" }
+            ),
+        },
+    };
+
+    if let Some(parent) = config.receipt.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create receipt directory {}", parent.display()))?;
+    }
+
+    let rendered = serde_json::to_string_pretty(&receipt).context("failed to serialize receipt")?;
+    fs::write(&config.receipt, rendered)
+        .with_context(|| format!("failed to write receipt to {}", config.receipt.display()))?;
+
+    // Validate against the shared receipt registry/schema when available.
+    if workspace_root.join(REGISTRY_PATH).exists() {
+        gate_receipts::validate(&config.receipt, gate_receipts::OutputFormat::Human)
+            .context("parser-ratchet receipt failed schema/registry validation")?;
+    }
+
+    println!("wrote parser-ratchet scaffold receipt to {}", config.receipt.display());
+    Ok(())
+}
+
+fn resolve_git_sha(workspace_root: &Path, reference: &str) -> Result<String> {
+    let output = Command::new("git")
+        .current_dir(workspace_root)
+        .args(["rev-parse", "--verify", &format!("{reference}^{{commit}}")])
+        .output()
+        .context("failed to execute git rev-parse")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git rev-parse failed for '{reference}': {}", stderr.trim());
+    }
+
+    let sha = String::from_utf8(output.stdout).context("git rev-parse stdout was not UTF-8")?;
+    Ok(sha.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use tempfile::TempDir;
+
+    #[test]
+    fn profile_names_are_stable() {
+        assert_eq!(ParserRatchetProfile::Pr.as_str(), "pr");
+        assert_eq!(ParserRatchetProfile::Nightly.as_str(), "nightly");
+        assert_eq!(ParserRatchetProfile::Release.as_str(), "release");
+    }
+
+    #[test]
+    fn resolve_git_sha_fails_for_missing_ref() -> Result<()> {
+        let dir = TempDir::new()?;
+        let result = resolve_git_sha(dir.path(), "missing-ref");
+        assert!(result.is_err(), "missing ref should fail");
+        Ok(())
+    }
+}

--- a/xtask/tests/parser_ratchet_cli.rs
+++ b/xtask/tests/parser_ratchet_cli.rs
@@ -1,0 +1,138 @@
+use anyhow::{Context, Result, bail};
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn parser_ratchet_run_succeeds_from_detached_head_with_explicit_refs() -> Result<()> {
+    let repo = TempDir::new()?;
+    init_git_repo(repo.path())?;
+
+    fs::write(repo.path().join("file.txt"), "v1\n")?;
+    run_git(repo.path(), &["add", "file.txt"])?;
+    run_git(repo.path(), &["commit", "-m", "first"])?;
+
+    fs::write(repo.path().join("file.txt"), "v2\n")?;
+    run_git(repo.path(), &["add", "file.txt"])?;
+    run_git(repo.path(), &["commit", "-m", "second"])?;
+
+    let base_sha = git_stdout(repo.path(), &["rev-parse", "HEAD~1"])?;
+    let head_sha = git_stdout(repo.path(), &["rev-parse", "HEAD"])?;
+    run_git(repo.path(), &["checkout", "--detach", &head_sha])?;
+
+    let receipt_rel = "target/receipts/parser-ratchet.json";
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd
+        .current_dir(repo.path())
+        .args([
+            "parser-ratchet",
+            "run",
+            "--profile",
+            "pr",
+            "--base",
+            &base_sha,
+            "--head",
+            "HEAD",
+            "--receipt",
+            receipt_rel,
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        bail!("xtask parser-ratchet run failed: {}", String::from_utf8_lossy(&output.stderr));
+    }
+
+    let receipt_path = repo.path().join(receipt_rel);
+    let receipt: Value = serde_json::from_str(&fs::read_to_string(&receipt_path)?)?;
+
+    assert_eq!(receipt["check"], Value::String("parser-ratchet".to_string()));
+    assert_eq!(receipt["profile"], Value::String("pr".to_string()));
+    assert_eq!(receipt["base_sha"], Value::String(base_sha));
+    assert_eq!(receipt["head_sha"], Value::String(head_sha));
+    assert_eq!(receipt["selected"], Value::Bool(false));
+    assert_eq!(receipt["verdict"], Value::String("pass".to_string()));
+
+    Ok(())
+}
+
+#[test]
+fn parser_ratchet_run_force_selected_sets_selected_true() -> Result<()> {
+    let repo = TempDir::new()?;
+    init_git_repo(repo.path())?;
+
+    fs::write(repo.path().join("file.txt"), "one\n")?;
+    run_git(repo.path(), &["add", "file.txt"])?;
+    run_git(repo.path(), &["commit", "-m", "first"])?;
+
+    fs::write(repo.path().join("file.txt"), "two\n")?;
+    run_git(repo.path(), &["add", "file.txt"])?;
+    run_git(repo.path(), &["commit", "-m", "second"])?;
+
+    let base = git_stdout(repo.path(), &["rev-parse", "HEAD~1"])?;
+
+    let receipt_rel = "target/receipts/parser-ratchet-force.json";
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd
+        .current_dir(repo.path())
+        .args([
+            "parser-ratchet",
+            "run",
+            "--profile",
+            "nightly",
+            "--base",
+            &base,
+            "--head",
+            "HEAD",
+            "--receipt",
+            receipt_rel,
+            "--force-selected",
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        bail!(
+            "xtask parser-ratchet run --force-selected failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let receipt: Value = serde_json::from_str(&fs::read_to_string(repo.path().join(receipt_rel))?)?;
+    assert_eq!(receipt["selected"], Value::Bool(true));
+    assert_eq!(receipt["profile"], Value::String("nightly".to_string()));
+
+    Ok(())
+}
+
+fn init_git_repo(repo: &Path) -> Result<()> {
+    run_git(repo, &["init"])?;
+    run_git(repo, &["config", "user.name", "xtask-test"])?;
+    run_git(repo, &["config", "user.email", "xtask-test@example.com"])?;
+    Ok(())
+}
+
+fn run_git(repo: &Path, args: &[&str]) -> Result<()> {
+    let status = Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .status()
+        .with_context(|| format!("failed to run git {}", args.join(" ")))?;
+    if !status.success() {
+        bail!("git {} failed", args.join(" "));
+    }
+    Ok(())
+}
+
+fn git_stdout(repo: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to run git {}", args.join(" ")))?;
+    if !output.status.success() {
+        bail!("git {} failed: {}", args.join(" "), String::from_utf8_lossy(&output.stderr));
+    }
+    Ok(String::from_utf8(output.stdout)?.trim().to_string())
+}


### PR DESCRIPTION
### Motivation
- Provide a safe, minimal `parser-ratchet` producer command that emits a stable scaffold receipt JSON for downstream gates and workflows. 
- Ensure the command works with explicit `--base`/`--head` refs (including detached HEAD) and does not run CPAN/measurements or mutate baselines.

### Description
- Added a new `parser-ratchet` top-level xtask command with a `run` subcommand and a `--profile` value-enum (`pr|nightly|release`), `--base`, `--head`, `--receipt`, and `--force-selected` flags (`xtask/src/main.rs`).
- Implemented `xtask/src/tasks/parser_ratchet.rs` which resolves explicit git refs to SHAs, emits a scaffold receipt JSON containing `schema_version`, `check`, `event`, `profile`, `base_sha`, `head_sha`, `selected`, `selection_reason`, `verdict`, and `repro.command`, and conditionally validates the receipt against the registry/schema if `.ci/receipts/registry.toml` is present.
- Kept behavior safe: no CPAN access, no measurement, no PR baseline mutation, and `--force-selected` only flips `selected` while still producing scaffold-only output.
- Registered the task module in `xtask/src/tasks/mod.rs` and added CLI integration/tests in `xtask/tests/parser_ratchet_cli.rs` plus small unit tests in the task module.

### Testing
- Ran `cargo test -p xtask parser_ratchet` and the added unit + integration tests passed.
- Ran `cargo check --all-targets -p xtask` which completed successfully.
- Ran `cargo xtask fmt --check --package xtask` after formatting and it passed.
- Manual verification: `cargo xtask parser-ratchet run --profile pr --base HEAD~1 --head HEAD --receipt target/receipts/parser-ratchet.json` wrote a valid scaffold JSON receipt (and the command printed success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a6810e2883339b1ef9dbbda79ba0)