### PR TITLE
docs(semantic): define substrate contract and readiness rails (#0000)

### DIFF
--- a/docs/project/SEMANTIC_FACT_SUBSTRATE.md
+++ b/docs/project/SEMANTIC_FACT_SUBSTRATE.md
@@ -1,0 +1,138 @@
+# Semantic Fact Substrate (Compiler-lite) — v1 Contract
+
+## Purpose
+
+This document defines the **canonical semantic substrate** we will build before provider cutover.
+It is intentionally scoped as a planning and contract artifact: it does **not** claim that migration is complete.
+
+Guiding principle for every box in this epic:
+
+> Produce the most reviewable and tested complete slice of this specific change. Do not optimize for a tiny diff; optimize for a reviewer being able to prove the change is correct quickly.
+
+## Why this exists
+
+Semantic data is currently spread across multiple crates:
+
+- `perl-symbol`: exact AST-oriented declarations/references
+- `perl-semantic-analyzer`: scoped and framework-informed synthesis
+- `perl-workspace-index`: cross-file indexing and query surfaces
+- export/import analysis paths in analyzer/workspace layers
+
+The substrate adds one neutral vocabulary layer so adapters and storage are explicit, testable, and migration-safe.
+
+## Layer model (target)
+
+```text
+Per-file producers
+  ├─ perl-symbol (exact facts)
+  └─ perl-semantic-analyzer (synthesized/framework facts)
+        ↓ adapters
+Canonical facts
+  └─ perl-semantic-facts (IDs, facts, edges, provenance, confidence)
+        ↓ write-through
+Workspace store/index
+  └─ perl-workspace-index (file shards, invalidation, candidate sets)
+        ↓ compatibility APIs + shadow compare
+Query contract
+  └─ definitions/references/visible symbols/rename/safe-delete
+        ↓ final migration
+LSP providers
+  └─ consume query APIs (not private semantic maps)
+```
+
+## Crate responsibilities
+
+- `perl-semantic-facts` (new): types only; no parsing, no provider logic, no workspace ownership.
+- `perl-symbol`: emit exact symbol declarations/references with high-confidence provenance.
+- `perl-semantic-analyzer`: emit framework, inheritance, role, and generated-member facts with explicit confidence.
+- `perl-workspace-index`: persist per-file fact shards, build query indexes, invalidate deterministically.
+- provider crates: consume stable query APIs and stop walking crate-private semantic structures.
+
+## Fact model summary (v1 vocabulary)
+
+Core IDs:
+
+- `FileId`, `ScopeId`, `EntityId`, `AnchorId`, `OccurrenceId`, `EdgeId`, `DiagnosticId`
+
+Core facts:
+
+- `AnchorFact`, `EntityFact`, `OccurrenceFact`, `EdgeFact`, `DiagnosticFact`
+
+Core enums:
+
+- `EntityKind`, `OccurrenceKind`, `EdgeKind`, `Provenance`, `Confidence`
+
+Expected minimum coverage for these enums is tracked in the Box 1 implementation prompt.
+
+## Provenance and confidence policy
+
+Every non-trivial semantic result should carry both:
+
+- **Provenance** (`ExactAst`, `SemanticAnalyzer`, `FrameworkSynthesis`, `ImportExportInference`, etc.)
+- **Confidence** (high-to-low certainty used for ranking and safety decisions)
+
+Policy:
+
+1. Prefer exact facts over heuristic facts when both exist.
+2. Keep heuristic/dynamic results visible but explicitly tagged.
+3. Do not silently upgrade confidence when data crosses crate boundaries.
+
+## Dynamic-boundary policy
+
+When static certainty is unavailable (for example: `eval STRING`, dynamic `require`, dynamic import dispatch, heavy typeglob indirection):
+
+- record an explicit dynamic-boundary occurrence/edge,
+- keep navigation/editing conservative,
+- preserve explainability in scorecards and receipts.
+
+## Query API contract (provider-facing target)
+
+```rust
+symbol_at(uri, pos)
+definitions(occurrence, policy)
+references(entity, scope, filter)
+visible_symbols_at(uri, pos, context)
+method_candidates(receiver, prefix)
+rename_plan(entity, new_name)
+safe_delete_plan(entity)
+```
+
+Contract intent:
+
+- deterministic ordering,
+- candidate-aware results where ambiguity exists,
+- explicit handling of unsupported/dynamic boundaries,
+- predictable serialization for fixtures and shadow receipts.
+
+## Migration order
+
+Dependency order remains:
+
+```text
+facts schema
+→ exact adapters
+→ workspace store
+→ query APIs
+→ provider migration
+```
+
+Execution waves:
+
+- **Wave 1 (rails)**: docs + fixture banks + scorecards + fact crate skeleton.
+- **Wave 2 (adapters/store)**: `SymbolDecl -> EntityFact`, `SymbolRef -> OccurrenceFact`, `ExportInfo -> ExportSet`, file shard write-through, candidate multimap, typed reference index.
+- **Wave 3 (first UX jump)**: import spec extraction, visible symbols query, completion/undefined diagnostics behind feature flags.
+
+## In scope vs deferred (v1)
+
+In scope now:
+
+- canonical vocabulary,
+- fixture and regression banks,
+- shadow-compare receipt design,
+- release-readiness scorecard hooks.
+
+Deferred until adapters/store are in:
+
+- full provider cutover,
+- broad ranking retuning,
+- dynamic execution modeling beyond conservative boundaries.

--- a/docs/project/WHAT_THE_REPO_STILL_NEEDS.md
+++ b/docs/project/WHAT_THE_REPO_STILL_NEEDS.md
@@ -87,6 +87,28 @@ Merged #5259 documents the semver contract for allowlisted crates. But nothing g
 
 #5263 enriched the gate receipt with `agent_receipt` block. But no agent actually consumes it yet — pr-responder still reads log tails. Next iteration: pr-responder wires into `agent_receipt.failures[].repro` directly and the receipt becomes the input protocol instead of stdout parsing.
 
+
+### 20. Semantic substrate first-wave readiness (workspace-wide awareness)
+
+To improve workspace-wide awareness and analysis without premature provider cutover, execute the first wave as rails-building:
+
+1. canonical facts vocabulary (`perl-semantic-facts`)
+2. fixture-heavy regression banks (definitions/references/import-export/framework-generated members)
+3. deterministic scorecards and shadow-compare receipts
+
+Success criteria for release-readiness tracking:
+
+- imported-symbol completion behavior has fixture coverage
+- export-tag visibility behavior has fixture coverage
+- definition exact-hit fixtures are tracked (`hit@1`, `hit@5`)
+- references can be scored by typed intent (definition/import/call/read/write)
+- generated accessor and inherited-method fixtures are present
+- dynamic-boundary policy is explicitly visible in docs/fixtures
+- rename and safe-delete safety scorecard rows exist
+- semantic query latency p50/p95 fields exist in scorecard output
+
+Reference architecture and migration contract: `docs/project/SEMANTIC_FACT_SUBSTRATE.md`.
+
 ## Lower-priority / nice-to-have
 
 ### 13. Release-engineering substrate


### PR DESCRIPTION
### Motivation

- Provide a single canonical architecture and migration contract for the semantic-fact substrate so later work can implement adapters and storage without guessing the target vocabulary.
- Surface measurable first-wave readiness criteria (fixtures, scorecards, shadow receipts) so release-readiness can track semantic progress before provider cutover.
- Improve workspace-wide awareness by linking the substrate contract to the repo's outstanding-work tracker to make next implementation waves reviewable and testable.

### Description

- Added `docs/project/SEMANTIC_FACT_SUBSTRATE.md` describing the layer model, crate responsibilities, core IDs/facts/enums, provenance/confidence policy, dynamic-boundary policy, provider-facing query API contract, and the wave-ordered migration plan.
- Updated `docs/project/WHAT_THE_REPO_STILL_NEEDS.md` with a new "Semantic substrate first-wave readiness" section that enumerates fixture and scorecard success criteria and links to the new substrate doc.
- Documentation-only change that does not modify runtime code or provider behavior and is intended as the planning/contract artifact for subsequent implementation PRs.

### Testing

- Ran `cargo check --workspace --all-targets`, which completed successfully (warnings only). 
- No unit tests were added or changed; the change is documentation-only and validated by the workspace build check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ae8cb9948333a3085f41ec45c887)