### PR TITLE
fix(perl-lsp-rs-core): ignore commented use pragmas in built-in critic (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs
@@ -191,7 +191,7 @@ fn missing_use_statement_violation(
     feature: &str,
     explanation: &str,
 ) -> Vec<Violation> {
-    if content.contains(&format!("use {feature}")) {
+    if has_use_statement(content, feature) {
         return Vec::new();
     }
 
@@ -203,6 +203,15 @@ fn missing_use_statement_violation(
         range: insertion_range(),
         file: String::new(),
     }]
+}
+
+
+fn has_use_statement(content: &str, feature: &str) -> bool {
+    let needle = format!("use {feature}");
+    content.lines().any(|line| {
+        let code = line.split('#').next().unwrap_or_default();
+        code.contains(&needle)
+    })
 }
 
 fn find_bareword_open_filehandles(content: &str) -> Vec<Range> {
@@ -511,6 +520,48 @@ eval $code;
         let has_two_arg_violation =
             violations.iter().any(|v| v.policy == "InputOutput::ProhibitTwoArgOpen");
         assert!(has_two_arg_violation, "expected InputOutput::ProhibitTwoArgOpen violation");
+        Ok(())
+    }
+
+    #[test]
+    fn builtin_analyzer_flags_missing_strict_when_only_comment_mentions_it() -> TestResult {
+        let source = "# use strict;
+use warnings;
+my $x = 1;
+";
+        let mut parser = Parser::new(source);
+        let ast = parser.parse()?;
+
+        let analyzer = BuiltInAnalyzer::new();
+        let violations = analyzer.analyze(&ast, source);
+
+        assert!(
+            violations
+                .iter()
+                .any(|v| v.policy == "TestingAndDebugging::RequireUseStrict"),
+            "commented use strict should not satisfy RequireUseStrict"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn builtin_analyzer_flags_missing_warnings_when_only_comment_mentions_it() -> TestResult {
+        let source = "use strict;
+# use warnings;
+my $x = 1;
+";
+        let mut parser = Parser::new(source);
+        let ast = parser.parse()?;
+
+        let analyzer = BuiltInAnalyzer::new();
+        let violations = analyzer.analyze(&ast, source);
+
+        assert!(
+            violations
+                .iter()
+                .any(|v| v.policy == "TestingAndDebugging::RequireUseWarnings"),
+            "commented use warnings should not satisfy RequireUseWarnings"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation

- The built-in Perl::Critic replacement was treating commented `use strict`/`use warnings` lines as real pragmas and thus suppressed real violations.
- Ensure the built-in analyzer only recognizes uncommented pragma directives so diagnostics reflect actual code, not comments.

### Description

- Replaced the naive `content.contains("use {feature}")` check with a new `has_use_statement(content, feature)` helper that inspects only the uncommented portion of each line by splitting on `#` before searching.
- Updated `missing_use_statement_violation` to use `has_use_statement` for correct pragma detection.
- Added two focused unit tests `builtin_analyzer_flags_missing_strict_when_only_comment_mentions_it` and `builtin_analyzer_flags_missing_warnings_when_only_comment_mentions_it` to prevent regressions.
- Changes are in `crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs` and are limited to the built-in critic policy logic and tests.

### Testing

- Ran `cargo test -p perl-lsp-rs-core builtin_analyzer_flags_missing_` and the new regression tests passed (2 passed; 0 failed).
- Full crate test run completed with no failures for the modified crate's unit tests during the session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c84f08c8333a3d1ba07ffd487e8)