### PR TITLE
test: add comprehensive unit tests for token, regex, and line-index crates (#6742)

### DIFF
--- a/crates/perl-line-index/src/lib.rs
+++ b/crates/perl-line-index/src/lib.rs
@@ -79,3 +79,81 @@ impl LineIndex {
         Some(start + column)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_string_has_one_line() {
+        let idx = LineIndex::new("");
+        assert_eq!(idx.byte_to_position(0), (0, 0));
+        assert_eq!(idx.position_to_byte(0, 0), Some(0));
+        assert_eq!(idx.position_to_byte(1, 0), None);
+    }
+
+    #[test]
+    fn single_line_no_newline() {
+        let idx = LineIndex::new("hello");
+        assert_eq!(idx.byte_to_position(0), (0, 0));
+        assert_eq!(idx.byte_to_position(4), (0, 4));
+        assert_eq!(idx.position_to_byte(0, 0), Some(0));
+        assert_eq!(idx.position_to_byte(0, 4), Some(4));
+        assert_eq!(idx.position_to_byte(0, 5), Some(5));
+        assert_eq!(idx.position_to_byte(0, 6), None);
+    }
+
+    #[test]
+    fn two_lines_byte_to_position() {
+        // "ab\ncd"  bytes: a=0, b=1, \n=2, c=3, d=4
+        let idx = LineIndex::new("ab\ncd");
+        assert_eq!(idx.byte_to_position(0), (0, 0));
+        assert_eq!(idx.byte_to_position(1), (0, 1));
+        assert_eq!(idx.byte_to_position(2), (0, 2)); // the newline is on line 0
+        assert_eq!(idx.byte_to_position(3), (1, 0));
+        assert_eq!(idx.byte_to_position(4), (1, 1));
+    }
+
+    #[test]
+    fn two_lines_position_to_byte() {
+        let idx = LineIndex::new("ab\ncd");
+        assert_eq!(idx.position_to_byte(0, 0), Some(0));
+        assert_eq!(idx.position_to_byte(0, 2), Some(2)); // newline byte
+        assert_eq!(idx.position_to_byte(1, 0), Some(3));
+        assert_eq!(idx.position_to_byte(1, 1), Some(4));
+        assert_eq!(idx.position_to_byte(1, 2), Some(5)); // last line, end of text
+        assert_eq!(idx.position_to_byte(1, 3), None); // beyond text
+        assert_eq!(idx.position_to_byte(2, 0), None); // no third line
+    }
+
+    #[test]
+    fn position_to_byte_checked_excludes_newline_as_next_line_start() {
+        // "ab\ncd"
+        let idx = LineIndex::new("ab\ncd");
+        // Line 0 ends at the newline (byte 2); col 2 = newline byte is still on line 0
+        assert_eq!(idx.position_to_byte_checked(0, 2), Some(2));
+        // col 3 is the first byte of line 1 — out of range for line 0
+        assert_eq!(idx.position_to_byte_checked(0, 3), None);
+        assert_eq!(idx.position_to_byte_checked(1, 0), Some(3));
+        assert_eq!(idx.position_to_byte_checked(2, 0), None);
+    }
+
+    #[test]
+    fn trailing_newline_creates_empty_last_line() {
+        // "foo\n" — line 1 starts at byte 4 and is empty
+        let idx = LineIndex::new("foo\n");
+        assert_eq!(idx.byte_to_position(3), (0, 3)); // newline
+        assert_eq!(idx.byte_to_position(4), (1, 0)); // empty last line start
+        assert_eq!(idx.position_to_byte(1, 0), Some(4));
+    }
+
+    #[test]
+    fn multiple_lines_roundtrip() {
+        let text = "line0\nline1\nline2";
+        let idx = LineIndex::new(text);
+        for (byte, _) in text.char_indices() {
+            let (line, col) = idx.byte_to_position(byte);
+            assert_eq!(idx.position_to_byte(line, col), Some(byte));
+        }
+    }
+}

--- a/crates/perl-regex/src/lib.rs
+++ b/crates/perl-regex/src/lib.rs
@@ -696,3 +696,295 @@ fn parse_named_capture_name_from(
     let name = String::from_utf8_lossy(&bytes[start..i]).into_owned();
     Some((name, i + 1))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- RegexError ---
+
+    #[test]
+    fn regex_error_syntax_stores_message_and_offset() {
+        let err = RegexError::syntax("unexpected char", 7);
+        match &err {
+            RegexError::Syntax { message, offset } => {
+                assert_eq!(message, "unexpected char");
+                assert_eq!(*offset, 7);
+            }
+        }
+        assert!(err.to_string().contains("7"));
+        assert!(err.to_string().contains("unexpected char"));
+    }
+
+    #[test]
+    fn regex_error_implements_clone_and_partialeq() {
+        let e1 = RegexError::syntax("msg", 3);
+        let e2 = e1.clone();
+        assert_eq!(e1, e2);
+    }
+
+    // --- RegexValidator::validate (valid patterns) ---
+
+    #[test]
+    fn validate_simple_pattern_ok() {
+        let v = RegexValidator::new();
+        assert!(v.validate("hello", 0).is_ok());
+        assert!(v.validate("", 0).is_ok());
+        assert!(v.validate("(a|b)+", 0).is_ok());
+    }
+
+    #[test]
+    fn validate_unicode_property_within_limit_ok() {
+        let v = RegexValidator::new();
+        // 50 unicode properties is the limit
+        let pattern = r"\p{L}".repeat(50);
+        assert!(v.validate(&pattern, 0).is_ok());
+    }
+
+    #[test]
+    fn validate_too_many_unicode_properties_errors() {
+        let v = RegexValidator::new();
+        let pattern = r"\p{L}".repeat(51);
+        let err = v.validate(&pattern, 0).unwrap_err();
+        assert!(err.to_string().contains("Unicode"));
+    }
+
+    #[test]
+    fn validate_unicode_property_offset_propagated() {
+        let v = RegexValidator::new();
+        let prefix = "x";
+        let pattern = format!("{}{}", prefix, r"\p{L}".repeat(51));
+        let err = v.validate(&pattern, 10).unwrap_err();
+        // The reported offset should be >= 10 (start_pos)
+        match err {
+            RegexError::Syntax { offset, .. } => assert!(offset >= 10),
+        }
+    }
+
+    #[test]
+    fn validate_lookbehind_within_limit_ok() {
+        let v = RegexValidator::new();
+        // 10 is the limit; 9 nested lookbehinds should be fine
+        let mut pattern = String::from("foo");
+        for _ in 0..9 {
+            pattern = format!("(?<={})", pattern);
+        }
+        assert!(v.validate(&pattern, 0).is_ok());
+    }
+
+    #[test]
+    fn validate_lookbehind_nesting_too_deep_errors() {
+        let v = RegexValidator::new();
+        // Build 11 nested lookbehinds to exceed the depth limit of 10
+        let mut pattern = String::from("a");
+        for _ in 0..11 {
+            pattern = format!("(?<={})", pattern);
+        }
+        let err = v.validate(&pattern, 0).unwrap_err();
+        assert!(err.to_string().contains("lookbehind") || err.to_string().contains("nesting"));
+    }
+
+    #[test]
+    fn validate_branch_reset_nesting_too_deep_errors() {
+        let v = RegexValidator::new();
+        let mut pattern = String::from("a");
+        for _ in 0..11 {
+            pattern = format!("(?|{})", pattern);
+        }
+        let err = v.validate(&pattern, 0).unwrap_err();
+        assert!(err.to_string().contains("branch reset") || err.to_string().contains("nesting"));
+    }
+
+    #[test]
+    fn validate_too_many_branches_in_reset_group_errors() {
+        let v = RegexValidator::new();
+        // 51 alternatives in one (?| ... ) group exceeds max 50 branches
+        let alts = (0u32..51).map(|i| format!("a{i}")).collect::<Vec<_>>().join("|");
+        let pattern = format!("(?|{alts})");
+        let err = v.validate(&pattern, 0).unwrap_err();
+        assert!(err.to_string().contains("branch") || err.to_string().contains("50"));
+    }
+
+    #[test]
+    fn validate_character_class_skipped() {
+        // `[(?{]` should not trigger embedded code detection in validate()
+        let v = RegexValidator::new();
+        assert!(v.validate("[(?{]", 0).is_ok());
+    }
+
+    // --- RegexValidator::detects_code_execution ---
+
+    #[test]
+    fn detects_code_execution_with_code_block() {
+        let v = RegexValidator::new();
+        assert!(v.detects_code_execution("(?{ print 'hi' })"));
+    }
+
+    #[test]
+    fn detects_code_execution_with_deferred_code_block() {
+        let v = RegexValidator::new();
+        assert!(v.detects_code_execution("(??{ some_code() })"));
+    }
+
+    #[test]
+    fn detects_code_execution_false_for_non_capturing() {
+        let v = RegexValidator::new();
+        assert!(!v.detects_code_execution("(?:foo)"));
+        assert!(!v.detects_code_execution("(?=ahead)"));
+        assert!(!v.detects_code_execution("(?!not)"));
+    }
+
+    #[test]
+    fn detects_code_execution_escaped_paren_not_detected() {
+        let v = RegexValidator::new();
+        assert!(!v.detects_code_execution(r"\(?{"));
+    }
+
+    #[test]
+    fn detects_code_execution_in_char_class_not_detected() {
+        let v = RegexValidator::new();
+        assert!(!v.detects_code_execution("[(?{]"));
+    }
+
+    #[test]
+    fn detects_code_execution_empty_pattern() {
+        let v = RegexValidator::new();
+        assert!(!v.detects_code_execution(""));
+    }
+
+    // --- RegexValidator::detect_nested_quantifiers ---
+
+    #[test]
+    fn detect_nested_quantifiers_finds_plus_plus() {
+        let v = RegexValidator::new();
+        assert!(v.detect_nested_quantifiers("(a+)+"));
+    }
+
+    #[test]
+    fn detect_nested_quantifiers_finds_star_star() {
+        let v = RegexValidator::new();
+        assert!(v.detect_nested_quantifiers("(a*)*"));
+    }
+
+    #[test]
+    fn detect_nested_quantifiers_finds_brace_quantifier() {
+        let v = RegexValidator::new();
+        assert!(v.detect_nested_quantifiers("(a+){2,5}"));
+    }
+
+    #[test]
+    fn detect_nested_quantifiers_safe_patterns() {
+        let v = RegexValidator::new();
+        assert!(!v.detect_nested_quantifiers("(abc)+")); // no inner quantifier
+        assert!(!v.detect_nested_quantifiers("[a-z]+")); // character class, not group
+        assert!(!v.detect_nested_quantifiers("a+b+")); // quantifiers outside groups
+    }
+
+    // --- RegexValidator::Default ---
+
+    #[test]
+    fn default_is_same_as_new() {
+        let v: RegexValidator = Default::default();
+        assert!(v.validate("simple", 0).is_ok());
+    }
+
+    // --- RegexAnalyzer::extract_named_captures ---
+
+    #[test]
+    fn extract_named_captures_angle_bracket_syntax() {
+        let caps = RegexAnalyzer::extract_named_captures(r"(?<year>\d{4})-(?<month>\d{2})");
+        assert_eq!(caps.len(), 2);
+        assert_eq!(caps[0].name, "year");
+        assert_eq!(caps[0].index, 1);
+        assert_eq!(caps[1].name, "month");
+        assert_eq!(caps[1].index, 2);
+    }
+
+    #[test]
+    fn extract_named_captures_single_quote_syntax() {
+        let caps = RegexAnalyzer::extract_named_captures(r"(?'name'\w+)");
+        assert_eq!(caps.len(), 1);
+        assert_eq!(caps[0].name, "name");
+        assert_eq!(caps[0].index, 1);
+    }
+
+    #[test]
+    fn extract_named_captures_no_captures() {
+        let caps = RegexAnalyzer::extract_named_captures(r"\d+\.\d+");
+        assert!(caps.is_empty());
+    }
+
+    #[test]
+    fn extract_named_captures_non_capturing_group_not_counted() {
+        let caps = RegexAnalyzer::extract_named_captures(r"(?:foo)(?<bar>baz)");
+        assert_eq!(caps.len(), 1);
+        assert_eq!(caps[0].name, "bar");
+        assert_eq!(caps[0].index, 1); // plain capturing groups before it still count
+    }
+
+    #[test]
+    fn extract_named_captures_lookbehind_not_counted() {
+        // (?<= ...) is lookbehind, not a named capture
+        let caps = RegexAnalyzer::extract_named_captures(r"(?<=foo)(?<word>\w+)");
+        assert_eq!(caps.len(), 1);
+        assert_eq!(caps[0].name, "word");
+    }
+
+    #[test]
+    fn extract_named_captures_escaped_paren_skipped() {
+        let caps = RegexAnalyzer::extract_named_captures(r"\((?<x>\d)\)");
+        assert_eq!(caps.len(), 1);
+        assert_eq!(caps[0].name, "x");
+    }
+
+    #[test]
+    fn extract_named_captures_stores_subpattern() {
+        let caps = RegexAnalyzer::extract_named_captures(r"(?<id>\d+)");
+        assert_eq!(caps.len(), 1);
+        assert_eq!(caps[0].pattern, r"\d+");
+    }
+
+    // --- RegexAnalyzer::hover_text_for_regex ---
+
+    #[test]
+    fn hover_text_includes_pattern_and_captures() {
+        let text = RegexAnalyzer::hover_text_for_regex(r"(?<id>\d+)", "i");
+        assert!(text.contains("id"));
+        assert!(text.contains("case"));
+    }
+
+    #[test]
+    fn hover_text_modifier_explanations() {
+        let text = RegexAnalyzer::hover_text_for_regex("foo", "imsx");
+        assert!(text.contains("case-insensitive"));
+        assert!(text.contains("multiline"));
+        assert!(text.contains("single-line"));
+        assert!(text.contains("extended"));
+    }
+
+    #[test]
+    fn hover_text_global_modifier() {
+        let text = RegexAnalyzer::hover_text_for_regex("foo", "g");
+        assert!(text.contains("global"));
+    }
+
+    #[test]
+    fn hover_text_no_modifiers() {
+        let text = RegexAnalyzer::hover_text_for_regex("hello", "");
+        assert!(text.contains("hello"));
+        assert!(!text.contains("Modifiers"));
+    }
+
+    #[test]
+    fn hover_text_empty_pattern() {
+        let text = RegexAnalyzer::hover_text_for_regex("", "");
+        assert!(text.is_empty());
+    }
+
+    #[test]
+    fn hover_text_unknown_modifier_ignored() {
+        let text = RegexAnalyzer::hover_text_for_regex("x", "z");
+        // z is not a known modifier, so no modifier section
+        assert!(!text.contains("Modifiers"));
+    }
+}

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -1227,3 +1227,336 @@ const TOKEN_KIND_ALL: [TokenKind; 132] = [
     TokenKind::Eof,
     TokenKind::Unknown,
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- TokenSpan ---
+
+    #[test]
+    fn token_span_new_and_accessors() {
+        let span = TokenSpan::new(5, 10);
+        assert_eq!(span.start, 5);
+        assert_eq!(span.end, 10);
+        assert_eq!(span.len(), 5);
+        assert!(!span.is_empty());
+        assert_eq!(span.range(), 5..10);
+    }
+
+    #[test]
+    fn token_span_is_empty_when_zero_length() {
+        let span = TokenSpan::new(3, 3);
+        assert!(span.is_empty());
+        assert_eq!(span.len(), 0);
+    }
+
+    #[test]
+    fn token_span_try_new_ok() {
+        let span = TokenSpan::try_new(0, 5).unwrap();
+        assert_eq!(span.start, 0);
+        assert_eq!(span.end, 5);
+    }
+
+    #[test]
+    fn token_span_try_new_end_before_start_errors() {
+        let err = TokenSpan::try_new(10, 5).unwrap_err();
+        assert_eq!(err, TokenSpanError::EndBeforeStart { start: 10, end: 5 });
+    }
+
+    #[test]
+    fn token_span_error_display_end_before_start() {
+        let err = TokenSpanError::EndBeforeStart { start: 10, end: 5 };
+        let msg = err.to_string();
+        assert!(msg.contains("10"));
+        assert!(msg.contains("5"));
+    }
+
+    #[test]
+    fn token_span_error_display_empty_span_not_allowed() {
+        let err = TokenSpanError::EmptySpanNotAllowed { kind: TokenKind::Identifier, at: 7 };
+        let msg = err.to_string();
+        assert!(msg.contains("Identifier"));
+        assert!(msg.contains("7"));
+    }
+
+    // --- Token ---
+
+    #[test]
+    fn token_new_stores_fields() {
+        let tok = Token::new(TokenKind::My, "my", 0, 2);
+        assert_eq!(tok.kind, TokenKind::My);
+        assert_eq!(&*tok.text, "my");
+        assert_eq!(tok.start, 0);
+        assert_eq!(tok.end, 2);
+    }
+
+    #[test]
+    fn token_len_and_is_empty() {
+        let tok = Token::new(TokenKind::Identifier, "foo", 10, 13);
+        assert_eq!(tok.len(), 3);
+        assert!(!tok.is_empty());
+
+        let eof = Token::eof_at(8);
+        assert_eq!(eof.len(), 0);
+        assert!(eof.is_empty());
+    }
+
+    #[test]
+    fn token_span_and_range() {
+        let tok = Token::new(TokenKind::Number, "42", 5, 7);
+        assert_eq!(tok.span(), TokenSpan::new(5, 7));
+        assert_eq!(tok.range(), 5..7);
+    }
+
+    #[test]
+    fn token_try_new_rejects_end_before_start() {
+        let err = Token::try_new(TokenKind::Identifier, "x", 10, 5).unwrap_err();
+        assert_eq!(err, TokenSpanError::EndBeforeStart { start: 10, end: 5 });
+    }
+
+    #[test]
+    fn token_new_checked_rejects_empty_non_eof() {
+        let err = Token::new_checked(TokenKind::Identifier, "", 5, 5).unwrap_err();
+        assert!(matches!(
+            err,
+            TokenSpanError::EmptySpanNotAllowed { kind: TokenKind::Identifier, at: 5 }
+        ));
+    }
+
+    #[test]
+    fn token_new_checked_allows_empty_eof() {
+        let tok = Token::new_checked(TokenKind::Eof, "", 5, 5).unwrap();
+        assert_eq!(tok.kind, TokenKind::Eof);
+        assert_eq!(tok.start, 5);
+    }
+
+    #[test]
+    fn token_eof_at() {
+        let eof = Token::eof_at(42);
+        assert_eq!(eof.kind, TokenKind::Eof);
+        assert_eq!(eof.start, 42);
+        assert_eq!(eof.end, 42);
+        assert!(eof.is_empty());
+    }
+
+    #[test]
+    fn token_unknown_at_normalises_inverted_span() {
+        let tok = Token::unknown_at("?", 5, 3); // end < start
+        assert_eq!(tok.kind, TokenKind::Unknown);
+        assert_eq!(tok.start, 5);
+        assert_eq!(tok.end, 5); // bounded to start
+    }
+
+    #[test]
+    fn token_with_kind() {
+        let tok = Token::new(TokenKind::Identifier, "sub", 0, 3);
+        let retyped = tok.with_kind(TokenKind::Sub);
+        assert_eq!(retyped.kind, TokenKind::Sub);
+        assert_eq!(&*retyped.text, "sub");
+        assert_eq!(retyped.start, 0);
+        assert_eq!(retyped.end, 3);
+    }
+
+    #[test]
+    fn token_with_span_ok() {
+        let tok = Token::new(TokenKind::String, "hello", 0, 5);
+        let moved = tok.with_span(10, 15).unwrap();
+        assert_eq!(moved.start, 10);
+        assert_eq!(moved.end, 15);
+    }
+
+    #[test]
+    fn token_display_name_delegates_to_kind() {
+        let tok = Token::new(TokenKind::LeftBrace, "{", 0, 1);
+        assert_eq!(tok.display_name(), "'{'");
+    }
+
+    #[test]
+    fn token_as_ref_token_round_trip() {
+        let tok = Token::new(TokenKind::Sub, "sub", 0, 3);
+        let tok_ref = tok.as_ref_token();
+        assert_eq!(tok_ref.kind, TokenKind::Sub);
+        assert_eq!(tok_ref.text, "sub");
+        assert_eq!(tok_ref.start, 0);
+        assert_eq!(tok_ref.end, 3);
+
+        let owned: Token = tok_ref.into();
+        assert_eq!(owned.kind, TokenKind::Sub);
+        assert_eq!(&*owned.text, "sub");
+    }
+
+    // --- TokenRef ---
+
+    #[test]
+    fn token_ref_accessors() {
+        let r = TokenRef::new(TokenKind::Number, "99", 4, 6);
+        assert_eq!(r.len(), 2);
+        assert!(!r.is_empty());
+        assert_eq!(r.span(), (4, 6));
+        assert_eq!(r.display_name(), "number");
+    }
+
+    #[test]
+    fn token_ref_to_owned_token() {
+        let r = TokenRef::new(TokenKind::Identifier, "foo", 1, 4);
+        let owned = r.to_owned_token();
+        assert_eq!(owned.kind, TokenKind::Identifier);
+        assert_eq!(&*owned.text, "foo");
+    }
+
+    // --- TokenKind::from_keyword ---
+
+    #[test]
+    fn from_keyword_recognises_perl_keywords() {
+        assert_eq!(TokenKind::from_keyword("my"), Some(TokenKind::My));
+        assert_eq!(TokenKind::from_keyword("sub"), Some(TokenKind::Sub));
+        assert_eq!(TokenKind::from_keyword("if"), Some(TokenKind::If));
+        assert_eq!(TokenKind::from_keyword("elsif"), Some(TokenKind::Elsif));
+        assert_eq!(TokenKind::from_keyword("else"), Some(TokenKind::Else));
+        assert_eq!(TokenKind::from_keyword("while"), Some(TokenKind::While));
+        assert_eq!(TokenKind::from_keyword("for"), Some(TokenKind::For));
+        assert_eq!(TokenKind::from_keyword("foreach"), Some(TokenKind::Foreach));
+        assert_eq!(TokenKind::from_keyword("return"), Some(TokenKind::Return));
+        assert_eq!(TokenKind::from_keyword("package"), Some(TokenKind::Package));
+        assert_eq!(TokenKind::from_keyword("use"), Some(TokenKind::Use));
+        assert_eq!(TokenKind::from_keyword("BEGIN"), Some(TokenKind::Begin));
+        assert_eq!(TokenKind::from_keyword("END"), Some(TokenKind::End));
+        assert_eq!(TokenKind::from_keyword("eval"), Some(TokenKind::Eval));
+        assert_eq!(TokenKind::from_keyword("class"), Some(TokenKind::Class));
+        assert_eq!(TokenKind::from_keyword("defer"), Some(TokenKind::Defer));
+        assert_eq!(TokenKind::from_keyword("and"), Some(TokenKind::WordAnd));
+        assert_eq!(TokenKind::from_keyword("or"), Some(TokenKind::WordOr));
+        assert_eq!(TokenKind::from_keyword("not"), Some(TokenKind::WordNot));
+        assert_eq!(TokenKind::from_keyword("xor"), Some(TokenKind::WordXor));
+        assert_eq!(TokenKind::from_keyword("cmp"), Some(TokenKind::StringCompare));
+    }
+
+    #[test]
+    fn from_keyword_unknown_returns_none() {
+        assert_eq!(TokenKind::from_keyword("MY"), None);
+        assert_eq!(TokenKind::from_keyword("Sub"), None);
+        assert_eq!(TokenKind::from_keyword("unknown"), None);
+        assert_eq!(TokenKind::from_keyword(""), None);
+    }
+
+    // --- TokenKind::from_operator ---
+
+    #[test]
+    fn from_operator_recognises_operators() {
+        assert_eq!(TokenKind::from_operator("="), Some(TokenKind::Assign));
+        assert_eq!(TokenKind::from_operator("+"), Some(TokenKind::Plus));
+        assert_eq!(TokenKind::from_operator("**"), Some(TokenKind::Power));
+        assert_eq!(TokenKind::from_operator("->"), Some(TokenKind::Arrow));
+        assert_eq!(TokenKind::from_operator("=>"), Some(TokenKind::FatArrow));
+        assert_eq!(TokenKind::from_operator("<=>"), Some(TokenKind::Spaceship));
+        assert_eq!(TokenKind::from_operator("//="), Some(TokenKind::DefinedOrAssign));
+        assert_eq!(TokenKind::from_operator("..."), Some(TokenKind::Ellipsis));
+        assert_eq!(TokenKind::from_operator("~~"), Some(TokenKind::SmartMatch));
+    }
+
+    #[test]
+    fn from_operator_unknown_returns_none() {
+        assert_eq!(TokenKind::from_operator(""), None);
+        assert_eq!(TokenKind::from_operator("xyz"), None);
+    }
+
+    // --- TokenKind::from_delimiter ---
+
+    #[test]
+    fn from_delimiter_recognises_all() {
+        assert_eq!(TokenKind::from_delimiter("("), Some(TokenKind::LeftParen));
+        assert_eq!(TokenKind::from_delimiter(")"), Some(TokenKind::RightParen));
+        assert_eq!(TokenKind::from_delimiter("{"), Some(TokenKind::LeftBrace));
+        assert_eq!(TokenKind::from_delimiter("}"), Some(TokenKind::RightBrace));
+        assert_eq!(TokenKind::from_delimiter("["), Some(TokenKind::LeftBracket));
+        assert_eq!(TokenKind::from_delimiter("]"), Some(TokenKind::RightBracket));
+        assert_eq!(TokenKind::from_delimiter(";"), Some(TokenKind::Semicolon));
+        assert_eq!(TokenKind::from_delimiter(","), Some(TokenKind::Comma));
+        assert_eq!(TokenKind::from_delimiter("x"), None);
+    }
+
+    // --- TokenKind::from_sigil ---
+
+    #[test]
+    fn from_sigil_recognises_all() {
+        assert_eq!(TokenKind::from_sigil("$"), Some(TokenKind::ScalarSigil));
+        assert_eq!(TokenKind::from_sigil("@"), Some(TokenKind::ArraySigil));
+        assert_eq!(TokenKind::from_sigil("%"), Some(TokenKind::HashSigil));
+        assert_eq!(TokenKind::from_sigil("&"), Some(TokenKind::SubSigil));
+        assert_eq!(TokenKind::from_sigil("*"), Some(TokenKind::GlobSigil));
+        assert_eq!(TokenKind::from_sigil("!"), None);
+    }
+
+    // --- TokenKind::category ---
+
+    #[test]
+    fn category_keyword_variants() {
+        assert_eq!(TokenKind::My.category(), TokenCategory::Keyword);
+        assert_eq!(TokenKind::Sub.category(), TokenCategory::Keyword);
+        assert_eq!(TokenKind::Defer.category(), TokenCategory::Keyword);
+    }
+
+    #[test]
+    fn category_operator_variants() {
+        assert_eq!(TokenKind::Plus.category(), TokenCategory::Operator);
+        assert_eq!(TokenKind::Spaceship.category(), TokenCategory::Operator);
+        assert_eq!(TokenKind::WordAnd.category(), TokenCategory::Operator);
+    }
+
+    #[test]
+    fn category_delimiter_variants() {
+        assert_eq!(TokenKind::LeftParen.category(), TokenCategory::Delimiter);
+        assert_eq!(TokenKind::Comma.category(), TokenCategory::Delimiter);
+    }
+
+    #[test]
+    fn category_literal_variants() {
+        assert_eq!(TokenKind::Number.category(), TokenCategory::Literal);
+        assert_eq!(TokenKind::HeredocStart.category(), TokenCategory::Literal);
+        assert_eq!(TokenKind::DataMarker.category(), TokenCategory::Literal);
+    }
+
+    #[test]
+    fn category_identifier_variants() {
+        assert_eq!(TokenKind::Identifier.category(), TokenCategory::Identifier);
+        assert_eq!(TokenKind::ScalarSigil.category(), TokenCategory::Identifier);
+        assert_eq!(TokenKind::GlobSigil.category(), TokenCategory::Identifier);
+    }
+
+    #[test]
+    fn category_special_variants() {
+        assert_eq!(TokenKind::Eof.category(), TokenCategory::Special);
+        assert_eq!(TokenKind::Unknown.category(), TokenCategory::Special);
+    }
+
+    // --- TokenKind::display_name ---
+
+    #[test]
+    fn display_name_selected_variants() {
+        assert_eq!(TokenKind::LeftBrace.display_name(), "'{'");
+        assert_eq!(TokenKind::RightBrace.display_name(), "'}'");
+        assert_eq!(TokenKind::Identifier.display_name(), "identifier");
+        assert_eq!(TokenKind::Eof.display_name(), "end of input");
+        assert_eq!(TokenKind::Number.display_name(), "number");
+        assert_eq!(TokenKind::Sub.display_name(), "'sub'");
+        assert_eq!(TokenKind::Semicolon.display_name(), "';'");
+        assert_eq!(TokenKind::HeredocStart.display_name(), "heredoc (<<)");
+        assert_eq!(TokenKind::DataMarker.display_name(), "data marker (__DATA__ or __END__)");
+    }
+
+    // --- TokenKind::all / metadata_count ---
+
+    #[test]
+    fn all_returns_132_variants() {
+        assert_eq!(TokenKind::all().len(), 132);
+        assert_eq!(TokenKind::metadata_count(), 132);
+    }
+
+    #[test]
+    fn metadata_round_trips_through_kind() {
+        let m = TokenKind::Sub.metadata();
+        assert_eq!(m.category, TokenCategory::Keyword);
+        assert_eq!(m.display_name, "'sub'");
+    }
+}

--- a/crates/perl-token/tests/span_invariant_tests.rs
+++ b/crates/perl-token/tests/span_invariant_tests.rs
@@ -64,9 +64,11 @@ fn unknown_at_clamps_inverted_span_to_start() -> Result<(), Box<dyn std::error::
 #[test]
 fn token_span_try_new_rejects_end_before_start() -> Result<(), Box<dyn std::error::Error>> {
     // TokenSpan::try_new is the span-level checked constructor (separate from Token::try_new).
-    let err =
-        TokenSpan::try_new(100, 50).expect_err("span-level try_new should reject end < start");
-    assert_eq!(err, TokenSpanError::EndBeforeStart { start: 100, end: 50 });
+    let result = TokenSpan::try_new(100, 50);
+    assert!(result.is_err(), "span-level try_new should reject end < start");
+    if let Err(err) = result {
+        assert_eq!(err, TokenSpanError::EndBeforeStart { start: 100, end: 50 });
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Salvage of #6742 (fresh-root strand, no common ancestor with current master). Cherry-picks the test additions cleanly onto master.

- Adds 77 inline `#[cfg(test)]` unit tests to three leaf crates that had zero inline test coverage: `perl-token`, `perl-line-index`, `perl-regex`
- Moves `TOKEN_KIND_ALL` const before test module in `perl-token/src/lib.rs` to fix `clippy::items_after_test_module`
- Fixes pre-existing `clippy::expect_used` in `span_invariant_tests.rs`
- All 496 tests pass; fmt and clippy clean

Closes #6742 (replaces the stale PR with the fresh-root strand)

## What the tests cover

**perl-token** (259 tests total after):
- `TokenSpan::new`, `TokenSpan::try_new` constructors and error paths
- `Token::new`, `Token::new_checked`, `Token::try_new` constructors
- `TokenRef` creation
- `TokenKind::from_keyword`, `from_operator`, `from_delimiter`, `from_sigil`
- `TokenKind::category`, `display_name`, `metadata` round-trips
- `TokenKind::all()` count and coverage

**perl-line-index** (52 tests total after):
- `LineIndex::byte_to_position` and `position_to_byte` round-trips
- Empty string, single-line, multi-line, trailing-newline edge cases
- Out-of-range and column boundary conditions
- `position_to_byte_checked` behavior

**perl-regex** (185 tests total after):
- `RegexValidator::validate` happy and error paths (unicode property limit, lookbehind nesting, branch reset nesting/count)
- `detects_code_execution` with escaped parens and char-class false positives
- `detect_nested_quantifiers` across multiple quantifier patterns
- `RegexAnalyzer::extract_named_captures` (angle-bracket and single-quote syntax, lookbehind exclusion, subpattern storage)
- `hover_text_for_regex` modifier descriptions

## Test plan

- [x] `cargo test -p perl-token` — 259 passed
- [x] `cargo test -p perl-line-index` — 52 passed
- [x] `cargo test -p perl-regex` — 185 passed
- [x] `cargo fmt --manifest-path crates/perl-{token,regex,line-index}/Cargo.toml -- --check` — all pass
- [x] `cargo clippy -p perl-token -p perl-regex -p perl-line-index --tests -- -D warnings` — no issues
- [x] `cargo xtask fmt` — exit 0