### PR TITLE
fix(devex): fail fast when just is missing (#0000)

### DIFF
--- a/scripts/run-gates.sh
+++ b/scripts/run-gates.sh
@@ -9,6 +9,12 @@ RECEIPTS_DIR="$ROOT/target/receipts"
 LOG_DIR="$RECEIPTS_DIR/logs"
 ARTIFACT_DIR="$RECEIPTS_DIR/artifacts"
 
+if ! command -v just >/dev/null 2>&1; then
+  echo "Error: 'just' is required to run merge gates." >&2
+  echo "Install it from https://github.com/casey/just#installation and re-run this script." >&2
+  exit 1
+fi
+
 mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 
 policy_path="ci/gate-policy.yaml"


### PR DESCRIPTION
### Motivation
- `scripts/run-gates.sh` could fail later with an unhelpful `just: command not found` error when `just` is not installed, which degrades developer experience.

### Description
- Add a preflight check using `command -v just` that prints a clear error and installation hint and exits early from `scripts/run-gates.sh`.

### Testing
- Ran `bash scripts/run-gates.sh` in an environment without `just` and it exited immediately with the expected error message and install guidance (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c52dad883339a9b50fdf9acdae0)