### PR TITLE
feat(perl-ast): add allocation-free child_count helper (#0000)

### DIFF
--- a/crates/perl-ast/src/ast.rs
+++ b/crates/perl-ast/src/ast.rs
@@ -1371,6 +1371,17 @@ impl Node {
         children
     }
 
+    /// Count direct child nodes without allocating an intermediate vector.
+    ///
+    /// This is more efficient than `children().len()` when callers only need
+    /// cardinality.
+    #[inline]
+    pub fn child_count(&self) -> usize {
+        let mut count = 0;
+        self.for_each_child(|_| count += 1);
+        count
+    }
+
     /// Get the first direct child node, if any.
     ///
     /// Optimized to avoid allocating the children vector.

--- a/crates/perl-ast/tests/additional_unit_tests.rs
+++ b/crates/perl-ast/tests/additional_unit_tests.rs
@@ -1087,9 +1087,7 @@ fn children_of_ternary() {
 #[test]
 fn child_count_matches_children_len_for_program() {
     let node = Node::new(
-        NodeKind::Program {
-            statements: vec![num_node("1"), num_node("2"), num_node("3")],
-        },
+        NodeKind::Program { statements: vec![num_node("1"), num_node("2"), num_node("3")] },
         loc(0, 20),
     );
     assert_eq!(node.child_count(), node.children().len());

--- a/crates/perl-ast/tests/additional_unit_tests.rs
+++ b/crates/perl-ast/tests/additional_unit_tests.rs
@@ -1081,6 +1081,24 @@ fn children_of_ternary() {
         loc(0, 10),
     );
     assert_eq!(node.children().len(), 3);
+    assert_eq!(node.child_count(), 3);
+}
+
+#[test]
+fn child_count_matches_children_len_for_program() {
+    let node = Node::new(
+        NodeKind::Program {
+            statements: vec![num_node("1"), num_node("2"), num_node("3")],
+        },
+        loc(0, 20),
+    );
+    assert_eq!(node.child_count(), node.children().len());
+}
+
+#[test]
+fn child_count_is_zero_for_leaf_nodes() {
+    let leaf = num_node("42");
+    assert_eq!(leaf.child_count(), 0);
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Callers that only need the number of direct AST children currently allocate via `children().len()`, which is wasteful for hot paths.

### Description
- Add `Node::child_count()` to count direct child nodes without allocating an intermediate `Vec`, and add focused tests in `crates/perl-ast/tests/additional_unit_tests.rs` to validate behavior for ternary nodes, program nodes, and leaf nodes.

### Testing
- Ran `cargo test -p perl-ast` (all tests passed), and `cargo check --all-targets -p perl-ast` + `cargo clippy -p perl-ast` (both passed); attempted `just pr-fast` but it failed in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c6683f08333b973846006400945)