### PR TITLE
feat(perl-semantic-facts): add neutral semantic facts foundation crate (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-semantic-facts"
+version = "0.12.4"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "perl-subprocess-runtime"
 version = "0.12.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/perl-parser-bench",
     "crates/perl-parser-core",
     "crates/perl-parser-pest",
+    "crates/perl-semantic-facts",
     "crates/perl-semantic-analyzer",
     "crates/perl-workspace-index",
     "crates/perl-refactoring",
@@ -252,6 +253,7 @@ perl-dead-code = { path = "crates/perl-dead-code", version = "0.12.4" }
 # (perl-feature-catalog absorbed into perl-lsp-rs-core::feature_catalog — Wave Final PR B)
 # Tier 2: Single-level dependencies
 perl-parser-core = { path = "crates/perl-parser-core", version = "0.12.4" }
+perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.12.4" }
 # (perl-lsp-transport absorbed into perl-lsp-rs-core::transport — Wave G3 step 4)
 # (perl-lsp-tooling absorbed into perl-lsp-rs-core::tooling — Wave G3 step 6)
 perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.12.4" }

--- a/crates/perl-semantic-facts/Cargo.toml
+++ b/crates/perl-semantic-facts/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "perl-semantic-facts"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Neutral semantic fact vocabulary for Perl analysis layers"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-semantic-facts"
+readme = "README.md"
+keywords = ["perl", "lsp", "semantic", "analysis", "facts"]
+categories = ["data-structures", "development-tools", "text-editors"]
+publish = true
+
+[lib]
+doctest = false
+
+[dependencies]
+serde = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/crates/perl-semantic-facts/README.md
+++ b/crates/perl-semantic-facts/README.md
@@ -1,0 +1,12 @@
+# perl-semantic-facts
+
+`perl-semantic-facts` defines a neutral, serializable vocabulary for semantic facts produced by
+Perl analysis layers.
+
+This crate intentionally does **not**:
+- parse Perl,
+- provide LSP handlers,
+- or own workspace storage/indexing.
+
+It provides stable typed IDs, fact records, provenance metadata, and confidence levels that can be
+shared between parser/semantic/indexing/provider components.

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -1,0 +1,229 @@
+//! Neutral semantic fact vocabulary shared across Perl analysis layers.
+//!
+//! This crate defines stable typed IDs and fact records that can be emitted by parsing,
+//! semantic analysis, import/export inference, and indexing subsystems.
+//!
+//! It intentionally does **not** parse Perl source, implement LSP providers, or own
+//! workspace-scale storage.
+
+use serde::{Deserialize, Serialize};
+
+macro_rules! semantic_id {
+    ($name:ident) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(pub u64);
+    };
+}
+
+semantic_id!(FileId);
+semantic_id!(ScopeId);
+semantic_id!(EntityId);
+semantic_id!(AnchorId);
+semantic_id!(OccurrenceId);
+semantic_id!(EdgeId);
+semantic_id!(DiagnosticId);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnchorFact {
+    pub id: AnchorId,
+    pub file_id: FileId,
+    pub start_byte: u32,
+    pub end_byte: u32,
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EntityFact {
+    pub id: EntityId,
+    pub kind: EntityKind,
+    pub canonical_name: String,
+    pub scope_id: Option<ScopeId>,
+    pub anchor_id: Option<AnchorId>,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OccurrenceFact {
+    pub id: OccurrenceId,
+    pub entity_id: EntityId,
+    pub anchor_id: AnchorId,
+    pub kind: OccurrenceKind,
+    pub file_id: FileId,
+    pub scope_id: Option<ScopeId>,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EdgeFact {
+    pub id: EdgeId,
+    pub source: EntityId,
+    pub target: EntityId,
+    pub kind: EdgeKind,
+    pub anchor_id: Option<AnchorId>,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiagnosticFact {
+    pub id: DiagnosticId,
+    pub file_id: FileId,
+    pub anchor_id: Option<AnchorId>,
+    pub message: String,
+    pub code: Option<String>,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum EntityKind {
+    Package,
+    Class,
+    Role,
+    Subroutine,
+    Method,
+    Variable,
+    Constant,
+    Field,
+    Label,
+    Format,
+    Module,
+    GeneratedMember,
+    ExternalSymbol,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum OccurrenceKind {
+    Definition,
+    Reference,
+    Read,
+    Write,
+    Call,
+    MethodCall,
+    StaticMethodCall,
+    Import,
+    Export,
+    Inheritance,
+    RoleComposition,
+    GeneratedUse,
+    DynamicBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum EdgeKind {
+    Defines,
+    References,
+    Reads,
+    Writes,
+    Calls,
+    ImportsModule,
+    ImportsSymbol,
+    ExportsSymbol,
+    ExportsGroup,
+    Inherits,
+    ComposesRole,
+    MemberOf,
+    GeneratedFrom,
+    AliasOf,
+    DependsOn,
+    DynamicBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum Provenance {
+    ExactAst,
+    DesugaredAst,
+    SemanticAnalyzer,
+    FrameworkSynthesis,
+    ImportExportInference,
+    PragmaInference,
+    NameHeuristic,
+    SearchFallback,
+    DynamicBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum Confidence {
+    Confirmed,
+    High,
+    Medium,
+    Low,
+    Unknown,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    #[test]
+    fn typed_ids_are_distinct_and_ordered() -> TestResult {
+        let file = FileId(10);
+        let entity = EntityId(10);
+        assert_eq!(file.0, 10);
+        assert_eq!(entity.0, 10);
+        assert!(EdgeId(2) > EdgeId(1));
+        Ok(())
+    }
+
+    #[test]
+    fn entity_fact_roundtrips_through_json() -> TestResult {
+        let fact = EntityFact {
+            id: EntityId(42),
+            kind: EntityKind::Method,
+            canonical_name: "My::Class::run".to_string(),
+            scope_id: Some(ScopeId(7)),
+            anchor_id: Some(AnchorId(11)),
+            provenance: Provenance::SemanticAnalyzer,
+            confidence: Confidence::High,
+        };
+
+        let json = serde_json::to_string(&fact)?;
+        let restored: EntityFact = serde_json::from_str(&json)?;
+        assert_eq!(restored, fact);
+        Ok(())
+    }
+
+    #[test]
+    fn deterministic_debug_output_for_snapshots() -> TestResult {
+        let edge = EdgeFact {
+            id: EdgeId(3),
+            source: EntityId(1),
+            target: EntityId(2),
+            kind: EdgeKind::Calls,
+            anchor_id: Some(AnchorId(5)),
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::Confirmed,
+        };
+
+        let debug = format!("{edge:?}");
+        assert_eq!(
+            debug,
+            "EdgeFact { id: EdgeId(3), source: EntityId(1), target: EntityId(2), kind: Calls, anchor_id: Some(AnchorId(5)), provenance: ExactAst, confidence: Confirmed }"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn all_kinds_serialize_with_stable_names() -> TestResult {
+        assert_eq!(serde_json::to_string(&EntityKind::GeneratedMember)?, "\"GeneratedMember\"");
+        assert_eq!(serde_json::to_string(&OccurrenceKind::StaticMethodCall)?, "\"StaticMethodCall\"");
+        assert_eq!(serde_json::to_string(&EdgeKind::ImportsSymbol)?, "\"ImportsSymbol\"");
+        assert_eq!(serde_json::to_string(&Provenance::ImportExportInference)?, "\"ImportExportInference\"");
+        assert_eq!(serde_json::to_string(&Confidence::Medium)?, "\"Medium\"");
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a single neutral, serializable vocabulary for semantic facts (typed stable IDs, provenance, confidence, and relation facts) so multiple analysis layers can interoperate without leaking parser/LSP or workspace storage concerns.

### Description

- Add a new crate `crates/perl-semantic-facts` with workspace-standard metadata, README, and docs config.
- Implement typed stable ID newtypes (`FileId`, `ScopeId`, `EntityId`, `AnchorId`, `OccurrenceId`, `EdgeId`, `DiagnosticId`) and core fact records (`AnchorFact`, `EntityFact`, `OccurrenceFact`, `EdgeFact`, `DiagnosticFact`) with `serde` support.
- Define enums for `EntityKind`, `OccurrenceKind`, `EdgeKind`, `Provenance`, and `Confidence` with `#[non_exhaustive]` to allow future extension.
- Wire the crate into the workspace `Cargo.toml` and add deterministic/debug/serialization unit tests covering roundtrip and stable JSON/debug output.

### Testing

- Ran `cargo test -p perl-semantic-facts`, which passed (4 tests: typed ID behavior, JSON roundtrip, deterministic debug format, stable enum serialization).
- Ran `cargo check --workspace --all-targets` in this environment which completed for the workspace; a subsequent re-run encountered a transient Cargo build-directory file-lock unrelated to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ae494e2083338bae2e2d542805f3)