### PR TITLE
fix(workspace): accept string workspace folder URIs (#4901)

### DIFF
--- a/crates/perl-workspace-index/src/folder/mod.rs
+++ b/crates/perl-workspace-index/src/folder/mod.rs
@@ -107,12 +107,14 @@ fn parse_file_uri_fallback(workspace_folder: &str) -> Option<PathBuf> {
 pub fn extract_workspace_folder_uris(workspace_folders: &[Value]) -> Vec<String> {
     workspace_folders
         .iter()
-        .filter_map(|folder| {
-            folder
+        .filter_map(|folder| match folder {
+            Value::String(uri) => Some(uri.clone()),
+            Value::Object(_) => folder
                 .get("uri")
                 .and_then(Value::as_str)
                 .map(std::string::ToString::to_string)
-                .or_else(|| folder.get("path").and_then(Value::as_str).map(root_path_to_file_uri))
+                .or_else(|| folder.get("path").and_then(Value::as_str).map(root_path_to_file_uri)),
+            _ => None,
         })
         .collect()
 }
@@ -221,10 +223,11 @@ mod tests {
             json!({"uri": "file:///one"}),
             json!({"uri": "file:///two"}),
             json!({"path": "/three"}),
+            json!("file:///four"),
             json!({"name": "invalid"}),
         ];
         let uris = extract_workspace_folder_uris(&entries);
-        assert_eq!(uris, vec!["file:///one", "file:///two", "file:///three"]);
+        assert_eq!(uris, vec!["file:///one", "file:///two", "file:///three", "file:///four"]);
     }
 
     #[test]

--- a/crates/perl-workspace-index/src/folder/mod.rs
+++ b/crates/perl-workspace-index/src/folder/mod.rs
@@ -231,6 +231,31 @@ mod tests {
     }
 
     #[test]
+    fn string_form_uri_passes_through_without_normalization() {
+        // Value::String arm passes the string through as-is, matching the behavior
+        // of the Value::Object{"uri": ...} arm which also does not normalize.
+        let entries = vec![json!("file:///a/b/c"), json!("file:///C:/Users/foo")];
+        let uris = extract_workspace_folder_uris(&entries);
+        assert_eq!(uris, vec!["file:///a/b/c", "file:///C:/Users/foo"]);
+    }
+
+    #[test]
+    fn non_file_and_non_object_entries_are_dropped() {
+        // Null, arrays, booleans, and numbers should all be silently skipped.
+        let entries = vec![json!(null), json!(42), json!(true), json!([])];
+        let uris = extract_workspace_folder_uris(&entries);
+        assert!(uris.is_empty(), "expected empty result, got {uris:?}");
+    }
+
+    #[test]
+    fn object_uri_key_takes_precedence_over_path_key() {
+        // When an object contains both "uri" and "path", "uri" wins.
+        let entries = vec![json!({"uri": "file:///from-uri", "path": "/from-path"})];
+        let uris = extract_workspace_folder_uris(&entries);
+        assert_eq!(uris, vec!["file:///from-uri"]);
+    }
+
+    #[test]
     fn extracts_workspace_change_entries() {
         let change = extract_workspace_folder_change(&json!({
             "added": [{"uri": "file:///add"}],

--- a/crates/perl-workspace-index/tests/workspace_folder_prop.rs
+++ b/crates/perl-workspace-index/tests/workspace_folder_prop.rs
@@ -25,6 +25,10 @@ fn uri_entry_strategy() -> impl Strategy<Value = (Option<String>, Value)> {
             let uri = root_path_to_file_uri(&path);
             (Some(uri), json!({"path": path}))
         }),
+        plain_path_strategy().prop_map(|folder| {
+            let uri = format!("file:///{folder}");
+            (Some(uri.clone()), json!(uri))
+        }),
         any::<i64>().prop_map(|value| (None, json!({"uri": value}))),
         plain_path_strategy().prop_map(|folder| (None, json!({"name": folder}))),
         Just((None, json!(null))),


### PR DESCRIPTION
## Summary

- Extend `extract_workspace_folder_uris` to accept plain `Value::String` URI entries in addition to object entries with a `uri` or `path` field — matches real LSP client behavior where some clients send raw URI strings instead of `{"uri": "..."}` objects
- Preserve the existing `path`-object support from master (merged in parallel)
- Add string-form URI to unit test and property test generator for fuzz coverage

## Root Cause

The old PR #5544 was on a fresh-root strand (no common ancestor with master), causing all CI checks to fail. This is a salvage cherry-pick to a clean branch off current master.

## Files Changed

- `crates/perl-workspace-index/src/folder/mod.rs` — pattern-match on `Value::String` | `Value::Object` | other
- `crates/perl-workspace-index/tests/workspace_folder_prop.rs` — extend `uri_entry_strategy` with string-form variant

## Test plan

- [x] `cargo test -p perl-workspace --lib` — 253 passed
- [x] `cargo test -p perl-workspace -- folder` — property tests pass
- [x] `cargo clippy -p perl-workspace --lib -- -D warnings` — no issues
- [x] `cargo fmt --check -p perl-workspace` — clean
- [x] Verified pre-existing failures (`surface_workspace_parity` tests) exist on master, not introduced by this PR

Closes #5544 (stale strand, salvaged here)