### PR TITLE
fix(vscode-extension): resolve relative perlcritic profiles in health check (#0000)

### DIFF
--- a/vscode-extension/src/onboarding.ts
+++ b/vscode-extension/src/onboarding.ts
@@ -263,7 +263,11 @@ export class OnboardingManager {
     }
 
     const primaryWorkspace = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-    return primaryWorkspace ? path.resolve(primaryWorkspace, profile) : profile;
+    // When no workspace folder is open we cannot resolve a relative path to a
+    // meaningful absolute location (CWD of the extension host is not the user's
+    // project directory).  Return `undefined` so the caller skips the existence
+    // check rather than silently probing the wrong location.
+    return primaryWorkspace ? path.resolve(primaryWorkspace, profile) : undefined;
   }
 
   /**

--- a/vscode-extension/src/onboarding.ts
+++ b/vscode-extension/src/onboarding.ts
@@ -8,6 +8,7 @@
  */
 
 import * as fs from 'fs';
+import * as path from 'path';
 import { execFile } from 'child_process';
 import * as vscode from 'vscode';
 
@@ -221,12 +222,13 @@ export class OnboardingManager {
       };
     }
 
-    if (profile && !fs.existsSync(profile)) {
+    const resolvedProfile = this.resolvePerlcriticProfilePath(profile);
+    if (resolvedProfile && !fs.existsSync(resolvedProfile)) {
       return {
         label,
         ok: false,
         status: HealthCheckStatus.Warning,
-        detail: `Configured perlcritic profile was not found: ${profile}`,
+        detail: `Configured perlcritic profile was not found: ${resolvedProfile}`,
       };
     }
 
@@ -249,6 +251,19 @@ export class OnboardingManager {
           'Install via: cpanm Perl::Critic',
       };
     }
+  }
+
+  private resolvePerlcriticProfilePath(profile: string): string | undefined {
+    if (!profile) {
+      return undefined;
+    }
+
+    if (path.isAbsolute(profile)) {
+      return profile;
+    }
+
+    const primaryWorkspace = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    return primaryWorkspace ? path.resolve(primaryWorkspace, profile) : profile;
   }
 
   /**

--- a/vscode-extension/src/test/onboarding.test.ts
+++ b/vscode-extension/src/test/onboarding.test.ts
@@ -13,6 +13,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import {
   OnboardingManager,
   HealthCheckResult,
@@ -217,6 +218,38 @@ describe('resolveUnixShellInvocationFallback', () => {
     );
 
     expect(fallback).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkPerlcriticSetup
+// ---------------------------------------------------------------------------
+
+describe('OnboardingManager.checkPerlcriticSetup', () => {
+  const originalWorkspaceFolders = vscode.workspace.workspaceFolders;
+
+  afterEach(() => {
+    (vscode.workspace as any).workspaceFolders = originalWorkspaceFolders;
+    jest.restoreAllMocks();
+  });
+
+  test('resolves relative perlcritic profile paths from workspace root', async () => {
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ob-critic-'));
+    const configDir = path.join(workspaceRoot, 'config');
+    const profilePath = path.join(configDir, 'perlcriticrc');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(profilePath, 'severity = 3\n');
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: workspaceRoot } }];
+    jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
+      get: jest.fn(() => ({ enabled: true, profile: 'config/perlcriticrc' })),
+    } as any);
+
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel()) as any;
+    mgr._execCheck = jest.fn(() => Promise.resolve({ stdout: 'perlcritic 1.148', stderr: '' }));
+    const result = await mgr.checkPerlcriticSetup();
+
+    expect(result.ok).toBe(true);
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
   });
 });
 

--- a/vscode-extension/src/test/onboarding.test.ts
+++ b/vscode-extension/src/test/onboarding.test.ts
@@ -251,6 +251,25 @@ describe('OnboardingManager.checkPerlcriticSetup', () => {
     expect(result.ok).toBe(true);
     fs.rmSync(workspaceRoot, { recursive: true, force: true });
   });
+
+  test('skips profile existence check when workspace is undefined and path is relative', async () => {
+    // When no workspace folder is open, a relative profile path cannot be resolved
+    // to an absolute location.  The health check must skip the fs.existsSync probe
+    // and proceed as if no profile is configured (i.e. not warn "profile not found").
+    (vscode.workspace as any).workspaceFolders = undefined;
+    jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
+      get: jest.fn(() => ({ enabled: true, profile: 'config/perlcriticrc' })),
+    } as any);
+
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel()) as any;
+    mgr._execCheck = jest.fn(() => Promise.resolve({ stdout: 'perlcritic 1.148', stderr: '' }));
+    const result = await mgr.checkPerlcriticSetup();
+
+    // Must not return a "profile not found" warning — without a workspace root
+    // we cannot verify existence, so we should proceed to check the binary.
+    expect(result.ok).toBe(true);
+    expect(result.status).not.toBe('warning');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- The onboarding health check treated relative `perl-lsp.perlcritic.profile` values as current-working-directory paths, which caused valid workspace-relative profiles to produce false “profile not found” warnings.

### Description

- Resolve non-absolute Perl::Critic profile paths against the primary workspace root via a new `resolvePerlcriticProfilePath` helper and use the resolved path for existence checks in `checkPerlcriticSetup` (`vscode-extension/src/onboarding.ts`).
- Update the health-check warning message to include the resolved profile path when a profile is not found.
- Add a regression unit test that exercises workspace-relative profile resolution by populating `vscode.workspace.workspaceFolders` and mocking the extension configuration (`vscode-extension/src/test/onboarding.test.ts`).
- Restore mocked state after the test to avoid cross-test leakage.

### Testing

- Ran `npm test -- onboarding.test.ts` in `vscode-extension`, which executed the modified test file but the run failed due to repository TypeScript/Jest global type configuration errors (multiple `TS2304: Cannot find name 'jest'` / test-runner globals), not due to the new test logic.
- No Rust or Cargo tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c7d5d388333948116b9baa07ed9)