### PR TITLE
fix(perl-lsp-rs): avoid executing binaries during command probe (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/execute_command/provider.rs
+++ b/crates/perl-lsp-rs/src/execute_command/provider.rs
@@ -954,8 +954,8 @@ pub fn command_exists(command: &str) -> bool {
         cmd.arg(command);
         cmd
     } else {
-        let mut cmd = std::process::Command::new(command);
-        cmd.arg("--version");
+        let mut cmd = std::process::Command::new("which");
+        cmd.arg(command);
         cmd
     };
     crate::util::run_command_with_timeout(cmd, 2)

--- a/crates/perl-lsp-rs/tests/execute_command_security_tests.rs
+++ b/crates/perl-lsp-rs/tests/execute_command_security_tests.rs
@@ -10,6 +10,7 @@ use perl_lsp::execute_command::ExecuteCommandProvider;
 use serde_json::Value;
 use std::error::Error;
 use std::fs;
+use std::path::Path;
 use tempfile::TempDir;
 
 /// Test that run_test_sub is protected against code injection via file_path.
@@ -239,6 +240,47 @@ fn test_empty_workspace_roots_enforces_cwd_boundary() -> Result<(), Box<dyn Erro
     );
 
     assert!(result.is_err(), "Should reject paths outside CWD when workspace_roots is empty");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn test_command_exists_does_not_execute_candidate_binary() -> Result<(), Box<dyn Error>> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = TempDir::new()?;
+    let script_path = temp_dir.path().join("fake-security-probe");
+    let marker_path = temp_dir.path().join("executed.marker");
+
+    fs::write(
+        &script_path,
+        format!(
+            "#!/bin/sh\nprintf 'executed' > '{}'\nexit 0\n",
+            marker_path.display()
+        ),
+    )?;
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755))?;
+
+    let original_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut path_entries = vec![temp_dir.path().to_path_buf()];
+    path_entries.extend(std::env::split_paths(&original_path));
+    let joined_path = std::env::join_paths(path_entries)?;
+
+    // SAFETY: test-only PATH mutation; restored before returning.
+    unsafe {
+        std::env::set_var("PATH", &joined_path);
+    }
+    let exists = perl_lsp::execute_command::command_exists("fake-security-probe");
+    // SAFETY: restore process environment for test isolation.
+    unsafe {
+        std::env::set_var("PATH", original_path);
+    }
+
+    assert!(exists, "command_exists should report that the candidate is discoverable in PATH");
+    assert!(
+        !Path::new(&marker_path).exists(),
+        "security regression: command_exists executed the candidate binary instead of probing PATH"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- On Unix the existing `command_exists` implementation launched `<command> --version`, which could execute an attacker-controlled binary when probing untrusted command names.

### Description
- Change Unix probing to call `which <command>` instead of running the candidate binary in `crates/perl-lsp-rs/src/execute_command/provider.rs`.
- Add a Unix-only security regression test `test_command_exists_does_not_execute_candidate_binary` in `crates/perl-lsp-rs/tests/execute_command_security_tests.rs` that places a fake executable on `PATH` and verifies discovery without execution.
- Update the test to call the public `command_exists` helper and add a `use std::path::Path` import.

### Testing
- Ran `cargo test -p perl-lsp-rs --test execute_command_security_tests test_command_exists_does_not_execute_candidate_binary` and it passed.
- The test verifies that the probe reports the candidate as discoverable and that no marker file was created, confirming the probe does not execute the candidate binary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c48ab048333a634f9d590b8364c)