### PR TITLE
fix(perl-lsp-rs-core): support fully-qualified perlcritic aliases (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -110,7 +110,11 @@ impl CodeActionsProvider {
         for diagnostic in diagnostics {
             let qf_diag = to_quick_fix_diagnostic(diagnostic);
             if let Some(code) = &diagnostic.code {
-                match code.as_str() {
+                let policy_code = code
+                    .strip_prefix("Perl::Critic::Policy::")
+                    .unwrap_or(code.as_str());
+
+                match policy_code {
                     // PL103: Undefined/undeclared variable
                     c if c == DiagnosticCode::UndefinedVariable.as_str() => {
                         actions.extend(quick_fixes::fix_undefined_variable(&self.source, &qf_diag));
@@ -168,7 +172,7 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_parse_error(&self.source, &qf_diag, c));
                     }
                     // parse-error-* subcodes (legacy subtype codes from error classifier)
-                    code if code.starts_with("parse-error-") => {
+                    c if c.starts_with("parse-error-") => {
                         actions.extend(quick_fixes::fix_parse_error(&self.source, &qf_diag, code));
                     }
                     // PL108: Unused parameter
@@ -492,6 +496,42 @@ mod tests {
                 range: (0, 4),
                 severity: DiagnosticSeverity::Warning,
                 code: Some("InputOutput::RequireThreeArgOpen".to_string()),
+                message: "Use 3-arg open".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+        ];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+        assert!(actions.iter().any(|a| a.title.contains("bareword filehandle")));
+        assert!(actions.iter().any(|a| a.title.contains("three-argument open() for safety")));
+    }
+
+
+    #[test]
+    fn test_fully_qualified_perlcritic_policy_aliases_produce_quick_fixes() {
+        let source = "open FH, $path;
+";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let diagnostics = vec![
+            Diagnostic {
+                range: (0, 4),
+                severity: DiagnosticSeverity::Warning,
+                code: Some(
+                    "Perl::Critic::Policy::InputOutput::ProhibitBarewordFileHandles".to_string(),
+                ),
+                message: "Bareword filehandle 'FH'".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+            Diagnostic {
+                range: (0, 4),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("Perl::Critic::Policy::InputOutput::RequireThreeArgOpen".to_string()),
                 message: "Use 3-arg open".to_string(),
                 suggestion: None,
                 related_information: Vec::new(),

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -110,9 +110,8 @@ impl CodeActionsProvider {
         for diagnostic in diagnostics {
             let qf_diag = to_quick_fix_diagnostic(diagnostic);
             if let Some(code) = &diagnostic.code {
-                let policy_code = code
-                    .strip_prefix("Perl::Critic::Policy::")
-                    .unwrap_or(code.as_str());
+                let policy_code =
+                    code.strip_prefix("Perl::Critic::Policy::").unwrap_or(code.as_str());
 
                 match policy_code {
                     // PL103: Undefined/undeclared variable
@@ -173,7 +172,7 @@ impl CodeActionsProvider {
                     }
                     // parse-error-* subcodes (legacy subtype codes from error classifier)
                     c if c.starts_with("parse-error-") => {
-                        actions.extend(quick_fixes::fix_parse_error(&self.source, &qf_diag, code));
+                        actions.extend(quick_fixes::fix_parse_error(&self.source, &qf_diag, c));
                     }
                     // PL108: Unused parameter
                     c if c == DiagnosticCode::UnusedParameter.as_str() => {
@@ -508,7 +507,6 @@ mod tests {
         assert!(actions.iter().any(|a| a.title.contains("bareword filehandle")));
         assert!(actions.iter().any(|a| a.title.contains("three-argument open() for safety")));
     }
-
 
     #[test]
     fn test_fully_qualified_perlcritic_policy_aliases_produce_quick_fixes() {


### PR DESCRIPTION
### Motivation
- Diagnostics emitted by `perlcritic` can include fully-qualified policy names like `Perl::Critic::Policy::InputOutput::RequireThreeArgOpen`, which did not match existing quick-fix routing that expected the short policy names.

### Description
- Normalize incoming diagnostic codes by stripping the `Perl::Critic::Policy::` prefix before match routing in `CodeActionsProvider::get_code_actions` so both short and fully-qualified names map to the same handlers.
- Fix a pattern-match variable name for `parse-error-*` guards to remain consistent with surrounding matches.
- Add a regression test `test_fully_qualified_perlcritic_policy_aliases_produce_quick_fixes` that verifies fully-qualified policy codes produce the same quick fixes for bareword filehandles and three-argument `open()` conversion.

### Testing
- Ran `cargo check --all-targets -p perl-lsp-rs-core` and it passed.
- Ran `cargo test -p perl-lsp-rs-core test_perlcritic_policy_aliases_produce_quick_fixes -- --exact` and it passed.
- Ran `cargo test -p perl-lsp-rs-core test_fully_qualified_perlcritic_policy_aliases_produce_quick_fixes -- --exact` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c84f08c8333a3d1ba07ffd487e8)