### PR TITLE
fix(xtask): add semantic-scorecard check mode (#0000)

### DIFF
--- a/docs/project/status/semantic_scorecard.md
+++ b/docs/project/status/semantic_scorecard.md
@@ -36,3 +36,5 @@ Fixtures loaded: `12`
 | undefined_symbol_false_positive_rate | baseline_pending | n/a |
 
 Initial harness: metrics intentionally baseline_pending until semantic facts land.
+
+Verification note: treat `cargo test -p xtask semantic_scorecard`, `cargo xtask semantic-scorecard`, and `cargo xtask semantic-scorecard --check` as the targeted validation path while unrelated `xtask` tests remain noisy.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1153,6 +1153,9 @@ enum Commands {
         /// Optional path to generated status markdown.
         #[arg(long)]
         status_md: Option<PathBuf>,
+        /// Verify committed scorecard outputs are up-to-date.
+        #[arg(long)]
+        check: bool,
     },
     /// Validate memory profiling functionality
     ValidateMemoryProfiler,
@@ -2175,8 +2178,8 @@ fn main() -> Result<()> {
             };
             ux_scorecard::run(format, input, output, status_md, ratchet_check)
         }
-        Commands::SemanticScorecard { manifest, output, status_md } => {
-            semantic_scorecard::run(manifest, output, status_md)
+        Commands::SemanticScorecard { manifest, output, status_md, check } => {
+            semantic_scorecard::run(manifest, output, status_md, check)
         }
         Commands::ValidateMemoryProfiler => compare::validate_memory_profiling(),
         Commands::E2eValidate { workspace_size, report, skip_workspace, skip_bench, verbose } => {

--- a/xtask/src/tasks/semantic_scorecard.rs
+++ b/xtask/src/tasks/semantic_scorecard.rs
@@ -1,5 +1,5 @@
 use crate::utils::project_root;
-use color_eyre::eyre::{Context, Result};
+use color_eyre::eyre::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
@@ -63,6 +63,7 @@ pub fn run(
     manifest: Option<PathBuf>,
     output: Option<PathBuf>,
     status_md: Option<PathBuf>,
+    check: bool,
 ) -> Result<()> {
     let root = project_root()?;
     let manifest_path =
@@ -73,12 +74,22 @@ pub fn run(
     let manifest = load_manifest(&manifest_path)?;
     let artifact = build_artifact(manifest);
 
-    write_json(&output_path, &artifact)?;
-    if let Some(parent) = status_path.parent() {
-        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    let expected_json = format!("{}\n", serde_json::to_string_pretty(&artifact)?);
+    let expected_markdown = render_status_markdown(&artifact);
+
+    if check {
+        check_file_contents(&output_path, &expected_json)?;
+        check_file_contents(&status_path, &expected_markdown)?;
+        println!(
+            "semantic scorecard check passed: {} and {} are up-to-date",
+            output_path.display(),
+            status_path.display()
+        );
+        return Ok(());
     }
-    fs::write(&status_path, render_status_markdown(&artifact))
-        .with_context(|| format!("writing {}", status_path.display()))?;
+
+    write_json(&output_path, &expected_json)?;
+    write_markdown(&status_path, &expected_markdown)?;
 
     println!("semantic scorecard updated: {}", output_path.display());
     println!("status page updated: {}", status_path.display());
@@ -113,12 +124,29 @@ fn build_artifact(manifest: SemanticManifest) -> Artifact {
     }
 }
 
-fn write_json(path: &Path, artifact: &Artifact) -> Result<()> {
+fn write_json(path: &Path, payload: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
     }
-    let payload = serde_json::to_string_pretty(artifact)?;
-    fs::write(path, format!("{payload}\n")).with_context(|| format!("writing {}", path.display()))
+    fs::write(path, payload).with_context(|| format!("writing {}", path.display()))
+}
+
+fn write_markdown(path: &Path, markdown: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    fs::write(path, markdown).with_context(|| format!("writing {}", path.display()))
+}
+
+fn check_file_contents(path: &Path, expected: &str) -> Result<()> {
+    let actual = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    if actual != expected {
+        bail!(
+            "{} is stale; regenerate with `cargo xtask semantic-scorecard`",
+            path.display()
+        );
+    }
+    Ok(())
 }
 
 fn render_status_markdown(artifact: &Artifact) -> String {


### PR DESCRIPTION
### Motivation

- Provide a CI/review-friendly verification mode for the semantic scorecard so reviewers can detect stale committed artifacts instead of always regenerating them.
- Document a focused verification surface for the semantic scorecard while broader `xtask` test noise is addressed.

### Description

- Add a `--check` flag to the `SemanticScorecard` CLI and thread it through the dispatcher in `xtask/src/main.rs` to `semantic_scorecard::run`.
- Generate deterministic JSON and markdown in-memory and compare them to the committed files using `check_file_contents`, failing with a clear message if they diverge.
- Add `write_markdown`, change `write_json` to accept payload strings, and avoid overwriting files when `--check` is used.
- Update `docs/project/status/semantic_scorecard.md` with a verification note pointing reviewers to the targeted validation commands.

### Testing

- Attempted the targeted verification commands (`cargo xtask fmt --check`, `cargo test -p xtask semantic_scorecard`, `cargo check -p xtask --all-targets`) but execution was blocked by Cargo build-directory lock contention in this environment, preventing completion.
- The change is committed as `fix(xtask): add semantic-scorecard check mode (#0000)` and a PR record was created; local test attempts were made but blocked as noted.
- Unit tests in `xtask/src/tasks/semantic_scorecard.rs` were left intact and the added functions follow the existing error handling patterns so they should run under normal CI where the Cargo lock is absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d2ff2008833392b65e9e0282bf1f)