### PR TITLE
fix(perl-pragma): normalize conditional pragma qw args (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -606,11 +606,13 @@ impl PragmaTracker {
                                 current_state.strict_refs = true;
                             } else {
                                 for arg in conditional_args {
-                                    match normalized_pragma_token(arg) {
-                                        "vars" => current_state.strict_vars = true,
-                                        "subs" => current_state.strict_subs = true,
-                                        "refs" => current_state.strict_refs = true,
-                                        _ => {}
+                                    for item in pragma_arg_items(arg) {
+                                        match item.as_str() {
+                                            "vars" => current_state.strict_vars = true,
+                                            "subs" => current_state.strict_subs = true,
+                                            "refs" => current_state.strict_refs = true,
+                                            _ => {}
+                                        }
                                     }
                                 }
                             }
@@ -785,11 +787,13 @@ impl PragmaTracker {
                                 current_state.strict_refs = false;
                             } else {
                                 for arg in conditional_args {
-                                    match normalized_pragma_token(arg) {
-                                        "vars" => current_state.strict_vars = false,
-                                        "subs" => current_state.strict_subs = false,
-                                        "refs" => current_state.strict_refs = false,
-                                        _ => {}
+                                    for item in pragma_arg_items(arg) {
+                                        match item.as_str() {
+                                            "vars" => current_state.strict_vars = false,
+                                            "subs" => current_state.strict_subs = false,
+                                            "refs" => current_state.strict_refs = false,
+                                            _ => {}
+                                        }
                                     }
                                 }
                             }
@@ -805,8 +809,9 @@ impl PragmaTracker {
                                 current_state.disabled_warning_categories.clear();
                             } else {
                                 for arg in conditional_args {
-                                    let category = normalized_pragma_token(arg);
-                                    add_disabled_warning_category(current_state, category);
+                                    for item in pragma_arg_items(arg) {
+                                        add_disabled_warning_category(current_state, &item);
+                                    }
                                 }
                             }
                             ranges.push((

--- a/crates/perl-pragma/tests/pragma_surface_regressions.rs
+++ b/crates/perl-pragma/tests/pragma_surface_regressions.rs
@@ -312,3 +312,23 @@ fn no_if_strict_qw_disables_only_requested_categories_conditionally()
     assert!(state.strict_refs, "refs was not in the qw list, must stay enabled");
     Ok(())
 }
+
+#[test]
+fn no_if_warnings_qw_disables_named_warning_categories_conditionally()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("warnings", &[], 0, 13),
+        no_node("if", &["$cond", "warnings", "qw(uninitialized once)"], 14, 60),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 30);
+    assert!(
+        state.warnings,
+        "conditional no-if-warnings with categories must keep global warnings enabled"
+    );
+    assert!(!state.is_warning_active("uninitialized"));
+    assert!(!state.is_warning_active("once"));
+    assert!(state.is_warning_active("numeric"));
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Conditional `use/no if|unless` handling treated arguments as single tokens, so grouped forms like `qw(vars refs)` were not expanded and conditional strict/ warning-category changes could be applied incorrectly.

### Description
- Route conditional `strict` argument handling through `pragma_arg_items` so conditional forms like `use if $cond, strict => qw(vars refs)` expand identically to non-conditional `use strict` (change in `crates/perl-pragma/src/lib.rs`).
- Route conditional `no ... warnings` category parsing through `pragma_arg_items` so `no if $cond, warnings => qw(cat1 cat2)` records each disabled category individually (change in `crates/perl-pragma/src/lib.rs`).
- Add a regression test `no_if_warnings_qw_disables_named_warning_categories_conditionally` in `crates/perl-pragma/tests/pragma_surface_regressions.rs` to cover conditional `qw(...)` warning-category behavior.
- Apply formatting to touched files with `cargo xtask fmt`.

### Testing
- `cargo check --all-targets -p perl-pragma` passed.
- `cargo clippy -p perl-pragma --all-targets -- -D warnings` passed.
- `cargo test -p perl-pragma` ran; the change’s targeted regressions and the new test pass, but three pre-existing failures remain: `duplicate_no_warnings_category_does_not_create_extra_entry`, `no_warnings_empty_string_category_is_ignored`, and `use_feature_all_enables_known_features`, which are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c2f2eb88333a5bc31d996078815)