### PR TITLE
style: workspace fmt cleanup post #7170 admin-merge

### DIFF
--- a/xtask/src/tasks/queue_reconciler.rs
+++ b/xtask/src/tasks/queue_reconciler.rs
@@ -827,7 +827,10 @@ mod tests {
         let pr = make_pr(1, &[MERGE_READY, NEEDS_CI_FIX]);
         let c = detect_contradictions(&pr, &[], CiOutcome::Skipped);
         let strips: Vec<&str> = c.iter().map(|x| x.strip.as_str()).collect();
-        assert!(strips.contains(&NEEDS_CI_FIX), "should strip needs-ci-fix when all checks SKIPPED");
+        assert!(
+            strips.contains(&NEEDS_CI_FIX),
+            "should strip needs-ci-fix when all checks SKIPPED"
+        );
         assert!(
             !strips.contains(&MERGE_READY),
             "should NOT strip merge-ready when CI is SKIPPED (gate inapplicable)"


### PR DESCRIPTION
## Summary

- Reformats `xtask/src/tasks/queue_reconciler.rs` line 827 to satisfy `rustfmt` line-length rules
- Single `assert!` macro call split from one line into multi-line form
- No logic changes — pure formatting fix

## Root cause

PR #7170 was admin-merged bypassing CI Gate, leaving `queue_reconciler.rs` unformatted. This causes master CI to fail at PR Smoke fmt-check.

## Verification

- `cargo xtask fmt --check` passes clean
- `cargo build -p xtask` compiles with no errors
- 1 file changed, 4 insertions(+), 1 deletion(-)

## Files reformatted

- `xtask/src/tasks/queue_reconciler.rs`