### PR TITLE
fix(perl-lsp-perltidy): keep extra args with profile mode (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -110,6 +110,7 @@ impl PerlTidyConfig {
 
         if let Some(profile) = &self.profile {
             args.push(format!("--profile={profile}"));
+            args.extend(self.extra_args.clone());
             return args;
         }
 

--- a/crates/perl-lsp-perltidy/tests/config_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/config_tests.rs
@@ -43,9 +43,23 @@ fn config_with_profile_ignores_other_settings() {
     };
     let args = config.to_args();
 
-    // Only profile flag should be present; all others suppressed
+    // Only profile flag should be present from primary settings; all others suppressed
     assert_eq!(args.len(), 1);
     assert!(args[0].starts_with("--profile="));
+}
+
+#[test]
+fn config_with_profile_keeps_extra_args() {
+    let config = PerlTidyConfig {
+        profile: Some(".perltidyrc".to_string()),
+        extra_args: vec!["--check-syntax".to_string()],
+        ..PerlTidyConfig::default()
+    };
+    let args = config.to_args();
+
+    assert_eq!(args.len(), 2);
+    assert_eq!(args[0], "--profile=.perltidyrc");
+    assert_eq!(args[1], "--check-syntax");
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- `PerlTidyConfig::to_args()` returned early when `profile` was set, which silently dropped `extra_args` and prevented callers from forwarding additional perltidy flags.

### Description

- Append `extra_args` when `profile` is present by calling `args.extend(self.extra_args.clone())` before returning in `to_args()`.
- Add a focused test `config_with_profile_keeps_extra_args` and clarify an existing test comment to cover the profile + extra args behavior.

### Testing

- Ran `cargo test -p perl-lsp-perltidy`, and all tests passed (unit/integration tests for the crate completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c78b3508333ab44296416f4c9c2)