### PR TITLE
fix(tree-sitter-perl-rs): remove expect from cursor path resolution (#0000)

### DIFF
--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -661,14 +661,18 @@ fn collect_visible_use_imports(
     node.for_each_child(|child| collect_visible_use_imports(child, source, offset, out));
 }
 
-// Invariant: TreeCursor path is constructed by the traversal that just yielded this
-// index, so child_at is guaranteed valid.
-#[allow(clippy::expect_used)]
 fn resolve_path<'tree>(root: &'tree AstNode, path: &[usize]) -> &'tree AstNode {
     let mut current = root;
     for &index in path {
-        current = ast_child_at(current, index)
-            .expect("TreeCursor path must always reference a valid child");
+        if let Some(child) = ast_child_at(current, index) {
+            current = child;
+        } else {
+            debug_assert!(
+                false,
+                "TreeCursor path must always reference a valid child index (index={index}, path={path:?})"
+            );
+            return root;
+        }
     }
     current
 }


### PR DESCRIPTION
### Motivation
- Prevent possible panics from `expect` in tree cursor path resolution and comply with the repository quality rule forbidding `unwrap`/`expect` in production code.

### Description
- Rewrote `resolve_path` to avoid `expect`: it now uses `if let Some(child)` to advance, emits a `debug_assert!` when the invariant is violated, and returns `root` as a safe fallback instead of panicking.

### Testing
- Ran `cargo test -p tree-sitter-perl-rs`, which passed (all unit, integration, and doctests succeeded). 
- Ran `cargo check --all-targets -p tree-sitter-perl-rs && cargo clippy -p tree-sitter-perl-rs`, which completed successfully with only unrelated warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14ca0f3d483338a2840e3fb12052a)