### PR TITLE
test(perl-refactoring): strengthen package scoped rename coverage (#0000)

### DIFF
--- a/crates/perl-refactoring/src/refactor/scoped_rename_tests.rs
+++ b/crates/perl-refactoring/src/refactor/scoped_rename_tests.rs
@@ -30,7 +30,6 @@ mod tests {
             vec![path.clone()],
         ));
 
-        println!("test_rename DEBUG: result={:?}", result);
         assert!(result.success);
         assert_eq!(result.files_modified, 1);
         let new_code = must(std::fs::read_to_string(&path));
@@ -39,10 +38,12 @@ mod tests {
     }
 
     #[test]
-    fn test_package_scoped_rename_placeholder() {
-        // AC1: support Package scope (currently delegates to file-wide as foundation)
+    fn test_package_scoped_rename_limits_changes_to_target_package() {
+        // AC1: support Package scope by limiting changes to requested package only
         let mut file = must(tempfile::NamedTempFile::new());
-        let code = "package P; my $foo = 1;";
+        let code = "package P; my $foo = 1;
+package Q; my $foo = 2;
+";
         must(write!(file, "{}", code));
         let path = file.path().to_path_buf();
 
@@ -62,10 +63,11 @@ mod tests {
             vec![path.clone()],
         ));
 
-        println!("test_rename DEBUG: result={:?}", result);
         assert!(result.success);
         let new_code = must(std::fs::read_to_string(&path));
-        assert!(new_code.contains("$bar"));
+        assert!(new_code.contains("package P; my $bar = 1;"));
+        assert!(new_code.contains("package Q; my $foo = 2;"));
+        assert!(!new_code.contains("package Q; my $bar = 2;"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- The existing package-scoped rename test was a placeholder that only asserted a positive rename and could miss regressions that incorrectly rename symbols in other packages within the same file.

### Description

- Replace the placeholder package-scope test with a behavior-focused test that writes two packages into a single temp file and requests a package-scoped rename for the first package only.
- Assert that only the target package (`P`) is updated and that the other package (`Q`) remains unchanged.
- Remove leftover debug `println!` noise from the test module.

### Testing

- Ran the full crate test suite with `cargo test -p perl-refactoring` which completed successfully (`110` unit tests + BDD and integration suites passed).
- Ran the scoped tests with `cargo test -p perl-refactoring scoped_rename_tests::tests::` which completed successfully (scoped rename tests passed).
- Verified build with `cargo check --all-targets -p perl-refactoring`, which passed.
- Ran lints with `cargo clippy -p perl-refactoring --all-targets -- -D warnings`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c8f7c5c83338b456c71dda33f86)