### PR TITLE
feat(perl-token): add category helper predicates (#0000)

### DIFF
--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -783,6 +783,21 @@ impl TokenKind {
         matches!(self.category(), TokenCategory::Literal)
     }
 
+    /// Returns `true` if this token kind is a delimiter.
+    pub const fn is_delimiter(self) -> bool {
+        matches!(self.category(), TokenCategory::Delimiter)
+    }
+
+    /// Returns `true` if this token kind is an identifier or sigil.
+    pub const fn is_identifier(self) -> bool {
+        matches!(self.category(), TokenCategory::Identifier)
+    }
+
+    /// Returns `true` if this token kind is a special sentinel/recovery token.
+    pub const fn is_special(self) -> bool {
+        matches!(self.category(), TokenCategory::Special)
+    }
+
     /// Map a canonical keyword spelling to its [`TokenKind`].
     ///
     /// This mapping is case-sensitive and only recognizes canonical Perl

--- a/crates/perl-token/tests/token_kind_mapping_tests.rs
+++ b/crates/perl-token/tests/token_kind_mapping_tests.rs
@@ -162,3 +162,15 @@ fn mappings_are_case_sensitive_and_contextual() {
     assert_eq!(TokenKind::from_delimiter("<"), None);
     assert_eq!(TokenKind::from_sigil("+"), None);
 }
+
+#[test]
+fn category_helpers_align_with_category_method() {
+    for kind in TokenKind::all() {
+        assert_eq!(kind.is_keyword(), kind.category() == perl_token::TokenCategory::Keyword);
+        assert_eq!(kind.is_operator(), kind.category() == perl_token::TokenCategory::Operator);
+        assert_eq!(kind.is_literal(), kind.category() == perl_token::TokenCategory::Literal);
+        assert_eq!(kind.is_delimiter(), kind.category() == perl_token::TokenCategory::Delimiter);
+        assert_eq!(kind.is_identifier(), kind.category() == perl_token::TokenCategory::Identifier);
+        assert_eq!(kind.is_special(), kind.category() == perl_token::TokenCategory::Special);
+    }
+}


### PR DESCRIPTION
### Motivation

- Call sites repeatedly compared `TokenKind::category()` to `TokenCategory` variants to test delimiter, identifier/sigil, and special classes, which is verbose and error-prone.

### Description

- Added `TokenKind::is_delimiter`, `TokenKind::is_identifier`, and `TokenKind::is_special` as `const fn` helpers in `crates/perl-token/src/lib.rs` to mirror existing predicate helpers.
- Implemented a unit test `category_helpers_align_with_category_method` in `crates/perl-token/tests/token_kind_mapping_tests.rs` that asserts all predicate helpers (`is_keyword`, `is_operator`, `is_literal`, plus the new helpers) remain consistent with `TokenKind::category()` for every variant.

### Testing

- Ran `cargo test -p perl-token` and all tests passed successfully.
- Ran `cargo check --all-targets -p perl-token` and it completed successfully.
- Ran `cargo clippy -p perl-token` and it completed without issues.
- `just pr-fast` was not available in the environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c977b4c833392828057c516cfe8)