### PR TITLE
test(lsp): restore current master gate stability (#0000)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_completion_tests.rs
@@ -1124,12 +1124,12 @@ fn test_completion_scope_distance_ranking() -> Result<(), Box<dyn std::error::Er
     let inner_sort = inner_item.unwrap()["sortText"].as_str().unwrap_or("");
     let outer_sort = outer_item.unwrap()["sortText"].as_str().unwrap_or("");
 
-    // Immediate scope → sort key 'a' → sort_text "1a_scope_inner"
-    // PackageLevel (file-scope `my`) → sort key 'c' → sort_text "1c_scope_outer"
+    // Immediate scope -> sort key 'a00' -> sort_text "1a00_scope_inner"
+    // PackageLevel (file-scope `my`) -> sort key 'c00' -> sort_text "1c00_scope_outer"
     //
     // Guard that sortText is actually present in the wire response.  Without
-    // this check the `!outer_sort.starts_with("1a_")` assertion passes vacuously
-    // when sortText is absent (empty string does not start with "1a_").
+    // this check the `!outer_sort.starts_with("1a00_")` assertion passes vacuously
+    // when sortText is absent (empty string does not start with "1a00_").
     assert!(
         !inner_sort.is_empty(),
         "$scope_inner must have a non-empty sortText — check that completion.rs \
@@ -1141,12 +1141,12 @@ fn test_completion_scope_distance_ranking() -> Result<(), Box<dyn std::error::Er
          serializes sort_text to the LSP wire response"
     );
     assert!(
-        inner_sort.starts_with("1a_"),
-        "$scope_inner should have Immediate scope sort_text (\"1a_...\"), got: '{inner_sort}'"
+        inner_sort.starts_with("1a00_"),
+        "$scope_inner should have Immediate scope sort_text (\"1a00_...\"), got: '{inner_sort}'"
     );
     assert!(
-        !outer_sort.starts_with("1a_"),
-        "$scope_outer should NOT have Immediate scope sort_text, got: '{outer_sort}'"
+        outer_sort.starts_with("1c00_"),
+        "$scope_outer should have PackageLevel scope sort_text (\"1c00_...\"), got: '{outer_sort}'"
     );
     assert!(
         inner_sort < outer_sort,

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
@@ -54,14 +54,20 @@ fn scenario_19_diagnostics_clear_after_fix() {
 
     // Drain the event queue so post-fix checks only see new notifications.
     //
-    // Two-pass flush: the stdout reader thread may still be delivering in-flight
-    // events from the broken-content analysis (async diagnostics pipeline).  A
-    // single drain races with those deliveries — the queue can appear empty, then
-    // the late events arrive and get misclassified as "post-fix".  Waiting a
-    // brief settle window (≥ one server round-trip) and draining again eliminates
-    // that window reliably.
+    // Three-pass flush: the stdout reader thread may still be delivering in-flight
+    // events from the broken-content analysis (async diagnostics pipeline).
+    // - First drain: remove any already-buffered events.
+    // - Settle window: wait for in-flight events from the server to arrive.
+    // - Second drain: remove events that arrived during the settle window.
+    // - Final drain immediately before didChange: close the race window between
+    //   the settle and the send.  Events that slip in during this last tiny gap
+    //   are cleared before we record the post-fix baseline.
     harness.collect_notifications();
     std::thread::sleep(Duration::from_millis(300));
+    harness.collect_notifications();
+
+    // Final drain immediately before the fix — eliminates events that snuck in
+    // between the settle drain and the didChange notification.
     harness.collect_notifications();
 
     // When: the user fixes the file via a full-document didChange.
@@ -70,13 +76,23 @@ fn scenario_19_diagnostics_clear_after_fix() {
     // Then: diagnostics eventually clear. Two acceptable outcomes:
     //   (a) Server sends explicit publishDiagnostics with empty array → cleared.
     //   (b) No new non-empty notification arrives within the grace period → also cleared.
+    //
+    // Important: we accumulate ONLY events that arrive after the final pre-fix drain
+    // by draining periodically and appending to a local list.  Using peek_notifications
+    // would re-read pre-fix events that raced into the queue between the drain and the
+    // didChange send, producing false failures when the server never sends an explicit
+    // empty clear for the fixed content.
     let uri = harness.workspace.uri("live.pl");
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
 
+    let mut post_fix_events: Vec<LspEvent> = Vec::new();
     let mut cleared = false;
+
     while std::time::Instant::now() < deadline {
-        let events = harness.peek_notifications();
-        let post_fix_diag_events: Vec<_> = events
+        // Drain any new events since the last iteration and append to our local list.
+        post_fix_events.extend(harness.collect_notifications());
+
+        let post_fix_diag_events: Vec<_> = post_fix_events
             .iter()
             .filter_map(|ev| match ev {
                 LspEvent::Diagnostics { uri: event_uri, diagnostics } if event_uri == &uri => {
@@ -98,10 +114,9 @@ fn scenario_19_diagnostics_clear_after_fix() {
         std::thread::sleep(Duration::from_millis(100));
     }
 
-    // Accept silence (no new non-empty notification) as "cleared" too.
+    // Accept silence (no new non-empty notification in our post-fix window) as "cleared" too.
     if !cleared {
-        let events = harness.peek_notifications();
-        let has_new_errors = events.iter().any(|ev| {
+        let has_new_errors = post_fix_events.iter().any(|ev| {
             matches!(ev, LspEvent::Diagnostics { uri: event_uri, diagnostics }
                 if event_uri == &uri && !diagnostics.is_empty())
         });
@@ -111,7 +126,7 @@ fn scenario_19_diagnostics_clear_after_fix() {
     assert!(
         cleared,
         "Expected diagnostics to clear (or no new errors) after fixing the file; events: {:?}",
-        harness.peek_notifications()
+        post_fix_events
     );
     harness.assert_no_crash();
 }

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
@@ -23,8 +23,8 @@ fn binary_available() -> bool {
     perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
-const BROKEN_SOURCE: &str = "use strict;\nmy $x = ;\n";
-const FIXED_SOURCE: &str = "use strict;\nmy $x = 1;\n";
+const BROKEN_SOURCE: &str = "use strict;\nuse warnings;\nmy $x = ;\n";
+const FIXED_SOURCE: &str = "use strict;\nuse warnings;\nmy $x = 1;\nprint $x;\n";
 
 /// Verifies the diagnostics edit lifecycle:
 ///   1. Broken content → diagnostics appear.
@@ -108,6 +108,10 @@ fn scenario_19_diagnostics_clear_after_fix() {
         cleared = !has_new_errors;
     }
 
-    assert!(cleared, "Expected diagnostics to clear (or no new errors) after fixing the file.");
+    assert!(
+        cleared,
+        "Expected diagnostics to clear (or no new errors) after fixing the file; events: {:?}",
+        harness.peek_notifications()
+    );
     harness.assert_no_crash();
 }


### PR DESCRIPTION
Problem: Current master has two deterministic test failures blocking required PR CI.
Fix: Align the completion sortText assertion with the current scope-distance key format and make the diagnostics lifecycle fixture clear all diagnostics after the fix.
Verification: `cargo test -p perl-lsp-rs --test lsp_completion_tests --locked test_completion_scope_distance_ranking -- --exact --nocapture` passes; `cargo test -p perl-lsp-ux-tests --test ux_scenario_19_diagnostics_lifecycle --locked scenario_19_diagnostics_clear_after_fix -- --exact --nocapture` passes.