### PR TITLE
fix(perl-lsp-rs-core): extend rust fallback to range formatting (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
+++ b/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
@@ -134,7 +134,17 @@ impl<R: perl_subprocess_runtime::SubprocessRuntime> FormattingProvider<R> {
         }
 
         let text_to_format = lines[start_line..=end_line].join("\n");
-        let formatted = self.run_perltidy(&text_to_format, options)?;
+        let formatted = match self.run_perltidy(&text_to_format, options) {
+            Ok(formatted) => formatted,
+            Err(FormattingError::PerltidyNotFound(message)) => {
+                let rust_only_formatted = apply_lsp_whitespace_options(&text_to_format, options);
+                if rust_only_formatted == text_to_format {
+                    return Err(FormattingError::PerltidyNotFound(message));
+                }
+                rust_only_formatted
+            }
+            Err(other) => return Err(other),
+        };
 
         if formatted == text_to_format {
             return Ok(FormattedDocument { text: content.to_string(), edits: vec![] });
@@ -311,6 +321,46 @@ mod tests {
         let result = provider.format_document("my $x = 1;\n", &options);
         assert!(matches!(result, Err(FormattingError::PerltidyNotFound(_))));
     }
+
+    #[test]
+    fn format_range_uses_rust_whitespace_fallback_when_perltidy_missing() -> Result<()> {
+        let provider = FormattingProvider::new(MissingPerltidyRuntime);
+        let options = FormattingOptions {
+            tab_size: 4,
+            insert_spaces: true,
+            trim_trailing_whitespace: Some(true),
+            insert_final_newline: Some(false),
+            trim_final_newlines: Some(false),
+        };
+        let range = FormatRange::new(FormatPosition::new(1, 0), FormatPosition::new(1, 10));
+
+        let formatted = provider.format_range("line1
+my $x = 1;   
+line3
+", &range, &options)?;
+
+        assert_eq!(formatted.edits.len(), 1);
+        assert_eq!(formatted.edits[0].new_text, "my $x = 1;");
+        Ok(())
+    }
+
+    #[test]
+    fn format_range_keeps_perltidy_not_found_error_when_no_rust_fallback_changes() {
+        let provider = FormattingProvider::new(MissingPerltidyRuntime);
+        let options = FormattingOptions {
+            tab_size: 4,
+            insert_spaces: true,
+            trim_trailing_whitespace: None,
+            insert_final_newline: None,
+            trim_final_newlines: None,
+        };
+        let range = FormatRange::new(FormatPosition::new(0, 0), FormatPosition::new(0, 10));
+
+        let result = provider.format_range("my $x = 1;
+", &range, &options);
+        assert!(matches!(result, Err(FormattingError::PerltidyNotFound(_))));
+    }
+
     #[test]
     fn apply_lsp_whitespace_options_trim_final_newlines_removes_all_trailing_newlines() {
         // Regression: previous implementation used `ends_with("\n\n")` which left

--- a/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
+++ b/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
@@ -137,7 +137,13 @@ impl<R: perl_subprocess_runtime::SubprocessRuntime> FormattingProvider<R> {
         let formatted = match self.run_perltidy(&text_to_format, options) {
             Ok(formatted) => formatted,
             Err(FormattingError::PerltidyNotFound(message)) => {
-                let rust_only_formatted = apply_lsp_whitespace_options(&text_to_format, options);
+                // `text_to_format` is a line-joined fragment (no surrounding newlines).
+                // `apply_lsp_whitespace_options` may append a trailing '\n' when
+                // `insert_final_newline` is true; strip it here so the LSP edit
+                // `new_text` does not inject an extra blank line into the document
+                // (the range replacement already sits between existing newlines).
+                let raw = apply_lsp_whitespace_options(&text_to_format, options);
+                let rust_only_formatted = raw.trim_end_matches('\n').to_string();
                 if rust_only_formatted == text_to_format {
                     return Err(FormattingError::PerltidyNotFound(message));
                 }
@@ -341,6 +347,31 @@ line3
 
         assert_eq!(formatted.edits.len(), 1);
         assert_eq!(formatted.edits[0].new_text, "my $x = 1;");
+        Ok(())
+    }
+
+    #[test]
+    fn format_range_fallback_does_not_inject_newline_when_insert_final_newline_set() -> Result<()> {
+        // Regression: apply_lsp_whitespace_options appends '\n' when insert_final_newline
+        // is true. For a range edit, new_text must not have a trailing newline because the
+        // replacement range already sits between existing document newlines.
+        let provider = FormattingProvider::new(MissingPerltidyRuntime);
+        let options = FormattingOptions {
+            tab_size: 4,
+            insert_spaces: true,
+            trim_trailing_whitespace: Some(true),
+            insert_final_newline: Some(true), // would normally append \n to fragment
+            trim_final_newlines: None,
+        };
+        let range = FormatRange::new(FormatPosition::new(1, 0), FormatPosition::new(1, 13));
+
+        let formatted = provider.format_range("line1\nmy $x = 1;   \nline3\n", &range, &options)?;
+
+        assert_eq!(formatted.edits.len(), 1);
+        // new_text must NOT end with '\n' — that would insert a spurious blank line
+        let new_text = &formatted.edits[0].new_text;
+        assert_eq!(new_text, "my $x = 1;");
+        assert!(!new_text.ends_with('\n'), "range edit new_text must not end with '\\n'");
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation
- Range formatting failed outright when the external `perltidy` tool was not available while document formatting already provided a Rust-only whitespace fallback.
- The change aims to make range formatting behavior consistent with document formatting in the absence of `perltidy` so clients receive whitespace-only edits instead of a hard error when possible.

### Description
- Extend `format_range` to catch `FormattingError::PerltidyNotFound` and apply `apply_lsp_whitespace_options` as a Rust-only fallback, returning the `perltidy_not_found` error only when the fallback makes no changes.
- Add focused unit tests for the range formatter covering the fallback-success path and the preserved `perltidy_not_found` error path in `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs`.
- No changes were made to the `run_perltidy` logic or to document-formatting behavior beyond reusing the same fallback strategy.

### Testing
- Ran `cargo test -p perl-lsp-rs-core -- providers::formatting::formatting` and the formatting provider tests passed (5 passed, 0 failed).
- The new unit tests validate both the fallback edit case and the preserved `perltidy_not_found` case and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c78b3508333ab44296416f4c9c2)