### PR TITLE
feat(perl-semantic-facts): add neutral semantic fact foundation (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-semantic-facts"
+version = "0.12.4"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "perl-subprocess-runtime"
 version = "0.12.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/perl-parser-core",
     "crates/perl-parser-pest",
     "crates/perl-semantic-analyzer",
+    "crates/perl-semantic-facts",
     "crates/perl-workspace-index",
     "crates/perl-refactoring",
     "crates/perl-incremental-parsing",
@@ -291,6 +292,7 @@ perl-refactoring = { path = "crates/perl-refactoring", version = "0.12.4" }
 
 # Tier 4: Three-level dependencies
 perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.12.4" }
+perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.12.4" }
 # (perl-lsp-providers absorbed into perl-lsp-rs-core::providers::lsp_compat — Wave G1b)
 
 # Tier 5: Application crates

--- a/crates/perl-semantic-facts/Cargo.toml
+++ b/crates/perl-semantic-facts/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "perl-semantic-facts"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Neutral semantic fact vocabulary for Perl analysis layers"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-semantic-facts"
+readme = "README.md"
+keywords = ["perl", "semantic", "facts", "lsp", "analysis"]
+categories = ["data-structures", "development-tools", "text-editors"]
+publish = true
+include = [
+  "src/**",
+  "Cargo.toml",
+  "README.md",
+  "LICENSE*",
+  "CLAUDE.md",
+]
+
+[lib]
+doctest = false
+
+[dependencies]
+serde = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/crates/perl-semantic-facts/README.md
+++ b/crates/perl-semantic-facts/README.md
@@ -1,0 +1,12 @@
+# perl-semantic-facts
+
+`perl-semantic-facts` defines a neutral, serializable semantic fact vocabulary shared
+across parsing, semantic analysis, and workspace indexing layers.
+
+This crate intentionally does **not**:
+- parse Perl source,
+- provide LSP behavior,
+- own workspace storage/index persistence.
+
+It provides stable typed identifiers, facts, confidence/provenance metadata, and enums
+for entity/occurrence/edge classification.

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -213,4 +213,37 @@ mod tests {
         );
         Ok(())
     }
+
+    /// Verify OccurrenceFact with a None entity_id round-trips correctly — this
+    /// exercises the optional foreign-key path that EntityFact's test does not cover.
+    #[test]
+    fn occurrence_fact_with_null_entity_id_roundtrips() -> Result<(), serde_json::Error> {
+        let fact = OccurrenceFact {
+            id: OccurrenceId(42),
+            kind: OccurrenceKind::Call,
+            entity_id: None,
+            anchor_id: AnchorId(10),
+            scope_id: Some(ScopeId(2)),
+            provenance: Provenance::NameHeuristic,
+            confidence: Confidence::Low,
+        };
+        let serialized = serde_json::to_string(&fact)?;
+        let decoded: OccurrenceFact = serde_json::from_str(&serialized)?;
+        assert_eq!(decoded, fact);
+        // entity_id: None must serialize as JSON null, not be omitted.
+        assert!(serialized.contains("\"entity_id\":null"), "entity_id null must be explicit in JSON");
+        Ok(())
+    }
+
+    /// Verify that u64::MAX is preserved through JSON serialization without
+    /// truncation — serde_json serializes u64 as a JSON number, which can
+    /// exceed JS safe-integer range but round-trips correctly in Rust.
+    #[test]
+    fn id_u64_max_roundtrips() -> Result<(), serde_json::Error> {
+        let id = EntityId(u64::MAX);
+        let serialized = serde_json::to_string(&id)?;
+        let decoded: EntityId = serde_json::from_str(&serialized)?;
+        assert_eq!(decoded, id);
+        Ok(())
+    }
 }

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -1,0 +1,216 @@
+//! Neutral semantic fact vocabulary for Perl analysis layers.
+//!
+//! This crate defines strongly-typed IDs and serializable fact records that can be shared
+//! between parser-derived semantics, semantic analyzer synthesis, and workspace indexing.
+//!
+//! It intentionally does **not** parse Perl, implement LSP providers, or own workspace
+//! storage backends.
+
+use serde::{Deserialize, Serialize};
+
+macro_rules! id_newtype {
+    ($name:ident) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+        pub struct $name(pub u64);
+    };
+}
+
+id_newtype!(FileId);
+id_newtype!(ScopeId);
+id_newtype!(EntityId);
+id_newtype!(AnchorId);
+id_newtype!(OccurrenceId);
+id_newtype!(EdgeId);
+id_newtype!(DiagnosticId);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum EntityKind {
+    Package,
+    Class,
+    Role,
+    Subroutine,
+    Method,
+    Variable,
+    Constant,
+    Field,
+    Label,
+    Format,
+    Module,
+    GeneratedMember,
+    ExternalSymbol,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum OccurrenceKind {
+    Definition,
+    Reference,
+    Read,
+    Write,
+    Call,
+    MethodCall,
+    StaticMethodCall,
+    Import,
+    Export,
+    Inheritance,
+    RoleComposition,
+    GeneratedUse,
+    DynamicBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum EdgeKind {
+    Defines,
+    References,
+    Reads,
+    Writes,
+    Calls,
+    ImportsModule,
+    ImportsSymbol,
+    ExportsSymbol,
+    ExportsGroup,
+    Inherits,
+    ComposesRole,
+    MemberOf,
+    GeneratedFrom,
+    AliasOf,
+    DependsOn,
+    DynamicBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Provenance {
+    ExactAst,
+    DesugaredAst,
+    SemanticAnalyzer,
+    FrameworkSynthesis,
+    ImportExportInference,
+    PragmaInference,
+    NameHeuristic,
+    SearchFallback,
+    DynamicBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Confidence {
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnchorFact {
+    pub id: AnchorId,
+    pub file_id: FileId,
+    pub span_start_byte: u32,
+    pub span_end_byte: u32,
+    pub scope_id: Option<ScopeId>,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EntityFact {
+    pub id: EntityId,
+    pub kind: EntityKind,
+    pub canonical_name: String,
+    pub anchor_id: Option<AnchorId>,
+    pub scope_id: Option<ScopeId>,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OccurrenceFact {
+    pub id: OccurrenceId,
+    pub kind: OccurrenceKind,
+    pub entity_id: Option<EntityId>,
+    pub anchor_id: AnchorId,
+    pub scope_id: Option<ScopeId>,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EdgeFact {
+    pub id: EdgeId,
+    pub kind: EdgeKind,
+    pub from_entity_id: EntityId,
+    pub to_entity_id: EntityId,
+    pub via_occurrence_id: Option<OccurrenceId>,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiagnosticFact {
+    pub id: DiagnosticId,
+    pub code: Option<String>,
+    pub message: String,
+    pub primary_anchor_id: AnchorId,
+    pub related_anchor_ids: Vec<AnchorId>,
+    pub scope_id: Option<ScopeId>,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entity_fact_roundtrips_through_json() -> Result<(), serde_json::Error> {
+        let fact = EntityFact {
+            id: EntityId(100),
+            kind: EntityKind::Method,
+            canonical_name: "Foo::bar".to_string(),
+            anchor_id: Some(AnchorId(12)),
+            scope_id: Some(ScopeId(3)),
+            provenance: Provenance::SemanticAnalyzer,
+            confidence: Confidence::High,
+        };
+
+        let serialized = serde_json::to_string(&fact)?;
+        let decoded: EntityFact = serde_json::from_str(&serialized)?;
+        assert_eq!(decoded, fact);
+        Ok(())
+    }
+
+    #[test]
+    fn deterministic_debug_for_edge_fact() {
+        let fact = EdgeFact {
+            id: EdgeId(7),
+            kind: EdgeKind::Calls,
+            from_entity_id: EntityId(11),
+            to_entity_id: EntityId(22),
+            via_occurrence_id: Some(OccurrenceId(33)),
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::Medium,
+        };
+
+        assert_eq!(
+            format!("{fact:?}"),
+            "EdgeFact { id: EdgeId(7), kind: Calls, from_entity_id: EntityId(11), to_entity_id: EntityId(22), via_occurrence_id: Some(OccurrenceId(33)), provenance: ExactAst, confidence: Medium }"
+        );
+    }
+
+    #[test]
+    fn pretty_json_for_anchor_fact_is_stable() -> Result<(), serde_json::Error> {
+        let fact = AnchorFact {
+            id: AnchorId(5),
+            file_id: FileId(1),
+            span_start_byte: 10,
+            span_end_byte: 15,
+            scope_id: None,
+            provenance: Provenance::DesugaredAst,
+            confidence: Confidence::Low,
+        };
+
+        let json = serde_json::to_string_pretty(&fact)?;
+        assert_eq!(
+            json,
+            "{\n  \"id\": 5,\n  \"file_id\": 1,\n  \"span_start_byte\": 10,\n  \"span_end_byte\": 15,\n  \"scope_id\": null,\n  \"provenance\": \"DesugaredAst\",\n  \"confidence\": \"Low\"\n}"
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a neutral, serializable vocabulary for semantic facts so parser, analyzer, and workspace layers can share a stable API. 
- Keep this crate limited to typed stable IDs, facts, provenance, and confidence metadata without parsing, LSP behavior, or workspace storage responsibilities. 
- Make the initial slice reviewable and testable before any consumer migration.

### Description

- Added a new crate `crates/perl-semantic-facts` with `Cargo.toml`, `README.md`, and `src/lib.rs` implementing typed IDs (`FileId`, `ScopeId`, `EntityId`, `AnchorId`, `OccurrenceId`, `EdgeId`, `DiagnosticId`) and fact records (`AnchorFact`, `EntityFact`, `OccurrenceFact`, `EdgeFact`, `DiagnosticFact`).
- Implemented core enums `EntityKind`, `OccurrenceKind`, `EdgeKind`, `Provenance`, and `Confidence` and derived `Serialize`/`Deserialize` for serialization support via `serde`.
- Added crate-level docs and a README that state the crate is a neutral facts vocabulary and does not parse Perl or own workspace storage.
- Wired the crate into the workspace `Cargo.toml` and updated lockfile entries so the new crate builds independently.

### Testing

- Ran `cargo test -p perl-semantic-facts` and the unit tests passed (3 tests: JSON roundtrip, deterministic `Debug`, pretty-JSON stability).
- Ran `cargo check -p perl-semantic-facts` which finished successfully.
- Ran `cargo check --workspace --all-targets` which completed; it reported pre-existing workspace warnings unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ae494e2083338bae2e2d542805f3)