### PR TITLE
fix(perl-lsp-ux-tests): fix scenario_19 pre-fix event leak causing CI panic (#7293)

### DIFF
--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
@@ -54,14 +54,20 @@ fn scenario_19_diagnostics_clear_after_fix() {
 
     // Drain the event queue so post-fix checks only see new notifications.
     //
-    // Two-pass flush: the stdout reader thread may still be delivering in-flight
-    // events from the broken-content analysis (async diagnostics pipeline).  A
-    // single drain races with those deliveries — the queue can appear empty, then
-    // the late events arrive and get misclassified as "post-fix".  Waiting a
-    // brief settle window (≥ one server round-trip) and draining again eliminates
-    // that window reliably.
+    // Three-pass flush: the stdout reader thread may still be delivering in-flight
+    // events from the broken-content analysis (async diagnostics pipeline).
+    // - First drain: remove any already-buffered events.
+    // - Settle window: wait for in-flight events from the server to arrive.
+    // - Second drain: remove events that arrived during the settle window.
+    // - Final drain immediately before didChange: close the race window between
+    //   the settle and the send.  Events that slip in during this last tiny gap
+    //   are cleared before we record the post-fix baseline.
     harness.collect_notifications();
     std::thread::sleep(Duration::from_millis(300));
+    harness.collect_notifications();
+
+    // Final drain immediately before the fix — eliminates events that snuck in
+    // between the settle drain and the didChange notification.
     harness.collect_notifications();
 
     // When: the user fixes the file via a full-document didChange.
@@ -70,13 +76,23 @@ fn scenario_19_diagnostics_clear_after_fix() {
     // Then: diagnostics eventually clear. Two acceptable outcomes:
     //   (a) Server sends explicit publishDiagnostics with empty array → cleared.
     //   (b) No new non-empty notification arrives within the grace period → also cleared.
+    //
+    // Important: we accumulate ONLY events that arrive after the final pre-fix drain
+    // by draining periodically and appending to a local list.  Using peek_notifications
+    // would re-read pre-fix events that raced into the queue between the drain and the
+    // didChange send, producing false failures when the server never sends an explicit
+    // empty clear for the fixed content.
     let uri = harness.workspace.uri("live.pl");
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
 
+    let mut post_fix_events: Vec<LspEvent> = Vec::new();
     let mut cleared = false;
+
     while std::time::Instant::now() < deadline {
-        let events = harness.peek_notifications();
-        let post_fix_diag_events: Vec<_> = events
+        // Drain any new events since the last iteration and append to our local list.
+        post_fix_events.extend(harness.collect_notifications());
+
+        let post_fix_diag_events: Vec<_> = post_fix_events
             .iter()
             .filter_map(|ev| match ev {
                 LspEvent::Diagnostics { uri: event_uri, diagnostics } if event_uri == &uri => {
@@ -98,10 +114,9 @@ fn scenario_19_diagnostics_clear_after_fix() {
         std::thread::sleep(Duration::from_millis(100));
     }
 
-    // Accept silence (no new non-empty notification) as "cleared" too.
+    // Accept silence (no new non-empty notification in our post-fix window) as "cleared" too.
     if !cleared {
-        let events = harness.peek_notifications();
-        let has_new_errors = events.iter().any(|ev| {
+        let has_new_errors = post_fix_events.iter().any(|ev| {
             matches!(ev, LspEvent::Diagnostics { uri: event_uri, diagnostics }
                 if event_uri == &uri && !diagnostics.is_empty())
         });


### PR DESCRIPTION
## Summary

- Closes #7293
- `scenario_19_diagnostics_clear_after_fix` was panicking on CI intermittently due to pre-fix diagnostic events leaking into the post-fix verification window
- Root cause: `peek_notifications()` reads all accumulated events without draining; events that raced into the queue between the settle drain and the `change_file_full` send appeared as post-fix events
- Fix: switch to periodic `collect_notifications()` drain pattern with a local `post_fix_events` accumulator; add a third drain immediately before `change_file_full` to close the settle→send race window

## Root cause detail

After `#7277`'s two-pass flush (drain → 300ms settle → drain), there's still a tiny race window between the final drain and the `change_file_full` notification send. The stdout reader thread can deliver pre-fix diagnostic events during this gap. `peek_notifications()` reads the entire queue so these events appear as post-fix, and when the server uses the silent-clear path (no explicit empty `publishDiagnostics`), `has_new_errors` becomes true — failing the assertion.

## Fix

1. Added a third `collect_notifications()` immediately before `change_file_full` to close the gap
2. Changed the post-fix loop from `peek_notifications()` (reads all) to periodic `collect_notifications()` drain appended to a local `post_fix_events` list — guaranteed to contain only post-fix events
3. The silence-check at the end also uses `post_fix_events` instead of `peek_notifications()`

## History

- Test added in #7168
- First stabilization (#7277): 300ms settle + second drain — improved but still flaky
- This PR: structural fix removing the data source for false positives

## Test plan

- [x] `cargo check -p perl-lsp-ux-tests` passes
- [x] `cargo fmt -p perl-lsp-ux-tests -- --check` passes
- [x] `cargo clippy -p perl-lsp-ux-tests` — no issues
- [ ] CI: `scenario_19_diagnostics_clear_after_fix` no longer panics on master