### PR TITLE
refactor(perl-refactoring): cache static import-analysis regexes (#0000)

### DIFF
--- a/crates/perl-refactoring/src/refactor/import_optimizer.rs
+++ b/crates/perl-refactoring/src/refactor/import_optimizer.rs
@@ -276,10 +276,10 @@ impl ImportOptimizer {
     /// # Ok::<(), String>(())
     /// ```
     pub fn analyze_content(&self, content: &str) -> Result<ImportAnalysis, String> {
-
         let mut imports = Vec::new();
         for (idx, line) in content.lines().enumerate() {
-            if let Some(caps) = USE_STATEMENT_RE.as_ref().map_err(|e| e.to_string())?.captures(line) {
+            if let Some(caps) = USE_STATEMENT_RE.as_ref().map_err(|e| e.to_string())?.captures(line)
+            {
                 let module = caps[1].to_string();
                 let symbols_str = caps.get(2).map(|m| m.as_str()).unwrap_or("");
                 let symbols = if symbols_str.is_empty() {
@@ -324,7 +324,6 @@ impl ImportOptimizer {
                 "
 ",
             );
-
 
         // Determine unused symbols for each import entry
         let mut unused_imports = Vec::new();
@@ -386,7 +385,8 @@ impl ImportOptimizer {
 
                     // Special handling for Data::Dumper - check for Dumper function usage
                     if !is_used && imp.module == "Data::Dumper" {
-                        if DUMPER_RE.as_ref().map_err(|e| e.to_string())?.is_match(&non_use_content) {
+                        if DUMPER_RE.as_ref().map_err(|e| e.to_string())?.is_match(&non_use_content)
+                        {
                             is_used = true;
                         }
                     }
@@ -429,23 +429,18 @@ impl ImportOptimizer {
             imports.iter().map(|imp| imp.module.clone()).collect();
 
         // Strip strings and comments before scanning for Module::symbol patterns
-        let stripped = STRING_RE.as_ref().map_err(|e| e.to_string())?.replace_all(content, " ").to_string();
+        let stripped =
+            STRING_RE.as_ref().map_err(|e| e.to_string())?.replace_all(content, " ").to_string();
         let stripped = REGEX_LITERAL_RE
             .as_ref()
             .map_err(|e| e.to_string())?
             .replace_all(&stripped, " ")
             .to_string();
-        let stripped = COMMENT_RE
-            .as_ref()
-            .map_err(|e| e.to_string())?
-            .replace_all(&stripped, " ")
-            .to_string();
+        let stripped =
+            COMMENT_RE.as_ref().map_err(|e| e.to_string())?.replace_all(&stripped, " ").to_string();
 
         let mut usage_map: BTreeMap<String, Vec<String>> = BTreeMap::new();
-        for caps in QUALIFIED_USAGE_RE
-            .as_ref()
-            .map_err(|e| e.to_string())?
-            .captures_iter(&stripped)
+        for caps in QUALIFIED_USAGE_RE.as_ref().map_err(|e| e.to_string())?.captures_iter(&stripped)
         {
             // Only process if both capture groups matched
             if let (Some(module_match), Some(symbol_match)) = (caps.get(1), caps.get(2)) {

--- a/crates/perl-refactoring/src/refactor/import_optimizer.rs
+++ b/crates/perl-refactoring/src/refactor/import_optimizer.rs
@@ -45,6 +45,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
+use std::sync::LazyLock;
 
 /// TextEdit for import optimization (local type for byte-offset ranges)
 ///
@@ -149,6 +150,20 @@ pub enum SuggestionPriority {
 /// - Finding duplicate imports that can be merged
 /// - Generating consolidated import statements
 pub struct ImportOptimizer;
+
+static USE_STATEMENT_RE: LazyLock<Result<Regex, regex::Error>> =
+    LazyLock::new(|| Regex::new(r"^\s*use\s+([A-Za-z0-9_:]+)(?:\s+qw\(([^)]*)\))?\s*;"));
+static DUMPER_RE: LazyLock<Result<Regex, regex::Error>> =
+    LazyLock::new(|| Regex::new(r"\bDumper\b"));
+static STRING_RE: LazyLock<Result<Regex, regex::Error>> =
+    LazyLock::new(|| Regex::new("'[^']*'|\"[^\"]*\""));
+static REGEX_LITERAL_RE: LazyLock<Result<Regex, regex::Error>> =
+    LazyLock::new(|| Regex::new(r"qr/[^/]*/"));
+static COMMENT_RE: LazyLock<Result<Regex, regex::Error>> =
+    LazyLock::new(|| Regex::new(r"(?m)#.*$"));
+static QUALIFIED_USAGE_RE: LazyLock<Result<Regex, regex::Error>> = LazyLock::new(|| {
+    Regex::new(r"\b([A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*)::([A-Za-z_][A-Za-z0-9_]*)")
+});
 
 /// Check if a module is a pragma (affects compilation, no exports)
 fn is_pragma_module(module: &str) -> bool {
@@ -261,13 +276,10 @@ impl ImportOptimizer {
     /// # Ok::<(), String>(())
     /// ```
     pub fn analyze_content(&self, content: &str) -> Result<ImportAnalysis, String> {
-        // Regex for basic `use` statement parsing
-        let re_use = Regex::new(r"^\s*use\s+([A-Za-z0-9_:]+)(?:\s+qw\(([^)]*)\))?\s*;")
-            .map_err(|e| e.to_string())?;
 
         let mut imports = Vec::new();
         for (idx, line) in content.lines().enumerate() {
-            if let Some(caps) = re_use.captures(line) {
+            if let Some(caps) = USE_STATEMENT_RE.as_ref().map_err(|e| e.to_string())?.captures(line) {
                 let module = caps[1].to_string();
                 let symbols_str = caps.get(2).map(|m| m.as_str()).unwrap_or("");
                 let symbols = if symbols_str.is_empty() {
@@ -313,8 +325,6 @@ impl ImportOptimizer {
 ",
             );
 
-        // Pre-compile regex for special Data::Dumper case
-        let dumper_re = Regex::new(r"\bDumper\b").map_err(|e| e.to_string())?;
 
         // Determine unused symbols for each import entry
         let mut unused_imports = Vec::new();
@@ -376,7 +386,7 @@ impl ImportOptimizer {
 
                     // Special handling for Data::Dumper - check for Dumper function usage
                     if !is_used && imp.module == "Data::Dumper" {
-                        if dumper_re.is_match(&non_use_content) {
+                        if DUMPER_RE.as_ref().map_err(|e| e.to_string())?.is_match(&non_use_content) {
                             is_used = true;
                         }
                     }
@@ -419,19 +429,24 @@ impl ImportOptimizer {
             imports.iter().map(|imp| imp.module.clone()).collect();
 
         // Strip strings and comments before scanning for Module::symbol patterns
-        let string_re = Regex::new("'[^']*'|\"[^\"]*\"").map_err(|e| e.to_string())?;
-        let stripped = string_re.replace_all(content, " ").to_string();
-        let regex_literal_re = Regex::new(r"qr/[^/]*/").map_err(|e| e.to_string())?;
-        let stripped = regex_literal_re.replace_all(&stripped, " ").to_string();
-        let comment_re = Regex::new(r"(?m)#.*$").map_err(|e| e.to_string())?;
-        let stripped = comment_re.replace_all(&stripped, " ").to_string();
+        let stripped = STRING_RE.as_ref().map_err(|e| e.to_string())?.replace_all(content, " ").to_string();
+        let stripped = REGEX_LITERAL_RE
+            .as_ref()
+            .map_err(|e| e.to_string())?
+            .replace_all(&stripped, " ")
+            .to_string();
+        let stripped = COMMENT_RE
+            .as_ref()
+            .map_err(|e| e.to_string())?
+            .replace_all(&stripped, " ")
+            .to_string();
 
-        let usage_re = Regex::new(
-            r"\b([A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*)::([A-Za-z_][A-Za-z0-9_]*)",
-        )
-        .map_err(|e| e.to_string())?;
         let mut usage_map: BTreeMap<String, Vec<String>> = BTreeMap::new();
-        for caps in usage_re.captures_iter(&stripped) {
+        for caps in QUALIFIED_USAGE_RE
+            .as_ref()
+            .map_err(|e| e.to_string())?
+            .captures_iter(&stripped)
+        {
             // Only process if both capture groups matched
             if let (Some(module_match), Some(symbol_match)) = (caps.get(1), caps.get(2)) {
                 let module = module_match.as_str().to_string();


### PR DESCRIPTION
### Motivation
- Avoid recompiling several fixed regexes on each `ImportOptimizer::analyze_content` invocation to reduce CPU and allocation overhead. 
- Preserve existing error propagation semantics while moving these hot-path patterns to module-level statics. 

### Description
- Introduced module-level `LazyLock<Result<Regex, regex::Error>>` statics for `use` parsing, `Dumper` detection, string stripping, regex-literal stripping, comment stripping, and qualified-usage detection. 
- Replaced per-call `Regex::new` invocations in `analyze_content` with uses of the cached statics and propagated any regex construction errors via `map_err(|e| e.to_string())`. 
- Kept conservative import-usage heuristics intact and updated code paths to call `.as_ref().map_err(...)?` where appropriate. 
- Modified only `crates/perl-refactoring/src/refactor/import_optimizer.rs`.

### Testing
- Ran `cargo test -p perl-refactoring`, and all tests passed. 
- Ran `cargo clippy -p perl-refactoring -- -D warnings`, and the lints passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c8f7c5c83338b456c71dda33f86)