### PR TITLE
fix(tree-sitter-perl-rs): avoid panic on stale cursor paths (#0000)

### DIFF
--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -661,14 +661,16 @@ fn collect_visible_use_imports(
     node.for_each_child(|child| collect_visible_use_imports(child, source, offset, out));
 }
 
-// Invariant: TreeCursor path is constructed by the traversal that just yielded this
-// index, so child_at is guaranteed valid.
-#[allow(clippy::expect_used)]
+// Invariant: TreeCursor path is constructed by cursor traversal and should
+// always reference valid children. If a stale/invalid path appears, fall back
+// to `root` instead of panicking so cursor APIs remain total.
 fn resolve_path<'tree>(root: &'tree AstNode, path: &[usize]) -> &'tree AstNode {
     let mut current = root;
     for &index in path {
-        current = ast_child_at(current, index)
-            .expect("TreeCursor path must always reference a valid child");
+        match ast_child_at(current, index) {
+            Some(child) => current = child,
+            None => return root,
+        }
     }
     current
 }


### PR DESCRIPTION
### Motivation
- Prevent panics when resolving `TreeCursor` paths if a stale or invalid path segment is encountered, making cursor traversal APIs total and more robust.

### Description
- In `crates/tree-sitter-perl-rs/src/lib.rs` replace the `expect(...)`-based child resolution in `resolve_path` with a safe `match` that returns the `root` on a missing child and update the invariant comment to document the fallback behavior.

### Testing
- Ran `cargo test -p tree-sitter-perl-rs --lib` which passed.
- Ran `cargo check --all-targets -p tree-sitter-perl-rs` which passed.
- Ran `cargo clippy -p tree-sitter-perl-rs -- -D warnings` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14ca0f3d483338a2840e3fb12052a)