### PR TITLE
fix(perl-pragma): normalize conditional warning category args (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -387,6 +387,10 @@ fn add_disabled_warning_category(state: &mut PragmaState, category: &str) {
     state.disabled_warning_categories.push(category.to_string());
 }
 
+fn warning_categories_from_args(args: &[String]) -> impl Iterator<Item = String> + '_ {
+    args.iter().flat_map(|arg| pragma_arg_items(arg))
+}
+
 fn remove_builtin_imports(state: &mut PragmaState, args: &[String]) {
     if args.is_empty() {
         state.builtin_imports.clear();
@@ -804,9 +808,8 @@ impl PragmaTracker {
                                 current_state.warnings = false;
                                 current_state.disabled_warning_categories.clear();
                             } else {
-                                for arg in conditional_args {
-                                    let category = normalized_pragma_token(arg);
-                                    add_disabled_warning_category(current_state, category);
+                                for category in warning_categories_from_args(conditional_args) {
+                                    add_disabled_warning_category(current_state, &category);
                                 }
                             }
                             ranges.push((
@@ -902,11 +905,8 @@ impl PragmaTracker {
                             // `no warnings 'CATEGORY'` — disable only the named
                             // categories; the global flag stays true so that other
                             // categories remain active.
-                            for arg in args {
-                                // Strip any surrounding single or double quotes that
-                                // the parser may have left on the argument.
-                                let category = arg.trim_matches('\'').trim_matches('"');
-                                add_disabled_warning_category(current_state, category);
+                            for category in warning_categories_from_args(args) {
+                                add_disabled_warning_category(current_state, &category);
                             }
                         }
                         ranges

--- a/crates/perl-pragma/tests/pragma_surface_regressions.rs
+++ b/crates/perl-pragma/tests/pragma_surface_regressions.rs
@@ -312,3 +312,28 @@ fn no_if_strict_qw_disables_only_requested_categories_conditionally()
     assert!(state.strict_refs, "refs was not in the qw list, must stay enabled");
     Ok(())
 }
+
+#[test]
+fn no_if_warnings_qw_disables_each_category_conditionally()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("warnings", &[], 0, 13),
+        no_node("if", &["$cond", "warnings", "qw(uninitialized numeric)"], 14, 64),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 40);
+    assert!(
+        !state.is_warning_active("uninitialized"),
+        "conditional no-if-warnings qw(...) must disable uninitialized"
+    );
+    assert!(
+        !state.is_warning_active("numeric"),
+        "conditional no-if-warnings qw(...) must disable numeric"
+    );
+    assert!(
+        state.is_warning_active("io"),
+        "categories not listed in the qw(...) should stay active"
+    );
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Conditional `no if/unless ... warnings => ...` paths did not expand `qw(...)` lists, causing grouped categories to be treated as a single token and preventing individual categories from being disabled.

### Description
- Add `warning_categories_from_args` helper that normalizes warning args via `pragma_arg_items` and reuses it for both conditional and direct `no warnings` handling in `crates/perl-pragma/src/lib.rs`.
- Replace ad-hoc token handling with the shared normalizer so `qw(...)` expansion yields separate category names for `no if/unless ... warnings` and plain `no warnings` cases.
- Add a regression test `no_if_warnings_qw_disables_each_category_conditionally` in `crates/perl-pragma/tests/pragma_surface_regressions.rs` that asserts each `qw(...)` entry is disabled independently and other categories remain active.

### Testing
- Ran `cargo test -p perl-pragma no_if_warnings_qw_disables_each_category_conditionally`, which passed.
- Ran `cargo check --all-targets -p perl-pragma`, which passed.
- Ran `cargo clippy -p perl-pragma -- -D warnings`, which completed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c2f2eb88333a5bc31d996078815)