### PR TITLE
feat(xtask): add semantic-scorecard check mode (#0000)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1153,6 +1153,9 @@ enum Commands {
         /// Optional path to generated status markdown.
         #[arg(long)]
         status_md: Option<PathBuf>,
+        /// Check committed outputs without writing updates.
+        #[arg(long)]
+        check: bool,
     },
     /// Validate memory profiling functionality
     ValidateMemoryProfiler,
@@ -2175,8 +2178,8 @@ fn main() -> Result<()> {
             };
             ux_scorecard::run(format, input, output, status_md, ratchet_check)
         }
-        Commands::SemanticScorecard { manifest, output, status_md } => {
-            semantic_scorecard::run(manifest, output, status_md)
+        Commands::SemanticScorecard { manifest, output, status_md, check } => {
+            semantic_scorecard::run(manifest, output, status_md, check)
         }
         Commands::ValidateMemoryProfiler => compare::validate_memory_profiling(),
         Commands::E2eValidate { workspace_size, report, skip_workspace, skip_bench, verbose } => {

--- a/xtask/src/tasks/semantic_scorecard.rs
+++ b/xtask/src/tasks/semantic_scorecard.rs
@@ -1,5 +1,5 @@
 use crate::utils::project_root;
-use color_eyre::eyre::{Context, Result};
+use color_eyre::eyre::{Context, Result, eyre};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
@@ -63,6 +63,7 @@ pub fn run(
     manifest: Option<PathBuf>,
     output: Option<PathBuf>,
     status_md: Option<PathBuf>,
+    check: bool,
 ) -> Result<()> {
     let root = project_root()?;
     let manifest_path =
@@ -73,12 +74,22 @@ pub fn run(
     let manifest = load_manifest(&manifest_path)?;
     let artifact = build_artifact(manifest);
 
-    write_json(&output_path, &artifact)?;
-    if let Some(parent) = status_path.parent() {
-        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    let json_payload = render_json(&artifact)?;
+    let markdown_payload = render_status_markdown(&artifact);
+
+    if check {
+        check_output_matches(&output_path, &json_payload)?;
+        check_output_matches(&status_path, &markdown_payload)?;
+        println!(
+            "semantic scorecard is up-to-date: {} and {}",
+            output_path.display(),
+            status_path.display()
+        );
+        return Ok(());
     }
-    fs::write(&status_path, render_status_markdown(&artifact))
-        .with_context(|| format!("writing {}", status_path.display()))?;
+
+    write_payload(&output_path, &json_payload)?;
+    write_payload(&status_path, &markdown_payload)?;
 
     println!("semantic scorecard updated: {}", output_path.display());
     println!("status page updated: {}", status_path.display());
@@ -113,12 +124,28 @@ fn build_artifact(manifest: SemanticManifest) -> Artifact {
     }
 }
 
-fn write_json(path: &Path, artifact: &Artifact) -> Result<()> {
+fn render_json(artifact: &Artifact) -> Result<String> {
+    let payload = serde_json::to_string_pretty(artifact)?;
+    Ok(format!("{payload}\n"))
+}
+
+fn write_payload(path: &Path, payload: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
     }
-    let payload = serde_json::to_string_pretty(artifact)?;
-    fs::write(path, format!("{payload}\n")).with_context(|| format!("writing {}", path.display()))
+    fs::write(path, payload).with_context(|| format!("writing {}", path.display()))
+}
+
+fn check_output_matches(path: &Path, expected: &str) -> Result<()> {
+    let actual = fs::read_to_string(path)
+        .with_context(|| format!("reading {} (run without --check to regenerate)", path.display()))?;
+    if actual == expected {
+        return Ok(());
+    }
+    Err(eyre!(
+        "stale semantic scorecard output: {} (run `cargo xtask semantic-scorecard` to regenerate)",
+        path.display()
+    ))
 }
 
 fn render_status_markdown(artifact: &Artifact) -> String {


### PR DESCRIPTION
### Motivation

- The `semantic-scorecard` xtask always rewrote committed JSON/MD outputs, which prevented CI/review from deterministically detecting stale outputs without mutating the repo.

### Description

- Add a `--check` flag to the `SemanticScorecard` CLI wiring in `xtask/src/main.rs` to enable non-mutating validation mode.
- Update `xtask/src/tasks/semantic_scorecard.rs` to render deterministic JSON and markdown in memory and, when `--check` is passed, compare them to the committed files and fail with a clear error if they differ.
- Factor writing/rendering logic into `render_json`, `write_payload`, and `check_output_matches` helpers and preserve original write behavior when not using `--check`.
- Error messaging instructs contributors to run `cargo xtask semantic-scorecard` to regenerate outputs when stale.

### Testing

- Ran the repository formatter via `cargo xtask fmt` to ensure formatting is clean for the changes; formatting run exercised compilation across the workspace.
- Invoked `cargo test -p xtask semantic_scorecard`; compilation and test invocation completed, but the full test run in this environment was long-running and did not finish before the session ended, so recommend CI or a local `cargo test -p xtask semantic_scorecard` to verify final pass.
- Verification note: `cargo xtask semantic-scorecard --check` can now be used in CI to detect stale committed scorecard outputs without mutating files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d2ff2008833392b65e9e0282bf1f)