### PR TITLE
ci: align pr-fast with ci-scope (#4816)

### DIFF
--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -131,6 +131,188 @@ gates:
     tags:
       - formatting
       - style
+    planning:
+      role: always_on
+
+  - name: check_conflict_markers
+    tier: pr_fast
+    description: "Prevent committed merge conflict markers"
+    required: true
+    command: just check-conflict-markers
+    timeout_seconds: 30
+    retry_count: 0
+    budgets:
+      max_duration_ms: 10000
+    quarantine: false
+    tags:
+      - hygiene
+      - conflict-markers
+    planning:
+      role: always_on
+
+  - name: release_history
+    tier: pr_fast
+    description: "Validate release-history surfaces"
+    required: true
+    command: just ci-release-history
+    timeout_seconds: 60
+    retry_count: 0
+    budgets:
+      max_duration_ms: 30000
+    quarantine: false
+    tags:
+      - release
+      - hygiene
+    planning:
+      role: always_on
+
+  - name: readme_heading_check
+    tier: pr_fast
+    description: "Prevent duplicate README level-2 headings"
+    required: true
+    command: just readme-heading-check
+    timeout_seconds: 30
+    retry_count: 0
+    budgets:
+      max_duration_ms: 10000
+    quarantine: false
+    tags:
+      - docs
+      - hygiene
+    planning:
+      role: always_on
+
+  - name: publish_closure
+    tier: pr_fast
+    description: "Check publish-closure transitive dependencies"
+    required: true
+    command: just ci-publish-closure
+    timeout_seconds: 60
+    retry_count: 0
+    budgets:
+      max_duration_ms: 30000
+    quarantine: false
+    tags:
+      - publish
+      - hygiene
+    planning:
+      role: always_on
+
+  - name: publish_manifest_check
+    tier: pr_fast
+    description: "Check publish manifest allowlist drift and license metadata"
+    required: true
+    command: just ci-publish-manifest-check
+    timeout_seconds: 60
+    retry_count: 0
+    budgets:
+      max_duration_ms: 30000
+    quarantine: false
+    tags:
+      - publish
+      - manifest
+    planning:
+      role: always_on
+
+  - name: layer_check
+    tier: pr_fast
+    description: "Enforce crate dependency layering"
+    required: true
+    command: just ci-layer-check
+    timeout_seconds: 60
+    retry_count: 0
+    budgets:
+      max_duration_ms: 30000
+    quarantine: false
+    tags:
+      - architecture
+      - hygiene
+    planning:
+      role: always_on
+
+  - name: published_crate_count_pr_fast
+    tier: pr_fast
+    description: "Ratchet published crate count"
+    required: true
+    command: just ci-published-crate-count
+    timeout_seconds: 30
+    retry_count: 0
+    budgets:
+      max_duration_ms: 10000
+    quarantine: false
+    tags:
+      - publish
+      - ratchet
+    planning:
+      role: always_on
+
+  - name: release_history_check
+    tier: pr_fast
+    description: "Check release-history drift"
+    required: true
+    command: just ci-release-history-check
+    timeout_seconds: 60
+    retry_count: 0
+    budgets:
+      max_duration_ms: 30000
+    quarantine: false
+    tags:
+      - release
+      - hygiene
+    planning:
+      role: always_on
+
+  - name: clippy_scoped
+    tier: pr_fast
+    description: "Scope-aware library clippy for ci-scope selected crates"
+    required: true
+    command: cargo clippy --locked --lib {package_args} -- -D warnings -A missing_docs
+    timeout_seconds: 180
+    retry_count: 0
+    budgets:
+      max_duration_ms: 120000
+      max_warnings: 0
+    quarantine: false
+    tags:
+      - lint
+      - clippy
+      - scoped
+    planning:
+      role: rust_scoped
+
+  - name: unit_scoped
+    tier: pr_fast
+    description: "Scope-aware library tests for ci-scope selected crates"
+    required: true
+    command: cargo test --locked --lib {package_args}
+    timeout_seconds: 180
+    retry_count: 1
+    budgets:
+      max_duration_ms: 150000
+    quarantine: false
+    tags:
+      - test
+      - unit
+      - scoped
+    planning:
+      role: rust_scoped
+
+  - name: check_tests_scoped
+    tier: pr_fast
+    description: "Compile integration tests for ci-scope selected crates"
+    required: true
+    command: cargo check --locked --tests {package_args}
+    timeout_seconds: 180
+    retry_count: 0
+    budgets:
+      max_duration_ms: 150000
+    quarantine: false
+    tags:
+      - check
+      - tests
+      - scoped
+    planning:
+      role: rust_scoped
 
   - name: clippy_core
     tier: pr_fast
@@ -151,6 +333,8 @@ gates:
     tags:
       - lint
       - clippy
+    planning:
+      role: rust_fallback
 
   - name: unit_core
     tier: pr_fast
@@ -170,6 +354,8 @@ gates:
     tags:
       - test
       - unit
+    planning:
+      role: rust_fallback
 
   - name: perl_token_leaf_contract
     tier: pr_fast
@@ -185,6 +371,8 @@ gates:
       - test
       - conformance
       - perl-token
+    planning:
+      role: always_on
 
   # ===========================================================================
   # Tier: merge_gate
@@ -218,10 +406,10 @@ gates:
     description: "All release-track workspace library tests (excluding internal tree-sitter harness)"
     required: true
     command: cargo test --workspace --lib --locked --exclude tree-sitter-perl
-    timeout_seconds: 300
+    timeout_seconds: 600
     retry_count: 1
     budgets:
-      max_duration_ms: 240000
+      max_duration_ms: 480000
     quarantine: false
     tags:
       - test

--- a/.ci/receipt.schema.json
+++ b/.ci/receipt.schema.json
@@ -473,6 +473,9 @@
         "suggested_next_actions": {
           "type": "array",
           "items": { "type": "string" }
+        },
+        "plan": {
+          "$ref": "#/$defs/agent_plan_receipt"
         }
       }
     },
@@ -481,10 +484,60 @@
       "required": ["direct_crates", "reverse_deps", "risk_tags"],
       "additionalProperties": false,
       "properties": {
+        "diff_class": { "type": "string" },
         "direct_crates": { "type": "array", "items": { "type": "string" } },
         "reverse_deps": { "type": "array", "items": { "type": "string" } },
+        "architecture_wideners": { "type": "array", "items": { "type": "string" } },
         "risk_tags": { "type": "array", "items": { "type": "string" } }
       }
+    },
+    "agent_plan_receipt": {
+      "type": "object",
+      "required": ["base", "scope_ok", "fallback_used", "package_args", "selected", "skipped"],
+      "additionalProperties": false,
+      "properties": {
+        "base": { "type": "string" },
+        "diff_class": { "type": "string" },
+        "scope_ok": { "type": "boolean" },
+        "fallback_used": { "type": "boolean" },
+        "fallback_reason": { "type": "string" },
+        "package_args": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "selected": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_planned_gate" }
+        },
+        "skipped": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/agent_skipped_gate" }
+        }
+      }
+    },
+    "agent_planned_gate": {
+      "type": "object",
+      "required": ["name", "role", "reason"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "role": { "$ref": "#/$defs/gate_planning_role" },
+        "reason": { "type": "string" }
+      }
+    },
+    "agent_skipped_gate": {
+      "type": "object",
+      "required": ["name", "reason"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "role": { "$ref": "#/$defs/gate_planning_role" },
+        "reason": { "type": "string" }
+      }
+    },
+    "gate_planning_role": {
+      "type": "string",
+      "enum": ["always_on", "rust_scoped", "rust_fallback", "rust_package_scoped", "static"]
     },
     "agent_lane": {
       "type": "object",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
-          # Fetch full history so ci-scope can diff against origin/master (auto-detection
-          # resolves this first in the fallback chain). 0 = full history.
+          # Fetch full history so ci-scope can diff against the explicit PR-fast base.
           fetch-depth: 0
 
       - name: Install Rust toolchain
@@ -138,12 +137,6 @@ jobs:
         with:
           tool: just
 
-      - name: Check formatting
-        run: cargo xtask fmt --check
-
-      - name: Check release history drift
-        run: bash scripts/check_release_history.sh
-
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
@@ -151,112 +144,22 @@ jobs:
           cache-all-crates: true
           shared-key: ci-gate-${{ hashFiles('Cargo.lock') }}
 
-      # Compute CI scope: classify the diff and select lanes.
-      # Falls back gracefully — if ci-scope fails, SCOPE_OK=false and we
-      # fall through to the hardcoded clippy-core / test-core baseline.
-      - name: Compute CI scope
-        id: scope
-        run: |
-          SCOPE_OK=true
-          SCOPE_JSON=$(cargo xtask ci-scope --base origin/master --format json 2>/dev/null) || SCOPE_OK=false
+      - name: Warm xtask
+        run: cargo build -p xtask --locked
 
-          if [ "$SCOPE_OK" = "false" ] || [ -z "$SCOPE_JSON" ]; then
-            echo "::warning::ci-scope failed or emitted empty output — falling back to clippy-core / test-core"
-            echo "scope_ok=false" >> "$GITHUB_OUTPUT"
-            echo "diff_class=unknown" >> "$GITHUB_OUTPUT"
-            echo "crates_args=" >> "$GITHUB_OUTPUT"
-          else
-            echo "scope_ok=true" >> "$GITHUB_OUTPUT"
+      - name: Run PR-fast via shared xtask gate runner
+        run: cargo xtask gates --tier pr-fast --base origin/master --receipt
 
-            # Extract diff_class
-            DIFF_CLASS=$(echo "$SCOPE_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('diff_class','unknown'))")
-            echo "diff_class=$DIFF_CLASS" >> "$GITHUB_OUTPUT"
-
-            # Build -p args from direct_crates + architecture_wideners (unique, non-empty)
-            CRATES_ARGS=$(echo "$SCOPE_JSON" | python3 -c "
-          import sys, json
-          d = json.load(sys.stdin)
-          names = set()
-          for c in d.get('direct_crates', []):
-              n = c.get('name', '').strip()
-              if n: names.add(n)
-          for c in d.get('architecture_wideners', []):
-              n = c.get('name', '').strip()
-              if n: names.add(n)
-          print(' '.join('-p ' + n for n in sorted(names)))
-          ")
-            echo "crates_args=$CRATES_ARGS" >> "$GITHUB_OUTPUT"
-
-            # Log the scope decision for debugging
-            echo "::notice::ci-scope diff_class=$DIFF_CLASS crates=$CRATES_ARGS"
-          fi
-
-      # Skip heavy lanes entirely for prose/docs-as-code/CI-config-only diffs.
-      - name: Skip notice (prose/docs-as-code/CI-config diff)
-        if: |
-          steps.scope.outputs.scope_ok == 'true' &&
-          (steps.scope.outputs.diff_class == 'prose_only' ||
-           steps.scope.outputs.diff_class == 'docs_as_code' ||
-           steps.scope.outputs.diff_class == 'ci_config')
-        run: |
-          echo "::notice::Prose/docs-as-code/CI-config diff — skipping Rust build lanes (no Rust code changed)"
-
-      # ── Scoped clippy (scope-aware path) ─────────────────────────────────
-      # Runs when ci-scope succeeded AND diff is not prose/CI-config AND
-      # there are crates to check.
-      - name: Scoped clippy
-        if: |
-          steps.scope.outputs.scope_ok == 'true' &&
-          steps.scope.outputs.diff_class != 'prose_only' &&
-          steps.scope.outputs.diff_class != 'docs_as_code' &&
-          steps.scope.outputs.diff_class != 'ci_config' &&
-          steps.scope.outputs.crates_args != ''
-        run: |
-          cargo clippy --locked ${{ steps.scope.outputs.crates_args }} -- -D warnings -A missing_docs
-
-      # ── Scoped test (scope-aware path) ───────────────────────────────────
-      - name: Scoped test
-        if: |
-          steps.scope.outputs.scope_ok == 'true' &&
-          steps.scope.outputs.diff_class != 'prose_only' &&
-          steps.scope.outputs.diff_class != 'docs_as_code' &&
-          steps.scope.outputs.diff_class != 'ci_config' &&
-          steps.scope.outputs.crates_args != ''
-        run: |
-          cargo test --locked --lib ${{ steps.scope.outputs.crates_args }}
-
-      # Compile integration tests for scoped crates to catch tests/* bit-rot.
-      - name: Scoped integration-test compile
-        if: |
-          steps.scope.outputs.scope_ok == 'true' &&
-          steps.scope.outputs.diff_class != 'prose_only' &&
-          steps.scope.outputs.diff_class != 'docs_as_code' &&
-          steps.scope.outputs.diff_class != 'ci_config' &&
-          steps.scope.outputs.crates_args != ''
-        run: |
-          cargo check --locked --tests ${{ steps.scope.outputs.crates_args }}
-
-      # ── Fallback: baseline clippy-core / test-core ────────────────────────
-      # Runs when: ci-scope failed (scope_ok=false), OR ci-scope returned no
-      # crates to check (empty crates_args on a non-prose diff — shouldn't
-      # happen but guards against gaps in the classifier).
-      - name: Fallback clippy-core
-        if: |
-          steps.scope.outputs.scope_ok == 'false' ||
-          (steps.scope.outputs.diff_class != 'prose_only' &&
-           steps.scope.outputs.diff_class != 'docs_as_code' &&
-           steps.scope.outputs.diff_class != 'ci_config' &&
-           steps.scope.outputs.crates_args == '')
-        run: just clippy-core
-
-      - name: Fallback test-core
-        if: |
-          steps.scope.outputs.scope_ok == 'false' ||
-          (steps.scope.outputs.diff_class != 'prose_only' &&
-           steps.scope.outputs.diff_class != 'docs_as_code' &&
-           steps.scope.outputs.diff_class != 'ci_config' &&
-           steps.scope.outputs.crates_args == '')
-        run: just test-core
+      - name: Upload PR-fast receipt
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-fast-receipt-${{ github.sha }}
+          path: |
+            target/receipts/receipt.json
+            target/receipts/logs/*.log
+          if-no-files-found: warn
+          retention-days: 7
 
       # Note: workspace-wide integration-test compilation is covered by the
       # parallel check-all-targets job (just check-all-targets), which runs
@@ -396,15 +299,23 @@ jobs:
             console.log(`Setting PR status to: ${status}`);
             console.log(`Description: ${description}`);
 
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.sha,
-              state: status,
-              context: 'ci/merge-gate',
-              description,
-              target_url: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
-            });
+            try {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: context.sha,
+                state: status,
+                context: 'ci/merge-gate',
+                description,
+                target_url: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
+              });
+            } catch (error) {
+              if (error.status === 403) {
+                core.warning(`Could not create ci/merge-gate commit status from this workflow context: ${error.message}`);
+              } else {
+                throw error;
+              }
+            }
 
   # ── UX Tests: first-5-minutes scenario regression suite ──────────────
   ux-tests:

--- a/justfile
+++ b/justfile
@@ -42,29 +42,12 @@ _timed name cmd:
 # Tier: PR-fast (required for every PR iteration, must be fast ~1-2 min)
 pr-fast: _check-tools-basic
     #!/usr/bin/env bash
-    set -uo pipefail
-    echo "=============================================="
-    echo "  PR-FAST GATE (quick validation)"
-    echo "=============================================="
-    START=$(date +%s)
-    just _timed "check-conflict-markers" "just check-conflict-markers" && \
-    just _timed "fmt-check" "just fmt-check" && \
-    just _timed "release-history" "just ci-release-history" && \
-    just _timed "readme-heading-check" "just readme-heading-check" && \
-    just _timed "clippy-core" "just clippy-core" && \
-    just _timed "test-core" "just test-core" && \
-    just _timed "publish-closure" "just ci-publish-closure" && \
-    just _timed "publish-manifest-check" "just ci-publish-manifest-check" && \
-    just _timed "layer-check" "just ci-layer-check" && \
-    just _timed "published-crate-count" "just ci-published-crate-count" && \
-    just _timed "release-history-check" "just ci-release-history-check"
-    RC=$?
-    END=$(date +%s)
-    echo ""
-    echo "=============================================="
-    echo "  PR-fast gate complete (total: $((END - START))s)"
-    echo "=============================================="
-    exit $RC
+    set -euo pipefail
+    args=(--tier pr-fast --receipt)
+    if [ -n "${CI_SCOPE_BASE:-}" ]; then
+        args+=(--base "$CI_SCOPE_BASE")
+    fi
+    cargo xtask gates "${args[@]}"
 
 # Compile-only gate: catches integration-test/benchmark bit-rot and also
 # validates feature-gated code paths without incurring full test runtime.
@@ -77,7 +60,7 @@ check-all-targets:
     cargo check --workspace --all-targets --all-features --locked
     @echo "All targets compile clean."
 
-# Scan every tracked file for committed git conflict markers (<<<<<<< / >>>>>>> / =======).
+# Scan every tracked file for committed git conflict marker lines.
 # Catches accidental conflict-marker commits before they break compilation or CI.
 # Historically caused: broken reconciler (3 cron cycles, #6869), corrupted docs (#7042).
 # Cost: <1s. Zero false positives for lines starting with exactly 7 < / > chars or =======$

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1185,6 +1185,10 @@ enum Commands {
         #[arg(long, short)]
         gate: Option<String>,
 
+        /// Base git ref used for scope-aware PR-fast planning
+        #[arg(long)]
+        base: Option<String>,
+
         /// List available gates without running them
         #[arg(long, short)]
         list: bool,
@@ -2176,6 +2180,7 @@ fn main() -> Result<()> {
         Commands::Gates {
             tier,
             gate,
+            base,
             list,
             format,
             receipt,
@@ -2187,6 +2192,7 @@ fn main() -> Result<()> {
         } => gates::run(gates::GateRunnerConfig {
             tier,
             gate_filter: gate,
+            base_ref: base,
             output_format: format,
             emit_receipt: receipt,
             receipt_path,

--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -23,7 +23,7 @@ use console::{Style, Term};
 use duct::cmd;
 use indicatif::{ProgressBar, ProgressStyle};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -79,7 +79,7 @@ pub enum OutputFormat {
 
 /// Top-level gate policy configuration
 #[allow(dead_code)]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct GatePolicy {
     pub schema_version: u32,
     pub global: GlobalSettings,
@@ -92,7 +92,7 @@ pub struct GatePolicy {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct GlobalSettings {
     pub default_timeout_seconds: u64,
     #[serde(default)]
@@ -106,7 +106,7 @@ pub struct GlobalSettings {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ToolchainConfig {
     pub msrv: Option<String>,
     #[serde(default)]
@@ -114,7 +114,7 @@ pub struct ToolchainConfig {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct TierDefinition {
     pub description: String,
     pub target_duration_seconds: u64,
@@ -124,7 +124,7 @@ pub struct TierDefinition {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct GateDefinition {
     pub name: String,
     pub tier: String,
@@ -146,6 +146,38 @@ pub struct GateDefinition {
     pub artifacts: Vec<String>,
     #[serde(default)]
     pub matrix: Option<serde_yaml_ng::Value>,
+    #[serde(default)]
+    pub planning: Option<GatePlanningConfig>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct GatePlanningConfig {
+    pub role: GatePlanningRole,
+    #[serde(default)]
+    pub packages: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GatePlanningRole {
+    AlwaysOn,
+    RustScoped,
+    RustFallback,
+    RustPackageScoped,
+    Static,
+}
+
+impl std::fmt::Display for GatePlanningRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GatePlanningRole::AlwaysOn => write!(f, "always_on"),
+            GatePlanningRole::RustScoped => write!(f, "rust_scoped"),
+            GatePlanningRole::RustFallback => write!(f, "rust_fallback"),
+            GatePlanningRole::RustPackageScoped => write!(f, "rust_package_scoped"),
+            GatePlanningRole::Static => write!(f, "static"),
+        }
+    }
 }
 
 fn default_true() -> bool {
@@ -157,14 +189,14 @@ fn default_timeout() -> u64 {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct GateBudgets {
     pub max_duration_ms: Option<u64>,
     pub max_warnings: Option<u32>,
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct FlakePolicy {
     pub max_retries: u32,
     pub auto_quarantine_threshold: u32,
@@ -176,7 +208,7 @@ pub struct FlakePolicy {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct QuarantinedGate {
     pub gate: String,
     pub reason: String,
@@ -185,14 +217,14 @@ pub struct QuarantinedGate {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct FlakyPattern {
     pub pattern: String,
     pub reason: String,
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct AuditConfig {
     pub receipt_path: String,
     pub log_directory: String,
@@ -224,13 +256,48 @@ pub struct AgentReceipt {
     pub selected_lanes: Vec<AgentLane>,
     pub failures: Vec<AgentFailure>,
     pub suggested_next_actions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan: Option<AgentPlanReceipt>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct AgentScope {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff_class: Option<String>,
     pub direct_crates: Vec<String>,
     pub reverse_deps: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub architecture_wideners: Vec<String>,
     pub risk_tags: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AgentPlanReceipt {
+    pub base: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diff_class: Option<String>,
+    pub scope_ok: bool,
+    pub fallback_used: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_reason: Option<String>,
+    pub package_args: Vec<String>,
+    pub selected: Vec<AgentPlannedGate>,
+    pub skipped: Vec<AgentSkippedGate>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AgentPlannedGate {
+    pub name: String,
+    pub role: GatePlanningRole,
+    pub reason: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AgentSkippedGate {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<GatePlanningRole>,
+    pub reason: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -460,10 +527,49 @@ pub struct MetricChange {
 // Gate Runner Implementation
 // =============================================================================
 
+#[derive(Debug, Clone)]
+struct GatePlan {
+    tier: GateTier,
+    base: String,
+    scope: Option<ScopeOutput>,
+    scope_ok: bool,
+    fallback_used: bool,
+    fallback_reason: Option<String>,
+    package_args: Vec<String>,
+    selected: Vec<PlannedGate>,
+    skipped: Vec<SkippedGate>,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedGate {
+    gate: GateDefinition,
+    role: GatePlanningRole,
+    reason: String,
+}
+
+#[derive(Debug, Clone)]
+struct SkippedGate {
+    name: String,
+    role: Option<GatePlanningRole>,
+    reason: String,
+}
+
+#[derive(Debug, Clone, Default)]
+struct PackageTargetIndex {
+    lib_packages: HashSet<String>,
+}
+
+impl PackageTargetIndex {
+    fn has_lib(&self, package: &str) -> bool {
+        self.lib_packages.contains(package)
+    }
+}
+
 /// Configuration for the gate runner
 pub struct GateRunnerConfig {
     pub tier: GateTier,
     pub gate_filter: Option<String>,
+    pub base_ref: Option<String>,
     pub output_format: OutputFormat,
     pub emit_receipt: bool,
     pub receipt_path: Option<PathBuf>,
@@ -481,6 +587,7 @@ impl Default for GateRunnerConfig {
         Self {
             tier: GateTier::MergeGate,
             gate_filter: None,
+            base_ref: None,
             output_format: OutputFormat::Human,
             emit_receipt: false,
             receipt_path: None,
@@ -502,24 +609,28 @@ pub fn run(config: GateRunnerConfig) -> Result<()> {
     let policy_path = root.join(".ci/gate-policy.yaml");
     let policy = load_policy(&policy_path)?;
 
-    // Filter gates based on tier and gate filter
-    let gates_to_run = filter_gates(&policy, &config)?;
-
-    // Handle list mode
+    // Handle list mode against the static policy catalog. Dynamic PR-fast scope
+    // planning is run only for actual execution/diff receipts.
     if config.list_only {
-        return list_gates(&gates_to_run, &policy);
+        let gates = filter_gates(&policy, &config)?;
+        return list_gates(&gates, &policy);
     }
+
+    // Build the executable plan. PR-fast uses the shared xtask runner plus
+    // ci-scope planning so local `just pr-fast` and CI execute the same lane
+    // decisions instead of duplicating shell/YAML logic.
+    let plan = plan_gates(&root, &policy, &config)?;
 
     // Handle diff mode
     if let Some(baseline_path) = &config.diff_baseline {
         let baseline = load_receipt(baseline_path)?;
-        let current = run_gates(&gates_to_run, &policy, &config)?;
+        let current = run_gate_plan(&plan, &policy, &config)?;
         let diff = compare_receipts(&baseline, &current)?;
         return output_diff(&diff, &config);
     }
 
     // Run gates
-    let receipt = run_gates(&gates_to_run, &policy, &config)?;
+    let receipt = run_gate_plan(&plan, &policy, &config)?;
 
     // Output results
     output_results(&receipt, &config)?;
@@ -551,11 +662,8 @@ fn load_policy(path: &PathBuf) -> Result<GatePolicy> {
 }
 
 /// Filter gates based on tier and gate name filter
-fn filter_gates<'a>(
-    policy: &'a GatePolicy,
-    config: &GateRunnerConfig,
-) -> Result<Vec<&'a GateDefinition>> {
-    let mut gates: Vec<&GateDefinition> = policy.gates.iter().collect();
+fn filter_gates(policy: &GatePolicy, config: &GateRunnerConfig) -> Result<Vec<GateDefinition>> {
+    let mut gates: Vec<GateDefinition> = policy.gates.clone();
 
     // Filter by specific gate name
     if let Some(gate_name) = &config.gate_filter {
@@ -589,14 +697,443 @@ fn filter_gates<'a>(
         "pr_fast" => 0,
         "merge_gate" => 1,
         "nightly" => 2,
-        _ => 3,
+        "release" => 3,
+        _ => 4,
     });
 
     Ok(gates)
 }
 
+fn plan_gates(root: &Path, policy: &GatePolicy, config: &GateRunnerConfig) -> Result<GatePlan> {
+    let base = config.base_ref.clone().unwrap_or_else(|| select_scope_base(root));
+
+    if config.gate_filter.is_some() {
+        return Ok(static_gate_plan(config.tier.clone(), base, filter_gates(policy, config)?));
+    }
+
+    match config.tier {
+        GateTier::PrFast => plan_pr_fast_gates(root, gates_for_tier(policy, "pr_fast"), base),
+        GateTier::MergeGate => {
+            let mut plan = plan_pr_fast_gates(root, gates_for_tier(policy, "pr_fast"), base)?;
+            plan.tier = GateTier::MergeGate;
+            extend_plan_with_static_tiers(&mut plan, policy, &["merge_gate"]);
+            Ok(plan)
+        }
+        GateTier::Nightly => {
+            let mut plan = plan_pr_fast_gates(root, gates_for_tier(policy, "pr_fast"), base)?;
+            plan.tier = GateTier::Nightly;
+            extend_plan_with_static_tiers(&mut plan, policy, &["merge_gate", "nightly"]);
+            Ok(plan)
+        }
+        GateTier::All => {
+            let mut plan = plan_pr_fast_gates(root, gates_for_tier(policy, "pr_fast"), base)?;
+            plan.tier = GateTier::All;
+            extend_plan_with_non_pr_fast_static_gates(&mut plan, policy);
+            Ok(plan)
+        }
+    }
+}
+
+fn static_gate_plan(tier: GateTier, base: String, gates: Vec<GateDefinition>) -> GatePlan {
+    let selected = gates.into_iter().map(static_gate).collect();
+
+    GatePlan {
+        tier,
+        base,
+        scope: None,
+        scope_ok: true,
+        fallback_used: false,
+        fallback_reason: None,
+        package_args: Vec::new(),
+        selected,
+        skipped: Vec::new(),
+    }
+}
+
+fn gates_for_tier(policy: &GatePolicy, tier: &str) -> Vec<GateDefinition> {
+    policy.gates.iter().filter(|gate| gate.tier == tier).cloned().collect()
+}
+
+fn extend_plan_with_static_tiers(plan: &mut GatePlan, policy: &GatePolicy, tiers: &[&str]) {
+    let tier_set: HashSet<&str> = tiers.iter().copied().collect();
+    plan.selected.extend(
+        policy
+            .gates
+            .iter()
+            .filter(|gate| tier_set.contains(gate.tier.as_str()))
+            .cloned()
+            .map(static_gate),
+    );
+}
+
+fn extend_plan_with_non_pr_fast_static_gates(plan: &mut GatePlan, policy: &GatePolicy) {
+    plan.selected.extend(
+        policy.gates.iter().filter(|gate| gate.tier != "pr_fast").cloned().map(static_gate),
+    );
+}
+
+fn static_gate(gate: GateDefinition) -> PlannedGate {
+    PlannedGate {
+        role: gate
+            .planning
+            .as_ref()
+            .map(|planning| planning.role)
+            .unwrap_or(GatePlanningRole::Static),
+        reason: "selected by static policy filter".to_string(),
+        gate,
+    }
+}
+
+/// Plan PR-fast from policy planning roles plus ci-scope output.
+fn plan_pr_fast_gates(root: &Path, gates: Vec<GateDefinition>, base: String) -> Result<GatePlan> {
+    let scope = match compute_scope_output(root, &base) {
+        Ok(scope) => scope,
+        Err(err) => {
+            let reason =
+                format!("ci-scope failed for base '{base}'; falling back to rust_fallback gates");
+            eprintln!("warning: {reason}: {err:#}");
+            return build_pr_fast_plan_from_scope_with_targets(
+                GateTier::PrFast,
+                base,
+                gates,
+                None,
+                false,
+                true,
+                Some(reason),
+                None,
+            );
+        }
+    };
+
+    let non_rust_diff = is_non_rust_diff(&scope);
+    let fallback_used = !non_rust_diff && selected_package_names(&scope).is_empty();
+    let fallback_reason = if fallback_used {
+        Some("ci-scope produced no package scope for a Rust-relevant diff".to_string())
+    } else {
+        None
+    };
+
+    let target_index = if !non_rust_diff && !fallback_used {
+        match load_package_target_index(root) {
+            Ok(index) => Some(index),
+            Err(err) => {
+                let reason =
+                    "cargo metadata target indexing failed; falling back to rust_fallback gates"
+                        .to_string();
+                eprintln!("warning: {reason}: {err:#}");
+                return build_pr_fast_plan_from_scope_with_targets(
+                    GateTier::PrFast,
+                    base,
+                    gates,
+                    Some(scope),
+                    true,
+                    true,
+                    Some(reason),
+                    None,
+                );
+            }
+        }
+    } else {
+        None
+    };
+
+    build_pr_fast_plan_from_scope_with_targets(
+        GateTier::PrFast,
+        base,
+        gates,
+        Some(scope),
+        true,
+        fallback_used,
+        fallback_reason,
+        target_index.as_ref(),
+    )
+}
+
+#[cfg(test)]
+fn build_pr_fast_plan_from_scope(
+    tier: GateTier,
+    base: String,
+    gates: Vec<GateDefinition>,
+    scope: Option<ScopeOutput>,
+    scope_ok: bool,
+    fallback_used: bool,
+    fallback_reason: Option<String>,
+) -> Result<GatePlan> {
+    build_pr_fast_plan_from_scope_with_targets(
+        tier,
+        base,
+        gates,
+        scope,
+        scope_ok,
+        fallback_used,
+        fallback_reason,
+        None,
+    )
+}
+
+fn build_pr_fast_plan_from_scope_with_targets(
+    tier: GateTier,
+    base: String,
+    gates: Vec<GateDefinition>,
+    scope: Option<ScopeOutput>,
+    scope_ok: bool,
+    fallback_used: bool,
+    fallback_reason: Option<String>,
+    target_index: Option<&PackageTargetIndex>,
+) -> Result<GatePlan> {
+    let non_rust_diff = scope.as_ref().is_some_and(is_non_rust_diff);
+    let package_names = scope.as_ref().map(selected_package_names).unwrap_or_default();
+    let package_args = package_args_from_names(&package_names);
+
+    let mut selected = Vec::new();
+    let mut skipped = Vec::new();
+
+    for gate in gates {
+        let role = pr_fast_role(&gate)?;
+        match role {
+            GatePlanningRole::AlwaysOn => {
+                selected.push(PlannedGate {
+                    role,
+                    reason: "always-on pr_fast gate".to_string(),
+                    gate,
+                });
+            }
+            GatePlanningRole::RustScoped => {
+                if fallback_used {
+                    skipped.push(SkippedGate {
+                        name: gate.name,
+                        role: Some(role),
+                        reason: fallback_reason
+                            .clone()
+                            .unwrap_or_else(|| "rust fallback selected".to_string()),
+                    });
+                } else if non_rust_diff {
+                    skipped.push(SkippedGate {
+                        name: gate.name,
+                        role: Some(role),
+                        reason: scope_skip_reason(scope.as_ref()),
+                    });
+                } else {
+                    let gate_package_names =
+                        package_names_for_gate(&gate, &package_names, target_index);
+                    let gate_package_args = package_args_from_names(&gate_package_names);
+                    if gate_package_args.is_empty() {
+                        skipped.push(SkippedGate {
+                            name: gate.name.clone(),
+                            role: Some(role),
+                            reason: no_eligible_package_reason(&gate),
+                        });
+                    } else {
+                        selected.push(PlannedGate {
+                            role,
+                            reason: format!(
+                                "code diff selected packages: {}",
+                                gate_package_names.join(", ")
+                            ),
+                            gate: render_package_args(gate, &gate_package_args)?,
+                        });
+                    }
+                }
+            }
+            GatePlanningRole::RustFallback => {
+                if fallback_used {
+                    selected.push(PlannedGate {
+                        role,
+                        reason: fallback_reason
+                            .clone()
+                            .unwrap_or_else(|| "rust fallback selected".to_string()),
+                        gate,
+                    });
+                } else if non_rust_diff {
+                    skipped.push(SkippedGate {
+                        name: gate.name,
+                        role: Some(role),
+                        reason: scope_skip_reason(scope.as_ref()),
+                    });
+                } else {
+                    skipped.push(SkippedGate {
+                        name: gate.name,
+                        role: Some(role),
+                        reason: "rust scoped plan selected".to_string(),
+                    });
+                }
+            }
+            GatePlanningRole::RustPackageScoped => {
+                if fallback_used {
+                    selected.push(PlannedGate {
+                        role,
+                        reason: fallback_reason
+                            .clone()
+                            .unwrap_or_else(|| "rust fallback selected".to_string()),
+                        gate,
+                    });
+                } else if let Some(reason) = package_scoped_reason(&gate, &package_names) {
+                    selected.push(PlannedGate { role, reason, gate });
+                } else {
+                    skipped.push(SkippedGate {
+                        name: gate.name.clone(),
+                        role: Some(role),
+                        reason: package_scoped_skip_reason(&gate, scope.as_ref()),
+                    });
+                }
+            }
+            GatePlanningRole::Static => {
+                bail!(
+                    "Gate '{}' in pr_fast must declare planning.role; static is not valid for pr_fast planning",
+                    gate.name
+                );
+            }
+        }
+    }
+
+    Ok(GatePlan {
+        tier,
+        base,
+        scope,
+        scope_ok,
+        fallback_used,
+        fallback_reason,
+        package_args,
+        selected,
+        skipped,
+    })
+}
+
+fn pr_fast_role(gate: &GateDefinition) -> Result<GatePlanningRole> {
+    gate.planning.as_ref().map(|planning| planning.role).ok_or_else(|| {
+        color_eyre::eyre::eyre!("Gate '{}' in pr_fast is missing planning.role", gate.name)
+    })
+}
+
+fn is_non_rust_diff(scope: &ScopeOutput) -> bool {
+    matches!(scope.diff_class.as_str(), "prose_only" | "docs_as_code" | "ci_config")
+}
+
+fn scope_skip_reason(scope: Option<&ScopeOutput>) -> String {
+    let diff_class = scope.map(|scope| scope.diff_class.as_str()).unwrap_or("unknown");
+    format!("Rust lanes skipped because diff_class={diff_class}")
+}
+
+fn selected_package_names(scope: &ScopeOutput) -> Vec<String> {
+    let mut package_names: Vec<String> = scope
+        .direct_crates
+        .iter()
+        .map(|entry| entry.name.clone())
+        .chain(scope.reverse_dep_closure.iter().map(|entry| entry.name.clone()))
+        .chain(scope.architecture_wideners.iter().map(|entry| entry.name.clone()))
+        .collect();
+    package_names.sort();
+    package_names.dedup();
+    package_names
+}
+
+fn package_args_from_names(package_names: &[String]) -> Vec<String> {
+    package_names.iter().flat_map(|name| ["-p".to_string(), name.clone()]).collect()
+}
+
+fn render_package_args(
+    mut gate: GateDefinition,
+    package_args: &[String],
+) -> Result<GateDefinition> {
+    if !gate.command.contains("{package_args}") {
+        bail!(
+            "Gate '{}' has planning.role=rust_scoped but its command has no {{package_args}} placeholder",
+            gate.name
+        );
+    }
+    gate.command = gate.command.replace("{package_args}", &package_args.join(" "));
+    Ok(gate)
+}
+
+fn load_package_target_index(root: &Path) -> Result<PackageTargetIndex> {
+    let metadata_raw = cmd("cargo", ["metadata", "--format-version=1", "--no-deps"])
+        .dir(root)
+        .read()
+        .context("Failed to load cargo metadata for package target planning")?;
+    let metadata: serde_json::Value =
+        serde_json::from_str(&metadata_raw).context("Failed to parse cargo metadata JSON")?;
+
+    let mut index = PackageTargetIndex::default();
+    let packages = metadata
+        .get("packages")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| color_eyre::eyre::eyre!("cargo metadata JSON missing packages array"))?;
+
+    for package in packages {
+        let Some(name) = package.get("name").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let has_lib =
+            package.get("targets").and_then(serde_json::Value::as_array).is_some_and(|targets| {
+                targets.iter().any(|target| {
+                    target
+                        .get("kind")
+                        .and_then(serde_json::Value::as_array)
+                        .is_some_and(|kinds| kinds.iter().any(|kind| kind.as_str() == Some("lib")))
+                })
+            });
+        if has_lib {
+            index.lib_packages.insert(name.to_string());
+        }
+    }
+
+    Ok(index)
+}
+
+fn package_names_for_gate(
+    gate: &GateDefinition,
+    package_names: &[String],
+    target_index: Option<&PackageTargetIndex>,
+) -> Vec<String> {
+    if gate_requires_lib(gate) {
+        if let Some(index) = target_index {
+            return package_names.iter().filter(|name| index.has_lib(name)).cloned().collect();
+        }
+    }
+    package_names.to_vec()
+}
+
+fn no_eligible_package_reason(gate: &GateDefinition) -> String {
+    if gate_requires_lib(gate) {
+        "no ci-scope selected packages have a lib target for this gate".to_string()
+    } else {
+        "no ci-scope package arguments available".to_string()
+    }
+}
+
+fn gate_requires_lib(gate: &GateDefinition) -> bool {
+    gate.command.split_whitespace().any(|part| part == "--lib")
+}
+
+fn package_scoped_reason(gate: &GateDefinition, package_names: &[String]) -> Option<String> {
+    let packages = gate.planning.as_ref()?.packages.as_slice();
+    let matched: Vec<String> = packages
+        .iter()
+        .filter(|package| package_names.iter().any(|name| name == *package))
+        .cloned()
+        .collect();
+    if matched.is_empty() {
+        None
+    } else {
+        Some(format!("package-scoped gate matched {}", matched.join(", ")))
+    }
+}
+
+fn package_scoped_skip_reason(gate: &GateDefinition, scope: Option<&ScopeOutput>) -> String {
+    if scope.is_some_and(is_non_rust_diff) {
+        return scope_skip_reason(scope);
+    }
+    let packages =
+        gate.planning.as_ref().map(|planning| planning.packages.join(", ")).unwrap_or_default();
+    if packages.is_empty() {
+        "package-scoped gate has no configured packages".to_string()
+    } else {
+        format!("selected packages did not include {packages}")
+    }
+}
+
 /// List available gates
-fn list_gates(gates: &[&GateDefinition], policy: &GatePolicy) -> Result<()> {
+fn list_gates(gates: &[GateDefinition], policy: &GatePolicy) -> Result<()> {
     let mut term = Term::stdout();
     let bold = Style::new().bold();
     let dim = Style::new().dim();
@@ -606,12 +1143,12 @@ fn list_gates(gates: &[&GateDefinition], policy: &GatePolicy) -> Result<()> {
     writeln!(term)?;
 
     // Group by tier
-    let mut by_tier: HashMap<&str, Vec<&&GateDefinition>> = HashMap::new();
+    let mut by_tier: HashMap<&str, Vec<&GateDefinition>> = HashMap::new();
     for gate in gates {
         by_tier.entry(gate.tier.as_str()).or_default().push(gate);
     }
 
-    for tier_name in &["pr_fast", "merge_gate", "nightly"] {
+    for tier_name in &["pr_fast", "merge_gate", "nightly", "release"] {
         if let Some(tier_gates) = by_tier.get(tier_name) {
             let tier_def = policy.tiers.get(*tier_name);
             let tier_desc = tier_def.map(|t| t.description.as_str()).unwrap_or("Unknown tier");
@@ -645,9 +1182,9 @@ fn list_gates(gates: &[&GateDefinition], policy: &GatePolicy) -> Result<()> {
     Ok(())
 }
 
-/// Run gates and collect results
-fn run_gates(
-    gates: &[&GateDefinition],
+/// Run a planned set of gates and collect results.
+fn run_gate_plan(
+    plan: &GatePlan,
     policy: &GatePolicy,
     config: &GateRunnerConfig,
 ) -> Result<Receipt> {
@@ -667,7 +1204,7 @@ fn run_gates(
     let mut tier_summaries: HashMap<String, TierSummary> = HashMap::new();
 
     let spinner = if config.output_format == OutputFormat::Human {
-        let pb = ProgressBar::new(gates.len() as u64);
+        let pb = ProgressBar::new(plan.selected.len() as u64);
         pb.set_style(
             ProgressStyle::default_bar()
                 .template("{spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} {wide_msg}")
@@ -679,7 +1216,8 @@ fn run_gates(
         None
     };
 
-    for (idx, gate) in gates.iter().enumerate() {
+    for (idx, planned_gate) in plan.selected.iter().enumerate() {
+        let gate = &planned_gate.gate;
         if let Some(ref pb) = spinner {
             pb.set_position(idx as u64);
             pb.set_message(format!("Running {}...", gate.name));
@@ -759,7 +1297,7 @@ fn run_gates(
         },
         aggregate_metrics: None, // Could aggregate test counts etc.
     };
-    let agent_receipt = Some(build_agent_receipt(&root, &results, &config.tier));
+    let agent_receipt = Some(build_agent_receipt(&root, &results, plan));
 
     Ok(Receipt {
         schema_version: "1.0.0".to_string(),
@@ -773,8 +1311,8 @@ fn run_gates(
 
 /// Phase-1 agent-facing receipt shape contract (Issue #5020):
 /// keep this as a stable, minimal JSON slice consumed by CI artifacts.
-fn build_agent_receipt(root: &Path, results: &[GateResult], tier: &GateTier) -> AgentReceipt {
-    let scope_output = compute_scope_output(root).ok();
+fn build_agent_receipt(root: &Path, results: &[GateResult], plan: &GatePlan) -> AgentReceipt {
+    let scope_output = plan.scope.clone();
     let gate_status_by_name: HashMap<String, String> =
         results.iter().map(|result| (result.gate_name.clone(), result.status.clone())).collect();
     let selected_lanes = scope_output
@@ -817,8 +1355,14 @@ fn build_agent_receipt(root: &Path, results: &[GateResult], tier: &GateTier) -> 
 
     let scope = if let Some(scope) = scope_output {
         AgentScope {
+            diff_class: Some(scope.diff_class),
             direct_crates: scope.direct_crates.into_iter().map(|entry| entry.name).collect(),
             reverse_deps: scope.reverse_dep_closure.into_iter().map(|entry| entry.name).collect(),
+            architecture_wideners: scope
+                .architecture_wideners
+                .into_iter()
+                .map(|entry| entry.name)
+                .collect(),
             risk_tags: scope.risk_tags,
         }
     } else {
@@ -828,11 +1372,41 @@ fn build_agent_receipt(root: &Path, results: &[GateResult], tier: &GateTier) -> 
     AgentReceipt {
         sha,
         is_latest,
-        tier: tier.to_string(),
+        tier: plan.tier.to_string(),
         scope,
         selected_lanes,
         failures,
         suggested_next_actions: next_actions,
+        plan: Some(agent_plan_receipt(plan)),
+    }
+}
+
+fn agent_plan_receipt(plan: &GatePlan) -> AgentPlanReceipt {
+    AgentPlanReceipt {
+        base: plan.base.clone(),
+        diff_class: plan.scope.as_ref().map(|scope| scope.diff_class.clone()),
+        scope_ok: plan.scope_ok,
+        fallback_used: plan.fallback_used,
+        fallback_reason: plan.fallback_reason.clone(),
+        package_args: plan.package_args.clone(),
+        selected: plan
+            .selected
+            .iter()
+            .map(|planned| AgentPlannedGate {
+                name: planned.gate.name.clone(),
+                role: planned.role,
+                reason: planned.reason.clone(),
+            })
+            .collect(),
+        skipped: plan
+            .skipped
+            .iter()
+            .map(|skipped| AgentSkippedGate {
+                name: skipped.name.clone(),
+                role: skipped.role,
+                reason: skipped.reason.clone(),
+            })
+            .collect(),
     }
 }
 
@@ -903,8 +1477,7 @@ fn is_latest_commit(root: &Path) -> bool {
     }
 }
 
-fn compute_scope_output(root: &Path) -> Result<ScopeOutput> {
-    let base = select_scope_base(root);
+fn compute_scope_output(root: &Path, base: &str) -> Result<ScopeOutput> {
     let changed_files = cmd("git", ["diff", "--name-only", &format!("{base}...HEAD")])
         .dir(root)
         .read()
@@ -923,7 +1496,7 @@ fn compute_scope_output(root: &Path) -> Result<ScopeOutput> {
 
     let workspace_root = root.to_string_lossy().replace('\\', "/");
     let mut scope = ci_scope::classify_files(&changed_files, &metadata, &workspace_root)?;
-    scope.base = base;
+    scope.base = base.to_string();
     scope.head_sha = cmd("git", ["rev-parse", "HEAD"]).dir(root).read()?.trim().to_string();
     scope.changed_files = changed_files;
     Ok(scope)
@@ -936,7 +1509,11 @@ fn select_scope_base(root: &Path) -> String {
         std::env::var("GITHUB_BASE_REF").ok(),
     ];
     let mut candidates: Vec<String> = env_candidates.into_iter().flatten().collect();
-    candidates.extend(["origin/master", "master", "HEAD~1"].into_iter().map(str::to_string));
+    candidates.extend(
+        ["origin/master", "origin/main", "origin/HEAD", "master", "main", "HEAD~1"]
+            .into_iter()
+            .map(str::to_string),
+    );
     for candidate in candidates {
         // Suppress stderr: in shallow clones "HEAD~1" does not exist and git prints
         // "fatal: Needed a single revision" to stderr, polluting CI output.
@@ -1005,8 +1582,37 @@ fn run_single_gate(
         });
     }
 
-    // Run the command
-    let result = cmd!("bash", "-lc", command).stderr_to_stdout().stdout_capture().unchecked().run();
+    if command == "just ci-publish-closure" || command == "cargo xtask publish-closure" {
+        return run_internal_xtask_gate(gate, &log_path, command, start, || {
+            super::publish_closure::run(None)
+        });
+    }
+
+    if command == "just ci-publish-manifest-check"
+        || command == "cargo xtask publish-manifest-check"
+    {
+        return run_internal_xtask_gate(gate, &log_path, command, start, || {
+            super::publish_manifest_check::run()
+        });
+    }
+
+    if command == "just ci-layer-check" || command == "cargo xtask layer-check" {
+        return run_internal_xtask_gate(gate, &log_path, command, start, || {
+            super::layer_check::run()
+        });
+    }
+
+    if command == "just ci-published-crate-count" || command == "cargo xtask published-crate-count"
+    {
+        return run_internal_xtask_gate(gate, &log_path, command, start, || {
+            super::count_ratchet::run()
+        });
+    }
+
+    // Run through the platform shell because gate commands are policy strings.
+    // Linux CI uses bash; Windows local runs use cmd.exe to keep `cargo`/`just`
+    // lookup and simple command chaining available without requiring Git Bash.
+    let result = shell_command(command).stderr_to_stdout().stdout_capture().unchecked().run();
 
     let duration_ms = start.elapsed().as_millis() as u64;
 
@@ -1085,6 +1691,16 @@ fn run_single_gate(
             })
         }
     }
+}
+
+#[cfg(windows)]
+fn shell_command(command: &str) -> duct::Expression {
+    cmd!("cmd", "/C", command)
+}
+
+#[cfg(not(windows))]
+fn shell_command(command: &str) -> duct::Expression {
+    cmd!("bash", "-lc", command)
 }
 
 fn run_internal_xtask_gate(
@@ -1880,10 +2496,18 @@ fn determine_overall_status(failed: u32, blocking_failures: &[String]) -> &'stat
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{BTreeMap, HashMap, HashSet};
+
     use super::{
-        DiffResult, FirstFailure, GateMetrics, GateResult, MetricChange, Receipt,
-        blocking_failure_gate_names, compare_receipts, determine_overall_status, failure_guidance,
-        is_blocking_gate_status, is_cargo_test_command, parse_first_failure,
+        DiffResult, FirstFailure, GateDefinition, GateMetrics, GatePlanningConfig,
+        GatePlanningRole, GatePolicy, GateResult, GateTier, GlobalSettings, MetricChange,
+        PackageTargetIndex, Receipt, blocking_failure_gate_names, build_pr_fast_plan_from_scope,
+        build_pr_fast_plan_from_scope_with_targets, compare_receipts, determine_overall_status,
+        extend_plan_with_non_pr_fast_static_gates, extend_plan_with_static_tiers, failure_guidance,
+        is_blocking_gate_status, is_cargo_test_command, load_policy, parse_first_failure,
+    };
+    use crate::tasks::ci_scope::{
+        ArchWidener, DirectCrate, PlatformOverrides, RevDepCrate, ScopeOutput,
     };
 
     fn gate_result(name: &str, status: &str, required: bool) -> GateResult {
@@ -1901,6 +2525,410 @@ mod tests {
             artifacts: None,
             first_failure: None,
         }
+    }
+
+    fn pr_gate(name: &str, role: GatePlanningRole, command: &str) -> GateDefinition {
+        GateDefinition {
+            name: name.to_string(),
+            tier: "pr_fast".to_string(),
+            description: name.to_string(),
+            required: true,
+            command: command.to_string(),
+            timeout_seconds: 30,
+            retry_count: 0,
+            budgets: None,
+            quarantine: false,
+            tags: Vec::new(),
+            artifacts: Vec::new(),
+            matrix: None,
+            planning: Some(GatePlanningConfig { role, packages: Vec::new() }),
+        }
+    }
+
+    fn tier_gate(name: &str, tier: &str, command: &str) -> GateDefinition {
+        GateDefinition {
+            tier: tier.to_string(),
+            planning: None,
+            ..pr_gate(name, GatePlanningRole::Static, command)
+        }
+    }
+
+    fn policy_with_gates(gates: Vec<GateDefinition>) -> GatePolicy {
+        GatePolicy {
+            schema_version: 1,
+            global: GlobalSettings {
+                default_timeout_seconds: 30,
+                artifact_retention_days: 0,
+                default_retry_count: 0,
+                environment: HashMap::new(),
+                toolchain: None,
+            },
+            tiers: HashMap::new(),
+            gates,
+            flake_policy: None,
+            audit: None,
+        }
+    }
+
+    fn package_pr_gate(name: &str, packages: Vec<String>) -> GateDefinition {
+        GateDefinition {
+            planning: Some(GatePlanningConfig {
+                role: GatePlanningRole::RustPackageScoped,
+                packages,
+            }),
+            ..pr_gate(name, GatePlanningRole::RustPackageScoped, "cargo test -p perl-token")
+        }
+    }
+
+    fn scope_output(
+        diff_class: &str,
+        direct: &[&str],
+        reverse: &[&str],
+        wideners: &[&str],
+    ) -> ScopeOutput {
+        ScopeOutput {
+            schema_version: 2,
+            base: "origin/master".to_string(),
+            head_sha: "head".to_string(),
+            changed_files: Vec::new(),
+            diff_class: diff_class.to_string(),
+            direct_crates: direct
+                .iter()
+                .map(|name| DirectCrate { name: (*name).to_string(), reason: "direct".to_string() })
+                .collect(),
+            reverse_dep_closure: reverse
+                .iter()
+                .map(|name| RevDepCrate {
+                    name: (*name).to_string(),
+                    reason: "reverse".to_string(),
+                })
+                .collect(),
+            architecture_wideners: wideners
+                .iter()
+                .map(|name| ArchWidener { name: (*name).to_string(), rule: "widener".to_string() })
+                .collect(),
+            risk_tags: Vec::new(),
+            platform_overrides: PlatformOverrides::default(),
+            selected_lanes: Vec::new(),
+            selected_heavy_lanes: Vec::new(),
+            lanes: BTreeMap::new(),
+            explanations: BTreeMap::new(),
+        }
+    }
+
+    fn selected_gate_names(plan: &super::GatePlan) -> Vec<String> {
+        plan.selected.iter().map(|planned| planned.gate.name.clone()).collect()
+    }
+
+    fn skipped_gate_names(plan: &super::GatePlan) -> Vec<String> {
+        plan.skipped.iter().map(|skipped| skipped.name.clone()).collect()
+    }
+
+    #[test]
+    fn pr_fast_prose_only_keeps_always_on_and_skips_rust_lanes() -> color_eyre::eyre::Result<()> {
+        let gates = vec![
+            pr_gate("fmt", GatePlanningRole::AlwaysOn, "cargo xtask fmt --check"),
+            pr_gate("clippy_scoped", GatePlanningRole::RustScoped, "cargo clippy {package_args}"),
+            pr_gate("unit_core", GatePlanningRole::RustFallback, "cargo test -p perl-parser"),
+        ];
+
+        let plan = build_pr_fast_plan_from_scope(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            gates,
+            Some(scope_output("prose_only", &[], &[], &[])),
+            true,
+            false,
+            None,
+        )?;
+
+        assert_eq!(selected_gate_names(&plan), vec!["fmt"]);
+        assert_eq!(skipped_gate_names(&plan), vec!["clippy_scoped", "unit_core"]);
+        assert!(!plan.fallback_used);
+        assert!(plan.skipped.iter().all(|gate| gate.reason.contains("diff_class=prose_only")));
+        Ok(())
+    }
+
+    #[test]
+    fn pr_fast_code_diff_selects_scoped_rust_lanes_with_full_package_scope()
+    -> color_eyre::eyre::Result<()> {
+        let gates = vec![
+            pr_gate("fmt", GatePlanningRole::AlwaysOn, "cargo xtask fmt --check"),
+            pr_gate(
+                "clippy_scoped",
+                GatePlanningRole::RustScoped,
+                "cargo clippy --locked {package_args} -- -D warnings",
+            ),
+            pr_gate(
+                "unit_scoped",
+                GatePlanningRole::RustScoped,
+                "cargo test --locked --lib {package_args}",
+            ),
+            pr_gate(
+                "check_tests_scoped",
+                GatePlanningRole::RustScoped,
+                "cargo check --locked --tests {package_args}",
+            ),
+            pr_gate("clippy_core", GatePlanningRole::RustFallback, "cargo clippy -p perl-parser"),
+        ];
+
+        let plan = build_pr_fast_plan_from_scope(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            gates,
+            Some(scope_output("code", &["perl-parser"], &["perl-lsp-rs"], &["perl-dap"])),
+            true,
+            false,
+            None,
+        )?;
+
+        assert_eq!(
+            selected_gate_names(&plan),
+            vec!["fmt", "clippy_scoped", "unit_scoped", "check_tests_scoped"]
+        );
+        assert_eq!(
+            plan.package_args,
+            vec!["-p", "perl-dap", "-p", "perl-lsp-rs", "-p", "perl-parser"]
+        );
+        assert_eq!(skipped_gate_names(&plan), vec!["clippy_core"]);
+        let clippy = plan
+            .selected
+            .iter()
+            .find(|planned| planned.gate.name == "clippy_scoped")
+            .ok_or_else(|| color_eyre::eyre::eyre!("missing clippy_scoped plan"))?;
+        assert!(clippy.gate.command.contains("-p perl-parser"));
+        assert!(clippy.gate.command.contains("-p perl-lsp-rs"));
+        assert!(clippy.gate.command.contains("-p perl-dap"));
+        Ok(())
+    }
+
+    #[test]
+    fn pr_fast_scope_failure_preserves_always_on_and_uses_fallback() -> color_eyre::eyre::Result<()>
+    {
+        let gates = vec![
+            pr_gate("fmt", GatePlanningRole::AlwaysOn, "cargo xtask fmt --check"),
+            pr_gate("clippy_scoped", GatePlanningRole::RustScoped, "cargo clippy {package_args}"),
+            pr_gate("clippy_core", GatePlanningRole::RustFallback, "cargo clippy -p perl-parser"),
+            pr_gate("unit_core", GatePlanningRole::RustFallback, "cargo test -p perl-parser"),
+        ];
+
+        let plan = build_pr_fast_plan_from_scope(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            gates,
+            None,
+            false,
+            true,
+            Some("scope failed".to_string()),
+        )?;
+
+        assert_eq!(selected_gate_names(&plan), vec!["fmt", "clippy_core", "unit_core"]);
+        assert_eq!(skipped_gate_names(&plan), vec!["clippy_scoped"]);
+        assert!(!plan.scope_ok);
+        assert!(plan.fallback_used);
+        assert_eq!(plan.fallback_reason.as_deref(), Some("scope failed"));
+        Ok(())
+    }
+
+    #[test]
+    fn pr_fast_package_scoped_gate_runs_only_when_package_selected() -> color_eyre::eyre::Result<()>
+    {
+        let gates = vec![
+            pr_gate("fmt", GatePlanningRole::AlwaysOn, "cargo xtask fmt --check"),
+            package_pr_gate("perl_token_leaf_contract", vec!["perl-token".to_string()]),
+        ];
+
+        let selected_plan = build_pr_fast_plan_from_scope(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            gates.clone(),
+            Some(scope_output("code", &["perl-token"], &[], &[])),
+            true,
+            false,
+            None,
+        )?;
+        assert_eq!(selected_gate_names(&selected_plan), vec!["fmt", "perl_token_leaf_contract"]);
+
+        let skipped_plan = build_pr_fast_plan_from_scope(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            gates,
+            Some(scope_output("code", &["perl-parser"], &[], &[])),
+            true,
+            false,
+            None,
+        )?;
+        assert_eq!(selected_gate_names(&skipped_plan), vec!["fmt"]);
+        assert_eq!(skipped_gate_names(&skipped_plan), vec!["perl_token_leaf_contract"]);
+        Ok(())
+    }
+
+    #[test]
+    fn pr_fast_package_scoped_gate_runs_on_scope_failure() -> color_eyre::eyre::Result<()> {
+        let gates = vec![
+            pr_gate("fmt", GatePlanningRole::AlwaysOn, "cargo xtask fmt --check"),
+            package_pr_gate("perl_token_leaf_contract", vec!["perl-token".to_string()]),
+            pr_gate("unit_core", GatePlanningRole::RustFallback, "cargo test -p perl-parser"),
+        ];
+
+        let plan = build_pr_fast_plan_from_scope(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            gates,
+            None,
+            false,
+            true,
+            Some("scope failed".to_string()),
+        )?;
+
+        assert_eq!(
+            selected_gate_names(&plan),
+            vec!["fmt", "perl_token_leaf_contract", "unit_core"]
+        );
+        assert!(plan.fallback_used);
+        Ok(())
+    }
+
+    #[test]
+    fn pr_fast_lib_scoped_gate_filters_packages_without_lib_targets() -> color_eyre::eyre::Result<()>
+    {
+        let gates = vec![
+            pr_gate(
+                "unit_scoped",
+                GatePlanningRole::RustScoped,
+                "cargo test --locked --lib {package_args}",
+            ),
+            pr_gate(
+                "check_tests_scoped",
+                GatePlanningRole::RustScoped,
+                "cargo check --locked --tests {package_args}",
+            ),
+        ];
+        let target_index =
+            PackageTargetIndex { lib_packages: HashSet::from(["perl-parser".to_string()]) };
+
+        let plan = build_pr_fast_plan_from_scope_with_targets(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            gates,
+            Some(scope_output("code", &["perl-parser", "xtask"], &[], &[])),
+            true,
+            false,
+            None,
+            Some(&target_index),
+        )?;
+
+        let Some(unit) = plan.selected.iter().find(|planned| planned.gate.name == "unit_scoped")
+        else {
+            color_eyre::eyre::bail!("missing unit_scoped plan");
+        };
+        assert!(unit.gate.command.contains("-p perl-parser"));
+        assert!(!unit.gate.command.contains("-p xtask"));
+
+        let Some(check_tests) =
+            plan.selected.iter().find(|planned| planned.gate.name == "check_tests_scoped")
+        else {
+            color_eyre::eyre::bail!("missing check_tests_scoped plan");
+        };
+        assert!(check_tests.gate.command.contains("-p perl-parser"));
+        assert!(check_tests.gate.command.contains("-p xtask"));
+        Ok(())
+    }
+
+    #[test]
+    fn pr_fast_policy_planning_roles_are_complete() -> color_eyre::eyre::Result<()> {
+        let root = crate::utils::project_root()?;
+        let policy_path = root.join(".ci/gate-policy.yaml");
+        let policy = load_policy(&policy_path)?;
+
+        for gate in policy.gates.iter().filter(|gate| gate.tier == "pr_fast") {
+            let Some(planning) = &gate.planning else {
+                color_eyre::eyre::bail!("pr_fast gate '{}' missing planning.role", gate.name);
+            };
+            if planning.role == GatePlanningRole::Static {
+                color_eyre::eyre::bail!(
+                    "pr_fast gate '{}' must not use planning.role=static",
+                    gate.name
+                );
+            }
+            if planning.role == GatePlanningRole::RustScoped
+                && !gate.command.contains("{package_args}")
+            {
+                color_eyre::eyre::bail!(
+                    "rust_scoped gate '{}' missing {{package_args}} placeholder",
+                    gate.name
+                );
+            }
+            if planning.role == GatePlanningRole::RustPackageScoped && planning.packages.is_empty()
+            {
+                color_eyre::eyre::bail!(
+                    "rust_package_scoped gate '{}' missing planning.packages",
+                    gate.name
+                );
+            }
+            if planning.role == GatePlanningRole::RustFallback
+                && gate.command.contains("{package_args}")
+            {
+                color_eyre::eyre::bail!(
+                    "rust_fallback gate '{}' must not contain {{package_args}}",
+                    gate.name
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn merge_gate_static_extension_does_not_add_raw_pr_fast_templates()
+    -> color_eyre::eyre::Result<()> {
+        let mut plan = build_pr_fast_plan_from_scope(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            vec![pr_gate("fmt", GatePlanningRole::AlwaysOn, "true")],
+            Some(scope_output("prose_only", &[], &[], &[])),
+            true,
+            false,
+            None,
+        )?;
+        let policy = policy_with_gates(vec![
+            pr_gate("clippy_scoped", GatePlanningRole::RustScoped, "cargo clippy {package_args}"),
+            tier_gate("clippy_full", "merge_gate", "cargo clippy --workspace"),
+        ]);
+
+        extend_plan_with_static_tiers(&mut plan, &policy, &["merge_gate"]);
+
+        assert_eq!(selected_gate_names(&plan), vec!["fmt", "clippy_full"]);
+        assert!(
+            plan.selected.iter().all(|planned| !planned.gate.command.contains("{package_args}"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn all_static_extension_includes_release_gates() -> color_eyre::eyre::Result<()> {
+        let mut plan = build_pr_fast_plan_from_scope(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            vec![pr_gate("fmt", GatePlanningRole::AlwaysOn, "true")],
+            Some(scope_output("prose_only", &[], &[], &[])),
+            true,
+            false,
+            None,
+        )?;
+        let policy = policy_with_gates(vec![
+            pr_gate("clippy_scoped", GatePlanningRole::RustScoped, "cargo clippy {package_args}"),
+            tier_gate("clippy_full", "merge_gate", "cargo clippy --workspace"),
+            tier_gate("nightly_corpus", "nightly", "cargo xtask corpus"),
+            tier_gate("release_build", "release", "cargo build --release"),
+        ]);
+
+        extend_plan_with_non_pr_fast_static_gates(&mut plan, &policy);
+
+        assert_eq!(
+            selected_gate_names(&plan),
+            vec!["fmt", "clippy_full", "nightly_corpus", "release_build"]
+        );
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Problem: local `just pr-fast` and the Tier-1 PR Smoke workflow had separate ci-scope implementations for #4816, so the two paths could drift.

Fix: move PR-fast planning into the shared `cargo xtask gates --tier pr-fast --receipt` runner. The runner now uses the existing Rust `ci-scope` classifier directly, includes direct crates + reverse-dep closure + architecture wideners in scoped package args, skips Rust build lanes for prose/docs/CI-config-only diffs, falls back to the core clippy/test baseline if scope detection fails, and emits the normal gate receipt at `target/receipts/receipt.json`. `just pr-fast` and PR Smoke both delegate to this same xtask runner.

Verification: `git diff --check` passed. Full compile/gate verification is deferred to CI because this cron runner has Cargo 1.75/no `just`, while this workspace requires the current edition2024 toolchain.