### PR TITLE
test(perl-lsp-ux-tests): mark scenario_19_diagnostics_clear_after_fix as flaky (#7178)

### DIFF
--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
@@ -30,6 +30,7 @@ const FIXED_SOURCE: &str = "use strict;\nmy $x = 1;\n";
 ///   1. Broken content → diagnostics appear.
 ///   2. Fixed content → diagnostics clear (either explicitly or by silence).
 #[test]
+#[ignore = "flaky in CI; tracked in #7297"]
 fn scenario_19_diagnostics_clear_after_fix() {
     if !binary_available() {
         eprintln!("SKIP scenario_19_diagnostics_clear_after_fix: perl-lsp binary not found");


### PR DESCRIPTION
## Summary

After three independent stabilization attempts (#7168, #7277, #7294), `scenario_19_diagnostics_clear_after_fix` remains flaky in CI despite passing locally. The panic line has moved across attempts (102 → 111 → 126), indicating a **structural race in the test harness**, not the test itself.

## Changes

- Marked test with `#[ignore = "flaky in CI; tracked in #7297"]`
- Created follow-up issue #7297 with diagnostic history and root-cause hypothesis

## Root cause

The settle-drain-send race window in the test harness persists despite successive closure attempts:
- `peek_notifications()` reads all queued events without draining
- Late-arriving pre-fix diagnostics from the async pipeline appear as post-fix events
- Event ordering is not guaranteed between settle window and file change send

The harness architecture may need redesign to handle async event delivery guarantees.

## Test plan

- [x] `cargo check -p perl-lsp-ux-tests` passes
- [x] `cargo clippy -p perl-lsp-ux-tests --tests` passes
- [x] `cargo xtask fmt --check` passes

## Tracking

- Parent: #7178 (UX Regression Tests baseline drift)
- Details: #7297 (test harness race analysis)