### PR TITLE
fix(formatting): add perltidy-missing range fallback (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
+++ b/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
@@ -134,7 +134,17 @@ impl<R: perl_subprocess_runtime::SubprocessRuntime> FormattingProvider<R> {
         }
 
         let text_to_format = lines[start_line..=end_line].join("\n");
-        let formatted = self.run_perltidy(&text_to_format, options)?;
+        let formatted = match self.run_perltidy(&text_to_format, options) {
+            Ok(formatted) => formatted,
+            Err(FormattingError::PerltidyNotFound(message)) => {
+                let rust_only_formatted = apply_lsp_whitespace_options(&text_to_format, options);
+                if rust_only_formatted == text_to_format {
+                    return Err(FormattingError::PerltidyNotFound(message));
+                }
+                rust_only_formatted
+            }
+            Err(other) => return Err(other),
+        };
 
         if formatted == text_to_format {
             return Ok(FormattedDocument { text: content.to_string(), edits: vec![] });
@@ -310,6 +320,24 @@ mod tests {
 
         let result = provider.format_document("my $x = 1;\n", &options);
         assert!(matches!(result, Err(FormattingError::PerltidyNotFound(_))));
+    }
+
+    #[test]
+    fn format_range_uses_rust_whitespace_fallback_when_perltidy_missing() -> Result<()> {
+        let provider = FormattingProvider::new(MissingPerltidyRuntime);
+        let options = FormattingOptions {
+            tab_size: 4,
+            insert_spaces: true,
+            trim_trailing_whitespace: Some(true),
+            insert_final_newline: None,
+            trim_final_newlines: None,
+        };
+        let range = FormatRange::new(FormatPosition::new(1, 0), FormatPosition::new(1, 12));
+        let formatted = provider.format_range("my $x = 1;\nmy $y = 2;   \n", &range, &options)?;
+
+        assert_eq!(formatted.edits.len(), 1);
+        assert_eq!(formatted.edits[0].new_text, "my $y = 2;");
+        Ok(())
     }
     #[test]
     fn apply_lsp_whitespace_options_trim_final_newlines_removes_all_trailing_newlines() {


### PR DESCRIPTION
### Motivation

- Range formatting was hard-failing with `PerltidyNotFound` even though whole-document formatting already provided a Rust-side whitespace fallback, causing degraded UX when `perltidy` is not installed.

### Description

- Update `FormattingProvider::format_range` to mirror the `format_document` fallback: when `run_perltidy` returns `PerltidyNotFound`, apply `apply_lsp_whitespace_options` and only return the error if that fallback would be a no-op.
- Add a unit test `format_range_uses_rust_whitespace_fallback_when_perltidy_missing` to validate trimming of trailing whitespace in a formatted range when `perltidy` is unavailable.
- Change is confined to `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs`.

### Testing

- Ran `cargo test -p perl-lsp-rs-core formatting:: -- --nocapture` and the formatting unit tests passed (new test included) with no failures.
- Ran `cargo check --all-targets -p perl-lsp-rs-core` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c78b3508333ab44296416f4c9c2)