### PR TITLE
feat(perl-ast): add source-span convenience APIs (#0000)

### DIFF
--- a/crates/perl-ast/src/ast.rs
+++ b/crates/perl-ast/src/ast.rs
@@ -1384,6 +1384,22 @@ impl Node {
         });
         result
     }
+
+    /// Returns `true` when this node's source span contains `offset`.
+    ///
+    /// The start position is inclusive and the end position is exclusive.
+    #[inline]
+    pub fn contains_offset(&self, offset: usize) -> bool {
+        self.location.start <= offset && offset < self.location.end
+    }
+
+    /// Returns the byte length of this node's source span.
+    ///
+    /// Uses saturating subtraction so malformed spans never underflow.
+    #[inline]
+    pub fn span_len(&self) -> usize {
+        self.location.end.saturating_sub(self.location.start)
+    }
 }
 
 /// Comprehensive enumeration of all Perl language constructs supported by the parser.
@@ -1415,13 +1431,10 @@ impl Node {
 ///     loc,
 /// );
 ///
-/// match &node.kind {
-///     NodeKind::Variable { sigil, name } => {
-///         assert_eq!(sigil, "$");
-///         assert_eq!(name, "foo");
-///     }
-///     _ => panic!("expected Variable"),
-/// }
+/// assert!(matches!(
+///     &node.kind,
+///     NodeKind::Variable { sigil, name } if sigil == "$" && name == "foo"
+/// ));
 /// ```
 ///
 /// Use [`kind_name()`](NodeKind::kind_name) for debugging and diagnostics:

--- a/crates/perl-ast/tests/ast_behavior_spec_tests.rs
+++ b/crates/perl-ast/tests/ast_behavior_spec_tests.rs
@@ -167,3 +167,19 @@ fn when_traversing_for_node_without_optional_parts_then_only_body_is_visited() {
 
     assert_eq!(visited, 1);
 }
+
+#[test]
+fn when_checking_contains_offset_then_start_is_inclusive_and_end_is_exclusive() {
+    let node = Node::new(NodeKind::Identifier { name: "foo".to_string() }, loc(3, 7));
+
+    assert!(node.contains_offset(3));
+    assert!(node.contains_offset(6));
+    assert!(!node.contains_offset(7));
+    assert!(!node.contains_offset(2));
+}
+
+#[test]
+fn when_requesting_span_len_then_it_matches_location_width() {
+    let node = Node::new(NodeKind::Identifier { name: "foo".to_string() }, loc(10, 14));
+    assert_eq!(node.span_len(), 4);
+}


### PR DESCRIPTION
### Motivation
- Provide lightweight helpers on `Node` to simplify common source-span queries and avoid repeated manual location arithmetic in callers.

### Description
- Add `Node::contains_offset(&self, offset: usize) -> bool` and `Node::span_len(&self) -> usize`, update a `NodeKind` doc example to use `matches!`, and add behavior tests exercising the new APIs in `crates/perl-ast/tests/ast_behavior_spec_tests.rs`.

### Testing
- Ran `cargo test -p perl-ast`, including unit tests and doctests, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c6683f08333b973846006400945)