### PR TITLE
feat(perl-ast): add last_child traversal helper (#0000)

### DIFF
--- a/crates/perl-ast/src/ast.rs
+++ b/crates/perl-ast/src/ast.rs
@@ -1412,6 +1412,35 @@ impl Node {
     pub fn span_len(&self) -> usize {
         self.location.end.saturating_sub(self.location.start)
     }
+
+    /// Get the last direct child node, if any.
+    ///
+    /// Optimized to avoid allocating the children vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use perl_ast::{Node, NodeKind, SourceLocation};
+    ///
+    /// let loc = SourceLocation { start: 0, end: 1 };
+    /// let first = Node::new(NodeKind::Number { value: "1".to_string() }, loc);
+    /// let second = Node::new(NodeKind::Number { value: "2".to_string() }, loc);
+    /// let program = Node::new(
+    ///     NodeKind::Program { statements: vec![first, second] },
+    ///     loc,
+    /// );
+    ///
+    /// assert_eq!(program.last_child().map(|n| n.kind.kind_name()), Some("Number"));
+    /// assert_eq!(Node::new(NodeKind::Block { statements: vec![] }, loc).last_child(), None);
+    /// ```
+    #[inline]
+    pub fn last_child(&self) -> Option<&Node> {
+        let mut result = None;
+        self.for_each_child(|child| {
+            result = Some(child);
+        });
+        result
+    }
 }
 
 /// Comprehensive enumeration of all Perl language constructs supported by the parser.

--- a/crates/perl-ast/tests/ast_behavior_spec_tests.rs
+++ b/crates/perl-ast/tests/ast_behavior_spec_tests.rs
@@ -183,3 +183,51 @@ fn when_requesting_span_len_then_it_matches_location_width() {
     let node = Node::new(NodeKind::Identifier { name: "foo".to_string() }, loc(10, 14));
     assert_eq!(node.span_len(), 4);
 }
+
+#[test]
+fn when_requesting_last_child_on_leaf_node_then_none_is_returned() {
+    let leaf = number("9");
+
+    assert!(leaf.last_child().is_none());
+}
+
+#[test]
+fn when_requesting_last_child_on_single_child_node_then_that_child_is_returned() {
+    let node = Node::new(
+        NodeKind::Unary { op: "-".to_string(), operand: Box::new(number("1")) },
+        loc(0, 2),
+    );
+
+    let child = node.last_child();
+
+    assert!(child.is_some());
+    assert_eq!(child.map(|c| c.kind.kind_name()), Some("Number"));
+}
+
+#[test]
+fn when_requesting_last_child_on_binary_node_then_right_operand_is_returned() {
+    let node = Node::new(
+        NodeKind::Binary {
+            op: "+".to_string(),
+            left: Box::new(ident("a")),
+            right: Box::new(number("2")),
+        },
+        loc(0, 3),
+    );
+
+    let child = node.last_child();
+
+    assert_eq!(child.map(|c| c.kind.kind_name()), Some("Number"));
+}
+
+#[test]
+fn when_requesting_last_child_on_program_then_last_statement_is_returned() {
+    let node = Node::new(
+        NodeKind::Program { statements: vec![number("1"), number("2"), ident("last")] },
+        loc(0, 10),
+    );
+
+    let child = node.last_child();
+
+    assert_eq!(child.map(|c| c.kind.kind_name()), Some("Identifier"));
+}


### PR DESCRIPTION
### Motivation
- Provide an allocation-free way to access the last direct child of a `Node` so callers that only need the tail child can avoid building a `Vec` via `children()`.

### Description
- Add `Node::last_child()` to `crates/perl-ast/src/ast.rs`, implemented with `for_each_child` and documented with rustdoc examples, and marked `#[inline]` to mirror existing traversal helpers.

### Testing
- Ran `cargo test -p perl-ast`, `cargo check --all-targets -p perl-ast`, `cargo clippy -p perl-ast --all-targets`, and `cargo xtask fmt`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c6683f08333b973846006400945)