### PR TITLE
fix(perl-uri): trim uri_key input before normalization (#0000)

### DIFF
--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -20,14 +20,16 @@ use url::Url;
 /// Both forms are converted to `file:///c:/path/file.pl`.
 #[must_use]
 pub fn uri_key(uri: &str) -> String {
+    let trimmed = uri.trim();
+
     // Try to normalize legacy Windows path forms before URL parsing, since
     // `file://C:\...` and `C:\...` are not valid URLs and fall through to the
     // else branch as-is without this pre-pass.
-    if let Some(normalized) = normalize_legacy_windows_uri(uri) {
+    if let Some(normalized) = normalize_legacy_windows_uri(trimmed) {
         return normalized;
     }
 
-    if let Ok(parsed) = Url::parse(uri) {
+    if let Ok(parsed) = Url::parse(trimmed) {
         let mut value = parsed.as_str().to_string();
 
         // Canonicalize localhost file authorities (file://localhost/...) to
@@ -49,7 +51,7 @@ pub fn uri_key(uri: &str) -> String {
         }
         value
     } else {
-        uri.to_string()
+        trimmed.to_string()
     }
 }
 

--- a/crates/perl-uri/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-uri/tests/comprehensive_unit_tests.rs
@@ -40,6 +40,12 @@ fn uri_key_returns_invalid_uri_as_is() {
 }
 
 #[test]
+fn uri_key_trims_surrounding_whitespace() {
+    assert_eq!(uri_key("  file:///tmp/test.pl  "), "file:///tmp/test.pl");
+    assert_eq!(uri_key("  C:\\Users\\dev\\file.pl  "), "file:///c:/Users/dev/file.pl");
+}
+
+#[test]
 fn uri_key_preserves_non_file_schemes() {
     let https = uri_key("https://example.com/path");
     assert!(https.starts_with("https://"));


### PR DESCRIPTION
### Motivation
- `uri_key` could preserve incidental leading/trailing whitespace, causing semantically identical URIs/paths to produce different lookup keys.

### Description
- Trim input once at the start of `uri_key` and use the trimmed value for legacy normalization and URL parsing.
- Ensure the fallback branch returns the trimmed string instead of the original input. 
- Add a regression test `uri_key_trims_surrounding_whitespace` in `crates/perl-uri/tests/comprehensive_unit_tests.rs` covering both a canonical `file:///` URI and a legacy Windows path.

### Testing
- Verification: `cargo test -p perl-uri` passes. 
- Ran `cargo test -p perl-uri` and the crate's unit tests and doctests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c93984483338ebcaab2989b2ad3)