### PR TITLE
feat(perl-corpus): include .plx fixtures in corpus discovery (#0000)

### DIFF
--- a/crates/perl-corpus/src/files.rs
+++ b/crates/perl-corpus/src/files.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 /// Environment variable used to override corpus root discovery.
 pub const CORPUS_ROOT_ENV: &str = "PERL_CORPUS_ROOT";
-const TEST_EXTENSIONS: &[&str] = &["pl", "pm", "t", "psgi", "cgi"];
+const TEST_EXTENSIONS: &[&str] = &["pl", "pm", "plx", "t", "psgi", "cgi"];
 
 /// Common corpus paths anchored at a root directory.
 #[derive(Debug, Clone)]
@@ -200,6 +200,7 @@ mod tests {
         let fixtures = [
             root.join("case.pl"),
             root.join("case.pm"),
+            root.join("case.plx"),
             root.join("case.t"),
             root.join("case.psgi"),
             root.join("case.cgi"),
@@ -223,7 +224,7 @@ mod tests {
             .collect();
         names.sort();
 
-        let expected = vec!["case.cgi", "case.pl", "case.pm", "case.psgi", "case.t", "nested.pl"];
+        let expected = vec!["case.cgi", "case.pl", "case.plx", "case.pm", "case.psgi", "case.t", "nested.pl"];
         assert_eq!(names, expected);
 
         fs::remove_dir_all(&root)?;
@@ -269,6 +270,7 @@ mod tests {
             root.join("upper.PL"),
             root.join("mixed.Pm"),
             root.join("suite.T"),
+            root.join("tool.PlX"),
             root.join("app.PsGi"),
             root.join("legacy.CgI"),
         ];
@@ -286,7 +288,7 @@ mod tests {
             .collect();
         names.sort();
 
-        let expected = vec!["app.PsGi", "legacy.CgI", "mixed.Pm", "suite.T", "upper.PL"];
+        let expected = vec!["app.PsGi", "legacy.CgI", "mixed.Pm", "suite.T", "tool.PlX", "upper.PL"];
         assert_eq!(names, expected);
 
         fs::remove_dir_all(&root)?;


### PR DESCRIPTION
### Motivation

- `.plx` scripts are valid Perl fixtures but were not included in the corpus discovery allowlist, causing them to be skipped by corpus-based tests and tooling.

### Description

- Added `"plx"` to the `TEST_EXTENSIONS` allowlist in `crates/perl-corpus/src/files.rs` so `.plx` files are discovered as Perl sources.
- Updated unit tests in `crates/perl-corpus/src/files.rs` to include `case.plx` and mixed-case `tool.PlX` fixtures to verify discovery and case-insensitive matching remain correct.
- No other runtime behavior was changed; discovery still uses `has_allowed_extension` for case-insensitive matching and existing sort/dedup semantics are preserved.

### Testing

- Ran `cargo test -p perl-corpus`, which completed successfully (all tests passed).
- Ran `cargo check --all-targets -p perl-corpus`, which completed successfully.
- Ran `cargo clippy -p perl-corpus --all-targets -- -D warnings`, which reported pre-existing `expect_err()` lint failures in `crates/perl-corpus/src/concepts.rs` unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c3e9730833384afb08be27fae32)