### PR TITLE
test(perl-refactoring): use canonical file URLs in workspace rename tests (#0000)

### DIFF
--- a/crates/perl-refactoring/tests/workspace_rename_tests.rs
+++ b/crates/perl-refactoring/tests/workspace_rename_tests.rs
@@ -12,6 +12,7 @@ use perl_refactoring::workspace_rename::{
 use perl_workspace::workspace_index::WorkspaceIndex;
 use std::sync::mpsc;
 use tempfile::TempDir;
+use url::Url;
 
 /// Test helper to set up a temporary workspace with indexed files
 fn setup_workspace(
@@ -27,8 +28,12 @@ fn setup_workspace(
         std::fs::write(&path, content)?;
 
         // Index the file in the workspace index
-        let uri = format!("file://{}", path.display());
-        index.index_file_str(&uri, content).map_err(|e| format!("index_file_str failed: {}", e))?;
+        let uri = Url::from_file_path(&path).map_err(|_| {
+            format!("failed to create file URL from path: {}", path.display())
+        })?;
+        index
+            .index_file_str(uri.as_str(), content)
+            .map_err(|e| format!("index_file_str failed: {}", e))?;
     }
     Ok((dir, index))
 }

--- a/crates/perl-refactoring/tests/workspace_rename_tests.rs
+++ b/crates/perl-refactoring/tests/workspace_rename_tests.rs
@@ -28,9 +28,8 @@ fn setup_workspace(
         std::fs::write(&path, content)?;
 
         // Index the file in the workspace index
-        let uri = Url::from_file_path(&path).map_err(|_| {
-            format!("failed to create file URL from path: {}", path.display())
-        })?;
+        let uri = Url::from_file_path(&path)
+            .map_err(|_| format!("failed to create file URL from path: {}", path.display()))?;
         index
             .index_file_str(uri.as_str(), content)
             .map_err(|e| format!("index_file_str failed: {}", e))?;


### PR DESCRIPTION
### Motivation
- Tests constructed file URIs with `format!("file://{}", path.display())`, which can produce invalid or non-portable URLs for paths with spaces or platform-specific separators, so use a canonical file URL builder instead.

### Description
- Replace manual `file://` string construction in the test helper `setup_workspace` with `url::Url::from_file_path(&path)` and pass `uri.as_str()` to `index_file_str`; also add `use url::Url;` in `crates/perl-refactoring/tests/workspace_rename_tests.rs`.

### Testing
- Ran `cargo test -p perl-refactoring --features workspace-rename-tests --test workspace_rename_tests` and all workspace-rename tests passed; ran `cargo test -p perl-refactoring` and the crate tests passed; ran `cargo check --all-targets -p perl-refactoring` and `cargo clippy -p perl-refactoring --all-targets -- -D warnings` and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c8f7c5c83338b456c71dda33f86)