### PR TITLE
refactor(tree-sitter-perl-c): unify parser helper error type (#0000)

### DIFF
--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -154,18 +154,15 @@ impl PerlParser {
     pub fn parse_bytes(
         &mut self,
         code: &[u8],
-    ) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-        match self.parser.parse(code, None) {
-            Some(tree) => Ok(tree),
-            None => Err("Failed to parse code".into()),
-        }
+    ) -> Result<tree_sitter::Tree, ParsePerlError> {
+        try_parse_with_parser(&mut self.parser, code)
     }
 
     /// Parses Perl source text using this parser instance.
     pub fn parse_code(
         &mut self,
         code: &str,
-    ) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
+    ) -> Result<tree_sitter::Tree, ParsePerlError> {
         self.parse_bytes(code.as_bytes())
     }
 }
@@ -243,11 +240,8 @@ pub fn try_parse_perl_bytes(code: &[u8]) -> Result<tree_sitter::Tree, ParsePerlE
 pub fn parse_perl_bytes_with_parser(
     parser: &mut Parser,
     code: &[u8],
-) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    match parser.parse(code, None) {
-        Some(tree) => Ok(tree),
-        None => Err("Failed to parse code".into()),
-    }
+) -> Result<tree_sitter::Tree, ParsePerlError> {
+    try_parse_with_parser(parser, code)
 }
 
 /// Parses a Perl source string and returns the resulting [`tree_sitter::Tree`].
@@ -289,7 +283,7 @@ pub fn try_parse_perl_code(code: &str) -> Result<tree_sitter::Tree, ParsePerlErr
 pub fn parse_perl_code_with_parser(
     parser: &mut Parser,
     code: &str,
-) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
+) -> Result<tree_sitter::Tree, ParsePerlError> {
     parse_perl_bytes_with_parser(parser, code.as_bytes())
 }
 


### PR DESCRIPTION
### Motivation

- The crate exposed multiple parser-reuse helpers that returned `Box<dyn std::error::Error>` with stringly-typed failures while the crate already defines a typed `ParsePerlError` for parse outcomes.

### Description

- Switched `PerlParser::parse_bytes` and `PerlParser::parse_code` to return `Result<tree_sitter::Tree, ParsePerlError>` and route through the shared `try_parse_with_parser` helper.
- Switched `parse_perl_bytes_with_parser` and `parse_perl_code_with_parser` to return `Result<tree_sitter::Tree, ParsePerlError>` and delegate to `try_parse_with_parser` for consistent error mapping.
- Kept the public typed file/bytes helpers (`try_parse_perl_bytes`, `try_parse_perl_code`, `try_parse_perl_file`) unchanged but unified internal error handling so `ParseReturnedNone` is produced for `None` parses.

### Testing

- Ran `cargo test -p tree-sitter-perl-c` and all tests passed.
- Ran `cargo check --all-targets -p tree-sitter-perl-c` and it completed successfully.
- Ran `cargo clippy -p tree-sitter-perl-c` with no new lints reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c9efac08333bb853c604ce2bfed)