### PR TITLE
refactor(perl-dap): prefer first capture access in inline values (#0000)

### DIFF
--- a/crates/perl-dap/src/inline_values.rs
+++ b/crates/perl-dap/src/inline_values.rs
@@ -313,7 +313,7 @@ fn collect_line_variables(line: &str, include_non_scalars: bool) -> Vec<(usize, 
     let base_re = if include_non_scalars { PERL_VAR_RE.as_ref() } else { SCALAR_VAR_RE.as_ref() };
     if let Some(re) = base_re {
         for cap in re.captures_iter(line) {
-            if let Some(m) = cap.get(0) {
+            if let Some(m) = cap.iter().flatten().next() {
                 matches.push((m.start(), m.end(), m.as_str().to_string()));
             }
         }
@@ -322,7 +322,7 @@ fn collect_line_variables(line: &str, include_non_scalars: bool) -> Vec<(usize, 
     if let Some(re) = BRACED_PERL_VAR_RE.as_ref() {
         for cap in re.captures_iter(line) {
             let (Some(full_match), Some(sigil_match), Some(name_match)) =
-                (cap.get(0), cap.get(1), cap.get(2))
+                (cap.iter().flatten().next(), cap.get(1), cap.get(2))
             else {
                 continue;
             };


### PR DESCRIPTION
### Motivation
- Prefer iterator-first access for regex capture full-match extraction to follow project idioms and make capture retrieval more explicit in `collect_line_variables`.

### Description
- Replaced `cap.get(0)` with `cap.iter().flatten().next()` in both capture paths inside `collect_line_variables` in `crates/perl-dap/src/inline_values.rs` while preserving existing behavior.

### Testing
- `cargo check --all-targets -p perl-dap` passed. 
- Attempted `cargo test -p perl-dap inline_values -- --nocapture` did not complete in this environment due to build/test file-lock contention and was therefore not finished.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c879a3c83339d342d514b4d30a9)