### PR TITLE
fix(perl-lsp-perltidy): preserve extra args when profile is set (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -110,6 +110,7 @@ impl PerlTidyConfig {
 
         if let Some(profile) = &self.profile {
             args.push(format!("--profile={profile}"));
+            args.extend(self.extra_args.clone());
             return args;
         }
 

--- a/crates/perl-lsp-perltidy/tests/config_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/config_tests.rs
@@ -53,6 +53,19 @@ fn config_with_profile_ignores_other_settings_but_keeps_extra_args() {
 }
 
 #[test]
+fn config_with_profile_and_no_extra_args_produces_only_profile_flag() {
+    // Profile without extra_args should still yield exactly one arg.
+    let config = PerlTidyConfig {
+        profile: Some("/home/user/.perltidyrc".to_string()),
+        ..PerlTidyConfig::default()
+    };
+    let args = config.to_args();
+
+    assert_eq!(args.len(), 1);
+    assert_eq!(args[0], "--profile=/home/user/.perltidyrc");
+}
+
+#[test]
 fn gnu_preset_sets_gnu_style_flag() {
     let args = PerlTidyConfig::gnu().to_args();
     assert!(args.contains(&"--gnu-style".to_string()));

--- a/crates/perl-lsp-perltidy/tests/config_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/config_tests.rs
@@ -21,31 +21,35 @@ fn pbp_preset_sets_best_practices_flag() {
 }
 
 #[test]
-fn config_with_profile_uses_only_profile_flag() {
+fn config_with_profile_uses_profile_flag_and_extra_args() {
     let config = PerlTidyConfig {
         profile: Some("/home/user/.perltidyrc".to_string()),
+        extra_args: vec!["--standard-output".to_string()],
         ..PerlTidyConfig::default()
     };
     let args = config.to_args();
 
-    assert_eq!(args.len(), 1);
+    assert_eq!(args.len(), 2);
     assert_eq!(args[0], "--profile=/home/user/.perltidyrc");
+    assert_eq!(args[1], "--standard-output");
 }
 
 #[test]
-fn config_with_profile_ignores_other_settings() {
+fn config_with_profile_ignores_other_settings_but_keeps_extra_args() {
     let config = PerlTidyConfig {
         maximum_line_length: Some(120),
         indent_columns: Some(8),
         tabs: Some(true),
         profile: Some(".perltidyrc".to_string()),
+        extra_args: vec!["--check-syntax".to_string()],
         ..PerlTidyConfig::default()
     };
     let args = config.to_args();
 
-    // Only profile flag should be present; all others suppressed
-    assert_eq!(args.len(), 1);
+    // Only profile and explicit extra args should be present; other config suppressed
+    assert_eq!(args.len(), 2);
     assert!(args[0].starts_with("--profile="));
+    assert_eq!(args[1], "--check-syntax");
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- `PerlTidyConfig::to_args()` dropped `extra_args` whenever a `profile` was configured, preventing users from combining a `.perltidyrc` profile with explicit CLI flags.

### Description
- Append `extra_args` when `profile` is set so `to_args()` emits `--profile=...` and still includes any explicit `extra_args`.
- Update unit tests in `crates/perl-lsp-perltidy/tests/config_tests.rs` to assert the profile flag is present and that explicit `extra_args` are preserved while other derived flags remain suppressed.

### Testing
- Ran `cargo test -p perl-lsp-perltidy` and all tests passed.
- Ran `cargo check --all-targets -p perl-lsp-perltidy` and it completed successfully.
- Ran `cargo clippy -p perl-lsp-perltidy -- -D warnings` and there were no lints reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c70cfd08333a09bf28f4d4352aa)