### PR TITLE
ci: exclude labeled trigger from ci.yml (prevent cancellation cascade)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,15 @@ name: CI
 on:
   pull_request:
     branches: [ main, master ]
-    types: [opened, synchronize, reopened, labeled, ready_for_review, converted_to_draft]
+    # Deliberately exclude `labeled` / `unlabeled` — every label-add (e.g., applying
+    # `ci-green`, `merge-ready`, pipeline sign-off labels) would trigger a fresh CI run
+    # that cancels the prior in-progress run (see `cancel-in-progress` below). This
+    # caused a cascade observed across ~20 admin-merges: each pipeline label applied by
+    # agents killed the running CI, restarting from scratch and eating minutes of compute
+    # per label. The merge-ready-reconciler.yml applies the same exclusion for the same
+    # reason (infinite-loop guard). `ready_for_review` and `converted_to_draft` are kept
+    # because they change the draft-pr-check guard behavior and must trigger CI.
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   merge_group: {}
   push:
     branches: [ main, master ]


### PR DESCRIPTION
## Summary

- Removes `labeled` from `pull_request.types` in `.github/workflows/ci.yml`
- Every label-add (e.g., `ci-green`, `merge-ready`, pipeline sign-off labels like `review-reviewed`, `deep-reviewed`) was triggering a fresh CI run that cancelled the prior in-progress run via `cancel-in-progress: true`
- This caused a cascade observed across ~20 admin-merges this session: each pipeline label applied by agents killed the running CI run and restarted from scratch, wasting 5-10 minutes of compute per label

## Root cause

`ci.yml` had `types: [opened, synchronize, reopened, labeled, ready_for_review, converted_to_draft]` combined with `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`. Result: any label event on a PR with in-progress CI immediately cancels and restarts the full CI suite.

The pearl-lsp agent pipeline applies many labels in sequence (accuracy-reviewed, plan-reviewed, review-reviewed, deep-reviewed, ci-green, merge-ready, etc.), each one cancelling and restarting CI.

## Precedent

`merge-ready-reconciler.yml` already excludes `labeled` / `unlabeled` with an explicit comment:
> "Deliberately exclude `labeled` / `unlabeled` — the reconciler itself adds/removes labels via gh API, which would fire those events and re-trigger this workflow in an infinite feedback loop."

The same logic applies to ci.yml: label-adds must not trigger the CI workflow.

## What's kept

- `ready_for_review` and `converted_to_draft` are kept — these change the `draft-pr-check` guard behavior (draft PRs skip CI, ready-for-review PRs run it) and must continue to trigger CI
- `opened`, `synchronize`, `reopened` are kept — these represent actual code changes

## Other workflows audited

Other workflows with `labeled` in types were reviewed:
- `ci-nightly.yml` — keeps `labeled` intentionally for **label-gated jobs** (`ci:nightly` label activates expensive tests). No cancel-in-progress cascade issue.
- `perl-version-matrix.yml` — keeps `labeled` intentionally (checks for `ci:perl-matrix` label to conditionally run). No cascade issue.
- `ux-regression-gate.yml` — has `labeled` + `cancel-in-progress: true` with a `paths:` filter limiting exposure. Narrower impact than ci.yml; left unchanged per scope.
- `pipeline-labels.yml` — uses `labeled` intentionally to react to specific label events (its entire purpose).

## Test plan

- [ ] Verify CI runs on `opened`, `synchronize`, `reopened` events
- [ ] Verify applying labels (ci-green, merge-ready, review-reviewed) to a PR with in-progress CI does NOT cancel the run
- [ ] Verify `ready_for_review` still triggers CI (draft → ready conversion)
- [ ] Verify `converted_to_draft` still triggers CI (ready → draft conversion skips future runs)