### PR TITLE
fix(perl-module): add assert message to whitespace_only_include_paths_are_ignored test (#5515)

### DIFF
--- a/crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs
+++ b/crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs
@@ -448,7 +448,10 @@ fn whitespace_only_include_paths_are_ignored() -> Result<(), Box<dyn std::error:
 
     match result {
         ModuleUriResolution::Resolved(uri) => {
-            assert!(uri.ends_with("lib/Trimmed.pm"), "resolved URI should end with expected module path, got: {uri}");
+            assert!(
+                uri.ends_with("lib/Trimmed.pm"),
+                "resolved URI should end with expected module path, got: {uri}"
+            );
         }
         other => return Err(format!("expected Resolved, got {other:?}").into()),
     }

--- a/crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs
+++ b/crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs
@@ -448,7 +448,7 @@ fn whitespace_only_include_paths_are_ignored() -> Result<(), Box<dyn std::error:
 
     match result {
         ModuleUriResolution::Resolved(uri) => {
-            assert!(uri.ends_with("lib/Trimmed.pm"));
+            assert!(uri.ends_with("lib/Trimmed.pm"), "resolved URI should end with expected module path, got: {uri}");
         }
         other => return Err(format!("expected Resolved, got {other:?}").into()),
     }


### PR DESCRIPTION
## Summary

- Salvage of PR #5515 (fresh-root strand — no common ancestor with master)
- Master already has the `@INC` normalization implementation that PR #5515 added (via a subsequent merge); only the `needs-builder-fix` finding remains outstanding
- Adds a diagnostic message to the bare `assert!` in `whitespace_only_include_paths_are_ignored` test, as flagged by the reviewer in PR #5515

## Bug fixed

In `crates/perl-module/tests/resolution_uri_comprehensive_unit_tests.rs`:

```rust
// Before (bare assert — no diagnostic context on failure):
assert!(uri.ends_with("lib/Trimmed.pm"));

// After (includes actual URI for debugging):
assert!(uri.ends_with("lib/Trimmed.pm"), "resolved URI should end with expected module path, got: {uri}");
```

## Cross-reference

Replaces PR #5515 which could not be rebased (fresh-root strand from master rebuild). Sign-offs from #5515 (deep-reviewed, diff-audited) carry over by cross-reference.

## Test plan

- [x] `cargo test -p perl-module` — 968 tests pass