### PR TITLE
test(perl-semantic-analyzer): add import-export visibility regression bank (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -201,3 +201,58 @@ fn use_exporter_import_does_not_resolve_as_import() {
         );
     }
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Import/export visibility regression bank (Box 5)
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn exporter_default_import_visibility_is_currently_conservative() {
+    let code = r#"use MyLib;
+foo();
+"#;
+    let pkg = parse_and_symbol_at(code, "foo()");
+    assert_ne!(
+        pkg.as_deref(),
+        Some("MyLib"),
+        "currently conservative: bare use MyLib should not claim @EXPORT ownership without export table"
+    );
+}
+
+#[test]
+fn exporter_explicit_export_ok_visibility_resolves_symbols() {
+    let code = r#"use MyLib qw(bar baz);
+bar();
+baz();
+"#;
+    let bar_pkg = parse_and_symbol_at(code, "bar()");
+    let baz_pkg = parse_and_symbol_at(code, "baz()");
+    assert_eq!(bar_pkg.as_deref(), Some("MyLib"));
+    assert_eq!(baz_pkg.as_deref(), Some("MyLib"));
+}
+
+#[test]
+fn exporter_tag_import_visibility_is_currently_conservative() {
+    let code = r#"use MyLib qw(:all);
+foo();
+bar();
+baz();
+"#;
+    for symbol in ["foo()", "bar()", "baz()"] {
+        let pkg = parse_and_symbol_at(code, symbol);
+        assert_ne!(pkg.as_deref(), Some("MyLib"), "currently conservative: {symbol} should not be attributed via :all without export table");
+    }
+}
+
+#[test]
+fn exporter_export_ok_not_visible_without_explicit_import() {
+    let code = r#"use MyLib;
+bar();
+"#;
+    let pkg = parse_and_symbol_at(code, "bar()");
+    assert_ne!(
+        pkg.as_deref(),
+        Some("MyLib"),
+        "@EXPORT_OK symbol should not be visible under bare use MyLib"
+    );
+}


### PR DESCRIPTION
### Motivation

- Provide a focused regression bank for import/export visibility to support upcoming work on `ImportSpec`, `ExportSet`, and `VisibleSymbols` by locking down expected behavior for Exporter patterns.

### Description

- Added a dedicated "Import/export visibility regression bank (Box 5)" to `crates/perl-semantic-analyzer/tests/require_import_resolution.rs` containing targeted tests.
- Tests cover conservative default-`use` behavior, explicit `@EXPORT_OK` imports via `use MyLib qw(bar baz)`, tag-based imports via `use MyLib qw(:all)`, and that `@EXPORT_OK` symbols are not visible under bare `use MyLib`.
- No production code was modified and the change is limited to test fixtures only.

### Testing

- Ran `cargo test -p perl-semantic-analyzer --test require_import_resolution` and the test binary completed with all tests passing (15 passed, 0 failed).
- Ran `cargo test -p perl-semantic-analyzer require_import_resolution -- --nocapture` to compile and exercise the harness, which finished successfully. 
- The crate compiled successfully as part of the test runs and the added tests behave as expected (conservative assertions were used where workspace export tables are not available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ae5b442883339fb293b89350eaf2)