### PR TITLE
fix(perl-uri): normalize legacy C| drive URIs (#0000)

### DIFF
--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -42,10 +42,11 @@ pub fn uri_key(uri: &str) -> String {
 
         if let Some(rest) = value.strip_prefix("file:///")
             && rest.len() > 1
-            && rest.as_bytes()[1] == b':'
+            && (rest.as_bytes()[1] == b':' || rest.as_bytes()[1] == b'|')
             && rest.as_bytes()[0].is_ascii_alphabetic()
         {
-            return format!("file:///{}{}", rest[0..1].to_ascii_lowercase(), &rest[1..]);
+            let separator = if rest.as_bytes()[1] == b'|' { ":" } else { &rest[1..2] };
+            return format!("file:///{}{}{}", rest[0..1].to_ascii_lowercase(), separator, &rest[2..]);
         }
         value
     } else {
@@ -96,12 +97,17 @@ fn normalize_windows_path_to_key(path: &str) -> Option<String> {
     }
 
     let bytes = path.as_bytes();
-    if !bytes[0].is_ascii_alphabetic() || bytes[1] != b':' {
+    if !bytes[0].is_ascii_alphabetic() || (bytes[1] != b':' && bytes[1] != b'|') {
         return None;
     }
 
     // Replace backslashes with forward slashes.
     let mut normalized = path.replace('\\', "/");
+
+    // Convert legacy drive separators (`C|`) to `C:`.
+    if normalized.as_bytes().get(1) == Some(&b'|') {
+        normalized.replace_range(1..2, ":");
+    }
 
     // Ensure there is a separator after the drive colon: `C:foo` → `C:/foo`.
     if normalized.as_bytes().get(2) != Some(&b'/') {
@@ -205,6 +211,12 @@ mod tests {
             uri_key("file://D:/projects/MyApp/script.pl"),
             "file:///d:/projects/MyApp/script.pl"
         );
+    }
+
+    #[test]
+    fn normalizes_legacy_windows_drive_pipe_separator() {
+        assert_eq!(uri_key("file:///C|/Users/dev/example.pl"), "file:///c:/Users/dev/example.pl");
+        assert_eq!(uri_key(r"file://D|\projects\MyApp\script.pl"), "file:///d:/projects/MyApp/script.pl");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Some legacy editors/clients emit Windows drive-letter URIs using `|` as the drive separator (for example `file:///C|/path`), which produced inconsistent keys and could lead to duplicate or mismatched lookups.

### Description
- Accept `|` as an alternative drive separator when normalizing parsed `file:///...` values and canonicalize it to `:` with a lowercase drive letter.
- Extend `normalize_windows_path_to_key` to accept `|` in legacy Windows-path forms, convert it to `:`, normalize backslashes to forward slashes, ensure a separator after the drive, and produce `file:///c:/...` keys.
- Add a focused unit test `normalizes_legacy_windows_drive_pipe_separator` in `crates/perl-uri/src/classify.rs` that covers `file:///C|/...` and `file://D|\...` inputs.
- Changed file: `crates/perl-uri/src/classify.rs`.

### Testing
- Ran `cargo test -p perl-uri` and all unit tests (including the new regression test) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c93984483338ebcaab2989b2ad3)