### PR TITLE
fix(tree-sitter-perl-rs): avoid panic on stale cursor paths (#0000)

### DIFF
--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -661,14 +661,19 @@ fn collect_visible_use_imports(
     node.for_each_child(|child| collect_visible_use_imports(child, source, offset, out));
 }
 
-// Invariant: TreeCursor path is constructed by the traversal that just yielded this
-// index, so child_at is guaranteed valid.
-#[allow(clippy::expect_used)]
+// Invariant: TreeCursor path is constructed by traversal methods in this type.
+// If a stale/invalid path somehow appears, return the last valid node instead
+// of panicking, preserving total API safety guarantees.
 fn resolve_path<'tree>(root: &'tree AstNode, path: &[usize]) -> &'tree AstNode {
     let mut current = root;
     for &index in path {
-        current = ast_child_at(current, index)
-            .expect("TreeCursor path must always reference a valid child");
+        match ast_child_at(current, index) {
+            Some(child) => current = child,
+            None => {
+                debug_assert!(false, "TreeCursor path must reference a valid child");
+                break;
+            }
+        }
     }
     current
 }

--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -1139,10 +1139,10 @@ mod tests {
 
         // Navigate to first statement
         assert!(cursor.goto_first_child());
-        let mut count = 1;
+        let mut _count = 1;
         // Keep advancing siblings until we can't
         while cursor.goto_next_sibling() {
-            count += 1;
+            _count += 1;
         }
         // After last goto_next_sibling returns false, cursor should still be valid
         // and still have a node (the last sibling).


### PR DESCRIPTION
### Motivation

- Prevent a potential panic in `TreeCursor` path resolution when a stale or invalid path is encountered, improving API safety for consumers.

### Description

- Replace `expect` in `resolve_path` with defensive `match` logic that returns the last valid node and emits a `debug_assert!` instead of panicking, and update the explanatory comment accordingly.

### Testing

- Ran `cargo test -p tree-sitter-perl-rs` and `cargo test -p tree-sitter-perl-rs --lib`, both completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14ca0f3d483338a2840e3fb12052a)