### PR TITLE
fix(perl-lsp-perltidy): clamp zero timeout for OS runtime (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -197,7 +197,9 @@ impl PerlTidyFormatter {
     #[must_use]
     pub fn with_os_runtime(config: PerlTidyConfig) -> Self {
         use perl_subprocess_runtime::OsSubprocessRuntime;
-        let timeout = config.timeout_secs;
+        // OsSubprocessRuntime::with_timeout panics on zero; clamp to 1s so
+        // misconfigured clients do not crash the language server process.
+        let timeout = config.timeout_secs.max(1);
         Self::new(config, Arc::new(OsSubprocessRuntime::with_timeout(timeout)))
     }
 

--- a/crates/perl-lsp-perltidy/tests/config_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/config_tests.rs
@@ -298,3 +298,10 @@ fn builtin_formatter_multi_closer_line_does_not_over_decrement() {
     assert_eq!(lines[5], "}"); // one closer — back to level 0
     assert_eq!(lines[6], "print 3;"); // at level 0, not negative
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn with_os_runtime_clamps_zero_timeout() {
+    let config = PerlTidyConfig { timeout_secs: 0, ..PerlTidyConfig::default() };
+    let _formatter = PerlTidyFormatter::with_os_runtime(config);
+}

--- a/crates/perl-lsp-perltidy/tests/config_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/config_tests.rs
@@ -302,6 +302,15 @@ fn builtin_formatter_multi_closer_line_does_not_over_decrement() {
 #[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn with_os_runtime_clamps_zero_timeout() {
+    // OsSubprocessRuntime::with_timeout panics on 0; this must not panic.
     let config = PerlTidyConfig { timeout_secs: 0, ..PerlTidyConfig::default() };
+    let _formatter = PerlTidyFormatter::with_os_runtime(config);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn with_os_runtime_accepts_minimum_valid_timeout() {
+    // timeout_secs = 1 is the minimum non-clamped value; must also not panic.
+    let config = PerlTidyConfig { timeout_secs: 1, ..PerlTidyConfig::default() };
     let _formatter = PerlTidyFormatter::with_os_runtime(config);
 }


### PR DESCRIPTION
### Motivation
- Prevent the language server from panicking when a client supplies `timeout_secs = 0` because `OsSubprocessRuntime::with_timeout(0)` panics; the change ensures misconfigured clients cannot crash the process.

### Description
- Clamp `config.timeout_secs` to at least `1` in `PerlTidyFormatter::with_os_runtime` and add a non-WASM regression test `with_os_runtime_clamps_zero_timeout` that constructs a formatter with `timeout_secs: 0`.

### Testing
- Ran `cargo test -p perl-lsp-perltidy` and all tests passed.
- Ran `cargo check --all-targets -p perl-lsp-perltidy` and it passed.
- Ran `cargo clippy -p perl-lsp-perltidy -- -D warnings` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c70cfd08333a09bf28f4d4352aa)