### PR TITLE
fix(docs): remove unresolved conflict markers from EDITOR_SETUP.md (master)

### DIFF
--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -24,15 +24,9 @@ perllsp --health
 | Editor | Fast path | Detailed guide |
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
-<<<<<<< HEAD
 | Trae (ByteDance) | install the VS Code-compatible `EffortlessMetrics.perl-lsp-rs` extension; use `perl-lsp.serverPath` only for manual/offline `perllsp` deployments | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
 | Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Vim | use `vim-lsp` or `coc.nvim` with `perllsp --stdio` | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
-=======
-| Trae (ByteDance) | install the VS Code-compatible `EffortlessMetrics.perl-lsp-rs` extension; use `perl-lsp.serverPath` only for manual/offline `perllsp` deployments | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
-| Neovim | configure `cmd = { "perllsp", "--stdio" }` | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
-| Vim | use `vim-lsp` or `coc.nvim` with `perllsp --stdio` | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
->>>>>>> 69fa1562a (Merge branch 'codex/update-helix-perl-lsp-guide-4ec6zc' into temp-helix-merge)
 | Emacs | use `lsp-mode` or `eglot` with `perllsp --stdio` | [docs/EDITORS/EMACS_SETUP.md](../EDITORS/EMACS_SETUP.md) |
 | Helix | override the built-in Perl language server from `perlnavigator` to `perllsp --stdio` in `languages.toml` | [docs/EDITORS/HELIX_SETUP.md](../EDITORS/HELIX_SETUP.md) |
 | Zed | install a Perl extension, then optionally point at `perllsp` | [docs/EDITORS/ZED_SETUP.md](../EDITORS/ZED_SETUP.md) |


### PR DESCRIPTION
## Summary

- PR #7042 (Helix editor setup guide) was merged with unresolved git conflict markers left in `docs/how-to/EDITOR_SETUP.md`
- The conflict markers appeared in the editor table between the VS Code row and the Emacs row (lines 27-35 of the committed file)
- Both HEAD and incoming sides were **identical** — the same three table rows for Trae, Neovim, and Vim — so this is a pure cleanup with no content decision required
- Fix removes the 3 conflict-marker lines (`<<<<<<<`, `=======`, `>>>>>>>`) and the 3 duplicate content lines, leaving exactly one copy of each row

## Files fixed

- `docs/how-to/EDITOR_SETUP.md` — 6 lines deleted (conflict markers + duplicate rows)

## What was kept

HEAD side (and the incoming side was identical):
- `| Trae (ByteDance) | ... |`
- `| Neovim | ... |`
- `| Vim | ... |`

## Test plan

- [x] `grep -E "^(<<<<<<<|>>>>>>>|=======)" docs/how-to/EDITOR_SETUP.md` returns nothing
- [x] Editor table renders correctly (VS Code → Trae → Neovim → Vim → Emacs → Helix → ...)
- [x] No Rust files modified — no build check needed