### PR TITLE
feat(perl-semantic-analyzer): adapt exporter extraction to ExportSet facts (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,6 +1849,7 @@ version = "0.12.4"
 dependencies = [
  "perl-module",
  "perl-parser-core",
+ "perl-semantic-facts",
  "perl-symbol",
  "perl-tdd-support",
  "perl-test-generators",

--- a/crates/perl-semantic-analyzer/Cargo.toml
+++ b/crates/perl-semantic-analyzer/Cargo.toml
@@ -27,6 +27,7 @@ perl-parser-core = { workspace = true }
 perl-module = { workspace = true }
 perl-workspace = { workspace = true }
 perl-symbol = { workspace = true }
+perl-semantic-facts = { workspace = true }
 regex.workspace = true
 rustc-hash = "2.1.2"
 tracing.workspace = true

--- a/crates/perl-semantic-analyzer/src/analysis/export_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/export_analyzer.rs
@@ -27,6 +27,7 @@
 //! forms are extracted.
 
 use crate::ast::{Node, NodeKind};
+use perl_semantic_facts::{Confidence, ExportSet, Provenance};
 use std::collections::{HashMap, HashSet};
 
 /// Information extracted from an Exporter-based module.
@@ -75,6 +76,28 @@ impl ExportSymbolExtractor {
         Self::walk_and_extract_exports(ast, &detector, &mut info);
 
         Some(info)
+    }
+
+    /// Extract canonical export facts from an AST when Exporter semantics are detected.
+    pub fn extract_export_set(ast: &Node) -> Option<ExportSet> {
+        let info = Self::extract(ast)?;
+        Some(Self::to_export_set(&info))
+    }
+
+    /// Convert extracted Exporter arrays to canonical facts.
+    pub fn to_export_set(info: &ExportInfo) -> ExportSet {
+        let tag_exports = info
+            .export_tags
+            .iter()
+            .map(|(tag, symbols)| (tag.clone(), symbols.iter().cloned().collect()))
+            .collect();
+        ExportSet {
+            default_exports: info.default_export.iter().cloned().collect(),
+            optional_exports: info.optional_export.iter().cloned().collect(),
+            tag_exports,
+            provenance: Provenance::ImportExportInference,
+            confidence: Confidence::High,
+        }
     }
 
     /// Detect if the AST represents an Exporter-based module.

--- a/crates/perl-semantic-analyzer/tests/export_set_adapter.rs
+++ b/crates/perl-semantic-analyzer/tests/export_set_adapter.rs
@@ -1,0 +1,85 @@
+use perl_semantic_analyzer::Parser;
+use perl_semantic_analyzer::analysis::export_analyzer::ExportSymbolExtractor;
+use perl_semantic_facts::Provenance;
+use std::error::Error;
+
+fn export_set_from(code: &str) -> Result<perl_semantic_facts::ExportSet, Box<dyn Error>> {
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    ExportSymbolExtractor::extract_export_set(&ast)
+        .ok_or_else(|| "expected exporter-backed module".into())
+}
+
+#[test]
+fn export_set_captures_export_and_export_ok() -> Result<(), Box<dyn Error>> {
+    let code = r#"
+package MyLib;
+use Exporter 'import';
+our @EXPORT = qw(foo);
+our @EXPORT_OK = qw(bar baz);
+1;
+"#;
+
+    let export_set = export_set_from(code)?;
+    assert!(export_set.default_exports.contains("foo"));
+    assert!(export_set.optional_exports.contains("bar"));
+    assert!(export_set.optional_exports.contains("baz"));
+    assert_eq!(export_set.provenance, Provenance::ImportExportInference);
+    Ok(())
+}
+
+#[test]
+fn export_set_captures_export_tags_membership() -> Result<(), Box<dyn Error>> {
+    let code = r#"
+package Color;
+use Exporter 'import';
+our %EXPORT_TAGS = (
+  primary => [qw(red green blue)],
+);
+1;
+"#;
+
+    let export_set = export_set_from(code)?;
+    let primary = export_set
+        .tag_exports
+        .get("primary")
+        .ok_or("missing primary tag")?;
+    assert!(primary.contains("red"));
+    assert!(primary.contains("green"));
+    assert!(primary.contains("blue"));
+    Ok(())
+}
+
+#[test]
+fn export_set_detects_parent_exporter_form() -> Result<(), Box<dyn Error>> {
+    let code = r#"
+package ParentStyle;
+use parent 'Exporter';
+our @EXPORT_OK = qw(alpha);
+1;
+"#;
+
+    let export_set = export_set_from(code)?;
+    assert!(export_set.optional_exports.contains("alpha"));
+    Ok(())
+}
+
+#[test]
+fn export_set_is_absent_for_dynamic_or_non_exporter_forms() -> Result<(), Box<dyn Error>> {
+    let code = r#"
+package Dynamic;
+our $maybe = 'Exporter';
+our @ISA = ($maybe);
+our @EXPORT = qw(fake);
+1;
+"#;
+
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    let export_set = ExportSymbolExtractor::extract_export_set(&ast);
+    assert!(
+        export_set.is_none(),
+        "dynamic @ISA form should remain conservatively unsupported"
+    );
+    Ok(())
+}

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -7,6 +7,7 @@
 //! storage backends.
 
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
 
 macro_rules! id_newtype {
     ($name:ident) => {
@@ -154,6 +155,21 @@ pub struct DiagnosticFact {
     pub confidence: Confidence,
 }
 
+/// Canonical export surface for a Perl package.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExportSet {
+    /// Symbols exported by default (`@EXPORT`).
+    pub default_exports: BTreeSet<String>,
+    /// Symbols exported on request (`@EXPORT_OK`).
+    pub optional_exports: BTreeSet<String>,
+    /// Export-tag groups (`%EXPORT_TAGS`), tag name -> member symbols.
+    pub tag_exports: BTreeMap<String, BTreeSet<String>>,
+    /// Inference source used to derive this export surface.
+    pub provenance: Provenance,
+    /// Confidence associated with the inferred export surface.
+    pub confidence: Confidence,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -244,6 +260,27 @@ mod tests {
         let serialized = serde_json::to_string(&id)?;
         let decoded: EntityId = serde_json::from_str(&serialized)?;
         assert_eq!(decoded, id);
+        Ok(())
+    }
+
+    #[test]
+    fn export_set_roundtrips_with_tag_membership() -> Result<(), serde_json::Error> {
+        let mut tag_exports = BTreeMap::new();
+        tag_exports.insert(
+            "all".to_string(),
+            BTreeSet::from(["foo".to_string(), "bar".to_string()]),
+        );
+        let fact = ExportSet {
+            default_exports: BTreeSet::from(["foo".to_string()]),
+            optional_exports: BTreeSet::from(["bar".to_string(), "baz".to_string()]),
+            tag_exports,
+            provenance: Provenance::ImportExportInference,
+            confidence: Confidence::High,
+        };
+
+        let serialized = serde_json::to_string(&fact)?;
+        let decoded: ExportSet = serde_json::from_str(&serialized)?;
+        assert_eq!(decoded, fact);
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Exporter analysis produced an ad-hoc `ExportInfo` but downstream semantic-fact consumers need a canonical, serializable export representation with provenance and deterministic containers.

### Description

- Add a canonical `ExportSet` type in `crates/perl-semantic-facts` with `BTreeSet`/`BTreeMap` containers and `provenance`/`confidence` metadata. 
- Add an `ExportSet` round-trip unit test to validate stable serialization and tag membership. 
- Add `perl-semantic-facts` as a dependency of `perl-semantic-analyzer` and implement `ExportSymbolExtractor::extract_export_set` and `ExportSymbolExtractor::to_export_set` to convert existing `ExportInfo` into `ExportSet` using `Provenance::ImportExportInference` and `Confidence::High`. 
- Add focused tests in `crates/perl-semantic-analyzer/tests/export_set_adapter.rs` covering `@EXPORT`, `@EXPORT_OK`, `%EXPORT_TAGS`, `use parent 'Exporter'` detection, and conservative handling of dynamic `@ISA` forms.

### Testing

- Ran `cargo test -p perl-semantic-analyzer export` and the adapter and existing exporter tests passed. 
- Ran `cargo test -p perl-semantic-facts` and the new `ExportSet` serialization test passed. 
- Ran `cargo check --workspace --all-targets` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ceca55b48333ad43599204f3903c)