### PR TITLE
feat(perl-token): add checked TokenRef constructors (#0000)

### DIFF
--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -123,6 +123,38 @@ impl<'src> TokenRef<'src> {
         Self { kind, text, start, end }
     }
 
+    /// Create a borrowed token view with checked span ordering.
+    ///
+    /// Unlike [`TokenRef::new`], this rejects spans where `end < start`.
+    pub fn try_new(
+        kind: TokenKind,
+        text: &'src str,
+        start: usize,
+        end: usize,
+    ) -> Result<Self, TokenSpanError> {
+        let span = TokenSpan::try_new(start, end)?;
+        Ok(Self { kind, text, start: span.start, end: span.end })
+    }
+
+    /// Create a borrowed token view while enforcing span invariants.
+    ///
+    /// Rules:
+    /// - `start <= end`
+    /// - zero-length spans are accepted only for EOF tokens
+    pub fn new_checked(
+        kind: TokenKind,
+        text: &'src str,
+        start: usize,
+        end: usize,
+    ) -> Result<Self, TokenSpanError> {
+        let token = Self::try_new(kind, text, start, end)?;
+        if token.is_empty() && token.kind != TokenKind::Eof {
+            return Err(TokenSpanError::EmptySpanNotAllowed { kind: token.kind, at: token.start });
+        }
+
+        Ok(token)
+    }
+
     /// Return the token span length in bytes.
     pub fn len(self) -> usize {
         self.end.saturating_sub(self.start)

--- a/crates/perl-token/tests/borrowed_token_tests.rs
+++ b/crates/perl-token/tests/borrowed_token_tests.rs
@@ -1,4 +1,4 @@
-use perl_token::{Token, TokenKind, TokenRef, TokenSpan};
+use perl_token::{Token, TokenKind, TokenRef, TokenSpan, TokenSpanError};
 use std::error::Error;
 use std::sync::Arc;
 
@@ -82,5 +82,30 @@ fn token_ref_is_empty_for_zero_length_span() -> TestResult {
     assert_eq!(borrowed.len(), 0);
     assert!(borrowed.is_empty());
     assert_eq!(borrowed.span(), (8, 8));
+    Ok(())
+}
+
+#[test]
+fn token_ref_try_new_rejects_end_before_start() -> TestResult {
+    let err = TokenRef::try_new(TokenKind::Identifier, "x", 10, 3)
+        .expect_err("TokenRef::try_new should reject end < start");
+    assert_eq!(err, TokenSpanError::EndBeforeStart { start: 10, end: 3 });
+    Ok(())
+}
+
+#[test]
+fn token_ref_new_checked_rejects_empty_non_eof() -> TestResult {
+    let err = TokenRef::new_checked(TokenKind::Identifier, "", 5, 5)
+        .expect_err("TokenRef::new_checked should reject empty non-EOF spans");
+    assert_eq!(err, TokenSpanError::EmptySpanNotAllowed { kind: TokenKind::Identifier, at: 5 });
+    Ok(())
+}
+
+#[test]
+fn token_ref_new_checked_allows_empty_eof() -> TestResult {
+    let token = TokenRef::new_checked(TokenKind::Eof, "", 12, 12)?;
+    assert_eq!(token.kind, TokenKind::Eof);
+    assert_eq!(token.span(), (12, 12));
+    assert!(token.is_empty());
     Ok(())
 }

--- a/crates/perl-token/tests/borrowed_token_tests.rs
+++ b/crates/perl-token/tests/borrowed_token_tests.rs
@@ -87,16 +87,20 @@ fn token_ref_is_empty_for_zero_length_span() -> TestResult {
 
 #[test]
 fn token_ref_try_new_rejects_end_before_start() -> TestResult {
-    let err = TokenRef::try_new(TokenKind::Identifier, "x", 10, 3)
-        .expect_err("TokenRef::try_new should reject end < start");
+    let err = match TokenRef::try_new(TokenKind::Identifier, "x", 10, 3) {
+        Ok(_) => return Err("TokenRef::try_new should reject end < start".into()),
+        Err(err) => err,
+    };
     assert_eq!(err, TokenSpanError::EndBeforeStart { start: 10, end: 3 });
     Ok(())
 }
 
 #[test]
 fn token_ref_new_checked_rejects_empty_non_eof() -> TestResult {
-    let err = TokenRef::new_checked(TokenKind::Identifier, "", 5, 5)
-        .expect_err("TokenRef::new_checked should reject empty non-EOF spans");
+    let err = match TokenRef::new_checked(TokenKind::Identifier, "", 5, 5) {
+        Ok(_) => return Err("TokenRef::new_checked should reject empty non-EOF spans".into()),
+        Err(err) => err,
+    };
     assert_eq!(err, TokenSpanError::EmptySpanNotAllowed { kind: TokenKind::Identifier, at: 5 });
     Ok(())
 }


### PR DESCRIPTION
### Motivation

- `TokenRef` had only an unchecked constructor so allocation-sensitive call sites could not validate span ordering or empty-span rules without first allocating a `Token`.

### Description

- Add `TokenRef::try_new` which rejects spans where `end < start` by returning `TokenSpanError`.
- Add `TokenRef::new_checked` which enforces `start <= end` and disallows zero-length spans except for `TokenKind::Eof` to mirror `Token` invariants.
- Add focused tests in `crates/perl-token/tests/borrowed_token_tests.rs` covering `try_new` rejection, `new_checked` rejection for non-EOF empty spans, and `new_checked` acceptance for EOF empty spans, and import `TokenSpanError` where needed.
- Changes are limited to `crates/perl-token/src/lib.rs` and the borrowed-token tests file to keep the scope minimal.

### Testing

- Ran `cargo test -p perl-token` and all tests passed (`ok` for unit and integration tests).
- Ran `cargo check --all-targets -p perl-token` and it completed successfully.
- Ran `cargo clippy -p perl-token -- -D warnings` and it passed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c977b4c833392828057c516cfe8)