### PR TITLE
feat(perl-symbol): adapt SymbolRef into semantic occurrence facts (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,7 @@ dependencies = [
  "criterion",
  "perl-ast",
  "perl-parser-core",
+ "perl-semantic-facts",
  "perl-tdd-support",
  "serde",
  "serde_json",

--- a/crates/perl-symbol/Cargo.toml
+++ b/crates/perl-symbol/Cargo.toml
@@ -27,6 +27,7 @@ doctest = false
 
 [dependencies]
 perl-ast = { workspace = true }
+perl-semantic-facts = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/crates/perl-symbol/src/api.rs
+++ b/crates/perl-symbol/src/api.rs
@@ -25,5 +25,6 @@ pub use crate::index::SymbolIndex;
 
 // surface — full public surface
 pub use crate::surface::{
-    SymbolDecl, SymbolRef, SymbolRefKind, extract_symbol_decls, extract_symbol_refs,
+    SymbolDecl, SymbolRef, SymbolRefKind, SymbolRefOccurrenceFacts, extract_symbol_decls,
+    extract_symbol_refs, symbol_ref_to_occurrence_facts,
 };

--- a/crates/perl-symbol/src/surface/mod.rs
+++ b/crates/perl-symbol/src/surface/mod.rs
@@ -28,7 +28,9 @@
 //! ```
 
 pub mod decl;
+pub mod occurrence_facts;
 pub mod r#ref;
 
 pub use decl::{SymbolDecl, extract_symbol_decls};
+pub use occurrence_facts::{SymbolRefOccurrenceFacts, symbol_ref_to_occurrence_facts};
 pub use r#ref::{SymbolRef, SymbolRefKind, extract_symbol_refs};

--- a/crates/perl-symbol/src/surface/occurrence_facts.rs
+++ b/crates/perl-symbol/src/surface/occurrence_facts.rs
@@ -1,0 +1,72 @@
+//! Adapter from phase-1 `SymbolRef` projections to canonical semantic facts.
+//!
+//! This adapter intentionally mirrors only the currently supported `SymbolRef`
+//! families (variables + function calls). It does not attempt to model phase-2
+//! families yet (method calls, coderef calls, indirect calls, typeglobs).
+
+use crate::surface::{SymbolRef, SymbolRefKind};
+use perl_semantic_facts::{
+    AnchorFact, AnchorId, Confidence, EdgeFact, EdgeId, EdgeKind, EntityId, FileId, OccurrenceFact,
+    OccurrenceId, OccurrenceKind, Provenance, ScopeId,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SymbolRefOccurrenceFacts {
+    pub anchor: AnchorFact,
+    pub occurrence: OccurrenceFact,
+    pub reference_edge: Option<EdgeFact>,
+}
+
+pub fn symbol_ref_to_occurrence_facts(
+    symbol_ref: &SymbolRef,
+    file_id: FileId,
+    scope_id: Option<ScopeId>,
+    anchor_id: AnchorId,
+    occurrence_id: OccurrenceId,
+    entity_id: Option<EntityId>,
+    edge_id: Option<EdgeId>,
+) -> SymbolRefOccurrenceFacts {
+    let (start, end) = symbol_ref.anchor_span.unwrap_or(symbol_ref.full_span);
+
+    let anchor = AnchorFact {
+        id: anchor_id,
+        file_id,
+        span_start_byte: start as u32,
+        span_end_byte: end as u32,
+        scope_id,
+        provenance: Provenance::ExactAst,
+        confidence: Confidence::High,
+    };
+
+    let occurrence = OccurrenceFact {
+        id: occurrence_id,
+        kind: occurrence_kind_for_ref(symbol_ref),
+        entity_id,
+        anchor_id,
+        scope_id,
+        provenance: Provenance::ExactAst,
+        confidence: Confidence::High,
+    };
+
+    let reference_edge = match (entity_id, edge_id) {
+        (Some(target_id), Some(id)) => Some(EdgeFact {
+            id,
+            kind: EdgeKind::References,
+            from_entity_id: target_id,
+            to_entity_id: target_id,
+            via_occurrence_id: Some(occurrence_id),
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        }),
+        _ => None,
+    };
+
+    SymbolRefOccurrenceFacts { anchor, occurrence, reference_edge }
+}
+
+fn occurrence_kind_for_ref(symbol_ref: &SymbolRef) -> OccurrenceKind {
+    match symbol_ref.kind {
+        SymbolRefKind::SubroutineCall => OccurrenceKind::Call,
+        SymbolRefKind::Variable(_) => OccurrenceKind::Reference,
+    }
+}

--- a/crates/perl-symbol/tests/symbol_ref_occurrence_facts.rs
+++ b/crates/perl-symbol/tests/symbol_ref_occurrence_facts.rs
@@ -1,0 +1,67 @@
+use perl_ast::{Node, NodeKind, SourceLocation};
+use perl_semantic_facts::{AnchorId, EdgeId, EntityId, FileId, OccurrenceId, OccurrenceKind, ScopeId};
+use perl_symbol::surface::{extract_symbol_refs, symbol_ref_to_occurrence_facts};
+
+fn loc(start: usize, end: usize) -> SourceLocation {
+    SourceLocation { start, end }
+}
+
+#[test]
+fn adapter_emits_anchor_occurrence_and_reference_edge_for_variable_refs() {
+    let variable = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "My::Pkg::value".to_string() },
+        loc(4, 18),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![variable] }, loc(0, 18));
+    let refs = extract_symbol_refs(&program);
+
+    assert_eq!(refs.len(), 1);
+    let facts = symbol_ref_to_occurrence_facts(
+        &refs[0],
+        FileId(7),
+        Some(ScopeId(3)),
+        AnchorId(11),
+        OccurrenceId(13),
+        Some(EntityId(17)),
+        Some(EdgeId(19)),
+    );
+
+    assert_eq!(facts.anchor.id, AnchorId(11));
+    assert_eq!(facts.anchor.file_id, FileId(7));
+    assert_eq!(facts.anchor.span_start_byte, 4);
+    assert_eq!(facts.anchor.span_end_byte, 18);
+    assert_eq!(facts.occurrence.kind, OccurrenceKind::Reference);
+    assert_eq!(facts.occurrence.entity_id, Some(EntityId(17)));
+
+    assert!(facts.reference_edge.is_some());
+    if let Some(edge) = facts.reference_edge {
+        assert_eq!(edge.id, EdgeId(19));
+        assert_eq!(edge.via_occurrence_id, Some(OccurrenceId(13)));
+    }
+}
+
+#[test]
+fn adapter_emits_call_occurrence_without_edge_when_ids_are_missing() {
+    let call = Node::new(
+        NodeKind::FunctionCall { name: "run_task".to_string(), args: vec![] },
+        loc(20, 28),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![call] }, loc(20, 28));
+    let refs = extract_symbol_refs(&program);
+
+    assert_eq!(refs.len(), 1);
+    let facts = symbol_ref_to_occurrence_facts(
+        &refs[0],
+        FileId(42),
+        None,
+        AnchorId(1),
+        OccurrenceId(2),
+        None,
+        None,
+    );
+
+    assert_eq!(facts.anchor.span_start_byte, 20);
+    assert_eq!(facts.anchor.span_end_byte, 28);
+    assert_eq!(facts.occurrence.kind, OccurrenceKind::Call);
+    assert!(facts.reference_edge.is_none());
+}


### PR DESCRIPTION
### Motivation

- Provide a small, reviewable adapter to convert the existing phase-1 `SymbolRef` projections into canonical semantic facts so downstream layers can consume stable `AnchorFact` / `OccurrenceFact` / `References` edge records.
- Keep the change narrowly focused on the high-confidence phase-1 families (variables and subroutine calls) and avoid modeling phase-2 families (methods, coderef/indirect calls, typeglobs).

### Description

- Added a focused adapter module `crates/perl-symbol/src/surface/occurrence_facts.rs` that converts a `SymbolRef` into an `AnchorFact`, an `OccurrenceFact` (mapping variables → `Reference`, subroutine calls → `Call`), and an optional `EdgeFact` with `EdgeKind::References` when `entity_id` and `edge_id` are provided.
- Re-exported the adapter and its result type from `surface/mod.rs` and the crate facade in `src/api.rs` as `SymbolRefOccurrenceFacts` and `symbol_ref_to_occurrence_facts` so callers can access it from `perl_symbol`.
- Added `perl-semantic-facts` as a dependency in `crates/perl-symbol/Cargo.toml` to consume the canonical fact types.
- Added deterministic unit tests at `crates/perl-symbol/tests/symbol_ref_occurrence_facts.rs` that validate anchor spans, occurrence kinds/fields, and the optional reference edge behavior.

### Testing

- Ran `cargo test -p perl-symbol` and all tests passed (including existing `SymbolRef` surface tests and the new adapter tests). 
- Ran `cargo test -p perl-semantic-facts` and all tests passed.
- Ran `cargo check --workspace --all-targets` which completed successfully (workspace emits unrelated pre-existing warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1cec583048333b20c4580ce7913c9)