### PR TITLE
feat(perl-semantic-facts): add foundational neutral fact vocabulary crate (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-semantic-facts"
+version = "0.12.4"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "perl-subprocess-runtime"
 version = "0.12.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/perl-parser-core",
     "crates/perl-parser-pest",
     "crates/perl-semantic-analyzer",
+    "crates/perl-semantic-facts",
     "crates/perl-workspace-index",
     "crates/perl-refactoring",
     "crates/perl-incremental-parsing",
@@ -288,6 +289,7 @@ perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.12.4" }
 perl-workspace = { path = "crates/perl-workspace-index", version = "0.12.4" }
 perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.12.4" }
 perl-refactoring = { path = "crates/perl-refactoring", version = "0.12.4" }
+perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.12.4" }
 
 # Tier 4: Three-level dependencies
 perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.12.4" }

--- a/crates/perl-semantic-facts/Cargo.toml
+++ b/crates/perl-semantic-facts/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "perl-semantic-facts"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Neutral semantic fact vocabulary for perl-lsp analysis layers"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-semantic-facts"
+readme = "README.md"
+keywords = ["perl", "semantic", "facts", "lsp", "analysis"]
+categories = ["development-tools", "data-structures", "text-editors"]
+publish = true
+include = [
+    "src/**",
+    "Cargo.toml",
+    "LICENSE*",
+    "README.md",
+    "CLAUDE.md",
+]
+
+[lib]
+doctest = false
+
+[dependencies]
+serde = { workspace = true }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/crates/perl-semantic-facts/README.md
+++ b/crates/perl-semantic-facts/README.md
@@ -1,0 +1,18 @@
+# perl-semantic-facts
+
+`perl-semantic-facts` defines a neutral, serializable vocabulary for semantic analysis facts in the `perl-lsp` workspace.
+
+It provides:
+
+- Typed, stable IDs (`FileId`, `EntityId`, `OccurrenceId`, etc.)
+- Core fact records (`AnchorFact`, `EntityFact`, `OccurrenceFact`, `EdgeFact`, `DiagnosticFact`)
+- Relationship and classification enums (`EntityKind`, `OccurrenceKind`, `EdgeKind`)
+- Provenance and confidence metadata (`Provenance`, `Confidence`)
+
+This crate intentionally does **not**:
+
+- parse Perl,
+- provide LSP protocol/provider behavior, or
+- own workspace storage/indexing.
+
+It is intended as a shared interchange layer between parser/semantic/indexer/exporter components.

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -1,0 +1,269 @@
+//! Neutral semantic fact vocabulary shared by perl-lsp analysis layers.
+//!
+//! This crate defines typed identifiers, fact records, and relationship enums used to
+//! exchange semantic analysis information across crates.
+//!
+//! It intentionally does not parse Perl, implement LSP providers, or own workspace
+//! persistence/indexing.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+macro_rules! typed_id {
+    ($name:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+        #[non_exhaustive]
+        pub struct $name(pub String);
+
+        impl $name {
+            #[must_use]
+            pub fn new(value: impl Into<String>) -> Self {
+                Self(value.into())
+            }
+
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl<T> From<T> for $name
+        where
+            T: Into<String>,
+        {
+            fn from(value: T) -> Self {
+                Self::new(value)
+            }
+        }
+    };
+}
+
+typed_id!(FileId);
+typed_id!(ScopeId);
+typed_id!(EntityId);
+typed_id!(AnchorId);
+typed_id!(OccurrenceId);
+typed_id!(EdgeId);
+typed_id!(DiagnosticId);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum EntityKind {
+    Package,
+    Class,
+    Role,
+    Subroutine,
+    Method,
+    Variable,
+    Constant,
+    Field,
+    Label,
+    Format,
+    Module,
+    GeneratedMember,
+    ExternalSymbol,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum OccurrenceKind {
+    Definition,
+    Reference,
+    Read,
+    Write,
+    Call,
+    MethodCall,
+    StaticMethodCall,
+    Import,
+    Export,
+    Inheritance,
+    RoleComposition,
+    GeneratedUse,
+    DynamicBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum EdgeKind {
+    Defines,
+    References,
+    Reads,
+    Writes,
+    Calls,
+    ImportsModule,
+    ImportsSymbol,
+    ExportsSymbol,
+    ExportsGroup,
+    Inherits,
+    ComposesRole,
+    MemberOf,
+    GeneratedFrom,
+    AliasOf,
+    DependsOn,
+    DynamicBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Provenance {
+    ExactAst,
+    DesugaredAst,
+    SemanticAnalyzer,
+    FrameworkSynthesis,
+    ImportExportInference,
+    PragmaInference,
+    NameHeuristic,
+    SearchFallback,
+    DynamicBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Confidence {
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AnchorFact {
+    pub id: AnchorId,
+    pub file_id: FileId,
+    pub scope_id: Option<ScopeId>,
+    pub start_byte: u32,
+    pub end_byte: u32,
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EntityFact {
+    pub id: EntityId,
+    pub kind: EntityKind,
+    pub canonical_name: String,
+    pub display_name: String,
+    pub defining_scope_id: Option<ScopeId>,
+    pub anchor_id: Option<AnchorId>,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+    pub attributes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct OccurrenceFact {
+    pub id: OccurrenceId,
+    pub entity_id: EntityId,
+    pub anchor_id: AnchorId,
+    pub kind: OccurrenceKind,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EdgeFact {
+    pub id: EdgeId,
+    pub from_entity_id: EntityId,
+    pub to_entity_id: EntityId,
+    pub kind: EdgeKind,
+    pub anchor_id: Option<AnchorId>,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+    pub attributes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct DiagnosticFact {
+    pub id: DiagnosticId,
+    pub anchor_id: Option<AnchorId>,
+    pub code: String,
+    pub message: String,
+    pub severity: String,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+    pub attributes: BTreeMap<String, String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use anyhow::Result;
+
+    use super::*;
+
+    #[test]
+    fn typed_ids_serialize_as_json_strings() -> Result<()> {
+        let id = EntityId::new("entity:My::Class");
+        let payload = serde_json::to_string(&id)?;
+
+        assert_eq!(payload, "\"entity:My::Class\"");
+        assert_eq!(id.as_str(), "entity:My::Class");
+
+        Ok(())
+    }
+
+    #[test]
+    fn entity_fact_roundtrips_with_deterministic_map_order() -> Result<()> {
+        let mut attributes = BTreeMap::new();
+        attributes.insert(String::from("zeta"), String::from("last"));
+        attributes.insert(String::from("alpha"), String::from("first"));
+
+        let fact = EntityFact {
+            id: EntityId::from("entity:My::Role"),
+            kind: EntityKind::Role,
+            canonical_name: String::from("My::Role"),
+            display_name: String::from("My::Role"),
+            defining_scope_id: Some(ScopeId::from("scope:file:main")),
+            anchor_id: Some(AnchorId::from("anchor:42")),
+            provenance: Provenance::SemanticAnalyzer,
+            confidence: Confidence::High,
+            attributes,
+        };
+
+        let json = serde_json::to_string(&fact)?;
+        let reparsed: EntityFact = serde_json::from_str(&json)?;
+
+        assert_eq!(fact, reparsed);
+        assert!(json.contains("\"alpha\":\"first\",\"zeta\":\"last\""));
+
+        Ok(())
+    }
+
+    #[test]
+    fn debug_output_is_stable_for_snapshot_style_assertions() {
+        let mut attrs = BTreeMap::new();
+        attrs.insert(String::from("framework"), String::from("moose"));
+
+        let edge = EdgeFact {
+            id: EdgeId::from("edge:1"),
+            from_entity_id: EntityId::from("entity:A"),
+            to_entity_id: EntityId::from("entity:B"),
+            kind: EdgeKind::ComposesRole,
+            anchor_id: None,
+            provenance: Provenance::FrameworkSynthesis,
+            confidence: Confidence::Medium,
+            attributes: attrs,
+        };
+
+        let debug = format!("{edge:?}");
+
+        assert!(debug.contains("ComposesRole"));
+        assert!(debug.contains("framework"));
+    }
+}


### PR DESCRIPTION
### Motivation
- Semantic facts are currently represented across multiple crates and a single neutral interchange vocabulary is needed for cleaner cross-layer communication.
- Provide typed, stable IDs and serializable fact records so parser, analyzer, indexer, and exporters can exchange data without sharing storage or LSP concerns.
- Keep the new crate narrowly focused so it does not parse Perl, implement LSP providers, or own workspace persistence.

### Description
- Add a new crate at `crates/perl-semantic-facts` including `Cargo.toml`, `README.md`, and `src/lib.rs` as the neutral facts vocabulary.
- Implement typed stable IDs using a `typed_id!` macro and define `FileId`, `ScopeId`, `EntityId`, `AnchorId`, `OccurrenceId`, `EdgeId`, and `DiagnosticId`.
- Define enums `EntityKind`, `OccurrenceKind`, `EdgeKind`, `Provenance`, and `Confidence` plus fact records `AnchorFact`, `EntityFact`, `OccurrenceFact`, `EdgeFact`, and `DiagnosticFact` with `serde` derives and deterministic `BTreeMap` attributes for snapshot-friendly serialization.
- Register the crate in the workspace `Cargo.toml` and add focused unit tests for JSON shape, serialization roundtrip, and stable debug output without migrating any consumers.

### Testing
- Ran `cargo test -p perl-semantic-facts` and the test suite completed successfully (3 passed).
- Ran `cargo check --workspace --all-targets` and the workspace check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ae494e2083338bae2e2d542805f3)