### PR TITLE
feat(xtask): add semantic fixture scorecard harness (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ For a full walkthrough, see [Getting Started](docs/tutorials/GETTING_STARTED.md)
 cargo test --workspace --lib
 cargo xtask fmt
 cargo clippy --workspace
+cargo xtask semantic-scorecard   # semantic fixture baseline (compiler-lite harness)
 nix develop -c just ci-gate   # required before merge
 ```
 

--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/manifest.toml
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/manifest.toml
@@ -1,0 +1,73 @@
+metrics = [
+  "definition_hit_at_1",
+  "definition_hit_at_5",
+  "reference_precision",
+  "reference_recall",
+  "completion_top1",
+  "completion_top5",
+  "undefined_symbol_false_positive_rate",
+  "rename_unsafe_edit_count",
+  "safe_delete_external_ref_detection",
+  "query_latency_p50",
+  "query_latency_p95",
+]
+
+[[fixtures]]
+id = "autoload-dynamic-boundary"
+family = "AUTOLOAD dynamic boundary"
+description = "Calls resolved only via AUTOLOAD remain dynamic and should not report hard references."
+
+[[fixtures]]
+id = "dynamic-require-boundary"
+family = "dynamic require boundary"
+description = "Runtime-built require strings should be treated as unresolved module loads."
+
+[[fixtures]]
+id = "empty-import-suppression"
+family = "empty import suppression"
+description = "Do not emit undefined symbol diagnostics for intentionally empty import lists."
+
+[[fixtures]]
+id = "eval-string-dynamic-boundary"
+family = "eval STRING dynamic boundary"
+description = "Symbols introduced through eval STRING stay behind an analysis boundary."
+
+[[fixtures]]
+id = "export-tag-expansion"
+family = "export tag expansion"
+description = "Import tags (e.g. :all) expand to concrete exported subroutines."
+
+[[fixtures]]
+id = "generated-accessor"
+family = "generated accessor"
+description = "Moose/Moo-style generated accessors should resolve to generated symbol definitions."
+
+[[fixtures]]
+id = "imported-function-visibility"
+family = "imported function visibility"
+description = "Imported subs from external packages should be visible to completion and goto-definition."
+
+[[fixtures]]
+id = "inherited-method"
+family = "inherited method"
+description = "Method lookup should traverse inheritance parents for references and navigation."
+
+[[fixtures]]
+id = "qualified-vs-bare-references"
+family = "qualified vs bare references"
+description = "Qualified calls and bare calls to the same sub are grouped into the same symbol identity when safe."
+
+[[fixtures]]
+id = "role-method"
+family = "role method"
+description = "Composed role methods should surface in completion/reference queries on consuming classes."
+
+[[fixtures]]
+id = "same-bare-sub-two-packages"
+family = "same bare sub in two packages"
+description = "Disambiguate bare sub names that appear in sibling packages."
+
+[[fixtures]]
+id = "typeglob-alias"
+family = "typeglob alias"
+description = "Typeglob-assigned aliases should propagate definition/reference mapping."

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1142,6 +1142,13 @@ enum Commands {
         ratchet_check: bool,
     },
 
+    /// Emit the semantic fixture/metric scorecard baseline as deterministic JSON.
+    SemanticScorecard {
+        /// Optional path to semantic fixture manifest TOML.
+        #[arg(long)]
+        manifest: Option<PathBuf>,
+    },
+
     /// Validate memory profiling functionality
     ValidateMemoryProfiler,
 
@@ -2163,6 +2170,7 @@ fn main() -> Result<()> {
             };
             ux_scorecard::run(format, input, output, status_md, ratchet_check)
         }
+        Commands::SemanticScorecard { manifest } => semantic_scorecard::run(manifest),
         Commands::ValidateMemoryProfiler => compare::validate_memory_profiling(),
         Commands::E2eValidate { workspace_size, report, skip_workspace, skip_bench, verbose } => {
             e2e_validate::run(e2e_validate::E2eConfig {

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -83,6 +83,7 @@ pub mod release_evidence;
 pub mod release_notes;
 pub mod release_turnkey;
 pub mod review_receipts;
+pub mod semantic_scorecard;
 pub mod srp_microcrates;
 pub mod swarm_summary;
 pub mod targeted_checks;

--- a/xtask/src/tasks/semantic_scorecard.rs
+++ b/xtask/src/tasks/semantic_scorecard.rs
@@ -1,0 +1,89 @@
+use color_eyre::eyre::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::utils;
+
+const DEFAULT_MANIFEST: &str = "crates/perl-workspace-index/tests/fixtures/semantic_scorecard/manifest.toml";
+
+#[derive(Debug, Clone, Deserialize)]
+struct SemanticManifest {
+    fixtures: Vec<SemanticFixture>,
+    metrics: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SemanticFixture {
+    id: String,
+    family: String,
+    description: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+enum MetricStatus {
+    BaselinePending,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+struct FixtureMetric {
+    metric: String,
+    status: MetricStatus,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+struct FixtureScore {
+    fixture_id: String,
+    family: String,
+    description: String,
+    metrics: Vec<FixtureMetric>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct SemanticScorecard {
+    manifest_path: String,
+    fixture_count: usize,
+    metric_count: usize,
+    scores: Vec<FixtureScore>,
+}
+
+pub fn run(manifest: Option<PathBuf>) -> Result<()> {
+    let root = utils::project_root()?;
+    let manifest_path = manifest.unwrap_or_else(|| root.join(DEFAULT_MANIFEST));
+    let scorecard = load_scorecard(&manifest_path)?;
+    println!("{}", serde_json::to_string_pretty(&scorecard)?);
+    Ok(())
+}
+
+pub fn load_scorecard(manifest_path: &Path) -> Result<SemanticScorecard> {
+    let raw = fs::read_to_string(manifest_path)
+        .wrap_err_with(|| format!("reading semantic scorecard manifest: {}", manifest_path.display()))?;
+    let mut manifest: SemanticManifest = toml::from_str(&raw).wrap_err("parsing semantic scorecard manifest TOML")?;
+
+    manifest.fixtures.sort_by(|a, b| a.id.cmp(&b.id));
+    manifest.metrics.sort();
+
+    let scores = manifest
+        .fixtures
+        .into_iter()
+        .map(|fixture| FixtureScore {
+            fixture_id: fixture.id,
+            family: fixture.family,
+            description: fixture.description,
+            metrics: manifest
+                .metrics
+                .iter()
+                .cloned()
+                .map(|metric| FixtureMetric { metric, status: MetricStatus::BaselinePending })
+                .collect(),
+        })
+        .collect::<Vec<_>>();
+
+    Ok(SemanticScorecard {
+        manifest_path: manifest_path.strip_prefix(utils::project_root()?).unwrap_or(manifest_path).display().to_string(),
+        fixture_count: scores.len(),
+        metric_count: manifest.metrics.len(),
+        scores,
+    })
+}

--- a/xtask/tests/semantic_scorecard_tests.rs
+++ b/xtask/tests/semantic_scorecard_tests.rs
@@ -1,0 +1,21 @@
+use assert_cmd::Command;
+use color_eyre::Result;
+
+#[test]
+fn semantic_scorecard_is_deterministic_and_loads_fixtures() -> Result<()> {
+    let mut cmd = Command::cargo_bin("xtask")?;
+    let output = cmd.arg("semantic-scorecard").assert().success().get_output().stdout.clone();
+    let as_text = String::from_utf8(output)?;
+
+    assert!(as_text.contains("\"fixture_count\": 12"));
+    assert!(as_text.contains("\"metric_count\": 11"));
+    assert!(as_text.contains("\"definition_hit_at_1\""));
+    assert!(as_text.contains("\"baseline_pending\""));
+
+    let mut second = Command::cargo_bin("xtask")?;
+    let second_output = second.arg("semantic-scorecard").assert().success().get_output().stdout.clone();
+    let second_text = String::from_utf8(second_output)?;
+    assert_eq!(as_text, second_text, "scorecard output must be deterministic");
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Provide a deterministic, repo-first harness to track semantic (compiler-lite) improvements across completion, diagnostics, navigation, references, rename, and safe-delete without depending on a new `perl-semantic-facts` crate. 

### Description

- Add a new `xtask` subcommand `semantic-scorecard` implemented in `xtask/src/tasks/semantic_scorecard.rs` that loads a manifest, sorts fixtures and metrics for stable output, and emits JSON with `baseline_pending` metric slots. 
- Wire the command into the CLI by adding `SemanticScorecard` to the `Commands` enum and a match arm in `xtask/src/main.rs`, and register the module in `xtask/src/tasks/mod.rs`. 
- Add a manifest of semantic fixtures and metrics at `crates/perl-workspace-index/tests/fixtures/semantic_scorecard/manifest.toml` covering the requested fixture families and metric names. 
- Add an integration test `xtask/tests/semantic_scorecard_tests.rs` that runs `cargo run -p xtask -- semantic-scorecard` via `assert_cmd` and verifies deterministic output, and update `README.md` to document the new command. 

### Testing

- Ran `cargo test -p xtask --test semantic_scorecard_tests` and the test passed.
- Ran `cargo xtask semantic-scorecard` and it produced deterministic JSON output (printed to stdout) as expected.
- Ran `cargo check --workspace --all-targets` and the workspace type-check succeeded.
- An initial `cargo test -p xtask` run failed due to a missing match arm while wiring the command; the wiring was fixed and all targeted automated tests above passed after the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ae4e882c8333b8c342bca506b9af)