### PR TITLE
refactor(dispatch): split cancellation flow into SRP submodule (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
@@ -48,6 +48,7 @@ mod ast_explorer;
 mod cancellation;
 mod experimental;
 mod lifecycle;
+mod request_cancellation;
 mod text_document;
 mod workspace;
 
@@ -55,101 +56,25 @@ pub(crate) use cancellation::early_cancel_or;
 pub(crate) use cancellation::enhanced_cancelled_response;
 
 use super::*;
-use crate::cancellation::{
-    GLOBAL_CANCELLATION_REGISTRY, PerlLspCancellationToken, ProviderCleanupContext,
+use request_cancellation::{
+    finalize_cancellation_state, handle_cancel_notification, register_request_cancellation,
 };
-use std::time::Instant;
 
 impl LspServer {
     /// Handle a JSON-RPC request
     pub fn handle_request(&self, request: JsonRpcRequest) -> Option<JsonRpcResponse> {
-        let id = request.id.and_then(|id| if id.is_null() { None } else { Some(id) });
+        let id = request
+            .id
+            .clone()
+            .and_then(|id| if id.is_null() { None } else { Some(id) });
         let should_respond = id.is_some();
 
-        // Handle $/cancelRequest notification with enhanced context processing
-        if request.method == "$/cancelRequest" {
-            if let Some(params) = request.params.as_ref() {
-                if let Some(idv) = params.get("id").cloned() {
-                    // Enhanced cancellation with provider context
-                    let start_time = Instant::now();
-
-                    // Use global registry for enhanced cancellation
-                    if let Ok(_cleanup_context) = GLOBAL_CANCELLATION_REGISTRY.cancel_request(&idv)
-                    {
-                        let latency = start_time.elapsed();
-
-                        // Log performance metrics for AC12 validation
-                        tracing::debug!(latency = ?latency, request = ?idv, "Enhanced cancellation processed");
-
-                        // Validate performance requirements (<50ms end-to-end response time)
-                        if latency.as_millis() > 50 {
-                            tracing::warn!(latency = ?latency, "Cancellation latency exceeded 50ms");
-                        }
-
-                        // Optional: Send response with enhanced context for client tracking
-                        // (Note: $/cancelRequest is typically a notification, but enhanced context
-                        // can be useful for debugging and performance analysis)
-                    }
-
-                    // Fallback to legacy cancellation for compatibility
-                    self.cancel_mark(&idv);
-                }
-            }
+        if handle_cancel_notification(self, &request) {
             return None; // Notifications don't get responses
         }
 
-        // Optimized cancellation setup - batch operations for better performance
-        if let Some(ref request_id) = id {
-            // Fast path: Check for immediate cancellation before expensive setup
-            if self.is_cancelled(request_id) {
-                return Some(cancelled_response_with_method(request_id, &request.method));
-            }
-
-            // Only register cancellation token for potentially long-running operations
-            let needs_cancellation = matches!(
-                request.method.as_str(),
-                "textDocument/completion"
-                    | "textDocument/hover"
-                    | "textDocument/definition"
-                    | "textDocument/references"
-                    | "textDocument/documentSymbol"
-                    | "textDocument/codeAction"
-                    | "textDocument/formatting"
-                    | "textDocument/rename"
-                    | "workspace/symbol"
-                    | "callHierarchy/incomingCalls"
-                    | "callHierarchy/outgoingCalls"
-                    | "textDocument/inlayHint"
-            );
-
-            if needs_cancellation {
-                let token =
-                    PerlLspCancellationToken::new(request_id.clone(), request.method.clone());
-                let cleanup_context =
-                    ProviderCleanupContext::new(request.method.clone(), request.params.clone());
-
-                // Batch registration to reduce lock overhead
-                if let Err(e) = GLOBAL_CANCELLATION_REGISTRY.register_token(token) {
-                    tracing::trace!(error = %e, "cancellation: failed to register token");
-                }
-                if let Err(e) =
-                    GLOBAL_CANCELLATION_REGISTRY.register_cleanup(request_id, cleanup_context)
-                {
-                    tracing::trace!(error = %e, "cancellation: failed to register cleanup");
-                }
-
-                // Quick cancellation check after registration
-                if GLOBAL_CANCELLATION_REGISTRY.is_cancelled(request_id) {
-                    if let Some(token) = GLOBAL_CANCELLATION_REGISTRY.get_token(request_id) {
-                        let cleanup_context =
-                            GLOBAL_CANCELLATION_REGISTRY.cancel_request(request_id).map_err(|e| {
-                                tracing::trace!(error = %e, "cancellation: failed to cancel request (early)");
-                            }).ok().flatten();
-                        return Some(enhanced_cancelled_response(&token, cleanup_context.as_ref()));
-                    }
-                    return Some(cancelled_response_with_method(request_id, &request.method));
-                }
-            }
+        if let Some(cancelled) = register_request_cancellation(self, id.as_ref(), &request) {
+            return Some(cancelled);
         }
 
         if !self.initialized.load(Ordering::Acquire)
@@ -349,19 +274,8 @@ impl LspServer {
         // Check for enhanced cancellation with provider context before cleanup.
         // This preserves cancelled responses for requests that are interrupted while
         // handlers are already running.
-        if let Some(ref request_id) = id {
-            if let Some(token) = GLOBAL_CANCELLATION_REGISTRY.get_token(request_id) {
-                if token.is_cancelled() {
-                    let cleanup_context =
-                        GLOBAL_CANCELLATION_REGISTRY.cancel_request(request_id).map_err(|e| {
-                            tracing::trace!(error = %e, "cancellation: failed to cancel request (post-dispatch)");
-                        }).ok().flatten();
-                    GLOBAL_CANCELLATION_REGISTRY.remove_request(request_id);
-                    return Some(enhanced_cancelled_response(&token, cleanup_context.as_ref()));
-                }
-            }
-            // Clean up cancellation token after request processing.
-            GLOBAL_CANCELLATION_REGISTRY.remove_request(request_id);
+        if let Some(cancelled) = finalize_cancellation_state(id.as_ref()) {
+            return Some(cancelled);
         }
 
         match result {

--- a/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
@@ -63,10 +63,7 @@ use request_cancellation::{
 impl LspServer {
     /// Handle a JSON-RPC request
     pub fn handle_request(&self, request: JsonRpcRequest) -> Option<JsonRpcResponse> {
-        let id = request
-            .id
-            .clone()
-            .and_then(|id| if id.is_null() { None } else { Some(id) });
+        let id = request.id.clone().and_then(|id| if id.is_null() { None } else { Some(id) });
         let should_respond = id.is_some();
 
         if handle_cancel_notification(self, &request) {

--- a/crates/perl-lsp-rs/src/runtime/dispatch/request_cancellation.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/request_cancellation.rs
@@ -1,0 +1,105 @@
+use super::*;
+use crate::cancellation::{
+    GLOBAL_CANCELLATION_REGISTRY, PerlLspCancellationToken, ProviderCleanupContext,
+};
+use std::time::Instant;
+
+pub(super) fn handle_cancel_notification(server: &LspServer, request: &JsonRpcRequest) -> bool {
+    if request.method != "$/cancelRequest" {
+        return false;
+    }
+
+    if let Some(params) = request.params.as_ref()
+        && let Some(idv) = params.get("id").cloned()
+    {
+        let start_time = Instant::now();
+        if let Ok(_cleanup_context) = GLOBAL_CANCELLATION_REGISTRY.cancel_request(&idv) {
+            let latency = start_time.elapsed();
+            tracing::debug!(latency = ?latency, request = ?idv, "Enhanced cancellation processed");
+            if latency.as_millis() > 50 {
+                tracing::warn!(latency = ?latency, "Cancellation latency exceeded 50ms");
+            }
+        }
+        server.cancel_mark(&idv);
+    }
+
+    true
+}
+
+pub(super) fn register_request_cancellation(
+    server: &LspServer,
+    request_id: Option<&Value>,
+    request: &JsonRpcRequest,
+) -> Option<JsonRpcResponse> {
+    let request_id = request_id?;
+
+    if server.is_cancelled(request_id) {
+        return Some(cancelled_response_with_method(request_id, &request.method));
+    }
+
+    let needs_cancellation = matches!(
+        request.method.as_str(),
+        "textDocument/completion"
+            | "textDocument/hover"
+            | "textDocument/definition"
+            | "textDocument/references"
+            | "textDocument/documentSymbol"
+            | "textDocument/codeAction"
+            | "textDocument/formatting"
+            | "textDocument/rename"
+            | "workspace/symbol"
+            | "callHierarchy/incomingCalls"
+            | "callHierarchy/outgoingCalls"
+            | "textDocument/inlayHint"
+    );
+
+    if !needs_cancellation {
+        return None;
+    }
+
+    let token = PerlLspCancellationToken::new(request_id.clone(), request.method.clone());
+    let cleanup_context = ProviderCleanupContext::new(request.method.clone(), request.params.clone());
+
+    if let Err(e) = GLOBAL_CANCELLATION_REGISTRY.register_token(token) {
+        tracing::trace!(error = %e, "cancellation: failed to register token");
+    }
+    if let Err(e) = GLOBAL_CANCELLATION_REGISTRY.register_cleanup(request_id, cleanup_context) {
+        tracing::trace!(error = %e, "cancellation: failed to register cleanup");
+    }
+
+    if GLOBAL_CANCELLATION_REGISTRY.is_cancelled(request_id) {
+        if let Some(token) = GLOBAL_CANCELLATION_REGISTRY.get_token(request_id) {
+            let cleanup_context = GLOBAL_CANCELLATION_REGISTRY
+                .cancel_request(request_id)
+                .map_err(|e| {
+                    tracing::trace!(error = %e, "cancellation: failed to cancel request (early)");
+                })
+                .ok()
+                .flatten();
+            return Some(enhanced_cancelled_response(&token, cleanup_context.as_ref()));
+        }
+        return Some(cancelled_response_with_method(request_id, &request.method));
+    }
+
+    None
+}
+
+pub(super) fn finalize_cancellation_state(request_id: Option<&Value>) -> Option<JsonRpcResponse> {
+    let request_id = request_id?;
+    if let Some(token) = GLOBAL_CANCELLATION_REGISTRY.get_token(request_id)
+        && token.is_cancelled()
+    {
+        let cleanup_context = GLOBAL_CANCELLATION_REGISTRY
+            .cancel_request(request_id)
+            .map_err(|e| {
+                tracing::trace!(error = %e, "cancellation: failed to cancel request (post-dispatch)");
+            })
+            .ok()
+            .flatten();
+        GLOBAL_CANCELLATION_REGISTRY.remove_request(request_id);
+        return Some(enhanced_cancelled_response(&token, cleanup_context.as_ref()));
+    }
+
+    GLOBAL_CANCELLATION_REGISTRY.remove_request(request_id);
+    None
+}

--- a/crates/perl-lsp-rs/src/runtime/dispatch/request_cancellation.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/request_cancellation.rs
@@ -58,7 +58,8 @@ pub(super) fn register_request_cancellation(
     }
 
     let token = PerlLspCancellationToken::new(request_id.clone(), request.method.clone());
-    let cleanup_context = ProviderCleanupContext::new(request.method.clone(), request.params.clone());
+    let cleanup_context =
+        ProviderCleanupContext::new(request.method.clone(), request.params.clone());
 
     if let Err(e) = GLOBAL_CANCELLATION_REGISTRY.register_token(token) {
         tracing::trace!(error = %e, "cancellation: failed to register token");


### PR DESCRIPTION
### Motivation

- The `runtime/dispatch/mod.rs` file mixed cancellation lifecycle concerns with request routing, increasing complexity and violating SRP.

### Description

- Extracted cancel-notification handling, request cancellation registration, and post-dispatch cancellation finalization into a new focused helper module at `crates/perl-lsp-rs/src/runtime/dispatch/request_cancellation.rs`.
- Updated `LspServer::handle_request` in `crates/perl-lsp-rs/src/runtime/dispatch/mod.rs` to orchestrate the new helpers via `handle_cancel_notification`, `register_request_cancellation`, and `finalize_cancellation_state` while preserving existing routing behavior.
- Fixed a borrow/move issue by cloning `request.id` when extracting the request identifier to allow the new helpers to borrow `request` safely.

### Testing

- Ran `cargo check --all-targets -p perl-lsp-rs`, which completed successfully.
- Invoked the targeted unit test `cargo test -p perl-lsp-rs requests_are_accepted_after_initialize_even_without_initialized_notification -- --exact`, which began but did not complete within the interaction window (compile/test run in progress at timeout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14cc521d08333993f4cd35d769156)