### PR TITLE
feat(perl-token): add checked TokenRef constructors (#0000)

### DIFF
--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -123,6 +123,38 @@ impl<'src> TokenRef<'src> {
         Self { kind, text, start, end }
     }
 
+    /// Create a borrowed token view with checked span ordering.
+    ///
+    /// Unlike [`TokenRef::new`], this rejects spans where `end < start`.
+    pub fn try_new(
+        kind: TokenKind,
+        text: &'src str,
+        start: usize,
+        end: usize,
+    ) -> Result<Self, TokenSpanError> {
+        let span = TokenSpan::try_new(start, end)?;
+        Ok(Self { kind, text, start: span.start, end: span.end })
+    }
+
+    /// Create a borrowed token view while enforcing span invariants.
+    ///
+    /// Rules:
+    /// - `start <= end`
+    /// - zero-length spans are accepted only for EOF tokens
+    pub fn new_checked(
+        kind: TokenKind,
+        text: &'src str,
+        start: usize,
+        end: usize,
+    ) -> Result<Self, TokenSpanError> {
+        let token = Self::try_new(kind, text, start, end)?;
+        if token.is_empty() && token.kind != TokenKind::Eof {
+            return Err(TokenSpanError::EmptySpanNotAllowed { kind: token.kind, at: token.start });
+        }
+
+        Ok(token)
+    }
+
     /// Return the token span length in bytes.
     pub fn len(self) -> usize {
         self.end.saturating_sub(self.start)

--- a/crates/perl-token/tests/borrowed_token_tests.rs
+++ b/crates/perl-token/tests/borrowed_token_tests.rs
@@ -84,3 +84,38 @@ fn token_ref_is_empty_for_zero_length_span() -> TestResult {
     assert_eq!(borrowed.span(), (8, 8));
     Ok(())
 }
+
+
+#[test]
+fn token_ref_try_new_rejects_end_before_start() -> TestResult {
+    let err = TokenRef::try_new(TokenKind::Identifier, "name", 7, 3).expect_err(
+        "try_new should reject spans where end < start",
+    );
+    assert_eq!(
+        err,
+        perl_token::TokenSpanError::EndBeforeStart { start: 7, end: 3 }
+    );
+    Ok(())
+}
+
+#[test]
+fn token_ref_new_checked_rejects_empty_non_eof() -> TestResult {
+    let err = TokenRef::new_checked(TokenKind::Identifier, "", 4, 4)
+        .expect_err("new_checked should reject empty spans for non-EOF tokens");
+    assert_eq!(
+        err,
+        perl_token::TokenSpanError::EmptySpanNotAllowed {
+            kind: TokenKind::Identifier,
+            at: 4,
+        }
+    );
+    Ok(())
+}
+
+#[test]
+fn token_ref_new_checked_accepts_empty_eof() -> TestResult {
+    let token = TokenRef::new_checked(TokenKind::Eof, "", 9, 9)?;
+    assert!(token.is_empty());
+    assert_eq!(token.span(), (9, 9));
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Borrowed `TokenRef` lacked constructors that enforce span invariants, requiring callers to allocate an owned `Token` to validate spans.
- Add checked constructors to allow allocation-free validation for callers that need to guarantee `start <= end` and non-empty spans for non-EOF tokens.

### Description
- Add `TokenRef::try_new(kind, text, start, end)` which reuses `TokenSpan::try_new` to reject `end < start` and normalize the stored span.
- Add `TokenRef::new_checked(kind, text, start, end)` which enforces `start <= end` and rejects zero-length spans for non-`Eof` kinds mirroring `Token::new_checked` semantics.
- Add focused regression tests in `crates/perl-token/tests/borrowed_token_tests.rs` covering `try_new` rejecting inverted spans, `new_checked` rejecting empty non-EOF spans, and accepting empty EOF spans.

### Testing
- Ran `cargo test -p perl-token` and all unit tests and doctests passed (`0 failed`).
- Ran `cargo check --all-targets -p perl-token` which completed successfully.
- Ran `cargo clippy -p perl-token -- -D warnings` which finished with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c977b4c833392828057c516cfe8)