### PR TITLE
fix(perl-lsp-perltidy): keep extra args with profile config (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -110,6 +110,7 @@ impl PerlTidyConfig {
 
         if let Some(profile) = &self.profile {
             args.push(format!("--profile={profile}"));
+            args.extend(self.extra_args.clone());
             return args;
         }
 

--- a/crates/perl-lsp-perltidy/tests/config_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/config_tests.rs
@@ -21,19 +21,18 @@ fn pbp_preset_sets_best_practices_flag() {
 }
 
 #[test]
-fn config_with_profile_uses_only_profile_flag() {
+fn config_with_profile_includes_profile_flag() {
     let config = PerlTidyConfig {
         profile: Some("/home/user/.perltidyrc".to_string()),
         ..PerlTidyConfig::default()
     };
     let args = config.to_args();
 
-    assert_eq!(args.len(), 1);
-    assert_eq!(args[0], "--profile=/home/user/.perltidyrc");
+    assert_eq!(args, vec!["--profile=/home/user/.perltidyrc".to_string()]);
 }
 
 #[test]
-fn config_with_profile_ignores_other_settings() {
+fn config_with_profile_ignores_structured_style_settings() {
     let config = PerlTidyConfig {
         maximum_line_length: Some(120),
         indent_columns: Some(8),
@@ -43,9 +42,27 @@ fn config_with_profile_ignores_other_settings() {
     };
     let args = config.to_args();
 
-    // Only profile flag should be present; all others suppressed
+    // Structured settings are suppressed when a profile is provided.
     assert_eq!(args.len(), 1);
     assert!(args[0].starts_with("--profile="));
+}
+
+#[test]
+fn config_with_profile_preserves_extra_args() {
+    let config = PerlTidyConfig {
+        profile: Some(".perltidyrc".to_string()),
+        extra_args: vec!["--backup-and-modify-in-place".to_string()],
+        ..PerlTidyConfig::default()
+    };
+    let args = config.to_args();
+
+    assert_eq!(
+        args,
+        vec![
+            "--profile=.perltidyrc".to_string(),
+            "--backup-and-modify-in-place".to_string()
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- Prevent `PerlTidyConfig::profile` from discarding `extra_args` so callers can combine a perltidy profile file with additional CLI flags.

### Description

- Preserve `extra_args` when `profile` is set by extending the args vector before returning in `PerlTidyConfig::to_args` (`crates/perl-lsp-perltidy/src/lib.rs`).
- Update tests to reflect the intended profile behavior by renaming the profile test for clarity and adding `config_with_profile_preserves_extra_args` to cover `profile + extra_args` (`crates/perl-lsp-perltidy/tests/config_tests.rs`).
- Include a focused commit with the project-style title and placeholder issue reference.

### Testing

- Ran `cargo test -p perl-lsp-perltidy`, which completed with all tests passing (`54` tests across modules; all ok).
- Ran `cargo check --all-targets -p perl-lsp-perltidy`, which completed successfully.
- Ran `cargo clippy -p perl-lsp-perltidy -- -D warnings`, which completed successfully with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c70cfd08333a09bf28f4d4352aa)