### PR TITLE
feat(perl-symbol): add SymbolDecl semantic facts adapter (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,7 @@ dependencies = [
  "criterion",
  "perl-ast",
  "perl-parser-core",
+ "perl-semantic-facts",
  "perl-tdd-support",
  "serde",
  "serde_json",

--- a/crates/perl-symbol/Cargo.toml
+++ b/crates/perl-symbol/Cargo.toml
@@ -28,6 +28,7 @@ doctest = false
 [dependencies]
 perl-ast = { workspace = true }
 serde = { workspace = true }
+perl-semantic-facts = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/perl-symbol/src/surface/mod.rs
+++ b/crates/perl-symbol/src/surface/mod.rs
@@ -29,6 +29,10 @@
 
 pub mod decl;
 pub mod r#ref;
+pub mod semantic_facts;
 
 pub use decl::{SymbolDecl, extract_symbol_decls};
 pub use r#ref::{SymbolRef, SymbolRefKind, extract_symbol_refs};
+pub use semantic_facts::{
+    SymbolDeclSemanticFacts, UnsupportedSymbolDecl, symbol_decls_to_semantic_facts,
+};

--- a/crates/perl-symbol/src/surface/semantic_facts.rs
+++ b/crates/perl-symbol/src/surface/semantic_facts.rs
@@ -1,0 +1,116 @@
+use crate::surface::decl::SymbolDecl;
+use crate::types::SymbolKind;
+use perl_semantic_facts::{
+    AnchorFact, AnchorId, Confidence, EdgeFact, EdgeId, EdgeKind, EntityFact, EntityId, EntityKind,
+    FileId, Provenance,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SymbolDeclSemanticFacts {
+    pub anchors: Vec<AnchorFact>,
+    pub entities: Vec<EntityFact>,
+    pub edges: Vec<EdgeFact>,
+    pub unsupported: Vec<UnsupportedSymbolDecl>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsupportedSymbolDecl {
+    pub symbol_name: String,
+    pub symbol_kind: SymbolKind,
+}
+
+pub fn symbol_decls_to_semantic_facts(
+    decls: &[SymbolDecl],
+    file_id: FileId,
+    scope_id: Option<perl_semantic_facts::ScopeId>,
+) -> SymbolDeclSemanticFacts {
+    let mut anchors = Vec::new();
+    let mut entities = Vec::new();
+    let mut edges = Vec::new();
+    let mut unsupported = Vec::new();
+
+    for decl in decls {
+        let Some(entity_kind) = map_entity_kind(decl.kind) else {
+            unsupported.push(UnsupportedSymbolDecl {
+                symbol_name: decl.qualified_name.clone(),
+                symbol_kind: decl.kind,
+            });
+            continue;
+        };
+
+        let entity_id = EntityId(stable_id("entity", file_id.0, decl));
+        let synthetic_span = decl.anchor_span.unwrap_or(decl.full_span);
+        let anchor_id = AnchorId(stable_id_with_span("anchor", file_id.0, decl, synthetic_span));
+
+        anchors.push(AnchorFact {
+            id: anchor_id,
+            file_id,
+            span_start_byte: synthetic_span.0 as u32,
+            span_end_byte: synthetic_span.1 as u32,
+            scope_id,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        entities.push(EntityFact {
+            id: entity_id,
+            kind: entity_kind,
+            canonical_name: decl.qualified_name.clone(),
+            anchor_id: Some(anchor_id),
+            scope_id,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        edges.push(EdgeFact {
+            id: EdgeId(stable_id("edge_defines", file_id.0, decl)),
+            kind: EdgeKind::Defines,
+            from_entity_id: entity_id,
+            to_entity_id: entity_id,
+            via_occurrence_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+    }
+
+    SymbolDeclSemanticFacts { anchors, entities, edges, unsupported }
+}
+
+fn map_entity_kind(kind: SymbolKind) -> Option<EntityKind> {
+    match kind {
+        SymbolKind::Package => Some(EntityKind::Package),
+        SymbolKind::Class => Some(EntityKind::Class),
+        SymbolKind::Subroutine => Some(EntityKind::Subroutine),
+        SymbolKind::Method => Some(EntityKind::Method),
+        SymbolKind::Variable(_) => Some(EntityKind::Variable),
+        SymbolKind::Constant => Some(EntityKind::Constant),
+        SymbolKind::Label => Some(EntityKind::Label),
+        SymbolKind::Format => Some(EntityKind::Format),
+        SymbolKind::Role | SymbolKind::Import | SymbolKind::Export => None,
+    }
+}
+
+fn stable_id(label: &str, file_id: u64, decl: &SymbolDecl) -> u64 {
+    let mut out = 0xcbf29ce484222325u64;
+    hash_mix(&mut out, label.as_bytes());
+    hash_mix(&mut out, &file_id.to_le_bytes());
+    hash_mix(&mut out, decl.name.as_bytes());
+    hash_mix(&mut out, decl.qualified_name.as_bytes());
+    hash_mix(&mut out, &(decl.full_span.0 as u64).to_le_bytes());
+    hash_mix(&mut out, &(decl.full_span.1 as u64).to_le_bytes());
+    out
+}
+
+fn stable_id_with_span(label: &str, file_id: u64, decl: &SymbolDecl, span: (usize, usize)) -> u64 {
+    let mut out = stable_id(label, file_id, decl);
+    hash_mix(&mut out, &(span.0 as u64).to_le_bytes());
+    hash_mix(&mut out, &(span.1 as u64).to_le_bytes());
+    out
+}
+
+fn hash_mix(state: &mut u64, bytes: &[u8]) {
+    for b in bytes {
+        *state ^= u64::from(*b);
+        *state = state.wrapping_mul(0x100000001b3);
+    }
+}

--- a/crates/perl-symbol/tests/surface_decl_semantic_facts.rs
+++ b/crates/perl-symbol/tests/surface_decl_semantic_facts.rs
@@ -1,0 +1,66 @@
+use perl_semantic_facts::{EdgeKind, EntityKind, FileId, ScopeId};
+use perl_symbol::surface::{SymbolDecl, symbol_decls_to_semantic_facts};
+use perl_symbol::{SymbolKind, VarKind};
+
+#[test]
+fn adapter_maps_supported_decl_kinds_and_is_deterministic() -> Result<(), serde_json::Error> {
+    let decls = vec![
+        SymbolDecl { kind: SymbolKind::Package, name: "Foo".into(), qualified_name: "Foo".into(), full_span: (0, 11), anchor_span: Some((8, 11)), container: None, declarator: None },
+        SymbolDecl { kind: SymbolKind::Class, name: "Thing".into(), qualified_name: "Foo::Thing".into(), full_span: (12, 30), anchor_span: None, container: Some("Foo".into()), declarator: None },
+        SymbolDecl { kind: SymbolKind::Subroutine, name: "run".into(), qualified_name: "Foo::run".into(), full_span: (31, 50), anchor_span: Some((35, 38)), container: Some("Foo".into()), declarator: None },
+        SymbolDecl { kind: SymbolKind::Method, name: "new".into(), qualified_name: "Foo::Thing::new".into(), full_span: (51, 70), anchor_span: None, container: Some("Foo::Thing".into()), declarator: None },
+        SymbolDecl { kind: SymbolKind::Variable(VarKind::Scalar), name: "x".into(), qualified_name: "Foo::x".into(), full_span: (71, 80), anchor_span: Some((74, 76)), container: Some("Foo".into()), declarator: Some("my".into()) },
+        SymbolDecl { kind: SymbolKind::Constant, name: "PI".into(), qualified_name: "Foo::PI".into(), full_span: (81, 100), anchor_span: None, container: Some("Foo".into()), declarator: None },
+        SymbolDecl { kind: SymbolKind::Label, name: "LOOP".into(), qualified_name: "LOOP".into(), full_span: (101, 110), anchor_span: None, container: Some("Foo".into()), declarator: None },
+        SymbolDecl { kind: SymbolKind::Format, name: "STDOUT".into(), qualified_name: "Foo::STDOUT".into(), full_span: (111, 130), anchor_span: None, container: Some("Foo".into()), declarator: None },
+    ];
+
+    let first = symbol_decls_to_semantic_facts(&decls, FileId(7), Some(ScopeId(9)));
+    let second = symbol_decls_to_semantic_facts(&decls, FileId(7), Some(ScopeId(9)));
+
+    assert_eq!(first, second);
+    assert!(first.unsupported.is_empty());
+    assert_eq!(first.entities.len(), 8);
+    assert!(first.edges.iter().all(|edge| edge.kind == EdgeKind::Defines));
+
+    let kinds: Vec<EntityKind> = first.entities.iter().map(|e| e.kind).collect();
+    assert_eq!(
+        kinds,
+        vec![
+            EntityKind::Package,
+            EntityKind::Class,
+            EntityKind::Subroutine,
+            EntityKind::Method,
+            EntityKind::Variable,
+            EntityKind::Constant,
+            EntityKind::Label,
+            EntityKind::Format,
+        ]
+    );
+
+    let json = serde_json::to_string_pretty(&first.entities)?;
+    assert_eq!(json, serde_json::to_string_pretty(&second.entities)?);
+    Ok(())
+}
+
+#[test]
+fn adapter_reports_unsupported_decl_kinds_explicitly() {
+    let decls = vec![SymbolDecl {
+        kind: SymbolKind::Role,
+        name: "Roley".into(),
+        qualified_name: "Foo::Roley".into(),
+        full_span: (0, 10),
+        anchor_span: None,
+        container: Some("Foo".into()),
+        declarator: None,
+    }];
+
+    let facts = symbol_decls_to_semantic_facts(&decls, FileId(1), None);
+
+    assert!(facts.anchors.is_empty());
+    assert!(facts.entities.is_empty());
+    assert!(facts.edges.is_empty());
+    assert_eq!(facts.unsupported.len(), 1);
+    assert_eq!(facts.unsupported[0].symbol_name, "Foo::Roley");
+    assert_eq!(facts.unsupported[0].symbol_kind, SymbolKind::Role);
+}


### PR DESCRIPTION
### Motivation
- Provide a canonical, testable adapter from `perl-symbol::surface::SymbolDecl` into the neutral `perl-semantic-facts` vocabulary for Wave 1 consumers.
- Emit the three elementary fact types an analyzer/indexer expects: anchors, entities, and `Defines` edges with deterministic IDs.
- Surface unsupported declaration kinds explicitly rather than dropping them silently so callers can handle later phases.

### Description
- Added `crates/perl-symbol/src/surface/semantic_facts.rs` implementing `symbol_decls_to_semantic_facts` which converts `SymbolDecl` to `AnchorFact`, `EntityFact`, and `EdgeFact::Defines` using deterministic stable IDs derived from file and declaration content.
- Explicitly records unsupported `SymbolKind` variants (`Role`, `Import`, `Export`) in an `unsupported` vector instead of emitting facts for them.
- Exported the adapter types and function from `crates/perl-symbol/src/surface/mod.rs` (`SymbolDeclSemanticFacts`, `UnsupportedSymbolDecl`, `symbol_decls_to_semantic_facts`).
- Added `perl-semantic-facts` workspace dependency to `crates/perl-symbol/Cargo.toml` and a focused test file `crates/perl-symbol/tests/surface_decl_semantic_facts.rs` that verifies mapping coverage and determinism.

### Testing
- Ran `cargo test -p perl-symbol`, which completed successfully and included the new adapter tests (`surface_decl_semantic_facts.rs`) (all tests passed).
- Ran `cargo test -p perl-semantic-facts`, which passed (crate unit tests for fact types succeeded).
- Ran `cargo check --workspace --all-targets`, which completed successfully (no type-check errors across the workspace).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1cec052888333b2d70415c254ed24)