### PR TITLE
style: cargo xtask fmt for master drift post ensemble admin-merges (#7018)

### DIFF
--- a/crates/perl-corpus/src/files.rs
+++ b/crates/perl-corpus/src/files.rs
@@ -224,7 +224,8 @@ mod tests {
             .collect();
         names.sort();
 
-        let expected = vec!["case.cgi", "case.pl", "case.plx", "case.pm", "case.psgi", "case.t", "nested.pl"];
+        let expected =
+            vec!["case.cgi", "case.pl", "case.plx", "case.pm", "case.psgi", "case.t", "nested.pl"];
         assert_eq!(names, expected);
 
         fs::remove_dir_all(&root)?;
@@ -288,7 +289,8 @@ mod tests {
             .collect();
         names.sort();
 
-        let expected = vec!["app.PsGi", "legacy.CgI", "mixed.Pm", "suite.T", "tool.PlX", "upper.PL"];
+        let expected =
+            vec!["app.PsGi", "legacy.CgI", "mixed.Pm", "suite.T", "tool.PlX", "upper.PL"];
         assert_eq!(names, expected);
 
         fs::remove_dir_all(&root)?;

--- a/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
+++ b/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
@@ -340,10 +340,14 @@ mod tests {
         };
         let range = FormatRange::new(FormatPosition::new(1, 0), FormatPosition::new(1, 10));
 
-        let formatted = provider.format_range("line1
+        let formatted = provider.format_range(
+            "line1
 my $x = 1;   
 line3
-", &range, &options)?;
+",
+            &range,
+            &options,
+        )?;
 
         assert_eq!(formatted.edits.len(), 1);
         assert_eq!(formatted.edits[0].new_text, "my $x = 1;");
@@ -387,8 +391,12 @@ line3
         };
         let range = FormatRange::new(FormatPosition::new(0, 0), FormatPosition::new(0, 10));
 
-        let result = provider.format_range("my $x = 1;
-", &range, &options);
+        let result = provider.format_range(
+            "my $x = 1;
+",
+            &range,
+            &options,
+        );
         assert!(matches!(result, Err(FormattingError::PerltidyNotFound(_))));
     }
 

--- a/crates/perl-lsp-rs/tests/execute_command_security_tests.rs
+++ b/crates/perl-lsp-rs/tests/execute_command_security_tests.rs
@@ -254,10 +254,7 @@ fn test_command_exists_does_not_execute_candidate_binary() -> Result<(), Box<dyn
 
     fs::write(
         &script_path,
-        format!(
-            "#!/bin/sh\nprintf 'executed' > '{}'\nexit 0\n",
-            marker_path.display()
-        ),
+        format!("#!/bin/sh\nprintf 'executed' > '{}'\nexit 0\n", marker_path.display()),
     )?;
     fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755))?;
 

--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -48,7 +48,12 @@ pub fn uri_key(uri: &str) -> String {
             && rest.as_bytes()[0].is_ascii_alphabetic()
         {
             let separator = if rest.as_bytes()[1] == b'|' { ":" } else { &rest[1..2] };
-            return format!("file:///{}{}{}", rest[0..1].to_ascii_lowercase(), separator, &rest[2..]);
+            return format!(
+                "file:///{}{}{}",
+                rest[0..1].to_ascii_lowercase(),
+                separator,
+                &rest[2..]
+            );
         }
         value
     } else {
@@ -238,7 +243,10 @@ mod tests {
     #[test]
     fn normalizes_legacy_windows_drive_pipe_separator() {
         assert_eq!(uri_key("file:///C|/Users/dev/example.pl"), "file:///c:/Users/dev/example.pl");
-        assert_eq!(uri_key(r"file://D|\projects\MyApp\script.pl"), "file:///d:/projects/MyApp/script.pl");
+        assert_eq!(
+            uri_key(r"file://D|\projects\MyApp\script.pl"),
+            "file:///d:/projects/MyApp/script.pl"
+        );
     }
 
     #[test]
@@ -250,10 +258,7 @@ mod tests {
 
     #[test]
     fn normalizes_legacy_unc_windows_path() {
-        assert_eq!(
-            uri_key(r"\\server\share\folder\file.pl"),
-            "file://server/share/folder/file.pl"
-        );
+        assert_eq!(uri_key(r"\\server\share\folder\file.pl"), "file://server/share/folder/file.pl");
         assert_eq!(
             uri_key(r"file://\\server\share\folder\file.pl"),
             "file://server/share/folder/file.pl"

--- a/crates/perl-workspace-index/src/discovery/mod.rs
+++ b/crates/perl-workspace-index/src/discovery/mod.rs
@@ -201,7 +201,8 @@ fn sort_paths_lexically(paths: &mut [PathBuf]) {
 }
 
 fn is_safe_relative_git_path(path: &Path) -> bool {
-    !path.is_absolute() && !path.components().any(|component| matches!(component, Component::ParentDir))
+    !path.is_absolute()
+        && !path.components().any(|component| matches!(component, Component::ParentDir))
 }
 
 fn log_discovery(result: &DiscoveryResult) {


### PR DESCRIPTION
## Summary

- Apply `cargo xtask fmt` to fix 5 crates with formatting drift after the ensemble admin-merge burst (~15 admin-merges)
- Pure whitespace/line-length reformatting — zero logic changes
- Fixes master CI PR Smoke fmt-check failures

## Files reformatted

| File | Lines changed |
|------|---------------|
| `crates/perl-workspace-index/src/discovery/mod.rs:201` | Line-length wrap on boolean expression |
| `crates/perl-uri/src/classify.rs:48, 238, 250` | Line-length wraps on format! and assert_eq! calls |
| `crates/perl-corpus/src/files.rs:224, 288` | Line-length wraps on vec! macro calls |
| `crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs:340, 387` | Multi-line function call reformatting |
| `crates/perl-lsp-rs/tests/execute_command_security_tests.rs:254` | format! collapsed to single line |

## Verification

- `cargo xtask fmt --check` passes (exit 0) after applying
- `cargo check --workspace` passes (exit 0, 54s)
- `cargo build --workspace` passes (exit 0)

## Test plan

- [ ] CI PR Smoke fmt-check passes
- [ ] No test failures (formatting-only change)