### PR TITLE
feat(xtask): add parser-ratchet scaffold command (#0000)

### DIFF
--- a/.ci/receipts/schemas/common-gate-receipt.schema.json
+++ b/.ci/receipts/schemas/common-gate-receipt.schema.json
@@ -6,7 +6,12 @@
   "required": ["check", "schema_version", "event", "verdict"],
   "properties": {
     "check": { "type": "string" },
-    "schema_version": { "type": "string" },
+    "schema_version": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "integer", "minimum": 1 }
+      ]
+    },
     "event": {
       "type": "string",
       "enum": ["pull_request", "merge_group", "push", "local"]
@@ -21,7 +26,15 @@
     "head_sha": { "type": "string" },
     "candidate_sha": { "type": "string" },
     "selected": { "type": "boolean" },
-    "selection_reason": { "type": "string" },
+    "selection_reason": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      ]
+    },
     "classification": {
       "type": "string",
       "enum": [

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -860,6 +860,12 @@ enum Commands {
         receipt: bool,
     },
 
+    /// Emit scaffold parser-ratchet receipts.
+    ParserRatchet {
+        #[command(subcommand)]
+        command: ParserRatchetCommand,
+    },
+
     /// Manage CPAN top-1000 corpus acquisition, sweep, and ratchet
     CpanCorpus {
         #[command(subcommand)]
@@ -1378,6 +1384,39 @@ enum CpanCorpusCommand {
         #[arg(long)]
         install_dir: Option<PathBuf>,
     },
+}
+
+#[derive(Subcommand)]
+enum ParserRatchetCommand {
+    /// Run parser-ratchet scaffold flow and emit a stable receipt.
+    Run {
+        /// Execution profile.
+        #[arg(long, value_enum)]
+        profile: ParserRatchetProfile,
+
+        /// Explicit base revision (required).
+        #[arg(long)]
+        base: String,
+
+        /// Explicit head revision (required).
+        #[arg(long)]
+        head: String,
+
+        /// Path to output receipt JSON.
+        #[arg(long)]
+        receipt: PathBuf,
+
+        /// Force selected=true while remaining scaffold-only.
+        #[arg(long)]
+        force_selected: bool,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum ParserRatchetProfile {
+    Pr,
+    Nightly,
+    Release,
 }
 
 #[derive(Subcommand)]
@@ -1929,6 +1968,23 @@ fn main() -> Result<()> {
                 receipt,
             })
         }
+        Commands::ParserRatchet { command } => match command {
+            ParserRatchetCommand::Run { profile, base, head, receipt, force_selected } => {
+                let profile = match profile {
+                    ParserRatchetProfile::Pr => parser_ratchet::ParserRatchetProfile::Pr,
+                    ParserRatchetProfile::Nightly => parser_ratchet::ParserRatchetProfile::Nightly,
+                    ParserRatchetProfile::Release => parser_ratchet::ParserRatchetProfile::Release,
+                };
+
+                parser_ratchet::run(parser_ratchet::ParserRatchetRunArgs {
+                    profile,
+                    base,
+                    head,
+                    receipt,
+                    force_selected,
+                })
+            }
+        },
         Commands::CpanCorpus { command } => {
             let mut config = cpan_corpus::CpanCorpusConfig::default();
             match command {

--- a/xtask/src/tasks/gate_receipts.rs
+++ b/xtask/src/tasks/gate_receipts.rs
@@ -213,6 +213,19 @@ fn validate_common_fields(receipt: &Value, errors: &mut Vec<String>) {
             errors.push(format!("missing required field: {field}"));
             continue;
         }
+        if *field == "schema_version" {
+            let is_string_or_integer = match value {
+                Some(Value::String(_)) => true,
+                Some(Value::Number(number)) => number.as_u64().is_some(),
+                _ => false,
+            };
+            if !is_string_or_integer {
+                errors.push(
+                    "field 'schema_version' must be a string or positive integer".to_string(),
+                );
+            }
+            continue;
+        }
         if value.and_then(Value::as_str).is_none() {
             errors.push(format!("field '{field}' must be a string"));
         }

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -62,6 +62,7 @@ pub mod metrics;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;
 pub mod parser_matrix;
+pub mod parser_ratchet;
 pub mod populate_book;
 pub mod prep_crates_io_launch;
 pub mod publication_facts;

--- a/xtask/src/tasks/parser_ratchet.rs
+++ b/xtask/src/tasks/parser_ratchet.rs
@@ -1,0 +1,147 @@
+use color_eyre::eyre::{Result, WrapErr, bail, eyre};
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ParserRatchetProfile {
+    Pr,
+    Nightly,
+    Release,
+}
+
+impl ParserRatchetProfile {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pr => "pr",
+            Self::Nightly => "nightly",
+            Self::Release => "release",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ParserRatchetRunArgs {
+    pub profile: ParserRatchetProfile,
+    pub base: String,
+    pub head: String,
+    pub receipt: PathBuf,
+    pub force_selected: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ParserRatchetReceipt {
+    schema_version: u32,
+    check: &'static str,
+    event: &'static str,
+    profile: String,
+    base_sha: String,
+    head_sha: String,
+    selected: bool,
+    selection_reason: Vec<String>,
+    verdict: &'static str,
+    repro: Repro,
+}
+
+#[derive(Debug, Serialize)]
+struct Repro {
+    command: String,
+}
+
+pub fn run(args: ParserRatchetRunArgs) -> Result<()> {
+    let base_sha = resolve_git_revision(&args.base)?;
+    let head_sha = resolve_git_revision(&args.head)?;
+
+    let selected = args.force_selected;
+    let selection_reason = if selected {
+        vec!["forced by --force-selected (scaffold-only run)".to_string()]
+    } else {
+        vec!["not selected by ci-scope".to_string()]
+    };
+
+    let receipt = ParserRatchetReceipt {
+        schema_version: 1,
+        check: "parser-ratchet",
+        event: "local",
+        profile: args.profile.as_str().to_string(),
+        base_sha,
+        head_sha,
+        selected,
+        selection_reason,
+        verdict: "pass",
+        repro: Repro {
+            command: format!(
+                "cargo xtask parser-ratchet run --profile {} --base {} --head {} --receipt {}{}",
+                args.profile.as_str(),
+                args.base,
+                args.head,
+                args.receipt.display(),
+                if args.force_selected { " --force-selected" } else { "" }
+            ),
+        },
+    };
+
+    write_receipt(&args.receipt, &receipt)?;
+    validate_receipt_if_registry_available(&args.receipt)?;
+    println!("parser-ratchet scaffold receipt written: {}", args.receipt.display());
+    Ok(())
+}
+
+fn resolve_git_revision(rev: &str) -> Result<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", rev])
+        .output()
+        .wrap_err_with(|| format!("failed to invoke git rev-parse for '{rev}'"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        bail!("invalid git revision '{rev}': {stderr}");
+    }
+
+    let sha = String::from_utf8(output.stdout)
+        .wrap_err("git rev-parse output was not valid UTF-8")?
+        .trim()
+        .to_string();
+
+    if sha.is_empty() {
+        bail!("resolved git revision '{rev}' to an empty SHA");
+    }
+
+    Ok(sha)
+}
+
+fn write_receipt(path: &Path, receipt: &ParserRatchetReceipt) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .wrap_err_with(|| format!("failed to create receipt directory {}", parent.display()))?;
+    }
+
+    let rendered = serde_json::to_string_pretty(receipt).wrap_err("failed to serialize receipt")?;
+    fs::write(path, format!("{rendered}\n"))
+        .wrap_err_with(|| format!("failed to write receipt {}", path.display()))
+}
+
+fn validate_receipt_if_registry_available(receipt_path: &Path) -> Result<()> {
+    let registry_path = Path::new(".ci/receipts/registry.toml");
+    if registry_path.exists() {
+        crate::tasks::gate_receipts::validate(
+            receipt_path,
+            crate::tasks::gate_receipts::OutputFormat::Human,
+        )
+        .map_err(|error| eyre!("parser-ratchet receipt failed gate schema validation: {error}"))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_string_mapping_is_stable() {
+        assert_eq!(ParserRatchetProfile::Pr.as_str(), "pr");
+        assert_eq!(ParserRatchetProfile::Nightly.as_str(), "nightly");
+        assert_eq!(ParserRatchetProfile::Release.as_str(), "release");
+    }
+}

--- a/xtask/tests/parser_ratchet_cli.rs
+++ b/xtask/tests/parser_ratchet_cli.rs
@@ -1,0 +1,123 @@
+use std::fs;
+use std::path::Path;
+
+use assert_cmd::Command;
+use color_eyre::eyre::{Context, Result, bail};
+use serde_json::Value;
+use tempfile::TempDir;
+
+#[test]
+fn parser_ratchet_run_writes_scaffold_receipt() -> Result<()> {
+    let receipt = tempfile::NamedTempFile::new()?;
+
+    Command::cargo_bin("xtask")?
+        .args([
+            "parser-ratchet",
+            "run",
+            "--profile",
+            "pr",
+            "--base",
+            "HEAD~1",
+            "--head",
+            "HEAD",
+            "--receipt",
+            receipt.path().to_string_lossy().as_ref(),
+        ])
+        .assert()
+        .success();
+
+    let parsed: Value = serde_json::from_str(&fs::read_to_string(receipt.path())?)?;
+    assert_eq!(parsed["profile"], "pr");
+    assert_eq!(parsed["selected"], false);
+    assert_eq!(parsed["verdict"], "pass");
+    assert!(parsed["base_sha"].as_str().is_some());
+    assert!(parsed["head_sha"].as_str().is_some());
+
+    Ok(())
+}
+
+#[test]
+fn parser_ratchet_detached_head_with_explicit_revisions_succeeds() -> Result<()> {
+    let repo = init_git_fixture_repo()?;
+    let receipt = repo.path().join("target/receipts/parser-ratchet.json");
+
+    let base = git_stdout(repo.path(), &["rev-parse", "HEAD~1"])?;
+    let head = git_stdout(repo.path(), &["rev-parse", "HEAD"])?;
+
+    git(repo.path(), &["checkout", "--detach", "HEAD"])?;
+
+    Command::cargo_bin("xtask")?
+        .current_dir(repo.path())
+        .args([
+            "parser-ratchet",
+            "run",
+            "--profile",
+            "pr",
+            "--base",
+            &base,
+            "--head",
+            &head,
+            "--receipt",
+            receipt.to_string_lossy().as_ref(),
+        ])
+        .assert()
+        .success();
+
+    let parsed: Value = serde_json::from_str(&fs::read_to_string(&receipt)?)?;
+    assert_eq!(parsed["selected"], false);
+    assert_eq!(parsed["verdict"], "pass");
+    assert_eq!(parsed["base_sha"], base);
+    assert_eq!(parsed["head_sha"], head);
+
+    Ok(())
+}
+
+fn init_git_fixture_repo() -> Result<TempDir> {
+    let dir = TempDir::new()?;
+    git(dir.path(), &["init"])?;
+    git(dir.path(), &["config", "user.name", "CI"])?;
+    git(dir.path(), &["config", "user.email", "ci@example.com"])?;
+
+    let file_path = dir.path().join("fixture.txt");
+    fs::write(&file_path, "one\n")?;
+    git(dir.path(), &["add", "fixture.txt"])?;
+    git(dir.path(), &["commit", "-m", "first"])?;
+
+    fs::write(&file_path, "two\n")?;
+    git(dir.path(), &["add", "fixture.txt"])?;
+    git(dir.path(), &["commit", "-m", "second"])?;
+
+    Ok(dir)
+}
+
+fn git(cwd: &Path, args: &[&str]) -> Result<()> {
+    let output = std::process::Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to spawn git {:?}", args))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8(output.stderr).context("git stderr invalid utf-8")?;
+    bail!("git {:?} failed: {}", args, stderr.trim());
+}
+
+fn git_stdout(cwd: &Path, args: &[&str]) -> Result<String> {
+    let output = std::process::Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to spawn git {:?}", args))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8(output.stderr).context("git stderr invalid utf-8")?;
+        bail!("git {:?} failed: {}", args, stderr.trim());
+    }
+
+    String::from_utf8(output.stdout)
+        .context("git stdout invalid utf-8")
+        .map(|value| value.trim().to_string())
+}


### PR DESCRIPTION
### Motivation
- Provide a safe, scaffold-only `parser-ratchet` producer command to emit a stable receipt shape for CI integration without running measurements or touching CPAN paths.
- Accept explicit `--base` and `--head` revisions (no branch inference) and support running from detached HEAD when revisions are provided.
- Establish the receipt surface (selected, selection_reason, profile, base_sha, head_sha, verdict, repro) and wire schema/registry validation for future enforcement.

### Description
- Add a new `parser-ratchet` subcommand and `parser-ratchet run` action with `--profile`, `--base`, `--head`, `--receipt`, and `--force-selected` flags and a `ParserRatchetProfile` enum (`pr`, `nightly`, `release`).
- Implement `xtask/src/tasks/parser_ratchet.rs` to resolve revisions via `git rev-parse`, emit a scaffold `parser-ratchet` JSON receipt (scaffold-only, `verdict: "pass"`), honor `--force-selected` to set `selected:true` without running measurements, and validate the receipt against the registry when available.
- Wire the task into the CLI dispatcher and add `pub mod parser_ratchet` so the task compiles and is discoverable by `cargo xtask`.
- Update the common gate receipt schema validator and JSON schema compatibility to accept integer `schema_version` and array-or-string `selection_reason` so the scaffold payload validates against the existing registry schema.
- Add integration tests `xtask/tests/parser_ratchet_cli.rs` that assert the scaffold receipt is written and that the command works from a detached HEAD when explicit `--base` and `--head` SHAs are provided.

### Testing
- Ran `cargo test -p xtask parser_ratchet` and the new CLI unit/integration tests passed (2 tests — both passed).
- Ran `cargo check --all-targets -p xtask` which completed successfully.
- Executed `cargo xtask parser-ratchet run --profile pr --base HEAD~1 --head HEAD --receipt target/receipts/parser-ratchet.json` which wrote a valid receipt and the registry validation passed when the registry was present.
- Ran `cargo clippy -p xtask -- -D warnings` and `cargo xtask fmt` which completed with no notable warnings; `just pr-fast` was not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a6810e2883339b1ef9dbbda79ba0)