### PR TITLE
fix(xtask): add detailed output to list-commands (#0000)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -38,7 +38,11 @@ struct Cli {
 enum Commands {
     /// Print all available top-level xtask commands.
     #[command(name = "list-commands")]
-    List,
+    List {
+        /// Print one-line descriptions next to command names.
+        #[arg(long)]
+        detailed: bool,
+    },
 
     /// Run lean CI suite (format, clippy, tests) for constrained environments
     Ci,
@@ -1745,8 +1749,8 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::List => {
-            print_top_level_commands();
+        Commands::List { detailed } => {
+            print_top_level_commands(detailed);
             Ok(())
         }
         Commands::Ci => ci::run(),
@@ -2252,15 +2256,25 @@ fn main() -> Result<()> {
     }
 }
 
-fn print_top_level_commands() {
-    let mut command_names = Cli::command()
+fn print_top_level_commands(detailed: bool) {
+    let mut commands = Cli::command()
         .get_subcommands()
-        .map(|subcommand| subcommand.get_name().to_string())
+        .map(|subcommand| {
+            (subcommand.get_name().to_string(), subcommand.get_about().map(ToString::to_string))
+        })
         .collect::<Vec<_>>();
-    command_names.sort_unstable();
+    commands.sort_unstable_by(|left, right| left.0.cmp(&right.0));
 
-    for command_name in command_names {
-        println!("{command_name}");
+    for (command_name, about) in commands {
+        if detailed {
+            if let Some(about) = about {
+                println!("{command_name}\t{about}");
+            } else {
+                println!("{command_name}");
+            }
+        } else {
+            println!("{command_name}");
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- Improve developer ergonomics because `cargo xtask list-commands` previously printed only command names, making discovery slower when developers need quick context.

### Description
- Turned the `List` subcommand into `List { detailed: bool }`, wired the flag through the `match` in `main` to call `print_top_level_commands(detailed)`, and updated `print_top_level_commands` to collect each subcommand's `about` text and print `name\tabout` when `--detailed` is set while preserving the original name-only output and deterministic sorting.

### Testing
- Ran `cargo xtask fmt` (passed) and verified `cargo run -p xtask -- list-commands --detailed | head -n 5` prints command names with descriptions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c52dad883339a9b50fdf9acdae0)