### PR TITLE
test(xtask): enforce parser status marker contract (#0000)

### DIFF
--- a/xtask/src/tasks/update_status/mod.rs
+++ b/xtask/src/tasks/update_status/mod.rs
@@ -125,7 +125,7 @@ fn replace_block(
 ) -> Result<String> {
     let escaped_begin = regex::escape(begin_marker);
     let escaped_end = regex::escape(end_marker);
-    let pattern = format!(r"(?s)({})\n.*?\n({})", escaped_begin, escaped_end);
+    let pattern = format!(r"(?s)({})\n.*?({})", escaped_begin, escaped_end);
     let re = Regex::new(&pattern).context("building block replacement regex")?;
 
     let replacement = format!("{begin_marker}\n{new_content}\n{end_marker}");

--- a/xtask/tests/post_merge_status_regen_tests.rs
+++ b/xtask/tests/post_merge_status_regen_tests.rs
@@ -20,6 +20,22 @@ fn project_root() -> PathBuf {
     dir
 }
 
+fn assert_marker_count(
+    content: &str,
+    target_file: &str,
+    marker_name: &str,
+    expected_count: usize,
+    marker_kind: &str,
+    marker_text: &str,
+) {
+    let actual_count = content.matches(marker_text).count();
+    assert!(
+        actual_count == expected_count,
+        "status marker contract violation: {marker_kind} marker `{marker_name}` in `{target_file}` expected {expected_count} occurrence(s), found {actual_count}.\n\
+         expected {marker_kind} string: {marker_text}"
+    );
+}
+
 /// The `policy_checks` gate in gate-policy.yaml must not run
 /// `update-current-status.py --check` as part of a PR merge gate.
 /// That check is now handled post-merge by the dedicated workflow.
@@ -296,6 +312,34 @@ fn test_subsystem_files_have_markers() -> Result<(), Box<dyn std::error::Error>>
         workspace_md.contains("<!-- BEGIN: WORKSPACE_METRICS_BULLETS -->"),
         "workspace.md missing WORKSPACE_METRICS_BULLETS block"
     );
+
+    Ok(())
+}
+
+/// Parser status marker contract: every marker used by parser status generation
+/// must appear exactly once as BEGIN and exactly once as END in parser.md.
+#[test]
+fn test_status_marker_parser_contract() -> Result<(), Box<dyn std::error::Error>> {
+    let root = project_root();
+    let parser_path = root.join("docs/project/status/parser.md");
+    let parser = fs::read_to_string(&parser_path)?;
+    let target_file = "docs/project/status/parser.md";
+    let parser_markers = [
+        "PARSER_TRACKING_TABLE",
+        "PARSER_PERFORMANCE_TABLE",
+        "PARSER_METRICS_BULLETS",
+        "TOKEN_HEALTH_TABLE",
+        "PARSER_NODEKIND_ROW",
+        "PARSER_RELIABILITY_ROW",
+        "PARSER_STRICT_CLEAN_ROW",
+    ];
+
+    for marker in parser_markers {
+        let begin = format!("<!-- BEGIN: {marker} -->");
+        let end = format!("<!-- END: {marker} -->");
+        assert_marker_count(&parser, target_file, marker, 1, "BEGIN", &begin);
+        assert_marker_count(&parser, target_file, marker, 1, "END", &end);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
### Motivation

- Post-merge status regeneration could fail when parser status marker blocks (notably `TOKEN_HEALTH_TABLE`) were missing or malformed, producing late, surprise failures during `update-status` runs.
- These marker problems should be a pre-merge/testable contract so CI/xtask catches them before merge.
- The parser status generation expects a fixed set of markers in `docs/project/status/parser.md` and those must be verified exactly once for `BEGIN` and `END`.

### Description

- Added a marker count helper and a focused test `test_status_marker_parser_contract` in `xtask/tests/post_merge_status_regen_tests.rs` that asserts each parser marker appears exactly once as `<!-- BEGIN: ... -->` and once as `<!-- END: ... -->`, and that failure messages name the missing/duplicate marker, the target file, and the expected strings.
- Hardened the block-replacement pattern in `xtask/src/tasks/update_status/mod.rs` (regex changed to allow empty marker blocks) so an empty marker skeleton is a valid replacement target and `update-status` no longer errors with "Expected 1 match ... got 0" for empty sections.
- No parser behavior or ratchet commands were changed and no broad status-doc rewrite was included in this PR.

### Testing

- Ran `cargo test -p xtask status_marker` and the new `test_status_marker_parser_contract` passed.
- Ran `cargo test -p xtask test_replace_block` to verify `replace_block` behavior and both `test_replace_block` tests passed.
- Ran `cargo check --all-targets -p xtask` which completed successfully.
- Ran `cargo run -p xtask -- update-status --write` which succeeded and a second run reported "All files are up to date." demonstrating idempotence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a68f57d08333972fe98e21ca5deb)