### PR TITLE
fix(perl-lsp-perltidy): preserve extra args with profile config (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -110,6 +110,7 @@ impl PerlTidyConfig {
 
         if let Some(profile) = &self.profile {
             args.push(format!("--profile={profile}"));
+            args.extend(self.extra_args.clone());
             return args;
         }
 

--- a/crates/perl-lsp-perltidy/tests/config_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/config_tests.rs
@@ -21,31 +21,33 @@ fn pbp_preset_sets_best_practices_flag() {
 }
 
 #[test]
-fn config_with_profile_uses_only_profile_flag() {
+fn config_with_profile_keeps_profile_first() {
     let config = PerlTidyConfig {
         profile: Some("/home/user/.perltidyrc".to_string()),
         ..PerlTidyConfig::default()
     };
     let args = config.to_args();
 
-    assert_eq!(args.len(), 1);
     assert_eq!(args[0], "--profile=/home/user/.perltidyrc");
+    assert_eq!(args.len(), 1);
 }
 
 #[test]
-fn config_with_profile_ignores_other_settings() {
+fn config_with_profile_ignores_structured_settings_but_keeps_extra_args() {
     let config = PerlTidyConfig {
         maximum_line_length: Some(120),
         indent_columns: Some(8),
         tabs: Some(true),
         profile: Some(".perltidyrc".to_string()),
+        extra_args: vec!["--custom-flag".to_string()],
         ..PerlTidyConfig::default()
     };
     let args = config.to_args();
 
-    // Only profile flag should be present; all others suppressed
-    assert_eq!(args.len(), 1);
-    assert!(args[0].starts_with("--profile="));
+    // Structured settings should be suppressed, but pass-through flags preserved.
+    assert_eq!(args[0], "--profile=.perltidyrc");
+    assert_eq!(args[1], "--custom-flag");
+    assert_eq!(args.len(), 2);
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- When `profile` was set `PerlTidyConfig::to_args()` returned only `--profile=...`, dropping any `extra_args` and preventing callers from passing safe pass-through flags alongside a profile.

### Description
- Preserve `extra_args` in profile mode by appending `args.extend(self.extra_args.clone())` after pushing `--profile=...` in `PerlTidyConfig::to_args()` in `crates/perl-lsp-perltidy/src/lib.rs`.
- Update and rename config tests in `crates/perl-lsp-perltidy/tests/config_tests.rs` to verify that the profile flag remains first, structured settings are suppressed, and `extra_args` are preserved.
- Changes touch only `crates/perl-lsp-perltidy/src/lib.rs` and `crates/perl-lsp-perltidy/tests/config_tests.rs`.

### Testing
- Ran `cargo test -p perl-lsp-perltidy`; all unit tests in the crate passed successfully (tests completed with all checks green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c70cfd08333a09bf28f4d4352aa)