### PR TITLE
refactor(agents): extend synthesize-with-prior-agents to architecture-reviewer + plan-reviewer (#4538)

### DIFF
--- a/.claude/commands/architecture-check.md
+++ b/.claude/commands/architecture-check.md
@@ -7,6 +7,19 @@ user-invocable: false
 
 Verify the proposed design respects the codebase's structural contracts.
 
+## Synthesize with prior agents (do this BEFORE running structural checks)
+
+You run after accuracy, research, oppositional, and diaboli. Their comments are on the issue. Your verdict must *engage* with theirs — your job is to add the structural-alignment lens, not echo what earlier agents already said.
+
+For each prior agent comment:
+
+- **accuracy-scout** — file paths and function names corrected? If the proposed design references wrong crate locations, the structural analysis changes. Evaluate against the *corrected* locations.
+- **research-verifier** — external claims verified or debunked? If Perl/LSP/crate API claims were debunked, the proposed architecture may be unsound at the foundation — name the structural implication.
+- **oppositional-planner** — scope-pivots or alternative approaches surfaced? If a pivot was proposed, evaluate the structural fit of the pivot, not just the original design. If the pivot is structurally cleaner, say so.
+- **advocatus-diaboli** — BUILD / DEFER / CLOSE? Diaboli's scope is PREMISE (is the work right in principle?); yours is STRUCTURAL FIT. If diaboli flagged architectural risk, that's potentially *your* lane — engage directly with the structural concern, don't just concur.
+
+**If the issue is part of a committed tracker / ADR / roadmap milestone:** the structural pattern was already decided. Start at ALIGNED and look for NEW structural concerns that weren't visible when the decision was made — don't re-litigate the original architecture from scratch.
+
 ## Checks
 
 1. **Dependency direction** — dependencies must flow downward (leaf → core → feature → provider → server). Check:

--- a/.claude/commands/plan-review-stress.md
+++ b/.claude/commands/plan-review-stress.md
@@ -7,6 +7,21 @@ user-invocable: false
 
 Think adversarially about the scout's recommended approach.
 
+## Synthesize with prior agents (do this BEFORE stress-testing)
+
+You run after accuracy, research, oppositional, diaboli, architecture, and maintainer-issue — the complete verification stack. You are the final synthesis point before the spec becomes builder-ready. Your stress-test must reflect what the full stack found, not just the original issue body.
+
+For each prior agent comment:
+
+- **accuracy-scout** — file paths and function names corrected? Build your stress-test around the *corrected* details. If accuracy-scout found the spec was targeting wrong locations, stress-test the corrected approach.
+- **research-verifier** — external claims verified or debunked? If Perl semantics, LSP spec, or crate API claims were debunked, the approach may need rethinking — surface that as a stress-test risk.
+- **oppositional-planner** — alternatives surfaced? If a scope-pivot or simpler alternative was proposed and not addressed, either confirm why the original is better or incorporate the pivot into the plan.
+- **architecture-reviewer** — ALIGNED / CONCERN / FAIL? If CONCERN or FAIL, the spec must resolve the structural issue before it can be builder-ready. If ALIGNED, the structural case is made — note it and move on.
+- **advocatus-diaboli** — BUILD / DEFER / CLOSE? If DEFER, the plan must explain what changed since the diaboli verdict to warrant proceeding. If CLOSE, consider whether a reduced scope still makes sense.
+- **maintainer-issue** — ALIGNED / DEFERRED / OUT OF SCOPE? If DEFERRED or OUT OF SCOPE, do not mark builder-ready — bounce to scout with the scope constraint.
+
+**Your synthesis note in the final plan-review comment should explicitly name:** which prior-agent finding most changed your assessment, and what the builder must know that isn't visible in the original issue body.
+
 ## Steps
 
 1. **What could go wrong with this fix?**


### PR DESCRIPTION
## Summary

Closes #4538.

Extends the **"Synthesize with prior agents"** pattern (introduced for `maintainer-issue` in PR #4537) to two more pipeline agents that were running siloed analysis without an explicit engagement step:

- **`architecture-check.md`** — architecture-reviewer now has a synthesis step before structural checks
- **`plan-review-stress.md`** — plan-reviewer (the final synthesis gate) now has an explicit engagement section covering all six prior agents

## What changed and why

### Background

PR #4537 added a `## Synthesize with prior agents` section to `maintainer-issue-check.md` after observing that agents running sequential analysis without explicit prior-agent engagement tend to echo each other's framings. The same gap existed for architecture-reviewer and plan-reviewer.

During Wave G3 planning (#4535), the plan-reviewer produced a strong BUILD verdict with six locked decisions — but only because the orchestrator explicitly instructed it to engage with each prior agent. That instruction should live in the skill file itself, not in ad-hoc orchestrator prompting.

### `architecture-check.md`

Added a 12-line synthesis section **before** the structural checks. Architecture-reviewer runs after accuracy, research, oppositional, and diaboli. The section:

- Names each prior agent's lane (corrected facts → debunked claims → scope pivots → premise verdict)
- Draws the correct lane boundary between diaboli (PREMISE) and architecture-reviewer (STRUCTURAL FIT) — if diaboli flagged architectural risk, that's the architecture-reviewer's lane
- Includes the ADR/tracker short-circuit: committed designs start at ALIGNED; look for new structural concerns, don't re-litigate

### `plan-review-stress.md`

Added a 18-line synthesis section **before** the stress-test steps. Plan-reviewer is the final synthesis point across all six agents. The section:

- Lists all six prior agents and their output shapes
- Specifies concrete routing decisions: if architecture returns CONCERN/FAIL, resolve before builder-ready; if maintainer returns DEFERRED/OUT OF SCOPE, bounce to scout
- Requires the synthesis note in the final comment to name which prior-agent finding most shifted the assessment

## Pattern consistency

Both sections follow the exact structure of `maintainer-issue-check.md`:
- Framing sentence naming which agents ran before this one
- Per-agent bullet naming what to look for and how to engage
- Anti-echo guard / special case for the most likely echoing scenario
- ADR/tracker short-circuit where applicable

## Verification

```bash
grep "Synthesize with prior agents" .claude/commands/architecture-check.md
# → ## Synthesize with prior agents (do this BEFORE running structural checks)

grep "Synthesize with prior agents" .claude/commands/plan-review-stress.md
# → ## Synthesize with prior agents (do this BEFORE stress-testing)

# Confirm no production code touched
git diff HEAD~1 -- crates/
# → (empty)
```

## Test plan

- [ ] `grep "Synthesize with prior agents" .claude/commands/architecture-check.md` returns the section header
- [ ] `grep "Synthesize with prior agents" .claude/commands/plan-review-stress.md` returns the section header
- [ ] `git diff HEAD~1 -- crates/` is empty (no production code changes)
- [ ] Both sections use the same structural pattern as `maintainer-issue-check.md`
- [ ] Architecture-reviewer section lists exactly 4 prior agents (accuracy, research, oppositional, diaboli)
- [ ] Plan-reviewer section lists exactly 6 prior agents (all of the above + architecture + maintainer-issue)

https://claude.ai/code/session_01AZLwV3jkK9c4oCFfXEMq9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZLwV3jkK9c4oCFfXEMq9N)_