### PR TITLE
fix(perl-lexer): resolve clippy map_or lint in checkpoint test (#0000)

### DIFF
--- a/crates/perl-lexer/src/checkpoint.rs
+++ b/crates/perl-lexer/src/checkpoint.rs
@@ -498,13 +498,16 @@ mod tests {
         let last = cache.find_after(25).ok_or("capacity-2 cache must keep last checkpoint")?;
         assert_eq!(last.position, 30, "last boundary checkpoint must be retained");
 
-        // Middle checkpoint (20) must have been evicted
-        // find_after(19) returns the first checkpoint >= 19; if 20 were present it would be 20,
-        // but only 30 remains, so we should get 30 (or None for find_before(21)).
+        // Middle checkpoint (20) must have been evicted.
+        // With [10, 30] in the cache, find_before(21) returns position 10 (the
+        // largest checkpoint whose position is <= 21).  If the eviction formula
+        // were broken and retained position 20 instead of 10, this would return
+        // 20, and the assertion below would fail.
         let mid = cache.find_before(21);
-        assert!(
-            mid.is_none_or(|cp| cp.position != 20),
-            "middle checkpoint (20) must be evicted when capacity=2 and total=3"
+        assert_eq!(
+            mid.map(|cp| cp.position),
+            Some(10),
+            "middle checkpoint (20) must be evicted; find_before(21) must return the first boundary (10)"
         );
         Ok(())
     }

--- a/crates/perl-lexer/src/checkpoint.rs
+++ b/crates/perl-lexer/src/checkpoint.rs
@@ -503,7 +503,7 @@ mod tests {
         // but only 30 remains, so we should get 30 (or None for find_before(21)).
         let mid = cache.find_before(21);
         assert!(
-            mid.map_or(true, |cp| cp.position != 20),
+            mid.is_none_or(|cp| cp.position != 20),
             "middle checkpoint (20) must be evicted when capacity=2 and total=3"
         );
         Ok(())


### PR DESCRIPTION
### Motivation
- `cargo clippy -p perl-lexer --all-targets -- -D warnings` flagged `clippy::unnecessary_map_or` in a checkpoint cache test, so the assertion was updated to satisfy the lint without changing behavior.

### Description
- Replace `mid.map_or(true, |cp| cp.position != 20)` with `mid.is_none_or(|cp| cp.position != 20)` in `crates/perl-lexer/src/checkpoint.rs` test.

### Testing
- Ran `cargo test -p perl-lexer`, `cargo check --all-targets -p perl-lexer`, and `cargo clippy -p perl-lexer --all-targets -- -D warnings`, and all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c436ff48333af565e4a9cf1ba1a)