### PR TITLE
fix(perl-lsp-ux-tests): align fixture matrix with scenarios on disk (#7178)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -520,6 +520,27 @@
       ]
     },
     {
+      "id": "incremental_text_sync_recovery",
+      "scenario_file": "ux_scenario_19_incremental_text_sync.rs",
+      "subsystem_owner": "text_sync",
+      "ci_tier": "pr",
+      "user_journey": "fix a parse error via didChange full-text sync and verify diagnostics recover and hover remains responsive",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "broken content yields at least one diagnostic",
+        "fixed content clears parse-like diagnostics after didChange",
+        "hover does not JSON-RPC error after didChange recovery"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
+      ]
+    },
+    {
       "id": "diagnostics_lifecycle_editing",
       "scenario_file": "ux_scenario_19_diagnostics_lifecycle.rs",
       "subsystem_owner": "diagnostics",


### PR DESCRIPTION
## Summary

- `ux_scenario_19_incremental_text_sync.rs` was added to the test directory by recent merges (#5337, #5349, #7168) but was never registered in `editor_ux_fixture_matrix.json`
- The lockstep assertion at `editor_ux_fixture_matrix.rs:149` (`scenarios_in_matrix == scenarios_on_disk`) chronically failed as a result, blocking master CI `UX Regression Tests`
- Added the missing `incremental_text_sync_recovery` workflow entry to the matrix with `subsystem_owner: text_sync`, baseline measures (`workflow_pass_rate`, `workflow_stability_rate`), and all three confidence signals

## What changed

**Added** to `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json`:
- `incremental_text_sync_recovery` workflow entry pointing at `ux_scenario_19_incremental_text_sync.rs`
- 27 total workflows (was 26); extended metric coverage remains above 30% (40.74%)

## Test plan

- [x] `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix editor_ux_fixture_matrix_covers_all_scenarios` — passes
- [x] `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix` (full suite) — passes
- [x] `cargo xtask fmt --check` — exit 0
- [x] `cargo clippy -p perl-lsp-ux-tests --tests -- -D warnings` — exit 0