### PR TITLE
fix(perl-uri): normalize legacy UNC paths in uri_key (#0000)

### DIFF
--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -80,7 +80,27 @@ fn normalize_legacy_windows_uri(uri: &str) -> Option<String> {
         trimmed
     };
 
-    normalize_windows_path_to_key(path)
+    normalize_windows_path_to_key(path).or_else(|| normalize_unc_path_to_key(path))
+}
+
+/// Convert a UNC path into canonical `file://server/share/...` key.
+///
+/// Handles both bare UNC paths (e.g. `\\server\share\file.pl`) and
+/// legacy two-slash URI payloads (e.g. `file://\\server\share\file.pl`).
+fn normalize_unc_path_to_key(path: &str) -> Option<String> {
+    let without_prefix = path.strip_prefix(r"\\").or_else(|| path.strip_prefix("//"))?;
+    let replaced = without_prefix.replace('\\', "/");
+    let mut parts = replaced.split('/').filter(|segment| !segment.is_empty());
+
+    let server = parts.next()?;
+    let share = parts.next()?;
+    let rest = parts.collect::<Vec<_>>().join("/");
+
+    if rest.is_empty() {
+        Some(format!("file://{server}/{share}"))
+    } else {
+        Some(format!("file://{server}/{share}/{rest}"))
+    }
 }
 
 /// Convert a Windows-style path string (with or without a drive letter) into a
@@ -212,6 +232,18 @@ mod tests {
         // Canonical `file:///c:/...` must NOT be double-processed by the legacy pass.
         assert_eq!(uri_key("file:///c:/Users/dev/example.pl"), "file:///c:/Users/dev/example.pl");
         assert_eq!(uri_key("file:///C:/Users/dev/example.pl"), "file:///c:/Users/dev/example.pl");
+    }
+
+    #[test]
+    fn normalizes_legacy_unc_windows_path() {
+        assert_eq!(
+            uri_key(r"\\server\share\folder\file.pl"),
+            "file://server/share/folder/file.pl"
+        );
+        assert_eq!(
+            uri_key(r"file://\\server\share\folder\file.pl"),
+            "file://server/share/folder/file.pl"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- `uri_key` previously normalized legacy drive-letter Windows inputs but did not handle legacy UNC-style payloads like `\\server\share\file.pl` or `file://\\server\share\file.pl`, causing inconsistent lookup keys for UNC resources.

### Description

- Add `normalize_unc_path_to_key` to detect bare UNC paths and two-slash `file://` UNC payloads and convert them to canonical `file://server/share/...` keys.
- Wire the new UNC normalization into the existing legacy pre-normalization by calling it from `normalize_legacy_windows_uri` as a fallback to `normalize_windows_path_to_key`.
- Add a focused regression test `normalizes_legacy_unc_windows_path` to `crates/perl-uri/src/classify.rs` covering both bare and `file://` UNC variants.
- Only touch `crates/perl-uri/src/classify.rs` and add no platform-wide behavioral changes beyond key canonicalization.

### Testing

- Ran `cargo test -p perl-uri` and all unit and doc tests passed.</n- Ran `cargo check --all-targets -p perl-uri` and it completed successfully.
- Ran `cargo clippy -p perl-uri` and it completed with no new lints reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c93984483338ebcaab2989b2ad3)