### PR TITLE
ci: add conflict-marker guard to CI and pr-fast (#7183)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,32 @@ jobs:
             echo "::notice::Superseded by $LATEST — skipping remaining jobs to save cost"
           fi
 
+  # ── Conflict-marker guard: <1s, no toolchain needed ─────────────────
+  # Prevents committed conflict markers reaching master (see #7183).
+  # Two incidents on 2026-04-28 each cost 1-3h of orchestrator + builder time.
+  conflict-markers:
+    name: Conflict marker check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    needs: [draft-pr-check, preflight-latest-check]
+    if: needs.draft-pr-check.outputs.run_ci == 'true' && needs.preflight-latest-check.outputs.is_latest == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
+      - name: Check for conflict markers
+        run: |
+          matches=$(git ls-files -z | xargs -0 grep -lP '^(<{7} |>{7} |={7}$)' 2>/dev/null || true)
+          if [ -n "$matches" ]; then
+            echo "❌ Conflict markers found in committed files:"
+            echo "$matches"
+            echo ""
+            echo "Run: grep -rn -P '^(<{7} |>{7} |={7}\$)' \$(git ls-files)"
+            echo "to locate exact lines, then resolve and re-commit."
+            exit 1
+          fi
+          echo "✅ No conflict markers found"
+
   # ── PR Smoke: fast feedback for every PR (~1-2 min) ──────────────────
   pr-smoke:
     name: PR Smoke (Fast Feedback)
@@ -234,7 +260,7 @@ jobs:
     name: CI Gate (Merge-Blocking)
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: [draft-pr-check, pr-smoke, preflight-latest-check]
+    needs: [draft-pr-check, pr-smoke, conflict-markers, preflight-latest-check]
     if: needs.draft-pr-check.outputs.run_ci == 'true' && needs.preflight-latest-check.outputs.is_latest == 'true'
     # Run on every PR push and on push to main/master
     # Earlier gating > label-gated gating (see #4675)

--- a/justfile
+++ b/justfile
@@ -47,6 +47,7 @@ pr-fast: _check-tools-basic
     echo "  PR-FAST GATE (quick validation)"
     echo "=============================================="
     START=$(date +%s)
+    just _timed "check-conflict-markers" "just check-conflict-markers" && \
     just _timed "fmt-check" "just fmt-check" && \
     just _timed "release-history" "just ci-release-history" && \
     just _timed "readme-heading-check" "just readme-heading-check" && \
@@ -75,6 +76,25 @@ check-all-targets:
     @echo "Compiling all targets (all features) — deep verification check..."
     cargo check --workspace --all-targets --all-features --locked
     @echo "All targets compile clean."
+
+# Scan every tracked file for committed git conflict markers (<<<<<<< / >>>>>>> / =======).
+# Catches accidental conflict-marker commits before they break compilation or CI.
+# Historically caused: broken reconciler (3 cron cycles, #6869), corrupted docs (#7042).
+# Cost: <1s. Zero false positives for lines starting with exactly 7 < / > chars or =======$
+check-conflict-markers:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Search tracked files only; avoid binary files and .git
+    matches=$(git ls-files -z | xargs -0 grep -lP '^(<{7} |>{7} |={7}$)' 2>/dev/null || true)
+    if [ -n "$matches" ]; then
+        echo "❌ Conflict markers found in committed files:"
+        echo "$matches"
+        echo ""
+        echo "Run: grep -rn -P '^(<{7} |>{7} |={7}\$)' \$(git ls-files)"
+        echo "to locate exact lines, then resolve and re-commit."
+        exit 1
+    fi
+    echo "✅ No conflict markers found"
 
 # Fail if README.md has duplicate level-2 headings. Helps catch accidental
 # copy/paste doc drift that is otherwise easy to miss during review.


### PR DESCRIPTION
## Summary

Implements the conflict-marker CI guard proposed in #7183.

Two separate incidents shipped unresolved git conflict markers to master on 2026-04-28:

| Incident | File | Cost |
|----------|------|------|
| #6869 (commit 73aa519b4) | `xtask/src/main.rs` | 8 xtask commands dropped + compilation broken, reconciler dead for 3 cron cycles, required #7163 + #7165 (~440 lines restored) |
| #7042 (commit a371a548e6) | `docs/how-to/EDITOR_SETUP.md` | Markers left in docs, required #7182 |

Combined cost: **~3 hours** of orchestrator + builder time. This check adds <1s to CI.

## Changes

### `.github/workflows/ci.yml`

New `conflict-markers` job:
- Runs after `preflight-latest-check` in **parallel with `pr-smoke`** — no Rust toolchain required, just a checkout + grep
- Covers all three trigger events: `pull_request`, `merge_group`, `push` to master/main
- **`merge-gate` now depends on it** — conflict markers block any merge

### `justfile`

New `check-conflict-markers` recipe:
- Same grep as the CI job: scans `git ls-files` output for lines starting with `<<<<<<< `, `>>>>>>> `, or `=======` (7-char conflict delimiters)
- **Wired as the first step in `pr-fast`** — developers get the error locally before pushing
- Error output includes the exact files and the `grep -rn` command to find the offending lines

## Detection pattern

```bash
git ls-files -z | xargs -0 grep -lP '^(<{7} |>{7} |={7}$)' 2>/dev/null
```

- `^<{7} ` — matches `<<<<<<< ` (7 `<` chars + space) at line start
- `^>{7} ` — matches `>>>>>>> ` (7 `>` chars + space) at line start  
- `^={7}$` — matches `=======` alone on a line

**Zero false positives**: normal code does not start a line with exactly 7 identical angle brackets or a bare `=======`. Verified against the current codebase (clean).

## Test plan

- [x] Verified `check-conflict-markers` exits 0 on current clean codebase
- [x] Verified pattern matches `<<<<<<< HEAD`, `=======`, `>>>>>>> branch` correctly
- [x] Verified no false positives on `let x = 7 < 5;` or `// <<<<< note:` style comments
- [x] `merge-gate` depends on `conflict-markers` — conflict markers block all merges
- [x] `pr-fast` now starts with this check — local pre-push hook catches it first

## Closes

Fixes #7183

---
_Generated by [Claude Code](https://claude.ai/code/session_012bVUZv46HBjUVayBQkgwXL)_