### PR TITLE
refactor(perl-lexer): remove unwrap from find_after doctest (#0000)

### DIFF
--- a/crates/perl-lexer/src/checkpoint.rs
+++ b/crates/perl-lexer/src/checkpoint.rs
@@ -286,12 +286,12 @@ impl CheckpointCache {
     /// // Find checkpoint at or after position 150
     /// let cp = cache.find_after(150);
     /// assert!(cp.is_some());
-    /// assert_eq!(cp.unwrap().position, 200);
+    /// assert!(matches!(cp, Some(found) if found.position == 200));
     ///
     /// // Find checkpoint at exact position
     /// let cp = cache.find_after(200);
     /// assert!(cp.is_some());
-    /// assert_eq!(cp.unwrap().position, 200);
+    /// assert!(matches!(cp, Some(found) if found.position == 200));
     ///
     /// // Position beyond last checkpoint returns None
     /// let cp = cache.find_after(400);


### PR DESCRIPTION
### Motivation
- The `CheckpointCache::find_after` documentation example used `unwrap()`, which violates the repository quality rule banning `unwrap()` in tests/doctests and risks panics in examples.

### Description
- Replace `assert_eq!(cp.unwrap().position, 200);` with `assert!(matches!(cp, Some(found) if found.position == 200));` in the `find_after` doctest in `crates/perl-lexer/src/checkpoint.rs` to avoid `unwrap()` while preserving the same check.

### Testing
- Ran `cargo test -p perl-lexer --doc`, `cargo check --all-targets -p perl-lexer`, and `cargo clippy -p perl-lexer -- -D warnings`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c2c2eb483339ac52b13399d96a7)