### PR TITLE
feat(xtask): add semantic-scorecard check mode (#0000)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1153,6 +1153,9 @@ enum Commands {
         /// Optional path to generated status markdown.
         #[arg(long)]
         status_md: Option<PathBuf>,
+        /// Verify committed scorecard outputs are up-to-date without writing files.
+        #[arg(long)]
+        check: bool,
     },
     /// Validate memory profiling functionality
     ValidateMemoryProfiler,
@@ -2175,8 +2178,8 @@ fn main() -> Result<()> {
             };
             ux_scorecard::run(format, input, output, status_md, ratchet_check)
         }
-        Commands::SemanticScorecard { manifest, output, status_md } => {
-            semantic_scorecard::run(manifest, output, status_md)
+        Commands::SemanticScorecard { manifest, output, status_md, check } => {
+            semantic_scorecard::run(manifest, output, status_md, check)
         }
         Commands::ValidateMemoryProfiler => compare::validate_memory_profiling(),
         Commands::E2eValidate { workspace_size, report, skip_workspace, skip_bench, verbose } => {

--- a/xtask/src/tasks/semantic_scorecard.rs
+++ b/xtask/src/tasks/semantic_scorecard.rs
@@ -1,5 +1,5 @@
 use crate::utils::project_root;
-use color_eyre::eyre::{Context, Result};
+use color_eyre::eyre::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
@@ -63,6 +63,7 @@ pub fn run(
     manifest: Option<PathBuf>,
     output: Option<PathBuf>,
     status_md: Option<PathBuf>,
+    check: bool,
 ) -> Result<()> {
     let root = project_root()?;
     let manifest_path =
@@ -73,12 +74,18 @@ pub fn run(
     let manifest = load_manifest(&manifest_path)?;
     let artifact = build_artifact(manifest);
 
-    write_json(&output_path, &artifact)?;
-    if let Some(parent) = status_path.parent() {
-        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    let json_payload = format!("{}\n", serde_json::to_string_pretty(&artifact)?);
+    let markdown_payload = render_status_markdown(&artifact);
+
+    if check {
+        verify_output(&output_path, &json_payload, "semantic scorecard JSON")?;
+        verify_output(&status_path, &markdown_payload, "semantic scorecard status markdown")?;
+        println!("semantic scorecard outputs are up-to-date");
+        return Ok(());
     }
-    fs::write(&status_path, render_status_markdown(&artifact))
-        .with_context(|| format!("writing {}", status_path.display()))?;
+
+    write_output(&output_path, &json_payload)?;
+    write_output(&status_path, &markdown_payload)?;
 
     println!("semantic scorecard updated: {}", output_path.display());
     println!("status page updated: {}", status_path.display());
@@ -113,12 +120,22 @@ fn build_artifact(manifest: SemanticManifest) -> Artifact {
     }
 }
 
-fn write_json(path: &Path, artifact: &Artifact) -> Result<()> {
+fn write_output(path: &Path, payload: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
     }
-    let payload = serde_json::to_string_pretty(artifact)?;
-    fs::write(path, format!("{payload}\n")).with_context(|| format!("writing {}", path.display()))
+    fs::write(path, payload).with_context(|| format!("writing {}", path.display()))
+}
+
+fn verify_output(path: &Path, expected: &str, label: &str) -> Result<()> {
+    let current = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    if current != expected {
+        bail!(
+            "{label} is stale at {}. Re-run `cargo xtask semantic-scorecard` and commit regenerated outputs.",
+            path.display()
+        );
+    }
+    Ok(())
 }
 
 fn render_status_markdown(artifact: &Artifact) -> String {


### PR DESCRIPTION
### Motivation

- Provide a CI-friendly `--check` mode for the semantic scorecard so committed JSON/markdown artifacts can be validated deterministically without mutating files.
- Fail fast with a clear regeneration instruction when committed scorecard outputs are stale to avoid accidental doc drift after Wave 1 merges.

### Description

- Add a `--check` flag to the `SemanticScorecard` CLI and wire it through `xtask` command parsing to the task runner (`xtask/src/main.rs`).
- Change `semantic_scorecard::run` to generate deterministic JSON and markdown payloads in-memory and either write them or, in `--check` mode, compare them to the committed files.
- Introduce `write_output` and `verify_output` helpers and use `color_eyre::eyre::bail!` to emit a clear message instructing the user to re-run and commit regenerated outputs when a diff is detected.
- Preserve existing behavior when not using `--check` by continuing to write the JSON and status markdown to disk.

### Testing

- Ran `cargo xtask semantic-scorecard --check`, which compiled `xtask` and executed the new check path with no errors observed in this environment.
- Ran `cargo check -p xtask --all-targets` to validate compilation of the changed code and observed successful progress through the workspace checks.
- `cargo test -p xtask semantic_scorecard` was attempted but was initially blocked by a concurrent build lock in this environment and could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d2ff2008833392b65e9e0282bf1f)