### PR TITLE
feat(perl-corpus): add parser fixture expectation sidecars (#0000)

### DIFF
--- a/crates/perl-corpus/src/lib.rs
+++ b/crates/perl-corpus/src/lib.rs
@@ -233,6 +233,7 @@ pub mod index;
 pub mod inventory;
 pub mod lint;
 pub mod meta;
+pub mod sidecar;
 pub mod tie_interface;
 
 use anyhow::{Context, Result};
@@ -275,6 +276,11 @@ pub use inventory::{
 };
 use meta::Section;
 use regex::Regex;
+pub use sidecar::{
+    ConceptRegistry, ExpectationMode, FixtureExpectationSidecar, SidecarConcept, SidecarExpect,
+    SidecarMetrics, SidecarSnapshots, SidecarValidation, discover_sidecars, expected_fixture_path,
+    load_and_validate_sidecar, parse_sidecar, validate_sidecar,
+};
 use std::collections::HashMap;
 use std::{fs, path::Path};
 pub use tie_interface::{

--- a/crates/perl-corpus/src/sidecar.rs
+++ b/crates/perl-corpus/src/sidecar.rs
@@ -1,0 +1,230 @@
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExpectationMode {
+    ParseClean,
+    RecoverWithoutPanic,
+    ExpectedError,
+    TokenOnly,
+    SpanOnly,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SidecarConcept {
+    pub id: String,
+    pub tier: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SidecarExpect {
+    pub panic: bool,
+    pub timeout: bool,
+    pub mode: ExpectationMode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SidecarMetrics {
+    pub max_error_nodes: Option<u32>,
+    pub must_emit_node_kinds: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SidecarSnapshots {
+    pub tokens: bool,
+    pub ast: bool,
+    pub spans: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FixtureExpectationSidecar {
+    pub concept: SidecarConcept,
+    pub expect: SidecarExpect,
+    pub metrics: Option<SidecarMetrics>,
+    pub snapshots: Option<SidecarSnapshots>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SidecarValidation {
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+impl SidecarValidation {
+    pub fn is_ok(&self) -> bool {
+        self.errors.is_empty()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConceptRegistry {
+    concept_ids: HashSet<String>,
+}
+
+impl ConceptRegistry {
+    pub fn load(path: &Path) -> Result<Self> {
+        let raw = fs::read_to_string(path)
+            .with_context(|| format!("reading concept registry {}", path.display()))?;
+        let value = toml::from_str::<toml::Value>(&raw)
+            .with_context(|| format!("parsing concept registry TOML {}", path.display()))?;
+
+        let mut concept_ids = HashSet::new();
+        collect_concept_ids(&value, &mut concept_ids);
+
+        Ok(Self { concept_ids })
+    }
+
+    pub fn contains(&self, concept_id: &str) -> bool {
+        self.concept_ids.contains(concept_id)
+    }
+}
+
+pub fn parse_sidecar(path: &Path) -> Result<FixtureExpectationSidecar> {
+    let raw =
+        fs::read_to_string(path).with_context(|| format!("reading sidecar {}", path.display()))?;
+    toml::from_str::<toml::Value>(&raw)
+        .with_context(|| format!("parsing sidecar TOML {}", path.display()))?;
+    let parsed: FixtureExpectationSidecar = toml::from_str(&raw)
+        .with_context(|| format!("deserializing sidecar {}", path.display()))?;
+    Ok(parsed)
+}
+
+pub fn expected_fixture_path(sidecar_path: &Path) -> Result<PathBuf> {
+    let file_name = sidecar_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow::anyhow!("invalid sidecar path: {}", sidecar_path.display()))?;
+
+    if !file_name.ends_with(".meta.toml") {
+        bail!("sidecar filename must end with .meta.toml: {}", sidecar_path.display());
+    }
+
+    let fixture_name = file_name.trim_end_matches(".meta.toml").to_string() + ".pl";
+    let parent = sidecar_path.parent().unwrap_or_else(|| Path::new("."));
+    Ok(parent.join(fixture_name))
+}
+
+pub fn validate_sidecar(
+    sidecar_path: &Path,
+    sidecar: &FixtureExpectationSidecar,
+    concept_registry: Option<&ConceptRegistry>,
+) -> SidecarValidation {
+    let mut validation = SidecarValidation::default();
+
+    match expected_fixture_path(sidecar_path) {
+        Ok(fixture_path) => {
+            if !fixture_path.exists() {
+                validation
+                    .errors
+                    .push(format!("fixture file does not exist: {}", fixture_path.display()));
+            }
+        }
+        Err(error) => validation.errors.push(error.to_string()),
+    }
+
+    if sidecar.concept.id.trim().is_empty() {
+        validation.errors.push("concept.id must not be empty".to_string());
+    } else if let Some(registry) = concept_registry {
+        if !registry.contains(&sidecar.concept.id) {
+            validation.errors.push(format!(
+                "concept.id '{}' is not present in the loaded concept registry",
+                sidecar.concept.id
+            ));
+        }
+    } else {
+        validation.warnings.push(format!(
+            "concept registry unavailable; concept resolution pending for '{}'",
+            sidecar.concept.id
+        ));
+    }
+
+    validation
+}
+
+pub fn load_and_validate_sidecar(
+    sidecar_path: &Path,
+    concept_registry: Option<&ConceptRegistry>,
+) -> Result<SidecarValidation> {
+    let sidecar = parse_sidecar(sidecar_path)?;
+    Ok(validate_sidecar(sidecar_path, &sidecar, concept_registry))
+}
+
+pub fn discover_sidecars(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut sidecars = Vec::new();
+    if !root.exists() {
+        return Ok(sidecars);
+    }
+
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries =
+            fs::read_dir(&dir).with_context(|| format!("reading directory {}", dir.display()))?;
+        for entry in entries {
+            let entry = entry.with_context(|| format!("reading entry in {}", dir.display()))?;
+            let path = entry.path();
+            let file_type = entry
+                .file_type()
+                .with_context(|| format!("getting file type for {}", path.display()))?;
+
+            if file_type.is_dir() {
+                stack.push(path);
+                continue;
+            }
+
+            if file_type.is_file() && path.to_string_lossy().ends_with(".meta.toml") {
+                sidecars.push(path);
+            }
+        }
+    }
+
+    sidecars.sort();
+    Ok(sidecars)
+}
+
+fn collect_concept_ids(value: &toml::Value, concept_ids: &mut HashSet<String>) {
+    match value {
+        toml::Value::Table(table) => {
+            for (key, item) in table {
+                if key == "id"
+                    && let toml::Value::String(id) = item
+                    && !id.trim().is_empty()
+                {
+                    concept_ids.insert(id.clone());
+                }
+                collect_concept_ids(item, concept_ids);
+            }
+        }
+        toml::Value::Array(items) => {
+            for item in items {
+                collect_concept_ids(item, concept_ids);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expectation_mode_rejects_unknown_value() {
+        let raw = r#"
+[concept]
+id = "parser.recovery.missing"
+tier = "pr"
+
+[expect]
+panic = false
+timeout = false
+mode = "mystery"
+"#;
+
+        let parsed = toml::from_str::<FixtureExpectationSidecar>(raw);
+        assert!(parsed.is_err());
+    }
+}

--- a/crates/perl-corpus/tests/sidecar_expectations.rs
+++ b/crates/perl-corpus/tests/sidecar_expectations.rs
@@ -1,0 +1,119 @@
+use perl_corpus::{
+    ConceptRegistry, SidecarValidation, discover_sidecars, load_and_validate_sidecar, parse_sidecar,
+};
+use std::error::Error;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_dir(prefix: &str) -> Result<PathBuf, Box<dyn Error>> {
+    let mut path = std::env::temp_dir();
+    let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    path.push(format!("{}_{}_{}", prefix, std::process::id(), nanos));
+    fs::create_dir_all(&path)?;
+    Ok(path)
+}
+
+fn write_file(path: &std::path::Path, contents: &str) -> Result<(), Box<dyn Error>> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, contents)?;
+    Ok(())
+}
+
+fn valid_sidecar(concept_id: &str) -> String {
+    format!(
+        r#"[concept]
+id = "{concept_id}"
+tier = "pr"
+
+[expect]
+panic = false
+timeout = false
+mode = "recover_without_panic"
+
+[metrics]
+max_error_nodes = 2
+must_emit_node_kinds = ["SubDecl", "Block"]
+
+[snapshots]
+tokens = false
+ast = true
+spans = true
+"#
+    )
+}
+
+#[test]
+fn sidecar_parse_and_validate_succeeds_without_registry() -> Result<(), Box<dyn Error>> {
+    let root = temp_dir("perl_corpus_sidecar_no_registry")?;
+    let meta = root.join("tests/perl-corpus/recovery/missing_brace.meta.toml");
+    let fixture = root.join("tests/perl-corpus/recovery/missing_brace.pl");
+
+    write_file(&fixture, "sub x { my $v = 1;\n")?;
+    write_file(&meta, &valid_sidecar("parser.recovery.missing_closing_brace"))?;
+
+    let parsed = parse_sidecar(&meta)?;
+    assert_eq!(parsed.concept.id, "parser.recovery.missing_closing_brace");
+
+    let validation = load_and_validate_sidecar(&meta, None)?;
+    assert!(validation.is_ok());
+    assert_eq!(validation.warnings.len(), 1);
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn sidecar_requires_fixture_file_to_exist() -> Result<(), Box<dyn Error>> {
+    let root = temp_dir("perl_corpus_sidecar_missing_fixture")?;
+    let meta = root.join("tests/perl-corpus/recovery/missing_brace.meta.toml");
+
+    write_file(&meta, &valid_sidecar("parser.recovery.missing_closing_brace"))?;
+
+    let validation = load_and_validate_sidecar(&meta, None)?;
+    assert!(!validation.is_ok());
+    assert!(validation.errors.iter().any(|item| item.contains("fixture file does not exist")));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn sidecar_validates_concept_id_when_registry_is_present() -> Result<(), Box<dyn Error>> {
+    let root = temp_dir("perl_corpus_sidecar_registry")?;
+    let meta = root.join("tests/perl-corpus/recovery/missing_brace.meta.toml");
+    let fixture = root.join("tests/perl-corpus/recovery/missing_brace.pl");
+    let registry_path = root.join("concept-registry.toml");
+
+    write_file(&fixture, "sub x { my $v = 1;\n")?;
+    write_file(&meta, &valid_sidecar("parser.recovery.missing_closing_brace"))?;
+    write_file(&registry_path, "[[concepts]]\nid = \"parser.recovery.missing_closing_brace\"\n")?;
+
+    let registry = ConceptRegistry::load(&registry_path)?;
+    let validation = load_and_validate_sidecar(&meta, Some(&registry))?;
+    assert_eq!(validation, SidecarValidation::default());
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn discover_sidecars_finds_nested_meta_files() -> Result<(), Box<dyn Error>> {
+    let root = temp_dir("perl_corpus_sidecar_discovery")?;
+    write_file(
+        &root.join("tests/perl-corpus/recovery/one.meta.toml"),
+        &valid_sidecar("parser.recovery.missing_closing_brace"),
+    )?;
+    write_file(
+        &root.join("tests/perl-corpus/recovery/two.meta.toml"),
+        &valid_sidecar("parser.recovery.missing_delimiter"),
+    )?;
+
+    let sidecars = discover_sidecars(&root)?;
+    assert_eq!(sidecars.len(), 2);
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}

--- a/tests/perl-corpus/ambiguity/regex_vs_division.pl
+++ b/tests/perl-corpus/ambiguity/regex_vs_division.pl
@@ -1,2 +1,2 @@
-my $regex = /foo/;
-my $ratio = $total / $count;
+my $ratio = $total / 2;
+my $ok = $text =~ /foo/;

--- a/tests/perl-corpus/heredoc/data_section.meta.toml
+++ b/tests/perl-corpus/heredoc/data_section.meta.toml
@@ -1,5 +1,5 @@
 [concept]
-id = "parser.ambiguity.regex_vs_division"
+id = "parser.heredoc.data_section_boundary"
 tier = "pr"
 
 [expect]
@@ -9,9 +9,9 @@ mode = "parse_clean"
 
 [metrics]
 max_error_nodes = 0
-must_emit_node_kinds = ["BinaryExpression", "RegexMatch"]
+must_emit_node_kinds = ["Heredoc"]
 
 [snapshots]
 tokens = true
 ast = true
-spans = false
+spans = true

--- a/tests/perl-corpus/heredoc/data_section.pl
+++ b/tests/perl-corpus/heredoc/data_section.pl
@@ -1,0 +1,6 @@
+my $payload = <<'TXT';
+hello
+TXT
+
+__DATA__
+trailing payload

--- a/tests/perl-corpus/position/utf16_crlf_span.meta.toml
+++ b/tests/perl-corpus/position/utf16_crlf_span.meta.toml
@@ -1,0 +1,17 @@
+[concept]
+id = "parser.position.utf16_crlf_span"
+tier = "pr"
+
+[expect]
+panic = false
+timeout = false
+mode = "span_only"
+
+[metrics]
+max_error_nodes = 0
+must_emit_node_kinds = ["StringLiteral"]
+
+[snapshots]
+tokens = false
+ast = false
+spans = true

--- a/tests/perl-corpus/position/utf16_crlf_span.pl
+++ b/tests/perl-corpus/position/utf16_crlf_span.pl
@@ -1,0 +1,2 @@
+my $emoji = "🙂";
+my $x = length($emoji);

--- a/tests/perl-corpus/quote_like/custom_delimiter.meta.toml
+++ b/tests/perl-corpus/quote_like/custom_delimiter.meta.toml
@@ -1,5 +1,5 @@
 [concept]
-id = "parser.ambiguity.regex_vs_division"
+id = "parser.quote_like.custom_delimiter"
 tier = "pr"
 
 [expect]
@@ -9,9 +9,9 @@ mode = "parse_clean"
 
 [metrics]
 max_error_nodes = 0
-must_emit_node_kinds = ["BinaryExpression", "RegexMatch"]
+must_emit_node_kinds = ["StringLiteral"]
 
 [snapshots]
 tokens = true
 ast = true
-spans = false
+spans = true

--- a/tests/perl-corpus/quote_like/custom_delimiter.pl
+++ b/tests/perl-corpus/quote_like/custom_delimiter.pl
@@ -1,0 +1,2 @@
+my $quoted = qq{alpha beta};
+my @parts = qw|one two three|;

--- a/tests/perl-corpus/recovery/missing_closing_brace.pl
+++ b/tests/perl-corpus/recovery/missing_closing_brace.pl
@@ -1,2 +1,2 @@
 sub broken {
-    my $x = 42;
+    my $value = 42;


### PR DESCRIPTION
### Motivation

- Provide a lightweight, repo-owned sidecar model and seed data so parser-ratchet can later enforce concept floors without shipping enforcement in this change.

### Description

- Add a new `sidecar` module (`crates/perl-corpus/src/sidecar.rs`) that defines the sidecar TOML schema, `ExpectationMode` enum, sidecar structs, parsing, discovery, and validation helpers.
- Expose the sidecar API from the crate root via `pub use` and add a `toml` dependency to `crates/perl-corpus/Cargo.toml` for parsing.
- Add focused unit tests (`crates/perl-corpus/tests/sidecar_expectations.rs`) for parsing, discovery, fixture pairing, and concept-registry validation behavior.
- Seed a small set of focused sidecar + fixture pairs under `tests/perl-corpus/` for high-value parser concepts: recovery (missing brace), regex/division ambiguity, quote-like delimiters, heredoc/data section, and a UTF-16/CRLF position span fixture.

### Testing

- Ran `cargo test -p perl-corpus` and the crate tests (including the new `sidecar_expectations` tests) passed.
- Ran `cargo xtask fmt` and formatting check completed successfully.
- Sidecar discovery, parsing, validation, and concept-registry behavior are covered by the new unit tests and succeeded locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a6750b848333bc172017462455a0)