### PR TITLE
fix(perl-parser): address perf scorecard clippy warnings (#0000)

### DIFF
--- a/crates/perl-parser/benches/support/perf_scorecard.rs
+++ b/crates/perl-parser/benches/support/perf_scorecard.rs
@@ -75,7 +75,7 @@ where
     // Using ceiling division avoids the off-by-one in the floor formula
     // ((n * 95) / 100) which returns the 100th-percentile sample for all
     // N <= 20.
-    let p95_idx = ((n * 95 + 99) / 100).saturating_sub(1).min(n.saturating_sub(1));
+    let p95_idx = (n * 95).div_ceil(100).saturating_sub(1).min(n.saturating_sub(1));
     let total: u128 = samples.iter().copied().sum();
 
     ScoreMetric {
@@ -110,7 +110,7 @@ fn now_epoch_seconds() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::sample_metric;
 
     /// Verify that `sample_metric` reports the correct median and p95 for a
     /// deterministic sequence.  We drive `run` with a counter so the elapsed


### PR DESCRIPTION
### Motivation
- Silence avoidable clippy warnings in the parser benchmark support code and make the percentile math more idiomatic.

### Description
- Replaced manual ceiling-division math with `.div_ceil()` for the p95 index calculation in `crates/perl-parser/benches/support/perf_scorecard.rs` to satisfy `clippy::manual_div_ceil` and preserve behavior.
- Narrowed the test module import to `use super::sample_metric;` to remove an unused-import warning.

### Testing
- Ran `cargo clippy -p perl-parser --all-targets`, and the prior `manual_div_ceil` and unused-import warnings in `perf_scorecard.rs` were resolved.
- Launched `cargo test -p perl-parser`, which progressed through extensive compilation in this environment but the full test run output was not captured to completion in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c26f8e48333bdaab7dd9cc097a8)