### PR TITLE
fix(perl-lsp-ux-tests): stabilize scenario_19 diagnostics-clear timing (#7168)

### DIFF
--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
@@ -53,6 +53,15 @@ fn scenario_19_diagnostics_clear_after_fix() {
     );
 
     // Drain the event queue so post-fix checks only see new notifications.
+    //
+    // Two-pass flush: the stdout reader thread may still be delivering in-flight
+    // events from the broken-content analysis (async diagnostics pipeline).  A
+    // single drain races with those deliveries — the queue can appear empty, then
+    // the late events arrive and get misclassified as "post-fix".  Waiting a
+    // brief settle window (≥ one server round-trip) and draining again eliminates
+    // that window reliably.
+    harness.collect_notifications();
+    std::thread::sleep(Duration::from_millis(300));
     harness.collect_notifications();
 
     // When: the user fixes the file via a full-document didChange.


### PR DESCRIPTION
## Summary

- **Root cause**: Race condition between the async stdout reader thread and the test's event queue drain. The single `collect_notifications()` call raced with in-flight diagnostic events from the broken-content analysis. The queue appeared empty at drain time; late-arriving events were then misclassified as post-fix events, making the `has_new_errors` check true and the assertion fail.
- **Fix**: Two-pass flush — drain → 300ms settle → drain again — before sending the fix content. This gives the async delivery thread time to flush all broken-file events before the post-fix observation window opens.
- **No behavioral change**: The fix only stabilizes timing. Both acceptance paths (explicit empty notification OR silence = cleared) remain unchanged.

## Test plan

- [x] `cargo test -p perl-lsp-ux-tests --test ux_scenario_19_diagnostics_lifecycle` passes (skips when binary absent, which is correct)
- [x] `cargo fmt -p perl-lsp-ux-tests -- --check` clean
- [x] `cargo clippy -p perl-lsp-ux-tests --tests -- -D warnings` clean
- [ ] Run 3x on CI with binary present to verify no flakiness