### PR TITLE
fix(perl-lsp-perltidy): preserve trailing newline behavior in builtin formatter (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -352,13 +352,15 @@ impl BuiltInFormatter {
     pub fn format(&self, code: &str) -> String {
         let mut result = String::new();
         let mut indent_level: i32 = 0;
+        let lines: Vec<&str> = code.lines().collect();
+        let had_trailing_newline = code.ends_with('\n');
         let indent_str = if self.config.tabs.unwrap_or(false) {
             "\t".to_string()
         } else {
             " ".repeat(self.config.indent_columns.unwrap_or(4) as usize)
         };
 
-        for line in code.lines() {
+        for (index, line) in lines.iter().enumerate() {
             let trimmed = line.trim();
             let leading_closers = count_leading_closers(trimmed) as i32;
             indent_level = indent_level.saturating_sub(leading_closers);
@@ -369,7 +371,11 @@ impl BuiltInFormatter {
                 }
                 result.push_str(trimmed);
             }
-            result.push('\n');
+
+            let is_last_line = index + 1 == lines.len();
+            if !is_last_line || had_trailing_newline {
+                result.push('\n');
+            }
 
             // net_delimiter_delta counts all delimiters including leading closers.
             // We already decremented by leading_closers before printing, so add them

--- a/crates/perl-lsp-perltidy/tests/config_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/config_tests.rs
@@ -264,6 +264,13 @@ fn builtin_formatter_handles_empty_input() {
 }
 
 #[test]
+fn builtin_formatter_preserves_missing_trailing_newline() {
+    let formatter = BuiltInFormatter::new(PerlTidyConfig::default());
+    let formatted = formatter.format("if ($x) {\nprint $x;\n}");
+    assert_eq!(formatted, "if ($x) {\n    print $x;\n}");
+}
+
+#[test]
 fn builtin_formatter_closing_line_does_not_double_decrement() {
     // Regression: leading closers were subtracted before printing AND again by
     // net_delimiter_delta after printing, causing the next line to be under-indented.

--- a/crates/perl-lsp-perltidy/tests/config_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/config_tests.rs
@@ -271,6 +271,28 @@ fn builtin_formatter_preserves_missing_trailing_newline() {
 }
 
 #[test]
+fn builtin_formatter_preserves_trailing_newline_when_present() {
+    let formatter = BuiltInFormatter::new(PerlTidyConfig::default());
+    let formatted = formatter.format("if ($x) {\nprint $x;\n}\n");
+    assert!(formatted.ends_with('\n'), "output must end with '\\n' when input does");
+}
+
+#[test]
+fn builtin_formatter_single_line_no_trailing_newline() {
+    let formatter = BuiltInFormatter::new(PerlTidyConfig::default());
+    let formatted = formatter.format("print 1;");
+    assert_eq!(formatted, "print 1;");
+    assert!(!formatted.ends_with('\n'));
+}
+
+#[test]
+fn builtin_formatter_single_line_with_trailing_newline() {
+    let formatter = BuiltInFormatter::new(PerlTidyConfig::default());
+    let formatted = formatter.format("print 1;\n");
+    assert_eq!(formatted, "print 1;\n");
+}
+
+#[test]
 fn builtin_formatter_closing_line_does_not_double_decrement() {
     // Regression: leading closers were subtracted before printing AND again by
     // net_delimiter_delta after printing, causing the next line to be under-indented.


### PR DESCRIPTION
### Motivation
- The built-in Rust fallback formatter always appended a trailing newline, which introduced spurious EOF diffs when `perltidy` is unavailable.
- Preserve the original document shape by keeping the presence or absence of a trailing newline unchanged by the fallback formatter.

### Description
- Update `BuiltInFormatter::format` to collect `lines`, detect `had_trailing_newline`, and only append a newline for the final output line when the input originally ended with one.
- Add a regression test `builtin_formatter_preserves_missing_trailing_newline` in `crates/perl-lsp-perltidy/tests/config_tests.rs` to assert newline-less input remains newline-less after formatting.
- Change is isolated to the perltidy fallback formatter and its unit tests with no public API changes.

### Testing
- Ran `cargo test -p perl-lsp-perltidy` and all tests passed.
- Ran `cargo check --all-targets -p perl-lsp-perltidy` and it passed.
- Ran `cargo clippy -p perl-lsp-perltidy --all-targets -- -D warnings` and it passed.
- Ran `cargo xtask fmt` to ensure formatting, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c78b3508333ab44296416f4c9c2)