### PR TITLE
fix(perl-dap): cap debugger identifiers to harden injection surface (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -111,6 +111,7 @@ const RECENT_OUTPUT_MAX_LINES: usize = 2048;
 const DEBUG_SESSION_TERMINATE_WAIT_MS: u64 = 250;
 const DEBUGGER_QUERY_WAIT_MS: u64 = 75;
 const DEBUGGER_FRAME_POLL_MS: u64 = 10;
+const MAX_DEBUGGER_IDENTIFIER_LEN: usize = 512;
 
 fn context_re() -> Option<&'static Regex> {
     CONTEXT_RE
@@ -362,7 +363,8 @@ fn set_variable_name_re() -> Option<&'static Regex> {
 
 /// Validate DAP setVariable names (e.g. `$x`, `%ENV`, `$Package::value`) for safe passthrough.
 fn is_valid_set_variable_name(name: &str) -> bool {
-    set_variable_name_re().is_some_and(|re| re.is_match(name))
+    name.len() <= MAX_DEBUGGER_IDENTIFIER_LEN
+        && set_variable_name_re().is_some_and(|re| re.is_match(name))
 }
 
 fn function_breakpoint_name_re() -> Option<&'static Regex> {
@@ -373,7 +375,8 @@ fn function_breakpoint_name_re() -> Option<&'static Regex> {
 }
 
 fn is_valid_function_breakpoint_name(name: &str) -> bool {
-    function_breakpoint_name_re().is_some_and(|re| re.is_match(name))
+    name.len() <= MAX_DEBUGGER_IDENTIFIER_LEN
+        && function_breakpoint_name_re().is_some_and(|re| re.is_match(name))
 }
 
 fn inc_re() -> Option<&'static Regex> {

--- a/crates/perl-dap/tests/dap_non_regression_tests.rs
+++ b/crates/perl-dap/tests/dap_non_regression_tests.rs
@@ -621,6 +621,21 @@ fn test_set_function_breakpoints_response_has_breakpoints_array()
 }
 
 #[test]
+fn test_set_function_breakpoints_rejects_overlong_name() -> Result<(), Box<dyn std::error::Error>> {
+    let mut adapter = new_adapter();
+    let long_name = format!("Foo::{}", "A".repeat(600));
+    let args = json!({"breakpoints": [{"name": long_name}]});
+    let body = assert_ok(
+        adapter.handle_request(1, "setFunctionBreakpoints", Some(args)),
+        "setFunctionBreakpoints",
+    )
+    .ok_or("setFunctionBreakpoints must return a body")?;
+
+    assert_eq!(body["breakpoints"][0]["verified"], json!(false));
+    Ok(())
+}
+
+#[test]
 // AC:17 — setExceptionBreakpoints response has 'breakpoints' array
 fn test_set_exception_breakpoints_response_has_breakpoints_array()
 -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
### Motivation

- The DAP handlers accepted arbitrarily long identifier strings for `setVariable` and `setFunctionBreakpoints`, which increases the attack surface for command-processing and resource-amplification from untrusted clients. 
- Limit identifier length to mitigate injection/amplification risks and reduce the surface area for malformed or adversarial inputs.

### Description

- Add a `const MAX_DEBUGGER_IDENTIFIER_LEN: usize = 512` to `crates/perl-dap/src/debug_adapter/mod.rs` to centralize the identifier length cap. 
- Enforce the length cap in `is_valid_set_variable_name` and `is_valid_function_breakpoint_name` by requiring `name.len() <= MAX_DEBUGGER_IDENTIFIER_LEN` in addition to existing regex checks. 
- Add a regression test `test_set_function_breakpoints_rejects_overlong_name` in `crates/perl-dap/tests/dap_non_regression_tests.rs` that verifies overlong function breakpoint names are rejected (unverified). 

### Testing

- Ran `cargo test -p perl-dap --test dap_non_regression_tests test_set_function_breakpoints_rejects_overlong_name`, and the targeted test passed (1 passed). 
- Ran `cargo check --all-targets -p perl-dap`, which completed successfully. 
- The change is limited to `crates/perl-dap` and the added test verifies the intended hardening behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c48ab048333a634f9d590b8364c)