### PR TITLE
fix(perl-workspace): reject unsafe git discovery paths (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/discovery/mod.rs
+++ b/crates/perl-workspace-index/src/discovery/mod.rs
@@ -11,6 +11,7 @@ use crate::ignore::{is_skipped_dir_name, path_contains_skipped_component};
 use perl_parser_core::source_file::is_perl_source_path;
 use std::collections::HashSet;
 use std::ffi::OsString;
+use std::path::Component;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use walkdir::{DirEntry, WalkDir};
@@ -110,6 +111,10 @@ fn parse_git_ls_files_output(root: &Path, stdout: &[u8]) -> (Vec<PathBuf>, usize
 
         let relative_path = PathBuf::from(bytes_to_os_string(entry));
         let relative_path = relative_path.as_path();
+        if !is_safe_relative_git_path(relative_path) {
+            excluded_count += 1;
+            continue;
+        }
         if path_contains_skipped_component(relative_path) {
             excluded_count += 1;
             continue;
@@ -193,6 +198,10 @@ fn should_skip_dir(entry: &DirEntry) -> bool {
 
 fn sort_paths_lexically(paths: &mut [PathBuf]) {
     paths.sort_unstable_by(|left, right| left.as_os_str().cmp(right.as_os_str()));
+}
+
+fn is_safe_relative_git_path(path: &Path) -> bool {
+    !path.is_absolute() && !path.components().any(|component| matches!(component, Component::ParentDir))
 }
 
 fn log_discovery(result: &DiscoveryResult) {
@@ -402,6 +411,16 @@ mod tests {
 
         assert_eq!(files.len(), 1);
         assert_eq!(files[0], Path::new("/home/user/project/lib/Module.pm"));
+    }
+
+    #[test]
+    fn parse_git_output_excludes_parent_directory_components() {
+        let root = Path::new("/tmp/workspace");
+        let payload = b"../outside.pm\0lib/ok.pm\0";
+        let (files, excluded_count) = parse_git_ls_files_output(root, payload);
+
+        assert_eq!(files, vec![root.join("lib/ok.pm")]);
+        assert_eq!(excluded_count, 1);
     }
 
     #[test]

--- a/crates/perl-workspace-index/src/discovery/mod.rs
+++ b/crates/perl-workspace-index/src/discovery/mod.rs
@@ -423,6 +423,7 @@ mod tests {
         assert_eq!(excluded_count, 1);
     }
 
+    #[cfg(unix)]
     #[test]
     fn parse_git_output_excludes_absolute_paths() {
         let root = Path::new("/tmp/workspace");

--- a/crates/perl-workspace-index/src/discovery/mod.rs
+++ b/crates/perl-workspace-index/src/discovery/mod.rs
@@ -424,6 +424,29 @@ mod tests {
     }
 
     #[test]
+    fn parse_git_output_excludes_absolute_paths() {
+        let root = Path::new("/tmp/workspace");
+        // git ls-files should never emit absolute paths, but defend against
+        // a corrupted or adversarial git output that attempts path escape.
+        let payload = b"/etc/passwd\0lib/ok.pm\0";
+        let (files, excluded_count) = parse_git_ls_files_output(root, payload);
+
+        assert_eq!(files, vec![root.join("lib/ok.pm")]);
+        assert_eq!(excluded_count, 1);
+    }
+
+    #[test]
+    fn parse_git_output_excludes_embedded_parent_directory_traversal() {
+        let root = Path::new("/tmp/workspace");
+        // Embedded `..` must be rejected even when not at the start of the path.
+        let payload = b"lib/../../etc/passwd\0lib/ok.pm\0";
+        let (files, excluded_count) = parse_git_ls_files_output(root, payload);
+
+        assert_eq!(files, vec![root.join("lib/ok.pm")]);
+        assert_eq!(excluded_count, 1);
+    }
+
+    #[test]
     fn parse_git_output_deduplicates_duplicate_entries() {
         let root = Path::new("/tmp/workspace");
         let payload = b"lib/Foo.pm\0lib/Foo.pm\0script.pl\0script.pl\0README.md\0";


### PR DESCRIPTION
### Motivation

- `git ls-files -z` can include absolute paths or `..` components which, when naively joined to the workspace root, allow traversal-style entries to escape the intended repository root and be treated as workspace files.

### Description

- Add `is_safe_relative_git_path` which rejects absolute paths and any path containing a `ParentDir` (`..`) component.
- Validate each NUL-delimited `git ls-files` entry with `is_safe_relative_git_path` in `parse_git_ls_files_output` and skip unsafe entries before joining with the workspace root.
- Import `std::path::Component` and add a unit test `parse_git_output_excludes_parent_directory_components` that verifies parent-directory entries are excluded while valid relative paths are accepted.

### Testing

- Ran `cargo test -p perl-workspace parse_git_output_excludes_parent_directory_components`, which passed.
- Ran `cargo check --all-targets -p perl-workspace`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c48ab048333a634f9d590b8364c)