### PR TITLE
fix(perl-uri): make special-scheme fallback case-insensitive (#0000)

### DIFF
--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -125,11 +125,11 @@ pub fn is_special_scheme(uri: &str) -> bool {
     if let Ok(url) = Url::parse(uri) {
         url.scheme() != "file"
     } else {
-        uri.starts_with("untitled:")
-            || uri.starts_with("git:")
-            || uri.starts_with("vscode-notebook:")
-            || uri.starts_with("vscode-notebook-cell:")
-            || uri.starts_with("vscode-vfs:")
+        uri.get(..9).is_some_and(|p| p.eq_ignore_ascii_case("untitled:"))
+            || uri.get(..4).is_some_and(|p| p.eq_ignore_ascii_case("git:"))
+            || uri.get(..17).is_some_and(|p| p.eq_ignore_ascii_case("vscode-notebook:"))
+            || uri.get(..22).is_some_and(|p| p.eq_ignore_ascii_case("vscode-notebook-cell:"))
+            || uri.get(..11).is_some_and(|p| p.eq_ignore_ascii_case("vscode-vfs:"))
     }
 }
 
@@ -237,6 +237,14 @@ mod tests {
         assert!(is_special_scheme("git:/foo/bar"));
         assert!(is_special_scheme("vscode-notebook-cell:/nb.ipynb#cell-id"));
         assert!(!is_special_scheme("file:///tmp/test.pl"));
+    }
+
+    #[test]
+    fn detects_special_schemes_case_insensitive_fallback() {
+        // Invalid URIs can still be recognized by prefix fallback, regardless of case.
+        assert!(is_special_scheme("UNTITLED:Untitled-1"));
+        assert!(is_special_scheme("GIT:relative/path"));
+        assert!(is_special_scheme("VSCODE-NOTEBOOK-CELL:bad uri"));
     }
 
     #[test]

--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -127,8 +127,8 @@ pub fn is_special_scheme(uri: &str) -> bool {
     } else {
         uri.get(..9).is_some_and(|p| p.eq_ignore_ascii_case("untitled:"))
             || uri.get(..4).is_some_and(|p| p.eq_ignore_ascii_case("git:"))
-            || uri.get(..17).is_some_and(|p| p.eq_ignore_ascii_case("vscode-notebook:"))
-            || uri.get(..22).is_some_and(|p| p.eq_ignore_ascii_case("vscode-notebook-cell:"))
+            || uri.get(..16).is_some_and(|p| p.eq_ignore_ascii_case("vscode-notebook:"))
+            || uri.get(..21).is_some_and(|p| p.eq_ignore_ascii_case("vscode-notebook-cell:"))
             || uri.get(..11).is_some_and(|p| p.eq_ignore_ascii_case("vscode-vfs:"))
     }
 }


### PR DESCRIPTION
### Motivation
- The fallback branch of `is_special_scheme` only matched lowercase prefixes for unparseable URIs, so uppercase variants (e.g. `UNTITLED:`) could be misclassified.

### Description
- Switch the fallback prefix checks in `is_special_scheme` to ASCII case-insensitive comparisons using `get(..).is_some_and(|p| p.eq_ignore_ascii_case(...))` to recognize prefixes regardless of case.
- Add a regression unit test `detects_special_schemes_case_insensitive_fallback` in `crates/perl-uri/src/classify.rs` to ensure uppercase invalid URIs are treated as special schemes.
- Change is confined to `crates/perl-uri/src/classify.rs` and does not alter other behavior.

### Testing
- Ran `cargo test -p perl-uri` and the entire test suite for the crate passed.
- The new test `detects_special_schemes_case_insensitive_fallback` executed and passed as part of the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c436ff48333af565e4a9cf1ba1a)