### PR TITLE
fix(perl-corpus): replace test unwraps in gold deserialization (#0000)

### DIFF
--- a/crates/perl-corpus/src/gold.rs
+++ b/crates/perl-corpus/src/gold.rs
@@ -468,18 +468,19 @@ pub fn load_document_symbol_gold_fixtures<P: AsRef<Path>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use perl_tdd_support::must;
 
     #[test]
     fn test_gold_assertion_deserialization() {
         let json = r#"{"assertion": "no_diagnostics"}"#;
-        let assertion: GoldAssertion = serde_json::from_str(json).unwrap();
+        let assertion: GoldAssertion = must(serde_json::from_str(json));
         assert!(matches!(assertion, GoldAssertion::NoDiagnostics));
     }
 
     #[test]
     fn test_gold_assertion_diagnostic_present() {
         let json = r#"{"assertion": "diagnostic_present", "code": "PL100", "byte_offset": 24}"#;
-        let assertion: GoldAssertion = serde_json::from_str(json).unwrap();
+        let assertion: GoldAssertion = must(serde_json::from_str(json));
         assert!(
             matches!(
                 &assertion,
@@ -496,7 +497,7 @@ mod tests {
     #[test]
     fn test_gold_expected_deserialization() {
         let json = r#"{"diagnostics": [{"assertion": "no_diagnostics"}]}"#;
-        let expected: GoldExpected = serde_json::from_str(json).unwrap();
+        let expected: GoldExpected = must(serde_json::from_str(json));
         assert_eq!(expected.diagnostics.len(), 1);
     }
 
@@ -512,14 +513,14 @@ mod tests {
     fn test_empty_diagnostics_array_deserializes() {
         // empty array is valid JSON but the harness will catch it as vacuous
         let json = r#"{"diagnostics": []}"#;
-        let expected: GoldExpected = serde_json::from_str(json).unwrap();
+        let expected: GoldExpected = must(serde_json::from_str(json));
         assert_eq!(expected.diagnostics.len(), 0);
     }
 
     #[test]
     fn test_no_diagnostic_deserialization() {
         let json = r#"{"assertion": "no_diagnostic", "code": "PL100"}"#;
-        let assertion: GoldAssertion = serde_json::from_str(json).unwrap();
+        let assertion: GoldAssertion = must(serde_json::from_str(json));
         assert!(
             matches!(&assertion, GoldAssertion::NoDiagnostic { code } if code == "PL100"),
             "Expected NoDiagnostic variant with code PL100"
@@ -529,7 +530,7 @@ mod tests {
     #[test]
     fn test_diagnostic_count_deserialization() {
         let json = r#"{"assertion": "diagnostic_count", "code": "PL001", "count": 3}"#;
-        let assertion: GoldAssertion = serde_json::from_str(json).unwrap();
+        let assertion: GoldAssertion = must(serde_json::from_str(json));
         assert!(
             matches!(&assertion, GoldAssertion::DiagnosticCount { code, count: 3 } if code == "PL001"),
             "Expected DiagnosticCount variant with code PL001 and count 3"


### PR DESCRIPTION
### Motivation
- Unit tests in `crates/perl-corpus/src/gold.rs` used `unwrap()` on `serde_json::from_str`, which violates the repository test-quality conventions that prefer `perl_tdd_support::must` or `Result`-returning tests.

### Description
- Added `use perl_tdd_support::must;` to the test module in `crates/perl-corpus/src/gold.rs`.
- Replaced occurrences of `serde_json::from_str(...).unwrap()` with `must(serde_json::from_str(...))` in the gold deserialization unit tests.
- Change is limited to test robustness and does not alter production code behavior.

### Testing
- Ran `cargo test -p perl-corpus` and all tests passed.
- Ran `cargo check --all-targets -p perl-corpus` and it succeeded.
- Ran `cargo clippy -p perl-corpus -- -D warnings` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c3e9730833384afb08be27fae32)