### PR TITLE
fix(perl-uri): normalize malformed localhost Windows URIs (#0000)

### DIFF
--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -90,10 +90,8 @@ fn normalize_legacy_windows_uri(uri: &str) -> Option<String> {
 
     // Accept malformed localhost authorities commonly emitted by some clients,
     // e.g. `file://localhost/C:\dir\file.pl` and `file://localhost/C:/dir/file.pl`.
-    let path = path
-        .strip_prefix("localhost/")
-        .or_else(|| path.strip_prefix("LOCALHOST/"))
-        .unwrap_or(path);
+    let path =
+        path.strip_prefix("localhost/").or_else(|| path.strip_prefix("LOCALHOST/")).unwrap_or(path);
 
     normalize_windows_path_to_key(path).or_else(|| normalize_unc_path_to_key(path))
 }

--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -88,6 +88,13 @@ fn normalize_legacy_windows_uri(uri: &str) -> Option<String> {
         trimmed
     };
 
+    // Accept malformed localhost authorities commonly emitted by some clients,
+    // e.g. `file://localhost/C:\dir\file.pl` and `file://localhost/C:/dir/file.pl`.
+    let path = path
+        .strip_prefix("localhost/")
+        .or_else(|| path.strip_prefix("LOCALHOST/"))
+        .unwrap_or(path);
+
     normalize_windows_path_to_key(path).or_else(|| normalize_unc_path_to_key(path))
 }
 
@@ -246,6 +253,22 @@ mod tests {
         assert_eq!(
             uri_key(r"file://D|\projects\MyApp\script.pl"),
             "file:///d:/projects/MyApp/script.pl"
+        );
+    }
+
+    #[test]
+    fn normalizes_legacy_localhost_windows_uri_variants() {
+        assert_eq!(
+            uri_key(r"file://localhost/C:\Users\dev\example.pl"),
+            "file:///c:/Users/dev/example.pl"
+        );
+        assert_eq!(
+            uri_key("file://localhost/C:/Users/dev/example.pl"),
+            "file:///c:/Users/dev/example.pl"
+        );
+        assert_eq!(
+            uri_key(r"file://LOCALHOST/D:\projects\myapp\script.pl"),
+            "file:///d:/projects/myapp/script.pl"
         );
     }
 


### PR DESCRIPTION
### Motivation
- Some editors/clients emit malformed Windows `file://localhost/<drive>...` URIs which were not normalized by `uri_key`, causing inconsistent lookup keys across clients.

### Description
- Update `normalize_legacy_windows_uri` in `crates/perl-uri/src/classify.rs` to strip a malformed `localhost/` (case-insensitive) prefix before Windows-path normalization so inputs like `file://localhost/C:\...` become canonical `file:///c:/...` keys.
- Add regression tests `normalizes_legacy_localhost_windows_uri_variants` covering backslash and forward-slash variants and uppercase `LOCALHOST` to verify the new behavior.

### Testing
- Ran `cargo test -p perl-uri`, and all unit tests and doctests in the crate passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c93984483338ebcaab2989b2ad3)