### PR TITLE
feat(perl-semantic-facts): add neutral semantic fact foundation (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-semantic-facts"
+version = "0.12.4"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "perl-subprocess-runtime"
 version = "0.12.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/perl-parser-core",
     "crates/perl-parser-pest",
     "crates/perl-semantic-analyzer",
+    "crates/perl-semantic-facts",
     "crates/perl-workspace-index",
     "crates/perl-refactoring",
     "crates/perl-incremental-parsing",
@@ -291,6 +292,7 @@ perl-refactoring = { path = "crates/perl-refactoring", version = "0.12.4" }
 
 # Tier 4: Three-level dependencies
 perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.12.4" }
+perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.12.4" }
 # (perl-lsp-providers absorbed into perl-lsp-rs-core::providers::lsp_compat — Wave G1b)
 
 # Tier 5: Application crates

--- a/crates/perl-semantic-facts/Cargo.toml
+++ b/crates/perl-semantic-facts/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "perl-semantic-facts"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-semantic-facts"
+description = "Neutral semantic fact vocabulary for Perl analysis layers"
+readme = "README.md"
+keywords = ["perl", "semantic", "facts", "analysis", "lsp"]
+categories = ["development-tools", "data-structures"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/crates/perl-semantic-facts/README.md
+++ b/crates/perl-semantic-facts/README.md
@@ -1,0 +1,7 @@
+# perl-semantic-facts
+
+`perl-semantic-facts` defines a neutral semantic fact vocabulary shared across analysis layers.
+
+This crate intentionally does **not** parse Perl, store workspace indexes, or implement LSP
+providers. It exists to provide typed IDs and interoperable fact structures that can be
+produced and consumed by other crates.

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -1,0 +1,227 @@
+//! Neutral semantic fact vocabulary for Perl analysis layers.
+//!
+//! This crate defines typed identifiers and fact records that can be shared between parser,
+//! semantic analyzer, indexing, and export/import inference components.
+//!
+//! ## Non-goals
+//! - Parsing Perl source.
+//! - Owning workspace storage and indexing.
+//! - Providing LSP protocol behavior.
+
+use serde::{Deserialize, Serialize};
+
+macro_rules! id_type {
+    ($name:ident) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(pub u64);
+    };
+}
+
+id_type!(FileId);
+id_type!(ScopeId);
+id_type!(EntityId);
+id_type!(AnchorId);
+id_type!(OccurrenceId);
+id_type!(EdgeId);
+id_type!(DiagnosticId);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum EntityKind {
+    Package,
+    Class,
+    Role,
+    Subroutine,
+    Method,
+    Variable,
+    Constant,
+    Field,
+    Label,
+    Format,
+    Module,
+    GeneratedMember,
+    ExternalSymbol,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum OccurrenceKind {
+    Definition,
+    Reference,
+    Read,
+    Write,
+    Call,
+    MethodCall,
+    StaticMethodCall,
+    Import,
+    Export,
+    Inheritance,
+    RoleComposition,
+    GeneratedUse,
+    DynamicBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum EdgeKind {
+    Defines,
+    References,
+    Reads,
+    Writes,
+    Calls,
+    ImportsModule,
+    ImportsSymbol,
+    ExportsSymbol,
+    ExportsGroup,
+    Inherits,
+    ComposesRole,
+    MemberOf,
+    GeneratedFrom,
+    AliasOf,
+    DependsOn,
+    DynamicBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum Provenance {
+    ExactAst,
+    DesugaredAst,
+    SemanticAnalyzer,
+    FrameworkSynthesis,
+    ImportExportInference,
+    PragmaInference,
+    NameHeuristic,
+    SearchFallback,
+    DynamicBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum Confidence {
+    Certain,
+    High,
+    Medium,
+    Low,
+    Speculative,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AnchorFact {
+    pub id: AnchorId,
+    pub file_id: FileId,
+    pub start_byte: u32,
+    pub end_byte: u32,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EntityFact {
+    pub id: EntityId,
+    pub scope_id: Option<ScopeId>,
+    pub anchor_id: Option<AnchorId>,
+    pub canonical_name: String,
+    pub kind: EntityKind,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct OccurrenceFact {
+    pub id: OccurrenceId,
+    pub entity_id: EntityId,
+    pub anchor_id: AnchorId,
+    pub kind: OccurrenceKind,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EdgeFact {
+    pub id: EdgeId,
+    pub from_entity_id: EntityId,
+    pub to_entity_id: EntityId,
+    pub kind: EdgeKind,
+    pub anchor_id: Option<AnchorId>,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct DiagnosticFact {
+    pub id: DiagnosticId,
+    pub anchor_id: Option<AnchorId>,
+    pub related_entity_id: Option<EntityId>,
+    pub code: String,
+    pub message: String,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_fact_bundle_is_stable() -> Result<(), serde_json::Error> {
+        let bundle = vec![
+            EntityFact {
+                id: EntityId(11),
+                scope_id: Some(ScopeId(7)),
+                anchor_id: Some(AnchorId(3)),
+                canonical_name: "My::Package::method".to_owned(),
+                kind: EntityKind::Method,
+                provenance: Provenance::SemanticAnalyzer,
+                confidence: Confidence::High,
+            },
+            EntityFact {
+                id: EntityId(99),
+                scope_id: None,
+                anchor_id: None,
+                canonical_name: "strict".to_owned(),
+                kind: EntityKind::Module,
+                provenance: Provenance::ImportExportInference,
+                confidence: Confidence::Medium,
+            },
+        ];
+
+        let json = serde_json::to_string_pretty(&bundle)?;
+        let decoded: Vec<EntityFact> = serde_json::from_str(&json)?;
+
+        assert_eq!(decoded, bundle);
+        Ok(())
+    }
+
+    #[test]
+    fn deterministic_debug_output_for_snapshot_style_assertions() {
+        let edge = EdgeFact {
+            id: EdgeId(1),
+            from_entity_id: EntityId(2),
+            to_entity_id: EntityId(3),
+            kind: EdgeKind::DependsOn,
+            anchor_id: Some(AnchorId(4)),
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::Certain,
+        };
+
+        let expected = "EdgeFact { id: EdgeId(1), from_entity_id: EntityId(2), to_entity_id: EntityId(3), kind: DependsOn, anchor_id: Some(AnchorId(4)), provenance: ExactAst, confidence: Certain }";
+        assert_eq!(format!("{edge:?}"), expected);
+    }
+
+    #[test]
+    fn ids_are_typed_and_not_interchangeable() {
+        let file = FileId(42);
+        let anchor = AnchorId(42);
+
+        assert_eq!(file.0, 42);
+        assert_eq!(anchor.0, 42);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a single, neutral vocabulary for semantic facts so analysis layers can interoperate without embedding typed IDs or facts in multiple crates.
- Define stable typed identifiers, provenance/confidence enums, and compact fact records to serve as the foundation for later consumer migrations.

### Description

- Add a new workspace crate `crates/perl-semantic-facts` with `Cargo.toml` and `README.md` describing scope and non-goals. 
- Implement typed newtype IDs (`FileId`, `ScopeId`, `EntityId`, `AnchorId`, `OccurrenceId`, `EdgeId`, `DiagnosticId`) and enums (`EntityKind`, `OccurrenceKind`, `EdgeKind`, `Provenance`, `Confidence`) in `src/lib.rs` with `serde` support. 
- Add core fact structs (`AnchorFact`, `EntityFact`, `OccurrenceFact`, `EdgeFact`, `DiagnosticFact`) and mark public records `#[non_exhaustive]` for forward compatibility. 
- Register the crate in the workspace `Cargo.toml` and include a `Cargo.lock` entry for the new package. 

### Testing

- Ran `cargo test -p perl-semantic-facts` and all unit tests passed (`3 passed; 0 failed`).
- Started `cargo check --workspace --all-targets`; compilation progressed through the workspace (numerous crates checked), but the run was bounded and interrupted after extensive output; no crate-level errors from the added crate were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ae494e2083338bae2e2d542805f3)