### PR TITLE
feat(xtask): add semantic fixture scorecard harness (#0000)

### DIFF
--- a/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/fixtures.json
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_scorecard/fixtures.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "fixture_set": "compiler_lite_semantic_v1",
+  "fixtures": [
+    {"id":"autoload_dynamic_boundary","family":"autoload_dynamic_boundary","description":"Track AUTOLOAD as a dynamic resolution boundary.","entry_file":"autoload_dynamic_boundary.pl"},
+    {"id":"dynamic_require_boundary","family":"dynamic_require_boundary","description":"Require with runtime expression marks unknown symbol import set.","entry_file":"dynamic_require_boundary.pl"},
+    {"id":"empty_import_suppression","family":"empty_import_suppression","description":"Do not create symbols for explicit empty import lists.","entry_file":"empty_import_suppression.pl"},
+    {"id":"eval_string_dynamic_boundary","family":"eval_string_dynamic_boundary","description":"String eval should stay isolated behind dynamic boundary.","entry_file":"eval_string_dynamic_boundary.pl"},
+    {"id":"export_tag_expansion","family":"export_tag_expansion","description":"Expand export tags into imported symbols.","entry_file":"export_tag_expansion.pl"},
+    {"id":"generated_accessor","family":"generated_accessor","description":"Generated accessor methods should be tracked as synthetic symbols.","entry_file":"generated_accessor.pl"},
+    {"id":"imported_function_visibility","family":"imported_function_visibility","description":"Imported functions appear in bare call sites.","entry_file":"imported_function_visibility.pl"},
+    {"id":"inherited_method","family":"inherited_method","description":"Inherited methods resolve through package ancestry.","entry_file":"inherited_method.pl"},
+    {"id":"qualified_vs_bare_references","family":"qualified_vs_bare_references","description":"Distinguish Foo::bar from local bare bar references.","entry_file":"qualified_vs_bare_references.pl"},
+    {"id":"role_method","family":"role_method","description":"Role-composed methods resolve as callable methods.","entry_file":"role_method.pl"},
+    {"id":"same_bare_sub_in_two_packages","family":"same_bare_sub_in_two_packages","description":"Same sub name in two packages should keep package disambiguation.","entry_file":"same_bare_sub_in_two_packages.pl"},
+    {"id":"typeglob_alias","family":"typeglob_alias","description":"Typeglob aliasing should unify symbol identity for rename/ref queries.","entry_file":"typeglob_alias.pl"}
+  ],
+  "metrics": {
+    "completion_top1": {"status":"baseline_pending","unit":"ratio","value":null,"notes":"Pending semantic facts implementation."},
+    "completion_top5": {"status":"baseline_pending","unit":"ratio","value":null,"notes":"Pending semantic facts implementation."},
+    "definition_hit_at_1": {"status":"baseline_pending","unit":"ratio","value":null,"notes":"Pending semantic facts implementation."},
+    "definition_hit_at_5": {"status":"baseline_pending","unit":"ratio","value":null,"notes":"Pending semantic facts implementation."},
+    "query_latency_p50": {"status":"not_implemented","unit":"milliseconds","value":null,"notes":"Harness exists; latency sampling to be added."},
+    "query_latency_p95": {"status":"not_implemented","unit":"milliseconds","value":null,"notes":"Harness exists; latency sampling to be added."},
+    "reference_precision": {"status":"baseline_pending","unit":"ratio","value":null,"notes":"Pending semantic facts implementation."},
+    "reference_recall": {"status":"baseline_pending","unit":"ratio","value":null,"notes":"Pending semantic facts implementation."},
+    "rename_unsafe_edit_count": {"status":"not_implemented","unit":"count","value":null,"notes":"Awaiting rename safety oracle wiring."},
+    "safe_delete_external_ref_detection": {"status":"not_implemented","unit":"ratio","value":null,"notes":"Awaiting external-reference signal plumbing."},
+    "undefined_symbol_false_positive_rate": {"status":"baseline_pending","unit":"ratio","value":null,"notes":"Pending semantic facts implementation."}
+  }
+}

--- a/docs/project/metrics/semantic_fixture_scorecard.md
+++ b/docs/project/metrics/semantic_fixture_scorecard.md
@@ -1,0 +1,26 @@
+# Semantic fixture scorecard (compiler-lite harness)
+
+This harness seeds the semantic fixture surface for compiler-lite behavior, without requiring a
+`perl-semantic-facts` crate.
+
+## Run
+
+```bash
+cargo xtask semantic-scorecard
+cargo xtask semantic-scorecard --json
+```
+
+## Source of truth
+
+- Manifest: `crates/perl-workspace-index/tests/fixtures/semantic_scorecard/fixtures.json`
+- Loader + deterministic checks: `xtask/src/tasks/semantic_scorecard.rs`
+
+## Adding future semantic-fact scenarios
+
+1. Add a fixture row to `fixtures` in sorted `id` order.
+2. Add/update metric entries under `metrics`.
+3. Keep unsupported metrics as `status: not_implemented` or `baseline_pending` with `value: null`.
+4. Run `cargo test -p xtask` and `cargo xtask semantic-scorecard --json`.
+
+This guarantees stable, deterministic scorecard output while semantic facts are incrementally
+implemented.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1082,6 +1082,16 @@ enum Commands {
         only: Option<update_status::StatusSubsystem>,
     },
 
+    /// Run semantic fixture scorecard harness for compiler-lite behavior.
+    SemanticScorecard {
+        /// Optional path to semantic fixture manifest JSON.
+        #[arg(long)]
+        manifest: Option<PathBuf>,
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Generate SRP microcrate inventory and split-candidate report
     SrpMicrocrates {
         /// Optional output path (default: docs/SRP_MICROCRATES.md)
@@ -2156,6 +2166,7 @@ fn main() -> Result<()> {
             }
             MetricsCommand::SweepStats { input } => metrics::sweep_stats::run(input),
         },
+        Commands::SemanticScorecard { manifest, json } => tasks::semantic_scorecard::run(manifest, json),
         Commands::UxScorecard { format, input, output, status_md, ratchet_check } => {
             let format = match format {
                 UxScorecardOutputFormat::Human => UxScorecardFormat::Human,

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -84,6 +84,7 @@ pub mod release_notes;
 pub mod release_turnkey;
 pub mod review_receipts;
 pub mod srp_microcrates;
+pub mod semantic_scorecard;
 pub mod swarm_summary;
 pub mod targeted_checks;
 pub mod test;

--- a/xtask/src/tasks/semantic_scorecard.rs
+++ b/xtask/src/tasks/semantic_scorecard.rs
@@ -1,0 +1,106 @@
+use std::{collections::BTreeMap, fs, path::PathBuf};
+
+use color_eyre::eyre::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_MANIFEST: &str = "crates/perl-workspace-index/tests/fixtures/semantic_scorecard/fixtures.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SemanticFixture {
+    pub id: String,
+    pub family: String,
+    pub description: String,
+    pub entry_file: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SemanticScorecardManifest {
+    pub schema_version: u32,
+    pub fixture_set: String,
+    pub fixtures: Vec<SemanticFixture>,
+    pub metrics: BTreeMap<String, MetricDefinition>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MetricDefinition {
+    pub status: String,
+    pub unit: String,
+    pub value: Option<f64>,
+    pub notes: String,
+}
+
+pub fn run(manifest: Option<PathBuf>, json: bool) -> Result<()> {
+    let root = crate::utils::project_root()?;
+    let manifest_path = manifest.unwrap_or_else(|| root.join(DEFAULT_MANIFEST));
+    let scorecard = load_manifest(&manifest_path)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&scorecard)?);
+    } else {
+        println!("semantic fixture set: {}", scorecard.fixture_set);
+        println!("schema version: {}", scorecard.schema_version);
+        println!("fixtures: {}", scorecard.fixtures.len());
+        for fixture in &scorecard.fixtures {
+            println!("- {} [{}] {}", fixture.id, fixture.family, fixture.description);
+        }
+        println!("\nmetrics:");
+        for (name, metric) in &scorecard.metrics {
+            let rendered = metric
+                .value
+                .map(|value| format!("{value:.3}"))
+                .unwrap_or_else(|| "baseline pending".to_string());
+            println!("- {name}: {} ({rendered} {})", metric.status, metric.unit);
+        }
+    }
+
+    Ok(())
+}
+
+fn load_manifest(path: &PathBuf) -> Result<SemanticScorecardManifest> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("reading semantic scorecard manifest at {}", path.display()))?;
+    let manifest: SemanticScorecardManifest =
+        serde_json::from_str(&raw).context("parsing semantic scorecard manifest")?;
+    Ok(manifest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_has_required_metric_keys() -> Result<()> {
+        let root = crate::utils::project_root()?;
+        let manifest = load_manifest(&root.join(DEFAULT_MANIFEST))?;
+        let required = [
+            "definition_hit_at_1",
+            "definition_hit_at_5",
+            "reference_precision",
+            "reference_recall",
+            "completion_top1",
+            "completion_top5",
+            "undefined_symbol_false_positive_rate",
+            "rename_unsafe_edit_count",
+            "safe_delete_external_ref_detection",
+            "query_latency_p50",
+            "query_latency_p95",
+        ];
+
+        for key in required {
+            assert!(manifest.metrics.contains_key(key), "missing metric: {key}");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn fixture_ids_are_deterministically_sorted() -> Result<()> {
+        let root = crate::utils::project_root()?;
+        let manifest = load_manifest(&root.join(DEFAULT_MANIFEST))?;
+        let ids: Vec<&str> = manifest.fixtures.iter().map(|fixture| fixture.id.as_str()).collect();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        assert_eq!(ids, sorted);
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a deterministic, minimal semantic fixture and scorecard harness for compiler-lite behavior so future semantic-fact PRs have a stable test/measurement surface. 

### Description

- Add `xtask/src/tasks/semantic_scorecard.rs` implementing `run(manifest: Option<PathBuf>, json: bool)` which loads a versioned JSON manifest, prints human/JSON output, and tolerates `baseline_pending` / `not_implemented` metrics. 
- Wire a new `SemanticScorecard` command into the `xtask` CLI in `xtask/src/main.rs` and register the module in `xtask/src/tasks/mod.rs`. 
- Add a manifest at `crates/perl-workspace-index/tests/fixtures/semantic_scorecard/fixtures.json` with 12 semantic fixture families and the requested metric keys as placeholders. 
- Add documentation `docs/project/metrics/semantic_fixture_scorecard.md` describing how to run the harness and how to add future fixtures/metrics; include two deterministic unit tests in the task module that assert required metric keys and sorted fixture IDs.

### Testing

- Ran `cargo xtask semantic-scorecard` which completed successfully and printed deterministic human-readable output and JSON via `--json` as implemented. 
- Executed the new unit tests for the semantic scorecard (they run under `-p xtask`) and they passed; however `cargo test -p xtask` completed with 7 failing tests that are pre-existing/unrelated to this change. 
- Started `cargo check --workspace --all-targets` and it progressed through workspace compilation with warnings during verification in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ae4e882c8333b8c342bca506b9af)