### PR TITLE
refactor(tree-sitter-perl-c): reuse typed parse error path (#0000)

### DIFF
--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -155,10 +155,7 @@ impl PerlParser {
         &mut self,
         code: &[u8],
     ) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-        match self.parser.parse(code, None) {
-            Some(tree) => Ok(tree),
-            None => Err("Failed to parse code".into()),
-        }
+        try_parse_with_parser(&mut self.parser, code).map_err(Into::into)
     }
 
     /// Parses Perl source text using this parser instance.
@@ -244,10 +241,7 @@ pub fn parse_perl_bytes_with_parser(
     parser: &mut Parser,
     code: &[u8],
 ) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    match parser.parse(code, None) {
-        Some(tree) => Ok(tree),
-        None => Err("Failed to parse code".into()),
-    }
+    try_parse_with_parser(parser, code).map_err(Into::into)
 }
 
 /// Parses a Perl source string and returns the resulting [`tree_sitter::Tree`].


### PR DESCRIPTION
### Motivation
- Unify parse-`None` handling so all parse entry points emit the typed `ParsePerlError::ParseReturnedNone` instead of returning ad-hoc boxed string errors.

### Description
- Route `PerlParser::parse_bytes` and `parse_perl_bytes_with_parser` through the shared helper `try_parse_with_parser(...)` and convert the typed error via `map_err(Into::into)` to preserve a single canonical `ParsePerlError` path.

### Testing
- Ran `cargo test --manifest-path crates/tree-sitter-perl-c/Cargo.toml` which passed; ran `cargo check --all-targets --manifest-path crates/tree-sitter-perl-c/Cargo.toml` which passed; and ran `cargo clippy --manifest-path crates/tree-sitter-perl-c/Cargo.toml --all-targets -- -D warnings` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c9efac08333bb853c604ce2bfed)