### PR TITLE
refactor(runtime): split workspace helpers into SRP submodules (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -62,7 +62,6 @@ fn send_index_ready_notification(outbound: &super::outbound::OutboundSender, rea
     }
 }
 
-
 /// Returns `true` when an I/O error represents a permission-denied condition.
 ///
 /// Covers both the portable `ErrorKind::PermissionDenied` and the Windows
@@ -82,7 +81,9 @@ fn is_permission_denied_error(e: &std::io::Error) -> bool {
 }
 
 #[cfg(feature = "workspace")]
-use progress::{send_progress_begin, send_progress_create, send_progress_end, send_progress_report};
+use progress::{
+    send_progress_begin, send_progress_create, send_progress_end, send_progress_report,
+};
 #[cfg(feature = "workspace")]
 use text_decode::read_text_with_encoding_fallback;
 

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -31,6 +31,11 @@ use std::time::Instant;
 #[cfg(feature = "workspace")]
 use url::Url;
 
+#[cfg(feature = "workspace")]
+mod progress;
+#[cfg(feature = "workspace")]
+mod text_decode;
+
 const WORKSPACE_CONFIGURATION_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 // Note: WalkDir logic has been extracted to super::file_discovery.
 // These helper functions are retained for potential future use by
@@ -57,80 +62,6 @@ fn send_index_ready_notification(outbound: &super::outbound::OutboundSender, rea
     }
 }
 
-/// Token used for workspace indexing progress notifications.
-#[cfg(feature = "workspace")]
-const WORKSPACE_INDEX_PROGRESS_TOKEN: &str = "workspace-index";
-
-/// Send `window/workDoneProgress/create` to register the indexing token.
-///
-/// This is a fire-and-forget request — the client response is not awaited.
-/// Per LSP 3.15+ the server must create the token before sending `$/progress`.
-#[cfg(feature = "workspace")]
-fn send_progress_create(outbound: &super::outbound::OutboundSender, request_id: i64) {
-    if let Err(e) = outbound.send_request(
-        request_id,
-        "window/workDoneProgress/create",
-        json!({ "token": WORKSPACE_INDEX_PROGRESS_TOKEN }),
-    ) {
-        tracing::warn!(error = %e, "Failed to send workDoneProgress/create");
-    }
-}
-
-/// Send a `$/progress` begin notification for workspace indexing.
-#[cfg(feature = "workspace")]
-fn send_progress_begin(outbound: &super::outbound::OutboundSender) {
-    if let Err(e) = outbound.send_notification(
-        "$/progress",
-        json!({
-            "token": WORKSPACE_INDEX_PROGRESS_TOKEN,
-            "value": {
-                "kind": "begin",
-                "title": "Indexing workspace",
-                "cancellable": false,
-                "percentage": 0
-            }
-        }),
-    ) {
-        tracing::warn!(error = %e, "Failed to send progress begin");
-    }
-}
-
-/// Send a `$/progress` report notification for workspace indexing.
-#[cfg(feature = "workspace")]
-fn send_progress_report(outbound: &super::outbound::OutboundSender, indexed: usize, total: usize) {
-    let percentage = if total > 0 { (indexed * 100 / total).min(99) as u32 } else { 0 };
-    let message = format!("Indexed {} of {} files", indexed, total);
-    if let Err(e) = outbound.send_notification(
-        "$/progress",
-        json!({
-            "token": WORKSPACE_INDEX_PROGRESS_TOKEN,
-            "value": {
-                "kind": "report",
-                "message": message,
-                "percentage": percentage
-            }
-        }),
-    ) {
-        tracing::warn!(error = %e, "Failed to send progress report");
-    }
-}
-
-/// Send a `$/progress` end notification for workspace indexing.
-#[cfg(feature = "workspace")]
-fn send_progress_end(outbound: &super::outbound::OutboundSender, message: &str) {
-    if let Err(e) = outbound.send_notification(
-        "$/progress",
-        json!({
-            "token": WORKSPACE_INDEX_PROGRESS_TOKEN,
-            "value": {
-                "kind": "end",
-                "message": message
-            }
-        }),
-    ) {
-        tracing::warn!(error = %e, "Failed to send progress end");
-    }
-}
 
 /// Returns `true` when an I/O error represents a permission-denied condition.
 ///
@@ -150,46 +81,10 @@ fn is_permission_denied_error(e: &std::io::Error) -> bool {
     false
 }
 
-/// Read source text from disk with basic encoding fallbacks.
-///
-/// Behavior:
-/// - UTF-8 BOM (`EF BB BF`) is removed.
-/// - UTF-16 LE/BE with BOM is decoded.
-/// - Other content first tries strict UTF-8, then falls back to lossy UTF-8.
-///
-/// Odd-length payloads after a UTF-16 BOM fall back to lossy UTF-8 decoding
-/// of the original bytes rather than silently dropping the trailing byte.
 #[cfg(feature = "workspace")]
-fn read_text_with_encoding_fallback(path: &Path) -> std::io::Result<String> {
-    let bytes = std::fs::read(path)?;
-    if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
-        return Ok(String::from_utf8_lossy(&bytes[3..]).into_owned());
-    }
-    if bytes.starts_with(&[0xFF, 0xFE]) {
-        let payload = &bytes[2..];
-        if !payload.len().is_multiple_of(2) {
-            // Odd-length UTF-16 payload; fall back to lossy UTF-8 of the
-            // full original bytes rather than truncating the trailing byte.
-            return Ok(String::from_utf8_lossy(&bytes).into_owned());
-        }
-        let units: Vec<u16> =
-            payload.chunks_exact(2).map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]])).collect();
-        return Ok(String::from_utf16_lossy(&units));
-    }
-    if bytes.starts_with(&[0xFE, 0xFF]) {
-        let payload = &bytes[2..];
-        if !payload.len().is_multiple_of(2) {
-            return Ok(String::from_utf8_lossy(&bytes).into_owned());
-        }
-        let units: Vec<u16> =
-            payload.chunks_exact(2).map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]])).collect();
-        return Ok(String::from_utf16_lossy(&units));
-    }
-    match String::from_utf8(bytes) {
-        Ok(text) => Ok(text),
-        Err(err) => Ok(String::from_utf8_lossy(&err.into_bytes()).into_owned()),
-    }
-}
+use progress::{send_progress_begin, send_progress_create, send_progress_end, send_progress_report};
+#[cfg(feature = "workspace")]
+use text_decode::read_text_with_encoding_fallback;
 
 /// RAII guard that clears the `indexing_in_progress` flag on drop.
 ///

--- a/crates/perl-lsp-rs/src/runtime/workspace/progress.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace/progress.rs
@@ -1,0 +1,76 @@
+#[cfg(feature = "workspace")]
+use crate::runtime::outbound::OutboundSender;
+#[cfg(feature = "workspace")]
+use serde_json::json;
+
+/// Token used for workspace indexing progress notifications.
+#[cfg(feature = "workspace")]
+const WORKSPACE_INDEX_PROGRESS_TOKEN: &str = "workspace-index";
+
+/// Send `window/workDoneProgress/create` to register the indexing token.
+#[cfg(feature = "workspace")]
+pub(super) fn send_progress_create(outbound: &OutboundSender, request_id: i64) {
+    if let Err(e) = outbound.send_request(
+        request_id,
+        "window/workDoneProgress/create",
+        json!({ "token": WORKSPACE_INDEX_PROGRESS_TOKEN }),
+    ) {
+        tracing::warn!(error = %e, "Failed to send workDoneProgress/create");
+    }
+}
+
+/// Send a `$/progress` begin notification for workspace indexing.
+#[cfg(feature = "workspace")]
+pub(super) fn send_progress_begin(outbound: &OutboundSender) {
+    if let Err(e) = outbound.send_notification(
+        "$/progress",
+        json!({
+            "token": WORKSPACE_INDEX_PROGRESS_TOKEN,
+            "value": {
+                "kind": "begin",
+                "title": "Indexing workspace",
+                "cancellable": false,
+                "percentage": 0
+            }
+        }),
+    ) {
+        tracing::warn!(error = %e, "Failed to send progress begin");
+    }
+}
+
+/// Send a `$/progress` report notification for workspace indexing.
+#[cfg(feature = "workspace")]
+pub(super) fn send_progress_report(outbound: &OutboundSender, indexed: usize, total: usize) {
+    let percentage = if total > 0 { (indexed * 100 / total).min(99) as u32 } else { 0 };
+    let message = format!("Indexed {} of {} files", indexed, total);
+    if let Err(e) = outbound.send_notification(
+        "$/progress",
+        json!({
+            "token": WORKSPACE_INDEX_PROGRESS_TOKEN,
+            "value": {
+                "kind": "report",
+                "message": message,
+                "percentage": percentage
+            }
+        }),
+    ) {
+        tracing::warn!(error = %e, "Failed to send progress report");
+    }
+}
+
+/// Send a `$/progress` end notification for workspace indexing.
+#[cfg(feature = "workspace")]
+pub(super) fn send_progress_end(outbound: &OutboundSender, message: &str) {
+    if let Err(e) = outbound.send_notification(
+        "$/progress",
+        json!({
+            "token": WORKSPACE_INDEX_PROGRESS_TOKEN,
+            "value": {
+                "kind": "end",
+                "message": message
+            }
+        }),
+    ) {
+        tracing::warn!(error = %e, "Failed to send progress end");
+    }
+}

--- a/crates/perl-lsp-rs/src/runtime/workspace/text_decode.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace/text_decode.rs
@@ -1,0 +1,33 @@
+#[cfg(feature = "workspace")]
+use std::path::Path;
+
+/// Read source text from disk with basic encoding fallbacks.
+#[cfg(feature = "workspace")]
+pub(super) fn read_text_with_encoding_fallback(path: &Path) -> std::io::Result<String> {
+    let bytes = std::fs::read(path)?;
+    if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        return Ok(String::from_utf8_lossy(&bytes[3..]).into_owned());
+    }
+    if bytes.starts_with(&[0xFF, 0xFE]) {
+        let payload = &bytes[2..];
+        if !payload.len().is_multiple_of(2) {
+            return Ok(String::from_utf8_lossy(&bytes).into_owned());
+        }
+        let units: Vec<u16> =
+            payload.chunks_exact(2).map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]])).collect();
+        return Ok(String::from_utf16_lossy(&units));
+    }
+    if bytes.starts_with(&[0xFE, 0xFF]) {
+        let payload = &bytes[2..];
+        if !payload.len().is_multiple_of(2) {
+            return Ok(String::from_utf8_lossy(&bytes).into_owned());
+        }
+        let units: Vec<u16> =
+            payload.chunks_exact(2).map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]])).collect();
+        return Ok(String::from_utf16_lossy(&units));
+    }
+    match String::from_utf8(bytes) {
+        Ok(text) => Ok(text),
+        Err(err) => Ok(String::from_utf8_lossy(&err.into_bytes()).into_owned()),
+    }
+}


### PR DESCRIPTION
### Motivation
- `runtime/workspace.rs` mixed workspace orchestration with progress notification and text-decoding helper logic, increasing file complexity and reducing single-responsibility clarity.

### Description
- Extracted progress notification helpers into `crates/perl-lsp-rs/src/runtime/workspace/progress.rs` and replaced the inline functions with `mod progress;` and `use` imports in `workspace.rs` preserving previous behavior.
- Extracted source text decoding and encoding-fallback logic into `crates/perl-lsp-rs/src/runtime/workspace/text_decode.rs` and imported it back into `workspace.rs` as `text_decode::read_text_with_encoding_fallback`.
- No behavioral changes were introduced; helpers were only moved and made `pub(super)` where needed to maintain visibility.

### Testing
- Ran `cargo check --all-targets -p perl-lsp-rs -q`, which completed successfully. 
- The build produced existing (pre-existing) `dead_code` warnings from test support files but no new errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14cc521d08333993f4cd35d769156)