### PR TITLE
feat(xtask): add semantic fixture scorecard harness (#0000)

### DIFF
--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/autoload_dynamic_boundary.pl
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/autoload_dynamic_boundary.pl
@@ -1,0 +1,1 @@
+# placeholder fixture: autoload_dynamic_boundary

--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/dynamic_require_boundary.pl
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/dynamic_require_boundary.pl
@@ -1,0 +1,1 @@
+# placeholder fixture: dynamic_require_boundary

--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/empty_import_suppression.pl
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/empty_import_suppression.pl
@@ -1,0 +1,1 @@
+# placeholder fixture: empty_import_suppression

--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/eval_string_dynamic_boundary.pl
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/eval_string_dynamic_boundary.pl
@@ -1,0 +1,1 @@
+# placeholder fixture: eval_string_dynamic_boundary

--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/export_tag_expansion.pl
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/export_tag_expansion.pl
@@ -1,0 +1,1 @@
+# placeholder fixture: export_tag_expansion

--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/generated_accessor.pl
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/generated_accessor.pl
@@ -1,0 +1,1 @@
+# placeholder fixture: generated_accessor

--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/imported_function_visibility.pl
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/imported_function_visibility.pl
@@ -1,0 +1,1 @@
+# placeholder fixture: imported_function_visibility

--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/inherited_method.pl
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/inherited_method.pl
@@ -1,0 +1,1 @@
+# placeholder fixture: inherited_method

--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/manifest.json
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/manifest.json
@@ -1,0 +1,17 @@
+{
+  "fixture_family_version": 1,
+  "fixtures": [
+    {"id": "autoload_dynamic_boundary", "family": "AUTOLOAD dynamic boundary", "path": "fixtures/autoload_dynamic_boundary.pl"},
+    {"id": "dynamic_require_boundary", "family": "dynamic require boundary", "path": "fixtures/dynamic_require_boundary.pl"},
+    {"id": "empty_import_suppression", "family": "empty import suppression", "path": "fixtures/empty_import_suppression.pl"},
+    {"id": "eval_string_dynamic_boundary", "family": "eval STRING dynamic boundary", "path": "fixtures/eval_string_dynamic_boundary.pl"},
+    {"id": "export_tag_expansion", "family": "export tag expansion", "path": "fixtures/export_tag_expansion.pl"},
+    {"id": "generated_accessor", "family": "generated accessor", "path": "fixtures/generated_accessor.pl"},
+    {"id": "imported_function_visibility", "family": "imported function visibility", "path": "fixtures/imported_function_visibility.pl"},
+    {"id": "inherited_method", "family": "inherited method", "path": "fixtures/inherited_method.pl"},
+    {"id": "qualified_vs_bare_references", "family": "qualified vs bare references", "path": "fixtures/qualified_vs_bare_references.pl"},
+    {"id": "role_method", "family": "role method", "path": "fixtures/role_method.pl"},
+    {"id": "same_bare_sub_two_packages", "family": "same bare sub in two packages", "path": "fixtures/same_bare_sub_two_packages.pl"},
+    {"id": "typeglob_alias", "family": "typeglob alias", "path": "fixtures/typeglob_alias.pl"}
+  ]
+}

--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/qualified_vs_bare_references.pl
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/qualified_vs_bare_references.pl
@@ -1,0 +1,1 @@
+# placeholder fixture: qualified_vs_bare_references

--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/role_method.pl
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/role_method.pl
@@ -1,0 +1,1 @@
+# placeholder fixture: role_method

--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/same_bare_sub_two_packages.pl
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/same_bare_sub_two_packages.pl
@@ -1,0 +1,1 @@
+# placeholder fixture: same_bare_sub_two_packages

--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/typeglob_alias.pl
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/typeglob_alias.pl
@@ -1,0 +1,1 @@
+# placeholder fixture: typeglob_alias

--- a/docs/project/status/semantic_scorecard.md
+++ b/docs/project/status/semantic_scorecard.md
@@ -1,0 +1,38 @@
+# Semantic Scorecard
+
+Measured: `deterministic-fixture-baseline`  
+Fixture family version: `1`  
+Fixtures loaded: `12`
+
+## Fixture IDs
+
+- `autoload_dynamic_boundary`
+- `dynamic_require_boundary`
+- `empty_import_suppression`
+- `eval_string_dynamic_boundary`
+- `export_tag_expansion`
+- `generated_accessor`
+- `imported_function_visibility`
+- `inherited_method`
+- `qualified_vs_bare_references`
+- `role_method`
+- `same_bare_sub_two_packages`
+- `typeglob_alias`
+
+## Metrics
+
+| Metric | Status | Value |
+|---|---|---:|
+| completion_top1 | baseline_pending | n/a |
+| completion_top5 | baseline_pending | n/a |
+| definition_hit_at_1 | baseline_pending | n/a |
+| definition_hit_at_5 | baseline_pending | n/a |
+| query_latency_p50 | baseline_pending | n/a |
+| query_latency_p95 | baseline_pending | n/a |
+| reference_precision | baseline_pending | n/a |
+| reference_recall | baseline_pending | n/a |
+| rename_unsafe_edit_count | baseline_pending | n/a |
+| safe_delete_external_ref_detection | baseline_pending | n/a |
+| undefined_symbol_false_positive_rate | baseline_pending | n/a |
+
+Initial harness: metrics intentionally baseline_pending until semantic facts land.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1142,6 +1142,19 @@ enum Commands {
         ratchet_check: bool,
     },
 
+
+    /// Publish semantic fixture scorecard artifact/status.
+    SemanticScorecard {
+        /// Optional path to semantic fixture manifest JSON.
+        #[arg(long)]
+        manifest: Option<PathBuf>,
+        /// Optional path to emitted scorecard JSON artifact.
+        #[arg(long)]
+        output: Option<PathBuf>,
+        /// Optional path to generated status markdown.
+        #[arg(long)]
+        status_md: Option<PathBuf>,
+    },
     /// Validate memory profiling functionality
     ValidateMemoryProfiler,
 
@@ -2162,6 +2175,9 @@ fn main() -> Result<()> {
                 UxScorecardOutputFormat::Json => UxScorecardFormat::Json,
             };
             ux_scorecard::run(format, input, output, status_md, ratchet_check)
+        }
+        Commands::SemanticScorecard { manifest, output, status_md } => {
+            semantic_scorecard::run(manifest, output, status_md)
         }
         Commands::ValidateMemoryProfiler => compare::validate_memory_profiling(),
         Commands::E2eValidate { workspace_size, report, skip_workspace, skip_bench, verbose } => {

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -84,6 +84,7 @@ pub mod release_notes;
 pub mod release_turnkey;
 pub mod review_receipts;
 pub mod srp_microcrates;
+pub mod semantic_scorecard;
 pub mod swarm_summary;
 pub mod targeted_checks;
 pub mod test;

--- a/xtask/src/tasks/semantic_scorecard.rs
+++ b/xtask/src/tasks/semantic_scorecard.rs
@@ -33,7 +33,11 @@ struct SemanticManifest {
 #[derive(Debug, Deserialize)]
 struct FixtureCase {
     id: String,
+    /// Fixture family label (reserved for future grouping/filtering).
+    #[allow(dead_code)]
     family: String,
+    /// Relative path to the fixture file (reserved for future harness use).
+    #[allow(dead_code)]
     path: String,
 }
 
@@ -65,6 +69,9 @@ pub fn run(manifest: Option<PathBuf>, output: Option<PathBuf>, status_md: Option
     let artifact = build_artifact(manifest);
 
     write_json(&output_path, &artifact)?;
+    if let Some(parent) = status_path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
     fs::write(&status_path, render_status_markdown(&artifact))
         .with_context(|| format!("writing {}", status_path.display()))?;
 
@@ -135,8 +142,10 @@ fn render_status_markdown(artifact: &Artifact) -> String {
 mod tests {
     use super::*;
 
+    /// Verify build_artifact preserves insertion order of fixture IDs and emits
+    /// all expected metric rows as baseline_pending.
     #[test]
-    fn scorecard_is_deterministic() -> Result<()> {
+    fn build_artifact_preserves_fixture_order_and_emits_all_metrics() -> Result<()> {
         let manifest = SemanticManifest {
             fixture_family_version: 1,
             fixtures: vec![
@@ -145,12 +154,35 @@ mod tests {
             ],
         };
         let artifact = build_artifact(manifest);
+
+        // Fixture IDs are preserved in input order (sorting is load_manifest's job).
         assert_eq!(artifact.measured_at, "deterministic-fixture-baseline");
         assert_eq!(artifact.fixture_ids, vec!["b".to_string(), "a".to_string()]);
-        assert!(artifact.rows.values().all(|row| row.status == "baseline_pending"));
+        assert_eq!(artifact.fixture_count, 2);
+
+        // All 11 canonical metric rows must be present and set to baseline_pending.
+        assert_eq!(artifact.rows.len(), METRICS.len(), "row count must match METRICS constant");
+        for &metric_name in METRICS {
+            let row = artifact.rows.get(metric_name).unwrap_or_else(|| {
+                panic!("expected metric '{metric_name}' to be present in artifact rows")
+            });
+            assert_eq!(
+                row.status, "baseline_pending",
+                "metric '{metric_name}' should be baseline_pending"
+            );
+            assert!(row.value.is_none(), "metric '{metric_name}' value should be None at baseline");
+        }
+
+        // Rows are in alphabetical order (BTreeMap) — spot-check boundary keys.
+        let keys: Vec<&str> = artifact.rows.keys().map(String::as_str).collect();
+        assert_eq!(keys.first().copied(), Some("completion_top1"));
+        assert_eq!(keys.last().copied(), Some("undefined_symbol_false_positive_rate"));
+
         Ok(())
     }
 
+    /// Verify load_manifest sorts fixtures by id, making the pipeline deterministic
+    /// regardless of the order fixtures appear in the JSON file.
     #[test]
     fn manifest_load_sorts_fixtures() -> Result<()> {
         let tmp = tempfile::NamedTempFile::new()?;
@@ -161,6 +193,35 @@ mod tests {
         let parsed = load_manifest(tmp.path())?;
         assert_eq!(parsed.fixtures[0].id, "a");
         assert_eq!(parsed.fixtures[1].id, "z");
+        Ok(())
+    }
+
+    /// Verify that the full pipeline (load_manifest -> build_artifact) is stable
+    /// across two calls with the same manifest data in a different order: the
+    /// fixture IDs in the artifact must be identical both times.
+    #[test]
+    fn full_pipeline_is_stable_across_orderings() -> Result<()> {
+        let tmp_fwd = tempfile::NamedTempFile::new()?;
+        let tmp_rev = tempfile::NamedTempFile::new()?;
+        // Same two fixtures, different JSON order.
+        fs::write(
+            tmp_fwd.path(),
+            r#"{"fixture_family_version":1,"fixtures":[{"id":"alpha","family":"f","path":"a.pl"},{"id":"beta","family":"f","path":"b.pl"}]}"#,
+        )?;
+        fs::write(
+            tmp_rev.path(),
+            r#"{"fixture_family_version":1,"fixtures":[{"id":"beta","family":"f","path":"b.pl"},{"id":"alpha","family":"f","path":"a.pl"}]}"#,
+        )?;
+
+        let artifact_fwd = build_artifact(load_manifest(tmp_fwd.path())?);
+        let artifact_rev = build_artifact(load_manifest(tmp_rev.path())?);
+
+        // Both should produce the same sorted fixture list.
+        assert_eq!(
+            artifact_fwd.fixture_ids, artifact_rev.fixture_ids,
+            "fixture IDs must be identical regardless of input order"
+        );
+        assert_eq!(artifact_fwd.fixture_ids, vec!["alpha".to_string(), "beta".to_string()]);
         Ok(())
     }
 }

--- a/xtask/src/tasks/semantic_scorecard.rs
+++ b/xtask/src/tasks/semantic_scorecard.rs
@@ -1,0 +1,166 @@
+use crate::utils::project_root;
+use color_eyre::eyre::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DEFAULT_FIXTURE_MANIFEST: &str =
+    "crates/perl-workspace-index/tests/fixtures/semantic_scorecard/manifest.json";
+const DEFAULT_OUTPUT: &str = "target/receipts/metrics/semantic_scorecard.json";
+const DEFAULT_STATUS_MD: &str = "docs/project/status/semantic_scorecard.md";
+
+const METRICS: &[&str] = &[
+    "definition_hit_at_1",
+    "definition_hit_at_5",
+    "reference_precision",
+    "reference_recall",
+    "completion_top1",
+    "completion_top5",
+    "undefined_symbol_false_positive_rate",
+    "rename_unsafe_edit_count",
+    "safe_delete_external_ref_detection",
+    "query_latency_p50",
+    "query_latency_p95",
+];
+
+#[derive(Debug, Deserialize)]
+struct SemanticManifest {
+    fixture_family_version: u32,
+    fixtures: Vec<FixtureCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureCase {
+    id: String,
+    family: String,
+    path: String,
+}
+
+#[derive(Debug, Serialize)]
+struct MetricRow {
+    status: &'static str,
+    value: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+struct Artifact {
+    schema_version: u32,
+    measured_at: &'static str,
+    subsystem: &'static str,
+    fixture_family_version: u32,
+    fixture_count: usize,
+    fixture_ids: Vec<String>,
+    rows: BTreeMap<String, MetricRow>,
+    notes: &'static str,
+}
+
+pub fn run(manifest: Option<PathBuf>, output: Option<PathBuf>, status_md: Option<PathBuf>) -> Result<()> {
+    let root = project_root()?;
+    let manifest_path = root.join(manifest.unwrap_or_else(|| PathBuf::from(DEFAULT_FIXTURE_MANIFEST)));
+    let output_path = root.join(output.unwrap_or_else(|| PathBuf::from(DEFAULT_OUTPUT)));
+    let status_path = root.join(status_md.unwrap_or_else(|| PathBuf::from(DEFAULT_STATUS_MD)));
+
+    let manifest = load_manifest(&manifest_path)?;
+    let artifact = build_artifact(manifest);
+
+    write_json(&output_path, &artifact)?;
+    fs::write(&status_path, render_status_markdown(&artifact))
+        .with_context(|| format!("writing {}", status_path.display()))?;
+
+    println!("semantic scorecard updated: {}", output_path.display());
+    println!("status page updated: {}", status_path.display());
+    Ok(())
+}
+
+fn load_manifest(path: &Path) -> Result<SemanticManifest> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let mut parsed: SemanticManifest =
+        serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?;
+    parsed.fixtures.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(parsed)
+}
+
+fn build_artifact(manifest: SemanticManifest) -> Artifact {
+    let fixture_ids = manifest.fixtures.iter().map(|fixture| fixture.id.clone()).collect::<Vec<_>>();
+    let mut rows = BTreeMap::new();
+    for &metric in METRICS {
+        rows.insert(metric.to_string(), MetricRow { status: "baseline_pending", value: None });
+    }
+
+    Artifact {
+        schema_version: 1,
+        measured_at: "deterministic-fixture-baseline",
+        subsystem: "semantic",
+        fixture_family_version: manifest.fixture_family_version,
+        fixture_count: fixture_ids.len(),
+        fixture_ids,
+        rows,
+        notes: "Initial harness: metrics intentionally baseline_pending until semantic facts land.",
+    }
+}
+
+fn write_json(path: &Path, artifact: &Artifact) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let payload = serde_json::to_string_pretty(artifact)?;
+    fs::write(path, format!("{payload}\n")).with_context(|| format!("writing {}", path.display()))
+}
+
+fn render_status_markdown(artifact: &Artifact) -> String {
+    let mut text = String::new();
+    text.push_str("# Semantic Scorecard\n\n");
+    text.push_str(&format!("Measured: `{}`  \n", artifact.measured_at));
+    text.push_str(&format!("Fixture family version: `{}`  \n", artifact.fixture_family_version));
+    text.push_str(&format!("Fixtures loaded: `{}`\n\n", artifact.fixture_count));
+    text.push_str("## Fixture IDs\n\n");
+    for id in &artifact.fixture_ids {
+        text.push_str(&format!("- `{id}`\n"));
+    }
+
+    text.push_str("\n## Metrics\n\n| Metric | Status | Value |\n|---|---|---:|\n");
+    for (metric, row) in &artifact.rows {
+        let value = row.value.map(|n| n.to_string()).unwrap_or_else(|| "n/a".to_string());
+        text.push_str(&format!("| {metric} | {} | {value} |\n", row.status));
+    }
+
+    text.push_str("\n");
+    text.push_str(artifact.notes);
+    text.push('\n');
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scorecard_is_deterministic() -> Result<()> {
+        let manifest = SemanticManifest {
+            fixture_family_version: 1,
+            fixtures: vec![
+                FixtureCase { id: "b".to_string(), family: "x".to_string(), path: "b.pl".to_string() },
+                FixtureCase { id: "a".to_string(), family: "x".to_string(), path: "a.pl".to_string() },
+            ],
+        };
+        let artifact = build_artifact(manifest);
+        assert_eq!(artifact.measured_at, "deterministic-fixture-baseline");
+        assert_eq!(artifact.fixture_ids, vec!["b".to_string(), "a".to_string()]);
+        assert!(artifact.rows.values().all(|row| row.status == "baseline_pending"));
+        Ok(())
+    }
+
+    #[test]
+    fn manifest_load_sorts_fixtures() -> Result<()> {
+        let tmp = tempfile::NamedTempFile::new()?;
+        fs::write(
+            tmp.path(),
+            r#"{"fixture_family_version":1,"fixtures":[{"id":"z","family":"f","path":"z.pl"},{"id":"a","family":"f","path":"a.pl"}]}"#,
+        )?;
+        let parsed = load_manifest(tmp.path())?;
+        assert_eq!(parsed.fixtures[0].id, "a");
+        assert_eq!(parsed.fixtures[1].id, "z");
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a deterministic, lightweight harness and fixture surface for future semantic-fact work to measure improvements in navigation, references, completion, diagnostics, rename, and safe-delete without requiring the full `perl-semantic-facts` implementation.

### Description

- Add `xtask/src/tasks/semantic_scorecard.rs` implementing `cargo xtask semantic-scorecard` that loads a fixture manifest, emits a deterministic JSON artifact and a status Markdown page, and marks metric rows as `baseline_pending`.
- Wire the new `SemanticScorecard` command into the xtask CLI and register the task module in `xtask/src/main.rs` and `xtask/src/tasks/mod.rs`.
- Add a manifest and 12 placeholder fixtures under `crates/perl-workspace-index/tests/fixtures/semantic_scorecard/` covering the requested fixture families (AUTOLOAD, eval/require dynamic boundaries, imports/exports, generated accessors, typeglobs, role/inherited/qualified vs bare references, same bare sub, etc.).
- Emit an initial deterministic status document at `docs/project/status/semantic_scorecard.md` and include unit tests that verify manifest loading/sorting and deterministic baseline output.

### Testing

- Ran `cargo xtask semantic-scorecard` which completed successfully and wrote `target/receipts/metrics/semantic_scorecard.json` and `docs/project/status/semantic_scorecard.md`.
- Ran `cargo test -p xtask` where the new semantic scorecard tests executed, but the overall xtask test suite failed due to pre-existing/unrelated failures in `update_status`/`token` tests (542 passed; 7 failed). 
- Ran `cargo check --workspace --all-targets` which was executed and progressed across the workspace and reported warnings but produced no new compilation errors for the added code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ae4e882c8333b8c342bca506b9af)