### PR TITLE
style: workspace fmt cleanup for master drift (#7172)

### DIFF
--- a/crates/perl-lsp-ux-tests/src/diagnostics.rs
+++ b/crates/perl-lsp-ux-tests/src/diagnostics.rs
@@ -100,10 +100,8 @@ mod tests {
     /// already satisfies the predicate — no polling delay.
     #[test]
     fn wait_for_uri_matching_returns_on_immediate_match() {
-        let events = vec![LspEvent::Diagnostics {
-            uri: "file:///a.pl".to_string(),
-            diagnostics: vec![],
-        }];
+        let events =
+            vec![LspEvent::Diagnostics { uri: "file:///a.pl".to_string(), diagnostics: vec![] }];
         let result = DiagnosticsTracker::wait_for_uri_matching(
             || events.clone(),
             "file:///a.pl",
@@ -149,10 +147,7 @@ mod tests {
                 } else {
                     vec![] // cleared on third call
                 };
-                vec![LspEvent::Diagnostics {
-                    uri: "file:///a.pl".to_string(),
-                    diagnostics: diags,
-                }]
+                vec![LspEvent::Diagnostics { uri: "file:///a.pl".to_string(), diagnostics: diags }]
             },
             "file:///a.pl",
             Duration::from_secs(5),


### PR DESCRIPTION
## Summary

- Recent admin-merges (#7167, #7168) bypassed the CI Gate aggregator, introducing `cargo fmt` drift in `crates/perl-lsp-ux-tests/src/diagnostics.rs`
- This caused every in-flight PR to fail `cargo xtask fmt --check` on files they did not touch, blocking the entire merge queue
- This PR applies `cargo xtask fmt` only — no semantic changes, no clippy fixes, no reorganization

## Files reformatted (1)

- `crates/perl-lsp-ux-tests/src/diagnostics.rs` — 2 struct literal reformats at lines 100 and 149 (rustfmt collapsed multi-line `LspEvent::Diagnostics { ... }` constructors to single lines)

## Verification

- `cargo xtask fmt --check` passes clean after this change
- `cargo build -p perl-lsp-ux-tests` compiles without errors
- Diff is exactly 1 file, 3 insertions, 8 deletions — pure whitespace/formatting only

## Test plan

- [ ] `cargo xtask fmt --check` reports no unformatted files
- [ ] `cargo build -p perl-lsp-ux-tests` compiles cleanly
- [ ] No other files are modified (confirm diff is scoped to diagnostics.rs only)