### PR TITLE
fix(perl-lsp-rs-core): harden built-in use statement detection (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs
@@ -583,4 +583,21 @@ eval $code;
         assert!(violations.iter().any(|v| v.policy == "TestingAndDebugging::RequireUseWarnings"));
         Ok(())
     }
+
+    #[test]
+    fn use_strictures_does_not_satisfy_use_strict_requirement() -> TestResult {
+        // "use strictures;" must NOT suppress RequireUseStrict — it is a different module.
+        // A substring check ("use strict" in "use strictures") would false-negative here.
+        let source = "use strictures;\nuse warnings;\nmy $x = 1;\n";
+        let mut parser = Parser::new(source);
+        let ast = parser.parse()?;
+        let analyzer = BuiltInAnalyzer::new();
+        let violations = analyzer.analyze(&ast, source);
+
+        assert!(
+            violations.iter().any(|v| v.policy == "TestingAndDebugging::RequireUseStrict"),
+            "use strictures should not satisfy RequireUseStrict — they are different modules"
+        );
+        Ok(())
+    }
 }

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/built_in.rs
@@ -191,7 +191,7 @@ fn missing_use_statement_violation(
     feature: &str,
     explanation: &str,
 ) -> Vec<Violation> {
-    if content.contains(&format!("use {feature}")) {
+    if has_use_statement(content, feature) {
         return Vec::new();
     }
 
@@ -203,6 +203,25 @@ fn missing_use_statement_violation(
         range: insertion_range(),
         file: String::new(),
     }]
+}
+
+fn has_use_statement(content: &str, feature: &str) -> bool {
+    content.lines().any(|line| has_use_statement_line(line, feature))
+}
+
+fn has_use_statement_line(line: &str, feature: &str) -> bool {
+    let code_portion = line.split('#').next().unwrap_or_default();
+    let mut tokens = code_portion.split_whitespace();
+    let Some(first) = tokens.next() else {
+        return false;
+    };
+    if first != "use" {
+        return false;
+    }
+    let Some(module) = tokens.next() else {
+        return false;
+    };
+    module.trim_end_matches(';') == feature
 }
 
 fn find_bareword_open_filehandles(content: &str) -> Vec<Range> {
@@ -549,6 +568,19 @@ eval $code;
             .ok_or("expected InputOutput::ProhibitTwoArgOpen violation")?;
 
         assert_eq!(v.range.start.line, 2, "violation should be on line 2 (zero-indexed)");
+        Ok(())
+    }
+
+    #[test]
+    fn comments_do_not_satisfy_use_statement_requirements() -> TestResult {
+        let source = "# use strict;\n# use warnings;\nmy $x = 1;\n";
+        let mut parser = Parser::new(source);
+        let ast = parser.parse()?;
+        let analyzer = BuiltInAnalyzer::new();
+        let violations = analyzer.analyze(&ast, source);
+
+        assert!(violations.iter().any(|v| v.policy == "TestingAndDebugging::RequireUseStrict"));
+        assert!(violations.iter().any(|v| v.policy == "TestingAndDebugging::RequireUseWarnings"));
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- The built-in Perl::Critic replacement treated commented lines like `# use strict;` / `# use warnings;` as real `use` declarations, which incorrectly suppressed required diagnostics.

### Description
- Replace the raw substring check in `missing_use_statement_violation` with `has_use_statement` that scans lines and ignores comments via `has_use_statement_line` to token-match `use <module>`.
- Add a regression test `comments_do_not_satisfy_use_statement_requirements` to ensure comment-only `use` lines do not satisfy the policies.
- Keep existing quick-fix logic and analyzer API unchanged while hardening detection to be comment-aware.

### Testing
- Ran `cargo test -p perl-lsp-rs-core comments_do_not_satisfy_use_statement_requirements -- --exact` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c84f08c8333a3d1ba07ffd487e8)