### PR TITLE
feat(perl-dap): honor launch perl interpreter override (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -80,27 +80,25 @@ fn detect_perl_info() -> String {
     }
 }
 
-fn format_perl_spawn_error(error: &std::io::Error) -> String {
+fn format_perl_spawn_error(perl_interpreter: &str, error: &std::io::Error) -> String {
     if error.kind() == std::io::ErrorKind::NotFound {
         #[cfg(windows)]
         {
-            return "Perl executable ('perl') is not available on PATH. Install Perl from \
+            return format!("Perl executable ('{perl_interpreter}') is not available on PATH. Install Perl from \
                     https://strawberryperl.com (or ActivePerl), then reload VS Code. \
-                    You can also set `perl-lsp.perl.path` or launch.json `perl` to a full Perl path."
-                .to_string();
+                    You can also set `perl-lsp.perl.path` or launch.json `perl` to a full Perl path.");
         }
         #[cfg(not(windows))]
         {
-            return "Perl executable ('perl') is not available on PATH. Install Perl with your package manager \
+            return format!("Perl executable ('{perl_interpreter}') is not available on PATH. Install Perl with your package manager \
                     (for example `brew install perl`, `apt install perl`, or your distro equivalent), \
                     then reload VS Code. You can also set `perl-lsp.perl.path` or launch.json `perl` \
-                    to a full Perl path."
-                .to_string();
+                    to a full Perl path.");
         }
     }
 
     format!(
-        "Perl executable ('perl') could not be started: {}. \
+        "Perl executable ('{perl_interpreter}') could not be started: {}. \
          Check file permissions, antivirus/AppLocker policy, and sandbox restrictions.",
         error
     )
@@ -208,6 +206,7 @@ impl DebugAdapter {
                 Some(args.clone());
 
             let program = args.get("program").and_then(|p| p.as_str()).unwrap_or("");
+            let perl_interpreter = args.get("perl").and_then(|p| p.as_str()).unwrap_or("perl");
 
             // Set workspace root for path validation (prefer cwd, fall back to program's parent)
             let workspace = args
@@ -244,7 +243,7 @@ impl DebugAdapter {
                 .unwrap_or_default();
 
             // Launch Perl debugger
-            match self.launch_debugger(program, perl_args, stop_on_entry, env_overrides) {
+            match self.launch_debugger(program, perl_interpreter, perl_args, stop_on_entry, env_overrides) {
                 Ok(thread_id) => {
                     // Send stopped event if stop on entry
                     if stop_on_entry {
@@ -306,6 +305,7 @@ impl DebugAdapter {
     pub(super) fn launch_debugger(
         &mut self,
         program: &str,
+        perl_interpreter: &str,
         args: Vec<String>,
         stop_on_entry: bool,
         env_overrides: HashMap<String, String>,
@@ -369,9 +369,9 @@ impl DebugAdapter {
         // debugger.  This catches syntax errors early and surfaces a clear,
         // actionable message to the user instead of a generic "Cannot start
         // Perl debugger" failure after `perl -d` exits immediately.
-        Self::check_syntax(program, &env_overrides)?;
+        Self::check_syntax(perl_interpreter, program, &env_overrides)?;
 
-        let mut cmd = Command::new("perl");
+        let mut cmd = Command::new(perl_interpreter);
         cmd.arg("-d");
 
         // Perl debugger stops on the first line by default
@@ -428,7 +428,7 @@ impl DebugAdapter {
 
                 Ok(thread_id)
             }
-            Err(e) => Err(format_perl_spawn_error(&e)),
+            Err(e) => Err(format_perl_spawn_error(perl_interpreter, &e)),
         }
     }
 
@@ -443,10 +443,11 @@ impl DebugAdapter {
     /// and `Ok(())` is returned so that the subsequent `perl -d` launch
     /// produces the correct "perl not on PATH" error to the user.
     pub(super) fn check_syntax(
+        perl_interpreter: &str,
         program: &str,
         env_overrides: &HashMap<String, String>,
     ) -> Result<(), String> {
-        let output = match Command::new("perl")
+        let output = match Command::new(perl_interpreter)
             .arg("-c")
             .arg("--")
             .arg(program)
@@ -1855,10 +1856,18 @@ mod tests {
         }
     }
 
+
+    #[test]
+    fn format_perl_spawn_error_includes_custom_interpreter_name() {
+        let error = std::io::Error::new(std::io::ErrorKind::NotFound, "No such file or directory");
+        let message = format_perl_spawn_error("/custom/perl", &error);
+
+        assert!(message.contains("/custom/perl"), "expected interpreter path in message, got: {message}");
+    }
     #[test]
     fn format_perl_spawn_error_for_missing_perl_is_actionable() {
         let error = std::io::Error::new(std::io::ErrorKind::NotFound, "No such file or directory");
-        let message = format_perl_spawn_error(&error);
+        let message = format_perl_spawn_error("perl", &error);
 
         assert!(message.contains("Install Perl"), "expected install guidance, got: {message}");
         assert!(

--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -84,16 +84,20 @@ fn format_perl_spawn_error(perl_interpreter: &str, error: &std::io::Error) -> St
     if error.kind() == std::io::ErrorKind::NotFound {
         #[cfg(windows)]
         {
-            return format!("Perl executable ('{perl_interpreter}') is not available on PATH. Install Perl from \
+            return format!(
+                "Perl executable ('{perl_interpreter}') is not available on PATH. Install Perl from \
                     https://strawberryperl.com (or ActivePerl), then reload VS Code. \
-                    You can also set `perl-lsp.perl.path` or launch.json `perl` to a full Perl path.");
+                    You can also set `perl-lsp.perl.path` or launch.json `perl` to a full Perl path."
+            );
         }
         #[cfg(not(windows))]
         {
-            return format!("Perl executable ('{perl_interpreter}') is not available on PATH. Install Perl with your package manager \
+            return format!(
+                "Perl executable ('{perl_interpreter}') is not available on PATH. Install Perl with your package manager \
                     (for example `brew install perl`, `apt install perl`, or your distro equivalent), \
                     then reload VS Code. You can also set `perl-lsp.perl.path` or launch.json `perl` \
-                    to a full Perl path.");
+                    to a full Perl path."
+            );
         }
     }
 
@@ -243,7 +247,13 @@ impl DebugAdapter {
                 .unwrap_or_default();
 
             // Launch Perl debugger
-            match self.launch_debugger(program, perl_interpreter, perl_args, stop_on_entry, env_overrides) {
+            match self.launch_debugger(
+                program,
+                perl_interpreter,
+                perl_args,
+                stop_on_entry,
+                env_overrides,
+            ) {
                 Ok(thread_id) => {
                     // Send stopped event if stop on entry
                     if stop_on_entry {
@@ -1856,13 +1866,15 @@ mod tests {
         }
     }
 
-
     #[test]
     fn format_perl_spawn_error_includes_custom_interpreter_name() {
         let error = std::io::Error::new(std::io::ErrorKind::NotFound, "No such file or directory");
         let message = format_perl_spawn_error("/custom/perl", &error);
 
-        assert!(message.contains("/custom/perl"), "expected interpreter path in message, got: {message}");
+        assert!(
+            message.contains("/custom/perl"),
+            "expected interpreter path in message, got: {message}"
+        );
     }
     #[test]
     fn format_perl_spawn_error_for_missing_perl_is_actionable() {


### PR DESCRIPTION
### Motivation

- The launcher advertised support for a `perl` field in `launch.json` but always spawned `perl` from `PATH`, preventing users from selecting a custom interpreter.

### Description

- Read the optional `perl` launch argument in `handle_launch`, defaulting to `"perl"` when absent.
- Thread the chosen interpreter through `launch_debugger` and `check_syntax` so `-c` syntax checks and `-d` debugger spawns use the same executable.
- Use the selected interpreter when constructing the `Command` and include the interpreter name in spawn error messages by updating `format_perl_spawn_error`.
- Add a unit test to ensure custom interpreter names are surfaced in spawn error messages.

### Testing

- Ran `cargo test -p perl-dap --lib` and all tests passed (380 passed, 0 failed).
- Ran `cargo check --all-targets -p perl-dap` and it completed successfully.
- Ran `cargo clippy -p perl-dap -- -D warnings` and it completed successfully with no new warnings.
- Attempted `cargo xtask fmt -p perl-dap` in this environment but the formatting run did not finish within the interactive window; the edited file was kept formatted and no unrelated files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c879a3c83339d342d514b4d30a9)