### PR TITLE
feat(perl-ast): add Display impls for AST nodes (#0000)

### DIFF
--- a/crates/perl-ast/src/ast.rs
+++ b/crates/perl-ast/src/ast.rs
@@ -105,6 +105,7 @@
 pub use perl_position_tracking::SourceLocation;
 // Re-export Token and TokenKind from perl-token for AST error nodes
 pub use perl_token::{Token, TokenKind};
+use std::fmt;
 
 /// Core AST node representing any Perl language construct within parsing workflows.
 ///
@@ -2249,6 +2250,20 @@ impl NodeKind {
         "MissingStatement",
         "UnknownRest",
     ];
+}
+
+impl fmt::Display for NodeKind {
+    /// Formats as the canonical `kind_name()` string.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.kind_name())
+    }
+}
+
+impl fmt::Display for Node {
+    /// Formats as the tree-sitter compatible S-expression.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_sexp())
+    }
 }
 
 /// Format unary operator for S-expression output

--- a/crates/perl-ast/tests/additional_unit_tests.rs
+++ b/crates/perl-ast/tests/additional_unit_tests.rs
@@ -95,6 +95,18 @@ fn debug_output_for_unit_variants() {
     }
 }
 
+#[test]
+fn display_for_nodekind_uses_kind_name() {
+    let kind = NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() };
+    assert_eq!(kind.to_string(), "Variable");
+}
+
+#[test]
+fn display_for_node_uses_sexp() {
+    let node = Node::new(NodeKind::Number { value: "42".to_string() }, loc(0, 2));
+    assert_eq!(node.to_string(), node.to_sexp());
+}
+
 // ===========================================================================
 // 2. Clone / PartialEq on complex trees
 // ===========================================================================


### PR DESCRIPTION
### Motivation
- Problem: `perl-ast` lacked ergonomic `Display` implementations for `NodeKind` and `Node`, which made diagnostics and logging less convenient.

### Description
- Fix: added `impl Display for NodeKind` (delegates to `kind_name()`) and `impl Display for Node` (delegates to `to_sexp()`), imported `std::fmt`, and added two focused tests to validate `to_string()` behavior.

### Testing
- Verification: ran `cargo test -p perl-ast` (all tests passed), `cargo check --all-targets -p perl-ast` passed, `cargo clippy -p perl-ast -- -D warnings` passed, and `cargo fmt --all --check` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c6683f08333b973846006400945)