### PR TITLE
feat(perl-symbol): adapt SymbolDecl into semantic facts (#0000)

### DIFF
--- a/crates/perl-symbol/Cargo.toml
+++ b/crates/perl-symbol/Cargo.toml
@@ -27,6 +27,7 @@ doctest = false
 
 [dependencies]
 perl-ast = { workspace = true }
+perl-semantic-facts = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/crates/perl-symbol/src/api.rs
+++ b/crates/perl-symbol/src/api.rs
@@ -25,5 +25,6 @@ pub use crate::index::SymbolIndex;
 
 // surface — full public surface
 pub use crate::surface::{
-    SymbolDecl, SymbolRef, SymbolRefKind, extract_symbol_decls, extract_symbol_refs,
+    DeclFactSet, SymbolDecl, SymbolRef, SymbolRefKind, UnsupportedDeclKind, extract_symbol_decls,
+    extract_symbol_refs, symbol_decls_to_facts,
 };

--- a/crates/perl-symbol/src/surface/facts.rs
+++ b/crates/perl-symbol/src/surface/facts.rs
@@ -1,0 +1,149 @@
+use crate::{SymbolDecl, SymbolKind};
+use perl_semantic_facts::{
+    AnchorFact, AnchorId, Confidence, EdgeFact, EdgeId, EdgeKind, EntityFact, EntityId, EntityKind,
+    FileId, Provenance,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeclFactSet {
+    pub anchors: Vec<AnchorFact>,
+    pub entities: Vec<EntityFact>,
+    pub edges: Vec<EdgeFact>,
+    pub unsupported: Vec<UnsupportedDeclKind>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsupportedDeclKind {
+    pub symbol_kind: SymbolKind,
+    pub qualified_name: String,
+}
+
+pub fn symbol_decls_to_facts(decls: &[SymbolDecl], file_id: FileId) -> DeclFactSet {
+    let mut anchors = Vec::new();
+    let mut entities = Vec::new();
+    let mut edges = Vec::new();
+    let mut unsupported = Vec::new();
+
+    for decl in decls {
+        let Some(entity_kind) = symbol_kind_to_entity_kind(decl.kind) else {
+            unsupported.push(UnsupportedDeclKind {
+                symbol_kind: decl.kind,
+                qualified_name: decl.qualified_name.clone(),
+            });
+            continue;
+        };
+
+        let entity_id = EntityId(stable_id("entity", &decl.qualified_name, decl.full_span));
+        let anchor_id =
+            decl.anchor_span.map(|span| AnchorId(stable_id("anchor", &decl.qualified_name, span)));
+
+        if let Some((start, end)) = decl.anchor_span {
+            anchors.push(AnchorFact {
+                id: AnchorId(stable_id("anchor", &decl.qualified_name, (start, end))),
+                file_id,
+                span_start_byte: start as u32,
+                span_end_byte: end as u32,
+                scope_id: None,
+                provenance: Provenance::ExactAst,
+                confidence: Confidence::High,
+            });
+        }
+
+        entities.push(EntityFact {
+            id: entity_id,
+            kind: entity_kind,
+            canonical_name: decl.qualified_name.clone(),
+            anchor_id,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        edges.push(EdgeFact {
+            id: EdgeId(stable_id("defines", &decl.qualified_name, decl.full_span)),
+            kind: EdgeKind::Defines,
+            from_entity_id: entity_id,
+            to_entity_id: entity_id,
+            via_occurrence_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+    }
+
+    DeclFactSet { anchors, entities, edges, unsupported }
+}
+
+fn symbol_kind_to_entity_kind(kind: SymbolKind) -> Option<EntityKind> {
+    match kind {
+        SymbolKind::Package => Some(EntityKind::Package),
+        SymbolKind::Class => Some(EntityKind::Class),
+        SymbolKind::Subroutine => Some(EntityKind::Subroutine),
+        SymbolKind::Method => Some(EntityKind::Method),
+        SymbolKind::Variable(_) => Some(EntityKind::Variable),
+        SymbolKind::Constant => Some(EntityKind::Constant),
+        SymbolKind::Label => Some(EntityKind::Label),
+        SymbolKind::Format => Some(EntityKind::Format),
+        SymbolKind::Role | SymbolKind::Import | SymbolKind::Export => None,
+    }
+}
+
+fn stable_id(kind: &str, name: &str, span: (usize, usize)) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in format!("{kind}|{name}|{}|{}", span.0, span.1).bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::VarKind;
+
+    #[test]
+    fn adapter_marks_unsupported_kinds_explicitly() {
+        let decl = SymbolDecl {
+            kind: SymbolKind::Role,
+            name: "RoleX".to_string(),
+            qualified_name: "RoleX".to_string(),
+            full_span: (1, 2),
+            anchor_span: Some((1, 2)),
+            container: None,
+            declarator: None,
+        };
+        let facts = symbol_decls_to_facts(&[decl], FileId(1));
+        assert_eq!(facts.entities.len(), 0);
+        assert_eq!(facts.unsupported.len(), 1);
+    }
+
+    #[test]
+    fn adapter_maps_supported_kinds() {
+        let decls = vec![
+            SymbolDecl {
+                kind: SymbolKind::Package,
+                name: "Foo".to_string(),
+                qualified_name: "Foo".to_string(),
+                full_span: (0, 10),
+                anchor_span: Some((8, 11)),
+                container: None,
+                declarator: None,
+            },
+            SymbolDecl {
+                kind: SymbolKind::Variable(VarKind::Scalar),
+                name: "x".to_string(),
+                qualified_name: "Foo::x".to_string(),
+                full_span: (12, 20),
+                anchor_span: Some((15, 17)),
+                container: Some("Foo".to_string()),
+                declarator: Some("my".to_string()),
+            },
+        ];
+
+        let facts = symbol_decls_to_facts(&decls, FileId(9));
+        assert_eq!(facts.entities.len(), 2);
+        assert_eq!(facts.anchors.len(), 2);
+        assert_eq!(facts.edges.len(), 2);
+        assert!(facts.unsupported.is_empty());
+    }
+}

--- a/crates/perl-symbol/src/surface/mod.rs
+++ b/crates/perl-symbol/src/surface/mod.rs
@@ -28,7 +28,9 @@
 //! ```
 
 pub mod decl;
+pub mod facts;
 pub mod r#ref;
 
 pub use decl::{SymbolDecl, extract_symbol_decls};
+pub use facts::{DeclFactSet, UnsupportedDeclKind, symbol_decls_to_facts};
 pub use r#ref::{SymbolRef, SymbolRefKind, extract_symbol_refs};

--- a/crates/perl-symbol/tests/surface_decl_facts.rs
+++ b/crates/perl-symbol/tests/surface_decl_facts.rs
@@ -1,0 +1,108 @@
+use perl_semantic_facts::FileId;
+use perl_symbol::surface::{SymbolDecl, symbol_decls_to_facts};
+use perl_symbol::{SymbolKind, VarKind};
+
+#[test]
+fn symbol_decl_adapter_snapshot_is_deterministic() -> Result<(), serde_json::Error> {
+    let decls = vec![
+        SymbolDecl {
+            kind: SymbolKind::Package,
+            name: "Foo".to_string(),
+            qualified_name: "Foo".to_string(),
+            full_span: (0, 13),
+            anchor_span: Some((8, 11)),
+            container: None,
+            declarator: None,
+        },
+        SymbolDecl {
+            kind: SymbolKind::Class,
+            name: "Thing".to_string(),
+            qualified_name: "Foo::Thing".to_string(),
+            full_span: (14, 40),
+            anchor_span: None,
+            container: Some("Foo".to_string()),
+            declarator: None,
+        },
+        SymbolDecl {
+            kind: SymbolKind::Subroutine,
+            name: "run".to_string(),
+            qualified_name: "Foo::run".to_string(),
+            full_span: (41, 70),
+            anchor_span: Some((45, 48)),
+            container: Some("Foo".to_string()),
+            declarator: None,
+        },
+        SymbolDecl {
+            kind: SymbolKind::Method,
+            name: "tick".to_string(),
+            qualified_name: "Foo::tick".to_string(),
+            full_span: (71, 100),
+            anchor_span: None,
+            container: Some("Foo".to_string()),
+            declarator: None,
+        },
+        SymbolDecl {
+            kind: SymbolKind::Variable(VarKind::Scalar),
+            name: "counter".to_string(),
+            qualified_name: "Foo::counter".to_string(),
+            full_span: (101, 120),
+            anchor_span: Some((105, 113)),
+            container: Some("Foo".to_string()),
+            declarator: Some("my".to_string()),
+        },
+        SymbolDecl {
+            kind: SymbolKind::Constant,
+            name: "MAX".to_string(),
+            qualified_name: "Foo::MAX".to_string(),
+            full_span: (121, 140),
+            anchor_span: Some((125, 128)),
+            container: Some("Foo".to_string()),
+            declarator: None,
+        },
+        SymbolDecl {
+            kind: SymbolKind::Label,
+            name: "RETRY".to_string(),
+            qualified_name: "RETRY".to_string(),
+            full_span: (141, 160),
+            anchor_span: None,
+            container: Some("Foo".to_string()),
+            declarator: None,
+        },
+        SymbolDecl {
+            kind: SymbolKind::Format,
+            name: "STDOUT".to_string(),
+            qualified_name: "Foo::STDOUT".to_string(),
+            full_span: (161, 190),
+            anchor_span: None,
+            container: Some("Foo".to_string()),
+            declarator: None,
+        },
+    ];
+
+    let first = symbol_decls_to_facts(&decls, FileId(77));
+    let second = symbol_decls_to_facts(&decls, FileId(77));
+
+    assert_eq!(first, second);
+    assert!(first.unsupported.is_empty());
+
+    let json = serde_json::to_string_pretty(&first.entities)?;
+    assert_eq!(json, serde_json::to_string_pretty(&second.entities)?);
+    Ok(())
+}
+
+#[test]
+fn symbol_decl_adapter_reports_unsupported_symbol_kinds() {
+    let decl = SymbolDecl {
+        kind: SymbolKind::Import,
+        name: "imported".to_string(),
+        qualified_name: "Foo::imported".to_string(),
+        full_span: (10, 20),
+        anchor_span: Some((12, 20)),
+        container: Some("Foo".to_string()),
+        declarator: None,
+    };
+
+    let facts = symbol_decls_to_facts(&[decl], FileId(1));
+    assert!(facts.entities.is_empty());
+    assert_eq!(facts.unsupported.len(), 1);
+}


### PR DESCRIPTION
### Motivation

- Provide a single, reviewable producer seam that converts `SymbolDecl` (parser surface) into the neutral `perl-semantic-facts` vocabulary so downstream analyzers and indexes can consume canonical facts.
- Ensure outputs are deterministic and test-friendly by producing stable IDs for `AnchorFact`, `EntityFact`, and `EdgeFact::Defines` rather than ad-hoc ids.
- Explicitly surface unsupported declaration kinds instead of silently dropping them so consumers can incrementally implement semantics for `Role`, `Import`, `Export`, etc.

### Description

- Added a new adapter module `surface::facts` with `symbol_decls_to_facts` that emits `AnchorFact`, `EntityFact`, and `EdgeFact::Defines` from `SymbolDecl` and collects unsupported kinds into `UnsupportedDeclKind`.
- Implemented deterministic ID generation via a local `stable_id(kind, name, span)` FNV-1a-style hasher to produce stable `EntityId`, `AnchorId`, and `EdgeId` values for tests and reproducible pipelines.
- Mapped `SymbolKind` -> `EntityKind` for supported kinds (package, class, subroutine, method, variable, constant, label, format) and return `None` for unsupported kinds to make them explicit.
- Exposed the adapter in `surface` and crate-level re-exports, added `perl-semantic-facts` as a dependency, and added deterministic snapshot-style tests in `crates/perl-symbol/tests/surface_decl_facts.rs`.

### Testing

- Ran `cargo xtask fmt` to format changes; formatting completed successfully.
- Ran `cargo test -p perl-symbol` and the crate unit tests (including new adapter tests) passed.
- Ran `cargo test -p perl-semantic-facts` and its unit tests passed.
- Ran `cargo check --workspace --all-targets` and the workspace check completed without hard errors (only expected warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1cec052888333b2d70415c254ed24)