### PR TITLE
fix(vscode-extension): support ~/ perlcritic profiles in onboarding (#0000)

### DIFF
--- a/vscode-extension/src/onboarding.ts
+++ b/vscode-extension/src/onboarding.ts
@@ -8,6 +8,7 @@
  */
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { execFile } from 'child_process';
 import * as vscode from 'vscode';
@@ -96,6 +97,19 @@ type ExecCheckFn = (
 interface ExecInvocation {
   command: string;
   args: string[];
+}
+
+function resolveUserPath(rawPath: string): string {
+  const trimmedPath = rawPath.trim();
+  if (trimmedPath === '~') {
+    return os.homedir();
+  }
+
+  if (trimmedPath.startsWith('~/') || trimmedPath.startsWith('~\\')) {
+    return path.join(os.homedir(), trimmedPath.slice(2));
+  }
+
+  return trimmedPath;
 }
 
 // ---------------------------------------------------------------------------
@@ -211,7 +225,10 @@ export class OnboardingManager {
     const label = 'perlcritic';
     const perlcriticConfig = vscode.workspace.getConfiguration('perl-lsp').get<any>('perlcritic', {});
     const enabled = Boolean(perlcriticConfig?.enabled);
-    const profile = typeof perlcriticConfig?.profile === 'string' ? perlcriticConfig.profile.trim() : '';
+    const profile =
+      typeof perlcriticConfig?.profile === 'string'
+        ? resolveUserPath(perlcriticConfig.profile)
+        : '';
 
     if (!enabled) {
       return {

--- a/vscode-extension/src/test/onboarding.test.ts
+++ b/vscode-extension/src/test/onboarding.test.ts
@@ -151,13 +151,19 @@ describe('OnboardingManager.checkPerltidyInstalled', () => {
   });
 });
 
-describe('OnboardingManager.checkPerlcriticSetup', () => {
+describe('OnboardingManager.checkPerlcriticSetup (tilde expansion)', () => {
+  // Use a unique temp file name to avoid collisions across parallel test runs.
+  // We write inside os.homedir() because resolveUserPath expands `~/` to
+  // os.homedir() and we need fs.existsSync to confirm the expansion is correct.
+  // The file is cleaned up in a `finally` block regardless of test outcome.
   test('accepts ~/ profile path when file exists in the home directory', async () => {
-    const profileName = '.perlcritic-onboarding-test.rc';
+    const profileName = `.perlcritic-test-${Date.now()}-${process.pid}.rc`;
     const profilePath = path.join(os.homedir(), profileName);
-    fs.writeFileSync(profilePath, 'severity = 3\n');
-
+    let profileWritten = false;
     try {
+      fs.writeFileSync(profilePath, 'severity = 3\n');
+      profileWritten = true;
+
       (vscode.workspace.getConfiguration as jest.Mock).mockImplementation(() => ({
         get: (key: string, defaultValue?: unknown) => {
           if (key === 'perlcritic') {
@@ -180,7 +186,9 @@ describe('OnboardingManager.checkPerlcriticSetup', () => {
       expect(result.status).toBe(HealthCheckStatus.Ok);
       expect(result.detail).toBe('perlcritic found');
     } finally {
-      fs.rmSync(profilePath, { force: true });
+      if (profileWritten) {
+        fs.rmSync(profilePath, { force: true });
+      }
     }
   });
 });

--- a/vscode-extension/src/test/onboarding.test.ts
+++ b/vscode-extension/src/test/onboarding.test.ts
@@ -151,6 +151,40 @@ describe('OnboardingManager.checkPerltidyInstalled', () => {
   });
 });
 
+describe('OnboardingManager.checkPerlcriticSetup', () => {
+  test('accepts ~/ profile path when file exists in the home directory', async () => {
+    const profileName = '.perlcritic-onboarding-test.rc';
+    const profilePath = path.join(os.homedir(), profileName);
+    fs.writeFileSync(profilePath, 'severity = 3\n');
+
+    try {
+      (vscode.workspace.getConfiguration as jest.Mock).mockImplementation(() => ({
+        get: (key: string, defaultValue?: unknown) => {
+          if (key === 'perlcritic') {
+            return {
+              enabled: true,
+              profile: `~/${profileName}`,
+            };
+          }
+          return defaultValue;
+        },
+      }));
+
+      const mgr = new OnboardingManager(makeContext(), makeOutputChannel()) as any;
+      mgr._execCheck = jest.fn(() =>
+        Promise.resolve({ stdout: 'Perl::Critic version 1.156', stderr: '' }),
+      );
+
+      const result = await mgr.checkPerlcriticSetup();
+      expect(result.ok).toBe(true);
+      expect(result.status).toBe(HealthCheckStatus.Ok);
+      expect(result.detail).toBe('perlcritic found');
+    } finally {
+      fs.rmSync(profilePath, { force: true });
+    }
+  });
+});
+
 describe('selectWindowsCommandCandidate', () => {
   test('prefers executable or wrapper paths over extensionless shims', () => {
     const selected = selectWindowsCommandCandidate(


### PR DESCRIPTION
### Motivation
- The onboarding health check treated configured `perlcritic.profile` paths literally so `~/...` home-relative profiles were reported as missing even when the file existed, causing a poor UX when using home-shorthand paths.

### Description
- Import `os` and `path` and add a `resolveUserPath` helper to expand `~` and `~/` into the user home directory and trim whitespace.
- Use `resolveUserPath` when reading `perlcritic.profile` in `checkPerlcriticSetup` so filesystem checks operate on normalized paths.
- Add a regression unit test `OnboardingManager.checkPerlcriticSetup` that writes a temp profile to `~` and verifies `checkPerlcriticSetup` accepts `~/...` profiles (file: `vscode-extension/src/test/onboarding.test.ts`).

### Testing
- Ran the extension test command `npm test -- onboarding.test.ts`, which failed due to TypeScript/Jest global-type resolution errors (unresolved `jest`, `describe`, `expect`) that are pre-existing in the workspace, so the automated test run did not complete successfully.
- The change is limited to `vscode-extension/src/onboarding.ts` and its test and is small and self-contained; the added regression test should pass in a correctly-configured Jest/TypeScript test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c7d5d388333948116b9baa07ed9)