### PR TITLE
fix(xtask): remove unresolved merge conflict markers (master fix)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -874,7 +874,6 @@ enum Commands {
         verbose: bool,
     },
 
-<<<<<<< HEAD
     /// Manage gate receipt schema registry and validate receipt payloads.
     GateReceipts {
         #[command(subcommand)]
@@ -887,8 +886,6 @@ enum Commands {
         command: GatePolicyCommand,
     },
 
-=======
->>>>>>> 73aa519b4 (feat(queue): project labels from canonical PR state (#6853))
     /// Show technical debt report from debt ledger
     ///
     /// Reads `.ci/debt-ledger.yaml` and reports on quarantined tests,
@@ -1055,7 +1052,7 @@ enum Commands {
 
         /// Output format (default: human)
         #[arg(long, short, value_enum, default_value = "human")]
-        format: OutputFormat,
+        format: GatesOutputFormat,
 
         /// Emit receipt JSON (also writes to target/receipts/receipt.json)
         #[arg(long, short)]
@@ -1080,6 +1077,33 @@ enum Commands {
         /// Verbose output (include quarantined gates)
         #[arg(long, short)]
         verbose: bool,
+    },
+
+    /// Detect contradictory PR label states and emit a methodology receipt.
+    MethodologyGate {
+        /// Fixture JSON file (local snapshot or GitHub event payload).
+        #[arg(long)]
+        fixture: Option<PathBuf>,
+
+        /// Pull request number to inspect via gh CLI.
+        #[arg(long)]
+        pr: Option<u64>,
+
+        /// Path to output receipt JSON.
+        #[arg(long, default_value = "target/receipts/methodology-gate.json")]
+        receipt: PathBuf,
+
+        /// Do not write receipt to disk.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Enforce mode: contradictory states fail the command.
+        #[arg(long)]
+        enforce: bool,
+
+        /// Output format.
+        #[arg(long, value_enum, default_value = "human")]
+        format: MethodologyOutputFormat,
     },
 
     /// Verify hook scripts are executable.
@@ -1372,6 +1396,38 @@ enum QueueCommand {
         #[arg(long, default_value = ".ci/state/label-projection.toml")]
         config: PathBuf,
     },
+}
+
+#[derive(Subcommand)]
+enum GateReceiptsCommand {
+    /// List registered receipt schemas.
+    List {
+        /// Output format (default: human).
+        #[arg(long, value_enum, default_value = "human")]
+        format: GateReceiptsFormat,
+    },
+    /// Validate a single receipt JSON file.
+    Validate {
+        /// Path to receipt JSON file.
+        path: PathBuf,
+        /// Output format (default: human).
+        #[arg(long, value_enum, default_value = "human")]
+        format: GateReceiptsFormat,
+    },
+    /// Validate all receipt JSON files under a directory.
+    ValidateAll {
+        /// Root directory containing receipt JSON files.
+        dir: PathBuf,
+        /// Output format (default: human).
+        #[arg(long, value_enum, default_value = "human")]
+        format: GateReceiptsFormat,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum GateReceiptsFormat {
+    Human,
+    Json,
 }
 
 #[derive(ValueEnum, Clone)]
@@ -1749,7 +1805,6 @@ fn main() -> Result<()> {
             parallel,
             verbose,
         }),
-<<<<<<< HEAD
         Commands::GateReceipts { command } => match command {
             GateReceiptsCommand::List { format } => {
                 gate_receipts::list(convert_gate_receipts_format(format))
@@ -1775,8 +1830,6 @@ fn main() -> Result<()> {
                 format,
             })
         }
-=======
->>>>>>> 73aa519b4 (feat(queue): project labels from canonical PR state (#6853))
         Commands::TargetedChecks { base, mode } => targeted_checks::run(base, mode),
         Commands::ResolvePackageName { crate_dir } => {
             // Use the current working directory as workspace root so this subcommand
@@ -1812,5 +1865,12 @@ fn print_top_level_commands() {
 
     for command_name in command_names {
         println!("{command_name}");
+    }
+}
+
+fn convert_gate_receipts_format(format: GateReceiptsFormat) -> gate_receipts::OutputFormat {
+    match format {
+        GateReceiptsFormat::Human => gate_receipts::OutputFormat::Human,
+        GateReceiptsFormat::Json => gate_receipts::OutputFormat::Json,
     }
 }

--- a/xtask/src/tasks/ci_scope.rs
+++ b/xtask/src/tasks/ci_scope.rs
@@ -65,14 +65,6 @@ pub struct HeavyLaneEntry {
     pub reason: String,
 }
 
-/// Decision envelope for lane-specific selectors.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct LaneDecision {
-    pub selected: bool,
-    pub profile: String,
-    pub reasons: Vec<String>,
-}
-
 /// Platform override flags.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PlatformOverrides {
@@ -599,41 +591,6 @@ fn reverse_dep_closure(
     closure
 }
 
-fn is_parser_adjacent_path(file: &str) -> bool {
-    PARSER_ADJACENT_PREFIXES.iter().any(|prefix| file.starts_with(prefix))
-        || PARSER_ADJACENT_EXACT.contains(&file)
-        || (file.starts_with("docs/project/status/") && file.contains("parser"))
-}
-
-fn is_control_plane_path(file: &str) -> bool {
-    CONTROL_PLANE_PREFIXES.iter().any(|prefix| file.starts_with(prefix))
-        || CONTROL_PLANE_EXACT.contains(&file)
-        || (file.starts_with("xtask/src/tasks/")
-            && (file.contains("parser") || file.contains("corpus") || file.contains("ratchet")))
-}
-
-fn parser_ratchet_decision(files: &[String], risk_tags: &[String]) -> LaneDecision {
-    let mut reasons: Vec<String> = files
-        .iter()
-        .filter(|file| is_parser_adjacent_path(file) || is_control_plane_path(file))
-        .map(|file| format!("changed_path:{file}"))
-        .collect();
-
-    if risk_tags.iter().any(|tag| tag == RISK_TAG_PARSER_RECOVERY) {
-        reasons.push("risk_tag:parser-recovery".to_string());
-    }
-
-    if reasons.is_empty() {
-        LaneDecision {
-            selected: false,
-            profile: "pr".to_string(),
-            reasons: vec!["no_parser_or_control_plane_changes".to_string()],
-        }
-    } else {
-        LaneDecision { selected: true, profile: "pr".to_string(), reasons }
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Main public API (testable without live git/cargo)
 // ---------------------------------------------------------------------------
@@ -667,14 +624,7 @@ pub fn classify_files(
             platform_overrides: PlatformOverrides::default(),
             selected_lanes: vec![],
             selected_heavy_lanes: vec![],
-<<<<<<< HEAD
             lanes: lanes_v2,
-=======
-            lanes: BTreeMap::from([(
-                "parser_ratchet".to_string(),
-                parser_ratchet_decision(files, &[]),
-            )]),
->>>>>>> 02377fe41 (feat(ci-scope): emit parser ratchet lane decision (#0000))
             explanations: BTreeMap::new(),
         });
     }
@@ -785,11 +735,6 @@ pub fn classify_files(
     let parser_ratchet = parser_ratchet_decision(files, &risk_tags);
     let lanes_v2 = BTreeMap::from([(String::from("parser_ratchet"), parser_ratchet)]);
 
-    let lanes_map = BTreeMap::from([(
-        "parser_ratchet".to_string(),
-        parser_ratchet_decision(files, &risk_tags),
-    )]);
-
     // Platform overrides (currently static — can be extended)
     let platform_overrides = PlatformOverrides { windows_runner: false };
 
@@ -806,11 +751,7 @@ pub fn classify_files(
         platform_overrides,
         selected_lanes: lanes,
         selected_heavy_lanes: heavy_lanes,
-<<<<<<< HEAD
         lanes: lanes_v2,
-=======
-        lanes: lanes_map,
->>>>>>> 02377fe41 (feat(ci-scope): emit parser ratchet lane decision (#0000))
         explanations,
     })
 }


### PR DESCRIPTION
## Summary

Master shipped with unresolved git conflict markers from commit `73aa519b4` (#6869 merge) and `02377fe41`, breaking all xtask compilation and blocking the queue-wide reconciler workflow for 3+ consecutive failures.

**Files fixed:**

- `xtask/src/main.rs` — two conflict regions:
  1. Enum variants block (~line 877): restored `GateReceipts` and `GatePolicy` variants (P0 receipt schema substrate from #6853)
  2. Match arm handlers block (~line 1752): restored `GateReceipts`, `GatePolicy`, and `MethodologyGate` match arms

  Additional fixes required to compile (types dropped by `73aa519b4`):
  - Added missing `GateReceiptsCommand` and `GateReceiptsFormat` enum definitions
  - Added missing `MethodologyGate` command variant
  - Added missing `convert_gate_receipts_format` helper function
  - Fixed `OutputFormat` to `GatesOutputFormat` type reference in `Gates` command

- `xtask/src/tasks/ci_scope.rs` — two conflict regions from `02377fe41`:
  1. Early-return lanes field: kept HEAD side (lanes_v2)
  2. Main return lanes field: kept HEAD side (lanes_v2)

  Additional deduplication required:
  - Removed duplicate `LaneDecision` struct definition
  - Removed duplicate `parser_ratchet_decision` function (old implementation)
  - Removed orphaned `is_parser_adjacent_path` and `is_control_plane_path` helpers
  - Removed unused `lanes_map` variable

## Verification

- `cargo check -p xtask`: passes (warnings only, 0 errors)
- `cargo check --workspace`: passes (warnings only, 0 errors)
- No conflict markers remain in working tree

## Test plan

- [ ] `cargo check -p xtask` passes
- [ ] `cargo check --workspace` passes
- [ ] No conflict markers detected by preflight script
- [ ] `cargo xtask --help` runs without panic