### PR TITLE
fix(perl-refactoring): support legacy package qualifiers in workspace rename (#0000)

### DIFF
--- a/crates/perl-refactoring/src/refactor/workspace_rename.rs
+++ b/crates/perl-refactoring/src/refactor/workspace_rename.rs
@@ -497,7 +497,8 @@ impl WorkspaceRename {
                     let in_scope = if let Some(ref pkg) = scope_package {
                         // Check if the reference is qualified with the correct package
                         let before = &text[..match_start];
-                        let is_qualified_with_pkg = before.ends_with(&format!("{}::", pkg));
+                        let is_qualified_with_pkg = before.ends_with(&format!("{}::", pkg))
+                            || before.ends_with(&format!("{pkg}'"));
 
                         // Check if we're within the right package scope
                         let current_package = find_package_at_offset(text, match_start);
@@ -816,6 +817,17 @@ fn build_replacement_text(
             let target_package = new_package.unwrap_or(pkg.as_str());
             return (match_start - prefix.len(), format!("{target_package}::{new_bare}"));
         }
+
+        let legacy_prefix = format!("{pkg}'");
+        if match_start >= legacy_prefix.len()
+            && text[match_start - legacy_prefix.len()..match_start] == *legacy_prefix
+        {
+            let target_package = new_package.unwrap_or(pkg.as_str());
+            return (
+                match_start - legacy_prefix.len(),
+                format!("{target_package}::{new_bare}"),
+            );
+        }
     }
 
     (match_start, new_bare.to_string())
@@ -922,5 +934,16 @@ mod tests {
 
         assert_eq!(start, 0);
         assert_eq!(replacement, "execute");
+    }
+
+    #[test]
+    fn test_build_replacement_text_legacy_qualified_rewrites_to_double_colon() {
+        let text = "Old'process()";
+        let scope_package = Some("Old".to_string());
+        let (start, replacement) =
+            build_replacement_text(text, "Old'".len(), &scope_package, Some("New"), "execute");
+
+        assert_eq!(start, 0);
+        assert_eq!(replacement, "New::execute");
     }
 }

--- a/crates/perl-refactoring/src/refactor/workspace_rename.rs
+++ b/crates/perl-refactoring/src/refactor/workspace_rename.rs
@@ -823,10 +823,7 @@ fn build_replacement_text(
             && text[match_start - legacy_prefix.len()..match_start] == *legacy_prefix
         {
             let target_package = new_package.unwrap_or(pkg.as_str());
-            return (
-                match_start - legacy_prefix.len(),
-                format!("{target_package}::{new_bare}"),
-            );
+            return (match_start - legacy_prefix.len(), format!("{target_package}::{new_bare}"));
         }
     }
 


### PR DESCRIPTION
### Motivation
- Workspace rename only recognized modern `Package::symbol` qualifiers and could miss or mis-handle legacy Perl `Package'symbol` references, causing incomplete or incorrect renames across a workspace.

### Description
- Extend scope detection to treat apostrophe-style qualifiers as qualified references by also checking `before.ends_with(&format!("{pkg}'"))` when scanning for matches.
- Update `build_replacement_text` to recognize a legacy `pkg'` prefix and normalize rewritten output to the modern `::` form (e.g. `Old'process` -> `New::execute`).
- Add a regression test `test_build_replacement_text_legacy_qualified_rewrites_to_double_colon` that asserts legacy qualifier rewriting behavior.

### Testing
- Ran the crate test suite with `cargo test -p perl-refactoring` (existing full run showed the suite passing prior to the focused change). 
- Ran the focused regression test with `cargo test -p perl-refactoring test_build_replacement_text_legacy_qualified_rewrites_to_double_colon`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c8f7c5c83338b456c71dda33f86)