### PR TITLE
chore(devex): clarify base-ref hint for targeted checks (#0000)

### DIFF
--- a/justfile
+++ b/justfile
@@ -767,7 +767,7 @@ devex-targeted base='' mode='all':
     fi
     if [ -z "$base" ]; then
         echo "ERROR: Could not auto-detect base branch."
-        echo "Hint: run 'just devex-targeted <base-ref>' (example: origin/main)."
+        echo "Hint: run 'just devex-targeted <base-ref>' (examples: origin/main, origin/master, main, master)."
         exit 1
     fi
     echo "Running targeted checks (base=$base, mode={{mode}})..."


### PR DESCRIPTION
### Motivation
- Improve developer experience when `devex-targeted` cannot auto-detect a base branch by providing clearer recovery hints for different repo layouts.

### Description
- Update the failure hint in the `devex-targeted` recipe in `justfile` to show multiple example base refs: `origin/main`, `origin/master`, `main`, and `master`.

### Testing
- Attempted to validate with `just --evaluate devex-targeted base='master' mode='all'`, but `just` is not installed in this environment so the check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c52dad883339a9b50fdf9acdae0)